### PR TITLE
feat(theming): port modul theming website LANGSUNG ke base (ADR-0034 Fase 3)

### DIFF
--- a/.changeset/theming-module-fase3.md
+++ b/.changeset/theming-module-fase3.md
@@ -1,0 +1,46 @@
+---
+"awcms": minor
+---
+
+Theming module (ADR-0034 Fase 3) — the FIRST website module implemented directly
+in the awcms base, proving ADR-0034's decision that content/website modules may
+now live in `src/modules/` here ("template dipakai-langsung"). Adapted from
+awcms-micro's `theming` (Issue #269 / awcms-micro ADR-0029). Bumps the base
+registry 10 → 11 modules.
+
+- **Data-only tenant theming, no uploaded code.** A THEME is trusted, reviewed,
+  BUILD-TIME source (a `ThemeDescriptor` composed by `theme-registry.ts` from the
+  reviewed in-repo base themes — never a database row or an uploaded artifact).
+  Only a tenant's DATA configuration of a theme lives in the database
+  (`awcms_theming_config_versions` draft + immutable published versions, and
+  `awcms_theming_tenant_state` active pointer; sql/033, all three tables
+  `ENABLE`+`FORCE ROW LEVEL SECURITY` with the standard `tenant_isolation` policy).
+- **Security spine — reject, never sanitize (`domain/css-value-validation.ts`).**
+  Every design-token value is validated by REJECTION against strict, bounded,
+  linear (no-ReDoS) grammars (hex/rgb/hsl colors, dimensions with an allowed-unit
+  list, bounded numbers, font families from a per-theme allow-list whose emitted
+  stack is descriptor-owned). `url(...)`, `expression()`, `@import`, `javascript:`,
+  comment breakouts, `;{}<>`, backslash, and unbalanced tokens can never reach the
+  emitted CSS. Token values ship as an EXTERNAL same-origin `text/css` stylesheet
+  (`/theming/{tenantCode}/tokens.css`), so `style-src 'self'` is never weakened.
+- **Immutable published versions + audited lifecycle.** draft → validate → preview
+  → publish → rollback/retire. Published versions are IMMUTABLE (INSERT-only engine
+  + a sql/033 `BEFORE UPDATE/DELETE` trigger); rollback/retire move the active
+  pointer while history stays intact. `PUT /api/v1/theming/draft`,
+  `POST /api/v1/theming/{validate,preview,publish,rollback,retire}` +
+  `GET /api/v1/theming` — ABAC-gated (`theming.config.*`/`theming.version.*`/
+  `theming.preview.create`, seeded in sql/034), idempotency-keyed on high-risk
+  mutations, and audited. Adds the `archive` action to the `AccessAction`
+  union/high-risk set.
+- **Non-indexable, hashed, short-lived previews.** `awcms_theming_preview_sessions`
+  stores only the SHA-256 hash of the raw preview token; every read filters
+  `expires_at >= now()`; the preview surfaces are `X-Robots-Tag: noindex` +
+  `private, no-store` on a URL namespace distinct from the public stylesheet.
+- **Port adaptations.** No derived-repo theme seam (the derived-application pathway
+  was removed in ADR-0034 Fase 2 — themes live in the base registry). `media_library`
+  is dropped (not in this base): asset-URL resolution is a documented no-op and
+  assets are omitted from render, degrading safely. The `data_lifecycle` purge
+  descriptor is dropped (no purge engine/worker role here); preview retention rides
+  the `expires_at` read filter. Public tenant resolution is `tenantCode`-based
+  (ADR-0009), not Host-based. Revokes the `no-content-website-modules` divergence
+  in `awcms-family-compatibility.yaml`.

--- a/awcms-family-compatibility.yaml
+++ b/awcms-family-compatibility.yaml
@@ -34,10 +34,11 @@ contracts:
   # CAPABILITY_CONTRACT_VERSIONS). Only capabilities whose owning module actually
   # ships in this base belong here. `party_directory` is owned by the base
   # `profile_identity` module (forward-declared ahead of an in-repo consumer,
-  # ADR-0011). Content capabilities (news_media/public_content/social_publishing)
-  # are deliberately NOT listed — their owning CMS modules are excluded from the
-  # base (`no-content-website-modules` divergence, ADR-0022); a derived content
-  # app declares those in its OWN manifest.
+  # ADR-0011). ADR-0034 Fase 3 admitted the first website module (`theming`)
+  # directly into the base, but `theming` provides no capability port, so it adds
+  # no entry here. Content capabilities whose owning CMS modules are not yet
+  # ported to this base (e.g. news_media/public_content/social_publishing) remain
+  # unlisted until those modules land here (ADR-0034 "template dipakai-langsung").
   capabilityContractVersions:
     party_directory: "1.0.0"
   apiResponseEnvelopeVersion: "1.0.0"
@@ -88,19 +89,12 @@ stack:
 # gate fails once a reviewDate is in the past (an unreviewed divergence cannot
 # live forever) or its ADR file is missing.
 intentionalDivergences:
-  - id: no-content-website-modules
-    summary: >-
-      The awcms-mini CMS/content modules (blog_content, news_portal,
-      social_publishing, visitor_analytics, public tenant_domain pages) are not
-      part of the awcms base.
-    reason: >-
-      awcms is an ERP-readiness FOUNDATION, not a website/CMS product. Content
-      and vertical modules live in derived/extension repositories composed on
-      top of this base, never in src/modules/ here.
-    owner: "@ahliweb"
-    reviewDate: "2027-07-19"
-    adr: 0022-erp-modules-live-in-extension-repos.md
-    since: "#177"
+  # The `no-content-website-modules` divergence (blog_content/news_portal/etc.
+  # are not part of the base) was REVOKED by ADR-0034 (§Konsekuensi): website
+  # modules may now live directly in `src/modules/` here ("template
+  # dipakai-langsung"), and the first one — `theming` — is implemented in the
+  # base (ADR-0034 Fase 3). Website/content modules that are not yet ported are
+  # simply not-yet-ported (drift is tracked per-module), not a standing divergence.
   - id: openapi-one-file-per-module
     summary: >-
       OpenAPI fragments are one-file-per-MODULE, not one-file-per-tag as in

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -3469,6 +3469,181 @@ Transactional, versioned domain-event outbox and dispatcher admin API — read-o
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
 
+## Theming
+
+Tenant-selectable presentation (ADR-0034 Fase 3 — the first website module in the base). Select a trusted, reviewed, build-time theme and configure it by DATA only (design tokens, slot variants, media asset ids, section order, nav placement) — no uploaded code, no arbitrary templates. Every token value is validated by rejection against strict CSS grammars; published versions are immutable; publish/rollback/retire are ABAC-gated, idempotency-keyed, and audited.
+
+### `GET /api/v1/theming` — Read this tenant's theme selection, available themes, draft, and version history
+
+- **operationId**: `themingRead`
+- **Security**: bearerAuth + tenantHeader
+
+Everything the theming admin surface needs: the available (reviewed, build-time) theme descriptors, this tenant's active theme pointer, its current draft config (if any), and its published version history. Gated by `theming.config.read`.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                  | Schema                                 |
+| ------ | ---------------------------- | -------------------------------------- |
+| 200    | This tenant's theming state. | object                                 |
+| 400    | Validation error.            | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.  | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.  | [`ApiError`](#standard-error-envelope) |
+
+### `PUT /api/v1/theming/draft` — Save/replace this tenant's draft theme config
+
+- **operationId**: `themingDraftUpdate`
+- **Security**: bearerAuth + tenantHeader
+
+Save the single draft config for a chosen theme (bounded, validated design tokens, slot variants, media asset ids, section order, nav placement). The body is validated against the theme descriptor (the CSS-injection spine + declared-surface bounding) before any DB work. High-risk (the draft is what publish promotes): requires an `Idempotency-Key`, audited. Gated by `theming.config.update`.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (required): [`ThemeConfigRequest`](#schema-themeconfigrequest)
+
+**Responses**
+
+| Status | Description                                                              | Schema                                 |
+| ------ | ------------------------------------------------------------------------ | -------------------------------------- |
+| 200    | Draft saved (or an idempotent replay).                                   | object                                 |
+| 400    | Validation error.                                                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                              | [`ApiError`](#standard-error-envelope) |
+| 409    | The `Idempotency-Key` was already used with a different request payload. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/theming/preview` — Create a short-lived, non-indexable preview session for the draft
+
+- **operationId**: `themingPreviewCreate`
+- **Security**: bearerAuth + tenantHeader
+
+Mint an authorized, short-lived, non-indexable preview of the current draft and return its URL (`/theming/preview/{token}`) + expiry. The raw token is returned once; only its hash is stored. Audited. Gated by `theming.preview.create`. Not idempotency-keyed (each preview is a distinct disposable token).
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (optional): object
+
+**Responses**
+
+| Status | Description                       | Schema                                 |
+| ------ | --------------------------------- | -------------------------------------- |
+| 200    | The preview session URL + expiry. | object                                 |
+| 400    | Validation error.                 | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.       | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.       | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/theming/publish` — Publish the draft as an immutable version (and make it live)
+
+- **operationId**: `themingPublish`
+- **Security**: bearerAuth + tenantHeader
+
+Publish the current draft as a new IMMUTABLE version and make it the live look (INSERT-only; published versions are immutable). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.publish`.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                                                              | Schema                                 |
+| ------ | ------------------------------------------------------------------------ | -------------------------------------- |
+| 200    | Published (or an idempotent replay).                                     | object                                 |
+| 400    | Validation error.                                                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                              | [`ApiError`](#standard-error-envelope) |
+| 409    | The `Idempotency-Key` was already used with a different request payload. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/theming/retire` — Retire the active theme (fall back to the default)
+
+- **operationId**: `themingRetire`
+- **Security**: bearerAuth + tenantHeader
+
+Clear the active theme pointer so the site falls back to the default theme; published versions stay intact (history/rollback). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.archive`.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                                                              | Schema                                 |
+| ------ | ------------------------------------------------------------------------ | -------------------------------------- |
+| 200    | Retired (or an idempotent replay).                                       | object                                 |
+| 400    | Validation error.                                                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                              | [`ApiError`](#standard-error-envelope) |
+| 409    | The `Idempotency-Key` was already used with a different request payload. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/theming/rollback` — Roll the active theme back to an earlier published version
+
+- **operationId**: `themingRollback`
+- **Security**: bearerAuth + tenantHeader
+
+Move the active pointer to an earlier published version of this tenant (never mutates a version row). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.restore`.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (required): object
+
+**Responses**
+
+| Status | Description                                                              | Schema                                 |
+| ------ | ------------------------------------------------------------------------ | -------------------------------------- |
+| 200    | Rolled back (or an idempotent replay).                                   | object                                 |
+| 400    | Validation error.                                                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                              | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                      | [`ApiError`](#standard-error-envelope) |
+| 409    | The `Idempotency-Key` was already used with a different request payload. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/theming/validate` — Validate a theme config (dry run) + preview its token CSS
+
+- **operationId**: `themingValidate`
+- **Security**: bearerAuth + tenantHeader
+
+Read-only: validate a proposed theme config against its theme descriptor and, when valid, return the exact `text/css` custom-property block it would produce — writing nothing. Gated by `theming.config.read`.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (required): [`ThemeConfigRequest`](#schema-themeconfigrequest)
+
+**Responses**
+
+| Status | Description                                     | Schema                                 |
+| ------ | ----------------------------------------------- | -------------------------------------- |
+| 200    | The validation result (+ token CSS when valid). | object                                 |
+| 400    | Validation error.                               | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                     | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                     | [`ApiError`](#standard-error-envelope) |
+
 ## Schema appendix
 
 Every schema referenced by at least one operation above (excluding the standard envelope schemas, covered in §Standard success/error envelope).
@@ -3570,6 +3745,32 @@ A bounded, deterministic condition AST (Issue #179). A node is either a composit
   "resourceType": "string",
   "resourceId": "00000000-0000-0000-0000-000000000000",
   "resourceAttributes": "(operation-specific payload)"
+}
+```
+
+### Schema: ThemeConfigRequest
+
+A tenant's DATA-only theme configuration. Every key/value is validated against the chosen theme descriptor; unknown tokens/slots/assets/sections are rejected, and token values are validated by rejection against strict CSS grammars (no url()/expression()/@import/javascript:/comment-breakout).
+
+| Field            | Type            | Required | Nullable | Description                                                                                                                   |
+| ---------------- | --------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `themeKey`       | string          | yes      | no       | A registered (build-time) theme key.                                                                                          |
+| `tokenOverrides` | object          | no       | no       | tokenKey -> validated token value (color/dimension/number, or a font-family allow-list key). Unknown token keys are rejected. |
+| `slotSelections` | object          | no       | no       | slotKey -> chosen variant key (from the slot's allow-list).                                                                   |
+| `assetRefs`      | object          | no       | no       | assetSlotKey -> media object UUID (never a URL); null clears the slot.                                                        |
+| `sectionOrder`   | array of string | no       | no       | An ordering of the theme's declared content-section keys.                                                                     |
+| `navPlacement`   | string          | no       | no       | One of the theme's declared nav placements.                                                                                   |
+
+**Example**
+
+```json
+{
+  "themeKey": "string",
+  "tokenOverrides": "(operation-specific payload)",
+  "slotSelections": "(operation-specific payload)",
+  "assetRefs": "(operation-specific payload)",
+  "sectionOrder": ["string"],
+  "navPlacement": "string"
 }
 ```
 

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -1,5 +1,5 @@
 {
-  "moduleCount": 10,
+  "moduleCount": 11,
   "valid": true,
   "issueCount": 0,
   "modules": [
@@ -150,6 +150,22 @@
       "status": "active",
       "type": null,
       "dependencies": [],
+      "capabilitiesProvided": [],
+      "capabilitiesConsumed": [],
+      "permissionCount": 6,
+      "navigationCount": 0,
+      "jobCount": 0,
+      "hasHealthCheck": false,
+      "hasReadinessCheck": false,
+      "deploymentProfiles": null
+    },
+    {
+      "key": "theming",
+      "name": "Theming",
+      "version": "1.0.0",
+      "status": "active",
+      "type": "domain",
+      "dependencies": ["tenant_admin", "identity_access"],
       "capabilitiesProvided": [],
       "capabilitiesConsumed": [],
       "permissionCount": 6,

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -43,6 +43,8 @@ tags:
     description: Module-contributed read-model projection extension to Management Reporting — list registered projection descriptors with live snapshot/freshness status, trigger/resume/cancel an idempotent full rebuild, trigger an on-demand reconciliation against a source control total, and manage/trigger/download scheduled exports (manifest/checksum/expiry, secure tenant-scoped download). A projection is a DERIVED read model, never an authorization source of truth — every operation independently re-checks RBAC/ABAC.
   - name: Domain Event Runtime
     description: Transactional, versioned domain-event outbox and dispatcher admin API — read-only inspection of outbox events and per-consumer deliveries (redacted payload projections only), permission-gated/reason-required/idempotent/audited replay of a dead-lettered delivery, and per-tenant pause/resume of a registered consumer.
+  - name: Theming
+    description: Tenant-selectable presentation (ADR-0034 Fase 3 — the first website module in the base). Select a trusted, reviewed, build-time theme and configure it by DATA only (design tokens, slot variants, media asset ids, section order, nav placement) — no uploaded code, no arbitrary templates. Every token value is validated by rejection against strict CSS grammars; published versions are immutable; publish/rollback/retire are ABAC-gated, idempotency-keyed, and audited.
 paths:
   /api/v1/abac/policies:
     get:
@@ -6221,6 +6223,306 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/theming:
+    get:
+      tags:
+        - Theming
+      summary: Read this tenant's theme selection, available themes, draft, and version history
+      description: "Everything the theming admin surface needs: the available (reviewed, build-time) theme descriptors, this tenant's active theme pointer, its current draft config (if any), and its published version history. Gated by `theming.config.read`."
+      operationId: themingRead
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: This tenant's theming state.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemingState"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/theming/draft:
+    put:
+      tags:
+        - Theming
+      summary: Save/replace this tenant's draft theme config
+      description: "Save the single draft config for a chosen theme (bounded, validated design tokens, slot variants, media asset ids, section order, nav placement). The body is validated against the theme descriptor (the CSS-injection spine + declared-surface bounding) before any DB work. High-risk (the draft is what publish promotes): requires an `Idempotency-Key`, audited. Gated by `theming.config.update`."
+      operationId: themingDraftUpdate
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ThemeConfigRequest"
+      responses:
+        "200":
+          description: Draft saved (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeDraft"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: The `Idempotency-Key` was already used with a different request payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/theming/preview:
+    post:
+      tags:
+        - Theming
+      summary: Create a short-lived, non-indexable preview session for the draft
+      description: Mint an authorized, short-lived, non-indexable preview of the current draft and return its URL (`/theming/preview/{token}`) + expiry. The raw token is returned once; only its hash is stored. Audited. Gated by `theming.preview.create`. Not idempotency-keyed (each preview is a distinct disposable token).
+      operationId: themingPreviewCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ttlMinutes:
+                  type: integer
+                  minimum: 1
+                  maximum: 120
+                  description: Preview lifetime in minutes (default 30, hard cap 120).
+      responses:
+        "200":
+          description: The preview session URL + expiry.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    required:
+                      - previewUrl
+                      - expiresAt
+                    properties:
+                      previewUrl:
+                        type: string
+                      expiresAt:
+                        type: string
+                        format: date-time
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/theming/publish:
+    post:
+      tags:
+        - Theming
+      summary: Publish the draft as an immutable version (and make it live)
+      description: "Publish the current draft as a new IMMUTABLE version and make it the live look (INSERT-only; published versions are immutable). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.publish`."
+      operationId: themingPublish
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Published (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeVersion"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: The `Idempotency-Key` was already used with a different request payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/theming/retire:
+    post:
+      tags:
+        - Theming
+      summary: Retire the active theme (fall back to the default)
+      description: "Clear the active theme pointer so the site falls back to the default theme; published versions stay intact (history/rollback). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.archive`."
+      operationId: themingRetire
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Retired (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    required:
+                      - previousThemeKey
+                    properties:
+                      previousThemeKey:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: The `Idempotency-Key` was already used with a different request payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/theming/rollback:
+    post:
+      tags:
+        - Theming
+      summary: Roll the active theme back to an earlier published version
+      description: "Move the active pointer to an earlier published version of this tenant (never mutates a version row). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.restore`."
+      operationId: themingRollback
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - versionId
+              properties:
+                versionId:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: Rolled back (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeVersion"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The `Idempotency-Key` was already used with a different request payload.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/theming/validate:
+    post:
+      tags:
+        - Theming
+      summary: Validate a theme config (dry run) + preview its token CSS
+      description: "Read-only: validate a proposed theme config against its theme descriptor and, when valid, return the exact `text/css` custom-property block it would produce — writing nothing. Gated by `theming.config.read`."
+      operationId: themingValidate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ThemeConfigRequest"
+      responses:
+        "200":
+          description: The validation result (+ token CSS when valid).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeValidationResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/users:
     get:
       operationId: listTenantUsers
@@ -8113,6 +8415,142 @@ components:
           items:
             type: string
           description: Assigned role codes (empty when the user holds no role).
+    ThemeConfigRequest:
+      type: object
+      description: A tenant's DATA-only theme configuration. Every key/value is validated against the chosen theme descriptor; unknown tokens/slots/assets/sections are rejected, and token values are validated by rejection against strict CSS grammars (no url()/expression()/@import/javascript:/comment-breakout).
+      required:
+        - themeKey
+      properties:
+        themeKey:
+          type: string
+          maxLength: 64
+          description: A registered (build-time) theme key.
+        tokenOverrides:
+          type: object
+          additionalProperties:
+            type: string
+          description: tokenKey -> validated token value (color/dimension/number, or a font-family allow-list key). Unknown token keys are rejected.
+        slotSelections:
+          type: object
+          additionalProperties:
+            type: string
+          description: slotKey -> chosen variant key (from the slot's allow-list).
+        assetRefs:
+          type: object
+          additionalProperties:
+            type: string
+            format: uuid
+            nullable: true
+          description: assetSlotKey -> media object UUID (never a URL); null clears the slot.
+        sectionOrder:
+          type: array
+          items:
+            type: string
+          description: An ordering of the theme's declared content-section keys.
+        navPlacement:
+          type: string
+          description: One of the theme's declared nav placements.
+    ThemeDraft:
+      type: object
+      required:
+        - versionId
+        - themeKey
+        - config
+        - configHash
+      properties:
+        versionId:
+          type: string
+          format: uuid
+        themeKey:
+          type: string
+        config:
+          type: object
+          description: The validated, normalized config as stored.
+        configHash:
+          type: string
+    ThemeValidationResult:
+      type: object
+      required:
+        - valid
+        - errors
+        - previewCss
+      properties:
+        valid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            type: object
+            required:
+              - field
+              - message
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+        previewCss:
+          type: string
+          nullable: true
+          description: The `:root { … }` custom-property block that would be served, when valid; null when invalid.
+    ThemeVersion:
+      type: object
+      required:
+        - versionId
+        - themeKey
+        - versionNumber
+      properties:
+        versionId:
+          type: string
+          format: uuid
+        themeKey:
+          type: string
+        versionNumber:
+          type: integer
+          nullable: true
+        configHash:
+          type: string
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+    ThemingState:
+      type: object
+      required:
+        - themes
+        - state
+        - draft
+        - versions
+      properties:
+        themes:
+          type: array
+          description: Available reviewed, build-time theme descriptors.
+          items:
+            type: object
+        state:
+          type: object
+          required:
+            - activeThemeKey
+            - activeVersionId
+            - draftThemeKey
+          properties:
+            activeThemeKey:
+              type: string
+              nullable: true
+            activeVersionId:
+              type: string
+              format: uuid
+              nullable: true
+            draftThemeKey:
+              type: string
+              nullable: true
+        draft:
+          type: object
+          nullable: true
+        versions:
+          type: array
+          items:
+            $ref: "#/components/schemas/ThemeVersion"
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/openapi/awcms-public-api.src.yaml
+++ b/openapi/awcms-public-api.src.yaml
@@ -47,6 +47,8 @@ tags:
     description: Module-contributed read-model projection extension to Management Reporting — list registered projection descriptors with live snapshot/freshness status, trigger/resume/cancel an idempotent full rebuild, trigger an on-demand reconciliation against a source control total, and manage/trigger/download scheduled exports (manifest/checksum/expiry, secure tenant-scoped download). A projection is a DERIVED read model, never an authorization source of truth — every operation independently re-checks RBAC/ABAC.
   - name: Domain Event Runtime
     description: Transactional, versioned domain-event outbox and dispatcher admin API — read-only inspection of outbox events and per-consumer deliveries (redacted payload projections only), permission-gated/reason-required/idempotent/audited replay of a dead-lettered delivery, and per-tenant pause/resume of a registered consumer.
+  - name: Theming
+    description: Tenant-selectable presentation (ADR-0034 Fase 3 — the first website module in the base). Select a trusted, reviewed, build-time theme and configure it by DATA only (design tokens, slot variants, media asset ids, section order, nav placement) — no uploaded code, no arbitrary templates. Every token value is validated by rejection against strict CSS grammars; published versions are immutable; publish/rollback/retire are ABAC-gated, idempotency-keyed, and audited.
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/openapi/modules/theming.openapi.yaml
+++ b/openapi/modules/theming.openapi.yaml
@@ -1,0 +1,434 @@
+# Source fragment for the "Theming" module/tag (ADR-0034 Fase 3 — the first
+# website module implemented directly in the awcms base; adapted from awcms-micro
+# Issue #269/ADR-0029).
+#
+# Owns the `/api/v1/theming/*` admin paths and the schemas referenced ONLY by
+# this tag's operations. Shared components (securitySchemes/parameters/responses,
+# ApiError/ApiMeta) live in the root file (openapi/awcms-public-api.src.yaml).
+#
+# The public token stylesheet (`/theming/{tenantCode}/tokens.css`) and the preview
+# surfaces (`/theming/preview/*`) are Astro text/css + HTML routes under
+# `src/pages/theming/**` (NOT `src/pages/api/v1/**`), so they are deliberately
+# absent here (they are not JSON APIs and are outside the api-spec-check route
+# tree).
+#
+# NOT independently valid OpenAPI -- $ref targets pointing at shared components
+# only resolve after `bun run openapi:bundle` merges this file with the root and
+# every sibling module fragment. Edit this file (or the root for shared
+# components), never the generated bundle.
+paths:
+  /api/v1/theming:
+    get:
+      tags:
+        - Theming
+      summary: Read this tenant's theme selection, available themes, draft, and version history
+      description: "Everything the theming admin surface needs: the available (reviewed, build-time) theme descriptors, this tenant's active theme pointer, its current draft config (if any), and its published version history. Gated by `theming.config.read`."
+      operationId: themingRead
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: This tenant's theming state.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemingState"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/theming/draft:
+    put:
+      tags:
+        - Theming
+      summary: Save/replace this tenant's draft theme config
+      description: "Save the single draft config for a chosen theme (bounded, validated design tokens, slot variants, media asset ids, section order, nav placement). The body is validated against the theme descriptor (the CSS-injection spine + declared-surface bounding) before any DB work. High-risk (the draft is what publish promotes): requires an `Idempotency-Key`, audited. Gated by `theming.config.update`."
+      operationId: themingDraftUpdate
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ThemeConfigRequest"
+      responses:
+        "200":
+          description: Draft saved (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeDraft"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: "The `Idempotency-Key` was already used with a different request payload."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/theming/validate:
+    post:
+      tags:
+        - Theming
+      summary: Validate a theme config (dry run) + preview its token CSS
+      description: "Read-only: validate a proposed theme config against its theme descriptor and, when valid, return the exact `text/css` custom-property block it would produce — writing nothing. Gated by `theming.config.read`."
+      operationId: themingValidate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ThemeConfigRequest"
+      responses:
+        "200":
+          description: The validation result (+ token CSS when valid).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeValidationResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/theming/preview:
+    post:
+      tags:
+        - Theming
+      summary: Create a short-lived, non-indexable preview session for the draft
+      description: "Mint an authorized, short-lived, non-indexable preview of the current draft and return its URL (`/theming/preview/{token}`) + expiry. The raw token is returned once; only its hash is stored. Audited. Gated by `theming.preview.create`. Not idempotency-keyed (each preview is a distinct disposable token)."
+      operationId: themingPreviewCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                ttlMinutes:
+                  type: integer
+                  minimum: 1
+                  maximum: 120
+                  description: "Preview lifetime in minutes (default 30, hard cap 120)."
+      responses:
+        "200":
+          description: The preview session URL + expiry.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    required: [previewUrl, expiresAt]
+                    properties:
+                      previewUrl:
+                        type: string
+                      expiresAt:
+                        type: string
+                        format: date-time
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/theming/publish:
+    post:
+      tags:
+        - Theming
+      summary: Publish the draft as an immutable version (and make it live)
+      description: "Publish the current draft as a new IMMUTABLE version and make it the live look (INSERT-only; published versions are immutable). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.publish`."
+      operationId: themingPublish
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Published (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeVersion"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: "The `Idempotency-Key` was already used with a different request payload."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/theming/rollback:
+    post:
+      tags:
+        - Theming
+      summary: Roll the active theme back to an earlier published version
+      description: "Move the active pointer to an earlier published version of this tenant (never mutates a version row). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.restore`."
+      operationId: themingRollback
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [versionId]
+              properties:
+                versionId:
+                  type: string
+                  format: uuid
+      responses:
+        "200":
+          description: Rolled back (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ThemeVersion"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: "The `Idempotency-Key` was already used with a different request payload."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/theming/retire:
+    post:
+      tags:
+        - Theming
+      summary: Retire the active theme (fall back to the default)
+      description: "Clear the active theme pointer so the site falls back to the default theme; published versions stay intact (history/rollback). High-risk: requires an `Idempotency-Key`, audited. Gated by `theming.version.archive`."
+      operationId: themingRetire
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Retired (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    required: [previousThemeKey]
+                    properties:
+                      previousThemeKey:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: "The `Idempotency-Key` was already used with a different request payload."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+components:
+  schemas:
+    ThemeConfigRequest:
+      type: object
+      description: "A tenant's DATA-only theme configuration. Every key/value is validated against the chosen theme descriptor; unknown tokens/slots/assets/sections are rejected, and token values are validated by rejection against strict CSS grammars (no url()/expression()/@import/javascript:/comment-breakout)."
+      required:
+        - themeKey
+      properties:
+        themeKey:
+          type: string
+          maxLength: 64
+          description: "A registered (build-time) theme key."
+        tokenOverrides:
+          type: object
+          additionalProperties:
+            type: string
+          description: "tokenKey -> validated token value (color/dimension/number, or a font-family allow-list key). Unknown token keys are rejected."
+        slotSelections:
+          type: object
+          additionalProperties:
+            type: string
+          description: "slotKey -> chosen variant key (from the slot's allow-list)."
+        assetRefs:
+          type: object
+          additionalProperties:
+            type: string
+            format: uuid
+            nullable: true
+          description: "assetSlotKey -> media object UUID (never a URL); null clears the slot."
+        sectionOrder:
+          type: array
+          items:
+            type: string
+          description: "An ordering of the theme's declared content-section keys."
+        navPlacement:
+          type: string
+          description: "One of the theme's declared nav placements."
+    ThemeDraft:
+      type: object
+      required: [versionId, themeKey, config, configHash]
+      properties:
+        versionId:
+          type: string
+          format: uuid
+        themeKey:
+          type: string
+        config:
+          type: object
+          description: "The validated, normalized config as stored."
+        configHash:
+          type: string
+    ThemeVersion:
+      type: object
+      required: [versionId, themeKey, versionNumber]
+      properties:
+        versionId:
+          type: string
+          format: uuid
+        themeKey:
+          type: string
+        versionNumber:
+          type: integer
+          nullable: true
+        configHash:
+          type: string
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+    ThemeValidationResult:
+      type: object
+      required: [valid, errors, previewCss]
+      properties:
+        valid:
+          type: boolean
+        errors:
+          type: array
+          items:
+            type: object
+            required: [field, message]
+            properties:
+              field:
+                type: string
+              message:
+                type: string
+        previewCss:
+          type: string
+          nullable: true
+          description: "The `:root { … }` custom-property block that would be served, when valid; null when invalid."
+    ThemingState:
+      type: object
+      required: [themes, state, draft, versions]
+      properties:
+        themes:
+          type: array
+          description: "Available reviewed, build-time theme descriptors."
+          items:
+            type: object
+        state:
+          type: object
+          required: [activeThemeKey, activeVersionId, draftThemeKey]
+          properties:
+            activeThemeKey:
+              type: string
+              nullable: true
+            activeVersionId:
+              type: string
+              format: uuid
+              nullable: true
+            draftThemeKey:
+              type: string
+              nullable: true
+        draft:
+          type: object
+          nullable: true
+        versions:
+          type: array
+          items:
+            $ref: "#/components/schemas/ThemeVersion"

--- a/sql/033_awcms_theming_config_schema.sql
+++ b/sql/033_awcms_theming_config_schema.sql
@@ -1,0 +1,210 @@
+-- Runtime schema for the `theming` module — the FIRST website module implemented
+-- directly in the awcms base (ADR-0034 Fase 3, "template dipakai-langsung";
+-- ported/adapted from awcms-micro migration 085). Tenant theme assignment,
+-- IMMUTABLE published configuration versions, and short-lived preview sessions.
+-- All three tables are tenant-scoped, ENABLE + FORCE ROW LEVEL SECURITY with the
+-- standard `tenant_isolation` policy (sql/013 convention). Tenant A's theme
+-- config can NEVER be read/resolved under tenant B's context — RLS is the
+-- structural floor under the explicit `tenant_id` filter every query also carries.
+--
+-- ## What is (and is NOT) in the database (ADR-0034/awcms-micro ADR-0029 §3/§4)
+--
+-- A THEME itself is trusted, reviewed, BUILD-TIME source code (a `ThemeDescriptor`
+-- composed by `src/modules/theming/theme-registry.ts`), NEVER a database row and
+-- NEVER uploaded/runtime-discovered. What lives here is only a tenant's DATA
+-- configuration OF a chosen theme: validated design-token overrides, slot variant
+-- selections, media asset ids, section ordering, nav placement — all bounded and
+-- schema-validated in `domain/theme-config.ts` before ever being stored, and all
+-- serialized to CSS only through the reject-not-sanitize spine
+-- (`domain/css-value-validation.ts`). There is NO executable-template column
+-- anywhere in this schema.
+--
+-- ## Published-version immutability ("a change is a new version")
+--
+-- `awcms_theming_config_versions` holds two statuses: a single mutable `draft`
+-- per tenant, and numbered `published` versions. A published version is IMMUTABLE
+-- — enforced at THREE layers: (1) the application engine only ever INSERTs a new
+-- published row, never UPDATEs an old one; (2) the BEFORE UPDATE OR DELETE trigger
+-- below RAISES on any attempt to mutate/delete a `status = 'published'` row; (3)
+-- the active pointer (which theme + which published version is live) lives in
+-- `awcms_theming_tenant_state`, so rollback/retire move a pointer and never touch
+-- a version row. This keeps published versions reproducible and history intact.
+--
+-- ## GRANTS / worker role (port adaptation)
+--
+-- No explicit GRANT statements: sql/019 (`019_awcms_db_role_separation.sql`) set
+-- `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT,INSERT,UPDATE,DELETE ...
+-- TO awcms_app`, so tables created here inherit the least-privilege runtime grant
+-- automatically (same posture as sql/024). awcms-micro 085 granted the preview
+-- table to `awcms_micro_worker` for a generic data_lifecycle purge job; awcms has
+-- NO `awcms_worker` role and the data_lifecycle purge engine is not ported, so
+-- that GRANT is deliberately dropped. Preview sessions stay safe without a purge
+-- job because every read filters on `expires_at >= now()` (see
+-- `application/theme-preview-directory.ts`).
+
+-- ===========================================================================
+-- 1. awcms_theming_config_versions — draft + immutable published versions
+-- ===========================================================================
+CREATE TABLE IF NOT EXISTS awcms_theming_config_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  -- The chosen theme's key (a `ThemeDescriptor.themeKey` from the build-time
+  -- registry) and the theme descriptor version bound at publish time, so a
+  -- published config is reproducible against the exact theme shape it validated
+  -- against.
+  theme_key text NOT NULL,
+  theme_version text NOT NULL,
+  -- 'draft' (the single mutable work-in-progress per tenant) | 'published'
+  -- (an immutable numbered version — see the trigger below).
+  status text NOT NULL DEFAULT 'draft',
+  -- Monotonic per-tenant version number, assigned only to published rows
+  -- (NULL for the draft). The partial unique index below prevents a race from
+  -- assigning the same number twice.
+  version_number integer,
+  -- The validated `ThemeConfig` (token overrides, slot selections, asset media
+  -- ids, section order, nav placement). Plain data — no template, no code.
+  config jsonb NOT NULL,
+  -- SHA-256 of the canonical config, for idempotent replays + cheap change
+  -- detection.
+  config_hash text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  published_at timestamptz,
+  published_by uuid,
+  CONSTRAINT awcms_theming_config_versions_status_check
+    CHECK (status IN ('draft', 'published')),
+  -- A published row must carry a version number + publish stamp; a draft must not.
+  CONSTRAINT awcms_theming_config_versions_publish_fields_check
+    CHECK (
+      (status = 'published' AND version_number IS NOT NULL AND published_at IS NOT NULL)
+      OR (status = 'draft' AND version_number IS NULL)
+    ),
+  CONSTRAINT awcms_theming_config_versions_theme_key_len_check
+    CHECK (theme_key <> '' AND char_length(theme_key) <= 64),
+  CONSTRAINT awcms_theming_config_versions_theme_version_len_check
+    CHECK (theme_version <> '' AND char_length(theme_version) <= 32),
+  -- Coarse size floor under the application validation — a config is a small,
+  -- bounded token/slot map, never a megabyte blob.
+  CONSTRAINT awcms_theming_config_versions_config_size_check
+    CHECK (octet_length(config::text) <= 65536)
+);
+
+-- Exactly one draft per tenant (the mutable working copy).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_theming_config_versions_one_draft
+  ON awcms_theming_config_versions (tenant_id)
+  WHERE status = 'draft';
+
+-- Published version numbers are unique per tenant (concurrency guard: two
+-- concurrent publishes computing the same next number -> one fails here).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_theming_config_versions_pub_number
+  ON awcms_theming_config_versions (tenant_id, version_number)
+  WHERE status = 'published';
+
+-- Version-history listing (newest published first) + rollback target lookup.
+CREATE INDEX IF NOT EXISTS awcms_theming_config_versions_history_idx
+  ON awcms_theming_config_versions (tenant_id, version_number DESC)
+  WHERE status = 'published';
+
+ALTER TABLE awcms_theming_config_versions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_theming_config_versions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_theming_config_versions_tenant_isolation
+  ON awcms_theming_config_versions
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Published-version immutability enforcement. A BEFORE trigger that RAISES on any
+-- UPDATE/DELETE of a published row. Draft rows stay freely mutable (the working
+-- copy). The BEGIN/END below are PL/pgSQL block delimiters inside a dollar-quoted
+-- body, NOT transaction control — the migration runner strips dollar-quoted
+-- blocks before its transaction-control scan (see scripts/db-migrate.ts).
+CREATE OR REPLACE FUNCTION awcms_theming_versions_guard()
+RETURNS trigger AS $awcms_theming_guard$
+BEGIN
+  IF OLD.status = 'published' THEN
+    RAISE EXCEPTION
+      'awcms_theming_config_versions row % is published and immutable (ADR-0034): a change must create a new version',
+      OLD.id
+      USING ERRCODE = 'restrict_violation';
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  RETURN NEW;
+END;
+$awcms_theming_guard$ LANGUAGE plpgsql;
+
+CREATE TRIGGER awcms_theming_versions_immutable
+  BEFORE UPDATE OR DELETE ON awcms_theming_config_versions
+  FOR EACH ROW
+  EXECUTE FUNCTION awcms_theming_versions_guard();
+
+-- ===========================================================================
+-- 2. awcms_theming_tenant_state — the tenant's active theme + pointers
+-- ===========================================================================
+-- One upsert-shaped row per tenant. The ACTIVE pointer is here, not on a version
+-- row, so publish/rollback/retire move a pointer while published versions stay
+-- immutable. `active_theme_key`/`active_version_id` NULL = this tenant has not
+-- published a theme yet (the site falls back to the default theme's defaults).
+CREATE TABLE IF NOT EXISTS awcms_theming_tenant_state (
+  tenant_id uuid PRIMARY KEY REFERENCES awcms_tenants (id),
+  active_theme_key text,
+  active_version_id uuid REFERENCES awcms_theming_config_versions (id),
+  -- The current draft's key (denormalized convenience; the draft row itself is
+  -- the source of truth via the one-draft-per-tenant index above).
+  draft_theme_key text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  CONSTRAINT awcms_theming_tenant_state_active_theme_len_check
+    CHECK (active_theme_key IS NULL OR char_length(active_theme_key) <= 64),
+  CONSTRAINT awcms_theming_tenant_state_draft_theme_len_check
+    CHECK (draft_theme_key IS NULL OR char_length(draft_theme_key) <= 64)
+);
+
+ALTER TABLE awcms_theming_tenant_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_theming_tenant_state FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_theming_tenant_state_tenant_isolation
+  ON awcms_theming_tenant_state
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- ===========================================================================
+-- 3. awcms_theming_preview_sessions — short-lived, non-indexable previews
+-- ===========================================================================
+-- An authorized, short-lived session that renders a tenant's DRAFT theme config
+-- at a non-indexable URL isolated from the public cache. Only the SHA-256 HASH of
+-- the raw token is stored (mirrors awcms_sessions) so a table leak never yields a
+-- usable token. Every read filters `expires_at >= now()` so a stale session is
+-- inert even without a background purge job (the generic data_lifecycle purge
+-- engine is NOT ported to awcms; see the GRANTS note in the header).
+CREATE TABLE IF NOT EXISTS awcms_theming_preview_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  -- SHA-256 hex of the raw preview token (never the raw token).
+  token_hash text NOT NULL,
+  -- The version the preview renders — a draft version id (the working copy).
+  version_id uuid NOT NULL REFERENCES awcms_theming_config_versions (id),
+  created_by uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  CONSTRAINT awcms_theming_preview_sessions_token_hash_len_check
+    CHECK (char_length(token_hash) = 64)
+);
+
+-- Token lookup is by hash — unique so a hash maps to at most one live session.
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_theming_preview_sessions_token_hash
+  ON awcms_theming_preview_sessions (token_hash);
+
+-- Age-based lookup cursor (tenant + expires_at) — supports the `expires_at >= now`
+-- read filter and any future age-based cleanup without a table scan.
+CREATE INDEX IF NOT EXISTS awcms_theming_preview_sessions_tenant_expires_idx
+  ON awcms_theming_preview_sessions (tenant_id, expires_at);
+
+ALTER TABLE awcms_theming_preview_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_theming_preview_sessions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_theming_preview_sessions_tenant_isolation
+  ON awcms_theming_preview_sessions
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/034_awcms_theming_permissions.sql
+++ b/sql/034_awcms_theming_permissions.sql
@@ -1,0 +1,38 @@
+-- Permission catalog seed for the `theming` module's admin API
+-- (`/api/v1/theming/*`) — ADR-0034 Fase 3, ported from awcms-micro migration 086.
+-- Wires up the constants in `theming/domain/theme-permissions.ts` and this
+-- module's own `module.ts` `permissions` declaration.
+--
+-- `awcms_permissions` is a GLOBAL catalog (no tenant_id / no RLS — sql/005); the
+-- unique key is `(module_key, activity_code, action)`, so this insert is
+-- idempotent via `ON CONFLICT ... DO NOTHING`. Same shape/limitation as every
+-- prior permission-seed migration here (sql/026/028): it extends the global ABAC
+-- catalog only. Existing tenants' `owner` role does NOT retroactively gain these —
+-- only tenants created after this migration runs get them at setup-wizard
+-- bootstrap (which seeds owner from the catalog).
+--
+-- ## Why the activities/actions are split this way
+--
+--  - `config.read`    — read theme state, available theme descriptors, the draft,
+--    and published version history (low blast radius; not audited).
+--  - `config.update`  — save/edit the draft config (tokens, slots, assets, order).
+--    Bounded, schema-validated data only; high-risk enough to audit.
+--  - `version.publish` — promote a validated draft to an IMMUTABLE published
+--    version and make it the tenant's active/live look. Changes the public
+--    presentation surface -> high-risk, idempotency-keyed, audited.
+--  - `version.restore` — roll the active pointer back to an earlier published
+--    version. High-risk (changes the live look), audited.
+--  - `version.archive` — retire the active theme (clear the active pointer; the
+--    site falls back to the default theme). High-risk, audited.
+--  - `preview.create` — mint a short-lived, non-indexable preview session for the
+--    draft. Audited (an authorization event), not idempotency-keyed (each preview
+--    session is intentionally distinct).
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('theming', 'config', 'read', 'Read this tenant''s theme selection, available themes, the draft config, and published version history'),
+  ('theming', 'config', 'update', 'Edit this tenant''s draft theme config (design tokens, slot variants, media assets, section order) — bounded, validated data (high-risk, audited)'),
+  ('theming', 'version', 'publish', 'Publish a validated draft as an immutable theme version and make it the live look (high-risk, idempotency-keyed, audited)'),
+  ('theming', 'version', 'restore', 'Roll the active theme back to an earlier published version (high-risk, idempotency-keyed, audited)'),
+  ('theming', 'version', 'archive', 'Retire the active theme so the site falls back to the default (high-risk, idempotency-keyed, audited)'),
+  ('theming', 'preview', 'create', 'Create a short-lived, non-indexable preview session for the draft theme config (audited)')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/layouts/PublicThemeLayout.astro
+++ b/src/layouts/PublicThemeLayout.astro
@@ -1,0 +1,246 @@
+---
+/**
+ * PublicThemeLayout — the trusted, reviewed, BUILD-TIME Astro layout that renders
+ * a tenant's selected `theming` theme (Issue #269, ADR-0029 §7). There is NO
+ * database-stored template: this component is the only thing that renders, and it
+ * only ever consumes a validated `PreviewViewModel` (section order, slot variants,
+ * a resolved logo URL) plus design-token custom properties supplied by an EXTERNAL
+ * same-origin stylesheet (`tokenCssHref`).
+ *
+ * ## CSP (never weakened — ADR-0029 §7)
+ *
+ * The structural CSS below is an Astro-scoped `<style>` block, hashed by Astro's
+ * own `security.csp` (astro.config.mjs) — no inline style attribute, no
+ * `is:inline` script, no external font/script. The per-tenant token VALUES arrive
+ * via `<link rel="stylesheet" href={tokenCssHref}>` (allowed by `style-src 'self'`),
+ * NOT an inline `<style>` (which Astro could not hash per-request → CSP block).
+ * Every `var(--awcms-theme-*)` here carries a safe literal fallback, so the layout
+ * is legible even if the token stylesheet fails to load.
+ *
+ * ## Accessibility (ADR-0029 threat model — a11y regression)
+ *
+ * Landmarks (`banner`/`navigation`/`main`/`contentinfo`), a skip link, a single
+ * `<h1>`, visible focus styles, and a `prefers-reduced-motion` guard. The default
+ * theme's token defaults meet WCAG AA contrast (asserted by the a11y test).
+ */
+import type { PreviewViewModel } from "../modules/theming/application/theme-preview-render";
+
+interface Props {
+  title: string;
+  tokenCssHref: string;
+  model: PreviewViewModel;
+  /** When true, emit `robots: noindex,nofollow` (preview surfaces). */
+  noindex?: boolean;
+  lang?: string;
+}
+
+const {
+  title,
+  tokenCssHref,
+  model,
+  noindex = false,
+  lang = "en"
+} = Astro.props;
+---
+
+<!doctype html>
+<html lang={lang} data-theme-key={model.themeKey}>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
+    <link rel="stylesheet" href={tokenCssHref} />
+  </head>
+  <body
+    data-header={model.headerVariant}
+    data-footer={model.footerVariant}
+    data-nav={model.navVariant}
+    data-nav-placement={model.navPlacement}
+  >
+    <a class="skip-link" href="#main">Skip to content</a>
+    <div class="theme-shell">
+      <header class="theme-header" role="banner">
+        <div class="theme-brand">
+          {
+            model.logo ? (
+              <img
+                class="theme-logo"
+                src={model.logo.url}
+                alt={model.logo.altText ?? model.themeName}
+              />
+            ) : (
+              <span class="theme-logo-fallback">{model.themeName}</span>
+            )
+          }
+        </div>
+        <nav class="theme-nav" role="navigation" aria-label="Primary">
+          <ul>
+            {
+              model.navItems.map((item) => (
+                <li>
+                  <a href={item.href}>{item.label}</a>
+                </li>
+              ))
+            }
+          </ul>
+        </nav>
+      </header>
+
+      <main id="main" class="theme-main" role="main">
+        <slot />
+      </main>
+
+      <footer class="theme-footer" role="contentinfo">
+        <p>Powered by AWCMS &middot; {model.themeName} theme</p>
+      </footer>
+    </div>
+
+    <style>
+      :root {
+        --_bg: var(--awcms-theme-color_background, #ffffff);
+        --_surface: var(--awcms-theme-color_surface, #f8fafc);
+        --_text: var(--awcms-theme-color_text, #0f172a);
+        --_muted: var(--awcms-theme-color_muted, #475569);
+        --_primary: var(--awcms-theme-color_primary, #2563eb);
+        --_on-primary: var(--awcms-theme-color_on_primary, #ffffff);
+        --_border: var(--awcms-theme-color_border, #e2e8f0);
+        --_accent: var(--awcms-theme-color_accent, #0ea5e9);
+        --_radius: var(--awcms-theme-radius_base, 0.5rem);
+        --_space: var(--awcms-theme-space_unit, 1rem);
+        --_container: var(--awcms-theme-container_max_width, 72rem);
+        --_font-body: var(--awcms-theme-font_body, system-ui, sans-serif);
+        --_font-heading: var(--awcms-theme-font_heading, system-ui, sans-serif);
+        --_font-size: var(--awcms-theme-font_size_base, 1rem);
+        --_line: var(--awcms-theme-line_height_base, 1.5);
+      }
+
+      body {
+        margin: 0;
+        background: var(--_bg);
+        color: var(--_text);
+        font-family: var(--_font-body);
+        font-size: var(--_font-size);
+        line-height: var(--_line);
+      }
+
+      .skip-link {
+        position: absolute;
+        left: -9999px;
+        top: 0;
+        background: var(--_primary);
+        color: var(--_on-primary);
+        padding: var(--_space);
+        z-index: 100;
+      }
+      .skip-link:focus {
+        left: 0;
+      }
+
+      a:focus-visible,
+      .theme-nav a:focus-visible {
+        outline: 3px solid var(--_accent);
+        outline-offset: 2px;
+      }
+
+      .theme-shell {
+        max-width: var(--_container);
+        margin: 0 auto;
+        padding: 0 var(--_space);
+      }
+
+      .theme-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--_space);
+        padding: var(--_space) 0;
+        border-bottom: 1px solid var(--_border);
+        flex-wrap: wrap;
+      }
+      body[data-header="centered"] .theme-header {
+        flex-direction: column;
+        text-align: center;
+      }
+
+      .theme-logo {
+        max-height: 3rem;
+        width: auto;
+      }
+      .theme-logo-fallback {
+        font-family: var(--_font-heading);
+        font-weight: 700;
+        font-size: 1.25rem;
+        color: var(--_primary);
+      }
+
+      .theme-nav ul {
+        display: flex;
+        gap: var(--_space);
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        flex-wrap: wrap;
+      }
+      .theme-nav a {
+        color: var(--_text);
+        text-decoration: none;
+        padding: 0.25rem 0.5rem;
+        border-radius: var(--_radius);
+      }
+      .theme-nav a:hover {
+        color: var(--_primary);
+      }
+
+      .theme-main {
+        padding: calc(var(--_space) * 2) 0;
+      }
+
+      .theme-main h1,
+      .theme-main h2 {
+        font-family: var(--_font-heading);
+        color: var(--_text);
+      }
+
+      .theme-section {
+        background: var(--_surface);
+        border: 1px solid var(--_border);
+        border-radius: var(--_radius);
+        padding: calc(var(--_space) * 1.5);
+        margin-bottom: var(--_space);
+      }
+      .theme-section p {
+        color: var(--_muted);
+      }
+
+      .theme-cta {
+        display: inline-block;
+        background: var(--_primary);
+        color: var(--_on-primary);
+        padding: 0.5rem 1rem;
+        border-radius: var(--_radius);
+        text-decoration: none;
+      }
+
+      .theme-footer {
+        border-top: 1px solid var(--_border);
+        padding: var(--_space) 0;
+        color: var(--_muted);
+      }
+
+      @media (max-width: 640px) {
+        .theme-header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        * {
+          animation-duration: 0.001ms !important;
+          transition-duration: 0.001ms !important;
+        }
+      }
+    </style>
+  </body>
+</html>

--- a/src/lib/theming/theme-media.ts
+++ b/src/lib/theming/theme-media.ts
@@ -1,0 +1,36 @@
+/**
+ * Theme asset media resolution composition root (ADR-0034 Fase 3; ported from
+ * awcms-micro Issue #269/ADR-0029 §7). Lives in `src/lib` (never inside the
+ * module's own `application`/`domain`) because it is where a media adapter would
+ * be wired into `theming` — the ports-and-adapters composition-root convention.
+ *
+ * ## Port adaptation: media resolution is a NO-OP in this base
+ *
+ * awcms-micro resolved a theme config's `assetRefs` (assetSlotKey -> media UUID)
+ * to safe, same-tenant, verified public URLs through its `media_library` module's
+ * `MediaLibraryPort`. That module is NOT part of the awcms base (ADR-0034 Fase 3
+ * ports only `theming` first), so there is nothing to resolve against. Rather
+ * than import a module that does not exist, this returns an EMPTY map: every
+ * asset slot is simply omitted from render and the theme degrades safely (a null
+ * logo renders the theme-name fallback in `PublicThemeLayout`). Stored asset ids
+ * remain valid DATA; only their URL resolution is deferred until a media module
+ * is ported, at which point this seam is the single place to wire it in.
+ */
+import type { ThemeConfig } from "../../modules/theming/domain/theme-config";
+
+export type ResolvedThemeAsset = { url: string; altText: string | null };
+
+/**
+ * Resolve a theme config's `assetRefs` to public URLs. No media module exists in
+ * this base yet (see the file header), so this is a documented no-op returning an
+ * empty map — every asset slot is omitted from render. The signature keeps the
+ * `tx`/`tenantId`/`config` shape so wiring a real media adapter later is a
+ * single-file change with no caller churn.
+ */
+export async function resolveThemeAssetUrls(
+  _tx: Bun.SQL,
+  _tenantId: string,
+  _config: ThemeConfig
+): Promise<Record<string, ResolvedThemeAsset>> {
+  return {};
+}

--- a/src/lib/theming/theme-preview.ts
+++ b/src/lib/theming/theme-preview.ts
@@ -1,0 +1,120 @@
+/**
+ * Theme preview composition root (ADR-0034 Fase 3; ported from awcms-micro
+ * Issue #269/ADR-0029 §6). Resolves a preview URL token to a renderable DRAFT
+ * theme context, and serves the preview's token CSS — both NON-INDEXABLE and
+ * isolated from the public cache.
+ *
+ * The URL token is `${tenantId}~${rawToken}` (see `domain/preview-token.ts`): the
+ * tenant id lets us open the correct tenant transaction so RLS can then confirm
+ * the SHA-256 of `rawToken` matches a live session for THAT tenant — a token can
+ * never resolve a session belonging to another tenant. Security rests on the
+ * 256-bit `rawToken`, not on the (non-secret) tenant id. Because the tenant id is
+ * carried in the token itself, this preview surface needs NO host/tenant-code
+ * resolution (unlike the public `/theming/{tenantCode}/tokens.css` stylesheet).
+ */
+import { getDatabaseClient } from "../database/client";
+import { withTenant } from "../database/tenant-context";
+import { fetchVersionById } from "../../modules/theming/application/theme-config-directory";
+import { findActivePreviewSession } from "../../modules/theming/application/theme-preview-directory";
+import { resolveVersionThemeCss } from "../../modules/theming/application/theme-render-resolver";
+import type { ThemeConfig } from "../../modules/theming/domain/theme-config";
+import type { ThemeDescriptor } from "../../modules/theming/domain/theme-descriptor";
+import {
+  hashPreviewToken,
+  parsePreviewUrlToken
+} from "../../modules/theming/domain/preview-token";
+import { getThemeDescriptor } from "../../modules/theming/theme-registry";
+import { resolveThemeAssetUrls, type ResolvedThemeAsset } from "./theme-media";
+
+export type PreviewRenderContext = {
+  descriptor: ThemeDescriptor;
+  config: ThemeConfig;
+  assetUrls: Record<string, ResolvedThemeAsset>;
+  urlToken: string;
+};
+
+/**
+ * Resolve a preview URL token to a renderable draft context, or `null` when the
+ * token is malformed, the session is unknown/expired, the version is gone, or the
+ * theme is no longer registered. Every DB read is strictly tenant-scoped, and the
+ * session lookup filters `expires_at >= now` so an expired token resolves to
+ * nothing.
+ */
+export async function resolvePreviewContext(
+  urlToken: string,
+  now: Date = new Date()
+): Promise<PreviewRenderContext | null> {
+  const parsed = parsePreviewUrlToken(urlToken);
+  if (!parsed) return null;
+  const sql = getDatabaseClient();
+  const tokenHash = hashPreviewToken(parsed.rawToken);
+
+  return withTenant(sql, parsed.tenantId, async (tx) => {
+    const session = await findActivePreviewSession(tx, tokenHash, now);
+    if (!session) return null;
+    const version = await fetchVersionById(
+      tx,
+      parsed.tenantId,
+      session.versionId
+    );
+    if (!version) return null;
+    const descriptor = getThemeDescriptor(version.themeKey);
+    if (!descriptor) return null;
+    const assetUrls = await resolveThemeAssetUrls(
+      tx,
+      parsed.tenantId,
+      version.config
+    );
+    return { descriptor, config: version.config, assetUrls, urlToken };
+  });
+}
+
+/**
+ * Serve the preview draft's token CSS. NON-INDEXABLE + `private, no-store` +
+ * a distinct URL namespace from the public tokens stylesheet, so a preview can
+ * never poison the public/CDN cache. Returns a 404 stylesheet comment when the
+ * token does not resolve (never leaks whether a token merely expired).
+ */
+export async function serveThemePreviewTokensCss(
+  urlToken: string,
+  now: Date = new Date()
+): Promise<Response> {
+  const parsed = parsePreviewUrlToken(urlToken);
+  const notFound = (): Response =>
+    new Response("/* preview not found or expired */\n", {
+      status: 404,
+      headers: {
+        "content-type": "text/css; charset=utf-8",
+        "cache-control": "private, no-store",
+        "x-robots-tag": "noindex, nofollow"
+      }
+    });
+  if (!parsed) return notFound();
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashPreviewToken(parsed.rawToken);
+
+  const css = await withTenant(sql, parsed.tenantId, async (tx) => {
+    const session = await findActivePreviewSession(tx, tokenHash, now);
+    if (!session) return null;
+    const version = await fetchVersionById(
+      tx,
+      parsed.tenantId,
+      session.versionId
+    );
+    if (!version) return null;
+    return resolveVersionThemeCss(version).css;
+  });
+
+  if (css === null) return notFound();
+
+  return new Response(css, {
+    status: 200,
+    headers: {
+      "content-type": "text/css; charset=utf-8",
+      // Preview must never be cached by a shared/CDN cache or indexed.
+      "cache-control": "private, no-store",
+      "x-robots-tag": "noindex, nofollow"
+    }
+  });
+}

--- a/src/lib/theming/theme-public-css.ts
+++ b/src/lib/theming/theme-public-css.ts
@@ -1,0 +1,100 @@
+/**
+ * Public theme token stylesheet composition root (ADR-0034 Fase 3; ported from
+ * awcms-micro Issue #269/ADR-0029 §7). Lives in `src/lib` because it wires the
+ * public-tenant resolver + the `module_management` enablement gate into
+ * `theming`'s render resolver (never a cross-module import inside the module's
+ * own application/domain).
+ *
+ * `GET /theming/{tenantCode}/tokens.css` — resolves the request's tenant FROM
+ * THE `tenantCode` PATH SEGMENT (ADR-0009: awcms resolves public tenants by an
+ * explicit `tenantCode`, not a Host/subdomain — this base defaults to a
+ * LAN-first/offline topology with no guaranteed public DNS/TLS per tenant; this
+ * is the port adaptation of awcms-micro's Host-based resolver), then serves that
+ * tenant's ACTIVE published theme tokens as `text/css`. It ALWAYS returns a valid
+ * 200: an unresolved/inactive tenant, a tenant with `theming` disabled, and a
+ * tenant with no active theme all serve the DEFAULT theme's tokens — so there is
+ * NO "does this code map to an active tenant" enumeration/timing oracle (the
+ * response is always a stylesheet; only the token values a tenant chose to
+ * publish differ).
+ *
+ * The stylesheet is same-origin, so it is served under the app's existing CSP
+ * `style-src 'self'` without any inline `<style>` — the whole reason token values
+ * ship as an external stylesheet (ADR-0029 §7: never weaken CSP).
+ */
+import { getDatabaseClient } from "../database/client";
+import { withTenant } from "../database/tenant-context";
+import { resolvePublicTenantByCode } from "../tenant/public-tenant-resolver";
+import { fetchTenantModuleEntry } from "../../modules/module-management/application/tenant-module-lifecycle";
+import { THEMING_MODULE_KEY } from "../../modules/theming/domain/theme-permissions";
+import {
+  defaultThemeCss,
+  resolveActiveThemeCssForTenant,
+  type ResolvedThemeCss
+} from "../../modules/theming/application/theme-render-resolver";
+
+/** ETag from a render fingerprint (strong validator). */
+function etagFor(css: ResolvedThemeCss): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(css.fingerprint);
+  return `"${hasher.digest("hex").slice(0, 32)}"`;
+}
+
+function cssResponse(css: ResolvedThemeCss, status = 200): Response {
+  return new Response(css.css, {
+    status,
+    headers: {
+      "content-type": "text/css; charset=utf-8",
+      etag: etagFor(css),
+      // Public, tenant-first (tenantCode determines tenant), safe to cache/CDN.
+      "cache-control":
+        "public, max-age=300, s-maxage=300, stale-while-revalidate=600"
+    }
+  });
+}
+
+function notModified(css: ResolvedThemeCss): Response {
+  return new Response(null, {
+    status: 304,
+    headers: {
+      etag: etagFor(css),
+      "cache-control":
+        "public, max-age=300, s-maxage=300, stale-while-revalidate=600"
+    }
+  });
+}
+
+/**
+ * Serve the active theme tokens CSS for the request's resolved tenant (always
+ * 200/304). `tenantCode` is the public path segment; an unknown or inactive code
+ * resolves to `null` and serves the default tokens (no enumeration oracle).
+ */
+export async function serveActiveThemeTokensCss(
+  request: Request,
+  tenantCode: string
+): Promise<Response> {
+  const sql = getDatabaseClient();
+  const tenant = tenantCode
+    ? await resolvePublicTenantByCode(sql, tenantCode)
+    : null;
+
+  let resolved: ResolvedThemeCss;
+  if (!tenant) {
+    resolved = defaultThemeCss();
+  } else {
+    resolved = await withTenant(sql, tenant.tenantId, async (tx) => {
+      const entry = await fetchTenantModuleEntry(
+        tx,
+        tenant.tenantId,
+        THEMING_MODULE_KEY
+      );
+      if (!(entry?.tenantEnabled ?? false)) return defaultThemeCss();
+      return resolveActiveThemeCssForTenant(tx, tenant.tenantId);
+    });
+  }
+
+  const ifNoneMatch = request.headers.get("if-none-match");
+  if (ifNoneMatch && ifNoneMatch === etagFor(resolved)) {
+    return notModified(resolved);
+  }
+  return cssResponse(resolved);
+}

--- a/src/modules/identity-access/domain/access-control.ts
+++ b/src/modules/identity-access/domain/access-control.ts
@@ -63,7 +63,11 @@ export type AccessAction =
   // high-risk — rejecting an exception is the SAFE outcome (the conflict stays
   // denied), unlike `approve`/`revoke` which change an override's standing.
   // (`approve`/`revoke` for exceptions reuse the existing high-risk actions.)
-  | "reject";
+  | "reject"
+  // Theming (ADR-0034 Fase 3): `archive` retires the active theme so the site
+  // falls back to the default. High-risk (it changes the live public
+  // presentation surface), same posture as `publish`/`restore`.
+  | "archive";
 
 export type AccessRequest = {
   moduleKey: string;
@@ -171,7 +175,8 @@ const HIGH_RISK_ACTIONS: ReadonlySet<AccessAction> = new Set([
   "force_decide",
   "revoke",
   "rebuild",
-  "export"
+  "export",
+  "archive"
 ]);
 
 export function isHighRiskAction(action: AccessAction): boolean {

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -9,6 +9,7 @@ import { syncStorageModule } from "./sync-storage/module";
 import { workflowApprovalModule } from "./workflow-approval/module";
 import { emailModule } from "./email/module";
 import { reportingModule } from "./reporting/module";
+import { themingModule } from "./theming/module";
 
 /**
  * The reviewed BASE registry. Every module below is reviewed, in-repo code.
@@ -23,7 +24,11 @@ const baseModules: ModuleDescriptor[] = [
   syncStorageModule,
   workflowApprovalModule,
   emailModule,
-  reportingModule
+  reportingModule,
+  // ADR-0034 Fase 3 — the first website module implemented directly in the base
+  // (depends only on the two Core modules; provides no capability, so the DAG is
+  // unchanged). See src/modules/theming/README.md.
+  themingModule
 ];
 
 /**

--- a/src/modules/theming/README.md
+++ b/src/modules/theming/README.md
@@ -1,0 +1,100 @@
+# theming — tenant-selectable presentation (ADR-0034 Fase 3)
+
+The FIRST website module implemented **directly in the awcms base** — the evidence
+for ADR-0034's decision that content/website modules may live in `src/modules/`
+here ("template dipakai-langsung"), superseding the old `no-content-website-modules`
+restriction. Adapted from awcms-micro's `theming` (Issue #269 / awcms-micro
+ADR-0029).
+
+Lets a tenant **select** a trusted theme and **configure** it by DATA (design
+tokens, layout slots, media, section order) — with **no uploaded code, no
+arbitrary templates, no raw CSS/HTML/JS**.
+
+## The two things this module keeps strictly apart
+
+| Trusted, build-time (code)                                                                                                                       | Tenant-authored (data)                                                                                                                                                                                                     |
+| ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A **theme** = a `ThemeDescriptor` composed by `theme-registry.ts` from the reviewed in-repo base themes. Reviewed source, bundled at build time. | A **`ThemeConfig`** = token overrides, slot selections, media ids, section order, nav placement. Stored in the DB (`awcms_theming_config_versions` + `_tenant_state`, sql/033, RLS FORCE'd), schema-validated and bounded. |
+| `PublicThemeLayout.astro` — the ONLY thing that renders.                                                                                         | —                                                                                                                                                                                                                          |
+
+There is no database-stored executable template anywhere. awcms has no
+derived-repo theme seam (the derived-application pathway was removed in ADR-0034
+Fase 2); new themes live directly in this base registry.
+
+## Security spine — `domain/css-value-validation.ts`
+
+Every design-token VALUE is validated by **REJECTION, never sanitization**:
+
+- `assertSafeCssPrimitive` — charset-limited, length-bounded, control-char-free,
+  and rejects `url(` / `expression` / `@import` / `javascript:` / `/*` / `;{}<>` /
+  backslash / unbalanced parens. Rejecting (not stripping) sidesteps the
+  `js/incomplete-multi-character-sanitization` class entirely.
+- `validateColorValue` / `validateDimensionValue` / `validateNumberValue` — strict,
+  linear (no-ReDoS) grammars.
+- font families are chosen from a per-theme **allow-list**; the emitted CSS stack
+  is descriptor-owned, so no font value is ever tenant-authored.
+- `serializeThemeTokensCss` is safe by construction (re-validates every value) and
+  emits a `:root { --awcms-theme-* }` block served as an **external same-origin
+  stylesheet** (`/theming/{tenantCode}/tokens.css`) — so the app's `style-src
+'self'` CSP is never weakened (no per-request inline `<style>`).
+
+## Lifecycle — draft → validate → preview → publish → rollback/retire
+
+- **draft** — one mutable working copy per tenant (`PUT /api/v1/theming/draft`).
+- **validate** — read-only dry run (`POST /api/v1/theming/validate`), returns the
+  token CSS that would be produced.
+- **preview** — a short-lived, **non-indexable**, authorized session
+  (`POST /api/v1/theming/preview` → `/theming/preview/{token}`): token stored as a
+  hash, `X-Robots-Tag: noindex`, `private, no-store`, distinct URL namespace from
+  the public stylesheet (cannot poison the public/CDN cache). Every read filters
+  `expires_at >= now()`, so a stale session is inert (there is no background purge
+  job — the generic data_lifecycle engine is not part of this base).
+- **publish** — INSERT a new **immutable** version and make it the live look
+  (`POST /api/v1/theming/publish`). Published versions can never be mutated (engine
+  INSERT-only + the sql/033 `BEFORE UPDATE/DELETE` trigger).
+- **rollback / retire** — move the active pointer only (`POST .../rollback`,
+  `POST .../retire`); history stays intact.
+
+All high-risk mutations require an `Idempotency-Key`, are ABAC-gated, and are
+audited.
+
+## Files
+
+- `domain/` — `css-value-validation.ts` (spine), `theme-descriptor.ts` (contract +
+  `assertValidThemeDescriptor` CSP/a11y gate), `theme-config.ts` (validate +
+  serialize), `theme-lifecycle.ts`, `preview-token.ts`, `theme-permissions.ts`.
+- `themes/default-theme.ts` — the base `aria` theme. `theme-registry.ts` — the
+  reviewed base composition root.
+- `application/` — `theme-config-directory.ts`, `theme-preview-directory.ts`,
+  `theme-service.ts` (orchestration + injected audit), `theme-render-resolver.ts`,
+  `theme-preview-render.ts`.
+- composition roots in `src/lib/theming/` (`theme-media.ts` — a documented no-op
+  until a media module is ported, `theme-public-css.ts` — the `tenantCode`-resolved
+  public stylesheet, `theme-preview.ts`).
+- routes: `src/pages/api/v1/theming/*` (admin API),
+  `src/pages/theming/[tenantCode]/tokens.css.ts` (public),
+  `src/pages/theming/preview/[token].astro` + `preview-tokens/[token].css.ts`.
+- `src/layouts/PublicThemeLayout.astro` — the trusted render layout.
+
+## Port adaptations vs awcms-micro (ADR-0034 Fase 3)
+
+- **No derived-repo theme seam** — the derived-application pathway was removed
+  (ADR-0034 Fase 2); themes live in `theme-registry.ts` directly.
+- **`media_library` dropped** — not part of this base. Asset-URL resolution
+  (`src/lib/theming/theme-media.ts`) is a documented no-op returning an empty map;
+  assets are omitted from render and the theme degrades safely. Stored asset ids
+  remain valid DATA.
+- **`data_lifecycle` purge descriptor dropped** — no purge engine/worker role in
+  this base; preview retention rides the `expires_at >= now()` read filter.
+- **Public tenant resolution is `tenantCode`-based** (ADR-0009), not Host-based —
+  the public stylesheet lives at `/theming/{tenantCode}/tokens.css`.
+
+## Documented follow-ups (deferred, API-first)
+
+- **Full admin UI screens** (rich token editor + responsive preview dashboard) —
+  the API + a minimal preview surface ship here; `navigation` is undeclared.
+- **Domain events** (`awcms.theming.version.published` / `.rolled-back` /
+  `.retired`) — publish/rollback/retire are audited synchronous hooks today.
+- **Media asset rendering** — lands when a media module is ported into this base.
+- **Public-route adoption** — the layout + token stylesheet are ready; wiring the
+  public home routes onto `PublicThemeLayout` is a follow-up.

--- a/src/modules/theming/application/theme-config-directory.ts
+++ b/src/modules/theming/application/theme-config-directory.ts
@@ -1,0 +1,257 @@
+/**
+ * Theme config data access (Issue #269, ADR-0029 §4) over
+ * `awcms_theming_config_versions` (draft + immutable published versions)
+ * and `awcms_theming_tenant_state` (the active pointer). Every query runs
+ * inside a caller-provided tenant transaction (`withTenant`, RLS FORCE'd on both
+ * tables), so tenant isolation holds twice: the explicit `tenant_id` filter here
+ * and RLS.
+ *
+ * This module holds ONLY plain reads/writes — the orchestration (validate →
+ * draft → publish → rollback → retire, with audit) lives in `theme-service.ts`.
+ * Published versions are never UPDATEd here (a change inserts a new version); the
+ * sql/033 trigger is the DB-level backstop for that invariant.
+ */
+import type { ThemeConfig } from "../domain/theme-config";
+import type { ThemeVersionStatus } from "../domain/theme-lifecycle";
+
+export type ThemeTenantState = {
+  activeThemeKey: string | null;
+  activeVersionId: string | null;
+  draftThemeKey: string | null;
+};
+
+export const EMPTY_THEME_TENANT_STATE: ThemeTenantState = {
+  activeThemeKey: null,
+  activeVersionId: null,
+  draftThemeKey: null
+};
+
+export type ThemeConfigVersion = {
+  id: string;
+  themeKey: string;
+  themeVersion: string;
+  status: ThemeVersionStatus;
+  versionNumber: number | null;
+  config: ThemeConfig;
+  configHash: string;
+  createdAt: Date;
+  publishedAt: Date | null;
+};
+
+type VersionRow = {
+  id: string;
+  theme_key: string;
+  theme_version: string;
+  status: ThemeVersionStatus;
+  version_number: number | null;
+  config: ThemeConfig;
+  config_hash: string;
+  created_at: Date;
+  published_at: Date | null;
+};
+
+const VERSION_COLUMNS =
+  "id, theme_key, theme_version, status, version_number, config, config_hash, created_at, published_at";
+
+function toVersion(row: VersionRow): ThemeConfigVersion {
+  return {
+    id: row.id,
+    themeKey: row.theme_key,
+    themeVersion: row.theme_version,
+    status: row.status,
+    versionNumber:
+      row.version_number === null ? null : Number(row.version_number),
+    config: row.config,
+    configHash: row.config_hash,
+    createdAt: row.created_at,
+    publishedAt: row.published_at
+  };
+}
+
+// --- tenant state --------------------------------------------------------
+
+export async function fetchThemeTenantState(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<ThemeTenantState> {
+  const rows = (await tx`
+    SELECT active_theme_key, active_version_id, draft_theme_key
+    FROM awcms_theming_tenant_state
+    WHERE tenant_id = ${tenantId}
+  `) as {
+    active_theme_key: string | null;
+    active_version_id: string | null;
+    draft_theme_key: string | null;
+  }[];
+  const row = rows[0];
+  if (!row) return { ...EMPTY_THEME_TENANT_STATE };
+  return {
+    activeThemeKey: row.active_theme_key,
+    activeVersionId: row.active_version_id,
+    draftThemeKey: row.draft_theme_key
+  };
+}
+
+/** Upsert the active pointer (publish/rollback set it; retire clears it to null). */
+export async function setActiveThemeVersion(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  activeThemeKey: string | null,
+  activeVersionId: string | null
+): Promise<void> {
+  await tx`
+    INSERT INTO awcms_theming_tenant_state
+      (tenant_id, active_theme_key, active_version_id, created_by, updated_by)
+    VALUES (${tenantId}, ${activeThemeKey}, ${activeVersionId}, ${actorTenantUserId}, ${actorTenantUserId})
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      active_theme_key = EXCLUDED.active_theme_key,
+      active_version_id = EXCLUDED.active_version_id,
+      updated_by = EXCLUDED.updated_by,
+      updated_at = now()
+  `;
+}
+
+/** Record the draft's theme key on the state row (denormalized convenience). */
+export async function setDraftThemeKey(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  draftThemeKey: string | null
+): Promise<void> {
+  await tx`
+    INSERT INTO awcms_theming_tenant_state
+      (tenant_id, draft_theme_key, created_by, updated_by)
+    VALUES (${tenantId}, ${draftThemeKey}, ${actorTenantUserId}, ${actorTenantUserId})
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      draft_theme_key = EXCLUDED.draft_theme_key,
+      updated_by = EXCLUDED.updated_by,
+      updated_at = now()
+  `;
+}
+
+// --- versions ------------------------------------------------------------
+
+export async function fetchDraftVersion(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<ThemeConfigVersion | null> {
+  const rows = (await tx`
+    SELECT ${tx.unsafe(VERSION_COLUMNS)}
+    FROM awcms_theming_config_versions
+    WHERE tenant_id = ${tenantId} AND status = 'draft'
+  `) as VersionRow[];
+  return rows[0] ? toVersion(rows[0]) : null;
+}
+
+export async function fetchVersionById(
+  tx: Bun.SQL,
+  tenantId: string,
+  versionId: string
+): Promise<ThemeConfigVersion | null> {
+  const rows = (await tx`
+    SELECT ${tx.unsafe(VERSION_COLUMNS)}
+    FROM awcms_theming_config_versions
+    WHERE tenant_id = ${tenantId} AND id = ${versionId}
+  `) as VersionRow[];
+  return rows[0] ? toVersion(rows[0]) : null;
+}
+
+/** Newest published versions first (version history listing), bounded. */
+export async function listPublishedVersions(
+  tx: Bun.SQL,
+  tenantId: string,
+  limit = 50
+): Promise<ThemeConfigVersion[]> {
+  const rows = (await tx`
+    SELECT ${tx.unsafe(VERSION_COLUMNS)}
+    FROM awcms_theming_config_versions
+    WHERE tenant_id = ${tenantId} AND status = 'published'
+    ORDER BY version_number DESC
+    LIMIT ${limit}
+  `) as VersionRow[];
+  return rows.map(toVersion);
+}
+
+/** The set of this tenant's published version ids — the valid rollback targets. */
+export async function listPublishedVersionIds(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<string[]> {
+  const rows = (await tx`
+    SELECT id
+    FROM awcms_theming_config_versions
+    WHERE tenant_id = ${tenantId} AND status = 'published'
+  `) as { id: string }[];
+  return rows.map((r) => r.id);
+}
+
+/**
+ * Upsert the tenant's single draft version. The one-draft-per-tenant partial
+ * unique index (sql/033) is the conflict target; the sql/033 trigger permits
+ * updating a draft (it only forbids mutating a `published` row).
+ */
+export async function upsertDraftVersion(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  themeKey: string,
+  themeVersion: string,
+  config: ThemeConfig,
+  configHash: string
+): Promise<ThemeConfigVersion> {
+  const rows = (await tx`
+    INSERT INTO awcms_theming_config_versions
+      (tenant_id, theme_key, theme_version, status, config, config_hash, created_by)
+    VALUES (${tenantId}, ${themeKey}, ${themeVersion}, 'draft', ${config}::jsonb, ${configHash}, ${actorTenantUserId})
+    ON CONFLICT (tenant_id) WHERE status = 'draft'
+    DO UPDATE SET
+      theme_key = EXCLUDED.theme_key,
+      theme_version = EXCLUDED.theme_version,
+      config = EXCLUDED.config,
+      config_hash = EXCLUDED.config_hash,
+      updated_at = now()
+    RETURNING ${tx.unsafe(VERSION_COLUMNS)}
+  `) as VersionRow[];
+  return toVersion(rows[0]!);
+}
+
+/**
+ * The next per-tenant published version number (max + 1, or 1). The partial
+ * unique index on (tenant_id, version_number) WHERE status='published' turns a
+ * concurrent double-publish into a unique-violation on one of them, so the
+ * caller never has to lock.
+ */
+export async function nextPublishedVersionNumber(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<number> {
+  const rows = (await tx`
+    SELECT COALESCE(MAX(version_number), 0) + 1 AS next
+    FROM awcms_theming_config_versions
+    WHERE tenant_id = ${tenantId} AND status = 'published'
+  `) as { next: number }[];
+  return Number(rows[0]?.next ?? 1);
+}
+
+/** Insert a new immutable published version (never mutates an existing one). */
+export async function insertPublishedVersion(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  themeKey: string,
+  themeVersion: string,
+  config: ThemeConfig,
+  configHash: string,
+  versionNumber: number
+): Promise<ThemeConfigVersion> {
+  const rows = (await tx`
+    INSERT INTO awcms_theming_config_versions
+      (tenant_id, theme_key, theme_version, status, version_number, config,
+       config_hash, created_by, published_at, published_by)
+    VALUES (${tenantId}, ${themeKey}, ${themeVersion}, 'published', ${versionNumber},
+       ${config}::jsonb, ${configHash}, ${actorTenantUserId}, now(), ${actorTenantUserId})
+    RETURNING ${tx.unsafe(VERSION_COLUMNS)}
+  `) as VersionRow[];
+  return toVersion(rows[0]!);
+}

--- a/src/modules/theming/application/theme-preview-directory.ts
+++ b/src/modules/theming/application/theme-preview-directory.ts
@@ -1,0 +1,54 @@
+/**
+ * Theme preview session data access (Issue #269, ADR-0029 §6) over
+ * `awcms_theming_preview_sessions` (RLS FORCE'd). Stores only the SHA-256
+ * HASH of the raw preview token; the raw token lives only in the URL handed to
+ * the authorized operator. Every query is tenant-scoped (`withTenant` + RLS),
+ * so a preview session created for tenant A is unreachable on tenant B.
+ */
+
+export type PreviewSessionRecord = {
+  id: string;
+  versionId: string;
+  expiresAt: Date;
+};
+
+/** Create a short-lived preview session for a draft version. Returns the row (the raw token stays with the caller). */
+export async function createPreviewSession(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  versionId: string,
+  tokenHash: string,
+  expiresAt: Date
+): Promise<PreviewSessionRecord> {
+  const rows = (await tx`
+    INSERT INTO awcms_theming_preview_sessions
+      (tenant_id, token_hash, version_id, created_by, expires_at)
+    VALUES (${tenantId}, ${tokenHash}, ${versionId}, ${actorTenantUserId}, ${expiresAt})
+    RETURNING id, version_id, expires_at
+  `) as { id: string; version_id: string; expires_at: Date }[];
+  const row = rows[0]!;
+  return { id: row.id, versionId: row.version_id, expiresAt: row.expires_at };
+}
+
+/**
+ * Look up a preview session by its token hash within a tenant transaction. The
+ * caller has already opened `withTenant(tenantId)` from the tenant id embedded in
+ * the URL token, so RLS guarantees a hash that belongs to a different tenant
+ * returns nothing here — the hash is not enough on its own to cross tenants.
+ * Returns the session only if it has NOT expired.
+ */
+export async function findActivePreviewSession(
+  tx: Bun.SQL,
+  tokenHash: string,
+  now: Date
+): Promise<PreviewSessionRecord | null> {
+  const rows = (await tx`
+    SELECT id, version_id, expires_at
+    FROM awcms_theming_preview_sessions
+    WHERE token_hash = ${tokenHash} AND expires_at >= ${now}
+  `) as { id: string; version_id: string; expires_at: Date }[];
+  const row = rows[0];
+  if (!row) return null;
+  return { id: row.id, versionId: row.version_id, expiresAt: row.expires_at };
+}

--- a/src/modules/theming/application/theme-preview-render.ts
+++ b/src/modules/theming/application/theme-preview-render.ts
@@ -1,0 +1,108 @@
+/**
+ * Preview VIEW MODEL builder (Issue #269, ADR-0029 §6). Pure: turns a theme
+ * descriptor + validated config into a structured model the trusted
+ * `PublicThemeLayout.astro` renders. No HTML is built here — Astro's own
+ * auto-escaping renders every value — and no tenant value reaches this model
+ * except the (already-validated) slot/section selections, so the preview cannot
+ * inject markup.
+ */
+import type { ThemeConfig } from "../domain/theme-config";
+import type { ThemeDescriptor } from "../domain/theme-descriptor";
+
+/** A media asset already resolved to a safe same-tenant URL by the composition root. */
+export type PreviewAsset = { url: string; altText: string | null };
+
+export type PreviewSection = {
+  key: string;
+  label: string;
+  heading: string;
+  body: string;
+};
+
+export type PreviewViewModel = {
+  themeName: string;
+  themeKey: string;
+  headerVariant: string;
+  footerVariant: string;
+  navVariant: string;
+  navPlacement: string;
+  sections: PreviewSection[];
+  logo: PreviewAsset | null;
+  navItems: { label: string; href: string }[];
+};
+
+/** Static demo copy per known section key (falls back to the section label). */
+const SAMPLE_COPY: Record<string, { heading: string; body: string }> = {
+  hero: {
+    heading: "Welcome to your site",
+    body: "This is a live preview of your theme with your selected design tokens applied."
+  },
+  featured: {
+    heading: "Featured",
+    body: "Highlight your most important content here."
+  },
+  latest: {
+    heading: "Latest posts",
+    body: "Your most recent articles will appear in this section."
+  },
+  about: {
+    heading: "About",
+    body: "Tell visitors who you are and what you do."
+  },
+  cta: {
+    heading: "Get in touch",
+    body: "Add a call to action to convert visitors."
+  },
+  showcase: {
+    heading: "Showcase",
+    body: "Show off your work in this section."
+  }
+};
+
+/**
+ * Build the preview view model. `sectionOrder` from the config drives the order;
+ * `slotSelections` drive the header/footer/nav variants (falling back to the
+ * descriptor defaults for any slot the theme declares but the config omits).
+ */
+export function buildPreviewViewModel(
+  descriptor: ThemeDescriptor,
+  config: ThemeConfig,
+  assetUrls: Record<string, PreviewAsset>
+): PreviewViewModel {
+  const sectionLabelByKey = new Map(
+    descriptor.contentSections.map((s) => [s.key, s.label])
+  );
+  const sections: PreviewSection[] = config.sectionOrder
+    .filter((key) => sectionLabelByKey.has(key))
+    .map((key) => {
+      const label = sectionLabelByKey.get(key) ?? key;
+      const copy = SAMPLE_COPY[key] ?? {
+        heading: label,
+        body: `Preview of the ${label} section.`
+      };
+      return { key, label, heading: copy.heading, body: copy.body };
+    });
+
+  const slot = (slotKey: string): string => {
+    const spec = descriptor.slots.find((s) => s.key === slotKey);
+    if (!spec) return "default";
+    return config.slotSelections[slotKey] ?? spec.default;
+  };
+
+  return {
+    themeName: descriptor.name,
+    themeKey: descriptor.themeKey,
+    headerVariant: slot("header"),
+    footerVariant: slot("footer"),
+    navVariant: slot("nav_style"),
+    navPlacement: config.navPlacement,
+    sections,
+    logo: assetUrls.logo ?? null,
+    navItems: [
+      { label: "Home", href: "#" },
+      { label: "About", href: "#" },
+      { label: "Blog", href: "#" },
+      { label: "Contact", href: "#" }
+    ]
+  };
+}

--- a/src/modules/theming/application/theme-render-resolver.ts
+++ b/src/modules/theming/application/theme-render-resolver.ts
@@ -1,0 +1,96 @@
+/**
+ * Theme render resolution (Issue #269, ADR-0029 §7): turn a persisted theme
+ * config version into the `text/css` custom-property stylesheet the public
+ * layout links, plus a stable cache fingerprint. Pure over its inputs except
+ * `resolveActiveThemeCssForTenant`, which reads the tenant's active pointer.
+ *
+ * A theme descriptor is looked up in the BUILD-TIME registry
+ * (`getThemeDescriptor`). If a stored config references a theme that is no
+ * longer in the registry (e.g. a derived theme removed in a later build), we
+ * fall back to the DEFAULT theme's default CSS rather than trying to serialize
+ * a config against an unknown token schema — safe by construction.
+ */
+import {
+  defaultThemeConfig,
+  serializeThemeTokensCss
+} from "../domain/theme-config";
+import { DEFAULT_THEME_KEY, getThemeDescriptor } from "../theme-registry";
+import {
+  fetchThemeTenantState,
+  fetchVersionById,
+  type ThemeConfigVersion
+} from "./theme-config-directory";
+
+export type ResolvedThemeCss = {
+  css: string;
+  /** Opaque cache validator — changes iff the emitted CSS would change. */
+  fingerprint: string;
+  themeKey: string;
+};
+
+/** The default theme's default-config CSS — the universal fallback. Computed once. */
+function defaultThemeCss(): ResolvedThemeCss {
+  const descriptor = getThemeDescriptor(DEFAULT_THEME_KEY);
+  if (!descriptor) {
+    // The base default theme is always registered; this is unreachable, but
+    // stay fail-safe with an empty :root block rather than throwing in a route.
+    return {
+      css: ":root {\n}\n",
+      fingerprint: "default-empty",
+      themeKey: DEFAULT_THEME_KEY
+    };
+  }
+  const css = serializeThemeTokensCss(
+    descriptor,
+    defaultThemeConfig(descriptor)
+  );
+  return {
+    css,
+    fingerprint: `${descriptor.themeKey}@${descriptor.version}:default`,
+    themeKey: descriptor.themeKey
+  };
+}
+
+/**
+ * Serialize a specific persisted version's config to CSS. Falls back to the
+ * default theme CSS if the version's theme is no longer registered OR its stored
+ * config fails re-validation (the serializer re-validates every token value; an
+ * unexpected failure must degrade to the safe default, never emit unvalidated
+ * CSS or 500 a public stylesheet).
+ */
+export function resolveVersionThemeCss(
+  version: ThemeConfigVersion
+): ResolvedThemeCss {
+  const descriptor = getThemeDescriptor(version.themeKey);
+  if (!descriptor) return defaultThemeCss();
+  try {
+    const css = serializeThemeTokensCss(descriptor, version.config);
+    return {
+      css,
+      fingerprint: `${version.id}:${version.configHash}`,
+      themeKey: descriptor.themeKey
+    };
+  } catch {
+    return defaultThemeCss();
+  }
+}
+
+/**
+ * Resolve the CSS for a tenant's ACTIVE published theme version. Returns the
+ * default theme CSS when the tenant has published nothing yet — so the public
+ * token stylesheet is ALWAYS a valid 200 (there is no "does this host map to a
+ * tenant" enumeration oracle: an unresolved tenant and a tenant with no active
+ * theme both simply serve the default tokens).
+ */
+export async function resolveActiveThemeCssForTenant(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<ResolvedThemeCss> {
+  const state = await fetchThemeTenantState(tx, tenantId);
+  if (!state.activeVersionId) return defaultThemeCss();
+  const version = await fetchVersionById(tx, tenantId, state.activeVersionId);
+  if (!version) return defaultThemeCss();
+  return resolveVersionThemeCss(version);
+}
+
+export { defaultThemeCss };

--- a/src/modules/theming/application/theme-service.ts
+++ b/src/modules/theming/application/theme-service.ts
@@ -1,0 +1,203 @@
+/**
+ * Theme lifecycle orchestration (Issue #269, ADR-0029 §4/§8): save draft →
+ * publish → rollback → retire, plus preview-session creation. Each mutating
+ * operation records an audit event through an INJECTED hook (the route wires
+ * `recordAuditEvent`; tests pass a spy) so this service stays testable without
+ * the whole logging module and the route composition root remains the single
+ * place cross-module wiring happens (the same injected-audit-hook convention
+ * every high-risk service in this base uses).
+ *
+ * Every function runs inside the caller's tenant transaction (`withTenant`), so
+ * the state change and its audit row commit atomically. Published versions are
+ * IMMUTABLE — publish INSERTs a new version, rollback/retire only move the active
+ * pointer (`awcms_theming_tenant_state`), never touching a version row.
+ */
+import { computeRequestHash } from "../../_shared/idempotency";
+import type { ThemeConfig } from "../domain/theme-config";
+import type { ThemeDescriptor } from "../domain/theme-descriptor";
+import { isValidRollbackTarget } from "../domain/theme-lifecycle";
+import {
+  fetchDraftVersion,
+  fetchThemeTenantState,
+  fetchVersionById,
+  insertPublishedVersion,
+  listPublishedVersionIds,
+  nextPublishedVersionNumber,
+  setActiveThemeVersion,
+  setDraftThemeKey,
+  upsertDraftVersion,
+  type ThemeConfigVersion
+} from "./theme-config-directory";
+
+export type ThemeAuditHook = (
+  tx: Bun.SQL,
+  detail: {
+    action: string;
+    resourceType: string;
+    resourceId: string;
+    attributes: Record<string, unknown>;
+  }
+) => Promise<void>;
+
+/** Canonical config hash — the idempotent-replay / change-detection fingerprint. */
+export function hashThemeConfig(themeKey: string, config: ThemeConfig): string {
+  return computeRequestHash({ themeKey, config });
+}
+
+/**
+ * Save/replace the tenant's single draft config for a chosen theme (the
+ * validated `ThemeConfig` is produced by the route via `validateThemeConfig`).
+ * Audited (high-risk: the draft is what a subsequent publish promotes).
+ */
+export async function saveThemeDraft(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  descriptor: ThemeDescriptor,
+  config: ThemeConfig,
+  recordAudit: ThemeAuditHook
+): Promise<ThemeConfigVersion> {
+  const configHash = hashThemeConfig(descriptor.themeKey, config);
+  const draft = await upsertDraftVersion(
+    tx,
+    tenantId,
+    actorTenantUserId,
+    descriptor.themeKey,
+    descriptor.version,
+    config,
+    configHash
+  );
+  await setDraftThemeKey(tx, tenantId, actorTenantUserId, descriptor.themeKey);
+  await recordAudit(tx, {
+    action: "theming.config.update",
+    resourceType: "theming_draft",
+    resourceId: draft.id,
+    attributes: { themeKey: descriptor.themeKey, configHash }
+  });
+  return draft;
+}
+
+export type PublishResult =
+  | { ok: true; version: ThemeConfigVersion }
+  | { ok: false; code: "NO_DRAFT"; message: string };
+
+/**
+ * Publish the current draft as a new IMMUTABLE version and make it the tenant's
+ * active/live look. INSERT-only (never mutates a published row); the version
+ * number comes from `nextPublishedVersionNumber` and the sql/033 partial unique
+ * index turns a concurrent double-publish into a rejection on one of them.
+ */
+export async function publishThemeDraft(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  recordAudit: ThemeAuditHook
+): Promise<PublishResult> {
+  const draft = await fetchDraftVersion(tx, tenantId);
+  if (!draft) {
+    return {
+      ok: false,
+      code: "NO_DRAFT",
+      message: "No draft theme config to publish."
+    };
+  }
+  const versionNumber = await nextPublishedVersionNumber(tx, tenantId);
+  const published = await insertPublishedVersion(
+    tx,
+    tenantId,
+    actorTenantUserId,
+    draft.themeKey,
+    draft.themeVersion,
+    draft.config,
+    draft.configHash,
+    versionNumber
+  );
+  await setActiveThemeVersion(
+    tx,
+    tenantId,
+    actorTenantUserId,
+    published.themeKey,
+    published.id
+  );
+  await recordAudit(tx, {
+    action: "theming.version.publish",
+    resourceType: "theming_version",
+    resourceId: published.id,
+    attributes: {
+      themeKey: published.themeKey,
+      versionNumber,
+      configHash: published.configHash
+    }
+  });
+  return { ok: true, version: published };
+}
+
+export type RollbackResult =
+  | { ok: true; version: ThemeConfigVersion }
+  | { ok: false; code: "INVALID_TARGET"; message: string };
+
+/**
+ * Roll the active pointer back to an earlier published version (never mutates a
+ * version row). The target must be one of THIS tenant's own published version
+ * ids (RLS + the explicit set check).
+ */
+export async function rollbackThemeVersion(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  targetVersionId: string,
+  recordAudit: ThemeAuditHook
+): Promise<RollbackResult> {
+  const publishedIds = await listPublishedVersionIds(tx, tenantId);
+  if (!isValidRollbackTarget(targetVersionId, publishedIds)) {
+    return {
+      ok: false,
+      code: "INVALID_TARGET",
+      message: "Rollback target is not a published version of this tenant."
+    };
+  }
+  const target = await fetchVersionById(tx, tenantId, targetVersionId);
+  // Non-null by construction (id is in the published set), but stay fail-closed.
+  if (!target || target.status !== "published") {
+    return {
+      ok: false,
+      code: "INVALID_TARGET",
+      message: "Rollback target is not a published version of this tenant."
+    };
+  }
+  await setActiveThemeVersion(
+    tx,
+    tenantId,
+    actorTenantUserId,
+    target.themeKey,
+    target.id
+  );
+  await recordAudit(tx, {
+    action: "theming.version.restore",
+    resourceType: "theming_version",
+    resourceId: target.id,
+    attributes: {
+      themeKey: target.themeKey,
+      versionNumber: target.versionNumber
+    }
+  });
+  return { ok: true, version: target };
+}
+
+/** Retire the active theme: clear the active pointer so the site falls back to the default. Audited. */
+export async function retireActiveTheme(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  recordAudit: ThemeAuditHook
+): Promise<{ previousThemeKey: string | null }> {
+  const state = await fetchThemeTenantState(tx, tenantId);
+  await setActiveThemeVersion(tx, tenantId, actorTenantUserId, null, null);
+  await recordAudit(tx, {
+    action: "theming.version.archive",
+    resourceType: "theming_state",
+    resourceId: tenantId,
+    attributes: { previousThemeKey: state.activeThemeKey }
+  });
+  return { previousThemeKey: state.activeThemeKey };
+}

--- a/src/modules/theming/domain/css-value-validation.ts
+++ b/src/modules/theming/domain/css-value-validation.ts
@@ -1,0 +1,358 @@
+/**
+ * CSS design-token VALUE validation — the security spine of the `theming`
+ * module (Issue #269, ADR-0029 §5). Pure, no I/O.
+ *
+ * ## Reject, never sanitize
+ *
+ * Every function here VALIDATES (accepts an already-safe value, or throws)
+ * rather than SANITIZES (strips dangerous substrings out of a value). This is
+ * deliberate and load-bearing:
+ *
+ *  - A tenant-supplied token value that is not EXACTLY one of the strict,
+ *    bounded shapes below is REJECTED with a `CssValueError` — it is never
+ *    "cleaned up" and stored. Multi-character sanitization (e.g. stripping
+ *    `expression(` or `/*` out of a value) is bypassable by construction and
+ *    is exactly the `js/incomplete-multi-character-sanitization` CodeQL class;
+ *    rejecting an unmatched value avoids that whole class structurally.
+ *  - Because accepted values are already constrained to a safe character set,
+ *    there is nothing left to escape when they are serialized into a
+ *    `text/css` custom-property declaration (`serializeThemeTokensCss`). The
+ *    serializer still re-runs validation as defense in depth.
+ *
+ * This is the single control ADR-0029's threat model relies on for "CSS
+ * injection" and "unsafe URL / exfiltration": a tenant can never place
+ * `url(javascript:…)`, `expression()`, `@import`, an unbalanced token, a
+ * comment breakout, or a raw `<script>`/`;`/`{}` into the emitted stylesheet.
+ */
+
+/** Thrown when a tenant-supplied CSS token value fails validation. */
+export class CssValueError extends Error {
+  readonly tokenValue: string;
+  constructor(message: string, tokenValue: string) {
+    super(message);
+    this.name = "CssValueError";
+    this.tokenValue = tokenValue;
+  }
+}
+
+/** Hard cap on any single token value — a design token is a short scalar, never a stylesheet. */
+export const MAX_CSS_TOKEN_VALUE_LENGTH = 128;
+
+/**
+ * The ONLY characters a validated primitive token value may contain. Letters,
+ * digits, and the small punctuation set the color/dimension/number grammars
+ * need: `#` (hex), `.` (decimal), `,` `%` `(` `)` and space/slash (functional
+ * color notation), `-` (negative dimensions / hyphenated named colors). Notably
+ * ABSENT: `;` `{` `}` `<` `>` `\` `` ` `` `@` `*` `!` `&` `"` `'` `=` `:` — the
+ * characters a CSS-injection / comment-breakout / at-rule / url() payload needs.
+ */
+const SAFE_CSS_PRIMITIVE_CHARSET = /^[A-Za-z0-9#.,%()\/ -]*$/;
+
+/**
+ * Substrings that must never appear in a token value even if every individual
+ * character is in the safe charset (e.g. `//` cannot form a comment here since
+ * `*` is already banned, but we reject defensively; a functional-notation
+ * lookalike like `expression` cannot appear because letters are allowed).
+ * These are belt-and-suspenders on top of the charset + grammar checks.
+ */
+const FORBIDDEN_CSS_SUBSTRINGS: readonly string[] = [
+  "//",
+  "/*",
+  "*/",
+  "url",
+  "expression",
+  "javascript",
+  "data:",
+  "import",
+  "@",
+  "\\"
+];
+
+/** True if every `(` in the string has a matching later `)` and vice versa (no nesting depth < 0, ends at 0). */
+function hasBalancedParens(value: string): boolean {
+  let depth = 0;
+  for (const char of value) {
+    if (char === "(") depth += 1;
+    else if (char === ")") {
+      depth -= 1;
+      if (depth < 0) return false;
+    }
+  }
+  return depth === 0;
+}
+
+/**
+ * The universal guard every typed validator below calls FIRST. Enforces:
+ * non-empty, length-bounded, no control characters / newlines, the safe
+ * charset only, no forbidden substrings, and balanced parentheses. Throws
+ * `CssValueError` on any violation — never returns a "cleaned" string.
+ */
+export function assertSafeCssPrimitive(value: string): void {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new CssValueError(
+      "Token value must be a non-empty string.",
+      String(value)
+    );
+  }
+  if (value.length > MAX_CSS_TOKEN_VALUE_LENGTH) {
+    throw new CssValueError(
+      `Token value exceeds ${MAX_CSS_TOKEN_VALUE_LENGTH} characters.`,
+      value
+    );
+  }
+  // Control characters (incl. newlines/tabs) are forbidden anywhere — a
+  // newline could split a declaration; a control char could smuggle intent
+  // past a naive downstream reader. Checked by char code so no control
+  // literal appears in this source file.
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 0x20 || code === 0x7f) {
+      throw new CssValueError(
+        "Token value contains a control character.",
+        value
+      );
+    }
+  }
+  if (!SAFE_CSS_PRIMITIVE_CHARSET.test(value)) {
+    throw new CssValueError(
+      "Token value contains a character outside the safe CSS token charset.",
+      value
+    );
+  }
+  const lowered = value.toLowerCase();
+  for (const forbidden of FORBIDDEN_CSS_SUBSTRINGS) {
+    if (lowered.includes(forbidden)) {
+      throw new CssValueError(
+        `Token value contains a forbidden CSS construct ("${forbidden}").`,
+        value
+      );
+    }
+  }
+  if (!hasBalancedParens(value)) {
+    throw new CssValueError("Token value has unbalanced parentheses.", value);
+  }
+}
+
+// --- Color ---------------------------------------------------------------
+
+/** `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`. */
+const HEX_COLOR = /^#(?:[0-9a-fA-F]{3,4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/**
+ * `rgb()`/`rgba()`/`hsl()`/`hsla()` with STRICTLY numeric/percent components.
+ * Linear regex (no nested unbounded quantifiers) — the `(?:[...]){0,3}` group is
+ * bounded, so no ReDoS. Components: number or percent, comma-or-space separated,
+ * optional `/ alpha`. Rejects any function argument that is not a number/percent
+ * (so `rgb(var(--x))` / `rgb(expression())` never match — and `var`/`expression`
+ * are already banned substrings anyway).
+ */
+const FUNCTIONAL_COLOR =
+  /^(?:rgb|rgba|hsl|hsla)\(\s*-?\d+(?:\.\d+)?%?(?:\s*[, ]\s*-?\d+(?:\.\d+)?%?){2,3}(?:\s*\/\s*-?\d+(?:\.\d+)?%?)?\s*\)$/;
+
+/**
+ * A small allow-list of CSS named colors a tenant may use by name. Kept short
+ * on purpose — the full 148-name list adds nothing a hex value can't express,
+ * and a shorter list is a smaller thing to reason about. `transparent`/
+ * `currentcolor` are the two genuinely useful keywords.
+ */
+const NAMED_COLOR_ALLOW_LIST: ReadonlySet<string> = new Set([
+  "transparent",
+  "currentcolor",
+  "black",
+  "white",
+  "red",
+  "green",
+  "blue",
+  "gray",
+  "grey"
+]);
+
+/**
+ * Validate a color token value. Accepts a hex color, a strictly-numeric
+ * functional color, or an allow-listed named color. Returns the value
+ * unchanged (already safe) or throws `CssValueError`.
+ */
+export function validateColorValue(value: string): string {
+  assertSafeCssPrimitive(value);
+  if (HEX_COLOR.test(value)) return value;
+  if (FUNCTIONAL_COLOR.test(value)) return value;
+  if (NAMED_COLOR_ALLOW_LIST.has(value.toLowerCase())) return value;
+  throw new CssValueError(
+    "Color must be a hex, rgb()/rgba()/hsl()/hsla() with numeric components, or an allow-listed named color.",
+    value
+  );
+}
+
+// --- Dimension -----------------------------------------------------------
+
+export type DimensionConstraint = {
+  units: readonly string[];
+  min: number;
+  max: number;
+};
+
+/** The units a dimension token may use — no `calc()`, no `var()`, no viewport-math expression. */
+export const DIMENSION_UNIT_ALLOW_LIST: readonly string[] = [
+  "px",
+  "rem",
+  "em",
+  "%",
+  "vh",
+  "vw",
+  "ch"
+];
+
+const DIMENSION_NUMBER_UNIT = /^(-?\d+(?:\.\d+)?)([a-z%]+)$/;
+
+/**
+ * Validate a dimension token value: a number followed by a unit from
+ * `constraint.units`, with the numeric part within `[min, max]`. `0` alone is
+ * accepted (unitless zero is valid CSS). Rejects `calc(...)`, `var(...)`, and
+ * anything with an out-of-range or non-numeric magnitude.
+ */
+export function validateDimensionValue(
+  value: string,
+  constraint: DimensionConstraint
+): string {
+  assertSafeCssPrimitive(value);
+  if (value === "0") return value;
+  const match = DIMENSION_NUMBER_UNIT.exec(value);
+  if (!match) {
+    throw new CssValueError(
+      "Dimension must be a number followed by an allowed unit.",
+      value
+    );
+  }
+  const magnitude = Number(match[1]);
+  const unit = match[2]!;
+  if (!constraint.units.includes(unit)) {
+    throw new CssValueError(
+      `Dimension unit "${unit}" is not one of ${constraint.units.join(", ")}.`,
+      value
+    );
+  }
+  if (
+    !Number.isFinite(magnitude) ||
+    magnitude < constraint.min ||
+    magnitude > constraint.max
+  ) {
+    throw new CssValueError(
+      `Dimension magnitude must be between ${constraint.min} and ${constraint.max}.`,
+      value
+    );
+  }
+  return value;
+}
+
+// --- Number --------------------------------------------------------------
+
+export type NumberConstraint = {
+  min: number;
+  max: number;
+  integer?: boolean;
+};
+
+const PLAIN_NUMBER = /^-?\d+(?:\.\d+)?$/;
+
+/**
+ * Validate a plain numeric token value (line-height, font-weight, z-index, …)
+ * within `[min, max]`, optionally integer-only.
+ */
+export function validateNumberValue(
+  value: string,
+  constraint: NumberConstraint
+): string {
+  assertSafeCssPrimitive(value);
+  if (!PLAIN_NUMBER.test(value)) {
+    throw new CssValueError(
+      "Number token must be a plain numeric value.",
+      value
+    );
+  }
+  const numeric = Number(value);
+  if (
+    !Number.isFinite(numeric) ||
+    numeric < constraint.min ||
+    numeric > constraint.max
+  ) {
+    throw new CssValueError(
+      `Number must be between ${constraint.min} and ${constraint.max}.`,
+      value
+    );
+  }
+  if (constraint.integer && !Number.isInteger(numeric)) {
+    throw new CssValueError("Number token must be an integer.", value);
+  }
+  return value;
+}
+
+// --- Font family stack ---------------------------------------------------
+
+/** A font-family stack is a short list of family names, never a stylesheet. */
+export const MAX_FONT_STACK_LENGTH = 256;
+
+/**
+ * The characters a descriptor-owned font-family STACK may contain. Broader than
+ * a primitive token value (a stack quotes multi-word family names and separates
+ * families with commas — e.g. `"Segoe UI", system-ui, sans-serif`) but STILL
+ * narrow enough that a CSS-injection payload is structurally impossible: it
+ * allows ONLY letters, digits, space, comma, single/double quote and hyphen.
+ * Notably ABSENT: `;` `{` `}` `<` `>` `\` `/` `@` `:` `(` `)` `#` `%` `.` `!`
+ * `&` `=` — every character a declaration-breakout / at-rule / `url()` /
+ * comment / `expression()` payload needs. So a stack can never escape its
+ * `--awcms-theme-<key>: <stack>;` declaration.
+ */
+const SAFE_FONT_STACK_CHARSET = /^[A-Za-z0-9 ,"'-]+$/;
+
+/** True if `"` and `'` each occur an even number of times (every quoted name is closed). */
+function hasBalancedQuotes(value: string): boolean {
+  let doubles = 0;
+  let singles = 0;
+  for (const char of value) {
+    if (char === '"') doubles += 1;
+    else if (char === "'") singles += 1;
+  }
+  return doubles % 2 === 0 && singles % 2 === 0;
+}
+
+/**
+ * Validate a font-family STACK string (the reviewed, descriptor-owned CSS the
+ * serializer emits when a tenant picks a font-family key — never tenant-
+ * authored, but validated as defense in depth so a mistaken/hostile DERIVED
+ * theme's stack fails compose/tests rather than reaching the stylesheet). Same
+ * reject-not-sanitize posture as the primitives: an unmatched value throws
+ * `CssValueError`, it is never "cleaned". Returns the value unchanged if safe.
+ */
+export function validateFontStack(value: string): string {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new CssValueError(
+      "Font stack must be a non-empty string.",
+      String(value)
+    );
+  }
+  if (value.length > MAX_FONT_STACK_LENGTH) {
+    throw new CssValueError(
+      `Font stack exceeds ${MAX_FONT_STACK_LENGTH} characters.`,
+      value
+    );
+  }
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code < 0x20 || code === 0x7f) {
+      throw new CssValueError(
+        "Font stack contains a control character.",
+        value
+      );
+    }
+  }
+  if (!SAFE_FONT_STACK_CHARSET.test(value)) {
+    throw new CssValueError(
+      "Font stack contains a character outside the safe font-family charset.",
+      value
+    );
+  }
+  if (!hasBalancedQuotes(value)) {
+    throw new CssValueError("Font stack has unbalanced quotes.", value);
+  }
+  return value;
+}

--- a/src/modules/theming/domain/preview-token.ts
+++ b/src/modules/theming/domain/preview-token.ts
@@ -1,0 +1,99 @@
+/**
+ * Theme preview session tokens (Issue #269, ADR-0029 §6). Pure token
+ * generation + hashing + expiry helpers — the DB access lives in
+ * `application/theme-preview-directory.ts`.
+ *
+ * A preview session lets an authorized operator open a NON-INDEXABLE,
+ * short-lived rendering of their DRAFT theme config — optionally in a separate
+ * browser/device (responsive check) without an admin session — while never
+ * touching the published version and never being reachable by search engines or
+ * the public/CDN cache.
+ *
+ * Security shape (mirrors `src/lib/auth/session-token.ts`): the RAW token is
+ * returned ONCE to the creating admin and put in the preview URL; the database
+ * stores only its SHA-256 HASH, so a leak of the table never yields a usable
+ * token. Tokens are single-tenant (RLS), high-entropy (256-bit), and expire.
+ */
+
+/** Default preview session lifetime — short by design (ADR-0029 §6). */
+export const PREVIEW_SESSION_TTL_MINUTES = 30;
+/** Hard cap a caller may request. */
+export const PREVIEW_SESSION_MAX_TTL_MINUTES = 120;
+
+/** A raw preview token is 64 lowercase hex chars (256 bits of entropy). */
+const RAW_TOKEN_PATTERN = /^[0-9a-f]{64}$/;
+
+/** Generate a fresh, high-entropy raw preview token (returned to the admin, never stored raw). */
+export function generatePreviewToken(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** True if a token from a URL is structurally a valid raw preview token (cheap pre-DB guard). */
+export function isWellFormedPreviewToken(token: string): boolean {
+  return typeof token === "string" && RAW_TOKEN_PATTERN.test(token);
+}
+
+/**
+ * SHA-256 hash of a raw preview token — what the database stores and looks up.
+ * Deterministic; a constant-time-ish equality is unnecessary because lookup is
+ * by the hash itself (an attacker cannot supply a hash without the preimage).
+ */
+export function hashPreviewToken(rawToken: string): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(rawToken);
+  return hasher.digest("hex");
+}
+
+/** Resolve the requested TTL to a bounded minutes value (default 30, hard cap 120). */
+export function resolvePreviewTtlMinutes(requested: unknown): number {
+  if (
+    typeof requested !== "number" ||
+    !Number.isFinite(requested) ||
+    requested <= 0
+  ) {
+    return PREVIEW_SESSION_TTL_MINUTES;
+  }
+  return Math.min(Math.floor(requested), PREVIEW_SESSION_MAX_TTL_MINUTES);
+}
+
+/** True when a preview session's `expiresAt` is at/after `now` (still usable). */
+export function isPreviewSessionActive(expiresAt: Date, now: Date): boolean {
+  return expiresAt.getTime() >= now.getTime();
+}
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * The value placed in the preview URL (`/theming/preview/{urlToken}`). It carries
+ * BOTH the tenant id and the raw secret token: `${tenantId}~${rawToken}`. The
+ * tenant id is NOT a secret — it only lets the tokenless preview route open the
+ * correct tenant transaction so RLS can then confirm the hashed `rawToken`
+ * belongs to that tenant. Security still rests entirely on the 256-bit raw token
+ * (an attacker who knows a tenant id but not the token gets nothing). This avoids
+ * a cross-tenant token lookup (which would need a privileged/RLS-bypassing query)
+ * while keeping every read strictly tenant-scoped.
+ */
+export function buildPreviewUrlToken(
+  tenantId: string,
+  rawToken: string
+): string {
+  return `${tenantId}~${rawToken}`;
+}
+
+/** Parse a `${tenantId}~${rawToken}` URL token, or `null` if malformed. */
+export function parsePreviewUrlToken(
+  urlToken: string
+): { tenantId: string; rawToken: string } | null {
+  if (typeof urlToken !== "string") return null;
+  const sep = urlToken.indexOf("~");
+  if (sep <= 0) return null;
+  const tenantId = urlToken.slice(0, sep);
+  const rawToken = urlToken.slice(sep + 1);
+  if (!UUID_PATTERN.test(tenantId) || !isWellFormedPreviewToken(rawToken)) {
+    return null;
+  }
+  return { tenantId, rawToken };
+}

--- a/src/modules/theming/domain/theme-config.ts
+++ b/src/modules/theming/domain/theme-config.ts
@@ -1,0 +1,373 @@
+/**
+ * Tenant theme configuration (Issue #269, ADR-0029 §4) — the DATA-ONLY shape a
+ * tenant may set for a chosen theme, plus its validation against the theme
+ * descriptor and its safe serialization into a `text/css` custom-property
+ * stylesheet. Pure, no I/O.
+ *
+ * A `ThemeConfig` is the ONLY tenant-authored input in this module. It carries
+ * no code, no template, no raw CSS/HTML/JS — only: token value overrides
+ * (validated per token kind by `css-value-validation.ts`), slot variant
+ * selections (from the descriptor's allow-list), media asset ids (UUIDs,
+ * resolved same-tenant/verified by a media module at render time — a no-op in
+ * this base until such a module is ported, ADR-0034 Fase 3), a content
+ * section ordering (a permutation of declared sections), and a nav placement
+ * (from the descriptor's allow-list). Anything not declared by the descriptor
+ * is REJECTED — the descriptor bounds the whole configurable surface.
+ */
+import {
+  CssValueError,
+  validateColorValue,
+  validateDimensionValue,
+  validateFontStack,
+  validateNumberValue
+} from "./css-value-validation";
+import type { ThemeDescriptor, ThemeTokenSpec } from "./theme-descriptor";
+
+/** The `--awcms-theme-` prefix every emitted design-token custom property carries. */
+export const THEME_CSS_CUSTOM_PROPERTY_PREFIX = "--awcms-theme-";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type ThemeConfig = {
+  themeKey: string;
+  /** tokenKey -> validated token value. Only declared tokens; missing tokens fall back to descriptor defaults. */
+  tokenOverrides: Record<string, string>;
+  /** slotKey -> chosen variant key (from the slot's allow-list). */
+  slotSelections: Record<string, string>;
+  /** assetSlotKey -> media object UUID. */
+  assetRefs: Record<string, string>;
+  /** An ordering (permutation/subset) of the descriptor's contentSections keys. */
+  sectionOrder: string[];
+  /** One of the descriptor's navPlacements. */
+  navPlacement: string;
+};
+
+export type ThemeConfigValidationError = { field: string; message: string };
+
+export type ThemeConfigValidationResult =
+  | { ok: true; value: ThemeConfig }
+  | { ok: false; errors: ThemeConfigValidationError[] };
+
+/** The neutral config for a descriptor: every token/slot/nav at its default, no overrides/assets. */
+export function defaultThemeConfig(descriptor: ThemeDescriptor): ThemeConfig {
+  return {
+    themeKey: descriptor.themeKey,
+    tokenOverrides: {},
+    slotSelections: Object.fromEntries(
+      descriptor.slots.map((slot) => [slot.key, slot.default])
+    ),
+    assetRefs: {},
+    sectionOrder: descriptor.contentSections.map((section) => section.key),
+    navPlacement: descriptor.navPlacements[0] ?? "top"
+  };
+}
+
+/**
+ * Validate a single token override value against its declared spec. Throws
+ * `CssValueError` on an unsafe/out-of-range value; for `font_family` it checks
+ * the value is a declared allow-list key (never a raw font stack).
+ */
+export function validateTokenOverride(
+  descriptor: ThemeDescriptor,
+  spec: ThemeTokenSpec,
+  value: string
+): void {
+  switch (spec.kind) {
+    case "color":
+      validateColorValue(value);
+      return;
+    case "dimension":
+      validateDimensionValue(value, spec.constraint);
+      return;
+    case "number":
+      validateNumberValue(value, spec.constraint);
+      return;
+    case "font_family": {
+      const allowed = descriptor.fontFamilies.some((f) => f.key === value);
+      if (!allowed) {
+        throw new CssValueError(
+          `Font family "${value}" is not one of this theme's allowed families.`,
+          value
+        );
+      }
+      return;
+    }
+  }
+}
+
+/**
+ * Validate + normalize an untrusted request body into a `ThemeConfig` for the
+ * given theme descriptor. Rejects any token/slot/asset/section/nav the
+ * descriptor does not declare, and any token value that fails its typed
+ * validator (the CSS-injection spine). Unknown top-level keys are ignored
+ * (forward-compatible), but unknown MAP keys inside tokenOverrides/
+ * slotSelections/assetRefs are hard errors — those are the attack surface.
+ */
+export function validateThemeConfig(
+  descriptor: ThemeDescriptor,
+  body: unknown
+): ThemeConfigValidationResult {
+  const errors: ThemeConfigValidationError[] = [];
+  if (body === null || typeof body !== "object" || Array.isArray(body)) {
+    return {
+      ok: false,
+      errors: [
+        { field: "body", message: "Request body must be a JSON object." }
+      ]
+    };
+  }
+  const input = body as Record<string, unknown>;
+
+  const tokenByKey = new Map(descriptor.tokens.map((t) => [t.key, t]));
+  const slotByKey = new Map(descriptor.slots.map((s) => [s.key, s]));
+  const assetByKey = new Map(descriptor.assetSlots.map((a) => [a.key, a]));
+  const sectionKeys = new Set(descriptor.contentSections.map((s) => s.key));
+
+  // --- token overrides ---
+  const tokenOverrides: Record<string, string> = {};
+  const rawTokens = input.tokenOverrides;
+  if (rawTokens !== undefined && rawTokens !== null) {
+    if (typeof rawTokens !== "object" || Array.isArray(rawTokens)) {
+      errors.push({
+        field: "tokenOverrides",
+        message: "Must be an object of tokenKey -> value."
+      });
+    } else {
+      for (const [key, rawValue] of Object.entries(
+        rawTokens as Record<string, unknown>
+      )) {
+        const spec = tokenByKey.get(key);
+        if (!spec) {
+          errors.push({
+            field: `tokenOverrides.${key}`,
+            message: "Unknown token — not declared by this theme."
+          });
+          continue;
+        }
+        if (typeof rawValue !== "string") {
+          errors.push({
+            field: `tokenOverrides.${key}`,
+            message: "Token value must be a string."
+          });
+          continue;
+        }
+        try {
+          validateTokenOverride(descriptor, spec, rawValue);
+          tokenOverrides[key] = rawValue;
+        } catch (error) {
+          const message =
+            error instanceof CssValueError
+              ? error.message
+              : "Invalid token value.";
+          errors.push({ field: `tokenOverrides.${key}`, message });
+        }
+      }
+    }
+  }
+
+  // --- slot selections ---
+  const slotSelections: Record<string, string> = {};
+  const rawSlots = input.slotSelections;
+  if (rawSlots !== undefined && rawSlots !== null) {
+    if (typeof rawSlots !== "object" || Array.isArray(rawSlots)) {
+      errors.push({
+        field: "slotSelections",
+        message: "Must be an object of slotKey -> variantKey."
+      });
+    } else {
+      for (const [key, rawValue] of Object.entries(
+        rawSlots as Record<string, unknown>
+      )) {
+        const spec = slotByKey.get(key);
+        if (!spec) {
+          errors.push({
+            field: `slotSelections.${key}`,
+            message: "Unknown slot — not declared by this theme."
+          });
+          continue;
+        }
+        if (
+          typeof rawValue !== "string" ||
+          !spec.variants.some((v) => v.key === rawValue)
+        ) {
+          errors.push({
+            field: `slotSelections.${key}`,
+            message: "Must be one of the slot's declared variants."
+          });
+          continue;
+        }
+        slotSelections[key] = rawValue;
+      }
+    }
+  }
+  // Fill unset slots with their defaults.
+  for (const slot of descriptor.slots) {
+    if (!(slot.key in slotSelections)) slotSelections[slot.key] = slot.default;
+  }
+
+  // --- asset refs (media UUIDs only) ---
+  const assetRefs: Record<string, string> = {};
+  const rawAssets = input.assetRefs;
+  if (rawAssets !== undefined && rawAssets !== null) {
+    if (typeof rawAssets !== "object" || Array.isArray(rawAssets)) {
+      errors.push({
+        field: "assetRefs",
+        message: "Must be an object of assetSlotKey -> media UUID."
+      });
+    } else {
+      for (const [key, rawValue] of Object.entries(
+        rawAssets as Record<string, unknown>
+      )) {
+        if (!assetByKey.has(key)) {
+          errors.push({
+            field: `assetRefs.${key}`,
+            message: "Unknown asset slot — not declared by this theme."
+          });
+          continue;
+        }
+        if (rawValue === null) continue; // explicit clear
+        if (typeof rawValue !== "string" || !UUID_PATTERN.test(rawValue)) {
+          errors.push({
+            field: `assetRefs.${key}`,
+            message: "Must be a media object UUID (never a URL)."
+          });
+          continue;
+        }
+        assetRefs[key] = rawValue;
+      }
+    }
+  }
+  for (const slot of descriptor.assetSlots) {
+    if (slot.required && !(slot.key in assetRefs)) {
+      errors.push({
+        field: `assetRefs.${slot.key}`,
+        message: "This asset slot is required."
+      });
+    }
+  }
+
+  // --- section order ---
+  let sectionOrder = descriptor.contentSections.map((s) => s.key);
+  const rawOrder = input.sectionOrder;
+  if (rawOrder !== undefined && rawOrder !== null) {
+    if (
+      !Array.isArray(rawOrder) ||
+      rawOrder.some((k) => typeof k !== "string")
+    ) {
+      errors.push({
+        field: "sectionOrder",
+        message: "Must be an array of section keys."
+      });
+    } else {
+      const seen = new Set<string>();
+      let bad = false;
+      for (const key of rawOrder as string[]) {
+        if (!sectionKeys.has(key) || seen.has(key)) {
+          bad = true;
+          break;
+        }
+        seen.add(key);
+      }
+      if (bad) {
+        errors.push({
+          field: "sectionOrder",
+          message:
+            "Must be a de-duplicated ordering of this theme's declared sections."
+        });
+      } else {
+        // Append any sections the caller omitted, preserving declared order.
+        const remaining = descriptor.contentSections
+          .map((s) => s.key)
+          .filter((k) => !seen.has(k));
+        sectionOrder = [...(rawOrder as string[]), ...remaining];
+      }
+    }
+  }
+
+  // --- nav placement ---
+  let navPlacement = descriptor.navPlacements[0] ?? "top";
+  const rawNav = input.navPlacement;
+  if (rawNav !== undefined && rawNav !== null) {
+    if (
+      typeof rawNav !== "string" ||
+      !descriptor.navPlacements.includes(rawNav)
+    ) {
+      errors.push({
+        field: "navPlacement",
+        message: "Must be one of this theme's declared nav placements."
+      });
+    } else {
+      navPlacement = rawNav;
+    }
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    value: {
+      themeKey: descriptor.themeKey,
+      tokenOverrides,
+      slotSelections,
+      assetRefs,
+      sectionOrder,
+      navPlacement
+    }
+  };
+}
+
+/**
+ * Resolve the final token value map (descriptor defaults with tenant overrides
+ * applied on top) as `tokenKey -> value`. RE-VALIDATES every value (defense in
+ * depth — a stored config should already be valid, but a token that somehow
+ * failed to round-trip must throw here rather than reach the stylesheet). For
+ * font_family tokens the returned value is the descriptor-owned CSS stack, NOT
+ * the tenant's allow-list key — so the emitted value is never tenant-authored.
+ */
+export function resolveThemeTokens(
+  descriptor: ThemeDescriptor,
+  config: ThemeConfig
+): Record<string, string> {
+  const fontStackByKey = new Map(
+    descriptor.fontFamilies.map((f) => [f.key, f.stack])
+  );
+  const resolved: Record<string, string> = {};
+  for (const spec of descriptor.tokens) {
+    const raw = config.tokenOverrides[spec.key] ?? spec.default;
+    // Re-validate (throws on any unsafe value) before it can be serialized.
+    validateTokenOverride(descriptor, spec, raw);
+    if (spec.kind === "font_family") {
+      const stack = fontStackByKey.get(raw);
+      if (stack === undefined) {
+        throw new CssValueError(`Font family key "${raw}" has no stack.`, raw);
+      }
+      // Re-validate the descriptor-owned stack before emit (defense in depth —
+      // it was validated at load, but the serializer trusts nothing it emits).
+      validateFontStack(stack);
+      resolved[spec.key] = stack;
+    } else {
+      resolved[spec.key] = raw;
+    }
+  }
+  return resolved;
+}
+
+/**
+ * Serialize a validated `ThemeConfig` into a `:root { … }` block of
+ * `--awcms-theme-<token>` custom properties. Safe by construction: only tokens
+ * that pass `resolveThemeTokens` (which re-validates) are emitted, so there is
+ * nothing left to escape. The font-family stack is descriptor-owned; a color/
+ * dimension/number value is already constrained to the safe charset.
+ */
+export function serializeThemeTokensCss(
+  descriptor: ThemeDescriptor,
+  config: ThemeConfig
+): string {
+  const tokens = resolveThemeTokens(descriptor, config);
+  const lines = descriptor.tokens.map(
+    (spec) =>
+      `  ${THEME_CSS_CUSTOM_PROPERTY_PREFIX}${spec.key}: ${tokens[spec.key]};`
+  );
+  return `:root {\n${lines.join("\n")}\n}\n`;
+}

--- a/src/modules/theming/domain/theme-descriptor.ts
+++ b/src/modules/theming/domain/theme-descriptor.ts
@@ -1,0 +1,368 @@
+/**
+ * Theme descriptor contract (Issue #269, ADR-0029 §3). A `ThemeDescriptor` is
+ * TRUSTED, REVIEWED, BUILD-TIME source code — a static TypeScript value bundled
+ * at `bun run build`/`typecheck` like any other import, NEVER a database row and
+ * NEVER an uploaded/runtime-discovered artifact. It declares the bounded surface
+ * a tenant may configure by DATA (`ThemeConfig`, `theme-config.ts`): the design
+ * tokens, layout/component slots, media asset slots, orderable content sections,
+ * the typography allow-list, plus the theme's accessibility and CSP declarations.
+ *
+ * Pure types + pure validation here (no I/O). The build-time registry that
+ * composes the reviewed base themes lives in `../theme-registry.ts`. (The
+ * awcms-micro origin had a derived-repo seam here; awcms removed the
+ * derived-application pathway in ADR-0034 Fase 2, so themes are composed from
+ * the in-repo base registry only.)
+ */
+import {
+  CssValueError,
+  validateColorValue,
+  validateDimensionValue,
+  validateFontStack,
+  validateNumberValue,
+  type DimensionConstraint,
+  type NumberConstraint
+} from "./css-value-validation";
+import { MODULE_CONTRACT_VERSION } from "../../_shared/module-contract";
+import { compareSemver, parseSemver } from "../../../lib/semver/compare";
+
+export type ThemeOrigin = "base" | "derived";
+
+export type ThemeTokenKind = "color" | "dimension" | "number" | "font_family";
+
+type ThemeTokenBase = {
+  /** `snake_or_kebab` style key; becomes `--awcms-theme-<key>` in the emitted CSS. */
+  key: string;
+  label: string;
+  description: string;
+};
+
+export type ThemeColorTokenSpec = ThemeTokenBase & {
+  kind: "color";
+  /** Default color value — validated against the color grammar by `assertValidThemeDescriptor` at registry compose time. */
+  default: string;
+};
+
+export type ThemeDimensionTokenSpec = ThemeTokenBase & {
+  kind: "dimension";
+  constraint: DimensionConstraint;
+  default: string;
+};
+
+export type ThemeNumberTokenSpec = ThemeTokenBase & {
+  kind: "number";
+  constraint: NumberConstraint;
+  default: string;
+};
+
+export type ThemeFontFamilyTokenSpec = ThemeTokenBase & {
+  kind: "font_family";
+  /**
+   * Default value = a `key` from the descriptor's `fontFamilies` allow-list
+   * (NOT a raw font stack). The tenant likewise selects a `fontFamilies` key;
+   * the serializer emits the descriptor-owned CSS stack, so no font value is
+   * ever tenant-authored.
+   */
+  default: string;
+};
+
+export type ThemeTokenSpec =
+  | ThemeColorTokenSpec
+  | ThemeDimensionTokenSpec
+  | ThemeNumberTokenSpec
+  | ThemeFontFamilyTokenSpec;
+
+/** One selectable typography family — the tenant picks `key`, the reviewed `stack` is what renders. */
+export type ThemeFontFamilyOption = {
+  key: string;
+  label: string;
+  /** A reviewed, safe CSS font-family stack, e.g. `"Inter", system-ui, sans-serif`. */
+  stack: string;
+};
+
+export type ThemeSlotVariant = { key: string; label: string };
+
+/** One layout/component slot the tenant may pick a bounded variant for (header/footer/nav style). */
+export type ThemeSlotSpec = {
+  key: string;
+  label: string;
+  variants: readonly ThemeSlotVariant[];
+  default: string;
+};
+
+export type ThemeAssetSlotKind = "logo" | "favicon" | "image";
+
+/** One media asset slot — the tenant supplies a media object id (never a URL). Asset-URL resolution is a no-op in this base until a media module is ported (ADR-0034 Fase 3). */
+export type ThemeAssetSlotSpec = {
+  key: string;
+  label: string;
+  kind: ThemeAssetSlotKind;
+  required?: boolean;
+};
+
+/** One orderable content section (the tenant may reorder these on the home layout). */
+export type ThemeContentSectionSpec = { key: string; label: string };
+
+/** Accessibility guarantees a theme declares (asserted by the a11y test suite). */
+export type ThemeAccessibilityDeclaration = {
+  /** Minimum text/background contrast ratio the theme's defaults meet (WCAG AA = 4.5). */
+  minContrastRatio: number;
+  supportsReducedMotion: boolean;
+  supportsResponsive: boolean;
+  keyboardNavigable: boolean;
+  /** Landmark roles the layout renders (e.g. `banner`, `main`, `contentinfo`, `navigation`). */
+  landmarks: readonly string[];
+};
+
+/**
+ * A theme's CSP posture. The base build's CSP (`astro.config.mjs`) is
+ * `default-src 'self'` with NO `unsafe-inline` for style/script. A theme MUST be
+ * self-contained: no inline script, no inline style requirement (token values
+ * ship as an EXTERNAL same-origin stylesheet), and no external script/style/
+ * frame sources beyond the (currently empty) global allow-lists. Enforced by
+ * `assertValidThemeDescriptor` so a theme can never weaken the app's CSP.
+ */
+export type ThemeCspDeclaration = {
+  requiresInlineStyle: boolean;
+  requiresInlineScript: boolean;
+  externalStyleSources: readonly string[];
+  externalScriptSources: readonly string[];
+  externalFrameSources: readonly string[];
+};
+
+export type ThemeCompatibility = {
+  /**
+   * The MINIMUM base module-contract (`MODULE_CONTRACT_VERSION`) this theme was
+   * built against. ENFORCED by `assertValidThemeDescriptor`: a theme requiring a
+   * newer contract than the running build ships is rejected at registry compose
+   * time (not inert metadata) — so a derived theme cannot silently target a base
+   * it is incompatible with. Plain `MAJOR.MINOR.PATCH`.
+   */
+  minModuleContractVersion: string;
+  /**
+   * The page/resource types this theme's layouts render. Declarative surface a
+   * render/routing layer may consult; validated here only for shape (non-empty
+   * list of non-empty keys) so it can never be silently empty/malformed.
+   */
+  supportedResourceTypes: readonly string[];
+};
+
+export type ThemeDescriptor = {
+  themeKey: string;
+  /** SemVer of the theme itself (independent of the module version). */
+  version: string;
+  name: string;
+  owner: string;
+  description: string;
+  origin: ThemeOrigin;
+  fontFamilies: readonly ThemeFontFamilyOption[];
+  tokens: readonly ThemeTokenSpec[];
+  slots: readonly ThemeSlotSpec[];
+  assetSlots: readonly ThemeAssetSlotSpec[];
+  contentSections: readonly ThemeContentSectionSpec[];
+  navPlacements: readonly string[];
+  accessibility: ThemeAccessibilityDeclaration;
+  csp: ThemeCspDeclaration;
+  compatibility: ThemeCompatibility;
+};
+
+/** Identity function that pins the `ThemeDescriptor` type at the definition site (mirrors `defineModule`). */
+export function defineTheme(descriptor: ThemeDescriptor): ThemeDescriptor {
+  return descriptor;
+}
+
+export const THEME_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+export const TOKEN_KEY_PATTERN = /^[a-z][a-z0-9_]*$/;
+
+/**
+ * The GLOBAL allow-lists for what external sources a theme may declare in its
+ * CSP posture. Both empty by decision (ADR-0029 §7): themes must be
+ * self-contained; adding an entry here is a reviewed CSP decision, not a
+ * per-theme choice. `assertValidThemeDescriptor` rejects a theme that declares
+ * any external script/style/frame source outside these lists.
+ */
+export const THEME_ALLOWED_EXTERNAL_STYLE_SOURCES: readonly string[] = [];
+export const THEME_ALLOWED_EXTERNAL_SCRIPT_SOURCES: readonly string[] = [];
+export const THEME_ALLOWED_EXTERNAL_FRAME_SOURCES: readonly string[] = [];
+
+/** Thrown when a `ThemeDescriptor` is malformed or would weaken CSP/a11y. */
+export class InvalidThemeDescriptorError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidThemeDescriptorError";
+  }
+}
+
+function assertSubset(
+  declared: readonly string[],
+  allowed: readonly string[],
+  label: string,
+  themeKey: string
+): void {
+  for (const entry of declared) {
+    if (!allowed.includes(entry)) {
+      throw new InvalidThemeDescriptorError(
+        `Theme "${themeKey}" declares ${label} "${entry}" outside the reviewed allow-list — a theme may not weaken CSP (ADR-0029 §7).`
+      );
+    }
+  }
+}
+
+/**
+ * Validate a `ThemeDescriptor` is well-formed AND cannot weaken the app's
+ * security/accessibility posture. Called by the registry for EVERY theme
+ * (base + derived) at load time, so a malformed or CSP-weakening theme fails
+ * the build/tests rather than shipping. Throws `InvalidThemeDescriptorError`.
+ */
+export function assertValidThemeDescriptor(descriptor: ThemeDescriptor): void {
+  const { themeKey } = descriptor;
+  if (!THEME_KEY_PATTERN.test(themeKey)) {
+    throw new InvalidThemeDescriptorError(
+      `Theme key "${themeKey}" must match ${THEME_KEY_PATTERN}.`
+    );
+  }
+
+  // CSP: no inline requirement, no external sources beyond the (empty) allow-lists.
+  if (descriptor.csp.requiresInlineScript) {
+    throw new InvalidThemeDescriptorError(
+      `Theme "${themeKey}" requires an inline script — forbidden (ADR-0029 §7: themes are self-contained, CSP is never weakened).`
+    );
+  }
+  if (descriptor.csp.requiresInlineStyle) {
+    throw new InvalidThemeDescriptorError(
+      `Theme "${themeKey}" requires inline style — forbidden; token values ship as an external same-origin stylesheet (ADR-0029 §7).`
+    );
+  }
+  assertSubset(
+    descriptor.csp.externalStyleSources,
+    THEME_ALLOWED_EXTERNAL_STYLE_SOURCES,
+    "external style source",
+    themeKey
+  );
+  assertSubset(
+    descriptor.csp.externalScriptSources,
+    THEME_ALLOWED_EXTERNAL_SCRIPT_SOURCES,
+    "external script source",
+    themeKey
+  );
+  assertSubset(
+    descriptor.csp.externalFrameSources,
+    THEME_ALLOWED_EXTERNAL_FRAME_SOURCES,
+    "external frame source",
+    themeKey
+  );
+
+  // A11y: a theme must declare it meets at least WCAG AA contrast + the core semantics.
+  if (descriptor.accessibility.minContrastRatio < 4.5) {
+    throw new InvalidThemeDescriptorError(
+      `Theme "${themeKey}" declares a contrast ratio below WCAG AA (4.5).`
+    );
+  }
+  if (
+    !descriptor.accessibility.keyboardNavigable ||
+    !descriptor.accessibility.supportsResponsive
+  ) {
+    throw new InvalidThemeDescriptorError(
+      `Theme "${themeKey}" must be keyboard-navigable and responsive.`
+    );
+  }
+
+  // Compatibility: the theme's declared minimum module-contract version must be
+  // satisfiable by THIS build's actual `MODULE_CONTRACT_VERSION`. A theme built
+  // against a newer contract than the running base is rejected at load rather
+  // than shipping as inert metadata (R-M3).
+  const declaredMin = descriptor.compatibility.minModuleContractVersion;
+  const parsedMin = parseSemver(declaredMin);
+  if (!parsedMin) {
+    throw new InvalidThemeDescriptorError(
+      `Theme "${themeKey}" declares an invalid compatibility.minModuleContractVersion "${declaredMin}" (must be MAJOR.MINOR.PATCH).`
+    );
+  }
+  const actualContract = parseSemver(MODULE_CONTRACT_VERSION);
+  if (actualContract && compareSemver(actualContract, parsedMin) < 0) {
+    throw new InvalidThemeDescriptorError(
+      `Theme "${themeKey}" requires module contract >= ${declaredMin}, but this build ships ${MODULE_CONTRACT_VERSION} — incompatible theme.`
+    );
+  }
+  if (
+    descriptor.compatibility.supportedResourceTypes.length === 0 ||
+    descriptor.compatibility.supportedResourceTypes.some(
+      (rt) => typeof rt !== "string" || rt.length === 0
+    )
+  ) {
+    throw new InvalidThemeDescriptorError(
+      `Theme "${themeKey}" must declare a non-empty compatibility.supportedResourceTypes list of non-empty keys.`
+    );
+  }
+
+  // Font-family stacks are emitted verbatim by the serializer — validate every
+  // reviewed stack against the font-stack grammar at load, so a mistaken/hostile
+  // DERIVED theme's stack fails compose rather than reaching the stylesheet (R-L4).
+  for (const family of descriptor.fontFamilies) {
+    try {
+      validateFontStack(family.stack);
+    } catch (error) {
+      if (error instanceof CssValueError) {
+        throw new InvalidThemeDescriptorError(
+          `Theme "${themeKey}" font family "${family.key}" has an unsafe stack "${family.stack}": ${error.message}`
+        );
+      }
+      throw error;
+    }
+  }
+
+  // Token keys unique + valid; font_family defaults reference a real allow-list
+  // key; every color/dimension/number DEFAULT value passes its typed validator
+  // at load (R-L4 — a bad default fails compose/tests, not lazily at first render).
+  const fontKeys = new Set(descriptor.fontFamilies.map((f) => f.key));
+  const seenTokens = new Set<string>();
+  for (const token of descriptor.tokens) {
+    if (!TOKEN_KEY_PATTERN.test(token.key)) {
+      throw new InvalidThemeDescriptorError(
+        `Theme "${themeKey}" token key "${token.key}" must match ${TOKEN_KEY_PATTERN}.`
+      );
+    }
+    if (seenTokens.has(token.key)) {
+      throw new InvalidThemeDescriptorError(
+        `Theme "${themeKey}" declares duplicate token key "${token.key}".`
+      );
+    }
+    seenTokens.add(token.key);
+    if (token.kind === "font_family") {
+      if (!fontKeys.has(token.default)) {
+        throw new InvalidThemeDescriptorError(
+          `Theme "${themeKey}" font_family token "${token.key}" default "${token.default}" is not a declared fontFamilies key.`
+        );
+      }
+      continue;
+    }
+    try {
+      switch (token.kind) {
+        case "color":
+          validateColorValue(token.default);
+          break;
+        case "dimension":
+          validateDimensionValue(token.default, token.constraint);
+          break;
+        case "number":
+          validateNumberValue(token.default, token.constraint);
+          break;
+      }
+    } catch (error) {
+      if (error instanceof CssValueError) {
+        throw new InvalidThemeDescriptorError(
+          `Theme "${themeKey}" token "${token.key}" default "${token.default}" is unsafe or out of range: ${error.message}`
+        );
+      }
+      throw error;
+    }
+  }
+
+  // Slot defaults must be one of the slot's own variants.
+  for (const slot of descriptor.slots) {
+    if (!slot.variants.some((v) => v.key === slot.default)) {
+      throw new InvalidThemeDescriptorError(
+        `Theme "${themeKey}" slot "${slot.key}" default "${slot.default}" is not one of its variants.`
+      );
+    }
+  }
+}

--- a/src/modules/theming/domain/theme-lifecycle.ts
+++ b/src/modules/theming/domain/theme-lifecycle.ts
@@ -1,0 +1,56 @@
+/**
+ * Theme configuration lifecycle (Issue #269, ADR-0029 §4). Pure state-machine
+ * helpers — the persistence layer (`application/theme-config-directory.ts`) and
+ * the DB trigger (sql/033) are the real enforcers; these functions make the
+ * allowed transitions explicit + unit-testable.
+ *
+ * Lifecycle: **draft → validate → preview → publish → rollback/retire.**
+ *
+ * `validate` and `preview` are READ-ONLY actions (they inspect a draft, writing
+ * no new state), so a persisted config version has only two statuses:
+ *
+ *  - `draft`     — the single, mutable work-in-progress config for a tenant.
+ *  - `published` — an IMMUTABLE, numbered version. A change never mutates a
+ *                  published row; it produces a NEW published version.
+ *
+ * "rollback" and "retire" are transitions of the tenant's ACTIVE POINTER
+ * (`awcms_theming_tenant_state.active_version_id`), not of any version
+ * row — so published versions stay immutable and history is preserved.
+ */
+
+export type ThemeVersionStatus = "draft" | "published";
+
+export type ThemeConfigAction =
+  "save_draft" | "validate" | "preview" | "publish" | "rollback" | "retire";
+
+/** A published version may become the active pointer via publish or rollback; a draft never can. */
+export function canActivateVersion(status: ThemeVersionStatus): boolean {
+  return status === "published";
+}
+
+/** Only a draft may be published; publishing a non-draft is a programming error. */
+export function canPublishFromStatus(status: ThemeVersionStatus): boolean {
+  return status === "draft";
+}
+
+/**
+ * Whether a version row may be mutated in place. ONLY drafts. A published row is
+ * immutable (this mirrors the sql/033 trigger that raises on UPDATE/DELETE of a
+ * `status='published'` row — the pure twin of the DB enforcement).
+ */
+export function isVersionMutable(status: ThemeVersionStatus): boolean {
+  return status === "draft";
+}
+
+/**
+ * Validate a requested rollback target: it must be a real published version id
+ * belonging to this tenant (the caller resolves the set of the tenant's own
+ * published version ids and passes it here). Returns `true` when the target is
+ * a valid rollback destination.
+ */
+export function isValidRollbackTarget(
+  targetVersionId: string,
+  tenantPublishedVersionIds: readonly string[]
+): boolean {
+  return tenantPublishedVersionIds.includes(targetVersionId);
+}

--- a/src/modules/theming/domain/theme-permissions.ts
+++ b/src/modules/theming/domain/theme-permissions.ts
@@ -1,0 +1,20 @@
+/**
+ * `theming` permission constants (Issue #269, ADR-0029 §8). Mirrors the seeded
+ * rows in `sql/034` exactly — the module's `permissions` descriptor and every
+ * route guard reference these constants rather than re-typing the literals, so a
+ * rename can never drift one copy from another (same convention every module's
+ * `*-permissions.ts` uses).
+ */
+export const THEMING_MODULE_KEY = "theming";
+
+/** Read theme state/descriptors/version history; edit the draft config/selections. */
+export const THEMING_CONFIG_ACTIVITY_CODE = "config";
+export type ThemingConfigAction = "read" | "update";
+
+/** Publish a draft to an immutable version; rollback (restore) to a prior version; retire (archive) the active theme. */
+export const THEMING_VERSION_ACTIVITY_CODE = "version";
+export type ThemingVersionAction = "publish" | "restore" | "archive";
+
+/** Create a short-lived, authorized preview session. */
+export const THEMING_PREVIEW_ACTIVITY_CODE = "preview";
+export type ThemingPreviewAction = "create";

--- a/src/modules/theming/module.ts
+++ b/src/modules/theming/module.ts
@@ -1,0 +1,116 @@
+import { defineModule } from "../_shared/module-contract";
+import {
+  THEMING_CONFIG_ACTIVITY_CODE,
+  THEMING_MODULE_KEY,
+  THEMING_PREVIEW_ACTIVITY_CODE,
+  THEMING_VERSION_ACTIVITY_CODE
+} from "./domain/theme-permissions";
+
+/**
+ * `theming` — the FIRST website module implemented DIRECTLY in the awcms base
+ * (ADR-0034 Fase 3, "template dipakai-langsung"), adapted from awcms-micro's
+ * `theming` (Issue #269 / awcms-micro ADR-0029). ADR-0034 revoked the
+ * `no-content-website-modules` restriction (content/website modules may now live
+ * in `src/modules/` here), and this module is the evidence for that decision. It
+ * bumps the base registry 10 -> 11 modules.
+ *
+ * ## What this module OWNS
+ *
+ * Tenant-selectable presentation with NO uploaded server code and NO arbitrary
+ * templates. A THEME is trusted, reviewed, BUILD-TIME source (a `ThemeDescriptor`
+ * composed by `theme-registry.ts` from the reviewed in-repo base themes); only a
+ * tenant's DATA configuration of a theme lives in the database
+ * (`awcms_theming_config_versions` + `_tenant_state`, sql/033, RLS FORCE'd).
+ *
+ * The security spine (`domain/css-value-validation.ts`) validates every design
+ * token VALUE by REJECTION (never sanitization) against strict, bounded grammars
+ * — colors, dimensions with an allowed-unit list, plain numbers, and font
+ * families chosen from a per-theme allow-list (the emitted font stack is
+ * descriptor-owned, never tenant-authored). `url(...)`, `expression()`,
+ * `@import`, `javascript:`, comment breakouts, `;{}<>` and unbalanced tokens can
+ * never reach the emitted CSS. Token values are serialized to a `text/css`
+ * custom-property block served as an EXTERNAL same-origin stylesheet
+ * (`/theming/{tenantCode}/tokens.css`), so the app's `style-src 'self'` CSP is
+ * never weakened (no per-request inline `<style>`). Rendering is only through the
+ * trusted build-time `PublicThemeLayout.astro` — there is NO database-stored
+ * executable template, no tenant-authored Astro/JS/SQL/eval/raw HTML.
+ *
+ * Published configuration versions are IMMUTABLE (INSERT-only engine + a sql/033
+ * BEFORE UPDATE/DELETE trigger); the active theme pointer lives on the state row,
+ * so publish/rollback/retire move a pointer while history stays intact.
+ *
+ * Preview sessions (`awcms_theming_preview_sessions`, sql/033) are authorized
+ * (token stored as a SHA-256 hash), short-lived (`expires_at`, filtered on every
+ * read), non-indexable (`X-Robots-Tag: noindex`), and isolated from the public
+ * cache (`private, no-store` + a distinct URL namespace).
+ *
+ * ## Dependencies / capabilities (port adaptations vs awcms-micro)
+ *
+ * Lifecycle `dependencies` are only the two Core modules (`tenant_admin`,
+ * `identity_access`). The awcms-micro origin OPTIONALLY consumed `media_library`
+ * (logo/favicon asset-id -> URL resolution) and registered a `data_lifecycle`
+ * purge descriptor for the preview table; neither module exists in awcms, so
+ * BOTH are dropped: asset-URL resolution is a documented no-op (assets are simply
+ * omitted from render, degrading safely) and preview retention rides the
+ * `expires_at >= now()` read filter instead of a purge job. `theming` `provides`
+ * no capability and nothing depends on it, so the DAG is unchanged.
+ *
+ * ## Deliberately NOT here yet (documented follow-ups)
+ *
+ * `navigation` is undeclared (no admin UI in awcms yet — the token editor /
+ * responsive-preview dashboard is deferred API-first). `events` stays undeclared:
+ * publish/rollback/retire are audited synchronous hooks, not yet domain events.
+ * `jobs` stays undeclared: no background purge (see the retention note above).
+ */
+export const themingModule = defineModule({
+  key: THEMING_MODULE_KEY,
+  name: "Theming",
+  version: "1.0.0",
+  status: "active",
+  type: "domain",
+  description:
+    "Tenant-selectable presentation via trusted, reviewed, BUILD-TIME theme descriptors (ADR-0034 Fase 3 — the first website module implemented directly in the awcms base). A theme is composed by `src/modules/theming/theme-registry.ts` from the reviewed in-repo base themes — NEVER a database row and NEVER an uploaded artifact (awcms has no derived-repo theme seam; the derived-application pathway was removed in ADR-0034 Fase 2). Only a tenant's DATA configuration of a theme lives in the database (`awcms_theming_config_versions` draft + immutable published versions, and `awcms_theming_tenant_state` active pointer, sql/033, RLS FORCE'd): bounded, schema-validated design-token overrides, slot variant selections, media asset ids (URL resolution is a no-op until a media module is ported), content-section order, and nav placement. The security spine (`domain/css-value-validation.ts`) validates every CSS token value by REJECTION against strict grammars (hex/rgb/hsl colors with numeric components, dimensions with an allowed-unit list, bounded numbers, font families from a per-theme allow-list whose emitted stack is descriptor-owned) — `url(...)`, `expression()`, `@import`, `javascript:`, comment breakouts, `;{}<>` and unbalanced tokens can never reach output. Token values ship as an EXTERNAL same-origin `text/css` stylesheet (`/theming/{tenantCode}/tokens.css`), so the app's `style-src 'self'` CSP is never weakened (no per-request inline style). Rendering is only through the trusted build-time `PublicThemeLayout.astro` (no DB-stored template, no tenant-authored Astro/JS/SQL/eval/raw HTML). Published versions are IMMUTABLE (INSERT-only engine + a sql/033 BEFORE UPDATE/DELETE trigger); lifecycle is draft → validate → preview → publish → rollback/retire, with rollback/retire moving the active pointer while history stays intact. Preview sessions (sql/033) are authorized (token stored hashed), short-lived, non-indexable (X-Robots-Tag: noindex), and isolated from the public cache (private, no-store + distinct URL namespace). Admin API under /api/v1/theming/* (selection, token edit, validate, preview, publish, version history, rollback, retire) is ABAC-gated, idempotency-keyed on high-risk mutations, and audited. A default theme (`aria`) ships in-repo.",
+  dependencies: ["tenant_admin", "identity_access"],
+  api: {
+    openApiPath: "openapi/modules/theming.openapi.yaml",
+    basePath: "/api/v1/theming"
+  },
+  permissions: [
+    {
+      activityCode: THEMING_CONFIG_ACTIVITY_CODE,
+      action: "read",
+      description:
+        "Read this tenant's theme selection, available themes, the draft config, and published version history"
+    },
+    {
+      activityCode: THEMING_CONFIG_ACTIVITY_CODE,
+      action: "update",
+      description:
+        "Edit this tenant's draft theme config (design tokens, slot variants, media assets, section order) — bounded, validated data (high-risk, audited)"
+    },
+    {
+      activityCode: THEMING_VERSION_ACTIVITY_CODE,
+      action: "publish",
+      description:
+        "Publish a validated draft as an immutable theme version and make it the live look (high-risk, idempotency-keyed, audited)"
+    },
+    {
+      activityCode: THEMING_VERSION_ACTIVITY_CODE,
+      action: "restore",
+      description:
+        "Roll the active theme back to an earlier published version (high-risk, idempotency-keyed, audited)"
+    },
+    {
+      activityCode: THEMING_VERSION_ACTIVITY_CODE,
+      action: "archive",
+      description:
+        "Retire the active theme so the site falls back to the default (high-risk, idempotency-keyed, audited)"
+    },
+    {
+      activityCode: THEMING_PREVIEW_ACTIVITY_CODE,
+      action: "create",
+      description:
+        "Create a short-lived, non-indexable preview session for the draft theme config (audited)"
+    }
+  ]
+});

--- a/src/modules/theming/theme-registry.ts
+++ b/src/modules/theming/theme-registry.ts
@@ -1,0 +1,77 @@
+/**
+ * The reviewed, build-time THEME registry (ADR-0034 Fase 3; ported from
+ * awcms-micro Issue #269/ADR-0029 §3) — the theme-descriptor analogue of
+ * `src/modules/index.ts` for module descriptors.
+ *
+ * `listThemeDescriptors()` returns the reviewed in-repo base themes
+ * (`BASE_THEME_DESCRIPTORS`). EVERY descriptor is validated by
+ * `assertValidThemeDescriptor` at load time, so a malformed or CSP-weakening
+ * theme fails the build/tests, never renders.
+ *
+ * awcms removed the derived-application pathway (ADR-0034 Fase 2), so — unlike
+ * the awcms-micro origin — there is NO `application-theme-registry.ts` seam and
+ * no derived theme. Website/theme modules live directly in this base
+ * ("template dipakai-langsung"). `composeThemeDescriptors` still accepts an
+ * optional `extraThemes` argument so its validate-and-dedupe logic (a theme may
+ * not shadow another theme's key) stays unit-testable without a seam file.
+ *
+ * This composition is 100% static/compile-time: no database, no upload, no
+ * runtime discovery. A theme is trusted, reviewed source; only a tenant's DATA
+ * configuration of a theme (`ThemeConfig`) lives in the database.
+ */
+import {
+  assertValidThemeDescriptor,
+  type ThemeDescriptor
+} from "./domain/theme-descriptor";
+import { defaultTheme } from "./themes/default-theme";
+
+/** The base themes this repository ships. Order is not significant. */
+export const BASE_THEME_DESCRIPTORS: readonly ThemeDescriptor[] = [
+  defaultTheme
+];
+
+/** The theme every tenant falls back to when none is selected. */
+export const DEFAULT_THEME_KEY = defaultTheme.themeKey;
+
+/**
+ * Compose the effective registry, validating each descriptor and rejecting a
+ * `themeKey` collision (no theme may shadow another theme's key). Pure over its
+ * `extraThemes` argument — the base build passes nothing (registry = the base
+ * themes); tests may pass extra themes to exercise the validate/dedupe gate.
+ */
+export function composeThemeDescriptors(
+  extraThemes: readonly ThemeDescriptor[] = []
+): ThemeDescriptor[] {
+  const composed: ThemeDescriptor[] = [];
+  const seen = new Set<string>();
+
+  const add = (descriptor: ThemeDescriptor): void => {
+    assertValidThemeDescriptor(descriptor);
+    if (seen.has(descriptor.themeKey)) {
+      throw new Error(
+        `Duplicate theme key "${descriptor.themeKey}" — a theme may not shadow another theme's key (ADR-0034 Fase 3).`
+      );
+    }
+    seen.add(descriptor.themeKey);
+    composed.push(descriptor);
+  };
+
+  for (const descriptor of BASE_THEME_DESCRIPTORS) add(descriptor);
+  for (const descriptor of extraThemes) add(descriptor);
+  return composed;
+}
+
+let cached: ThemeDescriptor[] | null = null;
+
+/** The effective, validated theme registry (the reviewed base themes). Cached. */
+export function listThemeDescriptors(): ThemeDescriptor[] {
+  if (cached === null) {
+    cached = composeThemeDescriptors();
+  }
+  return cached;
+}
+
+/** Look up one theme by key (latest/only version in the registry), or `null`. */
+export function getThemeDescriptor(themeKey: string): ThemeDescriptor | null {
+  return listThemeDescriptors().find((t) => t.themeKey === themeKey) ?? null;
+}

--- a/src/modules/theming/themes/default-theme.ts
+++ b/src/modules/theming/themes/default-theme.ts
@@ -1,0 +1,226 @@
+/**
+ * The base "Aria" default theme (Issue #269, ADR-0029). A trusted, reviewed,
+ * build-time `ThemeDescriptor` — the reference theme every AWCMS tenant
+ * can select and configure, and the shape every in-repo base theme mirrors.
+ * (awcms has no derived-repo theme seam; the derived-application pathway was
+ * removed in ADR-0034 Fase 2, so themes live directly in this base registry.)
+ *
+ * Every default value here is itself validated by the registry
+ * (`assertValidThemeDescriptor` + `resolveThemeTokens` in a unit test), so a
+ * malformed default fails the build/tests rather than shipping. The token
+ * defaults are chosen to meet WCAG AA contrast on the default surfaces.
+ */
+import { defineTheme } from "../domain/theme-descriptor";
+
+export const defaultTheme = defineTheme({
+  themeKey: "aria",
+  version: "1.0.0",
+  name: "Aria",
+  owner: "@ahliweb",
+  description:
+    "The AWCMS reference theme: a clean, accessible, responsive website layout with a semantic design-token palette, header/footer/nav slot variants, and orderable home sections. Self-contained (no inline script, no external font/script) so it never weakens CSP.",
+  origin: "base",
+  fontFamilies: [
+    {
+      key: "system",
+      label: "System sans-serif",
+      stack:
+        '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif'
+    },
+    {
+      key: "humanist",
+      label: "Humanist sans-serif",
+      stack: '"Inter", system-ui, sans-serif'
+    },
+    {
+      key: "serif",
+      label: "Serif",
+      stack: 'Georgia, "Times New Roman", serif'
+    },
+    {
+      key: "mono",
+      label: "Monospace",
+      stack: "ui-monospace, SFMono-Regular, Menlo, monospace"
+    }
+  ],
+  tokens: [
+    {
+      key: "color_primary",
+      kind: "color",
+      label: "Primary",
+      description: "Primary brand color (links, buttons).",
+      default: "#2563eb"
+    },
+    {
+      key: "color_on_primary",
+      kind: "color",
+      label: "On primary",
+      description: "Text/icon color on primary surfaces.",
+      default: "#ffffff"
+    },
+    {
+      key: "color_background",
+      kind: "color",
+      label: "Background",
+      description: "Page background.",
+      default: "#ffffff"
+    },
+    {
+      key: "color_surface",
+      kind: "color",
+      label: "Surface",
+      description: "Card/section surface.",
+      default: "#f8fafc"
+    },
+    {
+      key: "color_text",
+      kind: "color",
+      label: "Text",
+      description: "Primary body text.",
+      default: "#0f172a"
+    },
+    {
+      key: "color_muted",
+      kind: "color",
+      label: "Muted text",
+      description: "Secondary/muted text.",
+      default: "#475569"
+    },
+    {
+      key: "color_border",
+      kind: "color",
+      label: "Border",
+      description: "Divider/border color.",
+      default: "#e2e8f0"
+    },
+    {
+      key: "color_accent",
+      kind: "color",
+      label: "Accent",
+      description: "Accent/highlight color.",
+      default: "#0ea5e9"
+    },
+    {
+      key: "font_body",
+      kind: "font_family",
+      label: "Body font",
+      description: "Body text family.",
+      default: "system"
+    },
+    {
+      key: "font_heading",
+      kind: "font_family",
+      label: "Heading font",
+      description: "Heading family.",
+      default: "system"
+    },
+    {
+      key: "font_size_base",
+      kind: "dimension",
+      label: "Base font size",
+      description: "Root font size.",
+      constraint: { units: ["rem", "px"], min: 0.875, max: 1.5 },
+      default: "1rem"
+    },
+    {
+      key: "radius_base",
+      kind: "dimension",
+      label: "Corner radius",
+      description: "Base border radius.",
+      constraint: { units: ["rem", "px"], min: 0, max: 2 },
+      default: "0.5rem"
+    },
+    {
+      key: "space_unit",
+      kind: "dimension",
+      label: "Spacing unit",
+      description: "Base spacing scale unit.",
+      constraint: { units: ["rem", "px"], min: 0.25, max: 3 },
+      default: "1rem"
+    },
+    {
+      key: "container_max_width",
+      kind: "dimension",
+      label: "Container width",
+      description: "Max content container width.",
+      constraint: { units: ["rem", "px"], min: 20, max: 120 },
+      default: "72rem"
+    },
+    {
+      key: "line_height_base",
+      kind: "number",
+      label: "Line height",
+      description: "Base body line height.",
+      constraint: { min: 1.2, max: 2.2 },
+      default: "1.5"
+    }
+  ],
+  slots: [
+    {
+      key: "header",
+      label: "Header layout",
+      variants: [
+        { key: "minimal", label: "Minimal" },
+        { key: "centered", label: "Centered" },
+        { key: "split", label: "Split" }
+      ],
+      default: "centered"
+    },
+    {
+      key: "footer",
+      label: "Footer layout",
+      variants: [
+        { key: "simple", label: "Simple" },
+        { key: "columns", label: "Columns" }
+      ],
+      default: "simple"
+    },
+    {
+      key: "nav_style",
+      label: "Navigation style",
+      variants: [
+        { key: "inline", label: "Inline" },
+        { key: "hamburger", label: "Hamburger" }
+      ],
+      default: "inline"
+    }
+  ],
+  assetSlots: [
+    { key: "logo", label: "Logo", kind: "logo" },
+    { key: "favicon", label: "Favicon", kind: "favicon" },
+    { key: "hero_image", label: "Hero image", kind: "image" }
+  ],
+  contentSections: [
+    { key: "hero", label: "Hero" },
+    { key: "featured", label: "Featured" },
+    { key: "latest", label: "Latest" },
+    { key: "about", label: "About" },
+    { key: "cta", label: "Call to action" }
+  ],
+  navPlacements: ["top", "side"],
+  accessibility: {
+    minContrastRatio: 4.5,
+    supportsReducedMotion: true,
+    supportsResponsive: true,
+    keyboardNavigable: true,
+    landmarks: ["banner", "navigation", "main", "contentinfo"]
+  },
+  csp: {
+    requiresInlineStyle: false,
+    requiresInlineScript: false,
+    externalStyleSources: [],
+    externalScriptSources: [],
+    externalFrameSources: []
+  },
+  compatibility: {
+    minModuleContractVersion: "1.2.0",
+    supportedResourceTypes: [
+      "home",
+      "page",
+      "blog_index",
+      "blog_post",
+      "search",
+      "error"
+    ]
+  }
+});

--- a/src/pages/api/v1/theming/draft.ts
+++ b/src/pages/api/v1/theming/draft.ts
@@ -1,0 +1,178 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../modules/_shared/idempotency";
+import { validateThemeConfig } from "../../../../modules/theming/domain/theme-config";
+import { getThemeDescriptor } from "../../../../modules/theming/theme-registry";
+import { saveThemeDraft } from "../../../../modules/theming/application/theme-service";
+import {
+  THEMING_CONFIG_ACTIVITY_CODE,
+  THEMING_MODULE_KEY
+} from "../../../../modules/theming/domain/theme-permissions";
+
+/**
+ * `PUT /api/v1/theming/draft` (Issue #269, ADR-0029 §4) — save/replace this
+ * tenant's single draft theme config (chosen theme + bounded, validated design
+ * tokens, slot variants, media asset ids, section order, nav placement). The
+ * config body is validated against the chosen theme descriptor
+ * (`validateThemeConfig` — the CSS-injection spine + declared-surface bounding)
+ * BEFORE any DB work. High-risk (the draft is what publish promotes) → requires an
+ * `Idempotency-Key`, ABAC-gated (`theming.config.update`), tenant-scoped, audited.
+ */
+const UPDATE_GUARD = {
+  moduleKey: THEMING_MODULE_KEY,
+  activityCode: THEMING_CONFIG_ACTIVITY_CODE,
+  action: "update" as const
+};
+
+const IDEMPOTENCY_SCOPE = "theming_draft_update";
+
+export const PUT: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value as { themeKey?: unknown } | null;
+  const themeKey =
+    typeof rawBody?.themeKey === "string" ? rawBody.themeKey : null;
+  if (!themeKey) {
+    return fail(400, "VALIDATION_ERROR", "A themeKey string is required.");
+  }
+  const descriptor = getThemeDescriptor(themeKey);
+  if (!descriptor) {
+    return fail(
+      400,
+      "UNKNOWN_THEME",
+      `Theme "${themeKey}" is not a registered theme.`
+    );
+  }
+
+  const validation = validateThemeConfig(descriptor, bodyRead.value);
+  if (!validation.ok) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Theme config is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const config = validation.value;
+  const requestHash = computeRequestHash({ themeKey, config });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const draft = await saveThemeDraft(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      descriptor,
+      config,
+      async (auditTx, detail) => {
+        await recordAuditEvent(auditTx, {
+          tenantId,
+          actorTenantUserId: auth.context.tenantUserId,
+          moduleKey: THEMING_MODULE_KEY,
+          action: detail.action,
+          resourceType: detail.resourceType,
+          resourceId: detail.resourceId,
+          severity: "info",
+          message: "Theme draft config saved.",
+          attributes: detail.attributes,
+          correlationId
+        });
+      }
+    );
+
+    const response = ok({
+      versionId: draft.id,
+      themeKey: draft.themeKey,
+      config: draft.config,
+      configHash: draft.configHash
+    });
+    const body = await response.clone().json();
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+    return response;
+  });
+};

--- a/src/pages/api/v1/theming/index.ts
+++ b/src/pages/api/v1/theming/index.ts
@@ -1,0 +1,91 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  fetchDraftVersion,
+  fetchThemeTenantState,
+  listPublishedVersions
+} from "../../../../modules/theming/application/theme-config-directory";
+import { listThemeDescriptors } from "../../../../modules/theming/theme-registry";
+import {
+  THEMING_CONFIG_ACTIVITY_CODE,
+  THEMING_MODULE_KEY
+} from "../../../../modules/theming/domain/theme-permissions";
+
+/**
+ * `GET /api/v1/theming` (Issue #269, ADR-0029 §4) — everything the theming admin
+ * surface needs to render the selection/editor/history view for this tenant: the
+ * available (build-time, reviewed) theme descriptors, the tenant's active theme
+ * pointer, its current draft config (if any), and its published version history.
+ * ABAC-gated (`theming.config.read`) and tenant-scoped (`withTenant` + RLS).
+ */
+const READ_GUARD = {
+  moduleKey: THEMING_MODULE_KEY,
+  activityCode: THEMING_CONFIG_ACTIVITY_CODE,
+  action: "read" as const
+};
+
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const [state, draft, versions] = await Promise.all([
+      fetchThemeTenantState(tx, tenantId),
+      fetchDraftVersion(tx, tenantId),
+      listPublishedVersions(tx, tenantId, 50)
+    ]);
+
+    return ok({
+      themes: listThemeDescriptors(),
+      state,
+      draft: draft
+        ? {
+            versionId: draft.id,
+            themeKey: draft.themeKey,
+            config: draft.config,
+            configHash: draft.configHash
+          }
+        : null,
+      // Shape MUST match the shared OpenAPI `ThemeVersion` schema
+      // (openapi/modules/theming.openapi.yaml) that publish/rollback also
+      // return — `versionId` (not `id`), and no `themeVersion` field. The
+      // deferred rollback UI keys off `versions[].versionId`.
+      versions: versions.map((v) => ({
+        versionId: v.id,
+        themeKey: v.themeKey,
+        versionNumber: v.versionNumber,
+        configHash: v.configHash,
+        publishedAt: v.publishedAt
+      }))
+    });
+  });
+};

--- a/src/pages/api/v1/theming/preview.ts
+++ b/src/pages/api/v1/theming/preview.ts
@@ -1,0 +1,119 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import { fetchDraftVersion } from "../../../../modules/theming/application/theme-config-directory";
+import { createPreviewSession } from "../../../../modules/theming/application/theme-preview-directory";
+import {
+  buildPreviewUrlToken,
+  generatePreviewToken,
+  hashPreviewToken,
+  resolvePreviewTtlMinutes
+} from "../../../../modules/theming/domain/preview-token";
+import {
+  THEMING_MODULE_KEY,
+  THEMING_PREVIEW_ACTIVITY_CODE
+} from "../../../../modules/theming/domain/theme-permissions";
+
+/**
+ * `POST /api/v1/theming/preview` (Issue #269, ADR-0029 §6) — mint a short-lived,
+ * authorized, NON-INDEXABLE preview session for this tenant's current DRAFT theme
+ * config. Returns the preview URL (`/theming/preview/{token}`) and its expiry; the
+ * raw token is returned ONCE (only its hash is stored). ABAC-gated
+ * (`theming.preview.create`), tenant-scoped, audited. Not idempotency-keyed —
+ * each preview session is intentionally a distinct, disposable token.
+ */
+const PREVIEW_GUARD = {
+  moduleKey: THEMING_MODULE_KEY,
+  activityCode: THEMING_PREVIEW_ACTIVITY_CODE,
+  action: "create" as const
+};
+
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+  const rawBody = bodyRead.value as { ttlMinutes?: unknown } | null;
+  const ttlMinutes = resolvePreviewTtlMinutes(rawBody?.ttlMinutes);
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      PREVIEW_GUARD
+    );
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const draft = await fetchDraftVersion(tx, tenantId);
+    if (!draft) {
+      return fail(
+        400,
+        "NO_DRAFT",
+        "No draft theme config to preview — save a draft first."
+      );
+    }
+
+    const rawToken = generatePreviewToken();
+    const expiresAt = new Date(now.getTime() + ttlMinutes * 60_000);
+    const session = await createPreviewSession(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      draft.id,
+      hashPreviewToken(rawToken),
+      expiresAt
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: THEMING_MODULE_KEY,
+      action: "theming.preview.create",
+      resourceType: "theming_preview_session",
+      resourceId: session.id,
+      severity: "info",
+      message: "Theme preview session created.",
+      attributes: {
+        themeKey: draft.themeKey,
+        expiresAt: expiresAt.toISOString()
+      },
+      correlationId
+    });
+
+    const urlToken = buildPreviewUrlToken(tenantId, rawToken);
+    return ok({
+      previewUrl: `/theming/preview/${urlToken}`,
+      expiresAt: expiresAt.toISOString()
+    });
+  });
+};

--- a/src/pages/api/v1/theming/publish.ts
+++ b/src/pages/api/v1/theming/publish.ts
@@ -1,0 +1,142 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../modules/_shared/idempotency";
+import { publishThemeDraft } from "../../../../modules/theming/application/theme-service";
+import {
+  THEMING_MODULE_KEY,
+  THEMING_VERSION_ACTIVITY_CODE
+} from "../../../../modules/theming/domain/theme-permissions";
+
+/**
+ * `POST /api/v1/theming/publish` (Issue #269, ADR-0029 §4/§8) — publish this
+ * tenant's current draft as a new IMMUTABLE version and make it the live look.
+ * INSERT-only (never mutates a published row; the sql/085 trigger backstops it).
+ * High-risk (changes the public presentation surface) → requires an
+ * `Idempotency-Key`, ABAC-gated (`theming.version.publish`), tenant-scoped,
+ * audited.
+ */
+const PUBLISH_GUARD = {
+  moduleKey: THEMING_MODULE_KEY,
+  activityCode: THEMING_VERSION_ACTIVITY_CODE,
+  action: "publish" as const
+};
+
+const IDEMPOTENCY_SCOPE = "theming_version_publish";
+
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ op: "publish" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      PUBLISH_GUARD
+    );
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const result = await publishThemeDraft(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      async (auditTx, detail) => {
+        await recordAuditEvent(auditTx, {
+          tenantId,
+          actorTenantUserId: auth.context.tenantUserId,
+          moduleKey: THEMING_MODULE_KEY,
+          action: detail.action,
+          resourceType: detail.resourceType,
+          resourceId: detail.resourceId,
+          severity: "info",
+          message: "Theme version published.",
+          attributes: detail.attributes,
+          correlationId
+        });
+      }
+    );
+
+    if (!result.ok) {
+      return fail(400, "NO_DRAFT", result.message);
+    }
+
+    const response = ok({
+      versionId: result.version.id,
+      themeKey: result.version.themeKey,
+      versionNumber: result.version.versionNumber,
+      configHash: result.version.configHash,
+      publishedAt: result.version.publishedAt
+    });
+    const body = await response.clone().json();
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+    return response;
+  });
+};

--- a/src/pages/api/v1/theming/retire.ts
+++ b/src/pages/api/v1/theming/retire.ts
@@ -1,0 +1,132 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../modules/_shared/idempotency";
+import { retireActiveTheme } from "../../../../modules/theming/application/theme-service";
+import {
+  THEMING_MODULE_KEY,
+  THEMING_VERSION_ACTIVITY_CODE
+} from "../../../../modules/theming/domain/theme-permissions";
+
+/**
+ * `POST /api/v1/theming/retire` (Issue #269, ADR-0029 §4/§8) — retire the active
+ * theme: clear the active pointer so the site falls back to the default theme.
+ * Published versions stay intact (history/rollback). High-risk (changes the live
+ * look) → requires an `Idempotency-Key`, ABAC-gated (`theming.version.archive`),
+ * tenant-scoped, audited.
+ */
+const ARCHIVE_GUARD = {
+  moduleKey: THEMING_MODULE_KEY,
+  activityCode: THEMING_VERSION_ACTIVITY_CODE,
+  action: "archive" as const
+};
+
+const IDEMPOTENCY_SCOPE = "theming_version_retire";
+
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ op: "retire" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      ARCHIVE_GUARD
+    );
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const result = await retireActiveTheme(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      async (auditTx, detail) => {
+        await recordAuditEvent(auditTx, {
+          tenantId,
+          actorTenantUserId: auth.context.tenantUserId,
+          moduleKey: THEMING_MODULE_KEY,
+          action: detail.action,
+          resourceType: detail.resourceType,
+          resourceId: detail.resourceId,
+          severity: "info",
+          message:
+            "Active theme retired (site falls back to the default theme).",
+          attributes: detail.attributes,
+          correlationId
+        });
+      }
+    );
+
+    const response = ok({ previousThemeKey: result.previousThemeKey });
+    const body = await response.clone().json();
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+    return response;
+  });
+};

--- a/src/pages/api/v1/theming/rollback.ts
+++ b/src/pages/api/v1/theming/rollback.ts
@@ -1,0 +1,156 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../modules/_shared/idempotency";
+import { rollbackThemeVersion } from "../../../../modules/theming/application/theme-service";
+import {
+  THEMING_MODULE_KEY,
+  THEMING_VERSION_ACTIVITY_CODE
+} from "../../../../modules/theming/domain/theme-permissions";
+
+/**
+ * `POST /api/v1/theming/rollback` (Issue #269, ADR-0029 §4/§8) — roll the active
+ * theme pointer back to an earlier published version (never mutates a version
+ * row; published versions are immutable). The target must be one of THIS tenant's
+ * own published version ids. High-risk (changes the live look) → requires an
+ * `Idempotency-Key`, ABAC-gated (`theming.version.restore`), tenant-scoped,
+ * audited.
+ */
+const RESTORE_GUARD = {
+  moduleKey: THEMING_MODULE_KEY,
+  activityCode: THEMING_VERSION_ACTIVITY_CODE,
+  action: "restore" as const
+};
+
+const IDEMPOTENCY_SCOPE = "theming_version_rollback";
+
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+  const rawBody = bodyRead.value as { versionId?: unknown } | null;
+  const versionId =
+    typeof rawBody?.versionId === "string" ? rawBody.versionId : null;
+  if (!versionId) {
+    return fail(400, "VALIDATION_ERROR", "A versionId string is required.");
+  }
+
+  const requestHash = computeRequestHash({ op: "rollback", versionId });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      RESTORE_GUARD
+    );
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const result = await rollbackThemeVersion(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      versionId,
+      async (auditTx, detail) => {
+        await recordAuditEvent(auditTx, {
+          tenantId,
+          actorTenantUserId: auth.context.tenantUserId,
+          moduleKey: THEMING_MODULE_KEY,
+          action: detail.action,
+          resourceType: detail.resourceType,
+          resourceId: detail.resourceId,
+          severity: "info",
+          message: "Theme rolled back to an earlier published version.",
+          attributes: detail.attributes,
+          correlationId
+        });
+      }
+    );
+
+    if (!result.ok) {
+      return fail(404, "INVALID_TARGET", result.message);
+    }
+
+    const response = ok({
+      versionId: result.version.id,
+      themeKey: result.version.themeKey,
+      versionNumber: result.version.versionNumber
+    });
+    const body = await response.clone().json();
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+    return response;
+  });
+};

--- a/src/pages/api/v1/theming/validate.ts
+++ b/src/pages/api/v1/theming/validate.ts
@@ -1,0 +1,94 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
+  serializeThemeTokensCss,
+  validateThemeConfig
+} from "../../../../modules/theming/domain/theme-config";
+import { getThemeDescriptor } from "../../../../modules/theming/theme-registry";
+import {
+  THEMING_CONFIG_ACTIVITY_CODE,
+  THEMING_MODULE_KEY
+} from "../../../../modules/theming/domain/theme-permissions";
+
+/**
+ * `POST /api/v1/theming/validate` (Issue #269, ADR-0029 §4/§5) — read-only dry
+ * run: validate a proposed theme config against its theme descriptor (the same
+ * CSS-injection spine + declared-surface bounding the draft PUT applies) and, when
+ * valid, return the exact `text/css` custom-property block it would produce —
+ * writing nothing. ABAC-gated (`theming.config.read`). No idempotency (no write).
+ */
+const READ_GUARD = {
+  moduleKey: THEMING_MODULE_KEY,
+  activityCode: THEMING_CONFIG_ACTIVITY_CODE,
+  action: "read" as const
+};
+
+export const POST: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const rawBody = bodyRead.value as { themeKey?: unknown } | null;
+  const themeKey =
+    typeof rawBody?.themeKey === "string" ? rawBody.themeKey : null;
+  if (!themeKey) {
+    return fail(400, "VALIDATION_ERROR", "A themeKey string is required.");
+  }
+  const descriptor = getThemeDescriptor(themeKey);
+  if (!descriptor) {
+    return fail(
+      400,
+      "UNKNOWN_THEME",
+      `Theme "${themeKey}" is not a registered theme.`
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const validation = validateThemeConfig(descriptor, bodyRead.value);
+    if (!validation.ok) {
+      return ok({ valid: false, errors: validation.errors, previewCss: null });
+    }
+
+    // Safe by construction: only a validated config reaches the serializer, which
+    // re-validates every token value before emitting it.
+    const previewCss = serializeThemeTokensCss(descriptor, validation.value);
+    return ok({ valid: true, errors: [], previewCss });
+  });
+};

--- a/src/pages/theming/[tenantCode]/tokens.css.ts
+++ b/src/pages/theming/[tenantCode]/tokens.css.ts
@@ -1,0 +1,21 @@
+import type { APIRoute } from "astro";
+
+import { serveActiveThemeTokensCss } from "../../../lib/theming/theme-public-css";
+
+/**
+ * `GET /theming/{tenantCode}/tokens.css` (ADR-0034 Fase 3; ported from
+ * awcms-micro Issue #269/ADR-0029 §7) — the active published theme's design-token
+ * custom properties for the `tenantCode`-resolved tenant, as an EXTERNAL
+ * same-origin `text/css` stylesheet the public layout links (never an inline
+ * `<style>`, so the app's CSP `style-src 'self'` is never weakened).
+ *
+ * The public tenant is resolved by the `{tenantCode}` path segment (ADR-0009 —
+ * awcms resolves public tenants by code, not Host; this is the port adaptation of
+ * awcms-micro's Host-based resolver). Always a valid 200/304 (default theme
+ * tokens when no tenant/active theme resolves), so there is no tenant-enumeration
+ * oracle. Unauthenticated by design (a public presentation asset, like
+ * `/robots.txt`); the `theming`-enabled gate + cache validators live in
+ * `serveActiveThemeTokensCss`.
+ */
+export const GET: APIRoute = ({ request, params }) =>
+  serveActiveThemeTokensCss(request, params.tenantCode ?? "");

--- a/src/pages/theming/preview-tokens/[token].css.ts
+++ b/src/pages/theming/preview-tokens/[token].css.ts
@@ -1,0 +1,15 @@
+import type { APIRoute } from "astro";
+
+import { serveThemePreviewTokensCss } from "../../../lib/theming/theme-preview";
+
+/**
+ * `GET /theming/preview-tokens/{token}.css` (Issue #269, ADR-0029 §6) — the DRAFT
+ * theme's token stylesheet for an authorized preview session. NON-INDEXABLE
+ * (`X-Robots-Tag: noindex`) + `Cache-Control: private, no-store` + a URL namespace
+ * distinct from `/theming/tokens.css`, so a preview can never poison the public /
+ * CDN cache. The `{token}` is `${tenantId}~${rawToken}`; the raw token is hashed
+ * and matched inside the tenant transaction (RLS), so it cannot resolve another
+ * tenant's session.
+ */
+export const GET: APIRoute = ({ params }) =>
+  serveThemePreviewTokensCss(params.token ?? "");

--- a/src/pages/theming/preview/[token].astro
+++ b/src/pages/theming/preview/[token].astro
@@ -1,0 +1,88 @@
+---
+/**
+ * `GET /theming/preview/{token}` (Issue #269, ADR-0029 §6) — the authorized,
+ * short-lived, NON-INDEXABLE preview of a tenant's DRAFT theme, rendered through
+ * the trusted build-time `PublicThemeLayout` (no database template). The response
+ * is `noindex,nofollow` + `private, no-store` and links its token values from the
+ * distinct `/theming/preview-tokens/{token}.css` namespace, so it is invisible to
+ * search engines and cannot poison the public/CDN cache. It renders the DRAFT
+ * (never the published version), proving the theme + tokens across the default and
+ * any derived theme.
+ */
+import PublicThemeLayout from "../../../layouts/PublicThemeLayout.astro";
+import { resolvePreviewContext } from "../../../lib/theming/theme-preview";
+import { buildPreviewViewModel } from "../../../modules/theming/application/theme-preview-render";
+
+// Preview surfaces are ALWAYS non-indexable and never cached by a shared cache.
+Astro.response.headers.set("X-Robots-Tag", "noindex, nofollow");
+Astro.response.headers.set("Cache-Control", "private, no-store");
+
+const token = Astro.params.token ?? "";
+const context = await resolvePreviewContext(token);
+
+if (!context) {
+  Astro.response.status = 404;
+}
+
+const model = context
+  ? buildPreviewViewModel(context.descriptor, context.config, context.assetUrls)
+  : null;
+const tokenCssHref = `/theming/preview-tokens/${encodeURIComponent(token)}.css`;
+---
+
+{
+  model ? (
+    <PublicThemeLayout
+      title={`Preview — ${model.themeName}`}
+      tokenCssHref={tokenCssHref}
+      model={model}
+      noindex={true}
+    >
+      <h1 data-preview-heading>{model.themeName} preview</h1>
+      <p>This is a private, non-indexable preview of your draft theme.</p>
+      {model.sections.map((section) => (
+        <section
+          class="theme-section"
+          data-section={section.key}
+          aria-label={section.label}
+        >
+          <h2>{section.heading}</h2>
+          <p>{section.body}</p>
+          {section.key === "cta" && (
+            <a class="theme-cta" href="#">
+              Learn more
+            </a>
+          )}
+        </section>
+      ))}
+      <form class="theme-section" aria-label="Sample contact form">
+        <h2>Contact</h2>
+        <label>
+          Email
+          <input type="email" name="email" autocomplete="email" />
+        </label>
+        <button type="submit" class="theme-cta">
+          Send
+        </button>
+      </form>
+    </PublicThemeLayout>
+  ) : (
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex, nofollow" />
+        <title>Preview not found</title>
+      </head>
+      <body>
+        <main role="main">
+          <h1>Preview not found or expired</h1>
+          <p>
+            This preview link is invalid or has expired. Generate a new preview
+            from the theme admin.
+          </p>
+        </main>
+      </body>
+    </html>
+  )
+}

--- a/tests/integration/theming.integration.test.ts
+++ b/tests/integration/theming.integration.test.ts
@@ -1,0 +1,402 @@
+/**
+ * Integration tests for the `theming` module (ADR-0034 Fase 3; ported/adapted
+ * from awcms-micro Issue #269/ADR-0029) against a real PostgreSQL under the
+ * WORLD-1 ephemeral-database harness. Proves, with real DDL/RLS/FKs/triggers
+ * (not mocks):
+ *
+ *   - the draft -> publish -> rollback -> retire lifecycle + per-tenant version
+ *     numbering, driven through the module's own application services;
+ *   - PUBLISHED VERSION IMMUTABILITY — the sql/033 BEFORE UPDATE/DELETE trigger
+ *     RAISES on any mutation of a `status='published'` row;
+ *   - FORCE ROW LEVEL SECURITY tenant isolation on the config-version + state
+ *     tables, proven under the non-superuser `awcms_app` role;
+ *   - preview-session create + hashed lookup + `expires_at` expiry filtering;
+ *   - CSS-injection REJECTION at the domain boundary (the security spine) and
+ *     the render-path defense-in-depth fallback.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  appRoleActivated,
+  assertRejected,
+  getAdminSql,
+  getAppRoleSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import {
+  fetchThemeTenantState,
+  insertPublishedVersion,
+  listPublishedVersions,
+  nextPublishedVersionNumber,
+  upsertDraftVersion
+} from "../../src/modules/theming/application/theme-config-directory";
+import {
+  hashThemeConfig,
+  publishThemeDraft,
+  retireActiveTheme,
+  rollbackThemeVersion,
+  saveThemeDraft
+} from "../../src/modules/theming/application/theme-service";
+import {
+  createPreviewSession,
+  findActivePreviewSession
+} from "../../src/modules/theming/application/theme-preview-directory";
+import { resolveVersionThemeCss } from "../../src/modules/theming/application/theme-render-resolver";
+import {
+  resolveThemeTokens,
+  serializeThemeTokensCss,
+  validateThemeConfig,
+  type ThemeConfig
+} from "../../src/modules/theming/domain/theme-config";
+import { CssValueError } from "../../src/modules/theming/domain/css-value-validation";
+import { hashPreviewToken } from "../../src/modules/theming/domain/preview-token";
+import { defaultTheme } from "../../src/modules/theming/themes/default-theme";
+
+const TENANT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const ACTOR = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+/** A validated, normalized config for the base `aria` theme with one override. */
+function validConfig(primary = "#123456"): ThemeConfig {
+  const result = validateThemeConfig(defaultTheme, {
+    themeKey: "aria",
+    tokenOverrides: { color_primary: primary, font_body: "serif" },
+    slotSelections: { header: "split" },
+    sectionOrder: ["cta", "hero"],
+    navPlacement: "side"
+  });
+  if (!result.ok) throw new Error("fixture config should validate");
+  return result.value;
+}
+
+/** A no-op audit hook — the service records via an INJECTED hook; the route wires
+ * the real `recordAuditEvent`. These tests assert STATE, not the audit rows. */
+const noAudit = async (): Promise<void> => {};
+
+async function seedTenants(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT_A}, 'tenant-a', 'Tenant A'), (${TENANT_B}, 'tenant-b', 'Tenant B')
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("theming module (integration)", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  test("draft save + publish assigns version 1; a second publish is version 2; active pointer follows", async () => {
+    const runtime = getRuntimeSql();
+
+    // Save a draft, then publish it (version 1).
+    await withTenant(runtime, TENANT_A, (tx) =>
+      saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
+    );
+    const pub1 = await withTenant(runtime, TENANT_A, (tx) =>
+      publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
+    );
+    expect(pub1.ok).toBe(true);
+    if (!pub1.ok) return;
+    expect(pub1.version.versionNumber).toBe(1);
+
+    // A fresh draft + publish → version 2.
+    await withTenant(runtime, TENANT_A, (tx) =>
+      saveThemeDraft(
+        tx,
+        TENANT_A,
+        ACTOR,
+        defaultTheme,
+        validConfig("#abcdef"),
+        noAudit
+      )
+    );
+    const pub2 = await withTenant(runtime, TENANT_A, (tx) =>
+      publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
+    );
+    expect(pub2.ok).toBe(true);
+    if (!pub2.ok) return;
+    expect(pub2.version.versionNumber).toBe(2);
+
+    // The active pointer is the latest published version.
+    const state = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchThemeTenantState(tx, TENANT_A)
+    );
+    expect(state.activeThemeKey).toBe("aria");
+    expect(state.activeVersionId).toBe(pub2.version.id);
+
+    // rollback to v1, then retire.
+    const roll = await withTenant(runtime, TENANT_A, (tx) =>
+      rollbackThemeVersion(tx, TENANT_A, ACTOR, pub1.version.id, noAudit)
+    );
+    expect(roll.ok).toBe(true);
+    if (!roll.ok) return;
+    expect(roll.version.id).toBe(pub1.version.id);
+
+    const rolledState = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchThemeTenantState(tx, TENANT_A)
+    );
+    expect(rolledState.activeVersionId).toBe(pub1.version.id);
+
+    const retire = await withTenant(runtime, TENANT_A, (tx) =>
+      retireActiveTheme(tx, TENANT_A, ACTOR, noAudit)
+    );
+    expect(retire.previousThemeKey).toBe("aria");
+    const retiredState = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchThemeTenantState(tx, TENANT_A)
+    );
+    expect(retiredState.activeVersionId).toBeNull();
+  });
+
+  test("rollback to a foreign/nonexistent version id is refused (INVALID_TARGET)", async () => {
+    const runtime = getRuntimeSql();
+    await withTenant(runtime, TENANT_A, (tx) =>
+      saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
+    );
+    await withTenant(runtime, TENANT_A, (tx) =>
+      publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
+    );
+    const bad = await withTenant(runtime, TENANT_A, (tx) =>
+      rollbackThemeVersion(
+        tx,
+        TENANT_A,
+        ACTOR,
+        "99999999-9999-4999-8999-999999999999",
+        noAudit
+      )
+    );
+    expect(bad.ok).toBe(false);
+  });
+
+  test("a PUBLISHED version row is IMMUTABLE — UPDATE and DELETE both raise (sql/033 trigger)", async () => {
+    const runtime = getRuntimeSql();
+    const versionNumber = await withTenant(runtime, TENANT_A, (tx) =>
+      nextPublishedVersionNumber(tx, TENANT_A)
+    );
+    const published = await withTenant(runtime, TENANT_A, (tx) =>
+      insertPublishedVersion(
+        tx,
+        TENANT_A,
+        ACTOR,
+        "aria",
+        "1.0.0",
+        validConfig(),
+        "hash-x",
+        versionNumber
+      )
+    );
+
+    await assertRejected(
+      withTenant(
+        runtime,
+        TENANT_A,
+        (tx) =>
+          tx`UPDATE awcms_theming_config_versions SET config_hash = 'tampered' WHERE id = ${published.id}`
+      ),
+      "UPDATE of a published version row"
+    );
+    await assertRejected(
+      withTenant(
+        runtime,
+        TENANT_A,
+        (tx) =>
+          tx`DELETE FROM awcms_theming_config_versions WHERE id = ${published.id}`
+      ),
+      "DELETE of a published version row"
+    );
+
+    // The row is untouched.
+    const rows = (await getAdminSql()`
+      SELECT config_hash FROM awcms_theming_config_versions WHERE id = ${published.id}
+    `) as { config_hash: string }[];
+    expect(rows[0]?.config_hash).toBe("hash-x");
+  });
+
+  test("FORCE RLS isolates the config-version + state tables across tenants under non-superuser awcms_app", async () => {
+    if (!appRoleActivated) {
+      // Migration 019 absent — the isolation claim is only meaningful under a
+      // genuine non-owner role. Skip loudly rather than assert a false pass.
+      return;
+    }
+    const app = getAppRoleSql();
+
+    // Tenant A publishes a version (writes config_version + state rows).
+    await withTenant(app, TENANT_A, (tx) =>
+      saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
+    );
+    await withTenant(app, TENANT_A, (tx) =>
+      publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
+    );
+
+    // A really did write its own rows.
+    const aVersions = (await withTenant(
+      app,
+      TENANT_A,
+      (tx) => tx`SELECT count(*)::int AS c FROM awcms_theming_config_versions`
+    )) as { c: number }[];
+    expect(aVersions[0]!.c).toBeGreaterThan(0);
+
+    // Under B's tenant context, A's version + state rows are simply not visible.
+    const bVersions = (await withTenant(
+      app,
+      TENANT_B,
+      (tx) => tx`SELECT count(*)::int AS c FROM awcms_theming_config_versions`
+    )) as { c: number }[];
+    expect(bVersions[0]!.c).toBe(0);
+    const bState = (await withTenant(
+      app,
+      TENANT_B,
+      (tx) => tx`SELECT count(*)::int AS c FROM awcms_theming_tenant_state`
+    )) as { c: number }[];
+    expect(bState[0]!.c).toBe(0);
+  });
+
+  test("preview session resolves by hashed token, and an expired session does not", async () => {
+    const runtime = getRuntimeSql();
+    const now = new Date();
+
+    // A draft version to attach the preview to.
+    const draft = await withTenant(runtime, TENANT_A, (tx) =>
+      upsertDraftVersion(
+        tx,
+        TENANT_A,
+        ACTOR,
+        "aria",
+        "1.0.0",
+        validConfig(),
+        hashThemeConfig("aria", validConfig())
+      )
+    );
+
+    // A live session resolves; an expired one is filtered out by `expires_at`.
+    const liveRaw = "1".repeat(64);
+    const expiredRaw = "2".repeat(64);
+    await withTenant(runtime, TENANT_A, async (tx) => {
+      await createPreviewSession(
+        tx,
+        TENANT_A,
+        ACTOR,
+        draft.id,
+        hashPreviewToken(liveRaw),
+        new Date(now.getTime() + 30 * 60_000)
+      );
+      await createPreviewSession(
+        tx,
+        TENANT_A,
+        ACTOR,
+        draft.id,
+        hashPreviewToken(expiredRaw),
+        new Date(now.getTime() - 60 * 60_000)
+      );
+    });
+
+    const live = await withTenant(runtime, TENANT_A, (tx) =>
+      findActivePreviewSession(tx, hashPreviewToken(liveRaw), now)
+    );
+    expect(live?.versionId).toBe(draft.id);
+
+    const expired = await withTenant(runtime, TENANT_A, (tx) =>
+      findActivePreviewSession(tx, hashPreviewToken(expiredRaw), now)
+    );
+    expect(expired).toBeNull();
+
+    // A preview session created for A is invisible under B's tenant context.
+    const crossTenant = await withTenant(runtime, TENANT_B, (tx) =>
+      findActivePreviewSession(tx, hashPreviewToken(liveRaw), now)
+    );
+    expect(crossTenant).toBeNull();
+  });
+
+  test("published version history lists newest-first and only published rows", async () => {
+    const runtime = getRuntimeSql();
+    await withTenant(runtime, TENANT_A, (tx) =>
+      saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
+    );
+    await withTenant(runtime, TENANT_A, (tx) =>
+      publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
+    );
+    await withTenant(runtime, TENANT_A, (tx) =>
+      saveThemeDraft(
+        tx,
+        TENANT_A,
+        ACTOR,
+        defaultTheme,
+        validConfig("#abcdef"),
+        noAudit
+      )
+    );
+    await withTenant(runtime, TENANT_A, (tx) =>
+      publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
+    );
+    const history = await withTenant(runtime, TENANT_A, (tx) =>
+      listPublishedVersions(tx, TENANT_A, 50)
+    );
+    expect(history.map((v) => v.versionNumber)).toEqual([2, 1]);
+    expect(history.every((v) => v.status === "published")).toBe(true);
+  });
+
+  test("CSS-injection is rejected at the domain boundary + the render path degrades safely", () => {
+    // The spine rejects (never sanitizes) an unsafe token value.
+    const bad = validateThemeConfig(defaultTheme, {
+      themeKey: "aria",
+      tokenOverrides: { color_primary: "url(javascript:alert(1))" }
+    });
+    expect(bad.ok).toBe(false);
+
+    // Defense in depth: a hostile config that bypassed validation still throws
+    // at serialize time, so unvalidated CSS can never be emitted.
+    const hostile: ThemeConfig = {
+      themeKey: "aria",
+      tokenOverrides: { color_primary: "red;}body{display:none" },
+      slotSelections: {},
+      assetRefs: {},
+      sectionOrder: [],
+      navPlacement: "top"
+    };
+    expect(() => resolveThemeTokens(defaultTheme, hostile)).toThrow(
+      CssValueError
+    );
+    expect(() => serializeThemeTokensCss(defaultTheme, hostile)).toThrow(
+      CssValueError
+    );
+
+    // And the render resolver falls back to the safe default rather than
+    // emitting a hostile config's CSS or throwing in a public stylesheet.
+    const resolved = resolveVersionThemeCss({
+      id: "v1",
+      themeKey: "aria",
+      themeVersion: "1.0.0",
+      status: "published",
+      versionNumber: 1,
+      config: hostile,
+      configHash: "h",
+      createdAt: new Date(),
+      publishedAt: new Date()
+    });
+    expect(resolved.css).toContain(":root");
+    expect(resolved.css).not.toContain("display:none");
+  });
+});

--- a/tests/openapi-bundle.test.ts
+++ b/tests/openapi-bundle.test.ts
@@ -272,9 +272,11 @@ describe("openapi bundle — contract equivalence to pre-migration monolith", ()
       )
     );
     for (const name of beforeTags) expect(afterTags.has(name)).toBe(true);
-    // The only documented addition: the previously-undeclared operation tag.
-    const added = [...afterTags].filter((n) => !beforeTags.has(n));
-    expect(added).toEqual(["Domain Event Runtime"]);
+    // The documented additive tags beyond the pre-migration monolith:
+    // "Domain Event Runtime" (a previously-undeclared operation tag) and
+    // "Theming" (ADR-0034 Fase 3 — the first website module in the base).
+    const added = [...afterTags].filter((n) => !beforeTags.has(n)).sort();
+    expect(added).toEqual(["Domain Event Runtime", "Theming"]);
   });
 });
 

--- a/tests/theme-config.test.ts
+++ b/tests/theme-config.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for tenant theme config validation + safe serialization (Issue
+ * #269, ADR-0029 §4/§5). Proves the descriptor bounds the whole configurable
+ * surface (unknown tokens/slots/assets/sections rejected) and that only safe
+ * values ever reach the emitted CSS.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  THEME_CSS_CUSTOM_PROPERTY_PREFIX,
+  defaultThemeConfig,
+  resolveThemeTokens,
+  serializeThemeTokensCss,
+  validateThemeConfig,
+  type ThemeConfig
+} from "../src/modules/theming/domain/theme-config";
+import { CssValueError } from "../src/modules/theming/domain/css-value-validation";
+import { defaultTheme } from "../src/modules/theming/themes/default-theme";
+
+const UUID = "11111111-1111-1111-1111-111111111111";
+
+describe("validateThemeConfig", () => {
+  test("accepts a valid config and normalizes it", () => {
+    const result = validateThemeConfig(defaultTheme, {
+      themeKey: "aria",
+      tokenOverrides: {
+        color_primary: "#123456",
+        font_body: "serif",
+        line_height_base: "1.6"
+      },
+      slotSelections: { header: "split" },
+      assetRefs: { logo: UUID },
+      sectionOrder: ["cta", "hero"],
+      navPlacement: "side"
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.tokenOverrides.color_primary).toBe("#123456");
+    expect(result.value.slotSelections.header).toBe("split");
+    // Unset slots fall back to their defaults.
+    expect(result.value.slotSelections.footer).toBe("simple");
+    expect(result.value.assetRefs.logo).toBe(UUID);
+    // Omitted sections are appended in declared order.
+    expect(result.value.sectionOrder.slice(0, 2)).toEqual(["cta", "hero"]);
+    expect(result.value.sectionOrder).toContain("about");
+    expect(result.value.navPlacement).toBe("side");
+  });
+
+  test("rejects an unknown token key (declared-surface bounding)", () => {
+    const result = validateThemeConfig(defaultTheme, {
+      themeKey: "aria",
+      tokenOverrides: { not_a_token: "#fff" }
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(
+      result.errors.some((e) => e.field === "tokenOverrides.not_a_token")
+    ).toBe(true);
+  });
+
+  test("rejects a CSS-injection token value (the spine)", () => {
+    const result = validateThemeConfig(defaultTheme, {
+      themeKey: "aria",
+      tokenOverrides: { color_primary: "url(javascript:alert(1))" }
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(
+      result.errors.some((e) => e.field === "tokenOverrides.color_primary")
+    ).toBe(true);
+  });
+
+  test("rejects a font family outside the allow-list, accepts an allow-list key", () => {
+    const bad = validateThemeConfig(defaultTheme, {
+      themeKey: "aria",
+      tokenOverrides: { font_body: "Comic Sans" }
+    });
+    expect(bad.ok).toBe(false);
+    const good = validateThemeConfig(defaultTheme, {
+      themeKey: "aria",
+      tokenOverrides: { font_body: "mono" }
+    });
+    expect(good.ok).toBe(true);
+  });
+
+  test("rejects an unknown slot variant, unknown asset slot, non-UUID asset, unknown section, bad nav", () => {
+    expect(
+      validateThemeConfig(defaultTheme, {
+        themeKey: "aria",
+        slotSelections: { header: "nope" }
+      }).ok
+    ).toBe(false);
+    expect(
+      validateThemeConfig(defaultTheme, {
+        themeKey: "aria",
+        assetRefs: { not_a_slot: UUID }
+      }).ok
+    ).toBe(false);
+    expect(
+      validateThemeConfig(defaultTheme, {
+        themeKey: "aria",
+        assetRefs: { logo: "https://evil/x.png" }
+      }).ok
+    ).toBe(false);
+    expect(
+      validateThemeConfig(defaultTheme, {
+        themeKey: "aria",
+        sectionOrder: ["nope"]
+      }).ok
+    ).toBe(false);
+    expect(
+      validateThemeConfig(defaultTheme, {
+        themeKey: "aria",
+        navPlacement: "diagonal"
+      }).ok
+    ).toBe(false);
+  });
+});
+
+describe("serializeThemeTokensCss / resolveThemeTokens", () => {
+  test("emits a :root block of --awcms-theme-* custom properties with the default values", () => {
+    const css = serializeThemeTokensCss(
+      defaultTheme,
+      defaultThemeConfig(defaultTheme)
+    );
+    expect(css).toContain(":root {");
+    expect(css).toContain(
+      `${THEME_CSS_CUSTOM_PROPERTY_PREFIX}color_primary: #2563eb;`
+    );
+    // font_family tokens emit the descriptor-owned CSS STACK, never the tenant key.
+    expect(css).toContain("system-ui");
+    expect(css).not.toContain("font_body: system;");
+  });
+
+  test("a valid override flows through to the emitted CSS", () => {
+    const result = validateThemeConfig(defaultTheme, {
+      themeKey: "aria",
+      tokenOverrides: { color_primary: "#abcdef" }
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    const css = serializeThemeTokensCss(defaultTheme, result.value);
+    expect(css).toContain("color_primary: #abcdef;");
+  });
+
+  test("resolveThemeTokens RE-VALIDATES: a config smuggling an unsafe value throws at serialize time (defense in depth)", () => {
+    // Bypass validateThemeConfig and hand a hostile config straight to the serializer.
+    const hostile: ThemeConfig = {
+      themeKey: "aria",
+      tokenOverrides: { color_primary: "red;}body{display:none" },
+      slotSelections: {},
+      assetRefs: {},
+      sectionOrder: [],
+      navPlacement: "top"
+    };
+    expect(() => resolveThemeTokens(defaultTheme, hostile)).toThrow(
+      CssValueError
+    );
+    expect(() => serializeThemeTokensCss(defaultTheme, hostile)).toThrow(
+      CssValueError
+    );
+  });
+});

--- a/tests/theme-css-value-validation.test.ts
+++ b/tests/theme-css-value-validation.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Unit tests for the CSS design-token VALUE validation spine (Issue #269,
+ * ADR-0029 §5). This is the primary security control for "CSS injection" and
+ * "unsafe URL / exfiltration" — it must REJECT (never sanitize) every value that
+ * is not exactly one of the strict, bounded shapes.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  CssValueError,
+  DIMENSION_UNIT_ALLOW_LIST,
+  MAX_CSS_TOKEN_VALUE_LENGTH,
+  MAX_FONT_STACK_LENGTH,
+  assertSafeCssPrimitive,
+  validateColorValue,
+  validateDimensionValue,
+  validateFontStack,
+  validateNumberValue
+} from "../src/modules/theming/domain/css-value-validation";
+
+describe("assertSafeCssPrimitive — the universal guard", () => {
+  const INJECTION_VECTORS = [
+    "red; background: url(javascript:alert(1))",
+    "url(javascript:alert(1))",
+    "url('data:text/html,<script>')",
+    "expression(alert(1))",
+    "@import 'evil.css'",
+    "#fff}/**/body{display:none",
+    "1px;} * { color: red",
+    "<script>alert(1)</script>",
+    "'; DROP TABLE x; --",
+    "javascript:alert(1)",
+    "\\65 xpression(1)",
+    "rgb(0,0,0) /* comment */"
+  ];
+
+  test.each(INJECTION_VECTORS)("rejects injection vector %p", (vector) => {
+    expect(() => assertSafeCssPrimitive(vector)).toThrow(CssValueError);
+  });
+
+  test("rejects a value with a control character (checked by char code, no literal here)", () => {
+    expect(() =>
+      assertSafeCssPrimitive(`red${String.fromCharCode(10)}x`)
+    ).toThrow(CssValueError);
+    expect(() =>
+      assertSafeCssPrimitive(`red${String.fromCharCode(0)}`)
+    ).toThrow(CssValueError);
+    expect(() =>
+      assertSafeCssPrimitive(`red${String.fromCharCode(127)}`)
+    ).toThrow(CssValueError);
+  });
+
+  test("rejects an over-long value", () => {
+    expect(() =>
+      assertSafeCssPrimitive("1".repeat(MAX_CSS_TOKEN_VALUE_LENGTH + 1))
+    ).toThrow(CssValueError);
+  });
+
+  test("rejects unbalanced parentheses", () => {
+    expect(() => assertSafeCssPrimitive("rgb(0,0,0")).toThrow(CssValueError);
+    expect(() => assertSafeCssPrimitive("0,0,0)")).toThrow(CssValueError);
+  });
+
+  test("rejects the empty string / non-string", () => {
+    expect(() => assertSafeCssPrimitive("")).toThrow(CssValueError);
+    // @ts-expect-error deliberately wrong type
+    expect(() => assertSafeCssPrimitive(null)).toThrow(CssValueError);
+  });
+
+  test("accepts a plain safe primitive", () => {
+    expect(() => assertSafeCssPrimitive("#2563eb")).not.toThrow();
+    expect(() => assertSafeCssPrimitive("1.5rem")).not.toThrow();
+  });
+});
+
+describe("validateColorValue", () => {
+  test.each([
+    "#fff",
+    "#ffff",
+    "#2563eb",
+    "#2563ebff",
+    "rgb(0,0,0)",
+    "rgba(0, 0, 0, 0.5)",
+    "hsl(210, 50%, 50%)",
+    "hsla(210 50% 50% / 0.5)",
+    "transparent",
+    "currentcolor"
+  ])("accepts %p", (value) => {
+    expect(validateColorValue(value)).toBe(value);
+  });
+
+  test.each([
+    "#gggggg",
+    "#12",
+    "rgb(var(--x))",
+    "rgb(0,0,0);",
+    "url(#x)",
+    "expression(1)",
+    "blue url(x)",
+    "#fff!important"
+  ])("rejects %p", (value) => {
+    expect(() => validateColorValue(value)).toThrow(CssValueError);
+  });
+});
+
+describe("validateDimensionValue", () => {
+  const constraint = { units: DIMENSION_UNIT_ALLOW_LIST, min: 0, max: 100 };
+
+  test.each(["0", "1rem", "0.5rem", "16px", "50%", "10vh", "2ch"])(
+    "accepts %p",
+    (value) => {
+      expect(validateDimensionValue(value, constraint)).toBe(value);
+    }
+  );
+
+  test("rejects an out-of-range magnitude", () => {
+    expect(() => validateDimensionValue("200px", constraint)).toThrow(
+      CssValueError
+    );
+    expect(() => validateDimensionValue("-5px", constraint)).toThrow(
+      CssValueError
+    );
+  });
+
+  test("rejects a disallowed unit", () => {
+    expect(() => validateDimensionValue("1pt", constraint)).toThrow(
+      CssValueError
+    );
+  });
+
+  test("rejects calc()/var()/expressions", () => {
+    expect(() =>
+      validateDimensionValue("calc(100% - 1rem)", constraint)
+    ).toThrow(CssValueError);
+    expect(() => validateDimensionValue("var(--x)", constraint)).toThrow(
+      CssValueError
+    );
+  });
+});
+
+describe("validateNumberValue", () => {
+  test("accepts a bounded number", () => {
+    expect(validateNumberValue("1.5", { min: 1, max: 2 })).toBe("1.5");
+  });
+
+  test("rejects out of range / non-numeric / non-integer when integer required", () => {
+    expect(() => validateNumberValue("3", { min: 1, max: 2 })).toThrow(
+      CssValueError
+    );
+    expect(() => validateNumberValue("abc", { min: 0, max: 10 })).toThrow(
+      CssValueError
+    );
+    expect(() =>
+      validateNumberValue("1.5", { min: 0, max: 10, integer: true })
+    ).toThrow(CssValueError);
+  });
+});
+
+describe("validateFontStack — descriptor-owned font-family stacks", () => {
+  test.each([
+    "sans-serif",
+    "system-ui, sans-serif",
+    '"Segoe UI", system-ui, sans-serif',
+    "'Helvetica Neue', Arial, sans-serif",
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif'
+  ])("accepts the safe stack %p unchanged", (stack) => {
+    expect(validateFontStack(stack)).toBe(stack);
+  });
+
+  test.each([
+    "sans-serif; background: url(javascript:alert(1))", // declaration breakout
+    '"Segoe UI"} body { display: none', // rule breakout
+    "url('data:text/html,<script>')", // url() + angle brackets
+    "@import 'evil.css'", // at-rule
+    "expression(alert(1))", // legacy expression
+    "Segoe/**/UI", // comment
+    "family: value", // colon
+    "100%", // percent
+    "a#b" // hash
+  ])("rejects the injection-shaped stack %p", (stack) => {
+    expect(() => validateFontStack(stack)).toThrow(CssValueError);
+  });
+
+  test("rejects a control character (checked by char code)", () => {
+    expect(() => validateFontStack(`Arial${String.fromCharCode(10)}`)).toThrow(
+      CssValueError
+    );
+    expect(() => validateFontStack(`Arial${String.fromCharCode(127)}`)).toThrow(
+      CssValueError
+    );
+  });
+
+  test("rejects unbalanced quotes (an unclosed family name)", () => {
+    expect(() => validateFontStack('"Segoe UI, sans-serif')).toThrow(
+      CssValueError
+    );
+    expect(() => validateFontStack("'Helvetica, sans-serif")).toThrow(
+      CssValueError
+    );
+  });
+
+  test("rejects the empty string / non-string / an over-long stack", () => {
+    expect(() => validateFontStack("")).toThrow(CssValueError);
+    // @ts-expect-error deliberately wrong type
+    expect(() => validateFontStack(null)).toThrow(CssValueError);
+    expect(() =>
+      validateFontStack("a".repeat(MAX_FONT_STACK_LENGTH + 1))
+    ).toThrow(CssValueError);
+  });
+});

--- a/tests/theme-lifecycle-preview.test.ts
+++ b/tests/theme-lifecycle-preview.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Unit tests for the theme lifecycle state machine + preview token helpers
+ * (Issue #269, ADR-0029 §4/§6).
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  canActivateVersion,
+  canPublishFromStatus,
+  isValidRollbackTarget,
+  isVersionMutable
+} from "../src/modules/theming/domain/theme-lifecycle";
+import {
+  PREVIEW_SESSION_MAX_TTL_MINUTES,
+  PREVIEW_SESSION_TTL_MINUTES,
+  buildPreviewUrlToken,
+  generatePreviewToken,
+  hashPreviewToken,
+  isPreviewSessionActive,
+  isWellFormedPreviewToken,
+  parsePreviewUrlToken,
+  resolvePreviewTtlMinutes
+} from "../src/modules/theming/domain/preview-token";
+
+const TENANT = "22222222-2222-2222-2222-222222222222";
+
+describe("lifecycle", () => {
+  test("only published versions may become the active pointer", () => {
+    expect(canActivateVersion("published")).toBe(true);
+    expect(canActivateVersion("draft")).toBe(false);
+  });
+
+  test("only a draft may be published, only a draft is mutable", () => {
+    expect(canPublishFromStatus("draft")).toBe(true);
+    expect(canPublishFromStatus("published")).toBe(false);
+    expect(isVersionMutable("draft")).toBe(true);
+    expect(isVersionMutable("published")).toBe(false);
+  });
+
+  test("rollback target must be one of the tenant's own published versions", () => {
+    expect(isValidRollbackTarget("v1", ["v1", "v2"])).toBe(true);
+    expect(isValidRollbackTarget("v9", ["v1", "v2"])).toBe(false);
+  });
+});
+
+describe("preview token", () => {
+  test("generates unique 64-hex tokens", () => {
+    const a = generatePreviewToken();
+    const b = generatePreviewToken();
+    expect(isWellFormedPreviewToken(a)).toBe(true);
+    expect(a).not.toBe(b);
+    expect(isWellFormedPreviewToken("nope")).toBe(false);
+  });
+
+  test("hash is deterministic 64-hex and differs per token", () => {
+    const raw = generatePreviewToken();
+    expect(hashPreviewToken(raw)).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashPreviewToken(raw)).toBe(hashPreviewToken(raw));
+    expect(hashPreviewToken(raw)).not.toBe(
+      hashPreviewToken(generatePreviewToken())
+    );
+  });
+
+  test("TTL resolution defaults and caps", () => {
+    expect(resolvePreviewTtlMinutes(undefined)).toBe(
+      PREVIEW_SESSION_TTL_MINUTES
+    );
+    expect(resolvePreviewTtlMinutes(0)).toBe(PREVIEW_SESSION_TTL_MINUTES);
+    expect(resolvePreviewTtlMinutes(10)).toBe(10);
+    expect(resolvePreviewTtlMinutes(9999)).toBe(
+      PREVIEW_SESSION_MAX_TTL_MINUTES
+    );
+  });
+
+  test("session active only until expiry", () => {
+    const now = new Date("2026-01-01T00:00:00Z");
+    expect(isPreviewSessionActive(new Date("2026-01-01T00:30:00Z"), now)).toBe(
+      true
+    );
+    expect(isPreviewSessionActive(new Date("2025-12-31T23:59:00Z"), now)).toBe(
+      false
+    );
+  });
+
+  test("URL token round-trips tenant id + raw token, and rejects malformed", () => {
+    const raw = generatePreviewToken();
+    const urlToken = buildPreviewUrlToken(TENANT, raw);
+    const parsed = parsePreviewUrlToken(urlToken);
+    expect(parsed).toEqual({ tenantId: TENANT, rawToken: raw });
+    expect(parsePreviewUrlToken("no-separator")).toBeNull();
+    expect(parsePreviewUrlToken(`not-a-uuid~${raw}`)).toBeNull();
+    expect(parsePreviewUrlToken(`${TENANT}~short`)).toBeNull();
+  });
+});

--- a/tests/theme-preview-render.test.ts
+++ b/tests/theme-preview-render.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Unit tests for the preview view-model builder + the render resolver's safe
+ * fallbacks (Issue #269, ADR-0029 §6/§7).
+ */
+import { describe, expect, test } from "bun:test";
+
+import { buildPreviewViewModel } from "../src/modules/theming/application/theme-preview-render";
+import {
+  defaultThemeCss,
+  resolveVersionThemeCss
+} from "../src/modules/theming/application/theme-render-resolver";
+import type { ThemeConfigVersion } from "../src/modules/theming/application/theme-config-directory";
+import { defaultThemeConfig } from "../src/modules/theming/domain/theme-config";
+import { defaultTheme } from "../src/modules/theming/themes/default-theme";
+
+describe("buildPreviewViewModel", () => {
+  test("respects the section order and slot selections, maps the logo asset", () => {
+    const config = {
+      ...defaultThemeConfig(defaultTheme),
+      sectionOrder: ["cta", "hero"],
+      slotSelections: {
+        header: "split",
+        footer: "columns",
+        nav_style: "hamburger"
+      },
+      navPlacement: "side"
+    };
+    const model = buildPreviewViewModel(defaultTheme, config, {
+      logo: { url: "https://media.example/logo.png", altText: "Logo" }
+    });
+    expect(model.themeKey).toBe("aria");
+    expect(model.sections.map((s) => s.key).slice(0, 2)).toEqual([
+      "cta",
+      "hero"
+    ]);
+    expect(model.headerVariant).toBe("split");
+    expect(model.footerVariant).toBe("columns");
+    expect(model.navPlacement).toBe("side");
+    expect(model.logo?.url).toBe("https://media.example/logo.png");
+    expect(model.navItems.length).toBeGreaterThan(0);
+  });
+
+  test("falls back to slot defaults and null logo when unset", () => {
+    const model = buildPreviewViewModel(
+      defaultTheme,
+      defaultThemeConfig(defaultTheme),
+      {}
+    );
+    expect(model.headerVariant).toBe("centered");
+    expect(model.logo).toBeNull();
+  });
+});
+
+describe("resolveVersionThemeCss", () => {
+  const version = (themeKey: string): ThemeConfigVersion => ({
+    id: "v1",
+    themeKey,
+    themeVersion: "1.0.0",
+    status: "published",
+    versionNumber: 1,
+    config: defaultThemeConfig(defaultTheme),
+    configHash: "hash1",
+    createdAt: new Date(),
+    publishedAt: new Date()
+  });
+
+  test("serializes a known theme's version to CSS", () => {
+    const resolved = resolveVersionThemeCss(version("aria"));
+    expect(resolved.themeKey).toBe("aria");
+    expect(resolved.css).toContain("--awcms-theme-color_primary: #2563eb;");
+    expect(resolved.fingerprint).toBe("v1:hash1");
+  });
+
+  test("falls back to the default theme CSS when the version's theme is no longer registered", () => {
+    const resolved = resolveVersionThemeCss(version("removed_derived_theme"));
+    expect(resolved.themeKey).toBe(defaultThemeCss().themeKey);
+    expect(resolved.css).toContain(":root");
+  });
+});

--- a/tests/theme-registry.test.ts
+++ b/tests/theme-registry.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for theme descriptor validation + the build-time registry
+ * composition (ADR-0034 Fase 3; ported from awcms-micro Issue #269/ADR-0029 §3).
+ * Proves: a theme cannot weaken CSP or drop a11y; every theme composes through
+ * the SAME validation gate; a theme cannot shadow another theme's key; and every
+ * default theme token value is itself safe.
+ *
+ * PORT ADAPTATION: awcms removed the derived-application pathway (ADR-0034 Fase
+ * 2), so there is no `application-theme-registry.ts` seam and no
+ * `tests/fixtures/derived-theme-example`. `composeThemeDescriptors` now takes an
+ * optional `extraThemes` array; the "a second theme composes through the same
+ * gate / may not shadow a base key" coverage is exercised with an inline
+ * synthetic theme instead of a fixture file.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  InvalidThemeDescriptorError,
+  assertValidThemeDescriptor,
+  type ThemeDescriptor
+} from "../src/modules/theming/domain/theme-descriptor";
+import {
+  BASE_THEME_DESCRIPTORS,
+  composeThemeDescriptors,
+  getThemeDescriptor,
+  listThemeDescriptors
+} from "../src/modules/theming/theme-registry";
+import { defaultTheme } from "../src/modules/theming/themes/default-theme";
+import {
+  defaultThemeConfig,
+  resolveThemeTokens
+} from "../src/modules/theming/domain/theme-config";
+
+describe("assertValidThemeDescriptor", () => {
+  test("the base default theme is valid", () => {
+    expect(() => assertValidThemeDescriptor(defaultTheme)).not.toThrow();
+  });
+
+  test("rejects a theme that requires an inline script (CSP weakening)", () => {
+    const bad: ThemeDescriptor = {
+      ...defaultTheme,
+      csp: { ...defaultTheme.csp, requiresInlineScript: true }
+    };
+    expect(() => assertValidThemeDescriptor(bad)).toThrow(
+      InvalidThemeDescriptorError
+    );
+  });
+
+  test("rejects a theme that requires inline style", () => {
+    const bad: ThemeDescriptor = {
+      ...defaultTheme,
+      csp: { ...defaultTheme.csp, requiresInlineStyle: true }
+    };
+    expect(() => assertValidThemeDescriptor(bad)).toThrow(
+      InvalidThemeDescriptorError
+    );
+  });
+
+  test("rejects a theme declaring an external script source outside the allow-list", () => {
+    const bad: ThemeDescriptor = {
+      ...defaultTheme,
+      csp: {
+        ...defaultTheme.csp,
+        externalScriptSources: ["https://evil.example"]
+      }
+    };
+    expect(() => assertValidThemeDescriptor(bad)).toThrow(
+      InvalidThemeDescriptorError
+    );
+  });
+
+  test("rejects a theme below WCAG AA contrast or not keyboard-navigable", () => {
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        accessibility: { ...defaultTheme.accessibility, minContrastRatio: 3 }
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        accessibility: {
+          ...defaultTheme.accessibility,
+          keyboardNavigable: false
+        }
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+  });
+
+  test("rejects an invalid theme key and a slot default that is not one of its variants", () => {
+    expect(() =>
+      assertValidThemeDescriptor({ ...defaultTheme, themeKey: "Bad Key" })
+    ).toThrow(InvalidThemeDescriptorError);
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        slots: [
+          {
+            key: "header",
+            label: "H",
+            variants: [{ key: "a", label: "A" }],
+            default: "z"
+          }
+        ]
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+  });
+
+  test("rejects a theme requiring a newer module contract than this build ships (R-M3)", () => {
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        compatibility: {
+          ...defaultTheme.compatibility,
+          minModuleContractVersion: "99.0.0"
+        }
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+  });
+
+  test("rejects a theme with a malformed minModuleContractVersion", () => {
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        compatibility: {
+          ...defaultTheme.compatibility,
+          minModuleContractVersion: "not-a-version"
+        }
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+  });
+
+  test("rejects an empty or malformed supportedResourceTypes list", () => {
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        compatibility: {
+          ...defaultTheme.compatibility,
+          supportedResourceTypes: []
+        }
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        compatibility: {
+          ...defaultTheme.compatibility,
+          supportedResourceTypes: ["home", ""]
+        }
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+  });
+
+  test("rejects a theme whose font-family stack is CSS-injection-shaped (R-L4)", () => {
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        fontFamilies: [
+          {
+            key: "system",
+            label: "System",
+            stack: "sans-serif; background: url(javascript:alert(1))"
+          }
+        ]
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+  });
+
+  test("rejects a theme with an unsafe/out-of-range non-font default token value (R-L4)", () => {
+    const colorToken = defaultTheme.tokens.find((t) => t.kind === "color");
+    expect(colorToken).toBeDefined();
+    expect(() =>
+      assertValidThemeDescriptor({
+        ...defaultTheme,
+        tokens: defaultTheme.tokens.map((t) =>
+          t.key === colorToken!.key
+            ? { ...t, default: "red; background: url(x)" }
+            : t
+        )
+      })
+    ).toThrow(InvalidThemeDescriptorError);
+  });
+});
+
+describe("composeThemeDescriptors", () => {
+  test("base-only registry (no extra themes) is exactly the base themes", () => {
+    const composed = composeThemeDescriptors();
+    expect(composed.map((t) => t.themeKey)).toEqual(
+      BASE_THEME_DESCRIPTORS.map((t) => t.themeKey)
+    );
+    expect(composed.some((t) => t.themeKey === "aria")).toBe(true);
+  });
+
+  test("an extra reviewed theme composes through the SAME validation gate", () => {
+    const aurora: ThemeDescriptor = {
+      ...defaultTheme,
+      themeKey: "aurora",
+      name: "Aurora",
+      origin: "base"
+    };
+    const composed = composeThemeDescriptors([aurora]);
+    const keys = composed.map((t) => t.themeKey);
+    expect(keys).toContain("aria"); // base, untouched
+    expect(keys).toContain("aurora"); // the extra, added + validated
+  });
+
+  test("a theme may NOT shadow another theme's key", () => {
+    const shadow: ThemeDescriptor = { ...defaultTheme };
+    expect(() => composeThemeDescriptors([shadow])).toThrow(
+      /Duplicate theme key/
+    );
+  });
+
+  test("an extra theme that would weaken CSP fails the compose gate", () => {
+    const unsafe: ThemeDescriptor = {
+      ...defaultTheme,
+      themeKey: "unsafe",
+      csp: { ...defaultTheme.csp, requiresInlineScript: true }
+    };
+    expect(() => composeThemeDescriptors([unsafe])).toThrow(
+      InvalidThemeDescriptorError
+    );
+  });
+});
+
+describe("effective registry + default token safety", () => {
+  test("listThemeDescriptors + getThemeDescriptor resolve the base default", () => {
+    expect(listThemeDescriptors().length).toBeGreaterThanOrEqual(1);
+    expect(getThemeDescriptor("aria")?.themeKey).toBe("aria");
+    expect(getThemeDescriptor("does_not_exist")).toBeNull();
+  });
+
+  test("every default theme token value passes its own validator (defaults are safe)", () => {
+    // resolveThemeTokens re-validates every value; throwing would mean a default is unsafe.
+    expect(() =>
+      resolveThemeTokens(defaultTheme, defaultThemeConfig(defaultTheme))
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
**Fase 3 ADR-0034 — bukti pertama 'modul website hidup di src/modules base'** (repo derivatif dihapus di Fase 2). Modul `theming` di-port (bukan copy) dari awcms-micro dengan adaptasi penuh; **security spine dipertahankan persis**.

### Isi
- Modul `src/modules/theming/` (config CRUD, versi immutable publish/rollback/retire, preview session, validasi CSS by-rejection), migrasi **033/034** (RLS FORCE + trigger immutability + seed permission), route `/api/v1/theming/*` + Astro publik `/theming/{tenantCode}/tokens.css` (stylesheet EXTERNAL → `style-src 'self'` utuh), OpenAPI fragment per-modul, tests (unit CSS-validation + integration DB).
- Registry base 10→**11**; `AccessAction` +`archive` (high-risk); divergence `no-content-website-modules` **DICABUT** (ADR-0034).

### Adaptasi (dep tak-ada di awcms → drop aman)
- Seam turunan `application-theme-registry.ts` DIHAPUS (pola dihapus Fase 2).
- `media_library` consume → no-op terdokumentasi (asset di-omit). `data_lifecycle` purge → di-drop (preview aman via `expires_at`). `tenant_domain` → resolusi `tenantCode` yang sudah ada (ADR-0009). `dependencies` = `[tenant_admin, identity_access]`.

### Verifikasi
- `bun run check` **exit 0** (1206 pass / 0 fail, build Complete) — diverifikasi independen.
- DB (Postgres 18.4): 34 migrasi apply; theming integration **7 pass** (immutability trigger 23001, FORCE RLS cross-tenant, preview expiry, CSS reject); full integration **87 pass** (0 regresi otorisasi).

### Security spine (tak dilemahkan)
Validasi token by-REJECTION (url/expression/@import/javascript/comment-breakout/`;{}<>` ditolak), published immutable 3-lapis, preview token SHA-256 + short-lived + noindex + no-store, mutasi high-risk ABAC+idempotency+audit, semua tabel FORCE RLS.

Follow-up (terpisah): port modul media (aktifkan resolusi aset), adopsi public-route, domain events theming.

Refs ADR-0034 (Fase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)