### PR TITLE
fix(admin): refine knip signal and dashboard import

### DIFF
--- a/awcms/knip.json
+++ b/awcms/knip.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://unpkg.com/knip@6/schema.json",
+  "entry": [
+    "src/main.jsx",
+    "src/pages/**/*.jsx",
+    "src/scripts/**/*.js",
+    "src/extensions/**/src/index.js",
+    "src/plugins/**/index.js",
+    "test-eslint.config.js",
+    "debug-tenant.js",
+    "empty.js"
+  ],
+  "project": [
+    "src/**/*.{js,jsx}",
+    "scripts/**/*.js",
+    "*.js"
+  ],
+  "paths": {
+    "@": ["./src"],
+    "@/*": ["./src/*"],
+    "@plugins": ["./src/plugins"],
+    "@plugins/*": ["./src/plugins/*"]
+  },
+  "ignoreBinaries": [
+    "markdown-link-check",
+    "supabase"
+  ],
+  "ignoreDependencies": [
+    "bcryptjs",
+    "flowbite",
+    "leaflet",
+    "react-leaflet",
+    "tailwindcss-animate",
+    "@tailwindcss/typography",
+    "tailwindcss"
+  ],
+  "ignoreFiles": [
+    "public/leaflet/**",
+    "src/templates/**"
+  ],
+  "ignoreIssues": {
+    "src/extensions/**/src/index.js": ["exports", "duplicates"],
+    "src/plugins/**/index.js": ["exports", "duplicates"],
+    "src/templates/**": ["files", "exports", "duplicates"]
+  },
+  "ignoreExportsUsedInFile": true
+}

--- a/awcms/src/pages/Dashboard.jsx
+++ b/awcms/src/pages/Dashboard.jsx
@@ -13,7 +13,7 @@ import AnnouncementsManager from '@/components/dashboard/AnnouncementsManager';
 import PromotionsManager from '@/components/dashboard/PromotionsManager';
 import UsersManager from '@/components/dashboard/UsersManager';
 import RolesManager from '@/components/dashboard/RolesManager';
-import AuditLogsERP from '@/components/dashboard/AuditLogsERP';
+import AuditLogsManager from '@/components/dashboard/AuditLogsManager';
 import PolicyManager from '@/components/dashboard/PolicyManager';
 import UserProfile from '@/components/dashboard/UserProfile';
 import { Helmet } from 'react-helmet-async';
@@ -44,7 +44,7 @@ function Dashboard() {
       case 'roles':
         return <RolesManager />;
       case 'audit-logs':
-        return <AuditLogsERP />;
+        return <AuditLogsManager />;
       case 'policies':
         return <PolicyManager />;
       case 'profile':


### PR DESCRIPTION
## Summary
- add an `awcms/knip.json` configuration so the upgraded `knip@6` report reflects real admin cleanup work instead of repo-specific false positives from scripts, templates, aliases, and CSS plugin dependencies
- fix the unresolved `AuditLogsERP` import in `awcms/src/pages/Dashboard.jsx` by wiring it to the existing `AuditLogsManager` component
- keep the remaining `knip` output focused on actual unused files/exports backlog rather than misclassified dependencies and binaries

## Validation
- `cd awcms && npm run lint`
- `cd awcms && npm run test -- --run`
- `cd awcms && npm run build`
- `cd awcms && npm run lint:unused`
- `bash ./scripts/ci-validate-runtime.sh`

## Notes
- this PR does not try to remove the full unused-code backlog; it makes the `knip` signal actionable for a later cleanup pass
- the remaining `knip` output is intentionally preserved as the next cleanup backlog rather than hidden