### PR TITLE
fix(auth): check mounted state before using ref after async operation causing error when debugging

### DIFF
--- a/awcms-mobile/primary/lib/features/auth/screens/login_screen.dart
+++ b/awcms-mobile/primary/lib/features/auth/screens/login_screen.dart
@@ -41,9 +41,9 @@ class _LoginScreenState extends ConsumerState<LoginScreen> {
           _passwordController.text,
         );
 
-    final authState = ref.read(authProvider);
-
     if (!mounted) return;
+
+    final authState = ref.read(authProvider);
 
     if (authState.isAuthenticated) {
       context.go(AppRoutes.home);


### PR DESCRIPTION
## Summary
Fixes an exception that occurs during login when the widget unmounts before the async operation completes.

## Problem
The login screen throws a StateError during debugging:

Bad state: Using "ref" when a widget is about to or has been unmounted is unsafe

This happens because `ref.read(authProvider)` was called after the `async signInWithEmail` but before the mounted check.

## Solution
Moved the `if (!mounted) return;` check to occur before accessing `ref.read()` after the await, following Flutter/Riverpod best practices for async safety.

## Impact
- User impact: None (login already worked, just threw debug exceptions)
- Risk: Low — simple reordering of existing code