### PR TITLE
feat(admin): user/rbac/abac read APIs + management screens (#166)

### DIFF
--- a/.changeset/admin-rbac-abac-screens.md
+++ b/.changeset/admin-rbac-abac-screens.md
@@ -1,0 +1,11 @@
+---
+"awcms": patch
+---
+
+Add user (tenant-users), RBAC (roles), and ABAC (policies) read APIs + admin management screens (Issue #166, Stage 3b) — porting awcms-mini's access-management reads, adapted to awcms's schema/scope. Completes the requested management surface (auth, user, profile, rbac, abac, module, template) as read-only admin screens.
+
+- **Read layer** — `src/modules/identity-access/application/access-directory.ts`: `listTenantUsers` (users + assigned role codes, `login_identifier` **masked** via `maskIdentifierValue`), `listRoles` (non-deleted roles + permission count), `listAbacPolicies` (policies; seeded-empty by default — built-in rules apply). All bounded `LIMIT 100`, tenant-filtered, inside `withTenant`.
+- **Endpoints** — `GET /api/v1/users`, `GET /api/v1/roles`, `GET /api/v1/abac/policies`, all gated on the existing `identity_access.access_control.read` permission (no new permission migration needed; mini's `user_management` activity code does not exist in awcms, so `access_control.read` is used as the gate). OpenAPI updated with matching paths + `TenantUserMasked`/`Role`/`AbacPolicy` schemas.
+- **Screens** — `admin/users.astro`, `admin/roles.astro`, `admin/abac-policies.astro`, permission-gated, linked from `AdminLayout`. The authenticated E2E now navigates all three and asserts the users table shows the owner's **masked** login identifier (never the raw address).
+
+Docs synced: doc 07, `identity-access/README.md`, `ARCHITECTURE.md`. Read-only for this slice; assign/create/edit (RBAC write) is a follow-up.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -75,6 +75,15 @@ token mentah sekali saja. Klien mengirim token lewat header
 (`awcms_session`/`awcms_tenant_id`, untuk SSR admin shell). Tenant aktif wajib
 dikirim lewat header `X-AWCMS-Tenant-ID` untuk endpoint non-cookie.
 
+**Admin shell (Issue #166).** `src/pages/login.astro` + `src/pages/admin/*.astro`
+(dashboard + layar manajemen read-only: offices, profiles, users, roles,
+abac-policies, modules, email-templates) memakai `AdminLayout` + design token
+doc 14. `src/middleware.ts` menjaga `/admin/*` (resolve sesi via
+`resolveSsrContext`, redirect `/login` bila tak ada). CSP `default-src 'self'`
+dijaga satu sumber di middleware; halaman tak punya inline script/style
+(`build.inlineStylesheets: "never"` + script di-bundle eksternal). E2E Playwright
+(`tests/e2e/`, job CI `e2e-smoke`) memverifikasi alur browser sungguhan.
+
 ## RBAC/ABAC dasar
 
 `identity-access/domain/access-control.ts` — `evaluateAccess()`: default deny,

--- a/docs/awcms/07_sprint_testing_production_readiness.md
+++ b/docs/awcms/07_sprint_testing_production_readiness.md
@@ -195,17 +195,20 @@ playwright test`, Bun-only), terpisah dari `bun test`
 > pertama `not-found.e2e.ts` menguji route catch-all 404
 > (`src/pages/[...path].ts`, memakai ulang `src/lib/html/error-responses.ts`):
 > browser membuka path asing → dapat halaman 404 HTML bersih tanpa bocor
-> detail internal (Issue #540). Halaman `.astro` pertama kini **sudah ada**
-> (Issue #166): `login.astro`, `admin/index.astro` (dashboard), dan
-> `admin/offices.astro` (layar manajemen office, SSR-read via `listOffices`),
-> memakai `AdminLayout` + design token doc 14 (`src/styles/tokens.css`). Spec
+> detail internal (Issue #540). Halaman `.astro` admin kini **sudah ada**
+> (Issue #166): `login.astro`, `admin/index.astro` (dashboard), dan tujuh layar
+> manajemen read-only — `offices`, `profiles`, `users`, `roles`,
+> `abac-policies`, `modules`, `email-templates` — masing-masing SSR-read via
+> fungsi aplikasi yang sama dengan endpoint JSON-nya, di-gate ABAC, memakai
+> `AdminLayout` + design token doc 14 (`src/styles/tokens.css`). Spec
 > `login.e2e.ts` menguji render + properti CSP (script eksternal bukan inline —
 > `default-src 'self'`), dan `admin-offices.e2e.ts` menguji alur
 > ter-autentikasi penuh (login → cookie sesi → guard `/admin` → render tabel
-> offices). Dijalankan di CI oleh job `e2e-smoke` (`.github/workflows/ci.yml`),
-> yang menyalakan `postgres:18.4`, `db:migrate`, lalu men-seed satu
-> tenant+owner lewat `POST /api/v1/setup/initialize` (bootstrap sungguhan) dan
-> mengoperkan kredensialnya ke spec via env.
+> tiap layar, termasuk login identifier ter-mask di layar users). Dijalankan di
+> CI oleh job `e2e-smoke` (`.github/workflows/ci.yml`), yang menyalakan
+> `postgres:18.4`, `db:migrate`, lalu men-seed satu tenant+owner lewat
+> `POST /api/v1/setup/initialize` (bootstrap sungguhan) dan mengoperkan
+> kredensialnya ke spec via env.
 
 > **Runner test.** Runner = **`bun test`** (`bun:test`), berkas di
 > `tests/`. Daftar target di bawah bersifat **target rencana modul ERP**,

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -132,6 +132,34 @@ components:
         status: { type: string }
         createdAt: { type: string, format: date-time }
         updatedAt: { type: string, format: date-time }
+    TenantUserMasked:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        loginIdentifierMasked:
+          type: string
+          description: Masked login identifier — PII is never returned raw in a list.
+        status: { type: string }
+        roles:
+          type: array
+          items: { type: string }
+          description: Assigned role codes (empty when the user holds no role).
+    Role:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        roleCode: { type: string }
+        roleName: { type: string }
+        isSystem: { type: boolean }
+        permissionCount: { type: integer }
+    AbacPolicy:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        policyCode: { type: string }
+        effect: { type: string, enum: [allow, deny] }
+        description: { type: string, nullable: true }
+        isActive: { type: boolean }
     ProfileMasked:
       type: object
       properties:
@@ -1049,6 +1077,75 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/ApiError" }
+  /api/v1/users:
+    get:
+      operationId: listTenantUsers
+      tags: [Identity & Access]
+      summary: List the current tenant's users with their assigned role codes (login identifiers masked).
+      responses:
+        "200":
+          description: The tenant's users (limit 100), with masked login identifiers and assigned role codes.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: "#/components/schemas/TenantUserMasked" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+  /api/v1/roles:
+    get:
+      operationId: listRoles
+      tags: [Identity & Access]
+      summary: List the current tenant's (non-deleted) roles with a permission count.
+      responses:
+        "200":
+          description: The tenant's roles (limit 100), each with a permission count.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: "#/components/schemas/Role" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+  /api/v1/abac/policies:
+    get:
+      operationId: listAbacPolicies
+      tags: [Identity & Access]
+      summary: List the current tenant's ABAC policies (seeded-empty by default; built-in rules apply).
+      responses:
+        "200":
+          description: The tenant's ABAC policies (limit 100).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items: { $ref: "#/components/schemas/AbacPolicy" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
   /api/v1/auth/login:
     post:
       operationId: postAuthLogin

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -24,7 +24,15 @@ import "../styles/admin.css";
 interface Props {
   title: string;
   /** Sidebar key to mark `aria-current="page"`. */
-  active?: "dashboard" | "offices" | "profiles" | "modules" | "email-templates";
+  active?:
+    | "dashboard"
+    | "offices"
+    | "profiles"
+    | "users"
+    | "roles"
+    | "abac-policies"
+    | "modules"
+    | "email-templates";
 }
 
 const { title, active } = Astro.props;
@@ -77,6 +85,24 @@ const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
             aria-current={active === "profiles" ? "page" : undefined}
           >
             Profiles
+          </a>
+          <a
+            href="/admin/users"
+            aria-current={active === "users" ? "page" : undefined}
+          >
+            Users
+          </a>
+          <a
+            href="/admin/roles"
+            aria-current={active === "roles" ? "page" : undefined}
+          >
+            Roles
+          </a>
+          <a
+            href="/admin/abac-policies"
+            aria-current={active === "abac-policies" ? "page" : undefined}
+          >
+            ABAC policies
           </a>
           <a
             href="/admin/modules"

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -14,6 +14,22 @@ Login identity, sesi, tenant user membership, dan RBAC/ABAC dasar.
 
 Skema: `sql/004_awcms_identity_login_schema.sql`, `sql/005_awcms_abac_access_control_schema.sql`.
 
+## Access-management reads (admin, read-only — Issue #166)
+
+`application/access-directory.ts` mengekspos tiga list bertenant, semua di-gate
+`identity_access.access_control.read` dan dipakai oleh endpoint JSON **dan**
+layar admin SSR (`src/pages/admin/{users,roles,abac-policies}.astro`):
+
+- `listTenantUsers` → `GET /api/v1/users` — user tenant + kode role yang
+  di-assign. `login_identifier` **selalu ter-mask** via `maskIdentifierValue`
+  (PII tak pernah dikembalikan mentah di list).
+- `listRoles` → `GET /api/v1/roles` — role tenant non-deleted + jumlah permission.
+- `listAbacPolicies` → `GET /api/v1/abac/policies` — policy ABAC tenant
+  (default seeded-kosong; evaluator generik memakai aturan built-in).
+
+Semua bounded `LIMIT 100` (config low-cardinality, tanpa cursor), tenant-filtered,
+dan berjalan di dalam `withTenant` (RLS FORCE batas nyata).
+
 ## Auth flow
 
 `POST /api/v1/auth/login` — header `X-AWCMS-Tenant-ID` wajib, rate limit per `clientIp:tenantId` (backstop di luar lockout per-identity), verifikasi password, set cookie httpOnly (`awcms_session`/`awcms_tenant_id`) + kembalikan token untuk klien API. `POST /api/v1/auth/logout` merevoke sesi. `GET /api/v1/auth/me` hanya menerima bearer token.

--- a/src/modules/identity-access/application/access-directory.ts
+++ b/src/modules/identity-access/application/access-directory.ts
@@ -1,0 +1,149 @@
+/**
+ * Read-only access-management directory (Issue #166, Stage 3b — ported from
+ * awcms-mini's access-management reads, adapted to awcms's schema/scope).
+ *
+ * Three bounded list reads behind the admin RBAC/ABAC screens and their JSON
+ * endpoints, all gated on `identity_access.access_control.read` ("Read roles,
+ * permissions, and decision logs", seeded in `sql/005`):
+ *
+ * - `listTenantUsers`  — a tenant's users with their assigned role codes.
+ * - `listRoles`        — a tenant's (non-deleted) roles with a permission count.
+ * - `listAbacPolicies` — a tenant's ABAC policies.
+ *
+ * All are `LIMIT`-bounded low-cardinality config lists (same convention as
+ * `listEmailTemplates`), so no keyset cursor. Every query is tenant-filtered
+ * AND runs inside `withTenant` (RLS FORCE is the real boundary). Callers must
+ * be inside a `withTenant` transaction and must have passed the ABAC guard.
+ */
+import { maskIdentifierValue } from "../../profile-identity/domain/identifier";
+
+const LIST_LIMIT = 100;
+
+export type TenantUserView = {
+  id: string;
+  /** Masked — `login_identifier` is PII (usually an email). Never returned raw in a list. */
+  loginIdentifierMasked: string;
+  status: string;
+  /** Assigned role codes (empty when the user holds no role). */
+  roles: string[];
+};
+
+type TenantUserRow = {
+  id: string;
+  login_identifier: string;
+  status: string;
+  roles: string[] | null;
+};
+
+export async function listTenantUsers(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<TenantUserView[]> {
+  const rows = (await tx`
+    SELECT
+      tu.id,
+      i.login_identifier,
+      tu.status,
+      COALESCE(
+        array_agg(r.role_code) FILTER (WHERE r.id IS NOT NULL),
+        '{}'
+      ) AS roles
+    FROM awcms_tenant_users tu
+    JOIN awcms_identities i ON i.id = tu.identity_id
+    LEFT JOIN awcms_access_assignments aa ON aa.tenant_user_id = tu.id
+    LEFT JOIN awcms_roles r
+      ON r.id = aa.role_id AND r.deleted_at IS NULL
+    WHERE tu.tenant_id = ${tenantId}
+    GROUP BY tu.id, i.login_identifier, tu.status
+    ORDER BY i.login_identifier
+    LIMIT ${LIST_LIMIT}
+  `) as TenantUserRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    loginIdentifierMasked: maskIdentifierValue(row.login_identifier),
+    status: row.status,
+    roles: row.roles ?? []
+  }));
+}
+
+export type RoleView = {
+  id: string;
+  roleCode: string;
+  roleName: string;
+  isSystem: boolean;
+  permissionCount: number;
+};
+
+type RoleRow = {
+  id: string;
+  role_code: string;
+  role_name: string;
+  is_system: boolean;
+  permission_count: number;
+};
+
+export async function listRoles(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<RoleView[]> {
+  const rows = (await tx`
+    SELECT
+      r.id,
+      r.role_code,
+      r.role_name,
+      r.is_system,
+      count(rp.id)::int AS permission_count
+    FROM awcms_roles r
+    LEFT JOIN awcms_role_permissions rp ON rp.role_id = r.id
+    WHERE r.tenant_id = ${tenantId} AND r.deleted_at IS NULL
+    GROUP BY r.id, r.role_code, r.role_name, r.is_system
+    ORDER BY r.role_code
+    LIMIT ${LIST_LIMIT}
+  `) as RoleRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    roleCode: row.role_code,
+    roleName: row.role_name,
+    isSystem: row.is_system,
+    permissionCount: row.permission_count
+  }));
+}
+
+export type AbacPolicyView = {
+  id: string;
+  policyCode: string;
+  effect: string;
+  description: string | null;
+  isActive: boolean;
+};
+
+type AbacPolicyRow = {
+  id: string;
+  policy_code: string;
+  effect: string;
+  description: string | null;
+  is_active: boolean;
+};
+
+export async function listAbacPolicies(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<AbacPolicyView[]> {
+  const rows = (await tx`
+    SELECT id, policy_code, effect, description, is_active
+    FROM awcms_abac_policies
+    WHERE tenant_id = ${tenantId}
+    ORDER BY policy_code
+    LIMIT ${LIST_LIMIT}
+  `) as AbacPolicyRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    policyCode: row.policy_code,
+    effect: row.effect,
+    description: row.description,
+    isActive: row.is_active
+  }));
+}

--- a/src/pages/admin/abac-policies.astro
+++ b/src/pages/admin/abac-policies.astro
@@ -1,0 +1,106 @@
+---
+/**
+ * ABAC policy management screen (Issue #166, Stage 3b). SSR-reads via the same
+ * `listAbacPolicies` the `GET /api/v1/abac/policies` endpoint uses, gated on
+ * `identity_access.access_control.read`. Read-only.
+ *
+ * Note: like awcms-mini, the base ships this table seeded-EMPTY — the ABAC
+ * evaluator uses built-in role/permission rules by default, and per-tenant
+ * custom policies are an opt-in extension surface. An empty table here is the
+ * expected default, not an error.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listAbacPolicies,
+  type AbacPolicyView
+} from "../../modules/identity-access/application/access-directory";
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("identity_access", "access_control", "read")
+);
+
+let policies: AbacPolicyView[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, (tx) =>
+      listAbacPolicies(tx, ssr.tenantId)
+    );
+    if (result instanceof Response) loadError = true;
+    else policies = result;
+  } catch {
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title="ABAC policies" active="abac-policies">
+  <h1 id="abac-policies-heading">ABAC policies</h1>
+
+  {
+    !canRead && (
+      <p class="state-notice" id="abac-policies-denied">
+        You do not have permission to view ABAC policies.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice" id="abac-policies-error">
+        Policies could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll">
+        <table class="data-table" id="abac-policies-table">
+          <caption>{policies.length} policy(ies)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Code</th>
+              <th scope="col">Effect</th>
+              <th scope="col">Description</th>
+              <th scope="col">Active</th>
+            </tr>
+          </thead>
+          <tbody>
+            {policies.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan="4">
+                  No custom policies — the built-in role/permission rules apply.
+                </td>
+              </tr>
+            ) : (
+              policies.map((policy) => (
+                <tr>
+                  <td>{policy.policyCode}</td>
+                  <td>
+                    <span
+                      class="status-badge"
+                      data-variant={
+                        policy.effect === "allow" ? "success" : "warning"
+                      }
+                    >
+                      {policy.effect}
+                    </span>
+                  </td>
+                  <td>{policy.description ?? "—"}</td>
+                  <td>{policy.isActive ? "yes" : "no"}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>

--- a/src/pages/admin/roles.astro
+++ b/src/pages/admin/roles.astro
@@ -1,0 +1,99 @@
+---
+/**
+ * Role (RBAC) management screen (Issue #166, Stage 3b). SSR-reads via the same
+ * `listRoles` the `GET /api/v1/roles` endpoint uses, gated on
+ * `identity_access.access_control.read`. Read-only.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listRoles,
+  type RoleView
+} from "../../modules/identity-access/application/access-directory";
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("identity_access", "access_control", "read")
+);
+
+let roles: RoleView[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, (tx) =>
+      listRoles(tx, ssr.tenantId)
+    );
+    if (result instanceof Response) loadError = true;
+    else roles = result;
+  } catch {
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title="Roles" active="roles">
+  <h1 id="roles-heading">Roles</h1>
+
+  {
+    !canRead && (
+      <p class="state-notice" id="roles-denied">
+        You do not have permission to view roles.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice" id="roles-error">
+        Roles could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll">
+        <table class="data-table" id="roles-table">
+          <caption>{roles.length} role(s)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Code</th>
+              <th scope="col">Name</th>
+              <th scope="col">System</th>
+              <th scope="col">Permissions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {roles.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan="4">
+                  No roles yet.
+                </td>
+              </tr>
+            ) : (
+              roles.map((role) => (
+                <tr>
+                  <td>{role.roleCode}</td>
+                  <td>{role.roleName}</td>
+                  <td>
+                    <span
+                      class="status-badge"
+                      data-variant={role.isSystem ? "warning" : "neutral"}
+                    >
+                      {role.isSystem ? "system" : "custom"}
+                    </span>
+                  </td>
+                  <td>{role.permissionCount}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -1,0 +1,100 @@
+---
+/**
+ * User (tenant users) management screen (Issue #166, Stage 3b). SSR-reads via
+ * the same `listTenantUsers` the `GET /api/v1/users` endpoint uses, gated on
+ * `identity_access.access_control.read`. Login identifiers are masked (PII).
+ * Read-only.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listTenantUsers,
+  type TenantUserView
+} from "../../modules/identity-access/application/access-directory";
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("identity_access", "access_control", "read")
+);
+
+let users: TenantUserView[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, (tx) =>
+      listTenantUsers(tx, ssr.tenantId)
+    );
+    if (result instanceof Response) loadError = true;
+    else users = result;
+  } catch {
+    loadError = true;
+  }
+}
+---
+
+<AdminLayout title="Users" active="users">
+  <h1 id="users-heading">Users</h1>
+
+  {
+    !canRead && (
+      <p class="state-notice" id="users-denied">
+        You do not have permission to view users.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice" id="users-error">
+        Users could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll">
+        <table class="data-table" id="users-table">
+          <caption>{users.length} user(s)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Login identifier</th>
+              <th scope="col">Status</th>
+              <th scope="col">Roles</th>
+            </tr>
+          </thead>
+          <tbody>
+            {users.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan="3">
+                  No users yet.
+                </td>
+              </tr>
+            ) : (
+              users.map((user) => (
+                <tr>
+                  <td>{user.loginIdentifierMasked}</td>
+                  <td>
+                    <span
+                      class="status-badge"
+                      data-variant={
+                        user.status === "active" ? "success" : "neutral"
+                      }
+                    >
+                      {user.status}
+                    </span>
+                  </td>
+                  <td>{user.roles.length > 0 ? user.roles.join(", ") : "—"}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>

--- a/src/pages/api/v1/abac/policies/index.ts
+++ b/src/pages/api/v1/abac/policies/index.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { listAbacPolicies } from "../../../../../modules/identity-access/application/access-directory";
+
+const READ_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/abac/policies` — the tenant's ABAC policies (Issue #166).
+ * Read-only. Gated on `identity_access.access_control.read`.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    const items = await listAbacPolicies(tx, tenantId);
+    return ok({ items });
+  });
+};

--- a/src/pages/api/v1/roles/index.ts
+++ b/src/pages/api/v1/roles/index.ts
@@ -1,0 +1,47 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { listRoles } from "../../../../modules/identity-access/application/access-directory";
+
+const READ_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/roles` — the tenant's (non-deleted) roles with a permission
+ * count (Issue #166). Read-only. Gated on `identity_access.access_control.read`.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    const items = await listRoles(tx, tenantId);
+    return ok({ items });
+  });
+};

--- a/src/pages/api/v1/users/index.ts
+++ b/src/pages/api/v1/users/index.ts
@@ -1,0 +1,48 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { listTenantUsers } from "../../../../modules/identity-access/application/access-directory";
+
+const READ_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/users` — the tenant's users with their assigned role codes
+ * (Issue #166). Read-only; `login_identifier` is masked (PII). Gated on
+ * `identity_access.access_control.read`.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    const items = await listTenantUsers(tx, tenantId);
+    return ok({ items });
+  });
+};

--- a/tests/e2e/admin-offices.e2e.ts
+++ b/tests/e2e/admin-offices.e2e.ts
@@ -77,6 +77,25 @@ test.describe("admin offices (authenticated)", () => {
     await page.goto("/admin/profiles");
     await expect(page.locator("#profiles-table")).toBeVisible();
     await expect(page.locator("#profiles-denied")).toHaveCount(0);
+
+    // RBAC/ABAC screens (Stage 3b): the seeded owner IS a tenant-user holding
+    // the "owner" role and every permission, so all three render with data (or,
+    // for ABAC policies, the expected empty built-in-rules state).
+    await page.goto("/admin/users");
+    await expect(page.locator("#users-table")).toBeVisible();
+    // The owner's masked login identifier appears — never the raw address.
+    await expect(page.locator("#users-table")).toContainText("@example.com");
+    await expect(page.locator("#users-table")).not.toContainText(
+      "e2e-owner@example.com"
+    );
+
+    await page.goto("/admin/roles");
+    await expect(page.locator("#roles-table")).toBeVisible();
+    await expect(page.locator("#roles-table")).toContainText("owner");
+
+    await page.goto("/admin/abac-policies");
+    await expect(page.locator("#abac-policies-table")).toBeVisible();
+    await expect(page.locator("#abac-policies-denied")).toHaveCount(0);
   });
 
   test("rejects a wrong password with a generic error, not a stack trace", async ({


### PR DESCRIPTION
Stage 3b of #166 — ports awcms-mini's access-management reads to awcms (adapted to awcms's schema/scope) and adds their admin screens, **completing the requested management surface** (auth · user · profile · rbac · abac · module · template) as read-only admin screens.

## Backend (ported + adapted, mini-first)
`src/modules/identity-access/application/access-directory.ts`:
- **`listTenantUsers`** → `GET /api/v1/users` — users + assigned role codes. `login_identifier` is **masked** (`maskIdentifierValue`) — mini returned it raw; awcms's PII posture masks it.
- **`listRoles`** → `GET /api/v1/roles` — non-deleted roles + permission count.
- **`listAbacPolicies`** → `GET /api/v1/abac/policies` — policies (seeded-empty by default; the evaluator uses built-in role/permission rules — same as mini).

All gated on the **existing** `identity_access.access_control.read` permission — mini's `user_management` activity code doesn't exist in awcms, so no new permission migration is needed. Bounded `LIMIT 100`, tenant-filtered, inside `withTenant`. OpenAPI updated (3 paths + `TenantUserMasked`/`Role`/`AbacPolicy` schemas; `api:spec:check` green).

## Screens
`admin/users.astro`, `admin/roles.astro`, `admin/abac-policies.astro` — permission-gated, DB-error-degrading, in the `AdminLayout` sidebar. The authenticated E2E now navigates all three; the users assertion checks the owner's **masked** identifier appears and the **raw** address does not.

## Docs synced
doc 07 (E2E note), `identity-access/README.md` (new read layer + endpoints), `ARCHITECTURE.md` (admin shell section).

## Verification
`bun run check` green (incl. `api:spec:check`, typecheck, build). Local: new admin routes 302 → `/login`; new API routes 400 `TENANT_REQUIRED` (correctly wired); login + 404 E2E 4 passed. Authenticated user/roles/abac flow validates in CI `e2e-smoke`.

Read-only slice — RBAC write (assign/create/edit) is a follow-up (tracked on #166).

🤖 Generated with [Claude Code](https://claude.com/claude-code)