### PR TITLE
chore(db): mirror migrations to awcms folder for tooling

### DIFF
--- a/awcms/supabase/migrations/20260304100000_platform_tenant_separation_phase1.sql
+++ b/awcms/supabase/migrations/20260304100000_platform_tenant_separation_phase1.sql
@@ -1,0 +1,114 @@
+-- Migration: Platform vs Tenant Configuration Separation - Phase 1 Database Foundation
+
+-- 1. Function: auth_is_platform_admin() 
+-- Returns true if the authenticated user has a role with is_platform_admin or is_full_access = true
+CREATE OR REPLACE FUNCTION public.auth_is_platform_admin()
+RETURNS BOOLEAN AS $$
+BEGIN
+  RETURN EXISTS (
+    SELECT 1 FROM public.users u
+    JOIN public.roles r ON r.id = u.role_id
+    WHERE u.id = auth.uid()
+      AND (r.is_platform_admin = true OR r.is_full_access = true)
+      AND u.deleted_at IS NULL
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+-- 2. Table: platform_settings
+CREATE TABLE IF NOT EXISTS public.platform_settings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key TEXT NOT NULL UNIQUE,
+  value TEXT,
+  type TEXT DEFAULT 'string' CHECK (type IN ('string','boolean','number','json')),
+  description TEXT,
+  category TEXT DEFAULT 'general',
+  is_overridable BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- RLS for platform_settings
+ALTER TABLE public.platform_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Platform admins can manage platform_settings"
+  ON public.platform_settings FOR ALL
+  USING (public.auth_is_platform_admin());
+
+CREATE POLICY "Authenticated users can read overridable platform_settings"
+  ON public.platform_settings FOR SELECT
+  USING (auth.role() = 'authenticated');
+
+-- 3. Update Existing Tables with Scopes
+-- 3a. admin_menus
+DO $$ 
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'admin_menus' AND column_name = 'scope') THEN
+    ALTER TABLE public.admin_menus ADD COLUMN scope TEXT DEFAULT 'tenant' CHECK (scope IN ('platform', 'tenant', 'shared'));
+    
+    -- Update known platform scopes based on RESOURCE_MAP.md
+    UPDATE public.admin_menus 
+    SET scope = 'platform' 
+    WHERE key IN ('sidebar_manager', 'modules', 'extensions', 'tenants')
+       OR path IN ('/cmspanel/admin/menus', '/cmspanel/extensions', '/cmspanel/tenants');
+  END IF;
+END $$;
+
+-- 3b. settings
+DO $$ 
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema = 'public' AND table_name = 'settings' AND column_name = 'scope') THEN
+    ALTER TABLE public.settings ADD COLUMN scope TEXT DEFAULT 'tenant' CHECK (scope IN ('platform', 'tenant'));
+    -- We'll keep existing settings logic, just adding the constraint
+  END IF;
+END $$;
+
+-- 3c. resources_registry
+-- It already has a 'scope' column (TEXT NOT NULL), we just ensure the constraint or at least update data
+UPDATE public.resources_registry
+SET scope = 'platform'
+WHERE key IN ('extensions', 'modules', 'sidebar_manager', 'tenants');
+
+UPDATE public.resources_registry
+SET scope = 'tenant'
+WHERE scope NOT IN ('platform') OR scope IS NULL;
+
+-- 4. RPC: get_effective_setting(key, tenant_id)
+CREATE OR REPLACE FUNCTION public.get_effective_setting(p_key TEXT, p_tenant_id UUID)
+RETURNS TEXT AS $$
+DECLARE
+  v_tenant_val TEXT;
+  v_platform_val TEXT;
+BEGIN
+  -- Try tenant-level first if overridable is true (implied in this basic version, frontend will honor it)
+  SELECT value INTO v_tenant_val
+  FROM public.settings
+  WHERE key = p_key AND tenant_id = p_tenant_id;
+
+  IF v_tenant_val IS NOT NULL THEN 
+    RETURN v_tenant_val; 
+  END IF;
+
+  -- Fall back to platform default
+  SELECT value INTO v_platform_val
+  FROM public.platform_settings
+  WHERE key = p_key;
+
+  RETURN v_platform_val;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER STABLE;
+
+-- Trigger to update updated_at for platform_settings
+CREATE OR REPLACE FUNCTION public.set_platform_settings_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_platform_settings_updated_at ON public.platform_settings;
+CREATE TRIGGER trg_platform_settings_updated_at
+  BEFORE UPDATE ON public.platform_settings
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_platform_settings_updated_at();

--- a/awcms/supabase/migrations/20260304101000_platform_tenant_separation_phase2.sql
+++ b/awcms/supabase/migrations/20260304101000_platform_tenant_separation_phase2.sql
@@ -1,0 +1,74 @@
+-- Migration: Platform vs Tenant Configuration Separation - Phase 2 Roles & Permissions
+
+BEGIN;
+
+-- 1. Insert new platform-scoped permissions
+INSERT INTO public.permissions (name, description, resource, action, module)
+VALUES 
+  -- Platform Settings
+  ('platform.setting.read', 'View platform-level settings', 'platform.setting', 'read', 'platform'),
+  ('platform.setting.create', 'Create platform settings', 'platform.setting', 'create', 'platform'),
+  ('platform.setting.update', 'Modify platform settings', 'platform.setting', 'update', 'platform'),
+  ('platform.setting.delete', 'Remove platform settings', 'platform.setting', 'delete', 'platform'),
+  
+  -- Tenant Management at Platform Level
+  ('platform.tenant.read', 'View all tenants', 'platform.tenant', 'read', 'platform'),
+  ('platform.tenant.create', 'Create new tenants', 'platform.tenant', 'create', 'platform'),
+  ('platform.tenant.update', 'Modify tenant config', 'platform.tenant', 'update', 'platform'),
+  ('platform.tenant.delete', 'Deactivate tenants', 'platform.tenant', 'delete', 'platform'),
+  
+  -- Platform Modules & Extensions
+  ('platform.module.manage', 'Enable/disable modules globally', 'platform.module', 'manage', 'platform'),
+  ('platform.extensions.manage', 'Manage extensions globally', 'platform.extensions', 'manage', 'platform')
+ON CONFLICT (name) DO NOTHING;
+
+-- 2. Assign these new permissions to the Platform Admin and Super Admin roles
+DO $$
+DECLARE
+  v_role_id UUID;
+  v_perm_id UUID;
+  v_perm_name TEXT;
+  v_new_perms TEXT[] := ARRAY[
+    'platform.setting.read', 'platform.setting.create', 'platform.setting.update', 'platform.setting.delete',
+    'platform.tenant.read', 'platform.tenant.create', 'platform.tenant.update', 'platform.tenant.delete',
+    'platform.module.manage', 'platform.extensions.manage'
+  ];
+BEGIN
+  -- Loop through all roles that are either platform admin or full access
+  FOR v_role_id IN 
+    SELECT id FROM public.roles 
+    WHERE (is_platform_admin = true OR is_full_access = true) AND deleted_at IS NULL
+  LOOP
+    -- Loop through the new permissions
+    FOREACH v_perm_name IN ARRAY v_new_perms
+    LOOP
+      -- Get permission ID
+      SELECT id INTO v_perm_id FROM public.permissions WHERE name = v_perm_name AND deleted_at IS NULL;
+      
+      -- Assign if not exists
+      IF v_perm_id IS NOT NULL THEN
+        INSERT INTO public.role_permissions (role_id, permission_id)
+        VALUES (v_role_id, v_perm_id)
+        ON CONFLICT (role_id, permission_id) DO NOTHING;
+      END IF;
+    END LOOP;
+  END LOOP;
+END $$;
+
+-- 3. Log the migration
+INSERT INTO audit_logs (
+  action,
+  resource,
+  details,
+  created_at
+) VALUES (
+  'MIGRATION',
+  'permissions',
+  jsonb_build_object(
+    'description', 'Added platform-scoped permissions for Settings, Tenants, Modules, and Extensions',
+    'migration', '20260304101000_platform_tenant_separation_phase2'
+  ),
+  NOW()
+);
+
+COMMIT;

--- a/awcms/supabase/migrations/20260304102000_platform_tenant_separation_phase5.sql
+++ b/awcms/supabase/migrations/20260304102000_platform_tenant_separation_phase5.sql
@@ -1,0 +1,40 @@
+-- Migration to harden settings RLS: Only platform admins can modify 'platform' scoped settings
+-- Regular tenant admins can only modify 'tenant' and 'shared' scoped settings
+
+-- Update the existing can_manage_settings() function if needed, or add specific RLS policies
+-- Since RLS policies apply on top of existing ones, we can just add a restrictive policy or update the existing one.
+
+-- The settings table has tenant_hierarchy_resource_sharing policies, let's look at how they protect the rows.
+-- Wait, the simplest way to prevent non-platform admins from updating/deleting/inserting platform settings is to use a TRIGGER or a restrictive policy.
+-- A BEFORE trigger might be safer and universally applied.
+
+-- Let's create a trigger to prevent non-platform admins from modifying platform settings.
+CREATE OR REPLACE FUNCTION public.harden_platform_settings_rls()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- If the setting scope is 'platform'
+  IF (TG_OP = 'INSERT' AND NEW.scope = 'platform') OR 
+     (TG_OP = 'UPDATE' AND (NEW.scope = 'platform' OR OLD.scope = 'platform')) OR 
+     (TG_OP = 'DELETE' AND OLD.scope = 'platform') THEN
+    
+    -- Check if the user is a platform admin
+    IF NOT public.auth_is_platform_admin() THEN
+      RAISE EXCEPTION 'Only Platform Admins can modify platform-scoped settings.';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Drop trigger if exists
+DROP TRIGGER IF EXISTS harden_platform_settings_trigger ON public.settings;
+
+-- Create trigger
+CREATE TRIGGER harden_platform_settings_trigger
+BEFORE INSERT OR UPDATE OR DELETE ON public.settings
+FOR EACH ROW EXECUTE FUNCTION public.harden_platform_settings_rls();


### PR DESCRIPTION
Syncs the recent 3 Supabase migrations into the \wcms\ mirror folder. This resolves local/CI synchronization issues caused by missing files in \wcms/supabase/migrations\ which blocks \erify_supabase_migration_consistency.sh\.