### PR TITLE
feat(admin): create-office and create-profile forms (#166)

### DIFF
--- a/.changeset/admin-offices-create.md
+++ b/.changeset/admin-offices-create.md
@@ -1,0 +1,10 @@
+---
+"awcms": patch
+---
+
+Add a create-office form to the admin offices screen (Issue #166), permission-gated on `tenant_admin.office_management.create`, posting to the existing `POST /api/v1/offices` via cookie auth; CSP-safe (external bundled script). Authed E2E covers create → row appears.
+
+- **`admin/offices.astro`** — renders `#office-create-form` above the existing table only when the SSR context holds `tenant_admin.office_management.create`. On submit the bundled `<script>` (imports `lockElement`/`postJson` from `admin-form-client`, forcing Astro to emit it external per the `default-src 'self'` CSP) reads `officeCode`/`officeName`/`officeType`, `POST`s to `/api/v1/offices` (cookie auth — no tenant header), reloads on success, and shows a single generic error otherwise (never internal detail, Issue #540). Double-submit is guarded via `lockElement`.
+- **E2E** — new `tests/e2e/admin-offices-create.e2e.ts`, env-gated like `admin-offices.e2e.ts`: the seeded owner fills the form with a per-run unique code and the new row appears in `#offices-table` after reload.
+
+The endpoint, validation, ABAC guard, and duplicate/parent handling already existed; this slice is additive UI + coverage.

--- a/.changeset/admin-profiles-create.md
+++ b/.changeset/admin-profiles-create.md
@@ -1,0 +1,5 @@
+---
+"awcms": patch
+---
+
+Add a create-profile form to the admin profiles screen (Issue #166), permission-gated on profile_identity.profile_management.create, posting to POST /api/v1/profiles via cookie auth; CSP-safe external script. Authed E2E covers create → row appears.

--- a/.claude/skills/awcms-browser-test/SKILL.md
+++ b/.claude/skills/awcms-browser-test/SKILL.md
@@ -143,6 +143,21 @@ test:e2e` (atau `bunx playwright test`) diam-diam menjalankan proses
    spec menguji jalur error, assert isi pesan TIDAK mengandung kata kunci
    seperti "stack"/"postgres"/nama fungsi internal, bukan cuma assert
    "ada pesan error" (lihat contoh di `login.e2e.ts`'s kedua test).
+6. **CSP halaman `.astro`: script HARUS eksternal, jangan pernah inline
+   atau conditional** (Issue #166, memory `awcms-admin-ui-notes`). CSP
+   `default-src 'self'` (middleware) memblokir semua inline script/style.
+   Karena itu setiap `<script>` halaman **wajib meng-import** dari
+   `src/lib/ui/admin-form-client.ts` — import itu yang memaksa Astro
+   mem-bundle-nya jadi file eksternal; script tanpa import di-inline-kan
+   Astro dan **diblokir CSP** (perilaku mati diam-diam, tetap lolos build).
+   DAN: Astro meng-hoist `<script>` saat **build**, jadi JANGAN membungkusnya
+   di conditional runtime `{cond && (<script>…)}` — itu percuma (bundle tetap
+   ter-ship) DAN membuat `prettier`/parser Astro gagal (`SyntaxError`).
+   Taruh `<script>` sebagai elemen top-level tanpa conditional; guard di JS
+   (`const el = getElementById(...); el?.addEventListener(...)`). CSS: pakai
+   stylesheet eksternal (`build.inlineStylesheets: "never"`), bukan `<style>`
+   inline. Jalankan E2E terhadap build produksi (`build && start`), bukan
+   `dev` (dev server menyuntik HMR inline yang diblokir CSP ini).
 
 ## File referensi
 

--- a/docs/awcms/07_sprint_testing_production_readiness.md
+++ b/docs/awcms/07_sprint_testing_production_readiness.md
@@ -197,9 +197,11 @@ playwright test`, Bun-only), terpisah dari `bun test`
 > browser membuka path asing → dapat halaman 404 HTML bersih tanpa bocor
 > detail internal (Issue #540). Halaman `.astro` admin kini **sudah ada**
 > (Issue #166): `login.astro`, `admin/index.astro` (dashboard), dan tujuh layar
-> manajemen read-only — `offices`, `profiles`, `users`, `roles`,
-> `abac-policies`, `modules`, `email-templates` — masing-masing SSR-read via
-> fungsi aplikasi yang sama dengan endpoint JSON-nya, di-gate ABAC, memakai
+> manajemen — `offices`, `profiles`, `users`, `roles`, `abac-policies`,
+> `modules`, `email-templates` — masing-masing SSR-read via fungsi aplikasi
+> yang sama dengan endpoint JSON-nya, di-gate ABAC; `offices` & `profiles` juga
+> punya **create-form** ter-gate permission (POST via cookie auth, script
+> eksternal CSP-safe). Semua memakai
 > `AdminLayout` + design token doc 14 (`src/styles/tokens.css`). Spec
 > `login.e2e.ts` menguji render + properti CSP (script eksternal bukan inline —
 > `default-src 'self'`), dan `admin-offices.e2e.ts` menguji alur

--- a/src/lib/ui/admin-form-client.ts
+++ b/src/lib/ui/admin-form-client.ts
@@ -35,3 +35,37 @@ export function lockElement(
     element.textContent = originalLabel;
   };
 }
+
+/**
+ * POSTs a JSON body to a same-origin admin API endpoint using COOKIE auth: the
+ * session + tenant cookies ride along automatically (`credentials:
+ * "same-origin"`), and `resolveAuthInputs` reads the tenant from the
+ * `awcms_tenant_id` cookie — so an admin-page form needs no manual
+ * `X-AWCMS-Tenant-ID` header. Returns a narrow `{ ok, errorCode }` so callers
+ * show a generic message keyed off `errorCode` and never surface internal
+ * detail (Issue #540). Never throws.
+ */
+export async function postJson(
+  url: string,
+  body: unknown
+): Promise<{ ok: boolean; errorCode: string | null }> {
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "same-origin",
+      body: JSON.stringify(body)
+    });
+    const payload = (await response.json().catch(() => null)) as {
+      success?: boolean;
+      error?: { code?: string };
+    } | null;
+
+    if (response.ok && payload?.success === true) {
+      return { ok: true, errorCode: null };
+    }
+    return { ok: false, errorCode: payload?.error?.code ?? null };
+  } catch {
+    return { ok: false, errorCode: "NETWORK_ERROR" };
+  }
+}

--- a/src/modules/profile-identity/README.md
+++ b/src/modules/profile-identity/README.md
@@ -21,6 +21,8 @@ Skema: `sql/003_awcms_central_profile_schema.sql`.
 - `POST /api/v1/profiles/{id}/identifiers` — tempel identifier baru ke profile, guard `create`. `409 IDENTIFIER_ALREADY_EXISTS` bila identifier (tipe + nilai) sudah ada di tenant ini — unique index-nya (`23505`) diterjemahkan jadi `DuplicateIdentifierError` di `application/identifier-directory.ts`, lalu dipetakan ke 409 **di dalam** `withTenant` (kalau lolos ke luar, error itu bukan `PostgresError` sehingga ikut menghitung circuit breaker database).
 - `GET /api/v1/profiles/{id}/links` — baca entity link (kosong sampai modul lain menulis lewat kode).
 
+Layar admin `admin/profiles.astro` kini punya form create profile ter-gate permission `profile_identity.profile_management.create` yang mem-POST ke `POST /api/v1/profiles` (cookie auth, script eksternal aman-CSP).
+
 ## Belum tersedia
 
 Merge workflow (`awcms_profile_merge_requests` — tabel belum dibuat), channel komunikasi & alamat efektif-tanggal, restore/purge endpoint (permission `restore` sudah di-seed tapi belum ada konsumen), duplicate-candidate detection.

--- a/src/modules/tenant-admin/README.md
+++ b/src/modules/tenant-admin/README.md
@@ -26,6 +26,8 @@ Skema: `sql/002_awcms_tenant_office_schema.sql`, `sql/006_awcms_setup_wizard_sch
 
 `GET /api/v1/offices` **keyset-paginated**: maksimal 100 baris per halaman, urut **terbaru dulu**, plus `nextCursor` opaque (`null` di halaman terakhir). Cursor rusak → `400`, bukan diam-diam menyajikan halaman 1.
 
+Layar admin `admin/offices.astro` kini punya form **create office** yang di-gate permission `tenant_admin.office_management.create` (hanya render bila user punya izin), POST ke `POST /api/v1/offices` via cookie auth (CSP-safe: script bundled eksternal).
+
 ### Kenapa FK-nya komposit (GHSA-r7cx-c4jh-cvvw)
 
 `parent_office_id` dulu `REFERENCES awcms_offices (id)` — FK ke primary key saja, yang tidak berkata apa pun soal tenancy. Admin tenant A bisa mengirim `parentOfficeId` milik tenant B dan dapat `200 OK`; hierarkinya menyeberang tenant, dan field itu sekaligus jadi existence oracle (id nyata milik tenant lain → 200, uuid acak → FK violation → 500).

--- a/src/pages/admin/offices.astro
+++ b/src/pages/admin/offices.astro
@@ -9,9 +9,10 @@
  * ABAC is enforced server-side by the endpoints; this page additionally gates
  * its own render on the same `tenant_admin.office_management.read` permission
  * (from `Astro.locals.ssrContext.permissions`) so a user without it gets a
- * clean "no access" notice instead of an empty table. Read-only for this first
- * slice — creating/editing offices stays on `POST /api/v1/offices` and lands
- * as a later increment.
+ * clean "no access" notice instead of an empty table. A create-office form is
+ * shown to users holding `office_management.create` and posts to the existing
+ * `POST /api/v1/offices` (cookie auth) — the endpoint's ABAC guard is the real
+ * authority; the form gate is UX-only. Edit/delete remain a later increment.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import { getDatabaseClient } from "../../lib/database/client";
@@ -30,6 +31,9 @@ type OfficeRow = {
 const ssr = Astro.locals.ssrContext!;
 const canRead = ssr.permissions.has(
   permissionKey("tenant_admin", "office_management", "read")
+);
+const canCreate = ssr.permissions.has(
+  permissionKey("tenant_admin", "office_management", "create")
 );
 
 let offices: OfficeRow[] = [];
@@ -72,6 +76,45 @@ if (canRead) {
       <p class="state-notice" id="offices-error">
         Offices could not be loaded right now. Please try again later.
       </p>
+    )
+  }
+
+  {
+    canCreate && (
+      <form id="office-create-form" class="login-form admin-create-form">
+        <p id="office-create-error" class="login-error" role="alert" hidden />
+
+        <label for="office-code">Office code</label>
+        <input
+          id="office-code"
+          name="officeCode"
+          type="text"
+          required
+          autocomplete="off"
+        />
+
+        <label for="office-name">Office name</label>
+        <input
+          id="office-name"
+          name="officeName"
+          type="text"
+          required
+          autocomplete="off"
+        />
+
+        <label for="office-type">Office type</label>
+        <select id="office-type" name="officeType">
+          <option value="head_office">head_office</option>
+          <option value="branch">branch</option>
+          <option value="store">store</option>
+          <option value="warehouse">warehouse</option>
+          <option value="other">other</option>
+        </select>
+
+        <button type="submit" id="office-create-submit">
+          Create office
+        </button>
+      </form>
     )
   }
 
@@ -120,3 +163,62 @@ if (canRead) {
     )
   }
 </AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time, so it
+  // can't be runtime-conditional) — harmless for users without the create
+  // permission: the form only renders when `canCreate`, so `form` is null and
+  // the listener never binds. The import is deliberate — it forces Astro to
+  // bundle this script EXTERNAL (an import-free script would be inlined, and
+  // inline
+  // scripts are blocked by this app's CSP). See admin-form-client.ts.
+  import { lockElement, postJson } from "../../lib/ui/admin-form-client";
+
+  const form = document.getElementById(
+    "office-create-form"
+  ) as HTMLFormElement | null;
+  const errorBox = document.getElementById("office-create-error");
+  const submitButton = document.getElementById(
+    "office-create-submit"
+  ) as HTMLButtonElement | null;
+
+  function showError(message: string): void {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.hidden = false;
+  }
+
+  form?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    // Guard + disable the submit button for the request duration so a fast
+    // double-click can't fire two create POSTs.
+    if (!submitButton || submitButton.disabled) return;
+    const unlock = lockElement(submitButton, "Please wait…");
+
+    if (errorBox) errorBox.hidden = true;
+
+    const formData = new FormData(form);
+    const officeCode = String(formData.get("officeCode") ?? "").trim();
+    const officeName = String(formData.get("officeName") ?? "").trim();
+    const officeType = String(formData.get("officeType") ?? "").trim();
+
+    const result = await postJson("/api/v1/offices", {
+      officeCode,
+      officeName,
+      officeType
+    });
+
+    if (result.ok) {
+      // Reload so the SSR table re-renders with the new row.
+      window.location.reload();
+      return;
+    }
+
+    // Generic message only — never surface internal detail (Issue #540).
+    showError(
+      "Could not create the office. Check the code is unique and try again."
+    );
+    unlock();
+  });
+</script>

--- a/src/pages/admin/offices.astro
+++ b/src/pages/admin/offices.astro
@@ -81,8 +81,13 @@ if (canRead) {
 
   {
     canCreate && (
-      <form id="office-create-form" class="login-form admin-create-form">
-        <p id="office-create-error" class="login-error" role="alert" hidden />
+      <form id="office-create-form" class="admin-create-form">
+        <p
+          id="office-create-error"
+          class="admin-create-error"
+          role="alert"
+          hidden
+        />
 
         <label for="office-code">Office code</label>
         <input

--- a/src/pages/admin/profiles.astro
+++ b/src/pages/admin/profiles.astro
@@ -25,6 +25,9 @@ const ssr = Astro.locals.ssrContext!;
 const canRead = ssr.permissions.has(
   permissionKey("profile_identity", "profile_management", "read")
 );
+const canCreate = ssr.permissions.has(
+  permissionKey("profile_identity", "profile_management", "create")
+);
 
 let profiles: PartyRow[] = [];
 let loadError = false;
@@ -52,6 +55,40 @@ if (canRead) {
       <p class="state-notice" id="profiles-denied">
         You do not have permission to view profiles.
       </p>
+    )
+  }
+
+  {
+    canCreate && (
+      <form id="profile-create-form" class="admin-create-form" novalidate>
+        <label for="profile-type">
+          Type
+          <select id="profile-type" name="profileType">
+            <option value="person" selected>
+              person
+            </option>
+            <option value="organization">organization</option>
+          </select>
+        </label>
+        <label for="profile-display-name">
+          Display name
+          <input
+            id="profile-display-name"
+            name="displayName"
+            type="text"
+            required
+          />
+        </label>
+        <button type="submit" id="profile-create-submit">
+          Create profile
+        </button>
+        <p
+          id="profile-create-error"
+          class="admin-create-error"
+          role="alert"
+          hidden
+        />
+      </form>
     )
   }
 
@@ -107,4 +144,56 @@ if (canRead) {
       </div>
     )
   }
+
+  <script>
+    // The import is deliberate — it forces Astro to bundle this script to an
+    // external file. An import-free hoisted script would be inlined, and inline
+    // scripts are blocked by this app's CSP (`default-src 'self'`, no
+    // 'unsafe-inline'). See admin-form-client.ts / login.astro.
+    import { lockElement, postJson } from "../../lib/ui/admin-form-client";
+
+    const form = document.getElementById(
+      "profile-create-form"
+    ) as HTMLFormElement | null;
+    const errorBox = document.getElementById("profile-create-error");
+    const submitButton = document.getElementById(
+      "profile-create-submit"
+    ) as HTMLButtonElement | null;
+
+    form?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+
+      // Guard + disable the submit button for the request duration so a fast
+      // double-click can't fire two create POSTs before the reload lands.
+      if (!submitButton || submitButton.disabled) return;
+      const unlock = lockElement(submitButton, "Creating…");
+
+      if (errorBox) errorBox.hidden = true;
+
+      const formData = new FormData(form);
+      const profileType = String(formData.get("profileType") ?? "person");
+      const displayName = String(formData.get("displayName") ?? "").trim();
+
+      const result = await postJson("/api/v1/profiles", {
+        profileType,
+        displayName
+      });
+
+      if (result.ok) {
+        // Navigating away — leave the button disabled so it can't be
+        // re-clicked during the reload.
+        window.location.reload();
+        return;
+      }
+
+      // Generic message only — never reconstruct a specific deny/validation
+      // reason or surface internal detail (Issue #540).
+      if (errorBox) {
+        errorBox.textContent =
+          "Could not create the profile. Check your details and try again.";
+        errorBox.hidden = false;
+      }
+      unlock();
+    });
+  </script>
 </AdminLayout>

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -230,6 +230,62 @@
   color: var(--color-text);
 }
 
+/* ---- Create form (admin write actions) ------------------------------ */
+.admin-create-form {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-4);
+  padding: var(--sp-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+}
+
+.admin-create-form label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  font-size: var(--fs-sm);
+  color: var(--color-text-muted);
+}
+
+.admin-create-form input,
+.admin-create-form select {
+  min-height: 40px;
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  color: var(--color-text);
+}
+
+.admin-create-form button {
+  min-height: 40px;
+  padding: var(--sp-1) var(--sp-3);
+  background: var(--color-primary-strong);
+  color: var(--color-primary-contrast);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.admin-create-form button:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
+}
+
+.admin-create-error {
+  width: 100%;
+  color: var(--color-primary-contrast);
+  background: var(--color-danger-strong);
+  border-radius: var(--radius-sm);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--fs-sm);
+}
+
 /* ---- State notice --------------------------------------------------- */
 .state-notice {
   padding: var(--sp-4);

--- a/tests/e2e/admin-offices-create.e2e.ts
+++ b/tests/e2e/admin-offices-create.e2e.ts
@@ -1,0 +1,63 @@
+/**
+ * Authenticated admin write-action E2E (Issue #166) — exercises the
+ * permission-gated create-office form on `/admin/offices`: log in through the
+ * real `/login` form → session cookies → `/admin` guard → fill the create form
+ * → `POST /api/v1/offices` via cookie auth → page reload → the new row appears
+ * in the SSR-rendered `#offices-table`.
+ *
+ * Env-gated exactly like `admin-offices.e2e.ts`: the CI `e2e-smoke` job seeds a
+ * tenant + owner via `POST /api/v1/setup/initialize` and hands the credentials
+ * through env vars. Skipped (not failed) when they are absent, so a local
+ * `bun run test:e2e` without a seeded DB stays green. The seeded owner role
+ * holds every permission, so the `office_management.create` gate passes and the
+ * form renders.
+ */
+import { test, expect } from "@playwright/test";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
+const password = process.env.E2E_PASSWORD;
+
+const seeded = Boolean(tenantId && loginIdentifier && password);
+
+test.describe("admin offices create (authenticated)", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant — CI e2e-smoke provisions one via POST /api/v1/setup/initialize"
+  );
+
+  test("owner creates an office and sees the new row appear", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+
+    // The client script redirects to /admin on success.
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/offices");
+
+    // The owner holds `office_management.create`, so the form renders.
+    const form = page.locator("#office-create-form");
+    await expect(form).toBeVisible();
+
+    // A per-run unique code so re-running the suite doesn't collide on the
+    // `(tenant_id, office_code)` uniqueness constraint.
+    const newCode = `BR-E2E-${Date.now()}`;
+
+    await page.locator("#office-code").fill(newCode);
+    await page.locator("#office-name").fill("E2E Branch");
+    await page.locator("#office-type").selectOption("branch");
+    await page.locator("#office-create-submit").click();
+
+    // The client reloads the page on success; wait for the SSR table to
+    // re-render with the new row.
+    const table = page.locator("#offices-table");
+    await expect(table).toBeVisible();
+    await expect(table).toContainText(newCode);
+    await expect(page.locator("#office-create-error")).toBeHidden();
+  });
+});

--- a/tests/e2e/admin-profiles-create.e2e.ts
+++ b/tests/e2e/admin-profiles-create.e2e.ts
@@ -42,13 +42,19 @@ test.describe("admin profiles create (authenticated)", () => {
     // The owner holds the create permission, so the form renders.
     await expect(page.locator("#profile-create-form")).toBeVisible();
 
+    // Per-run unique name — a fixed name would let a leftover row from a prior
+    // run (or a retry) pass the `toContainText` check even if THIS run's create
+    // silently failed (a false green). Same discipline as the offices spec.
+    const displayName = `E2E Person ${Date.now()}`;
     await page.locator("#profile-type").selectOption("person");
-    await page.locator("#profile-display-name").fill("E2E Person Alpha");
+    await page.locator("#profile-display-name").fill(displayName);
     await page.locator("#profile-create-submit").click();
 
-    // On success the client reloads; the reloaded SSR table now lists the row.
+    // On success the client reloads; the reloaded SSR table now lists the row,
+    // and the error box stays hidden (proves the create actually succeeded).
     const table = page.locator("#profiles-table");
     await expect(table).toBeVisible();
-    await expect(table).toContainText("E2E Person Alpha");
+    await expect(table).toContainText(displayName);
+    await expect(page.locator("#profile-create-error")).toBeHidden();
   });
 });

--- a/tests/e2e/admin-profiles-create.e2e.ts
+++ b/tests/e2e/admin-profiles-create.e2e.ts
@@ -1,0 +1,54 @@
+/**
+ * Authenticated create-profile E2E (Issue #166 write actions) — the full loop:
+ * log in through the real `/login` form → session cookies → `/admin` guard →
+ * the create form on the profiles screen POSTs to `POST /api/v1/profiles` via
+ * cookie auth, then the reloaded table shows the new row.
+ *
+ * Env-gated exactly like `admin-offices.e2e.ts`: the CI `e2e-smoke` job seeds a
+ * tenant + owner once via `POST /api/v1/setup/initialize` and hands them here
+ * through env vars. Skipped (not failed) when absent so a local
+ * `bun run test:e2e` without a seeded DB stays green. The seeded owner holds
+ * every permission, so the `profile_identity.profile_management.create` gate on
+ * the form passes.
+ */
+import { test, expect } from "@playwright/test";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
+const password = process.env.E2E_PASSWORD;
+
+const seeded = Boolean(tenantId && loginIdentifier && password);
+
+test.describe("admin profiles create (authenticated)", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant — CI e2e-smoke provisions one via POST /api/v1/setup/initialize"
+  );
+
+  test("owner creates a profile and sees the new row in the table", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+
+    // The client script redirects to /admin on success.
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/profiles");
+
+    // The owner holds the create permission, so the form renders.
+    await expect(page.locator("#profile-create-form")).toBeVisible();
+
+    await page.locator("#profile-type").selectOption("person");
+    await page.locator("#profile-display-name").fill("E2E Person Alpha");
+    await page.locator("#profile-create-submit").click();
+
+    // On success the client reloads; the reloaded SSR table now lists the row.
+    const table = page.locator("#profiles-table");
+    await expect(table).toBeVisible();
+    await expect(table).toContainText("E2E Person Alpha");
+  });
+});


### PR DESCRIPTION
Adds the first **write actions** to the admin UI — create forms on the offices and profiles screens — completing the "first admin management UI" scope of #166. Both post to their **existing** `POST` endpoint via cookie auth; UI-only, no backend change. Built by **2 parallel agents on disjoint files**, integrated + validated centrally.

## What
- **`admin/offices.astro`** — create-office form (code/name/type), gated `tenant_admin.office_management.create` → `POST /api/v1/offices`.
- **`admin/profiles.astro`** — create-profile form (type/display name), gated `profile_identity.profile_management.create` → `POST /api/v1/profiles`.
- **`admin-form-client.ts`** — shared `postJson(url, body)` (cookie auth, `credentials:same-origin` — no tenant header; returns a narrow `{ok, errorCode}` so only a generic message is shown, Issue #540).
- **`admin.css`** — `.admin-create-form`.
- **New authed E2E** (`admin-offices-create` / `admin-profiles-create.e2e.ts`) — create → row appears; env-gated, runs in CI `e2e-smoke`.

## CSP (kept intact)
Client scripts **import** from `admin-form-client` so Astro bundles them **external** (an inline script would be blocked by `default-src 'self'`). Scripts are top-level, never runtime-conditional (Astro hoists `<script>` at build — verified: the offices agent initially wrapped it in `{canCreate && …}`, which broke the parser; fixed to an unconditional top-level script guarded on `form?` null).

## Docs / hygiene
doc 07, tenant-admin + profile-identity READMEs, and the `awcms-browser-test` skill (new CSP-script convention) updated. Memory `awcms-admin-ui-notes` records the CSP/hoisting lessons.

## Verification
`bun run check` green. Local E2E: **4 passed / 5 skipped** (authed specs incl. the 2 new create specs skip without seed; run in CI). New API paths already covered by prior PRs.

Remaining write/CRUD (email-template/modules toggle, RBAC/ABAC write, edit/delete) tracked in the follow-up issue.

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)