### PR TITLE
feat(admin): complete write/CRUD actions — roles, ABAC, users RBAC, offices lifecycle (#171)

### DIFF
--- a/.changeset/admin-abac-write.md
+++ b/.changeset/admin-abac-write.md
@@ -1,0 +1,14 @@
+---
+"awcms": patch
+---
+
+Admin UI: author and manage ABAC policies (Issue #171). Adds
+`POST /api/v1/abac/policies` (create) and `PATCH /api/v1/abac/policies/{id}`
+(update effect/description and enable/disable toggle), both gated default-deny on
+`identity_access.access_control.configure` (the access-control administration
+permission — that activity seeds only `read`/`assign`/`configure`, and the owner
+holds only seeded permissions) and audit-logged as high-risk access-control
+changes. A duplicate `policyCode` returns 409. The
+`/admin/abac-policies` screen gains a create-policy form plus per-row Edit and
+Enable/Disable controls (UX-only gating; the endpoint ABAC guard is the
+authority).

--- a/.changeset/admin-offices-edit-delete.md
+++ b/.changeset/admin-offices-edit-delete.md
@@ -1,0 +1,14 @@
+---
+"awcms": patch
+---
+
+Admin offices lifecycle: soft-delete + restore (Issue #171). Adds
+`DELETE /api/v1/offices/{id}` (audited soft-delete; optional/bodyless reason)
+and `POST /api/v1/offices/{id}/restore` (audited restore, 409 when a live
+office has retaken the code). The `/admin/offices` screen gains permission-gated
+per-row inline edit (name + status via the existing PATCH), soft-delete, and a
+deleted-offices section with restore controls. Seeds the new
+`tenant_admin.office_management.delete` permission via migration
+`sql/023_awcms_seed_office_management_delete_permission.sql` (so the owner,
+granted only catalogued permissions at bootstrap, can actually delete); restore
+reuses `office_management.update`.

--- a/.changeset/admin-roles-crud.md
+++ b/.changeset/admin-roles-crud.md
@@ -1,0 +1,14 @@
+---
+"awcms": patch
+---
+
+Admin roles CRUD + role↔permission management (Issue #171). Adds
+`POST /api/v1/roles` (create), `PATCH`/`DELETE /api/v1/roles/{id}` (rename /
+soft-delete), `POST /api/v1/roles/{id}/restore`, and `POST`/`DELETE
+/api/v1/roles/{id}/permissions` (grant / revoke), plus write controls on the
+`/admin/roles` screen (create form, per-row rename / soft-delete, restore, and
+a manage-permissions panel). All writes are HIGH-RISK: authorized on the
+existing `identity_access.access_control.configure` permission and audited.
+System roles (e.g. `owner`) cannot be soft-deleted (409). Duplicate role code
+(409) and duplicate permission grant (409) are caught inside the tenant
+transaction.

--- a/.changeset/admin-users-rbac.md
+++ b/.changeset/admin-users-rbac.md
@@ -1,0 +1,12 @@
+---
+"awcms": patch
+---
+
+Add tenant-user activate/deactivate + role assign/unassign to the admin UI (Issue #171) — the next slice of admin write actions, backed by new guarded, audited endpoints in the identity-access module.
+
+- **`user-admin.ts`** (new application layer) — `setTenantUserStatus` (activate/deactivate; `awcms_tenant_users` has no `deleted_at`, so deactivate = `status='inactive'` / reactivate = `status='active'`), `assignRole` (DB-idempotent via the `(tenant_id, tenant_user_id, role_id)` unique index; a repeat assign raises 23505 → 409), and `unassignRole`. Each writes a high-risk audit event; login identifiers (PII) are never logged — the audit row references the stable `tenant_user_id`.
+- **`PATCH /api/v1/users/{id}`** (new) — set a tenant user's status. Guarded on `identity_access.access_control.configure`.
+- **`POST` / `DELETE /api/v1/access/assignments`** (new) — assign / revoke a role. Guarded on `identity_access.access_control.assign`. 23505 → 409 is caught INSIDE `withTenant`; target-not-found → 404 is raised before any write.
+- **`admin/users.astro`** — now renders per-user activate/deactivate and assign-role (with per-role remove) controls, each UX-gated on the same permission its endpoint enforces (the endpoint guard is the authority). Login identifiers stay masked in the render. The client script is external (CSP-safe) and uses the shared `sendJson` PATCH/DELETE helper.
+
+GUARD NOTE (no migration): the seed (`sql/005`) provides `identity_access.access_control.{read,assign,configure}` but no `.update`, and the owner role is granted only SEEDED permissions — so guarding on `update` would deny even the owner. Role assignment therefore uses the exactly-named `assign` permission; user activate/deactivate uses `configure` (the broadest identity-access admin permission), since deactivating revokes all of a user's access. A future migration adding a dedicated `access_control.update` (or a `user_management` activity) would let user-status be gated independently of role/permission administration.

--- a/.changeset/admin-write-lockout-guards.md
+++ b/.changeset/admin-write-lockout-guards.md
@@ -1,0 +1,23 @@
+---
+"awcms": patch
+---
+
+Harden the admin access-control write surface against privilege-escalation and
+lockout foot-guns (Issue #171 review follow-up):
+
+- **System-role permission set is immutable via the API.** `POST`/`DELETE
+  /api/v1/roles/{id}/permissions` now refuse `is_system` roles (409
+  `ROLE_SYSTEM_PROTECTED`) — a delegated `configure` holder can no longer strip
+  the seeded `owner` role's grants and lock the tenant out (parity with
+  `softDeleteRole`, which already blocked system roles).
+- **System roles cannot be hand-assigned/unassigned.** `POST`/`DELETE
+  /api/v1/access/assignments` refuse `is_system` roles (409
+  `ROLE_SYSTEM_PROTECTED`) — the `assign` permission can no longer be used to
+  self-assign `owner` (escalation) or strip it from the sole owner (lockout).
+- **Deactivation lockout guards.** `PATCH /api/v1/users/{id}` refuses to
+  deactivate the actor's own account (409 `CANNOT_DEACTIVATE_SELF`) or the last
+  active member of a system role (409 `USER_LAST_ADMIN_PROTECTED`), so a tenant
+  can never be left with no active administrator and no in-app recovery.
+
+All guards are checked before any write, audited on the success path only, and
+scoped to the tenant (no cross-tenant existence oracle).

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -1100,6 +1100,125 @@ paths:
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
+  /api/v1/users/{id}:
+    patch:
+      operationId: setTenantUserStatus
+      tags: [Identity & Access]
+      summary: Activate or deactivate a tenant user (high-risk, audited).
+      description: >-
+        Sets the tenant user's status. `awcms_tenant_users` has no `deleted_at`,
+        so deactivate = status `inactive`, reactivate = status `active`. Gated on
+        `identity_access.access_control.configure`.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [status]
+              properties:
+                status: { type: string, enum: [active, inactive] }
+      responses:
+        "200":
+          description: The tenant user's new status.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      id: { type: string, format: uuid }
+                      status: { type: string, enum: [active, inactive] }
+                      updatedAt: { type: string, format: date-time }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/access/assignments:
+    post:
+      operationId: createRoleAssignment
+      tags: [Identity & Access]
+      summary: Assign a role to a tenant user (high-risk, audited, idempotent).
+      description: >-
+        Grants a role to a tenant user. Idempotent at the DB unique index — a
+        repeat assign returns 409. Gated on
+        `identity_access.access_control.assign`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tenantUserId, roleId]
+              properties:
+                tenantUserId: { type: string, format: uuid }
+                roleId: { type: string, format: uuid }
+      responses:
+        "200":
+          description: The created assignment.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      id: { type: string, format: uuid }
+                      tenantUserId: { type: string, format: uuid }
+                      roleId: { type: string, format: uuid }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409":
+          description: The role is already assigned to this tenant user.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiError" }
+    delete:
+      operationId: deleteRoleAssignment
+      tags: [Identity & Access]
+      summary: Revoke a role from a tenant user (high-risk, audited).
+      description: >-
+        Removes a role assignment. 404 when no such assignment exists. Gated on
+        `identity_access.access_control.assign`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tenantUserId, roleId]
+              properties:
+                tenantUserId: { type: string, format: uuid }
+                roleId: { type: string, format: uuid }
+      responses:
+        "200":
+          description: The assignment was removed.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      removed: { type: boolean, enum: [true] }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
   /api/v1/roles:
     get:
       operationId: listRoles
@@ -1123,6 +1242,222 @@ paths:
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
+    post:
+      operationId: createRole
+      tags: [Identity & Access]
+      summary: Create a custom role for the current tenant (audited; requires access_control.configure).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [roleCode, roleName]
+              properties:
+                roleCode:
+                  type: string
+                  description: "Slug: 2–64 chars, lowercase letters, digits, '_' or '-'. Unique per tenant among live roles."
+                roleName: { type: string }
+      responses:
+        "200":
+          description: Role created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data: { $ref: "#/components/schemas/Role" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "409":
+          description: roleCode is already taken by a live role in this tenant (ROLE_CODE_ALREADY_EXISTS).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiError" }
+  /api/v1/roles/{id}:
+    patch:
+      operationId: updateRole
+      tags: [Identity & Access]
+      summary: Rename a role (audited; requires access_control.configure).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [roleName]
+              properties:
+                roleName: { type: string }
+      responses:
+        "200":
+          description: Role updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data: { $ref: "#/components/schemas/Role" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+    delete:
+      operationId: deleteRole
+      tags: [Identity & Access]
+      summary: Soft-delete a role (audited; requires access_control.configure). System roles are rejected with 409.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason:
+                  type: string
+                  description: Optional free-text reason echoed into the soft-delete audit event.
+      responses:
+        "200":
+          description: Role soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      id: { type: string, format: uuid }
+                      status: { type: string }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409":
+          description: The role is a system role and cannot be deleted (ROLE_SYSTEM_PROTECTED).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiError" }
+  /api/v1/roles/{id}/restore:
+    post:
+      operationId: restoreRole
+      tags: [Identity & Access]
+      summary: Restore a soft-deleted role (audited; requires access_control.configure).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Role restored.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data: { $ref: "#/components/schemas/Role" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409":
+          description: The role's code was re-used by a live role while it was deleted (ROLE_CODE_ALREADY_EXISTS).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiError" }
+  /api/v1/roles/{id}/permissions:
+    post:
+      operationId: grantRolePermission
+      tags: [Identity & Access]
+      summary: Grant a catalogued permission to a role (audited; requires access_control.configure).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [permissionId]
+              properties:
+                permissionId: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Permission granted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      roleId: { type: string, format: uuid }
+                      permissionId: { type: string, format: uuid }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409":
+          description: The permission is already granted to this role (ROLE_PERMISSION_ALREADY_GRANTED).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiError" }
+    delete:
+      operationId: revokeRolePermission
+      tags: [Identity & Access]
+      summary: Revoke a permission from a role (audited; requires access_control.configure).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [permissionId]
+              properties:
+                permissionId: { type: string, format: uuid }
+      responses:
+        "200":
+          description: Permission revoked.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      roleId: { type: string, format: uuid }
+                      permissionId: { type: string, format: uuid }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
   /api/v1/abac/policies:
     get:
       operationId: listAbacPolicies
@@ -1146,6 +1481,76 @@ paths:
         "400": { $ref: "#/components/responses/BadRequest" }
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
+    post:
+      operationId: createAbacPolicy
+      tags: [Identity & Access]
+      summary: Author a new ABAC policy for the current tenant (high-risk access-control change; audit-logged).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [policyCode, effect]
+              properties:
+                policyCode:
+                  type: string
+                  description: Unique per tenant. Starts alphanumeric; letters, digits, '.', '_', '-' only (max 100 chars).
+                effect: { type: string, enum: [allow, deny] }
+                description: { type: string, nullable: true }
+      responses:
+        "201":
+          description: Policy created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data: { $ref: "#/components/schemas/AbacPolicy" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "409":
+          description: policyCode is already taken in this tenant (POLICY_CODE_ALREADY_EXISTS).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiError" }
+  /api/v1/abac/policies/{id}:
+    patch:
+      operationId: updateAbacPolicy
+      tags: [Identity & Access]
+      summary: Update an ABAC policy's effect/description and/or enable-disable it (high-risk; audit-logged).
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+      requestBody:
+        required: true
+        description: "Provide at least one of effect, description, isActive. A null description clears it."
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                effect: { type: string, enum: [allow, deny] }
+                description: { type: string, nullable: true }
+                isActive: { type: boolean }
+      responses:
+        "200":
+          description: Policy updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data: { $ref: "#/components/schemas/AbacPolicy" }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
   /api/v1/auth/login:
     post:
       operationId: postAuthLogin
@@ -1419,6 +1824,74 @@ paths:
         "401": { $ref: "#/components/responses/Unauthorized" }
         "403": { $ref: "#/components/responses/Forbidden" }
         "404": { $ref: "#/components/responses/NotFound" }
+    delete:
+      operationId: deleteOffice
+      tags: [Tenant Admin]
+      summary: Soft-delete an office (audited, restorable).
+      description: Sets deleted_at/deleted_by/delete_reason; the office code is freed for reuse and the row remains restorable via POST /api/v1/offices/{id}/restore. Not a hard delete.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: false
+        description: Optional. A bodyless delete is accepted (delete_reason stays null); a present reason is stored and audited. A blank reason is rejected.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                reason: { type: string }
+      responses:
+        "200":
+          description: Office soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data:
+                    type: object
+                    properties:
+                      id: { type: string, format: uuid }
+                      status: { type: string, enum: [deleted] }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /api/v1/offices/{id}/restore:
+    post:
+      operationId: restoreOffice
+      tags: [Tenant Admin]
+      summary: Restore a soft-deleted office (audited).
+      description: Clears the delete stamps and records restored_at/restored_by. 404 when the id is not currently soft-deleted (idempotent-safe). 409 when a live office has since taken the same code.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string, format: uuid }
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Office restored.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success: { type: boolean, enum: [true] }
+                  data: { $ref: "#/components/schemas/Office" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "403": { $ref: "#/components/responses/Forbidden" }
+        "404": { $ref: "#/components/responses/NotFound" }
+        "409":
+          description: A live office already uses this office code (OFFICE_CODE_ALREADY_EXISTS).
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ApiError" }
   /api/v1/profiles:
     get:
       operationId: listProfiles

--- a/sql/023_awcms_seed_office_management_delete_permission.sql
+++ b/sql/023_awcms_seed_office_management_delete_permission.sql
@@ -1,0 +1,21 @@
+-- Issue #171 (Admin UI: complete write/CRUD actions) — seed the
+-- `tenant_admin.office_management.delete` permission that gates the new office
+-- soft-delete endpoint (`DELETE /api/v1/offices/{id}`).
+--
+-- WHY A SEPARATE SEED MIGRATION: `awcms_offices` already carries the
+-- soft-delete columns (`deleted_at`/`deleted_by`/`delete_reason`), so no schema
+-- change is needed — but the permission CATALOG in sql/005 seeded
+-- `office_management` with only `read`/`create`/`update`. The owner role is
+-- granted every row of `awcms_permissions` at bootstrap
+-- (`platform-bootstrap.ts`), and the e2e-smoke seed runs migrations THEN
+-- `POST /setup/initialize` with no module permission-sync in between — so a
+-- guard on an un-seeded action would default-deny even the owner. Declaring the
+-- action in `tenant-admin/module.ts` alone is not enough; it must exist as a
+-- catalog row before bootstrap. sql/005 is an APPLIED, immutable migration, so
+-- the row is added here as a forward migration (idempotent) instead of editing
+-- it. This mirrors the `profile_management.delete` precedent already seeded in
+-- sql/005 and keeps the module descriptor and DB catalog in agreement.
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('tenant_admin', 'office_management', 'delete', 'Soft-delete office records')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/lib/ui/admin-form-client.ts
+++ b/src/lib/ui/admin-form-client.ts
@@ -37,24 +37,30 @@ export function lockElement(
 }
 
 /**
- * POSTs a JSON body to a same-origin admin API endpoint using COOKIE auth: the
- * session + tenant cookies ride along automatically (`credentials:
- * "same-origin"`), and `resolveAuthInputs` reads the tenant from the
- * `awcms_tenant_id` cookie — so an admin-page form needs no manual
- * `X-AWCMS-Tenant-ID` header. Returns a narrow `{ ok, errorCode }` so callers
- * show a generic message keyed off `errorCode` and never surface internal
- * detail (Issue #540). Never throws.
+ * Sends a JSON body to a same-origin admin API endpoint with the given HTTP
+ * method, using COOKIE auth: the session + tenant cookies ride along
+ * automatically (`credentials: "same-origin"`), and `resolveAuthInputs` reads
+ * the tenant from the `awcms_tenant_id` cookie — so an admin-page form needs no
+ * manual `X-AWCMS-Tenant-ID` header. Returns a narrow `{ ok, errorCode }` so
+ * callers show a generic message keyed off `errorCode` and never surface
+ * internal detail (Issue #540). Never throws.
+ *
+ * `body` is optional so a bodyless mutation (e.g. `DELETE /roles/{id}`, a
+ * restore/toggle) can be sent without an empty-object payload; when omitted no
+ * request body and no `Content-Type` header are attached.
  */
-export async function postJson(
+export async function sendJson(
+  method: "POST" | "PATCH" | "PUT" | "DELETE",
   url: string,
-  body: unknown
+  body?: unknown
 ): Promise<{ ok: boolean; errorCode: string | null }> {
   try {
+    const hasBody = body !== undefined;
     const response = await fetch(url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+      method,
+      headers: hasBody ? { "Content-Type": "application/json" } : undefined,
       credentials: "same-origin",
-      body: JSON.stringify(body)
+      body: hasBody ? JSON.stringify(body) : undefined
     });
     const payload = (await response.json().catch(() => null)) as {
       success?: boolean;
@@ -68,4 +74,16 @@ export async function postJson(
   } catch {
     return { ok: false, errorCode: "NETWORK_ERROR" };
   }
+}
+
+/**
+ * POSTs a JSON body to a same-origin admin API endpoint. Thin wrapper over
+ * {@link sendJson} kept for the existing create-form call sites; new edit /
+ * delete / toggle forms should call `sendJson` with the appropriate method.
+ */
+export async function postJson(
+  url: string,
+  body: unknown
+): Promise<{ ok: boolean; errorCode: string | null }> {
+  return sendJson("POST", url, body);
 }

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -30,6 +30,42 @@ layar admin SSR (`src/pages/admin/{users,roles,abac-policies}.astro`):
 Semua bounded `LIMIT 100` (config low-cardinality, tanpa cursor), tenant-filtered,
 dan berjalan di dalam `withTenant` (RLS FORCE batas nyata).
 
+## Access-management writes (admin — Issue #171)
+
+Layar admin `roles`/`abac-policies`/`users` kini punya aksi tulis, masing-masing
+di-gate default-deny oleh `authorizeInTransaction` di dalam `withTenant`; gate
+UI hanya UX, endpoint-lah otoritasnya. Setiap tulis adalah high-risk →
+menulis audit event (severity `warning`) SETELAH tulis sukses (tak ada audit
+di jalur 409/404).
+
+**Catatan permission (penting).** Katalog `awcms_permissions` (`sql/005`)
+menyemai aktivitas `identity_access.access_control` HANYA dengan
+`read`/`assign`/`configure` — TIDAK ada `create`/`update`/`delete`. Owner
+di-grant seluruh baris katalog saat bootstrap, jadi guard pada action
+tak-ter-seed akan men-deny bahkan owner. Karena itu semua tulis di sini memakai
+action ter-seed:
+
+- `POST /api/v1/roles`, `PATCH`/`DELETE /api/v1/roles/{id}`,
+  `POST /api/v1/roles/{id}/restore`, `POST`/`DELETE /api/v1/roles/{id}/permissions`
+  (`application/role-admin.ts`) — buat/rename/soft-delete/restore role + grant/
+  revoke permission. Gate **`configure`** ("Manage roles and role permissions").
+  Role sistem (`is_system`) tak bisa di-soft-delete (409). Duplikat role code /
+  duplikat grant → 409 di dalam `withTenant`.
+- `POST /api/v1/abac/policies`, `PATCH /api/v1/abac/policies/{id}`
+  (`application/abac-admin.ts`) — author + edit + enable/disable policy. Gate
+  **`configure`** (administrasi access-control). Duplikat `policyCode` → 409.
+- `PATCH /api/v1/users/{id}` (`application/user-admin.ts` `setTenantUserStatus`)
+  — activate/deactivate (tak ada `deleted_at`; `status` `active`/`inactive`).
+  Gate **`configure`**.
+- `POST`/`DELETE /api/v1/access/assignments` (`application/user-admin.ts`
+  `assignRole`/`unassignRole`) — assign/unassign role↔user. Gate **`assign`**.
+  Assign idempotent di unique index `(tenant_id, tenant_user_id, role_id)`
+  (23505→409); target tak ada → 404 sebelum tulis (anti existence-oracle).
+
+Klien admin memakai helper `sendJson(method, url, body?)`
+(`src/lib/ui/admin-form-client.ts`) untuk PATCH/DELETE — script eksternal
+(CSP-safe).
+
 ## Auth flow
 
 `POST /api/v1/auth/login` — header `X-AWCMS-Tenant-ID` wajib, rate limit per `clientIp:tenantId` (backstop di luar lockout per-identity), verifikasi password, set cookie httpOnly (`awcms_session`/`awcms_tenant_id`) + kembalikan token untuk klien API. `POST /api/v1/auth/logout` merevoke sesi. `GET /api/v1/auth/me` hanya menerima bearer token.

--- a/src/modules/identity-access/application/abac-admin.ts
+++ b/src/modules/identity-access/application/abac-admin.ts
@@ -1,0 +1,194 @@
+/**
+ * ABAC policy authoring — write side of the access-control admin surface
+ * (Issue #171). READS live in `access-directory.ts` (`listAbacPolicies`); all
+ * WRITE logic is here so the read module stays side-effect-free.
+ *
+ * Every write is a HIGH-RISK access-control change and is audit-logged
+ * (`awcms_audit_events`, severity `warning`). Callers MUST already be inside a
+ * `withTenant` transaction AND have passed the `identity_access.access_control`
+ * ABAC guard for the matching action — RLS FORCE on `awcms_abac_policies` is
+ * the real tenant boundary.
+ *
+ * `awcms_abac_policies` columns (schema unchanged): id, tenant_id, policy_code
+ * (unique per tenant), effect (CHECK IN 'allow'|'deny'), description (nullable),
+ * is_active, created_at, updated_at.
+ */
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import type { AbacPolicyView } from "./access-directory";
+import type {
+  CreateAbacPolicyInput,
+  UpdateAbacPolicyInput
+} from "../domain/abac-admin-validation";
+
+const AUDIT_MODULE_KEY = "identity_access";
+const AUDIT_RESOURCE_TYPE = "abac_policy";
+const POSTGRES_UNIQUE_VIOLATION = "23505";
+
+/**
+ * `policy_code` is unique per tenant (`awcms_abac_policies` unique index on
+ * `(tenant_id, policy_code)`). A collision is a rule the CALLER can act on —
+ * pick another code — so it must surface as 409, not an unhandled 500.
+ */
+export class DuplicatePolicyCodeError extends Error {
+  constructor(policyCode: string) {
+    super(`An ABAC policy with code "${policyCode}" already exists.`);
+    this.name = "DuplicatePolicyCodeError";
+  }
+}
+
+type AbacPolicyRow = {
+  id: string;
+  policy_code: string;
+  effect: string;
+  description: string | null;
+  is_active: boolean;
+};
+
+function toView(row: AbacPolicyRow): AbacPolicyView {
+  return {
+    id: row.id,
+    policyCode: row.policy_code,
+    effect: row.effect,
+    description: row.description,
+    isActive: row.is_active
+  };
+}
+
+async function fetchPolicyById(
+  tx: Bun.SQL,
+  tenantId: string,
+  policyId: string
+): Promise<AbacPolicyRow | null> {
+  const rows = (await tx`
+    SELECT id, policy_code, effect, description, is_active
+    FROM awcms_abac_policies
+    WHERE tenant_id = ${tenantId} AND id = ${policyId}
+  `) as AbacPolicyRow[];
+  return rows[0] ?? null;
+}
+
+/**
+ * @throws {DuplicatePolicyCodeError} `policyCode` already exists for the tenant.
+ *   Raised from the unique-violation that has already ABORTED the transaction —
+ *   the route must map it to 409 without writing anything further to `tx`.
+ */
+export async function createPolicy(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: CreateAbacPolicyInput,
+  correlationId?: string
+): Promise<AbacPolicyView> {
+  let rows: AbacPolicyRow[];
+
+  try {
+    rows = (await tx`
+      INSERT INTO awcms_abac_policies (tenant_id, policy_code, effect, description)
+      VALUES (${tenantId}, ${input.policyCode}, ${input.effect}, ${input.description})
+      RETURNING id, policy_code, effect, description, is_active
+    `) as AbacPolicyRow[];
+  } catch (error) {
+    if (
+      error instanceof Bun.SQL.PostgresError &&
+      String(error.errno) === POSTGRES_UNIQUE_VIOLATION
+    ) {
+      throw new DuplicatePolicyCodeError(input.policyCode);
+    }
+    throw error;
+  }
+
+  const view = toView(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "create",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: view.id,
+    severity: "warning",
+    message: `ABAC policy created: ${view.policyCode} (${view.effect}).`,
+    attributes: { effect: view.effect, isActive: view.isActive },
+    correlationId
+  });
+
+  return view;
+}
+
+/**
+ * Applies any subset of {effect, description, isActive} to one policy. The
+ * single update path backs BOTH the edit form and the enable/disable toggle.
+ * Returns `null` when the policy does not exist in this tenant (route → 404);
+ * `description: null` explicitly clears the column (distinct from "unchanged").
+ */
+export async function updatePolicy(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  policyId: string,
+  input: UpdateAbacPolicyInput,
+  correlationId?: string
+): Promise<AbacPolicyView | null> {
+  const existing = await fetchPolicyById(tx, tenantId, policyId);
+  if (!existing) return null;
+
+  // `description` must distinguish "not provided" (keep existing) from an
+  // explicit null (clear it) — `??` can't, so key-presence decides.
+  const nextDescription =
+    "description" in input ? (input.description ?? null) : existing.description;
+  const nextEffect = input.effect ?? existing.effect;
+  const nextIsActive = input.isActive ?? existing.is_active;
+
+  const rows = (await tx`
+    UPDATE awcms_abac_policies
+    SET
+      effect = ${nextEffect},
+      description = ${nextDescription},
+      is_active = ${nextIsActive},
+      updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${policyId}
+    RETURNING id, policy_code, effect, description, is_active
+  `) as AbacPolicyRow[];
+
+  if (rows.length === 0) return null;
+
+  const view = toView(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "update",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: view.id,
+    severity: "warning",
+    message: `ABAC policy updated: ${view.policyCode}.`,
+    attributes: { fields: Object.keys(input), isActive: view.isActive },
+    correlationId
+  });
+
+  return view;
+}
+
+/**
+ * Enable/disable convenience over {@link updatePolicy} — the toggle is just an
+ * `isActive`-only update, kept as a named function so callers reading like
+ * `setPolicyActive(false)` don't have to construct the input object.
+ */
+export function setPolicyActive(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  policyId: string,
+  isActive: boolean,
+  correlationId?: string
+): Promise<AbacPolicyView | null> {
+  return updatePolicy(
+    tx,
+    tenantId,
+    actorTenantUserId,
+    policyId,
+    { isActive },
+    correlationId
+  );
+}

--- a/src/modules/identity-access/application/role-admin.ts
+++ b/src/modules/identity-access/application/role-admin.ts
@@ -396,10 +396,17 @@ export async function restoreRole(
 }
 
 export type GrantResult =
-  { outcome: "granted" } | { outcome: "role_not_found" };
+  | { outcome: "granted" }
+  | { outcome: "role_not_found" }
+  | { outcome: "system_blocked" };
 
 /**
  * Grants a catalogued permission to a live role.
+ *
+ * `is_system` roles (e.g. the seeded `owner`) are BLOCKED: their permission set
+ * is an immutable invariant seeded at bootstrap. Allowing mutation via the API
+ * would let a delegated `configure` holder alter the tenant's root role — the
+ * same foot-gun `softDeleteRole` already blocks. The caller maps it to 409.
  *
  * @throws {DuplicateRolePermissionError} the grant already exists (23505).
  * @throws {PermissionNotFoundError} `permissionId` is not in the catalog (the
@@ -415,6 +422,7 @@ export async function grantPermissionToRole(
 ): Promise<GrantResult> {
   const role = await fetchLiveRoleById(tx, tenantId, roleId);
   if (!role) return { outcome: "role_not_found" };
+  if (role.isSystem) return { outcome: "system_blocked" };
 
   try {
     await tx`
@@ -452,9 +460,15 @@ export async function grantPermissionToRole(
 export type RevokeResult =
   | { outcome: "revoked" }
   | { outcome: "role_not_found" }
+  | { outcome: "system_blocked" }
   | { outcome: "grant_not_found" };
 
-/** Revokes a permission from a live role. */
+/**
+ * Revokes a permission from a live role. `is_system` roles are BLOCKED — see
+ * {@link grantPermissionToRole}: stripping `access_control.*` from the seeded
+ * `owner` role would lock the tenant out of its own administration. The caller
+ * maps it to 409.
+ */
 export async function revokePermissionFromRole(
   tx: Bun.SQL,
   tenantId: string,
@@ -465,6 +479,7 @@ export async function revokePermissionFromRole(
 ): Promise<RevokeResult> {
   const role = await fetchLiveRoleById(tx, tenantId, roleId);
   if (!role) return { outcome: "role_not_found" };
+  if (role.isSystem) return { outcome: "system_blocked" };
 
   const rows = (await tx`
     DELETE FROM awcms_role_permissions

--- a/src/modules/identity-access/application/role-admin.ts
+++ b/src/modules/identity-access/application/role-admin.ts
@@ -1,0 +1,492 @@
+/**
+ * Role (RBAC) WRITE logic for the admin management screen (Issue #171). Kept
+ * separate from the READ-only `access-directory.ts` (owned by another slice):
+ * every function here mutates and is HIGH-RISK, so each writes an audit event
+ * and is gated by the caller's `identity_access.access_control.configure`
+ * guard.
+ *
+ * ABAC ACTION NOTE: role CRUD and role↔permission management all authorize on
+ * the seeded `configure` permission ("Manage roles and role permissions",
+ * `identity_access` module.ts + `sql/005`), NOT distinct create/update/delete
+ * permission keys. Those finer keys are not in the permission catalog and
+ * cannot be added without a migration (out of scope for this slice), so
+ * guarding on them would default-deny every actor — including the owner, who is
+ * granted every catalogued permission. `configure` is a HIGH_RISK_ACTION, so
+ * the audit posture is unchanged.
+ *
+ * Every function assumes it runs INSIDE `withTenant` (RLS FORCE is the real
+ * tenant boundary) and after the ABAC guard has passed; each still filters
+ * `tenant_id` explicitly (defense in depth) and scopes soft-delete reads to
+ * `deleted_at IS NULL`.
+ */
+import { recordAuditEvent } from "../../logging/application/audit-log";
+
+const AUDIT_MODULE_KEY = "identity_access";
+const AUDIT_RESOURCE_TYPE_ROLE = "role";
+const AUDIT_RESOURCE_TYPE_PERMISSION = "role_permission";
+
+const POSTGRES_UNIQUE_VIOLATION = "23505";
+const POSTGRES_FK_VIOLATION = "23503";
+
+/**
+ * `role_code` is unique per tenant among LIVE roles
+ * (`awcms_roles_tenant_code_key`, partial `WHERE deleted_at IS NULL`,
+ * sql/005:45). A collision is caller-actionable — pick another code — so it
+ * surfaces as 409, not an unhandled `PostgresError` (500).
+ */
+export class DuplicateRoleCodeError extends Error {
+  constructor(roleCode: string) {
+    super(`A role with code "${roleCode}" already exists for this tenant.`);
+    this.name = "DuplicateRoleCodeError";
+  }
+}
+
+/**
+ * The `(tenant_id, role_id, permission_id)` grant already exists
+ * (`awcms_role_permissions_key`, sql/005:64). Idempotent from the caller's
+ * point of view but reported as 409 so the UI can tell "already granted" apart
+ * from success.
+ */
+export class DuplicateRolePermissionError extends Error {
+  constructor() {
+    super("That permission is already granted to this role.");
+    this.name = "DuplicateRolePermissionError";
+  }
+}
+
+/** `permission_id` does not reference a row in the global permission catalog. */
+export class PermissionNotFoundError extends Error {
+  constructor() {
+    super("permissionId does not reference a known permission.");
+    this.name = "PermissionNotFoundError";
+  }
+}
+
+export type RoleAdminRecord = {
+  id: string;
+  roleCode: string;
+  roleName: string;
+  isSystem: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type RoleRow = {
+  id: string;
+  role_code: string;
+  role_name: string;
+  is_system: boolean;
+  created_at: Date;
+  updated_at: Date;
+};
+
+function toRecord(row: RoleRow): RoleAdminRecord {
+  return {
+    id: row.id,
+    roleCode: row.role_code,
+    roleName: row.role_name,
+    isSystem: row.is_system,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+export async function fetchLiveRoleById(
+  tx: Bun.SQL,
+  tenantId: string,
+  roleId: string
+): Promise<RoleAdminRecord | null> {
+  const rows = (await tx`
+    SELECT id, role_code, role_name, is_system, created_at, updated_at
+    FROM awcms_roles
+    WHERE tenant_id = ${tenantId} AND id = ${roleId} AND deleted_at IS NULL
+  `) as RoleRow[];
+
+  return rows[0] ? toRecord(rows[0]) : null;
+}
+
+export type DeletedRoleView = {
+  id: string;
+  roleCode: string;
+  roleName: string;
+  isSystem: boolean;
+};
+
+/**
+ * The tenant's soft-deleted roles (restore targets for the admin screen).
+ * Bounded/low-cardinality config list, so no cursor.
+ */
+export async function listDeletedRoles(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<DeletedRoleView[]> {
+  const rows = (await tx`
+    SELECT id, role_code, role_name, is_system
+    FROM awcms_roles
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NOT NULL
+    ORDER BY role_code
+    LIMIT 100
+  `) as Array<{
+    id: string;
+    role_code: string;
+    role_name: string;
+    is_system: boolean;
+  }>;
+
+  return rows.map((row) => ({
+    id: row.id,
+    roleCode: row.role_code,
+    roleName: row.role_name,
+    isSystem: row.is_system
+  }));
+}
+
+// --- Permission catalog + role-permission reads (for the manage-permissions UI) ---
+
+export type PermissionCatalogEntry = {
+  id: string;
+  moduleKey: string;
+  activityCode: string;
+  action: string;
+  description: string | null;
+};
+
+type PermissionRow = {
+  id: string;
+  module_key: string;
+  activity_code: string;
+  action: string;
+  description: string | null;
+};
+
+/**
+ * The whole global permission catalog (`awcms_permissions` has no `tenant_id`;
+ * it is platform-wide reference data). Bounded and low-cardinality, so no
+ * cursor. Used to render the "add permission" picker.
+ */
+export async function listPermissionCatalog(
+  tx: Bun.SQL
+): Promise<PermissionCatalogEntry[]> {
+  const rows = (await tx`
+    SELECT id, module_key, activity_code, action, description
+    FROM awcms_permissions
+    ORDER BY module_key, activity_code, action
+  `) as PermissionRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    moduleKey: row.module_key,
+    activityCode: row.activity_code,
+    action: row.action,
+    description: row.description
+  }));
+}
+
+/** The permissions currently granted to `roleId`, joined to the catalog. */
+export async function listRolePermissions(
+  tx: Bun.SQL,
+  tenantId: string,
+  roleId: string
+): Promise<PermissionCatalogEntry[]> {
+  const rows = (await tx`
+    SELECT p.id, p.module_key, p.activity_code, p.action, p.description
+    FROM awcms_role_permissions rp
+    JOIN awcms_permissions p ON p.id = rp.permission_id
+    WHERE rp.tenant_id = ${tenantId} AND rp.role_id = ${roleId}
+    ORDER BY p.module_key, p.activity_code, p.action
+  `) as PermissionRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    moduleKey: row.module_key,
+    activityCode: row.activity_code,
+    action: row.action,
+    description: row.description
+  }));
+}
+
+// --- Writes ---
+
+/** @throws {DuplicateRoleCodeError} `roleCode` is already taken by a live role. */
+export async function createRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: { roleCode: string; roleName: string },
+  correlationId?: string
+): Promise<RoleAdminRecord> {
+  let rows: RoleRow[];
+
+  try {
+    rows = (await tx`
+      INSERT INTO awcms_roles (tenant_id, role_code, role_name, is_system)
+      VALUES (${tenantId}, ${input.roleCode}, ${input.roleName}, false)
+      RETURNING id, role_code, role_name, is_system, created_at, updated_at
+    `) as RoleRow[];
+  } catch (error) {
+    if (
+      error instanceof Bun.SQL.PostgresError &&
+      String(error.errno) === POSTGRES_UNIQUE_VIOLATION
+    ) {
+      throw new DuplicateRoleCodeError(input.roleCode);
+    }
+    throw error;
+  }
+
+  const record = toRecord(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "create",
+    resourceType: AUDIT_RESOURCE_TYPE_ROLE,
+    resourceId: record.id,
+    severity: "warning",
+    message: `Role created: ${record.roleCode}.`,
+    correlationId
+  });
+
+  return record;
+}
+
+/** Edits `role_name` only. Returns `null` when the role does not exist / is deleted. */
+export async function updateRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  roleId: string,
+  input: { roleName: string },
+  correlationId?: string
+): Promise<RoleAdminRecord | null> {
+  const rows = (await tx`
+    UPDATE awcms_roles
+    SET role_name = ${input.roleName}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${roleId} AND deleted_at IS NULL
+    RETURNING id, role_code, role_name, is_system, created_at, updated_at
+  `) as RoleRow[];
+
+  if (rows.length === 0) return null;
+
+  const record = toRecord(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "update",
+    resourceType: AUDIT_RESOURCE_TYPE_ROLE,
+    resourceId: record.id,
+    severity: "warning",
+    message: `Role updated: ${record.roleCode}.`,
+    correlationId
+  });
+
+  return record;
+}
+
+export type SoftDeleteRoleResult =
+  | { outcome: "deleted"; role: RoleAdminRecord }
+  | { outcome: "not_found" }
+  | { outcome: "system_blocked" };
+
+/**
+ * Soft-deletes a role. `is_system` roles (e.g. the seeded `owner`) are BLOCKED:
+ * deleting them would strip the tenant's only administrator of their grants.
+ * The block is checked before the UPDATE — the caller maps it to 409.
+ */
+export async function softDeleteRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  roleId: string,
+  reason: string | null,
+  correlationId?: string
+): Promise<SoftDeleteRoleResult> {
+  const existing = await fetchLiveRoleById(tx, tenantId, roleId);
+  if (!existing) return { outcome: "not_found" };
+  if (existing.isSystem) return { outcome: "system_blocked" };
+
+  const rows = (await tx`
+    UPDATE awcms_roles
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId},
+        delete_reason = ${reason}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${roleId} AND deleted_at IS NULL
+    RETURNING id, role_code, role_name, is_system, created_at, updated_at
+  `) as RoleRow[];
+
+  if (rows.length === 0) return { outcome: "not_found" };
+
+  const record = toRecord(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "delete",
+    resourceType: AUDIT_RESOURCE_TYPE_ROLE,
+    resourceId: record.id,
+    severity: "warning",
+    message: `Role soft-deleted: ${record.roleCode}.`,
+    attributes: reason ? { reason } : undefined,
+    correlationId
+  });
+
+  return { outcome: "deleted", role: record };
+}
+
+/**
+ * Restores a soft-deleted role. Returns `null` when the role is not currently
+ * soft-deleted (absent or already live) — the same 404-on-retry posture as the
+ * email-template restore. `delete_reason` is kept for history.
+ *
+ * @throws {DuplicateRoleCodeError} its `role_code` was re-used by a live role
+ *   while it was deleted (the partial unique index fires on restore).
+ */
+export async function restoreRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  roleId: string,
+  correlationId?: string
+): Promise<RoleAdminRecord | null> {
+  let rows: RoleRow[];
+
+  try {
+    rows = (await tx`
+      UPDATE awcms_roles
+      SET deleted_at = NULL, deleted_by = NULL,
+          restored_at = now(), restored_by = ${actorTenantUserId},
+          updated_at = now()
+      WHERE tenant_id = ${tenantId} AND id = ${roleId} AND deleted_at IS NOT NULL
+      RETURNING id, role_code, role_name, is_system, created_at, updated_at
+    `) as RoleRow[];
+  } catch (error) {
+    if (
+      error instanceof Bun.SQL.PostgresError &&
+      String(error.errno) === POSTGRES_UNIQUE_VIOLATION
+    ) {
+      // Read the (still-deleted) role_code for the error message.
+      const conflict = (await tx`
+        SELECT role_code FROM awcms_roles
+        WHERE tenant_id = ${tenantId} AND id = ${roleId}
+      `) as { role_code: string }[];
+      throw new DuplicateRoleCodeError(conflict[0]?.role_code ?? "unknown");
+    }
+    throw error;
+  }
+
+  if (rows.length === 0) return null;
+
+  const record = toRecord(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "restore",
+    resourceType: AUDIT_RESOURCE_TYPE_ROLE,
+    resourceId: record.id,
+    severity: "warning",
+    message: `Role restored: ${record.roleCode}.`,
+    correlationId
+  });
+
+  return record;
+}
+
+export type GrantResult =
+  { outcome: "granted" } | { outcome: "role_not_found" };
+
+/**
+ * Grants a catalogued permission to a live role.
+ *
+ * @throws {DuplicateRolePermissionError} the grant already exists (23505).
+ * @throws {PermissionNotFoundError} `permissionId` is not in the catalog (the
+ *   `permission_id` FK, 23503).
+ */
+export async function grantPermissionToRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  roleId: string,
+  permissionId: string,
+  correlationId?: string
+): Promise<GrantResult> {
+  const role = await fetchLiveRoleById(tx, tenantId, roleId);
+  if (!role) return { outcome: "role_not_found" };
+
+  try {
+    await tx`
+      INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+      VALUES (${tenantId}, ${roleId}, ${permissionId})
+    `;
+  } catch (error) {
+    if (error instanceof Bun.SQL.PostgresError) {
+      if (String(error.errno) === POSTGRES_UNIQUE_VIOLATION) {
+        throw new DuplicateRolePermissionError();
+      }
+      if (String(error.errno) === POSTGRES_FK_VIOLATION) {
+        throw new PermissionNotFoundError();
+      }
+    }
+    throw error;
+  }
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "assign",
+    resourceType: AUDIT_RESOURCE_TYPE_PERMISSION,
+    resourceId: roleId,
+    severity: "warning",
+    message: `Permission granted to role ${role.roleCode}.`,
+    attributes: { permissionId },
+    correlationId
+  });
+
+  return { outcome: "granted" };
+}
+
+export type RevokeResult =
+  | { outcome: "revoked" }
+  | { outcome: "role_not_found" }
+  | { outcome: "grant_not_found" };
+
+/** Revokes a permission from a live role. */
+export async function revokePermissionFromRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  roleId: string,
+  permissionId: string,
+  correlationId?: string
+): Promise<RevokeResult> {
+  const role = await fetchLiveRoleById(tx, tenantId, roleId);
+  if (!role) return { outcome: "role_not_found" };
+
+  const rows = (await tx`
+    DELETE FROM awcms_role_permissions
+    WHERE tenant_id = ${tenantId} AND role_id = ${roleId}
+      AND permission_id = ${permissionId}
+    RETURNING id
+  `) as { id: string }[];
+
+  if (rows.length === 0) return { outcome: "grant_not_found" };
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "revoke",
+    resourceType: AUDIT_RESOURCE_TYPE_PERMISSION,
+    resourceId: roleId,
+    severity: "warning",
+    message: `Permission revoked from role ${role.roleCode}.`,
+    attributes: { permissionId },
+    correlationId
+  });
+
+  return { outcome: "revoked" };
+}

--- a/src/modules/identity-access/application/user-admin.ts
+++ b/src/modules/identity-access/application/user-admin.ts
@@ -1,0 +1,284 @@
+/**
+ * Tenant-user administration writes (Issue #171) — the write counterpart to the
+ * read-only `access-directory.ts`. Three high-risk mutations behind the admin
+ * Users screen and its JSON endpoints:
+ *
+ * - `setTenantUserStatus` — activate / deactivate a tenant user. There is no
+ *   `deleted_at` on `awcms_tenant_users`, so a "soft delete" is `status =
+ *   'inactive'` (deactivate) and a "restore" is `status = 'active'`
+ *   (reactivate). Deactivating revokes all of a user's access at once.
+ * - `assignRole` — grant a role to a tenant user. Idempotent at the DB via the
+ *   `(tenant_id, tenant_user_id, role_id)` unique index: a repeat assign raises
+ *   23505, mapped to `DuplicateAssignmentError` (→ 409) by the caller.
+ * - `unassignRole` — revoke a role from a tenant user.
+ *
+ * ALL are gated by the caller's ABAC guard and run inside `withTenant` (RLS
+ * FORCE is the real boundary); every query is additionally tenant-filtered as
+ * defence-in-depth. Every mutation writes an audit event (high-risk actions,
+ * doc 03/10). Login identifiers are PII and are NEVER logged here — the audit
+ * row references the stable `tenant_user_id`, not the identifier.
+ */
+import { recordAuditEvent } from "../../logging/application/audit-log";
+
+const AUDIT_MODULE_KEY = "identity_access";
+const POSTGRES_UNIQUE_VIOLATION = "23505";
+
+export const TENANT_USER_STATUSES = ["active", "inactive"] as const;
+export type TenantUserStatus = (typeof TENANT_USER_STATUSES)[number];
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ValidationError = { field: string; message: string };
+type ValidationResult<T> =
+  { valid: true; value: T } | { valid: false; errors: ValidationError[] };
+
+/**
+ * The tenant user or role referenced by an assignment does not exist in this
+ * tenant. Deliberately ONE error for both causes so the response cannot be used
+ * as an existence oracle for ids belonging to another tenant (same posture as
+ * `ParentOfficeNotFoundError`). Raised BEFORE any write.
+ */
+export class AssignmentTargetNotFoundError extends Error {
+  constructor() {
+    super(
+      "tenantUserId or roleId does not reference a live record in this tenant."
+    );
+    this.name = "AssignmentTargetNotFoundError";
+  }
+}
+
+/** The role is already assigned to the tenant user (unique-index 23505). */
+export class DuplicateAssignmentError extends Error {
+  constructor() {
+    super("The role is already assigned to this tenant user.");
+    this.name = "DuplicateAssignmentError";
+  }
+}
+
+export type SetStatusInput = { status: TenantUserStatus };
+
+export function validateSetStatusInput(
+  body: unknown
+): ValidationResult<SetStatusInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (
+    typeof record.status !== "string" ||
+    !TENANT_USER_STATUSES.includes(record.status as TenantUserStatus)
+  ) {
+    errors.push({
+      field: "status",
+      message: `status must be one of: ${TENANT_USER_STATUSES.join(", ")}.`
+    });
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, value: { status: record.status as TenantUserStatus } };
+}
+
+export type AssignmentInput = { tenantUserId: string; roleId: string };
+
+export function validateAssignmentInput(
+  body: unknown
+): ValidationResult<AssignmentInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (
+    typeof record.tenantUserId !== "string" ||
+    !UUID_PATTERN.test(record.tenantUserId)
+  ) {
+    errors.push({
+      field: "tenantUserId",
+      message: "tenantUserId must be a valid UUID."
+    });
+  }
+
+  if (typeof record.roleId !== "string" || !UUID_PATTERN.test(record.roleId)) {
+    errors.push({ field: "roleId", message: "roleId must be a valid UUID." });
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return {
+    valid: true,
+    value: {
+      tenantUserId: record.tenantUserId as string,
+      roleId: record.roleId as string
+    }
+  };
+}
+
+export type TenantUserStatusRecord = {
+  id: string;
+  status: string;
+  updatedAt: Date;
+};
+
+type TenantUserStatusRow = {
+  id: string;
+  status: string;
+  updated_at: Date;
+};
+
+/**
+ * Sets a tenant user's status. Returns `null` when no live user matches in this
+ * tenant (→ 404 at the caller) — the UPDATE is itself the existence check, so
+ * there is no oracle-leaking pre-read. Audits the change (high-risk).
+ */
+export async function setTenantUserStatus(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  tenantUserId: string,
+  status: TenantUserStatus,
+  correlationId?: string
+): Promise<TenantUserStatusRecord | null> {
+  const rows = (await tx`
+    UPDATE awcms_tenant_users
+    SET status = ${status}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${tenantUserId}
+    RETURNING id, status, updated_at
+  `) as TenantUserStatusRow[];
+
+  if (rows.length === 0) return null;
+
+  const record: TenantUserStatusRecord = {
+    id: rows[0]!.id,
+    status: rows[0]!.status,
+    updatedAt: rows[0]!.updated_at
+  };
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "update",
+    resourceType: "tenant_user",
+    resourceId: record.id,
+    severity: "warning",
+    // No identifier in the message — `tenant_user_id` (resourceId) is the
+    // stable reference; the login identifier is PII and is never logged.
+    message: `Tenant user status set to ${record.status}.`,
+    attributes: { status: record.status },
+    correlationId
+  });
+
+  return record;
+}
+
+export type AssignmentRecord = {
+  id: string;
+  tenantUserId: string;
+  roleId: string;
+};
+
+/**
+ * Assigns a role to a tenant user.
+ *
+ * @throws {AssignmentTargetNotFoundError} the tenant user or role is not a live
+ *   record in this tenant. Checked BEFORE the INSERT: `withTenant` COMMITs on a
+ *   normal return, so any 4xx-mapped throw must precede the first write, and the
+ *   composite FKs would otherwise surface as an opaque 500.
+ * @throws {DuplicateAssignmentError} the role is already assigned (23505). This
+ *   follows the unique violation that already aborted the transaction, so the
+ *   caller must NOT write anything further (e.g. an audit row) before returning
+ *   409 — that write would fail with 25P02 and turn the 409 into a 500.
+ */
+export async function assignRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  tenantUserId: string,
+  roleId: string,
+  correlationId?: string
+): Promise<AssignmentRecord> {
+  const targets = (await tx`
+    SELECT
+      EXISTS (
+        SELECT 1 FROM awcms_tenant_users
+        WHERE tenant_id = ${tenantId} AND id = ${tenantUserId}
+      ) AS user_exists,
+      EXISTS (
+        SELECT 1 FROM awcms_roles
+        WHERE tenant_id = ${tenantId} AND id = ${roleId} AND deleted_at IS NULL
+      ) AS role_exists
+  `) as Array<{ user_exists: boolean; role_exists: boolean }>;
+
+  if (!targets[0]!.user_exists || !targets[0]!.role_exists) {
+    throw new AssignmentTargetNotFoundError();
+  }
+
+  let rows: Array<{ id: string }>;
+  try {
+    rows = (await tx`
+      INSERT INTO awcms_access_assignments (tenant_id, tenant_user_id, role_id, assigned_by)
+      VALUES (${tenantId}, ${tenantUserId}, ${roleId}, ${actorTenantUserId})
+      RETURNING id
+    `) as Array<{ id: string }>;
+  } catch (error) {
+    if (
+      error instanceof Bun.SQL.PostgresError &&
+      String(error.errno) === POSTGRES_UNIQUE_VIOLATION
+    ) {
+      throw new DuplicateAssignmentError();
+    }
+    throw error;
+  }
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "assign",
+    resourceType: "tenant_user",
+    resourceId: tenantUserId,
+    severity: "warning",
+    message: "Role assigned to tenant user.",
+    attributes: { roleId },
+    correlationId
+  });
+
+  return { id: rows[0]!.id, tenantUserId, roleId };
+}
+
+/**
+ * Revokes a role from a tenant user. Returns `false` when no matching
+ * assignment existed (→ 404 at the caller); audits only a real revocation.
+ */
+export async function unassignRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  tenantUserId: string,
+  roleId: string,
+  correlationId?: string
+): Promise<boolean> {
+  const rows = (await tx`
+    DELETE FROM awcms_access_assignments
+    WHERE tenant_id = ${tenantId}
+      AND tenant_user_id = ${tenantUserId}
+      AND role_id = ${roleId}
+    RETURNING id
+  `) as Array<{ id: string }>;
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "revoke",
+    resourceType: "tenant_user",
+    resourceId: tenantUserId,
+    severity: "warning",
+    message: "Role revoked from tenant user.",
+    attributes: { roleId },
+    correlationId
+  });
+
+  return true;
+}

--- a/src/modules/identity-access/application/user-admin.ts
+++ b/src/modules/identity-access/application/user-admin.ts
@@ -56,6 +56,21 @@ export class DuplicateAssignmentError extends Error {
   }
 }
 
+/**
+ * Assigning or unassigning an `is_system` role (e.g. the seeded `owner`) is
+ * refused. The `assign` permission reads as "attach ordinary roles"; letting it
+ * grant `owner` would be a self-escalation to full tenant admin, and letting it
+ * strip `owner` from the sole owner would lock the tenant out. Root-role
+ * membership is an invariant set at bootstrap, not an admin-surface mutation.
+ * The caller maps it to 409.
+ */
+export class SystemRoleAssignmentError extends Error {
+  constructor() {
+    super("System roles cannot be assigned or unassigned through this API.");
+    this.name = "SystemRoleAssignmentError";
+  }
+}
+
 export type SetStatusInput = { status: TenantUserStatus };
 
 export function validateSetStatusInput(
@@ -125,9 +140,28 @@ type TenantUserStatusRow = {
 };
 
 /**
- * Sets a tenant user's status. Returns `null` when no live user matches in this
- * tenant (→ 404 at the caller) — the UPDATE is itself the existence check, so
- * there is no oracle-leaking pre-read. Audits the change (high-risk).
+ * Outcome of {@link setTenantUserStatus}. `updated` carries the new record;
+ * `not_found` → 404; `self_blocked`/`last_admin_blocked` → 409 lockout guards.
+ */
+export type SetStatusResult =
+  | { outcome: "updated"; record: TenantUserStatusRecord }
+  | { outcome: "not_found" }
+  | { outcome: "self_blocked" }
+  | { outcome: "last_admin_blocked" };
+
+/**
+ * Sets a tenant user's status.
+ *
+ * Deactivation (`status = 'inactive'`) revokes all of a user's access (login
+ * reads this status), so two lockout foot-guns are blocked BEFORE the write —
+ * mirroring `softDeleteRole`'s `is_system` guard:
+ *  - `self_blocked` — an actor cannot deactivate themselves.
+ *  - `last_admin_blocked` — the last active member of an `is_system` (owner)
+ *    role cannot be deactivated, or no active administrator would remain and
+ *    the tenant would be locked out with no in-app recovery.
+ *
+ * Activation carries no such guard. `not_found` (no live user in this tenant) is
+ * detected by the UPDATE itself (no oracle-leaking pre-read). Audits on success.
  */
 export async function setTenantUserStatus(
   tx: Bun.SQL,
@@ -136,7 +170,46 @@ export async function setTenantUserStatus(
   tenantUserId: string,
   status: TenantUserStatus,
   correlationId?: string
-): Promise<TenantUserStatusRecord | null> {
+): Promise<SetStatusResult> {
+  if (status === "inactive") {
+    if (actorTenantUserId === tenantUserId) {
+      return { outcome: "self_blocked" };
+    }
+
+    const adminState = (await tx`
+      SELECT
+        EXISTS (
+          SELECT 1 FROM awcms_access_assignments aa
+          JOIN awcms_roles r
+            ON r.id = aa.role_id AND r.tenant_id = aa.tenant_id
+          WHERE aa.tenant_id = ${tenantId}
+            AND aa.tenant_user_id = ${tenantUserId}
+            AND r.is_system = true AND r.deleted_at IS NULL
+        ) AS target_is_admin,
+        EXISTS (
+          SELECT 1 FROM awcms_access_assignments aa
+          JOIN awcms_roles r
+            ON r.id = aa.role_id AND r.tenant_id = aa.tenant_id
+          JOIN awcms_tenant_users tu
+            ON tu.id = aa.tenant_user_id AND tu.tenant_id = aa.tenant_id
+          WHERE aa.tenant_id = ${tenantId}
+            AND aa.tenant_user_id <> ${tenantUserId}
+            AND r.is_system = true AND r.deleted_at IS NULL
+            AND tu.status = 'active'
+        ) AS other_active_admin_exists
+    `) as Array<{
+      target_is_admin: boolean;
+      other_active_admin_exists: boolean;
+    }>;
+
+    if (
+      adminState[0]!.target_is_admin &&
+      !adminState[0]!.other_active_admin_exists
+    ) {
+      return { outcome: "last_admin_blocked" };
+    }
+  }
+
   const rows = (await tx`
     UPDATE awcms_tenant_users
     SET status = ${status}, updated_at = now()
@@ -144,7 +217,7 @@ export async function setTenantUserStatus(
     RETURNING id, status, updated_at
   `) as TenantUserStatusRow[];
 
-  if (rows.length === 0) return null;
+  if (rows.length === 0) return { outcome: "not_found" };
 
   const record: TenantUserStatusRecord = {
     id: rows[0]!.id,
@@ -167,7 +240,7 @@ export async function setTenantUserStatus(
     correlationId
   });
 
-  return record;
+  return { outcome: "updated", record };
 }
 
 export type AssignmentRecord = {
@@ -205,11 +278,25 @@ export async function assignRole(
       EXISTS (
         SELECT 1 FROM awcms_roles
         WHERE tenant_id = ${tenantId} AND id = ${roleId} AND deleted_at IS NULL
-      ) AS role_exists
-  `) as Array<{ user_exists: boolean; role_exists: boolean }>;
+      ) AS role_exists,
+      EXISTS (
+        SELECT 1 FROM awcms_roles
+        WHERE tenant_id = ${tenantId} AND id = ${roleId}
+          AND deleted_at IS NULL AND is_system = true
+      ) AS role_is_system
+  `) as Array<{
+    user_exists: boolean;
+    role_exists: boolean;
+    role_is_system: boolean;
+  }>;
 
   if (!targets[0]!.user_exists || !targets[0]!.role_exists) {
     throw new AssignmentTargetNotFoundError();
+  }
+  // Refuse before any write: `withTenant` COMMITs on a normal return, so the
+  // guard must precede the INSERT.
+  if (targets[0]!.role_is_system) {
+    throw new SystemRoleAssignmentError();
   }
 
   let rows: Array<{ id: string }>;
@@ -257,6 +344,19 @@ export async function unassignRole(
   roleId: string,
   correlationId?: string
 ): Promise<boolean> {
+  // Refuse to unassign a system role (e.g. `owner`) — stripping it from the
+  // sole owner locks the tenant out. Scoped to this tenant, so a foreign
+  // `roleId` finds nothing and falls through to the DELETE (→ 404), leaking no
+  // cross-tenant existence.
+  const systemRole = (await tx`
+    SELECT 1 FROM awcms_roles
+    WHERE tenant_id = ${tenantId} AND id = ${roleId}
+      AND deleted_at IS NULL AND is_system = true
+  `) as Array<{ "?column?": number }>;
+  if (systemRole.length > 0) {
+    throw new SystemRoleAssignmentError();
+  }
+
   const rows = (await tx`
     DELETE FROM awcms_access_assignments
     WHERE tenant_id = ${tenantId}

--- a/src/modules/identity-access/domain/abac-admin-validation.ts
+++ b/src/modules/identity-access/domain/abac-admin-validation.ts
@@ -1,0 +1,164 @@
+/**
+ * Validation for ABAC policy authoring (Issue #171). Pure functions, no I/O —
+ * the same posture as `office-validation.ts`: shape/enum checks here, uniqueness
+ * (a DB constraint) is enforced downstream and surfaced as 409.
+ *
+ * `awcms_abac_policies` columns worked within (schema unchanged): policy_code
+ * (text, unique per tenant), effect (text CHECK IN 'allow'|'deny'), description
+ * (text, nullable), is_active (boolean).
+ */
+export type ValidationError = { field: string; message: string };
+
+type ValidationResult<T> =
+  { valid: true; value: T } | { valid: false; errors: ValidationError[] };
+
+export const ABAC_EFFECTS = ["allow", "deny"] as const;
+export type AbacEffect = (typeof ABAC_EFFECTS)[number];
+
+/**
+ * A conservative policy-code shape: a leading alphanumeric then alphanumerics
+ * plus `.`, `_`, `-`. Bounds the length so a caller can't wedge an unbounded
+ * string into the unique index, and keeps codes URL/log-safe.
+ */
+const POLICY_CODE_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,99}$/;
+const DESCRIPTION_MAX = 500;
+
+export type CreateAbacPolicyInput = {
+  policyCode: string;
+  effect: AbacEffect;
+  description: string | null;
+};
+
+function validateEffect(
+  value: unknown,
+  errors: ValidationError[]
+): AbacEffect | undefined {
+  if (
+    typeof value !== "string" ||
+    !ABAC_EFFECTS.includes(value as AbacEffect)
+  ) {
+    errors.push({
+      field: "effect",
+      message: `effect must be one of: ${ABAC_EFFECTS.join(", ")}.`
+    });
+    return undefined;
+  }
+  return value as AbacEffect;
+}
+
+/**
+ * `description` accepts a non-empty string (trimmed, length-bounded) or an
+ * explicit `null` to clear it. `undefined` means "not provided" and is handled
+ * by the caller (kept as null on create, left unchanged on update). An empty /
+ * whitespace-only string is normalised to null.
+ */
+function validateDescription(
+  value: unknown,
+  errors: ValidationError[]
+): string | null | undefined {
+  if (value === undefined) return undefined;
+  if (value === null) return null;
+  if (typeof value !== "string") {
+    errors.push({
+      field: "description",
+      message: "description must be a string or null."
+    });
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return null;
+  if (trimmed.length > DESCRIPTION_MAX) {
+    errors.push({
+      field: "description",
+      message: `description must be at most ${DESCRIPTION_MAX} characters.`
+    });
+    return undefined;
+  }
+  return trimmed;
+}
+
+export function validateCreateAbacPolicyInput(
+  body: unknown
+): ValidationResult<CreateAbacPolicyInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  let policyCode = "";
+  if (
+    typeof record.policyCode !== "string" ||
+    record.policyCode.trim().length === 0
+  ) {
+    errors.push({ field: "policyCode", message: "policyCode is required." });
+  } else {
+    policyCode = record.policyCode.trim();
+    if (!POLICY_CODE_PATTERN.test(policyCode)) {
+      errors.push({
+        field: "policyCode",
+        message:
+          "policyCode must start alphanumeric and contain only letters, digits, '.', '_', '-' (max 100 chars)."
+      });
+    }
+  }
+
+  const effect = validateEffect(record.effect, errors);
+  const description = validateDescription(record.description, errors);
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return {
+    valid: true,
+    value: {
+      policyCode,
+      effect: effect!,
+      description: description ?? null
+    }
+  };
+}
+
+export type UpdateAbacPolicyInput = {
+  effect?: AbacEffect;
+  description?: string | null;
+  isActive?: boolean;
+};
+
+export function validateUpdateAbacPolicyInput(
+  body: unknown
+): ValidationResult<UpdateAbacPolicyInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const value: UpdateAbacPolicyInput = {};
+
+  if (record.effect !== undefined) {
+    const effect = validateEffect(record.effect, errors);
+    if (effect !== undefined) value.effect = effect;
+  }
+
+  if (record.description !== undefined) {
+    const description = validateDescription(record.description, errors);
+    // A cleared description is represented as null, which we must keep — so
+    // only skip assignment when validation itself pushed an error.
+    if (errors.length === 0) value.description = description ?? null;
+  }
+
+  if (record.isActive !== undefined) {
+    if (typeof record.isActive !== "boolean") {
+      errors.push({
+        field: "isActive",
+        message: "isActive must be a boolean."
+      });
+    } else {
+      value.isActive = record.isActive;
+    }
+  }
+
+  if (errors.length === 0 && Object.keys(value).length === 0) {
+    errors.push({
+      field: "body",
+      message: "Provide at least one of effect, description, isActive."
+    });
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, value };
+}

--- a/src/modules/identity-access/domain/role-admin-validation.ts
+++ b/src/modules/identity-access/domain/role-admin-validation.ts
@@ -1,0 +1,162 @@
+/**
+ * Input validation for the role (RBAC) write actions (Issue #171). Pure —
+ * no I/O — so it can be unit-tested without a database. Mirrors the shape of
+ * `tenant-admin/domain/office-validation.ts`: a discriminated
+ * `ValidationResult<T>` with a flat `{ field, message }` error list that the
+ * route surfaces via `fail(400, "VALIDATION_ERROR", …)`.
+ */
+export type ValidationError = { field: string; message: string };
+
+export type ValidationResult<T> =
+  { valid: true; value: T } | { valid: false; errors: ValidationError[] };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * `role_code` is the stable machine identifier joined against
+ * `awcms_access_assignments` and surfaced in `TenantContext.roles`, so it is
+ * constrained to a slug: lowercase letters, digits, `_` and `-`. `role_name`
+ * is the free-text display label.
+ */
+const ROLE_CODE_PATTERN = /^[a-z0-9][a-z0-9_-]{1,63}$/;
+
+const MAX_ROLE_NAME_LENGTH = 120;
+const MAX_REASON_LENGTH = 500;
+
+export type CreateRoleInput = {
+  roleCode: string;
+  roleName: string;
+};
+
+export function validateCreateRoleInput(
+  body: unknown
+): ValidationResult<CreateRoleInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  const roleCode =
+    typeof record.roleCode === "string" ? record.roleCode.trim() : "";
+  if (roleCode.length === 0) {
+    errors.push({ field: "roleCode", message: "roleCode is required." });
+  } else if (!ROLE_CODE_PATTERN.test(roleCode)) {
+    errors.push({
+      field: "roleCode",
+      message:
+        "roleCode must be 2–64 chars: lowercase letters, digits, '_' or '-'."
+    });
+  }
+
+  const roleName =
+    typeof record.roleName === "string" ? record.roleName.trim() : "";
+  if (roleName.length === 0) {
+    errors.push({ field: "roleName", message: "roleName is required." });
+  } else if (roleName.length > MAX_ROLE_NAME_LENGTH) {
+    errors.push({
+      field: "roleName",
+      message: `roleName must be at most ${MAX_ROLE_NAME_LENGTH} characters.`
+    });
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, value: { roleCode, roleName } };
+}
+
+export type UpdateRoleInput = {
+  roleName: string;
+};
+
+export function validateUpdateRoleInput(
+  body: unknown
+): ValidationResult<UpdateRoleInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  const roleName =
+    typeof record.roleName === "string" ? record.roleName.trim() : "";
+  if (roleName.length === 0) {
+    errors.push({ field: "roleName", message: "roleName is required." });
+  } else if (roleName.length > MAX_ROLE_NAME_LENGTH) {
+    errors.push({
+      field: "roleName",
+      message: `roleName must be at most ${MAX_ROLE_NAME_LENGTH} characters.`
+    });
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, value: { roleName } };
+}
+
+export type DeleteRoleInput = {
+  /** Optional free-text reason echoed into the soft-delete audit event. */
+  reason: string | null;
+};
+
+/**
+ * The DELETE body is OPTIONAL (a bodyless `DELETE /roles/{id}` is valid, and
+ * the admin UI's delete control sends none) — `delete_reason` is nullable. When
+ * a `reason` IS supplied it must be a non-empty string within the length cap.
+ */
+export function validateDeleteRoleInput(
+  body: unknown
+): ValidationResult<DeleteRoleInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  let reason: string | null = null;
+
+  if (record.reason !== undefined && record.reason !== null) {
+    if (
+      typeof record.reason !== "string" ||
+      record.reason.trim().length === 0
+    ) {
+      errors.push({
+        field: "reason",
+        message: "reason must be a non-empty string when provided."
+      });
+    } else if (record.reason.trim().length > MAX_REASON_LENGTH) {
+      errors.push({
+        field: "reason",
+        message: `reason must be at most ${MAX_REASON_LENGTH} characters.`
+      });
+    } else {
+      reason = record.reason.trim();
+    }
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, value: { reason } };
+}
+
+export type PermissionRefInput = {
+  permissionId: string;
+};
+
+/** Shared by grant (POST) and revoke (DELETE): both carry a `permissionId` UUID. */
+export function validatePermissionRefInput(
+  body: unknown
+): ValidationResult<PermissionRefInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  const permissionId =
+    typeof record.permissionId === "string" ? record.permissionId.trim() : "";
+  if (permissionId.length === 0) {
+    errors.push({
+      field: "permissionId",
+      message: "permissionId is required."
+    });
+  } else if (!UUID_PATTERN.test(permissionId)) {
+    errors.push({
+      field: "permissionId",
+      message: "permissionId must be a valid UUID."
+    });
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, value: { permissionId } };
+}

--- a/src/modules/tenant-admin/README.md
+++ b/src/modules/tenant-admin/README.md
@@ -22,11 +22,18 @@ Skema: `sql/002_awcms_tenant_office_schema.sql`, `sql/006_awcms_setup_wizard_sch
 
 ## Offices
 
-`GET/POST /api/v1/offices`, `GET/PATCH /api/v1/offices/{id}` — guard `tenant_admin.office_management.{read,create,update}`. Soft delete belum punya endpoint (belum ada permission `delete` yang di-seed — tambahkan lewat migration terpisah bila dibutuhkan).
+`GET/POST /api/v1/offices`, `GET/PATCH/DELETE /api/v1/offices/{id}`, `POST /api/v1/offices/{id}/restore` — guard `tenant_admin.office_management.{read,create,update,delete}`.
 
 `GET /api/v1/offices` **keyset-paginated**: maksimal 100 baris per halaman, urut **terbaru dulu**, plus `nextCursor` opaque (`null` di halaman terakhir). Cursor rusak → `400`, bukan diam-diam menyajikan halaman 1.
 
-Layar admin `admin/offices.astro` kini punya form **create office** yang di-gate permission `tenant_admin.office_management.create` (hanya render bila user punya izin), POST ke `POST /api/v1/offices` via cookie auth (CSP-safe: script bundled eksternal).
+### Soft-delete + restore (Issue #171)
+
+- `DELETE /api/v1/offices/{id}` — guard `office_management.delete`. Soft delete (`deleted_at/deleted_by/delete_reason`), **bukan** hard delete: baris tetap restorable dan kode office langsung bebas dipakai ulang (partial unique index `WHERE deleted_at IS NULL`). Body opsional/bodyless — `reason` yang ada disimpan+diaudit, `reason` kosong ditolak. Audit `delete` severity `warning`. 404 bila id tak ada/tenant lain/sudah terhapus.
+- `POST /api/v1/offices/{id}/restore` — guard **`office_management.update`** (bukan `delete`, bukan action `restore` tersendiri: activity ini tak punya permission `restore`, dan un-delete adalah edit siklus-hidup record — otoritas yang sama dengan mengubah office). Membersihkan stempel delete, mengisi `restored_at/restored_by`, audit `restore` severity `warning`. Idempotent-safe: restore ulang → 404. **409 `OFFICE_CODE_ALREADY_EXISTS`** bila office live lain sudah mengambil kode itu selagi terhapus — partial unique index memicu 23505 pada UPDATE; ditangkap **di dalam** `withTenant` (tanpa tulis apa pun setelahnya) dan dipetakan 409, aturan yang sama dengan `createOffice`.
+
+`restoreOffice` membaca `office_code` baris terhapus **sebelum** UPDATE — untuk menamai `DuplicateOfficeCodeError` dengan presisi sekaligus jadi cek eksistensi (id live/absen → tak ada baris → 404 sebelum tulis apa pun).
+
+Layar admin `admin/offices.astro`: form **create office** (gate `.create`), plus **inline edit per-baris** (name + status → PATCH, gate `.update`), tombol **soft-delete** per-baris (gate `.delete`), dan section **"Deleted offices"** dengan tombol **Restore** (gate `.update`). Semua gate UI hanya UX — otoritas tetap guard endpoint. Script bundled eksternal (CSP-safe), pakai `sendJson(method,url,body?)` dari `admin-form-client.ts` termasuk DELETE/restore bodyless.
 
 ### Kenapa FK-nya komposit (GHSA-r7cx-c4jh-cvvw)
 

--- a/src/modules/tenant-admin/application/office-directory.ts
+++ b/src/modules/tenant-admin/application/office-directory.ts
@@ -282,3 +282,145 @@ export async function updateOffice(
 
   return record;
 }
+
+/**
+ * One page of SOFT-DELETED offices, most-recently-deleted first, so the admin
+ * screen can offer a restore control. The active-office `listOffices` filters
+ * `deleted_at IS NULL`, so deleted rows are otherwise unreachable from the UI;
+ * this is their only read path. Bounded by the same page limit — the deleted
+ * set is expected to be small, and an unbounded scan is exactly what Issue #149
+ * forbids.
+ */
+export async function listDeletedOffices(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<OfficeRecord[]> {
+  const rows = (await tx`
+    SELECT id, office_code, office_name, office_type, parent_office_id, status, created_at, updated_at
+    FROM awcms_offices
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NOT NULL
+    ORDER BY deleted_at DESC, id DESC
+    LIMIT ${OFFICE_LIST_LIMIT}
+  `) as OfficeRow[];
+
+  return rows.map(toRecord);
+}
+
+/**
+ * Soft-deletes a live office: stamps `deleted_at`/`deleted_by`/`delete_reason`
+ * and audits the removal (severity `warning`, a high-risk lifecycle action).
+ * Returns `false` when the id is absent, in another tenant, or ALREADY
+ * soft-deleted (`deleted_at IS NULL` guard) — the route maps that to 404.
+ * Soft delete, never a hard `DELETE`: the row must remain restorable, and the
+ * partial unique index (`WHERE deleted_at IS NULL`) frees the office code for
+ * reuse the instant it is deleted.
+ */
+export async function softDeleteOffice(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  officeId: string,
+  reason: string | null,
+  correlationId?: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_offices
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId},
+        delete_reason = ${reason}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${officeId} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "delete",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: officeId,
+    severity: "warning",
+    message: "Office soft-deleted.",
+    attributes: { reason },
+    correlationId
+  });
+
+  return true;
+}
+
+/**
+ * Restores a soft-deleted office: clears the delete stamps, records
+ * `restored_at`/`restored_by`, and audits it (`warning`). Returns `null` when
+ * the id is absent, in another tenant, or NOT currently soft-deleted
+ * (`deleted_at IS NOT NULL` guard) → 404 at the route. Restoring is idempotent-
+ * safe: a second restore is a 404, not a duplicate.
+ *
+ * @throws {DuplicateOfficeCodeError} restoring would resurrect a code that a
+ *   DIFFERENT live office has taken while this one was deleted. The partial
+ *   unique index (`awcms_offices_tenant_code_key WHERE deleted_at IS NULL`)
+ *   raises 23505 on the UPDATE; that is caller-actionable (rename or delete the
+ *   conflicting office) so it must surface as 409, not 500.
+ */
+export async function restoreOffice(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  officeId: string,
+  correlationId?: string
+): Promise<OfficeRecord | null> {
+  // Read the deleted row's code first: it names the DuplicateOfficeCodeError
+  // precisely AND is the existence check (a live/absent id yields no row → the
+  // caller gets a 404 before any write is attempted).
+  const deletedRows = (await tx`
+    SELECT office_code FROM awcms_offices
+    WHERE tenant_id = ${tenantId} AND id = ${officeId} AND deleted_at IS NOT NULL
+  `) as { office_code: string }[];
+
+  if (deletedRows.length === 0) return null;
+  const officeCode = deletedRows[0]!.office_code;
+
+  let rows: OfficeRow[];
+
+  try {
+    rows = (await tx`
+      UPDATE awcms_offices
+      SET deleted_at = NULL, deleted_by = NULL, delete_reason = NULL,
+          restored_at = now(), restored_by = ${actorTenantUserId}, updated_at = now()
+      WHERE tenant_id = ${tenantId} AND id = ${officeId} AND deleted_at IS NOT NULL
+      RETURNING id, office_code, office_name, office_type, parent_office_id, status, created_at, updated_at
+    `) as OfficeRow[];
+  } catch (error) {
+    if (
+      error instanceof Bun.SQL.PostgresError &&
+      String(error.errno) === POSTGRES_UNIQUE_VIOLATION
+    ) {
+      // The 23505 has already ABORTED this transaction. The route catches this
+      // and returns 409 on `withTenant`'s normal path, whose commit degrades
+      // to a rollback — and NO audit event may be written past this point, or
+      // it would fail 25P02 and turn the 409 into a 500 (same rule as
+      // createOffice's duplicate handling).
+      throw new DuplicateOfficeCodeError(officeCode);
+    }
+
+    throw error;
+  }
+
+  if (rows.length === 0) return null;
+
+  const record = toRecord(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "restore",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: record.id,
+    severity: "warning",
+    message: `Office restored: ${record.officeCode}.`,
+    correlationId
+  });
+
+  return record;
+}

--- a/src/modules/tenant-admin/domain/office-validation.ts
+++ b/src/modules/tenant-admin/domain/office-validation.ts
@@ -160,3 +160,41 @@ export function validateUpdateOfficeInput(
 
   return { valid: true, value };
 }
+
+export type DeleteOfficeInput = { reason: string | null };
+
+/**
+ * Validates the OPTIONAL body of `DELETE /api/v1/offices/{id}`. `reason` is
+ * echoed into `awcms_offices.delete_reason` and the audit event, but the verb
+ * is meaningful with no body at all (a bodyless soft-delete), so an absent /
+ * null reason is accepted and normalised to `null`. A `reason` that is present
+ * but blank is rejected — an empty string carries no more intent than omitting
+ * it, and silently storing `""` would hide that.
+ */
+export function validateDeleteOfficeInput(
+  body: unknown
+): ValidationResult<DeleteOfficeInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  let reason: string | null = null;
+
+  if (record.reason !== undefined && record.reason !== null) {
+    if (
+      typeof record.reason !== "string" ||
+      record.reason.trim().length === 0
+    ) {
+      errors.push({
+        field: "reason",
+        message: "reason must be a non-empty string when provided."
+      });
+    } else {
+      reason = record.reason.trim();
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value: { reason } };
+}

--- a/src/modules/tenant-admin/module.ts
+++ b/src/modules/tenant-admin/module.ts
@@ -29,6 +29,11 @@ export const tenantAdminModule = defineModule({
       description: "Update office records"
     },
     {
+      activityCode: "office_management",
+      action: "delete",
+      description: "Soft-delete office records"
+    },
+    {
       activityCode: "tenant_settings",
       action: "read",
       description: "Read tenant settings"

--- a/src/pages/admin/abac-policies.astro
+++ b/src/pages/admin/abac-policies.astro
@@ -1,8 +1,18 @@
 ---
 /**
- * ABAC policy management screen (Issue #166, Stage 3b). SSR-reads via the same
- * `listAbacPolicies` the `GET /api/v1/abac/policies` endpoint uses, gated on
- * `identity_access.access_control.read`. Read-only.
+ * ABAC policy management screen (Issue #166 read; write authoring + toggle added
+ * #171). SSR-reads via the same `listAbacPolicies` the
+ * `GET /api/v1/abac/policies` endpoint uses, gated on
+ * `identity_access.access_control.read`.
+ *
+ * A create-policy form and per-row Edit / Enable-Disable controls both post to
+ * `POST` / `PATCH /api/v1/abac/policies[/{id}]`, gated on
+ * `identity_access.access_control.configure` — the access-control
+ * administration permission. That activity seeds only `read`/`assign`/
+ * `configure` (no `create`/`update`), and the owner is granted only seeded
+ * permissions, so `configure` is the write gate for policy authoring. The gates
+ * are UX-only — the endpoints' ABAC guards are the real authority; the buttons
+ * just avoid rendering controls the user can't use.
  *
  * Note: like awcms-mini, the base ships this table seeded-EMPTY — the ABAC
  * evaluator uses built-in role/permission rules by default, and per-tenant
@@ -22,6 +32,13 @@ const ssr = Astro.locals.ssrContext!;
 const canRead = ssr.permissions.has(
   permissionKey("identity_access", "access_control", "read")
 );
+// Both write surfaces gate on `configure` — the only seeded write action for
+// this activity (no `create`/`update` exist in the catalog).
+const canConfigure = ssr.permissions.has(
+  permissionKey("identity_access", "access_control", "configure")
+);
+const canCreate = canConfigure;
+const canUpdate = canConfigure;
 
 let policies: AbacPolicyView[] = [];
 let loadError = false;
@@ -60,6 +77,57 @@ if (canRead) {
   }
 
   {
+    canCreate && (
+      <form id="policy-create-form" class="admin-create-form">
+        <p
+          id="policy-create-error"
+          class="admin-create-error"
+          role="alert"
+          hidden
+        />
+
+        <label for="policy-code">Policy code</label>
+        <input
+          id="policy-code"
+          name="policyCode"
+          type="text"
+          required
+          autocomplete="off"
+        />
+
+        <label for="policy-effect">Effect</label>
+        <select id="policy-effect" name="effect">
+          <option value="allow">allow</option>
+          <option value="deny">deny</option>
+        </select>
+
+        <label for="policy-description">Description (optional)</label>
+        <input
+          id="policy-description"
+          name="description"
+          type="text"
+          autocomplete="off"
+        />
+
+        <button type="submit" id="policy-create-submit">
+          Create policy
+        </button>
+      </form>
+    )
+  }
+
+  {
+    canUpdate && (
+      <p
+        id="policy-update-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
     canRead && !loadError && (
       <div class="data-table-scroll">
         <table class="data-table" id="abac-policies-table">
@@ -70,12 +138,13 @@ if (canRead) {
               <th scope="col">Effect</th>
               <th scope="col">Description</th>
               <th scope="col">Active</th>
+              {canUpdate && <th scope="col">Actions</th>}
             </tr>
           </thead>
           <tbody>
             {policies.length === 0 ? (
               <tr>
-                <td class="data-table-empty" colspan="4">
+                <td class="data-table-empty" colspan={canUpdate ? 5 : 4}>
                   No custom policies — the built-in role/permission rules apply.
                 </td>
               </tr>
@@ -95,6 +164,28 @@ if (canRead) {
                   </td>
                   <td>{policy.description ?? "—"}</td>
                   <td>{policy.isActive ? "yes" : "no"}</td>
+                  {canUpdate && (
+                    <td>
+                      <button
+                        type="button"
+                        class="policy-edit"
+                        data-policy-id={policy.id}
+                        data-policy-code={policy.policyCode}
+                        data-effect={policy.effect}
+                        data-description={policy.description ?? ""}
+                      >
+                        Edit
+                      </button>{" "}
+                      <button
+                        type="button"
+                        class="policy-toggle"
+                        data-policy-id={policy.id}
+                        data-active={policy.isActive ? "true" : "false"}
+                      >
+                        {policy.isActive ? "Disable" : "Enable"}
+                      </button>
+                    </td>
+                  )}
                 </tr>
               ))
             )}
@@ -104,3 +195,142 @@ if (canRead) {
     )
   }
 </AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time, so it
+  // can't be runtime-conditional). Harmless for users without create/update
+  // permission: the form and buttons only render when their gate passes, so the
+  // lookups below find nothing and no listener binds. The import forces Astro to
+  // bundle this script EXTERNAL — an import-free script would be inlined, and
+  // inline scripts are blocked by this app's CSP. See admin-form-client.ts.
+  import {
+    lockElement,
+    postJson,
+    sendJson
+  } from "../../lib/ui/admin-form-client";
+
+  const createForm = document.getElementById(
+    "policy-create-form"
+  ) as HTMLFormElement | null;
+  const createError = document.getElementById("policy-create-error");
+  const createSubmit = document.getElementById(
+    "policy-create-submit"
+  ) as HTMLButtonElement | null;
+  const updateError = document.getElementById("policy-update-error");
+
+  function show(box: HTMLElement | null, message: string): void {
+    if (!box) return;
+    box.textContent = message;
+    box.hidden = false;
+  }
+
+  // --- Create ---------------------------------------------------------------
+  createForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!createSubmit || createSubmit.disabled) return;
+    const unlock = lockElement(createSubmit, "Please wait…");
+    if (createError) createError.hidden = true;
+
+    const formData = new FormData(createForm);
+    const policyCode = String(formData.get("policyCode") ?? "").trim();
+    const effect = String(formData.get("effect") ?? "").trim();
+    const description = String(formData.get("description") ?? "").trim();
+
+    const result = await postJson("/api/v1/abac/policies", {
+      policyCode,
+      effect,
+      // Empty string clears / omits the description; the endpoint normalises
+      // it to null.
+      description: description.length > 0 ? description : null
+    });
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    // Generic message only — never surface internal detail (Issue #540).
+    show(
+      createError,
+      "Could not create the policy. Check the code is unique and try again."
+    );
+    unlock();
+  });
+
+  // --- Edit effect / description --------------------------------------------
+  for (const button of document.querySelectorAll<HTMLButtonElement>(
+    "button.policy-edit"
+  )) {
+    button.addEventListener("click", async () => {
+      if (button.disabled) return;
+      const policyId = button.dataset.policyId;
+      if (!policyId) return;
+
+      const currentEffect = button.dataset.effect ?? "allow";
+      const nextEffect = window.prompt(
+        `Effect for "${button.dataset.policyCode}" (allow or deny):`,
+        currentEffect
+      );
+      if (nextEffect === null) return; // cancelled
+      const effect = nextEffect.trim();
+      if (effect !== "allow" && effect !== "deny") {
+        show(updateError, "Effect must be exactly 'allow' or 'deny'.");
+        return;
+      }
+
+      const nextDescription = window.prompt(
+        "Description (leave blank to clear):",
+        button.dataset.description ?? ""
+      );
+      if (nextDescription === null) return; // cancelled
+
+      const unlock = lockElement(button, "Please wait…");
+      if (updateError) updateError.hidden = true;
+
+      const result = await sendJson(
+        "PATCH",
+        `/api/v1/abac/policies/${encodeURIComponent(policyId)}`,
+        {
+          effect,
+          description:
+            nextDescription.trim().length > 0 ? nextDescription.trim() : null
+        }
+      );
+
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+      show(updateError, "Could not update the policy. Please try again.");
+      unlock();
+    });
+  }
+
+  // --- Enable / disable toggle ----------------------------------------------
+  for (const button of document.querySelectorAll<HTMLButtonElement>(
+    "button.policy-toggle"
+  )) {
+    button.addEventListener("click", async () => {
+      if (button.disabled) return;
+      const policyId = button.dataset.policyId;
+      if (!policyId) return;
+
+      const currentlyActive = button.dataset.active === "true";
+      const unlock = lockElement(button, "Please wait…");
+      if (updateError) updateError.hidden = true;
+
+      const result = await sendJson(
+        "PATCH",
+        `/api/v1/abac/policies/${encodeURIComponent(policyId)}`,
+        { isActive: !currentlyActive }
+      );
+
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+      show(updateError, "Could not change the policy state. Please try again.");
+      unlock();
+    });
+  }
+</script>

--- a/src/pages/admin/offices.astro
+++ b/src/pages/admin/offices.astro
@@ -12,13 +12,24 @@
  * clean "no access" notice instead of an empty table. A create-office form is
  * shown to users holding `office_management.create` and posts to the existing
  * `POST /api/v1/offices` (cookie auth) — the endpoint's ABAC guard is the real
- * authority; the form gate is UX-only. Edit/delete remain a later increment.
+ * authority; the form gate is UX-only.
+ *
+ * Write increment (Issue #171): users holding `office_management.update` get
+ * per-row inline edit (name + status → `PATCH /api/v1/offices/{id}`) plus a
+ * restore control on soft-deleted rows (`POST /api/v1/offices/{id}/restore`);
+ * users holding `office_management.delete` get a per-row soft-delete control
+ * (`DELETE /api/v1/offices/{id}`). Every gate here is UX-only — the endpoint
+ * guards are the authority. Deleted offices are listed in their own section so
+ * they are reachable for restore.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
-import { listOffices } from "../../modules/tenant-admin/application/office-directory";
+import {
+  listDeletedOffices,
+  listOffices
+} from "../../modules/tenant-admin/application/office-directory";
 
 type OfficeRow = {
   id: string;
@@ -35,8 +46,20 @@ const canRead = ssr.permissions.has(
 const canCreate = ssr.permissions.has(
   permissionKey("tenant_admin", "office_management", "create")
 );
+const canUpdate = ssr.permissions.has(
+  permissionKey("tenant_admin", "office_management", "update")
+);
+const canDelete = ssr.permissions.has(
+  permissionKey("tenant_admin", "office_management", "delete")
+);
+
+const OFFICE_STATUS_OPTIONS = ["active", "inactive"];
+
+// One action column is rendered when the viewer can edit and/or delete.
+const showActions = canUpdate || canDelete;
 
 let offices: OfficeRow[] = [];
+let deletedOffices: OfficeRow[] = [];
 let loadError = false;
 
 if (canRead) {
@@ -44,7 +67,15 @@ if (canRead) {
     const sql = getDatabaseClient();
     const result = await withTenant(sql, ssr.tenantId, async (tx) => {
       const page = await listOffices(tx, ssr.tenantId, null);
-      return page.items as OfficeRow[];
+      // Only fetch the deleted set for viewers who can act on it (restore is
+      // gated on `update`); otherwise it is noise they cannot use.
+      const deleted = canUpdate
+        ? await listDeletedOffices(tx, ssr.tenantId)
+        : [];
+      return {
+        active: page.items as OfficeRow[],
+        deleted: deleted as OfficeRow[]
+      };
     });
     // `withTenant` returns a 503 `Response` when the DB circuit breaker is
     // open / a work-class queue is saturated — degrade to an error notice
@@ -52,7 +83,8 @@ if (canRead) {
     if (result instanceof Response) {
       loadError = true;
     } else {
-      offices = result;
+      offices = result.active;
+      deletedOffices = result.deleted;
     }
   } catch {
     loadError = true;
@@ -125,6 +157,17 @@ if (canRead) {
 
   {
     canRead && !loadError && (
+      <p
+        id="office-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
       <div class="data-table-scroll">
         <table class="data-table" id="offices-table">
           <caption>{offices.length} office(s)</caption>
@@ -134,37 +177,130 @@ if (canRead) {
               <th scope="col">Name</th>
               <th scope="col">Type</th>
               <th scope="col">Status</th>
+              {showActions && <th scope="col">Actions</th>}
             </tr>
           </thead>
           <tbody>
             {offices.length === 0 ? (
               <tr>
-                <td class="data-table-empty" colspan="4">
+                <td class="data-table-empty" colspan={showActions ? 5 : 4}>
                   No offices yet.
                 </td>
               </tr>
             ) : (
               offices.map((office) => (
-                <tr>
+                <tr data-office-row={office.id}>
                   <td>{office.officeCode}</td>
-                  <td>{office.officeName}</td>
+                  <td>
+                    {canUpdate ? (
+                      <input
+                        class="office-name-input"
+                        type="text"
+                        value={office.officeName}
+                        aria-label={`Office name for ${office.officeCode}`}
+                        data-office-name={office.id}
+                      />
+                    ) : (
+                      office.officeName
+                    )}
+                  </td>
                   <td>{office.officeType}</td>
                   <td>
-                    <span
-                      class="status-badge"
-                      data-variant={
-                        office.status === "active" ? "success" : "neutral"
-                      }
-                    >
-                      {office.status}
-                    </span>
+                    {canUpdate ? (
+                      <select
+                        class="office-status-select"
+                        aria-label={`Status for ${office.officeCode}`}
+                        data-office-status={office.id}
+                      >
+                        {OFFICE_STATUS_OPTIONS.map((value) => (
+                          <option
+                            value={value}
+                            selected={office.status === value}
+                          >
+                            {value}
+                          </option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span
+                        class="status-badge"
+                        data-variant={
+                          office.status === "active" ? "success" : "neutral"
+                        }
+                      >
+                        {office.status}
+                      </span>
+                    )}
                   </td>
+                  {showActions && (
+                    <td>
+                      {canUpdate && (
+                        <button
+                          type="button"
+                          class="office-save-btn"
+                          data-office-id={office.id}
+                        >
+                          Save
+                        </button>
+                      )}
+                      {canDelete && (
+                        <button
+                          type="button"
+                          class="office-delete-btn"
+                          data-office-id={office.id}
+                          data-office-code={office.officeCode}
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </td>
+                  )}
                 </tr>
               ))
             )}
           </tbody>
         </table>
       </div>
+    )
+  }
+
+  {
+    canRead && !loadError && canUpdate && deletedOffices.length > 0 && (
+      <section id="deleted-offices">
+        <h2>Deleted offices</h2>
+        <div class="data-table-scroll">
+          <table class="data-table" id="deleted-offices-table">
+            <caption>{deletedOffices.length} deleted office(s)</caption>
+            <thead>
+              <tr>
+                <th scope="col">Code</th>
+                <th scope="col">Name</th>
+                <th scope="col">Type</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {deletedOffices.map((office) => (
+                <tr data-deleted-office-row={office.id}>
+                  <td>{office.officeCode}</td>
+                  <td>{office.officeName}</td>
+                  <td>{office.officeType}</td>
+                  <td>
+                    <button
+                      type="button"
+                      class="office-restore-btn"
+                      data-office-id={office.id}
+                      data-office-code={office.officeCode}
+                    >
+                      Restore
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
     )
   }
 </AdminLayout>
@@ -177,7 +313,11 @@ if (canRead) {
   // bundle this script EXTERNAL (an import-free script would be inlined, and
   // inline
   // scripts are blocked by this app's CSP). See admin-form-client.ts.
-  import { lockElement, postJson } from "../../lib/ui/admin-form-client";
+  import {
+    lockElement,
+    postJson,
+    sendJson
+  } from "../../lib/ui/admin-form-client";
 
   const form = document.getElementById(
     "office-create-form"
@@ -226,4 +366,107 @@ if (canRead) {
     );
     unlock();
   });
+
+  // Per-row edit / delete / restore (Issue #171). All three bind
+  // unconditionally: the controls only render when the matching permission
+  // gate passed server-side, so `querySelectorAll` finds none for a viewer who
+  // lacks them and the listeners simply never fire. The endpoint guard is the
+  // real authority; these gates are UX-only.
+  const actionError = document.getElementById("office-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  function clearActionError(): void {
+    if (actionError) actionError.hidden = true;
+  }
+
+  // Save: PATCH the row's current name + status.
+  document
+    .querySelectorAll<HTMLButtonElement>(".office-save-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.officeId;
+        if (!id) return;
+        clearActionError();
+        const unlock = lockElement(button, "Saving…");
+
+        const nameInput = document.querySelector<HTMLInputElement>(
+          `[data-office-name="${id}"]`
+        );
+        const statusSelect = document.querySelector<HTMLSelectElement>(
+          `[data-office-status="${id}"]`
+        );
+        const officeName = nameInput?.value.trim() ?? "";
+        const status = statusSelect?.value ?? "";
+
+        const result = await sendJson("PATCH", `/api/v1/offices/${id}`, {
+          officeName,
+          status
+        });
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showActionError("Could not save the office. Please try again.");
+        unlock();
+      });
+    });
+
+  // Delete: bodyless soft-delete after an explicit confirm.
+  document
+    .querySelectorAll<HTMLButtonElement>(".office-delete-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.officeId;
+        if (!id) return;
+        const code = button.dataset.officeCode ?? "this office";
+        if (!window.confirm(`Delete ${code}? It can be restored later.`)) {
+          return;
+        }
+        clearActionError();
+        const unlock = lockElement(button, "Deleting…");
+
+        const result = await sendJson("DELETE", `/api/v1/offices/${id}`);
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showActionError("Could not delete the office. Please try again.");
+        unlock();
+      });
+    });
+
+  // Restore: bodyless POST; a 409 means the code was retaken by a live office.
+  document
+    .querySelectorAll<HTMLButtonElement>(".office-restore-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.officeId;
+        if (!id) return;
+        clearActionError();
+        const unlock = lockElement(button, "Restoring…");
+
+        const result = await sendJson("POST", `/api/v1/offices/${id}/restore`);
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showActionError(
+          result.errorCode === "OFFICE_CODE_ALREADY_EXISTS"
+            ? "Cannot restore: another office already uses this code."
+            : "Could not restore the office. Please try again."
+        );
+        unlock();
+      });
+    });
 </script>

--- a/src/pages/admin/roles.astro
+++ b/src/pages/admin/roles.astro
@@ -1,8 +1,21 @@
 ---
 /**
- * Role (RBAC) management screen (Issue #166, Stage 3b). SSR-reads via the same
- * `listRoles` the `GET /api/v1/roles` endpoint uses, gated on
- * `identity_access.access_control.read`. Read-only.
+ * Role (RBAC) management screen (Issue #166 read; write CRUD + permission
+ * management added #171). SSR-reads via the same `listRoles` the
+ * `GET /api/v1/roles` endpoint uses, gated on
+ * `identity_access.access_control.read`.
+ *
+ * Users holding `identity_access.access_control.configure` ("Manage roles and
+ * role permissions") additionally get: a create-role form, per-row rename /
+ * soft-delete controls, a per-role manage-permissions panel (grant/revoke from
+ * the global permission catalog), and a restore control for soft-deleted roles.
+ * All write forms/buttons post to the `/api/v1/roles/**` endpoints via cookie
+ * auth — the endpoints' ABAC `configure` guard is the real authority; these
+ * gates are UX-only. System roles (e.g. `owner`) are never offered a delete
+ * button (the endpoint also rejects it with 409).
+ *
+ * The permission-management data (catalog + per-role grants + deleted roles) is
+ * only loaded when `canConfigure`, so a read-only viewer pays no extra reads.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import { getDatabaseClient } from "../../lib/database/client";
@@ -12,27 +25,80 @@ import {
   listRoles,
   type RoleView
 } from "../../modules/identity-access/application/access-directory";
+import {
+  listDeletedRoles,
+  listPermissionCatalog,
+  listRolePermissions,
+  type DeletedRoleView,
+  type PermissionCatalogEntry
+} from "../../modules/identity-access/application/role-admin";
 
 const ssr = Astro.locals.ssrContext!;
 const canRead = ssr.permissions.has(
   permissionKey("identity_access", "access_control", "read")
 );
+const canConfigure = ssr.permissions.has(
+  permissionKey("identity_access", "access_control", "configure")
+);
+
+type RolePermRow = {
+  role: RoleView;
+  granted: PermissionCatalogEntry[];
+  available: PermissionCatalogEntry[];
+};
 
 let roles: RoleView[] = [];
+let rolePerms: RolePermRow[] = [];
+let deletedRoles: DeletedRoleView[] = [];
 let loadError = false;
+
+function permLabel(p: PermissionCatalogEntry): string {
+  return `${p.moduleKey}.${p.activityCode}.${p.action}`;
+}
 
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, (tx) =>
-      listRoles(tx, ssr.tenantId)
-    );
-    if (result instanceof Response) loadError = true;
-    else roles = result;
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      const liveRoles = await listRoles(tx, ssr.tenantId);
+      if (!canConfigure) {
+        return {
+          liveRoles,
+          rolePerms: [] as RolePermRow[],
+          deletedRoles: [] as DeletedRoleView[]
+        };
+      }
+      const catalog = await listPermissionCatalog(tx);
+      const perms: RolePermRow[] = [];
+      for (const role of liveRoles) {
+        const granted = await listRolePermissions(tx, ssr.tenantId, role.id);
+        const grantedIds = new Set(granted.map((p) => p.id));
+        const available = catalog.filter((p) => !grantedIds.has(p.id));
+        perms.push({ role, granted, available });
+      }
+      const deleted = await listDeletedRoles(tx, ssr.tenantId);
+      return { liveRoles, rolePerms: perms, deletedRoles: deleted };
+    });
+    // `withTenant` returns a 503 `Response` when the DB circuit breaker is open
+    // / a work-class queue is saturated — degrade to an error notice.
+    if (result instanceof Response) {
+      loadError = true;
+    } else {
+      roles = result.liveRoles;
+      rolePerms = result.rolePerms;
+      deletedRoles = result.deletedRoles;
+    }
   } catch {
     loadError = true;
   }
 }
+
+// A uniform row list so the table renders the same whether or not the viewer
+// can configure (a read-only viewer gets empty grant/available lists).
+const rows: RolePermRow[] = canConfigure
+  ? rolePerms
+  : roles.map((role) => ({ role, granted: [], available: [] }));
+const colCount = canConfigure ? 5 : 4;
 ---
 
 <AdminLayout title="Roles" active="roles">
@@ -55,6 +121,52 @@ if (canRead) {
   }
 
   {
+    canConfigure && !loadError && (
+      <p
+        id="roles-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canConfigure && !loadError && (
+      <form id="role-create-form" class="admin-create-form">
+        <p
+          id="role-create-error"
+          class="admin-create-error"
+          role="alert"
+          hidden
+        />
+
+        <label for="role-code">Role code</label>
+        <input
+          id="role-code"
+          name="roleCode"
+          type="text"
+          required
+          autocomplete="off"
+        />
+
+        <label for="role-name">Role name</label>
+        <input
+          id="role-name"
+          name="roleName"
+          type="text"
+          required
+          autocomplete="off"
+        />
+
+        <button type="submit" id="role-create-submit">
+          Create role
+        </button>
+      </form>
+    )
+  }
+
+  {
     canRead && !loadError && (
       <div class="data-table-scroll">
         <table class="data-table" id="roles-table">
@@ -65,17 +177,18 @@ if (canRead) {
               <th scope="col">Name</th>
               <th scope="col">System</th>
               <th scope="col">Permissions</th>
+              {canConfigure && <th scope="col">Actions</th>}
             </tr>
           </thead>
           <tbody>
-            {roles.length === 0 ? (
+            {rows.length === 0 ? (
               <tr>
-                <td class="data-table-empty" colspan="4">
+                <td class="data-table-empty" colspan={colCount}>
                   No roles yet.
                 </td>
               </tr>
             ) : (
-              roles.map((role) => (
+              rows.map(({ role, granted, available }) => (
                 <tr>
                   <td>{role.roleCode}</td>
                   <td>{role.roleName}</td>
@@ -88,6 +201,67 @@ if (canRead) {
                     </span>
                   </td>
                   <td>{role.permissionCount}</td>
+                  {canConfigure && (
+                    <td>
+                      <button
+                        type="button"
+                        data-role-action="rename"
+                        data-role-id={role.id}
+                        data-role-name={role.roleName}
+                      >
+                        Rename
+                      </button>
+                      {!role.isSystem && (
+                        <button
+                          type="button"
+                          data-role-action="delete"
+                          data-role-id={role.id}
+                          data-role-code={role.roleCode}
+                        >
+                          Delete
+                        </button>
+                      )}
+                      <details class="role-permissions">
+                        <summary>Permissions ({granted.length})</summary>
+                        <ul>
+                          {granted.length === 0 ? (
+                            <li>No permissions granted.</li>
+                          ) : (
+                            granted.map((p) => (
+                              <li>
+                                <code>{permLabel(p)}</code>{" "}
+                                <button
+                                  type="button"
+                                  data-role-action="revoke"
+                                  data-role-id={role.id}
+                                  data-permission-id={p.id}
+                                >
+                                  Remove
+                                </button>
+                              </li>
+                            ))
+                          )}
+                        </ul>
+                        {available.length > 0 && (
+                          <form
+                            class="admin-create-form"
+                            data-role-grant-form
+                            data-role-id={role.id}
+                          >
+                            <label for={`grant-${role.id}`}>
+                              Add permission
+                            </label>
+                            <select id={`grant-${role.id}`} name="permissionId">
+                              {available.map((p) => (
+                                <option value={p.id}>{permLabel(p)}</option>
+                              ))}
+                            </select>
+                            <button type="submit">Add</button>
+                          </form>
+                        )}
+                      </details>
+                    </td>
+                  )}
                 </tr>
               ))
             )}
@@ -96,4 +270,213 @@ if (canRead) {
       </div>
     )
   }
+
+  {
+    canConfigure && !loadError && deletedRoles.length > 0 && (
+      <section id="deleted-roles">
+        <h2>Deleted roles</h2>
+        <div class="data-table-scroll">
+          <table class="data-table" id="deleted-roles-table">
+            <caption>{deletedRoles.length} deleted role(s)</caption>
+            <thead>
+              <tr>
+                <th scope="col">Code</th>
+                <th scope="col">Name</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {deletedRoles.map((role) => (
+                <tr>
+                  <td>{role.roleCode}</td>
+                  <td>{role.roleName}</td>
+                  <td>
+                    <button
+                      type="button"
+                      data-role-action="restore"
+                      data-role-id={role.id}
+                      data-role-code={role.roleCode}
+                    >
+                      Restore
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
 </AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time, so it
+  // can't be runtime-conditional). Harmless for users without the configure
+  // permission: the forms/buttons only render when `canConfigure`, so the
+  // listeners find no targets. The import forces Astro to bundle this script
+  // EXTERNAL — an import-free script would be inlined, and inline scripts are
+  // blocked by this app's CSP. See admin-form-client.ts.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("roles-action-error");
+  const createError = document.getElementById("role-create-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  function showCreateError(message: string): void {
+    if (!createError) return;
+    createError.textContent = message;
+    createError.hidden = false;
+  }
+
+  // Create-role and grant-permission are both form submits, routed by id/attr.
+  document.addEventListener("submit", async (event) => {
+    const form = (event.target as HTMLElement).closest("form");
+    if (!form) return;
+
+    if (form.id === "role-create-form") {
+      event.preventDefault();
+      const submit = form.querySelector<HTMLButtonElement>(
+        "#role-create-submit"
+      );
+      if (!submit || submit.disabled) return;
+      const unlock = lockElement(submit, "Please wait…");
+      if (createError) createError.hidden = true;
+
+      const data = new FormData(form);
+      const roleCode = String(data.get("roleCode") ?? "").trim();
+      const roleName = String(data.get("roleName") ?? "").trim();
+
+      const result = await sendJson("POST", "/api/v1/roles", {
+        roleCode,
+        roleName
+      });
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+      // Generic message only — never surface internal detail (Issue #540).
+      showCreateError(
+        "Could not create the role. Check the code is unique and valid."
+      );
+      unlock();
+      return;
+    }
+
+    if (form.hasAttribute("data-role-grant-form")) {
+      event.preventDefault();
+      const roleId = form.getAttribute("data-role-id");
+      const submit = form.querySelector<HTMLButtonElement>(
+        "button[type='submit']"
+      );
+      const select = form.querySelector<HTMLSelectElement>(
+        "select[name='permissionId']"
+      );
+      if (!roleId || !submit || submit.disabled || !select) return;
+      const permissionId = select.value;
+      if (!permissionId) return;
+
+      const unlock = lockElement(submit, "Please wait…");
+      if (actionError) actionError.hidden = true;
+
+      const result = await sendJson(
+        "POST",
+        `/api/v1/roles/${encodeURIComponent(roleId)}/permissions`,
+        { permissionId }
+      );
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+      showActionError("Could not grant the permission. Please try again.");
+      unlock();
+      return;
+    }
+  });
+
+  // Rename / delete / restore / revoke are all button clicks.
+  document.addEventListener("click", async (event) => {
+    const button = (event.target as HTMLElement).closest<HTMLButtonElement>(
+      "button[data-role-action]"
+    );
+    if (!button || button.disabled) return;
+
+    const action = button.dataset.roleAction;
+    const roleId = button.dataset.roleId;
+    if (!roleId) return;
+
+    if (actionError) actionError.hidden = true;
+
+    if (action === "rename") {
+      const current = button.dataset.roleName ?? "";
+      const next = window.prompt("New role name?", current);
+      if (next === null || next.trim().length === 0) return;
+      const unlock = lockElement(button, "…");
+      const result = await sendJson(
+        "PATCH",
+        `/api/v1/roles/${encodeURIComponent(roleId)}`,
+        { roleName: next.trim() }
+      );
+      if (result.ok) return void window.location.reload();
+      showActionError("Could not rename the role. Please try again.");
+      unlock();
+      return;
+    }
+
+    if (action === "delete") {
+      const code = button.dataset.roleCode ?? roleId;
+      if (!window.confirm(`Soft-delete role "${code}"?`)) return;
+      const reason = window.prompt("Reason for deleting (optional)?") ?? "";
+      const trimmed = reason.trim();
+      const unlock = lockElement(button, "…");
+      const result = await sendJson(
+        "DELETE",
+        `/api/v1/roles/${encodeURIComponent(roleId)}`,
+        trimmed.length > 0 ? { reason: trimmed } : undefined
+      );
+      if (result.ok) return void window.location.reload();
+      showActionError(
+        "Could not delete the role. System roles cannot be deleted."
+      );
+      unlock();
+      return;
+    }
+
+    if (action === "restore") {
+      const code = button.dataset.roleCode ?? roleId;
+      if (!window.confirm(`Restore role "${code}"?`)) return;
+      const unlock = lockElement(button, "…");
+      const result = await sendJson(
+        "POST",
+        `/api/v1/roles/${encodeURIComponent(roleId)}/restore`
+      );
+      if (result.ok) return void window.location.reload();
+      showActionError(
+        "Could not restore the role. Its code may now be in use."
+      );
+      unlock();
+      return;
+    }
+
+    if (action === "revoke") {
+      const permissionId = button.dataset.permissionId;
+      if (!permissionId) return;
+      if (!window.confirm("Remove this permission from the role?")) return;
+      const unlock = lockElement(button, "…");
+      const result = await sendJson(
+        "DELETE",
+        `/api/v1/roles/${encodeURIComponent(roleId)}/permissions`,
+        { permissionId }
+      );
+      if (result.ok) return void window.location.reload();
+      showActionError("Could not revoke the permission. Please try again.");
+      unlock();
+      return;
+    }
+  });
+</script>

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -1,16 +1,29 @@
 ---
 /**
- * User (tenant users) management screen (Issue #166, Stage 3b). SSR-reads via
- * the same `listTenantUsers` the `GET /api/v1/users` endpoint uses, gated on
- * `identity_access.access_control.read`. Login identifiers are masked (PII).
- * Read-only.
+ * User (tenant users) management screen (Issue #166 read + Issue #171 writes).
+ * SSR-reads via the same `listTenantUsers` the `GET /api/v1/users` endpoint
+ * uses, gated on `identity_access.access_control.read`. Login identifiers are
+ * masked (PII) both in the render and everywhere they are logged.
+ *
+ * Write controls (Issue #171), each UX-gated on the permission its endpoint
+ * enforces (the endpoint guard is the real authority — the gate only hides
+ * controls a user cannot use):
+ *  - activate / deactivate a user (`PATCH /api/v1/users/{id}`), gated on
+ *    `identity_access.access_control.configure`.
+ *  - assign / unassign a role (`POST` / `DELETE /api/v1/access/assignments`),
+ *    gated on `identity_access.access_control.assign`.
+ *
+ * `listTenantUsers` returns each user's assigned role CODES; the unassign
+ * endpoint needs the role ID, so we resolve code → id here from `listRoles`.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
+  listRoles,
   listTenantUsers,
+  type RoleView,
   type TenantUserView
 } from "../../modules/identity-access/application/access-directory";
 
@@ -18,22 +31,38 @@ const ssr = Astro.locals.ssrContext!;
 const canRead = ssr.permissions.has(
   permissionKey("identity_access", "access_control", "read")
 );
+const canConfigure = ssr.permissions.has(
+  permissionKey("identity_access", "access_control", "configure")
+);
+const canAssign = ssr.permissions.has(
+  permissionKey("identity_access", "access_control", "assign")
+);
 
 let users: TenantUserView[] = [];
+let roles: RoleView[] = [];
 let loadError = false;
 
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, (tx) =>
-      listTenantUsers(tx, ssr.tenantId)
-    );
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => ({
+      users: await listTenantUsers(tx, ssr.tenantId),
+      roles: await listRoles(tx, ssr.tenantId)
+    }));
     if (result instanceof Response) loadError = true;
-    else users = result;
+    else {
+      users = result.users;
+      roles = result.roles;
+    }
   } catch {
     loadError = true;
   }
 }
+
+// role code -> role id, so a user's assigned role codes can be turned into
+// removable controls carrying the id the unassign endpoint expects.
+const roleIdByCode = new Map(roles.map((role) => [role.roleCode, role.id]));
+const showActions = canConfigure || canAssign;
 ---
 
 <AdminLayout title="Users" active="users">
@@ -57,44 +86,264 @@ if (canRead) {
 
   {
     canRead && !loadError && (
-      <div class="data-table-scroll">
-        <table class="data-table" id="users-table">
-          <caption>{users.length} user(s)</caption>
-          <thead>
-            <tr>
-              <th scope="col">Login identifier</th>
-              <th scope="col">Status</th>
-              <th scope="col">Roles</th>
-            </tr>
-          </thead>
-          <tbody>
-            {users.length === 0 ? (
+      <>
+        <p
+          id="users-action-error"
+          class="admin-create-error"
+          role="alert"
+          hidden
+        />
+        <div class="data-table-scroll">
+          <table class="data-table" id="users-table">
+            <caption>{users.length} user(s)</caption>
+            <thead>
               <tr>
-                <td class="data-table-empty" colspan="3">
-                  No users yet.
-                </td>
+                <th scope="col">Login identifier</th>
+                <th scope="col">Status</th>
+                <th scope="col">Roles</th>
+                {showActions && <th scope="col">Actions</th>}
               </tr>
-            ) : (
-              users.map((user) => (
+            </thead>
+            <tbody>
+              {users.length === 0 ? (
                 <tr>
-                  <td>{user.loginIdentifierMasked}</td>
-                  <td>
-                    <span
-                      class="status-badge"
-                      data-variant={
-                        user.status === "active" ? "success" : "neutral"
-                      }
-                    >
-                      {user.status}
-                    </span>
+                  <td class="data-table-empty" colspan={showActions ? 4 : 3}>
+                    No users yet.
                   </td>
-                  <td>{user.roles.length > 0 ? user.roles.join(", ") : "—"}</td>
                 </tr>
-              ))
-            )}
-          </tbody>
-        </table>
-      </div>
+              ) : (
+                users.map((user) => (
+                  <tr>
+                    <td>{user.loginIdentifierMasked}</td>
+                    <td>
+                      <span
+                        class="status-badge"
+                        data-variant={
+                          user.status === "active" ? "success" : "neutral"
+                        }
+                      >
+                        {user.status}
+                      </span>
+                    </td>
+                    <td>
+                      {user.roles.length === 0 ? (
+                        "—"
+                      ) : (
+                        <ul class="role-chip-list">
+                          {user.roles.map((code) => (
+                            <li>
+                              <span class="role-chip">{code}</span>
+                              {canAssign && roleIdByCode.has(code) && (
+                                <button
+                                  type="button"
+                                  class="link-button js-unassign-role"
+                                  data-user-id={user.id}
+                                  data-role-id={roleIdByCode.get(code)}
+                                  aria-label={`Remove role ${code}`}
+                                >
+                                  Remove
+                                </button>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </td>
+                    {showActions && (
+                      <td>
+                        {canConfigure && (
+                          <button
+                            type="button"
+                            class="module-toggle js-user-status"
+                            data-user-id={user.id}
+                            data-next-status={
+                              user.status === "active" ? "inactive" : "active"
+                            }
+                          >
+                            {user.status === "active"
+                              ? "Deactivate"
+                              : "Activate"}
+                          </button>
+                        )}
+                        {canAssign && roles.length > 0 && (
+                          <span class="assign-role-control">
+                            <label
+                              class="visually-hidden"
+                              for={`assign-role-${user.id}`}
+                            >
+                              Role to assign
+                            </label>
+                            <select
+                              id={`assign-role-${user.id}`}
+                              class="js-assign-role-select"
+                            >
+                              {roles.map((role) => (
+                                <option value={role.id}>{role.roleCode}</option>
+                              ))}
+                            </select>
+                            <button
+                              type="button"
+                              class="module-toggle js-assign-role"
+                              data-user-id={user.id}
+                              data-select-id={`assign-role-${user.id}`}
+                            >
+                              Assign
+                            </button>
+                          </span>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </>
     )
   }
 </AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time). The
+  // import forces Astro to emit this EXTERNAL, where the app's
+  // `default-src 'self'` CSP allows it — an import-free script would inline and
+  // be blocked. See admin-form-client.ts. Handlers are attached via event
+  // delegation so they bind whether or not any given control rendered.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const errorBox = document.getElementById("users-action-error");
+
+  function showError(message: string): void {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.hidden = false;
+  }
+
+  async function run(
+    button: HTMLButtonElement,
+    action: () => Promise<{ ok: boolean; errorCode: string | null }>,
+    failureMessage: string
+  ): Promise<void> {
+    if (button.disabled) return;
+    if (errorBox) errorBox.hidden = true;
+    const unlock = lockElement(button, "Please wait…");
+
+    const result = await action();
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+    showError(failureMessage);
+    unlock();
+  }
+
+  document.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement | null)?.closest("button");
+    if (!(target instanceof HTMLButtonElement)) return;
+
+    if (target.classList.contains("js-user-status")) {
+      const userId = target.dataset.userId;
+      const nextStatus = target.dataset.nextStatus;
+      if (!userId || !nextStatus) return;
+      void run(
+        target,
+        () =>
+          sendJson("PATCH", `/api/v1/users/${userId}`, { status: nextStatus }),
+        "Could not update the user status. Please try again."
+      );
+      return;
+    }
+
+    if (target.classList.contains("js-assign-role")) {
+      const userId = target.dataset.userId;
+      const selectId = target.dataset.selectId;
+      if (!userId || !selectId) return;
+      const select = document.getElementById(
+        selectId
+      ) as HTMLSelectElement | null;
+      const roleId = select?.value;
+      if (!roleId) return;
+      void run(
+        target,
+        () =>
+          sendJson("POST", "/api/v1/access/assignments", {
+            tenantUserId: userId,
+            roleId
+          }),
+        "Could not assign the role. It may already be assigned."
+      );
+      return;
+    }
+
+    if (target.classList.contains("js-unassign-role")) {
+      const userId = target.dataset.userId;
+      const roleId = target.dataset.roleId;
+      if (!userId || !roleId) return;
+      void run(
+        target,
+        () =>
+          sendJson("DELETE", "/api/v1/access/assignments", {
+            tenantUserId: userId,
+            roleId
+          }),
+        "Could not remove the role. Please try again."
+      );
+    }
+  });
+</script>
+
+<style>
+  .visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  .role-chip-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .role-chip-list li {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-1);
+  }
+
+  .role-chip {
+    padding: var(--sp-1) var(--sp-2);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-sm);
+    background: var(--color-surface);
+    font-size: var(--fs-sm);
+  }
+
+  .link-button {
+    padding: 0;
+    border: 0;
+    background: none;
+    color: var(--color-text-muted);
+    font-size: var(--fs-sm);
+    text-decoration: underline;
+    cursor: pointer;
+  }
+
+  .assign-role-control {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--sp-2);
+    margin-inline-start: var(--sp-2);
+  }
+</style>

--- a/src/pages/api/v1/abac/policies/[id].ts
+++ b/src/pages/api/v1/abac/policies/[id].ts
@@ -1,0 +1,83 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { updatePolicy } from "../../../../../modules/identity-access/application/abac-admin";
+import { validateUpdateAbacPolicyInput } from "../../../../../modules/identity-access/domain/abac-admin-validation";
+
+const UPDATE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "configure" as const
+};
+
+/**
+ * `PATCH /api/v1/abac/policies/{id}` — update a policy's effect/description
+ * and/or enable/disable it (Issue #171). One endpoint backs BOTH the edit form
+ * and the enable/disable toggle. High-risk access-control change: gated on
+ * `identity_access.access_control.configure` (the access-control administration
+ * permission — the only seeded write action for this activity; there is no
+ * `update`), audit-logged in the application layer. 404 when the policy does
+ * not exist in this tenant.
+ */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const policyId = params.id;
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!policyId) return fail(400, "VALIDATION_ERROR", "Policy id is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validateUpdateAbacPolicyInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "ABAC policy update input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    const policy = await updatePolicy(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      policyId,
+      validation.value,
+      correlationId
+    );
+    if (!policy) return fail(404, "RESOURCE_NOT_FOUND", "Policy not found.");
+
+    return ok(policy);
+  });
+};

--- a/src/pages/api/v1/abac/policies/index.ts
+++ b/src/pages/api/v1/abac/policies/index.ts
@@ -1,19 +1,33 @@
 import type { APIRoute } from "astro";
 
-import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { created, fail, ok } from "../../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
 import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { listAbacPolicies } from "../../../../../modules/identity-access/application/access-directory";
+import {
+  createPolicy,
+  DuplicatePolicyCodeError
+} from "../../../../../modules/identity-access/application/abac-admin";
+import { validateCreateAbacPolicyInput } from "../../../../../modules/identity-access/domain/abac-admin-validation";
 
 const READ_GUARD = {
   moduleKey: "identity_access",
   activityCode: "access_control",
   action: "read" as const
+};
+const CREATE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "configure" as const
 };
 
 /**
@@ -43,5 +57,74 @@ export const GET: APIRoute = async ({ request, cookies }) => {
 
     const items = await listAbacPolicies(tx, tenantId);
     return ok({ items });
+  });
+};
+
+/**
+ * `POST /api/v1/abac/policies` — author a new ABAC policy (Issue #171).
+ * High-risk access-control change: gated on
+ * `identity_access.access_control.configure` (the access-control
+ * administration permission — the only seeded write action for this activity;
+ * there is no `create`), audit-logged in the application layer. A duplicate
+ * `policyCode` surfaces as 409.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validateCreateAbacPolicyInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "ABAC policy input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CREATE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    try {
+      const policy = await createPolicy(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        validation.value,
+        correlationId
+      );
+      return created(policy);
+    } catch (error) {
+      // Caught INSIDE `withTenant` on purpose: `DuplicatePolicyCodeError` is not
+      // a `Bun.SQL.PostgresError` here, so `tenant-context.ts`'s client-input
+      // carve-out would not recognise it and a burst of duplicate submits would
+      // count toward the shared circuit breaker. Returning 409 from in here is
+      // safe because the unique violation already ABORTED the transaction, so
+      // the commit degrades to a rollback and nothing further is written to
+      // `tx` (a stray audit write would fail 25P02 and turn this into a 500).
+      if (error instanceof DuplicatePolicyCodeError) {
+        return fail(409, "POLICY_CODE_ALREADY_EXISTS", error.message);
+      }
+      throw error;
+    }
   });
 };

--- a/src/pages/api/v1/access/assignments.ts
+++ b/src/pages/api/v1/access/assignments.ts
@@ -16,6 +16,7 @@ import {
   assignRole,
   AssignmentTargetNotFoundError,
   DuplicateAssignmentError,
+  SystemRoleAssignmentError,
   unassignRole,
   validateAssignmentInput
 } from "../../../../modules/identity-access/application/user-admin";
@@ -94,6 +95,9 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
       if (error instanceof AssignmentTargetNotFoundError) {
         return fail(404, "RESOURCE_NOT_FOUND", error.message);
       }
+      if (error instanceof SystemRoleAssignmentError) {
+        return fail(409, "ROLE_SYSTEM_PROTECTED", error.message);
+      }
       if (error instanceof DuplicateAssignmentError) {
         return fail(409, "ASSIGNMENT_ALREADY_EXISTS", error.message);
       }
@@ -143,17 +147,26 @@ export const DELETE: APIRoute = async ({ request, cookies, locals }) => {
     );
     if (!auth.allowed) return auth.denied;
 
-    const removed = await unassignRole(
-      tx,
-      tenantId,
-      auth.context.tenantUserId,
-      validation.value.tenantUserId,
-      validation.value.roleId,
-      correlationId
-    );
-    if (!removed)
-      return fail(404, "RESOURCE_NOT_FOUND", "Assignment not found.");
+    try {
+      const removed = await unassignRole(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        validation.value.tenantUserId,
+        validation.value.roleId,
+        correlationId
+      );
+      if (!removed)
+        return fail(404, "RESOURCE_NOT_FOUND", "Assignment not found.");
 
-    return ok({ removed: true });
+      return ok({ removed: true });
+    } catch (error) {
+      // `SystemRoleAssignmentError` is raised before any write (the is_system
+      // pre-check), so mapping it to 409 inside `withTenant` persists nothing.
+      if (error instanceof SystemRoleAssignmentError) {
+        return fail(409, "ROLE_SYSTEM_PROTECTED", error.message);
+      }
+      throw error;
+    }
   });
 };

--- a/src/pages/api/v1/access/assignments.ts
+++ b/src/pages/api/v1/access/assignments.ts
@@ -1,0 +1,159 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import {
+  assignRole,
+  AssignmentTargetNotFoundError,
+  DuplicateAssignmentError,
+  unassignRole,
+  validateAssignmentInput
+} from "../../../../modules/identity-access/application/user-admin";
+
+/**
+ * Both verbs are guarded on `identity_access.access_control.assign` ("Assign
+ * roles to tenant users", seeded in `sql/005`) — the permission that exactly
+ * names this action, held by the owner role.
+ */
+const ASSIGN_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "assign" as const
+};
+
+/**
+ * `POST /api/v1/access/assignments` — grant a role to a tenant user
+ * (body: `{ tenantUserId, roleId }`). Idempotency is enforced at the DB unique
+ * index: a repeat assign is a 23505 mapped to 409, caught INSIDE `withTenant`.
+ * High-risk: audited.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validateAssignmentInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Assignment input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      ASSIGN_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    try {
+      const record = await assignRole(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        validation.value.tenantUserId,
+        validation.value.roleId,
+        correlationId
+      );
+      return ok(record);
+    } catch (error) {
+      // Caught INSIDE `withTenant` on purpose (same reasoning as
+      // `offices/index.ts`): neither error is a `Bun.SQL.PostgresError` here,
+      // so the circuit-breaker carve-out in `tenant-context.ts` would not
+      // recognise them. `AssignmentTargetNotFoundError` is raised before any
+      // write (commit persists nothing); `DuplicateAssignmentError` follows the
+      // 23505 that already aborted the transaction (commit degrades to
+      // rollback). Neither path writes anything further to `tx`.
+      if (error instanceof AssignmentTargetNotFoundError) {
+        return fail(404, "RESOURCE_NOT_FOUND", error.message);
+      }
+      if (error instanceof DuplicateAssignmentError) {
+        return fail(409, "ASSIGNMENT_ALREADY_EXISTS", error.message);
+      }
+      throw error;
+    }
+  });
+};
+
+/**
+ * `DELETE /api/v1/access/assignments` — revoke a role from a tenant user
+ * (body: `{ tenantUserId, roleId }`). 404 when no such assignment exists.
+ * High-risk: audited.
+ */
+export const DELETE: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validateAssignmentInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Assignment input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      ASSIGN_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    const removed = await unassignRole(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      validation.value.tenantUserId,
+      validation.value.roleId,
+      correlationId
+    );
+    if (!removed)
+      return fail(404, "RESOURCE_NOT_FOUND", "Assignment not found.");
+
+    return ok({ removed: true });
+  });
+};

--- a/src/pages/api/v1/offices/[id]/restore.ts
+++ b/src/pages/api/v1/offices/[id]/restore.ts
@@ -1,0 +1,91 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import {
+  DuplicateOfficeCodeError,
+  restoreOffice
+} from "../../../../../modules/tenant-admin/application/office-directory";
+
+/**
+ * Restore reuses the `office_management.update` permission rather than a
+ * dedicated `restore` action: the activity has no `restore` permission to gate
+ * on, and un-deleting is an edit of a record's lifecycle state — the same
+ * authority that may change an office may bring one back. The endpoint guard is
+ * the authority; the admin page mirrors this by gating its restore control on
+ * `.update`.
+ */
+const RESTORE_GUARD = {
+  moduleKey: "tenant_admin",
+  activityCode: "office_management",
+  action: "update" as const
+};
+
+/**
+ * `POST /api/v1/offices/{id}/restore` — un-soft-deletes an office. 404 when the
+ * id is not currently soft-deleted (idempotent-safe: a repeat restore is a 404,
+ * never a duplicate). 409 when a live office has since taken the same code — the
+ * partial unique index blocks the restore and the caller must resolve the clash.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const officeId = params.id;
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!officeId) return fail(400, "VALIDATION_ERROR", "Office id is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      RESTORE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    try {
+      const office = await restoreOffice(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        officeId,
+        correlationId
+      );
+
+      if (!office) {
+        return fail(
+          404,
+          "RESOURCE_NOT_FOUND",
+          "Office not found or not currently soft-deleted."
+        );
+      }
+
+      return ok(office);
+    } catch (error) {
+      // A `DuplicateOfficeCodeError` follows a unique violation that already
+      // aborted the transaction; returning 409 here is safe because the commit
+      // degrades to a rollback and nothing further is written to `tx`. Caught
+      // inside `withTenant` so the burst does not count toward the shared
+      // circuit breaker (same reasoning as the create route).
+      if (error instanceof DuplicateOfficeCodeError) {
+        return fail(409, "OFFICE_CODE_ALREADY_EXISTS", error.message);
+      }
+
+      throw error;
+    }
+  });
+};

--- a/src/pages/api/v1/roles/[id].ts
+++ b/src/pages/api/v1/roles/[id].ts
@@ -13,79 +13,45 @@ import {
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
 import {
-  fetchOfficeById,
-  softDeleteOffice,
-  updateOffice
-} from "../../../../modules/tenant-admin/application/office-directory";
+  softDeleteRole,
+  updateRole
+} from "../../../../modules/identity-access/application/role-admin";
 import {
-  validateDeleteOfficeInput,
-  validateUpdateOfficeInput
-} from "../../../../modules/tenant-admin/domain/office-validation";
+  validateDeleteRoleInput,
+  validateUpdateRoleInput
+} from "../../../../modules/identity-access/domain/role-admin-validation";
 
-const READ_GUARD = {
-  moduleKey: "tenant_admin",
-  activityCode: "office_management",
-  action: "read" as const
-};
-const UPDATE_GUARD = {
-  moduleKey: "tenant_admin",
-  activityCode: "office_management",
-  action: "update" as const
-};
-const DELETE_GUARD = {
-  moduleKey: "tenant_admin",
-  activityCode: "office_management",
-  action: "delete" as const
+// Role CRUD authorizes on `configure` ("Manage roles and role permissions") —
+// the catalogued, owner-granted, HIGH_RISK action.
+const CONFIGURE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "configure" as const
 };
 
-export const GET: APIRoute = async ({ request, params, cookies }) => {
-  const { tenantId, token } = resolveAuthInputs(request, cookies);
-  const officeId = params.id;
-
-  if (!tenantId)
-    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  if (!officeId) return fail(400, "VALIDATION_ERROR", "Office id is required.");
-  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
-
-  const sql = getDatabaseClient();
-  const tokenHash = hashSessionToken(token);
-  const now = new Date();
-
-  return withTenant(sql, tenantId, async (tx) => {
-    const auth = await authorizeInTransaction(
-      tx,
-      tenantId,
-      tokenHash,
-      now,
-      READ_GUARD
-    );
-    if (!auth.allowed) return auth.denied;
-
-    const office = await fetchOfficeById(tx, tenantId, officeId);
-    if (!office) return fail(404, "RESOURCE_NOT_FOUND", "Office not found.");
-
-    return ok(office);
-  });
-};
-
+/**
+ * `PATCH /api/v1/roles/{id}` — rename a role (`role_name`) (Issue #171).
+ * HIGH-RISK: gated on `identity_access.access_control.configure`, audited by
+ * `updateRole`. 404 if the role does not exist or is soft-deleted.
+ */
 export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
-  const officeId = params.id;
+  const roleId = params.id;
 
   if (!tenantId)
     return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  if (!officeId) return fail(400, "VALIDATION_ERROR", "Office id is required.");
+  if (!roleId) return fail(400, "VALIDATION_ERROR", "Role id is required.");
   if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
 
   const bodyRead = await readJsonBody(request);
   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
 
-  const validation = validateUpdateOfficeInput(bodyRead.value);
+  const validation = validateUpdateRoleInput(bodyRead.value);
   if (!validation.valid) {
     return fail(
       400,
       "VALIDATION_ERROR",
-      "Office update input is invalid.",
+      "Role update input is invalid.",
       {},
       validation.errors
     );
@@ -102,24 +68,30 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       tenantId,
       tokenHash,
       now,
-      UPDATE_GUARD
+      CONFIGURE_GUARD
     );
     if (!auth.allowed) return auth.denied;
 
-    const office = await updateOffice(
+    const role = await updateRole(
       tx,
       tenantId,
       auth.context.tenantUserId,
-      officeId,
+      roleId,
       validation.value,
       correlationId
     );
-    if (!office) return fail(404, "RESOURCE_NOT_FOUND", "Office not found.");
+    if (!role) return fail(404, "RESOURCE_NOT_FOUND", "Role not found.");
 
-    return ok(office);
+    return ok(role);
   });
 };
 
+/**
+ * `DELETE /api/v1/roles/{id}` — soft-delete a role (Issue #171). HIGH-RISK:
+ * gated on `identity_access.access_control.configure`, audited by
+ * `softDeleteRole`. `is_system` roles are refused with 409. An optional
+ * `reason` in the body is echoed into the audit event.
+ */
 export const DELETE: APIRoute = async ({
   request,
   params,
@@ -127,24 +99,22 @@ export const DELETE: APIRoute = async ({
   locals
 }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
-  const officeId = params.id;
+  const roleId = params.id;
 
   if (!tenantId)
     return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  if (!officeId) return fail(400, "VALIDATION_ERROR", "Office id is required.");
+  if (!roleId) return fail(400, "VALIDATION_ERROR", "Role id is required.");
   if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
 
   const bodyRead = await readJsonBody(request);
   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
 
-  // Bodyless DELETE is allowed (reason → null); a present-but-blank reason is
-  // rejected here rather than stored as "".
-  const validation = validateDeleteOfficeInput(bodyRead.value);
+  const validation = validateDeleteRoleInput(bodyRead.value);
   if (!validation.valid) {
     return fail(
       400,
       "VALIDATION_ERROR",
-      "Office delete input is invalid.",
+      "Role delete input is invalid.",
       {},
       validation.errors
     );
@@ -161,20 +131,30 @@ export const DELETE: APIRoute = async ({
       tenantId,
       tokenHash,
       now,
-      DELETE_GUARD
+      CONFIGURE_GUARD
     );
     if (!auth.allowed) return auth.denied;
 
-    const deleted = await softDeleteOffice(
+    const result = await softDeleteRole(
       tx,
       tenantId,
       auth.context.tenantUserId,
-      officeId,
+      roleId,
       validation.value.reason,
       correlationId
     );
-    if (!deleted) return fail(404, "RESOURCE_NOT_FOUND", "Office not found.");
 
-    return ok({ id: officeId, status: "deleted" });
+    if (result.outcome === "not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "Role not found.");
+    }
+    if (result.outcome === "system_blocked") {
+      return fail(
+        409,
+        "ROLE_SYSTEM_PROTECTED",
+        "System roles cannot be deleted."
+      );
+    }
+
+    return ok({ id: roleId, status: "deleted" });
   });
 };

--- a/src/pages/api/v1/roles/[id]/permissions.ts
+++ b/src/pages/api/v1/roles/[id]/permissions.ts
@@ -85,6 +85,13 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       if (result.outcome === "role_not_found") {
         return fail(404, "RESOURCE_NOT_FOUND", "Role not found.");
       }
+      if (result.outcome === "system_blocked") {
+        return fail(
+          409,
+          "ROLE_SYSTEM_PROTECTED",
+          "System roles have an immutable permission set."
+        );
+      }
       return ok({ roleId, permissionId: validation.value.permissionId });
     } catch (error) {
       // Caught INSIDE `withTenant`. `DuplicateRolePermissionError` follows the
@@ -164,6 +171,13 @@ export const DELETE: APIRoute = async ({
 
     if (result.outcome === "role_not_found") {
       return fail(404, "RESOURCE_NOT_FOUND", "Role not found.");
+    }
+    if (result.outcome === "system_blocked") {
+      return fail(
+        409,
+        "ROLE_SYSTEM_PROTECTED",
+        "System roles have an immutable permission set."
+      );
     }
     if (result.outcome === "grant_not_found") {
       return fail(404, "RESOURCE_NOT_FOUND", "Permission grant not found.");

--- a/src/pages/api/v1/roles/[id]/permissions.ts
+++ b/src/pages/api/v1/roles/[id]/permissions.ts
@@ -1,0 +1,174 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import {
+  DuplicateRolePermissionError,
+  grantPermissionToRole,
+  PermissionNotFoundError,
+  revokePermissionFromRole
+} from "../../../../../modules/identity-access/application/role-admin";
+import { validatePermissionRefInput } from "../../../../../modules/identity-access/domain/role-admin-validation";
+
+// Role↔permission management authorizes on `configure` ("Manage roles and role
+// permissions") — the catalogued, owner-granted, HIGH_RISK action.
+const CONFIGURE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "configure" as const
+};
+
+/**
+ * `POST /api/v1/roles/{id}/permissions` — grant a catalogued permission
+ * (`permissionId`) to the role (Issue #171). HIGH-RISK: gated on
+ * `identity_access.access_control.configure`, audited by
+ * `grantPermissionToRole`. 404 if the role is absent/deleted; 409 if the grant
+ * already exists; 400 if `permissionId` is unknown.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const roleId = params.id;
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!roleId) return fail(400, "VALIDATION_ERROR", "Role id is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validatePermissionRefInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Permission grant input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    try {
+      const result = await grantPermissionToRole(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        roleId,
+        validation.value.permissionId,
+        correlationId
+      );
+      if (result.outcome === "role_not_found") {
+        return fail(404, "RESOURCE_NOT_FOUND", "Role not found.");
+      }
+      return ok({ roleId, permissionId: validation.value.permissionId });
+    } catch (error) {
+      // Caught INSIDE `withTenant`. `DuplicateRolePermissionError` follows the
+      // 23505 that already aborted the transaction, `PermissionNotFoundError`
+      // the 23503 — returning 4xx here commits nothing.
+      if (error instanceof DuplicateRolePermissionError) {
+        return fail(409, "ROLE_PERMISSION_ALREADY_GRANTED", error.message);
+      }
+      if (error instanceof PermissionNotFoundError) {
+        return fail(400, "VALIDATION_ERROR", error.message, {}, [
+          { field: "permissionId", message: error.message }
+        ]);
+      }
+      throw error;
+    }
+  });
+};
+
+/**
+ * `DELETE /api/v1/roles/{id}/permissions` — revoke a permission
+ * (`permissionId`) from the role (Issue #171). HIGH-RISK: gated on
+ * `identity_access.access_control.configure`, audited by
+ * `revokePermissionFromRole`. 404 if the role is absent/deleted or the grant
+ * does not exist.
+ */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const roleId = params.id;
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!roleId) return fail(400, "VALIDATION_ERROR", "Role id is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validatePermissionRefInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Permission revoke input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    const result = await revokePermissionFromRole(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      roleId,
+      validation.value.permissionId,
+      correlationId
+    );
+
+    if (result.outcome === "role_not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "Role not found.");
+    }
+    if (result.outcome === "grant_not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "Permission grant not found.");
+    }
+
+    return ok({ roleId, permissionId: validation.value.permissionId });
+  });
+};

--- a/src/pages/api/v1/roles/[id]/restore.ts
+++ b/src/pages/api/v1/roles/[id]/restore.ts
@@ -1,0 +1,82 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import {
+  DuplicateRoleCodeError,
+  restoreRole
+} from "../../../../../modules/identity-access/application/role-admin";
+
+// Restore authorizes on `configure` ("Manage roles and role permissions") —
+// the catalogued, owner-granted, HIGH_RISK action.
+const CONFIGURE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "configure" as const
+};
+
+/**
+ * `POST /api/v1/roles/{id}/restore` — restore a soft-deleted role (Issue #171,
+ * same precedent as `POST /profiles/{id}/restore` and
+ * `POST /email/templates/{id}/restore`). HIGH-RISK: gated on
+ * `identity_access.access_control.configure`, audited by `restoreRole`. 404 if
+ * the role is not currently soft-deleted (idempotent-safe on retry). 409 if its
+ * `role_code` was re-used by a live role while it was deleted.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const roleId = params.id;
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!roleId) return fail(400, "VALIDATION_ERROR", "Role id is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    try {
+      const role = await restoreRole(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        roleId,
+        correlationId
+      );
+      if (!role) {
+        return fail(
+          404,
+          "RESOURCE_NOT_FOUND",
+          "Role not found or not currently soft-deleted."
+        );
+      }
+      return ok(role);
+    } catch (error) {
+      // Caught INSIDE `withTenant`: the unique violation that produced this
+      // error already aborted the transaction, so returning 409 here commits
+      // nothing.
+      if (error instanceof DuplicateRoleCodeError) {
+        return fail(409, "ROLE_CODE_ALREADY_EXISTS", error.message);
+      }
+      throw error;
+    }
+  });
+};

--- a/src/pages/api/v1/roles/index.ts
+++ b/src/pages/api/v1/roles/index.ts
@@ -5,15 +5,33 @@ import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
   authorizeInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
 import { listRoles } from "../../../../modules/identity-access/application/access-directory";
+import {
+  createRole,
+  DuplicateRoleCodeError
+} from "../../../../modules/identity-access/application/role-admin";
+import { validateCreateRoleInput } from "../../../../modules/identity-access/domain/role-admin-validation";
 
 const READ_GUARD = {
   moduleKey: "identity_access",
   activityCode: "access_control",
   action: "read" as const
+};
+// Role CRUD + role↔permission management all authorize on `configure`
+// ("Manage roles and role permissions") — the catalogued, owner-granted,
+// HIGH_RISK action. See role-admin.ts for why finer create/update/delete keys
+// are not used.
+const CONFIGURE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "configure" as const
 };
 
 /**
@@ -43,5 +61,69 @@ export const GET: APIRoute = async ({ request, cookies }) => {
 
     const items = await listRoles(tx, tenantId);
     return ok({ items });
+  });
+};
+
+/**
+ * `POST /api/v1/roles` — create a custom role (`role_code`, `role_name`) for the
+ * tenant (Issue #171). HIGH-RISK: gated on `identity_access.access_control.
+ * configure`, audited by `createRole`. A duplicate live `role_code` is 409.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validateCreateRoleInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Role creation input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    try {
+      const role = await createRole(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        validation.value,
+        correlationId
+      );
+      return ok(role);
+    } catch (error) {
+      // Caught INSIDE `withTenant`: `DuplicateRoleCodeError` follows the unique
+      // violation that already aborted the transaction, so returning 409 here
+      // commits nothing (the commit degrades to a rollback), and — being no
+      // longer a `Bun.SQL.PostgresError` — it must not reach the shared DB
+      // circuit breaker as a server fault. No further write to `tx` may follow.
+      if (error instanceof DuplicateRoleCodeError) {
+        return fail(409, "ROLE_CODE_ALREADY_EXISTS", error.message);
+      }
+      throw error;
+    }
   });
 };

--- a/src/pages/api/v1/users/[id].ts
+++ b/src/pages/api/v1/users/[id].ts
@@ -75,7 +75,7 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
     );
     if (!auth.allowed) return auth.denied;
 
-    const record = await setTenantUserStatus(
+    const result = await setTenantUserStatus(
       tx,
       tenantId,
       auth.context.tenantUserId,
@@ -83,8 +83,25 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       validation.value.status,
       correlationId
     );
-    if (!record) return fail(404, "RESOURCE_NOT_FOUND", "User not found.");
 
-    return ok(record);
+    if (result.outcome === "not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "User not found.");
+    }
+    if (result.outcome === "self_blocked") {
+      return fail(
+        409,
+        "CANNOT_DEACTIVATE_SELF",
+        "You cannot deactivate your own account."
+      );
+    }
+    if (result.outcome === "last_admin_blocked") {
+      return fail(
+        409,
+        "USER_LAST_ADMIN_PROTECTED",
+        "Cannot deactivate the last active administrator."
+      );
+    }
+
+    return ok(result.record);
   });
 };

--- a/src/pages/api/v1/users/[id].ts
+++ b/src/pages/api/v1/users/[id].ts
@@ -1,0 +1,90 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import {
+  setTenantUserStatus,
+  validateSetStatusInput
+} from "../../../../modules/identity-access/application/user-admin";
+
+/**
+ * Guarded on `identity_access.access_control.configure` ("Manage roles and role
+ * permissions", seeded in `sql/005`). Deactivating a tenant user revokes all of
+ * their access, so it is gated by the heaviest identity_access admin permission
+ * the seed provides — there is no `access_control.update` permission in the
+ * catalogue, so guarding on `update` would deny even the owner (who is granted
+ * every SEEDED permission and nothing more). See `user-admin.ts`.
+ */
+const UPDATE_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "access_control",
+  action: "configure" as const
+};
+
+/**
+ * `PATCH /api/v1/users/{id}` — activate / deactivate a tenant user by setting
+ * `status` to `active` / `inactive` (there is no `deleted_at` on
+ * `awcms_tenant_users`). High-risk: audited. Cookie or bearer auth.
+ */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const tenantUserId = params.id;
+
+  if (!tenantId)
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  if (!tenantUserId)
+    return fail(400, "VALIDATION_ERROR", "User id is required.");
+  if (!token) return fail(401, "AUTH_REQUIRED", "Authentication required.");
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+  const validation = validateSetStatusInput(bodyRead.value);
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "User status input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+    if (!auth.allowed) return auth.denied;
+
+    const record = await setTenantUserStatus(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      tenantUserId,
+      validation.value.status,
+      correlationId
+    );
+    if (!record) return fail(404, "RESOURCE_NOT_FOUND", "User not found.");
+
+    return ok(record);
+  });
+};

--- a/tests/abac-admin-validation.test.ts
+++ b/tests/abac-admin-validation.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateCreateAbacPolicyInput,
+  validateUpdateAbacPolicyInput
+} from "../src/modules/identity-access/domain/abac-admin-validation";
+
+describe("validateCreateAbacPolicyInput", () => {
+  test("requires policyCode and effect", () => {
+    const result = validateCreateAbacPolicyInput({});
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      const fields = result.errors.map((e) => e.field);
+      expect(fields).toContain("policyCode");
+      expect(fields).toContain("effect");
+    }
+  });
+
+  test("accepts a minimal valid policy and defaults description to null", () => {
+    const result = validateCreateAbacPolicyInput({
+      policyCode: "deny.after_hours",
+      effect: "deny"
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({
+        policyCode: "deny.after_hours",
+        effect: "deny",
+        description: null
+      });
+    }
+  });
+
+  test("trims policyCode/description and normalises blank description to null", () => {
+    const result = validateCreateAbacPolicyInput({
+      policyCode: "  allow.weekday  ",
+      effect: "allow",
+      description: "   "
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.policyCode).toBe("allow.weekday");
+      expect(result.value.description).toBe(null);
+    }
+  });
+
+  test("rejects an effect outside allow/deny", () => {
+    const result = validateCreateAbacPolicyInput({
+      policyCode: "x",
+      effect: "maybe"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((e) => e.field)).toContain("effect");
+    }
+  });
+
+  test("rejects a malformed policyCode (leading punctuation / illegal chars)", () => {
+    for (const bad of [".starts-with-dot", "has space", "has/slash"]) {
+      const result = validateCreateAbacPolicyInput({
+        policyCode: bad,
+        effect: "allow"
+      });
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.map((e) => e.field)).toContain("policyCode");
+      }
+    }
+  });
+});
+
+describe("validateUpdateAbacPolicyInput", () => {
+  test("rejects an empty patch (no updatable field provided)", () => {
+    const result = validateUpdateAbacPolicyInput({});
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((e) => e.field)).toContain("body");
+    }
+  });
+
+  test("accepts an isActive-only toggle patch", () => {
+    const result = validateUpdateAbacPolicyInput({ isActive: false });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({ isActive: false });
+    }
+  });
+
+  test("keeps an explicit null description as a clear, not 'unchanged'", () => {
+    const result = validateUpdateAbacPolicyInput({ description: null });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect("description" in result.value).toBe(true);
+      expect(result.value.description).toBe(null);
+    }
+  });
+
+  test("rejects a non-boolean isActive", () => {
+    const result = validateUpdateAbacPolicyInput({ isActive: "yes" });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((e) => e.field)).toContain("isActive");
+    }
+  });
+
+  test("accepts a combined effect + description update", () => {
+    const result = validateUpdateAbacPolicyInput({
+      effect: "deny",
+      description: "Blocks weekend posting"
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({
+        effect: "deny",
+        description: "Blocks weekend posting"
+      });
+    }
+  });
+});

--- a/tests/e2e/admin-abac-policies.e2e.ts
+++ b/tests/e2e/admin-abac-policies.e2e.ts
@@ -1,0 +1,82 @@
+/**
+ * Authenticated admin write-action E2E (Issue #171) — exercises the
+ * permission-gated create + toggle controls on `/admin/abac-policies`: log in
+ * through the real `/login` form → session cookies → `/admin` guard → fill the
+ * create-policy form → `POST /api/v1/abac/policies` via cookie auth → page
+ * reload → the new row appears in the SSR-rendered `#abac-policies-table` → then
+ * disable it via `PATCH /api/v1/abac/policies/{id}` and confirm the state flips.
+ *
+ * Env-gated exactly like `admin-offices-create.e2e.ts`: the CI `e2e-smoke` job
+ * seeds a tenant + owner via `POST /api/v1/setup/initialize` and hands the
+ * credentials through env vars. Skipped (not failed) when they are absent, so a
+ * local `bun run test:e2e` without a seeded DB stays green. The seeded owner
+ * role holds every permission, so the `access_control.{create,update}` gates
+ * pass and the controls render.
+ */
+import { test, expect } from "@playwright/test";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
+const password = process.env.E2E_PASSWORD;
+
+const seeded = Boolean(tenantId && loginIdentifier && password);
+
+test.describe("admin ABAC policies write (authenticated)", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant — CI e2e-smoke provisions one via POST /api/v1/setup/initialize"
+  );
+
+  test("owner creates a policy, sees the row, then disables it", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+
+    // The client script redirects to /admin on success.
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/abac-policies");
+
+    // The owner holds `access_control.create`, so the form renders.
+    const form = page.locator("#policy-create-form");
+    await expect(form).toBeVisible();
+
+    // A per-run unique code so re-running the suite doesn't collide on the
+    // `(tenant_id, policy_code)` uniqueness constraint.
+    const newCode = `e2e.policy.${Date.now()}`;
+
+    await page.locator("#policy-code").fill(newCode);
+    await page.locator("#policy-effect").selectOption("deny");
+    await page.locator("#policy-description").fill("E2E authored policy");
+    await page.locator("#policy-create-submit").click();
+
+    // The client reloads the page on success; wait for the SSR table to
+    // re-render with the new row.
+    const table = page.locator("#abac-policies-table");
+    await expect(table).toBeVisible();
+    await expect(table).toContainText(newCode);
+    await expect(page.locator("#policy-create-error")).toBeHidden();
+
+    // The new row is active, so its toggle offers "Disable". Click it and
+    // confirm the row's Active cell flips to "no" after the reload.
+    const newRow = page.locator("#abac-policies-table tbody tr", {
+      hasText: newCode
+    });
+    const toggle = newRow.locator("button.policy-toggle");
+    await expect(toggle).toHaveText("Disable");
+
+    // The toggle triggers a full reload; re-resolve the row afterwards.
+    await Promise.all([page.waitForLoadState("load"), toggle.click()]);
+
+    const reloadedRow = page.locator("#abac-policies-table tbody tr", {
+      hasText: newCode
+    });
+    await expect(reloadedRow.locator("button.policy-toggle")).toHaveText(
+      "Enable"
+    );
+  });
+});

--- a/tests/e2e/admin-offices-edit.e2e.ts
+++ b/tests/e2e/admin-offices-edit.e2e.ts
@@ -1,0 +1,85 @@
+/**
+ * Authenticated admin office-lifecycle E2E (Issue #171) — exercises the
+ * permission-gated per-row write actions on `/admin/offices`: log in through
+ * the real `/login` form → session cookies → create a throwaway office →
+ * inline-edit its name (`PATCH /api/v1/offices/{id}`) → soft-delete it
+ * (`DELETE /api/v1/offices/{id}`) → restore it from the deleted-offices section
+ * (`POST /api/v1/offices/{id}/restore`), asserting the SSR table reflects each
+ * step after reload.
+ *
+ * Env-gated exactly like `admin-offices-create.e2e.ts`: the CI `e2e-smoke` job
+ * seeds a tenant + owner via `POST /api/v1/setup/initialize` and hands the
+ * credentials through env vars. Skipped (not failed) when they are absent, so a
+ * local `bun run test:e2e` without a seeded DB stays green. The seeded owner
+ * role holds every permission, so the `office_management.update`/`.delete`
+ * gates pass and the controls render.
+ */
+import { test, expect } from "@playwright/test";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
+const password = process.env.E2E_PASSWORD;
+
+const seeded = Boolean(tenantId && loginIdentifier && password);
+
+test.describe("admin offices edit/delete/restore (authenticated)", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant — CI e2e-smoke provisions one via POST /api/v1/setup/initialize"
+  );
+
+  test("owner edits, soft-deletes, then restores an office", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/offices");
+
+    // Create a throwaway office to act on (unique code per run).
+    const code = `ED-E2E-${Date.now()}`;
+    await expect(page.locator("#office-create-form")).toBeVisible();
+    await page.locator("#office-code").fill(code);
+    await page.locator("#office-name").fill("Edit E2E Original");
+    await page.locator("#office-type").selectOption("branch");
+    await page.locator("#office-create-submit").click();
+
+    const table = page.locator("#offices-table");
+    await expect(table).toContainText(code);
+
+    // The row is keyed by its office id; find it via the code cell.
+    const row = page.locator("tr", { hasText: code });
+    await expect(row).toBeVisible();
+
+    // Inline edit: change the name and Save → reload → new name shown.
+    await row.locator(".office-name-input").fill("Edit E2E Renamed");
+    await row.locator(".office-save-btn").click();
+    await expect(page.locator("#offices-table")).toBeVisible();
+    const renamedRow = page.locator("tr", { hasText: code });
+    await expect(renamedRow.locator(".office-name-input")).toHaveValue(
+      "Edit E2E Renamed"
+    );
+
+    // Soft-delete: accept the confirm dialog → row leaves the active table and
+    // appears in the deleted-offices section.
+    page.once("dialog", (dialog) => dialog.accept());
+    await renamedRow.locator(".office-delete-btn").click();
+
+    const deletedTable = page.locator("#deleted-offices-table");
+    await expect(deletedTable).toBeVisible();
+    await expect(deletedTable).toContainText(code);
+    await expect(page.locator("#offices-table")).not.toContainText(code);
+
+    // Restore: bring it back → returns to the active table.
+    const deletedRow = page.locator("#deleted-offices-table tr", {
+      hasText: code
+    });
+    await deletedRow.locator(".office-restore-btn").click();
+
+    await expect(page.locator("#offices-table")).toContainText(code);
+  });
+});

--- a/tests/e2e/admin-roles.e2e.ts
+++ b/tests/e2e/admin-roles.e2e.ts
@@ -1,0 +1,73 @@
+/**
+ * Authenticated admin write-action E2E (Issue #171) — exercises the
+ * permission-gated role CRUD on `/admin/roles`: log in through the real
+ * `/login` form → session cookies → create a role via the create form →
+ * `POST /api/v1/roles` (cookie auth) → page reload → the new row appears in the
+ * SSR-rendered `#roles-table` → the row exposes rename / delete / manage-
+ * permissions controls.
+ *
+ * Env-gated exactly like `admin-offices-create.e2e.ts`: the CI `e2e-smoke` job
+ * seeds a tenant + owner via `POST /api/v1/setup/initialize` and hands the
+ * credentials through env vars. Skipped (not failed) when they are absent, so a
+ * local `bun run test:e2e` without a seeded DB stays green. The seeded owner
+ * role holds every permission, so `access_control.configure` passes and the
+ * create form + action controls render.
+ */
+import { test, expect } from "@playwright/test";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
+const password = process.env.E2E_PASSWORD;
+
+const seeded = Boolean(tenantId && loginIdentifier && password);
+
+test.describe("admin roles CRUD (authenticated)", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant — CI e2e-smoke provisions one via POST /api/v1/setup/initialize"
+  );
+
+  test("owner creates a role and sees the new row + action controls", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+
+    // The client script redirects to /admin on success.
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/roles");
+
+    // The owner holds `access_control.configure`, so the form renders.
+    const form = page.locator("#role-create-form");
+    await expect(form).toBeVisible();
+
+    // A per-run unique code so re-running the suite doesn't collide on the
+    // `(tenant_id, role_code)` uniqueness constraint.
+    const newCode = `qa-e2e-${Date.now()}`;
+
+    await page.locator("#role-code").fill(newCode);
+    await page.locator("#role-name").fill("E2E Role");
+    await page.locator("#role-create-submit").click();
+
+    // The client reloads the page on success; wait for the SSR table to
+    // re-render with the new row.
+    const table = page.locator("#roles-table");
+    await expect(table).toBeVisible();
+    await expect(table).toContainText(newCode);
+    await expect(page.locator("#role-create-error")).toBeHidden();
+
+    // The new (custom) role's row exposes rename + delete + manage-permissions.
+    const row = table.locator("tr", { hasText: newCode });
+    await expect(
+      row.locator("button[data-role-action='rename']")
+    ).toBeVisible();
+    await expect(
+      row.locator("button[data-role-action='delete']")
+    ).toBeVisible();
+    await expect(row.locator("details.role-permissions")).toBeVisible();
+  });
+});

--- a/tests/e2e/admin-users.e2e.ts
+++ b/tests/e2e/admin-users.e2e.ts
@@ -1,0 +1,60 @@
+/**
+ * Authenticated admin write-action E2E (Issue #171) — exercises the
+ * permission-gated write controls on `/admin/users`: log in through the real
+ * `/login` form → session cookies → `/admin` guard → the Users screen renders
+ * the activate/deactivate + role-assignment controls (the seeded owner holds
+ * `identity_access.access_control.configure` and `.assign`) → a role-assign
+ * round-trips through `POST /api/v1/access/assignments` via cookie auth.
+ *
+ * Env-gated exactly like `admin-offices-create.e2e.ts`: the CI `e2e-smoke` job
+ * seeds a tenant + owner via `POST /api/v1/setup/initialize` and hands the
+ * credentials through env vars. Skipped (not failed) when they are absent.
+ *
+ * The single seeded user is the owner, who already holds the only role, so the
+ * assertion is deliberately non-destructive: re-assigning the already-held role
+ * is rejected (409) and the client surfaces the generic error — proving the
+ * external CSP-safe script, `sendJson`, and the guarded endpoint all round-trip
+ * without deactivating the owner (which would revoke the running session).
+ */
+import { test, expect } from "@playwright/test";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
+const password = process.env.E2E_PASSWORD;
+
+const seeded = Boolean(tenantId && loginIdentifier && password);
+
+test.describe("admin users write controls (authenticated)", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant — CI e2e-smoke provisions one via POST /api/v1/setup/initialize"
+  );
+
+  test("owner sees the write controls and a duplicate assign is rejected", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await page.locator("#tenant-id").fill(tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+
+    await page.waitForURL("**/admin");
+    await page.goto("/admin/users");
+
+    // The owner holds read + configure + assign, so the table and its Actions
+    // column render.
+    const table = page.locator("#users-table");
+    await expect(table).toBeVisible();
+
+    // Deactivate control renders for the active owner (configure gate).
+    await expect(page.locator(".js-user-status").first()).toBeVisible();
+
+    // Assign the already-held role → 409 → the client shows the generic error.
+    const assignButton = page.locator(".js-assign-role").first();
+    await expect(assignButton).toBeVisible();
+    await assignButton.click();
+
+    await expect(page.locator("#users-action-error")).toBeVisible();
+  });
+});

--- a/tests/role-admin-validation.test.ts
+++ b/tests/role-admin-validation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateCreateRoleInput,
+  validateDeleteRoleInput,
+  validatePermissionRefInput,
+  validateUpdateRoleInput
+} from "../src/modules/identity-access/domain/role-admin-validation";
+
+describe("validateCreateRoleInput", () => {
+  test("requires roleCode and roleName", () => {
+    const result = validateCreateRoleInput({});
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      const fields = result.errors.map((e) => e.field);
+      expect(fields).toContain("roleCode");
+      expect(fields).toContain("roleName");
+    }
+  });
+
+  test("rejects a roleCode that is not a lowercase slug", () => {
+    const result = validateCreateRoleInput({
+      roleCode: "Not A Slug!",
+      roleName: "Ops"
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((e) => e.field)).toContain("roleCode");
+    }
+  });
+
+  test("rejects a single-character roleCode (min length 2)", () => {
+    const result = validateCreateRoleInput({ roleCode: "a", roleName: "Ops" });
+    expect(result.valid).toBe(false);
+  });
+
+  test("trims and accepts a valid slug role", () => {
+    const result = validateCreateRoleInput({
+      roleCode: "  store_manager ",
+      roleName: "  Store Manager "
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({
+        roleCode: "store_manager",
+        roleName: "Store Manager"
+      });
+    }
+  });
+});
+
+describe("validateUpdateRoleInput", () => {
+  test("requires a non-empty roleName", () => {
+    const result = validateUpdateRoleInput({ roleName: "   " });
+    expect(result.valid).toBe(false);
+  });
+
+  test("trims a valid roleName", () => {
+    const result = validateUpdateRoleInput({ roleName: " Renamed " });
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value).toEqual({ roleName: "Renamed" });
+  });
+});
+
+describe("validateDeleteRoleInput", () => {
+  test("allows an absent body (reason is null)", () => {
+    const result = validateDeleteRoleInput(undefined);
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value).toEqual({ reason: null });
+  });
+
+  test("allows an explicit null reason", () => {
+    const result = validateDeleteRoleInput({ reason: null });
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value.reason).toBeNull();
+  });
+
+  test("rejects a blank string reason", () => {
+    const result = validateDeleteRoleInput({ reason: "   " });
+    expect(result.valid).toBe(false);
+  });
+
+  test("trims a provided reason", () => {
+    const result = validateDeleteRoleInput({ reason: "  offboarding " });
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value.reason).toBe("offboarding");
+  });
+});
+
+describe("validatePermissionRefInput", () => {
+  test("requires a permissionId", () => {
+    const result = validatePermissionRefInput({});
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a non-UUID permissionId", () => {
+    const result = validatePermissionRefInput({ permissionId: "not-a-uuid" });
+    expect(result.valid).toBe(false);
+  });
+
+  test("accepts a valid UUID permissionId", () => {
+    const id = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+    const result = validatePermissionRefInput({ permissionId: id });
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value).toEqual({ permissionId: id });
+  });
+});

--- a/tests/user-admin-validation.test.ts
+++ b/tests/user-admin-validation.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Pure-unit tests for the tenant-user admin write validators (Issue #171). No
+ * database — the DB-backed behaviour (audit, 23505 → 409, existence checks)
+ * belongs to a real-PostgreSQL suite; here we pin the input contract the routes
+ * rely on before they ever open a transaction.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateAssignmentInput,
+  validateSetStatusInput
+} from "../src/modules/identity-access/application/user-admin";
+
+const UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+describe("validateSetStatusInput", () => {
+  test("accepts active / inactive", () => {
+    expect(validateSetStatusInput({ status: "active" })).toEqual({
+      valid: true,
+      value: { status: "active" }
+    });
+    expect(validateSetStatusInput({ status: "inactive" }).valid).toBe(true);
+  });
+
+  test("rejects an unknown or missing status", () => {
+    for (const body of [{}, { status: "deleted" }, { status: 1 }, null]) {
+      const result = validateSetStatusInput(body);
+      expect(result.valid).toBe(false);
+      if (!result.valid) expect(result.errors[0]!.field).toBe("status");
+    }
+  });
+});
+
+describe("validateAssignmentInput", () => {
+  test("accepts two valid UUIDs", () => {
+    expect(
+      validateAssignmentInput({ tenantUserId: UUID, roleId: UUID })
+    ).toEqual({ valid: true, value: { tenantUserId: UUID, roleId: UUID } });
+  });
+
+  test("rejects a non-UUID tenantUserId or roleId", () => {
+    const missingRole = validateAssignmentInput({ tenantUserId: UUID });
+    expect(missingRole.valid).toBe(false);
+
+    const badUser = validateAssignmentInput({
+      tenantUserId: "not-a-uuid",
+      roleId: UUID
+    });
+    expect(badUser.valid).toBe(false);
+    if (!badUser.valid) {
+      expect(badUser.errors.map((e) => e.field)).toContain("tenantUserId");
+    }
+  });
+});

--- a/tests/user-admin-validation.test.ts
+++ b/tests/user-admin-validation.test.ts
@@ -7,11 +7,13 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  setTenantUserStatus,
   validateAssignmentInput,
   validateSetStatusInput
 } from "../src/modules/identity-access/application/user-admin";
 
 const UUID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const OTHER_UUID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
 describe("validateSetStatusInput", () => {
   test("accepts active / inactive", () => {
@@ -50,5 +52,31 @@ describe("validateAssignmentInput", () => {
     if (!badUser.valid) {
       expect(badUser.errors.map((e) => e.field)).toContain("tenantUserId");
     }
+  });
+});
+
+describe("setTenantUserStatus self-deactivation guard", () => {
+  // A `tx` that throws if touched — proves the self-block short-circuits BEFORE
+  // any database access (no oracle, no write).
+  const explodingTx = new Proxy(
+    () => {
+      throw new Error("tx must not be called on the self-block path");
+    },
+    {
+      get() {
+        throw new Error("tx must not be accessed on the self-block path");
+      }
+    }
+  ) as unknown as Bun.SQL;
+
+  test("refuses to deactivate the actor's own account without hitting the DB", async () => {
+    const result = await setTenantUserStatus(
+      explodingTx,
+      UUID,
+      OTHER_UUID, // actor
+      OTHER_UUID, // target === actor
+      "inactive"
+    );
+    expect(result).toEqual({ outcome: "self_blocked" });
   });
 });


### PR DESCRIPTION
Closes #171.

Finishes the admin UI write/CRUD work remaining after #166. Implemented as **four parallel, file-disjoint worktree slices** then integrated with a consolidated permission-guard reconciliation. **No schema change** beyond one permission-seed migration.

## What's added
| Area | Endpoints | Screen |
|---|---|---|
| **Roles** (identity-access) | `POST /roles`, `PATCH`/`DELETE /roles/{id}`, `POST /roles/{id}/restore`, `POST`/`DELETE /roles/{id}/permissions` | `/admin/roles`: create, rename, soft-delete, restore, manage-permissions panel |
| **ABAC policies** | `POST /abac/policies`, `PATCH /abac/policies/{id}` (edit + enable/disable) | `/admin/abac-policies`: create form + per-row edit/toggle |
| **Users + RBAC assignment** | `PATCH /users/{id}` (activate/deactivate), `POST`/`DELETE /access/assignments` | `/admin/users`: activate/deactivate + assign/unassign roles |
| **Offices lifecycle** | `DELETE /offices/{id}` (soft-delete), `POST /offices/{id}/restore` | `/admin/offices`: inline edit, delete, deleted-offices restore section |

## Cross-cutting: permission-guard reconciliation
`awcms_permissions` seeds only `access_control.{read,assign,configure}` and `office_management.{read,create,update}`. The owner is granted **only seeded rows** at bootstrap, and the e2e-smoke path runs migrations → `setup/initialize` with **no module permission-sync** — so guarding on a non-seeded action (`create`/`update`/`delete`) would deny even the owner while still passing env-gated CI (a latent authz bug). Resolution:
- Roles / ABAC / user-status guard on **`configure`**; role assignment on **`assign`**.
- Office soft-delete gets a proper seed migration `sql/023` (mirrors the existing `profile_management.delete` precedent) so the descriptor and DB catalog agree.

## Conventions upheld
- Every write is **default-deny guarded** inside `withTenant`, **audit-logged** (high-risk, `warning`) only after the write succeeds, and maps **23505 → 409 inside `withTenant`**.
- Identifiers stay **masked** in user renders/logs.
- New shared client helper `sendJson(method,url,body?)` (PATCH/DELETE/bodyless); admin scripts stay **CSP-safe external bundles**.
- Per-screen **env-gated E2E**, OpenAPI, changesets (4× patch), and module READMEs updated.

## Verification
`bun run check` green — 734 pass / 107 skip / 0 fail, build complete. E2E is env-gated (exercised by CI `e2e-smoke` against a seeded owner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)