### PR TITLE
feat(auth): deployment-profile-aware Cloudflare Turnstile bot protection (#186)

### DIFF
--- a/.changeset/turnstile-bot-protection.md
+++ b/.changeset/turnstile-bot-protection.md
@@ -1,0 +1,30 @@
+---
+"awcms": minor
+---
+
+Add deployment-profile-aware Cloudflare Turnstile bot protection (Issue #186,
+epic #177), ported and hardened from awcms-mini. A new full-online deployment
+gate (`AUTH_ONLINE_SECURITY_ENABLED`/`AUTH_ONLINE_SECURITY_PROFILE`) plus
+`TURNSTILE_ENABLED` activate a server-side Turnstile challenge on
+`POST /api/v1/auth/login` and `POST /api/v1/setup/initialize`. The verifier runs
+after request-shape/rate-limit checks and before password verification, outside
+any DB transaction, and validates success, action (per endpoint), hostname, and
+challenge freshness with a timeout, response-size cap, and secret/token
+redaction (the token is never logged or audited). On the full-online profile it
+fails closed with a single generic error (no account-enumeration oracle); rate
+limit and lockout keep working independently.
+
+Every LAN/offline deployment (the default) is unchanged: no widget, no iframe,
+no CSP origin, and no outbound verification call — `isTurnstileRequired()`
+returns false there, and `TURNSTILE_ENABLED=true` alone (without the full-online
+profile) is still fully off. When enabled, the middleware CSP opens exactly the
+one `challenges.cloudflare.com` origin in `script-src`/`frame-src`, the login
+page renders the widget, and `config:validate` + `security:readiness` +
+production preflight validate the site key, secret key, and expected hostname
+consistently while distinguishing "disabled intentionally" from "misconfigured".
+The login/setup request contract gains an optional `turnstileToken` field.
+
+No database migration is added — Turnstile is configuration/env only; the secret
+key lives in the environment and never touches the database, logs, audit,
+responses, or health output. MFA (#184) and OIDC break-glass (#185) login
+branches are preserved intact.

--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,38 @@ AUTH_SSO_OAUTH_REQUEST_TTL_SEC=600
 # (config:validate rejects a non-empty value when APP_ENV=production).
 AUTH_SSO_ALLOW_INSECURE_HOSTS=
 
+# Full-online deployment-profile gate + Cloudflare Turnstile (Issue #186).
+# LAN/offline (the default below) runs with NO widget, NO CSP origin, and NO
+# outbound Turnstile call — leave every var here as shipped.
+#
+# AUTH_ONLINE_SECURITY_* is the deployment profile. Turnstile activates at
+# runtime ONLY when AUTH_ONLINE_SECURITY_ENABLED=true AND
+# AUTH_ONLINE_SECURITY_PROFILE=full_online AND TURNSTILE_ENABLED=true. Setting
+# the gate on with any other profile value is a MISCONFIGURATION
+# (config:validate/security:readiness flag it), distinct from "disabled".
+AUTH_ONLINE_SECURITY_ENABLED=false
+AUTH_ONLINE_SECURITY_PROFILE=disabled
+# When TURNSTILE_ENABLED=true, ALL THREE below are REQUIRED (fail-closed):
+#  - TURNSTILE_SITE_KEY: public, embedded in the widget HTML (NOT a secret).
+#  - TURNSTILE_SECRET_KEY: server-side siteverify only, NEVER sent to the client,
+#    NEVER logged/audited. Rotate via the Cloudflare dashboard (see docs).
+#  - TURNSTILE_EXPECTED_HOSTNAME: the public hostname the widget is served from;
+#    a token solved on any other hostname is rejected (hostname-confusion guard).
+TURNSTILE_ENABLED=false
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+TURNSTILE_EXPECTED_HOSTNAME=
+# Bounded siteverify timeout, challenge-timestamp freshness window, and the
+# response-size cap the verifier enforces (all optional; safe defaults shown).
+TURNSTILE_VERIFY_TIMEOUT_MS=5000
+TURNSTILE_MAX_TOKEN_AGE_SEC=300
+TURNSTILE_MAX_RESPONSE_BYTES=16384
+# Source-scoped rate limit for POST /setup/initialize (Issue #186) — the public
+# bootstrap endpoint has no tenant to key on, so it is bounded per source. Loose
+# by design (setup is once-only); bounds outbound siteverify round-trips.
+SETUP_RATE_LIMIT_MAX=10
+SETUP_RATE_LIMIT_WINDOW_SEC=60
+
 AWCMS_SYNC_ENABLED=false
 AWCMS_SYNC_HMAC_SECRET=change-me
 AWCMS_SYNC_MAX_SKEW_SEC=300

--- a/docs/adr/0029-deployment-profile-aware-turnstile-bot-protection.md
+++ b/docs/adr/0029-deployment-profile-aware-turnstile-bot-protection.md
@@ -1,0 +1,43 @@
+# ADR-0029 — Cloudflare Turnstile bot protection yang sadar deployment-profile
+
+- **Status:** Accepted
+- **Tanggal:** 2026-07-19
+- **Pengambil keputusan:** maintainer
+- **Terkait:** Issue #186, epic #177 (kesiapan fondasi ERP turunan); ADR-0027 (MFA/step-up), ADR-0028 (OIDC/SSO) — kompatibel & berurutan sebelumnya di jalur login; ADR-0026 (modular OpenAPI); doc `docs/awcms/turnstile-bot-protection.md`; port dari awcms-mini Issue #587/#588 (diadaptasi & dikeraskan, bukan disalin).
+
+## Konteks
+
+AWCMS mendukung deployment LAN/offline-first sekaligus dapat dijalankan full-online. Login publik dan endpoint setup pada profil full-online butuh mitigasi bot tambahan (bot mengelola argon2id verify mahal, credential-stuffing, dan race terhadap bootstrap tenant), tetapi ketergantungan Cloudflare **tidak boleh** memblokir instalasi LAN, setup lokal, atau alur operasional saat fitur dinonaktifkan.
+
+Turnstile harus menjadi kontrol **berlapis di atas** rate limiting, lockout, audit, dan generic authentication error — bukan pengganti. awcms-mini sudah punya slice Turnstile (Issue #588), tetapi (1) mini hanya memeriksa `success` dari siteverify (tidak memvalidasi `action`/`hostname`/freshness), dan (2) membaca body respons di luar timer timeout (body slow-drip bisa melewati deadline). Jalur login base ini juga **lebih keras** dari mini (dummy argon2id, deny reason kolaps, `TRUSTED_PROXY_ENABLED`, cabang MFA #184 + break-glass OIDC #185) — port naif bisa meregresinya.
+
+## Keputusan
+
+Kami memutuskan **mem-port Turnstile dari mini dan mengeraskannya**, digerbangi profil deployment:
+
+1. **Gerbang profil deployment (`src/lib/auth/online-security-config.ts`).** Berbeda dari MFA (#184) dan OIDC (#185) yang di base ini menjatuhkan konsep profil dan hanya bergantung flag masing-masing, Turnstile adalah kontrol yang menjangkau Cloudflare sehingga **wajib** inert di LAN/offline. `isFullOnlineSecurityActive(env)` true hanya bila `AUTH_ONLINE_SECURITY_ENABLED=true` **dan** `AUTH_ONLINE_SECURITY_PROFILE=full_online`. Ini yang membedakan "disabled intentionally" (flag mati — LAN sah) dari "misconfigured" (flag hidup tapi profil bukan `full_online`) di preflight.
+2. **Satu fungsi gerbang: `isTurnstileRequired(env) = isFullOnlineSecurityActive(env) && TURNSTILE_ENABLED==="true"`.** Widget, origin CSP, dan panggilan verifikasi outbound SEMUA digerbangi fungsi ini. Konsekuensi krusial: `TURNSTILE_ENABLED=true` pada profil LAN → **tetap OFF total** (tak ada widget/iframe/CSP origin/outbound call).
+3. **Verifikasi server-side via adapter terpisah (`src/lib/security/turnstile.ts`).** `verifyTurnstileToken` memanggil siteverify Cloudflare, memvalidasi `success`, **`action`** (per-endpoint: `login` vs `setup` — satu token tak bisa dipakai lintas action), **`hostname`** (anti hostname-confusion), dan **freshness `challenge_ts`** (anti replay basi). Timeout + response-size cap dijalankan oleh **satu `AbortController`** yang mspan fetch **dan** baca body (menutup celah slow-drip mini). Zero akses DB, tak pernah di dalam transaksi — dipanggil sebelum `withTenant`, sebelum password verify.
+4. **Fail-closed generik pada profil yang mewajibkannya.** Token hilang → `TURNSTILE_REQUIRED`. Misconfig (enabled tanpa secret/hostname), provider outage/timeout, malformed, hostname/action mismatch, atau stale → SEMUA kolaps ke satu kode `TURNSTILE_INVALID`. Karena verifikasi berjalan **sebelum** lookup identity apa pun, tidak ada oracle enumerasi akun. Rate limit + lockout tetap bekerja **independen** dari Turnstile.
+5. **Circuit breaker bersama (`getProviderCircuitBreaker("turnstile")`).** Hanya kegagalan transport (non-2xx, unparseable, timeout, error jaringan) yang men-trip breaker; `success:false` dan mismatch hostname/action/freshness dihitung sebagai **sukses provider** (outcome yang bisa diulang attacker tak boleh mengunci login lintas-tenant — pelajaran mini PR #596).
+6. **Integrasi CSP sempit & hanya saat aktif (`src/lib/security/security-headers.ts`).** Saat `isTurnstileRequired()`, middleware membuka **satu** origin `https://challenges.cloudflare.com` di `script-src` (plus `'self'`) dan `frame-src`. Saat nonaktif, CSP byte-identik dengan sebelum issue ini (tak ada `script-src`/`frame-src`, tak ada origin pihak ketiga). Builder tetap satu-satunya pemilik CSP (ADR jalur reporting: middleware, bukan `astro.config`).
+7. **Widget kondisional (`src/pages/login.astro`).** `<div class="cf-turnstile">` + loader `<script is:inline src="…cloudflare…api.js">` dirender HANYA saat `isTurnstileRequired()`. Loader adalah script eksternal eksplisit (bukan modul Astro-bundled yang hanya dari `'self'`). `TURNSTILE_SITE_KEY` publik (Cloudflare menaruhnya di widget); `TURNSTILE_SECRET_KEY` server-side saja, tak pernah sampai halaman.
+8. **Endpoint yang di-wire:** `POST /api/v1/auth/login` (action `login`) dan `POST /api/v1/setup/initialize` (action `setup`). Base ini tak punya route password reset/forgot, jadi hanya dua form publik ini yang di-wire. Field request opsional `turnstileToken` didokumentasikan di OpenAPI (`api:spec:check`/`api:docs:check` hijau).
+9. **Preflight konsisten & tanpa bocor secret.** `config:validate` (cross-rule profil + `TURNSTILE_*` required-when-enabled), `security:readiness` (`checkOnlineAuthSecurityReady` + `checkTurnstileReady`, keduanya membedakan disabled-intentionally dari misconfigured dan tak pernah mencetak nilai secret), dan `.env.example` selaras. Secret dari env, tak pernah di DB/source/log/audit.
+10. **Fake verifier untuk test.** `config.verifyUrl` (dari konfigurasi, bukan input request — SSRF-safe) memungkinkan fake siteverify lokal (`Bun.serve`) di unit/integration test tanpa memanggil Cloudflare nyata.
+11. **Jalur login yang lebih keras dipertahankan utuh.** Enforcement Turnstile disisipkan SETELAH cek request-shape + rate-limit dan SEBELUM `withTenant`/password — di depan cabang MFA (#184) dan break-glass OIDC (#185). `resolveLoginPolicyConfig`/`verifyPasswordOrDummy` tak disentuh; tak ada `Number(process.env…)` mini yang masuk.
+
+## Konsekuensi
+
+- **Tanpa migration.** Turnstile murni config/env (identik keputusan mini) — tak ada tabel/kolom baru; secret tak pernah menyentuh DB.
+- **LAN/offline tak berubah sama sekali.** Default `AUTH_ONLINE_SECURITY_ENABLED=false` → `isTurnstileRequired()` false → nol perilaku baru, nol origin CSP, nol outbound call (dibuktikan test spy `globalThis.fetch` count 0).
+- **Snapshot OpenAPI beku** (`tests/fixtures/openapi-pre-migration-snapshot.openapi.yaml`) TETAP TIDAK DISENTUH — snapshot pre-#182 harus tetap beku. Field opsional `turnstileToken` pada dua path pre-migration (`/auth/login`, `/setup/initialize`) diakui lewat allow-list `INTENTIONALLY_EVOLVED_PATHS` di test contract-equivalence (`tests/openapi-bundle.test.ts`): path yang terdaftar tidak wajib byte-identik, tetapi kontrak beku-nya harus tetap **strict subset** dari kontrak sekarang (cek `isAdditiveSuperset` — setiap field lama dipertahankan, hanya penambahan yang diizinkan). Penghapusan field ATAU sebuah field opsional menjadi `required` tetap MEMERAHKAN test. Mengedit snapshot dilarang (akan membuat test membandingkan bundle dengan salinan dirinya sendiri).
+- **Residual (diterima, didokumentasi di threat model):** verifikasi hostname bergantung pada satu `TURNSTILE_EXPECTED_HOSTNAME` (deployment multi-hostname perlu penyesuaian); freshness bergantung jam server; DNS-rebinding ke siteverify tidak relevan (URL tetap milik Cloudflare, bukan input). Token single-use ditegakkan Cloudflare (verify kedua → `success:false`), jadi tak bisa mem-bypass idempotency (Turnstile berjalan sebelum lapisan idempotency dan tak menyentuh store-nya).
+
+## Alternatif yang ditolak
+
+- **Menyamakan pola MFA/OIDC (flag saja, tanpa profil).** Ditolak: kontrol yang menjangkau Cloudflare harus benar-benar mati di LAN; profil deployment adalah inti permintaan issue #186 ("deployment profile applicability", "fully OFF on LAN").
+- **Menyalin verifier mini apa adanya.** Ditolak: mini tak memvalidasi action/hostname/freshness dan membaca body di luar timer — tidak memenuhi ketentuan keamanan #186.
+- **Mempercayai respons widget klien sebagai hasil final.** Ditolak eksplisit oleh issue — verifikasi wajib server-side.
+- **Menaruh Turnstile di dalam transaksi DB / setelah password verify.** Ditolak: provider eksternal di luar transaksi (ADR-0006), dan gerbang bot harus mendahului kerja mahal.
+- **Kode error berbeda untuk misconfig/mismatch/outage.** Ditolak: akan jadi oracle bagi caller tak terautentikasi — semua kolaps ke `TURNSTILE_INVALID`.

--- a/docs/awcms/turnstile-bot-protection.md
+++ b/docs/awcms/turnstile-bot-protection.md
@@ -1,0 +1,130 @@
+# Cloudflare Turnstile — bot protection sadar deployment-profile
+
+Referensi implementasi Issue #186 (epic #177). Modul: `identity-access` (jalur login) + `tenant-admin` (setup). ADR: [ADR-0029](../adr/0029-deployment-profile-aware-turnstile-bot-protection.md). **Tanpa migration** — Turnstile murni konfigurasi/env; tak ada tabel/kolom baru dan secret tak pernah menyentuh DB.
+
+Fitur aktif **hanya** saat profil deployment full-online DAN `TURNSTILE_ENABLED=true`. Setiap deployment LAN/offline (default) merender halaman login byte-identik seperti sebelum fitur ini: tak ada widget, tak ada iframe, tak ada origin CSP Cloudflare, tak ada panggilan verifikasi keluar.
+
+Turnstile adalah lapisan **di atas** rate limiting, lockout, audit, dan generic authentication error — bukan pengganti. Rate limit + lockout tetap bekerja independen dari Turnstile.
+
+## 1. Gerbang aktivasi
+
+Satu fungsi memutuskan segalanya: `isTurnstileRequired(env)` (`src/lib/security/turnstile.ts`):
+
+```
+isTurnstileRequired = isFullOnlineSecurityActive(env) && TURNSTILE_ENABLED === "true"
+
+isFullOnlineSecurityActive = AUTH_ONLINE_SECURITY_ENABLED === "true"
+                          && AUTH_ONLINE_SECURITY_PROFILE === "full_online"
+```
+
+| Profil                            | `AUTH_ONLINE_SECURITY_*`    | `TURNSTILE_ENABLED` | Hasil                                  |
+| --------------------------------- | --------------------------- | ------------------- | -------------------------------------- |
+| LAN/offline (default)             | unset / `false`             | apa pun             | **OFF** — tak ada widget/CSP/outbound  |
+| LAN dengan flag Turnstile menyala | `false` / profil `disabled` | `true`              | **OFF total** (gerbang profil menang)  |
+| Full-online, Turnstile mati       | `true` + `full_online`      | `false` / unset     | OFF (staging kredensial diperbolehkan) |
+| Full-online, Turnstile hidup      | `true` + `full_online`      | `true`              | **AKTIF** — enforcement fail-closed    |
+
+Widget (`login.astro`), origin CSP (`security-headers.ts`), dan enforcement (`login.ts`/`initialize.ts`) semuanya digerbangi fungsi yang sama, sehingga tak mungkin drift (mis. CSP terbuka tapi widget tak dirender).
+
+## 2. Referensi konfigurasi / env
+
+Semua var opsional; LAN/offline default lulus `config:validate` tanpa satu pun diisi. Lihat `.env.example`.
+
+| Var                            | Tipe                           | Default    | Keterangan                                                                                                                      |
+| ------------------------------ | ------------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `AUTH_ONLINE_SECURITY_ENABLED` | bool                           | `false`    | Master gerbang profil full-online.                                                                                              |
+| `AUTH_ONLINE_SECURITY_PROFILE` | enum `disabled`\|`full_online` | `disabled` | `full_online` wajib saat gerbang menyala.                                                                                       |
+| `TURNSTILE_ENABLED`            | bool                           | `false`    | Flag fitur Turnstile.                                                                                                           |
+| `TURNSTILE_SITE_KEY`           | string (**publik**)            | —          | Site key; disematkan di widget. **Bukan** secret. Wajib saat enabled.                                                           |
+| `TURNSTILE_SECRET_KEY`         | string (**secret**)            | —          | Secret siteverify server-side. Tak pernah ke klien/log/audit/DB. Wajib saat enabled.                                            |
+| `TURNSTILE_EXPECTED_HOSTNAME`  | string                         | —          | Hostname publik tempat widget disajikan; token dari hostname lain ditolak. Wajib saat enabled (fail-closed hostname-confusion). |
+| `TURNSTILE_VERIFY_TIMEOUT_MS`  | int > 0                        | `5000`     | Timeout siteverify (span fetch + baca body).                                                                                    |
+| `TURNSTILE_MAX_TOKEN_AGE_SEC`  | int > 0                        | `300`      | Jendela freshness `challenge_ts`.                                                                                               |
+| `TURNSTILE_MAX_RESPONSE_BYTES` | int > 0                        | `16384`    | Cap ukuran respons siteverify.                                                                                                  |
+
+**Cross-rule preflight** (`bun run config:validate`):
+
+- `AUTH_ONLINE_SECURITY_ENABLED=true` mewajibkan `AUTH_ONLINE_SECURITY_PROFILE=full_online` — ini yang membedakan **misconfigured** dari **disabled intentionally**.
+- `TURNSTILE_ENABLED=true` mewajibkan `TURNSTILE_SITE_KEY`, `TURNSTILE_SECRET_KEY`, dan `TURNSTILE_EXPECTED_HOSTNAME` non-kosong (independen dari gerbang profil, sehingga kredensial bisa di-stage lebih dulu).
+
+`bun run security:readiness` menambah dua cek bernama — `checkOnlineAuthSecurityReady` dan `checkTurnstileReady` — critical saat misconfigured, informational-pass saat disabled-intentionally, dan **tak pernah mencetak nilai secret** (hanya nama var yang hilang).
+
+## 3. Alur auth (login flow)
+
+```
+Klien (login.astro)                     Server (login.ts)                 Cloudflare
+──────────────────                      ─────────────────                 ──────────
+[widget cf-turnstile] --solve-->
+  hidden cf-turnstile-response
+POST /auth/login {..,turnstileToken} -->
+                                        1. cek header tenant
+                                        2. rate limit (source+tenant)
+                                        3. validasi bentuk body
+                                        4. enforceTurnstileIfRequired ------ siteverify -->
+                                           (SEBELUM withTenant & password)   <-- success/action/
+                                                                                 hostname/ts
+                                           - required?  tidak → lanjut (LAN)
+                                           - token hilang → 400 TURNSTILE_REQUIRED
+                                           - invalid/mismatch/outage → 400 TURNSTILE_INVALID
+                                        5. withTenant → lookup identity
+                                        6. verifyPasswordOrDummy (argon2id)
+                                        7. deny-block → cabang break-glass (#185)
+                                           → cabang MFA (#184) → sesi
+```
+
+Kunci ordering: Turnstile berjalan **setelah** rate-limit/bentuk-request, **sebelum** kerja password mahal dan **di luar** transaksi DB — mendahului cabang MFA & OIDC break-glass, tanpa meregresinya. Karena berjalan sebelum lookup identity, kegagalan Turnstile tak pernah jadi oracle enumerasi akun (respons identik untuk identifier dikenal/tak dikenal).
+
+Setup (`POST /api/v1/setup/initialize`) mengikuti pola sama dengan action `setup` (token login tak bisa dipakai ulang di sini). Base ini tak punya halaman UI setup, jadi enforcement setup adalah pertahanan bagi operator yang menjalankan bootstrap pada deployment full-online.
+
+## 4. Setup Cloudflare & rotasi secret
+
+**Provisioning:**
+
+1. Dashboard Cloudflare → Turnstile → Add Site. Domain = hostname publik deployment (mis. `app.example.com`). Widget mode sesuai kebutuhan (managed direkomendasikan).
+2. Salin **Site Key** → `TURNSTILE_SITE_KEY` (publik, boleh di-commit ke config non-secret env). Salin **Secret Key** → `TURNSTILE_SECRET_KEY` (secret manager, **jangan** commit).
+3. Set `TURNSTILE_EXPECTED_HOSTNAME` = hostname publik yang sama dengan domain widget.
+4. (Opsional) Set `action` per widget di dashboard tak diperlukan — base ini mengirim `data-action="login"` dan memvalidasi echo-nya server-side.
+5. Nyalakan: `AUTH_ONLINE_SECURITY_ENABLED=true`, `AUTH_ONLINE_SECURITY_PROFILE=full_online`, `TURNSTILE_ENABLED=true`.
+6. Jalankan `bun run config:validate` lalu `bun run security:readiness` — keduanya harus hijau sebelum go-live.
+
+**Rotasi Secret Key (zero-downtime):**
+
+1. Cloudflare dashboard → widget → rotate secret. Cloudflare menerima secret lama **dan** baru selama masa transisi singkat.
+2. Perbarui `TURNSTILE_SECRET_KEY` di secret manager → rolling-restart instance. Karena verifikasi stateless (tak ada state di DB), tak ada migrasi/backfill.
+3. Validasi login sukses pada satu instance, lalu selesaikan rollout.
+4. Site key jarang dirotasi; bila diganti, perbarui `TURNSTILE_SITE_KEY` (redeploy agar widget membawa key baru) bersamaan.
+
+Secret **tidak pernah** disimpan di DB/source/log/audit — hanya di env/secret manager. Backup DB tak pernah menghasilkan secret Turnstile.
+
+## 5. Incident / fallback SOP (Turnstile unavailable)
+
+Pada profil full-online, kegagalan Cloudflare **fail-closed**: login/setup ditolak `TURNSTILE_INVALID` selama outage (circuit breaker `turnstile` membuka setelah kegagalan transport beruntun dan menolak cepat). Ini disengaja — bukan bug.
+
+Opsi mitigasi, dari paling aman:
+
+1. **Tunggu pemulihan.** Breaker mencoba ulang otomatis setelah `openDurationMs`. Log `turnstile.circuit_breaker_open` (warning) menandai outage berkelanjutan.
+2. **Downgrade profil sementara** bila outage Cloudflare berkepanjangan dan akses admin kritis: set `TURNSTILE_ENABLED=false` (atau `AUTH_ONLINE_SECURITY_ENABLED=false`) → rolling-restart. Rate limit + lockout **tetap** melindungi login. Kembalikan setelah pulih. Catat keputusan di audit operasional.
+3. **Jangan** menonaktifkan rate limit/lockout sebagai "kompensasi" — itu justru menghapus lapisan yang tetap bekerja.
+
+Break-glass admin (OIDC #185) dan lockout tak bergantung pada Turnstile; jalur password lokal untuk identity break-glass tetap tunduk pada rate limit + Turnstile (bila masih enabled) — matikan flag bila benar-benar terkunci oleh outage provider.
+
+## 6. Threat model
+
+| Ancaman                                            | Mitigasi di base ini                                                                                                                                                                                                                                                         |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Bot abuse / credential stuffing**                | Widget managed Cloudflare + verifikasi server-side sebelum argon2id verify; berlapis dengan rate limit source+tenant dan lockout per-identity.                                                                                                                               |
+| **Token replay (lintas request)**                  | Cloudflare menjadikan token single-use (verify kedua → `success:false` → ditolak). Verifier juga cek freshness `challenge_ts` (`TURNSTILE_MAX_TOKEN_AGE_SEC`). Turnstile berjalan sebelum lapisan idempotency dan tak menyentuh store-nya → tak bisa mem-bypass idempotency. |
+| **Token replay (lintas action)**                   | `action` divalidasi per-endpoint (`login` vs `setup`); token yang di-solve untuk login ditolak di setup. Mutation test membuktikannya (hapus cek action → test merah).                                                                                                       |
+| **Fail-open**                                      | Semua kegagalan (misconfig/outage/timeout/malformed/mismatch/stale) kolaps ke penolakan `TURNSTILE_INVALID`. Misconfig runtime (enabled tanpa secret/hostname) fail-closed, bukan skip.                                                                                      |
+| **Hostname confusion**                             | `hostname` respons divalidasi terhadap `TURNSTILE_EXPECTED_HOSTNAME` (wajib saat enabled). Token yang di-solve pada halaman attacker yang menyematkan site key kita ditolak. Mutation test membuktikannya.                                                                   |
+| **Provider outage → lockout massal lintas-tenant** | Circuit breaker hanya trip pada kegagalan **transport**; `success:false`/mismatch dihitung sukses provider, jadi token sampah tak bisa mengunci login semua tenant.                                                                                                          |
+| **Account enumeration oracle**                     | Enforcement berjalan sebelum lookup identity; semua kegagalan kode generik tunggal; token/secret tak pernah di respons/log/audit.                                                                                                                                            |
+| **Secret exposure**                                | Secret dari env saja; tak pernah di DB/source/log/audit/response/health output (readiness hanya cetak nama var). Redaction defense-in-depth pada pesan error verifier.                                                                                                       |
+| **SSRF via verify endpoint**                       | URL siteverify tetap (`config.verifyUrl` hanya dari konfigurasi, tak pernah input request).                                                                                                                                                                                  |
+| **DoS via respons besar**                          | Cap ukuran respons (`TURNSTILE_MAX_RESPONSE_BYTES`) + timeout satu-`AbortController` yang menutup fetch dan baca body (anti slow-drip).                                                                                                                                      |
+
+## 7. Testing
+
+- `tests/turnstile-verifier.test.ts` — verifier terhadap fake siteverify (`Bun.serve`): success, reject, timeout, malformed, non-2xx, oversize, breaker open, hostname/action/stale mismatch (mutation proofs), dan token/secret tak pernah bocor ke log/detail.
+- `tests/turnstile-enforcement.test.ts` — enforcement: LAN/disabled **nol outbound** (spy `globalThis.fetch`), full-online fail-closed (missing/misconfig/reject/mismatch → satu kode generik), plus matriks preflight LAN / full-online valid / full-online misconfigured (`validateEnv` + `checkTurnstileReady` + `checkOnlineAuthSecurityReady`).
+- `tests/security-headers-csp.test.ts` — origin CSP terbuka hanya saat enabled, sempit ke satu origin Cloudflare, dan enabled vs disabled berbeda **hanya** pada dua direktif.

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -356,6 +356,9 @@ paths:
                   type: string
                 password:
                   type: string
+                turnstileToken:
+                  type: string
+                  description: "Cloudflare Turnstile response token (Issue #186). Required only on a full-online deployment where Turnstile is enabled; absent and ignored on every LAN/offline deployment. Verified server-side before password verification."
       responses:
         "200":
           description: Session issued.
@@ -4539,6 +4542,9 @@ paths:
                   minLength: 8
                 ownerDisplayName:
                   type: string
+                turnstileToken:
+                  type: string
+                  description: "Cloudflare Turnstile response token (Issue #186). Required only on a full-online deployment where Turnstile is enabled; absent and ignored on every LAN/offline deployment. Verified server-side before the tenant/owner bootstrap."
       responses:
         "200":
           description: Tenant bootstrapped.

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -286,6 +286,13 @@ paths:
                   type: string
                 password:
                   type: string
+                turnstileToken:
+                  type: string
+                  description: >-
+                    Cloudflare Turnstile response token (Issue #186). Required
+                    only on a full-online deployment where Turnstile is enabled;
+                    absent and ignored on every LAN/offline deployment. Verified
+                    server-side before password verification.
       responses:
         "200":
           description: Session issued.

--- a/openapi/modules/tenant-admin.openapi.yaml
+++ b/openapi/modules/tenant-admin.openapi.yaml
@@ -427,6 +427,13 @@ paths:
                   minLength: 8
                 ownerDisplayName:
                   type: string
+                turnstileToken:
+                  type: string
+                  description: >-
+                    Cloudflare Turnstile response token (Issue #186). Required
+                    only on a full-online deployment where Turnstile is enabled;
+                    absent and ignored on every LAN/offline deployment. Verified
+                    server-side before the tenant/owner bootstrap.
       responses:
         "200":
           description: Tenant bootstrapped.

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -50,6 +50,15 @@ import { evaluateAccess } from "../src/modules/identity-access/domain/access-con
 import { evaluateLoginAttempt } from "../src/modules/identity-access/domain/login-policy";
 import { checkRateLimit } from "../src/lib/security/rate-limit";
 import { buildSecurityHeaders } from "../src/lib/security/security-headers";
+import {
+  isTurnstileEnabled,
+  TURNSTILE_REQUIRED_WHEN_ENABLED
+} from "../src/lib/security/turnstile";
+import {
+  isFullOnlineSecurityActive,
+  isOnlineSecurityEnabled,
+  resolveOnlineSecurityProfile
+} from "../src/lib/auth/online-security-config";
 import { validateEnv } from "./validate-env";
 
 export type CheckSeverity = "critical" | "warning" | "info";
@@ -1505,6 +1514,131 @@ export function checkSsoCredentialEncryptionKeyConfigured(
 }
 
 // ---------------------------------------------------------------------------
+// Full-online deployment-profile gate is correctly configured (Issue #186) —
+// critical when misconfigured, informational when disabled intentionally
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue #186 — the deployment-profile gate every full-online-only control
+ * (today: Turnstile) checks. This is what lets a production preflight tell
+ * "disabled intentionally" (the flag is unset — LAN/offline is fine, nothing
+ * required) apart from "misconfigured" (the flag is on but the profile is
+ * anything other than `full_online`). `critical` because a misconfigured gate
+ * silently changes whether an online-only control activates at all.
+ */
+export function checkOnlineAuthSecurityReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "Full-online deployment-profile gate is correctly configured";
+  const severity: CheckSeverity = "critical";
+
+  if (!isOnlineSecurityEnabled(env)) {
+    return {
+      name,
+      severity: "info",
+      status: "pass",
+      evidence:
+        'AUTH_ONLINE_SECURITY_ENABLED is not "true" — full-online auth hardening (Turnstile) is disabled intentionally; LAN/offline deployments are unaffected.'
+    };
+  }
+
+  const profile = resolveOnlineSecurityProfile(env);
+
+  if (profile !== "full_online") {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `AUTH_ONLINE_SECURITY_ENABLED=true but AUTH_ONLINE_SECURITY_PROFILE is "${
+        env.AUTH_ONLINE_SECURITY_PROFILE ?? "unset"
+      }", not "full_online" — this is a MISCONFIGURED gate, not "disabled intentionally".`
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence:
+      "AUTH_ONLINE_SECURITY_ENABLED=true and AUTH_ONLINE_SECURITY_PROFILE=full_online — the full-online gate is active."
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Cloudflare Turnstile configuration is complete when enabled (Issue #186) —
+// critical when misconfigured, informational when disabled intentionally
+// ---------------------------------------------------------------------------
+
+/**
+ * Issue #186 — when `TURNSTILE_ENABLED=true`, the public site key, the secret
+ * key, AND the expected hostname must all be present or Turnstile fails closed
+ * for every gated request (login/setup) on the full-online profile. `critical`
+ * because it silently defeats a bot-mitigation control the deployment declared
+ * it wanted. Deliberately independent of the outer profile gate (an operator
+ * may stage credentials before flipping the profile on).
+ *
+ * NEVER prints a secret value — only which required var NAME is missing, from
+ * the feature's own `TURNSTILE_REQUIRED_WHEN_ENABLED` list, so this check can
+ * never drift from `validate-env.ts` and never leaks the key.
+ */
+export function checkTurnstileReady(
+  env: NodeJS.ProcessEnv = process.env
+): SecurityCheckResult {
+  const name = "Turnstile configuration is complete when enabled";
+  const severity: CheckSeverity = "critical";
+
+  if (!isTurnstileEnabled(env)) {
+    return {
+      name,
+      severity: "info",
+      status: "pass",
+      evidence:
+        'TURNSTILE_ENABLED is not "true" — Cloudflare Turnstile is disabled intentionally; no widget, CSP origin, or outbound verification call is active.'
+    };
+  }
+
+  const missing = TURNSTILE_REQUIRED_WHEN_ENABLED.filter(
+    (varName) => (env[varName] ?? "").trim() === ""
+  );
+
+  if (missing.length > 0) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `TURNSTILE_ENABLED=true but missing/empty: ${missing.join(
+        ", "
+      )} — Turnstile would fail closed for every gated request (secret values are never printed).`
+    };
+  }
+
+  // Issue #186 (F3) — fully configured but INERT. `TURNSTILE_ENABLED=true` with
+  // every key present, yet the full-online deployment-profile gate is off, means
+  // `isTurnstileRequired()` is false: login/setup run with NO Turnstile at all.
+  // This is a LEGITIMATE staging state (keys provisioned ahead of the profile
+  // flip), so it is a `warning`, not blocking — but it must be surfaced loudly,
+  // because otherwise an operator who staged the keys and forgot to flip the
+  // profile sees every preflight check pass green while the control does nothing.
+  if (!isFullOnlineSecurityActive(env)) {
+    return {
+      name,
+      severity: "warning",
+      status: "fail",
+      evidence:
+        "TURNSTILE_ENABLED=true and all keys present, but Turnstile is INERT: the full-online profile gate is off (needs AUTH_ONLINE_SECURITY_ENABLED=true AND AUTH_ONLINE_SECURITY_PROFILE=full_online). Login/setup run WITHOUT Turnstile until the profile is flipped on — legitimate only if you are staging credentials ahead of go-live."
+    };
+  }
+
+  return {
+    name,
+    severity,
+    status: "pass",
+    evidence:
+      "TURNSTILE_ENABLED=true, all keys present, AND the full-online profile gate is active — Turnstile is enforced (secret values never printed)."
+  };
+}
+
+// ---------------------------------------------------------------------------
 // 12. Login rate limiting is implemented (warning)
 // ---------------------------------------------------------------------------
 
@@ -1649,6 +1783,8 @@ export async function runSecurityReadinessChecks(): Promise<
     checkSyncHmacSecretNotDefault(),
     checkMfaEncryptionKeyConfigured(),
     checkSsoCredentialEncryptionKeyConfigured(),
+    checkOnlineAuthSecurityReady(),
+    checkTurnstileReady(),
     checkLoginRateLimitImplemented(),
     checkSecurityHeadersBuilt()
   ];

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -66,6 +66,8 @@ const RULES: readonly Rule[] = [
     type: "int",
     min: 1
   },
+  { name: "SETUP_RATE_LIMIT_MAX", required: false, type: "int", min: 1 },
+  { name: "SETUP_RATE_LIMIT_WINDOW_SEC", required: false, type: "int", min: 1 },
   { name: "TRUSTED_PROXY_ENABLED", required: false, type: "bool" },
   {
     name: "AUTH_IP_HASH_SECRET",
@@ -134,6 +136,40 @@ const RULES: readonly Rule[] = [
     min: 1
   },
   { name: "AUTH_SSO_ALLOW_INSECURE_HOSTS", required: false, type: "string" },
+
+  // Full-online deployment-profile gate + Cloudflare Turnstile (Issue #186).
+  // All optional/off by default so every LAN/offline deployment passes with
+  // none of them set. `TURNSTILE_SITE_KEY` is public (embedded in the widget),
+  // so it is NOT marked `secret`; only `TURNSTILE_SECRET_KEY` is.
+  { name: "AUTH_ONLINE_SECURITY_ENABLED", required: false, type: "bool" },
+  {
+    name: "AUTH_ONLINE_SECURITY_PROFILE",
+    required: false,
+    type: "enum",
+    values: ["disabled", "full_online"]
+  },
+  { name: "TURNSTILE_ENABLED", required: false, type: "bool" },
+  { name: "TURNSTILE_SITE_KEY", required: false, type: "string" },
+  {
+    name: "TURNSTILE_SECRET_KEY",
+    required: false,
+    type: "string",
+    secret: true
+  },
+  { name: "TURNSTILE_EXPECTED_HOSTNAME", required: false, type: "string" },
+  {
+    name: "TURNSTILE_VERIFY_TIMEOUT_MS",
+    required: false,
+    type: "int",
+    min: 1
+  },
+  { name: "TURNSTILE_MAX_TOKEN_AGE_SEC", required: false, type: "int", min: 1 },
+  {
+    name: "TURNSTILE_MAX_RESPONSE_BYTES",
+    required: false,
+    type: "int",
+    min: 1
+  },
 
   { name: "AWCMS_SYNC_ENABLED", required: false, type: "bool" },
   {
@@ -325,6 +361,42 @@ export function validateEnv(env: EnvBag): string[] {
     problems.push(
       "AUTH_SSO_ALLOW_INSECURE_HOSTS harus kosong di produksi — hanya untuk fake IdP lokal saat test."
     );
+  }
+
+  // Full-online deployment-profile gate (Issue #186). This is what lets a
+  // production preflight distinguish "disabled intentionally" (flag unset —
+  // nothing required, LAN/offline is fine) from "misconfigured" (flag on but
+  // the profile is anything other than full_online, including the explicitly
+  // contradictory "disabled"). Enforced regardless of APP_ENV.
+  if (env.AUTH_ONLINE_SECURITY_ENABLED === "true") {
+    const profile = (env.AUTH_ONLINE_SECURITY_PROFILE ?? "").trim();
+
+    if (profile !== "full_online") {
+      problems.push(
+        `AUTH_ONLINE_SECURITY_ENABLED=true membutuhkan AUTH_ONLINE_SECURITY_PROFILE=full_online; dapat ${
+          profile ? `"${profile}"` : "kosong"
+        }.`
+      );
+    }
+  }
+
+  // Cloudflare Turnstile (Issue #186): when enabled, the public site key, the
+  // secret key, AND the expected hostname must all be present — the hostname is
+  // required so the runtime hostname-confusion check fails closed rather than
+  // being silently skipped. Independent of the deployment-profile gate above,
+  // so an operator can stage the credentials before flipping the profile on.
+  if (env.TURNSTILE_ENABLED === "true") {
+    for (const name of [
+      "TURNSTILE_SITE_KEY",
+      "TURNSTILE_SECRET_KEY",
+      "TURNSTILE_EXPECTED_HOSTNAME"
+    ] as const) {
+      if ((env[name] ?? "").trim() === "") {
+        problems.push(
+          `${name} wajib diisi saat TURNSTILE_ENABLED=true (Turnstile fail-closed).`
+        );
+      }
+    }
   }
 
   // Tidak ada default yang aman untuk dua-duanya, jadi produksi wajib memilih

--- a/src/lib/auth/online-security-config.ts
+++ b/src/lib/auth/online-security-config.ts
@@ -1,0 +1,81 @@
+/**
+ * Deployment-profile gate for full-online-only auth hardening (Issue #186,
+ * epic ERP-readiness enterprise auth #177). Ported/adapted from awcms-mini
+ * `src/lib/auth/online-security-config.ts` (Issue #587).
+ *
+ * WHY THIS EXISTS IN awcms (unlike MFA #184 / OIDC #185, which dropped it)
+ * ----------------------------------------------------------------------
+ * MFA and OIDC in this base gate purely on their own feature flag
+ * (`AUTH_MFA_ENABLED` / `AUTH_SSO_ENABLED`) — they carry no deployment-profile
+ * concept, because those controls are equally desirable on a LAN/offline
+ * deployment. Cloudflare Turnstile is the exact opposite: it is a bot-mitigation
+ * control that reaches out to Cloudflare, so it MUST be fully inert on any
+ * LAN/offline install (no widget, no CSP origin, no outbound call) and active
+ * ONLY on a deployment that has deliberately declared itself full-online. That
+ * "which deployment profile am I?" decision is what this module models, and it
+ * is exactly what Issue #186 asks for ("deployment profile applicability",
+ * "fully OFF on LAN/offline").
+ *
+ * Pure — no `process.env` reads baked in; `scripts/validate-env.ts` and
+ * `scripts/security-readiness.ts` both pass in whatever `env` they were given,
+ * the same split `mfa-config.ts` / `sso-config.ts` already use for their own
+ * conditional config. Local/offline/LAN deployments (the default — this pair of
+ * env vars is entirely unset) always get `false` from `isFullOnlineSecurityActive`
+ * and never depend on this gate for anything.
+ *
+ * Deliberately an auth-specific gate, NOT a reuse of `APP_ENV=production`: an
+ * offline/LAN deployment can be production-grade operationally without ever
+ * wanting an online-only bot challenge (see doc 18 deployment profiles).
+ */
+
+export const KNOWN_ONLINE_SECURITY_PROFILES = [
+  "disabled",
+  "full_online"
+] as const;
+
+export type OnlineSecurityProfile =
+  (typeof KNOWN_ONLINE_SECURITY_PROFILES)[number];
+
+export function isKnownOnlineSecurityProfile(
+  value: string | undefined
+): value is OnlineSecurityProfile {
+  return (KNOWN_ONLINE_SECURITY_PROFILES as readonly string[]).includes(
+    value ?? ""
+  );
+}
+
+export function isOnlineSecurityEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return env.AUTH_ONLINE_SECURITY_ENABLED === "true";
+}
+
+/** Falls back to `"disabled"` for an unset or unrecognized value — never throws. */
+export function resolveOnlineSecurityProfile(
+  env: NodeJS.ProcessEnv = process.env
+): OnlineSecurityProfile {
+  const raw = env.AUTH_ONLINE_SECURITY_PROFILE;
+
+  return isKnownOnlineSecurityProfile(raw) ? raw : "disabled";
+}
+
+/**
+ * The single boolean every full-online-only feature (today: Turnstile #186)
+ * gates on. True only when BOTH the enable flag is `"true"` AND the profile is
+ * exactly `"full_online"` — mirroring `validateEnv`'s own cross-rule that
+ * `AUTH_ONLINE_SECURITY_ENABLED=true` requires
+ * `AUTH_ONLINE_SECURITY_PROFILE=full_online`, so any deployment that has passed
+ * `bun run config:validate` will always have this agree with
+ * `isOnlineSecurityEnabled` alone. Checking BOTH here (rather than trusting
+ * that validation already ran — `bun run dev`/`start` never runs it) keeps this
+ * gate fail-closed even if a deployment somehow skipped that step: a truthy
+ * flag with a missing/`"disabled"` profile stays OFF, never accidentally on.
+ */
+export function isFullOnlineSecurityActive(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return (
+    isOnlineSecurityEnabled(env) &&
+    resolveOnlineSecurityProfile(env) === "full_online"
+  );
+}

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -20,6 +20,18 @@ type Bucket = { count: number; windowStart: number };
 
 const buckets = new Map<string, Bucket>();
 
+/**
+ * Clear all in-process rate-limit buckets. Test-only: the integration harness
+ * calls this per test (alongside the DB circuit-breaker reset) so that a suite
+ * which drives a rate-limited endpoint many times from the same client IP —
+ * e.g. the harness bootstrapping a fresh tenant via `POST /setup/initialize`
+ * for every test — does not carry a tripped counter across tests and start
+ * returning 429. Never call this from production code.
+ */
+export function resetRateLimitForTests(): void {
+  buckets.clear();
+}
+
 export function checkRateLimit(
   key: string,
   config: RateLimitConfig,

--- a/src/lib/security/security-headers.ts
+++ b/src/lib/security/security-headers.ts
@@ -35,35 +35,66 @@
  * hash list to keep in sync. A future page that genuinely needs inline
  * script/style must revisit the single-owner decision (see astro.config.mjs).
  *
- * Directives mirror mini's set, minus `frame-src` and the Turnstile/YouTube
- * origins it allowlists — this base has no widget, no embed, and no iframe
- * of any kind, so `frame-src` correctly falls through to `default-src`.
- *
  * `base-uri 'none'` + `form-action 'self'` are the two that carry real
  * weight for an API-only deployment even though session cookies are already
  * `httpOnly` (Issue #148's own reasoning): `httpOnly` stops XSS from
  * READING a token, but not from RIDING the session via a same-origin
  * `fetch()`, and without `base-uri` an injected `<base href>` can redirect
  * a relative form POST to an attacker origin.
+ *
+ * CLOUDFLARE TURNSTILE (Issue #186) — `frame-src` and the single
+ * `challenges.cloudflare.com` origin are added to `script-src`/`frame-src`
+ * ONLY when `turnstileEnabled` is true (the caller passes
+ * `isTurnstileRequired()`; `src/middleware.ts`). On every LAN/offline
+ * deployment (the default, `turnstileEnabled` false/omitted) the policy is
+ * byte-identical to before this issue: no extra origin, no `frame-src`,
+ * `script-src` still falls through to `default-src 'self'`. This is what keeps
+ * the "fully off on LAN — no CSP origin" guarantee. When enabled, the widget
+ * loader (`api.js`) needs `script-src` and its challenge iframe needs
+ * `frame-src`, both narrowed to that one origin; `'self'` is re-stated in
+ * `script-src` so the Astro-bundled login client (served from this origin)
+ * keeps working once `script-src` is present.
  */
-const CONTENT_SECURITY_POLICY = [
+import { TURNSTILE_ORIGIN } from "./turnstile";
+
+const BASE_CSP_DIRECTIVES = [
   "default-src 'self'",
   "object-src 'none'",
   "base-uri 'none'",
   "form-action 'self'",
   "frame-ancestors 'none'"
-].join("; ");
+] as const;
+
+function buildContentSecurityPolicy(turnstileEnabled: boolean): string {
+  const directives: string[] = [...BASE_CSP_DIRECTIVES];
+
+  if (turnstileEnabled) {
+    directives.push(`script-src 'self' ${TURNSTILE_ORIGIN}`);
+    directives.push(`frame-src ${TURNSTILE_ORIGIN}`);
+  }
+
+  return directives.join("; ");
+}
 
 export type SecurityHeaderOptions = {
   /** Gates `Strict-Transport-Security` — only meaningful once TLS is real. */
   isProduction: boolean;
+  /**
+   * Opens the Cloudflare Turnstile origin in `script-src`/`frame-src` (Issue
+   * #186). Defaults to `false` — omit it and the policy is exactly the
+   * pre-#186 LAN/offline policy. Callers pass `isTurnstileRequired()`.
+   */
+  turnstileEnabled?: boolean;
 };
 
 export function buildSecurityHeaders(
   options: SecurityHeaderOptions
 ): Array<[string, string]> {
   const headers: Array<[string, string]> = [
-    ["Content-Security-Policy", CONTENT_SECURITY_POLICY],
+    [
+      "Content-Security-Policy",
+      buildContentSecurityPolicy(options.turnstileEnabled === true)
+    ],
     ["X-Content-Type-Options", "nosniff"],
     // Kept alongside `frame-ancestors 'none'` as a second, independent
     // layer (older-browser compatibility) — same rationale mini documents.

--- a/src/lib/security/turnstile.ts
+++ b/src/lib/security/turnstile.ts
@@ -1,0 +1,582 @@
+/**
+ * Cloudflare Turnstile bot-protection adapter (Issue #186, epic ERP-readiness
+ * enterprise auth #177). Ported and HARDENED from awcms-mini
+ * `src/lib/security/turnstile.ts` (Issue #588).
+ *
+ * Active ONLY when the full-online deployment-profile gate
+ * (`../auth/online-security-config`'s `isFullOnlineSecurityActive`) is on AND
+ * `TURNSTILE_ENABLED=true` — `isTurnstileRequired` below is the ONE function
+ * every gated surface (the login route, the setup route, the login-page widget,
+ * and the CSP builder) checks. Local/offline/LAN deployments (the default, both
+ * env vars unset) NEVER call Cloudflare, NEVER require these env vars, NEVER add
+ * a CSP origin, and NEVER change behavior.
+ *
+ * Verifies a client-submitted Turnstile response token against Cloudflare's
+ * siteverify endpoint SERVER-SIDE (the client widget alone is not security).
+ *
+ * HARDENING vs mini (this base validates strictly, per Issue #186):
+ *  - mini checked only `success`; this also validates `action`, `hostname`, and
+ *    challenge-timestamp freshness — closing the token-replay-across-action and
+ *    hostname-confusion threats named in the issue's threat model.
+ *  - mini used `withTimeout(fetch())` then read the body OUTSIDE the timer (a
+ *    slow-drip body could beat the deadline); this base spans a single
+ *    `AbortController` across the fetch AND the bounded body read, and caps the
+ *    response size — the exact F3 gap the OIDC SSRF port already fixed.
+ *
+ * The token is NEVER logged or audited; the secret is redacted out of any error
+ * text before it can be returned or logged. This file has ZERO database access
+ * and never participates in a transaction — callers run it BEFORE entering
+ * `withTenant`, ahead of password verification (issue: "di luar transaksi
+ * database", "sebelum password verification mahal").
+ */
+import { getProviderCircuitBreaker } from "../database/circuit-breaker";
+import { log } from "../logging/logger";
+import { isFullOnlineSecurityActive } from "../auth/online-security-config";
+
+const PROVIDER_KEY = "turnstile";
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 16 * 1024;
+const DEFAULT_MAX_TOKEN_AGE_SEC = 300;
+const MAX_ERROR_MESSAGE_LENGTH = 300;
+const MAX_CLOCK_SKEW_SEC = 60;
+const DEFAULT_SITEVERIFY_URL =
+  "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+/**
+ * The single Cloudflare origin the widget script (`api.js`) and its challenge
+ * iframe load from. Consumed by `src/lib/security/security-headers.ts` to open
+ * `script-src`/`frame-src` NARROWLY and ONLY when Turnstile is required — never
+ * hardcoded a second time there.
+ */
+export const TURNSTILE_ORIGIN = "https://challenges.cloudflare.com";
+
+/**
+ * The per-endpoint Turnstile `action` labels. A token is bound to the action
+ * the widget was solved for, and `verifyTurnstileToken` rejects a token whose
+ * echoed `action` does not match — so a token minted for the login form can
+ * never be replayed against the setup bootstrap, and vice versa (issue: "satu
+ * token tidak boleh dikaitkan lintas action"). Shared by the widget markup,
+ * the route enforcement, and the tests, so the three can never drift.
+ */
+export const LOGIN_TURNSTILE_ACTION = "login";
+export const SETUP_TURNSTILE_ACTION = "setup";
+
+/**
+ * Env vars required only when `TURNSTILE_ENABLED=true` (validated by
+ * `scripts/validate-env.ts` and `scripts/security-readiness.ts`).
+ * `TURNSTILE_SITE_KEY` is NOT a secret (Cloudflare's own docs: it is embedded
+ * in the public HTML widget) but the feature cannot work without it, so it is
+ * still required-when-enabled. `TURNSTILE_EXPECTED_HOSTNAME` is required so the
+ * hostname check can fail closed at runtime rather than being silently skipped
+ * (hostname-confusion defense). Only `TURNSTILE_SECRET_KEY` carries the
+ * redaction discipline `verifyTurnstileToken` applies.
+ */
+export const TURNSTILE_REQUIRED_WHEN_ENABLED = [
+  "TURNSTILE_SITE_KEY",
+  "TURNSTILE_SECRET_KEY",
+  "TURNSTILE_EXPECTED_HOSTNAME"
+] as const;
+
+export type TurnstileConfig = {
+  secretKey: string;
+  /** Override for tests only — a local fake HTTP server standing in for Cloudflare's siteverify endpoint. Always from configuration, never request input (SSRF-safe). */
+  verifyUrl?: string;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+};
+
+export type TurnstileExpectations = {
+  /** The action this token must have been solved for (per endpoint). Always required — a token with a missing/other action is rejected. */
+  action: string;
+  /** The hostname the challenge must have been solved on. When set, a mismatch is rejected. */
+  hostname?: string;
+  /** Reject a token whose `challenge_ts` is older than this many seconds (freshness). Undefined disables the check. */
+  maxTokenAgeSec?: number;
+  /** Injectable clock for deterministic freshness/breaker tests. */
+  now?: Date;
+};
+
+export type TurnstileVerifyReason =
+  | "provider_unavailable"
+  | "provider_error"
+  | "rejected"
+  | "hostname_mismatch"
+  | "action_mismatch"
+  | "stale";
+
+export type TurnstileVerifyResult =
+  | { ok: true }
+  | {
+      ok: false;
+      reason: TurnstileVerifyReason;
+      detail: string;
+      retryable: boolean;
+    };
+
+type SiteverifyResponse = {
+  success?: boolean;
+  "error-codes"?: string[];
+  challenge_ts?: string;
+  hostname?: string;
+  action?: string;
+  cdata?: string;
+};
+
+function truncate(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_LENGTH
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`
+    : message;
+}
+
+/**
+ * Strips the configured secret out of `message` before it is ever returned to
+ * a caller or logged — defense in depth against a thrown error accidentally
+ * echoing part of the request body.
+ */
+function redact(message: string, secrets: readonly string[]): string {
+  let sanitized = message;
+
+  for (const secret of secrets) {
+    if (secret) {
+      sanitized = sanitized.split(secret).join("[redacted]");
+    }
+  }
+
+  return sanitized;
+}
+
+function redactTruncate(message: string, secrets: readonly string[]): string {
+  return truncate(redact(message, secrets));
+}
+
+/**
+ * Reads at most `maxBytes` of the response body, aborting (via the caller's
+ * shared `AbortController`, threaded through `response.body`) once the cap is
+ * exceeded. Returns `null` on overflow so the caller treats an oversized body
+ * as a provider error rather than parsing an unbounded string.
+ */
+async function readCappedText(
+  response: Response,
+  maxBytes: number
+): Promise<string | null> {
+  const body = response.body;
+
+  if (!body) {
+    const text = await response.text();
+    return text.length > maxBytes ? null : text;
+  }
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+
+    if (done) {
+      break;
+    }
+
+    if (value) {
+      total += value.byteLength;
+
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        return null;
+      }
+
+      chunks.push(value);
+    }
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
+/**
+ * True when `challengeTs` (an ISO-8601 timestamp Cloudflare returns for when
+ * the challenge was solved) is within `maxAgeSec` of `now` and not implausibly
+ * in the future. A missing or unparseable timestamp fails closed (returns
+ * false) — the freshness guarantee cannot be verified, so the token is treated
+ * as stale rather than trusted.
+ */
+function isFreshChallenge(
+  challengeTs: string | undefined,
+  now: Date,
+  maxAgeSec: number
+): boolean {
+  if (!challengeTs) {
+    return false;
+  }
+
+  const parsed = Date.parse(challengeTs);
+
+  if (Number.isNaN(parsed)) {
+    return false;
+  }
+
+  const ageSec = (now.getTime() - parsed) / 1000;
+
+  if (ageSec > maxAgeSec) {
+    return false;
+  }
+
+  // A timestamp more than a minute in the future is a clock problem or a forged
+  // value — reject rather than accept an "age" that is negative by design.
+  return ageSec >= -MAX_CLOCK_SKEW_SEC;
+}
+
+/**
+ * Verifies `token` (the client-submitted Turnstile response, e.g. from the
+ * widget's auto-injected `cf-turnstile-response` form field) against
+ * Cloudflare's siteverify endpoint. `remoteIp`, if provided, is forwarded per
+ * Cloudflare's own API (optional, improves their fraud scoring — never
+ * required). Never throws: every failure mode is a structured
+ * `{ ok: false, reason, ... }` the enforcement layer collapses to one generic
+ * client-facing error.
+ */
+export async function verifyTurnstileToken(
+  token: string,
+  config: TurnstileConfig,
+  expectations: TurnstileExpectations,
+  remoteIp?: string
+): Promise<TurnstileVerifyResult> {
+  const verifyUrl = config.verifyUrl ?? DEFAULT_SITEVERIFY_URL;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxBytes = config.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+  const now = expectations.now ?? new Date();
+  const breaker = getProviderCircuitBreaker(PROVIDER_KEY);
+  // Redaction set: the configured secret AND the client-submitted token
+  // (Issue #186 F4, defense-in-depth). The token is never intentionally placed
+  // in any returned error or log line, but if some future thrown error ever
+  // echoed part of the request, both must be scrubbed to `[redacted]` before it
+  // can surface. `redact` no-ops on empty strings, so a zero-length value is
+  // harmless.
+  const secrets = [config.secretKey, token];
+
+  if (!breaker.canAttempt(now)) {
+    // While the shared breaker is open, `enforceTurnstileIfRequired` fails
+    // closed and blocks every gated request for every tenant. Logged at
+    // `warning` so a sustained open breaker (a real Cloudflare outage) is
+    // distinguishable from normal traffic. The token is never in this line.
+    log("warning", "turnstile.circuit_breaker_open");
+
+    return {
+      ok: false,
+      reason: "provider_unavailable",
+      detail: "Turnstile circuit breaker is open; skipping attempt.",
+      retryable: true
+    };
+  }
+
+  const formData = new URLSearchParams();
+  formData.set("secret", config.secretKey);
+  formData.set("response", token);
+
+  if (remoteIp) {
+    formData.set("remoteip", remoteIp);
+  }
+
+  // ONE controller + timer spans the fetch AND the bounded body read: a slow
+  // body streamed under the size cap cannot beat the deadline (the F3 lesson).
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(verifyUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: formData.toString(),
+      signal: controller.signal
+    });
+
+    const rawBody = await readCappedText(response, maxBytes);
+    let body: SiteverifyResponse | undefined;
+
+    if (rawBody != null) {
+      try {
+        body = JSON.parse(rawBody) as SiteverifyResponse;
+      } catch {
+        body = undefined;
+      }
+    }
+
+    // Only a transport-level problem with Cloudflare itself (non-2xx status, or
+    // a 2xx we could not parse / that overflowed the size cap) counts as a
+    // PROVIDER failure for the shared circuit breaker. A well-formed 2xx with
+    // `success: false` is Cloudflare correctly telling us the token was bad —
+    // the normal, attacker-repeatable outcome for a garbage/expired/reused
+    // token. Feeding THAT into `recordFailure` would let anyone trip this
+    // shared, cross-tenant breaker (and, since enforcement fails closed while
+    // it is open, lock out login/setup for every tenant) with a handful of junk
+    // tokens (mini PR #596 security review). The same reasoning applies to the
+    // hostname/action/freshness rejections below.
+    if (response.status < 200 || response.status >= 300 || !body) {
+      breaker.recordFailure(now);
+      log("warning", "turnstile.provider_call_failed", {
+        httpStatus: response.status
+      });
+
+      return {
+        ok: false,
+        reason: "provider_error",
+        detail: redactTruncate(
+          `Turnstile provider call failed (HTTP ${response.status}).`,
+          secrets
+        ),
+        retryable: response.status >= 500 || response.status === 0
+      };
+    }
+
+    if (body.success !== true) {
+      breaker.recordSuccess(now);
+
+      return {
+        ok: false,
+        reason: "rejected",
+        detail: redactTruncate(
+          `Turnstile token rejected (error codes: ${
+            (body["error-codes"] ?? []).join(", ") || "none"
+          }).`,
+          secrets
+        ),
+        retryable: false
+      };
+    }
+
+    // Cloudflare says the token is valid — now enforce OUR expectations. A
+    // token that is technically valid but solved for a different hostname or
+    // action, or too old, is a client/attacker problem (not a provider
+    // outage), so the breaker records a success. Each rejection logs only its
+    // structured reason — never the token, hostname, or action values.
+    if (expectations.hostname && body.hostname !== expectations.hostname) {
+      breaker.recordSuccess(now);
+      log("warning", "turnstile.verification_rejected", {
+        reason: "hostname_mismatch"
+      });
+
+      return {
+        ok: false,
+        reason: "hostname_mismatch",
+        detail: "Turnstile hostname did not match the expected hostname.",
+        retryable: false
+      };
+    }
+
+    if (body.action !== expectations.action) {
+      breaker.recordSuccess(now);
+      log("warning", "turnstile.verification_rejected", {
+        reason: "action_mismatch"
+      });
+
+      return {
+        ok: false,
+        reason: "action_mismatch",
+        detail: "Turnstile action did not match the expected action.",
+        retryable: false
+      };
+    }
+
+    if (
+      expectations.maxTokenAgeSec !== undefined &&
+      !isFreshChallenge(body.challenge_ts, now, expectations.maxTokenAgeSec)
+    ) {
+      breaker.recordSuccess(now);
+      log("warning", "turnstile.verification_rejected", { reason: "stale" });
+
+      return {
+        ok: false,
+        reason: "stale",
+        detail: "Turnstile challenge timestamp is missing or too old.",
+        retryable: false
+      };
+    }
+
+    breaker.recordSuccess(now);
+    return { ok: true };
+  } catch (error) {
+    breaker.recordFailure(now);
+    const message = error instanceof Error ? error.message : String(error);
+    log("warning", "turnstile.provider_call_errored", {
+      error: redactTruncate(message, secrets)
+    });
+
+    return {
+      ok: false,
+      reason: "provider_unavailable",
+      detail: redactTruncate(message, secrets),
+      retryable: true
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function isTurnstileEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return env.TURNSTILE_ENABLED === "true";
+}
+
+/**
+ * The single boolean every gated surface checks — true ONLY when BOTH the
+ * full-online deployment-profile gate is active AND this feature's own flag is
+ * set. On a LAN/offline profile (or with the flag off) it is false, and no
+ * widget renders, no CSP origin opens, and no outbound verification call is
+ * made. This is what makes "TURNSTILE_ENABLED=true but LAN profile" resolve to
+ * fully OFF, exactly as the issue requires.
+ */
+export function isTurnstileRequired(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return isFullOnlineSecurityActive(env) && isTurnstileEnabled(env);
+}
+
+function resolvePositiveIntEnv(
+  raw: string | undefined,
+  fallback: number
+): number {
+  const value = Number(raw);
+
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function resolveTurnstileTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  return resolvePositiveIntEnv(
+    env.TURNSTILE_VERIFY_TIMEOUT_MS,
+    DEFAULT_TIMEOUT_MS
+  );
+}
+
+export function resolveTurnstileMaxTokenAgeSec(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  return resolvePositiveIntEnv(
+    env.TURNSTILE_MAX_TOKEN_AGE_SEC,
+    DEFAULT_MAX_TOKEN_AGE_SEC
+  );
+}
+
+export function resolveTurnstileMaxResponseBytes(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  return resolvePositiveIntEnv(
+    env.TURNSTILE_MAX_RESPONSE_BYTES,
+    DEFAULT_MAX_RESPONSE_BYTES
+  );
+}
+
+/**
+ * The public site key for the widget, or `null` when unset. Read by
+ * `login.astro`'s frontmatter ONLY when `isTurnstileRequired()` is already
+ * true, so a disabled/LAN deployment never renders a `data-sitekey`.
+ */
+export function resolveTurnstileSiteKey(
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  const siteKey = env.TURNSTILE_SITE_KEY?.trim();
+
+  return siteKey ? siteKey : null;
+}
+
+/**
+ * Builds the fetch-bound `TurnstileConfig` from env. Returns `null` if the
+ * secret key is missing — callers MUST treat `null` as "cannot verify" and fail
+ * closed (reject), never as "skip verification", since `isTurnstileRequired`
+ * already said this deployment wants Turnstile enforced.
+ */
+export function resolveTurnstileConfig(
+  env: NodeJS.ProcessEnv = process.env
+): TurnstileConfig | null {
+  const secretKey = env.TURNSTILE_SECRET_KEY?.trim();
+
+  if (!secretKey) {
+    return null;
+  }
+
+  return {
+    secretKey,
+    timeoutMs: resolveTurnstileTimeoutMs(env),
+    maxResponseBytes: resolveTurnstileMaxResponseBytes(env)
+  };
+}
+
+export type TurnstileEnforcementResult =
+  | { ok: true }
+  | { ok: false; code: "TURNSTILE_REQUIRED" | "TURNSTILE_INVALID" };
+
+export type EnforceTurnstileOptions = {
+  /** The per-endpoint action the token must match (see `LOGIN_TURNSTILE_ACTION`/`SETUP_TURNSTILE_ACTION`). */
+  action: string;
+  env?: NodeJS.ProcessEnv;
+  now?: Date;
+};
+
+/**
+ * The one function every gated endpoint calls — consolidates the "skip if not
+ * required / reject if missing / reject if misconfigured / verify and reject if
+ * invalid" branching so it isn't duplicated per route. `turnstileToken` is
+ * deliberately typed `unknown`: it comes straight from an untrusted parsed JSON
+ * request body.
+ *
+ * Fail-closed contract (issue's non-negotiable): on the full-online profile
+ * that requires Turnstile, a missing token, a misconfigured deployment, a
+ * provider outage/timeout, a malformed response, or a hostname/action/freshness
+ * mismatch ALL deny. Every verification failure collapses to the single generic
+ * `TURNSTILE_INVALID` code so an unauthenticated caller can never distinguish
+ * "server misconfigured" from "token bad" from "hostname wrong" — no oracle.
+ */
+export async function enforceTurnstileIfRequired(
+  turnstileToken: unknown,
+  remoteIp: string | undefined,
+  options: EnforceTurnstileOptions
+): Promise<TurnstileEnforcementResult> {
+  const env = options.env ?? process.env;
+
+  if (!isTurnstileRequired(env)) {
+    return { ok: true };
+  }
+
+  if (typeof turnstileToken !== "string" || turnstileToken.length === 0) {
+    return { ok: false, code: "TURNSTILE_REQUIRED" };
+  }
+
+  const config = resolveTurnstileConfig(env);
+  const expectedHostname = env.TURNSTILE_EXPECTED_HOSTNAME?.trim();
+
+  // Misconfigured (enabled but no secret / no expected hostname): fail closed
+  // rather than silently skipping verification or skipping the hostname check.
+  // Reusing TURNSTILE_INVALID (not a distinct code) avoids telling an
+  // unauthenticated caller that the server is misconfigured.
+  if (!config || !expectedHostname) {
+    log("warning", "turnstile.misconfigured");
+    return { ok: false, code: "TURNSTILE_INVALID" };
+  }
+
+  const result = await verifyTurnstileToken(
+    turnstileToken,
+    config,
+    {
+      action: options.action,
+      hostname: expectedHostname,
+      maxTokenAgeSec: resolveTurnstileMaxTokenAgeSec(env),
+      now: options.now
+    },
+    remoteIp
+  );
+
+  if (!result.ok) {
+    return { ok: false, code: "TURNSTILE_INVALID" };
+  }
+
+  return { ok: true };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,7 @@ import { defineMiddleware } from "astro:middleware";
 
 import { resolveSsrContext } from "./lib/auth/ssr-session";
 import { buildSecurityHeaders } from "./lib/security/security-headers";
+import { isTurnstileRequired } from "./lib/security/turnstile";
 import {
   BODY_SIZE_HARD_CEILING_BYTES,
   bodyTooLargeResponse,
@@ -27,7 +28,11 @@ function applyResponseHeaders(
   response.headers.set(CORRELATION_ID_HEADER, correlationId);
 
   for (const [name, value] of buildSecurityHeaders({
-    isProduction: process.env.APP_ENV === "production"
+    isProduction: process.env.APP_ENV === "production",
+    // Issue #186 — opens the one Cloudflare Turnstile origin in the CSP ONLY on
+    // a full-online deployment that requires Turnstile; false (no extra origin)
+    // on every LAN/offline deployment.
+    turnstileEnabled: isTurnstileRequired()
   })) {
     response.headers.set(name, value);
   }

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -32,6 +32,10 @@ import {
   readJsonBody
 } from "../../../../lib/security/request-body-limit";
 import {
+  enforceTurnstileIfRequired,
+  LOGIN_TURNSTILE_ACTION
+} from "../../../../lib/security/turnstile";
+import {
   isMfaFeatureEnabled,
   resolveChallengeTtlSec
 } from "../../../../lib/auth/mfa-config";
@@ -50,7 +54,11 @@ import { isSsoEnabled } from "../../../../lib/auth/sso-config";
 import { isPasswordLoginDisabledForIdentity } from "../../../../modules/identity-access/application/tenant-auth-policy";
 import { log } from "../../../../lib/logging/logger";
 
-type LoginBody = { loginIdentifier?: unknown; password?: unknown };
+type LoginBody = {
+  loginIdentifier?: unknown;
+  password?: unknown;
+  turnstileToken?: unknown;
+};
 
 /**
  * Issue #145 — source attribution shared by the `login_succeeded` and
@@ -249,6 +257,32 @@ export const POST: APIRoute = async ({
       400,
       "VALIDATION_ERROR",
       "loginIdentifier and password are required."
+    );
+  }
+
+  // Issue #186 — Cloudflare Turnstile bot challenge. A no-op on every
+  // local/offline/LAN deployment (isTurnstileRequired() is false there, so no
+  // outbound call is made), and run here — AFTER the request-shape and
+  // rate-limit checks above, BEFORE the expensive argon2id/password work and
+  // any DB transaction below, and ahead of the SSO/MFA branches inside
+  // `withTenant` — exactly as the issue requires. Fails closed on the
+  // full-online profile: a missing/invalid/mismatched/timed-out token is denied
+  // with ONE generic response (no account-enumeration oracle: this runs before
+  // any identity lookup, so it cannot distinguish accounts). Rate limit and
+  // lockout above/below keep working independently of this.
+  const turnstileResult = await enforceTurnstileIfRequired(
+    body.turnstileToken,
+    clientIp,
+    { action: LOGIN_TURNSTILE_ACTION }
+  );
+
+  if (!turnstileResult.ok) {
+    return fail(
+      400,
+      turnstileResult.code,
+      turnstileResult.code === "TURNSTILE_REQUIRED"
+        ? "Turnstile verification token is required."
+        : "Turnstile verification failed."
     );
   }
 

--- a/src/pages/api/v1/setup/initialize.ts
+++ b/src/pages/api/v1/setup/initialize.ts
@@ -3,18 +3,67 @@ import type { APIRoute } from "astro";
 import { fail, ok } from "../../../../modules/_shared/api-response";
 import { getSetupDatabaseClient } from "../../../../lib/database/client";
 import {
+  checkRateLimit,
+  resolveClientIp
+} from "../../../../lib/security/rate-limit";
+import {
   bodyTooLargeResponse,
   readJsonBody
 } from "../../../../lib/security/request-body-limit";
+import {
+  enforceTurnstileIfRequired,
+  SETUP_TURNSTILE_ACTION
+} from "../../../../lib/security/turnstile";
 import { validateSetupInitializeInput } from "../../../../modules/tenant-admin/domain/setup-validation";
 import { bootstrapPlatformTenant } from "../../../../modules/tenant-admin/application/platform-bootstrap";
+
+/**
+ * Source-scoped volumetric rate limit for the public, unauthenticated setup
+ * endpoint (Issue #186, F5 — symmetric with `auth/login.ts`). There is no
+ * tenant yet (this endpoint CREATES the first one), so the bucket is keyed by
+ * source alone. A loose ceiling: setup is a once-only bootstrap, so a
+ * legitimate operator never approaches it, but it bounds how many outbound
+ * Cloudflare siteverify round-trips (and multi-row bootstrap attempts) an
+ * unauthenticated caller can drive on a full-online deployment.
+ */
+const SETUP_RATE_LIMIT_MAX = Number(process.env.SETUP_RATE_LIMIT_MAX ?? 10);
+const SETUP_RATE_LIMIT_WINDOW_SEC = Number(
+  process.env.SETUP_RATE_LIMIT_WINDOW_SEC ?? 60
+);
 
 /**
  * Uses `getSetupDatabaseClient()` — a dedicated setup role, not the
  * ordinary web-runtime connection every other route uses. The only route
  * that creates a tenant/office/owner from scratch.
  */
-export const POST: APIRoute = async ({ request }) => {
+export const POST: APIRoute = async ({ request, clientAddress }) => {
+  // Rate limit FIRST (cheapest rejection, before body read / Turnstile /
+  // bootstrap) — mirrors login.ts. Keyed by source so a caller can't drive
+  // unbounded siteverify round-trips or bootstrap attempts.
+  const clientIp = resolveClientIp(request, clientAddress);
+  const rateLimit = checkRateLimit(`setup:${clientIp}`, {
+    maxAttempts:
+      Number.isFinite(SETUP_RATE_LIMIT_MAX) && SETUP_RATE_LIMIT_MAX > 0
+        ? SETUP_RATE_LIMIT_MAX
+        : 10,
+    windowMs:
+      (Number.isFinite(SETUP_RATE_LIMIT_WINDOW_SEC) &&
+      SETUP_RATE_LIMIT_WINDOW_SEC > 0
+        ? SETUP_RATE_LIMIT_WINDOW_SEC
+        : 60) * 1000
+  });
+
+  if (!rateLimit.allowed) {
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many setup attempts from this source. Try again later.",
+      {},
+      undefined,
+      { "retry-after": String(rateLimit.retryAfterSec) }
+    );
+  }
+
   const bodyRead = await readJsonBody(request);
   if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
 
@@ -27,6 +76,30 @@ export const POST: APIRoute = async ({ request }) => {
       "Setup input is invalid.",
       {},
       validation.errors
+    );
+  }
+
+  // Issue #186 — Cloudflare Turnstile bot challenge, BEFORE the multi-row
+  // tenant/owner bootstrap below and outside its transaction. A no-op on every
+  // local/offline/LAN deployment. Setup is a once-only, singleton-locked
+  // endpoint, but still worth gating on a full-online profile: an attacker
+  // racing this public, unauthenticated, high-value bootstrap before a real
+  // operator completes it is exactly what Turnstile exists for. Bound to a
+  // distinct `setup` action so a token minted for the login form cannot be
+  // replayed here.
+  const turnstileResult = await enforceTurnstileIfRequired(
+    (bodyRead.value as Record<string, unknown> | null)?.turnstileToken,
+    clientIp,
+    { action: SETUP_TURNSTILE_ACTION }
+  );
+
+  if (!turnstileResult.ok) {
+    return fail(
+      400,
+      turnstileResult.code,
+      turnstileResult.code === "TURNSTILE_REQUIRED"
+        ? "Turnstile verification token is required."
+        : "Turnstile verification failed."
     );
   }
 

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -6,8 +6,8 @@
  * guard in `src/middleware.ts` then consumes.
  *
  * Simplified vs mini: NO i18n (strings hardcoded English — awcms has no
- * gettext catalog yet), NO Cloudflare Turnstile, NO Google OIDC button, and
- * NO `<script type="application/json">` strings blob. What is kept 1:1 is the
+ * gettext catalog yet), NO Google OIDC button, and NO
+ * `<script type="application/json">` strings blob. What is kept 1:1 is the
  * stable element ids the E2E specs and the client script rely on
  * (`#login-form`, `#tenant-id`, `#login-identifier`, `#password`,
  * `#login-submit`, `#login-error`).
@@ -16,12 +16,32 @@
  * exactly as in mini — a derived app resolves the tenant by domain instead of
  * asking the user to paste a UUID (out of scope here).
  *
+ * Cloudflare Turnstile (Issue #186) — the widget and its loader script render
+ * ONLY when `isTurnstileRequired()` (the full-online deployment-profile gate
+ * AND `TURNSTILE_ENABLED=true`) is true. Every local/offline/LAN deployment
+ * (the default) renders this page byte-identically to before this issue: no
+ * `cf-turnstile` div, no `challenges.cloudflare.com` script, no iframe. When
+ * required, the middleware CSP opens `script-src`/`frame-src` for that one
+ * Cloudflare origin (see `src/lib/security/security-headers.ts`), and the
+ * external loader is an explicit `is:inline` `<script src>` (NOT an
+ * Astro-bundled module — those only load from `'self'`). `TURNSTILE_SITE_KEY`
+ * is public (Cloudflare embeds it in every widget); `TURNSTILE_SECRET_KEY` is
+ * server-side only and never reaches this page.
+ *
  * CSP: `tokens.css`/`admin.css` are external <link>s (`inlineStylesheets:
- * "never"`) and the client below is an Astro-bundled module script — no inline
- * script/style, so the middleware `default-src 'self'` policy holds.
+ * "never"`) and the login client below is an Astro-bundled module script — no
+ * inline script/style, so the middleware `default-src 'self'` policy holds.
  */
 import "../styles/tokens.css";
 import "../styles/admin.css";
+import {
+  isTurnstileRequired,
+  resolveTurnstileSiteKey,
+  LOGIN_TURNSTILE_ACTION
+} from "../lib/security/turnstile";
+
+const turnstileActive = isTurnstileRequired();
+const turnstileSiteKey = turnstileActive ? resolveTurnstileSiteKey() : null;
 ---
 
 <!doctype html>
@@ -64,9 +84,30 @@ import "../styles/admin.css";
           autocomplete="current-password"
         />
 
+        {
+          turnstileActive && turnstileSiteKey && (
+            <div
+              class="cf-turnstile"
+              data-sitekey={turnstileSiteKey}
+              data-action={LOGIN_TURNSTILE_ACTION}
+            />
+          )
+        }
+
         <button type="submit" id="login-submit">Sign in</button>
       </form>
     </main>
+
+    {
+      turnstileActive && turnstileSiteKey && (
+        <script
+          is:inline
+          src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+          async
+          defer
+        />
+      )
+    }
 
     <script>
       // The import is deliberate — it forces Astro to bundle this script to an
@@ -104,6 +145,11 @@ import "../styles/admin.css";
           formData.get("loginIdentifier") ?? ""
         ).trim();
         const password = String(formData.get("password") ?? "");
+        // Cloudflare Turnstile (Issue #186) auto-injects a hidden
+        // `cf-turnstile-response` field into this form once solved — absent
+        // entirely when the widget is not rendered (Turnstile not required for
+        // this deployment), matching the server's own optional field.
+        const turnstileToken = formData.get("cf-turnstile-response");
 
         try {
           const response = await fetch("/api/v1/auth/login", {
@@ -113,7 +159,11 @@ import "../styles/admin.css";
               "X-AWCMS-Tenant-ID": tenantId
             },
             credentials: "same-origin",
-            body: JSON.stringify({ loginIdentifier, password })
+            body: JSON.stringify({
+              loginIdentifier,
+              password,
+              ...(turnstileToken ? { turnstileToken } : {})
+            })
           });
 
           const payload = await response.json().catch(() => null);

--- a/tests/integration/harness.ts
+++ b/tests/integration/harness.ts
@@ -113,6 +113,7 @@ import {
 } from "../../src/lib/database/client";
 import { resetDatabaseCircuitBreakerForTests } from "../../src/lib/database/circuit-breaker";
 import { resetWorkClassGatesForTests } from "../../src/lib/database/work-class";
+import { resetRateLimitForTests } from "../../src/lib/security/rate-limit";
 
 /**
  * Captured at module load. The privileged/admin connection string the CI
@@ -445,6 +446,7 @@ export async function teardownIntegrationDatabase(): Promise<void> {
 export async function resetDatabase(): Promise<void> {
   resetDatabaseCircuitBreakerForTests();
   resetWorkClassGatesForTests();
+  resetRateLimitForTests();
 
   await truncateAwcmsTables(getAdminSql());
 }
@@ -576,6 +578,7 @@ export async function teardownHandlerDatabase(): Promise<void> {
 export async function resetHandlerDatabase(): Promise<void> {
   resetDatabaseCircuitBreakerForTests();
   resetWorkClassGatesForTests();
+  resetRateLimitForTests();
 
   await truncateAwcmsTables(getHandlerAdminSql());
 }

--- a/tests/openapi-bundle.test.ts
+++ b/tests/openapi-bundle.test.ts
@@ -44,6 +44,34 @@ function sortDeep(value: unknown): unknown {
   return value;
 }
 
+/**
+ * True iff `subset` is fully contained in `superset`: every leaf value in the
+ * pre-migration contract is present and equal in the current one, with NEW keys
+ * allowed only in `superset`. Removing or changing a pre-existing field returns
+ * false. Arrays must match length + element-wise (adding an optional property
+ * to a schema touches `properties` — an object — not `required`/`parameters`
+ * arrays, so a genuinely additive change stays a subset here).
+ */
+function isAdditiveSuperset(subset: unknown, superset: unknown): boolean {
+  if (Array.isArray(subset)) {
+    return (
+      Array.isArray(superset) &&
+      subset.length === superset.length &&
+      subset.every((v, i) => isAdditiveSuperset(v, superset[i]))
+    );
+  }
+  if (subset && typeof subset === "object") {
+    if (!superset || typeof superset !== "object" || Array.isArray(superset)) {
+      return false;
+    }
+    const sup = superset as AnyRecord;
+    return Object.entries(subset as AnyRecord).every(
+      ([k, v]) => k in sup && isAdditiveSuperset(v, sup[k])
+    );
+  }
+  return subset === superset;
+}
+
 async function loadFragment(fileName: string): Promise<AnyRecord> {
   const raw = await readFile(
     path.join(ROOT, "openapi/modules", fileName),
@@ -149,8 +177,11 @@ describe("openapi bundle — contract equivalence to pre-migration monolith", ()
     // existed before the split — NOT to mirror the current bundle. So this is a
     // SUBSET assertion: each pre-migration path/schema must still be present and
     // byte-identical; new endpoints (e.g. MFA #184) may be added on top. Never
-    // edit the frozen snapshot to add new endpoints — that would make this test
-    // compare the bundle against a copy of itself and silently defeat it.
+    // edit the frozen snapshot — that would make this test compare the bundle
+    // against a copy of itself and silently defeat it. A backward-compatible
+    // change to an EXISTING pre-migration endpoint (e.g. Turnstile #186 adding
+    // an optional field) is acknowledged in INTENTIONALLY_EVOLVED_PATHS below,
+    // NOT by mutating the snapshot.
     const [snapshotRaw, bundleRaw] = await Promise.all([
       readFile(
         path.join(
@@ -174,14 +205,38 @@ describe("openapi bundle — contract equivalence to pre-migration monolith", ()
       );
     }
 
-    // Per-operation contract: every pre-migration path is byte-identical now.
+    // Documented, reviewed BACKWARD-COMPATIBLE evolutions of a pre-migration
+    // endpoint (like the tags test's single allowed `Domain Event Runtime`
+    // addition). A path listed here is NOT required to stay byte-identical, but
+    // its pre-migration contract must remain a strict subset of the current one
+    // (every pre-existing field preserved; only additive changes allowed) — a
+    // removal or a type change still fails. The FROZEN snapshot is never edited;
+    // intentional divergences are acknowledged HERE instead. Each entry needs a
+    // reason so an accidental drift can't hide behind the allow-list.
+    const INTENTIONALLY_EVOLVED_PATHS: Record<string, string> = {
+      // Turnstile #186 adds an OPTIONAL `turnstileToken` to the request body.
+      "/api/v1/auth/login":
+        "#186 optional turnstileToken (backward-compatible)",
+      "/api/v1/setup/initialize":
+        "#186 optional turnstileToken (backward-compatible)"
+    };
+
+    // Per-operation contract: every pre-migration path is byte-identical now,
+    // except the explicitly-acknowledged additive evolutions above.
     const beforePaths = before.paths as AnyRecord;
     const afterPaths = after.paths as AnyRecord;
     for (const pathKey of Object.keys(beforePaths)) {
       expect(afterPaths[pathKey]).toBeDefined();
-      expect(sortDeep(afterPaths[pathKey])).toEqual(
-        sortDeep(beforePaths[pathKey])
-      );
+      if (pathKey in INTENTIONALLY_EVOLVED_PATHS) {
+        // Additive-only: the frozen contract must still be fully contained.
+        expect(
+          isAdditiveSuperset(beforePaths[pathKey], afterPaths[pathKey])
+        ).toBe(true);
+      } else {
+        expect(sortDeep(afterPaths[pathKey])).toEqual(
+          sortDeep(beforePaths[pathKey])
+        );
+      }
     }
 
     // Every pre-migration schema is byte-identical now (new schemas allowed).

--- a/tests/security-headers-csp.test.ts
+++ b/tests/security-headers-csp.test.ts
@@ -16,8 +16,8 @@ import { describe, expect, test } from "bun:test";
 
 import { buildSecurityHeaders } from "../src/lib/security/security-headers";
 
-function cspFor(isProduction: boolean): string {
-  const header = buildSecurityHeaders({ isProduction }).find(
+function cspFor(isProduction: boolean, turnstileEnabled = false): string {
+  const header = buildSecurityHeaders({ isProduction, turnstileEnabled }).find(
     ([name]) => name === "Content-Security-Policy"
   );
 
@@ -28,8 +28,8 @@ function cspFor(isProduction: boolean): string {
   return header[1];
 }
 
-function directives(isProduction = false): string[] {
-  return cspFor(isProduction)
+function directives(isProduction = false, turnstileEnabled = false): string[] {
+  return cspFor(isProduction, turnstileEnabled)
     .split(";")
     .map((directive) => directive.trim());
 }
@@ -62,12 +62,15 @@ describe("buildSecurityHeaders — Content-Security-Policy (Issue #148)", () => 
     expect(policy).not.toContain("unsafe-eval");
   });
 
-  test("drops mini's Turnstile/YouTube origins — no third-party origin is allowlisted anywhere", () => {
-    const policy = cspFor(true);
+  test("with Turnstile disabled (the default / every LAN-offline deployment) no third-party origin is allowlisted", () => {
+    const policy = cspFor(true, false);
 
     expect(policy).not.toContain("challenges.cloudflare.com");
     expect(policy).not.toContain("youtube-nocookie.com");
     expect(policy).not.toMatch(/https?:\/\//);
+    // No script-src / frame-src at all — both fall through to default-src 'self'.
+    expect(policy).not.toContain("script-src");
+    expect(policy).not.toContain("frame-src");
   });
 
   test("keeps X-Frame-Options: DENY alongside frame-ancestors 'none' as an independent older-browser layer", () => {
@@ -95,5 +98,47 @@ describe("buildSecurityHeaders — Content-Security-Policy (Issue #148)", () => 
 
     expect(names).not.toContain("Strict-Transport-Security");
     expect(names).toContain("Content-Security-Policy");
+  });
+});
+
+describe("buildSecurityHeaders — Turnstile CSP origin (Issue #186)", () => {
+  const CF = "https://challenges.cloudflare.com";
+
+  test("opens EXACTLY the one Cloudflare origin in script-src and frame-src when enabled", () => {
+    const list = directives(true, true);
+
+    expect(list).toContain(`script-src 'self' ${CF}`);
+    expect(list).toContain(`frame-src ${CF}`);
+    // The Turnstile origin is the ONLY third-party origin — narrow, as required.
+    const policy = cspFor(true, true);
+    const origins = policy.match(/https?:\/\/[^\s;]+/g) ?? [];
+    expect(new Set(origins)).toEqual(new Set([CF]));
+  });
+
+  test("re-states 'self' in script-src so the bundled login client still loads once script-src is present", () => {
+    expect(cspFor(true, true)).toContain(`script-src 'self' ${CF}`);
+  });
+
+  test("keeps every base directive unchanged when enabled (origin is purely additive)", () => {
+    const list = directives(false, true);
+
+    for (const base of [
+      "default-src 'self'",
+      "object-src 'none'",
+      "base-uri 'none'",
+      "form-action 'self'",
+      "frame-ancestors 'none'"
+    ]) {
+      expect(list).toContain(base);
+    }
+  });
+
+  test("enabled vs disabled differ ONLY by the two Turnstile directives — proof the origin never leaks into the LAN/offline policy", () => {
+    const disabled = directives(true, false);
+    const enabled = directives(true, true);
+    const added = enabled.filter((d) => !disabled.includes(d));
+
+    expect(added).toEqual([`script-src 'self' ${CF}`, `frame-src ${CF}`]);
+    expect(disabled.every((d) => enabled.includes(d))).toBe(true);
   });
 });

--- a/tests/turnstile-enforcement.test.ts
+++ b/tests/turnstile-enforcement.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Turnstile enforcement + config/preflight matrix (Issue #186).
+ *
+ * `enforceTurnstileIfRequired` is the one function the login and setup routes
+ * call. These tests prove:
+ *  - DISABLED/LAN profile → ok with ZERO outbound call (a `globalThis.fetch`
+ *    spy asserts the count is 0), and this holds even when TURNSTILE_ENABLED is
+ *    "true" but the deployment profile is not full_online (fully OFF on LAN);
+ *  - the full-online profile fails closed on missing token / misconfiguration /
+ *    Cloudflare rejection / hostname+action mismatch, always with ONE generic
+ *    code (no oracle);
+ *  - config:validate + security:readiness agree across the LAN / full-online
+ *    valid / full-online misconfigured matrix, and never print the secret.
+ *
+ * Secret/token are generated at RUNTIME (no static literal for GitGuardian).
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  enforceTurnstileIfRequired,
+  LOGIN_TURNSTILE_ACTION,
+  isTurnstileRequired
+} from "../src/lib/security/turnstile";
+import { resetProviderCircuitBreakersForTests } from "../src/lib/database/circuit-breaker";
+import { setLogSink } from "../src/lib/logging/logger";
+import { validateEnv } from "../scripts/validate-env";
+import {
+  checkOnlineAuthSecurityReady,
+  checkTurnstileReady
+} from "../scripts/security-readiness";
+
+function randomOpaque(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}${crypto.randomUUID()}`.replace(
+    /-/g,
+    ""
+  );
+}
+
+const SECRET = randomOpaque("sk");
+const TOKEN = randomOpaque("tok");
+const HOSTNAME = "app.example.test";
+
+const realFetch = globalThis.fetch;
+let fetchCalls = 0;
+let siteverify: () => Response = () =>
+  Response.json({ success: true, hostname: HOSTNAME, action: "login" });
+
+function installFetchSpy(): void {
+  fetchCalls = 0;
+  globalThis.fetch = (async () => {
+    fetchCalls += 1;
+    return siteverify();
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  resetProviderCircuitBreakersForTests();
+  setLogSink(() => undefined); // swallow logs; assertions below don't need them
+  installFetchSpy();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  setLogSink(null);
+});
+
+const fullOnlineEnv = (
+  over: Record<string, string> = {}
+): NodeJS.ProcessEnv => ({
+  AUTH_ONLINE_SECURITY_ENABLED: "true",
+  AUTH_ONLINE_SECURITY_PROFILE: "full_online",
+  TURNSTILE_ENABLED: "true",
+  TURNSTILE_SITE_KEY: "public-site-key",
+  TURNSTILE_SECRET_KEY: SECRET,
+  TURNSTILE_EXPECTED_HOSTNAME: HOSTNAME,
+  ...over
+});
+
+const login = { action: LOGIN_TURNSTILE_ACTION };
+
+describe("enforceTurnstileIfRequired — disabled / LAN makes NO outbound call", () => {
+  test("empty env (LAN/offline default) → ok, zero fetch calls", async () => {
+    const env: NodeJS.ProcessEnv = {};
+    expect(isTurnstileRequired(env)).toBe(false);
+
+    const result = await enforceTurnstileIfRequired(TOKEN, "1.2.3.4", {
+      ...login,
+      env
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("TURNSTILE_ENABLED=true but LAN profile → still fully OFF, zero fetch calls", async () => {
+    // The flag alone must never activate Turnstile without the full-online
+    // deployment profile — this is the "fully off on LAN even if the key is
+    // present" guarantee.
+    const env = fullOnlineEnv({
+      AUTH_ONLINE_SECURITY_ENABLED: "false",
+      AUTH_ONLINE_SECURITY_PROFILE: "disabled"
+    });
+    expect(isTurnstileRequired(env)).toBe(false);
+
+    const result = await enforceTurnstileIfRequired(TOKEN, "1.2.3.4", {
+      ...login,
+      env
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchCalls).toBe(0);
+  });
+});
+
+describe("enforceTurnstileIfRequired — full-online fail-closed", () => {
+  test("missing token → TURNSTILE_REQUIRED, no outbound call", async () => {
+    const result = await enforceTurnstileIfRequired(undefined, "1.2.3.4", {
+      ...login,
+      env: fullOnlineEnv()
+    });
+
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_REQUIRED" });
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("misconfigured (no secret) → TURNSTILE_INVALID, no outbound call", async () => {
+    const result = await enforceTurnstileIfRequired(TOKEN, "1.2.3.4", {
+      ...login,
+      env: fullOnlineEnv({ TURNSTILE_SECRET_KEY: "" })
+    });
+
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_INVALID" });
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("misconfigured (no expected hostname) → TURNSTILE_INVALID, no outbound call", async () => {
+    const result = await enforceTurnstileIfRequired(TOKEN, "1.2.3.4", {
+      ...login,
+      env: fullOnlineEnv({ TURNSTILE_EXPECTED_HOSTNAME: "" })
+    });
+
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_INVALID" });
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("valid token → ok, exactly one outbound verification call", async () => {
+    siteverify = () =>
+      Response.json({
+        success: true,
+        hostname: HOSTNAME,
+        action: "login",
+        challenge_ts: new Date().toISOString()
+      });
+
+    const result = await enforceTurnstileIfRequired(TOKEN, "1.2.3.4", {
+      ...login,
+      env: fullOnlineEnv()
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(fetchCalls).toBe(1);
+  });
+
+  test("Cloudflare rejection → generic TURNSTILE_INVALID (no oracle)", async () => {
+    siteverify = () => Response.json({ success: false, "error-codes": ["x"] });
+
+    const result = await enforceTurnstileIfRequired(TOKEN, "1.2.3.4", {
+      ...login,
+      env: fullOnlineEnv()
+    });
+
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_INVALID" });
+  });
+
+  test("hostname/action mismatch collapse to the SAME generic code as a rejection", async () => {
+    siteverify = () =>
+      Response.json({
+        success: true,
+        hostname: "attacker.example",
+        action: "phishing",
+        challenge_ts: new Date().toISOString()
+      });
+
+    const result = await enforceTurnstileIfRequired(TOKEN, "1.2.3.4", {
+      ...login,
+      env: fullOnlineEnv()
+    });
+
+    // Same code as a plain rejection above — an unauthenticated caller can not
+    // tell "hostname wrong" from "token bad" from "server misconfigured".
+    expect(result).toEqual({ ok: false, code: "TURNSTILE_INVALID" });
+  });
+});
+
+describe("config/preflight matrix — LAN / full-online valid / full-online misconfigured", () => {
+  const base = {
+    APP_ENV: "development",
+    APP_URL: "http://localhost:4321",
+    DATABASE_URL: "postgres://a:b@localhost:5432/c"
+  } as Record<string, string | undefined>;
+
+  test("LAN: validate-env clean; both readiness checks are informational passes (disabled intentionally)", () => {
+    expect(validateEnv(base)).toEqual([]);
+
+    const gate = checkOnlineAuthSecurityReady(base);
+    const turnstile = checkTurnstileReady(base);
+
+    expect(gate).toMatchObject({ severity: "info", status: "pass" });
+    expect(turnstile).toMatchObject({ severity: "info", status: "pass" });
+    expect(gate.evidence).toContain("disabled intentionally");
+    expect(turnstile.evidence).toContain("disabled intentionally");
+  });
+
+  test("full-online valid: validate-env clean; both readiness checks pass at critical severity; secret never printed", () => {
+    const env = {
+      ...base,
+      AUTH_ONLINE_SECURITY_ENABLED: "true",
+      AUTH_ONLINE_SECURITY_PROFILE: "full_online",
+      TURNSTILE_ENABLED: "true",
+      TURNSTILE_SITE_KEY: "public-site-key",
+      TURNSTILE_SECRET_KEY: SECRET,
+      TURNSTILE_EXPECTED_HOSTNAME: HOSTNAME
+    };
+
+    expect(validateEnv(env)).toEqual([]);
+
+    const gate = checkOnlineAuthSecurityReady(env);
+    const turnstile = checkTurnstileReady(env);
+
+    expect(gate).toMatchObject({ severity: "critical", status: "pass" });
+    expect(turnstile).toMatchObject({ severity: "critical", status: "pass" });
+    expect(JSON.stringify(turnstile)).not.toContain(SECRET);
+  });
+
+  test("full-online MISCONFIGURED: profile wrong + Turnstile keys missing → both fail critical, and validate-env reports both", () => {
+    const env = {
+      ...base,
+      AUTH_ONLINE_SECURITY_ENABLED: "true",
+      AUTH_ONLINE_SECURITY_PROFILE: "disabled", // contradictory
+      TURNSTILE_ENABLED: "true"
+      // no site key / secret / hostname
+    };
+
+    const problems = validateEnv(env);
+    expect(
+      problems.some((p) => p.startsWith("AUTH_ONLINE_SECURITY_ENABLED=true"))
+    ).toBe(true);
+    expect(problems.some((p) => p.startsWith("TURNSTILE_SITE_KEY"))).toBe(true);
+    expect(problems.some((p) => p.startsWith("TURNSTILE_SECRET_KEY"))).toBe(
+      true
+    );
+    expect(
+      problems.some((p) => p.startsWith("TURNSTILE_EXPECTED_HOSTNAME"))
+    ).toBe(true);
+
+    const gate = checkOnlineAuthSecurityReady(env);
+    const turnstile = checkTurnstileReady(env);
+
+    expect(gate).toMatchObject({ severity: "critical", status: "fail" });
+    expect(turnstile).toMatchObject({ severity: "critical", status: "fail" });
+    // Distinguishes misconfigured from "disabled intentionally".
+    expect(gate.evidence).toContain("MISCONFIGURED");
+  });
+
+  test("Turnstile fully configured but profile gate OFF → warning INERT, not a silent green (F3)", () => {
+    // Keys staged, TURNSTILE_ENABLED=true, but the full-online profile gate is
+    // off — isTurnstileRequired() is false, so login runs WITHOUT Turnstile.
+    const env = {
+      ...base,
+      TURNSTILE_ENABLED: "true",
+      TURNSTILE_SITE_KEY: "public-site-key",
+      TURNSTILE_SECRET_KEY: SECRET,
+      TURNSTILE_EXPECTED_HOSTNAME: HOSTNAME
+      // AUTH_ONLINE_SECURITY_* unset → gate off
+    };
+
+    // validate-env stays clean (staging is legitimate), but readiness must warn.
+    expect(validateEnv(env)).toEqual([]);
+
+    const turnstile = checkTurnstileReady(env);
+    expect(turnstile).toMatchObject({ severity: "warning", status: "fail" });
+    expect(turnstile.evidence).toContain("INERT");
+    expect(JSON.stringify(turnstile)).not.toContain(SECRET);
+  });
+});

--- a/tests/turnstile-login-e2e.test.ts
+++ b/tests/turnstile-login-e2e.test.ts
@@ -1,0 +1,399 @@
+/**
+ * Route-level integration tests for Turnstile ENABLED (Issue #186, F2).
+ *
+ * Drives the ACTUAL Astro route handlers `auth/login.ts` and `setup/initialize.ts`
+ * with the full-online profile gate ON and a FAKE Cloudflare siteverify (a
+ * `globalThis.fetch` spy returning a controllable success/failure/action/hostname
+ * — login/setup use `fetch` for NOTHING else, so the spy captures exactly the
+ * siteverify call). Same fake-Astro-context pattern as `tests/mfa-login-e2e.test.ts`.
+ *
+ * Proves the wiring the unit tests cannot: that Turnstile runs BEFORE identity
+ * lookup / password work on the real handler, fails closed with the right code,
+ * lets a valid token PROCEED to the password path, and that each route binds to
+ * its own action (login rejects a `setup` token and vice-versa).
+ *
+ * Env is set in beforeAll and restored in afterAll (no cross-file leak). Secret/
+ * token values are generated at RUNTIME (no static literal for GitGuardian).
+ *
+ * MUTATION PROOF (repo discipline): delete the `if (!turnstileResult.ok) return
+ * fail(...)` short-circuit in `login.ts` (or move Turnstile to AFTER password
+ * verify) → the "missing token" and "rejected token" tests go RED.
+ *
+ * Requires a throwaway database with `sql/` applied; gated on `DATABASE_URL`.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+import type { APIRoute } from "astro";
+
+import { POST as loginPOST } from "../src/pages/api/v1/auth/login";
+import { POST as setupPOST } from "../src/pages/api/v1/setup/initialize";
+import { hashPassword } from "../src/lib/auth/password";
+import { resetProviderCircuitBreakersForTests } from "../src/lib/database/circuit-breaker";
+
+const DATABASE_URL =
+  process.env.TURNSTILE_TEST_DATABASE_URL ?? process.env.DATABASE_URL;
+const describeOrSkip = DATABASE_URL ? describe : describe.skip;
+
+function randomOpaque(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}${crypto.randomUUID()}`.replace(
+    /-/g,
+    ""
+  );
+}
+
+const SECRET = randomOpaque("sk");
+const SITE_KEY = randomOpaque("site");
+const HOSTNAME = "app.example.test";
+const PASSWORD = "correct horse battery staple";
+
+/** Minimal AstroCookies stub — routes only use `.get(name)?.value` and `.set`. */
+function fakeCookies() {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get(name: string) {
+      return store.has(name) ? { value: store.get(name)! } : undefined;
+    },
+    set(name: string, value: string) {
+      store.set(name, value);
+    },
+    delete(name: string) {
+      store.delete(name);
+    },
+    has(name: string) {
+      return store.has(name);
+    }
+  };
+}
+
+let ipCounter = 0;
+function nextIp(): string {
+  ipCounter += 1;
+  return `192.0.2.${(ipCounter % 250) + 1}`;
+}
+
+type CallResult = { status: number; body: any };
+
+async function callRoute(
+  handler: APIRoute,
+  opts: { headers?: Record<string, string>; body?: unknown }
+): Promise<CallResult> {
+  const headers = new Headers({
+    "content-type": "application/json",
+    ...(opts.headers ?? {})
+  });
+  const request = new Request("http://localhost/api/v1/route", {
+    method: "POST",
+    headers,
+    body: opts.body === undefined ? undefined : JSON.stringify(opts.body)
+  });
+  const res = (await handler({
+    request,
+    cookies: fakeCookies(),
+    clientAddress: nextIp(),
+    locals: {}
+  } as never)) as Response;
+  const body = await res.json().catch(() => null);
+  return { status: res.status, body };
+}
+
+// -- Fake Cloudflare siteverify (globalThis.fetch spy) ----------------------
+const realFetch = globalThis.fetch;
+let siteverifyBody: Record<string, unknown> = { success: true };
+let siteverifyStatus = 200;
+let fetchCalls = 0;
+const outboundBodies: string[] = [];
+
+function installFetchSpy(): void {
+  globalThis.fetch = (async (_input: unknown, init?: { body?: unknown }) => {
+    fetchCalls += 1;
+    if (init && typeof init.body === "string") {
+      outboundBodies.push(init.body);
+    }
+    return Response.json(siteverifyBody, { status: siteverifyStatus });
+  }) as unknown as typeof fetch;
+}
+
+function freshSuccess(action: string): Record<string, unknown> {
+  return {
+    success: true,
+    hostname: HOSTNAME,
+    action,
+    challenge_ts: new Date().toISOString()
+  };
+}
+
+describeOrSkip(
+  "Turnstile ENABLED — route-level login + setup (real PostgreSQL)",
+  () => {
+    let sql: Bun.SQL;
+    const createdTenantIds: string[] = [];
+    const savedEnv: Record<string, string | undefined> = {};
+
+    const TURNSTILE_ENV_KEYS = [
+      "AUTH_ONLINE_SECURITY_ENABLED",
+      "AUTH_ONLINE_SECURITY_PROFILE",
+      "TURNSTILE_ENABLED",
+      "TURNSTILE_SITE_KEY",
+      "TURNSTILE_SECRET_KEY",
+      "TURNSTILE_EXPECTED_HOSTNAME"
+    ] as const;
+
+    beforeAll(() => {
+      sql = new Bun.SQL(DATABASE_URL!, { max: 4 });
+      for (const key of TURNSTILE_ENV_KEYS) savedEnv[key] = process.env[key];
+      process.env.AUTH_ONLINE_SECURITY_ENABLED = "true";
+      process.env.AUTH_ONLINE_SECURITY_PROFILE = "full_online";
+      process.env.TURNSTILE_ENABLED = "true";
+      process.env.TURNSTILE_SITE_KEY = SITE_KEY;
+      process.env.TURNSTILE_SECRET_KEY = SECRET;
+      process.env.TURNSTILE_EXPECTED_HOSTNAME = HOSTNAME;
+      installFetchSpy();
+    });
+
+    afterAll(async () => {
+      globalThis.fetch = realFetch;
+      for (const key of TURNSTILE_ENV_KEYS) {
+        if (savedEnv[key] === undefined) delete process.env[key];
+        else process.env[key] = savedEnv[key];
+      }
+      // Clear the setup singleton FIRST: `awcms_setup_state.tenant_id` FK-refs a
+      // bootstrapped tenant, so it must go before any `awcms_tenants` delete (and
+      // restores the throwaway DB to its pre-test unclaimed state so it is not
+      // left permanently "already initialized").
+      await sql`DELETE FROM awcms_setup_state`;
+      // Reverse any setup bootstrap that committed, and every seeded login tenant.
+      // Child tables first (FK order): everything that references an identity/
+      // role/tenant_user must be deleted before it.
+      const setupTables = [
+        "awcms_sessions",
+        "awcms_audit_events",
+        "awcms_abac_decision_logs",
+        "awcms_access_assignments",
+        "awcms_role_permissions",
+        "awcms_roles",
+        "awcms_tenant_users",
+        "awcms_identities",
+        "awcms_profiles",
+        "awcms_offices",
+        "awcms_tenant_settings"
+      ];
+      for (const tenantId of createdTenantIds) {
+        await sql`SELECT set_config('app.current_tenant_id', ${tenantId}, false)`;
+        for (const table of setupTables) {
+          await sql.unsafe(`DELETE FROM ${table} WHERE tenant_id = $1`, [
+            tenantId
+          ]);
+        }
+        await sql`DELETE FROM awcms_tenants WHERE id = ${tenantId}`;
+      }
+      await sql.close({ timeout: 5 });
+    });
+
+    beforeEach(() => {
+      resetProviderCircuitBreakersForTests();
+      fetchCalls = 0;
+      outboundBodies.length = 0;
+      siteverifyStatus = 200;
+      siteverifyBody = freshSuccess("login");
+    });
+
+    async function seedTenantAndUser(): Promise<{
+      tenantId: string;
+      loginIdentifier: string;
+    }> {
+      const suffix = Math.random().toString(36).slice(2, 10);
+      const tenant = (await sql`
+      INSERT INTO awcms_tenants (tenant_code, tenant_name)
+      VALUES (${`turn-${suffix}`}, ${"Turnstile e2e"}) RETURNING id
+    `) as { id: string }[];
+      const tenantId = tenant[0]!.id;
+      createdTenantIds.push(tenantId);
+      await sql`SELECT set_config('app.current_tenant_id', ${tenantId}, false)`;
+      const loginIdentifier = `user-${suffix}`;
+      const profile = (await sql`
+      INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'Turnstile User') RETURNING id
+    `) as { id: string }[];
+      const passwordHash = await hashPassword(PASSWORD);
+      const identity = (await sql`
+      INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, ${loginIdentifier}, ${passwordHash})
+      RETURNING id
+    `) as { id: string }[];
+      await sql`
+      INSERT INTO awcms_tenant_users (tenant_id, identity_id, status)
+      VALUES (${tenantId}, ${identity[0]!.id}, 'active')
+    `;
+      return { tenantId, loginIdentifier };
+    }
+
+    // -- LOGIN ----------------------------------------------------------------
+
+    test("(a) missing token → 400 TURNSTILE_REQUIRED, NO siteverify call, NO password acceptance", async () => {
+      const { tenantId, loginIdentifier } = await seedTenantAndUser();
+
+      // Correct password on purpose: if Turnstile did NOT short-circuit first,
+      // this would succeed (200) — so a 400 TURNSTILE_REQUIRED proves the gate
+      // ran BEFORE any identity lookup / password verification.
+      const res = await callRoute(loginPOST, {
+        headers: { "x-awcms-tenant-id": tenantId },
+        body: { loginIdentifier, password: PASSWORD }
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body?.error?.code).toBe("TURNSTILE_REQUIRED");
+      expect(fetchCalls).toBe(0);
+    });
+
+    test("(b) rejected token → 400 TURNSTILE_INVALID (siteverify called, login blocked)", async () => {
+      const { tenantId, loginIdentifier } = await seedTenantAndUser();
+      siteverifyBody = {
+        success: false,
+        "error-codes": ["invalid-input-response"]
+      };
+
+      const res = await callRoute(loginPOST, {
+        headers: { "x-awcms-tenant-id": tenantId },
+        body: {
+          loginIdentifier,
+          password: PASSWORD,
+          turnstileToken: randomOpaque("tok")
+        }
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body?.error?.code).toBe("TURNSTILE_INVALID");
+      expect(fetchCalls).toBe(1);
+    });
+
+    test("(b') action mismatch (setup token at login) → 400 TURNSTILE_INVALID", async () => {
+      const { tenantId, loginIdentifier } = await seedTenantAndUser();
+      siteverifyBody = freshSuccess("setup"); // wrong action for the login route
+
+      const res = await callRoute(loginPOST, {
+        headers: { "x-awcms-tenant-id": tenantId },
+        body: {
+          loginIdentifier,
+          password: PASSWORD,
+          turnstileToken: randomOpaque("tok")
+        }
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body?.error?.code).toBe("TURNSTILE_INVALID");
+    });
+
+    test("(c) valid token → login PROCEEDS to password path and succeeds (Turnstile is not the blocker)", async () => {
+      const { tenantId, loginIdentifier } = await seedTenantAndUser();
+      siteverifyBody = freshSuccess("login");
+
+      const res = await callRoute(loginPOST, {
+        headers: { "x-awcms-tenant-id": tenantId },
+        body: {
+          loginIdentifier,
+          password: PASSWORD,
+          turnstileToken: randomOpaque("tok")
+        }
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body?.success).toBe(true);
+      expect(res.body?.data?.token).toBeTruthy();
+      expect(fetchCalls).toBe(1);
+    });
+
+    test("(c') valid token + WRONG password → PROCEEDS past Turnstile to 401 AUTH_INVALID_CREDENTIALS", async () => {
+      const { tenantId, loginIdentifier } = await seedTenantAndUser();
+      siteverifyBody = freshSuccess("login");
+
+      const res = await callRoute(loginPOST, {
+        headers: { "x-awcms-tenant-id": tenantId },
+        body: {
+          loginIdentifier,
+          password: "wrong-password",
+          turnstileToken: randomOpaque("tok")
+        }
+      });
+
+      // Not a Turnstile error — it got past Turnstile and password verification
+      // is what denied it (proving Turnstile is not the account-enumeration gate).
+      expect(res.status).toBe(401);
+      expect(res.body?.error?.code).toBe("AUTH_INVALID_CREDENTIALS");
+    });
+
+    test("(d) outbound siteverify carries the client token as `response` (never a secret leak beyond `secret`)", async () => {
+      const { tenantId, loginIdentifier } = await seedTenantAndUser();
+      const token = randomOpaque("tok");
+      siteverifyBody = freshSuccess("login");
+
+      await callRoute(loginPOST, {
+        headers: { "x-awcms-tenant-id": tenantId },
+        body: { loginIdentifier, password: PASSWORD, turnstileToken: token }
+      });
+
+      expect(outboundBodies.length).toBe(1);
+      const params = new URLSearchParams(outboundBodies[0]);
+      expect(params.get("response")).toBe(token);
+      expect(params.get("secret")).toBe(SECRET);
+    });
+
+    // -- SETUP ----------------------------------------------------------------
+
+    const setupBody = (turnstileToken?: string) => ({
+      tenantCode: `stc-${Math.random().toString(36).slice(2, 8)}`,
+      tenantName: "Setup Turnstile",
+      officeCode: "HQ",
+      officeName: "Head Office",
+      ownerLoginIdentifier: `owner-${Math.random().toString(36).slice(2, 8)}`,
+      ownerPassword: "owner-password-123",
+      ownerDisplayName: "Owner",
+      ...(turnstileToken ? { turnstileToken } : {})
+    });
+
+    test("setup: missing token → 400 TURNSTILE_REQUIRED, NO siteverify, NO bootstrap", async () => {
+      const res = await callRoute(setupPOST, { body: setupBody() });
+
+      expect(res.status).toBe(400);
+      expect(res.body?.error?.code).toBe("TURNSTILE_REQUIRED");
+      expect(fetchCalls).toBe(0);
+    });
+
+    test("setup: a LOGIN-action token is rejected here (action bound to `setup`) → 400 TURNSTILE_INVALID", async () => {
+      siteverifyBody = freshSuccess("login"); // wrong action for the setup route
+
+      const res = await callRoute(setupPOST, {
+        body: setupBody(randomOpaque("tok"))
+      });
+
+      expect(res.status).toBe(400);
+      expect(res.body?.error?.code).toBe("TURNSTILE_INVALID");
+    });
+
+    test("setup: valid `setup`-action token PROCEEDS past Turnstile to the bootstrap", async () => {
+      siteverifyBody = freshSuccess("setup");
+
+      const res = await callRoute(setupPOST, {
+        body: setupBody(randomOpaque("tok"))
+      });
+
+      // Proceeded past Turnstile: either it bootstrapped (200) or the singleton
+      // was already claimed (403) — never a Turnstile 400.
+      expect(
+        res.status === 200 || res.status === 403,
+        `expected 200/403, got ${res.status} ${JSON.stringify(res.body?.error)}`
+      ).toBe(true);
+      expect(res.body?.error?.code).not.toBe("TURNSTILE_INVALID");
+      expect(res.body?.error?.code).not.toBe("TURNSTILE_REQUIRED");
+      if (res.status === 200 && res.body?.data?.tenantId) {
+        createdTenantIds.push(res.body.data.tenantId);
+      }
+    });
+  }
+);

--- a/tests/turnstile-verifier.test.ts
+++ b/tests/turnstile-verifier.test.ts
@@ -1,0 +1,361 @@
+/**
+ * Cloudflare Turnstile verifier unit tests (Issue #186).
+ *
+ * Drives `verifyTurnstileToken` against a LOCAL fake siteverify server
+ * (`Bun.serve`) injected via `config.verifyUrl` — the same test seam the OIDC
+ * fake-IdP and Cloudflare DNS adapter use, so no real network call is ever made
+ * and Cloudflare's contract is stood in for deterministically.
+ *
+ * All secret/token values are generated at RUNTIME (no static literal that
+ * GitGuardian could flag; `tests/` is also outside the secret scanner's paths).
+ *
+ * MUTATION PROOFS (repo security-readiness discipline — "abaikan hostname/action
+ * harus membuat test merah"):
+ *  - delete the hostname check in `verifyTurnstileToken` → "hostname mismatch"
+ *    test goes RED (a wrong-hostname token is accepted).
+ *  - delete the action check → "action mismatch" test goes RED.
+ *  - delete the freshness check → "stale timestamp" test goes RED.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import { verifyTurnstileToken } from "../src/lib/security/turnstile";
+import { resetProviderCircuitBreakersForTests } from "../src/lib/database/circuit-breaker";
+import { setLogSink, type LogEntry } from "../src/lib/logging/logger";
+
+function randomOpaque(prefix: string): string {
+  return `${prefix}_${crypto.randomUUID()}${crypto.randomUUID()}`.replace(
+    /-/g,
+    ""
+  );
+}
+
+const SECRET = randomOpaque("sk");
+const TOKEN = randomOpaque("tok");
+const HOSTNAME = "app.example.test";
+const ACTION = "login";
+const FIXED_NOW = new Date("2026-07-19T00:00:00.000Z");
+
+type FakeBehavior =
+  | { kind: "json"; status?: number; body: unknown }
+  | { kind: "text"; status?: number; body: string }
+  | { kind: "delayMs"; ms: number; body: unknown }
+  | { kind: "oversize"; bytes: number };
+
+let behavior: FakeBehavior = { kind: "json", body: { success: true } };
+let server: ReturnType<typeof Bun.serve>;
+let verifyUrl = "";
+let requestCount = 0;
+let logs: LogEntry[] = [];
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    async fetch() {
+      requestCount += 1;
+
+      if (behavior.kind === "delayMs") {
+        await Bun.sleep(behavior.ms);
+        return Response.json(behavior.body as Record<string, unknown>);
+      }
+
+      if (behavior.kind === "text") {
+        return new Response(behavior.body, {
+          status: behavior.status ?? 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+
+      if (behavior.kind === "oversize") {
+        return new Response("x".repeat(behavior.bytes), {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        });
+      }
+
+      return Response.json(behavior.body as Record<string, unknown>, {
+        status: behavior.status ?? 200
+      });
+    }
+  });
+  verifyUrl = `http://127.0.0.1:${server.port}/siteverify`;
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+beforeEach(() => {
+  resetProviderCircuitBreakersForTests();
+  requestCount = 0;
+  logs = [];
+  setLogSink((entry) => logs.push(entry));
+});
+
+afterEach(() => {
+  setLogSink(null);
+});
+
+const config = () => ({ secretKey: SECRET, verifyUrl, timeoutMs: 500 });
+const expectations = (over: Record<string, unknown> = {}) => ({
+  action: ACTION,
+  hostname: HOSTNAME,
+  maxTokenAgeSec: 300,
+  now: FIXED_NOW,
+  ...over
+});
+
+describe("verifyTurnstileToken — success + Cloudflare-side rejection", () => {
+  test("valid token with matching hostname + action + fresh timestamp → ok", async () => {
+    behavior = {
+      kind: "json",
+      body: {
+        success: true,
+        hostname: HOSTNAME,
+        action: ACTION,
+        challenge_ts: FIXED_NOW.toISOString()
+      }
+    };
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result.ok).toBe(true);
+    expect(requestCount).toBe(1);
+  });
+
+  test("success:false (bad/expired/reused token) → rejected, not retryable", async () => {
+    behavior = {
+      kind: "json",
+      body: { success: false, "error-codes": ["invalid-input-response"] }
+    };
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "rejected",
+      retryable: false
+    });
+  });
+});
+
+describe("verifyTurnstileToken — provider failures", () => {
+  test("non-2xx status → provider_error (retryable on 5xx)", async () => {
+    behavior = { kind: "json", status: 500, body: {} };
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result).toMatchObject({ ok: false, reason: "provider_error" });
+  });
+
+  test("malformed (non-JSON) 2xx payload → provider_error", async () => {
+    behavior = { kind: "text", status: 200, body: "definitely not json" };
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result).toMatchObject({ ok: false, reason: "provider_error" });
+  });
+
+  test("timeout (slow provider) → provider_unavailable, retryable", async () => {
+    behavior = {
+      kind: "delayMs",
+      ms: 400,
+      body: { success: true, hostname: HOSTNAME, action: ACTION }
+    };
+
+    const result = await verifyTurnstileToken(
+      TOKEN,
+      { secretKey: SECRET, verifyUrl, timeoutMs: 40 },
+      expectations()
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "provider_unavailable",
+      retryable: true
+    });
+  });
+
+  test("oversized response body (exceeds cap) → provider_error", async () => {
+    behavior = { kind: "oversize", bytes: 100 };
+
+    const result = await verifyTurnstileToken(
+      TOKEN,
+      { secretKey: SECRET, verifyUrl, timeoutMs: 500, maxResponseBytes: 10 },
+      expectations()
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: "provider_error" });
+  });
+
+  test("open circuit breaker fails closed without an outbound call and logs it", async () => {
+    behavior = { kind: "json", status: 500, body: {} };
+
+    // Trip the shared breaker (default threshold 5) at a fixed clock so it is
+    // open for the 6th attempt.
+    for (let i = 0; i < 5; i += 1) {
+      await verifyTurnstileToken(TOKEN, config(), expectations());
+    }
+    const callsBefore = requestCount;
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result).toMatchObject({
+      ok: false,
+      reason: "provider_unavailable"
+    });
+    expect(requestCount).toBe(callsBefore); // no 6th outbound call
+    expect(
+      logs.some((e) => e.message === "turnstile.circuit_breaker_open")
+    ).toBe(true);
+  });
+});
+
+describe("verifyTurnstileToken — expectation enforcement (MUTATION PROOFS)", () => {
+  test("hostname mismatch → rejected (delete the hostname check ⇒ RED)", async () => {
+    behavior = {
+      kind: "json",
+      body: {
+        success: true,
+        hostname: "attacker.example",
+        action: ACTION,
+        challenge_ts: FIXED_NOW.toISOString()
+      }
+    };
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result).toMatchObject({ ok: false, reason: "hostname_mismatch" });
+  });
+
+  test("action mismatch → rejected (delete the action check ⇒ RED)", async () => {
+    behavior = {
+      kind: "json",
+      body: {
+        success: true,
+        hostname: HOSTNAME,
+        action: "setup",
+        challenge_ts: FIXED_NOW.toISOString()
+      }
+    };
+
+    const result = await verifyTurnstileToken(
+      TOKEN,
+      config(),
+      expectations({ action: "login" })
+    );
+
+    expect(result).toMatchObject({ ok: false, reason: "action_mismatch" });
+  });
+
+  test("stale challenge_ts → rejected (delete the freshness check ⇒ RED)", async () => {
+    behavior = {
+      kind: "json",
+      body: {
+        success: true,
+        hostname: HOSTNAME,
+        action: ACTION,
+        challenge_ts: new Date(FIXED_NOW.getTime() - 3_600_000).toISOString()
+      }
+    };
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result).toMatchObject({ ok: false, reason: "stale" });
+  });
+
+  test("missing challenge_ts with freshness required → stale (fail closed)", async () => {
+    behavior = {
+      kind: "json",
+      body: { success: true, hostname: HOSTNAME, action: ACTION }
+    };
+
+    const result = await verifyTurnstileToken(TOKEN, config(), expectations());
+
+    expect(result).toMatchObject({ ok: false, reason: "stale" });
+  });
+});
+
+describe("verifyTurnstileToken — token/secret never leak", () => {
+  test("neither the token nor the secret appears in any log line or returned detail", async () => {
+    // Exercise every log-emitting path: rejection, provider error, thrown
+    // network error, and (indirectly) the success path (which logs nothing).
+    behavior = { kind: "json", body: { success: false, "error-codes": ["x"] } };
+    const rejected = await verifyTurnstileToken(
+      TOKEN,
+      config(),
+      expectations()
+    );
+
+    behavior = { kind: "json", status: 502, body: {} };
+    const providerError = await verifyTurnstileToken(
+      TOKEN,
+      config(),
+      expectations()
+    );
+
+    // Unreachable endpoint → fetch throws → caught + logged (redacted).
+    const thrown = await verifyTurnstileToken(
+      TOKEN,
+      {
+        secretKey: SECRET,
+        verifyUrl: "http://127.0.0.1:1/nope",
+        timeoutMs: 200
+      },
+      expectations()
+    );
+
+    const haystacks = [
+      ...logs.map((entry) => JSON.stringify(entry)),
+      JSON.stringify(rejected),
+      JSON.stringify(providerError),
+      JSON.stringify(thrown)
+    ];
+
+    for (const text of haystacks) {
+      expect(text).not.toContain(TOKEN);
+      expect(text).not.toContain(SECRET);
+    }
+    // Sanity: we actually produced log lines to scan.
+    expect(logs.length).toBeGreaterThan(0);
+  });
+
+  test("if an error message ever echoes the token or secret, both are actively [redacted] (F4)", async () => {
+    // Force the token AND secret into a thrown error message, then prove the
+    // redaction set scrubs BOTH — not merely that they happened to be absent.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new Error(`boom response=${TOKEN} secret=${SECRET}`);
+    }) as unknown as typeof fetch;
+
+    try {
+      const result = await verifyTurnstileToken(
+        TOKEN,
+        config(),
+        expectations()
+      );
+
+      expect(result.ok).toBe(false);
+      const detail = result.ok ? "" : result.detail;
+      expect(detail).toContain("[redacted]");
+      expect(detail).not.toContain(TOKEN);
+      expect(detail).not.toContain(SECRET);
+
+      const loggedError = logs.find(
+        (e) => e.message === "turnstile.provider_call_errored"
+      );
+      expect(loggedError).toBeDefined();
+      expect(JSON.stringify(loggedError)).not.toContain(TOKEN);
+      expect(JSON.stringify(loggedError)).not.toContain(SECRET);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Ringkasan

Mini-first **port** (awcms-mini #587/#588), dikeraskan. Epik #177 **Wave 3** (melengkapi trio auth MFA/OIDC/Turnstile). Config/env saja — **TANPA migration**; secret tak pernah menyentuh DB.

### Kontrol
- Turnstile aktif HANYA saat profil deployment full-online DAN `TURNSTILE_ENABLED=true`. Setiap deployment LAN/offline byte-identik dengan sebelumnya: tanpa widget, iframe, CSP origin, atau outbound call (**fetch-spy membuktikan 0 outbound** saat disabled/LAN).
- Verifier server-side (adapter, fakeable) memvalidasi token + success + **action + hostname + freshness**; satu AbortController deadline meliputi semua hop + baca body (anti slow-drip); cap 16KB; error terstruktur; **token & secret di-redaksi** (tak pernah di log/audit/response). Circuit-breaker trip hanya pada kegagalan transport → token sampah tak bisa mengunci login lintas-tenant.
- Berjalan setelah request-shape/rate-limit, **sebelum verifikasi password**, DI LUAR transaksi DB — mendahului cabang MFA (#184) & OIDC break-glass (#185), keduanya utuh. setup/initialize kini punya rate-limit source-scoped simetris.
- **Fail-closed generik** pada profil full-online: outage/timeout/malformed/hostname/action/stale → satu kode sebelum lookup identitas (tanpa oracle enumerasi). Action per-endpoint mencegah reuse lintas-action.
- **CSP** origin Turnstile dibuka SEMPIT (script-src + frame-src) hanya saat enabled; widget kondisional di login.astro (CSP single-owner utuh).
- `config:validate` + `security:readiness` + preflight memvalidasi key + action/hostname saat enabled, membedakan "disabled sengaja" vs "misconfigured", dan **memperingatkan keras saat key ter-stage tapi profile gate masih off (INERT)**.

### Kontrak
- Optional `turnstileToken` di request body login + setup; bundle/docs regenerasi. **Snapshot pra-#182 beku dibiarkan utuh**; perubahan aditif diakui via allow-list `INTENTIONALLY_EVOLVED_PATHS` (cek additive-superset yang tetap gagal pada penghapusan/field jadi required). ADR-0029 + `docs/awcms/turnstile-bot-protection.md`.

## Review
- **awcms-reviewer**: Request changes untuk 2 item DoD (kontradiksi ADR + test route-level fake-verifier yang diwajibkan issue) → **keduanya diperbaiki**.
- **awcms-security-auditor**: **PASS, tanpa critical/high**. Dua Low (redaksi token, peringatan preflight inert) → **diperbaiki**.

## Verifikasi
- `bun run check` hijau (910 test, 0 fail, build clean).
- DB-gated vs Postgres nyata: Turnstile unit+enforcement+CSP+route-level 46 pass; regresi login/MFA/OIDC 12 — 0 fail. Test route-level fake-verifier **mutation-proven** (hapus short-circuit → RED). Disabled=no-outbound dibuktikan fetch spy. Tanpa dependency; secret test di-generate runtime.

Closes #186
🤖 Generated with [Claude Code](https://claude.com/claude-code)