### PR TITLE
Potential fix for code scanning alert no. 131: Overly permissive regular expression range

### DIFF
--- a/awcms/src/lib/stitch/constants.js
+++ b/awcms/src/lib/stitch/constants.js
@@ -66,4 +66,4 @@ export const STITCH_FORBID_TAGS = ['script', 'style', 'noscript', 'form', 'input
 
 export const STITCH_FORBID_ATTR = ['style'];
 
-export const STITCH_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel):|data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,|[^a-z]|[a-z0-9.+-]+(?:[^a-z0-9+.-:]|$))/i;
+export const STITCH_ALLOWED_URI_REGEXP = /^(?:(?:https?|mailto|tel):|data:image\/(?:png|jpe?g|gif|webp|svg\+xml);base64,|[^a-z]|[a-z0-9.+\-]+(?:[^a-z0-9+\.\-:]|$))/i;


### PR DESCRIPTION
Potential fix for [https://github.com/ahliweb/awcms/security/code-scanning/131](https://github.com/ahliweb/awcms/security/code-scanning/131)

In general, to fix overly permissive ranges in regex character classes, any dash (`-`) that is meant to be a literal must be either escaped (`\-`) or moved to the beginning or end of the class (where it is not interpreted as a range). This avoids accidental ranges like `.-:`.

Here, the problematic part is `[a-z0-9.+-]+(?:[^a-z0-9+.-:]|$)`. The intent appears to be “letters, digits, dot, plus, minus” for the allowed run. Currently, `.+-` is parsed as `.` and the range `.-:`, i.e. `./0123456789:`, not literal `.` and `+` and `-`. The minimal, behavior-preserving fix is to escape the dash in both character classes so that `-` is treated literally: `[a-z0-9.+\-]+` and `[^a-z0-9+\.\-:]`. This keeps the allowed literal characters the same as intended and removes the unintended range.

Concretely, in `awcws/src/lib/stitch/constants.js`, on line 69, replace `.+-` with `.+\-` in the first character class, and replace `+.-` with `+\.\-` in the negated character class. No new imports or helpers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
