### PR TITLE
fix(public): prebundle Cloudflare dev dependencies

### DIFF
--- a/awcms-public/primary/astro.config.ts
+++ b/awcms-public/primary/astro.config.ts
@@ -34,6 +34,35 @@ const whenExternalScripts = (
 
 import react from "@astrojs/react";
 
+function optimizeWorkerdDeps() {
+  return {
+    name: "awcms-workerd-deps",
+    configEnvironment(environment: string) {
+      if (environment === "client") {
+        return;
+      }
+
+      return {
+        optimizeDeps: {
+          include: [
+            "astro-icon",
+            "astro-embed",
+            "@astro-community/astro-embed-bluesky",
+            "@iconify/utils",
+            "@iconify/utils > debug",
+            "@atproto/api",
+            "@atproto/common-web",
+            "@atproto/lexicon",
+            "@atproto/xrpc",
+            "@atproto/syntax",
+            "debug",
+          ],
+        },
+      };
+    },
+  };
+}
+
 export default defineConfig({
   output: "static",
   adapter: cloudflare({ imageService: "compile" }),
@@ -93,7 +122,9 @@ export default defineConfig({
   },
 
   vite: {
-    plugins: [tailwindcss()] as NonNullable<AstroUserConfig["vite"]>["plugins"],
+    plugins: [tailwindcss(), optimizeWorkerdDeps()] as NonNullable<
+      AstroUserConfig["vite"]
+    >["plugins"],
     resolve: {
       alias: {
         "~": path.resolve(__dirname, "./src"),

--- a/awcms-public/primary/src/pages/[locale]/p/[slug].astro
+++ b/awcms-public/primary/src/pages/[locale]/p/[slug].astro
@@ -9,7 +9,7 @@ import PuckRenderer from "~/components/common/PuckRenderer.astro";
 import { createClientFromEnv } from "~/lib/supabase";
 import { getPublicTenantId } from "~/lib/publicTenant";
 import { getPageBySlug } from "~/lib/content";
-import { supportedLocales, type Locale } from "~/utils/i18n";
+import { supportedLocales } from "~/utils/i18n";
 
 export const prerender = true;
 


### PR DESCRIPTION
## Summary
- prebundle Cloudflare workerd dev dependencies used by `astro-icon` and `astro-embed` so Astro dev no longer crashes on CommonJS `debug` and `@atproto/*` modules
- keep the existing static public portal setup intact while aligning the workaround with Astro's documented `optimizeDeps` guidance for Cloudflare
- remove the unused `Locale` import in the localized page route to clear the remaining Astro diagnostic hint

## Validation
- npm run build
- npm run check:astro
- npm run dev and verify `/en` renders without `module is not defined` or `exports is not defined`