### PR TITLE
feat(redis): add optional Bun-native Redis readiness foundation

### DIFF
--- a/.changeset/redis-native-bun-readiness-197.md
+++ b/.changeset/redis-native-bun-readiness-197.md
@@ -1,0 +1,9 @@
+---
+"awcms": minor
+---
+
+feat(redis): add optional Bun-native Redis readiness foundation (#197)
+
+Adds an opt-in, fail-open Redis capability for scalable AWCMS-derived applications without changing PostgreSQL as the authoritative transactional store. The additive foundation includes typed configuration, tenant-aware key namespacing, JSON cache-aside helpers with mandatory TTL, a credential-safe Redis health CLI, unit tests without a live Redis dependency, a hardened standalone Compose deployment, and operational/security guidance for LAN and Coolify deployments.
+
+Redis remains disabled by default. No session, audit, workflow, durable outbox, authorization boundary, or authoritative ERP/domain state is migrated to Redis, and no third-party runtime dependency is added.

--- a/config/redis.env.example
+++ b/config/redis.env.example
@@ -1,0 +1,33 @@
+# Optional Redis readiness profile for AWCMS.
+#
+# Redis is disabled by default in the main application configuration. Use this
+# file only when explicitly enabling the optional Redis layer. Never commit a
+# real password or a production REDIS_URL.
+
+REDIS_ENABLED=true
+
+# Bare-metal/systemd example. For container deployment, use the internal Redis
+# service hostname and a dedicated ACL user. Replace <password> with the
+# REDIS_PASSWORD value below — both are placeholders; never commit a real one.
+REDIS_URL=redis://awcms_app:<password>@127.0.0.1:6379/0
+
+# Prefix all keys owned by this foundation/deployment. The Redis ACL should
+# restrict the application user to this prefix. A derived application that
+# shares an instance must choose its own stable prefix.
+REDIS_KEY_PREFIX=awcms
+
+# Fail-fast client behavior. Redis is an optimization, not a transactional
+# dependency, so commands are not queued while disconnected.
+REDIS_CONNECTION_TIMEOUT_MS=2000
+REDIS_COMMAND_TIMEOUT_MS=1000
+REDIS_MAX_RETRIES=3
+
+# Default TTL for generic JSON cache-aside helpers. Individual modules may use
+# a shorter TTL after documenting staleness and invalidation behavior.
+REDIS_CACHE_DEFAULT_TTL_SEC=300
+
+# Deployment-only values for provisioning Redis. Store REDIS_PASSWORD in the
+# deployment secret manager; use a long random URL-safe value.
+REDIS_PASSWORD=change-me
+REDIS_MAXMEMORY=256mb
+REDIS_MAXMEMORY_POLICY=noeviction

--- a/deploy/redis/docker-compose.yml
+++ b/deploy/redis/docker-compose.yml
@@ -1,0 +1,109 @@
+# Standalone optional Redis deployment for AWCMS.
+#
+# AWCMS does not currently expose a canonical root Compose application stack,
+# so this file provisions Redis independently. The AWCMS application must join
+# the same Docker network (AWCMS_REDIS_NETWORK) and use the internal hostname
+# `redis`; port 6379 is intentionally never published to the host.
+
+name: awcms-redis
+
+services:
+  redis-acl-init:
+    image: alpine:3.23.1
+    restart: "no"
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?Set REDIS_PASSWORD in deployment secrets}
+      REDIS_KEY_PREFIX: ${REDIS_KEY_PREFIX:-awcms}
+    command:
+      - sh
+      - -ec
+      - |
+        case "$${REDIS_PASSWORD}" in
+          *[!A-Za-z0-9_-]*|'')
+            echo "REDIS_PASSWORD must use only A-Z, a-z, 0-9, _ or -." >&2
+            exit 1
+            ;;
+        esac
+        case "$${REDIS_KEY_PREFIX}" in
+          *[!A-Za-z0-9._-]*|'')
+            echo "REDIS_KEY_PREFIX contains unsupported characters." >&2
+            exit 1
+            ;;
+        esac
+        password_hash="$$(printf '%s' "$${REDIS_PASSWORD}" | sha256sum | awk '{print $$1}')"
+        umask 022
+        {
+          printf 'user default off\n'
+          printf 'user awcms_app on #%s ~%s:* +ping +@read +@write -@dangerous\n' \
+            "$${password_hash}" "$${REDIS_KEY_PREFIX}"
+        } > /redis-config/users.acl
+        chmod 0644 /redis-config/users.acl
+    volumes:
+      - awcms-redis-config:/redis-config
+    networks:
+      - awcms-redis-internal
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "0.25"
+          memory: 64M
+
+  redis:
+    image: redis:8.2.7-alpine
+    restart: unless-stopped
+    command:
+      - redis-server
+      - --aclfile
+      - /redis-config/users.acl
+      - --appendonly
+      - "yes"
+      - --appendfsync
+      - everysec
+      - --save
+      - "60"
+      - "1000"
+      - --maxmemory
+      - ${REDIS_MAXMEMORY:-256mb}
+      - --maxmemory-policy
+      - ${REDIS_MAXMEMORY_POLICY:-noeviction}
+      - --protected-mode
+      - "yes"
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?Set REDIS_PASSWORD in deployment secrets}
+    volumes:
+      - awcms-redis-data:/data
+      - awcms-redis-config:/redis-config:ro
+    networks:
+      - awcms-redis-internal
+    depends_on:
+      redis-acl-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "REDISCLI_AUTH=$${REDIS_PASSWORD} redis-cli --user awcms_app ping | grep -q PONG"
+        ]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 5s
+    cap_drop: [ALL]
+    security_opt:
+      - no-new-privileges:true
+    deploy:
+      resources:
+        limits:
+          cpus: "1"
+          memory: 384M
+
+networks:
+  awcms-redis-internal:
+    name: ${AWCMS_REDIS_NETWORK:-awcms-redis-internal}
+
+volumes:
+  awcms-redis-data:
+  awcms-redis-config:

--- a/docs/awcms/redis-readiness.md
+++ b/docs/awcms/redis-readiness.md
@@ -1,0 +1,304 @@
+# Redis Readiness — Kapabilitas Opsional Native Bun
+
+> Status: implementasi draft Issue #197. Redis **tidak aktif secara default** dan
+> tidak mengubah PostgreSQL sebagai sumber kebenaran AWCMS.
+
+## 1. Tujuan
+
+AWCMS menyiapkan lapisan Redis opsional untuk aplikasi turunan yang membutuhkan
+cache baca terbatas atau koordinasi sementara ketika mulai berjalan pada lebih
+dari satu instance. Implementasi memakai [`RedisClient` native Bun](https://bun.sh/docs/runtime/redis),
+sehingga tidak menambah package runtime `redis`, `ioredis`, atau adapter Node.js.
+
+Bun menyediakan client Redis Promise-based dengan connection management,
+auto-pipelining, TLS, reconnect, raw command, dan health/status connection.
+Client native Bun memerlukan Redis server 7.2 atau lebih baru. Redis Sentinel dan
+Redis Cluster belum didukung oleh client native ini dan tidak termasuk scope
+fondasi awal.
+
+## 2. Keputusan arsitektur
+
+```mermaid
+flowchart LR
+  REQ[Request atau worker] --> APP[AWCMS Bun + Astro]
+  APP -->|authoritative read/write| PG[(PostgreSQL + RLS)]
+  APP -. cache-aside / ephemeral coordination .-> REDIS[(Redis opsional)]
+  PG --> OUTBOX[Durable outbox]
+  OUTBOX --> PROVIDER[Provider eksternal]
+
+  REDIS -. unavailable .-> MISS[Cache miss / write skip]
+  MISS --> PG
+```
+
+Prinsip wajib:
+
+1. **Default disabled.** `REDIS_ENABLED=false` atau tidak diisi berarti AWCMS
+   tidak membuat client dan tidak mencoba terhubung ke Redis.
+2. **PostgreSQL authoritative.** RLS, audit trail, durable outbox, workflow,
+   session authority, idempotency record, dan data ERP/domain tetap di
+   PostgreSQL.
+3. **Fail-open untuk cache.** Gangguan Redis menjadi cache miss, cache write
+   skip, atau invalidation skip; transaksi bisnis tidak ikut gagal.
+4. **Tenant-aware key.** Data tenant wajib menggunakan `tenantId` melalui
+   `buildRedisKey()`.
+5. **TTL wajib.** Helper JSON menggunakan atomic `SET ... EX`; tidak ada cache
+   tanpa masa kedaluwarsa.
+6. **Tidak di dalam transaksi database.** Redis tidak dipanggil sebagai
+   dependency wajib dari callback transaksi PostgreSQL.
+7. **Tidak ada port publik.** Redis hanya boleh tersedia melalui jaringan
+   internal/privat.
+8. **No hidden fallback.** AWCMS tidak memakai singleton `redis` bawaan Bun yang
+   dapat otomatis mengarah ke localhost. Client dibuat eksplisit hanya ketika
+   `REDIS_ENABLED=true` dan `REDIS_URL` valid.
+
+## 3. Komponen implementasi
+
+| Komponen                              | Fungsi                                                                    |
+| ------------------------------------- | ------------------------------------------------------------------------- |
+| `src/lib/redis/config.ts`             | Parsing, validasi, redaksi URL, dan key builder tenant-aware              |
+| `src/lib/redis/client.ts`             | Singleton `RedisClient` native Bun, lifecycle, timeout, dan health        |
+| `src/lib/redis/cache.ts`              | Helper JSON cache-aside, invalidasi, dan fail-open                        |
+| `scripts/redis-health.ts`             | Preflight konfigurasi dan authenticated `PING` tanpa kebocoran credential |
+| `config/redis.env.example`            | Contoh env opsional yang terpisah dari profil default                     |
+| `deploy/redis/docker-compose.yml`     | Redis standalone hardened tanpa publikasi port                            |
+| `tests/unit/redis-foundation.test.ts` | Unit test tanpa Redis/network hidup                                       |
+
+Tidak ada dependency runtime baru dan `bun.lock` tidak perlu berubah.
+
+## 4. Konfigurasi
+
+| Variable                      |   Default | Keterangan                                    |
+| ----------------------------- | --------: | --------------------------------------------- |
+| `REDIS_ENABLED`               |   `false` | Feature gate; false berarti tidak ada koneksi |
+| `REDIS_URL`                   | tidak ada | URL eksplisit; wajib ketika Redis enabled     |
+| `REDIS_KEY_PREFIX`            |   `awcms` | Namespace aplikasi dan boundary ACL key       |
+| `REDIS_CONNECTION_TIMEOUT_MS` |    `2000` | Batas koneksi awal, 100–30000 ms              |
+| `REDIS_COMMAND_TIMEOUT_MS`    |    `1000` | Batas command aplikasi, 50–30000 ms           |
+| `REDIS_MAX_RETRIES`           |       `3` | Maksimum reconnect, 0–20                      |
+| `REDIS_CACHE_DEFAULT_TTL_SEC` |     `300` | TTL default cache JSON, 1–86400 detik         |
+
+URL yang diterima:
+
+- `redis://`
+- `rediss://`
+- `redis+tls://`
+- `redis+unix://`
+- `redis+tls+unix://`
+
+Gunakan `rediss://` atau jaringan internal tepercaya untuk staging/production.
+Credential harus berasal dari environment/secret manager, bukan source code,
+dokumentasi, module settings, atau commit.
+
+## 5. Health dan preflight
+
+```bash
+bun run redis:health
+```
+
+Status:
+
+- `disabled`: valid, exit code 0, tidak mencoba koneksi;
+- `healthy`: konfigurasi valid dan `PING` menghasilkan `PONG`;
+- `unhealthy`: koneksi atau command gagal, exit code 1;
+- `invalid_configuration`: enabled tetapi konfigurasi tidak valid, exit code 1.
+
+Username dan password pada URL selalu diredaksi. Payload cache dan secret tidak
+pernah dicetak oleh health command.
+
+## 6. Contoh implementasi
+
+### 6.1 Cache laporan agregat
+
+```ts
+import { redisCacheAside } from "../../lib/redis/cache";
+import { buildRedisKey } from "../../lib/redis/config";
+
+const key = buildRedisKey({
+  namespace: "reporting",
+  tenantId,
+  key: `activity:${range}`
+});
+
+const report = await redisCacheAside(
+  key,
+  () => loadActivityReportFromPostgres(tenantId, range),
+  { ttlSec: 60 }
+);
+```
+
+Cocok untuk dashboard yang mahal dihitung dan boleh stale 30–300 detik.
+
+### 6.2 Cache metadata referensi
+
+```ts
+const key = buildRedisKey({
+  namespace: "reference-data",
+  tenantId,
+  key: "active-uom"
+});
+
+const items = await redisCacheAside(key, loadActiveUomFromPostgres, {
+  ttlSec: 300
+});
+```
+
+Mutation harus menulis PostgreSQL lebih dahulu, lalu menghapus atau me-refresh
+cache setelah commit. TTL tetap menjadi fallback bila invalidasi gagal.
+
+### 6.3 Invalidasi setelah mutation berhasil
+
+```ts
+const result = await updateAuthoritativeRecordInPostgres(input);
+await deleteRedisCache(
+  buildRedisKey({ namespace: "reference-data", tenantId, key: "active-uom" })
+);
+return result;
+```
+
+Gagal menghapus cache tidak boleh mengubah mutation PostgreSQL menjadi gagal.
+
+### 6.4 Akselerasi idempotency
+
+Redis dapat menjadi positive/negative cache jangka pendek untuk mengurangi baca
+berulang, tetapi key, status, response replay, dan hasil transaksi authoritative
+harus tetap disimpan di PostgreSQL. Implementasi konkret memerlukan issue dan
+test race-condition terpisah.
+
+### 6.5 Distributed rate limiting atau lock
+
+Redis native Bun dapat dipakai pada fase berikutnya, tetapi bukan melalui helper
+cache generik. Rate limiting harus atomic dan memiliki kebijakan fail-open atau
+fail-closed per endpoint. Lock harus memakai ownership token, TTL, atomic release,
+dan fencing token untuk dampak tinggi. Constraint PostgreSQL, unique index, row
+lock, dan serialisasi transaksi tetap menjadi kontrol utama.
+
+## 7. Penggunaan yang dilarang tanpa desain baru
+
+Redis tidak boleh langsung digunakan sebagai:
+
+- sumber tunggal sesi autentikasi;
+- penyimpanan audit log atau security event;
+- pengganti PostgreSQL outbox/inbox;
+- penyimpanan workflow approval;
+- penyimpanan transaksi, ledger, saldo, stok, payroll, atau dokumen posted;
+- pengganti RLS, RBAC, atau ABAC;
+- queue dengan klaim exactly-once;
+- tempat menyimpan password, provider token, NIK, data kesehatan, atau data
+  pribadi mentah;
+- dependency sinkron wajib di dalam transaksi PostgreSQL.
+
+Perubahan pada area tersebut memerlukan issue tersendiri, threat model, data
+classification, RTO/RPO, recovery plan, pengujian kegagalan, dan kontrak API/event
+bila relevan.
+
+## 8. Deployment standalone
+
+AWCMS belum memiliki canonical root Compose stack. Karena itu Redis disediakan
+sebagai deployment terpisah, bukan overlay yang mengasumsikan service `app` atau
+PostgreSQL tertentu.
+
+```bash
+cp config/redis.env.example .env.redis
+# Ganti REDIS_PASSWORD dengan secret panjang dari secret manager.
+
+docker compose \
+  --env-file .env.redis \
+  -f deploy/redis/docker-compose.yml \
+  up -d
+```
+
+Deployment membuat network bernama `awcms-redis-internal` secara default. Aplikasi
+AWCMS harus bergabung ke network yang sama dan memakai:
+
+```env
+REDIS_ENABLED=true
+REDIS_URL=redis://awcms_app:${REDIS_PASSWORD}@redis:6379/0
+REDIS_KEY_PREFIX=awcms
+```
+
+Untuk nama network lain, set `AWCMS_REDIS_NETWORK`. Pada Coolify, gunakan resource
+Redis/Compose dalam internal network yang sama dan simpan seluruh secret pada
+Environment Variables/Secrets. Jangan expose port 6379.
+
+Hardening deployment:
+
+- default Redis user dimatikan;
+- user `awcms_app` dibatasi ke `${REDIS_KEY_PREFIX}:*`;
+- kategori command berbahaya ditolak;
+- ACL file hanya berisi hash SHA-256 password;
+- AOF `everysec` dan snapshot diaktifkan untuk recovery operasional;
+- `protected-mode=yes`;
+- authenticated health check;
+- resource limit;
+- `cap_drop: [ALL]` dan `no-new-privileges`;
+- volume data dan konfigurasi terpisah;
+- tidak ada `ports:`.
+
+## 9. Konsistensi dan invalidasi
+
+Pola default adalah cache-aside:
+
+1. Bentuk key versioned dan tenant-aware.
+2. Baca Redis.
+3. Jika miss, baca PostgreSQL melalui tenant context + RLS.
+4. Setelah nilai authoritative tersedia, tulis Redis dengan TTL.
+5. Mutation menulis PostgreSQL lebih dahulu.
+6. Setelah commit berhasil, hapus atau refresh key terkait.
+7. Bila invalidasi gagal, TTL membatasi staleness.
+
+Jangan membuat dual-write PostgreSQL + Redis sebagai transaksi semu. Keduanya
+tidak memiliki atomic commit bersama. Untuk invalidasi lintas proses, gunakan
+event/outbox setelah commit pada issue terpisah.
+
+## 10. Kapasitas, eviction, dan pemisahan purpose
+
+Mulai dari `maxmemory=256mb` dan `noeviction`, lalu ukur. Instance yang dipastikan
+cache-only dapat memilih LRU/LFU setelah review. Jangan mencampur cache yang boleh
+dievict dengan lock/rate-limit state yang membutuhkan kebijakan berbeda tanpa
+analisis kapasitas.
+
+| Purpose              | Persistence                | Eviction                  | Dampak kehilangan data         |
+| -------------------- | -------------------------- | ------------------------- | ------------------------------ |
+| Cache laporan        | opsional                   | LRU/LFU dapat diterima    | query ulang PostgreSQL         |
+| Rate limiting        | biasanya tidak wajib       | hindari eviction prematur | limit sementara kurang akurat  |
+| Lock/coordination    | bukan untuk recovery       | `noeviction`              | duplicate work mungkin terjadi |
+| Pub/Sub invalidation | tidak persisten            | tidak relevan             | TTL memperbaiki akhirnya       |
+| Durable queue        | jangan memakai fondasi ini | `noeviction`              | perlu desain queue terpisah    |
+
+Monitor minimal: latency, `used_memory`, `evicted_keys`, rejected connections,
+persistence error, reconnect, buffered amount, dan restart count.
+
+## 11. Security dan compliance mapping
+
+| Kontrol                 | Implementasi praktis                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| ISO/IEC 27001 & 27002   | least privilege ACL, secret management, logging redaction, network isolation          |
+| ISO/IEC 27005           | threat model sebelum sesi, lock, queue, atau data sensitif dipindah ke Redis          |
+| ISO/IEC 27017/27018     | pemisahan environment, cloud secret, data minimization, tidak menyimpan PII mentah    |
+| ISO/IEC 27701 & UU PDP  | purpose limitation, TTL, minimisasi payload, larangan credential/PII pada key         |
+| ISO/IEC 20000           | health command, monitoring, configuration record, rollback feature flag               |
+| ISO 22301               | Redis bukan single point of failure; layanan inti tetap berjalan tanpa cache          |
+| PP PSTE / UU ITE        | pengamanan akses, keandalan layanan, pencatatan dan perlindungan informasi elektronik |
+| OWASP ASVS/API Security | default-off, timeout, no error leakage, least privilege, dependency isolation         |
+
+## 12. Testing dan rollback
+
+Unit test tidak membutuhkan Redis hidup:
+
+```bash
+bun test tests/unit/redis-foundation.test.ts
+bun run typecheck
+```
+
+Verifikasi deployment opsional:
+
+```bash
+bun run redis:health
+```
+
+Rollback tidak membutuhkan migration database:
+
+1. Set `REDIS_ENABLED=false`.
+2. Deploy ulang aplikasi.
+3. Hentikan resource Redis bila tidak lagi dipakai.
+4. Nilai authoritative tetap tersedia di PostgreSQL.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "api:docs:generate": "bun scripts/api-docs-generate.ts",
     "api:docs:check": "bun scripts/api-docs-check.ts",
     "db:pool:health": "bun scripts/db-pool-health.ts",
+    "redis:health": "bun scripts/redis-health.ts",
     "changesets:policy:check": "bun scripts/changeset-policy-check.ts",
     "release:verify": "bun scripts/release-verify.ts",
     "modules:dag:check": "bun scripts/validate-module-graph.ts",

--- a/scripts/redis-health.ts
+++ b/scripts/redis-health.ts
@@ -1,0 +1,49 @@
+#!/usr/bin/env bun
+
+import { checkRedisHealth, closeRedisClient } from "../src/lib/redis/client";
+import {
+  loadRedisConfig,
+  redactRedisUrl,
+  validateRedisConfig
+} from "../src/lib/redis/config";
+
+const config = loadRedisConfig();
+const findings = validateRedisConfig(config);
+const failures = findings.filter((finding) => finding.severity === "fail");
+
+if (failures.length > 0) {
+  console.error(
+    JSON.stringify(
+      {
+        check: "redis",
+        status: "invalid_configuration",
+        url: redactRedisUrl(config.url),
+        findings
+      },
+      null,
+      2
+    )
+  );
+  process.exitCode = 1;
+} else {
+  const health = await checkRedisHealth(config);
+
+  console.log(
+    JSON.stringify(
+      {
+        check: "redis",
+        url: redactRedisUrl(config.url),
+        findings,
+        ...health
+      },
+      null,
+      2
+    )
+  );
+
+  if (health.status === "unhealthy") {
+    process.exitCode = 1;
+  }
+}
+
+closeRedisClient();

--- a/src/lib/redis/cache.ts
+++ b/src/lib/redis/cache.ts
@@ -1,0 +1,181 @@
+import type { RedisClient } from "bun";
+
+import { safeErrorDetail } from "../logging/error-sanitizer";
+import { log } from "../logging/logger";
+import { getRedisClient, withRedisCommandTimeout } from "./client";
+import { loadRedisConfig, type RedisConfig } from "./config";
+
+export type RedisCacheClient = Pick<RedisClient, "get" | "send">;
+
+export type RedisCacheOptions = {
+  client?: RedisCacheClient | null;
+  config?: RedisConfig;
+  ttlSec?: number;
+};
+
+function resolveClient(options: RedisCacheOptions): {
+  client: RedisCacheClient | null;
+  config: RedisConfig;
+} {
+  const config = options.config ?? loadRedisConfig();
+  const client =
+    options.client === undefined ? getRedisClient(config) : options.client;
+
+  return { client, config };
+}
+
+/**
+ * Best-effort JSON cache read. Redis unavailability, timeout, or malformed
+ * cached JSON becomes a cache miss; it never blocks the authoritative loader.
+ */
+export async function getRedisJson<T>(
+  key: string,
+  options: RedisCacheOptions = {}
+): Promise<T | null> {
+  const { client, config } = resolveClient(options);
+
+  if (!client) {
+    return null;
+  }
+
+  try {
+    const value = await withRedisCommandTimeout(
+      client.get(key),
+      config.commandTimeoutMs,
+      "GET"
+    );
+
+    if (value === null) {
+      return null;
+    }
+
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      await withRedisCommandTimeout(
+        client.send("DEL", [key]),
+        config.commandTimeoutMs,
+        "DEL malformed cache entry"
+      ).catch(() => undefined);
+
+      log("warning", "Malformed Redis JSON entry treated as cache miss.", {
+        moduleKey: "redis-foundation"
+      });
+
+      return null;
+    }
+  } catch (error) {
+    log("warning", "Redis cache read failed open.", {
+      moduleKey: "redis-foundation",
+      error: safeErrorDetail(error)
+    });
+
+    return null;
+  }
+}
+
+/**
+ * Best-effort atomic SET with expiry. Returns false when Redis is disabled or
+ * unavailable; callers must not interpret a cache write failure as a domain
+ * transaction failure.
+ */
+export async function setRedisJson<T>(
+  key: string,
+  value: T,
+  options: RedisCacheOptions = {}
+): Promise<boolean> {
+  const { client, config } = resolveClient(options);
+
+  if (!client) {
+    return false;
+  }
+
+  const ttlSec = options.ttlSec ?? config.cacheDefaultTtlSec;
+
+  if (!Number.isInteger(ttlSec) || ttlSec < 1 || ttlSec > 86_400) {
+    throw new Error(
+      "Redis cache TTL must be an integer between 1 and 86400 seconds."
+    );
+  }
+
+  try {
+    const payload = JSON.stringify(value);
+
+    if (payload === undefined) {
+      log("warning", "Non-serializable Redis cache value was skipped.", {
+        moduleKey: "redis-foundation"
+      });
+      return false;
+    }
+
+    const result = await withRedisCommandTimeout(
+      client.send("SET", [key, payload, "EX", String(ttlSec)]),
+      config.commandTimeoutMs,
+      "SET"
+    );
+
+    return result === "OK";
+  } catch (error) {
+    log("warning", "Redis cache write failed open.", {
+      moduleKey: "redis-foundation",
+      error: safeErrorDetail(error)
+    });
+
+    return false;
+  }
+}
+
+export async function deleteRedisCache(
+  key: string,
+  options: RedisCacheOptions = {}
+): Promise<boolean> {
+  const { client, config } = resolveClient(options);
+
+  if (!client) {
+    return false;
+  }
+
+  try {
+    await withRedisCommandTimeout(
+      client.send("DEL", [key]),
+      config.commandTimeoutMs,
+      "DEL"
+    );
+
+    return true;
+  } catch (error) {
+    log("warning", "Redis cache invalidation failed open.", {
+      moduleKey: "redis-foundation",
+      error: safeErrorDetail(error)
+    });
+
+    return false;
+  }
+}
+
+export type RedisCacheAsideOptions = RedisCacheOptions & {
+  refresh?: boolean;
+};
+
+/**
+ * Generic cache-aside flow. The loader is always the source of truth; Redis
+ * only accelerates reads and is never consulted inside a database transaction.
+ */
+export async function redisCacheAside<T>(
+  key: string,
+  loader: () => Promise<T>,
+  options: RedisCacheAsideOptions = {}
+): Promise<T> {
+  if (!options.refresh) {
+    const cached = await getRedisJson<T>(key, options);
+
+    if (cached !== null) {
+      return cached;
+    }
+  }
+
+  const authoritativeValue = await loader();
+  await setRedisJson(key, authoritativeValue, options);
+
+  return authoritativeValue;
+}

--- a/src/lib/redis/client.ts
+++ b/src/lib/redis/client.ts
@@ -1,0 +1,176 @@
+import { RedisClient } from "bun";
+
+import { safeErrorDetail } from "../logging/error-sanitizer";
+import { log } from "../logging/logger";
+import {
+  loadRedisConfig,
+  validateRedisConfig,
+  type RedisConfig
+} from "./config";
+
+let singleton: RedisClient | null = null;
+let singletonConfig: RedisConfig | null = null;
+
+function createRedisClient(config: RedisConfig): RedisClient {
+  if (!config.url) {
+    throw new Error("REDIS_URL is required when Redis is enabled.");
+  }
+
+  return new RedisClient(config.url, {
+    connectionTimeout: config.connectionTimeoutMs,
+    autoReconnect: true,
+    maxRetries: config.maxRetries,
+    enableOfflineQueue: false,
+    enableAutoPipelining: true
+  });
+}
+
+function hasSameConnectionConfig(
+  current: RedisConfig | null,
+  requested: RedisConfig
+): boolean {
+  return (
+    current !== null &&
+    current.url === requested.url &&
+    current.connectionTimeoutMs === requested.connectionTimeoutMs &&
+    current.maxRetries === requested.maxRetries
+  );
+}
+
+/**
+ * Returns null when Redis is disabled. Configuration errors throw before any
+ * connection attempt so deployment mistakes are visible during preflight.
+ */
+export function getRedisClient(
+  config: RedisConfig = loadRedisConfig()
+): RedisClient | null {
+  if (!config.enabled) {
+    return null;
+  }
+
+  const failures = validateRedisConfig(config).filter(
+    (finding) => finding.severity === "fail"
+  );
+
+  if (failures.length > 0) {
+    throw new Error(failures.map((finding) => finding.message).join(" "));
+  }
+
+  if (singleton && hasSameConnectionConfig(singletonConfig, config)) {
+    return singleton;
+  }
+
+  singleton?.close();
+  singleton = createRedisClient(config);
+  singletonConfig = config;
+
+  singleton.onconnect = () => {
+    log("info", "Redis connection established.", {
+      moduleKey: "redis-foundation"
+    });
+  };
+
+  singleton.onclose = (error) => {
+    log("warning", "Redis connection closed.", {
+      moduleKey: "redis-foundation",
+      error: safeErrorDetail(error)
+    });
+  };
+
+  return singleton;
+}
+
+export function closeRedisClient(): void {
+  singleton?.close();
+  singleton = null;
+  singletonConfig = null;
+}
+
+/** Test helper; never leaves a network connection open between test cases. */
+export function resetRedisClientForTests(): void {
+  closeRedisClient();
+}
+
+export async function withRedisCommandTimeout<T>(
+  operation: Promise<T>,
+  timeoutMs: number,
+  operationName: string
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Redis ${operationName} timed out.`)),
+          timeoutMs
+        );
+      })
+    ]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+export type RedisHealthResult = {
+  enabled: boolean;
+  status: "disabled" | "healthy" | "unhealthy";
+  latencyMs: number | null;
+  connected: boolean;
+  bufferedAmount: number;
+  error?: string;
+};
+
+export async function checkRedisHealth(
+  config: RedisConfig = loadRedisConfig()
+): Promise<RedisHealthResult> {
+  if (!config.enabled) {
+    return {
+      enabled: false,
+      status: "disabled",
+      latencyMs: null,
+      connected: false,
+      bufferedAmount: 0
+    };
+  }
+
+  const startedAt = performance.now();
+
+  try {
+    const client = getRedisClient(config);
+
+    if (!client) {
+      throw new Error("Redis client is unexpectedly disabled.");
+    }
+
+    const response = await withRedisCommandTimeout(
+      client.send("PING", []),
+      config.commandTimeoutMs,
+      "PING"
+    );
+
+    if (response !== "PONG") {
+      throw new Error("Redis PING returned an unexpected response.");
+    }
+
+    return {
+      enabled: true,
+      status: "healthy",
+      latencyMs: Math.round((performance.now() - startedAt) * 100) / 100,
+      connected: client.connected,
+      bufferedAmount: client.bufferedAmount
+    };
+  } catch (error) {
+    return {
+      enabled: true,
+      status: "unhealthy",
+      latencyMs: Math.round((performance.now() - startedAt) * 100) / 100,
+      connected: singleton?.connected ?? false,
+      bufferedAmount: singleton?.bufferedAmount ?? 0,
+      error: safeErrorDetail(error)
+    };
+  }
+}

--- a/src/lib/redis/config.ts
+++ b/src/lib/redis/config.ts
@@ -1,0 +1,249 @@
+export type RedisEnvironment = Readonly<Record<string, string | undefined>>;
+
+export type RedisConfig = {
+  enabled: boolean;
+  url: string | null;
+  keyPrefix: string;
+  connectionTimeoutMs: number;
+  commandTimeoutMs: number;
+  maxRetries: number;
+  cacheDefaultTtlSec: number;
+};
+
+export type RedisValidationFinding = {
+  severity: "warning" | "fail";
+  code: string;
+  message: string;
+};
+
+const DEFAULTS = {
+  keyPrefix: "awcms",
+  connectionTimeoutMs: 2_000,
+  commandTimeoutMs: 1_000,
+  maxRetries: 3,
+  cacheDefaultTtlSec: 300
+} as const;
+
+const SUPPORTED_SCHEMES = [
+  "redis://",
+  "rediss://",
+  "redis+tls://",
+  "redis+unix://",
+  "redis+tls+unix://"
+] as const;
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  return value.trim().toLowerCase() === "true";
+}
+
+function parseBoundedInteger(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < min || parsed > max) {
+    return fallback;
+  }
+
+  return parsed;
+}
+
+export function loadRedisConfig(
+  env: RedisEnvironment = process.env
+): RedisConfig {
+  const url = env.REDIS_URL?.trim() || null;
+
+  return {
+    enabled: parseBoolean(env.REDIS_ENABLED, false),
+    url,
+    keyPrefix: env.REDIS_KEY_PREFIX?.trim() || DEFAULTS.keyPrefix,
+    connectionTimeoutMs: parseBoundedInteger(
+      env.REDIS_CONNECTION_TIMEOUT_MS,
+      DEFAULTS.connectionTimeoutMs,
+      100,
+      30_000
+    ),
+    commandTimeoutMs: parseBoundedInteger(
+      env.REDIS_COMMAND_TIMEOUT_MS,
+      DEFAULTS.commandTimeoutMs,
+      50,
+      30_000
+    ),
+    maxRetries: parseBoundedInteger(
+      env.REDIS_MAX_RETRIES,
+      DEFAULTS.maxRetries,
+      0,
+      20
+    ),
+    cacheDefaultTtlSec: parseBoundedInteger(
+      env.REDIS_CACHE_DEFAULT_TTL_SEC,
+      DEFAULTS.cacheDefaultTtlSec,
+      1,
+      86_400
+    )
+  };
+}
+
+export function validateRedisConfig(
+  config: RedisConfig,
+  env: RedisEnvironment = process.env
+): RedisValidationFinding[] {
+  const findings: RedisValidationFinding[] = [];
+
+  if (!config.enabled) {
+    return findings;
+  }
+
+  if (!config.url) {
+    findings.push({
+      severity: "fail",
+      code: "redis_url_required",
+      message: "REDIS_URL is required when REDIS_ENABLED=true."
+    });
+  } else if (
+    !SUPPORTED_SCHEMES.some((scheme) => config.url?.startsWith(scheme))
+  ) {
+    findings.push({
+      severity: "fail",
+      code: "redis_url_scheme_unsupported",
+      message:
+        "REDIS_URL must use redis://, rediss://, redis+tls://, redis+unix://, or redis+tls+unix://."
+    });
+  }
+
+  if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]{1,63}$/.test(config.keyPrefix)) {
+    findings.push({
+      severity: "fail",
+      code: "redis_key_prefix_invalid",
+      message:
+        "REDIS_KEY_PREFIX must be 2-64 characters using letters, numbers, dot, underscore, or hyphen."
+    });
+  }
+
+  const appEnv = env.APP_ENV?.trim().toLowerCase();
+  const isOnlineEnvironment = appEnv === "staging" || appEnv === "production";
+
+  if (
+    isOnlineEnvironment &&
+    config.url?.startsWith("redis://") &&
+    !isPrivateRedisHost(config.url)
+  ) {
+    findings.push({
+      severity: "warning",
+      code: "redis_tls_recommended",
+      message:
+        "Use rediss:// or a private/internal network for Redis in staging and production."
+    });
+  }
+
+  if (isOnlineEnvironment && config.url && !hasRedisCredentials(config.url)) {
+    findings.push({
+      severity: "warning",
+      code: "redis_auth_recommended",
+      message:
+        "Use a dedicated Redis ACL username and secret in staging and production."
+    });
+  }
+
+  return findings;
+}
+
+function isPrivateRedisHost(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    const hostname = parsed.hostname.toLowerCase();
+
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "::1" ||
+      hostname === "redis" ||
+      hostname.endsWith(".internal") ||
+      hostname.endsWith(".local") ||
+      hostname.startsWith("10.") ||
+      hostname.startsWith("192.168.") ||
+      /^172\.(1[6-9]|2\d|3[01])\./.test(hostname)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function hasRedisCredentials(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.username.length > 0 && parsed.password.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function redactRedisUrl(url: string | null): string | null {
+  if (!url) {
+    return null;
+  }
+
+  try {
+    const parsed = new URL(url);
+
+    if (parsed.username) {
+      parsed.username = "***";
+    }
+
+    if (parsed.password) {
+      parsed.password = "***";
+    }
+
+    return parsed.toString();
+  } catch {
+    return "[invalid-redis-url]";
+  }
+}
+
+export type RedisKeyParts = {
+  namespace: string;
+  key: string;
+  tenantId?: string | null;
+  version?: string;
+};
+
+function encodeKeySegment(segment: string, label: string): string {
+  const normalized = segment.trim();
+
+  if (!normalized) {
+    throw new Error(`Redis key ${label} must not be empty.`);
+  }
+
+  return encodeURIComponent(normalized);
+}
+
+/**
+ * Builds a collision-resistant key with explicit tenant scope. Derived modules
+ * must pass tenantId for tenant-scoped data; global is reserved for genuinely
+ * cross-tenant, non-sensitive platform state.
+ */
+export function buildRedisKey(
+  parts: RedisKeyParts,
+  config: Pick<RedisConfig, "keyPrefix"> = loadRedisConfig()
+): string {
+  const prefix = encodeKeySegment(config.keyPrefix, "prefix");
+  const version = encodeKeySegment(parts.version ?? "v1", "version");
+  const namespace = encodeKeySegment(parts.namespace, "namespace");
+  const scope = parts.tenantId
+    ? `tenant:${encodeKeySegment(parts.tenantId, "tenantId")}`
+    : "global";
+  const key = encodeKeySegment(parts.key, "key");
+
+  return `${prefix}:${version}:${namespace}:${scope}:${key}`;
+}

--- a/tests/unit/redis-foundation.test.ts
+++ b/tests/unit/redis-foundation.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  deleteRedisCache,
+  getRedisJson,
+  redisCacheAside,
+  setRedisJson,
+  type RedisCacheClient
+} from "../../src/lib/redis/cache";
+import {
+  getRedisClient,
+  withRedisCommandTimeout
+} from "../../src/lib/redis/client";
+import {
+  buildRedisKey,
+  loadRedisConfig,
+  redactRedisUrl,
+  validateRedisConfig,
+  type RedisConfig
+} from "../../src/lib/redis/config";
+
+function enabledConfig(overrides: Partial<RedisConfig> = {}): RedisConfig {
+  return {
+    enabled: true,
+    url: "redis://awcms_app:secret@localhost:6379/0",
+    keyPrefix: "awcms",
+    connectionTimeoutMs: 2_000,
+    commandTimeoutMs: 1_000,
+    maxRetries: 3,
+    cacheDefaultTtlSec: 300,
+    ...overrides
+  };
+}
+
+class FakeRedisClient {
+  readonly values = new Map<string, string>();
+  readonly commands: Array<{ command: string; args: string[] }> = [];
+  failReads = false;
+  failWrites = false;
+
+  async get(key: string): Promise<string | null> {
+    if (this.failReads) {
+      throw new Error("simulated Redis read outage");
+    }
+
+    return this.values.get(key) ?? null;
+  }
+
+  async send(command: string, args: string[]): Promise<unknown> {
+    const normalized = command.toUpperCase();
+    this.commands.push({ command: normalized, args });
+
+    if (this.failWrites) {
+      throw new Error("simulated Redis write outage");
+    }
+
+    if (normalized === "SET") {
+      this.values.set(args[0]!, args[1]!);
+      return "OK";
+    }
+
+    if (normalized === "DEL") {
+      const existed = this.values.delete(args[0]!);
+      return existed ? 1 : 0;
+    }
+
+    return null;
+  }
+
+  asClient(): RedisCacheClient {
+    return this as unknown as RedisCacheClient;
+  }
+}
+
+describe("Redis configuration", () => {
+  test("is disabled by default and does not create a client", () => {
+    const config = loadRedisConfig({});
+
+    expect(config.enabled).toBe(false);
+    expect(config.url).toBeNull();
+    expect(validateRedisConfig(config, {})).toEqual([]);
+    expect(getRedisClient(config)).toBeNull();
+  });
+
+  test("requires REDIS_URL only when explicitly enabled", () => {
+    const config = loadRedisConfig({ REDIS_ENABLED: "true" });
+    const findings = validateRedisConfig(config, {});
+
+    expect(
+      findings.some(
+        (finding) =>
+          finding.severity === "fail" && finding.code === "redis_url_required"
+      )
+    ).toBe(true);
+  });
+
+  test("rejects unsupported URL schemes", () => {
+    const config = loadRedisConfig({
+      REDIS_ENABLED: "true",
+      REDIS_URL: "http://localhost:6379"
+    });
+    const findings = validateRedisConfig(config, {});
+
+    expect(
+      findings.some(
+        (finding) => finding.code === "redis_url_scheme_unsupported"
+      )
+    ).toBe(true);
+  });
+
+  test("warns about unauthenticated public Redis in production", () => {
+    const config = loadRedisConfig({
+      REDIS_ENABLED: "true",
+      REDIS_URL: "redis://cache.example.com:6379/0"
+    });
+    const findings = validateRedisConfig(config, { APP_ENV: "production" });
+
+    expect(
+      findings.some((finding) => finding.code === "redis_tls_recommended")
+    ).toBe(true);
+    expect(
+      findings.some((finding) => finding.code === "redis_auth_recommended")
+    ).toBe(true);
+  });
+
+  test("redacts username and password from diagnostic URLs", () => {
+    const redacted = redactRedisUrl(
+      "redis://awcms_app:very-secret@redis.internal:6379/0"
+    );
+
+    expect(redacted).not.toContain("very-secret");
+    expect(redacted).not.toContain("awcms_app");
+    expect(redacted).toContain("***");
+  });
+
+  test("falls back to bounded defaults for malformed numeric values", () => {
+    const config = loadRedisConfig({
+      REDIS_CONNECTION_TIMEOUT_MS: "not-a-number",
+      REDIS_COMMAND_TIMEOUT_MS: "0",
+      REDIS_MAX_RETRIES: "999",
+      REDIS_CACHE_DEFAULT_TTL_SEC: "-1"
+    });
+
+    expect(config.connectionTimeoutMs).toBe(2_000);
+    expect(config.commandTimeoutMs).toBe(1_000);
+    expect(config.maxRetries).toBe(3);
+    expect(config.cacheDefaultTtlSec).toBe(300);
+  });
+
+  test("bounds command execution time", async () => {
+    const never = new Promise<string>(() => undefined);
+
+    await expect(
+      withRedisCommandTimeout(never, 5, "test command")
+    ).rejects.toThrow("Redis test command timed out.");
+  });
+});
+
+describe("Redis key namespacing", () => {
+  test("separates tenant keys and global keys", () => {
+    const tenantA = buildRedisKey(
+      { namespace: "reports", tenantId: "tenant-a", key: "summary" },
+      { keyPrefix: "awcms" }
+    );
+    const tenantB = buildRedisKey(
+      { namespace: "reports", tenantId: "tenant-b", key: "summary" },
+      { keyPrefix: "awcms" }
+    );
+    const global = buildRedisKey(
+      { namespace: "reports", key: "summary" },
+      { keyPrefix: "awcms" }
+    );
+
+    expect(tenantA).toBe("awcms:v1:reports:tenant:tenant-a:summary");
+    expect(tenantB).not.toBe(tenantA);
+    expect(global).toBe("awcms:v1:reports:global:summary");
+  });
+
+  test("encodes delimiter characters so callers cannot inject key segments", () => {
+    const key = buildRedisKey(
+      { namespace: "report:admin", tenantId: "tenant:1", key: "a:b" },
+      { keyPrefix: "awcms" }
+    );
+
+    expect(key).toBe("awcms:v1:report%3Aadmin:tenant:tenant%3A1:a%3Ab");
+  });
+});
+
+describe("Redis cache-aside helpers", () => {
+  test("reads and writes JSON with an explicit TTL", async () => {
+    const fake = new FakeRedisClient();
+    const config = enabledConfig();
+
+    expect(
+      await setRedisJson(
+        "awcms:v1:test:global:item",
+        { value: 42 },
+        { client: fake.asClient(), config, ttlSec: 60 }
+      )
+    ).toBe(true);
+
+    expect(fake.commands[0]).toEqual({
+      command: "SET",
+      args: ["awcms:v1:test:global:item", '{"value":42}', "EX", "60"]
+    });
+
+    expect(
+      await getRedisJson<{ value: number }>("awcms:v1:test:global:item", {
+        client: fake.asClient(),
+        config
+      })
+    ).toEqual({ value: 42 });
+  });
+
+  test("rejects cache entries without a bounded positive TTL", async () => {
+    const fake = new FakeRedisClient();
+
+    await expect(
+      setRedisJson(
+        "awcms:v1:test:global:item",
+        { value: 42 },
+        { client: fake.asClient(), config: enabledConfig(), ttlSec: 0 }
+      )
+    ).rejects.toThrow("Redis cache TTL must be an integer");
+  });
+
+  test("treats malformed JSON as a miss and removes the bad entry", async () => {
+    const fake = new FakeRedisClient();
+    const key = "awcms:v1:test:global:bad-json";
+    fake.values.set(key, "{not-json");
+
+    const value = await getRedisJson(key, {
+      client: fake.asClient(),
+      config: enabledConfig()
+    });
+
+    expect(value).toBeNull();
+    expect(fake.values.has(key)).toBe(false);
+    expect(fake.commands.some((entry) => entry.command === "DEL")).toBe(true);
+  });
+
+  test("fails open to cache miss and write skip during Redis outage", async () => {
+    const fake = new FakeRedisClient();
+    fake.failReads = true;
+    fake.failWrites = true;
+
+    expect(
+      await getRedisJson("awcms:v1:test:global:item", {
+        client: fake.asClient(),
+        config: enabledConfig()
+      })
+    ).toBeNull();
+
+    expect(
+      await setRedisJson(
+        "awcms:v1:test:global:item",
+        { value: 42 },
+        { client: fake.asClient(), config: enabledConfig() }
+      )
+    ).toBe(false);
+
+    expect(
+      await deleteRedisCache("awcms:v1:test:global:item", {
+        client: fake.asClient(),
+        config: enabledConfig()
+      })
+    ).toBe(false);
+  });
+
+  test("returns a cache hit without calling the authoritative loader", async () => {
+    const fake = new FakeRedisClient();
+    const key = "awcms:v1:test:global:item";
+    fake.values.set(key, '{"source":"cache"}');
+    let loaderCalls = 0;
+
+    const value = await redisCacheAside(
+      key,
+      async () => {
+        loaderCalls += 1;
+        return { source: "database" };
+      },
+      { client: fake.asClient(), config: enabledConfig() }
+    );
+
+    expect(value).toEqual({ source: "cache" });
+    expect(loaderCalls).toBe(0);
+  });
+
+  test("loads authoritative data on miss and populates Redis best-effort", async () => {
+    const fake = new FakeRedisClient();
+    const key = "awcms:v1:test:global:item";
+
+    const value = await redisCacheAside(
+      key,
+      async () => ({ source: "database" }),
+      { client: fake.asClient(), config: enabledConfig(), ttlSec: 30 }
+    );
+
+    expect(value).toEqual({ source: "database" });
+    expect(JSON.parse(fake.values.get(key)!)).toEqual({ source: "database" });
+  });
+});


### PR DESCRIPTION
## Summary

Implements the AWCMS-side draft for #197 using Bun's built-in `RedisClient` (`import { RedisClient } from "bun"`) with no third-party Redis runtime package.

Redis remains disabled by default and fail-open for cache use. PostgreSQL, RLS, audit, durable outbox, sessions, workflow state, idempotency records, authorization controls, and all ERP/domain data remain authoritative.

## Changes

- typed optional Redis configuration and validation;
- explicit Bun-native `RedisClient` singleton with bounded connection/retry behavior;
- `enableOfflineQueue=false` and native auto-pipelining;
- tenant-aware, versioned Redis key namespace with AWCMS prefix;
- best-effort JSON cache-aside helpers with mandatory TTL;
- credential-redacting `bun run redis:health` command;
- standalone `config/redis.env.example`;
- hardened standalone Redis Compose deployment because AWCMS has no canonical root app Compose stack yet;
- unit coverage without a live Redis/network dependency;
- architecture, security, Coolify/LAN, capacity, recovery, standards, and phased-adoption documentation;
- release changeset.

## Security and architecture decisions

- No Redis command is introduced as a required dependency inside a PostgreSQL transaction.
- Cache failures become cache misses/write/invalidation skips.
- No secrets, Redis values, or raw credential-bearing URLs are logged.
- Tenant-scoped data must use the tenant-aware key builder.
- Redis is not approved here as a source of truth, durable queue, session/auth store, audit store, workflow store, or authorization boundary.
- Redis port 6379 is not published; the deployment uses a dedicated ACL user, disabled default user, key-prefix restriction, dangerous-command denial, authenticated health check, resource limits, and internal networking.
- Redis Sentinel and Cluster remain out of scope because Bun's native client does not currently support them.

## Mini-first dependency

This PR is intentionally **draft** while `ahliweb/awcms-mini#891` remains open/draft. Before this PR can be marked ready or merged:

- [ ] Mini PR #891 is merged and its final merge SHA is recorded here.
- [ ] This branch is compared with the final reviewed Mini diff.
- [ ] Any intentional AWCMS divergence is documented; otherwise family-compatible behavior is preserved.

AWCMS-specific adaptation already applied: `REDIS_KEY_PREFIX=awcms` and a standalone Redis deployment rather than copying Mini's app overlay against a nonexistent AWCMS root Compose file.

## Validation

- [x] Redis-disabled path requires no Redis/network.
- [x] Unit tests cover config, credential redaction, tenant keys, TTL, timeout, malformed JSON, fail-open behavior, invalidation, and authoritative loader behavior.
- [x] Repository hygiene: Bun-only and no committed secrets.
- [x] Prettier, documentation, translation, API contracts, module graph/composition, extension seam, family conformance, logging lint, TypeScript typecheck, unit tests, and production build.
- [x] PostgreSQL/RLS integration tests.
- [x] Playwright E2E smoke.
- [x] Minimum-supported Bun 1.3.0 typecheck/build/conformance.
- [x] Changesets policy.
- [x] CodeQL for JavaScript/TypeScript and Actions.
- [ ] Optional authenticated live Redis `PING` deployment verification.

CI green on head `04f5e5bb09e215ae9a696304151c6fd5728859f6`.

## Rollback

Set `REDIS_ENABLED=false` and remove/stop the optional Redis resource. No database migration or business-data rollback is required.

Closes #197.