### PR TITLE
fix(ci): replace PR db lint with migration parity check

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -327,20 +327,10 @@ jobs:
   db-check:
     name: Database Migrations Check
     runs-on: ubuntu-latest
-    # Assuming this check doesn't need secrets in 'db lint'?
-    # Supabase link might need access token? 
-    # db lint is static offline check usually.
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup Supabase CLI
-        uses: supabase/setup-cli@v1
-        with:
-          version: latest
-
-      - name: Validate migrations
-        run: |
-          cd awcms/supabase
-          supabase db lint
+      - name: Validate migration parity and history safety
+        run: bash ./scripts/verify_supabase_migration_consistency.sh


### PR DESCRIPTION
## Summary
- replace the PR-only `Database Migrations Check` job's `supabase db lint` call with `scripts/verify_supabase_migration_consistency.sh`
- stop relying on a nonexistent local Supabase/Postgres service in GitHub Actions for PR checks
- keep migration safety coverage by validating root/mirror parity and migration-history consistency through the existing repo script

## Verification
- ran `bash ./scripts/verify_supabase_migration_consistency.sh`
- confirmed the workflow diff only changes `.github/workflows/ci-pr.yml`

## Context
- the old PR workflow always failed with `dial tcp 127.0.0.1:54322: connect: connection refused`
- the runtime-validation path already uses the same migration consistency script successfully in CI after the previous fix
- `Cloudflare Pages: awcms-public` still looks like a persistent external deployment failure and was not changed in this PR