### PR TITLE
fix(ci): format ported modules with prettier + require full check

### DIFF
--- a/.claude/skills/awcms-port-from-mini/SKILL.md
+++ b/.claude/skills/awcms-port-from-mini/SKILL.md
@@ -58,15 +58,18 @@ Kalau salah satu dependency modul **belum** ada di awcms → port dependency itu
 ```bash
 cd /home/data/dev_bun/awcms
 git add -A                       # agar check:docs memindai .md baru (changeset/README)
+bun run format                   # WAJIB dulu: prettier --write (file buatan subagent sering belum terformat)
+bun run lint                     # WAJIB: prettier --check — CI gagal bila ada 1 file tak terformat
 bun run typecheck
 bun test
 bun run api:spec:check
 bun run modules:dag:check
 bun run logging:lint:check
 bun run check:docs
+bun run build                    # WAJIB: CI menjalankan build; port bisa lolos typecheck tapi gagal build
 ```
 
-JANGAN jalankan `config:validate` (butuh env) atau `db:migrate` tanpa DB. Untuk **memvalidasi migrasi terhadap Postgres nyata** tanpa konektivitas host→container, pakai skill `docker-host-container-network` §7 (`docker cp sql/` + `psql -f` di dalam container). Tambah changeset **minor**.
+**Jangan cukup dengan subset.** CI (`.github/workflows/ci.yml`) menjalankan `lint` (prettier) DAN `build` selain cek di atas — melewati keduanya adalah penyebab paling umum "hijau lokal tapi merah di CI". Selalu `bun run format` + `bun run lint` + `bun run build` sebelum commit/PR (setara `bun run check` penuh). JANGAN jalankan `config:validate` (butuh env) atau `db:migrate` tanpa DB. Untuk **memvalidasi migrasi terhadap Postgres nyata** tanpa konektivitas host→container, pakai skill `docker-host-container-network` §7 (`docker cp sql/` + `psql -f` di dalam container). Tambah changeset **minor**.
 
 ## 7. Commit atomic
 

--- a/.claude/skills/awcms-port-from-mini/SKILL.md
+++ b/.claude/skills/awcms-port-from-mini/SKILL.md
@@ -22,6 +22,7 @@ grep -rl "<mod>\|<Symbol>" $M/tests                               # test (port y
 grep -rn "<mod>:" $M/package.json                                 # script (dispatcher/worker)
 ls -1 $A/sql | tail -1                                            # nomor migrasi terakhir di awcms → +1
 ```
+
 Kalau salah satu dependency modul **belum** ada di awcms → port dependency itu dulu (urut dependensi), atau adaptasi agar tak mengimpornya (§4).
 
 ## 2. Aturan rename (non-negotiable)
@@ -64,6 +65,7 @@ bun run modules:dag:check
 bun run logging:lint:check
 bun run check:docs
 ```
+
 JANGAN jalankan `config:validate` (butuh env) atau `db:migrate` tanpa DB. Untuk **memvalidasi migrasi terhadap Postgres nyata** tanpa konektivitas host→container, pakai skill `docker-host-container-network` §7 (`docker cp sql/` + `psql -f` di dalam container). Tambah changeset **minor**.
 
 ## 7. Commit atomic

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ AWCMS adalah rebuild ber-skop ERP di atas fondasi **awcms-mini** (repo standar).
 3. Kerjakan atomic — satu PR = satu perubahan yang jelas dan terisolasi.
 4. Tulis test yang gagal sebelum fix, lulus sesudahnya.
 5. Perbarui dokumentasi (OpenAPI/AsyncAPI/docs/awcms) dan changeset bila perilaku berubah.
-6. Validasi lokal (`bun run check`) sebelum membuka PR.
+6. Validasi lokal **`bun run check` PENUH** sebelum membuka PR — bukan subset. `check` mencakup `lint` (prettier `--check`) dan `build`; melewati keduanya adalah penyebab tersering "hijau lokal, merah di CI" (`.github/workflows/ci.yml` menjalankan keduanya). Jalankan `bun run format` dulu bila perlu, lalu `bun run check`.
 
 ## Aturan wajib (non-negotiable)
 

--- a/docs/awcms/alur-pengembangan-mini-first.md
+++ b/docs/awcms/alur-pengembangan-mini-first.md
@@ -11,15 +11,15 @@
 AWCMS bukan repo tunggal — ia hidup berpasangan dengan repo standarnya,
 **awcms-mini**.
 
-| Aspek         | **awcms-mini** (fondasi/standar)                             | **awcms** (repo ini)                                             |
-| ------------- | ----------------------------------------------------------- | --------------------------------------------------------------- |
+| Aspek         | **awcms-mini** (fondasi/standar)                            | **awcms** (repo ini)                                                                                                                                    |
+| ------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Peran         | _Modular monolith standard_ — laboratorium & sumber standar | **Fondasi + kontrak kesiapan ERP** ber-skop ERP; modul ERP nyata hidup di repo turunan ([ADR-0022](../adr/0022-erp-modules-live-in-extension-repos.md)) |
-| Kematangan    | Matang — banyak modul sudah teruji end-to-end               | Tahap fondasi (Sprint 1–2), tumbuh bertahap                     |
-| Modul di kode | ~23 modul (fondasi + CMS + pendukung)                       | Baru 4: `logging`, `tenant-admin`, `profile-identity`, `identity-access` |
-| Migrasi SQL   | 76 (`001`–`076`)                                            | 7 (`001`–`007`)                                                  |
-| Route API     | ~290                                                        | ~16                                                             |
-| Prefix DB     | `awcms_mini_…`                                              | `awcms_…`                                                        |
-| Sifat         | Referensi/standar yang stabil                               | Produk turunan yang mengonsumsi & memperluas standar            |
+| Kematangan    | Matang — banyak modul sudah teruji end-to-end               | Tahap fondasi (Sprint 1–2), tumbuh bertahap                                                                                                             |
+| Modul di kode | ~23 modul (fondasi + CMS + pendukung)                       | Baru 4: `logging`, `tenant-admin`, `profile-identity`, `identity-access`                                                                                |
+| Migrasi SQL   | 76 (`001`–`076`)                                            | 7 (`001`–`007`)                                                                                                                                         |
+| Route API     | ~290                                                        | ~16                                                                                                                                                     |
+| Prefix DB     | `awcms_mini_…`                                              | `awcms_…`                                                                                                                                               |
+| Sifat         | Referensi/standar yang stabil                               | Produk turunan yang mengonsumsi & memperluas standar                                                                                                    |
 
 **Rantai tiga lapis:** `awcms-mini` (standar terbukti) → **`awcms`** (fondasi ber-skop ERP, port bertahap) → repo turunan/ekstensi (modul ERP & vertikal nyata di atas awcms). Repo ini menyediakan fondasi + kontrak kesiapan ERP — **bukan** tempat membangun modul domain ERP itu sendiri (ADR-0022).
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -743,7 +743,8 @@ paths:
           schema: { type: string }
         - name: status
           in: query
-          schema: { type: string, enum: [pending, completed, skipped, cancelled] }
+          schema:
+            { type: string, enum: [pending, completed, skipped, cancelled] }
         - name: overdue
           in: query
           schema: { type: boolean }
@@ -1636,7 +1637,8 @@ paths:
                     properties:
                       modules:
                         type: array
-                        items: { $ref: "#/components/schemas/ModuleCatalogEntry" }
+                        items:
+                          { $ref: "#/components/schemas/ModuleCatalogEntry" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
   /api/v1/modules/sync:
@@ -1778,7 +1780,8 @@ paths:
                 type: object
                 properties:
                   success: { type: boolean, enum: [true] }
-                  data: { $ref: "#/components/schemas/ModulePermissionSyncReport" }
+                  data:
+                    { $ref: "#/components/schemas/ModulePermissionSyncReport" }
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
@@ -2115,7 +2118,8 @@ paths:
         - name: status
           in: query
           required: false
-          schema: { type: string, enum: [pending, delivered, dead_letter, skipped] }
+          schema:
+            { type: string, enum: [pending, delivered, dead_letter, skipped] }
         - name: consumerName
           in: query
           required: false
@@ -2356,7 +2360,8 @@ paths:
                     properties:
                       objectKey: { type: string }
                       localPath: { type: string }
-                      checksumSha256: { type: string, pattern: "^[a-f0-9]{64}$" }
+                      checksumSha256:
+                        { type: string, pattern: "^[a-f0-9]{64}$" }
                       byteSize: { type: integer, minimum: 0 }
       responses:
         "200":
@@ -2501,7 +2506,11 @@ paths:
               type: object
               required: [resolution]
               properties:
-                resolution: { type: string, enum: [accept_incoming, keep_existing, manual] }
+                resolution:
+                  {
+                    type: string,
+                    enum: [accept_incoming, keep_existing, manual]
+                  }
                 note: { type: string }
       responses:
         "200":
@@ -2806,7 +2815,8 @@ paths:
           required: false
           schema:
             type: string
-            enum: [queued, sending, sent, failed, retry_wait, cancelled, suppressed]
+            enum:
+              [queued, sending, sent, failed, retry_wait, cancelled, suppressed]
         - name: cursor
           in: query
           required: false

--- a/src/modules/domain-event-runtime/README.md
+++ b/src/modules/domain-event-runtime/README.md
@@ -66,16 +66,16 @@ representative consumers, to exercise the full mechanism end-to-end:
 
 ## HTTP surface (`/api/v1/domain-events`)
 
-| Method & path | Permission | Notes |
-| --- | --- | --- |
-| `GET /events` | `events.read` | Bounded list, redacted payload projections only. |
-| `GET /events/{id}` | `events.read` | Redacted payload projection only. |
-| `GET /deliveries` | `deliveries.read` | `status=dead_letter` is the DLQ view. |
-| `GET /deliveries/{id}` | `deliveries.read` | Single-record DLQ inspection with joined event. |
-| `POST /deliveries/{id}/replay` | `deliveries.replay` | Reason-required, `Idempotency-Key`, audited. |
-| `GET /consumers` | `consumers.read` | Registry + pause state + backlog counts. |
-| `POST /consumers/{name}/pause` | `consumers.manage` | Reason-required, audited (naturally idempotent). |
-| `POST /consumers/{name}/resume` | `consumers.manage` | Audited (naturally idempotent). |
+| Method & path                   | Permission          | Notes                                            |
+| ------------------------------- | ------------------- | ------------------------------------------------ |
+| `GET /events`                   | `events.read`       | Bounded list, redacted payload projections only. |
+| `GET /events/{id}`              | `events.read`       | Redacted payload projection only.                |
+| `GET /deliveries`               | `deliveries.read`   | `status=dead_letter` is the DLQ view.            |
+| `GET /deliveries/{id}`          | `deliveries.read`   | Single-record DLQ inspection with joined event.  |
+| `POST /deliveries/{id}/replay`  | `deliveries.replay` | Reason-required, `Idempotency-Key`, audited.     |
+| `GET /consumers`                | `consumers.read`    | Registry + pause state + backlog counts.         |
+| `POST /consumers/{name}/pause`  | `consumers.manage`  | Reason-required, audited (naturally idempotent). |
+| `POST /consumers/{name}/resume` | `consumers.manage`  | Audited (naturally idempotent).                  |
 
 All endpoints are tenant-scoped, guarded by default-deny ABAC
 (`authorizeInTransaction`), and run inside `withTenant` so RLS enforces

--- a/src/modules/domain-event-runtime/domain/event-type-registry.ts
+++ b/src/modules/domain-event-runtime/domain/event-type-registry.ts
@@ -106,14 +106,12 @@ export const DOMAIN_EVENT_TYPE_REGISTRY: readonly RegisteredDomainEventType[] =
     {
       eventType: WORKFLOW_DELEGATION_CREATED_EVENT_TYPE,
       eventVersion: WORKFLOW_EVENT_VERSION,
-      description:
-        "A workflow delegation/substitute assignment was created."
+      description: "A workflow delegation/substitute assignment was created."
     },
     {
       eventType: WORKFLOW_DELEGATION_REVOKED_EVENT_TYPE,
       eventVersion: WORKFLOW_EVENT_VERSION,
-      description:
-        "A workflow delegation/substitute assignment was revoked."
+      description: "A workflow delegation/substitute assignment was revoked."
     }
   ];
 

--- a/src/modules/email/README.md
+++ b/src/modules/email/README.md
@@ -128,17 +128,17 @@ rejected at create (fail-closed).
 
 ## Configuration
 
-| Var                             | Required          | Default | Function                              |
-| ------------------------------- | ----------------- | ------- | ------------------------------------- |
-| `EMAIL_ENABLED`                 | –                 | `false` | Enable the email module               |
-| `EMAIL_PROVIDER`                | when enabled      | –       | `"mailketing"` or `"log"`             |
-| `EMAIL_FROM_ADDRESS`            | when enabled      | –       | Default sender address                |
-| `EMAIL_FROM_NAME`               | –                 | `AWCMS` | Default sender name                   |
-| `EMAIL_SEND_TIMEOUT_MS`         | –                 | `10000` | Per-attempt send timeout              |
-| `EMAIL_SEND_MAX_RETRIES`        | –                 | `5`     | Retry ceiling before `failed`         |
-| `EMAIL_MAILKETING_ACCOUNT_ID`   | when mailketing   | –       | Operator label (never sent)           |
-| `EMAIL_MAILKETING_API_TOKEN`    | when mailketing   | –       | Mailketing API token (secret)         |
-| `EMAIL_MAILKETING_API_BASE_URL` | when mailketing   | –       | Mailketing API base URL               |
+| Var                             | Required        | Default | Function                      |
+| ------------------------------- | --------------- | ------- | ----------------------------- |
+| `EMAIL_ENABLED`                 | –               | `false` | Enable the email module       |
+| `EMAIL_PROVIDER`                | when enabled    | –       | `"mailketing"` or `"log"`     |
+| `EMAIL_FROM_ADDRESS`            | when enabled    | –       | Default sender address        |
+| `EMAIL_FROM_NAME`               | –               | `AWCMS` | Default sender name           |
+| `EMAIL_SEND_TIMEOUT_MS`         | –               | `10000` | Per-attempt send timeout      |
+| `EMAIL_SEND_MAX_RETRIES`        | –               | `5`     | Retry ceiling before `failed` |
+| `EMAIL_MAILKETING_ACCOUNT_ID`   | when mailketing | –       | Operator label (never sent)   |
+| `EMAIL_MAILKETING_API_TOKEN`    | when mailketing | –       | Mailketing API token (secret) |
+| `EMAIL_MAILKETING_API_BASE_URL` | when mailketing | –       | Mailketing API base URL       |
 
 All `.env.example` values are placeholders, never real credentials. When
 `EMAIL_ENABLED=false` (the default) nothing blocks the app: messages sit in

--- a/src/modules/email/application/announcement-directory.ts
+++ b/src/modules/email/application/announcement-directory.ts
@@ -95,7 +95,10 @@ export async function resolveAnnouncementTargets(
 
   return rows
     .filter((row) => {
-      const normalized = normalizeIdentifierValue("email", row.login_identifier);
+      const normalized = normalizeIdentifierValue(
+        "email",
+        row.login_identifier
+      );
       return !suppressedHashes.has(hashIdentifierValue(normalized));
     })
     .map((row) => ({
@@ -181,7 +184,10 @@ export async function enqueueAnnouncement(
   const priority = target.type === "tenant" ? "normal" : "high";
 
   for (const recipient of recipients) {
-    const normalized = normalizeIdentifierValue("email", recipient.loginIdentifier);
+    const normalized = normalizeIdentifierValue(
+      "email",
+      recipient.loginIdentifier
+    );
     const recipientVariables = {
       ...variables,
       userName: recipient.displayName

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -52,21 +52,21 @@ that needs the registry row to exist (`enableTenantModule`,
 
 ## API surface
 
-| Method + Path                                     | Permission                          |
-| ------------------------------------------------- | ----------------------------------- |
-| `GET /api/v1/modules`                             | `module_management.modules.read`    |
-| `GET /api/v1/modules/{moduleKey}`                 | `module_management.modules.read`    |
-| `POST /api/v1/modules/sync`                       | `module_management.modules.sync`    |
-| `GET /api/v1/modules/{moduleKey}/health`          | `module_management.health.read`     |
-| `POST /api/v1/modules/{moduleKey}/health/check`   | `module_management.health.check`    |
-| `GET /api/v1/modules/{moduleKey}/jobs`            | `module_management.jobs.read`       |
-| `GET /api/v1/modules/{moduleKey}/permissions`     | `module_management.permissions.read`|
-| `GET /api/v1/tenant/modules`                      | `module_management.tenant_modules.read`   |
-| `POST /api/v1/tenant/modules/{moduleKey}/enable`  | `module_management.tenant_modules.enable`  |
-| `POST /api/v1/tenant/modules/{moduleKey}/disable` | `module_management.tenant_modules.disable` |
-| `GET /api/v1/tenant/modules/{moduleKey}/settings` | `module_management.settings.read`   |
-| `PATCH /api/v1/tenant/modules/{moduleKey}/settings` | `module_management.settings.update` |
-| `GET /api/v1/access/modules`                      | `identity_access.access_control.read` |
+| Method + Path                                       | Permission                                 |
+| --------------------------------------------------- | ------------------------------------------ |
+| `GET /api/v1/modules`                               | `module_management.modules.read`           |
+| `GET /api/v1/modules/{moduleKey}`                   | `module_management.modules.read`           |
+| `POST /api/v1/modules/sync`                         | `module_management.modules.sync`           |
+| `GET /api/v1/modules/{moduleKey}/health`            | `module_management.health.read`            |
+| `POST /api/v1/modules/{moduleKey}/health/check`     | `module_management.health.check`           |
+| `GET /api/v1/modules/{moduleKey}/jobs`              | `module_management.jobs.read`              |
+| `GET /api/v1/modules/{moduleKey}/permissions`       | `module_management.permissions.read`       |
+| `GET /api/v1/tenant/modules`                        | `module_management.tenant_modules.read`    |
+| `POST /api/v1/tenant/modules/{moduleKey}/enable`    | `module_management.tenant_modules.enable`  |
+| `POST /api/v1/tenant/modules/{moduleKey}/disable`   | `module_management.tenant_modules.disable` |
+| `GET /api/v1/tenant/modules/{moduleKey}/settings`   | `module_management.settings.read`          |
+| `PATCH /api/v1/tenant/modules/{moduleKey}/settings` | `module_management.settings.update`        |
+| `GET /api/v1/access/modules`                        | `identity_access.access_control.read`      |
 
 All high-risk mutations (sync, enable, disable, settings update, health check)
 write an audit event to `awcms_audit_events` with

--- a/src/modules/module-management/domain/job-registry.ts
+++ b/src/modules/module-management/domain/job-registry.ts
@@ -16,8 +16,7 @@ import type { ModuleJobDescriptor } from "../../_shared/module-contract";
 export type JobRegistryEntry = ModuleJobDescriptor & { moduleKey: string };
 
 export type JobDescriptorValidationResult =
-  | { valid: true }
-  | { valid: false; errors: string[] };
+  { valid: true } | { valid: false; errors: string[] };
 
 const COMMAND_PATTERN = /^bun run [a-z0-9][a-z0-9:_-]*$/;
 

--- a/src/modules/sync-storage/README.md
+++ b/src/modules/sync-storage/README.md
@@ -53,7 +53,7 @@ Schema: `sql/011_awcms_sync_storage_conflict_schema.sql`.
 
 - `awcms_object_sync_queue` — queue of local objects (e.g. receipt/attachment
   files) awaiting upload to object storage. Unique `(tenant_id, node_id,
-  object_key)` — re-enqueuing the same `objectKey` upserts (not duplicates):
+object_key)` — re-enqueuing the same `objectKey` upserts (not duplicates):
   `local_path`, `checksum_sha256`, `byte_size`, `requires_upload` are updated
   and the row is reset to `status='pending'`.
 - `requires_upload` is set from `R2_ENABLED` at enqueue time. Enqueue itself

--- a/src/modules/workflow-approval/README.md
+++ b/src/modules/workflow-approval/README.md
@@ -9,9 +9,9 @@ Implementation of Issue 11.1 (`docs/awcms/06_github_issues_detail.md` §Issue 11
 | One `status: active/inactive` per definition       | `version` + `lifecycle_status: draft/active/retired`, full version history, immutable published/retired rows  |
 | `steps` (ordered jsonb list)                       | `graph` (nodes/transitions — approval/condition/parallel/join/notify/end)                                     |
 | No public create-definition endpoint               | `POST/PUT/DELETE /workflows/definitions`, `.../publish`, `.../retire`, `.../new-version`, `.../validate`      |
-| `current_step_order` (single int)                  | `awcms_workflow_tasks` rows (one per activated node) — supports multiple concurrently-active nodes       |
-| One implicit assignee (whoever calls the decision) | `awcms_workflow_task_assignments` — explicit assignees, quorum/any/all, delegation-resolved deciders     |
-| No delegation                                      | `awcms_workflow_delegations` — effective-dated, scoped, reason, audited, revocable                       |
+| `current_step_order` (single int)                  | `awcms_workflow_tasks` rows (one per activated node) — supports multiple concurrently-active nodes            |
+| One implicit assignee (whoever calls the decision) | `awcms_workflow_task_assignments` — explicit assignees, quorum/any/all, delegation-resolved deciders          |
+| No delegation                                      | `awcms_workflow_delegations` — effective-dated, scoped, reason, audited, revocable                            |
 | No escalation/timeout                              | Per-node `escalation` config + `bun run workflow:escalations:dispatch`, idempotent via optimistic concurrency |
 | No administrative recovery                         | Reassign / cancel / force-approve / force-reject, permission-gated + `Idempotency-Key` + audit                |
 | `GET /workflows/tasks` (offset-free, no filters)   | Keyset-paginated, filterable (workflow key/resource type/status/overdue), safe search, action-history view    |

--- a/src/pages/api/v1/sync/objects/index.ts
+++ b/src/pages/api/v1/sync/objects/index.ts
@@ -21,11 +21,7 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   if (!nodeCode) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "X-AWCMS-Node-ID header is required."
-    );
+    return fail(400, "VALIDATION_ERROR", "X-AWCMS-Node-ID header is required.");
   }
 
   const bodyRead = await readTextBody(request, "large");

--- a/src/pages/api/v1/sync/objects/status.ts
+++ b/src/pages/api/v1/sync/objects/status.ts
@@ -22,11 +22,7 @@ export const GET: APIRoute = async ({ request }) => {
   }
 
   if (!nodeCode) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "X-AWCMS-Node-ID header is required."
-    );
+    return fail(400, "VALIDATION_ERROR", "X-AWCMS-Node-ID header is required.");
   }
 
   const bodyRead = await readTextBody(request);

--- a/src/pages/api/v1/sync/pull.ts
+++ b/src/pages/api/v1/sync/pull.ts
@@ -23,11 +23,7 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   if (!nodeCode) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "X-AWCMS-Node-ID header is required."
-    );
+    return fail(400, "VALIDATION_ERROR", "X-AWCMS-Node-ID header is required.");
   }
 
   const bodyRead = await readTextBody(request);

--- a/src/pages/api/v1/sync/push.ts
+++ b/src/pages/api/v1/sync/push.ts
@@ -22,11 +22,7 @@ export const POST: APIRoute = async ({ request }) => {
   }
 
   if (!nodeCode) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "X-AWCMS-Node-ID header is required."
-    );
+    return fail(400, "VALIDATION_ERROR", "X-AWCMS-Node-ID header is required.");
   }
 
   const bodyRead = await readTextBody(request, "large");

--- a/src/pages/api/v1/sync/status.ts
+++ b/src/pages/api/v1/sync/status.ts
@@ -20,11 +20,7 @@ export const GET: APIRoute = async ({ request }) => {
   }
 
   if (!nodeCode) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "X-AWCMS-Node-ID header is required."
-    );
+    return fail(400, "VALIDATION_ERROR", "X-AWCMS-Node-ID header is required.");
   }
 
   const bodyRead = await readTextBody(request);

--- a/tests/domain-event-runtime-envelope.test.ts
+++ b/tests/domain-event-runtime-envelope.test.ts
@@ -87,9 +87,9 @@ describe("validateDomainEventPayload", () => {
 
 describe("isValidEventType / isValidEventVersion", () => {
   test("accepts a well-formed namespace.aggregate.action event type", () => {
-    expect(
-      isValidEventType("awcms.domain-event-runtime.sample.recorded")
-    ).toBe(true);
+    expect(isValidEventType("awcms.domain-event-runtime.sample.recorded")).toBe(
+      true
+    );
   });
 
   test("rejects an event type without at least one dot-separated segment", () => {


### PR DESCRIPTION
Memperbaiki kegagalan CI pada run setelah merge #135: `bun run lint` (prettier `--check`) gagal karena 17 file hasil port 6 modul belum diformat.

- `bun run format` (prettier --write) — tanpa perubahan logika
- Dokumentasikan kewajiban menjalankan `bun run check` PENUH (lint+build), bukan subset, di AGENTS.md §alur kerja step 6 + DoD skill `awcms-port-from-mini` (agar tidak terulang)

### Verifikasi lokal
`bun run lint` (bersih), `bun run build` (sukses), `bun run typecheck`, **527 test**, `check:docs` — semua hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)