### PR TITLE
fix(extensions): align analytics package build scripts

### DIFF
--- a/awcms-ext/primary-analytics/package.json
+++ b/awcms-ext/primary-analytics/package.json
@@ -14,8 +14,8 @@
         "vite": "^7.0.0"
     },
     "scripts": {
-        "build": "vite build",
-        "build:ci": "vite build --ssr src/index.js",
+        "build": "vite build --ssr src/index.js --outDir ../../temp_debug_files/primary-analytics-build",
+        "build:ci": "vite build --ssr src/index.js --outDir ../../temp_debug_files/primary-analytics-build",
         "dev": "vite"
     }
 }

--- a/awcms/src/extensions/ahliweb-analytics/package.json
+++ b/awcms/src/extensions/ahliweb-analytics/package.json
@@ -14,7 +14,8 @@
         "vite": "^7.0.0"
     },
     "scripts": {
-        "build": "vite build",
+        "build": "vite build --ssr src/index.js --outDir ../../../../temp_debug_files/ahliweb-analytics-build",
+        "build:ci": "vite build --ssr src/index.js --outDir ../../../../temp_debug_files/ahliweb-analytics-build",
         "dev": "vite"
     }
 }

--- a/awcms/src/extensions/ahliweb-analytics/src/components/AnalyticsWidget.jsx
+++ b/awcms/src/extensions/ahliweb-analytics/src/components/AnalyticsWidget.jsx
@@ -3,7 +3,7 @@
  * Compact widget for dashboard integration
  */
 
-import { cn } from '@/lib/utils';
+import { cn } from '../../../../lib/utils';
 import { ArrowRight } from 'lucide-react';
 
 const AnalyticsWidget = ({ className = '' }) => {


### PR DESCRIPTION
## Summary
- make both analytics extension packages build as SSR/library-style entry bundles instead of expecting an `index.html`
- add a `build:ci` script to the in-repo analytics extension for parity with the external extension package
- replace the in-repo extension's admin-only `@/lib/utils` alias import with a stable relative import so the package can build independently of the admin app Vite config

## Validation
- `cd awcms-ext/primary-analytics && npm run build && npm run build:ci`
- `cd awcms/src/extensions/ahliweb-analytics && npm run build && npm run build:ci`
- `bash ./scripts/ci-validate-runtime.sh`

## Notes
- both extension packages now emit their build output to `temp_debug_files/...` so repo-wide admin lint does not trip over generated SSR artifacts inside the source tree
- no dependency versions changed in this PR; this is a focused script-quality fix