### PR TITLE
fix(mobile): refresh primary app dependencies and security baseline

### DIFF
--- a/awcms-mobile/primary/pubspec.lock
+++ b/awcms-mobile/primary/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: build_config
-      sha256: "4f64382b97504dc2fcdf487d5aae33418e08b4703fc21249e4db6d804a4d0187"
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   build_daemon:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: "direct dev"
     description:
       name: build_runner
-      sha256: "110c56ef29b5eb367b4d17fc79375fa8c18a6cd7acd92c05bb3986c17a079057"
+      sha256: "521daf8d189deb79ba474e43a696b41c49fb3987818dbacf3308f1e03673a75e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.4"
+    version: "2.13.1"
   built_collection:
     dependency: transitive
     description:
@@ -325,18 +325,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "3669e1b68d7bffb60192ac6ba9fd2c0306804d7a00e5879f6364c69ecde53a7f"
+      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
       url: "https://pub.dev"
     source: hosted
-    version: "2.30.0"
+    version: "2.31.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: afe4d1d2cfce6606c86f11a6196e974a2ddbfaa992956ce61e054c9b1899c769
+      sha256: "917184b2fb867b70a548a83bf0d36268423b38d39968c06cce4905683da49587"
       url: "https://pub.dev"
     source: hosted
-    version: "2.30.0"
+    version: "2.31.0"
   drift_flutter:
     dependency: "direct main"
     description:
@@ -504,10 +504,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_riverpod
-      sha256: "38ec6c303e2c83ee84512f5fc2a82ae311531021938e63d7137eccc107bf3c02"
+      sha256: "4e166be88e1dbbaa34a280bdb744aeae73b7ef25fdf8db7a3bb776760a3648e2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.3.1"
   flutter_secure_storage:
     dependency: "direct main"
     description:
@@ -690,10 +690,10 @@ packages:
     dependency: "direct main"
     description:
       name: go_router
-      sha256: eff94d2a6fc79fa8b811dde79c7549808c2346037ee107a1121b4a644c745f2a
+      sha256: "7974313e217a7771557add6ff2238acb63f635317c35fa590d348fb238f00896"
       url: "https://pub.dev"
     source: hosted
-    version: "17.0.1"
+    version: "17.1.0"
   gotrue:
     dependency: transitive
     description:
@@ -1170,10 +1170,10 @@ packages:
     dependency: transitive
     description:
       name: riverpod
-      sha256: "16ff608d21e8ea64364f2b7c049c94a02ab81668f78845862b6e88b71dd4935a"
+      sha256: "8c22216be8ad3ef2b44af3a329693558c98eca7b8bd4ef495c92db0bba279f83"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.2.1"
   rxdart:
     dependency: transitive
     description:
@@ -1375,10 +1375,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: "162435ede92bcc793ea939fdc0452eef0a73d11f8ed053b58a89792fba749da5"
+      sha256: "337e9997f7141ffdd054259128553c348635fa318f7ca492f07a4ab76f850d19"
       url: "https://pub.dev"
     source: hosted
-    version: "0.42.1"
+    version: "0.43.1"
   stack_trace:
     dependency: transitive
     description:

--- a/awcms-mobile/primary/pubspec.yaml
+++ b/awcms-mobile/primary/pubspec.yaml
@@ -21,10 +21,10 @@ dependencies:
   supabase_flutter: ^2.8.0
   
   # State Management
-  flutter_riverpod: ^3.1.0
+  flutter_riverpod: ^3.3.1
   
   # Routing
-  go_router: ^17.0.1
+  go_router: ^17.1.0
   
   # Environment
   flutter_dotenv: ^6.0.0
@@ -33,7 +33,7 @@ dependencies:
   shared_preferences: ^2.3.3
   
   # Local Database (Offline-First)
-  drift: ^2.30.0
+  drift: ^2.31.0
   drift_flutter: ^0.2.8
   
   # Connectivity
@@ -66,8 +66,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
-  drift_dev: ^2.30.0
-  build_runner: ^2.4.15
+  drift_dev: ^2.31.0
+  build_runner: ^2.13.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- refresh the `awcms-mobile/primary` workspace to the latest safe resolvable direct dependency set for Riverpod, Go Router, Drift, Drift Dev, and Build Runner
- keep the mobile workspace on a clean dependency/security baseline using Flutter resolution plus static analysis and widget tests
- defer major-version migrations like `flutter_local_notifications` and `drift_flutter` to a separate mobile migration pass

## Validation
- `cd awcms-mobile/primary && flutter pub get`
- `cd awcms-mobile/primary && flutter analyze`
- `cd awcms-mobile/primary && flutter test`
- `bash ./scripts/ci-validate-runtime.sh`

## Notes
- `flutter pub audit` is not available in the installed Flutter toolchain, so this workspace uses `flutter pub outdated`, successful dependency resolution, `flutter analyze`, and `flutter test` as the validation baseline
- the remaining Flutter updates are either transitive-only or major-version migrations outside this safe batch