### PR TITLE
fix: audit wave 3 — keyset precision, awcms_app grant narrowing, sync HMAC v2

### DIFF
--- a/.changeset/db-role-grants-narrow.md
+++ b/.changeset/db-role-grants-narrow.md
@@ -1,0 +1,21 @@
+---
+"awcms": minor
+---
+
+Narrow the `awcms_app` runtime DB role's blanket DML on the global, RLS-free
+tables (Issue #160, `sql/021_awcms_db_role_grants_narrow.sql`). Closes the
+residual documented by `sql/019`: `awcms_app` can no longer `DELETE`
+`awcms_tenants`, `DELETE` `awcms_schema_migrations`, or write `awcms_permissions`
+(now read-only), and loses `DELETE` on `awcms_setup_state`. The
+`INSERT`/`UPDATE`/`SELECT` that real code paths use (setup-wizard fallback,
+tenant-settings screen, module-registry sync) are kept.
+
+Deployment-affecting: apply the new migration with the migration-owner
+connection string, as usual. The worker/setup role split (mini's migration 045)
+remains deferred.
+
+Adds a `security:readiness` grant check ("Runtime role table grants match
+least-privilege matrix") that fails when `awcms_app` is over-granted on a global
+table or, critically, when a tenant-scoped table is RLS-forced but ungranted
+(`permission denied` at runtime) — the executing-role-bound `ALTER DEFAULT
+PRIVILEGES` gap that the RLS-flag check cannot see.

--- a/.changeset/keyset-pagination-microseconds.md
+++ b/.changeset/keyset-pagination-microseconds.md
@@ -1,0 +1,30 @@
+---
+"awcms": patch
+---
+
+Fix silent row loss in keyset pagination: the shared cursor now carries
+`created_at` at full microsecond precision instead of flooring it to
+milliseconds (Issue #158).
+
+`encodeKeysetCursor` used to serialise a row's `created_at` as a JS `Date`
+(`.toISOString()`), which holds only milliseconds — but `timestamptz` holds
+microseconds, and the driver had already floored them on the way out
+(`...:00.029058+00` arrives as `...:00.029Z`). A cursor built from that `Date`
+denoted an instant strictly EARLIER than the row it came from, so
+`(created_at, id) < (cursor)` skipped every row that shared that millisecond
+across a page boundary — rows that no later cursor could reach either. Measured
+against a batch of rows sharing one millisecond, page 2 came back empty.
+
+The fix carries the value through the cursor as full-precision UTC ISO-8601
+text (`_shared/keyset-pagination.ts`, `KEYSET_CURSOR_CREATED_AT_SQL`), keeping
+`ORDER BY (created_at, id)` on the bare column so the existing
+`(tenant_id, created_at DESC)` indexes still serve the query. `KeysetCursor.createdAt`
+is now a string, not a `Date`; the cursor stays opaque to clients and remains
+backward-compatible with any millisecond cursor already in flight.
+
+Endpoints corrected: `GET /api/v1/workflows/tasks`, `GET /api/v1/email/messages`,
+`GET /api/v1/sync/object-queue`, and `GET /api/v1/offices` (whose earlier local
+`date_trunc('milliseconds', …)` guard is removed now that the fix is central).
+The `GET /api/v1/email/messages` and `GET /api/v1/sync/object-queue` response
+bodies are unchanged (`{ …, nextCursor }`); only the value of `nextCursor` is
+now correct.

--- a/.changeset/sync-hmac-versioned-signature.md
+++ b/.changeset/sync-hmac-versioned-signature.md
@@ -1,0 +1,29 @@
+---
+"awcms": minor
+---
+
+Sync HMAC: versioned signatures + inactive-by-default node registration (security advisory GHSA-c972-3q5p-g3h4, cross-tenant sync forgery).
+
+- **Signature v2 binds tenant + node.** New `computeSyncSignatureV2` /
+  `verifySyncSignatureV2` sign `"v2:<tenantId>:<nodeCode>:<timestamp>:<body>"`,
+  so a signature minted for one tenant no longer verifies when
+  `X-AWCMS-Tenant-ID` is swapped to another tenant. Nodes send
+  `X-AWCMS-Signature-Version: 2`. Timing-safe compare is preserved for both
+  versions.
+- **Backward-compatible with an off-switch.** `verifySyncHeaders` verifies v2
+  when the version header is `2`; requests without the header fall back to the
+  legacy v1 scheme (`"<timestamp>.<body>"`) — which remains **cross-tenant
+  forgeable** — only while the new env `SYNC_HMAC_ALLOW_LEGACY` is not `false`
+  (default allow). Setting `SYNC_HMAC_ALLOW_LEGACY=false` rejects v1 entirely.
+- **Nodes auto-register `inactive`.** First-contact sync nodes are quarantined
+  `inactive` (code-only change, no migration) and require admin approval via
+  `PATCH /api/v1/sync/nodes/{id}` before they can push/pull. Nodes already
+  `active` are unaffected. This closes the "new node id" path independently of
+  the signature.
+
+Not a complete close on its own: the advisory is fully closed only when
+`SYNC_HMAC_ALLOW_LEGACY=false` **and** every node has migrated to v2. This is a
+cross-repo change — the v2 material is canonical here, but **awcms-mini** and
+the node spec/skill must be updated to emit v2 before legacy is disabled in any
+deployment. v1 is deprecated-transitional. New env var `SYNC_HMAC_ALLOW_LEGACY`
+(default `true`) must be wired into shared env docs/validation.

--- a/.claude/skills/awcms-sync-hmac/SKILL.md
+++ b/.claude/skills/awcms-sync-hmac/SKILL.md
@@ -7,39 +7,78 @@ description: Amankan sinkronisasi offline-online AWCMS dengan HMAC signature dan
 
 Ikuti `docs/awcms/08_sop_operasional_user_guide.md` dan `docs/awcms/10_template_kode_coding_standard.md`.
 
-## ⚠️ Spek di bawah ini punya celah lintas-tenant yang diketahui — jangan sebarkan
+## Signature ber-versi (perbaikan GHSA-c972-3q5p-g3h4)
 
-Skema signature yang didokumentasikan skill ini **cacat** dan sedang dilacak di security advisory privat (`GHSA-c972-3q5p-g3h4`). Jangan jadikan ia contoh untuk kode baru sebelum advisory itu selesai.
+Celah lintas-tenant lama (tenant & node **di luar** material tanda tangan)
+sudah ditutup dengan skema signature **ber-versi**. Gunakan **v2** untuk semua
+kode & node baru.
 
-Masalahnya: **tenant dan node berada di luar material tanda tangan**. Digabung dengan satu secret deployment-wide dan auto-registrasi node berstatus `active`, pemegang secret sah milik satu tenant dapat menukar header `X-AWCMS-Tenant-ID` dan membaca/menulis data tenant lain — signature yang sama valid untuk **setiap** tenant.
-
-Perhatikan juga: aturan 4 ("Node inactive ditolak") saat ini **hampa**, karena `resolveOrRegisterSyncNode` meng-INSERT node tak dikenal dan `sql/010` memberi `status DEFAULT 'active'` — sehingga cek status selalu lolos.
-
-Arah perbaikan (butuh koordinasi awcms + awcms-mini + skill ini, dan **memutus kompatibilitas protokol** dengan node yang sudah berjalan):
+### v2 — kanonik (WAJIB untuk kode baru)
 
 ```text
-signature = HMAC(secret, "<tenantId>.<nodeCode>.<timestamp>.<body>")
+signature = HMAC-SHA256(secret, "v2:<tenantId>:<nodeCode>:<timestamp>:<body>")
 ```
 
-plus registrasi node default `inactive` (wajib approve admin), dan idealnya secret per-node.
+- Tenant dan node **di dalam** material → signature yang dibuat untuk tenant A
+  tidak lagi valid saat header `X-AWCMS-Tenant-ID` ditukar ke tenant B.
+- Node **wajib** mengirim header `X-AWCMS-Signature-Version: 2`.
+- Field constraint agar material tidak ambigu: `tenantId` = UUID; `nodeCode` &
+  `timestamp` dari HTTP header (tak boleh mengandung CR/LF); `body` adalah field
+  terakhir sehingga `:` di dalamnya tak menggeser batas field sebelumnya.
+- Implementasi kanonik ada di repo **awcms** (`domain/sync-hmac.ts`
+  `computeSyncSignatureV2` / `verifySyncSignatureV2`).
 
-## Signature (kondisi saat ini — lihat peringatan di atas)
+### v1 — legacy, RENTAN (transisi saja)
 
 ```text
-signature = HMAC(secret, "<timestamp>.<body>")
+signature = HMAC-SHA256(secret, "<timestamp>.<body>")
 ```
 
-Header: `X-AWCMS-Tenant-ID`, `X-AWCMS-Node-ID`, `X-AWCMS-Timestamp`, `X-AWCMS-Signature`. Tenant dibaca dari header dan **tidak diverifikasi terhadap signature** — inilah inti celahnya.
+- Dipakai bila node **tidak** mengirim `X-AWCMS-Signature-Version`.
+- Tenant & node tidak terikat → **masih bisa dipalsukan lintas-tenant**. Ada
+  hanya supaya node lama tetap jalan selama migrasi.
+- Diterima **hanya** selama env `SYNC_HMAC_ALLOW_LEGACY` bukan `false`
+  (default: mengizinkan). Operator men-set `SYNC_HMAC_ALLOW_LEGACY=false`
+  setelah semua node pindah ke v2 untuk menolak v1 sepenuhnya.
+- **Celah tertutup penuh hanya saat `SYNC_HMAC_ALLOW_LEGACY=false` DAN semua
+  node memakai v2.** Jangan klaim advisory tertutup sebelum kedua syarat itu.
+
+### Koordinasi lintas-repo
+
+v2 kanonik di **awcms** (base ini). **awcms-mini** dan skill/spec node harus
+di-update agar node & spec mencerminkan material v2 yang persis sama sebelum
+`SYNC_HMAC_ALLOW_LEGACY=false` diaktifkan di deployment mana pun. Idealnya
+lanjutkan ke **secret per-node** (saran advisory ke-3) — di luar scope patch ini.
+
+## Registrasi node — default `inactive` + approve admin
+
+`resolveOrRegisterSyncNode` meng-INSERT node first-contact dengan
+`status='inactive'` (bukan `active`). Node dikarantina sampai admin menyetujui
+lewat `PATCH /api/v1/sync/nodes/{id}` (`status: "active"`, guarded
+`sync_storage.node_management.update`, audited). Ini menutup jalur "node-id
+baru" — request palsu untuk tenant lain mendarat di node inactive dan ditolak
+gate `node.status !== "active"`. Node yang sudah `active` tak terpengaruh.
+(Kolom `sql/010` masih default `active` untuk baris historis; INSERT di kode
+yang membuat baris baru jadi eksplisit `inactive` — tanpa mengedit migration
+terapan.)
+
+## Header
+
+`X-AWCMS-Tenant-ID`, `X-AWCMS-Node-ID`, `X-AWCMS-Timestamp`,
+`X-AWCMS-Signature`, `X-AWCMS-Signature-Version` (`2` untuk v2).
 
 ## Aturan validasi
 
 1. Signature **wajib** ada; tolak jika kosong.
 2. Timestamp valid; **max skew default 300 detik** (anti replay).
-3. **Timing-safe compare** untuk signature.
-4. Node inactive ditolak — lihat peringatan di atas: aturan ini belum efektif selama node auto-register berstatus `active`.
-5. Duplicate event idempotent (tidak dobel) — lihat `awcms-idempotency`.
-6. Posted transaction **immutable**; sync tidak menimpa transaksi posted.
-7. HMAC secret & R2 credential hanya dari **environment**.
+3. **Timing-safe compare** untuk signature (kedua versi).
+4. v2: material mengikat tenant+node — tenant-swap otomatis invalid.
+5. v1 diterima hanya bila `SYNC_HMAC_ALLOW_LEGACY` ≠ `false`.
+6. Node **inactive** ditolak (`node.status !== "active"` → 403); node baru
+   auto-register `inactive` dan wajib approve admin.
+7. Duplicate event idempotent (tidak dobel) — lihat `awcms-idempotency`.
+8. Posted transaction **immutable**; sync tidak menimpa transaksi posted.
+9. HMAC secret & R2 credential hanya dari **environment**.
 
 ## Alur
 
@@ -47,8 +86,8 @@ Header: `X-AWCMS-Tenant-ID`, `X-AWCMS-Node-ID`, `X-AWCMS-Timestamp`, `X-AWCMS-Si
 sequenceDiagram
   participant N as Node
   participant S as Server
-  N->>S: push (Node-ID + Timestamp + Signature + body)
-  S->>S: cek node aktif · verifikasi HMAC · cek skew · idempotent
+  N->>S: push (Tenant-ID + Node-ID + Timestamp + Signature + Signature-Version:2 + body)
+  S->>S: cek node aktif · verifikasi HMAC v2 (tenant+node bound) · cek skew · idempotent
   S-->>N: ack + checkpoint (atau tolak)
   N->>S: pull update
   S-->>N: event baru
@@ -62,6 +101,9 @@ sequenceDiagram
 
 ## Verifikasi (test)
 
+- v2 tenant-swap ditolak (material beda → HMAC beda).
+- v1 diterima saat `SYNC_HMAC_ALLOW_LEGACY=true`, ditolak saat `false`.
+- Node auto-register `inactive` → pull ditolak; node `active` tetap jalan.
 - HMAC valid diterima; invalid/expired ditolak.
 - Duplicate batch idempotent; checkpoint updated.
 - Conflict tercatat immutable + audit.

--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,11 @@ AUDIT_LOG_RETENTION_DAYS=730
 #   ALTER ROLE awcms_app LOGIN PASSWORD '<secret>';
 # `bun run db:migrate` membaca DATABASE_URL yang SAMA, jadi jalankan migrasi
 # dengan var ini ditimpa ke connection string owner/superuser — bukan awcms_app
-# (awcms_app sengaja tidak bisa CREATE/ALTER/DROP apa pun).
+# (awcms_app sengaja tidak bisa CREATE/ALTER/DROP apa pun). Grant awcms_app pada
+# tabel global tanpa RLS sudah dipersempit oleh
+# `sql/021_awcms_db_role_grants_narrow.sql` (Issue #160): read-only di
+# awcms_permissions/awcms_schema_migrations, tanpa DELETE di
+# awcms_tenants/awcms_setup_state — lihat doc 18 §Model role database.
 DATABASE_URL=postgres://awcms:awcms_password@localhost:5432/awcms
 DATABASE_POOL_MAX=20
 DATABASE_STATEMENT_TIMEOUT_MS=15000
@@ -47,6 +51,11 @@ AUTH_IP_HASH_SECRET=change-me
 AWCMS_SYNC_ENABLED=false
 AWCMS_SYNC_HMAC_SECRET=change-me
 AWCMS_SYNC_MAX_SKEW_SEC=300
+# Terima signature sync legacy v1 (`<timestamp>.<body>`, TIDAK mengikat tenant/node).
+# Default true selama transisi agar node lama tetap jalan. v1 masih rentan
+# forgery lintas-tenant (GHSA-c972); setel `false` setelah SEMUA node kirim v2
+# (`X-AWCMS-Signature-Version: 2`) untuk menutup celah sepenuhnya.
+SYNC_HMAC_ALLOW_LEGACY=true
 
 STORAGE_DRIVER=local
 LOCAL_STORAGE_PATH=./storage

--- a/docs/awcms/05_openapi_asyncapi_detail.md
+++ b/docs/awcms/05_openapi_asyncapi_detail.md
@@ -49,17 +49,18 @@ Response error:
 
 ## Header standard
 
-| Header              |                       Wajib | Fungsi                  |
-| ------------------- | --------------------------: | ----------------------- |
-| `Authorization`     |           Ya kecuali public | Bearer token            |
-| `X-AWCMS-Tenant-ID` |  Ya untuk tenant-scoped API | Tenant aktif            |
-| `Idempotency-Key`   | Ya untuk mutation high-risk | Anti duplicate mutation |
-| `X-Correlation-ID`  |                    Opsional | Trace request           |
-| `X-Request-ID`      |                    Opsional | Trace client request    |
-| `Accept-Language`   |                    Opsional | Locale                  |
-| `X-AWCMS-Node-ID`   |               Ya untuk sync | Sync node               |
-| `X-AWCMS-Timestamp` |        Ya untuk signed sync | Anti replay             |
-| `X-AWCMS-Signature` |               Ya untuk sync | HMAC signature          |
+| Header                      |                       Wajib | Fungsi                                                        |
+| --------------------------- | --------------------------: | ------------------------------------------------------------- |
+| `Authorization`             |           Ya kecuali public | Bearer token                                                  |
+| `X-AWCMS-Tenant-ID`         |  Ya untuk tenant-scoped API | Tenant aktif                                                  |
+| `Idempotency-Key`           | Ya untuk mutation high-risk | Anti duplicate mutation                                       |
+| `X-Correlation-ID`          |                    Opsional | Trace request                                                 |
+| `X-Request-ID`              |                    Opsional | Trace client request                                          |
+| `Accept-Language`           |                    Opsional | Locale                                                        |
+| `X-AWCMS-Node-ID`           |               Ya untuk sync | Sync node                                                     |
+| `X-AWCMS-Timestamp`         |        Ya untuk signed sync | Anti replay                                                   |
+| `X-AWCMS-Signature`         |               Ya untuk sync | HMAC signature                                                |
+| `X-AWCMS-Signature-Version` |  Disarankan untuk sync (v2) | Versi skema signature; `"2"` mengikat tenant+node (GHSA-c972) |
 
 ## Soft delete API standard
 

--- a/docs/awcms/13_final_master_index_traceability.md
+++ b/docs/awcms/13_final_master_index_traceability.md
@@ -148,7 +148,7 @@ struktur repo NYATA, sehingga mengikuti data real, bukan ilustrasi.
 
 | Modul (`key`)                | Migration                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| _(Foundation, lintas-modul)_ | `001_awcms_foundation_schema.sql`, `017_awcms_enforce_rls_force.sql`, `019_awcms_db_role_separation.sql`                                                                                                                                                                                                                                                                                                                                |
+| _(Foundation, lintas-modul)_ | `001_awcms_foundation_schema.sql`, `017_awcms_enforce_rls_force.sql`, `019_awcms_db_role_separation.sql`, `021_awcms_db_role_grants_narrow.sql`                                                                                                                                                                                                                                                                                         |
 | `tenant_admin`               | `002_awcms_tenant_office_schema.sql`, `006_awcms_setup_wizard_schema.sql`, `015_awcms_tenant_settings_management_permission_schema.sql`, `016_awcms_tenant_default_locale_english_schema.sql`                                                                                                                                                                                                                                           |
 | `profile_identity`           | `003_awcms_central_profile_management_schema.sql`                                                                                                                                                                                                                                                                                                                                                                                       |
 | `identity_access`            | `004_awcms_identity_login_schema.sql`, `005_awcms_abac_access_control_schema.sql`, `022_awcms_password_reset_schema.sql`, `034_awcms_mfa_totp_schema.sql`, `035_awcms_google_oidc_schema.sql`, `036_awcms_tenant_oidc_sso_schema.sql`, `037_awcms_tenant_oidc_sso_permissions.sql`                                                                                                                                                      |
@@ -169,14 +169,15 @@ struktur repo NYATA, sehingga mengikuti data real, bukan ilustrasi.
 Tiga migration di baris "Foundation, lintas-modul" tidak dipetakan ke
 satu modul karena sifatnya benar-benar lintas-modul: `001` adalah
 bootstrap murni (ledger migrasi + extension Postgres, sebelum modul
-apa pun terdaftar); `017` dan `019` adalah hardening keamanan
+apa pun terdaftar); `017`, `019`, dan `021` adalah hardening keamanan
 lintas-tabel (RLS `FORCE` di 23 tabel, lalu role runtime `awcms_app`
-least-privilege + default GUC fail-closed) yang menyentuh tabel banyak
+least-privilege + default GUC fail-closed, lalu penyempitan grant `awcms_app`
+pada tabel global RLS-free — Issue #160) yang menyentuh tabel banyak
 modul sekaligus, bukan schema satu modul — lihat
 `docs/awcms/20_threat_model_security_architecture.md` dan
 `docs/awcms/18_configuration_env_reference.md` §Model role database.
 
-> **Peringatan akurasi (Issue #155).** Baris `001`/`017`/`019` di atas sudah
+> **Peringatan akurasi (Issue #155).** Baris `001`/`017`/`019`/`021` di atas sudah
 > dicocokkan dengan `sql/` nyata. **Baris modul lain di tabel ini belum**:
 > sebagian besar masih memakai penomoran/penamaan awcms-mini (mis.
 > `045_awcms_db_role_separation.sql` yang dulu tercantum di baris Foundation

--- a/docs/awcms/18_configuration_env_reference.md
+++ b/docs/awcms/18_configuration_env_reference.md
@@ -134,13 +134,30 @@ Yang **benar-benar ada** di repo ini (Issue #141) adalah **dua** role:
    baris**, bukan error `unrecognized configuration parameter` dan bukan data
    tenant lain.
 
-Batas yang diakui terbuka: di tabel **global tanpa RLS** (`awcms_tenants`,
-`awcms_permissions`, `awcms_setup_state`, `awcms_schema_migrations`,
-`awcms_modules` + turunannya) `awcms_app` memegang DML penuh yang tidak semuanya
-dipakai. Penyempitannya adalah migration `045` awcms-mini (yang memecah runtime
-jadi `awcms_app`/`awcms_worker`/`awcms_setup`) dan **belum diport** ke sini —
-butuh audit per-jalur-tulis. Dibanding kondisi sebelum 019 (semuanya lewat
-superuser), ini tetap perbaikan tegas, bukan kemunduran.
+Penyempitan grant tabel global (Issue #160,
+`sql/021_awcms_db_role_grants_narrow.sql`): pada tabel **global tanpa RLS**,
+`awcms_app` **tidak lagi** memegang DML berlebih yang jadi residual #159 —
+sekarang **read-only** pada `awcms_permissions` (katalog permission, hanya diseed
+migration) dan `awcms_schema_migrations` (ledger migrasi, hanya ditulis
+`db:migrate` sebagai owner), dan **tidak bisa `DELETE`** `awcms_tenants` maupun
+`awcms_setup_state`. Yang **sengaja dipertahankan** karena benar-benar dipakai
+jalur kode `awcms_app`: `INSERT`/`UPDATE`/`SELECT` pada `awcms_tenants` (INSERT
+lewat wizard setup yang fallback ke koneksi `awcms_app`; UPDATE lewat layar
+tenant-settings) dan `awcms_setup_state` (lock singleton via jalur setup), plus
+DML penuh pada tabel module-registry (`awcms_modules` + turunannya) yang ditulis
+saat request oleh module-management. Regresi (tabel global baru ikut terbawa
+blanket DML dari default privileges, atau tabel tenant-scoped baru RLS-forced
+tapi **ungranted** → `permission denied`) ditangkap cek `security:readiness`
+"Runtime role table grants match least-privilege matrix".
+
+Batas yang masih terbuka (defense-in-depth, bukan residual #159): pemecahan
+runtime jadi role `awcms_worker`/`awcms_setup` sungguhan (migration `045`
+awcms-mini) **belum diport** — butuh audit per-jalur-tulis atas tujuh script
+worker + bootstrap setup, dan perubahan fallback `client.ts` yang breaking untuk
+setiap deployment yang belum opt-in ke `WORKER_DATABASE_URL`/`SETUP_DATABASE_URL`.
+Karena `awcms_app` sudah dipersempit di atas, residual konkret #159 sudah
+tertutup tanpa pemecahan itu. Dibanding kondisi sebelum 019 (semuanya lewat
+superuser), ini perbaikan tegas berlapis, bukan kemunduran.
 
 Karena itu `WORKER_DATABASE_URL`/`SETUP_DATABASE_URL` **bukan** pemetaan role:
 tidak ada role `awcms_worker`/`awcms_setup` di `sql/`. Keduanya adalah seam
@@ -286,11 +303,12 @@ PAYLOAD_TOO_LARGE`.
 
 ### Sync & node
 
-| Var                       | Wajib     | Default | Sensitif | Fungsi                                      |
-| ------------------------- | --------- | ------- | -------- | ------------------------------------------- |
-| `AWCMS_SYNC_ENABLED`      | –         | `false` | –        | Aktifkan sync hybrid (offline-first outbox) |
-| `AWCMS_SYNC_HMAC_SECRET`  | bila sync | –       | Ya       | Signature HMAC                              |
-| `AWCMS_SYNC_MAX_SKEW_SEC` | –         | `300`   | –        | Toleransi anti-replay                       |
+| Var                       | Wajib     | Default | Sensitif | Fungsi                                                                                                    |
+| ------------------------- | --------- | ------- | -------- | --------------------------------------------------------------------------------------------------------- |
+| `AWCMS_SYNC_ENABLED`      | –         | `false` | –        | Aktifkan sync hybrid (offline-first outbox)                                                               |
+| `AWCMS_SYNC_HMAC_SECRET`  | bila sync | –       | Ya       | Signature HMAC                                                                                            |
+| `AWCMS_SYNC_MAX_SKEW_SEC` | –         | `300`   | –        | Toleransi anti-replay                                                                                     |
+| `SYNC_HMAC_ALLOW_LEGACY`  | –         | `true`  | –        | Terima signature v1 (tak mengikat tenant/node, rentan GHSA-c972); set `false` setelah semua node kirim v2 |
 
 Identitas node direncanakan berasal dari tabel `awcms_sync_nodes` (DB),
 teregistrasi otomatis lewat header/HMAC saat request sync pertama — bukan
@@ -424,6 +442,7 @@ AUTH_SSO_MAX_PROVIDERS_PER_TENANT=20
 AWCMS_SYNC_ENABLED=false
 AWCMS_SYNC_HMAC_SECRET=change-me
 AWCMS_SYNC_MAX_SKEW_SEC=300
+SYNC_HMAC_ALLOW_LEGACY=true
 
 # Storage
 OBJECT_SYNC_UPLOAD_TIMEOUT_MS=10000

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -653,6 +653,213 @@ export async function checkLeastPrivilegeRoleProvisioned(): Promise<SecurityChec
 }
 
 // ---------------------------------------------------------------------------
+// 7b. Runtime role table grants match least-privilege matrix (critical) —
+//     Issue #160
+// ---------------------------------------------------------------------------
+
+/**
+ * Privileges `awcms_app` must NOT hold on each GLOBAL, RLS-free table after
+ * `sql/021_awcms_db_role_grants_narrow.sql` narrows the blanket grant. This is
+ * the OTHER half of the residual `sql/019` documented and #160 closes: RLS
+ * cannot claw anything back on these tables because they have none, so an
+ * over-broad grant here is a real, un-mitigated privilege. Absence from this
+ * map = "full DML legitimately kept" (the five module-registry tables, written
+ * at request time — see `sql/021`'s header). `awcms_tenants`/`awcms_setup_state`
+ * keep SELECT/INSERT/UPDATE (setup-fallback + tenant-settings write paths); only
+ * DELETE is forbidden. `awcms_permissions`/`awcms_schema_migrations` are
+ * read-only at runtime, so every write is forbidden.
+ */
+const GLOBAL_TABLE_FORBIDDEN_PRIVILEGES: Record<string, string[]> = {
+  awcms_permissions: ["INSERT", "UPDATE", "DELETE"],
+  awcms_schema_migrations: ["INSERT", "UPDATE", "DELETE"],
+  awcms_tenants: ["DELETE"],
+  awcms_setup_state: ["DELETE"]
+};
+
+/**
+ * Privileges every TENANT-SCOPED table must grant `awcms_app`. `sql/019` grants
+ * all four blanket + an `ALTER DEFAULT PRIVILEGES` that re-grants all four on
+ * future tables. Requiring all four here is the exact mirror of that — and it
+ * catches the failure mode `checkRlsEnabled` structurally cannot: a table
+ * created by a DIFFERENT owner than the one the default privileges are bound to
+ * ends up RLS-forced (so the RLS check passes) but UNGRANTED, which is
+ * `permission denied` at runtime, not "no data". The reviewer of #159 flagged
+ * exactly this (`ALTER DEFAULT PRIVILEGES` is executing-role-bound, so a
+ * `db:migrate` under a second superuser produces forced-but-ungranted tables).
+ */
+const TENANT_SCOPED_REQUIRED_PRIVILEGES = [
+  "SELECT",
+  "INSERT",
+  "UPDATE",
+  "DELETE"
+];
+
+type RoleGrantRow = {
+  relname: string;
+  sel: boolean;
+  ins: boolean;
+  upd: boolean;
+  del: boolean;
+};
+
+/**
+ * A grant check, distinct from `checkRlsEnabled` (flags) and
+ * `checkLeastPrivilegeRoleProvisioned` (role attributes). Two directions, both
+ * of which the other checks miss:
+ *
+ * - UNDER-granted: a tenant-scoped table missing any of SELECT/INSERT/UPDATE/
+ *   DELETE for `awcms_app` — RLS-forced but unreachable, `permission denied`
+ *   at runtime. The `ALTER DEFAULT PRIVILEGES`-is-executing-role-bound gap.
+ * - OVER-granted: a global RLS-free table where `awcms_app` still holds a
+ *   forbidden write — the residual #160 closes, and its regression guard for a
+ *   FUTURE global table silently inheriting blanket DML from default privileges.
+ *
+ * Uses `has_table_privilege(role, oid, priv)` so it reports the EFFECTIVE grant
+ * (direct + default-privilege + PUBLIC), which is what the runtime actually
+ * gets — reading `relacl` directly would miss default-privilege grants. The
+ * function is available to any role and does not require membership in the
+ * checked role, so this runs correctly even when `security:readiness` is run
+ * AS `awcms_app` (the recommended way to run it).
+ *
+ * Non-blocking when `awcms_app` does not exist: a database migrated before
+ * `sql/019` legitimately has no such role, and a `critical` fail there would
+ * cry wolf over a merely-un-migrated state — the missing-role signal is already
+ * the job of `checkLeastPrivilegeRoleProvisioned` (warning). Once the role
+ * exists, wrong grants ARE `critical`.
+ */
+export async function checkRuntimeRoleGrants(): Promise<SecurityCheckResult> {
+  const name = "Runtime role table grants match least-privilege matrix";
+  const severity: CheckSeverity = "critical";
+
+  try {
+    if (!process.env.DATABASE_URL) {
+      throw new Error("DATABASE_URL is not set.");
+    }
+
+    const sql = getDatabaseClient();
+
+    const roleRows = (await sql`
+      SELECT 1 AS present FROM pg_roles WHERE rolname = ${LEAST_PRIVILEGE_APP_ROLE}
+    `) as { present: number }[];
+
+    if (roleRows.length === 0) {
+      return {
+        name,
+        severity,
+        status: "pass",
+        evidence: `Role "${LEAST_PRIVILEGE_APP_ROLE}" does not exist (this database has not been migrated onto sql/019 yet) — grants cannot be checked. The "Dedicated least-privilege app DB role is provisioned" warning covers the missing-role state; this check does not block for it.`
+      };
+    }
+
+    const rows = (await sql`
+      SELECT
+        c.relname,
+        has_table_privilege(${LEAST_PRIVILEGE_APP_ROLE}, c.oid, 'SELECT') AS sel,
+        has_table_privilege(${LEAST_PRIVILEGE_APP_ROLE}, c.oid, 'INSERT') AS ins,
+        has_table_privilege(${LEAST_PRIVILEGE_APP_ROLE}, c.oid, 'UPDATE') AS upd,
+        has_table_privilege(${LEAST_PRIVILEGE_APP_ROLE}, c.oid, 'DELETE') AS del
+      FROM pg_class c
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+      WHERE c.relname LIKE 'awcms\\_%' AND c.relkind IN ('r', 'p')
+        AND n.nspname = current_schema()
+      ORDER BY c.relname
+    `) as RoleGrantRow[];
+
+    if (rows.length === 0) {
+      return {
+        name,
+        severity,
+        status: "fail",
+        evidence:
+          "No awcms_% tables found in pg_class — has `bun run db:migrate` been run against this database?"
+      };
+    }
+
+    const held = (row: RoleGrantRow): Record<string, boolean> => ({
+      SELECT: row.sel,
+      INSERT: row.ins,
+      UPDATE: row.upd,
+      DELETE: row.del
+    });
+
+    const overGranted: string[] = [];
+    const underGranted: string[] = [];
+
+    for (const row of rows) {
+      const privileges = held(row);
+      const forbidden = GLOBAL_TABLE_FORBIDDEN_PRIVILEGES[row.relname];
+
+      if (forbidden) {
+        const excess = forbidden.filter((privilege) => privileges[privilege]);
+
+        if (excess.length > 0) {
+          overGranted.push(`${row.relname} (still has ${excess.join(", ")})`);
+        }
+
+        continue;
+      }
+
+      if (RLS_FREE_TABLES.has(row.relname)) {
+        // Global table with full DML kept by design (module registry). Not
+        // asserted in either direction.
+        continue;
+      }
+
+      const missing = TENANT_SCOPED_REQUIRED_PRIVILEGES.filter(
+        (privilege) => !privileges[privilege]
+      );
+
+      if (missing.length > 0) {
+        underGranted.push(`${row.relname} (missing ${missing.join(", ")})`);
+      }
+    }
+
+    if (overGranted.length > 0 || underGranted.length > 0) {
+      const parts: string[] = [];
+
+      if (overGranted.length > 0) {
+        parts.push(
+          `over-granted on global RLS-free table(s): ${overGranted.join("; ")}`
+        );
+      }
+
+      if (underGranted.length > 0) {
+        parts.push(
+          `tenant-scoped table(s) unreachable at runtime (RLS-forced but ungranted -> permission denied; ALTER DEFAULT PRIVILEGES is executing-role-bound, see sql/021): ${underGranted.join("; ")}`
+        );
+      }
+
+      return {
+        name,
+        severity,
+        status: "fail",
+        evidence: `Role "${LEAST_PRIVILEGE_APP_ROLE}" grants do not match the least-privilege matrix — ${parts.join(". ")}.`
+      };
+    }
+
+    const tenantScopedCount = rows.filter(
+      (row) =>
+        !RLS_FREE_TABLES.has(row.relname) &&
+        !GLOBAL_TABLE_FORBIDDEN_PRIVILEGES[row.relname]
+    ).length;
+
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence: `Role "${LEAST_PRIVILEGE_APP_ROLE}" holds SELECT/INSERT/UPDATE/DELETE on all ${tenantScopedCount} tenant-scoped table(s) and none of the forbidden writes on the narrowed global tables (${Object.keys(GLOBAL_TABLE_FORBIDDEN_PRIVILEGES).join(", ")}).`
+    };
+  } catch (error) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `Could not verify runtime role grants: ${errorMessage(error)}.`
+    };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // 8. ABAC default-deny works (critical)
 // ---------------------------------------------------------------------------
 
@@ -913,11 +1120,6 @@ export function checkSecurityHeadersBuilt(): SecurityCheckResult {
 
 export const OUT_OF_SCOPE_ITEMS: OutOfScopeItem[] = [
   {
-    name: "Runtime role grant allowlist (per-table, per-role)",
-    reason:
-      "mini's equivalent check compares real `pg_class.relacl` grants against the per-table matrix in its own role-separation migration, to catch a new GLOBAL (non-RLS) table silently inheriting a blanket default-privileges grant. This repo's `sql/019_awcms_db_role_separation.sql` (Issue #141) grants `awcms_app` SELECT/INSERT/UPDATE/DELETE on ALL TABLES uniformly, plus matching ALTER DEFAULT PRIVILEGES — there is no differentiated matrix to compare against yet, so the check would have nothing to assert. Add it if/when grants are narrowed per table."
-  },
-  {
     name: "Audit log retention is actually being executed",
     reason:
       "`bun run logs:audit:purge` (Issue #146) implements retention, but whether it is SCHEDULED is a deployment concern (cron/systemd timer/k8s CronJob) this script cannot observe from the repo. Run `bun run logs:audit:purge --dry-run` against the target database to see the real backlog past cutoff."
@@ -959,6 +1161,7 @@ export async function runSecurityReadinessChecks(): Promise<
     await checkRlsEnabled(),
     await checkAppDbUserNotSuperuser(),
     await checkLeastPrivilegeRoleProvisioned(),
+    await checkRuntimeRoleGrants(),
     checkAbacDefaultDeny(),
     await checkAuditLogTableReachable(),
     checkEnvConfigValid(),

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -82,6 +82,7 @@ const RULES: readonly Rule[] = [
     secret: true
   },
   { name: "AWCMS_SYNC_MAX_SKEW_SEC", required: false, type: "int", min: 1 },
+  { name: "SYNC_HMAC_ALLOW_LEGACY", required: false, type: "bool" },
 
   {
     name: "STORAGE_DRIVER",

--- a/sql/021_awcms_db_role_grants_narrow.sql
+++ b/sql/021_awcms_db_role_grants_narrow.sql
@@ -1,0 +1,97 @@
+-- Issue #160 (area:security, area:database) — narrow `awcms_app`'s blanket DML
+-- on the GLOBAL, RLS-free tables. Follow-up to `sql/019_awcms_db_role_
+-- separation.sql`, which deliberately ported awcms-mini's blanket-DML role
+-- (its migration 013) exactly, leaving the per-table narrowing (mini's later
+-- migration 045) for a separate, deployment-affecting migration. This is it —
+-- for the `awcms_app` half only (see SCOPE below).
+--
+-- WHY THIS EXISTS (residual confirmed by the PR #159 security audit, verified
+-- empirically as `awcms_app` on Postgres 18): `sql/019` grants
+-- `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public`. That
+-- is correct and safe on the tenant-scoped tables — RLS `FORCE` (sql/017) is
+-- the real row-level boundary there, and the table-level grant is coarse by
+-- design (ADR-0003). But it ALSO covers the nine GLOBAL tables that have NO
+-- row-level security at all, so RLS cannot claw any of it back. On those,
+-- `awcms_app` held DML it never uses at runtime:
+--   * `UPDATE awcms_permissions`      — the permission catalog (read-only at
+--                                        runtime; seeded only by migrations).
+--   * `DELETE awcms_schema_migrations` — the migration ledger (written only by
+--                                        `bun run db:migrate`, as the owner).
+--   * `DELETE awcms_tenants`           — deleting another tenant's root row.
+-- A compromised runtime connection could corrupt the migration ledger or the
+-- permission catalog. This migration removes exactly that excess and nothing
+-- that a real code path uses.
+--
+-- SCOPE — `awcms_app` ONLY; the worker/setup role split is deferred (Issue
+-- #160 also proposes porting mini 045's `awcms_worker`/`awcms_setup` split).
+-- That split needs a per-write-path audit of all seven `getWorkerDatabaseClient`
+-- scripts and the setup bootstrap, PLUS a `src/lib/database/client.ts` fallback
+-- change to make `WORKER_DATABASE_URL`/`SETUP_DATABASE_URL` map to real roles —
+-- a change that breaks every deployment that has not opted into those URLs
+-- (mini's own attempt surfaced 423 fixture failures through the setup fallback
+-- path). mini itself only did the split after 30+ migrations of the blanket
+-- role in production. Narrowing `awcms_app` here fully closes the confirmed
+-- residual on its own; the split is defense-in-depth beyond it and is left as a
+-- follow-up rather than half-done. Doc 18 §Model role database records this.
+--
+-- WHAT IS DELIBERATELY KEPT (verified by grepping every write path, not
+-- assumed — same discipline mini's 045 header documents):
+--   * `awcms_tenants`     — DELETE revoked, but SELECT/INSERT/UPDATE KEPT.
+--       INSERT: `platform-bootstrap.ts` creates the tenant row through the
+--       setup path, which FALLS BACK to the `awcms_app` connection when
+--       `SETUP_DATABASE_URL` is unset (`getSetupDatabaseClient`). UPDATE:
+--       `tenant-settings-directory.ts` edits tenant name/legal name/locale/
+--       theme at request time AS `awcms_app` (the web runtime). Revoking
+--       either would break the setup wizard and the tenant-settings screen.
+--   * `awcms_setup_state` — DELETE revoked, but SELECT/INSERT/UPDATE KEPT.
+--       `platform-bootstrap.ts` INSERTs the singleton lock and UPDATEs it with
+--       the new tenant id, again through the `awcms_app` setup-fallback path.
+--       Nothing ever deletes the setup-state singleton.
+--   * The five module-registry tables (`awcms_modules`,
+--     `awcms_module_dependencies`, `awcms_module_navigation`,
+--     `awcms_module_jobs`, `awcms_module_health_checks`) — full DML KEPT.
+--     `descriptor-sync.ts` (INSERT/UPDATE/DELETE) and `health-registry.ts`
+--     (INSERT) genuinely write these at runtime through the module-management
+--     module. Not part of the confirmed residual; left untouched.
+--
+-- Read-only narrowing (INSERT/UPDATE/DELETE revoked, SELECT kept):
+--   * `awcms_permissions`       — never written by any runtime code path
+--     (permission-sync.ts only SELECTs; the module README states it "never
+--     writes to the catalog"). Migrations seed it.
+--   * `awcms_schema_migrations` — written only by the migration runner
+--     (`scripts/db-migrate.ts`), which connects as the owner, never `awcms_app`.
+--
+-- The `ALTER DEFAULT PRIVILEGES` from `sql/019` is INTENTIONALLY LEFT AS-IS: it
+-- keeps auto-granting full DML on FUTURE tenant-scoped tables (so a new
+-- tenant table cannot ship unreachable-at-runtime). The nine global tables all
+-- already exist, so a per-table REVOKE on them is permanent — default
+-- privileges only affect tables created LATER. The regression guard for a
+-- FUTURE global table silently inheriting blanket DML again is the new
+-- `checkRuntimeRoleGrants` grant check in `scripts/security-readiness.ts`
+-- (Issue #160), which is where "trust every future migration to narrow itself"
+-- is replaced by a real assertion.
+--
+-- NO DML in this migration (only REVOKE — pure DDL, idempotent, re-appliable):
+-- it therefore does NOT touch a `FORCE ROW LEVEL SECURITY` table's rows, so the
+-- `NO FORCE` -> DML -> `FORCE` pattern (`sql/018`/`020`) is not needed here.
+-- `REVOKE` on a privilege the role does not hold is a silent no-op, so re-runs
+-- are safe. Depends on `sql/019` having created `awcms_app` (migrations run in
+-- order; 019 always creates it before 021 runs).
+
+BEGIN;
+
+-- 1. Read-only global catalogs — no runtime write path, dedicated role or
+-- fallback. Revoke every write, keep SELECT.
+REVOKE INSERT, UPDATE, DELETE ON awcms_permissions FROM awcms_app;
+REVOKE INSERT, UPDATE, DELETE ON awcms_schema_migrations FROM awcms_app;
+
+-- 2. Tenant root + setup singleton — only DELETE is excess. INSERT/UPDATE/SELECT
+-- stay: both are written at runtime by `awcms_app` (setup fallback path and, for
+-- awcms_tenants, the tenant-settings screen). See header for the exact callers.
+REVOKE DELETE ON awcms_tenants FROM awcms_app;
+REVOKE DELETE ON awcms_setup_state FROM awcms_app;
+
+-- The five module-registry tables keep their full DML grant from `sql/019`
+-- (genuine request-time writes via descriptor-sync/health-registry) — no REVOKE.
+
+COMMIT;

--- a/src/lib/database/client.ts
+++ b/src/lib/database/client.ts
@@ -125,7 +125,12 @@ function buildClient(databaseUrl: string, kind: ClientKind): Bun.SQL {
  *   deployment activates LOGIN + a secret and points `DATABASE_URL` at it —
  *   doc 18 §Model role database). Not superuser, not BYPASSRLS, not the
  *   tables' owner, so RLS is genuinely enforced against it, with a
- *   fail-closed default `app.current_tenant_id` GUC as the backstop.
+ *   fail-closed default `app.current_tenant_id` GUC as the backstop. Its
+ *   blanket DML on the RLS-free global tables was narrowed by
+ *   `sql/021_awcms_db_role_grants_narrow.sql` (Issue #160): it can no longer
+ *   DELETE `awcms_tenants`, DELETE `awcms_schema_migrations`, or write
+ *   `awcms_permissions`. The worker/setup role split (mini's migration 045)
+ *   is still deferred — see below.
  * - `worker` -> `WORKER_DATABASE_URL`, `setup` -> `SETUP_DATABASE_URL` —
  *   these are connection/pool seams ONLY. This repo ships NO `awcms_worker`
  *   / `awcms_setup` role for them to point at (that is awcms-mini's later

--- a/src/modules/_shared/keyset-pagination.ts
+++ b/src/modules/_shared/keyset-pagination.ts
@@ -10,19 +10,68 @@
  * from, never `OFFSET`. A malformed/forged cursor value is rejected with
  * `400 VALIDATION_ERROR` rather than silently ignored, since accepting junk
  * input silently is how cursor bugs go unnoticed.
+ *
+ * PRECISION — WHY `createdAt` IS TEXT, NOT A JS `Date` (Issue #158):
+ * `timestamptz` stores MICROSECONDS; a JS `Date` holds only milliseconds,
+ * and the driver floors the microseconds when it materialises a row's
+ * `created_at` as a `Date` (`...:00.029058+00` arrives as `...:00.029Z`,
+ * verified against PostgreSQL 18 — it truncates, not rounds). A cursor built
+ * from that `Date` therefore denotes an instant strictly EARLIER than the row
+ * it came from, so `(created_at, id) < (cursor)` skips every row that shares
+ * that millisecond — including rows never yet shown, unreachable by any later
+ * cursor. Measured: 105 rows → page 2 returned 4; a batch-insert sharing one
+ * millisecond → page 2 returned 0.
+ *
+ * The fix (chosen over truncating both sides to milliseconds, which would put
+ * an expression in `ORDER BY` and risk dropping the `(tenant_id, created_at
+ * DESC)` index): carry the FULL microsecond precision through the cursor as
+ * text and never route it through a JS `Date`. The SQL side exposes the value
+ * via `KEYSET_CURSOR_CREATED_AT_SQL` (a canonical UTC ISO-8601 string with
+ * microseconds), the cursor stores that string verbatim, and the WHERE clause
+ * binds it back as `${cursor.createdAt}::timestamptz` — an exact,
+ * index-friendly comparison on bare `(created_at, id)`.
  */
 
 export type KeysetCursor = {
-  createdAt: Date;
+  /**
+   * Full-precision `timestamptz` as text, e.g.
+   * `"2026-07-17T10:00:00.029058+00:00"` — NOT a JS `Date` (which would lose
+   * the microseconds). Produced by `KEYSET_CURSOR_CREATED_AT_SQL` and bound
+   * back with an explicit `::timestamptz` cast; see the module note above.
+   */
+  createdAt: string;
   id: string;
 };
 
 const CURSOR_SEPARATOR = "|";
 
-/** Encode a row's `(created_at, id)` into an opaque pagination cursor. */
-export function encodeKeysetCursor(createdAt: Date, id: string): string {
+/**
+ * SQL expression a paginated query must SELECT (aliased, conventionally
+ * `AS created_at_cursor`) to obtain the full-precision text that
+ * {@link encodeKeysetCursor} expects. `to_char(... AT TIME ZONE 'UTC', ...)`
+ * renders the instant at UTC with 6 fractional digits (`US`) so the value is
+ * deterministic regardless of the session `TimeZone`, and re-parsing it with
+ * `::timestamptz` yields the exact same instant (round-trip verified against
+ * PostgreSQL 18). `created_at` here refers to the row's own column; wrap it in
+ * a table alias at the call site if the query joins (e.g. `t.created_at`).
+ */
+export const KEYSET_CURSOR_CREATED_AT_SQL =
+  "to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:MI:SS.US\"+00:00\"')";
+
+/**
+ * Encode a row's `(created_at, id)` into an opaque pagination cursor.
+ *
+ * `createdAtCursor` MUST be the full-precision text the row exposes for this
+ * purpose (select {@link KEYSET_CURSOR_CREATED_AT_SQL}), NOT
+ * `row.created_at.toISOString()` — a JS `Date` has already dropped the
+ * microseconds and would resurrect the row-skipping bug (Issue #158).
+ */
+export function encodeKeysetCursor(
+  createdAtCursor: string,
+  id: string
+): string {
   return Buffer.from(
-    `${createdAt.toISOString()}${CURSOR_SEPARATOR}${id}`,
+    `${createdAtCursor}${CURSOR_SEPARATOR}${id}`,
     "utf-8"
   ).toString("base64url");
 }
@@ -31,11 +80,24 @@ const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
+ * Accepts an ISO-8601 timestamp with an optional fractional part of 1–6
+ * digits and either a `Z` or `±HH:MM` offset. Deliberately lenient about the
+ * fractional width so both the microsecond cursors this module now emits
+ * (`.029058+00:00`) and any millisecond cursor minted by an older build
+ * (`.029Z`) decode and re-bind cleanly as `::timestamptz`.
+ */
+const TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
  * Decode and validate a client-supplied cursor. Returns `null` for a
  * malformed value (not a validly-shaped ISO timestamp + UUID pair) so the
  * caller can respond `400 VALIDATION_ERROR` — a corrupt cursor must never be
  * treated as "no cursor" (that would silently show page 1 instead of
  * signalling the error to the caller).
+ *
+ * `createdAt` is returned as the verbatim text (never a `Date`) so the
+ * microsecond precision survives all the way to the SQL `::timestamptz` bind.
  */
 export function decodeKeysetCursor(cursor: string): KeysetCursor | null {
   let decoded: string;
@@ -52,11 +114,18 @@ export function decodeKeysetCursor(cursor: string): KeysetCursor | null {
     return null;
   }
 
-  const createdAtRaw = decoded.slice(0, separatorIndex);
+  const createdAt = decoded.slice(0, separatorIndex);
   const id = decoded.slice(separatorIndex + 1);
-  const createdAt = new Date(createdAtRaw);
 
-  if (Number.isNaN(createdAt.getTime()) || !UUID_PATTERN.test(id)) {
+  if (!TIMESTAMP_PATTERN.test(createdAt) || !UUID_PATTERN.test(id)) {
+    return null;
+  }
+
+  // Shape is valid; reject an out-of-range date (e.g. month 13) that the
+  // regex admits but `::timestamptz` would throw on — a 500 the caller
+  // cannot act on. `Date` is used ONLY for this validity probe, never for the
+  // value we return.
+  if (Number.isNaN(new Date(createdAt).getTime())) {
     return null;
   }
 

--- a/src/modules/email/application/email-message-directory.ts
+++ b/src/modules/email/application/email-message-directory.ts
@@ -8,7 +8,10 @@
  * keyset-pagination shape. Never selects `to_address` — only
  * `to_address_masked` (doc 04 §Alur perlindungan data sensitif).
  */
-import type { KeysetCursor } from "../../_shared/keyset-pagination";
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
 
 export const EMAIL_MESSAGE_LIST_LIMIT = 100;
 
@@ -46,7 +49,15 @@ type EmailMessageRow = {
   retry_count: number;
   last_error: string | null;
   created_at: Date;
+  // Full-precision cursor text (Issue #158) — kept out of the response DTO;
+  // see `_shared/keyset-pagination` for why a JS `Date` cannot carry it.
+  created_at_cursor: string;
   sent_at: Date | null;
+};
+
+export type EmailMessageListPage = {
+  messages: EmailMessageEntry[];
+  nextCursor: string | null;
 };
 
 function toView(row: EmailMessageRow): EmailMessageEntry {
@@ -65,12 +76,22 @@ function toView(row: EmailMessageRow): EmailMessageEntry {
   };
 }
 
+/**
+ * One keyset-paginated page of email messages, newest first.
+ *
+ * The cursor is generated HERE (not in the route) so the full microsecond
+ * precision of `created_at` survives — a route that rebuilt the cursor from
+ * the response DTO's `createdAt` (a JS `Date`/ISO-ms string) would floor the
+ * microseconds and silently skip every message sharing that millisecond
+ * across the page boundary (Issue #158). `created_at_cursor` carries the
+ * full-precision text and never leaves this function.
+ */
 export async function fetchEmailMessageEntries(
   tx: Bun.SQL,
   tenantId: string,
   statusFilter?: EmailMessageStatus,
   cursor?: KeysetCursor
-): Promise<EmailMessageEntry[]> {
+): Promise<EmailMessageListPage> {
   const cursorCreatedAt = cursor?.createdAt ?? null;
   const cursorId = cursor?.id ?? null;
 
@@ -78,7 +99,9 @@ export async function fetchEmailMessageEntries(
     statusFilter
       ? await tx`
         SELECT id, correlation_id, category, status, priority, to_address_masked,
-               subject, retry_count, last_error, created_at, sent_at
+               subject, retry_count, last_error, created_at,
+               to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor,
+               sent_at
         FROM awcms_email_messages
         WHERE tenant_id = ${tenantId} AND status = ${statusFilter}
           AND (
@@ -90,7 +113,9 @@ export async function fetchEmailMessageEntries(
       `
       : await tx`
         SELECT id, correlation_id, category, status, priority, to_address_masked,
-               subject, retry_count, last_error, created_at, sent_at
+               subject, retry_count, last_error, created_at,
+               to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor,
+               sent_at
         FROM awcms_email_messages
         WHERE tenant_id = ${tenantId}
           AND (
@@ -102,7 +127,13 @@ export async function fetchEmailMessageEntries(
       `
   ) as EmailMessageRow[];
 
-  return rows.map(toView);
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === EMAIL_MESSAGE_LIST_LIMIT && last
+      ? encodeKeysetCursor(last.created_at_cursor, last.id)
+      : null;
+
+  return { messages: rows.map(toView), nextCursor };
 }
 
 export type CancelEmailMessageResult =

--- a/src/modules/sync-storage/README.md
+++ b/src/modules/sync-storage/README.md
@@ -79,15 +79,36 @@ Schema: `sql/012_awcms_object_sync_queue_schema.sql`.
 The node-to-node endpoints (`/sync/push`, `/sync/pull`, `/sync/status`,
 `/sync/objects`, `/sync/objects/status`) are machine-to-machine and do **not**
 use bearer token/session. They authenticate via HMAC headers
-(`X-AWCMS-Node-ID`, `X-AWCMS-Timestamp`, `X-AWCMS-Signature`) with a single
-deployment-wide secret from the environment (`AWCMS_SYNC_HMAC_SECRET`). The
-signature is `HMAC-SHA256("<timestamp>.<body>")`, verified with a timing-safe
-compare against a max skew (`AWCMS_SYNC_MAX_SKEW_SEC`, default 300s) for
-anti-replay. `X-AWCMS-Tenant-ID` is required for tenant isolation.
+(`X-AWCMS-Node-ID`, `X-AWCMS-Timestamp`, `X-AWCMS-Signature`,
+`X-AWCMS-Signature-Version`) with a single deployment-wide secret from the
+environment (`AWCMS_SYNC_HMAC_SECRET`), verified with a timing-safe compare
+against a max skew (`AWCMS_SYNC_MAX_SKEW_SEC`, default 300s) for anti-replay.
+`X-AWCMS-Tenant-ID` is required for tenant isolation.
+
+### Signature versions (security advisory GHSA-c972-3q5p-g3h4)
+
+- **v2 (canonical)** — `HMAC-SHA256("v2:<tenantId>:<nodeCode>:<timestamp>:<body>")`.
+  The tenant and node are **inside** the signed material, so a signature minted
+  for one tenant no longer verifies when `X-AWCMS-Tenant-ID` is swapped to
+  another tenant. Nodes send `X-AWCMS-Signature-Version: 2`. This is the
+  canonical scheme, mirrored across awcms, awcms-mini, and the `awcms-sync-hmac`
+  skill.
+- **v1 (legacy, VULNERABLE)** — `HMAC-SHA256("<timestamp>.<body>")`, used when no
+  `X-AWCMS-Signature-Version` header is sent. Neither tenant nor node is bound,
+  so it is **cross-tenant forgeable** and is kept only so already-deployed nodes
+  keep working during migration. It is accepted while `SYNC_HMAC_ALLOW_LEGACY`
+  is not `false` (env, default allow). **Set `SYNC_HMAC_ALLOW_LEGACY=false` once
+  every node has moved to v2 to reject v1 and close the cross-tenant hole
+  completely.** The advisory is only fully closed when legacy is disabled AND
+  every node is on v2.
 
 Endpoints return `403` when `AWCMS_SYNC_ENABLED` is not `true`, and `403` for
-any node whose status is not `active` (deactivating a node via the admin
-endpoint takes effect immediately across push/pull/status/objects).
+any node whose status is not `active`. First-contact nodes now auto-register
+`inactive` (advisory GHSA-c972-3q5p-g3h4) — an admin must approve them via
+`PATCH /api/v1/sync/nodes/{id}` (`status: "active"`) before they can push/pull.
+This quarantines a forged first-contact node id for another tenant. Nodes
+already `active` are unaffected; deactivating a node via the admin endpoint
+takes effect immediately across push/pull/status/objects.
 
 ## Admin surfaces (session-authenticated)
 

--- a/src/modules/sync-storage/application/sync-auth.ts
+++ b/src/modules/sync-storage/application/sync-auth.ts
@@ -1,6 +1,8 @@
 import {
   isTimestampWithinSkew,
-  verifySyncSignature
+  SYNC_SIGNATURE_VERSION_V2,
+  verifySyncSignature,
+  verifySyncSignatureV2
 } from "../domain/sync-hmac";
 
 export type SyncAuthFailure = {
@@ -17,9 +19,33 @@ export type SyncAuthSuccess = {
 
 const DEFAULT_MAX_SKEW_SECONDS = 300;
 
+/**
+ * Whether legacy (v1) sync signatures are still accepted. Default `true` so
+ * already-deployed nodes keep working during the v2 migration. Operators close
+ * the cross-tenant hole (GHSA-c972-3q5p-g3h4) completely by setting
+ * `SYNC_HMAC_ALLOW_LEGACY=false` once every node has moved to v2 — v1 remains
+ * cross-tenant forgeable while it is accepted.
+ */
+function legacyAllowed(): boolean {
+  return process.env.SYNC_HMAC_ALLOW_LEGACY !== "false";
+}
+
+/**
+ * Verify the HMAC auth headers of a node-to-node sync request.
+ *
+ * Prefers v2 (tenant+node bound). A request carrying
+ * `X-AWCMS-Signature-Version: 2` is verified against the v2 material only —
+ * there is no v1 fallback for it, so swapping `X-AWCMS-Tenant-ID` invalidates
+ * the signature. A request without that header (or with version `1`) is a
+ * legacy v1 request and is accepted only while `SYNC_HMAC_ALLOW_LEGACY` is not
+ * `false`.
+ */
 export function verifySyncHeaders(
+  tenantId: string,
+  nodeCode: string,
   timestamp: string | null,
   signature: string | null,
+  signatureVersion: string | null,
   rawBody: string
 ): SyncAuthFailure | { ok: true } {
   if (process.env.AWCMS_SYNC_ENABLED !== "true") {
@@ -64,6 +90,41 @@ export function verifySyncHeaders(
     };
   }
 
+  if (signatureVersion === SYNC_SIGNATURE_VERSION_V2) {
+    if (
+      !verifySyncSignatureV2(
+        secret,
+        tenantId,
+        nodeCode,
+        timestamp,
+        rawBody,
+        signature
+      )
+    ) {
+      return {
+        ok: false,
+        status: 401,
+        code: "AUTH_REQUIRED",
+        message: "Invalid sync signature."
+      };
+    }
+
+    return { ok: true };
+  }
+
+  // No (or v1) version header: legacy signature. Reject entirely once the
+  // operator has disabled legacy — this is the switch that fully closes the
+  // cross-tenant hole for a fleet that has finished migrating to v2.
+  if (!legacyAllowed()) {
+    return {
+      ok: false,
+      status: 401,
+      code: "AUTH_REQUIRED",
+      message:
+        "Legacy sync signatures are disabled; send X-AWCMS-Signature-Version: 2."
+    };
+  }
+
   if (!verifySyncSignature(secret, timestamp, rawBody, signature)) {
     return {
       ok: false,
@@ -76,6 +137,19 @@ export function verifySyncHeaders(
   return { ok: true };
 }
 
+/**
+ * Resolve an existing sync node, or register an unknown one as `inactive`.
+ *
+ * Auto-registration is intentionally `inactive` (security advisory
+ * GHSA-c972-3q5p-g3h4): a first-contact node id is quarantined until an admin
+ * approves it via `PATCH /api/v1/sync/nodes/{id}` (`status: "active"`). This
+ * closes the "new node id" path — an attacker who forges a request for another
+ * tenant lands on an inactive node and is rejected by the `status !== "active"`
+ * gate in every sync route. Nodes already `active` are unaffected. The column
+ * default is `active` (`sql/010`) for historical rows; the INSERT here makes
+ * the status explicit so new rows land inactive without editing an applied
+ * migration.
+ */
 export async function resolveOrRegisterSyncNode(
   tx: Bun.SQL,
   tenantId: string,
@@ -91,8 +165,8 @@ export async function resolveOrRegisterSyncNode(
   }
 
   const inserted = await tx`
-    INSERT INTO awcms_sync_nodes (tenant_id, node_code, node_name)
-    VALUES (${tenantId}, ${nodeCode}, ${nodeCode})
+    INSERT INTO awcms_sync_nodes (tenant_id, node_code, node_name, status)
+    VALUES (${tenantId}, ${nodeCode}, ${nodeCode}, 'inactive')
     ON CONFLICT (tenant_id, node_code) DO NOTHING
     RETURNING id, status
   `;

--- a/src/modules/sync-storage/application/sync-directory.ts
+++ b/src/modules/sync-storage/application/sync-directory.ts
@@ -6,7 +6,10 @@
  * Access & Users endpoints and `admin/access-users.astro`.
  */
 
-import type { KeysetCursor } from "../../_shared/keyset-pagination";
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
 
 export type SyncNodeSummary = {
   nodeId: string;
@@ -82,6 +85,14 @@ type ObjectQueueRow = {
   requires_upload: boolean;
   uploaded_at: Date | null;
   created_at: Date;
+  // Full-precision cursor text (Issue #158) — kept out of the response DTO;
+  // see `_shared/keyset-pagination` for why a JS `Date` cannot carry it.
+  created_at_cursor: string;
+};
+
+export type ObjectQueuePage = {
+  objects: ObjectQueueEntry[];
+  nextCursor: string | null;
 };
 
 export const OBJECT_QUEUE_LIMIT = 200;
@@ -109,17 +120,18 @@ export const OBJECT_QUEUE_LIMIT = 200;
  * `cursor` (optional, keyset `(created_at, id) < (cursor)`, doc: skill
  * `awcms-performance` §Pagination keyset) lets `GET
  * /api/v1/sync/object-queue` page past the first `OBJECT_QUEUE_LIMIT`
- * (200) rows without `OFFSET`. `admin/sync.astro`'s SSR call (only ever
- * `status: "failed"`, first page) omits it, so its existing
- * `Awaited<ReturnType<typeof fetchObjectQueueEntries>>`/array usage is
- * unaffected.
+ * (200) rows without `OFFSET`. `nextCursor` is built HERE, from the
+ * full-precision `created_at_cursor` text, rather than in the route — a route
+ * that rebuilt it from the DTO's `createdAt` (a JS `Date`) would floor the
+ * microseconds and skip every row sharing that millisecond across the page
+ * boundary (Issue #158).
  */
 export async function fetchObjectQueueEntries(
   tx: Bun.SQL,
   tenantId: string,
   statusFilter?: "pending" | "sent" | "failed",
   cursor?: KeysetCursor
-): Promise<ObjectQueueEntry[]> {
+): Promise<ObjectQueuePage> {
   const cursorCreatedAt = cursor?.createdAt ?? null;
   const cursorId = cursor?.id ?? null;
 
@@ -128,10 +140,11 @@ export async function fetchObjectQueueEntries(
       ? await tx`
         SELECT q.id, q.node_id, n.node_code, q.object_key, q.status, q.retry_count,
                q.next_retry_at, q.last_error, q.byte_size, q.requires_upload,
-               q.uploaded_at, q.created_at
+               q.uploaded_at, q.created_at, q.created_at_cursor
         FROM (
           SELECT id, node_id, object_key, status, retry_count, next_retry_at,
                  last_error, byte_size, requires_upload, uploaded_at, created_at,
+                 to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor,
                  tenant_id
           FROM awcms_object_sync_queue
           WHERE tenant_id = ${tenantId} AND status = ${statusFilter}
@@ -148,10 +161,11 @@ export async function fetchObjectQueueEntries(
       : await tx`
         SELECT q.id, q.node_id, n.node_code, q.object_key, q.status, q.retry_count,
                q.next_retry_at, q.last_error, q.byte_size, q.requires_upload,
-               q.uploaded_at, q.created_at
+               q.uploaded_at, q.created_at, q.created_at_cursor
         FROM (
           SELECT id, node_id, object_key, status, retry_count, next_retry_at,
                  last_error, byte_size, requires_upload, uploaded_at, created_at,
+                 to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor,
                  tenant_id
           FROM awcms_object_sync_queue
           WHERE tenant_id = ${tenantId}
@@ -167,18 +181,27 @@ export async function fetchObjectQueueEntries(
       `
   ) as ObjectQueueRow[];
 
-  return rows.map((row) => ({
-    objectQueueId: row.id,
-    nodeId: row.node_id,
-    nodeCode: row.node_code,
-    objectKey: row.object_key,
-    status: row.status,
-    retryCount: Number(row.retry_count),
-    nextRetryAt: row.next_retry_at?.toISOString() ?? null,
-    lastError: row.last_error,
-    byteSize: Number(row.byte_size),
-    requiresUpload: row.requires_upload,
-    uploadedAt: row.uploaded_at?.toISOString() ?? null,
-    createdAt: row.created_at.toISOString()
-  }));
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === OBJECT_QUEUE_LIMIT && last
+      ? encodeKeysetCursor(last.created_at_cursor, last.id)
+      : null;
+
+  return {
+    objects: rows.map((row) => ({
+      objectQueueId: row.id,
+      nodeId: row.node_id,
+      nodeCode: row.node_code,
+      objectKey: row.object_key,
+      status: row.status,
+      retryCount: Number(row.retry_count),
+      nextRetryAt: row.next_retry_at?.toISOString() ?? null,
+      lastError: row.last_error,
+      byteSize: Number(row.byte_size),
+      requiresUpload: row.requires_upload,
+      uploadedAt: row.uploaded_at?.toISOString() ?? null,
+      createdAt: row.created_at.toISOString()
+    })),
+    nextCursor
+  };
 }

--- a/src/modules/sync-storage/domain/sync-hmac.ts
+++ b/src/modules/sync-storage/domain/sync-hmac.ts
@@ -1,5 +1,37 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 
+/**
+ * Versioned sync HMAC signatures (security advisory GHSA-c972-3q5p-g3h4).
+ *
+ * v1 (legacy, VULNERABLE): `HMAC(secret, "<timestamp>.<body>")`. Neither the
+ * tenant nor the node is part of the signed material, so — combined with a
+ * single deployment-wide secret — a signature computed for one tenant is
+ * byte-for-byte valid for *every* tenant. It is kept only so already-deployed
+ * nodes keep working during migration, and only while
+ * `SYNC_HMAC_ALLOW_LEGACY` is not `false`.
+ *
+ * v2 (canonical): binds tenant + node into the signed material with an explicit
+ * version tag:
+ *
+ *   HMAC(secret, "v2:<tenantId>:<nodeCode>:<timestamp>:<body>")
+ *
+ * A v2 signature minted for tenant A no longer verifies when the request's
+ * `X-AWCMS-Tenant-ID` header is swapped to tenant B, because the tenant id is
+ * inside the signed material (different material → different HMAC). v2 is the
+ * canonical scheme mirrored across awcms, awcms-mini, and the `awcms-sync-hmac`
+ * skill; nodes MUST send `X-AWCMS-Signature-Version: 2`.
+ *
+ * Field constraints that keep the v2 material unambiguous: `tenantId` is a
+ * UUID and `nodeCode` / `timestamp` come from HTTP headers, which cannot
+ * contain the `:` delimiter's problematic neighbours (raw CR/LF) — and `body`
+ * is the trailing field, so any `:` it contains cannot shift an earlier field
+ * boundary.
+ */
+
+export const SYNC_SIGNATURE_VERSION_HEADER = "X-AWCMS-Signature-Version";
+export const SYNC_SIGNATURE_VERSION_V2 = "2";
+
+/** v1 legacy material — tenant/node NOT bound (see file header). */
 export function computeSyncSignature(
   secret: string,
   timestamp: string,
@@ -10,21 +42,55 @@ export function computeSyncSignature(
     .digest("hex");
 }
 
-export function verifySyncSignature(
+/** v2 canonical material — binds tenant + node into the signature. */
+export function computeSyncSignatureV2(
   secret: string,
+  tenantId: string,
+  nodeCode: string,
   timestamp: string,
-  body: string,
-  providedSignature: string
-): boolean {
-  const expected = computeSyncSignature(secret, timestamp, body);
+  body: string
+): string {
+  return createHmac("sha256", secret)
+    .update(`v2:${tenantId}:${nodeCode}:${timestamp}:${body}`)
+    .digest("hex");
+}
+
+/** Timing-safe comparison of two hex-encoded digests. */
+function timingSafeHexEqual(expected: string, provided: string): boolean {
   const expectedBuffer = Buffer.from(expected, "hex");
-  const providedBuffer = Buffer.from(providedSignature, "hex");
+  const providedBuffer = Buffer.from(provided, "hex");
 
   if (expectedBuffer.length !== providedBuffer.length) {
     return false;
   }
 
   return timingSafeEqual(expectedBuffer, providedBuffer);
+}
+
+export function verifySyncSignature(
+  secret: string,
+  timestamp: string,
+  body: string,
+  providedSignature: string
+): boolean {
+  return timingSafeHexEqual(
+    computeSyncSignature(secret, timestamp, body),
+    providedSignature
+  );
+}
+
+export function verifySyncSignatureV2(
+  secret: string,
+  tenantId: string,
+  nodeCode: string,
+  timestamp: string,
+  body: string,
+  providedSignature: string
+): boolean {
+  return timingSafeHexEqual(
+    computeSyncSignatureV2(secret, tenantId, nodeCode, timestamp, body),
+    providedSignature
+  );
 }
 
 export function isTimestampWithinSkew(

--- a/src/modules/tenant-admin/application/office-directory.ts
+++ b/src/modules/tenant-admin/application/office-directory.ts
@@ -106,34 +106,22 @@ export type OfficeListPage = {
  * tiebreaker in both the comparison and the ORDER BY, such rows would be
  * skipped or repeated across a page boundary.
  *
- * WHY `date_trunc('milliseconds', ...)` AND NOT BARE `created_at`:
- * the sort key must be expressed at the SAME precision the cursor can carry,
- * or the keyset silently loses rows. `encodeKeysetCursor` serialises a JS
- * `Date`, which holds milliseconds, while `timestamptz` holds MICROSECONDS —
- * and the driver has already floored them on the way out (`...:45.029058+00`
- * arrives as `...:45.029Z`; verified against PostgreSQL 18 that the driver
- * truncates rather than rounds, for `.029058`, `.029958` and `.029999`
- * alike). A cursor built from that Date therefore denotes an instant strictly
- * EARLIER than the row it came from, so a bare `(created_at, id) < (cursor)`
- * excludes every row sharing that millisecond regardless of id — including
- * rows never yet shown, which no subsequent cursor can reach either. Measured
- * on this table before this guard: 105 offices, page 1 returned 100, page 2
- * returned 4. One office silently unreachable.
+ * PRECISION (Issue #158): the cursor must round-trip `created_at` at the SAME
+ * precision it is compared on, or the keyset silently loses rows. A JS `Date`
+ * holds only milliseconds while `timestamptz` holds MICROSECONDS (the driver
+ * floors them on the way out — `...:45.029058+00` arrives as `...:45.029Z`),
+ * so a cursor built from a `Date` denotes an instant strictly EARLIER than
+ * the row it came from and `(created_at, id) < (cursor)` would skip every row
+ * sharing that millisecond. Measured before the fix: 105 offices → page 1
+ * returned 100, page 2 returned 4; one office silently unreachable.
  *
- * `date_trunc('milliseconds', created_at)` matches the driver's flooring
- * exactly, making the SQL-side key identical to what the cursor round-trips.
- * The pair `(trunc_ms(created_at), id)` is still a total order (`id` is
- * unique), so paging remains exact: no row skipped, none repeated. The only
- * concession is that offices created within the same millisecond order by
- * `id` rather than by microsecond — an ordering the driver cannot represent
- * to a client anyway.
- *
- * NOTE: the same precision trap applies to every other caller of the shared
- * helper (workflow inbox, object sync queue, email messages), which do compare
- * on bare `created_at`. Fixing it centrally — carrying microseconds through
- * the cursor — belongs in `_shared/keyset-pagination.ts` and is reported
- * separately; this guard keeps offices correct in the meantime and stays
- * correct either way.
+ * The fix is central (`_shared/keyset-pagination.ts`): `created_at_cursor`
+ * carries the FULL microsecond precision as UTC ISO-8601 text, the cursor
+ * stores it verbatim, and the WHERE clause binds it back with `::timestamptz`.
+ * This keeps `ORDER BY (created_at, id)` on the bare column — index-friendly
+ * (`(tenant_id, created_at DESC)`) — instead of an expression the planner
+ * might not match. This replaced an earlier local `date_trunc('milliseconds',
+ * ...)` guard, removed here now that the shared helper carries microseconds.
  */
 export async function listOffices(
   tx: Bun.SQL,
@@ -144,22 +132,23 @@ export async function listOffices(
   const cursorId = cursor?.id ?? null;
 
   const rows = (await tx`
-    SELECT id, office_code, office_name, office_type, parent_office_id, status, created_at, updated_at
+    SELECT id, office_code, office_name, office_type, parent_office_id, status, created_at, updated_at,
+           to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
     FROM awcms_offices
     WHERE tenant_id = ${tenantId}
       AND deleted_at IS NULL
       AND (
         ${cursorCreatedAt}::timestamptz IS NULL
-        OR (date_trunc('milliseconds', created_at), id) < (${cursorCreatedAt}, ${cursorId})
+        OR (created_at, id) < (${cursorCreatedAt}, ${cursorId})
       )
-    ORDER BY date_trunc('milliseconds', created_at) DESC, id DESC
+    ORDER BY created_at DESC, id DESC
     LIMIT ${OFFICE_LIST_LIMIT}
-  `) as OfficeRow[];
+  `) as (OfficeRow & { created_at_cursor: string })[];
 
   const last = rows[rows.length - 1];
   const nextCursor =
     rows.length === OFFICE_LIST_LIMIT && last
-      ? encodeKeysetCursor(last.created_at, last.id)
+      ? encodeKeysetCursor(last.created_at_cursor, last.id)
       : null;
 
   return { items: rows.map(toRecord), nextCursor };

--- a/src/modules/workflow-approval/application/workflow-inbox-directory.ts
+++ b/src/modules/workflow-approval/application/workflow-inbox-directory.ts
@@ -9,7 +9,10 @@
  * `awcms_audit_events`) rather than a new dedicated history table.
  */
 import { assertUuid } from "../../../lib/database/tenant-context";
-import { encodeKeysetCursor } from "../../_shared/keyset-pagination";
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
 
 export type WorkflowTaskListFilters = {
   workflowKey?: string;
@@ -54,7 +57,7 @@ export async function listWorkflowInboxTasks(
   tenantId: string,
   filters: WorkflowTaskListFilters,
   now: Date,
-  cursor: { createdAt: Date; id: string } | null
+  cursor: KeysetCursor | null
 ): Promise<WorkflowTaskListResult> {
   const safeTenantId = assertUuid(tenantId);
   const statusFilter = filters.status ?? "pending";
@@ -71,6 +74,8 @@ export async function listWorkflowInboxTasks(
     quorum_rule: string;
     due_at: Date | null;
     created_at: Date;
+    // Full-precision cursor text (Issue #158) — see `_shared/keyset-pagination`.
+    created_at_cursor: string;
     instance_id: string;
     resource_type: string;
     resource_id: string;
@@ -82,6 +87,7 @@ export async function listWorkflowInboxTasks(
 
   const rows = (await tx`
     SELECT t.id, t.node_id, t.status, t.quorum_rule, t.due_at, t.created_at,
+           to_char(t.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor,
            i.id AS instance_id, i.resource_type, i.resource_id,
            i.requested_by_tenant_user_id,
            d.id AS definition_id, d.workflow_key, d.name AS definition_name
@@ -110,7 +116,7 @@ export async function listWorkflowInboxTasks(
   const nextCursor =
     rows.length === TASK_LIST_LIMIT
       ? encodeKeysetCursor(
-          rows[rows.length - 1]!.created_at,
+          rows[rows.length - 1]!.created_at_cursor,
           rows[rows.length - 1]!.id
         )
       : null;

--- a/src/pages/api/v1/email/messages/index.ts
+++ b/src/pages/api/v1/email/messages/index.ts
@@ -9,14 +9,10 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import {
-  EMAIL_MESSAGE_LIST_LIMIT,
   fetchEmailMessageEntries,
   type EmailMessageStatus
 } from "../../../../../modules/email/application/email-message-directory";
-import {
-  decodeKeysetCursor,
-  encodeKeysetCursor
-} from "../../../../../modules/_shared/keyset-pagination";
+import { decodeKeysetCursor } from "../../../../../modules/_shared/keyset-pagination";
 
 const READ_GUARD = {
   moduleKey: "email",
@@ -88,20 +84,12 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
       return auth.denied;
     }
 
-    const messages = await fetchEmailMessageEntries(
+    const { messages, nextCursor } = await fetchEmailMessageEntries(
       tx,
       tenantId,
       (statusParam as EmailMessageStatus | null) ?? undefined,
       cursor ?? undefined
     );
-
-    const nextCursor =
-      messages.length === EMAIL_MESSAGE_LIST_LIMIT
-        ? encodeKeysetCursor(
-            new Date(messages[messages.length - 1]!.createdAt),
-            messages[messages.length - 1]!.id
-          )
-        : null;
 
     return ok({ messages, nextCursor });
   });

--- a/src/pages/api/v1/sync/object-queue/index.ts
+++ b/src/pages/api/v1/sync/object-queue/index.ts
@@ -8,14 +8,8 @@ import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
-import {
-  fetchObjectQueueEntries,
-  OBJECT_QUEUE_LIMIT
-} from "../../../../../modules/sync-storage/application/sync-directory";
-import {
-  decodeKeysetCursor,
-  encodeKeysetCursor
-} from "../../../../../modules/_shared/keyset-pagination";
+import { fetchObjectQueueEntries } from "../../../../../modules/sync-storage/application/sync-directory";
+import { decodeKeysetCursor } from "../../../../../modules/_shared/keyset-pagination";
 
 const READ_GUARD = {
   moduleKey: "sync_storage",
@@ -75,20 +69,12 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
       return auth.denied;
     }
 
-    const objects = await fetchObjectQueueEntries(
+    const { objects, nextCursor } = await fetchObjectQueueEntries(
       tx,
       tenantId,
       (statusParam as "pending" | "sent" | "failed" | null) ?? undefined,
       cursor ?? undefined
     );
-
-    const nextCursor =
-      objects.length === OBJECT_QUEUE_LIMIT
-        ? encodeKeysetCursor(
-            new Date(objects[objects.length - 1]!.createdAt),
-            objects[objects.length - 1]!.objectQueueId
-          )
-        : null;
 
     return ok({ objects, nextCursor });
   });

--- a/src/pages/api/v1/sync/objects/index.ts
+++ b/src/pages/api/v1/sync/objects/index.ts
@@ -32,8 +32,11 @@ export const POST: APIRoute = async ({ request }) => {
 
   const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
+    tenantId,
+    nodeCode,
     request.headers.get("x-awcms-timestamp"),
     request.headers.get("x-awcms-signature"),
+    request.headers.get("x-awcms-signature-version"),
     rawBody
   );
 

--- a/src/pages/api/v1/sync/objects/status.ts
+++ b/src/pages/api/v1/sync/objects/status.ts
@@ -33,8 +33,11 @@ export const GET: APIRoute = async ({ request }) => {
 
   const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
+    tenantId,
+    nodeCode,
     request.headers.get("x-awcms-timestamp"),
     request.headers.get("x-awcms-signature"),
+    request.headers.get("x-awcms-signature-version"),
     rawBody
   );
 

--- a/src/pages/api/v1/sync/pull.ts
+++ b/src/pages/api/v1/sync/pull.ts
@@ -34,8 +34,11 @@ export const POST: APIRoute = async ({ request }) => {
 
   const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
+    tenantId,
+    nodeCode,
     request.headers.get("x-awcms-timestamp"),
     request.headers.get("x-awcms-signature"),
+    request.headers.get("x-awcms-signature-version"),
     rawBody
   );
 

--- a/src/pages/api/v1/sync/push.ts
+++ b/src/pages/api/v1/sync/push.ts
@@ -33,8 +33,11 @@ export const POST: APIRoute = async ({ request }) => {
 
   const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
+    tenantId,
+    nodeCode,
     request.headers.get("x-awcms-timestamp"),
     request.headers.get("x-awcms-signature"),
+    request.headers.get("x-awcms-signature-version"),
     rawBody
   );
 

--- a/src/pages/api/v1/sync/status.ts
+++ b/src/pages/api/v1/sync/status.ts
@@ -31,8 +31,11 @@ export const GET: APIRoute = async ({ request }) => {
 
   const rawBody = bodyRead.value;
   const authResult = verifySyncHeaders(
+    tenantId,
+    nodeCode,
     request.headers.get("x-awcms-timestamp"),
     request.headers.get("x-awcms-signature"),
+    request.headers.get("x-awcms-signature-version"),
     rawBody
   );
 

--- a/tests/db-role-grants-narrow-migration.test.ts
+++ b/tests/db-role-grants-narrow-migration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #160 — contract tests for `sql/021_awcms_db_role_grants_narrow.sql`,
+ * the migration that narrows `awcms_app`'s blanket DML on the GLOBAL, RLS-free
+ * tables (the residual `sql/019` documented and left for a follow-up).
+ *
+ * Static-text assertions, same rationale as
+ * `db-role-separation-migration.test.ts`: the behavioural property (an
+ * `awcms_app` LOGIN can no longer DELETE a tenant but can still INSERT one
+ * through the setup path) can only be proven against a real PostgreSQL
+ * connected AS `awcms_app`, which was done manually against Postgres 18 when
+ * this shipped. What this file locks down is the ways this migration can
+ * silently rot or be regressed by an edit that "looks fine":
+ *
+ * 1. It must REVOKE exactly the confirmed-residual privileges and no more.
+ * 2. It must NOT revoke the grants real code paths depend on (INSERT/UPDATE on
+ *    awcms_tenants/awcms_setup_state — the setup fallback + tenant-settings).
+ * 3. It must contain no DML (a write to a FORCE-RLS table is green on empty CI,
+ *    red on a populated production DB).
+ * 4. It must NOT create the deferred awcms_worker/awcms_setup roles (that split
+ *    is explicitly out of scope for #160 as implemented).
+ */
+import { describe, expect, test } from "bun:test";
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const repoRoot = path.resolve(import.meta.dir, "..");
+
+function readRepoFile(relativePath: string): string {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8");
+}
+
+const MIGRATION_PATH = "sql/021_awcms_db_role_grants_narrow.sql";
+const migrationSql = readRepoFile(MIGRATION_PATH);
+
+/** Strips `--` line comments so prose about SQL is never mistaken for SQL. */
+function statementsOnly(sql: string): string {
+  return sql
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n");
+}
+
+const migrationStatements = statementsOnly(migrationSql);
+
+describe("sql/021 — revokes the confirmed residual, nothing more", () => {
+  test("revokes all writes on the read-only global catalogs", () => {
+    expect(migrationStatements).toMatch(
+      /REVOKE INSERT, UPDATE, DELETE ON awcms_permissions FROM awcms_app/
+    );
+    expect(migrationStatements).toMatch(
+      /REVOKE INSERT, UPDATE, DELETE ON awcms_schema_migrations FROM awcms_app/
+    );
+  });
+
+  test("revokes DELETE (only) on the tenant root and setup singleton", () => {
+    expect(migrationStatements).toMatch(
+      /REVOKE DELETE ON awcms_tenants FROM awcms_app/
+    );
+    expect(migrationStatements).toMatch(
+      /REVOKE DELETE ON awcms_setup_state FROM awcms_app/
+    );
+  });
+
+  test("does NOT revoke INSERT/UPDATE on awcms_tenants/awcms_setup_state", () => {
+    // The setup-wizard fallback path and the tenant-settings screen run those
+    // statements AS awcms_app; revoking them would break both. Only DELETE goes.
+    for (const table of ["awcms_tenants", "awcms_setup_state"]) {
+      expect(migrationStatements).not.toMatch(
+        new RegExp(`REVOKE[^;]*\\b(INSERT|UPDATE)\\b[^;]*ON ${table}\\b`)
+      );
+    }
+  });
+
+  test("does not touch the module-registry tables' grants", () => {
+    // Full DML is legitimately kept there (descriptor-sync/health-registry
+    // write them at request time). No REVOKE against any of them.
+    for (const table of [
+      "awcms_modules",
+      "awcms_module_dependencies",
+      "awcms_module_navigation",
+      "awcms_module_jobs",
+      "awcms_module_health_checks"
+    ]) {
+      expect(migrationStatements).not.toMatch(
+        new RegExp(`REVOKE[^;]*ON ${table}\\b`)
+      );
+    }
+  });
+});
+
+describe("sql/021 — safety invariants", () => {
+  test("contains no DML — it would break on a populated production database", () => {
+    for (const dml of [
+      /\bINSERT\s+INTO\b/i,
+      /\bUPDATE\s+awcms_/i,
+      /\bDELETE\s+FROM\b/i
+    ]) {
+      expect(migrationStatements).not.toMatch(dml);
+    }
+  });
+
+  test("does not create the deferred awcms_worker/awcms_setup roles", () => {
+    // The worker/setup split (mini migration 045) is explicitly out of scope
+    // for #160 as implemented — narrowing awcms_app closes the residual on its
+    // own. Creating those roles here without the client.ts fallback change
+    // would ship dead roles.
+    expect(migrationStatements).not.toMatch(
+      /\bCREATE ROLE (awcms_worker|awcms_setup)\b/
+    );
+  });
+
+  test("never grants awcms_app an RLS-bypassing attribute", () => {
+    for (const attribute of [
+      "SUPERUSER",
+      "BYPASSRLS",
+      "CREATEDB",
+      "CREATEROLE"
+    ]) {
+      expect(migrationStatements).not.toMatch(new RegExp(`\\b${attribute}\\b`));
+    }
+  });
+
+  test("only REVOKE/GRANT statements act on the role (pure DDL, idempotent)", () => {
+    // Every non-comment statement that names awcms_app must be a REVOKE (this
+    // migration only removes privileges). Guards against someone slipping an
+    // ALTER ROLE / GRANT / DML in later.
+    const roleStatements = migrationStatements
+      .split(";")
+      .map((statement) => statement.trim())
+      .filter((statement) => /\bawcms_app\b/.test(statement));
+
+    expect(roleStatements.length).toBeGreaterThan(0);
+    for (const statement of roleStatements) {
+      expect(statement).toMatch(/^REVOKE\b/);
+    }
+  });
+});

--- a/tests/keyset-pagination-precision-postgres.test.ts
+++ b/tests/keyset-pagination-precision-postgres.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Real-PostgreSQL proof for Issue #158 — the shared keyset cursor must carry
+ * the MICROSECOND precision of `timestamptz`, not the millisecond precision a
+ * JS `Date` can hold.
+ *
+ * The bug: `encodeKeysetCursor` used to serialise `row.created_at` as a JS
+ * `Date` (`.toISOString()`), which the driver had already floored from
+ * microseconds to milliseconds. A cursor built from `...:00.029058+00` became
+ * `...:00.029Z`, i.e. an instant strictly EARLIER than the row it came from,
+ * so `(created_at, id) < (cursor)` skipped EVERY row sharing that millisecond
+ * — page 2 came back EMPTY when a batch of rows shared one millisecond, and
+ * those rows were unreachable by any later cursor. This is silent data loss on
+ * live list endpoints.
+ *
+ * Each test below pins the failure with a batch of rows that all share one
+ * exact `created_at` (microseconds included): the FIXED directory cursor
+ * returns the remaining rows on page 2 (a clean partition), while a cursor
+ * rebuilt the OLD (millisecond-floored) way returns NOTHING — proving both the
+ * bug and its fix against the same seeded data.
+ *
+ * Gated on `DATABASE_URL` (the convention this repo's CI uses:
+ * `ci.yml` has no database and skips cleanly; `release.yml` provides a
+ * `postgres:18.4` service and sets `DATABASE_URL`, so it runs there). No
+ * `mock.module` anywhere — it mutates the live module namespace and leaks into
+ * every later test file in the process. The suite only touches tenants it
+ * creates and deletes.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import {
+  decodeKeysetCursor,
+  encodeKeysetCursor
+} from "../src/modules/_shared/keyset-pagination";
+import { listWorkflowInboxTasks } from "../src/modules/workflow-approval/application/workflow-inbox-directory";
+import {
+  fetchEmailMessageEntries,
+  EMAIL_MESSAGE_LIST_LIMIT
+} from "../src/modules/email/application/email-message-directory";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeOrSkip = DATABASE_URL ? describe : describe.skip;
+
+// One fixed instant with a non-zero MICROSECOND tail, shared by every seeded
+// row in a batch. `.029058` is exactly the value the driver floors to `.029Z`,
+// which is what made the old cursor sort ahead of its own row.
+const SHARED_CREATED_AT = "2026-07-17 10:00:00.029058+00";
+const REQUESTER = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+describeOrSkip(
+  "keyset pagination precision (Issue #158, real PostgreSQL)",
+  () => {
+    let sql: Bun.SQL;
+    const createdTenantIds: string[] = [];
+
+    beforeAll(() => {
+      sql = new Bun.SQL(DATABASE_URL!, { max: 5 });
+    });
+
+    afterAll(async () => {
+      for (const tenantId of createdTenantIds) {
+        await sql`SELECT set_config('app.current_tenant_id', ${tenantId}, false)`;
+        await sql`DELETE FROM awcms_workflow_tasks WHERE tenant_id = ${tenantId}`;
+        await sql`DELETE FROM awcms_workflow_instances WHERE tenant_id = ${tenantId}`;
+        await sql`DELETE FROM awcms_workflow_definitions WHERE tenant_id = ${tenantId}`;
+        await sql`DELETE FROM awcms_email_messages WHERE tenant_id = ${tenantId}`;
+        await sql`DELETE FROM awcms_tenants WHERE id = ${tenantId}`;
+      }
+      await sql.close({ timeout: 5 });
+    });
+
+    async function createTenant(label: string): Promise<string> {
+      const suffix = Math.random().toString(36).slice(2, 10);
+      const rows = (await sql`
+      INSERT INTO awcms_tenants (tenant_code, tenant_name)
+      VALUES (${`ks158-${label}-${suffix}`}, ${`Keyset 158 ${label}`})
+      RETURNING id
+    `) as { id: string }[];
+      const tenantId = rows[0]!.id;
+      createdTenantIds.push(tenantId);
+      await sql`SELECT set_config('app.current_tenant_id', ${tenantId}, false)`;
+      return tenantId;
+    }
+
+    /** Mirrors `withTenant`: pins the tenant GUC, runs in one transaction. */
+    async function inTenant<T>(
+      tenantId: string,
+      fn: (tx: Bun.SQL) => Promise<T>
+    ): Promise<T> {
+      return sql.begin(async (tx) => {
+        await tx`SELECT set_config('app.current_tenant_id', ${tenantId}, true)`;
+        return fn(tx as unknown as Bun.SQL);
+      }) as Promise<T>;
+    }
+
+    test("workflow inbox — page 2 is empty under the OLD cursor and complete under the fix", async () => {
+      const tenantId = await createTenant("wf");
+      const total = 103; // page size is 100 → 3 rows must land on page 2.
+
+      const definitionRows = (await sql`
+      INSERT INTO awcms_workflow_definitions
+        (tenant_id, workflow_key, name, version, lifecycle_status, graph, facts_schema)
+      VALUES (${tenantId}, ${"ks158"}, ${"Keyset 158"}, 1, 'active',
+              ${"{}"}::jsonb, ${"[]"}::jsonb)
+      RETURNING id
+    `) as { id: string }[];
+      const instanceRows = (await sql`
+      INSERT INTO awcms_workflow_instances
+        (tenant_id, workflow_definition_id, workflow_definition_version,
+         resource_type, resource_id, status, requested_by_tenant_user_id, facts)
+      VALUES (${tenantId}, ${definitionRows[0]!.id}, 1, ${"invoice"}, ${"inv-1"},
+              'pending', ${REQUESTER}, ${"{}"}::jsonb)
+      RETURNING id
+    `) as { id: string }[];
+      const instanceId = instanceRows[0]!.id;
+
+      // Every task shares the SAME microsecond-bearing created_at — the batch
+      // that the millisecond-floored cursor cannot page past.
+      for (let index = 0; index < total; index += 1) {
+        await sql`
+        INSERT INTO awcms_workflow_tasks
+          (tenant_id, workflow_instance_id, node_id, quorum_rule, status, created_at)
+        VALUES (${tenantId}, ${instanceId}, ${"approval"}, 'all', 'pending',
+                ${SHARED_CREATED_AT}::timestamptz)
+      `;
+      }
+
+      const page1 = await inTenant(tenantId, (tx) =>
+        listWorkflowInboxTasks(tx, tenantId, {}, new Date(), null)
+      );
+      expect(page1.tasks).toHaveLength(100);
+      expect(page1.nextCursor).not.toBeNull();
+
+      // FIX: the directory's own cursor carries full precision → page 2 returns
+      // the remaining rows and the two pages partition the set exactly.
+      const page2Fixed = await inTenant(tenantId, (tx) =>
+        listWorkflowInboxTasks(
+          tx,
+          tenantId,
+          {},
+          new Date(),
+          decodeKeysetCursor(page1.nextCursor!)
+        )
+      );
+      expect(page2Fixed.tasks).toHaveLength(total - 100);
+      expect(page2Fixed.nextCursor).toBeNull();
+      const seen = [...page1.tasks, ...page2Fixed.tasks].map((t) => t.id);
+      expect(new Set(seen).size).toBe(total);
+
+      // BUG: rebuild the cursor the OLD way (from the DTO's JS `Date`, floored to
+      // milliseconds) — page 2 comes back EMPTY, the silent data loss #158 fixes.
+      const last = page1.tasks[page1.tasks.length - 1]!;
+      const oldCursor = encodeKeysetCursor(
+        last.createdAt.toISOString(),
+        last.id
+      );
+      const page2Old = await inTenant(tenantId, (tx) =>
+        listWorkflowInboxTasks(
+          tx,
+          tenantId,
+          {},
+          new Date(),
+          decodeKeysetCursor(oldCursor)
+        )
+      );
+      expect(page2Old.tasks).toHaveLength(0);
+    });
+
+    test("email messages — page 2 is empty under the OLD cursor and complete under the fix", async () => {
+      const tenantId = await createTenant("email");
+      const total = EMAIL_MESSAGE_LIST_LIMIT + 3;
+
+      for (let index = 0; index < total; index += 1) {
+        await sql`
+        INSERT INTO awcms_email_messages
+          (tenant_id, category, status, to_address, to_address_hash,
+           to_address_masked, subject, created_at)
+        VALUES (${tenantId}, ${"workflow.notification"}, 'queued',
+                ${`u${index}@example.com`}, ${`hash-${index}`}, ${"u***@example.com"},
+                ${"Subject"}, ${SHARED_CREATED_AT}::timestamptz)
+      `;
+      }
+
+      const page1 = await inTenant(tenantId, (tx) =>
+        fetchEmailMessageEntries(tx, tenantId, undefined, undefined)
+      );
+      expect(page1.messages).toHaveLength(EMAIL_MESSAGE_LIST_LIMIT);
+      expect(page1.nextCursor).not.toBeNull();
+
+      const page2Fixed = await inTenant(tenantId, (tx) =>
+        fetchEmailMessageEntries(
+          tx,
+          tenantId,
+          undefined,
+          decodeKeysetCursor(page1.nextCursor!) ?? undefined
+        )
+      );
+      expect(page2Fixed.messages).toHaveLength(
+        total - EMAIL_MESSAGE_LIST_LIMIT
+      );
+      expect(page2Fixed.nextCursor).toBeNull();
+      const seen = [...page1.messages, ...page2Fixed.messages].map((m) => m.id);
+      expect(new Set(seen).size).toBe(total);
+
+      // OLD (millisecond) cursor: the DTO's `createdAt` is already floored to
+      // `...029Z`, exactly what the buggy route fed back — page 2 is empty.
+      const last = page1.messages[page1.messages.length - 1]!;
+      const oldCursor = encodeKeysetCursor(last.createdAt, last.id);
+      const page2Old = await inTenant(tenantId, (tx) =>
+        fetchEmailMessageEntries(
+          tx,
+          tenantId,
+          undefined,
+          decodeKeysetCursor(oldCursor) ?? undefined
+        )
+      );
+      expect(page2Old.messages).toHaveLength(0);
+    });
+  }
+);

--- a/tests/keyset-pagination.test.ts
+++ b/tests/keyset-pagination.test.ts
@@ -2,19 +2,50 @@ import { describe, expect, test } from "bun:test";
 
 import {
   decodeKeysetCursor,
-  encodeKeysetCursor
+  encodeKeysetCursor,
+  KEYSET_CURSOR_CREATED_AT_SQL
 } from "../src/modules/_shared/keyset-pagination";
 
 const id = "11111111-2222-4333-8444-555555555555";
-const createdAt = new Date("2026-01-02T03:04:05.678Z");
+// Full microsecond precision — the whole point of Issue #158. A JS `Date`
+// could not represent the `.029058` tail; the cursor carries it as text.
+const createdAt = "2026-01-02T03:04:05.029058+00:00";
 
 describe("keyset pagination cursor", () => {
-  test("round-trips (created_at, id) through an opaque cursor", () => {
+  test("round-trips (created_at, id) through an opaque cursor at microsecond precision", () => {
     const decoded = decodeKeysetCursor(encodeKeysetCursor(createdAt, id));
 
     expect(decoded).not.toBeNull();
     expect(decoded!.id).toBe(id);
-    expect(decoded!.createdAt.toISOString()).toBe(createdAt.toISOString());
+    // Verbatim string, NOT a Date — the microseconds survive untouched.
+    expect(decoded!.createdAt).toBe(createdAt);
+  });
+
+  test("preserves microseconds a JS Date would floor to milliseconds", () => {
+    // Three instants a JS Date collapses onto the same `.029Z` (the exact bug
+    // in Issue #158) stay distinct through the cursor.
+    for (const micro of [
+      "2026-01-02T03:04:05.029058+00:00",
+      "2026-01-02T03:04:05.029958+00:00",
+      "2026-01-02T03:04:05.029999+00:00"
+    ]) {
+      const decoded = decodeKeysetCursor(encodeKeysetCursor(micro, id));
+      expect(decoded!.createdAt).toBe(micro);
+      // The collapse the fix avoids: all three floor to the same Date.
+      expect(new Date(decoded!.createdAt).toISOString()).toBe(
+        "2026-01-02T03:04:05.029Z"
+      );
+    }
+  });
+
+  test("still accepts a legacy millisecond `Z` cursor (backward compatible)", () => {
+    const legacy = Buffer.from(
+      `2026-01-02T03:04:05.678Z|${id}`,
+      "utf-8"
+    ).toString("base64url");
+    const decoded = decodeKeysetCursor(legacy);
+    expect(decoded).not.toBeNull();
+    expect(decoded!.createdAt).toBe("2026-01-02T03:04:05.678Z");
   });
 
   test("rejects a forged/garbage cursor with null (never treated as page 1)", () => {
@@ -23,15 +54,29 @@ describe("keyset pagination cursor", () => {
   });
 
   test("rejects a cursor whose id is not a UUID", () => {
+    const bad = Buffer.from(`${createdAt}|not-a-uuid`, "utf-8").toString(
+      "base64url"
+    );
+    expect(decodeKeysetCursor(bad)).toBeNull();
+  });
+
+  test("rejects a cursor whose timestamp is malformed", () => {
+    const bad = Buffer.from(`not-a-date|${id}`, "utf-8").toString("base64url");
+    expect(decodeKeysetCursor(bad)).toBeNull();
+  });
+
+  test("rejects a shaped-but-out-of-range timestamp before it reaches SQL", () => {
+    // Passes the shape regex but is not a real instant — must not slip through
+    // to become a 500 at the `::timestamptz` bind.
     const bad = Buffer.from(
-      `${createdAt.toISOString()}|not-a-uuid`,
+      `2026-13-45T99:99:99.000000+00:00|${id}`,
       "utf-8"
     ).toString("base64url");
     expect(decodeKeysetCursor(bad)).toBeNull();
   });
 
-  test("rejects a cursor whose timestamp is invalid", () => {
-    const bad = Buffer.from(`not-a-date|${id}`, "utf-8").toString("base64url");
-    expect(decodeKeysetCursor(bad)).toBeNull();
+  test("exposes the SQL expression that emits the full-precision cursor text", () => {
+    expect(KEYSET_CURSOR_CREATED_AT_SQL).toContain("AT TIME ZONE 'UTC'");
+    expect(KEYSET_CURSOR_CREATED_AT_SQL).toContain("US");
   });
 });

--- a/tests/office-directory-postgres.test.ts
+++ b/tests/office-directory-postgres.test.ts
@@ -347,17 +347,18 @@ describeOrSkip("office directory (real PostgreSQL)", () => {
     });
 
     /**
-     * The worst case for the cursor's millisecond precision, and the reason
-     * `listOffices` truncates its sort key to milliseconds rather than
-     * comparing bare `created_at`: rows created inside ONE transaction share
-     * `created_at` exactly (it is transaction time), so a page boundary landing
-     * inside such a group is decided entirely by the `id` tiebreaker.
+     * The worst case for cursor precision, and the reason the shared keyset
+     * cursor now carries the full microsecond `created_at` as text (Issue #158)
+     * instead of a millisecond-precision JS `Date`: rows created inside ONE
+     * transaction share `created_at` exactly (it is transaction time), so a page
+     * boundary landing inside such a group is decided entirely by the `id`
+     * tiebreaker.
      *
-     * Against a bare `(created_at, id) < (cursor)` this returned 100 of 103 —
-     * page 2 came back EMPTY, because the millisecond-precision cursor sorts
-     * strictly before every microsecond-bearing row it was built from, and
-     * three offices became permanently unreachable through the API. Asserting
-     * the partition (rather than just the lengths) is what catches that:
+     * Against the old millisecond cursor this returned 100 of 103 — page 2 came
+     * back EMPTY, because a millisecond-precision cursor sorts strictly before
+     * every microsecond-bearing row it was built from, and three offices became
+     * permanently unreachable through the API. Asserting the partition (rather
+     * than just the lengths) is what catches that:
      * silent loss looks like success to a caller who only checks page 1.
      */
     test("pages correctly when created_at ties across the page boundary", async () => {

--- a/tests/security-readiness-rls.test.ts
+++ b/tests/security-readiness-rls.test.ts
@@ -24,7 +24,8 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
   checkAppDbUserNotSuperuser,
   checkLeastPrivilegeRoleProvisioned,
-  checkRlsEnabled
+  checkRlsEnabled,
+  checkRuntimeRoleGrants
 } from "../scripts/security-readiness";
 
 const DATABASE_URL = process.env.DATABASE_URL;
@@ -141,3 +142,142 @@ describeOrSkip("security:readiness RLS checks (real PostgreSQL)", () => {
     expect(["pass", "fail"]).toContain(result.status);
   });
 });
+
+/**
+ * Issue #160 — real-PostgreSQL tests for `checkRuntimeRoleGrants`, the grant
+ * check that closes the gap `checkRlsEnabled` structurally cannot see: a
+ * table's RLS FLAGS say nothing about whether `awcms_app` can actually reach
+ * it. This is a property of PostgreSQL's grant system (`has_table_privilege`,
+ * `ALTER DEFAULT PRIVILEGES` being executing-role-bound), so a stubbed driver
+ * would prove nothing — same reasoning as the RLS suite above.
+ */
+describeOrSkip(
+  "security:readiness runtime-role grant check (real PostgreSQL)",
+  () => {
+    let sql: Bun.SQL;
+
+    beforeAll(async () => {
+      sql = new Bun.SQL(DATABASE_URL!, { max: 2 });
+    });
+
+    afterAll(async () => {
+      await sql.close({ timeout: 1 });
+    });
+
+    async function awcmsAppExists(): Promise<boolean> {
+      const rows = (await sql`
+      SELECT 1 AS present FROM pg_roles WHERE rolname = 'awcms_app'
+    `) as { present: number }[];
+      return rows.length > 0;
+    }
+
+    async function connectionIsSuperuser(): Promise<boolean> {
+      const rows = (await sql`
+      SELECT rolsuper FROM pg_roles WHERE rolname = current_user
+    `) as { rolsuper: boolean }[];
+      return rows[0]?.rolsuper === true;
+    }
+
+    test("passes on a correctly-narrowed, fully-migrated database", async () => {
+      if (!(await awcmsAppExists())) {
+        // Pre-sql/019 database: the check is non-blocking by design. Its own
+        // unit-level "role absent -> pass" path is asserted separately; here we
+        // only guard against a false failure when the role is simply not present.
+        const result = await checkRuntimeRoleGrants();
+        expect(result.severity).toBe("critical");
+        expect(result.status).toBe("pass");
+        return;
+      }
+
+      // Independently derive the two halves of the expectation from the database,
+      // NOT from the check under test: sql/021 must have removed the residual
+      // writes, and the tenant root must still be reachable for the writes real
+      // code paths use. This proves the migration actually took effect AND that
+      // the check agrees with reality.
+      const probes = (await sql`
+      SELECT
+        has_table_privilege('awcms_app', 'awcms_tenants', 'DELETE') AS tenants_delete,
+        has_table_privilege('awcms_app', 'awcms_permissions', 'INSERT') AS perms_insert,
+        has_table_privilege('awcms_app', 'awcms_schema_migrations', 'DELETE') AS migrations_delete,
+        has_table_privilege('awcms_app', 'awcms_tenants', 'INSERT') AS tenants_insert,
+        has_table_privilege('awcms_app', 'awcms_tenants', 'UPDATE') AS tenants_update
+    `) as {
+        tenants_delete: boolean;
+        perms_insert: boolean;
+        migrations_delete: boolean;
+        tenants_insert: boolean;
+        tenants_update: boolean;
+      }[];
+      const p = probes[0]!;
+
+      // The residual #160 closes.
+      expect(p.tenants_delete).toBe(false);
+      expect(p.perms_insert).toBe(false);
+      expect(p.migrations_delete).toBe(false);
+      // The grants the setup fallback + tenant-settings screen depend on.
+      expect(p.tenants_insert).toBe(true);
+      expect(p.tenants_update).toBe(true);
+
+      const result = await checkRuntimeRoleGrants();
+      expect(result.severity).toBe("critical");
+      expect(result.status).toBe("pass");
+    });
+
+    test("flags a tenant-scoped table that is RLS-forced but ungranted", async () => {
+      if (!(await awcmsAppExists()) || !(await connectionIsSuperuser())) {
+        // The setup needs to CREATE a table owned by a DIFFERENT role than the
+        // one `ALTER DEFAULT PRIVILEGES` is bound to (the exact bug: a db:migrate
+        // under a second superuser). That requires superuser + the role present.
+        // Where either is missing (e.g. connected as awcms_app itself), skip
+        // rather than assert a scenario we cannot construct.
+        return;
+      }
+
+      const probeTable = "awcms_grant_probe_ungranted_owner";
+      const probeOwner = "awcms_grant_probe_owner_role";
+
+      try {
+        await sql.unsafe(`DROP TABLE IF EXISTS ${probeTable}`);
+        await sql.unsafe(`
+        DO $$ BEGIN
+          IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '${probeOwner}') THEN
+            CREATE ROLE ${probeOwner} NOLOGIN;
+          END IF;
+        END $$;
+      `);
+        await sql.unsafe(`GRANT CREATE ON SCHEMA public TO ${probeOwner}`);
+        // Create the table AS the probe owner so the migration owner's default
+        // privileges do NOT fire — awcms_app ends up with zero grant on it, i.e.
+        // RLS-forced-but-ungranted once RLS is enforced.
+        await sql.unsafe(`SET ROLE ${probeOwner}`);
+        await sql.unsafe(`
+        CREATE TABLE ${probeTable} (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          tenant_id uuid NOT NULL
+        )
+      `);
+        await sql.unsafe(`RESET ROLE`);
+        await sql.unsafe(`ALTER TABLE ${probeTable} ENABLE ROW LEVEL SECURITY`);
+        await sql.unsafe(`ALTER TABLE ${probeTable} FORCE ROW LEVEL SECURITY`);
+
+        // Guard the guard: awcms_app really holds no privilege on the probe.
+        const priv = (await sql.unsafe(`
+        SELECT has_table_privilege('awcms_app', '${probeTable}', 'SELECT') AS sel
+      `)) as { sel: boolean }[];
+        expect(priv[0]?.sel).toBe(false);
+
+        const result = await checkRuntimeRoleGrants();
+
+        expect(result.severity).toBe("critical");
+        expect(result.status).toBe("fail");
+        expect(result.evidence).toContain(probeTable);
+        expect(result.evidence).toContain("permission denied");
+      } finally {
+        await sql.unsafe(`RESET ROLE`);
+        await sql.unsafe(`DROP TABLE IF EXISTS ${probeTable}`);
+        await sql.unsafe(`REVOKE CREATE ON SCHEMA public FROM ${probeOwner}`);
+        await sql.unsafe(`DROP ROLE IF EXISTS ${probeOwner}`);
+      }
+    });
+  }
+);

--- a/tests/sync-hmac-versioned.test.ts
+++ b/tests/sync-hmac-versioned.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Versioned sync HMAC signatures — security advisory GHSA-c972-3q5p-g3h4
+ * (cross-tenant sync forgery).
+ *
+ * Two layers proved here:
+ *  1. v2 signatures bind tenant + node into the signed material, so a signature
+ *     minted for tenant A no longer verifies once `X-AWCMS-Tenant-ID` is swapped
+ *     to tenant B.
+ *  2. Legacy (v1) signatures are accepted only while `SYNC_HMAC_ALLOW_LEGACY`
+ *     is not `false` — the operator off-switch that fully closes the hole.
+ *  3. First-contact nodes auto-register `inactive` (real-PostgreSQL block,
+ *     gated on `DATABASE_URL`), so a forged request for another tenant lands on
+ *     a node the `status !== "active"` route gate rejects; an already-`active`
+ *     node keeps working.
+ *
+ * No `mock.module` here: it mutates the live module namespace in place and
+ * leaks into every test file that runs afterwards in the same process
+ * (see memory `awcms-test-and-txn-traps`). `process.env` is snapshotted and
+ * restored around each test for the same reason.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  computeSyncSignature,
+  computeSyncSignatureV2,
+  verifySyncSignatureV2
+} from "../src/modules/sync-storage/domain/sync-hmac";
+import {
+  resolveOrRegisterSyncNode,
+  verifySyncHeaders
+} from "../src/modules/sync-storage/application/sync-auth";
+
+const TENANT_A = "11111111-1111-4111-8111-111111111111";
+const TENANT_B = "22222222-2222-4222-8222-222222222222";
+const NODE = "kasir-1";
+const SECRET = "shared-deployment-secret";
+
+describe("computeSyncSignatureV2 binds tenant + node", () => {
+  const timestamp = "2026-07-18T00:00:00.000Z";
+  const body = "{}";
+
+  test("a v2 signature for tenant A does not verify under tenant B", () => {
+    const sig = computeSyncSignatureV2(SECRET, TENANT_A, NODE, timestamp, body);
+
+    expect(
+      verifySyncSignatureV2(SECRET, TENANT_A, NODE, timestamp, body, sig)
+    ).toBe(true);
+    // Swap the tenant id → different signed material → verification fails.
+    expect(
+      verifySyncSignatureV2(SECRET, TENANT_B, NODE, timestamp, body, sig)
+    ).toBe(false);
+  });
+
+  test("a v2 signature for one node does not verify under another node", () => {
+    const sig = computeSyncSignatureV2(SECRET, TENANT_A, NODE, timestamp, body);
+
+    expect(
+      verifySyncSignatureV2(
+        SECRET,
+        TENANT_A,
+        "other-node",
+        timestamp,
+        body,
+        sig
+      )
+    ).toBe(false);
+  });
+
+  test("v2 material differs from v1 material for the same inputs", () => {
+    expect(
+      computeSyncSignatureV2(SECRET, TENANT_A, NODE, timestamp, body)
+    ).not.toBe(computeSyncSignature(SECRET, timestamp, body));
+  });
+});
+
+describe("verifySyncHeaders (versioned)", () => {
+  const ENV_KEYS = [
+    "AWCMS_SYNC_ENABLED",
+    "AWCMS_SYNC_HMAC_SECRET",
+    "AWCMS_SYNC_MAX_SKEW_SEC",
+    "SYNC_HMAC_ALLOW_LEGACY"
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of ENV_KEYS) {
+      saved[key] = process.env[key];
+    }
+    process.env.AWCMS_SYNC_ENABLED = "true";
+    process.env.AWCMS_SYNC_HMAC_SECRET = SECRET;
+    delete process.env.AWCMS_SYNC_MAX_SKEW_SEC;
+    delete process.env.SYNC_HMAC_ALLOW_LEGACY;
+  });
+
+  afterEach(() => {
+    for (const key of ENV_KEYS) {
+      if (saved[key] === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = saved[key];
+      }
+    }
+  });
+
+  const freshTimestamp = () => new Date().toISOString();
+
+  test("v2: accepts a correctly bound request", () => {
+    const ts = freshTimestamp();
+    const body = "{}";
+    const sig = computeSyncSignatureV2(SECRET, TENANT_A, NODE, ts, body);
+
+    const result = verifySyncHeaders(TENANT_A, NODE, ts, sig, "2", body);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("v2: rejects a tenant-swapped request (the advisory attack)", () => {
+    const ts = freshTimestamp();
+    const body = "{}";
+    // Attacker mints a valid v2 signature for their own tenant A ...
+    const sig = computeSyncSignatureV2(SECRET, TENANT_A, NODE, ts, body);
+
+    // ... then replays it with X-AWCMS-Tenant-ID swapped to tenant B.
+    const result = verifySyncHeaders(TENANT_B, NODE, ts, sig, "2", body);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  test("v1: accepted while legacy is allowed (default)", () => {
+    const ts = freshTimestamp();
+    const body = "{}";
+    const sig = computeSyncSignature(SECRET, ts, body);
+
+    // No X-AWCMS-Signature-Version header → legacy path.
+    const result = verifySyncHeaders(TENANT_A, NODE, ts, sig, null, body);
+
+    expect(result.ok).toBe(true);
+  });
+
+  test("v1: rejected once SYNC_HMAC_ALLOW_LEGACY=false (off-switch)", () => {
+    process.env.SYNC_HMAC_ALLOW_LEGACY = "false";
+    const ts = freshTimestamp();
+    const body = "{}";
+    const sig = computeSyncSignature(SECRET, ts, body);
+
+    const result = verifySyncHeaders(TENANT_A, NODE, ts, sig, null, body);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  test("v2: still accepted when legacy is disabled", () => {
+    process.env.SYNC_HMAC_ALLOW_LEGACY = "false";
+    const ts = freshTimestamp();
+    const body = "{}";
+    const sig = computeSyncSignatureV2(SECRET, TENANT_A, NODE, ts, body);
+
+    const result = verifySyncHeaders(TENANT_A, NODE, ts, sig, "2", body);
+
+    expect(result.ok).toBe(true);
+  });
+});
+
+// --- Real-PostgreSQL: node auto-registration is quarantined `inactive` -------
+
+const DATABASE_URL =
+  process.env.SYNC_TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const describeOrSkip = DATABASE_URL ? describe : describe.skip;
+
+describeOrSkip("resolveOrRegisterSyncNode (real PostgreSQL)", () => {
+  let sql: Bun.SQL;
+  const createdTenantIds: string[] = [];
+
+  async function createTenant(label: string): Promise<string> {
+    const suffix = Math.random().toString(36).slice(2, 10);
+    const rows = (await sql`
+      INSERT INTO awcms_tenants (tenant_code, tenant_name)
+      VALUES (${`sync-${label}-${suffix}`}, ${`Sync HMAC test ${label}`})
+      RETURNING id
+    `) as { id: string }[];
+    const tenantId = rows[0]!.id;
+    createdTenantIds.push(tenantId);
+    return tenantId;
+  }
+
+  /** Mirrors `withTenant`: pins the tenant GUC inside one transaction. */
+  async function inTenant<T>(
+    tenantId: string,
+    fn: (tx: Bun.SQL) => Promise<T>
+  ): Promise<T> {
+    return sql.begin(async (tx) => {
+      await tx`SELECT set_config('app.current_tenant_id', ${tenantId}, true)`;
+      return fn(tx as unknown as Bun.SQL);
+    });
+  }
+
+  beforeAll(() => {
+    sql = new Bun.SQL(DATABASE_URL!, { max: 5 });
+  });
+
+  afterAll(async () => {
+    for (const tenantId of createdTenantIds) {
+      await sql`SELECT set_config('app.current_tenant_id', ${tenantId}, false)`;
+      await sql`DELETE FROM awcms_sync_nodes WHERE tenant_id = ${tenantId}`;
+      await sql`DELETE FROM awcms_tenants WHERE id = ${tenantId}`;
+    }
+    await sql.close({ timeout: 5 });
+  });
+
+  test("a first-contact node auto-registers as inactive (not active)", async () => {
+    const tenantId = await createTenant("inactive");
+
+    const node = await inTenant(tenantId, (tx) =>
+      resolveOrRegisterSyncNode(tx, tenantId, "kasir-new")
+    );
+
+    expect(node).not.toBeNull();
+    expect(node!.status).toBe("inactive");
+    // This is exactly the route gate `node.status !== "active"` — an
+    // unapproved node cannot pull/push.
+    expect(node!.status !== "active").toBe(true);
+  });
+
+  test("an already-active node keeps working", async () => {
+    const tenantId = await createTenant("active");
+
+    await inTenant(tenantId, async (tx) => {
+      await tx`
+        INSERT INTO awcms_sync_nodes (tenant_id, node_code, node_name, status)
+        VALUES (${tenantId}, ${"kasir-approved"}, ${"kasir-approved"}, 'active')
+      `;
+    });
+
+    const node = await inTenant(tenantId, (tx) =>
+      resolveOrRegisterSyncNode(tx, tenantId, "kasir-approved")
+    );
+
+    expect(node).not.toBeNull();
+    expect(node!.status).toBe("active");
+  });
+});


### PR DESCRIPTION
Tiga agen paralel pada file disjoint, menutup issue terbuka tersisa + advisory sync HMAC critical. `bun run check` hijau: **693 pass / 100 skip / 0 fail** tanpa DB; **771 pass / 0 fail** dengan `DATABASE_URL` (bentuk release.yml, semua test integration jalan).

Closes #158, closes #160

## #158 — keyset pagination kehilangan baris

Cursor menyandikan `created_at` via `Date.toISOString()` (milidetik), tapi `timestamptz` menyimpan mikrodetik dan driver **membulatkannya ke bawah** — cursor karena itu sorts strictly sebelum baris asalnya, jadi setiap baris yang berbagi milidetik terlewati melintasi batas halaman (**103 baris dalam satu transaksi → halaman 2 = 0**).

Perbaikan: bawa `created_at` lewat cursor sebagai **teks UTC presisi penuh** (`KEYSET_CURSOR_CREATED_AT_SQL`), `ORDER BY` tetap pada kolom telanjang sehingga index `(tenant_id, created_at DESC)` yang ada tetap terpakai (Opsi 1, ramah-index). Generasi cursor dipindah ke empat directory function agar tak ada route yang membulatkan ulang; penambal `date_trunc` lokal office dari #159 dihapus.

**Bukti:** regress encode → halaman 2 kosong di Postgres nyata; pulihkan → halaman 2 mengembalikan sisa baris dengan partisi 103-way bersih.

## #160 — persempit grant awcms_app (sql/021)

Role dari #159 memegang DML blanket pada tabel global RLS-free — koneksi runtime ter-kompromi bisa `DELETE awcms_tenants`, `UPDATE awcms_permissions`, atau merusak ledger migrasi. 021 me-`REVOKE` sampai hanya yang benar-benar dipakai kode (diverifikasi lawan jalur tulis nyata, bukan port mentah): `awcms_permissions`/`awcms_schema_migrations` jadi read-only, `awcms_tenants` menyimpan UPDATE (tenant-settings menulisnya saat request) tapi kehilangan DELETE.

Ditambah `security:readiness` grant-check yang juga menangkap celah `ALTER DEFAULT PRIVILEGES` yang ditandai reviewer (tabel RLS-forced tapi ungranted). Split `awcms_worker`/`awcms_setup` (mini 045) **ditunda, bukan setengah jadi** — didokumentasikan, karena butuh audit per-jalur-tulis + perubahan `client.ts` yang breaking.

**Verifikasi DB (login awcms_app nyata, non-superuser):** DELETE tenants ditolak, UPDATE permissions ditolak, DML tenant-scoped jalan, fail-closed 0 baris tanpa GUC.

## GHSA-c972 — sync HMAC lintas-tenant (signature v2)

Signature tak mengikat tenant maupun node, jadi node pemegang secret bersama bisa menukar header tenant dan membaca data tenant lain. Sesuai pendekatan yang dipilih — **hardening aman + signature ber-versi, tanpa putus protokol**:

- **v2 mengikat tenant+node** ke material (`v2:<tenantId>:<nodeCode>:<timestamp>:<body>`). Verifier ambil v2 saat header versi menyatakannya; terima v1 legacy **hanya** selama `SYNC_HMAC_ALLOW_LEGACY != "false"` — tombol yang menutup celah sepenuhnya setelah node bermigrasi.
- **Node auto-register kini `inactive`** wajib approve admin — lapisan yang benar-benar memblokir baca lintas-tenant via node-id baru dengan secret bersama. Kode-saja (tanpa migration, tanpa jebakan FORCE-RLS-DML).

**Tidak diklaim tertutup penuh:** butuh legacy off **dan** semua node v2, dan awcms-mini + spec node harus memancarkan v2 lebih dulu — dinyatakan di changeset dan skill.

**Bukti (eksekusi):** v2 tenant-swap → `false`, node-swap → `false`; v1 diterima saat legacy on, ditolak saat off; node auto-register → `inactive`.

## Integrasi saat menggabung

- Menyambungkan dua perubahan bentuk-return directory ke route email-messages dan sync/object-queue.
- Integrasi `SYNC_HMAC_ALLOW_LEGACY` ke `.env.example`/`validate-env`/doc 18.
- **Nol migration terapan diedit** (`git diff main -- sql/` kosong selain 021 baru); deployment lama upgrade dengan hanya apply 021, nol checksum mismatch — diverifikasi empiris.

Difile terpisah: koordinasi lintas-repo sync v2 (mini + spec node) sebelum `SYNC_HMAC_ALLOW_LEGACY=false`; split role worker/setup (#160 header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)