### PR TITLE
fix: restore legacy template static builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to the **AWCMS** project will be documented in this file.
 - Docs: Restored `cd awcms && npm run docs:check` by removing the dead deployment-cell specification link in `docs/architecture/deployment-cells/overview.md`.
 - Public Portal: Restored `cd awcms-public/primary && npm run check` after the Astro upgrade by replacing the removed `@astrojs/markdown-remark` type import with unified/mdast/hast-compatible plugin typing in `awcms-public/primary/src/utils/frontmatter.ts`.
 - Tooling Security: Eliminated the remaining dev-time audit findings by overriding `flatted` in the admin and MCP workspaces and `yauzl` in the public workspaces, while keeping Astro/public build validation green.
+- Legacy Template: Restored `awcms/src/templates/flowbiteadminastro` static builds by fixing the `SideBar.astro` client script guard and routing SSR/static data loading through local service operations instead of a localhost-only API fetch.
 
 ## [4.0.0] "Cellular" - 2026-03-13
 

--- a/awcms/src/templates/flowbiteadminastro/src/app/SideBar.astro
+++ b/awcms/src/templates/flowbiteadminastro/src/app/SideBar.astro
@@ -577,35 +577,33 @@ const renderIcon = (name, className = navIconClass) => {
 			'toggleSidebarMobileSearch',
 		);
 
-		if (!sidebarBackdrop || !toggleSidebarMobileHamburger || !toggleSidebarMobileClose) {
-			return;
+		if (sidebarBackdrop && toggleSidebarMobileHamburger && toggleSidebarMobileClose) {
+			toggleSidebarMobileSearch?.addEventListener('click', () => {
+				toggleSidebarMobile(
+					sidebar,
+					sidebarBackdrop,
+					toggleSidebarMobileHamburger,
+					toggleSidebarMobileClose,
+				);
+			});
+
+			toggleSidebarMobileEl?.addEventListener('click', () => {
+				toggleSidebarMobile(
+					sidebar,
+					sidebarBackdrop,
+					toggleSidebarMobileHamburger,
+					toggleSidebarMobileClose,
+				);
+			});
+
+			sidebarBackdrop.addEventListener('click', () => {
+				toggleSidebarMobile(
+					sidebar,
+					sidebarBackdrop,
+					toggleSidebarMobileHamburger,
+					toggleSidebarMobileClose,
+				);
+			});
 		}
-
-		toggleSidebarMobileSearch?.addEventListener('click', () => {
-			toggleSidebarMobile(
-				sidebar,
-				sidebarBackdrop,
-				toggleSidebarMobileHamburger,
-				toggleSidebarMobileClose,
-			);
-		});
-
-		toggleSidebarMobileEl?.addEventListener('click', () => {
-			toggleSidebarMobile(
-				sidebar,
-				sidebarBackdrop,
-				toggleSidebarMobileHamburger,
-				toggleSidebarMobileClose,
-			);
-		});
-
-		sidebarBackdrop?.addEventListener('click', () => {
-			toggleSidebarMobile(
-				sidebar,
-				sidebarBackdrop,
-				toggleSidebarMobileHamburger,
-				toggleSidebarMobileClose,
-			);
-		});
 	}
 </script>

--- a/awcms/src/templates/flowbiteadminastro/src/lib/data.ts
+++ b/awcms/src/templates/flowbiteadminastro/src/lib/data.ts
@@ -2,9 +2,19 @@
 // GraphQL, Databases, REST APIs, CDNs, proxies, S3, Matrix, IPFS, you name it…
 
 import { API_URL, REMOTE_ASSETS_BASE_URL } from '../app/constants.js';
+import * as operations from '../services/index.js';
 import type { Endpoint, EndpointsToOperations } from '../types/entities.js';
 
+const localOperations: EndpointsToOperations = {
+	products: operations.getProducts,
+	users: operations.getUsers,
+};
+
 export async function fetchData<Selected extends Endpoint>(endpoint: Selected) {
+	if (import.meta.env.SSR) {
+		return localOperations[endpoint]() as ReturnType<EndpointsToOperations[Selected]>;
+	}
+
 	const apiEndpoint = `${API_URL}${endpoint}`;
 
 	console.info(`Fetching ${apiEndpoint}…`);


### PR DESCRIPTION
## Summary
- fix the invalid top-level `return` in `awcms/src/templates/flowbiteadminastro/src/app/SideBar.astro`
- update `awcms/src/templates/flowbiteadminastro/src/lib/data.ts` so SSR/static builds use local service operations instead of trying to fetch a localhost-only API during build
- record the legacy template build restoration in `CHANGELOG.md`

## Validation
- `cd awcms/src/templates/flowbiteadminastro && npm run lint`
- `cd awcms/src/templates/flowbiteadminastro && npm run build`
- `cd awcms/src/templates/flowbiteadminastro && npm audit --json`

## Result
- the legacy `flowbiteadminastro` template now lints, builds, and audits cleanly