### PR TITLE
Potential fix for code scanning alert no. 131: Overly permissive regular expression range

### DIFF
--- a/awcms/src/lib/stitch/constants.js
+++ b/awcms/src/lib/stitch/constants.js
@@ -66,4 +66,4 @@ export const STITCH_FORBID_TAGS = ['script', 'style', 'noscript', 'form', 'input
 
 export const STITCH_FORBID_ATTR = ['style'];
 
-export const STITCH_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel):|data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,|[^a-z]|[a-z0-9+.-]+(?:[^a-z0-9+.-:]|$))/i;
+export const STITCH_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel):|data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,|[^a-z]|[a-z0-9.+-]+(?:[^a-z0-9+.-:]|$))/i;


### PR DESCRIPTION
Potential fix for [https://github.com/ahliweb/awcms/security/code-scanning/131](https://github.com/ahliweb/awcms/security/code-scanning/131)

In general, overly permissive ranges occur when `-` is used inside a character class without being escaped or placed where it can only mean a literal. To fix this, rewrite the class so that `-` is clearly literal (by escaping it, or placing it first/last) and avoid any accidental ranges.

Here, the problematic part is `[a-z0-9+.-]+`. The intent is almost certainly “lowercase letters, digits, plus, dot, and hyphen,” i.e. the typical URL hostname/authority token characters. To keep functionality but remove ambiguity, we should change this to a class that clearly lists those literals, such as `[a-z0-9.+-]+` or `[a-z0-9+.-]+` with an escaped hyphen (`[a-z0-9+.\-]+`). The rest of the regex should stay identical.

Concretely, in `awcms/src/lib/stitch/constants.js`, on line 69, replace the `.-` range with a safe placement of `-` so that the class is unambiguous. The best minimal change is:

- Original fragment: `[a-z0-9+.-]+`
- Fixed fragment: `[a-z0-9.+-]+`

No new imports or helper methods are needed; this is a simple literal regex modification within the existing export.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
