### PR TITLE
docs(deploy): add awcms-public Pages incident note

### DIFF
--- a/docs/deploy/awcms-public-pages-incident.md
+++ b/docs/deploy/awcms-public-pages-incident.md
@@ -1,0 +1,90 @@
+> **Documentation Authority**: [SYSTEM_MODEL.md](../../SYSTEM_MODEL.md) Section 1 (Tech Stack)
+
+# awcms-public Pages Incident Note
+
+## Purpose
+
+Capture the current failure pattern for the `awcms-public` Cloudflare Pages deployment and separate repo-controlled checks from Cloudflare project-side ownership.
+
+## Current State
+
+- GitHub repo-controlled checks for the primary public portal pass.
+- The external Cloudflare Pages check `Cloudflare Pages: awcms-public` still fails.
+- Other Pages targets in the same repository continue to pass, including `awcms` and `awcms-smandapangkalanbun-web`.
+
+## Evidence
+
+- `Lint & Build (Public Portal)` passes in `CI (PR)`.
+- `Runtime Validation` passes after the Node `22.12.0` storage-guard fix.
+- `Database Migrations Check` passes after switching the PR workflow to `scripts/verify_supabase_migration_consistency.sh`.
+- The remaining failing check is the external Cloudflare deployment integration for the `awcms-public` Pages project.
+
+## Likely Ownership Boundary
+
+Most evidence points to a Cloudflare Pages project/environment issue rather than a source-code build failure in this repository.
+
+Likely Cloudflare-side causes:
+
+- missing or mis-scoped Pages environment variables
+- incorrect root directory, build command, or output directory
+- branch/deployment configuration drift
+- stale Pages project settings or integration state
+
+## Repo-Side Baseline
+
+Expected `awcms-public` Pages settings:
+
+| Setting | Expected value |
+| --- | --- |
+| Project | `awcms-public` |
+| Root directory | `awcms-public/primary` |
+| Build command | `npm run build` |
+| Output directory | `dist` |
+| Node version | `22.12.0` or newer |
+
+Required environment variables:
+
+- `PUBLIC_SUPABASE_URL`
+- `PUBLIC_SUPABASE_PUBLISHABLE_KEY`
+- `PUBLIC_TENANT_ID`
+
+Recommended aligned variables:
+
+- `PUBLIC_TENANT_SLUG`
+- `PUBLIC_TURNSTILE_SITE_KEY` (if the tenant uses Turnstile on public pages)
+
+## Important Runtime Guard
+
+`awcms-public/primary/scripts/run-with-deployment-env.mjs` intentionally fails Cloudflare builds when the required public deployment variables are missing.
+
+That means a Cloudflare log containing a message like this is a project/env configuration issue, not a code bug:
+
+```text
+[AWCMS Public] Missing deployment env: ...
+```
+
+## Operator Checklist
+
+1. Open the `awcms-public` Pages project in Cloudflare.
+2. Confirm the root directory is `awcms-public/primary`.
+3. Confirm the build command is `npm run build`.
+4. Confirm the output directory is `dist`.
+5. Confirm the Node version is `22.12.0` or newer.
+6. Verify `PUBLIC_SUPABASE_URL`, `PUBLIC_SUPABASE_PUBLISHABLE_KEY`, and `PUBLIC_TENANT_ID` exist for the failing environment.
+7. Compare the Production and Preview env sets for drift.
+8. Check that no stale custom override bypasses the package build script.
+9. Re-run the deployment and inspect the first fatal error in the Cloudflare build log.
+
+## Related Files
+
+- `awcms-public/primary/package.json`
+- `awcms-public/primary/scripts/run-with-deployment-env.mjs`
+- `awcms-public/primary/scripts/sanitize-generated-wrangler.mjs`
+- `.github/workflows/ci-pr.yml`
+- `docs/deploy/cloudflare.md`
+
+## References
+
+- `docs/deploy/cloudflare.md`
+- `docs/dev/environment-bootstrap.md`
+- `docs/dev/ci-cd.md`

--- a/docs/deploy/cloudflare.md
+++ b/docs/deploy/cloudflare.md
@@ -119,8 +119,10 @@ Use `scripts/update_cloudflare_secrets.sh` (repo root) to sync project env value
 
 - Build failures: verify root directory and Node version.
 - Tenant resolution issues: confirm `PUBLIC_TENANT_ID` for canonical static builds; only inspect middleware/host settings when working on non-canonical SSR/runtime experiments.
+- For the standing external `awcms-public` Pages deployment failure pattern and operator checklist, see `docs/deploy/awcms-public-pages-incident.md`.
 
 ## References
 
 - `docs/deploy/overview.md`
 - `docs/tenancy/overview.md`
+- `docs/deploy/awcms-public-pages-incident.md`

--- a/docs/dev/ci-cd.md
+++ b/docs/dev/ci-cd.md
@@ -45,7 +45,7 @@ Describe the GitHub Actions workflows used for AWCMS.
 | `build-ext-primary-analytics` | Install dependencies and run the extension SSR smoke build | `awcms-ext/primary-analytics/` | ci-push, ci-pr |
 | `typecheck-shared` | Install dependencies and run `@awcms/shared` TypeScript checks | `packages/awcms-shared/` | ci-push, ci-pr |
 | `lint-build-smandapbun` | Check and build the SMANDAPBUN public portal | `awcms-public/smandapbun/` | ci-push, ci-pr |
-| `db-check` | Supabase migration lint | `awcms/supabase` | ci-pr |
+| `db-check` | Migration parity and history safety check | repo root | ci-pr |
 | `deploy-production` | Cloudflare Pages deploy (admin panel artifact) | `awcms/` | ci-push |
 | `link-check` | Markdown link validation | repo root | docs-link-check |
 | `deploy` | Build and deploy SMANDAPBUN portal to Cloudflare Pages; also ensures custom domains | `awcms-public/smandapbun/` | deploy-smandapbun |


### PR DESCRIPTION
## Summary
- add a focused incident note for the persistent external `awcms-public` Cloudflare Pages deployment failure
- link the Cloudflare deployment runbook to that incident note for operator troubleshooting
- update CI/CD docs so the `db-check` job description matches the current PR workflow behavior

## Verification
- reviewed the docs diff for only the three intended files
- confirmed the note matches the current repo-controlled check state: public build passes, runtime validation passes, and database migrations check now passes

## Context
- the remaining `awcms-public` failure pattern appears external to repo build/test logic
- this note captures the likely Cloudflare-side ownership boundary and the dashboard checklist needed for follow-up