### PR TITLE
fix(security): enforce module disable and FORCE RLS on 23 tables

### DIFF
--- a/.changeset/enforce-module-disable-and-rls.md
+++ b/.changeset/enforce-module-disable-and-rls.md
@@ -1,0 +1,32 @@
+---
+"awcms": minor
+---
+
+Enforce two tenant-isolation controls that were declared but never actually
+applied. Both are ports of code already proven in awcms-mini.
+
+**Disabling a module now blocks its endpoints.** `authorizeInTransaction` did
+not check tenant module status, so `POST /api/v1/tenant/modules/{key}/disable`
+was cosmetic: the navigation hid the module and the audit event was recorded,
+but any actor still holding the module's permissions could call its API
+directly and keep working. `resolveModuleEnabled` is now checked before
+permissions are even looked up, so a disabled module is refused with
+`403 MODULE_DISABLED` regardless of what the actor was granted, and the denial
+is recorded to the decision log as `matchedPolicy: "module_disabled"`. This
+covers all 70 guarded endpoints at once. `module_management` is `isCore` and
+cannot be disabled, so a tenant can never lock itself out of re-enabling.
+
+**New migration `017_awcms_enforce_rls_force.sql`** adds `FORCE ROW LEVEL
+SECURITY` to the 23 tenant-scoped tables that only `ENABLE`d it (migrations
+002-008, 010-012), including `awcms_identities`, `awcms_sessions`,
+`awcms_access_assignments` and `awcms_profiles`. PostgreSQL bypasses RLS for a
+table's owner unless `FORCE`, and the app connects as the migration owner via
+`DATABASE_URL` — so those tenant-isolation policies were never evaluated, and
+isolation rested entirely on application-level `WHERE tenant_id` clauses with
+RLS as a non-functioning backstop. Every one of the 23 tables already had
+`tenant_id` and a policy, so this only starts enforcing what was declared; all
+access paths already go through `withTenant()`.
+
+This closes the table-owner bypass only. A SUPERUSER/BYPASSRLS connection still
+bypasses RLS regardless of `FORCE`; closing that needs the least-privilege
+`awcms_app` role, which is deployment-affecting and tracked separately.

--- a/sql/017_awcms_enforce_rls_force.sql
+++ b/sql/017_awcms_enforce_rls_force.sql
@@ -1,0 +1,66 @@
+-- Enforce RLS on the 23 tenant-scoped tables that only `ENABLE`d it (ported
+-- from awcms-mini migration 013_awcms_mini_enforce_rls_least_privilege.sql,
+-- part 1 of 2).
+--
+-- FINDING: the multi-tenant RLS control (ADR-0003) was inert for these
+-- tables. Migrations 002-008 and 010-012 only `ENABLE ROW LEVEL SECURITY`;
+-- PostgreSQL bypasses RLS for a table's OWNER unless `FORCE` is set, and the
+-- app connects as the migration owner via `DATABASE_URL` (stated outright in
+-- the header of 014). So the `awcms_*_tenant_isolation` policies on these
+-- tables were never evaluated: tenant isolation rested entirely on the
+-- application's `WHERE tenant_id` clauses, with RLS as a non-functioning
+-- backstop. Migrations 009 and 013-015 already set `FORCE` (48 tables
+-- `ENABLE`, 25 `FORCE`), which is why this looked like a settled convention
+-- rather than a gap — the header of 014 asserts the convention holds "since
+-- migration 002", which was not true.
+--
+-- Every table below already has `tenant_id` and a tenant-isolation policy, so
+-- this only starts enforcing what was already declared. All access paths go
+-- through `withTenant()` (which issues `SET LOCAL app.current_tenant_id`), so
+-- no read/write path loses rows: `scripts/object-sync-dispatch.ts` is the only
+-- worker touching one of these tables outside a request, and its own raw query
+-- reads `awcms_tenants` (the root table, deliberately without RLS) while the
+-- queue work goes through `dispatchObjectSyncQueue` -> `withTenant`.
+--
+-- SCOPE — this closes the OWNER bypass only. A connection with SUPERUSER or
+-- BYPASSRLS still bypasses RLS regardless of `FORCE`. Closing that requires
+-- part 2 of mini's migration: a least-privilege `awcms_app` role plus a
+-- fail-closed default GUC, which this base does not have yet (no `CREATE ROLE`
+-- or `GRANT` exists anywhere in sql/, and `src/lib/database/client.ts` cites a
+-- `sql/045_awcms_db_role_separation.sql` that does not exist). Tracked
+-- separately, because introducing a role is a deployment-affecting change.
+
+BEGIN;
+
+ALTER TABLE awcms_offices FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_tenant_settings FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE awcms_profiles FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_profile_identifiers FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_profile_entity_links FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE awcms_identities FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_tenant_users FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_sessions FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE awcms_roles FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_role_permissions FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_access_assignments FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_abac_policies FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_abac_decision_logs FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE awcms_audit_events FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE awcms_tenant_modules FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_module_settings FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE awcms_sync_nodes FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_sync_outbox FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_sync_inbox FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_sync_push_batches FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_sync_aggregate_versions FORCE ROW LEVEL SECURITY;
+ALTER TABLE awcms_sync_conflicts FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE awcms_object_sync_queue FORCE ROW LEVEL SECURITY;
+
+COMMIT;

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -22,6 +22,8 @@ Skema: `sql/004_awcms_identity_login_schema.sql`, `sql/005_awcms_abac_access_con
 
 `domain/access-control.ts` — `evaluateAccess()`: default deny, deny overrides allow, permission diidentifikasi `module_key.activity_code.action`. `application/access-guard.ts` — `authorizeInTransaction()` adalah satu-satunya chokepoint yang dipanggil setiap route terproteksi.
 
+Status disabled sebuah modul bukan sekadar sinyal UI: `authorizeInTransaction` mengecek `resolveModuleEnabled(tx, tenantId, guard.moduleKey)` (`auth-context.ts`) **sebelum** permission di-lookup, sehingga modul yang dinonaktifkan untuk sebuah tenant ditolak `403 MODULE_DISABLED` apa pun permission yang dipegang aktor, dan penolakannya tetap tercatat di decision log (`matchedPolicy: "module_disabled"`). Karena guard ini dipakai setiap endpoint terproteksi, satu cek ini menutup seluruh endpoint milik modul nonaktif tanpa menyentuh tiap route. `module_management` sendiri `isCore` (tidak bisa dinonaktifkan), jadi tenant tak pernah terkunci dari mengaktifkannya kembali.
+
 ## Belum tersedia (Sprint 3+)
 
-Evaluator ABAC penuh (business-scope/office hierarchy, segregation-of-duties), module-management (enable/disable modul per tenant — `authorizeInTransaction` belum mengecek status modul), endpoint manajemen user/role (`/users`, `/roles`), MFA/OIDC/SSO/Turnstile.
+Evaluator ABAC penuh (business-scope/office hierarchy, segregation-of-duties), endpoint manajemen user/role (`/users`, `/roles`), MFA/OIDC/SSO/Turnstile.

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -9,6 +9,7 @@ import type { AccessRequest, TenantContext } from "../domain/access-control";
 import { evaluateAccess } from "../domain/access-control";
 import {
   fetchGrantedPermissionKeys,
+  resolveModuleEnabled,
   resolveTenantContext
 } from "./auth-context";
 import { recordDecisionLog } from "./decision-log";
@@ -65,6 +66,38 @@ export async function authorizeInTransaction(
     return {
       allowed: false,
       denied: fail(401, "AUTH_REQUIRED", "Session is invalid or expired.")
+    };
+  }
+
+  // Disabling a module must block its endpoints server-side, not just hide
+  // them from the navigation — checked here, before permissions are even
+  // looked up, so a disabled module is refused no matter what the actor was
+  // granted. `module_management` is `isCore` and cannot be disabled, so its
+  // own lifecycle endpoints can never lock a tenant out of re-enabling.
+  const moduleEnabled = await resolveModuleEnabled(
+    tx,
+    tenantId,
+    guard.moduleKey
+  );
+
+  if (!moduleEnabled) {
+    const decision = {
+      allowed: false,
+      reason: "Module is disabled for this tenant.",
+      matchedPolicy: "module_disabled"
+    };
+
+    await recordDecisionLog(
+      tx,
+      tenantId,
+      context.tenantUserId,
+      guard,
+      decision
+    );
+
+    return {
+      allowed: false,
+      denied: fail(403, "MODULE_DISABLED", decision.reason)
     };
   }
 

--- a/src/modules/identity-access/application/auth-context.ts
+++ b/src/modules/identity-access/application/auth-context.ts
@@ -33,6 +33,24 @@ export async function resolveTenantContext(
   };
 }
 
+/**
+ * Whether `moduleKey` is available for `tenantId`. No row means "never
+ * toggled" — available by default, the same convention the tenant module
+ * lifecycle service itself uses (`tenant-module-lifecycle.ts`).
+ */
+export async function resolveModuleEnabled(
+  tx: Bun.SQL,
+  tenantId: string,
+  moduleKey: string
+): Promise<boolean> {
+  const rows = (await tx`
+    SELECT enabled FROM awcms_tenant_modules
+    WHERE tenant_id = ${tenantId} AND module_key = ${moduleKey}
+  `) as { enabled: boolean }[];
+
+  return rows[0]?.enabled ?? true;
+}
+
 export async function fetchGrantedPermissionKeys(
   tx: Bun.SQL,
   tenantId: string,


### PR DESCRIPTION
Dua kontrol isolasi tenant yang **dideklarasikan tapi tidak pernah benar-benar berlaku**. Keduanya port dari kode yang sudah teruji di awcms-mini.

## 1. Disable modul kini benar-benar memblokir endpoint-nya

`authorizeInTransaction` tidak pernah mengecek status modul tenant, sehingga `POST /api/v1/tenant/modules/{key}/disable` bersifat **kosmetik**: navigasi menyembunyikan modul dan audit tercatat, tapi aktor yang masih memegang permission modul itu cukup memanggil API-nya langsung dan tetap bekerja.

Cek `resolveModuleEnabled` kini dijalankan **sebelum** permission di-lookup → `403 MODULE_DISABLED` apa pun grant yang dipegang, dan penolakannya masuk decision log (`matchedPolicy: "module_disabled"`). Satu cek ini menutup **70 endpoint ber-guard** sekaligus. `module_management` `isCore` sehingga tenant tak pernah terkunci dari mengaktifkan kembali.

## 2. Migration 017 — FORCE RLS untuk 23 tabel

Migration 002–008 dan 010–012 hanya `ENABLE ROW LEVEL SECURITY`. Postgres **melewati RLS untuk pemilik tabel kecuali ada `FORCE`**, dan app connect sebagai migration owner via `DATABASE_URL` — fakta yang diakui header `sql/014` sendiri. Jadi policy isolasi tenant di 23 tabel itu **tidak pernah dievaluasi**; isolasi bersandar 100% pada klausa `WHERE tenant_id` di aplikasi.

Terdampak termasuk `awcms_identities`, `awcms_sessions`, `awcms_access_assignments`, `awcms_profiles`. Hitungan: **48 tabel ENABLE, 25 FORCE, 23 inert** — dan migration ini mencakup persis ke-23 itu. Semuanya sudah punya `tenant_id` + policy, jadi ini hanya mulai menegakkan yang sudah dideklarasikan.

## Verifikasi end-to-end (Postgres 18, role pemilik non-superuser)

Bukan inspeksi kode — dijalankan sungguhan:

| Kondisi | Tenant A membaca office milik B | Tenant B membaca miliknya |
|---|---|---|
| Sebelum 017 | **1 baris — bocor** | — |
| Sesudah 017 | **0 baris — diblokir** | 1 baris — normal |

Guard, dengan aktor yang **memegang** `reporting.dashboard.read`:

| Kondisi | Hasil |
|---|---|
| Modul aktif | ALLOW |
| Modul di-disable | **DENY 403 MODULE_DISABLED** |

`bun run check` penuh hijau — 536 test, 0 gagal, build OK.

## Lingkup

FORCE menutup bypass **pemilik tabel** saja. Koneksi SUPERUSER/BYPASSRLS tetap melewati RLS apa pun FORCE-nya; menutup itu butuh role least-privilege `awcms_app` yang berdampak ke deployment — dilacak terpisah.

Ditemukan lewat audit sistematis awcms vs awcms-mini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)