### PR TITLE
docs(governance): ADR-0034 — template dipakai-langsung, hapus jalur turunan (Fase 1)

### DIFF
--- a/docs/adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md
+++ b/docs/adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md
@@ -1,0 +1,61 @@
+# ADR-0034 — Keluarga AWCMS sebagai template dipakai-LANGSUNG untuk pengembangan apa pun, dan penghapusan jalur aplikasi-turunan
+
+- **Status:** Accepted
+- **Tanggal:** 2026-07-21
+- **Pengambil keputusan:** @ahliweb
+- **Men-supersede:** [ADR-0013](0013-extension-layers-and-boundary-model.md) (lapisan Derived Application), [ADR-0014](0014-deterministic-build-time-module-composition.md) (komposisi build-time untuk aplikasi turunan / `application-registry.ts`), [ADR-0015](0015-derived-application-compatibility-manifest.md) (manifest kompatibilitas turunan + `extension:check`), [ADR-0022](0022-erp-modules-live-in-extension-repos.md) (modul domain hidup di repo ekstensi), [ADR-0025](0025-implement-deterministic-build-time-module-composition.md) (implementasi komposisi untuk registry base + aplikasi turunan). Menegaskan kembali: konvensi teknis inti (ADR-0001 Bun-only/RLS/RBAC-ABAC, ADR-0003 RLS, ADR-0004 default-deny, ADR-0011 capability ports).
+- **Selaras dengan:** awcms-micro `ADR-0034` (template dipakai-langsung, deprecation jalur turunan) dan `ADR-0035` (mekanisme komposisi base tetap ada) — dokumen ini menyelaraskan keputusan itu ke seluruh keluarga (lihat §5), dengan awcms mengambil langkah lebih jauh: **menghapus** permukaan jalur-turunan, bukan sekadar men-deprecate.
+
+## Konteks
+
+Epic #177 dan pilot #187 membangun **jalur aplikasi-turunan**: `awcms` dipakai sebagai fondasi yang di atasnya dibangun aplikasi domain di **repo terpisah** (mis. `awcms-erp-pilot`) lewat seam `src/modules/application-registry.ts` + migration namespace 900–999 + manifest kompatibilitas + gerbang `bun run extension:check`. ADR-0022 bahkan menetapkan bahwa modul domain (termasuk seluruh modul konten/website) **tidak boleh** hidup di `src/modules/` base, melainkan di repo ekstensi.
+
+Dua konsekuensi yang tidak diinginkan:
+
+1. **Repo derivatif menambah lapisan tanpa manfaat setara.** Untuk membangun apa pun, model "buat repo turunan terpisah di atas base" mewajibkan registry aplikasi, penomoran migrasi khusus, manifest kompatibilitas, dan gate yang harus dipelihara — padahal untuk banyak kebutuhan cukup **memakai repo template secara langsung** dan menambah modul di dalamnya.
+2. **Ketiga repo keluarga sebenarnya adalah template yang berdiri sendiri.** `awcms-mini` (standar modular-monolith), `awcms` (fondasi ERP + solusi back-office), dan `awcms-micro` (website full-online hingga toko online) masing-masing sudah lengkap sebagai titik-awal. awcms-micro sudah menyatakan sikap ini (ADR-0034/0035 miliknya). Framing "base wajib + turunan terpisah" bertentangan dengan kenyataan itu.
+
+## Keputusan
+
+### 1. Tiga repo keluarga = template dipakai-LANGSUNG untuk pengembangan apa pun
+
+`awcms-mini`, `awcms`, dan `awcms-micro` adalah **tiga template dasar yang sejajar**, masing-masing **dipakai langsung** sebagai titik awal pengembangan — bukan basis-turunan-wajib yang di atasnya harus dibangun repo aplikasi terpisah. Perbedaan mereka adalah **scope/lineage**, bukan hierarki:
+
+| Repositori    | Peran (dipakai langsung)           | Scope                                        |
+| ------------- | ---------------------------------- | -------------------------------------------- |
+| `awcms-mini`  | Template standar modular-monolith  | Fondasi reusable generik                     |
+| `awcms`       | Template lineage ERP / back-office | ERP, solusi bisnis, dan pengembangan apa pun |
+| `awcms-micro` | Template website full-online       | Situs konten hingga toko online (e-commerce) |
+
+Cara pakai utama: **fork/gunakan repo yang scope-nya paling dekat, lalu kembangkan modul langsung di dalamnya.** Warisan konvensi antar-repo tetap dicatat (Bun-only, RLS/FORCE, RBAC/ABAC default-deny, kontrak OpenAPI/AsyncAPI, gate CI), tetapi tidak ada repo yang diposisikan sebagai "turunan yang wajib mem-port dari repo lain secara berkelanjutan".
+
+### 2. TIDAK membuat repo derivatif
+
+Pengembangan baru **tidak** dilakukan dengan membuat repo aplikasi-turunan terpisah di atas salah satu template. Modul domain — termasuk modul konten/website — **boleh dan seharusnya** hidup langsung di `src/modules/` template yang dipakai. Ini men-supersede ADR-0022 (yang melarang modul domain di base): pembatasan itu dicabut.
+
+### 3. Jalur aplikasi-turunan di `awcms`: DIHAPUS
+
+Berbeda dari awcms-micro yang men-deprecate (ADR-0034 miliknya) lalu **menahan** kodenya (ADR-0035, karena mekanisme komposisi = infrastruktur base load-bearing), `awcms` **menghapus** permukaan yang **khusus jalur-turunan**:
+
+- Seam turunan `src/modules/application-registry.ts` (yang selalu `undefined` di base), gerbang `bun run extension:check`, dan fixture `tests/fixtures/derived-application-example`.
+- Konsep migration namespace turunan (900–999) dan manifest kompatibilitas turunan (`extension.manifest.json`, ADR-0015).
+
+**Yang DIPERTAHANKAN** karena load-bearing base (bukan derived-only, dipakai perakitan registry base, SoD, reporting, conformance): `src/modules/index.ts` `listModules()`, kontrak `ModuleDescriptor`/`defineModule` (`_shared/module-contract.ts`), `module-management`, dan validasi komposisi base sejauh ia memeriksa **registry base sendiri** (bukan registry aplikasi turunan). Penghapusan dilakukan sebagai langkah **evidence-gated** terpisah (PR sendiri, `bun run check` + CI penuh hijau) — bukan di ADR ini; ADR ini adalah keputusannya.
+
+### 4. Dokumen & issue jalur-turunan: usang
+
+`docs/awcms/derived-application-guide.md`, `derived-app-pilot-plan.md`, `derived-app-pilot-purchase-requisition-plan.md`, dan `derived-app-pilot-purchase-requisition-execution.md` ditandai **DEPRECATED** (menunjuk ADR ini). Issue #187 (pilot derived ERP) dan bagian pilot-turunan dari EPIC #177 ditutup sebagai usang; kapabilitas fondasi yang sudah selesai dan bernilai (authorization ABAC/SoD/business-scope #179–#181, kontrak OpenAPI modular #182, conformance #183) **tetap** — hanya premis "repo turunan terpisah" yang dicabut.
+
+### 5. Harmonisasi lintas keluarga
+
+Sikap yang sama diterapkan ke ketiga repo (langkah terpisah per-repo):
+
+- **awcms-micro:** sudah pada posisi ini (ADR-0034/0035 miliknya). Diselaraskan ke framing "tiga template sejajar + tidak membuat repo derivatif". Penghapusan kode komposisi **tidak** dipaksakan di sini — ADR-0035 miliknya sudah membuktikan mekanisme itu load-bearing; hanya narasi/positioning yang diselaraskan.
+- **awcms-mini:** direposisi dari "base yang di atasnya dibangun aplikasi turunan" menjadi "template standar dipakai-langsung"; dokumen/ADR jalur-turunan (ADR-0013/0015) di-deprecate; penghapusan kode mengikuti kenyataan load-bearing per-repo (seperti micro).
+- **awcms:** dokumen ini + penghapusan penuh permukaan derived-only (§3).
+
+## Konsekuensi
+
+- **Positif:** tidak ada lapisan repo-turunan wajib; pengembangan langsung di template; modul website boleh masuk base (`no-content-website-modules` dicabut, membuka jalan implementasi langsung modul website mis. `theming`).
+- **Ditegakkan terpisah:** (a) penghapusan kode/gate derived-only di `awcms` (§3) — PR evidence-gated; (b) implementasi langsung modul website pertama (`theming`, diadaptasi dari awcms-micro); (c) pembaruan `awcms-family-compatibility.yaml` (mencabut divergence `no-content-website-modules`, menyesuaikan `module-type-without-derived`); (d) reposisi README/AGENTS; (e) harmonisasi mini/micro.
+- **Tidak berubah:** seluruh konvensi runtime (Bun-only, RLS/FORCE, RBAC/ABAC default-deny, kontrak, registry base saat ini, gate CI non-derived). ADR ini mengubah **model pemakaian & tata kelola**, bukan arsitektur runtime.

--- a/docs/adr/README.id.md
+++ b/docs/adr/README.id.md
@@ -30,40 +30,41 @@ flowchart LR
 
 ## Indeks
 
-| ADR                                                                   | Judul                                                                                             | Status   |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------- |
-| [0001](0001-rebuild-on-awcms-foundation-erp-scope.md)                 | Rebuild AWCMS sebagai platform ERP di atas standar modular monolith                               | Accepted |
-| [0002](0002-bun-only-runtime.md)                                      | Runtime & tooling Bun-only                                                                        | Accepted |
-| [0003](0003-postgresql-rls-multi-tenant.md)                           | PostgreSQL + RLS untuk isolasi multi-tenant                                                       | Accepted |
-| [0004](0004-rbac-abac-default-deny.md)                                | RBAC + ABAC default-deny sebagai baseline akses                                                   | Accepted |
-| [0005](0005-soft-delete-and-immutability.md)                          | Soft delete untuk master/config, immutability untuk data posted                                   | Accepted |
-| [0006](0006-offline-first-sync-outbox.md)                             | Offline-first + transactional outbox + sync HMAC                                                  | Accepted |
-| [0007](0007-openapi-asyncapi-contracts.md)                            | OpenAPI & AsyncAPI sebagai kontrak wajib                                                          | Accepted |
-| [0008](0008-independent-contract-and-module-versioning.md)            | Versioning independen: package, kontrak API/event, module descriptor                              | Accepted |
-| [0009](0009-public-tenant-scoped-routes.md)                           | Resolusi tenant untuk rute publik (tanpa sesi)                                                    | Accepted |
-| [0010](0010-public-host-tenant-routing.md)                            | Host/domain-based public tenant routing                                                           | Accepted |
-| [0011](0011-capability-ports-for-cross-module-collaboration.md)       | Capability ports untuk kolaborasi lintas-modul                                                    | Accepted |
-| [0012](0012-module-admission-and-trusted-registry-boundary.md)        | Module admission categories & trusted static registry boundary                                    | Accepted |
-| [0013](0013-extension-layers-and-boundary-model.md)                   | Lapisan ekstensi platform, batas tenant/bisnis, kriteria ekstraksi layanan                        | Accepted |
-| [0014](0014-deterministic-build-time-module-composition.md)           | Komposisi modul deterministik build-time (registry base + aplikasi turunan)                       | Accepted |
-| [0015](0015-derived-application-compatibility-manifest.md)            | Derived-application compatibility manifest, test kit, semantic-version gates                      | Accepted |
-| [0016](0016-organization-structure-module-admission.md)               | Admission `organization_structure` (Official Optional Business Foundation)                        | Accepted |
-| [0017](0017-document-infrastructure-module-admission.md)              | Admission `document_infrastructure` (Official Optional Business Foundation)                       | Accepted |
-| [0018](0018-data-exchange-module-admission.md)                        | Admission `data_exchange` (Official Optional Business Foundation)                                 | Accepted |
-| [0019](0019-integration-hub-module-admission.md)                      | Admission `integration_hub` (System Foundation)                                                   | Accepted |
-| [0020](0020-erp-extension-readiness-contracts.md)                     | Kontrak kesiapan ekstensi ERP (business transaction, posting, period-lock, item, projection)      | Accepted |
-| [0021](0021-reference-data-module-admission.md)                       | Admission `reference_data` (Official Optional Business Foundation)                                | Accepted |
-| [0022](0022-erp-modules-live-in-extension-repos.md)                   | Modul domain ERP hidup di repo ekstensi, bukan di base (amandemen ADR-0001 poin 3)                | Accepted |
-| [0023](0023-bilingual-docs-indonesian-source-english-default.md)      | Dokumentasi dwibahasa: sumber Indonesia, Inggris default, digerbang staleness                     | Accepted |
-| [0024](0024-semver-numbering-continues-legacy-major-line.md)          | Penomoran SemVer melanjutkan lini major legacy (lompat ke 5.0.0), bukan reset ke 1.0.0            | Accepted |
-| [0025](0025-implement-deterministic-build-time-module-composition.md) | Implementasi nyata komposisi modul deterministik build-time di awcms (adendum ADR-0014)           | Accepted |
-| [0026](0026-modular-openapi-ownership-and-composition.md)             | Kontrak OpenAPI modular: kepemilikan per modul, bundle deterministik, kontribusi fragment turunan | Accepted |
-| [0027](0027-mfa-totp-session-assurance-step-up.md)                    | MFA TOTP, recovery codes, session assurance (aal1/aal2), dan step-up                              | Accepted |
-| [0028](0028-oidc-sso-tenant-aware-account-linking-break-glass.md)     | OIDC/SSO tenant-aware, account linking fail-closed, SSRF guard, dan break-glass                   | Accepted |
-| [0029](0029-deployment-profile-aware-turnstile-bot-protection.md)     | Cloudflare Turnstile bot protection sadar profil deployment (LAN/offline exempt)                  | Accepted |
-| [0030](0030-business-scope-hierarchy-generic-authorization-layer.md)  | Lapisan authorization generik business-scope hierarchy (multi-entity/unit)                        | Accepted |
-| [0031](0031-segregation-of-duties-conflict-enforcement.md)            | Segregation of duties (SoD) generik, exception/override, conflict enforcement                     | Accepted |
-| [0032](0032-family-compatibility-manifest-and-ci-conformance.md)      | Compatibility manifest keluarga + CI conformance terhadap standar AWCMS-Mini                      | Accepted |
-| [0033](0033-abac-dynamic-policy-evaluator.md)                         | Evaluator ABAC dinamis: DSL kondisi terbatas, precedence deny-overrides, cache tenant-keyed       | Accepted |
+| ADR                                                                           | Judul                                                                                                    | Status   |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------- |
+| [0001](0001-rebuild-on-awcms-foundation-erp-scope.md)                         | Rebuild AWCMS sebagai platform ERP di atas standar modular monolith                                      | Accepted |
+| [0002](0002-bun-only-runtime.md)                                              | Runtime & tooling Bun-only                                                                               | Accepted |
+| [0003](0003-postgresql-rls-multi-tenant.md)                                   | PostgreSQL + RLS untuk isolasi multi-tenant                                                              | Accepted |
+| [0004](0004-rbac-abac-default-deny.md)                                        | RBAC + ABAC default-deny sebagai baseline akses                                                          | Accepted |
+| [0005](0005-soft-delete-and-immutability.md)                                  | Soft delete untuk master/config, immutability untuk data posted                                          | Accepted |
+| [0006](0006-offline-first-sync-outbox.md)                                     | Offline-first + transactional outbox + sync HMAC                                                         | Accepted |
+| [0007](0007-openapi-asyncapi-contracts.md)                                    | OpenAPI & AsyncAPI sebagai kontrak wajib                                                                 | Accepted |
+| [0008](0008-independent-contract-and-module-versioning.md)                    | Versioning independen: package, kontrak API/event, module descriptor                                     | Accepted |
+| [0009](0009-public-tenant-scoped-routes.md)                                   | Resolusi tenant untuk rute publik (tanpa sesi)                                                           | Accepted |
+| [0010](0010-public-host-tenant-routing.md)                                    | Host/domain-based public tenant routing                                                                  | Accepted |
+| [0011](0011-capability-ports-for-cross-module-collaboration.md)               | Capability ports untuk kolaborasi lintas-modul                                                           | Accepted |
+| [0012](0012-module-admission-and-trusted-registry-boundary.md)                | Module admission categories & trusted static registry boundary                                           | Accepted |
+| [0013](0013-extension-layers-and-boundary-model.md)                           | Lapisan ekstensi platform, batas tenant/bisnis, kriteria ekstraksi layanan                               | Accepted |
+| [0014](0014-deterministic-build-time-module-composition.md)                   | Komposisi modul deterministik build-time (registry base + aplikasi turunan)                              | Accepted |
+| [0015](0015-derived-application-compatibility-manifest.md)                    | Derived-application compatibility manifest, test kit, semantic-version gates                             | Accepted |
+| [0016](0016-organization-structure-module-admission.md)                       | Admission `organization_structure` (Official Optional Business Foundation)                               | Accepted |
+| [0017](0017-document-infrastructure-module-admission.md)                      | Admission `document_infrastructure` (Official Optional Business Foundation)                              | Accepted |
+| [0018](0018-data-exchange-module-admission.md)                                | Admission `data_exchange` (Official Optional Business Foundation)                                        | Accepted |
+| [0019](0019-integration-hub-module-admission.md)                              | Admission `integration_hub` (System Foundation)                                                          | Accepted |
+| [0020](0020-erp-extension-readiness-contracts.md)                             | Kontrak kesiapan ekstensi ERP (business transaction, posting, period-lock, item, projection)             | Accepted |
+| [0021](0021-reference-data-module-admission.md)                               | Admission `reference_data` (Official Optional Business Foundation)                                       | Accepted |
+| [0022](0022-erp-modules-live-in-extension-repos.md)                           | Modul domain ERP hidup di repo ekstensi, bukan di base (amandemen ADR-0001 poin 3)                       | Accepted |
+| [0023](0023-bilingual-docs-indonesian-source-english-default.md)              | Dokumentasi dwibahasa: sumber Indonesia, Inggris default, digerbang staleness                            | Accepted |
+| [0024](0024-semver-numbering-continues-legacy-major-line.md)                  | Penomoran SemVer melanjutkan lini major legacy (lompat ke 5.0.0), bukan reset ke 1.0.0                   | Accepted |
+| [0025](0025-implement-deterministic-build-time-module-composition.md)         | Implementasi nyata komposisi modul deterministik build-time di awcms (adendum ADR-0014)                  | Accepted |
+| [0026](0026-modular-openapi-ownership-and-composition.md)                     | Kontrak OpenAPI modular: kepemilikan per modul, bundle deterministik, kontribusi fragment turunan        | Accepted |
+| [0027](0027-mfa-totp-session-assurance-step-up.md)                            | MFA TOTP, recovery codes, session assurance (aal1/aal2), dan step-up                                     | Accepted |
+| [0028](0028-oidc-sso-tenant-aware-account-linking-break-glass.md)             | OIDC/SSO tenant-aware, account linking fail-closed, SSRF guard, dan break-glass                          | Accepted |
+| [0029](0029-deployment-profile-aware-turnstile-bot-protection.md)             | Cloudflare Turnstile bot protection sadar profil deployment (LAN/offline exempt)                         | Accepted |
+| [0030](0030-business-scope-hierarchy-generic-authorization-layer.md)          | Lapisan authorization generik business-scope hierarchy (multi-entity/unit)                               | Accepted |
+| [0031](0031-segregation-of-duties-conflict-enforcement.md)                    | Segregation of duties (SoD) generik, exception/override, conflict enforcement                            | Accepted |
+| [0032](0032-family-compatibility-manifest-and-ci-conformance.md)              | Compatibility manifest keluarga + CI conformance terhadap standar AWCMS-Mini                             | Accepted |
+| [0033](0033-abac-dynamic-policy-evaluator.md)                                 | Evaluator ABAC dinamis: DSL kondisi terbatas, precedence deny-overrides, cache tenant-keyed              | Accepted |
+| [0034](0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md) | Keluarga AWCMS = template dipakai-langsung; jalur aplikasi-turunan dihapus; tidak membuat repo derivatif | Accepted |
 
 ADR spesifik skop fondasi ERP & integrasi bisnis ditambahkan mulai nomor berikutnya seiring keputusan diambil.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,6 +1,6 @@
 🇬🇧 English (default) · 🇮🇩 [Bahasa Indonesia (sumber)](README.id.md)
 
-<!-- i18n-source-hash: sha256:6af849352cc010957057084a6141a42f312a2d2126ac9bb05b2e9df785d8057d -->
+<!-- i18n-source-hash: sha256:fb8bc307682db3f02bca8064c374525c8998f4e8f81e57788aa5cc0ede411909 -->
 
 # Architecture Decision Records (ADR)
 
@@ -32,40 +32,41 @@ flowchart LR
 
 ## Index
 
-| ADR                                                                   | Title                                                                                                   | Status   |
-| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
-| [0001](0001-rebuild-on-awcms-foundation-erp-scope.md)                 | Rebuild AWCMS as an ERP platform on a modular-monolith standard                                         | Accepted |
-| [0002](0002-bun-only-runtime.md)                                      | Bun-only runtime & tooling                                                                              | Accepted |
-| [0003](0003-postgresql-rls-multi-tenant.md)                           | PostgreSQL + RLS for multi-tenant isolation                                                             | Accepted |
-| [0004](0004-rbac-abac-default-deny.md)                                | RBAC + ABAC default-deny as the access baseline                                                         | Accepted |
-| [0005](0005-soft-delete-and-immutability.md)                          | Soft delete for master/config, immutability for posted data                                             | Accepted |
-| [0006](0006-offline-first-sync-outbox.md)                             | Offline-first + transactional outbox + HMAC sync                                                        | Accepted |
-| [0007](0007-openapi-asyncapi-contracts.md)                            | OpenAPI & AsyncAPI as mandatory contracts                                                               | Accepted |
-| [0008](0008-independent-contract-and-module-versioning.md)            | Independent versioning: package, API/event contracts, module descriptor                                 | Accepted |
-| [0009](0009-public-tenant-scoped-routes.md)                           | Tenant resolution for public routes (sessionless)                                                       | Accepted |
-| [0010](0010-public-host-tenant-routing.md)                            | Host/domain-based public tenant routing                                                                 | Accepted |
-| [0011](0011-capability-ports-for-cross-module-collaboration.md)       | Capability ports for cross-module collaboration                                                         | Accepted |
-| [0012](0012-module-admission-and-trusted-registry-boundary.md)        | Module admission categories & trusted static registry boundary                                          | Accepted |
-| [0013](0013-extension-layers-and-boundary-model.md)                   | Extension layers, tenant/business boundaries, service-extraction criteria                               | Accepted |
-| [0014](0014-deterministic-build-time-module-composition.md)           | Deterministic build-time module composition (base registry + derived apps)                              | Accepted |
-| [0015](0015-derived-application-compatibility-manifest.md)            | Derived-application compatibility manifest, test kit, semantic-version gates                            | Accepted |
-| [0016](0016-organization-structure-module-admission.md)               | Admission of `organization_structure` (Official Optional Business Foundation)                           | Accepted |
-| [0017](0017-document-infrastructure-module-admission.md)              | Admission of `document_infrastructure` (Official Optional Business Foundation)                          | Accepted |
-| [0018](0018-data-exchange-module-admission.md)                        | Admission of `data_exchange` (Official Optional Business Foundation)                                    | Accepted |
-| [0019](0019-integration-hub-module-admission.md)                      | Admission of `integration_hub` (System Foundation)                                                      | Accepted |
-| [0020](0020-erp-extension-readiness-contracts.md)                     | ERP extension readiness contracts (business transaction, posting, period-lock, item, projection)        | Accepted |
-| [0021](0021-reference-data-module-admission.md)                       | Admission of `reference_data` (Official Optional Business Foundation)                                   | Accepted |
-| [0022](0022-erp-modules-live-in-extension-repos.md)                   | ERP domain modules live in extension repos, not the base (amends ADR-0001 point 3)                      | Accepted |
-| [0023](0023-bilingual-docs-indonesian-source-english-default.md)      | Bilingual docs: Indonesian source, English default, staleness-gated                                     | Accepted |
-| [0024](0024-semver-numbering-continues-legacy-major-line.md)          | SemVer numbering continues the legacy major line (jump to 5.0.0), not a reset to 1.0.0                  | Accepted |
-| [0025](0025-implement-deterministic-build-time-module-composition.md) | Real implementation of deterministic build-time module composition in awcms (addendum to ADR-0014)      | Accepted |
-| [0026](0026-modular-openapi-ownership-and-composition.md)             | Modular OpenAPI contract: per-module ownership, deterministic bundle, derived-app fragment contribution | Accepted |
-| [0027](0027-mfa-totp-session-assurance-step-up.md)                    | MFA TOTP, recovery codes, session assurance (aal1/aal2), and step-up                                    | Accepted |
-| [0028](0028-oidc-sso-tenant-aware-account-linking-break-glass.md)     | OIDC/SSO tenant-aware, fail-closed account linking, SSRF guard, and break-glass                         | Accepted |
-| [0029](0029-deployment-profile-aware-turnstile-bot-protection.md)     | Deployment-profile-aware Cloudflare Turnstile bot protection (LAN/offline exempt)                       | Accepted |
-| [0030](0030-business-scope-hierarchy-generic-authorization-layer.md)  | Generic business-scope hierarchy authorization layer (multi-entity/unit)                                | Accepted |
-| [0031](0031-segregation-of-duties-conflict-enforcement.md)            | Generic segregation of duties (SoD), exception/override, conflict enforcement                           | Accepted |
-| [0032](0032-family-compatibility-manifest-and-ci-conformance.md)      | Family compatibility manifest + CI conformance to the AWCMS-Mini standard                               | Accepted |
-| [0033](0033-abac-dynamic-policy-evaluator.md)                         | Dynamic ABAC policy evaluator: bounded condition DSL, deny-overrides precedence, tenant-keyed cache     | Accepted |
+| ADR                                                                           | Title                                                                                                   | Status   |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------- |
+| [0001](0001-rebuild-on-awcms-foundation-erp-scope.md)                         | Rebuild AWCMS as an ERP platform on a modular-monolith standard                                         | Accepted |
+| [0002](0002-bun-only-runtime.md)                                              | Bun-only runtime & tooling                                                                              | Accepted |
+| [0003](0003-postgresql-rls-multi-tenant.md)                                   | PostgreSQL + RLS for multi-tenant isolation                                                             | Accepted |
+| [0004](0004-rbac-abac-default-deny.md)                                        | RBAC + ABAC default-deny as the access baseline                                                         | Accepted |
+| [0005](0005-soft-delete-and-immutability.md)                                  | Soft delete for master/config, immutability for posted data                                             | Accepted |
+| [0006](0006-offline-first-sync-outbox.md)                                     | Offline-first + transactional outbox + HMAC sync                                                        | Accepted |
+| [0007](0007-openapi-asyncapi-contracts.md)                                    | OpenAPI & AsyncAPI as mandatory contracts                                                               | Accepted |
+| [0008](0008-independent-contract-and-module-versioning.md)                    | Independent versioning: package, API/event contracts, module descriptor                                 | Accepted |
+| [0009](0009-public-tenant-scoped-routes.md)                                   | Tenant resolution for public routes (sessionless)                                                       | Accepted |
+| [0010](0010-public-host-tenant-routing.md)                                    | Host/domain-based public tenant routing                                                                 | Accepted |
+| [0011](0011-capability-ports-for-cross-module-collaboration.md)               | Capability ports for cross-module collaboration                                                         | Accepted |
+| [0012](0012-module-admission-and-trusted-registry-boundary.md)                | Module admission categories & trusted static registry boundary                                          | Accepted |
+| [0013](0013-extension-layers-and-boundary-model.md)                           | Extension layers, tenant/business boundaries, service-extraction criteria                               | Accepted |
+| [0014](0014-deterministic-build-time-module-composition.md)                   | Deterministic build-time module composition (base registry + derived apps)                              | Accepted |
+| [0015](0015-derived-application-compatibility-manifest.md)                    | Derived-application compatibility manifest, test kit, semantic-version gates                            | Accepted |
+| [0016](0016-organization-structure-module-admission.md)                       | Admission of `organization_structure` (Official Optional Business Foundation)                           | Accepted |
+| [0017](0017-document-infrastructure-module-admission.md)                      | Admission of `document_infrastructure` (Official Optional Business Foundation)                          | Accepted |
+| [0018](0018-data-exchange-module-admission.md)                                | Admission of `data_exchange` (Official Optional Business Foundation)                                    | Accepted |
+| [0019](0019-integration-hub-module-admission.md)                              | Admission of `integration_hub` (System Foundation)                                                      | Accepted |
+| [0020](0020-erp-extension-readiness-contracts.md)                             | ERP extension readiness contracts (business transaction, posting, period-lock, item, projection)        | Accepted |
+| [0021](0021-reference-data-module-admission.md)                               | Admission of `reference_data` (Official Optional Business Foundation)                                   | Accepted |
+| [0022](0022-erp-modules-live-in-extension-repos.md)                           | ERP domain modules live in extension repos, not the base (amends ADR-0001 point 3)                      | Accepted |
+| [0023](0023-bilingual-docs-indonesian-source-english-default.md)              | Bilingual docs: Indonesian source, English default, staleness-gated                                     | Accepted |
+| [0024](0024-semver-numbering-continues-legacy-major-line.md)                  | SemVer numbering continues the legacy major line (jump to 5.0.0), not a reset to 1.0.0                  | Accepted |
+| [0025](0025-implement-deterministic-build-time-module-composition.md)         | Real implementation of deterministic build-time module composition in awcms (addendum to ADR-0014)      | Accepted |
+| [0026](0026-modular-openapi-ownership-and-composition.md)                     | Modular OpenAPI contract: per-module ownership, deterministic bundle, derived-app fragment contribution | Accepted |
+| [0027](0027-mfa-totp-session-assurance-step-up.md)                            | MFA TOTP, recovery codes, session assurance (aal1/aal2), and step-up                                    | Accepted |
+| [0028](0028-oidc-sso-tenant-aware-account-linking-break-glass.md)             | OIDC/SSO tenant-aware, fail-closed account linking, SSRF guard, and break-glass                         | Accepted |
+| [0029](0029-deployment-profile-aware-turnstile-bot-protection.md)             | Deployment-profile-aware Cloudflare Turnstile bot protection (LAN/offline exempt)                       | Accepted |
+| [0030](0030-business-scope-hierarchy-generic-authorization-layer.md)          | Generic business-scope hierarchy authorization layer (multi-entity/unit)                                | Accepted |
+| [0031](0031-segregation-of-duties-conflict-enforcement.md)                    | Generic segregation of duties (SoD), exception/override, conflict enforcement                           | Accepted |
+| [0032](0032-family-compatibility-manifest-and-ci-conformance.md)              | Family compatibility manifest + CI conformance to the AWCMS-Mini standard                               | Accepted |
+| [0033](0033-abac-dynamic-policy-evaluator.md)                                 | Dynamic ABAC policy evaluator: bounded condition DSL, deny-overrides precedence, tenant-keyed cache     | Accepted |
+| [0034](0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md) | AWCMS family = direct-use templates; derived-application pathway removed; no derivative repos           | Accepted |
 
 ADRs specific to the ERP-foundation & business-integration scope are added starting at the next number as decisions are made.

--- a/docs/awcms/derived-app-pilot-plan.md
+++ b/docs/awcms/derived-app-pilot-plan.md
@@ -1,5 +1,7 @@
 # Rencana Pilot Aplikasi Turunan Pertama
 
+> **⚠️ DEPRECATED ([ADR-0034](../adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md)).** Model aplikasi-turunan di repo terpisah DICABUT — keluarga AWCMS (`awcms-mini`/`awcms`/`awcms-micro`) kini template **dipakai-langsung**, tanpa membuat repo derivatif (kembangkan modul langsung di template). Dokumen ini dipertahankan sebagai catatan historis.
+
 Issue #465. Base AWCMS sudah stabil (v0.23.5, 18 issue backlog doc06 +
 epic M9 pasca-backlog tuntas) dan `derived-application-guide.md` sudah
 menjelaskan cara membangun aplikasi turunan di atasnya. Dokumen ini

--- a/docs/awcms/derived-app-pilot-purchase-requisition-execution.md
+++ b/docs/awcms/derived-app-pilot-purchase-requisition-execution.md
@@ -1,5 +1,7 @@
 # Runbook Eksekusi Increment-1 — Pilot Turunan #187 (`awcms-erp-pilot`, Purchase Requisition)
 
+> **⚠️ DEPRECATED ([ADR-0034](../adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md)).** Model aplikasi-turunan di repo terpisah DICABUT — keluarga AWCMS (`awcms-mini`/`awcms`/`awcms-micro`) kini template **dipakai-langsung**, tanpa membuat repo derivatif (kembangkan modul langsung di template). Dokumen ini dipertahankan sebagai catatan historis.
+
 > **Status: rencana eksekusi terperinci (belum dieksekusi).** Dokumen ini TIDAK
 > menulis kode. Ia adalah runbook langkah-demi-langkah untuk pekerjaan yang
 > **sengaja TIDAK dikerjakan di repo base `ahliweb/awcms`** — implementasi domain

--- a/docs/awcms/derived-app-pilot-purchase-requisition-plan.md
+++ b/docs/awcms/derived-app-pilot-purchase-requisition-plan.md
@@ -1,5 +1,7 @@
 # Rencana Pilot Turunan #187 — Purchase Requisition (`awcms-erp-pilot`), Increment 1
 
+> **⚠️ DEPRECATED ([ADR-0034](../adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md)).** Model aplikasi-turunan di repo terpisah DICABUT — keluarga AWCMS (`awcms-mini`/`awcms`/`awcms-micro`) kini template **dipakai-langsung**, tanpa membuat repo derivatif (kembangkan modul langsung di template). Dokumen ini dipertahankan sebagai catatan historis.
+
 > **Status: rencana (belum dieksekusi).** Dokumen ini adalah rencana implementasi
 > Increment-1 untuk Issue #187 (pilot aplikasi turunan). Tidak ada kode yang
 > ditulis oleh dokumen ini. Melengkapi (bukan menggantikan)

--- a/docs/awcms/derived-application-guide.md
+++ b/docs/awcms/derived-application-guide.md
@@ -1,5 +1,7 @@
 # Panduan Implementasi Aplikasi Turunan
 
+> **⚠️ DEPRECATED ([ADR-0034](../adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md)).** Model aplikasi-turunan di repo terpisah DICABUT — keluarga AWCMS (`awcms-mini`/`awcms`/`awcms-micro`) kini template **dipakai-langsung**, tanpa membuat repo derivatif (kembangkan modul langsung di template). Dokumen ini dipertahankan sebagai catatan historis.
+
 > **Dokumen base (bukan contoh domain).** Dokumen ini menjelaskan cara membangun aplikasi turunan **di atas** AWCMS setelah base generik selesai (v0.23.5, seluruh 18 issue backlog doc06 + peningkatan pasca-backlog M9 tuntas — lihat [`README.md`](README.md) §Langkah berikutnya dan [`AGENTS.md`](../../AGENTS.md) §Mulai dari sini). Lima contoh aplikasi di §Contoh aplikasi turunan adalah **ilustrasi**, bukan modul yang ditambahkan ke base ini.
 >
 > **Lapisan ekstensi (epic #738).** Semua aplikasi turunan di dokumen ini hidup di lapisan **Derived Application** — satu dari tiga lapisan "di luar base" (Derived Application generik, SaaS Control Plane, ERP Extension) yang didefinisikan `docs/adr/0013-extension-layers-and-boundary-model.md`. ADR itu juga mendefinisikan batas tenant vs legal entity vs organization unit, dan aturan "no shared-table write" untuk kolaborasi lintas-repo — baca sebelum aplikasi turunan Anda perlu berbagi data dengan repo turunan lain (mis. sebuah SaaS billing control-plane yang menagih tenant yang sama).


### PR DESCRIPTION
**Fase 1 dari perubahan aturan tata-kelola keluarga AWCMS.**

Membalik model aplikasi-turunan: `awcms-mini`, `awcms`, `awcms-micro` = **tiga template dasar sejajar yang dipakai LANGSUNG** untuk pengembangan apa pun; **TIDAK** membuat repo derivatif; modul domain/website boleh hidup di `src/modules/` base. Selaras dengan awcms-micro (ADR-0034/0035).

### Isi Fase 1 (aturan, docs-only)
- **ADR-0034** baru — men-supersede ADR-0013/0014/0015/0022/0025 (framing jalur turunan + `no-content-website-modules`).
- Indeks ADR (`README.id.md` + `README.md` + i18n-source-hash) diperbarui.
- Banner **DEPRECATED** pada 4 dokumen jalur-turunan (guide + 3 pilot #187).

### Menyusul (fase terpisah, di-track ADR-0034 §Konsekuensi)
- Fase 2: hapus kode/gate derived-only awcms (`application-registry.ts`, `extension:check`, fixture) — evidence-gated, CI penuh.
- Fase 3: implementasi langsung modul **theming** (adaptasi dari awcms-micro) + cabut divergence `no-content-website-modules`.
- Fase 4: harmonisasi positioning ke awcms-mini & awcms-micro.

Gate lokal hijau: `check:docs`, `check:docs:translation`, `family:conformance:check` (29/29), prettier.

Refs #177 #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)