### PR TITLE
chore(mobile): upgrade local notifications major version

### DIFF
--- a/awcms-mobile/primary/lib/core/services/local_notification_service.dart
+++ b/awcms-mobile/primary/lib/core/services/local_notification_service.dart
@@ -47,7 +47,7 @@ class LocalNotificationService {
     );
 
     await _plugin.initialize(
-      initSettings,
+      settings: initSettings,
       onDidReceiveNotificationResponse: _onNotificationTapped,
     );
 
@@ -108,12 +108,18 @@ class LocalNotificationService {
       iOS: iosDetails,
     );
 
-    await _plugin.show(id, title, body, details, payload: payload);
+    await _plugin.show(
+      id: id,
+      title: title,
+      body: body,
+      notificationDetails: details,
+      payload: payload,
+    );
   }
 
   /// Cancel a specific notification
   Future<void> cancel(int id) async {
-    await _plugin.cancel(id);
+    await _plugin.cancel(id: id);
   }
 
   /// Cancel all notifications

--- a/awcms-mobile/primary/pubspec.lock
+++ b/awcms-mobile/primary/pubspec.lock
@@ -459,34 +459,34 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_local_notifications
-      sha256: "19ffb0a8bb7407875555e5e98d7343a633bb73707bae6c6a5f37c90014077875"
+      sha256: "0d9035862236fe38250fe1644d7ed3b8254e34a21b2c837c9f539fbb3bba5ef1"
       url: "https://pub.dev"
     source: hosted
-    version: "19.5.0"
+    version: "21.0.0"
   flutter_local_notifications_linux:
     dependency: transitive
     description:
       name: flutter_local_notifications_linux
-      sha256: e3c277b2daab8e36ac5a6820536668d07e83851aeeb79c446e525a70710770a5
+      sha256: e0f25e243c6c44c825bbbc6b2b2e76f7d9222362adcfe9fd780bf01923c840bd
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.0"
   flutter_local_notifications_platform_interface:
     dependency: transitive
     description:
       name: flutter_local_notifications_platform_interface
-      sha256: "277d25d960c15674ce78ca97f57d0bae2ee401c844b6ac80fcd972a9c99d09fe"
+      sha256: e7db3d5b49c2b7ecc68deba4aaaa67a348f92ee0fef34c8e4b4459dbef0d7307
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "11.0.0"
   flutter_local_notifications_windows:
     dependency: transitive
     description:
       name: flutter_local_notifications_windows
-      sha256: "8d658f0d367c48bd420e7cf2d26655e2d1130147bca1eea917e576ca76668aaf"
+      sha256: "3a2654ba104fbb52c618ebed9def24ef270228470718c43b3a6afcd5c81bef0c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "3.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -1487,10 +1487,10 @@ packages:
     dependency: transitive
     description:
       name: timezone
-      sha256: dd14a3b83cfd7cb19e7888f1cbc20f258b8d71b54c06f79ac585f14093a287d1
+      sha256: "784a5e34d2eb62e1326f24d6f600aaaee452eb8ca8ef2f384a59244e292d158b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.10.1"
+    version: "0.11.0"
   typed_data:
     dependency: transitive
     description:
@@ -1677,4 +1677,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.0"
+  flutter: ">=3.38.1"

--- a/awcms-mobile/primary/pubspec.yaml
+++ b/awcms-mobile/primary/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
   geocoding: ^4.0.0
   
   # Notifications
-  flutter_local_notifications: ^19.5.0
+  flutter_local_notifications: ^21.0.0
   
   # Utils
   intl: ^0.20.2


### PR DESCRIPTION
## Summary
- upgrade `flutter_local_notifications` in `awcms-mobile/primary` from `19.5.0` to `21.0.0`
- update `LocalNotificationService` to the new named-parameter API for `initialize`, `show`, and `cancel`
- keep `drift_flutter` pinned at `0.2.8` because `0.3.0` is not currently compatible with the workspace's Flutter SDK/test matrix and `drift_dev` constraints

## Validation
- `cd awcms-mobile/primary && flutter pub get`
- `cd awcms-mobile/primary && flutter analyze`
- `cd awcms-mobile/primary && flutter test`
- `bash ./scripts/ci-validate-runtime.sh`

## Notes
- this PR intentionally narrows the mobile major-upgrade lane to the direct major that resolves cleanly today
- `drift_flutter` remains a deferred migration item and should be revisited together with a wider Drift/Flutter toolchain upgrade