### PR TITLE
[AWCMS][DOCS] docs: sync AGENTS/SYSTEM_MODEL/DOCS_INDEX/README dengan arah arsitektur (ADRs)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,23 @@ All agent work must respect this chain:
 
 ---
 
+## Arah Arsitektur (Decided — ADRs)
+
+> **Penting:** Bagian lain dokumen ini mendeskripsikan **current state** (berbasis Supabase). Keputusan arsitektur berikut adalah **target yang sudah diputuskan**; migrasi sedang berjalan. Saat menulis kode baru, ikuti arah ini.
+
+- **PostgreSQL murni tanpa Supabase** (ADR-014) — migrasi keluar Supabase (auth/data/RLS). Inventaris: `docs/architecture/supabase-usage-inventory.md`. Epic #103 (sub: #109 auth, #110 schema+RLS, #111 pooler).
+- **RLS wajib** semua tabel tenant (ADR-015) — port policy Supabase ke RLS PostgreSQL murni.
+- **Connection pooler OSS** (ADR-013) — `awcms-edge` (Workers) = Transaction mode + `prepare:false`; backend Node = Session mode.
+- **EmDash = rujukan arsitektur saja** (ADR-020) — bukan dependency; CMS = modul native bila perlu. Full EmDash hanya `awcms-micro`.
+- **Toolchain Bun** (ADR-019) — admin/public/mcp; `awcms-edge` runtime tetap Workers (workerd). #113.
+- **Logging Pino / Workers-native** (ADR-021) — `awcms-edge` pakai `src/lib/logger.ts` (NDJSON + redaction). #114.
+- **CQRS-lite untuk pencarian** (ADR-023) — query side read-only, read DTO, RLS+masking; OpenSearch hanya saat skala besar. #117.
+- **Tiga rujukan arsitektur** (ADR-022) — Supabase (pola PostgreSQL-native) + Odoo (ERP modular) + EmDash (CMS), stack sendiri tanpa lock-in.
+
+Detail keputusan: repo `personal-coding` (`docs/concepts/canvas-arsitektur-...`, `docs/ahliweb-repo-decision-log.md`).
+
+---
+
 ## 🤖 Agent Overview
 
 In the AWCMS ecosystem, AI Agents are treated as specialized team members. We define three primary personas for AI interactions:

--- a/DOCS_INDEX.md
+++ b/DOCS_INDEX.md
@@ -54,6 +54,7 @@ All documentation follows this authority structure:
 | Core Standards | [docs/architecture/standards.md](docs/architecture/standards.md) | UI, coding, and quality standards |
 | Folder Structure | [docs/architecture/folder-structure.md](docs/architecture/folder-structure.md) | Monorepo layout |
 | Database Schema | [docs/architecture/database.md](docs/architecture/database.md) | Tables and relations |
+| Supabase Usage Inventory | [docs/architecture/supabase-usage-inventory.md](docs/architecture/supabase-usage-inventory.md) | Audit ketergantungan Supabase + peta migrasi off-Supabase (ADR-014, #103/#108) |
 | Runtime Boundaries | [docs/architecture/runtime-boundaries.md](docs/architecture/runtime-boundaries.md) | Cloudflare-only runtime and scope guarantees |
 | Edge OpenAPI Contract | [docs/architecture/edge-openapi-spec.md](docs/architecture/edge-openapi-spec.md) | Boundary-separated OpenAPI 3.1 and Swagger UI rules for `awcms-edge/` |
 | Queue Topology | [docs/architecture/queue-topology.md](docs/architecture/queue-topology.md) | Cloudflare Queues: topology, message contracts, consumer patterns |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 >
 > Backlog penyelarasan: #103 (off-Supabase), #104 (RLS), #105 (standar bersama), #106 (docs).
 
-Welcome to the AWCMS Ecosystem. AWCMS is a **multi-tenant CMS platform** with admin, public, mobile, and IoT clients backed by Supabase.
+Welcome to the AWCMS Ecosystem. AWCMS is a **multi-tenant CMS platform** with admin, public, mobile, and IoT clients. **Current state:** backed by Supabase. **Target (decided, migrasi berjalan):** PostgreSQL murni tanpa Supabase (ADR-014) — lihat `docs/architecture/supabase-usage-inventory.md` & #103.
 
 ## Status Snapshot (2026-03-29)
 

--- a/SYSTEM_MODEL.md
+++ b/SYSTEM_MODEL.md
@@ -5,6 +5,8 @@
 
 This document serves as the single source of truth for the AWCMS architecture, technology stack, and security mandates. All Agents (Coding, Communication, Public Experience) must adhere strictly to these definitions.
 
+> **Arah Arsitektur (Decided — ADRs, migrasi berjalan):** definisi di bawah mendeskripsikan **current state** (berbasis Supabase). Target yang sudah diputuskan: **PostgreSQL murni tanpa Supabase** (ADR-014; inventaris `docs/architecture/supabase-usage-inventory.md`, epic #103), **RLS wajib** (ADR-015), **pooler OSS** (ADR-013), **EmDash = rujukan saja** (ADR-020), **toolchain Bun** (ADR-019; `awcms-edge` tetap Workers), **Pino/Workers-native logging** (ADR-021), **CQRS-lite pencarian** (ADR-023), **tiga rujukan Supabase/Odoo/EmDash** (ADR-022). Saat menulis kode baru, ikuti arah ini. Detail: repo `personal-coding`.
+
 ---
 
 ## 1. Technology Stack Mandates


### PR DESCRIPTION
## Summary
Sinkronkan docs root awcms dengan keputusan arsitektur (ADR-013..023), **tanpa salah menggambarkan current state** (repo masih berbasis Supabase — migrasi berjalan).

- **AGENTS.md** + **SYSTEM_MODEL.md**: section/catatan "Arah Arsitektur (Decided — ADRs)" — PostgreSQL murni off-Supabase (ADR-014), RLS wajib (ADR-015), pooler OSS (ADR-013), EmDash=rujukan saja (ADR-020), Bun (ADR-019; edge tetap Workers), Pino/Workers-native (ADR-021), CQRS-lite (ADR-023), tiga rujukan (ADR-022).
- **DOCS_INDEX.md**: tambah `supabase-usage-inventory.md`.
- **README.md**: perjelas current (Supabase) vs target (PostgreSQL-only, #103).

## Sifat
- Pure docs; tidak ada perubahan kode.
- Current state Supabase **dipertahankan** (jujur); hanya menambah arah target + tautan inventaris.

🤖 Generated with [Claude Code](https://claude.com/claude-code)