### PR TITLE
fix(security): harden v2 signature material and fail-close the readiness grant guard

### DIFF
--- a/.changeset/readiness-grant-failclosed.md
+++ b/.changeset/readiness-grant-failclosed.md
@@ -1,0 +1,34 @@
+---
+"awcms": patch
+---
+
+Harden `checkRuntimeRoleGrants` (`bun run security:readiness`) to fail CLOSED
+for undeclared global RLS-free tables (Issue #162 / L2, from the PR #161
+security audit).
+
+The runtime-role grant check kept two independent structures: an
+`RLS_FREE_TABLES` set (read by `checkRlsEnabled`) and a separate
+forbidden-privilege map (read by `checkRuntimeRoleGrants`). A future global,
+RLS-free table added to the SET to make `checkRlsEnabled` pass but forgotten in
+the MAP was `continue`d as "full DML kept by design" and passed silently — the
+exact "a new global table inherits blanket DML from `ALTER DEFAULT PRIVILEGES`"
+regression this check exists to catch. Non-exploitable today (the 9 tables are
+curated correctly) but a latent trap for the next migration.
+
+- The two structures are merged into ONE source of truth
+  (`GLOBAL_TABLE_FORBIDDEN_PRIVILEGES`, keyed by table name; `RLS_FREE_TABLES`
+  is now derived from its keys). You can no longer register a table in one
+  place without the other — every RLS-free table carries an explicit
+  privilege declaration. The five module-registry tables that legitimately
+  keep full DML get an explicit empty (`[]`) forbidden list — a visible
+  "allow", not an implicit default.
+- The over-granted direction is now fail-closed: any table treated as RLS-free
+  but missing an explicit declaration is asserted to hold ZERO writes. A
+  forgotten registration that still holds INSERT/UPDATE/DELETE now FAILS
+  `critical` with a "register the privileges awcms_app may hold" message
+  instead of passing.
+
+Behaviour on the current, correctly-curated database is unchanged (still PASS).
+No schema, API, or event changes. Verified against a fully-migrated PostgreSQL
+18 database (sql/001..021): the 9-table default policy still passes, and a
+simulated undeclared global table holding blanket DML now fails the check.

--- a/.changeset/sync-hmac-delimiter-hardening.md
+++ b/.changeset/sync-hmac-delimiter-hardening.md
@@ -1,0 +1,9 @@
+---
+"awcms": patch
+---
+
+Harden sync HMAC v2 signature material against delimiter ambiguity (audit finding L1, GHSA-c972-3q5p-g3h4).
+
+The v2 material `v2:<tenantId>:<nodeCode>:<timestamp>:<body>` was cryptographically ambiguous at the tenant/node boundary because `nodeCode` may contain `:` (schema `node_code text`, no format constraint): `(tenantId="A", nodeCode="x:y")` and `(tenantId="A:x", nodeCode="y")` produced byte-identical material and mutually-accepted signatures. This was confirmed NOT cross-tenant exploitable (a request's `tenantId` must be a valid UUID to reach tenant data via `withTenant`), but was a latent weakness in security-signature code.
+
+`computeSyncSignatureV2`/`verifySyncSignatureV2` now require `tenantId` to be a UUID before the material is built — a UUID is a fixed 36 chars with no `:`, so the tenant field boundary is unambiguous. `computeSyncSignatureV2` throws on a non-UUID tenantId; `verifySyncSignatureV2` fails closed (returns `false`). Only `tenantId` is constrained — `nodeCode` is untouched, and the v2 material format is unchanged, so already-deployed v1/v2 nodes (whose tenant ids are UUIDs) are unaffected. v1 signatures (`computeSyncSignature`/`verifySyncSignature`) are not changed. Timing-safe comparison is preserved.

--- a/.claude/skills/awcms-sync-hmac/SKILL.md
+++ b/.claude/skills/awcms-sync-hmac/SKILL.md
@@ -25,6 +25,16 @@ signature = HMAC-SHA256(secret, "v2:<tenantId>:<nodeCode>:<timestamp>:<body>")
 - Field constraint agar material tidak ambigu: `tenantId` = UUID; `nodeCode` &
   `timestamp` dari HTTP header (tak boleh mengandung CR/LF); `body` adalah field
   terakhir sehingga `:` di dalamnya tak menggeser batas field sebelumnya.
+- **Enforcement L1 (delimiter hardening, GHSA-c972):** `tenantId` = UUID
+  **ditegakkan** di boundary v2, bukan sekadar diasumsikan. `nodeCode` boleh
+  mengandung `:` (schema `node_code text`), jadi tanpa syarat UUID, batas
+  tenant/node ambigu — `(tenantId="A", nodeCode="x:y")` dan
+  `(tenantId="A:x", nodeCode="y")` menghasilkan material identik. UUID = 36 char
+  tetap tanpa `:` → batas tak ambigu. `computeSyncSignatureV2` **throw** bila
+  `tenantId` bukan UUID; `verifySyncSignatureV2` **fail-closed** (return
+  `false`). Hanya `tenantId` yang dibatasi; `nodeCode` tak disentuh dan **format
+  material v2 TIDAK berubah** → node v1/v2 lama (tenant id-nya UUID) tak
+  terpengaruh; mini/spec tak perlu ubah format material.
 - Implementasi kanonik ada di repo **awcms** (`domain/sync-hmac.ts`
   `computeSyncSignatureV2` / `verifySyncSignatureV2`).
 

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -373,13 +373,14 @@ export function checkLoginLockoutImplemented(): SecurityCheckResult {
 // ---------------------------------------------------------------------------
 
 /**
- * Tables that are intentionally RLS-free because they are not tenant-scoped
- * (no per-tenant row ownership) — derived by reading `sql/*.sql` directly,
- * not guessed. Cross-checked against the migrations: these are exactly the
- * `awcms_%` tables that are `CREATE TABLE`d but never
- * `ENABLE ROW LEVEL SECURITY`d.
+ * Single source of truth for every GLOBAL, RLS-free table. Maps each table's
+ * name to the privileges `awcms_app` must NOT hold on it at runtime — and, by
+ * its KEYS, defines the set of `awcms_%` tables that are intentionally RLS-free
+ * because they are not tenant-scoped (no per-tenant row ownership). Derived by
+ * reading `sql/*.sql` directly, not guessed: these are exactly the `awcms_%`
+ * tables that are `CREATE TABLE`d but never `ENABLE ROW LEVEL SECURITY`d.
  *
- * - `awcms_schema_migrations` (sql/001) — migration bookkeeping.
+ * - `awcms_schema_migrations` (sql/001) — migration bookkeeping ledger.
  * - `awcms_modules` (sql/008) — global module registry, no `tenant_id`.
  * - `awcms_module_dependencies`, `awcms_module_navigation`,
  *   `awcms_module_jobs`, `awcms_module_health_checks` (sql/008) —
@@ -395,25 +396,63 @@ export function checkLoginLockoutImplemented(): SecurityCheckResult {
  * - `awcms_setup_state` (sql/006) — global singleton setup lock that exists
  *   before any tenant does.
  *
- * Anything NOT in this set that matches `awcms_%` is treated as
- * tenant-scoped and MUST have both `relrowsecurity` and
- * `relforcerowsecurity`. That default-deny direction is the point: a new
- * migration adding a tenant table with `ENABLE` but no `FORCE` fails this
- * check without anyone having to remember to register it anywhere. A new
- * genuinely-global table is the case that requires a deliberate edit here,
- * with a reason — which is the correct place to force that conversation.
+ * ## Why ONE map, not two lists (Issue #162 / L2)
+ *
+ * This used to be two independent structures: an `RLS_FREE_TABLES` set (read by
+ * `checkRlsEnabled`) plus a separate forbidden-privilege map (read by
+ * `checkRuntimeRoleGrants`). The auditor of PR #161 flagged the "one-list
+ * omission" gap: a future global RLS-free table added to the SET (to satisfy
+ * `checkRlsEnabled`) but forgotten in the forbidden-privilege MAP was
+ * `continue`d as "full DML kept by design" and passed silently — the exact "a
+ * new global table inherits blanket DML from `ALTER DEFAULT PRIVILEGES`"
+ * regression this whole check exists to catch. Merging them means you cannot
+ * register a table in one place without the other: adding a key here FORCES an
+ * explicit privilege declaration for it, and `checkRuntimeRoleGrants` fails
+ * closed ("assert zero write") on any RLS-free table still missing one.
+ *
+ * The value is the list of privileges FORBIDDEN for `awcms_app`:
+ * - `[]` — full DML legitimately kept. The five module-registry tables are
+ *   written at request time by `descriptor-sync.ts`/`health-registry.ts` (see
+ *   `sql/021`'s header). A DELIBERATE, explicit "allow" a reviewer can see and
+ *   challenge — not an implicit default.
+ * - `["INSERT", "UPDATE", "DELETE"]` — read-only at runtime, every write
+ *   forbidden: `awcms_permissions` (global permission catalog, never written by
+ *   the app) and `awcms_schema_migrations` (migration ledger, only `db:migrate`
+ *   as owner writes it).
+ * - `["DELETE"]` — keep SELECT/INSERT/UPDATE, forbid DELETE only:
+ *   `awcms_tenants` (tenant-settings write path + setup-fallback bootstrap) and
+ *   `awcms_setup_state` (setup-fallback singleton).
+ *
+ * Anything NOT keyed here that matches `awcms_%` is treated as tenant-scoped and
+ * MUST have both `relrowsecurity` and `relforcerowsecurity` (`checkRlsEnabled`)
+ * AND all four grants (`checkRuntimeRoleGrants`). That default-deny direction is
+ * the point: a new migration adding a tenant table needs no registration to be
+ * protected; a new genuinely-global table is the one case that requires a
+ * deliberate edit here, with a reason — the correct place to force that
+ * conversation.
  */
-const RLS_FREE_TABLES = new Set([
-  "awcms_schema_migrations",
-  "awcms_modules",
-  "awcms_module_dependencies",
-  "awcms_module_navigation",
-  "awcms_module_jobs",
-  "awcms_module_health_checks",
-  "awcms_tenants",
-  "awcms_permissions",
-  "awcms_setup_state"
-]);
+const GLOBAL_TABLE_FORBIDDEN_PRIVILEGES: Record<string, string[]> = {
+  // Module registry (sql/008) — global, code-derived, full DML kept by design.
+  awcms_modules: [],
+  awcms_module_dependencies: [],
+  awcms_module_navigation: [],
+  awcms_module_jobs: [],
+  awcms_module_health_checks: [],
+  // Read-only at runtime — every write forbidden.
+  awcms_permissions: ["INSERT", "UPDATE", "DELETE"],
+  awcms_schema_migrations: ["INSERT", "UPDATE", "DELETE"],
+  // Write-limited — only DELETE forbidden.
+  awcms_tenants: ["DELETE"],
+  awcms_setup_state: ["DELETE"]
+};
+
+/**
+ * The set of intentionally RLS-free tables, DERIVED from the single source of
+ * truth above so the two can never diverge (see that comment for the L2 gap
+ * this closes). Read by `checkRlsEnabled` to know which `awcms_%` tables are
+ * exempt from the RLS-forced requirement.
+ */
+const RLS_FREE_TABLES = new Set(Object.keys(GLOBAL_TABLE_FORBIDDEN_PRIVILEGES));
 
 type RlsRow = {
   relname: string;
@@ -658,23 +697,15 @@ export async function checkLeastPrivilegeRoleProvisioned(): Promise<SecurityChec
 // ---------------------------------------------------------------------------
 
 /**
- * Privileges `awcms_app` must NOT hold on each GLOBAL, RLS-free table after
- * `sql/021_awcms_db_role_grants_narrow.sql` narrows the blanket grant. This is
- * the OTHER half of the residual `sql/019` documented and #160 closes: RLS
- * cannot claw anything back on these tables because they have none, so an
- * over-broad grant here is a real, un-mitigated privilege. Absence from this
- * map = "full DML legitimately kept" (the five module-registry tables, written
- * at request time — see `sql/021`'s header). `awcms_tenants`/`awcms_setup_state`
- * keep SELECT/INSERT/UPDATE (setup-fallback + tenant-settings write paths); only
- * DELETE is forbidden. `awcms_permissions`/`awcms_schema_migrations` are
- * read-only at runtime, so every write is forbidden.
+ * The three write privileges. A GLOBAL, RLS-free table that is registered as
+ * RLS-free (in `RLS_FREE_TABLES`) but has NO entry in
+ * `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES` is asserted fail-closed against this list
+ * — "zero write allowed" — so a forgotten registration FAILS the check instead
+ * of silently keeping blanket DML (Issue #162 / L2). In practice the two are
+ * derived from one map so this cannot happen in shipped code; the fail-closed
+ * default is the belt-and-suspenders guard against any future re-split.
  */
-const GLOBAL_TABLE_FORBIDDEN_PRIVILEGES: Record<string, string[]> = {
-  awcms_permissions: ["INSERT", "UPDATE", "DELETE"],
-  awcms_schema_migrations: ["INSERT", "UPDATE", "DELETE"],
-  awcms_tenants: ["DELETE"],
-  awcms_setup_state: ["DELETE"]
-};
+const ALL_WRITE_PRIVILEGES = ["INSERT", "UPDATE", "DELETE"];
 
 /**
  * Privileges every TENANT-SCOPED table must grant `awcms_app`. `sql/019` grants
@@ -714,6 +745,15 @@ type RoleGrantRow = {
  *   forbidden write — the residual #160 closes, and its regression guard for a
  *   FUTURE global table silently inheriting blanket DML from default privileges.
  *
+ * The over-granted direction is FAIL-CLOSED (Issue #162 / L2): a table that is
+ * RLS-free (present in `rlsFreeTables`) but carries NO explicit privilege
+ * declaration in `forbiddenPrivileges` is asserted to hold ZERO writes. Any
+ * write it does hold is reported as an over-grant with a "register the allowed
+ * privileges" message, rather than being skipped as "full DML by design". This
+ * closes the exact gap the auditor of #161 flagged: a future global table added
+ * to the RLS-free set but forgotten in the forbidden-privilege map now FAILS
+ * instead of passing silently.
+ *
  * Uses `has_table_privilege(role, oid, priv)` so it reports the EFFECTIVE grant
  * (direct + default-privilege + PUBLIC), which is what the runtime actually
  * gets — reading `relacl` directly would miss default-privilege grants. The
@@ -726,10 +766,39 @@ type RoleGrantRow = {
  * cry wolf over a merely-un-migrated state — the missing-role signal is already
  * the job of `checkLeastPrivilegeRoleProvisioned` (warning). Once the role
  * exists, wrong grants ARE `critical`.
+ *
+ * `policy` is injectable purely so tests can simulate the divergence the guard
+ * defends against — an RLS-free table absent from the forbidden map — without
+ * mutating shared module state (the `mock.module` cross-file-leak trap). It
+ * defaults to the single source of truth, which is always internally consistent.
  */
-export async function checkRuntimeRoleGrants(): Promise<SecurityCheckResult> {
+export type RuntimeRoleGrantsPolicy = {
+  rlsFreeTables: ReadonlySet<string>;
+  forbiddenPrivileges: Record<string, string[]>;
+};
+
+/**
+ * The real, internally-consistent policy `checkRuntimeRoleGrants` uses by
+ * default. Exposed so tests can build a DIVERGENT policy from it (e.g. an
+ * RLS-free table registered in `rlsFreeTables` but absent from
+ * `forbiddenPrivileges`) to exercise the fail-closed guard, without mutating
+ * shared module state.
+ */
+export function defaultRuntimeRoleGrantsPolicy(): RuntimeRoleGrantsPolicy {
+  return {
+    rlsFreeTables: RLS_FREE_TABLES,
+    forbiddenPrivileges: GLOBAL_TABLE_FORBIDDEN_PRIVILEGES
+  };
+}
+
+export async function checkRuntimeRoleGrants(
+  policy?: Partial<RuntimeRoleGrantsPolicy>
+): Promise<SecurityCheckResult> {
   const name = "Runtime role table grants match least-privilege matrix";
   const severity: CheckSeverity = "critical";
+  const rlsFreeTables = policy?.rlsFreeTables ?? RLS_FREE_TABLES;
+  const forbiddenPrivileges =
+    policy?.forbiddenPrivileges ?? GLOBAL_TABLE_FORBIDDEN_PRIVILEGES;
 
   try {
     if (!process.env.DATABASE_URL) {
@@ -787,21 +856,27 @@ export async function checkRuntimeRoleGrants(): Promise<SecurityCheckResult> {
 
     for (const row of rows) {
       const privileges = held(row);
-      const forbidden = GLOBAL_TABLE_FORBIDDEN_PRIVILEGES[row.relname];
 
-      if (forbidden) {
+      if (rlsFreeTables.has(row.relname)) {
+        // Global, RLS-free table. RLS can claw nothing back here (no policy),
+        // so any write `awcms_app` holds is a real, un-mitigated privilege. The
+        // table MUST carry an explicit privilege declaration. A registered
+        // RLS-free table missing from `forbiddenPrivileges` is asserted
+        // FAIL-CLOSED against every write (zero-write allowed) — the L2 guard:
+        // a forgotten registration FAILS instead of silently keeping blanket
+        // DML (Issue #162).
+        const declared = forbiddenPrivileges[row.relname];
+        const forbidden = declared ?? ALL_WRITE_PRIVILEGES;
         const excess = forbidden.filter((privilege) => privileges[privilege]);
 
         if (excess.length > 0) {
-          overGranted.push(`${row.relname} (still has ${excess.join(", ")})`);
+          overGranted.push(
+            declared === undefined
+              ? `${row.relname} (RLS-free but not declared in GLOBAL_TABLE_FORBIDDEN_PRIVILEGES — register the privileges awcms_app may hold; asserted zero-write until then, found ${excess.join(", ")})`
+              : `${row.relname} (still has ${excess.join(", ")})`
+          );
         }
 
-        continue;
-      }
-
-      if (RLS_FREE_TABLES.has(row.relname)) {
-        // Global table with full DML kept by design (module registry). Not
-        // asserted in either direction.
         continue;
       }
 
@@ -838,16 +913,18 @@ export async function checkRuntimeRoleGrants(): Promise<SecurityCheckResult> {
     }
 
     const tenantScopedCount = rows.filter(
-      (row) =>
-        !RLS_FREE_TABLES.has(row.relname) &&
-        !GLOBAL_TABLE_FORBIDDEN_PRIVILEGES[row.relname]
+      (row) => !rlsFreeTables.has(row.relname)
     ).length;
+    const narrowedGlobalTables = Object.entries(forbiddenPrivileges)
+      .filter(([, forbidden]) => forbidden.length > 0)
+      .map(([table]) => table)
+      .join(", ");
 
     return {
       name,
       severity,
       status: "pass",
-      evidence: `Role "${LEAST_PRIVILEGE_APP_ROLE}" holds SELECT/INSERT/UPDATE/DELETE on all ${tenantScopedCount} tenant-scoped table(s) and none of the forbidden writes on the narrowed global tables (${Object.keys(GLOBAL_TABLE_FORBIDDEN_PRIVILEGES).join(", ")}).`
+      evidence: `Role "${LEAST_PRIVILEGE_APP_ROLE}" holds SELECT/INSERT/UPDATE/DELETE on all ${tenantScopedCount} tenant-scoped table(s) and none of the forbidden writes on the narrowed global tables (${narrowedGlobalTables}).`
     };
   } catch (error) {
     return {

--- a/src/modules/sync-storage/README.md
+++ b/src/modules/sync-storage/README.md
@@ -92,7 +92,14 @@ against a max skew (`AWCMS_SYNC_MAX_SKEW_SEC`, default 300s) for anti-replay.
   for one tenant no longer verifies when `X-AWCMS-Tenant-ID` is swapped to
   another tenant. Nodes send `X-AWCMS-Signature-Version: 2`. This is the
   canonical scheme, mirrored across awcms, awcms-mini, and the `awcms-sync-hmac`
-  skill.
+  skill. `tenantId` **must be a UUID** and this is enforced at the v2 boundary
+  (audit finding L1): because `nodeCode` may contain `:` (schema `node_code
+text`), a non-UUID `tenantId` would make the tenant/node boundary ambiguous
+  (`v2:A:x:y:…` matches both `tenantId="A", nodeCode="x:y"` and `tenantId="A:x",
+nodeCode="y"`). A UUID is a fixed 36 chars with no `:`, so the boundary is
+  unambiguous; `computeSyncSignatureV2` throws and `verifySyncSignatureV2` fails
+  closed on a non-UUID tenant. The material format is unchanged (`nodeCode` is
+  not constrained), so this is transparent to existing nodes.
 - **v1 (legacy, VULNERABLE)** — `HMAC-SHA256("<timestamp>.<body>")`, used when no
   `X-AWCMS-Signature-Version` header is sent. Neither tenant nor node is bound,
   so it is **cross-tenant forgeable** and is kept only so already-deployed nodes

--- a/src/modules/sync-storage/domain/sync-hmac.ts
+++ b/src/modules/sync-storage/domain/sync-hmac.ts
@@ -22,14 +22,46 @@ import { createHmac, timingSafeEqual } from "node:crypto";
  * skill; nodes MUST send `X-AWCMS-Signature-Version: 2`.
  *
  * Field constraints that keep the v2 material unambiguous: `tenantId` is a
- * UUID and `nodeCode` / `timestamp` come from HTTP headers, which cannot
- * contain the `:` delimiter's problematic neighbours (raw CR/LF) — and `body`
- * is the trailing field, so any `:` it contains cannot shift an earlier field
- * boundary.
+ * UUID (enforced below) and `nodeCode` / `timestamp` come from HTTP headers,
+ * which cannot contain the `:` delimiter's problematic neighbours (raw CR/LF) —
+ * and `body` is the trailing field, so any `:` it contains cannot shift an
+ * earlier field boundary.
+ *
+ * L1 delimiter hardening (audit PR #161, GHSA-c972-3q5p-g3h4): the schema
+ * (`sql/010`, `node_code text`) puts no format constraint on `nodeCode`, so
+ * `nodeCode` MAY contain `:`. Without a constrained `tenantId` that makes the
+ * tenant/node boundary in `v2:<tenantId>:<nodeCode>:...` ambiguous —
+ * `(tenantId="A", nodeCode="x:y")` and `(tenantId="A:x", nodeCode="y")` both
+ * render `v2:A:x:y:...`, so their signatures are byte-identical and mutually
+ * accepted. The auditor confirmed this is NOT cross-tenant exploitable (a
+ * request's `tenantId` must be a valid UUID — no `:` — to reach any tenant data
+ * via `withTenant`), but it is a latent ambiguity in security-signature code.
+ *
+ * Fix = Option A (zero regression): require `tenantId` to be a UUID at the v2
+ * compute/verify boundary, BEFORE the material is built. A UUID is a fixed 36
+ * chars and contains no `:`, so the tenant field boundary becomes unambiguous
+ * and no two distinct (tenantId, nodeCode) pairs can collide on the tenant/node
+ * split. This constrains ONLY `tenantId` — `nodeCode` is untouched, so every
+ * already-deployed v1/v2 node (whose tenant id is a UUID) is unaffected. v1
+ * material has no tenant field and is therefore not touched by this change.
  */
 
 export const SYNC_SIGNATURE_VERSION_HEADER = "X-AWCMS-Signature-Version";
 export const SYNC_SIGNATURE_VERSION_V2 = "2";
+
+/**
+ * Canonical tenant-id shape accepted in v2 material. Mirrors `UUID_PATTERN` in
+ * `src/lib/database/tenant-context.ts` — the exact shape `withTenant` requires
+ * before any tenant-scoped SQL runs. Kept as a local copy on purpose so this
+ * domain module stays free of database/runtime imports (it only needs
+ * `node:crypto`).
+ */
+const TENANT_ID_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isTenantIdUuid(tenantId: string): boolean {
+  return TENANT_ID_UUID_PATTERN.test(tenantId);
+}
 
 /** v1 legacy material — tenant/node NOT bound (see file header). */
 export function computeSyncSignature(
@@ -50,6 +82,16 @@ export function computeSyncSignatureV2(
   timestamp: string,
   body: string
 ): string {
+  // A non-UUID tenantId is the only input that makes the v2 material
+  // delimiter-ambiguous (see file header). Fail loudly rather than sign
+  // ambiguous material — every legitimate caller already holds a UUID tenant
+  // id, so this never fires on a real node.
+  if (!isTenantIdUuid(tenantId)) {
+    throw new Error(
+      "computeSyncSignatureV2: tenantId must be a UUID (v2 material integrity)."
+    );
+  }
+
   return createHmac("sha256", secret)
     .update(`v2:${tenantId}:${nodeCode}:${timestamp}:${body}`)
     .digest("hex");
@@ -87,6 +129,15 @@ export function verifySyncSignatureV2(
   body: string,
   providedSignature: string
 ): boolean {
+  // Fail-closed on a non-UUID tenant id: it is the only input that makes the v2
+  // material delimiter-ambiguous, and a real request's tenantId must be a UUID
+  // to reach any tenant-scoped data (`withTenant`). Rejecting here — before the
+  // material is built — means an ambiguous material is never even a candidate
+  // match, and keeps `computeSyncSignatureV2`'s throw from escaping `verify`.
+  if (!isTenantIdUuid(tenantId)) {
+    return false;
+  }
+
   return timingSafeHexEqual(
     computeSyncSignatureV2(secret, tenantId, nodeCode, timestamp, body),
     providedSignature

--- a/tests/security-readiness-failclosed.test.ts
+++ b/tests/security-readiness-failclosed.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Issue #162 / L2 — real-PostgreSQL test that `checkRuntimeRoleGrants` fails
+ * CLOSED for a global, RLS-free table that is registered as RLS-free (as one
+ * would to satisfy `checkRlsEnabled`) but carries NO explicit privilege
+ * declaration in the forbidden-privilege map.
+ *
+ * Before this fix such a table was `continue`d as "full DML kept by design" and
+ * passed silently — the exact "a new global table inherits blanket DML from
+ * `ALTER DEFAULT PRIVILEGES`" regression the check exists to catch. The 9 real
+ * tables are curated correctly and merged into ONE source of truth, so the
+ * divergence cannot occur in shipped code; the guard is exercised here by
+ * INJECTING a divergent policy (`rlsFreeTables` augmented with a probe table
+ * the default forbidden map does not know about). Injection — not `mock.module`
+ * — because stubbing a shared module leaks across every later test file in the
+ * same process (PR #157: green locally, 12 CI failures on the same commit).
+ *
+ * Requires `awcms_app` (sql/019) and the narrowed grants (sql/021) to be
+ * present. Gated on `DATABASE_URL`, same convention as
+ * `security-readiness-rls.test.ts`: `ci.yml` has no database so it skips
+ * cleanly; `release.yml` provides a throwaway `postgres:18.4` and sets it.
+ *
+ * The suite only creates/drops its own probe table. It NEVER drops or mutates
+ * the cluster-wide `awcms_app` role — grants on the probe vanish when the probe
+ * is dropped.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import {
+  checkRuntimeRoleGrants,
+  defaultRuntimeRoleGrantsPolicy
+} from "../scripts/security-readiness";
+
+const DATABASE_URL = process.env.DATABASE_URL;
+const describeOrSkip = DATABASE_URL ? describe : describe.skip;
+
+/** A synthetic "future global table": matches `awcms\_%`, has no RLS. */
+const PROBE_TABLE = "awcms_l2_failclosed_probe";
+
+describeOrSkip(
+  "security:readiness runtime-role grant check fails closed (Issue #162 / L2)",
+  () => {
+    let sql: Bun.SQL;
+
+    beforeAll(async () => {
+      sql = new Bun.SQL(DATABASE_URL!, { max: 2 });
+      await sql.unsafe(`DROP TABLE IF EXISTS ${PROBE_TABLE}`);
+    });
+
+    afterAll(async () => {
+      await sql.unsafe(`DROP TABLE IF EXISTS ${PROBE_TABLE}`);
+      await sql.close({ timeout: 1 });
+    });
+
+    async function awcmsAppExists(): Promise<boolean> {
+      const rows = (await sql`
+        SELECT 1 AS present FROM pg_roles WHERE rolname = 'awcms_app'
+      `) as { present: number }[];
+      return rows.length > 0;
+    }
+
+    test("state (a): the curated 9-table default policy still PASSES", async () => {
+      const result = await checkRuntimeRoleGrants();
+
+      expect(result.severity).toBe("critical");
+      // On a pre-sql/019 database the role is absent and the check is
+      // non-blocking-pass by design; on a fully-migrated one it is a real pass.
+      // Either way the curated default must NOT be a critical failure — the
+      // whole point of the merge is that the 9 tables stay correct.
+      expect(result.status).toBe("pass");
+    });
+
+    test("state (b): an RLS-free table with NO forbidden entry FAILS closed", async () => {
+      if (!(await awcmsAppExists())) {
+        // Pre-sql/019 database: the check returns non-blocking-pass before it
+        // ever inspects grants, so the fail-closed branch cannot be reached.
+        // Its behaviour is asserted where the role exists (release.yml).
+        return;
+      }
+
+      await sql.unsafe(`
+        CREATE TABLE ${PROBE_TABLE} (
+          id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+          label text
+        )
+      `);
+      // Give awcms_app blanket DML on the probe. In production this is exactly
+      // what a new global table inherits from sql/019's ALTER DEFAULT
+      // PRIVILEGES — the blanket-DML-by-inheritance this guard defends against.
+      // Granting explicitly makes the scenario deterministic regardless of
+      // which owner's default privileges happen to fire.
+      await sql.unsafe(
+        `GRANT SELECT, INSERT, UPDATE, DELETE ON ${PROBE_TABLE} TO awcms_app`
+      );
+
+      // Guard the guard: awcms_app really holds a write on the probe, so a
+      // "pass" below could only mean the guard skipped it (the old bug).
+      const priv = (await sql.unsafe(`
+        SELECT has_table_privilege('awcms_app', '${PROBE_TABLE}', 'INSERT') AS ins
+      `)) as { ins: boolean }[];
+      expect(priv[0]?.ins).toBe(true);
+
+      const base = defaultRuntimeRoleGrantsPolicy();
+
+      // Register the probe as RLS-free (what a future migration author would do
+      // to make checkRlsEnabled pass for a new global table) but leave the
+      // forbidden map at its real default — i.e. they forgot to declare it.
+      const failClosed = await checkRuntimeRoleGrants({
+        rlsFreeTables: new Set([...base.rlsFreeTables, PROBE_TABLE])
+      });
+
+      expect(failClosed.severity).toBe("critical");
+      expect(failClosed.status).toBe("fail");
+      expect(failClosed.evidence).toContain(PROBE_TABLE);
+      expect(failClosed.evidence).toContain("register the privileges");
+      expect(failClosed.evidence).toContain("INSERT, UPDATE, DELETE");
+
+      // Control — SAME table, SAME grants, only difference is the registration:
+      // under the REAL default policy the probe is not registered RLS-free, so
+      // it is treated tenant-scoped, and with all four grants it is not a
+      // finding. This proves the failure above is the L2 mechanism (RLS-free +
+      // undeclared), not the probe's mere presence.
+      const underDefault = await checkRuntimeRoleGrants();
+      expect(underDefault.status).toBe("pass");
+      expect(underDefault.evidence).not.toContain(PROBE_TABLE);
+    });
+  }
+);

--- a/tests/sync-hmac-versioned.test.ts
+++ b/tests/sync-hmac-versioned.test.ts
@@ -81,6 +81,93 @@ describe("computeSyncSignatureV2 binds tenant + node", () => {
   });
 });
 
+// --- L1: delimiter ambiguity between tenantId and nodeCode is closed ---------
+//
+// Regression guard for audit finding L1 (PR #161, GHSA-c972-3q5p-g3h4). Before
+// the fix the v2 material `v2:<tenantId>:<nodeCode>:...` was ambiguous because
+// `nodeCode` may contain `:` (schema `node_code text`, no format constraint):
+//   (tenantId="A",   nodeCode="x:y")  ->  "v2:A:x:y:<ts>:<body>"
+//   (tenantId="A:x", nodeCode="y")    ->  "v2:A:x:y:<ts>:<body>"
+// Identical material -> byte-identical signature -> mutually accepted. The fix
+// (Option A) requires `tenantId` to be a UUID at the v2 boundary; a UUID is a
+// fixed 36 chars with no `:`, so the tenant/node boundary is unambiguous. Both
+// colliding shapes carry a non-UUID tenantId, so both are now rejected. Only
+// `tenantId` is constrained — `nodeCode` is untouched (zero regression for real
+// UUID-tenant nodes).
+describe("v2 delimiter hardening (L1): tenantId must be a UUID", () => {
+  const timestamp = "2026-07-18T00:00:00.000Z";
+  const body = "{}";
+
+  test("the two historically-colliding shapes can no longer be produced", () => {
+    // Both carry a non-UUID tenantId ("A" and "A:x"); compute now throws for
+    // each, so the ambiguous material is never even minted.
+    expect(() =>
+      computeSyncSignatureV2(SECRET, "A", "x:y", timestamp, body)
+    ).toThrow(/tenantId must be a UUID/);
+    expect(() =>
+      computeSyncSignatureV2(SECRET, "A:x", "y", timestamp, body)
+    ).toThrow(/tenantId must be a UUID/);
+  });
+
+  test("verify fails closed on a non-UUID tenantId (no cross-accept)", () => {
+    // A legitimately-signed v2 request for tenant A + node "x:y" ...
+    const sig = computeSyncSignatureV2(
+      SECRET,
+      TENANT_A,
+      "x:y",
+      timestamp,
+      body
+    );
+    expect(
+      verifySyncSignatureV2(SECRET, TENANT_A, "x:y", timestamp, body, sig)
+    ).toBe(true);
+
+    // ... cannot be re-attributed by shifting the tenant/node boundary into a
+    // non-UUID tenantId. verify rejects (returns false, never throws).
+    expect(
+      verifySyncSignatureV2(SECRET, "A:x", "y", timestamp, body, sig)
+    ).toBe(false);
+    // And the reverse-shaped forgery of tenant A's signature is rejected too.
+    const forged = TENANT_A + ":x";
+    expect(
+      verifySyncSignatureV2(SECRET, forged, "y", timestamp, body, sig)
+    ).toBe(false);
+  });
+
+  test("a nodeCode containing ':' still verifies for a valid UUID tenant", () => {
+    // nodeCode is deliberately NOT constrained — a real node whose code
+    // contains ':' keeps working, as long as its tenantId is a UUID.
+    const sig = computeSyncSignatureV2(
+      SECRET,
+      TENANT_A,
+      "kasir:pos:1",
+      timestamp,
+      body
+    );
+    expect(
+      verifySyncSignatureV2(
+        SECRET,
+        TENANT_A,
+        "kasir:pos:1",
+        timestamp,
+        body,
+        sig
+      )
+    ).toBe(true);
+    // Tenant-swap between two valid UUIDs is still rejected.
+    expect(
+      verifySyncSignatureV2(
+        SECRET,
+        TENANT_B,
+        "kasir:pos:1",
+        timestamp,
+        body,
+        sig
+      )
+    ).toBe(false);
+  });
+});
+
 describe("verifySyncHeaders (versioned)", () => {
   const ENV_KEYS = [
     "AWCMS_SYNC_ENABLED",
@@ -155,6 +242,23 @@ describe("verifySyncHeaders (versioned)", () => {
     const sig = computeSyncSignature(SECRET, ts, body);
 
     const result = verifySyncHeaders(TENANT_A, NODE, ts, sig, null, body);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(401);
+    }
+  });
+
+  test("v2: a non-UUID tenant header is rejected (L1 delimiter guard)", () => {
+    const ts = freshTimestamp();
+    const body = "{}";
+    // Even if an attacker crafts material with a colon-bearing "tenantId", the
+    // v2 verify boundary fails closed on the non-UUID tenant id -> 401. The
+    // signature value is irrelevant: verify rejects before any comparison (and
+    // compute would itself refuse to mint ambiguous material), so a dummy
+    // 64-char hex digest stands in here.
+    const sig = "0".repeat(64);
+    const result = verifySyncHeaders("A:x", "y", ts, sig, "2", body);
 
     expect(result.ok).toBe(false);
     if (!result.ok) {


### PR DESCRIPTION
Dua temuan defense-in-depth dari audit keamanan PR #161 (issue #162), keduanya non-blocking dan dikonfirmasi tak dapat dieksploitasi, ditutup di file disjoint. Dua agen paralel. `bun run check` hijau: **697 pass / 104 skip / 0 fail** tanpa DB; **777 pass / 0 fail** dengan `DATABASE_URL`. Kode-saja — nol migration.

Closes #162

## L1 — ambiguitas delimiter signature v2 (`sync-hmac.ts`)

Material v2 `v2:<tenantId>:<nodeCode>:<timestamp>:<body>` ambigu karena `node_code` bebas-format, jadi `(tenantId="A", nodeCode="x:y")` dan `(tenantId="A:x", nodeCode="y")` menghasilkan hash identik dan saling-terima.

Ditutup dengan mewajibkan `tenantId` berupa **UUID** di boundary compute/verify — UUID panjang tetap tanpa `:`, jadi batas `tenantId:nodeCode` tak ambigu **tanpa menyentuh `node_code`** (Opsi A: nol regresi untuk node v1/v2 yang ada, dan byte material v2 **tidak berubah** sehingga awcms-mini + spec node tak perlu diubah). `compute` throw untuk tenantId non-UUID; `verify` fail-closed. v1 tak tersentuh.

**Bukti (eksekusi):** kolisi lama saling-terima → kini throw; node UUID-tenant dengan `:` di code tetap verify benar; tenant-swap antar dua UUID valid tetap ditolak.

## L2 — guard grant readiness fail-closed (`security-readiness.ts`)

`checkRuntimeRoleGrants` memakai dua daftar terpisah (`RLS_FREE_TABLES` + `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES`), jadi tabel global RLS-free baru yang masuk daftar pertama tapi lupa di kedua di-`continue` sebagai "full DML by design" — persis regresi blanket-DML yang check ini ada untuk menjaga.

Digabung jadi **satu sumber kebenaran** (`RLS_FREE_TABLES` kini diturunkan dari peta privilege) dan tabel tak-terdaftar dibuat **fail-closed**: di-assert nol-write, dan grant INSERT/UPDATE/DELETE apa pun padanya jadi temuan critical yang menuntut deklarasi eksplisit. Test menyuntik policy lewat parameter, bukan `mock.module`.

**Bukti (eksekusi):** state 9-tabel ter-kurasi tetap PASS; simulasi tabel RLS-free tak-terdaftar dengan DML kini GAGAL di tempat yang dulu lolos.

## Catatan

Format material v2 **tidak berubah** (Opsi A), jadi tidak ada koordinasi mini/spec yang diperlukan untuk L1. Guard L2 backward-compatible (`checkRuntimeRoleGrants(policy?)` opsional).

🤖 Generated with [Claude Code](https://claude.com/claude-code)