### PR TITLE
feat(admin): profiles, modules, email-templates management screens (#166)

### DIFF
--- a/.changeset/admin-management-screens.md
+++ b/.changeset/admin-management-screens.md
@@ -1,0 +1,13 @@
+---
+"awcms": patch
+---
+
+Add admin management screens for profiles, modules, and email templates (Issue #166) — extending the admin UI to more of the requested management surface, each following the offices screen's SSR-read-then-render pattern backed by an existing awcms API.
+
+- **`admin/profiles.astro`** — the tenant's central profiles/parties via `listParties` (gated `profile_identity.profile_management.read`). Identifiers (masked PII) are deliberately not bulk-listed.
+- **`admin/modules.astro`** — the module catalog via `fetchModuleCatalog` (gated `module_management.modules.read`).
+- **`admin/email-templates.astro`** — tenant email templates via `listEmailTemplates` (gated `email.template.read`), including inactive.
+
+All three are permission-gated (clean "no access" notice otherwise), degrade to an error notice on a DB circuit-breaker `Response`, and are linked from the `AdminLayout` sidebar. The authenticated E2E (`admin-offices.e2e.ts`) now also navigates through them and asserts their tables render for the seeded owner (the module catalog assertion is data-seed-free — it lists the code-registered core modules).
+
+Read-only for this slice. NOTE: the other requested domains — user management, RBAC (roles/assignments), and ABAC (policies) — have no read API in awcms yet (the tables exist but no `listTenantUsers`/`listRoles`/`listAbacPolicies` application function or route is ported), so their admin screens depend on porting those backend reads from awcms-mini first, per the mini-first flow.

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -24,7 +24,7 @@ import "../styles/admin.css";
 interface Props {
   title: string;
   /** Sidebar key to mark `aria-current="page"`. */
-  active?: "dashboard" | "offices";
+  active?: "dashboard" | "offices" | "profiles" | "modules" | "email-templates";
 }
 
 const { title, active } = Astro.props;
@@ -71,6 +71,24 @@ const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
             aria-current={active === "offices" ? "page" : undefined}
           >
             Offices
+          </a>
+          <a
+            href="/admin/profiles"
+            aria-current={active === "profiles" ? "page" : undefined}
+          >
+            Profiles
+          </a>
+          <a
+            href="/admin/modules"
+            aria-current={active === "modules" ? "page" : undefined}
+          >
+            Modules
+          </a>
+          <a
+            href="/admin/email-templates"
+            aria-current={active === "email-templates" ? "page" : undefined}
+          >
+            Email templates
           </a>
         </nav>
       </aside>

--- a/src/pages/admin/email-templates.astro
+++ b/src/pages/admin/email-templates.astro
@@ -1,0 +1,104 @@
+---
+/**
+ * Email template management screen (Issue #166). Same pattern as
+ * `offices.astro`: calls the same `listEmailTemplates` the
+ * `GET /api/v1/email/templates` endpoint uses, gated on `email.template.read`.
+ * Read-only; includes inactive templates so the list is the full config
+ * surface.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { listEmailTemplates } from "../../modules/email/application/email-template-directory";
+
+type TemplateRow = {
+  id: string;
+  templateKey: string;
+  name: string;
+  isActive: boolean;
+  updatedAt: string;
+};
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(permissionKey("email", "template", "read"));
+
+let templates: TemplateRow[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      return (await listEmailTemplates(tx, ssr.tenantId, {
+        includeInactive: true
+      })) as TemplateRow[];
+    });
+    if (result instanceof Response) loadError = true;
+    else templates = result;
+  } catch {
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title="Email templates" active="email-templates">
+  <h1 id="email-templates-heading">Email templates</h1>
+
+  {
+    !canRead && (
+      <p class="state-notice" id="email-templates-denied">
+        You do not have permission to view email templates.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice" id="email-templates-error">
+        Templates could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll">
+        <table class="data-table" id="email-templates-table">
+          <caption>{templates.length} template(s)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              <th scope="col">Name</th>
+              <th scope="col">Active</th>
+            </tr>
+          </thead>
+          <tbody>
+            {templates.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan="3">
+                  No templates yet.
+                </td>
+              </tr>
+            ) : (
+              templates.map((template) => (
+                <tr>
+                  <td>{template.templateKey}</td>
+                  <td>{template.name}</td>
+                  <td>
+                    <span
+                      class="status-badge"
+                      data-variant={template.isActive ? "success" : "neutral"}
+                    >
+                      {template.isActive ? "active" : "inactive"}
+                    </span>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>

--- a/src/pages/admin/modules.astro
+++ b/src/pages/admin/modules.astro
@@ -1,0 +1,102 @@
+---
+/**
+ * Module management screen (Issue #166) — the module catalog: every module
+ * registered in code merged with its DB-tracked lifecycle row. Same
+ * SSR-read-then-render pattern as `offices.astro`: calls the same
+ * `fetchModuleCatalog` the `GET /api/v1/modules` endpoint uses, gated on the
+ * same `module_management.modules.read` permission. Read-only.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { fetchModuleCatalog } from "../../modules/module-management/application/module-catalog";
+
+type ModuleRow = {
+  moduleKey: string;
+  name: string;
+  version: string;
+  status: string;
+  isCore: boolean;
+};
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("module_management", "modules", "read")
+);
+
+let modules: ModuleRow[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      return (await fetchModuleCatalog(tx)) as ModuleRow[];
+    });
+    if (result instanceof Response) loadError = true;
+    else modules = result;
+  } catch {
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title="Modules" active="modules">
+  <h1 id="modules-heading">Modules</h1>
+
+  {
+    !canRead && (
+      <p class="state-notice" id="modules-denied">
+        You do not have permission to view modules.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice" id="modules-error">
+        Modules could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll">
+        <table class="data-table" id="modules-table">
+          <caption>{modules.length} module(s)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Key</th>
+              <th scope="col">Name</th>
+              <th scope="col">Version</th>
+              <th scope="col">Status</th>
+              <th scope="col">Core</th>
+            </tr>
+          </thead>
+          <tbody>
+            {modules.map((module) => (
+              <tr>
+                <td>{module.moduleKey}</td>
+                <td>{module.name}</td>
+                <td>{module.version}</td>
+                <td>
+                  <span
+                    class="status-badge"
+                    data-variant={
+                      module.status === "active" ? "success" : "neutral"
+                    }
+                  >
+                    {module.status}
+                  </span>
+                </td>
+                <td>{module.isCore ? "yes" : "no"}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>

--- a/src/pages/admin/profiles.astro
+++ b/src/pages/admin/profiles.astro
@@ -1,0 +1,110 @@
+---
+/**
+ * Profile (party) management screen (Issue #166) — the tenant's central
+ * profiles/parties. Same pattern as `offices.astro`: calls the same
+ * `listParties` the `GET /api/v1/profiles` endpoint uses, gated on
+ * `profile_identity.profile_management.read`. Read-only. Identifiers (email/
+ * phone/NIK) are deliberately NOT shown here — they are masked PII surfaced
+ * only through the dedicated identifiers endpoint, never a bulk list.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { listParties } from "../../modules/profile-identity/application/party-directory";
+
+type PartyRow = {
+  id: string;
+  displayName: string;
+  profileType: string;
+  status: string;
+  verificationStatus: string;
+};
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("profile_identity", "profile_management", "read")
+);
+
+let profiles: PartyRow[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      const page = await listParties(tx, ssr.tenantId, {});
+      return page.items as PartyRow[];
+    });
+    if (result instanceof Response) loadError = true;
+    else profiles = result;
+  } catch {
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title="Profiles" active="profiles">
+  <h1 id="profiles-heading">Profiles</h1>
+
+  {
+    !canRead && (
+      <p class="state-notice" id="profiles-denied">
+        You do not have permission to view profiles.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice" id="profiles-error">
+        Profiles could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll">
+        <table class="data-table" id="profiles-table">
+          <caption>{profiles.length} profile(s)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Display name</th>
+              <th scope="col">Type</th>
+              <th scope="col">Status</th>
+              <th scope="col">Verification</th>
+            </tr>
+          </thead>
+          <tbody>
+            {profiles.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan="4">
+                  No profiles yet.
+                </td>
+              </tr>
+            ) : (
+              profiles.map((profile) => (
+                <tr>
+                  <td>{profile.displayName}</td>
+                  <td>{profile.profileType}</td>
+                  <td>
+                    <span
+                      class="status-badge"
+                      data-variant={
+                        profile.status === "active" ? "success" : "neutral"
+                      }
+                    >
+                      {profile.status}
+                    </span>
+                  </td>
+                  <td>{profile.verificationStatus}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>

--- a/tests/e2e/admin-offices.e2e.ts
+++ b/tests/e2e/admin-offices.e2e.ts
@@ -49,6 +49,36 @@ test.describe("admin offices (authenticated)", () => {
     await expect(page.locator("#offices-denied")).toHaveCount(0);
   });
 
+  test("the other management screens render their tables for the owner", async ({
+    page
+  }) => {
+    // Log in first (fresh page/context per test).
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+    await page.waitForURL("**/admin");
+
+    // Modules: the catalog always lists the code-registered core modules, so
+    // this is data-seed-free — assert a known core module appears.
+    await page.goto("/admin/modules");
+    await expect(page.locator("#modules-table")).toBeVisible();
+    await expect(page.locator("#modules-table")).toContainText(
+      "module_management"
+    );
+
+    // Email templates + profiles: the owner has the permission, so the table
+    // (possibly empty) renders rather than the "no access" notice.
+    await page.goto("/admin/email-templates");
+    await expect(page.locator("#email-templates-table")).toBeVisible();
+    await expect(page.locator("#email-templates-denied")).toHaveCount(0);
+
+    await page.goto("/admin/profiles");
+    await expect(page.locator("#profiles-table")).toBeVisible();
+    await expect(page.locator("#profiles-denied")).toHaveCount(0);
+  });
+
   test("rejects a wrong password with a generic error, not a stack trace", async ({
     page
   }) => {


### PR DESCRIPTION
Extends the admin UI (#166) to three more of the requested management domains — **user profile, module, template** — each following the offices screen's SSR-read-then-render pattern backed by an **existing** awcms API. Additive UI, no backend change.

## Screens
- **`admin/profiles.astro`** — central profiles/parties via `listParties` (gated `profile_identity.profile_management.read`). Masked-PII identifiers deliberately not bulk-listed.
- **`admin/modules.astro`** — module catalog via `fetchModuleCatalog` (gated `module_management.modules.read`).
- **`admin/email-templates.astro`** — tenant email templates via `listEmailTemplates` (gated `email.template.read`), incl. inactive.

All permission-gated (clean "no access" notice otherwise), degrade to an error notice on a DB circuit-breaker `Response`, and linked from the `AdminLayout` sidebar. CSP unchanged (no page scripts — pure SSR tables + the layout's external logout bundle).

## E2E
`admin-offices.e2e.ts` now also logs in and navigates through `/admin/modules` (asserts a code-registered core module appears — data-seed-free), `/admin/email-templates`, and `/admin/profiles`, asserting each table renders (not the denied notice) for the seeded owner. Runs in CI `e2e-smoke` (Postgres + setup-seed).

## Verification
`bun run check` green; typecheck clean; local login + 404 E2E: 4 passed; the 3 new routes 302 → `/login` when unauthenticated. Authed screens validate in CI.

## Scope note (requested domains not in this PR)
`user` (tenant users), `rbac` (roles/assignments), and `abac` (policies) have **no read API in awcms yet** — the tables exist but no `listTenantUsers`/`listRoles`/`listAbacPolicies` application function or route is ported. Their admin screens need those backend reads ported from awcms-mini first (mini-first flow) — planned as the next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)