### PR TITLE
fix(_shared): redact DSN, truncated PEM, and AWS key ids in free text

### DIFF
--- a/.changeset/redaction-free-text-secrets.md
+++ b/.changeset/redaction-free-text-secrets.md
@@ -1,0 +1,28 @@
+---
+"awcms": patch
+---
+
+Close three gaps in `redactSecretsInText` where secret-shaped substrings
+passed through free text (error messages, stack traces) unredacted. Each shape
+was already covered by the anchored `SECRET_VALUE_PATTERNS` list in the same
+file, but was missing from the free-text `TEXT_SECRET_PATTERNS` list — so
+object values were masked while the identical secret in an error string was
+not.
+
+- Connection-string credentials (`scheme://user:password@host`). This is the
+  highest-impact of the three: `DATABASE_URL`/`WORKER_DATABASE_URL` are DSNs,
+  so the app's own database password reached `sanitizeErrorForLog` unredacted
+  and was persisted to `awcms_domain_event_deliveries.last_error_message` /
+  `dead_letter_reason`, then served verbatim by
+  `GET /api/v1/domain-events/deliveries` — whose read path documented (and
+  relied on) the invariant that write-time redaction had already run.
+- PEM private-key blocks truncated before their `-----END-----` marker (a log
+  line cut off by a buffer limit). The existing paired pattern cannot match an
+  unterminated block, so the raw base64 key body was emitted in full. The new
+  fallback is ordered after the paired pattern, which has already consumed
+  every well-formed block.
+- AWS access key ids (`AKIA…`) embedded in prose.
+
+Adds `tests/redaction.test.ts` pinning all three shapes plus the pattern
+ordering; the module previously had no test coverage, which is why the gaps
+went unnoticed.

--- a/src/modules/_shared/redaction.ts
+++ b/src/modules/_shared/redaction.ts
@@ -213,12 +213,38 @@ const TEXT_SECRET_PATTERNS: ReadonlyArray<{
     replacement: "[REDACTED_PRIVATE_KEY]"
   },
   {
+    // Fallback for a TRUNCATED PEM block with no matching END marker (a log
+    // line cut off by a buffer limit before the key finished): the paired
+    // pattern above cannot match at all in that case, so the raw base64 key
+    // body would pass through unredacted. MUST stay ordered after the paired
+    // pattern — that one has already consumed every well-formed block, so
+    // this only ever finds a genuinely unterminated one. Over-redacts any
+    // trailing non-key text after a lone BEGIN marker, which is the safe
+    // direction to err in.
+    pattern: /-----BEGIN [A-Z ]*PRIVATE KEY-----[\s\S]*$/g,
+    replacement: "[REDACTED_PRIVATE_KEY]"
+  },
+  {
     pattern: /eyJ[a-zA-Z0-9_-]{5,}\.[a-zA-Z0-9_-]{5,}\.[a-zA-Z0-9_-]*/g,
     replacement: "[REDACTED_JWT]"
   },
   {
+    pattern: /AKIA[0-9A-Z]{16}/g,
+    replacement: "[REDACTED_AWS_KEY]"
+  },
+  {
     pattern: /\b(Bearer|Basic)\s+\S+/gi,
     replacement: "$1 [REDACTED]"
+  },
+  {
+    // Connection-string credentials (`DATABASE_URL`/`WORKER_DATABASE_URL` are
+    // DSNs, so this is the app's own primary secret leaking through any DB
+    // error text). Free-text twin of the anchored DSN entry in
+    // `SECRET_VALUE_PATTERNS`. The password class excludes only `/` and
+    // whitespace so that `:`/`@` inside a password still match; the greedy
+    // `+` backtracks to the LAST `@`, which is what makes such passwords work.
+    pattern: /([a-zA-Z][a-zA-Z0-9+.-]*:\/\/)[^:@/\s]+:[^/\s]+@/g,
+    replacement: "$1[REDACTED]@"
   },
   {
     pattern:

--- a/tests/redaction.test.ts
+++ b/tests/redaction.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+
+import { redactSecretsInText } from "../src/modules/_shared/redaction";
+
+describe("redactSecretsInText", () => {
+  test("redacts connection-string credentials in free text", () => {
+    const output = redactSecretsInText(
+      'FATAL: password authentication failed for user "awcms" (postgres://awcms:S3cr3tP@ss@db:5432/awcms)'
+    );
+
+    expect(output).not.toContain("S3cr3tP@ss");
+    expect(output).toContain("postgres://[REDACTED]@db:5432/awcms");
+  });
+
+  test("keeps the host and database name readable after redacting a DSN", () => {
+    expect(
+      redactSecretsInText("connect postgres://user:pw@db.internal:5432/reports")
+    ).toBe("connect postgres://[REDACTED]@db.internal:5432/reports");
+  });
+
+  test("redacts a DSN password containing ':' and '@'", () => {
+    const output = redactSecretsInText(
+      "postgres://awcms:p@ss:word@db:5432/awcms"
+    );
+
+    expect(output).not.toContain("p@ss:word");
+    expect(output).toBe("postgres://[REDACTED]@db:5432/awcms");
+  });
+
+  test("redacts a well-formed PEM block", () => {
+    const output = redactSecretsInText(
+      "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA1234abcd\n-----END RSA PRIVATE KEY-----"
+    );
+
+    expect(output).toBe("[REDACTED_PRIVATE_KEY]");
+  });
+
+  test("redacts a PEM block truncated before its END marker", () => {
+    const output = redactSecretsInText(
+      "-----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEA1234abcd\n(log line cut off"
+    );
+
+    expect(output).not.toContain("MIIEowIBAAKCAQEA1234abcd");
+    expect(output).toBe("[REDACTED_PRIVATE_KEY]");
+  });
+
+  test("redacts each of two well-formed PEM blocks without the truncation fallback swallowing the tail", () => {
+    const output = redactSecretsInText(
+      "-----BEGIN RSA PRIVATE KEY-----\nAAAA\n-----END RSA PRIVATE KEY-----\nkeep this\n-----BEGIN EC PRIVATE KEY-----\nBBBB\n-----END EC PRIVATE KEY-----"
+    );
+
+    expect(output).toBe(
+      "[REDACTED_PRIVATE_KEY]\nkeep this\n[REDACTED_PRIVATE_KEY]"
+    );
+  });
+
+  test("redacts an AWS access key id", () => {
+    expect(redactSecretsInText("using AKIAIOSFODNN7EXAMPLE for upload")).toBe(
+      "using [REDACTED_AWS_KEY] for upload"
+    );
+  });
+
+  test("still redacts the previously covered shapes", () => {
+    expect(redactSecretsInText("Authorization: Bearer abc.def")).toBe(
+      "Authorization: Bearer [REDACTED]"
+    );
+    expect(redactSecretsInText("token=eyJhbGciOi.eyJzdWIiOi.sig")).toContain(
+      "[REDACTED"
+    );
+    expect(redactSecretsInText("password: hunter2")).toBe(
+      "password: [REDACTED]"
+    );
+  });
+
+  test("leaves text without secrets untouched", () => {
+    expect(redactSecretsInText("connection refused to db:5432")).toBe(
+      "connection refused to db:5432"
+    );
+  });
+});


### PR DESCRIPTION
## Masalah

`redactSecretsInText` hanya menutup 4 bentuk rahasia, padahal daftar anchored `SECRET_VALUE_PATTERNS` **di file yang sama** sudah memuat pola DSN (`redaction.ts:147`) dan `AKIA` (`:141`). Jadi nilai objek tersamarkan, tapi rahasia identik di dalam string error lolos. Ini port setengah dari awcms-mini, bukan keputusan desain.

Yang paling berdampak: **password database aplikasi sendiri bocor**. `DATABASE_URL`/`WORKER_DATABASE_URL` berbentuk DSN, sehingga teks error koneksi/auth Postgres mengalir lewat `sanitizeErrorForLog` → dipersist ke `awcms_domain_event_deliveries.last_error_message`/`dead_letter_reason` → disajikan apa adanya oleh `GET /api/v1/domain-events/deliveries`. Jalur baca itu bahkan punya komentar yang menyatakan invarian *"Already redacted by sanitizeErrorForLog/redactSecretsInText at write time — no further masking needed here"* — invarian yang tidak benar sebelum PR ini.

## Bukti (dieksekusi, bukan inspeksi)

| Input | Sebelum | Sesudah |
|---|---|---|
| `postgres://awcms:S3cr3tP@ss@db:5432/awcms` | bocor utuh | `postgres://[REDACTED]@db:5432/awcms` |
| PEM terpotong tanpa `END` | body base64 utuh | `[REDACTED_PRIVATE_KEY]` |
| `AKIAIOSFODNN7EXAMPLE` | bocor utuh | `[REDACTED_AWS_KEY]` |

## Perubahan

- Pola connection-string free-text (kembaran dari entri anchored yang sudah ada).
- Fallback PEM terpotong — pola berpasangan tidak bisa match blok tanpa `END`, sehingga body kunci lolos utuh. **Diurutkan setelah** pola berpasangan, yang sudah melahap tiap blok well-formed; ada test yang memaku urutan ini.
- Kembaran free-text `AKIA`.
- `tests/redaction.test.ts` baru — modul ini sebelumnya **nol coverage**, itulah sebabnya ketiga celah lolos.

## Verifikasi

- `bun run check` penuh hijau — 536 test lulus (dari 527), 0 gagal, build OK.
- Test dibuktikan menangkap bug: dijalankan melawan kode sebelum perbaikan → **5 gagal**; dengan perbaikan → 9 lulus.

Ditemukan lewat audit sistematis awcms vs awcms-mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)