### PR TITLE
fix(scripts): repair dead media-type fallback in api-spec-check (CodeQL #140)

### DIFF
--- a/.changeset/codeql-140-media-fallback.md
+++ b/.changeset/codeql-140-media-fallback.md
@@ -1,0 +1,5 @@
+---
+"awcms": patch
+---
+
+Perbaiki logika fallback media type di `scripts/api-spec-check.ts` (CodeQL alert #140, `js/trivial-conditional`). `asRecord()` selalu mengembalikan objek non-null, sehingga operator `??` pada `asRecord(content["application/json"]) ?? Object.values(content)[0]` membuat cabang fallback jadi dead code — response error yang hanya memakai media type non-`application/json` salah dilaporkan tidak beresolusi ke envelope `ApiError`. Nullish-coalescing dipindahkan ke dalam `asRecord` agar fallback ke media type pertama benar-benar berjalan.

--- a/scripts/api-spec-check.ts
+++ b/scripts/api-spec-check.ts
@@ -252,9 +252,10 @@ export function collectStandardErrorSchemaProblems(
       node = componentResponses[name];
     }
     const content = asRecord(asRecord(node).content);
-    const media =
-      asRecord(content["application/json"]) ?? Object.values(content)[0];
-    const schema = asRecord(media).schema;
+    const media = asRecord(
+      content["application/json"] ?? Object.values(content)[0]
+    );
+    const schema = media.schema;
     if (schema === undefined) return false;
     return schemaReachesApiError(schema, new Set());
   }


### PR DESCRIPTION
## Masalah

CodeQL alert [#140](https://github.com/ahliweb/awcms/security/code-scanning/140) (`js/trivial-conditional`) di [scripts/api-spec-check.ts:256](https://github.com/ahliweb/awcms/blob/main/scripts/api-spec-check.ts#L256): *"This call to asRecord always evaluates to true."*

Ini **bug nyata**, bukan false positive. `asRecord()` selalu mengembalikan objek non-null (`{}` bila input bukan record), sehingga operator `??` pada:

```ts
const media = asRecord(content["application/json"]) ?? Object.values(content)[0];
```

membuat sisi kanan (`Object.values(content)[0]`) menjadi **dead code** — tidak pernah dieksekusi.

### Dampak
Saat sebuah response error hanya mengekspos media type non-`application/json` (mis. `application/xml`), `asRecord(undefined)` menghasilkan `{}`, fallback tak jalan, `media` = `{}`, schema `undefined` → response salah dilaporkan **tidak** beresolusi ke envelope `ApiError` bersama.

## Perbaikan

Pindahkan nullish-coalescing ke **dalam** `asRecord`, agar bekerja pada nilai mentah (yang memang bisa `undefined`) dan fallback ke media type pertama benar-benar berjalan:

```ts
const media = asRecord(
  content["application/json"] ?? Object.values(content)[0]
);
const schema = media.schema;
```

## Verifikasi
- `bun run api:spec:check` ✅
- `bun run typecheck` ✅
- `bun test tests/openapi-route-parity-mutation.test.ts tests/openapi-bundle.test.ts` → 20 pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)