### PR TITLE
fix(security): fix CWE-134 tainted format string in VisualPageBuilder

### DIFF
--- a/awcms/src/components/visual-builder/VisualPageBuilder.jsx
+++ b/awcms/src/components/visual-builder/VisualPageBuilder.jsx
@@ -337,7 +337,7 @@ const VisualPageBuilder = ({ page: initialPage, mode: initialMode, onClose, onSu
                 .maybeSingle();
 
             if (error) {
-                console.error(`Error loading ${mode} translation:`, error);
+                console.error("Error loading %s translation:", mode, error);
                 return;
             }
 
@@ -348,7 +348,7 @@ const VisualPageBuilder = ({ page: initialPage, mode: initialMode, onClose, onSu
                 try {
                     translatedVisualContent = JSON.parse(translation.content);
                 } catch (parseError) {
-                    console.warn(`Failed to parse translated ${mode} visual content, using default locale content:`, parseError);
+                    console.warn("Failed to parse translated %s visual content, using default locale content:", mode, parseError);
                 }
             }
 
@@ -854,7 +854,7 @@ const VisualPageBuilder = ({ page: initialPage, mode: initialMode, onClose, onSu
                 description: isOffline ? "Changes saved locally. Status will update when online." : `Your ${mode === 'blog' ? 'blog' : 'page'} is now live.`,
             });
         } catch (error) {
-            console.error(`Error publishing ${mode}:`, error);
+            console.error("Error publishing %s:", mode, error);
             toast({
                 title: "Publish Failed",
                 description: error.message,


### PR DESCRIPTION
## Summary

Fixes 3 CodeQL **High** severity alerts (`js/tainted-format-string`, CWE-134) in `awcms/src/components/visual-builder/VisualPageBuilder.jsx`.

## Root Cause

Three `console.error`/`console.warn` calls used template literals containing the `mode` prop (an externally-controlled value) directly as the format string. If `mode` contained a format specifier like `%d` or `%s`, the logger would misinterpret subsequent arguments, producing garbled or misleading output.

## Fix

Replaced the template literals with static format strings using `%s` specifiers, passing `mode` as a separate positional argument — the pattern recommended by CodeQL and the Node.js `util.format` documentation.

| Line | Before | After |
|------|--------|-------|
| 340 | `` console.error(`Error loading ${mode} translation:`, error) `` | `console.error("Error loading %s translation:", mode, error)` |
| 351 | `` console.warn(`Failed to parse translated ${mode} visual content…`, parseError) `` | `console.warn("Failed to parse translated %s visual content…", mode, parseError)` |
| 857 | `` console.error(`Error publishing ${mode}:`, error) `` | `console.error("Error publishing %s:", mode, error)` |

## Closes

- CodeQL alert #135 (line 857)
- CodeQL alert #134 (line 351)
- CodeQL alert #133 (line 340)