### PR TITLE
[AWCMS][SEQ-14] feat(edge): structured logger Workers-native + redaction (#114)

### DIFF
--- a/awcms-edge/src/lib/logger.ts
+++ b/awcms-edge/src/lib/logger.ts
@@ -1,0 +1,137 @@
+/**
+ * Structured HTTP/general logger untuk awcms-edge (Cloudflare Workers).
+ *
+ * Pino tidak berjalan di runtime Workers (workerd), jadi ini adapter native yang
+ * menghasilkan **NDJSON** selaras format `queues/observability.ts` (kompatibel
+ * Cloudflare Workers Logs / Logpush) dan selaras logging Pino di awcms-mini
+ * (ADR-021): JSON terstruktur, child logger ber-`requestId`, redaction field
+ * sensitif.
+ *
+ * Pakai ini sebagai pengganti `console.error`/`console.log` ad-hoc di jalur HTTP.
+ *
+ * Authority: personal-coding `awcms-shared-standards.md` §8.1/§8.3, ADR-021.
+ */
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
+
+const CENSOR = '[REDACTED]'
+
+/**
+ * Nama key yang WAJIB di-redact (case-insensitive). Selaras klasifikasi data:
+ * jangan log restricted/highly_restricted mentah.
+ */
+const REDACT_KEYS = new Set(
+  [
+    'password',
+    'passwordhash',
+    'password_hash',
+    'token',
+    'accesstoken',
+    'access_token',
+    'refreshtoken',
+    'refresh_token',
+    'secret',
+    'apikey',
+    'api_key',
+    'authorization',
+    'cookie',
+    'set-cookie',
+    'nik',
+    'nikenc',
+    'nik_enc',
+    'service_role',
+    'service_role_key',
+  ].map((k) => k.toLowerCase()),
+)
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Kembalikan salinan dengan field sensitif tersensor (deep). Tidak memutasi input.
+ */
+export function redact(value: unknown, depth = 0): unknown {
+  if (depth > 8) return value
+  if (Array.isArray(value)) return value.map((v) => redact(v, depth + 1))
+  if (isPlainObject(value)) {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = REDACT_KEYS.has(k.toLowerCase()) ? CENSOR : redact(v, depth + 1)
+    }
+    return out
+  }
+  return value
+}
+
+const LEVEL_ORDER: Record<LogLevel, number> = { debug: 10, info: 20, warn: 30, error: 40 }
+
+export interface Logger {
+  debug(msg: string, fields?: Record<string, unknown>): void
+  info(msg: string, fields?: Record<string, unknown>): void
+  warn(msg: string, fields?: Record<string, unknown>): void
+  error(msg: string, fields?: Record<string, unknown>): void
+  /** Logger turunan dengan binding tetap (mis. requestId, tenant_id). */
+  child(bindings: Record<string, unknown>): Logger
+}
+
+export interface CreateLoggerOptions {
+  /** Field dasar yang disertakan di setiap baris (mis. service). */
+  base?: Record<string, unknown>
+  /** Level minimum (default env LOG_LEVEL atau "info"). */
+  level?: LogLevel
+  /** Sink kustom (untuk test). Default: console sesuai level. */
+  sink?: (level: LogLevel, line: string) => void
+}
+
+function defaultSink(level: LogLevel, line: string): void {
+  // NDJSON satu baris — diparse oleh Workers Logs / Logpush.
+  if (level === 'error') console.error(line)
+  else if (level === 'warn') console.warn(line)
+  else console.log(line)
+}
+
+/**
+ * Buat structured logger. Output: satu baris JSON per log dengan
+ * `{ ts, level, msg, ...base, ...fields }`, field sensitif ter-redact.
+ */
+export function createLogger(options: CreateLoggerOptions = {}): Logger {
+  const base = options.base ?? {}
+  const minLevel = LEVEL_ORDER[options.level ?? 'info']
+  const sink = options.sink ?? defaultSink
+
+  function emit(level: LogLevel, msg: string, fields?: Record<string, unknown>): void {
+    if (LEVEL_ORDER[level] < minLevel) return
+    const record = {
+      ts: new Date().toISOString(),
+      level,
+      msg,
+      ...base,
+      ...(fields ?? {}),
+    }
+    sink(level, JSON.stringify(redact(record)))
+  }
+
+  return {
+    debug: (msg, fields) => emit('debug', msg, fields),
+    info: (msg, fields) => emit('info', msg, fields),
+    warn: (msg, fields) => emit('warn', msg, fields),
+    error: (msg, fields) => emit('error', msg, fields),
+    child(bindings) {
+      return createLogger({ base: { ...base, ...bindings }, level: options.level, sink })
+    },
+  }
+}
+
+/**
+ * Buat child logger terikat pada satu request (ber-`requestId`).
+ * Pasang dari header `x-request-id` atau `crypto.randomUUID()`.
+ */
+export function loggerForRequest(
+  request: Request,
+  options: CreateLoggerOptions = {},
+): Logger {
+  const headerId = request.headers.get('x-request-id')?.trim()
+  const requestId = headerId && headerId.length > 0 ? headerId : crypto.randomUUID()
+  return createLogger(options).child({ requestId })
+}

--- a/awcms-edge/tests/logger.test.mjs
+++ b/awcms-edge/tests/logger.test.mjs
@@ -1,0 +1,90 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { createLogger, redact, loggerForRequest } from '../src/lib/logger.ts'
+
+function capture(level = 'debug') {
+  const lines = []
+  const logger = createLogger({
+    base: { service: 'awcms-edge' },
+    level,
+    sink: (lvl, line) => lines.push({ lvl, json: JSON.parse(line) }),
+  })
+  return { logger, lines }
+}
+
+test('logger: emit JSON terstruktur dengan ts/level/msg/base', () => {
+  const { logger, lines } = capture()
+  logger.info('hello', { foo: 'bar' })
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].json.level, 'info')
+  assert.equal(lines[0].json.msg, 'hello')
+  assert.equal(lines[0].json.service, 'awcms-edge')
+  assert.equal(lines[0].json.foo, 'bar')
+  assert.match(lines[0].json.ts, /^\d{4}-\d{2}-\d{2}T/)
+})
+
+test('logger: level filtering — debug di bawah info tidak diemit', () => {
+  const { logger, lines } = capture('info')
+  logger.debug('skipme')
+  logger.info('keepme')
+  assert.equal(lines.length, 1)
+  assert.equal(lines[0].json.msg, 'keepme')
+})
+
+test('logger: error/warn memakai level yang benar', () => {
+  const { logger, lines } = capture()
+  logger.warn('w')
+  logger.error('e')
+  assert.equal(lines[0].lvl, 'warn')
+  assert.equal(lines[1].lvl, 'error')
+})
+
+test('logger: redaction menyensor password/token/secret (nested)', () => {
+  const { logger, lines } = capture()
+  logger.info('login', { password: 'rahasia', data: { token: 'abc', ok: 'visible' } })
+  assert.equal(lines[0].json.password, '[REDACTED]')
+  assert.equal(lines[0].json.data.token, '[REDACTED]')
+  assert.equal(lines[0].json.data.ok, 'visible')
+})
+
+test('logger: redaction menyensor authorization & NIK & service_role', () => {
+  const { logger, lines } = capture()
+  logger.info('ctx', { authorization: 'Bearer x', nik: '3201', service_role_key: 'srv' })
+  assert.equal(lines[0].json.authorization, '[REDACTED]')
+  assert.equal(lines[0].json.nik, '[REDACTED]')
+  assert.equal(lines[0].json.service_role_key, '[REDACTED]')
+})
+
+test('logger: redact() pure — tidak memutasi input', () => {
+  const input = { password: 'x', nested: { token: 'y' } }
+  const out = redact(input)
+  assert.equal(input.password, 'x', 'input asli tidak boleh berubah')
+  assert.equal(out.password, '[REDACTED]')
+  assert.equal(out.nested.token, '[REDACTED]')
+})
+
+test('logger: child menambahkan binding (requestId)', () => {
+  const lines = []
+  const logger = createLogger({ sink: (_l, line) => lines.push(JSON.parse(line)) })
+  const child = logger.child({ requestId: 'req-1', tenant_id: 't1' })
+  child.info('x')
+  assert.equal(lines[0].requestId, 'req-1')
+  assert.equal(lines[0].tenant_id, 't1')
+})
+
+test('logger: loggerForRequest memakai x-request-id header bila ada', () => {
+  const lines = []
+  const req = new Request('https://x/', { headers: { 'x-request-id': 'hdr-123' } })
+  const logger = loggerForRequest(req, { sink: (_l, line) => lines.push(JSON.parse(line)) })
+  logger.info('hit')
+  assert.equal(lines[0].requestId, 'hdr-123')
+})
+
+test('logger: loggerForRequest generate requestId bila header kosong', () => {
+  const lines = []
+  const req = new Request('https://x/')
+  const logger = loggerForRequest(req, { sink: (_l, line) => lines.push(JSON.parse(line)) })
+  logger.info('hit')
+  assert.ok(typeof lines[0].requestId === 'string' && lines[0].requestId.length >= 8)
+})


### PR DESCRIPTION
## Summary

Logger terstruktur **Workers-native** untuk `awcms-edge` (ADR-021/#114). Pino tidak berjalan di workerd, jadi adapter NDJSON selaras format `queues/observability.ts` (Cloudflare Workers Logs/Logpush) dan logging Pino `awcms-mini`.

- `awcms-edge/src/lib/logger.ts`:
  - `createLogger({ base, level, sink })` → `{ ts, level, msg, ...base, ...fields }` (NDJSON).
  - `child(bindings)` → logger turunan ber-`requestId`/`tenant_id`.
  - `loggerForRequest(request)` → ambil `x-request-id` atau `crypto.randomUUID()`.
  - `redact()` deep — sensor field sensitif (password/token/secret/apiKey/authorization/cookie/**nik**/**service_role**).
- `awcms-edge/tests/logger.test.mjs` — 9 test, semua pass (`node --import tsx --test`).

## Mengapa native (bukan Pino)
`awcms-edge` runtime = Cloudflare Workers (workerd); Pino tidak kompatibel. Logger ini memberi format JSON terstruktur yang **selaras** dengan Pino di awcms-mini + observability queue yang sudah ada, tanpa dependency yang tak jalan di Workers.

## Keamanan (§8.3)
Redaction deep field sensitif → `[REDACTED]`; termasuk `service_role`/`service_role_key` (relevan saat masih ada Supabase) dan `nik`/`nik_enc`. Diuji eksplisit (nested + pure, tidak memutasi input).

## Scope
- Pengganti `console.error`/`console.log` ad-hoc di jalur HTTP — **adopsi bertahap** (PR ini menyediakan tool + test; migrasi call-site menyusul).
- **Tidak** mengubah runtime/PM (tetap Workers/Wrangler). Hanya menambah file (tidak menyentuh `index.ts`).

## Test plan
- [x] 9/9 test pass: JSON shape, level filter, redaction nested, child binding, requestId header/generate.
- [x] Valid TS (dikompilasi tsx saat test).
- [ ] Migrasi call-site `console.*` → logger (follow-up bertahap).

Bagian dari #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)