### PR TITLE
docs(readme): add CI, CodeQL, license, and runtime badges

### DIFF
--- a/README.id.md
+++ b/README.id.md
@@ -1,5 +1,7 @@
 🇮🇩 Bahasa Indonesia (sumber) · 🇬🇧 [English (default)](README.md)
 
+[![CI](https://img.shields.io/github/actions/workflow/status/ahliweb/awcms/ci.yml?branch=main&label=CI&logo=github)](https://github.com/ahliweb/awcms/actions/workflows/ci.yml) [![CodeQL](https://img.shields.io/github/actions/workflow/status/ahliweb/awcms/codeql.yml?branch=main&label=CodeQL&logo=github)](https://github.com/ahliweb/awcms/actions/workflows/codeql.yml) [![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE) [![runtime](https://img.shields.io/badge/runtime-Bun-blue?logo=bun&logoColor=white)](https://bun.sh)
+
 # AWCMS — Basis Platform untuk ERP & Solusi Bisnis
 
 > **AWCMS bukan sebuah ERP.** Ia adalah **basis/fondasi modular monolith** tempat aplikasi ERP & solusi bisnis dibangun di atasnya (di repo ekstensi/turunan terpisah). Tidak ada chart of accounts, general ledger, jurnal, AR/AP, valuasi inventori, payroll, atau perhitungan pajak di repo ini — dan tidak akan pernah ada; base hanya menyediakan modul fondasi reusable + **kontrak netral** kesiapan ERP. Lihat [ADR-0013](docs/adr/0013-extension-layers-and-boundary-model.md), [ADR-0020](docs/adr/0020-erp-extension-readiness-contracts.md), [ADR-0022](docs/adr/0022-erp-modules-live-in-extension-repos.md), dan [`docs/awcms/erp-extension-contracts.md`](docs/awcms/erp-extension-contracts.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 🇬🇧 English (default) · 🇮🇩 [Bahasa Indonesia (sumber)](README.id.md)
 
-<!-- i18n-source-hash: sha256:3ee7d3e62741206daf218bc4d73a43b59ccd6fd06b379c851deb13a540739e3f -->
+<!-- i18n-source-hash: sha256:eff502bf089aa19e67a05036e2858dedcfd9e781c701906cb383d1ea4e70bf73 -->
+
+[![CI](https://img.shields.io/github/actions/workflow/status/ahliweb/awcms/ci.yml?branch=main&label=CI&logo=github)](https://github.com/ahliweb/awcms/actions/workflows/ci.yml) [![CodeQL](https://img.shields.io/github/actions/workflow/status/ahliweb/awcms/codeql.yml?branch=main&label=CodeQL&logo=github)](https://github.com/ahliweb/awcms/actions/workflows/codeql.yml) [![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE) [![runtime](https://img.shields.io/badge/runtime-Bun-blue?logo=bun&logoColor=white)](https://bun.sh)
 
 # AWCMS — Foundation Platform for ERP & Business Solutions
 


### PR DESCRIPTION
## Ringkasan

Menambahkan baris badge di bagian atas README, sesuai permintaan: **CI**, **CodeQL**, **License MIT**, dan **runtime Bun**.

- Badge ditambahkan ke `README.id.md` (sumber otoritatif per ADR-0023) dan hasil generate `README.md`.
- Penanda `i18n-source-hash` di `README.md` diperbarui ke hash sumber ID yang baru, supaya gate `check:docs:translation` tetap hijau.
- Badge CI/CodeQL memakai endpoint status shields, jadi warnanya mengikuti keadaan workflow `ci.yml`/`codeql.yml` di `main` secara live.

## Verifikasi

- `bun run check` penuh (lint + docs + translation + typecheck + test + build) hijau — 527 test lulus, 0 gagal.
- Keempat URL badge diverifikasi merender (HTTP 200): `CI: passing`, `CodeQL: passing`, `License: MIT`, `runtime: Bun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)