### PR TITLE
feat(admin): first admin management UI — login + shell + offices screen (#166)

### DIFF
--- a/.changeset/admin-ui-first-slice.md
+++ b/.changeset/admin-ui-first-slice.md
@@ -1,0 +1,11 @@
+---
+"awcms": patch
+---
+
+Add awcms's first admin management UI — login + admin shell + offices screen — with full E2E coverage (Issue #166, Stage 2). Ports awcms-mini's admin UI pattern, adapted to awcms's fondasi scope; the auth/session/middleware plumbing (`/admin` guard, `resolveSsrContext`, login/logout endpoints) already existed, so this is additive UI.
+
+- **Pages**: `login.astro` (posts to `POST /api/v1/auth/login` with `X-AWCMS-Tenant-ID`, redirects to `/admin`), `admin/index.astro` (dashboard rendered purely from `ssrContext`), `admin/offices.astro` (management screen — SSR-reads the tenant's offices via the same `listOffices` the JSON endpoint uses, permission-gated on `tenant_admin.office_management.read`, renders an accessible table + status badges). A stripped `AdminLayout` and the doc-14 design tokens (`src/styles/tokens.css`) + `admin.css` back them.
+- **CSP handled correctly** (Issue #148): the middleware stays the single CSP owner (`default-src 'self'`, covering JSON + HTML + pages). `astro.config.mjs` sets `build.inlineStylesheets: "never"` (external stylesheets) and every page `<script>` imports from `src/lib/ui/admin-form-client.ts` — which forces Astro to bundle it to an external file rather than inline it (an inline script would be CSP-blocked, silently breaking the page). Verified: the login page ships zero inline script/style.
+- **E2E**: `login.e2e.ts` (form render + the CSP "no inline script" property) validated live locally; `admin-offices.e2e.ts` drives the full authenticated loop (login → session → `/admin` → offices table + wrong-password generic-error path). The CI `e2e-smoke` job now provisions `postgres:18.4`, runs `db:migrate`, and seeds a tenant+owner through the real `POST /api/v1/setup/initialize` bootstrap.
+
+Read-only offices for this first slice; create/edit stays on `POST /api/v1/offices` and lands later.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@
 # awcms-mini (`.github/workflows/ci.yml`), dipangkas ke apa yang benar-benar
 # ada di repo ini: belum ada test integrasi yang butuh Postgres hidup (semua
 # 174+ test adalah unit murni), dan belum ada docker-compose*.yml untuk
-# divalidasi. Sejak Issue #166 ada job `e2e-smoke` (Playwright + Bun) —
-# untuk sekarang hanya spec `not-found.e2e.ts` yang tidak butuh Postgres,
-# jadi job-nya belum menyalakan service DB (akan ditambah begitu ada spec E2E
-# yang butuh sesi/tenant ter-seed, mengikuti pola dua-fase awcms-mini).
+# divalidasi. Sejak Issue #166 ada job `e2e-smoke` (Playwright + Bun): 404 +
+# login render tidak butuh DB, tapi alur admin ter-autentikasi butuh, jadi
+# job-nya menyalakan service `postgres:18.4`, `db:migrate`, lalu men-seed satu
+# tenant+owner lewat `POST /api/v1/setup/initialize` (bootstrap sungguhan,
+# bukan seed SQL ad-hoc) dan mengoperkan kredensialnya ke spec via env.
 name: CI
 
 on:
@@ -100,6 +101,29 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      POSTGRES_USER: awcms
+      POSTGRES_PASSWORD: awcms_ci_password
+      POSTGRES_DB: awcms
+    # Ephemeral per-job Postgres, created + torn down by the runner for THIS
+    # job only. Migrations run as this superuser and the app connects as it
+    # too — E2E smoke proves the UI flow (login → session → SSR render), not
+    # RLS enforcement (that is the DB-gated `bun:test` integration suite's
+    # job, run under a non-superuser role there).
+    services:
+      postgres:
+        image: postgres:18.4
+        env:
+          POSTGRES_USER: awcms
+          POSTGRES_PASSWORD: awcms_ci_password
+          POSTGRES_DB: awcms
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U awcms -d awcms"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
@@ -116,8 +140,14 @@ jobs:
           restore-keys: |
             bun-${{ runner.os }}-
 
+      - name: Assemble DATABASE_URL for this job's Postgres
+        run: echo "DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:5432/${POSTGRES_DB}" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Apply migrations
+        run: bun run db:migrate
 
       - name: Build Astro foundation
         run: bun run build
@@ -125,38 +155,46 @@ jobs:
       - name: Install Playwright Chromium (with OS deps)
         run: bun run test:e2e:install
 
-      # The only E2E spec today (`not-found.e2e.ts`) exercises the catch-all
-      # 404 route, which touches NO database — so the app boots against a
-      # placeholder `DATABASE_URL` purely to satisfy the connection-string
-      # requirement, never actually connecting. A spec that needs a seeded
-      # session/tenant will require a real `services.postgres` + `db:migrate`
-      # here first (awcms-mini's `e2e-smoke` job is the template to follow).
-      # HOST=127.0.0.1 is load-bearing: @astrojs/node binds to `localhost`
-      # by default, which on the CI runner resolves to IPv6 `::1` while the
-      # curl probe and Playwright hit IPv4 `127.0.0.1` — the server is up but
-      # unreachable, and the probe times out. Pinning HOST (and matching
-      # E2E_BASE_URL) forces both ends onto the same IPv4 address.
-      - name: Start the built server and run E2E
+      # HOST=127.0.0.1 is load-bearing: @astrojs/node binds to `localhost` by
+      # default, which on the CI runner resolves to IPv6 `::1` while the probe,
+      # the seed curl, and Playwright hit IPv4 `127.0.0.1` — the server is up
+      # but unreachable, and the probe times out. Pinning HOST (and matching
+      # E2E_BASE_URL) forces every end onto the same IPv4 address.
+      - name: Start server, seed a tenant via the setup wizard, run E2E
         env:
           HOST: 127.0.0.1
           PORT: "4321"
-          DATABASE_URL: postgres://placeholder:placeholder@127.0.0.1:5999/placeholder
           E2E_BASE_URL: http://127.0.0.1:4321
+          E2E_LOGIN_IDENTIFIER: e2e-owner@example.com
+          E2E_PASSWORD: e2e-password-123
+          E2E_OFFICE_CODE: HQ-E2E
         run: |
           bun ./dist/server/entry.mjs &
           APP_PID=$!
-          # Wait until the catch-all 404 answers (server up); fail if it never does.
+          cleanup() { kill "$APP_PID" 2>/dev/null || true; }
+          trap cleanup EXIT
+
+          # Wait until the catch-all 404 answers (server up).
           up=""
           for i in $(seq 1 30); do
             code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:4321/__e2e_probe" || true)
             if [ "$code" = "404" ]; then up="yes"; break; fi
             sleep 1
           done
-          if [ -z "$up" ]; then echo "::error::server never became ready on 127.0.0.1:4321"; kill "$APP_PID" || true; exit 1; fi
+          if [ -z "$up" ]; then echo "::error::server never became ready on 127.0.0.1:4321"; exit 1; fi
+
+          # Seed one tenant + owner + head office through the REAL bootstrap
+          # (singleton — runs once against this fresh DB), then hand its
+          # tenantId to the authenticated spec.
+          seed=$(curl -s -X POST "http://127.0.0.1:4321/api/v1/setup/initialize" \
+            -H "Content-Type: application/json" \
+            -d "{\"tenantCode\":\"e2e\",\"tenantName\":\"E2E Tenant\",\"officeCode\":\"${E2E_OFFICE_CODE}\",\"officeName\":\"E2E Head Office\",\"ownerDisplayName\":\"E2E Owner\",\"ownerLoginIdentifier\":\"${E2E_LOGIN_IDENTIFIER}\",\"ownerPassword\":\"${E2E_PASSWORD}\"}")
+          echo "setup response: $seed"
+          tenant_id=$(echo "$seed" | jq -r '.data.tenantId // empty')
+          if [ -z "$tenant_id" ]; then echo "::error::setup/initialize did not return a tenantId"; exit 1; fi
+          export E2E_TENANT_ID="$tenant_id"
+
           bun run test:e2e
-          status=$?
-          kill "$APP_PID" || true
-          exit $status
 
   hygiene:
     name: Repo hygiene (Bun-only + no secrets)

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -6,16 +6,31 @@ import node from "@astrojs/node";
 // §Standar platform backend) karena Astro belum punya adapter Bun first-party.
 // Runtime tetap Bun: hasil build dijalankan `bun ./dist/server/entry.mjs`.
 //
-// TIDAK ADA blok `security.csp` di sini — SENGAJA (Issue #148). Astro hanya
-// memancarkan header CSP dari jalur render HALAMAN
-// (`astro/dist/runtime/server/render/page.js`), sedangkan base ini tidak
-// punya halaman sama sekali: `src/pages/` hanya berisi API endpoint. Blok
-// `security.csp` di sini akan inert (nol header). CSP base ini di-set di
-// `src/lib/security/security-headers.ts`, yang dipasang `src/middleware.ts`
-// ke SETIAP response. Baca header file itu sebelum menambah halaman `.astro`
-// pertama ke repo ini — dua sumber CSP tidak otomatis komposabel.
+// TIDAK ADA blok `security.csp` di sini — SENGAJA (Issue #148, dipertahankan
+// #166). CSP di-set SATU sumber saja: `src/lib/security/security-headers.ts`,
+// dipasang `src/middleware.ts` ke SETIAP response (JSON API, HTML 404, dan
+// halaman admin). Mengaktifkan `security.csp` Astro akan membuat DUA sumber
+// CSP yang saling menimpa (baca header security-headers.ts) — jadi tidak
+// dilakukan.
+//
+// Konsekuensi untuk halaman `.astro` (login/admin, #166): CSP itu
+// `default-src 'self'` TANPA `'unsafe-inline'`, jadi `<script>`/`<style>`
+// inline akan diblokir. Karena itu:
+//   - `build.inlineStylesheets: "never"` memaksa SEMUA CSS (termasuk
+//     `<style>` ber-scope Astro dan `import "*.css"`) di-emit sebagai
+//     `<link>` eksternal dari origin sendiri → lolos `default-src 'self'`.
+//   - Setiap `<script>` di halaman ditulis sebagai module script yang
+//     di-bundle Astro (BUKAN `is:inline`) → file eksternal dari origin
+//     sendiri → lolos `default-src 'self'`.
+// Dengan dua aturan itu halaman tidak pernah mengandung script/style inline,
+// jadi CSP ketat middleware tetap satu-satunya sumber dan tidak ada yang
+// bocor. Jalankan E2E terhadap build produksi (`bun run build && start`) —
+// dev server Astro menyuntik HMR inline yang memang diblokir CSP ini.
 export default defineConfig({
   output: "server",
   adapter: node({ mode: "standalone" }),
-  site: "http://localhost:4321"
+  site: "http://localhost:4321",
+  build: {
+    inlineStylesheets: "never"
+  }
 });

--- a/docs/awcms/07_sprint_testing_production_readiness.md
+++ b/docs/awcms/07_sprint_testing_production_readiness.md
@@ -195,11 +195,17 @@ playwright test`, Bun-only), terpisah dari `bun test`
 > pertama `not-found.e2e.ts` menguji route catch-all 404
 > (`src/pages/[...path].ts`, memakai ulang `src/lib/html/error-responses.ts`):
 > browser membuka path asing → dapat halaman 404 HTML bersih tanpa bocor
-> detail internal (Issue #540). Dijalankan di CI oleh job `e2e-smoke`
-> (`.github/workflows/ci.yml`) — belum menyalakan Postgres karena spec 404 tak
-> butuh DB. Spec berikutnya (layar admin/manajemen: login, offices, dst.)
-> ditambah begitu halaman `.astro` pertama landing, dan job CI-nya akan
-> menyalakan Postgres + `db:migrate` + seed mengikuti pola dua-fase awcms-mini.
+> detail internal (Issue #540). Halaman `.astro` pertama kini **sudah ada**
+> (Issue #166): `login.astro`, `admin/index.astro` (dashboard), dan
+> `admin/offices.astro` (layar manajemen office, SSR-read via `listOffices`),
+> memakai `AdminLayout` + design token doc 14 (`src/styles/tokens.css`). Spec
+> `login.e2e.ts` menguji render + properti CSP (script eksternal bukan inline —
+> `default-src 'self'`), dan `admin-offices.e2e.ts` menguji alur
+> ter-autentikasi penuh (login → cookie sesi → guard `/admin` → render tabel
+> offices). Dijalankan di CI oleh job `e2e-smoke` (`.github/workflows/ci.yml`),
+> yang menyalakan `postgres:18.4`, `db:migrate`, lalu men-seed satu
+> tenant+owner lewat `POST /api/v1/setup/initialize` (bootstrap sungguhan) dan
+> mengoperkan kredensialnya ke spec via env.
 
 > **Runner test.** Runner = **`bun test`** (`bun:test`), berkas di
 > `tests/`. Daftar target di bawah bersifat **target rencana modul ERP**,

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,0 +1,111 @@
+---
+/**
+ * Admin shell (Issue #166 — ported from awcms-mini's `AdminLayout.astro`,
+ * stripped to awcms's fondasi scope). Deliberately minimal vs mini: NO
+ * TenantBadge / SyncIndicator / ThemeToggle / LanguageSwitcher / responsive
+ * drawer / i18n — those drag in visitor-analytics, theme persistence, and the
+ * gettext catalog awcms does not have yet. Kept: brand, the signed-in user's
+ * roles, a permission-agnostic sidebar, logout, and the page slot.
+ *
+ * Auth is NOT enforced here — `src/middleware.ts` already guards `/admin/*`
+ * (resolves the session, redirects to `/login` when absent, and sets
+ * `Astro.locals.ssrContext`). This layout only READS that context; a missing
+ * one is a middleware invariant violation, not a user-facing state, so it
+ * throws rather than rendering a half-authenticated page.
+ *
+ * CSP (see astro.config.mjs / security-headers.ts): styles come from external
+ * stylesheets (`tokens.css` + `admin.css`, emitted as <link> by
+ * `inlineStylesheets: "never"`) and the only script is the Astro-bundled
+ * logout module below — no inline script/style, so `default-src 'self'` holds.
+ */
+import "../styles/tokens.css";
+import "../styles/admin.css";
+
+interface Props {
+  title: string;
+  /** Sidebar key to mark `aria-current="page"`. */
+  active?: "dashboard" | "offices";
+}
+
+const { title, active } = Astro.props;
+const ssr = Astro.locals.ssrContext;
+
+if (!ssr) {
+  throw new Error(
+    "AdminLayout rendered without Astro.locals.ssrContext — the /admin guard in src/middleware.ts must run first."
+  );
+}
+
+const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title} · AWCMS</title>
+  </head>
+  <body class="admin-body">
+    <header class="admin-topbar">
+      <a href="/admin" class="admin-brand">AWCMS</a>
+      <div class="admin-topbar-right">
+        <span class="admin-roles" id="admin-roles">{roles}</span>
+        <button type="button" id="admin-logout" class="admin-logout">
+          Sign out
+        </button>
+      </div>
+    </header>
+
+    <div class="admin-layout">
+      <aside class="admin-sidebar">
+        <nav aria-label="Admin">
+          <a
+            href="/admin"
+            aria-current={active === "dashboard" ? "page" : undefined}
+          >
+            Dashboard
+          </a>
+          <a
+            href="/admin/offices"
+            aria-current={active === "offices" ? "page" : undefined}
+          >
+            Offices
+          </a>
+        </nav>
+      </aside>
+
+      <main class="admin-main">
+        <slot />
+      </main>
+    </div>
+
+    <script>
+      // The import forces Astro to bundle this to an EXTERNAL file — an
+      // import-free script would be inlined, and inline scripts are blocked by
+      // the middleware CSP (`default-src 'self'`). See admin-form-client.ts.
+      import { lockElement } from "../lib/ui/admin-form-client";
+
+      const logoutButton = document.getElementById(
+        "admin-logout"
+      ) as HTMLButtonElement | null;
+
+      logoutButton?.addEventListener("click", async () => {
+        if (logoutButton.disabled) return;
+        lockElement(logoutButton, "Signing out…");
+        try {
+          await fetch("/api/v1/auth/logout", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            credentials: "same-origin"
+          });
+        } catch {
+          // Even if the network call fails, send the user to /login — the
+          // cookie may already be cleared, and staying on a stale admin page
+          // is worse than an optimistic redirect.
+        }
+        window.location.href = "/login";
+      });
+    </script>
+  </body>
+</html>

--- a/src/lib/security/security-headers.ts
+++ b/src/lib/security/security-headers.ts
@@ -17,24 +17,23 @@
  * returned from endpoints, not rendered pages.
  *
  * `src/middleware.ts` applies these headers to EVERY response, so setting
- * the policy here is what actually covers this app's real surface. The
- * hand-rolled-hash-drift hazard that ruled this approach out for mini does
- * not exist here: this repo ships no `.astro` component, no inline script,
- * no inline style, no inline event handler, and no external origin (grep
- * `is:inline|define:vars|<script|<style|on[a-z]+=|https://` over `src/` —
- * all empty), so there is nothing for `'self'` to break and no hash list to
- * keep in sync.
+ * the policy here is what actually covers this app's real surface — the JSON
+ * API, the HTML 404 (`src/lib/html/error-responses.ts`), AND the admin
+ * `.astro` pages (#166). This builder stays the SINGLE CSP owner.
  *
- * IF THIS BASE EVER GAINS REAL `.astro` PAGES (read before doing so):
- * enabling Astro's `security.csp` at that point would NOT compose with this
- * — Astro would set its own `content-security-policy` (including the
- * script-src/style-src hashes its inlined assets need) during page render,
- * and `src/middleware.ts`'s `headers.set(...)` would then silently REPLACE
- * it with the policy below, which allows no inline script at all. The
- * result is a broken page with no obvious cause. Whoever adds the first
- * page must pick ONE owner for this header: either extend this builder to
- * skip HTML page responses that Astro already stamped, or drop this
- * directive set here and move it into `security.csp`'s `directives`.
+ * REAL `.astro` PAGES EXIST NOW (login + admin, #166) — how they stay
+ * compatible with this `default-src 'self'` (no `'unsafe-inline'`) policy,
+ * WITHOUT enabling Astro's own `security.csp` (which would set a SECOND,
+ * conflicting `content-security-policy` during page render that this
+ * middleware's `headers.set(...)` then silently replaces — a broken page
+ * with no obvious cause): the pages ship NO inline script and NO inline
+ * style. `astro.config.mjs`'s `build.inlineStylesheets: "never"` forces every
+ * stylesheet (including Astro scoped `<style>`) out to an external `<link>`
+ * from this origin, and every page `<script>` is an Astro-bundled module
+ * (never `is:inline`), also external from this origin — both satisfied by
+ * `'self'`. So there is still nothing inline for this policy to break, and no
+ * hash list to keep in sync. A future page that genuinely needs inline
+ * script/style must revisit the single-owner decision (see astro.config.mjs).
  *
  * Directives mirror mini's set, minus `frame-src` and the Turnstile/YouTube
  * origins it allowlists — this base has no widget, no embed, and no iframe

--- a/src/lib/ui/admin-form-client.ts
+++ b/src/lib/ui/admin-form-client.ts
@@ -1,0 +1,37 @@
+/**
+ * Tiny client-side helpers shared by the admin/login page `<script>`s
+ * (Issue #166, ported from awcms-mini's `admin-form-client.ts`).
+ *
+ * Its existence as an IMPORTED module is load-bearing for CSP, not just DRY:
+ * Astro inlines a hoisted `<script>` that has no imports (emitting
+ * `<script type="module">…code…</script>`), but bundles one that DOES import
+ * into an EXTERNAL `/_astro/*.js` file. This app's middleware CSP is
+ * `default-src 'self'` with no `'unsafe-inline'` (see astro.config.mjs /
+ * security-headers.ts), so an inline script is BLOCKED and the page's
+ * behaviour silently dies. Importing `lockElement` from here forces every
+ * page script that uses it external, where `'self'` allows it. Verified
+ * empirically: without the import the login script inlined; with it, it emits
+ * an external module.
+ */
+
+/**
+ * Disables a button and swaps its label to a busy string for the duration of
+ * an async action, returning an `unlock()` that restores both. Guards against
+ * double-submit (a fast double-click firing two requests before a redirect).
+ */
+export function lockElement(
+  element: HTMLButtonElement,
+  busyLabel: string
+): () => void {
+  const originalLabel = element.textContent;
+  element.disabled = true;
+  element.textContent = busyLabel;
+
+  let unlocked = false;
+  return () => {
+    if (unlocked) return;
+    unlocked = true;
+    element.disabled = false;
+    element.textContent = originalLabel;
+  };
+}

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -1,0 +1,26 @@
+---
+/**
+ * Admin dashboard (Issue #166). The simplest real authenticated page: it
+ * renders only from `Astro.locals.ssrContext` (already resolved + guarded by
+ * `src/middleware.ts`), so it needs no additional DB read of its own. Proves
+ * the login → session-cookie → `/admin` guard → SSR render loop end to end.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+
+const ssr = Astro.locals.ssrContext!;
+const permissionCount = ssr.permissions.size;
+---
+
+<AdminLayout title="Dashboard" active="dashboard">
+  <h1 id="admin-dashboard-heading">Dashboard</h1>
+  <p>You are signed in.</p>
+  <dl>
+    <dt>Tenant</dt>
+    <dd id="dashboard-tenant-id">{ssr.tenantId}</dd>
+    <dt>Roles</dt>
+    <dd>{ssr.roles.length > 0 ? ssr.roles.join(", ") : "—"}</dd>
+    <dt>Granted permissions</dt>
+    <dd id="dashboard-permission-count">{permissionCount}</dd>
+  </dl>
+  <p><a href="/admin/offices">Manage offices →</a></p>
+</AdminLayout>

--- a/src/pages/admin/offices.astro
+++ b/src/pages/admin/offices.astro
@@ -1,0 +1,122 @@
+---
+/**
+ * Offices management screen (Issue #166) — the first real admin management
+ * page, mirroring awcms-mini's SSR-read-then-render pattern: read the tenant's
+ * offices server-side by calling the SAME application function the JSON
+ * endpoint uses (`listOffices`, `src/pages/api/v1/offices/index.ts`) inside
+ * `withTenant`, then render a plain accessible table + status badges.
+ *
+ * ABAC is enforced server-side by the endpoints; this page additionally gates
+ * its own render on the same `tenant_admin.office_management.read` permission
+ * (from `Astro.locals.ssrContext.permissions`) so a user without it gets a
+ * clean "no access" notice instead of an empty table. Read-only for this first
+ * slice — creating/editing offices stays on `POST /api/v1/offices` and lands
+ * as a later increment.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { listOffices } from "../../modules/tenant-admin/application/office-directory";
+
+type OfficeRow = {
+  id: string;
+  officeCode: string;
+  officeName: string;
+  officeType: string;
+  status: string;
+};
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("tenant_admin", "office_management", "read")
+);
+
+let offices: OfficeRow[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      const page = await listOffices(tx, ssr.tenantId, null);
+      return page.items as OfficeRow[];
+    });
+    // `withTenant` returns a 503 `Response` when the DB circuit breaker is
+    // open / a work-class queue is saturated — degrade to an error notice
+    // rather than letting a Response leak where rows are expected.
+    if (result instanceof Response) {
+      loadError = true;
+    } else {
+      offices = result;
+    }
+  } catch {
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title="Offices" active="offices">
+  <h1 id="offices-heading">Offices</h1>
+
+  {
+    !canRead && (
+      <p class="state-notice" id="offices-denied">
+        You do not have permission to view offices.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice" id="offices-error">
+        Offices could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll">
+        <table class="data-table" id="offices-table">
+          <caption>{offices.length} office(s)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Code</th>
+              <th scope="col">Name</th>
+              <th scope="col">Type</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {offices.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan="4">
+                  No offices yet.
+                </td>
+              </tr>
+            ) : (
+              offices.map((office) => (
+                <tr>
+                  <td>{office.officeCode}</td>
+                  <td>{office.officeName}</td>
+                  <td>{office.officeType}</td>
+                  <td>
+                    <span
+                      class="status-badge"
+                      data-variant={
+                        office.status === "active" ? "success" : "neutral"
+                      }
+                    >
+                      {office.status}
+                    </span>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,0 +1,140 @@
+---
+/**
+ * Login page (Issue #166 — ported from awcms-mini's `login.astro`, simplified
+ * to awcms scope). POSTs to `POST /api/v1/auth/login`, which sets the two
+ * httpOnly SSR session cookies (`src/lib/auth/ssr-session.ts`) the `/admin`
+ * guard in `src/middleware.ts` then consumes.
+ *
+ * Simplified vs mini: NO i18n (strings hardcoded English — awcms has no
+ * gettext catalog yet), NO Cloudflare Turnstile, NO Google OIDC button, and
+ * NO `<script type="application/json">` strings blob. What is kept 1:1 is the
+ * stable element ids the E2E specs and the client script rely on
+ * (`#login-form`, `#tenant-id`, `#login-identifier`, `#password`,
+ * `#login-submit`, `#login-error`).
+ *
+ * The manual Tenant ID field is a demo simplification for this fondasi repo,
+ * exactly as in mini — a derived app resolves the tenant by domain instead of
+ * asking the user to paste a UUID (out of scope here).
+ *
+ * CSP: `tokens.css`/`admin.css` are external <link>s (`inlineStylesheets:
+ * "never"`) and the client below is an Astro-bundled module script — no inline
+ * script/style, so the middleware `default-src 'self'` policy holds.
+ */
+import "../styles/tokens.css";
+import "../styles/admin.css";
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sign in · AWCMS</title>
+  </head>
+  <body>
+    <main class="login-page">
+      <form id="login-form" class="login-form" novalidate>
+        <h1>AWCMS</h1>
+        <p id="login-error" class="login-error" role="alert" hidden></p>
+
+        <label for="tenant-id">Tenant ID</label>
+        <input
+          id="tenant-id"
+          name="tenantId"
+          type="text"
+          required
+          autocomplete="off"
+        />
+
+        <label for="login-identifier">Login identifier</label>
+        <input
+          id="login-identifier"
+          name="loginIdentifier"
+          type="text"
+          required
+          autocomplete="username"
+        />
+
+        <label for="password">Password</label>
+        <input
+          id="password"
+          name="password"
+          type="password"
+          required
+          autocomplete="current-password"
+        />
+
+        <button type="submit" id="login-submit">Sign in</button>
+      </form>
+    </main>
+
+    <script>
+      // The import is deliberate — it forces Astro to bundle this script to an
+      // external file (an import-free script would be inlined, and inline
+      // scripts are blocked by this app's CSP). See admin-form-client.ts.
+      import { lockElement } from "../lib/ui/admin-form-client";
+
+      const form = document.getElementById(
+        "login-form"
+      ) as HTMLFormElement | null;
+      const errorBox = document.getElementById("login-error");
+      const submitButton = document.getElementById(
+        "login-submit"
+      ) as HTMLButtonElement | null;
+
+      function showError(message: string): void {
+        if (!errorBox) return;
+        errorBox.textContent = message;
+        errorBox.hidden = false;
+      }
+
+      form?.addEventListener("submit", async (event) => {
+        event.preventDefault();
+
+        // Guard + disable the submit button for the request duration so a fast
+        // double-click can't fire two login POSTs before the redirect lands.
+        if (!submitButton || submitButton.disabled) return;
+        const unlock = lockElement(submitButton, "Please wait…");
+
+        if (errorBox) errorBox.hidden = true;
+
+        const formData = new FormData(form);
+        const tenantId = String(formData.get("tenantId") ?? "").trim();
+        const loginIdentifier = String(
+          formData.get("loginIdentifier") ?? ""
+        ).trim();
+        const password = String(formData.get("password") ?? "");
+
+        try {
+          const response = await fetch("/api/v1/auth/login", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-AWCMS-Tenant-ID": tenantId
+            },
+            credentials: "same-origin",
+            body: JSON.stringify({ loginIdentifier, password })
+          });
+
+          const payload = await response.json().catch(() => null);
+
+          if (!response.ok || !payload || payload.success !== true) {
+            // Generic message only — the server deliberately collapses every
+            // deny reason so the UI must not reconstruct a specific one, and it
+            // must never surface internal detail (Issue #540).
+            showError("Sign in failed. Check your details and try again.");
+            unlock();
+            return;
+          }
+
+          // Navigating away — leave the button disabled so it can't be
+          // re-clicked during the redirect.
+          window.location.href = "/admin";
+        } catch {
+          showError("Network error. Please try again.");
+          unlock();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1,0 +1,240 @@
+/*
+ * Admin + login shared styles (Issue #166 — first .astro pages ported from
+ * awcms-mini's admin shell, adapted to awcms scope). Uses ONLY the design
+ * tokens from `tokens.css` (doc 14). Kept as an external stylesheet (imported
+ * by the pages, emitted as an external <link> by `build.inlineStylesheets:
+ * "never"`) so it never becomes an inline <style> the middleware CSP
+ * (`default-src 'self'`) would block — see astro.config.mjs.
+ */
+
+/* ---- Login ---------------------------------------------------------- */
+.login-page {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg);
+  padding: var(--sp-4);
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  width: 100%;
+  max-width: 360px;
+  padding: var(--sp-5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-md);
+}
+
+.login-form h1 {
+  margin: 0 0 var(--sp-2);
+  font-size: var(--fs-lg);
+  color: var(--color-text);
+}
+
+.login-form label {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.login-form input {
+  min-height: 44px;
+  padding: var(--sp-2) var(--sp-3);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.login-form button {
+  margin-top: var(--sp-3);
+  min-height: 44px;
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-primary-strong);
+  color: var(--color-primary-contrast);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.login-form button:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+.login-error {
+  color: var(--color-primary-contrast);
+  background: var(--color-danger-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--fs-sm);
+}
+
+/* ---- Admin shell ---------------------------------------------------- */
+.admin-body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+}
+
+.admin-topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-brand {
+  font-weight: 700;
+  font-size: var(--fs-md);
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.admin-topbar-right {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-3);
+}
+
+.admin-roles {
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.admin-logout {
+  min-height: 36px;
+  padding: var(--sp-1) var(--sp-3);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--fs-sm);
+}
+
+.admin-layout {
+  display: flex;
+  min-height: calc(100vh - 57px);
+}
+
+.admin-sidebar {
+  width: 220px;
+  flex-shrink: 0;
+  padding: var(--sp-4) var(--sp-3);
+  background: var(--color-surface);
+  border-right: 1px solid var(--color-border);
+}
+
+.admin-sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.admin-sidebar a {
+  padding: var(--sp-2) var(--sp-3);
+  border-radius: var(--radius-sm);
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: var(--fs-sm);
+}
+
+.admin-sidebar a[aria-current="page"] {
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+  font-weight: 600;
+}
+
+.admin-main {
+  flex: 1;
+  padding: var(--sp-5);
+  min-width: 0;
+}
+
+.admin-main h1 {
+  margin-top: 0;
+  font-size: var(--fs-xl);
+}
+
+/* ---- Data table ----------------------------------------------------- */
+.data-table-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: var(--fs-sm);
+}
+
+.data-table caption {
+  text-align: left;
+  padding: var(--sp-3);
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.data-table th,
+.data-table td {
+  padding: var(--sp-2) var(--sp-3);
+  text-align: left;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.data-table th {
+  background: var(--color-bg);
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.data-table-empty {
+  padding: var(--sp-4);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+/* ---- Status badge --------------------------------------------------- */
+.status-badge {
+  display: inline-block;
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-full);
+  font-size: var(--fs-xs);
+  font-weight: 600;
+}
+
+.status-badge[data-variant="success"] {
+  background: var(--color-success-strong);
+  color: var(--color-primary-contrast);
+}
+
+.status-badge[data-variant="neutral"] {
+  background: var(--color-border);
+  color: var(--color-text);
+}
+
+.status-badge[data-variant="warning"] {
+  background: var(--color-warning);
+  color: var(--color-text);
+}
+
+/* ---- State notice --------------------------------------------------- */
+.state-notice {
+  padding: var(--sp-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,195 @@
+/*
+ * Design tokens — AWCMS (Issue 8.1 — Build Admin Layout Shell).
+ *
+ * Nilai persis mengikuti tabel `docs/awcms/14_ui_ux_design_system.md`
+ * §Design tokens. Ini adalah placeholder brand-neutral, boleh diganti brand
+ * tenant oleh aplikasi turunan. Di-scope ke `:root` (light, default) dengan
+ * override `:root[data-theme="dark"]`; resolusi tema (system/light/dark)
+ * dilakukan oleh skrip inline di `src/layouts/AdminLayout.astro`.
+ */
+
+:root {
+  color-scheme: light;
+
+  /* Warna semantik (light) */
+  --color-bg: #f7f8fa;
+  --color-surface: #ffffff;
+  --color-surface-2: #eef1f5;
+  --color-border: #d8dee6;
+  --color-text: #1a1f26;
+  --color-text-muted: #5b6672;
+  --color-primary: #2563eb;
+  --color-primary-contrast: #ffffff;
+  --color-success: #16a34a;
+  --color-warning: #d97706;
+  --color-danger: #dc2626;
+  --color-info: #0891b2;
+  --color-focus: #2563eb;
+
+  /*
+   * "-strong" variants — Issue #434 (UX/UI audit). `--color-primary`,
+   * `--color-success`, `--color-danger` above are tuned for use as *text* or
+   * *border* color against a light/tinted surface (links, status text,
+   * icons) — that is a different contrast job than a *solid fill* with
+   * `--color-primary-contrast` (white) text on top of it (buttons, solid
+   * status badges, error banners). Measured against WCAG 2.1 AA (4.5:1,
+   * see docs/awcms/14_ui_ux_design_system.md §Aksesibilitas): the plain
+   * tokens fail that second job in several cases (e.g. dark-theme
+   * `--color-primary` + white text is only 3.68:1). These derived, slightly
+   * darker values keep the same hue while restoring >=4.5:1 with white text
+   * in both themes. Use these — not the plain token — whenever
+   * `--color-primary-contrast` text sits directly on the fill.
+   */
+  --color-primary-strong: #2563eb;
+  --color-success-strong: #12873d;
+  --color-danger-strong: #dc2626;
+  /* Reviewer Medium finding on PR #720: StatusBadge's `info` variant used
+     the plain --color-info token as a solid fill with white text, only
+     3.68:1 (light) / 2.43:1 (dark) — below the 4.5:1 this same doc-comment
+     already promises. Measured: 5.36:1 against white in both themes. */
+  --color-info-strong: #0e7490;
+
+  /* Font */
+  --font-sans: system-ui, -apple-system, "Inter", "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", "Menlo", monospace;
+
+  /* Font size (xs .. 2xl) */
+  --fs-xs: 12px;
+  --fs-sm: 14px;
+  --fs-base: 16px;
+  --fs-md: 18px;
+  --fs-lg: 20px;
+  --fs-xl: 24px;
+  --fs-2xl: 32px;
+
+  /* Spacing (1 .. 8) */
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+
+  /* Radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  /* Shadow */
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.12);
+  --shadow-lg: 0 12px 32px rgba(15, 23, 42, 0.18);
+
+  /* Z-index */
+  --z-nav: 100;
+  /* Mobile admin sidebar drawer + its scrim (Issue #693) — above the sticky
+     topbar (`--z-nav`) so the drawer visually overlays it when open, below
+     `--z-dropdown` since a dropdown opened from within the drawer (if any)
+     must still render on top of the drawer itself. */
+  --z-drawer: 150;
+  --z-dropdown: 200;
+  --z-dialog: 300;
+  --z-toast: 400;
+
+  /* Breakpoint (referensi dokumentasi — dipakai di media query literal,
+     custom property tidak bisa dipakai langsung sebagai kondisi @media) */
+  --bp-sm: 640px;
+  --bp-md: 768px;
+  --bp-lg: 1024px;
+  --bp-xl: 1280px;
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --color-bg: #0e1116;
+  --color-surface: #161b22;
+  --color-surface-2: #1f262e;
+  --color-border: #2b333c;
+  --color-text: #e6edf3;
+  --color-text-muted: #9aa7b2;
+  --color-primary: #3b82f6;
+  --color-primary-contrast: #ffffff;
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-danger: #ef4444;
+  --color-info: #06b6d4;
+  --color-focus: #60a5fa;
+
+  /* See :root's comment above — darkened so white text on a solid fill of
+     these stays >=4.5:1 in the dark theme too (the plain tokens above are
+     tuned brighter for legibility as text-on-dark-surface instead). */
+  --color-primary-strong: #3472d8;
+  --color-success-strong: #178841;
+  --color-danger-strong: #d73d3d;
+  /* Reviewer Medium finding on PR #720 — see :root's --color-info-strong
+     comment. Same value works in both themes since the contrast math is
+     against the constant white fill-text, not the page background. */
+  --color-info-strong: #0e7490;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.55);
+}
+
+/* Reset minimal */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--fs-base);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+img,
+picture,
+svg {
+  max-width: 100%;
+  display: block;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+a {
+  color: var(--color-primary);
+}
+
+/* Fokus terlihat (WCAG 2.1 AA) — jangan pernah outline:none tanpa pengganti */
+:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/tests/e2e/admin-offices.e2e.ts
+++ b/tests/e2e/admin-offices.e2e.ts
@@ -1,0 +1,72 @@
+/**
+ * Authenticated admin management E2E (Issue #166) — the full loop: log in
+ * through the real `/login` form → session cookies → `/admin` guard → SSR
+ * render of the offices management screen backed by `listOffices`.
+ *
+ * Needs a seeded tenant + owner, which the CI `e2e-smoke` job provisions ONCE
+ * via `POST /api/v1/setup/initialize` (the real bootstrap — no bespoke seed
+ * SQL) and hands to this spec through env vars. Skipped (not failed) when they
+ * are absent, so a local `bun run test:e2e` without a seeded DB stays green —
+ * the same "provide the environment" convention the DB-gated `bun:test`
+ * integration suite uses. The seeded owner role holds every permission, so the
+ * `office_management.read` gate on the page passes and the bootstrap's
+ * `head_office` row is what the table must show.
+ */
+import { test, expect } from "@playwright/test";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
+const password = process.env.E2E_PASSWORD;
+const officeCode = process.env.E2E_OFFICE_CODE;
+
+const seeded = Boolean(tenantId && loginIdentifier && password && officeCode);
+
+test.describe("admin offices (authenticated)", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant — CI e2e-smoke provisions one via POST /api/v1/setup/initialize"
+  );
+
+  test("logs in, lands on the dashboard, and sees the seeded office", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+
+    // The client script redirects to /admin on success.
+    await page.waitForURL("**/admin");
+    await expect(page.locator("#admin-dashboard-heading")).toBeVisible();
+    await expect(page.locator("#dashboard-tenant-id")).toHaveText(tenantId!);
+
+    await page.goto("/admin/offices");
+    const table = page.locator("#offices-table");
+    await expect(table).toBeVisible();
+    // The bootstrap created exactly one office (head_office) with this code.
+    await expect(table).toContainText(officeCode!);
+    await expect(page.locator("#offices-denied")).toHaveCount(0);
+  });
+
+  test("rejects a wrong password with a generic error, not a stack trace", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill("definitely-the-wrong-password");
+    await page.locator("#login-submit").click();
+
+    const error = page.locator("#login-error");
+    await expect(error).toBeVisible();
+
+    const text = ((await error.textContent()) ?? "").toLowerCase();
+    expect(text.length).toBeGreaterThan(0);
+    for (const marker of ["stack", "postgres", "at object", "invalid"]) {
+      expect(text).not.toContain(marker);
+    }
+    // Still on /login — no session was minted.
+    await expect(page).toHaveURL(/\/login$/);
+  });
+});

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -1,0 +1,53 @@
+/**
+ * Login page render spec (Issue #166) — see skill `awcms-browser-test`.
+ *
+ * `/login` renders the same form regardless of DB contents (it does no
+ * server-side DB read of its own), so this needs zero seeded data — the
+ * "pick a target that needs no fixtures" convention (skill #4). It proves the
+ * first `.astro` page renders in a real browser AND that its client script
+ * executes under the middleware CSP (`default-src 'self'`): if Astro had
+ * inlined the script, CSP would block it and the form's stable ids would still
+ * be present but dead — so a follow-up render assertion is not enough on its
+ * own; the submit-behaviour path is covered by `admin-offices.e2e.ts` where a
+ * seeded session exists.
+ *
+ * Run: `bun run build && bun run start` (DATABASE_URL may be a placeholder —
+ * this page never connects), then `bun run test:e2e`.
+ */
+import { test, expect } from "@playwright/test";
+
+test.describe("login page", () => {
+  test("renders the login form with its stable fields", async ({ page }) => {
+    const response = await page.goto("/login");
+
+    expect(response?.status()).toBe(200);
+    await expect(page.locator("#login-form")).toBeVisible();
+    await expect(page.locator("#tenant-id")).toBeVisible();
+    await expect(page.locator("#login-identifier")).toBeVisible();
+    await expect(page.locator("#password")).toBeVisible();
+    await expect(page.locator("#login-submit")).toBeVisible();
+    await expect(page.locator("#login-error")).toBeHidden();
+  });
+
+  test("the page ships no inline script (CSP: default-src 'self') — its behaviour comes from an external bundle", async ({
+    page
+  }) => {
+    await page.goto("/login");
+
+    // Every <script> the page loaded must be external (has a src) — an inline
+    // one would have been blocked by CSP, so asserting "no inline script"
+    // doubles as asserting the login behaviour can actually run.
+    const inlineScripts = await page.$$eval(
+      "script",
+      (nodes) =>
+        nodes.filter((n) => !n.getAttribute("src") && n.textContent?.trim())
+          .length
+    );
+    expect(inlineScripts).toBe(0);
+
+    const scriptSrcs = await page.$$eval("script[src]", (nodes) =>
+      nodes.map((n) => n.getAttribute("src"))
+    );
+    expect(scriptSrcs.some((s) => s?.startsWith("/_astro/"))).toBe(true);
+  });
+});


### PR DESCRIPTION
Stage 2 of #166 — awcms's **first `.astro` pages**, porting awcms-mini's admin UI adapted to fondasi scope. awcms's auth/session/middleware plumbing (`/admin` guard, `resolveSsrContext`, login/logout endpoints, `awcms_sessions`) already existed and is byte-compatible with mini, so this is **additive UI, not backend rework**.

## Pages
- **`login.astro`** — posts to `POST /api/v1/auth/login` (`X-AWCMS-Tenant-ID` header, `{loginIdentifier, password}` body), redirects to `/admin`. Stable ids (`#login-form`, `#tenant-id`, …) for E2E.
- **`admin/index.astro`** — dashboard rendered purely from `Astro.locals.ssrContext` (no extra DB read); proves the login → cookie → `/admin` guard → SSR render loop.
- **`admin/offices.astro`** — the management screen: SSR-reads the tenant's offices via the **same `listOffices`** the JSON endpoint uses, gated on `tenant_admin.office_management.read`, renders an accessible table + status badges. Read-only for this slice.
- **`AdminLayout.astro`** (stripped: brand + roles + logout + sidebar + slot) · **`src/styles/tokens.css`** (doc-14 design tokens) · **`admin.css`**.

## CSP handled (Issue #148)
Middleware stays the **single CSP owner** (`default-src 'self'`, covering JSON + HTML 404 + pages — Astro's page-only `security.csp` can't cover the API). To keep pages compatible without weakening the policy: `astro.config.mjs` sets `build.inlineStylesheets: "never"` (external `<link>`s), and every page `<script>` imports from `src/lib/ui/admin-form-client.ts` — which forces Astro to **bundle it external** instead of inlining it (an inline script would be CSP-blocked and silently break the page). Verified: `/login` ships **zero** inline script/style; its behaviour comes from `/_astro/*.js`.

## E2E
- `login.e2e.ts` — form render + the CSP property (no inline script; behaviour from an external bundle). **Validated live locally** (system Chromium): 4 passed (with the 404 specs).
- `admin-offices.e2e.ts` — full authenticated loop: login → session → `/admin` dashboard → offices table shows the seeded office; plus wrong-password → generic error (no leak). Env-gated (skips locally without a seed).
- CI `e2e-smoke` now provisions `postgres:18.4`, runs `db:migrate`, and **seeds a tenant+owner via the real `POST /api/v1/setup/initialize`** bootstrap (no bespoke seed SQL), handing credentials to the spec.

## Verification
`bun run check`: green. Local login + 404 E2E: **4 passed**. `/admin` + `/admin/offices` correctly 302 → `/login` when unauthenticated. The authenticated offices flow validates in CI (`e2e-smoke`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)