### PR TITLE
feat(e2e): port Playwright browser E2E harness + catch-all 404 page (#166)

### DIFF
--- a/.changeset/e2e-harness-and-404.md
+++ b/.changeset/e2e-harness-and-404.md
@@ -1,0 +1,11 @@
+---
+"awcms": patch
+---
+
+Add the browser E2E harness (Playwright + Bun) and a real catch-all 404 page — the first slice of porting awcms-mini's E2E layer, following the mini-first flow.
+
+- **Harness** (`playwright.config.ts`, `test:e2e`/`test:e2e:install` scripts, `@playwright/test` devDep) ported from awcms-mini and adapted: specs live in `tests/e2e/*.e2e.ts` (the `.e2e.ts` suffix keeps `bun test` from ever picking them up), run via `bun --bun playwright test` (Bun-only, AGENTS.md #14), against an already-running app (Playwright's `webServer` can't provision the Postgres this app boots against). See skill `awcms-browser-test`.
+- **Catch-all 404** (`src/pages/[...path].ts`) wires the previously-dormant public HTML error responses (`src/lib/html/error-responses.ts`): an unknown browser path now gets a clean, generic 404 HTML page that leaks nothing internal (Issue #540), and an unknown `/api/*` path gets the standard JSON error envelope instead of framework-default chrome. Astro ranks rest params lowest, so every real route still wins.
+- **First E2E spec** (`tests/e2e/not-found.e2e.ts`) drives a real Chromium at the 404 page and asserts the clean render + no internal-detail leak. Validated live locally (system Chrome) and wired into a new CI `e2e-smoke` job (`.github/workflows/ci.yml`) — no Postgres needed since the 404 route touches no DB.
+
+Foundation for the admin/management screens (login, offices, …) whose specs land with the first `.astro` pages.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,11 @@
 # bukan daftar independen yang bisa drift darinya. Diadaptasi dari
 # awcms-mini (`.github/workflows/ci.yml`), dipangkas ke apa yang benar-benar
 # ada di repo ini: belum ada test integrasi yang butuh Postgres hidup (semua
-# 174+ test adalah unit murni), belum ada Playwright/E2E, dan belum ada
-# docker-compose*.yml untuk divalidasi.
+# 174+ test adalah unit murni), dan belum ada docker-compose*.yml untuk
+# divalidasi. Sejak Issue #166 ada job `e2e-smoke` (Playwright + Bun) —
+# untuk sekarang hanya spec `not-found.e2e.ts` yang tidak butuh Postgres,
+# jadi job-nya belum menyalakan service DB (akan ditambah begitu ada spec E2E
+# yang butuh sesi/tenant ter-seed, mengikuti pola dua-fase awcms-mini).
 name: CI
 
 on:
@@ -91,6 +94,60 @@ jobs:
             !dist/**/*.map
           retention-days: 5
           if-no-files-found: ignore
+
+  e2e-smoke:
+    name: E2E smoke (Playwright)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Cache Bun install cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build Astro foundation
+        run: bun run build
+
+      - name: Install Playwright Chromium (with OS deps)
+        run: bun run test:e2e:install
+
+      # The only E2E spec today (`not-found.e2e.ts`) exercises the catch-all
+      # 404 route, which touches NO database — so the app boots against a
+      # placeholder `DATABASE_URL` purely to satisfy the connection-string
+      # requirement, never actually connecting. A spec that needs a seeded
+      # session/tenant will require a real `services.postgres` + `db:migrate`
+      # here first (awcms-mini's `e2e-smoke` job is the template to follow).
+      - name: Start the built server and run E2E
+        run: |
+          DATABASE_URL="postgres://placeholder:placeholder@127.0.0.1:5999/placeholder" \
+            bun ./dist/server/entry.mjs &
+          APP_PID=$!
+          # Wait until the catch-all 404 answers (server up); fail if it never does.
+          up=""
+          for i in $(seq 1 30); do
+            code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:4321/__e2e_probe || true)
+            if [ "$code" = "404" ]; then up="yes"; break; fi
+            sleep 1
+          done
+          if [ -z "$up" ]; then echo "::error::server never became ready on :4321"; kill "$APP_PID" || true; exit 1; fi
+          bun run test:e2e
+          status=$?
+          kill "$APP_PID" || true
+          exit $status
 
   hygiene:
     name: Repo hygiene (Bun-only + no secrets)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,19 +131,28 @@ jobs:
       # requirement, never actually connecting. A spec that needs a seeded
       # session/tenant will require a real `services.postgres` + `db:migrate`
       # here first (awcms-mini's `e2e-smoke` job is the template to follow).
+      # HOST=127.0.0.1 is load-bearing: @astrojs/node binds to `localhost`
+      # by default, which on the CI runner resolves to IPv6 `::1` while the
+      # curl probe and Playwright hit IPv4 `127.0.0.1` — the server is up but
+      # unreachable, and the probe times out. Pinning HOST (and matching
+      # E2E_BASE_URL) forces both ends onto the same IPv4 address.
       - name: Start the built server and run E2E
+        env:
+          HOST: 127.0.0.1
+          PORT: "4321"
+          DATABASE_URL: postgres://placeholder:placeholder@127.0.0.1:5999/placeholder
+          E2E_BASE_URL: http://127.0.0.1:4321
         run: |
-          DATABASE_URL="postgres://placeholder:placeholder@127.0.0.1:5999/placeholder" \
-            bun ./dist/server/entry.mjs &
+          bun ./dist/server/entry.mjs &
           APP_PID=$!
           # Wait until the catch-all 404 answers (server up); fail if it never does.
           up=""
           for i in $(seq 1 30); do
-            code=$(curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:4321/__e2e_probe || true)
+            code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:4321/__e2e_probe" || true)
             if [ "$code" = "404" ]; then up="yes"; break; fi
             sleep 1
           done
-          if [ -z "$up" ]; then echo "::error::server never became ready on :4321"; kill "$APP_PID" || true; exit 1; fi
+          if [ -z "$up" ]; then echo "::error::server never became ready on 127.0.0.1:4321"; kill "$APP_PID" || true; exit 1; fi
           bun run test:e2e
           status=$?
           kill "$APP_PID" || true

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.9",
+        "@playwright/test": "^1.61.1",
         "@types/bun": "^1.3.14",
         "prettier": "^3.9.5",
         "prettier-plugin-astro": "^0.14.1",
@@ -252,6 +253,8 @@
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
@@ -511,7 +514,7 @@
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "get-tsconfig": ["get-tsconfig@5.0.0-beta.4", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ=="],
 
@@ -698,6 +701,10 @@
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
+
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
     "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
@@ -900,6 +907,8 @@
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "read-yaml-file/js-yaml": ["js-yaml@3.15.0", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog=="],
+
+    "vite/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
 

--- a/docs/awcms/07_sprint_testing_production_readiness.md
+++ b/docs/awcms/07_sprint_testing_production_readiness.md
@@ -187,12 +187,19 @@ flowchart TB
 
 Piramida: banyak unit test di dasar, sedikit end-to-end di puncak; security & performance test mengawal.
 
-> **E2E browser sungguhan (Playwright + Bun).** Base `awcms-mini` yang
-> menjadi fondasi teknis AWCMS sudah menyediakan tooling nyata untuk lapisan
-> ini (`playwright.config.ts` + `tests/e2e/*.e2e.ts`), dijalankan lewat
-> `bun run test:e2e`, terpisah dari `bun test` (unit/integration/API-
-> contract). AWCMS akan mengikuti pola yang sama begitu layar/endpoint ERP
-> pertama ada — saat ini belum ada target E2E domain ERP untuk dijalankan.
+> **E2E browser sungguhan (Playwright + Bun).** Harness-nya kini **sudah ada**
+> di repo ini (Issue #166, port dari awcms-mini): `playwright.config.ts` +
+> `tests/e2e/*.e2e.ts`, dijalankan lewat `bun run test:e2e` (→ `bun --bun
+playwright test`, Bun-only), terpisah dari `bun test`
+> (unit/integration/API-contract) — lihat skill `awcms-browser-test`. Spec
+> pertama `not-found.e2e.ts` menguji route catch-all 404
+> (`src/pages/[...path].ts`, memakai ulang `src/lib/html/error-responses.ts`):
+> browser membuka path asing → dapat halaman 404 HTML bersih tanpa bocor
+> detail internal (Issue #540). Dijalankan di CI oleh job `e2e-smoke`
+> (`.github/workflows/ci.yml`) — belum menyalakan Postgres karena spec 404 tak
+> butuh DB. Spec berikutnya (layar admin/manajemen: login, offices, dst.)
+> ditambah begitu halaman `.astro` pertama landing, dan job CI-nya akan
+> menyalakan Postgres + `db:migrate` + seed mengikuti pola dua-fase awcms-mini.
 
 > **Runner test.** Runner = **`bun test`** (`bun:test`), berkas di
 > `tests/`. Daftar target di bawah bersifat **target rencana modul ERP**,

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "test:coverage": "bun test --coverage",
+    "test:e2e": "bun --bun playwright test",
+    "test:e2e:install": "bun --bun playwright install --with-deps chromium",
     "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run modules:dag:check && bun run reporting:projections:registry:check && bun run logging:lint:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
@@ -69,6 +71,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.9",
+    "@playwright/test": "^1.61.1",
     "@types/bun": "^1.3.14",
     "prettier": "^3.9.5",
     "prettier-plugin-astro": "^0.14.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,52 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * E2E browser test config (Playwright + Bun). See skill
+ * `.claude/skills/awcms-browser-test/SKILL.md` for the full setup rationale,
+ * conventions, and known Bun/Playwright gotchas. Ported from awcms-mini's
+ * harness (mini-first flow, `docs/awcms/alur-pengembangan-mini-first.md`) and
+ * adapted to this repo.
+ *
+ * Naming: specs use `*.e2e.ts` (not `.spec.ts`/`.test.ts`) so `bun test`'s own
+ * recursive discovery — which matches `*.test.*`/`*_test.*`/`*.spec.*`/
+ * `*_spec.*` by default — never picks these files up and tries to run them as
+ * `bun:test` files (they use `@playwright/test`'s own `test`/`expect`, a
+ * different runtime context entirely). Verify: `bun test tests/e2e` reports
+ * "did not match any test files".
+ *
+ * This suite assumes an already-running app (`bun run dev` or `bun run
+ * build && bun run start`, with `DATABASE_URL` set) at `E2E_BASE_URL` — the
+ * same "you provide the environment" convention `tests/integration/*` uses for
+ * `DATABASE_URL`. Playwright's own `webServer` auto-start is intentionally NOT
+ * used: this app's server needs a live Postgres connection to boot at all,
+ * which `webServer` has no way to provision.
+ */
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: "**/*.e2e.ts",
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: process.env.E2E_BASE_URL ?? "http://localhost:4321",
+    headless: true,
+    trace: "retain-on-failure",
+    // Root-less sandboxes (no `apt-get`, so `playwright install --with-deps`
+    // can't run) can point this at a pre-installed system browser instead of
+    // Playwright's own bundled Chromium — e.g.
+    // `PLAYWRIGHT_CHROMIUM_EXECUTABLE=/usr/bin/google-chrome`. Leave unset
+    // wherever `bun run test:e2e:install` succeeds normally (dev machines, CI
+    // with `--with-deps`).
+    launchOptions: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE
+      ? { executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE }
+      : {}
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/src/pages/[...path].ts
+++ b/src/pages/[...path].ts
@@ -1,0 +1,33 @@
+import type { APIRoute } from "astro";
+
+import { fail } from "../modules/_shared/api-response";
+import { notFoundHtmlResponse } from "../lib/html/error-responses";
+
+/**
+ * Catch-all fallback for any request path that no more-specific route matches.
+ * Astro ranks rest params (`[...path]`) lowest, so every real route — every
+ * `src/pages/api/v1/**` endpoint and every future admin `.astro` page — wins
+ * over this file; it only ever runs for genuinely unmatched paths.
+ *
+ * WHY THIS EXISTS: without it, an unknown path falls through to Astro's own
+ * default 404, which is framework chrome, not something this app controls. A
+ * public API server should answer a bad path with (a) a clean, generic HTML
+ * page for a browser, leaking NOTHING about internals (Issue #540: "error
+ * output must not expose stack traces" — enforced by
+ * `tests/e2e/not-found.e2e.ts`), and (b) the standard JSON error envelope for
+ * an `/api/*` client, so a mistyped endpoint answers in the same shape as
+ * every other API error rather than as HTML. This finally wires the
+ * public-facing HTML error responses (`src/lib/html/error-responses.ts`) that
+ * shipped for exactly this purpose.
+ *
+ * `ALL` handles every method: a bad path is 404 regardless of verb. (A real
+ * route with the path but no handler for the method still returns 405 from
+ * that route — Astro matches the path first, so this never masks a 405.)
+ */
+export const ALL: APIRoute = ({ url }) => {
+  if (url.pathname.startsWith("/api/")) {
+    return fail(404, "NOT_FOUND", "The requested resource does not exist.");
+  }
+
+  return notFoundHtmlResponse();
+};

--- a/tests/e2e/not-found.e2e.ts
+++ b/tests/e2e/not-found.e2e.ts
@@ -1,0 +1,52 @@
+/**
+ * First real E2E spec for awcms (Playwright + Bun) — see skill
+ * `.claude/skills/awcms-browser-test/SKILL.md`.
+ *
+ * awcms is API-only today: no seeded data and (until the admin UI lands) no
+ * rendered pages EXCEPT the catch-all 404 (`src/pages/[...path].ts`, reusing
+ * `src/lib/html/error-responses.ts`). That makes an unknown path the one
+ * browser target that needs zero fixtures — exactly the "pick a target that
+ * needs no seeded data" convention (skill #4) — while still exercising a real
+ * property worth a browser: a public server must answer a bad path with a
+ * clean page that leaks NOTHING internal (skill #5, Issue #540).
+ *
+ * Run: `bun run dev` (or `bun run build && bun run start`) in one terminal with
+ * `DATABASE_URL` set, then `bun run test:e2e` in another.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("catch-all 404 page", () => {
+  test("an unknown browser path renders a clean 404 HTML page", async ({
+    page
+  }) => {
+    const response = await page.goto("/this-path-does-not-exist-42");
+
+    expect(response?.status()).toBe(404);
+    await expect(page.locator("h1")).toHaveText("Not Found");
+    await expect(page.locator("body")).toContainText(
+      "The page you requested does not exist."
+    );
+  });
+
+  test("the 404 page leaks no internal detail (no stack trace, no infra names)", async ({
+    page
+  }) => {
+    await page.goto("/boom-" + "x".repeat(8));
+
+    // Assert on the FULL served HTML, not just visible text: a leak could hide
+    // in a comment or attribute. The generic error page must never carry any
+    // of these markers regardless of how the miss was produced.
+    const html = (await page.content()).toLowerCase();
+    for (const marker of [
+      "stack",
+      "at object",
+      "postgres",
+      "econnrefused",
+      "node_modules",
+      "/home/",
+      "bun.sql"
+    ]) {
+      expect(html).not.toContain(marker);
+    }
+  });
+});


### PR DESCRIPTION
Stage 1 of #166 — port awcms-mini's browser E2E layer, following the mini-first flow. awcms is API-only (zero `.astro` pages), so mini's admin-page specs have no target here yet; this ports the **reusable harness** plus the one browser surface awcms can already offer (a clean 404).

## What

- **Harness** — `playwright.config.ts`, `test:e2e` / `test:e2e:install` scripts, `@playwright/test` devDep (ported + adapted from mini). Specs are `tests/e2e/*.e2e.ts` (the `.e2e.ts` suffix keeps `bun test` from ever discovering them), run via `bun --bun playwright test` (Bun-only, AGENTS.md #14), against an already-running app (Playwright's `webServer` can't provision the Postgres this app boots against). See skill `awcms-browser-test`.
- **Catch-all 404** (`src/pages/[...path].ts`) — wires the previously-**dormant** public HTML error responses (`src/lib/html/error-responses.ts`, shipped for exactly this): unknown browser path → clean generic 404 HTML leaking nothing internal (Issue #540); unknown `/api/*` → standard JSON error envelope instead of framework-default chrome. Astro ranks rest params lowest, so every real route (`api/v1/**`, future `.astro`) still wins; `ALL` handler never masks a real route's 405.
- **First spec** `tests/e2e/not-found.e2e.ts` — drives a real Chromium at the 404 and asserts the clean render + no internal-detail leak.
- **CI `e2e-smoke` job** — DB-less (the 404 route touches no Postgres): build → install Chromium (with OS deps) → start the built server against a placeholder `DATABASE_URL` → run `test:e2e`. A future spec needing a seeded session will add `services.postgres` + `db:migrate` here (mini's two-phase job is the template).

## Verification

- `bun run check`: **707 pass / 0 fail**, build OK.
- E2E validated **live locally** against a real running server + system Chromium: **2 passed**.
- `bun test tests/e2e` correctly reports "no test files" (the `.e2e.ts` suffix is excluded from `bun test`).

Foundation for the admin/management UI slice (login + offices) landing next under #166.

🤖 Generated with [Claude Code](https://claude.com/claude-code)