### PR TITLE
feat(ui): overhaul UI/UX — mobile-first, professional motion, auto tenant picker

### DIFF
--- a/.changeset/ui-public-blog-reading-experience.md
+++ b/.changeset/ui-public-blog-reading-experience.md
@@ -1,7 +1,0 @@
----
-"awcms": patch
----
-
-Redesign pengalaman baca halaman blog publik (`/blog/{tenantCode}/...`): tipografi baca yang nyaman (measure ~65ch, skala heading, spacing antar blok), layout mobile-first responsif (kartu post grid→stack, gambar/galeri/video/tabel/kode responsif dengan scroll-container sendiri), dan animasi entrance halus (fade-in-up + stagger kartu, hover kartu) berbasis CSS murni.
-
-Styling di-serve via satu stylesheet same-origin `public/css/public-content.css` yang di-link `renderPublicPageShell` — bukan `<style>` inline (yang akan diblokir CSP `default-src 'self'` tanpa `'unsafe-inline'`), sehingga jaminan "zero third-party CSP origin di LAN/offline" tetap utuh. Tema light/dark mengikuti `prefers-color-scheme` (tanpa JS). Semua animasi di-guard `prefers-reduced-motion`. `renderPublicPageShell` menambah opsi presentasional `variant` (`"list"`/`"article"`) dan membungkus body dalam `<main class="pc-page">` plus skip-link; renderer `content_json` whitelist-based tidak diubah (sanitasi tetap sama).

--- a/.changeset/ui-public-blog-reading-experience.md
+++ b/.changeset/ui-public-blog-reading-experience.md
@@ -1,0 +1,7 @@
+---
+"awcms": patch
+---
+
+Redesign pengalaman baca halaman blog publik (`/blog/{tenantCode}/...`): tipografi baca yang nyaman (measure ~65ch, skala heading, spacing antar blok), layout mobile-first responsif (kartu post grid→stack, gambar/galeri/video/tabel/kode responsif dengan scroll-container sendiri), dan animasi entrance halus (fade-in-up + stagger kartu, hover kartu) berbasis CSS murni.
+
+Styling di-serve via satu stylesheet same-origin `public/css/public-content.css` yang di-link `renderPublicPageShell` — bukan `<style>` inline (yang akan diblokir CSP `default-src 'self'` tanpa `'unsafe-inline'`), sehingga jaminan "zero third-party CSP origin di LAN/offline" tetap utuh. Tema light/dark mengikuti `prefers-color-scheme` (tanpa JS). Semua animasi di-guard `prefers-reduced-motion`. `renderPublicPageShell` menambah opsi presentasional `variant` (`"list"`/`"article"`) dan membungkus body dalam `<main class="pc-page">` plus skip-link; renderer `content_json` whitelist-based tidak diubah (sanitasi tetap sama).

--- a/.changeset/ui-ux-overhaul.md
+++ b/.changeset/ui-ux-overhaul.md
@@ -1,0 +1,10 @@
+---
+"awcms": minor
+---
+
+Overhaul UI/UX seluruh surface pengguna: mobile-first responsif, animasi profesional CSS-murni, dan aksesibilitas (WCAG AA, `prefers-reduced-motion`, skip-link, target sentuh ≥44px). Semua di dalam jaminan CSP single-owner "zero third-party origin di LAN/offline" — tanpa font CDN/library eksternal; animasi = keyframes/transition CSS; styling di-serve same-origin (bundle Astro atau `public/css/*.css`), tidak ada `<style>`/`<script>` inline.
+
+- **Design system (fondasi)**: perkaya `tokens.css` (skala tipografi/spacing/radius/elevation, tint interaksi, token MOTION durasi+easing), tambah lapisan utility animasi reusable `motion.css` (fade/scale/slide/stagger/hover-lift/skeleton/spinner), dan shell layout admin+publik responsif dengan drawer mobile CSS-only.
+- **Login**: redesign form + auto tenant picker — 1 tenant disembunyikan/prefilled, 2–50 dropdown nama tenant, >50 fallback manual (anti mass-enumeration), fail-closed ke input manual saat pre-setup/DB error. Tanpa endpoint publik baru; kontrak DOM login dipertahankan.
+- **Admin**: 8 layar (`index`/`users`/`roles`/`offices`/`profiles`/`modules`/`abac-policies`/`email-templates`) mobile-first — tabel lebar → pola kartu/stack (`data-label` per sel), stat/quick-link beranimasi, hierarki visual & empty state konsisten. Selektor/hook E2E dipertahankan.
+- **Blog publik** (`/blog/{tenantCode}/...`): tipografi baca nyaman (measure ~65ch), kartu post grid→stack, media/tabel/kode responsif, animasi entrance halus; renderer `content_json` whitelist-based tidak dilonggarkan.

--- a/public/css/public-content.css
+++ b/public/css/public-content.css
@@ -1,0 +1,713 @@
+/*
+ * Public blog reading experience — served same-origin at
+ * `/css/public-content.css` and linked from `renderPublicPageShell`
+ * (src/modules/blog-content/domain/public-page-rendering.ts).
+ *
+ * WHY A SERVED FILE AND NOT AN INLINE <style>
+ * -------------------------------------------
+ * The middleware CSP (src/lib/security/security-headers.ts) is
+ * `default-src 'self'` with NO `'unsafe-inline'` (asserted by
+ * tests/security-headers-csp.test.ts). An inline <style> block would
+ * therefore be BLOCKED by the browser at runtime. A same-origin stylesheet
+ * fetched via <link> falls under `default-src 'self'` and is allowed — this
+ * is the only CSP-correct way to style these hand-rendered HTML pages. No
+ * third-party origin, no font CDN, no external asset: the "zero third-party
+ * CSP origin on LAN/offline" guarantee stays intact.
+ *
+ * WHY THE TOKENS ARE RE-DECLARED HERE
+ * -----------------------------------
+ * These pages are hand-rolled HTML strings, not Astro components, so the
+ * shared `src/styles/tokens.css` (bundled only into `.astro` pages) is not
+ * loaded here. The `:root` block below MIRRORS the design-system token
+ * values from `src/styles/tokens.css` (read-only for this task) so the rest
+ * of this file consumes the same `var(--...)` names and stays visually
+ * consistent with the admin surface. If tokens.css changes, mirror it here.
+ *
+ * THEME
+ * -----
+ * No theme-toggle script runs on these public pages, so light/dark is driven
+ * purely by `prefers-color-scheme` (CSP-safe, no JS). `:root[data-theme=...]`
+ * overrides are kept too so an operator who later injects a theme attribute
+ * still wins.
+ *
+ * MOTION / A11Y
+ * -------------
+ * Every entrance animation (and its initial hidden state) lives inside
+ * `@media (prefers-reduced-motion: no-preference)`, so reduced-motion users
+ * — and any browser that never runs the animation — always see fully
+ * visible, non-transformed content. Focus states, heading hierarchy, and AA
+ * contrast are preserved.
+ */
+
+:root {
+  color-scheme: light;
+
+  --color-bg: #f7f8fa;
+  --color-surface: #ffffff;
+  --color-surface-2: #eef1f5;
+  --color-border: #d8dee6;
+  --color-text: #1a1f26;
+  --color-text-muted: #5b6672;
+  --color-primary: #2563eb;
+  --color-primary-hover: #1d4ed8;
+  --color-primary-soft: #e8effc;
+  --color-surface-hover: #f0f3f8;
+  --color-focus: #2563eb;
+
+  --font-sans: system-ui, -apple-system, "Inter", "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", "Menlo", monospace;
+
+  --fs-sm: 14px;
+  --fs-base: 16px;
+  --fs-md: 18px;
+  --fs-lg: 20px;
+  --fs-xl: 24px;
+  --fs-2xl: 32px;
+  --fs-3xl: 40px;
+
+  --fw-normal: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  --lh-tight: 1.2;
+  --lh-snug: 1.35;
+  --lh-normal: 1.5;
+  --lh-relaxed: 1.7;
+
+  --tracking-tight: -0.01em;
+
+  --sp-1: 4px;
+  --sp-2: 8px;
+  --sp-3: 12px;
+  --sp-4: 16px;
+  --sp-5: 24px;
+  --sp-6: 32px;
+  --sp-7: 48px;
+  --sp-8: 64px;
+
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-full: 9999px;
+
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
+  --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.12);
+  --shadow-lg: 0 12px 32px rgba(15, 23, 42, 0.18);
+
+  --motion-fast: 140ms;
+  --motion-base: 240ms;
+  --motion-slow: 400ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Comfortable reading measure for body prose (~65 characters). */
+  --measure: 65ch;
+}
+
+:root[data-theme="dark"],
+:root[data-theme="dark"] body {
+  color-scheme: dark;
+
+  --color-bg: #0e1116;
+  --color-surface: #161b22;
+  --color-surface-2: #1f262e;
+  --color-border: #2b333c;
+  --color-text: #e6edf3;
+  --color-text-muted: #9aa7b2;
+  --color-primary: #3b82f6;
+  --color-primary-hover: #2f6fd6;
+  --color-primary-soft: #16233b;
+  --color-surface-hover: #1c2430;
+  --color-focus: #60a5fa;
+
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+  --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.55);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+
+    --color-bg: #0e1116;
+    --color-surface: #161b22;
+    --color-surface-2: #1f262e;
+    --color-border: #2b333c;
+    --color-text: #e6edf3;
+    --color-text-muted: #9aa7b2;
+    --color-primary: #3b82f6;
+    --color-primary-hover: #2f6fd6;
+    --color-primary-soft: #16233b;
+    --color-surface-hover: #1c2430;
+    --color-focus: #60a5fa;
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
+    --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.55);
+  }
+}
+
+/* Minimal reset — tokens.css's reset is not loaded on these hand-rolled pages. */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: var(--fs-base);
+  line-height: var(--lh-normal);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+img,
+picture,
+svg,
+video,
+iframe {
+  max-width: 100%;
+}
+
+img,
+picture,
+svg,
+video {
+  display: block;
+  height: auto;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration-thickness: 0.06em;
+  text-underline-offset: 0.18em;
+  transition: color var(--motion-fast) var(--ease-standard);
+}
+
+a:hover {
+  color: var(--color-primary-hover);
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+
+/* Skip link — visible only when focused. */
+.pc-skip {
+  position: absolute;
+  left: var(--sp-3);
+  top: var(--sp-3);
+  z-index: 10;
+  padding: var(--sp-2) var(--sp-4);
+  background: var(--color-surface);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-150%);
+  transition: transform var(--motion-base) var(--ease-out);
+}
+
+.pc-skip:focus {
+  transform: translateY(0);
+}
+
+/* Page container. */
+.pc-page {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: var(--sp-6) var(--sp-4) var(--sp-8);
+}
+
+@media (min-width: 640px) {
+  .pc-page {
+    padding: var(--sp-7) var(--sp-5) var(--sp-8);
+  }
+}
+
+.pc-page > h1 {
+  font-size: var(--fs-2xl);
+  line-height: var(--lh-tight);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--fw-bold);
+  margin: 0 0 var(--sp-5);
+}
+
+@media (min-width: 640px) {
+  .pc-page > h1 {
+    font-size: var(--fs-3xl);
+  }
+}
+
+/* ---- Listing (index / category / tag / search) ---- */
+
+.posts {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--sp-4);
+  margin-block: var(--sp-5);
+}
+
+@media (min-width: 640px) {
+  .posts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: var(--sp-5);
+  }
+}
+
+@media (min-width: 1024px) {
+  .posts {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.posts article {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  padding: var(--sp-5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  transition:
+    transform var(--motion-base) var(--ease-standard),
+    box-shadow var(--motion-base) var(--ease-standard),
+    border-color var(--motion-base) var(--ease-standard);
+}
+
+.posts article:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow-lg);
+  border-color: var(--color-primary);
+}
+
+.posts article h2 {
+  margin: 0;
+  font-size: var(--fs-lg);
+  line-height: var(--lh-snug);
+  font-weight: var(--fw-semibold);
+  letter-spacing: var(--tracking-tight);
+}
+
+.posts article h2 a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.posts article:hover h2 a,
+.posts article h2 a:focus-visible {
+  color: var(--color-primary);
+}
+
+/* Make the whole card clickable via the title link's stretched hit area. */
+.posts article h2 a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: var(--radius-lg);
+}
+
+.posts article {
+  position: relative;
+}
+
+.posts article p {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--fs-base);
+  line-height: var(--lh-normal);
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+/* Friendly empty / no-results state (the list renderer emits a bare <p>). */
+.posts > p {
+  grid-column: 1 / -1;
+  margin: 0;
+  padding: var(--sp-7) var(--sp-5);
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--fs-md);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+/* Search form. */
+form[action$="/search"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+  margin: var(--sp-5) 0;
+}
+
+form[action$="/search"] input[type="text"] {
+  flex: 1 1 16rem;
+  min-width: 0;
+  padding: var(--sp-3) var(--sp-4);
+  font-size: var(--fs-base);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  transition:
+    border-color var(--motion-fast) var(--ease-standard),
+    box-shadow var(--motion-fast) var(--ease-standard);
+}
+
+form[action$="/search"] input[type="text"]:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+form[action$="/search"] button {
+  padding: var(--sp-3) var(--sp-5);
+  font-weight: var(--fw-semibold);
+  color: #ffffff;
+  background: var(--color-primary);
+  border: 1px solid transparent;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background var(--motion-fast) var(--ease-standard),
+    transform var(--motion-fast) var(--ease-standard);
+}
+
+form[action$="/search"] button:hover {
+  background: var(--color-primary-hover);
+}
+
+form[action$="/search"] button:active {
+  transform: translateY(1px);
+}
+
+/* Pagination. */
+.pc-page > nav {
+  display: flex;
+  gap: var(--sp-3);
+  justify-content: space-between;
+  margin-top: var(--sp-6);
+  padding-top: var(--sp-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.pc-page > nav:empty {
+  display: none;
+}
+
+.pc-page > nav a {
+  padding: var(--sp-2) var(--sp-4);
+  font-weight: var(--fw-medium);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition:
+    background var(--motion-fast) var(--ease-standard),
+    border-color var(--motion-fast) var(--ease-standard);
+}
+
+.pc-page > nav a:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+/* ---- Article detail ---- */
+
+.pc-page--article {
+  max-width: 48rem;
+}
+
+.pc-page--article > article {
+  font-size: var(--fs-md);
+  line-height: var(--lh-relaxed);
+}
+
+.pc-page--article > article > h1 {
+  font-size: var(--fs-2xl);
+  line-height: var(--lh-tight);
+  letter-spacing: var(--tracking-tight);
+  font-weight: var(--fw-bold);
+  margin: 0 0 var(--sp-3);
+}
+
+@media (min-width: 640px) {
+  .pc-page--article > article > h1 {
+    font-size: var(--fs-3xl);
+  }
+}
+
+/* Post meta line (the <p><time>…</time></p> just below the title). */
+.pc-page--article > article > h1 + p {
+  margin: 0 0 var(--sp-6);
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+/* Body prose: constrain the reading measure of text-level blocks, but let
+   media (figures / galleries) use the full column width. */
+.pc-page--article > article > p,
+.pc-page--article > article > ul,
+.pc-page--article > article > ol,
+.pc-page--article > article > blockquote,
+.pc-page--article > article > h2,
+.pc-page--article > article > h3,
+.pc-page--article > article > h4 {
+  max-width: var(--measure);
+}
+
+.pc-page--article > article > p {
+  margin: 0 0 var(--sp-5);
+}
+
+.pc-page--article > article h2 {
+  font-size: var(--fs-xl);
+  line-height: var(--lh-snug);
+  font-weight: var(--fw-bold);
+  letter-spacing: var(--tracking-tight);
+  margin: var(--sp-7) 0 var(--sp-3);
+}
+
+.pc-page--article > article h3 {
+  font-size: var(--fs-lg);
+  line-height: var(--lh-snug);
+  font-weight: var(--fw-semibold);
+  margin: var(--sp-6) 0 var(--sp-3);
+}
+
+.pc-page--article > article ul,
+.pc-page--article > article ol {
+  margin: 0 0 var(--sp-5);
+  padding-left: var(--sp-5);
+}
+
+.pc-page--article > article li {
+  margin-bottom: var(--sp-2);
+}
+
+.pc-page--article > article blockquote {
+  margin: var(--sp-6) 0;
+  padding: var(--sp-3) var(--sp-5);
+  border-left: 4px solid var(--color-primary);
+  background: var(--color-primary-soft);
+  border-radius: 0 var(--radius-md) var(--radius-md) 0;
+  color: var(--color-text);
+  font-style: italic;
+}
+
+/* Long inline elements (code / tables) must scroll inside their own box,
+   never widen the page. */
+.pc-page pre,
+.pc-page table {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.pc-page pre {
+  padding: var(--sp-4);
+  background: var(--color-surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
+}
+
+.pc-page code {
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+/* Figures / images inside prose. */
+.pc-page figure {
+  margin: var(--sp-6) 0;
+}
+
+.pc-page figure img,
+.pc-page figure video {
+  width: 100%;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.pc-page figcaption {
+  margin-top: var(--sp-2);
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-snug);
+  text-align: center;
+}
+
+/* Gallery grid. */
+.gallery {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--sp-4);
+  margin: var(--sp-6) 0;
+}
+
+@media (min-width: 560px) {
+  .gallery {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.gallery figure {
+  margin: 0;
+}
+
+/* Video-news embed — responsive 16:9 iframe. */
+.video-news iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  border: 0;
+  border-radius: var(--radius-md);
+}
+
+.video-news-thumbnail {
+  width: 100%;
+  border-radius: var(--radius-md);
+  margin-bottom: var(--sp-3);
+}
+
+.video-news-source {
+  margin: var(--sp-2) 0 0;
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+}
+
+/* Social share widget (from social-share-links.ts). */
+.news-share {
+  max-width: 48rem;
+  margin: var(--sp-7) auto 0;
+  padding-top: var(--sp-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.news-share__list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.news-share__list a,
+.news-share__list button {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--sp-2) var(--sp-4);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--color-text);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background var(--motion-fast) var(--ease-standard),
+    border-color var(--motion-fast) var(--ease-standard),
+    color var(--motion-fast) var(--ease-standard);
+}
+
+.news-share__list a:hover,
+.news-share__list button:hover {
+  background: var(--color-primary-soft);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.news-share__note,
+.news-share__status {
+  margin: var(--sp-3) 0 0;
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+}
+
+/* "Back to blog" trailing link. */
+.pc-page--article > p:last-child {
+  margin-top: var(--sp-7);
+  padding-top: var(--sp-5);
+  border-top: 1px solid var(--color-border);
+}
+
+.pc-page--article > p:last-child a {
+  font-weight: var(--fw-medium);
+}
+
+/* ---- Motion (entrances) — opt-in, never for reduced-motion users ---- */
+
+@media (prefers-reduced-motion: no-preference) {
+  @keyframes pc-fade-up {
+    from {
+      opacity: 0;
+      transform: translateY(14px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+
+  .pc-page > h1,
+  .pc-page > form,
+  .pc-page > nav,
+  .pc-page--article > article {
+    animation: pc-fade-up var(--motion-slow) var(--ease-out) both;
+  }
+
+  .posts article {
+    animation: pc-fade-up var(--motion-base) var(--ease-out) both;
+  }
+
+  /* Stagger the card entrances for a polished cascade. */
+  .posts article:nth-child(1) {
+    animation-delay: 40ms;
+  }
+  .posts article:nth-child(2) {
+    animation-delay: 90ms;
+  }
+  .posts article:nth-child(3) {
+    animation-delay: 140ms;
+  }
+  .posts article:nth-child(4) {
+    animation-delay: 190ms;
+  }
+  .posts article:nth-child(5) {
+    animation-delay: 240ms;
+  }
+  .posts article:nth-child(6) {
+    animation-delay: 290ms;
+  }
+  .posts article:nth-child(n + 7) {
+    animation-delay: 340ms;
+  }
+}

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -1,11 +1,19 @@
 ---
 /**
- * Admin shell (Issue #166 — ported from awcms-mini's `AdminLayout.astro`,
- * stripped to awcms's fondasi scope). Deliberately minimal vs mini: NO
- * TenantBadge / SyncIndicator / ThemeToggle / LanguageSwitcher / responsive
- * drawer / i18n — those drag in visitor-analytics, theme persistence, and the
- * gettext catalog awcms does not have yet. Kept: brand, the signed-in user's
- * roles, a permission-agnostic sidebar, logout, and the page slot.
+ * Admin shell (Issue #166; grown into a mobile-first responsive shell by the
+ * UI/UX overhaul foundation). Still deliberately minimal vs awcms-mini: NO
+ * TenantBadge / SyncIndicator / ThemeToggle / LanguageSwitcher / i18n — those
+ * drag in visitor-analytics, theme persistence, and the gettext catalog awcms
+ * does not have yet. Kept: brand, the signed-in user's roles, a
+ * permission-agnostic sidebar, logout, and the page slot. Added: a skip link
+ * and a CSS-only responsive sidebar drawer for small screens.
+ *
+ * Responsive sidebar (mobile-first): below `--bp-md` (768px) the sidebar is an
+ * off-canvas drawer toggled by a hidden, keyboard-focusable checkbox
+ * (`#admin-nav-toggle`) driven by a hamburger `<label>` and a scrim `<label>` —
+ * ALL CSS-only (see admin.css). No JS is used for the toggle, so there is
+ * nothing for the strict CSP to block; on desktop the sidebar is static and the
+ * toggle/scrim are `display: none`.
  *
  * Auth is NOT enforced here — `src/middleware.ts` already guards `/admin/*`
  * (resolves the session, redirects to `/login` when absent, and sets
@@ -14,11 +22,13 @@
  * throws rather than rendering a half-authenticated page.
  *
  * CSP (see astro.config.mjs / security-headers.ts): styles come from external
- * stylesheets (`tokens.css` + `admin.css`, emitted as <link> by
- * `inlineStylesheets: "never"`) and the only script is the Astro-bundled
- * logout module below — no inline script/style, so `default-src 'self'` holds.
+ * stylesheets (`tokens.css` + `admin.css` + `motion.css`, emitted as <link> by
+ * `inlineStylesheets: "never"`) and the only script is the Astro-bundled logout
+ * module below — no inline script/style, no third-party origin, so
+ * `default-src 'self'` holds and the CSP guarantee is unchanged.
  */
 import "../styles/tokens.css";
+import "../styles/motion.css";
 import "../styles/admin.css";
 
 interface Props {
@@ -55,7 +65,24 @@ const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
     <title>{title} · AWCMS</title>
   </head>
   <body class="admin-body">
+    <a class="skip-link" href="#admin-main">Skip to main content</a>
+
+    {
+      /* CSS-only responsive drawer toggle (see admin.css). Hidden + static
+        sidebar on desktop; off-canvas drawer + this hamburger on mobile. */
+    }
+    <input
+      type="checkbox"
+      id="admin-nav-toggle"
+      class="admin-nav-toggle-checkbox"
+      aria-label="Toggle navigation menu"
+    />
+
     <header class="admin-topbar">
+      <label class="admin-nav-toggle" for="admin-nav-toggle">
+        <span class="admin-nav-toggle-bars" aria-hidden="true"></span>
+        <span class="sr-only">Toggle navigation menu</span>
+      </label>
       <a href="/admin" class="admin-brand">AWCMS</a>
       <div class="admin-topbar-right">
         <span class="admin-roles" id="admin-roles">{roles}</span>
@@ -66,7 +93,9 @@ const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
     </header>
 
     <div class="admin-layout">
-      <aside class="admin-sidebar">
+      <label class="admin-scrim" for="admin-nav-toggle" aria-hidden="true"
+      ></label>
+      <aside class="admin-sidebar" id="admin-sidebar">
         <nav aria-label="Admin">
           <a
             href="/admin"
@@ -119,7 +148,7 @@ const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
         </nav>
       </aside>
 
-      <main class="admin-main">
+      <main class="admin-main" id="admin-main" tabindex="-1">
         <slot />
       </main>
     </div>

--- a/src/layouts/PublicThemeLayout.astro
+++ b/src/layouts/PublicThemeLayout.astro
@@ -113,6 +113,38 @@ const {
         --_font-heading: var(--awcms-theme-font_heading, system-ui, sans-serif);
         --_font-size: var(--awcms-theme-font_size_base, 1rem);
         --_line: var(--awcms-theme-line_height_base, 1.5);
+        /* Motion — self-contained (this layout deliberately does NOT import the
+           admin tokens.css/motion.css; it only ever consumes --awcms-theme-*).
+           Every value has a literal fallback so entrances work even without a
+           theme override. All entrance motion is neutralised by the
+           prefers-reduced-motion block below. */
+        --_motion-base: var(--awcms-theme-motion_base, 420ms);
+        --_ease-out: var(
+          --awcms-theme-motion_ease,
+          cubic-bezier(0.16, 1, 0.3, 1)
+        );
+      }
+
+      /* Subtle, tasteful entrance for the public shell (guarded below). */
+      @keyframes theme-enter-down {
+        from {
+          opacity: 0;
+          transform: translateY(-8px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
+      }
+      @keyframes theme-enter-up {
+        from {
+          opacity: 0;
+          transform: translateY(14px);
+        }
+        to {
+          opacity: 1;
+          transform: translateY(0);
+        }
       }
 
       body {
@@ -149,17 +181,27 @@ const {
         padding: 0 var(--_space);
       }
 
+      /* Mobile-first: stacked header; becomes a row once there's width. */
       .theme-header {
         display: flex;
-        align-items: center;
-        justify-content: space-between;
+        flex-direction: column;
+        align-items: flex-start;
         gap: var(--_space);
         padding: var(--_space) 0;
         border-bottom: 1px solid var(--_border);
-        flex-wrap: wrap;
+        animation: theme-enter-down var(--_motion-base) var(--_ease-out) both;
+      }
+      @media (min-width: 640px) {
+        .theme-header {
+          flex-direction: row;
+          align-items: center;
+          justify-content: space-between;
+          flex-wrap: wrap;
+        }
       }
       body[data-header="centered"] .theme-header {
         flex-direction: column;
+        align-items: center;
         text-align: center;
       }
 
@@ -194,6 +236,8 @@ const {
 
       .theme-main {
         padding: calc(var(--_space) * 2) 0;
+        animation: theme-enter-up var(--_motion-base) var(--_ease-out) both;
+        animation-delay: 80ms;
       }
 
       .theme-main h1,
@@ -228,13 +272,10 @@ const {
         color: var(--_muted);
       }
 
-      @media (max-width: 640px) {
-        .theme-header {
-          flex-direction: column;
-          align-items: flex-start;
-        }
-      }
-
+      /* Reduced motion: neutralise every entrance/transition. With
+         `animation-fill-mode: both` on the entrances above, collapsing the
+         duration lands each element on its final, fully-visible keyframe — no
+         content is left hidden. */
       @media (prefers-reduced-motion: reduce) {
         * {
           animation-duration: 0.001ms !important;

--- a/src/modules/blog-content/domain/public-page-rendering.ts
+++ b/src/modules/blog-content/domain/public-page-rendering.ts
@@ -69,7 +69,28 @@ export type PublicPageShellOptions = {
    * `</head>`. `null`/omitted renders nothing extra.
    */
   structuredDataJsonLd?: Record<string, unknown> | null;
+  /**
+   * UI redesign — selects the reading layout the body is wrapped in
+   * (`<main class="pc-page pc-page--{variant}">`), styled by the same-origin
+   * `/css/public-content.css` stylesheet this shell links. `"article"` is the
+   * narrow single-column reading measure used by the post detail route;
+   * `"list"` (the default when omitted) is the wider listing/grid layout used
+   * by the index/category/tag/search routes. Purely presentational — omitting
+   * it keeps the generic `pc-page` container with no modifier, and callers
+   * that predate this option (or the domain unit tests) are unaffected.
+   */
+  variant?: "list" | "article";
 };
+
+/**
+ * Same-origin stylesheet for the public blog reading experience. Served from
+ * `public/css/public-content.css` (i.e. `/css/public-content.css`), so it
+ * satisfies the middleware CSP `default-src 'self'` (no inline `<style>`,
+ * which that policy — `src/lib/security/security-headers.ts` — would block).
+ * No third-party origin, keeping the LAN/offline "zero third-party CSP
+ * origin" guarantee intact.
+ */
+const PUBLIC_CONTENT_STYLESHEET_HREF = "/css/public-content.css";
 
 /**
  * `og:title`/`og:description`/`og:url` + `twitter:title`/`twitter:description`/
@@ -167,6 +188,13 @@ export function renderPublicPageShell(options: PublicPageShellOptions): string {
     ? renderJsonLdScriptTag(options.structuredDataJsonLd)
     : "";
 
+  const pageClass =
+    options.variant === "article"
+      ? "pc-page pc-page--article"
+      : options.variant === "list"
+        ? "pc-page pc-page--list"
+        : "pc-page";
+
   return `<!doctype html>
 <html lang="${escapeHtml(options.locale)}">
 <head>
@@ -174,13 +202,17 @@ export function renderPublicPageShell(options: PublicPageShellOptions): string {
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>${escapeHtml(options.title)}</title>
 <meta name="description" content="${escapeHtml(options.description)}" />
+<link rel="stylesheet" href="${PUBLIC_CONTENT_STYLESHEET_HREF}" />
 ${canonicalTag}
 ${robotsTag}
 ${ogTags}
 ${jsonLdTag}
 </head>
 <body>
+<a class="pc-skip" href="#pc-main">Skip to content</a>
+<main id="pc-main" class="${pageClass}">
 ${options.bodyHtml}
+</main>
 </body>
 </html>`;
 }

--- a/src/pages/admin/abac-policies.astro
+++ b/src/pages/admin/abac-policies.astro
@@ -20,6 +20,7 @@
  * expected default, not an error.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
@@ -58,11 +59,18 @@ if (canRead) {
 ---
 
 <AdminLayout title="ABAC policies" active="abac-policies">
-  <h1 id="abac-policies-heading">ABAC policies</h1>
+  <header class="page-header fade-in-up">
+    <h1 id="abac-policies-heading">ABAC policies</h1>
+    <p class="page-description">
+      Per-tenant custom access policies. This table is empty by default — the
+      evaluator applies the built-in role/permission rules, and custom policies
+      are an opt-in extension surface.
+    </p>
+  </header>
 
   {
     !canRead && (
-      <p class="state-notice" id="abac-policies-denied">
+      <p class="state-notice fade-in-up" id="abac-policies-denied">
         You do not have permission to view ABAC policies.
       </p>
     )
@@ -70,7 +78,7 @@ if (canRead) {
 
   {
     canRead && loadError && (
-      <p class="state-notice" id="abac-policies-error">
+      <p class="state-notice fade-in-up" id="abac-policies-error">
         Policies could not be loaded right now. Please try again later.
       </p>
     )
@@ -78,7 +86,8 @@ if (canRead) {
 
   {
     canCreate && (
-      <form id="policy-create-form" class="admin-create-form">
+      <form id="policy-create-form" class="admin-create-form fade-in-up">
+        <p class="form-legend">Create a policy</p>
         <p
           id="policy-create-error"
           class="admin-create-error"
@@ -129,8 +138,8 @@ if (canRead) {
 
   {
     canRead && !loadError && (
-      <div class="data-table-scroll">
-        <table class="data-table" id="abac-policies-table">
+      <div class="data-table-scroll fade-in-up">
+        <table class="data-table data-table--stack" id="abac-policies-table">
           <caption>{policies.length} policy(ies)</caption>
           <thead>
             <tr>
@@ -145,45 +154,68 @@ if (canRead) {
             {policies.length === 0 ? (
               <tr>
                 <td class="data-table-empty" colspan={canUpdate ? 5 : 4}>
-                  No custom policies — the built-in role/permission rules apply.
+                  <div class="empty-state">
+                    <span class="empty-state-icon" aria-hidden="true">
+                      ⚖
+                    </span>
+                    <span class="empty-state-title">No custom policies</span>
+                    <span class="empty-state-text">
+                      The built-in role/permission rules apply. Add a custom
+                      policy to extend or override them for this tenant.
+                    </span>
+                  </div>
                 </td>
               </tr>
             ) : (
               policies.map((policy) => (
                 <tr>
-                  <td>{policy.policyCode}</td>
-                  <td>
+                  <td data-label="Code">
+                    <span class="cell-code">{policy.policyCode}</span>
+                  </td>
+                  <td data-label="Effect">
                     <span
                       class="status-badge"
                       data-variant={
-                        policy.effect === "allow" ? "success" : "warning"
+                        policy.effect === "allow" ? "success" : "danger"
                       }
                     >
+                      <span class="status-dot" aria-hidden="true" />
                       {policy.effect}
                     </span>
                   </td>
-                  <td>{policy.description ?? "—"}</td>
-                  <td>{policy.isActive ? "yes" : "no"}</td>
+                  <td data-label="Description">
+                    {policy.description ?? <span class="cell-muted">—</span>}
+                  </td>
+                  <td data-label="Active">
+                    <span
+                      class="status-badge"
+                      data-variant={policy.isActive ? "success" : "neutral"}
+                    >
+                      {policy.isActive ? "active" : "inactive"}
+                    </span>
+                  </td>
                   {canUpdate && (
-                    <td>
-                      <button
-                        type="button"
-                        class="policy-edit"
-                        data-policy-id={policy.id}
-                        data-policy-code={policy.policyCode}
-                        data-effect={policy.effect}
-                        data-description={policy.description ?? ""}
-                      >
-                        Edit
-                      </button>{" "}
-                      <button
-                        type="button"
-                        class="policy-toggle"
-                        data-policy-id={policy.id}
-                        data-active={policy.isActive ? "true" : "false"}
-                      >
-                        {policy.isActive ? "Disable" : "Enable"}
-                      </button>
+                    <td data-label="Actions" class="stacked-block">
+                      <div class="row-actions">
+                        <button
+                          type="button"
+                          class="module-toggle policy-edit"
+                          data-policy-id={policy.id}
+                          data-policy-code={policy.policyCode}
+                          data-effect={policy.effect}
+                          data-description={policy.description ?? ""}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          class="module-toggle policy-toggle"
+                          data-policy-id={policy.id}
+                          data-active={policy.isActive ? "true" : "false"}
+                        >
+                          {policy.isActive ? "Disable" : "Enable"}
+                        </button>
+                      </div>
                     </td>
                   )}
                 </tr>

--- a/src/pages/admin/email-templates.astro
+++ b/src/pages/admin/email-templates.astro
@@ -15,6 +15,7 @@
  * accepts the full `{ locale: text }` map, this UI seeds one locale.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
@@ -55,11 +56,18 @@ if (canRead) {
 ---
 
 <AdminLayout title="Email templates" active="email-templates">
-  <h1 id="email-templates-heading">Email templates</h1>
+  <header class="page-header fade-in-up">
+    <h1 id="email-templates-heading">Email templates</h1>
+    <p class="page-description">
+      Transactional email templates for this tenant, including inactive ones.
+      Subject and body are captured for the <code>en</code> locale; the endpoint validates
+      and escapes the content.
+    </p>
+  </header>
 
   {
     !canRead && (
-      <p class="state-notice" id="email-templates-denied">
+      <p class="state-notice fade-in-up" id="email-templates-denied">
         You do not have permission to view email templates.
       </p>
     )
@@ -67,7 +75,7 @@ if (canRead) {
 
   {
     canRead && loadError && (
-      <p class="state-notice" id="email-templates-error">
+      <p class="state-notice fade-in-up" id="email-templates-error">
         Templates could not be loaded right now. Please try again later.
       </p>
     )
@@ -75,7 +83,11 @@ if (canRead) {
 
   {
     canCreate && (
-      <form id="email-template-create-form" class="admin-create-form">
+      <form
+        id="email-template-create-form"
+        class="admin-create-form fade-in-up"
+      >
+        <p class="form-legend">Create a template</p>
         <p
           id="email-template-create-error"
           class="admin-create-error"
@@ -120,8 +132,8 @@ if (canRead) {
 
   {
     canRead && !loadError && (
-      <div class="data-table-scroll">
-        <table class="data-table" id="email-templates-table">
+      <div class="data-table-scroll fade-in-up">
+        <table class="data-table data-table--stack" id="email-templates-table">
           <caption>{templates.length} template(s)</caption>
           <thead>
             <tr>
@@ -134,19 +146,32 @@ if (canRead) {
             {templates.length === 0 ? (
               <tr>
                 <td class="data-table-empty" colspan="3">
-                  No templates yet.
+                  <div class="empty-state">
+                    <span class="empty-state-icon" aria-hidden="true">
+                      ✉
+                    </span>
+                    <span class="empty-state-title">No templates yet</span>
+                    <span class="empty-state-text">
+                      {canCreate
+                        ? "Create your first email template using the form above."
+                        : "Email templates configured for this tenant will appear here."}
+                    </span>
+                  </div>
                 </td>
               </tr>
             ) : (
               templates.map((template) => (
                 <tr>
-                  <td>{template.templateKey}</td>
-                  <td>{template.name}</td>
-                  <td>
+                  <td data-label="Key">
+                    <span class="cell-code">{template.templateKey}</span>
+                  </td>
+                  <td data-label="Name">{template.name}</td>
+                  <td data-label="Active">
                     <span
                       class="status-badge"
                       data-variant={template.isActive ? "success" : "neutral"}
                     >
+                      <span class="status-dot" aria-hidden="true" />
                       {template.isActive ? "active" : "inactive"}
                     </span>
                   </td>

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -4,23 +4,80 @@
  * renders only from `Astro.locals.ssrContext` (already resolved + guarded by
  * `src/middleware.ts`), so it needs no additional DB read of its own. Proves
  * the login → session-cookie → `/admin` guard → SSR render loop end to end.
+ *
+ * UI/UX phase-2: presents the session facts as scannable stat cards + quick
+ * navigation tiles using only Phase-1 utilities (`.fade-in-up`,
+ * `.stagger-children`, `.hover-lift`) and admin-screens.css helpers. The
+ * `#admin-dashboard-heading`, `#dashboard-tenant-id` and
+ * `#dashboard-permission-count` hooks (asserted by tests/e2e) are preserved.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 
 const ssr = Astro.locals.ssrContext!;
 const permissionCount = ssr.permissions.size;
+const roleCount = ssr.roles.length;
+const roleSummary = roleCount > 0 ? ssr.roles.join(", ") : "—";
+
+const quickLinks = [
+  { href: "/admin/offices", label: "Offices" },
+  { href: "/admin/profiles", label: "Profiles" },
+  { href: "/admin/users", label: "Users" },
+  { href: "/admin/roles", label: "Roles" },
+  { href: "/admin/abac-policies", label: "ABAC policies" },
+  { href: "/admin/modules", label: "Modules" },
+  { href: "/admin/email-templates", label: "Email templates" }
+];
 ---
 
 <AdminLayout title="Dashboard" active="dashboard">
-  <h1 id="admin-dashboard-heading">Dashboard</h1>
-  <p>You are signed in.</p>
-  <dl>
-    <dt>Tenant</dt>
-    <dd id="dashboard-tenant-id">{ssr.tenantId}</dd>
-    <dt>Roles</dt>
-    <dd>{ssr.roles.length > 0 ? ssr.roles.join(", ") : "—"}</dd>
-    <dt>Granted permissions</dt>
-    <dd id="dashboard-permission-count">{permissionCount}</dd>
-  </dl>
-  <p><a href="/admin/offices">Manage offices →</a></p>
+  <header class="page-header fade-in-up">
+    <h1 id="admin-dashboard-heading">Dashboard</h1>
+    <p class="page-description">
+      You are signed in. Here is a snapshot of your current session and the
+      areas you can manage.
+    </p>
+  </header>
+
+  <section aria-label="Session overview">
+    <ul class="stat-grid stagger-children">
+      <li class="stat-card hover-lift fade-in-up">
+        <div class="stat-label">Tenant</div>
+        <div class="stat-value stat-value--mono" id="dashboard-tenant-id">
+          {ssr.tenantId}
+        </div>
+        <div class="stat-hint">Active tenant context</div>
+      </li>
+      <li class="stat-card hover-lift fade-in-up">
+        <div class="stat-label">Roles</div>
+        <div class="stat-value">{roleCount}</div>
+        <div class="stat-hint">{roleSummary}</div>
+      </li>
+      <li class="stat-card hover-lift fade-in-up">
+        <div class="stat-label">Granted permissions</div>
+        <div class="stat-value" id="dashboard-permission-count">
+          {permissionCount}
+        </div>
+        <div class="stat-hint">Across all assigned roles</div>
+      </li>
+    </ul>
+  </section>
+
+  <section class="admin-section" aria-label="Quick navigation">
+    <h2 class="admin-section-title">Manage</h2>
+    <ul class="quick-links stagger-children">
+      {
+        quickLinks.map((link) => (
+          <li class="fade-in-up">
+            <a class="quick-link transition-base" href={link.href}>
+              <span>{link.label}</span>
+              <span class="quick-link-arrow" aria-hidden="true">
+                →
+              </span>
+            </a>
+          </li>
+        ))
+      }
+    </ul>
+  </section>
 </AdminLayout>

--- a/src/pages/admin/modules.astro
+++ b/src/pages/admin/modules.astro
@@ -21,6 +21,7 @@
  * generic error.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
@@ -64,11 +65,17 @@ if (canRead) {
 ---
 
 <AdminLayout title="Modules" active="modules">
-  <h1 id="modules-heading">Modules</h1>
+  <header class="page-header fade-in-up">
+    <h1 id="modules-heading">Modules</h1>
+    <p class="page-description">
+      Per-module enablement for this tenant. Core modules cannot be disabled,
+      and a module other enabled modules depend on will refuse to turn off.
+    </p>
+  </header>
 
   {
     !canRead && (
-      <p class="state-notice" id="modules-denied">
+      <p class="state-notice fade-in-up" id="modules-denied">
         You do not have permission to view modules.
       </p>
     )
@@ -76,7 +83,7 @@ if (canRead) {
 
   {
     canRead && loadError && (
-      <p class="state-notice" id="modules-error">
+      <p class="state-notice fade-in-up" id="modules-error">
         Modules could not be loaded right now. Please try again later.
       </p>
     )
@@ -95,8 +102,8 @@ if (canRead) {
 
   {
     canRead && !loadError && (
-      <div class="data-table-scroll">
-        <table class="data-table" id="modules-table">
+      <div class="data-table-scroll fade-in-up">
+        <table class="data-table data-table--stack" id="modules-table">
           <caption>{modules.length} module(s)</caption>
           <thead>
             <tr>
@@ -109,57 +116,91 @@ if (canRead) {
             </tr>
           </thead>
           <tbody>
-            {modules.map((module) => {
-              // Only offer the action the current state + permission allows: an
-              // enabled non-core module can be disabled; a disabled module can
-              // be enabled. Core modules are never disable-able (endpoint 409s),
-              // so they get no disable button.
-              const showDisable =
-                module.tenantEnabled && !module.isCore && canDisable;
-              const showEnable = !module.tenantEnabled && canEnable;
-              return (
-                <tr>
-                  <td>{module.moduleKey}</td>
-                  <td>{module.name}</td>
-                  <td>{module.version}</td>
-                  <td>
-                    <span
-                      class="status-badge"
-                      data-variant={
-                        module.tenantEnabled ? "success" : "neutral"
-                      }
-                    >
-                      {module.tenantEnabled ? "enabled" : "disabled"}
+            {modules.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan={canToggle ? 6 : 5}>
+                  <div class="empty-state">
+                    <span class="empty-state-icon" aria-hidden="true">
+                      ▦
                     </span>
-                  </td>
-                  <td>{module.isCore ? "yes" : "no"}</td>
-                  {canToggle && (
-                    <td>
-                      {showDisable && (
-                        <button
-                          type="button"
-                          class="module-toggle"
-                          data-module-key={module.moduleKey}
-                          data-action="disable"
-                        >
-                          Disable
-                        </button>
-                      )}
-                      {showEnable && (
-                        <button
-                          type="button"
-                          class="module-toggle"
-                          data-module-key={module.moduleKey}
-                          data-action="enable"
-                        >
-                          Enable
-                        </button>
+                    <span class="empty-state-title">No modules</span>
+                    <span class="empty-state-text">
+                      No modules are registered for this tenant yet.
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              modules.map((module) => {
+                // Only offer the action the current state + permission allows:
+                // an enabled non-core module can be disabled; a disabled module
+                // can be enabled. Core modules are never disable-able (endpoint
+                // 409s), so they get no disable button.
+                const showDisable =
+                  module.tenantEnabled && !module.isCore && canDisable;
+                const showEnable = !module.tenantEnabled && canEnable;
+                return (
+                  <tr>
+                    <td data-label="Key">
+                      <span class="cell-code">{module.moduleKey}</span>
+                    </td>
+                    <td data-label="Name">{module.name}</td>
+                    <td data-label="Version">
+                      <span class="cell-muted">{module.version}</span>
+                    </td>
+                    <td data-label="Enabled">
+                      <span
+                        class="status-badge"
+                        data-variant={
+                          module.tenantEnabled ? "success" : "neutral"
+                        }
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {module.tenantEnabled ? "enabled" : "disabled"}
+                      </span>
+                    </td>
+                    <td data-label="Core">
+                      {module.isCore ? (
+                        <span class="status-badge" data-variant="info">
+                          core
+                        </span>
+                      ) : (
+                        <span class="cell-muted">—</span>
                       )}
                     </td>
-                  )}
-                </tr>
-              );
-            })}
+                    {canToggle && (
+                      <td data-label="Actions" class="stacked-block">
+                        <div class="row-actions">
+                          {showDisable && (
+                            <button
+                              type="button"
+                              class="module-toggle"
+                              data-module-key={module.moduleKey}
+                              data-action="disable"
+                            >
+                              Disable
+                            </button>
+                          )}
+                          {showEnable && (
+                            <button
+                              type="button"
+                              class="module-toggle"
+                              data-module-key={module.moduleKey}
+                              data-action="enable"
+                            >
+                              Enable
+                            </button>
+                          )}
+                          {!showDisable && !showEnable && (
+                            <span class="cell-muted">—</span>
+                          )}
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                );
+              })
+            )}
           </tbody>
         </table>
       </div>

--- a/src/pages/admin/offices.astro
+++ b/src/pages/admin/offices.astro
@@ -23,6 +23,7 @@
  * they are reachable for restore.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
@@ -93,11 +94,18 @@ if (canRead) {
 ---
 
 <AdminLayout title="Offices" active="offices">
-  <h1 id="offices-heading">Offices</h1>
+  <header class="page-header fade-in-up">
+    <h1 id="offices-heading">Offices</h1>
+    <p class="page-description">
+      The tenant's office hierarchy. Offices can be edited inline, soft-deleted,
+      and restored — deleted offices are listed separately so they remain
+      reachable.
+    </p>
+  </header>
 
   {
     !canRead && (
-      <p class="state-notice" id="offices-denied">
+      <p class="state-notice fade-in-up" id="offices-denied">
         You do not have permission to view offices.
       </p>
     )
@@ -105,7 +113,7 @@ if (canRead) {
 
   {
     canRead && loadError && (
-      <p class="state-notice" id="offices-error">
+      <p class="state-notice fade-in-up" id="offices-error">
         Offices could not be loaded right now. Please try again later.
       </p>
     )
@@ -113,7 +121,8 @@ if (canRead) {
 
   {
     canCreate && (
-      <form id="office-create-form" class="admin-create-form">
+      <form id="office-create-form" class="admin-create-form fade-in-up">
+        <p class="form-legend">Create an office</p>
         <p
           id="office-create-error"
           class="admin-create-error"
@@ -168,8 +177,8 @@ if (canRead) {
 
   {
     canRead && !loadError && (
-      <div class="data-table-scroll">
-        <table class="data-table" id="offices-table">
+      <div class="data-table-scroll fade-in-up">
+        <table class="data-table data-table--stack" id="offices-table">
           <caption>{offices.length} office(s)</caption>
           <thead>
             <tr>
@@ -184,14 +193,29 @@ if (canRead) {
             {offices.length === 0 ? (
               <tr>
                 <td class="data-table-empty" colspan={showActions ? 5 : 4}>
-                  No offices yet.
+                  <div class="empty-state">
+                    <span class="empty-state-icon" aria-hidden="true">
+                      ⌂
+                    </span>
+                    <span class="empty-state-title">No offices yet</span>
+                    <span class="empty-state-text">
+                      {canCreate
+                        ? "Create your first office using the form above."
+                        : "Offices created for this tenant will appear here."}
+                    </span>
+                  </div>
                 </td>
               </tr>
             ) : (
               offices.map((office) => (
                 <tr data-office-row={office.id}>
-                  <td>{office.officeCode}</td>
-                  <td>
+                  <td data-label="Code">
+                    <span class="cell-code">{office.officeCode}</span>
+                  </td>
+                  <td
+                    data-label="Name"
+                    class={canUpdate ? "stacked-block" : ""}
+                  >
                     {canUpdate ? (
                       <input
                         class="office-name-input"
@@ -204,8 +228,13 @@ if (canRead) {
                       office.officeName
                     )}
                   </td>
-                  <td>{office.officeType}</td>
-                  <td>
+                  <td data-label="Type">
+                    <span class="cell-muted">{office.officeType}</span>
+                  </td>
+                  <td
+                    data-label="Status"
+                    class={canUpdate ? "stacked-block" : ""}
+                  >
                     {canUpdate ? (
                       <select
                         class="office-status-select"
@@ -228,31 +257,34 @@ if (canRead) {
                           office.status === "active" ? "success" : "neutral"
                         }
                       >
+                        <span class="status-dot" aria-hidden="true" />
                         {office.status}
                       </span>
                     )}
                   </td>
                   {showActions && (
-                    <td>
-                      {canUpdate && (
-                        <button
-                          type="button"
-                          class="office-save-btn"
-                          data-office-id={office.id}
-                        >
-                          Save
-                        </button>
-                      )}
-                      {canDelete && (
-                        <button
-                          type="button"
-                          class="office-delete-btn"
-                          data-office-id={office.id}
-                          data-office-code={office.officeCode}
-                        >
-                          Delete
-                        </button>
-                      )}
+                    <td data-label="Actions" class="stacked-block">
+                      <div class="row-actions">
+                        {canUpdate && (
+                          <button
+                            type="button"
+                            class="module-toggle office-save-btn"
+                            data-office-id={office.id}
+                          >
+                            Save
+                          </button>
+                        )}
+                        {canDelete && (
+                          <button
+                            type="button"
+                            class="module-toggle office-delete-btn"
+                            data-office-id={office.id}
+                            data-office-code={office.officeCode}
+                          >
+                            Delete
+                          </button>
+                        )}
+                      </div>
                     </td>
                   )}
                 </tr>
@@ -266,10 +298,16 @@ if (canRead) {
 
   {
     canRead && !loadError && canUpdate && deletedOffices.length > 0 && (
-      <section id="deleted-offices">
-        <h2>Deleted offices</h2>
+      <section class="admin-section fade-in-up" id="deleted-offices">
+        <h2 class="admin-section-title">
+          Deleted offices
+          <span class="count-pill">{deletedOffices.length}</span>
+        </h2>
         <div class="data-table-scroll">
-          <table class="data-table" id="deleted-offices-table">
+          <table
+            class="data-table data-table--stack"
+            id="deleted-offices-table"
+          >
             <caption>{deletedOffices.length} deleted office(s)</caption>
             <thead>
               <tr>
@@ -282,18 +320,24 @@ if (canRead) {
             <tbody>
               {deletedOffices.map((office) => (
                 <tr data-deleted-office-row={office.id}>
-                  <td>{office.officeCode}</td>
-                  <td>{office.officeName}</td>
-                  <td>{office.officeType}</td>
-                  <td>
-                    <button
-                      type="button"
-                      class="office-restore-btn"
-                      data-office-id={office.id}
-                      data-office-code={office.officeCode}
-                    >
-                      Restore
-                    </button>
+                  <td data-label="Code">
+                    <span class="cell-code">{office.officeCode}</span>
+                  </td>
+                  <td data-label="Name">{office.officeName}</td>
+                  <td data-label="Type">
+                    <span class="cell-muted">{office.officeType}</span>
+                  </td>
+                  <td data-label="Actions" class="stacked-block">
+                    <div class="row-actions">
+                      <button
+                        type="button"
+                        class="module-toggle office-restore-btn"
+                        data-office-id={office.id}
+                        data-office-code={office.officeCode}
+                      >
+                        Restore
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/src/pages/admin/profiles.astro
+++ b/src/pages/admin/profiles.astro
@@ -8,6 +8,7 @@
  * only through the dedicated identifiers endpoint, never a bulk list.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
@@ -48,11 +49,18 @@ if (canRead) {
 ---
 
 <AdminLayout title="Profiles" active="profiles">
-  <h1 id="profiles-heading">Profiles</h1>
+  <header class="page-header fade-in-up">
+    <h1 id="profiles-heading">Profiles</h1>
+    <p class="page-description">
+      The tenant's central directory of people and organizations. Sensitive
+      identifiers (email, phone, NIK) are never listed here — they are surfaced
+      only through the dedicated, masked identifiers view.
+    </p>
+  </header>
 
   {
     !canRead && (
-      <p class="state-notice" id="profiles-denied">
+      <p class="state-notice fade-in-up" id="profiles-denied">
         You do not have permission to view profiles.
       </p>
     )
@@ -60,7 +68,12 @@ if (canRead) {
 
   {
     canCreate && (
-      <form id="profile-create-form" class="admin-create-form" novalidate>
+      <form
+        id="profile-create-form"
+        class="admin-create-form fade-in-up"
+        novalidate
+      >
+        <p class="form-legend">Create a profile</p>
         <label for="profile-type">
           Type
           <select id="profile-type" name="profileType">
@@ -94,7 +107,7 @@ if (canRead) {
 
   {
     canRead && loadError && (
-      <p class="state-notice" id="profiles-error">
+      <p class="state-notice fade-in-up" id="profiles-error">
         Profiles could not be loaded right now. Please try again later.
       </p>
     )
@@ -102,8 +115,8 @@ if (canRead) {
 
   {
     canRead && !loadError && (
-      <div class="data-table-scroll">
-        <table class="data-table" id="profiles-table">
+      <div class="data-table-scroll fade-in-up">
+        <table class="data-table data-table--stack" id="profiles-table">
           <caption>{profiles.length} profile(s)</caption>
           <thead>
             <tr>
@@ -117,25 +130,40 @@ if (canRead) {
             {profiles.length === 0 ? (
               <tr>
                 <td class="data-table-empty" colspan="4">
-                  No profiles yet.
+                  <div class="empty-state">
+                    <span class="empty-state-icon" aria-hidden="true">
+                      ○
+                    </span>
+                    <span class="empty-state-title">No profiles yet</span>
+                    <span class="empty-state-text">
+                      {canCreate
+                        ? "Create the first profile using the form above."
+                        : "Profiles created for this tenant will appear here."}
+                    </span>
+                  </div>
                 </td>
               </tr>
             ) : (
               profiles.map((profile) => (
                 <tr>
-                  <td>{profile.displayName}</td>
-                  <td>{profile.profileType}</td>
-                  <td>
+                  <td data-label="Display name">{profile.displayName}</td>
+                  <td data-label="Type">
+                    <span class="cell-muted">{profile.profileType}</span>
+                  </td>
+                  <td data-label="Status">
                     <span
                       class="status-badge"
                       data-variant={
                         profile.status === "active" ? "success" : "neutral"
                       }
                     >
+                      <span class="status-dot" aria-hidden="true" />
                       {profile.status}
                     </span>
                   </td>
-                  <td>{profile.verificationStatus}</td>
+                  <td data-label="Verification">
+                    <span class="cell-muted">{profile.verificationStatus}</span>
+                  </td>
                 </tr>
               ))
             )}

--- a/src/pages/admin/roles.astro
+++ b/src/pages/admin/roles.astro
@@ -18,6 +18,7 @@
  * only loaded when `canConfigure`, so a read-only viewer pays no extra reads.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
@@ -102,11 +103,17 @@ const colCount = canConfigure ? 5 : 4;
 ---
 
 <AdminLayout title="Roles" active="roles">
-  <h1 id="roles-heading">Roles</h1>
+  <header class="page-header fade-in-up">
+    <h1 id="roles-heading">Roles</h1>
+    <p class="page-description">
+      RBAC roles for this tenant and the permissions granted to each. System
+      roles (such as <code>owner</code>) are protected and cannot be deleted.
+    </p>
+  </header>
 
   {
     !canRead && (
-      <p class="state-notice" id="roles-denied">
+      <p class="state-notice fade-in-up" id="roles-denied">
         You do not have permission to view roles.
       </p>
     )
@@ -114,7 +121,7 @@ const colCount = canConfigure ? 5 : 4;
 
   {
     canRead && loadError && (
-      <p class="state-notice" id="roles-error">
+      <p class="state-notice fade-in-up" id="roles-error">
         Roles could not be loaded right now. Please try again later.
       </p>
     )
@@ -133,7 +140,8 @@ const colCount = canConfigure ? 5 : 4;
 
   {
     canConfigure && !loadError && (
-      <form id="role-create-form" class="admin-create-form">
+      <form id="role-create-form" class="admin-create-form fade-in-up">
+        <p class="form-legend">Create a role</p>
         <p
           id="role-create-error"
           class="admin-create-error"
@@ -168,8 +176,8 @@ const colCount = canConfigure ? 5 : 4;
 
   {
     canRead && !loadError && (
-      <div class="data-table-scroll">
-        <table class="data-table" id="roles-table">
+      <div class="data-table-scroll fade-in-up">
+        <table class="data-table data-table--stack" id="roles-table">
           <caption>{roles.length} role(s)</caption>
           <thead>
             <tr>
@@ -184,15 +192,27 @@ const colCount = canConfigure ? 5 : 4;
             {rows.length === 0 ? (
               <tr>
                 <td class="data-table-empty" colspan={colCount}>
-                  No roles yet.
+                  <div class="empty-state">
+                    <span class="empty-state-icon" aria-hidden="true">
+                      ◆
+                    </span>
+                    <span class="empty-state-title">No roles yet</span>
+                    <span class="empty-state-text">
+                      {canConfigure
+                        ? "Create the first role using the form above."
+                        : "Roles defined for this tenant will appear here."}
+                    </span>
+                  </div>
                 </td>
               </tr>
             ) : (
               rows.map(({ role, granted, available }) => (
                 <tr>
-                  <td>{role.roleCode}</td>
-                  <td>{role.roleName}</td>
-                  <td>
+                  <td data-label="Code">
+                    <span class="cell-code">{role.roleCode}</span>
+                  </td>
+                  <td data-label="Name">{role.roleName}</td>
+                  <td data-label="System">
                     <span
                       class="status-badge"
                       data-variant={role.isSystem ? "warning" : "neutral"}
@@ -200,38 +220,49 @@ const colCount = canConfigure ? 5 : 4;
                       {role.isSystem ? "system" : "custom"}
                     </span>
                   </td>
-                  <td>{role.permissionCount}</td>
+                  <td data-label="Permissions">
+                    <span class="cell-muted">{role.permissionCount}</span>
+                  </td>
                   {canConfigure && (
-                    <td>
-                      <button
-                        type="button"
-                        data-role-action="rename"
-                        data-role-id={role.id}
-                        data-role-name={role.roleName}
-                      >
-                        Rename
-                      </button>
-                      {!role.isSystem && (
+                    <td data-label="Actions" class="stacked-block">
+                      <div class="row-actions">
                         <button
                           type="button"
-                          data-role-action="delete"
+                          class="module-toggle"
+                          data-role-action="rename"
                           data-role-id={role.id}
-                          data-role-code={role.roleCode}
+                          data-role-name={role.roleName}
                         >
-                          Delete
+                          Rename
                         </button>
-                      )}
+                        {!role.isSystem && (
+                          <button
+                            type="button"
+                            class="module-toggle"
+                            data-role-action="delete"
+                            data-role-id={role.id}
+                            data-role-code={role.roleCode}
+                          >
+                            Delete
+                          </button>
+                        )}
+                      </div>
                       <details class="role-permissions">
                         <summary>Permissions ({granted.length})</summary>
-                        <ul>
+                        <ul class="perm-list">
                           {granted.length === 0 ? (
-                            <li>No permissions granted.</li>
+                            <li>
+                              <span class="cell-muted">
+                                No permissions granted.
+                              </span>
+                            </li>
                           ) : (
                             granted.map((p) => (
                               <li>
-                                <code>{permLabel(p)}</code>{" "}
+                                <code>{permLabel(p)}</code>
                                 <button
                                   type="button"
+                                  class="btn-inline btn-inline--danger"
                                   data-role-action="revoke"
                                   data-role-id={role.id}
                                   data-permission-id={p.id}
@@ -273,10 +304,13 @@ const colCount = canConfigure ? 5 : 4;
 
   {
     canConfigure && !loadError && deletedRoles.length > 0 && (
-      <section id="deleted-roles">
-        <h2>Deleted roles</h2>
+      <section class="admin-section fade-in-up" id="deleted-roles">
+        <h2 class="admin-section-title">
+          Deleted roles
+          <span class="count-pill">{deletedRoles.length}</span>
+        </h2>
         <div class="data-table-scroll">
-          <table class="data-table" id="deleted-roles-table">
+          <table class="data-table data-table--stack" id="deleted-roles-table">
             <caption>{deletedRoles.length} deleted role(s)</caption>
             <thead>
               <tr>
@@ -288,17 +322,22 @@ const colCount = canConfigure ? 5 : 4;
             <tbody>
               {deletedRoles.map((role) => (
                 <tr>
-                  <td>{role.roleCode}</td>
-                  <td>{role.roleName}</td>
-                  <td>
-                    <button
-                      type="button"
-                      data-role-action="restore"
-                      data-role-id={role.id}
-                      data-role-code={role.roleCode}
-                    >
-                      Restore
-                    </button>
+                  <td data-label="Code">
+                    <span class="cell-code">{role.roleCode}</span>
+                  </td>
+                  <td data-label="Name">{role.roleName}</td>
+                  <td data-label="Actions" class="stacked-block">
+                    <div class="row-actions">
+                      <button
+                        type="button"
+                        class="module-toggle"
+                        data-role-action="restore"
+                        data-role-id={role.id}
+                        data-role-code={role.roleCode}
+                      >
+                        Restore
+                      </button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -17,6 +17,7 @@
  * endpoint needs the role ID, so we resolve code → id here from `listRoles`.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
@@ -66,11 +67,18 @@ const showActions = canConfigure || canAssign;
 ---
 
 <AdminLayout title="Users" active="users">
-  <h1 id="users-heading">Users</h1>
+  <header class="page-header fade-in-up">
+    <h1 id="users-heading">Users</h1>
+    <p class="page-description">
+      Tenant users, their status, and their assigned roles. Login identifiers
+      are masked here — they are personal data and are never shown in full in a
+      list view.
+    </p>
+  </header>
 
   {
     !canRead && (
-      <p class="state-notice" id="users-denied">
+      <p class="state-notice fade-in-up" id="users-denied">
         You do not have permission to view users.
       </p>
     )
@@ -78,7 +86,7 @@ const showActions = canConfigure || canAssign;
 
   {
     canRead && loadError && (
-      <p class="state-notice" id="users-error">
+      <p class="state-notice fade-in-up" id="users-error">
         Users could not be loaded right now. Please try again later.
       </p>
     )
@@ -93,8 +101,8 @@ const showActions = canConfigure || canAssign;
           role="alert"
           hidden
         />
-        <div class="data-table-scroll">
-          <table class="data-table" id="users-table">
+        <div class="data-table-scroll fade-in-up">
+          <table class="data-table data-table--stack" id="users-table">
             <caption>{users.length} user(s)</caption>
             <thead>
               <tr>
@@ -108,26 +116,39 @@ const showActions = canConfigure || canAssign;
               {users.length === 0 ? (
                 <tr>
                   <td class="data-table-empty" colspan={showActions ? 4 : 3}>
-                    No users yet.
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ◑
+                      </span>
+                      <span class="empty-state-title">No users yet</span>
+                      <span class="empty-state-text">
+                        Users provisioned for this tenant will appear here.
+                      </span>
+                    </div>
                   </td>
                 </tr>
               ) : (
                 users.map((user) => (
                   <tr>
-                    <td>{user.loginIdentifierMasked}</td>
-                    <td>
+                    <td data-label="Login identifier">
+                      <span class="cell-code">
+                        {user.loginIdentifierMasked}
+                      </span>
+                    </td>
+                    <td data-label="Status">
                       <span
                         class="status-badge"
                         data-variant={
                           user.status === "active" ? "success" : "neutral"
                         }
                       >
+                        <span class="status-dot" aria-hidden="true" />
                         {user.status}
                       </span>
                     </td>
-                    <td>
+                    <td data-label="Roles" class="stacked-block">
                       {user.roles.length === 0 ? (
-                        "—"
+                        <span class="cell-muted">—</span>
                       ) : (
                         <ul class="role-chip-list">
                           {user.roles.map((code) => (
@@ -150,47 +171,51 @@ const showActions = canConfigure || canAssign;
                       )}
                     </td>
                     {showActions && (
-                      <td>
-                        {canConfigure && (
-                          <button
-                            type="button"
-                            class="module-toggle js-user-status"
-                            data-user-id={user.id}
-                            data-next-status={
-                              user.status === "active" ? "inactive" : "active"
-                            }
-                          >
-                            {user.status === "active"
-                              ? "Deactivate"
-                              : "Activate"}
-                          </button>
-                        )}
-                        {canAssign && roles.length > 0 && (
-                          <span class="assign-role-control">
-                            <label
-                              class="visually-hidden"
-                              for={`assign-role-${user.id}`}
-                            >
-                              Role to assign
-                            </label>
-                            <select
-                              id={`assign-role-${user.id}`}
-                              class="js-assign-role-select"
-                            >
-                              {roles.map((role) => (
-                                <option value={role.id}>{role.roleCode}</option>
-                              ))}
-                            </select>
+                      <td data-label="Actions" class="stacked-block">
+                        <div class="row-actions">
+                          {canConfigure && (
                             <button
                               type="button"
-                              class="module-toggle js-assign-role"
+                              class="module-toggle js-user-status"
                               data-user-id={user.id}
-                              data-select-id={`assign-role-${user.id}`}
+                              data-next-status={
+                                user.status === "active" ? "inactive" : "active"
+                              }
                             >
-                              Assign
+                              {user.status === "active"
+                                ? "Deactivate"
+                                : "Activate"}
                             </button>
-                          </span>
-                        )}
+                          )}
+                          {canAssign && roles.length > 0 && (
+                            <span class="assign-role-control">
+                              <label
+                                class="visually-hidden"
+                                for={`assign-role-${user.id}`}
+                              >
+                                Role to assign
+                              </label>
+                              <select
+                                id={`assign-role-${user.id}`}
+                                class="js-assign-role-select"
+                              >
+                                {roles.map((role) => (
+                                  <option value={role.id}>
+                                    {role.roleCode}
+                                  </option>
+                                ))}
+                              </select>
+                              <button
+                                type="button"
+                                class="module-toggle js-assign-role"
+                                data-user-id={user.id}
+                                data-select-id={`assign-role-${user.id}`}
+                              >
+                                Assign
+                              </button>
+                            </span>
+                          )}
+                        </div>
                       </td>
                     )}
                   </tr>
@@ -325,25 +350,38 @@ const showActions = canConfigure || canAssign;
   .role-chip {
     padding: var(--sp-1) var(--sp-2);
     border: 1px solid var(--color-border);
-    border-radius: var(--radius-sm);
-    background: var(--color-surface);
-    font-size: var(--fs-sm);
+    border-radius: var(--radius-full);
+    background: var(--color-surface-2);
+    font-size: var(--fs-xs);
+    font-weight: var(--fw-medium);
   }
 
   .link-button {
-    padding: 0;
+    min-height: 32px;
+    padding: 0 var(--sp-1);
     border: 0;
     background: none;
     color: var(--color-text-muted);
-    font-size: var(--fs-sm);
+    font-size: var(--fs-xs);
     text-decoration: underline;
     cursor: pointer;
+    transition: color var(--motion-fast) var(--ease-standard);
+  }
+
+  .link-button:hover {
+    color: var(--color-danger);
   }
 
   .assign-role-control {
     display: inline-flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: var(--sp-2);
-    margin-inline-start: var(--sp-2);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .link-button {
+      transition: none;
+    }
   }
 </style>

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -139,7 +139,8 @@ ${shareButtonsHtml}
         articleSection: seoMetadata.articleSection,
         articleTags: seoMetadata.articleTags,
         robotsContent: seoMetadata.robotsContent,
-        structuredDataJsonLd: seoMetadata.structuredDataJsonLd
+        structuredDataJsonLd: seoMetadata.structuredDataJsonLd,
+        variant: "article"
       });
 
       return new Response(html, {

--- a/src/pages/blog/[tenantCode]/category/[slug].ts
+++ b/src/pages/blog/[tenantCode]/category/[slug].ts
@@ -75,7 +75,8 @@ ${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}/categor
           term.description ?? `Posts categorized under ${term.name}.`,
         canonicalUrl: `${url.origin}/blog/${tenantCode}/category/${term.slug}`,
         bodyHtml,
-        locale: tenant.defaultLocale
+        locale: tenant.defaultLocale,
+        variant: "list"
       });
 
       return new Response(html, {

--- a/src/pages/blog/[tenantCode]/index.ts
+++ b/src/pages/blog/[tenantCode]/index.ts
@@ -80,7 +80,8 @@ ${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}`)}`;
           `Latest posts from ${tenant.tenantName}.`,
         canonicalUrl: `${url.origin}/blog/${tenantCode}`,
         bodyHtml,
-        locale: tenant.defaultLocale
+        locale: tenant.defaultLocale,
+        variant: "list"
       });
 
       return new Response(html, {

--- a/src/pages/blog/[tenantCode]/search.ts
+++ b/src/pages/blog/[tenantCode]/search.ts
@@ -87,7 +87,8 @@ export const GET: APIRoute = async ({ params, url }) => {
         description: `Search results for "${query}" on the ${tenant.tenantName} blog.`,
         canonicalUrl: null,
         bodyHtml,
-        locale: tenant.defaultLocale
+        locale: tenant.defaultLocale,
+        variant: "list"
       });
 
       return new Response(html, {

--- a/src/pages/blog/[tenantCode]/tag/[slug].ts
+++ b/src/pages/blog/[tenantCode]/tag/[slug].ts
@@ -74,7 +74,8 @@ ${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}/tag/${t
         description: term.description ?? `Posts tagged ${term.name}.`,
         canonicalUrl: `${url.origin}/blog/${tenantCode}/tag/${term.slug}`,
         bodyHtml,
-        locale: tenant.defaultLocale
+        locale: tenant.defaultLocale,
+        variant: "list"
       });
 
       return new Response(html, {

--- a/src/pages/login.astro
+++ b/src/pages/login.astro
@@ -1,47 +1,110 @@
 ---
 /**
- * Login page (Issue #166 — ported from awcms-mini's `login.astro`, simplified
- * to awcms scope). POSTs to `POST /api/v1/auth/login`, which sets the two
- * httpOnly SSR session cookies (`src/lib/auth/ssr-session.ts`) the `/admin`
- * guard in `src/middleware.ts` then consumes.
+ * Login page (Issue #166 — ported from awcms-mini's `login.astro`; redesigned
+ * into a modern, mobile-first auth screen by the UI/UX overhaul phase 2).
+ * POSTs to `POST /api/v1/auth/login`, which sets the two httpOnly SSR session
+ * cookies (`src/lib/auth/ssr-session.ts`) the `/admin` guard in
+ * `src/middleware.ts` then consumes.
  *
- * Simplified vs mini: NO i18n (strings hardcoded English — awcms has no
- * gettext catalog yet), NO Google OIDC button, and NO
- * `<script type="application/json">` strings blob. What is kept 1:1 is the
- * stable element ids the E2E specs and the client script rely on
- * (`#login-form`, `#tenant-id`, `#login-identifier`, `#password`,
- * `#login-submit`, `#login-error`).
+ * ## Stable DOM contract (do not rename — E2E specs + client script depend on
+ * these): `#login-form`, `#tenant-id`, `#login-identifier`, `#password`,
+ * `#login-submit`, `#login-error`. The tenant field ALWAYS carries
+ * `name="tenantId"` and id `#tenant-id` regardless of which of the three
+ * shapes below it takes, so `String(formData.get("tenantId"))` in the client
+ * script keeps working and the submit still sends the `X-AWCMS-Tenant-ID`
+ * header. `<select>` and `<input>` both expose `.value` via `FormData`.
  *
- * The manual Tenant ID field is a demo simplification for this fondasi repo,
- * exactly as in mini — a derived app resolves the tenant by domain instead of
- * asking the user to paste a UUID (out of scope here).
+ * ## Auto tenant picker (UI/UX phase 2)
+ * The manual "paste a UUID" field is a poor experience, so this page reads the
+ * active tenant registry SERVER-SIDE (SSR frontmatter) — `awcms_tenants` is the
+ * root table, deliberately WITHOUT RLS (see `sql/017`), so it is queried on the
+ * app connection with NO tenant context (there is none yet — the user has not
+ * picked one). Only `id` + `tenant_name` of `status = 'active'` rows are read,
+ * nothing sensitive. The shape adapts to the count:
+ *   - 0 rows (pre-setup) OR any DB error (placeholder `DATABASE_URL`, not
+ *     migrated, breaker open) → the original manual TEXT `#tenant-id` input,
+ *     preserving backward-compatibility and the zero-fixture E2E render path.
+ *   - exactly 1 → a HIDDEN `#tenant-id` prefilled with that tenant's id plus a
+ *     read-only "Signing in to <name>" readout; the user types nothing.
+ *   - 2..TENANT_PICKER_LIMIT → a `<select id="tenant-id">` of tenant NAMES
+ *     (value = UUID).
+ *   - more than TENANT_PICKER_LIMIT → fall back to the manual input rather than
+ *     render a huge public dropdown (bounds the query AND avoids mass tenant
+ *     enumeration; a deployment with that many tenants resolves the tenant by
+ *     domain, not by asking the user to scroll a list).
+ * Rendering tenant names to an unauthenticated visitor when count > 1 is an
+ * accepted product decision for this base repo's small multi-tenant dev
+ * setups; the query is capped and read-only.
  *
- * Cloudflare Turnstile (Issue #186) — the widget and its loader script render
- * ONLY when `isTurnstileRequired()` (the full-online deployment-profile gate
- * AND `TURNSTILE_ENABLED=true`) is true. Every local/offline/LAN deployment
- * (the default) renders this page byte-identically to before this issue: no
- * `cf-turnstile` div, no `challenges.cloudflare.com` script, no iframe. When
- * required, the middleware CSP opens `script-src`/`frame-src` for that one
- * Cloudflare origin (see `src/lib/security/security-headers.ts`), and the
- * external loader is an explicit `is:inline` `<script src>` (NOT an
- * Astro-bundled module — those only load from `'self'`). `TURNSTILE_SITE_KEY`
- * is public (Cloudflare embeds it in every widget); `TURNSTILE_SECRET_KEY` is
- * server-side only and never reaches this page.
+ * ## Cloudflare Turnstile (Issue #186)
+ * The widget and its loader render ONLY when `isTurnstileRequired()` (the
+ * full-online deployment-profile gate AND `TURNSTILE_ENABLED=true`). Every
+ * local/offline/LAN deployment (the default) renders no `cf-turnstile` div and
+ * no `challenges.cloudflare.com` script. When required, the middleware CSP
+ * opens `script-src`/`frame-src` for that one Cloudflare origin
+ * (`src/lib/security/security-headers.ts`) and the external loader is an
+ * explicit `is:inline` `<script src>`. `TURNSTILE_SITE_KEY` is public;
+ * `TURNSTILE_SECRET_KEY` is server-side only and never reaches this page.
  *
- * CSP: `tokens.css`/`admin.css` are external <link>s (`inlineStylesheets:
- * "never"`) and the login client below is an Astro-bundled module script — no
- * inline script/style, so the middleware `default-src 'self'` policy holds.
+ * ## CSP (strict, single-owner)
+ * `default-src 'self'` with NO `'unsafe-inline'`. Everything on this page obeys
+ * it: `tokens.css`/`motion.css` and the Astro-scoped `<style>` below are all
+ * emitted as external same-origin `<link>`s (`build.inlineStylesheets:
+ * "never"`, see astro.config.mjs), the login client is an Astro-BUNDLED module
+ * script (not `is:inline`), animations are pure CSS, and no third-party origin
+ * (font CDN / library) is referenced. Non-essential motion degrades under
+ * `@media (prefers-reduced-motion: reduce)`.
  */
 import "../styles/tokens.css";
-import "../styles/admin.css";
+import "../styles/motion.css";
 import {
   isTurnstileRequired,
   resolveTurnstileSiteKey,
   LOGIN_TURNSTILE_ACTION
 } from "../lib/security/turnstile";
+import { getDatabaseClient } from "../lib/database/client";
 
 const turnstileActive = isTurnstileRequired();
 const turnstileSiteKey = turnstileActive ? resolveTurnstileSiteKey() : null;
+
+// --- Auto tenant picker (read-only SSR read of the root tenant registry) ---
+type TenantOption = { id: string; name: string };
+type TenantPickerMode = "manual" | "single" | "select";
+
+/**
+ * Hard cap on the public dropdown. `LIMIT +1` lets us detect "more than this"
+ * without counting the whole table; past the cap we render the manual input
+ * instead of a giant enumerable list.
+ */
+const TENANT_PICKER_LIMIT = 50;
+
+let tenantOptions: TenantOption[] = [];
+let tenantPickerMode: TenantPickerMode = "manual";
+
+try {
+  const sql = getDatabaseClient();
+  // No `withTenant` — `awcms_tenants` is the RLS-free root table and there is
+  // no tenant context to set before the user has chosen one.
+  const rows = (await sql`
+    SELECT id, tenant_name
+    FROM awcms_tenants
+    WHERE status = 'active'
+    ORDER BY tenant_name ASC
+    LIMIT ${TENANT_PICKER_LIMIT + 1}
+  `) as Array<{ id: string; tenant_name: string }>;
+
+  if (rows.length >= 1 && rows.length <= TENANT_PICKER_LIMIT) {
+    tenantOptions = rows.map((row) => ({ id: row.id, name: row.tenant_name }));
+    tenantPickerMode = tenantOptions.length === 1 ? "single" : "select";
+  }
+  // rows.length === 0 (pre-setup) or > cap → keep the manual input.
+} catch {
+  // No DB / placeholder DATABASE_URL / not migrated / breaker open — degrade to
+  // the manual Tenant ID field so /login always renders.
+  tenantPickerMode = "manual";
+}
+
+const singleTenant = tenantPickerMode === "single" ? tenantOptions[0]! : null;
 ---
 
 <!doctype html>
@@ -49,53 +112,131 @@ const turnstileSiteKey = turnstileActive ? resolveTurnstileSiteKey() : null;
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
     <title>Sign in · AWCMS</title>
   </head>
-  <body>
-    <main class="login-page">
-      <form id="login-form" class="login-form" novalidate>
-        <h1>AWCMS</h1>
-        <p id="login-error" class="login-error" role="alert" hidden></p>
+  <body class="auth-body">
+    <main class="auth">
+      <div class="auth-card fade-in-up">
+        <div class="auth-head">
+          <div class="auth-brand">
+            <span class="auth-mark" aria-hidden="true">A</span>
+            <span class="auth-wordmark">AWCMS</span>
+          </div>
+          <h1 class="auth-title">Sign in</h1>
+          <p class="auth-subtitle">Welcome back. Sign in to your workspace.</p>
+        </div>
 
-        <label for="tenant-id">Tenant ID</label>
-        <input
-          id="tenant-id"
-          name="tenantId"
-          type="text"
-          required
-          autocomplete="off"
-        />
+        <form id="login-form" class="auth-form" novalidate>
+          <p id="login-error" class="auth-error" role="alert" hidden></p>
 
-        <label for="login-identifier">Login identifier</label>
-        <input
-          id="login-identifier"
-          name="loginIdentifier"
-          type="text"
-          required
-          autocomplete="username"
-        />
+          {
+            singleTenant && (
+              <div class="auth-tenant-context">
+                <span class="auth-tenant-context-label">Signing in to</span>
+                <span class="auth-tenant-context-name">
+                  {singleTenant.name}
+                </span>
+                <input
+                  id="tenant-id"
+                  name="tenantId"
+                  type="hidden"
+                  value={singleTenant.id}
+                />
+              </div>
+            )
+          }
 
-        <label for="password">Password</label>
-        <input
-          id="password"
-          name="password"
-          type="password"
-          required
-          autocomplete="current-password"
-        />
+          {
+            tenantPickerMode === "select" && (
+              <div class="auth-field">
+                <label for="tenant-id">Organization</label>
+                <div class="auth-select">
+                  <select
+                    id="tenant-id"
+                    name="tenantId"
+                    required
+                    autocomplete="organization"
+                  >
+                    <option value="" disabled selected>
+                      Choose your organization
+                    </option>
+                    {tenantOptions.map((tenant) => (
+                      <option value={tenant.id}>{tenant.name}</option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+            )
+          }
 
-        {
-          turnstileActive && turnstileSiteKey && (
-            <div
-              class="cf-turnstile"
-              data-sitekey={turnstileSiteKey}
-              data-action={LOGIN_TURNSTILE_ACTION}
+          {
+            tenantPickerMode === "manual" && (
+              <div class="auth-field">
+                <label for="tenant-id">Tenant ID</label>
+                <input
+                  id="tenant-id"
+                  name="tenantId"
+                  type="text"
+                  required
+                  autocomplete="off"
+                  spellcheck={false}
+                />
+              </div>
+            )
+          }
+
+          <div class="auth-field">
+            <label for="login-identifier">Login identifier</label>
+            <input
+              id="login-identifier"
+              name="loginIdentifier"
+              type="text"
+              required
+              autocomplete="username"
+              spellcheck={false}
             />
-          )
-        }
+          </div>
 
-        <button type="submit" id="login-submit">Sign in</button>
-      </form>
+          <div class="auth-field">
+            <label for="password">Password</label>
+            <div class="auth-password">
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                autocomplete="current-password"
+              />
+              <button
+                type="button"
+                id="password-toggle"
+                class="auth-password-toggle"
+                aria-pressed="false"
+                aria-label="Show password"
+              >
+                <span class="auth-password-toggle-label">Show</span>
+              </button>
+            </div>
+          </div>
+
+          {
+            turnstileActive && turnstileSiteKey && (
+              <div
+                class="cf-turnstile auth-turnstile"
+                data-sitekey={turnstileSiteKey}
+                data-action={LOGIN_TURNSTILE_ACTION}
+              />
+            )
+          }
+
+          <button type="submit" id="login-submit" class="auth-submit">
+            Sign in
+          </button>
+        </form>
+
+        <p class="auth-foot">Secured workspace access · AWCMS</p>
+      </div>
     </main>
 
     {
@@ -122,6 +263,33 @@ const turnstileSiteKey = turnstileActive ? resolveTurnstileSiteKey() : null;
       const submitButton = document.getElementById(
         "login-submit"
       ) as HTMLButtonElement | null;
+
+      // Password visibility toggle — pure enhancement, wired here (no inline
+      // handler) so the strict CSP is respected. Absent-safe if the elements
+      // are ever removed.
+      const passwordInput = document.getElementById(
+        "password"
+      ) as HTMLInputElement | null;
+      const passwordToggle = document.getElementById(
+        "password-toggle"
+      ) as HTMLButtonElement | null;
+      const passwordToggleLabel = passwordToggle?.querySelector(
+        ".auth-password-toggle-label"
+      );
+
+      passwordToggle?.addEventListener("click", () => {
+        if (!passwordInput) return;
+        const reveal = passwordInput.type === "password";
+        passwordInput.type = reveal ? "text" : "password";
+        passwordToggle.setAttribute("aria-pressed", String(reveal));
+        passwordToggle.setAttribute(
+          "aria-label",
+          reveal ? "Hide password" : "Show password"
+        );
+        if (passwordToggleLabel) {
+          passwordToggleLabel.textContent = reveal ? "Hide" : "Show";
+        }
+      });
 
       function showError(message: string): void {
         if (!errorBox) return;
@@ -186,5 +354,309 @@ const turnstileSiteKey = turnstileActive ? resolveTurnstileSiteKey() : null;
         }
       });
     </script>
+
+    <style>
+      /*
+       * Login surface styles — Astro-scoped, so emitted as an EXTERNAL
+       * same-origin stylesheet (build.inlineStylesheets: "never"); never an
+       * inline <style> the middleware CSP would block. Tokens only (no literal
+       * colours/sizes) from tokens.css. Mobile-first: base rules target small
+       * screens, one min-width query enhances larger ones.
+       */
+      .auth-body {
+        margin: 0;
+      }
+
+      .auth {
+        min-height: 100vh;
+        min-height: 100dvh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: var(--sp-4);
+        background:
+          radial-gradient(
+            120% 90% at 15% 0%,
+            var(--color-primary-soft) 0%,
+            transparent 55%
+          ),
+          radial-gradient(
+            110% 80% at 100% 100%,
+            var(--color-surface-2) 0%,
+            transparent 60%
+          ),
+          var(--color-bg);
+      }
+
+      .auth-card {
+        width: 100%;
+        max-width: 400px;
+        padding: var(--sp-6) var(--sp-5);
+        background: var(--color-surface);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-xl);
+        box-shadow: var(--shadow-lg);
+      }
+
+      .auth-head {
+        margin-bottom: var(--sp-5);
+      }
+
+      .auth-brand {
+        display: flex;
+        align-items: center;
+        gap: var(--sp-2);
+        margin-bottom: var(--sp-4);
+      }
+
+      .auth-mark {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 36px;
+        height: 36px;
+        border-radius: var(--radius-md);
+        background: linear-gradient(
+          135deg,
+          var(--color-primary) 0%,
+          var(--color-primary-hover) 100%
+        );
+        color: var(--color-primary-contrast);
+        font-weight: var(--fw-bold);
+        font-size: var(--fs-lg);
+        line-height: 1;
+        box-shadow: var(--shadow-sm);
+      }
+
+      .auth-wordmark {
+        font-weight: var(--fw-bold);
+        font-size: var(--fs-md);
+        letter-spacing: var(--tracking-wide);
+        color: var(--color-text);
+      }
+
+      .auth-title {
+        margin: 0;
+        font-size: var(--fs-2xl);
+        font-weight: var(--fw-bold);
+        line-height: var(--lh-tight);
+        letter-spacing: var(--tracking-tight);
+        color: var(--color-text);
+      }
+
+      .auth-subtitle {
+        margin: var(--sp-2) 0 0;
+        font-size: var(--fs-sm);
+        color: var(--color-text-muted);
+        line-height: var(--lh-snug);
+      }
+
+      .auth-form {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-4);
+      }
+
+      .auth-field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--sp-1);
+      }
+
+      .auth-field label {
+        font-size: var(--fs-sm);
+        font-weight: var(--fw-medium);
+        color: var(--color-text);
+      }
+
+      .auth-form input[type="text"],
+      .auth-form input[type="password"],
+      .auth-form select {
+        width: 100%;
+        min-height: 44px;
+        padding: 0 var(--sp-3);
+        background: var(--color-surface);
+        color: var(--color-text);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        font-size: var(--fs-base);
+        transition:
+          border-color var(--motion-fast) var(--ease-standard),
+          box-shadow var(--motion-fast) var(--ease-standard);
+      }
+
+      .auth-form input::placeholder {
+        color: var(--color-text-muted);
+      }
+
+      .auth-form input[type="text"]:hover,
+      .auth-form input[type="password"]:hover,
+      .auth-form select:hover {
+        border-color: var(--color-text-muted);
+      }
+
+      .auth-form input[type="text"]:focus-visible,
+      .auth-form input[type="password"]:focus-visible,
+      .auth-form select:focus-visible {
+        outline: none;
+        border-color: var(--color-focus);
+        box-shadow: 0 0 0 3px var(--color-primary-soft);
+      }
+
+      /* Tenant readout (single-tenant deployment). */
+      .auth-tenant-context {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        padding: var(--sp-3);
+        background: var(--color-primary-soft);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+      }
+
+      .auth-tenant-context-label {
+        font-size: var(--fs-xs);
+        text-transform: uppercase;
+        letter-spacing: var(--tracking-wide);
+        color: var(--color-text-muted);
+      }
+
+      .auth-tenant-context-name {
+        font-size: var(--fs-base);
+        font-weight: var(--fw-semibold);
+        color: var(--color-text);
+      }
+
+      /* Select wrapper — CSS-drawn caret (no data: URI, CSP-safe). */
+      .auth-select {
+        position: relative;
+      }
+
+      .auth-select select {
+        appearance: none;
+        -webkit-appearance: none;
+        padding-right: var(--sp-6);
+        cursor: pointer;
+      }
+
+      .auth-select::after {
+        content: "";
+        position: absolute;
+        right: var(--sp-3);
+        top: 50%;
+        width: 8px;
+        height: 8px;
+        border-right: 2px solid var(--color-text-muted);
+        border-bottom: 2px solid var(--color-text-muted);
+        transform: translateY(-70%) rotate(45deg);
+        pointer-events: none;
+      }
+
+      /* Password field with inline show/hide toggle. */
+      .auth-password {
+        position: relative;
+        display: flex;
+        align-items: center;
+      }
+
+      .auth-password input {
+        padding-right: 72px;
+      }
+
+      .auth-password-toggle {
+        position: absolute;
+        right: var(--sp-1);
+        top: 50%;
+        transform: translateY(-50%);
+        min-height: 36px;
+        min-width: 56px;
+        padding: 0 var(--sp-2);
+        background: transparent;
+        border: none;
+        border-radius: var(--radius-sm);
+        color: var(--color-primary);
+        font-size: var(--fs-sm);
+        font-weight: var(--fw-medium);
+        cursor: pointer;
+      }
+
+      .auth-password-toggle:hover {
+        background: var(--color-surface-hover);
+      }
+
+      .auth-error {
+        margin: 0;
+        padding: var(--sp-3);
+        background: var(--color-danger-strong);
+        color: var(--color-primary-contrast);
+        border-radius: var(--radius-md);
+        font-size: var(--fs-sm);
+        line-height: var(--lh-snug);
+      }
+
+      .auth-turnstile {
+        min-height: 65px;
+      }
+
+      .auth-submit {
+        margin-top: var(--sp-1);
+        min-height: 48px;
+        padding: 0 var(--sp-4);
+        background: var(--color-primary-strong);
+        color: var(--color-primary-contrast);
+        border: none;
+        border-radius: var(--radius-md);
+        font-size: var(--fs-base);
+        font-weight: var(--fw-semibold);
+        cursor: pointer;
+        transition:
+          background-color var(--motion-fast) var(--ease-standard),
+          transform var(--motion-fast) var(--ease-standard);
+      }
+
+      .auth-submit:hover {
+        background: var(--color-primary-hover);
+      }
+
+      .auth-submit:active {
+        transform: translateY(1px);
+      }
+
+      .auth-submit:disabled {
+        cursor: not-allowed;
+        opacity: 0.7;
+      }
+
+      .auth-foot {
+        margin: var(--sp-5) 0 0;
+        text-align: center;
+        font-size: var(--fs-xs);
+        color: var(--color-text-muted);
+      }
+
+      @media (min-width: 640px) {
+        .auth-card {
+          padding: var(--sp-7) var(--sp-6);
+        }
+      }
+
+      /*
+       * Non-essential motion: the submit's active-nudge is decorative. The card
+       * entrance uses motion.css's `.fade-in-up`, which is itself reduced-motion
+       * guarded there. Kill the local transitions/transforms too so nothing
+       * moves for reduced-motion users.
+       */
+      @media (prefers-reduced-motion: reduce) {
+        .auth-form input[type="text"],
+        .auth-form input[type="password"],
+        .auth-form select,
+        .auth-submit {
+          transition: none;
+        }
+        .auth-submit:active {
+          transform: none;
+        }
+      }
+    </style>
   </body>
 </html>

--- a/src/styles/admin-screens.css
+++ b/src/styles/admin-screens.css
@@ -1,0 +1,431 @@
+/*
+ * admin-screens.css — additive presentation layer for the 8 admin management
+ * screens (`src/pages/admin/*.astro`). Phase-2 of the UI/UX overhaul.
+ *
+ * SCOPE: imported ONLY by the admin page frontmatter (never by the login or
+ * public/blog shells), so it is an admin-owned file — it does NOT modify the
+ * shared Phase-1 foundation (`tokens.css`, `motion.css`, `admin.css`,
+ * layouts). It COMPOSES those: every value here is a `tokens.css` custom
+ * property, and every animation reuses a `motion.css` utility applied in the
+ * markup (`.fade-in-up`, `.stagger-children`, `.hover-lift`, …). This file
+ * introduces NO new design token.
+ *
+ * CSP (unchanged): pure same-origin CSS, no @import / font / CDN / inline. With
+ * `build.inlineStylesheets: "never"` (astro.config.mjs) an `import "*.css"`
+ * from a page is emitted as an external <link> from our own origin, so the
+ * strict `default-src 'self'` policy (tests/security-headers-csp.test.ts)
+ * holds — nothing here weakens it.
+ *
+ * ACCESSIBILITY: the only local transitions are on `.admin-panel`/`.stat-card`
+ * hover and the details/summary marker; all are decorative and stripped under
+ * `@media (prefers-reduced-motion: reduce)` at the bottom. Entrance motion is
+ * delegated entirely to `motion.css` (already reduced-motion guarded). Touch
+ * targets in tables are bumped to >=44px on small screens.
+ */
+
+/* ==================================================================== */
+/* Page header — title + supporting description                         */
+/* ==================================================================== */
+.page-header {
+  margin-bottom: var(--sp-5);
+}
+
+.page-header .page-description {
+  margin: var(--sp-2) 0 0;
+  max-width: 68ch;
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
+}
+
+/* Action row that sits under a header (e.g. a count + a right-aligned CTA). */
+.admin-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  margin-bottom: var(--sp-4);
+}
+
+/* ==================================================================== */
+/* Panel / section wrapper — a titled surface card                       */
+/* ==================================================================== */
+.admin-panel {
+  padding: var(--sp-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+}
+
+.admin-section {
+  margin-top: var(--sp-6);
+}
+
+.admin-section-title {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--sp-2);
+  margin: 0 0 var(--sp-3);
+  font-size: var(--fs-lg);
+  line-height: var(--lh-tight);
+}
+
+.admin-section-title .count-pill {
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-full);
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  font-size: var(--fs-xs);
+  font-weight: var(--fw-semibold);
+}
+
+/* A form title so the create-form card reads as a labelled section. */
+.form-legend {
+  margin: 0 0 var(--sp-3);
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--color-text);
+  flex: 1 1 100%;
+}
+
+/* ==================================================================== */
+/* Stat cards (dashboard)                                                */
+/* ==================================================================== */
+.stat-grid {
+  display: grid;
+  gap: var(--sp-4);
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .stat-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.stat-card {
+  padding: var(--sp-5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-xs);
+}
+
+.stat-card .stat-label {
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  color: var(--color-text-muted);
+}
+
+.stat-card .stat-value {
+  margin-top: var(--sp-2);
+  font-size: var(--fs-2xl);
+  font-weight: var(--fw-bold);
+  line-height: var(--lh-tight);
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.stat-card .stat-value.stat-value--mono {
+  font-family: var(--font-mono);
+  font-size: var(--fs-lg);
+}
+
+.stat-card .stat-hint {
+  margin-top: var(--sp-2);
+  font-size: var(--fs-xs);
+  color: var(--color-text-muted);
+}
+
+/* Quick-link tiles (dashboard shortcuts). */
+.quick-links {
+  display: grid;
+  gap: var(--sp-3);
+  grid-template-columns: 1fr;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+@media (min-width: 640px) {
+  .quick-links {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
+.quick-link {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  min-height: 48px;
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  color: var(--color-text);
+  text-decoration: none;
+  font-weight: var(--fw-semibold);
+  font-size: var(--fs-sm);
+  box-shadow: var(--shadow-xs);
+}
+
+.quick-link .quick-link-arrow {
+  margin-left: auto;
+  color: var(--color-text-muted);
+  transition: transform var(--motion-fast) var(--ease-standard);
+}
+
+.quick-link:hover {
+  border-color: var(--color-primary);
+}
+
+.quick-link:hover .quick-link-arrow {
+  transform: translateX(3px);
+  color: var(--color-primary);
+}
+
+/* ==================================================================== */
+/* Friendly empty state (rendered inside a full-width table cell)        */
+/* ==================================================================== */
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-6) var(--sp-4);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.empty-state .empty-state-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-2);
+  color: var(--color-text-muted);
+  font-size: var(--fs-lg);
+  line-height: 1;
+}
+
+.empty-state .empty-state-title {
+  font-size: var(--fs-md);
+  font-weight: var(--fw-semibold);
+  color: var(--color-text);
+}
+
+.empty-state .empty-state-text {
+  max-width: 44ch;
+  font-size: var(--fs-sm);
+}
+
+/* ==================================================================== */
+/* Status badge — additive variants (composes admin.css .status-badge)   */
+/* ==================================================================== */
+.status-badge[data-variant="info"] {
+  background: var(--color-info-strong);
+  color: var(--color-primary-contrast);
+}
+
+.status-badge[data-variant="danger"] {
+  background: var(--color-danger-strong);
+  color: var(--color-primary-contrast);
+}
+
+/* A subtle "dot" prefix so a badge reads as a live status pill. */
+.status-badge .status-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: var(--sp-1);
+  border-radius: var(--radius-full);
+  background: currentcolor;
+  vertical-align: baseline;
+}
+
+/* ==================================================================== */
+/* Small inline / row action buttons                                     */
+/* ==================================================================== */
+.btn-inline {
+  min-height: 32px;
+  padding: 2px var(--sp-2);
+  background: transparent;
+  color: var(--color-primary);
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  transition:
+    background-color var(--motion-fast) var(--ease-standard),
+    color var(--motion-fast) var(--ease-standard);
+}
+
+.btn-inline:hover {
+  background: var(--color-primary-soft);
+  color: var(--color-primary-hover);
+}
+
+.btn-inline.btn-inline--danger {
+  color: var(--color-danger);
+}
+
+.btn-inline.btn-inline--danger:hover {
+  background: var(--color-surface-2);
+  color: var(--color-danger-strong);
+}
+
+.btn-inline:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* A tidy inline group so row actions wrap gracefully instead of butting up. */
+.row-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--sp-2);
+  align-items: center;
+}
+
+/* ==================================================================== */
+/* Permission chips (roles screen) + granted list                        */
+/* ==================================================================== */
+.perm-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  margin: var(--sp-2) 0;
+  padding: 0;
+  list-style: none;
+}
+
+.perm-list li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  padding: var(--sp-1) 0;
+}
+
+.perm-list code {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-text);
+  word-break: break-all;
+}
+
+/* details/summary as a compact disclosure "chip". */
+.role-permissions > summary {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  min-height: 32px;
+  padding: 2px var(--sp-2);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-medium);
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+  transition: background-color var(--motion-fast) var(--ease-standard);
+}
+
+.role-permissions > summary::-webkit-details-marker {
+  display: none;
+}
+
+.role-permissions > summary::before {
+  content: "▸";
+  display: inline-block;
+  font-size: var(--fs-xs);
+  transition: transform var(--motion-fast) var(--ease-standard);
+}
+
+.role-permissions[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.role-permissions > summary:hover {
+  background: var(--color-surface-hover);
+  color: var(--color-text);
+}
+
+/* ==================================================================== */
+/* Table polish (composes admin.css .data-table / .data-table--stack)    */
+/* ==================================================================== */
+
+/* Numeric/id cells in a monospace so codes line up + scan cleanly. */
+.data-table td .cell-code {
+  font-family: var(--font-mono);
+  font-size: var(--fs-xs);
+  color: var(--color-text);
+}
+
+.data-table td .cell-muted {
+  color: var(--color-text-muted);
+}
+
+/* On small screens, when a table opts into the card/stack layout, drop the
+   scroll wrapper's frame so we don't nest a border around the cards. */
+@media (max-width: 767.98px) {
+  .data-table-scroll:has(.data-table--stack) {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    overflow: visible;
+  }
+
+  /* A stacked cell that holds a full-width control (input/select) or a row of
+     buttons reads better as label-on-top than as a squeezed right column. */
+  .data-table--stack td.stacked-block {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: left;
+  }
+
+  .data-table--stack td.stacked-block::before {
+    margin-bottom: var(--sp-1);
+  }
+
+  .data-table--stack td.stacked-block .row-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  /* Comfortable touch targets for any control living inside a table on mobile
+     (admin.css bases some at 40px; 44px is the WCAG target). */
+  .data-table td button,
+  .data-table td .module-toggle,
+  .data-table td input,
+  .data-table td select {
+    min-height: 44px;
+    width: 100%;
+  }
+
+  .data-table td .btn-inline {
+    width: auto;
+  }
+}
+
+/* ==================================================================== */
+/* Reduced motion — strip this file's few local transitions              */
+/* ==================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .quick-link .quick-link-arrow,
+  .quick-link:hover .quick-link-arrow,
+  .btn-inline,
+  .role-permissions > summary,
+  .role-permissions > summary::before,
+  .role-permissions[open] > summary::before {
+    transition: none;
+    transform: none;
+  }
+}

--- a/src/styles/admin.css
+++ b/src/styles/admin.css
@@ -1,13 +1,48 @@
 /*
- * Admin + login shared styles (Issue #166 — first .astro pages ported from
- * awcms-mini's admin shell, adapted to awcms scope). Uses ONLY the design
- * tokens from `tokens.css` (doc 14). Kept as an external stylesheet (imported
- * by the pages, emitted as an external <link> by `build.inlineStylesheets:
- * "never"`) so it never becomes an inline <style> the middleware CSP
- * (`default-src 'self'`) would block — see astro.config.mjs.
+ * Admin + login shared styles (Issue #166; hardened into a mobile-first
+ * responsive shell by the UI/UX overhaul foundation). Uses ONLY the design
+ * tokens from `tokens.css` (doc 14) — no literal colours/sizes. Kept as an
+ * external stylesheet (imported by the pages/layout, emitted as an external
+ * <link> by `build.inlineStylesheets: "never"`) so it never becomes an inline
+ * <style> the middleware CSP (`default-src 'self'`) would block — see
+ * astro.config.mjs.
+ *
+ * Layout method: MOBILE-FIRST. Base rules target small screens; `min-width`
+ * media queries progressively enhance for larger ones. All motion is guarded
+ * by `prefers-reduced-motion` (motion tokens live in tokens.css; shared motion
+ * utilities in motion.css).
+ *
+ * Responsive admin shell (Issue #693 pattern, implemented CSS-only here):
+ * below `--bp-md` (768px) the sidebar is an off-canvas drawer toggled by a
+ * hidden, keyboard-focusable checkbox (`#admin-nav-toggle`) — no JS, so nothing
+ * to be blocked by CSP. The closed drawer is `visibility: hidden` so its links
+ * leave the tab order; a scrim `<label>` closes it on tap.
  */
 
-/* ---- Login ---------------------------------------------------------- */
+/* ==================================================================== */
+/* Skip link (keyboard a11y) — shared by admin shell                    */
+/* ==================================================================== */
+.skip-link {
+  position: absolute;
+  left: var(--sp-2);
+  top: -100px;
+  z-index: var(--z-toast);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--color-primary-strong);
+  color: var(--color-primary-contrast);
+  border-radius: var(--radius-sm);
+  font-size: var(--fs-sm);
+  font-weight: var(--fw-semibold);
+  text-decoration: none;
+  transition: top var(--motion-fast) var(--ease-out);
+}
+.skip-link:focus {
+  top: var(--sp-2);
+}
+
+/* ==================================================================== */
+/* Login                                                                */
+/* ==================================================================== */
 .login-page {
   min-height: 100vh;
   display: flex;
@@ -28,6 +63,18 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow-md);
+  animation: awcms-login-enter var(--motion-slow) var(--ease-out) both;
+}
+
+@keyframes awcms-login-enter {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .login-form h1 {
@@ -48,6 +95,13 @@
   border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
+  transition:
+    border-color var(--motion-fast) var(--ease-standard),
+    box-shadow var(--motion-fast) var(--ease-standard);
+}
+
+.login-form input:focus-visible {
+  border-color: var(--color-focus);
 }
 
 .login-form button {
@@ -59,7 +113,12 @@
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
+  transition: background-color var(--motion-fast) var(--ease-standard);
+}
+
+.login-form button:hover {
+  background: var(--color-primary-hover);
 }
 
 .login-form button:disabled {
@@ -75,7 +134,9 @@
   font-size: var(--fs-sm);
 }
 
-/* ---- Admin shell ---------------------------------------------------- */
+/* ==================================================================== */
+/* Admin shell                                                          */
+/* ==================================================================== */
 .admin-body {
   margin: 0;
   min-height: 100vh;
@@ -84,10 +145,13 @@
   font-family: var(--font-sans);
 }
 
+/* ---- Topbar (sticky) ------------------------------------------------ */
 .admin-topbar {
+  position: sticky;
+  top: 0;
+  z-index: var(--z-nav);
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: var(--sp-3);
   padding: var(--sp-3) var(--sp-4);
   background: var(--color-surface);
@@ -95,21 +159,29 @@
 }
 
 .admin-brand {
-  font-weight: 700;
+  font-weight: var(--fw-bold);
   font-size: var(--fs-md);
   color: var(--color-text);
   text-decoration: none;
+  /* Sit between the toggle and the right-hand group. */
+  margin-right: auto;
 }
 
 .admin-topbar-right {
   display: flex;
   align-items: center;
   gap: var(--sp-3);
+  min-width: 0;
 }
 
 .admin-roles {
   font-size: var(--fs-sm);
   color: var(--color-text-muted);
+  /* On narrow screens keep the role list from pushing the logout off-screen. */
+  max-width: 40vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .admin-logout {
@@ -121,19 +193,140 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: var(--fs-sm);
+  white-space: nowrap;
+  transition:
+    background-color var(--motion-fast) var(--ease-standard),
+    border-color var(--motion-fast) var(--ease-standard);
+}
+.admin-logout:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-muted);
+}
+.admin-logout:disabled {
+  cursor: not-allowed;
+  opacity: 0.75;
 }
 
+/* ---- Nav toggle (hamburger) — mobile only, CSS-only checkbox hack --- */
+.admin-nav-toggle-checkbox {
+  /* Visually hidden but focusable (keyboard operable). */
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.admin-nav-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  flex-shrink: 0;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  color: var(--color-text);
+}
+.admin-nav-toggle:hover {
+  background: var(--color-surface-hover);
+}
+
+/* Three-bar icon drawn with a span + its pseudo-elements. */
+.admin-nav-toggle-bars,
+.admin-nav-toggle-bars::before,
+.admin-nav-toggle-bars::after {
+  display: block;
+  width: 20px;
+  height: 2px;
+  border-radius: var(--radius-full);
+  background: currentcolor;
+  transition:
+    transform var(--motion-fast) var(--ease-standard),
+    opacity var(--motion-fast) var(--ease-standard);
+}
+.admin-nav-toggle-bars {
+  position: relative;
+}
+.admin-nav-toggle-bars::before,
+.admin-nav-toggle-bars::after {
+  content: "";
+  position: absolute;
+  left: 0;
+}
+.admin-nav-toggle-bars::before {
+  top: -6px;
+}
+.admin-nav-toggle-bars::after {
+  top: 6px;
+}
+
+/* Focus ring on the visible hamburger when its (hidden) checkbox is focused. */
+.admin-nav-toggle-checkbox:focus-visible + .admin-topbar .admin-nav-toggle {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+}
+
+/* Open state: morph the hamburger into an X. */
+.admin-nav-toggle-checkbox:checked + .admin-topbar .admin-nav-toggle-bars {
+  background: transparent;
+}
+.admin-nav-toggle-checkbox:checked
+  + .admin-topbar
+  .admin-nav-toggle-bars::before {
+  top: 0;
+  transform: rotate(45deg);
+}
+.admin-nav-toggle-checkbox:checked
+  + .admin-topbar
+  .admin-nav-toggle-bars::after {
+  top: 0;
+  transform: rotate(-45deg);
+}
+
+/* ---- Layout: sidebar + main ---------------------------------------- */
 .admin-layout {
-  display: flex;
+  position: relative;
   min-height: calc(100vh - 57px);
 }
 
+/* Scrim (mobile only) — a <label> that also closes the drawer on tap. */
+.admin-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--z-drawer) - 1);
+  background: var(--color-overlay);
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  cursor: pointer;
+  transition:
+    opacity var(--motion-base) var(--ease-standard),
+    visibility var(--motion-base) var(--ease-standard);
+}
+
 .admin-sidebar {
-  width: 220px;
-  flex-shrink: 0;
+  /* Base = off-canvas drawer (mobile-first). */
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  z-index: var(--z-drawer);
+  width: min(80vw, 280px);
   padding: var(--sp-4) var(--sp-3);
   background: var(--color-surface);
   border-right: 1px solid var(--color-border);
+  box-shadow: var(--shadow-lg);
+  overflow-y: auto;
+  transform: translateX(-100%);
+  visibility: hidden;
+  transition:
+    transform var(--motion-base) var(--ease-out),
+    visibility var(--motion-base) var(--ease-out);
 }
 
 .admin-sidebar nav {
@@ -144,34 +337,88 @@
 
 .admin-sidebar a {
   padding: var(--sp-2) var(--sp-3);
+  min-height: 44px;
+  display: flex;
+  align-items: center;
   border-radius: var(--radius-sm);
   color: var(--color-text);
   text-decoration: none;
   font-size: var(--fs-sm);
+  transition:
+    background-color var(--motion-fast) var(--ease-standard),
+    color var(--motion-fast) var(--ease-standard);
+}
+
+.admin-sidebar a:hover {
+  background: var(--color-surface-hover);
 }
 
 .admin-sidebar a[aria-current="page"] {
-  background: var(--color-primary);
+  background: var(--color-primary-strong);
   color: var(--color-primary-contrast);
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
+}
+
+/* Drawer open (checkbox checked) — slide in + reveal scrim. */
+.admin-nav-toggle-checkbox:checked ~ .admin-layout .admin-sidebar {
+  transform: translateX(0);
+  visibility: visible;
+}
+.admin-nav-toggle-checkbox:checked ~ .admin-layout .admin-scrim {
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
 }
 
 .admin-main {
-  flex: 1;
-  padding: var(--sp-5);
+  padding: var(--sp-4);
   min-width: 0;
 }
 
 .admin-main h1 {
   margin-top: 0;
   font-size: var(--fs-xl);
+  line-height: var(--lh-tight);
 }
 
-/* ---- Data table ----------------------------------------------------- */
+/* ---- Desktop: static sidebar, no drawer/toggle/scrim --------------- */
+@media (min-width: 768px) {
+  .admin-nav-toggle,
+  .admin-nav-toggle-checkbox,
+  .admin-scrim {
+    display: none;
+  }
+
+  .admin-layout {
+    display: flex;
+  }
+
+  .admin-sidebar {
+    position: static;
+    z-index: auto;
+    width: 220px;
+    flex-shrink: 0;
+    box-shadow: none;
+    transform: none;
+    visibility: visible;
+    overflow-y: visible;
+  }
+
+  .admin-main {
+    flex: 1;
+    padding: var(--sp-5);
+  }
+}
+
+/* ==================================================================== */
+/* Data table                                                           */
+/* ==================================================================== */
 .data-table-scroll {
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
+  background: var(--color-surface);
 }
 
 .data-table {
@@ -183,7 +430,7 @@
 .data-table caption {
   text-align: left;
   padding: var(--sp-3);
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
   color: var(--color-text-muted);
 }
 
@@ -197,7 +444,15 @@
 .data-table th {
   background: var(--color-bg);
   color: var(--color-text-muted);
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
+  white-space: nowrap;
+}
+
+.data-table tbody tr {
+  transition: background-color var(--motion-fast) var(--ease-standard);
+}
+.data-table tbody tr:hover {
+  background: var(--color-surface-hover);
 }
 
 .data-table-empty {
@@ -206,13 +461,70 @@
   color: var(--color-text-muted);
 }
 
-/* ---- Status badge --------------------------------------------------- */
+/*
+ * OPT-IN mobile card/stack pattern. Horizontal scroll (above) is the safe
+ * default for every table. A phase-2 page whose table is too wide to scroll
+ * comfortably can instead add `data-table--stack` to the <table> AND a
+ * `data-label="Column name"` attribute to every <td>: below `--bp-md` each row
+ * becomes a card and each cell shows its label. Headers are hidden (the labels
+ * replace them). No page here uses it yet; it exists for phase 2 to adopt.
+ */
+@media (max-width: 767.98px) {
+  .data-table--stack,
+  .data-table--stack tbody,
+  .data-table--stack tr,
+  .data-table--stack td {
+    display: block;
+    width: 100%;
+  }
+
+  .data-table--stack thead {
+    /* Visually hidden — labels come from each td's data-label instead. */
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+  }
+
+  .data-table--stack tr {
+    margin: var(--sp-3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background: var(--color-surface);
+    box-shadow: var(--shadow-xs);
+    overflow: hidden;
+  }
+
+  .data-table--stack td {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: var(--sp-3);
+    text-align: right;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .data-table--stack td:last-child {
+    border-bottom: none;
+  }
+  .data-table--stack td::before {
+    content: attr(data-label);
+    font-weight: var(--fw-semibold);
+    color: var(--color-text-muted);
+    text-align: left;
+  }
+}
+
+/* ==================================================================== */
+/* Status badge                                                         */
+/* ==================================================================== */
 .status-badge {
   display: inline-block;
   padding: 2px var(--sp-2);
   border-radius: var(--radius-full);
   font-size: var(--fs-xs);
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
 }
 
 .status-badge[data-variant="success"] {
@@ -230,17 +542,20 @@
   color: var(--color-text);
 }
 
-/* ---- Create form (admin write actions) ------------------------------ */
+/* ==================================================================== */
+/* Create form (admin write actions)                                    */
+/* ==================================================================== */
 .admin-create-form {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-end;
-  gap: var(--sp-2);
+  gap: var(--sp-3);
   margin-bottom: var(--sp-4);
-  padding: var(--sp-3);
+  padding: var(--sp-4);
   background: var(--color-surface);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
+  box-shadow: var(--shadow-xs);
 }
 
 .admin-create-form label {
@@ -249,36 +564,61 @@
   gap: var(--sp-1);
   font-size: var(--fs-sm);
   color: var(--color-text-muted);
+  /* Mobile-first: fields stack full-width; they sit inline once there's room. */
+  flex: 1 1 100%;
+}
+
+@media (min-width: 640px) {
+  .admin-create-form label {
+    flex: 1 1 auto;
+  }
 }
 
 .admin-create-form input,
 .admin-create-form select,
 .admin-create-form textarea {
-  min-height: 40px;
-  padding: var(--sp-1) var(--sp-2);
+  min-height: 44px;
+  padding: var(--sp-2) var(--sp-3);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: var(--color-surface);
   color: var(--color-text);
+  transition: border-color var(--motion-fast) var(--ease-standard);
+}
+.admin-create-form input:focus-visible,
+.admin-create-form select:focus-visible,
+.admin-create-form textarea:focus-visible {
+  border-color: var(--color-focus);
 }
 
 .admin-create-form textarea {
-  min-width: 260px;
+  min-width: 0;
+  width: 100%;
+  min-height: 88px;
   font-family: inherit;
   resize: vertical;
 }
 
+@media (min-width: 640px) {
+  .admin-create-form textarea {
+    min-width: 260px;
+  }
+}
+
 .admin-create-form button {
-  min-height: 40px;
-  padding: var(--sp-1) var(--sp-3);
+  min-height: 44px;
+  padding: var(--sp-2) var(--sp-4);
   background: var(--color-primary-strong);
   color: var(--color-primary-contrast);
   border: none;
   border-radius: var(--radius-sm);
   cursor: pointer;
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
+  transition: background-color var(--motion-fast) var(--ease-standard);
 }
-
+.admin-create-form button:hover {
+  background: var(--color-primary-hover);
+}
 .admin-create-form button:disabled {
   cursor: not-allowed;
   opacity: 0.75;
@@ -293,9 +633,11 @@
   font-size: var(--fs-sm);
 }
 
-/* ---- Row action button (module toggle, etc.) ------------------------ */
+/* ==================================================================== */
+/* Row action button (module toggle, etc.)                              */
+/* ==================================================================== */
 .module-toggle {
-  min-height: 32px;
+  min-height: 40px;
   padding: var(--sp-1) var(--sp-3);
   background: var(--color-surface);
   color: var(--color-text);
@@ -303,19 +645,57 @@
   border-radius: var(--radius-sm);
   cursor: pointer;
   font-size: var(--fs-sm);
-  font-weight: 600;
+  font-weight: var(--fw-semibold);
+  transition:
+    background-color var(--motion-fast) var(--ease-standard),
+    border-color var(--motion-fast) var(--ease-standard);
 }
-
+.module-toggle:hover {
+  background: var(--color-surface-hover);
+  border-color: var(--color-text-muted);
+}
 .module-toggle:disabled {
   cursor: not-allowed;
   opacity: 0.75;
 }
 
-/* ---- State notice --------------------------------------------------- */
+/* ==================================================================== */
+/* State notice                                                         */
+/* ==================================================================== */
 .state-notice {
   padding: var(--sp-4);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-surface);
   color: var(--color-text-muted);
+}
+
+/* ==================================================================== */
+/* Reduced motion — strip the shell's decorative transitions/animation  */
+/* ==================================================================== */
+@media (prefers-reduced-motion: reduce) {
+  .login-form {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
+  .skip-link,
+  .admin-logout,
+  .admin-sidebar,
+  .admin-sidebar a,
+  .admin-scrim,
+  .admin-nav-toggle-bars,
+  .admin-nav-toggle-bars::before,
+  .admin-nav-toggle-bars::after,
+  .data-table tbody tr,
+  .login-form input,
+  .login-form button,
+  .admin-create-form input,
+  .admin-create-form select,
+  .admin-create-form textarea,
+  .admin-create-form button,
+  .module-toggle {
+    transition: none;
+  }
 }

--- a/src/styles/motion.css
+++ b/src/styles/motion.css
@@ -1,0 +1,318 @@
+/*
+ * motion.css — shared, reusable animation/motion utility layer for AWCMS
+ * (UI/UX overhaul foundation). Consumed globally by the admin + public shells
+ * (imported by `AdminLayout.astro` and `PublicThemeLayout.astro`, emitted as an
+ * external <link> by `build.inlineStylesheets: "never"`), and meant to be the
+ * ONE place page-level UI opts into motion — phase-2 screens should reuse these
+ * class names instead of hand-rolling keyframes so the whole app moves with one
+ * rhythm.
+ *
+ * ## CSP (single-owner, never weakened)
+ * Pure CSS: keyframes + transitions only. NO third-party font/CDN/@import, NO
+ * external animation library, NO inline style — same-origin stylesheet under
+ * `default-src 'self'` (see astro.config.mjs / security-headers.ts). The
+ * "zero third-party CSP origin" guarantee (tests/security-headers-csp.test.ts)
+ * is unaffected by this file.
+ *
+ * ## Accessibility (WCAG 2.1 — 2.3.3 Animation from Interactions)
+ * Every effect here is NON-ESSENTIAL decoration. The whole file is wrapped so
+ * that under `@media (prefers-reduced-motion: reduce)` all motion is removed
+ * AND every entrance utility resets to its final, fully-visible state (opacity
+ * 1, no transform) — an entrance that started at `opacity: 0` must never be
+ * left invisible for a reduced-motion user.
+ *
+ * ## Tokens
+ * Durations/easings come from `tokens.css` (`--motion-*`, `--ease-*`). Every
+ * `var()` here carries a literal fallback so this file still degrades sensibly
+ * if loaded without tokens.css.
+ *
+ * ## Naming
+ * Keyframes are namespaced `awcms-*` to avoid collision with any theme CSS.
+ */
+
+/* ------------------------------------------------------------------ */
+/* Keyframes                                                          */
+/* ------------------------------------------------------------------ */
+@keyframes awcms-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes awcms-fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes awcms-fade-in-down {
+  from {
+    opacity: 0;
+    transform: translateY(-12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes awcms-scale-in {
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes awcms-slide-in-left {
+  from {
+    opacity: 0;
+    transform: translateX(-16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+/* Indeterminate loading shimmer (skeleton placeholders). */
+@keyframes awcms-shimmer {
+  from {
+    background-position: -160% 0;
+  }
+  to {
+    background-position: 160% 0;
+  }
+}
+
+/* Spinner for busy/loading affordances. */
+@keyframes awcms-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+/* Gentle attention pulse (opacity only — safe, no scale flashing). */
+@keyframes awcms-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.55;
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/* Entrance utilities (one-shot on mount)                             */
+/* ------------------------------------------------------------------ */
+.fade-in,
+.fade-in-up,
+.fade-in-down,
+.scale-in,
+.slide-in-left {
+  animation-duration: var(--motion-base, 240ms);
+  animation-timing-function: var(--ease-out, cubic-bezier(0.16, 1, 0.3, 1));
+  animation-fill-mode: both;
+}
+
+.fade-in {
+  animation-name: awcms-fade-in;
+}
+.fade-in-up {
+  animation-name: awcms-fade-in-up;
+}
+.fade-in-down {
+  animation-name: awcms-fade-in-down;
+}
+.scale-in {
+  animation-name: awcms-scale-in;
+}
+.slide-in-left {
+  animation-name: awcms-slide-in-left;
+}
+
+/* Speed modifiers (compose with any entrance utility). */
+.motion-fast {
+  animation-duration: var(--motion-fast, 140ms);
+}
+.motion-slow {
+  animation-duration: var(--motion-slow, 400ms);
+}
+
+/*
+ * Staggered entrance for lists/grids: put `.stagger-children` on the container
+ * and give each child `.fade-in-up` (or any entrance). Direct children animate
+ * in sequence. Depth is bounded (10) — beyond that everything shares the last
+ * delay, which is the desired "batch in" behaviour for long lists.
+ */
+.stagger-children > * {
+  animation-delay: 0ms;
+}
+.stagger-children > *:nth-child(1) {
+  animation-delay: 0ms;
+}
+.stagger-children > *:nth-child(2) {
+  animation-delay: 40ms;
+}
+.stagger-children > *:nth-child(3) {
+  animation-delay: 80ms;
+}
+.stagger-children > *:nth-child(4) {
+  animation-delay: 120ms;
+}
+.stagger-children > *:nth-child(5) {
+  animation-delay: 160ms;
+}
+.stagger-children > *:nth-child(6) {
+  animation-delay: 200ms;
+}
+.stagger-children > *:nth-child(7) {
+  animation-delay: 240ms;
+}
+.stagger-children > *:nth-child(8) {
+  animation-delay: 280ms;
+}
+.stagger-children > *:nth-child(9) {
+  animation-delay: 320ms;
+}
+.stagger-children > *:nth-child(n + 10) {
+  animation-delay: 360ms;
+}
+
+/* ------------------------------------------------------------------ */
+/* Interaction utilities (hover/press feedback)                       */
+/* ------------------------------------------------------------------ */
+
+/* Lift a card/tile on hover — subtle rise + deeper shadow. */
+.hover-lift {
+  transition:
+    transform var(--motion-fast, 140ms)
+      var(--ease-standard, cubic-bezier(0.2, 0, 0, 1)),
+    box-shadow var(--motion-fast, 140ms)
+      var(--ease-standard, cubic-bezier(0.2, 0, 0, 1));
+}
+.hover-lift:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg, 0 12px 32px rgba(15, 23, 42, 0.18));
+}
+.hover-lift:active {
+  transform: translateY(0);
+}
+
+/* Grow a control slightly on hover (icon buttons, chips). */
+.hover-grow {
+  transition: transform var(--motion-fast, 140ms)
+    var(--ease-spring, cubic-bezier(0.34, 1.56, 0.64, 1));
+}
+.hover-grow:hover {
+  transform: scale(1.04);
+}
+.hover-grow:active {
+  transform: scale(0.98);
+}
+
+/* Generic "animate my declared properties" opt-in for interactive elements. */
+.transition-base {
+  transition-property: color, background-color, border-color, box-shadow,
+    transform, opacity;
+  transition-duration: var(--motion-fast, 140ms);
+  transition-timing-function: var(--ease-standard, cubic-bezier(0.2, 0, 0, 1));
+}
+
+/* ------------------------------------------------------------------ */
+/* Loading / status utilities                                         */
+/* ------------------------------------------------------------------ */
+
+/*
+ * Skeleton placeholder. Give the element a width/height and (optionally) a
+ * radius; it renders as a shimmering block for the loading state.
+ */
+.skeleton {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--color-surface-2, #eef1f5);
+  border-radius: var(--radius-sm, 4px);
+  background-image: linear-gradient(
+    100deg,
+    transparent 30%,
+    var(--color-surface-hover, rgba(255, 255, 255, 0.55)) 50%,
+    transparent 70%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: awcms-shimmer 1.4s ease-in-out infinite;
+}
+.skeleton::after {
+  /* Keep intrinsic height when used on an empty block. */
+  content: "\00a0";
+}
+
+/* Inline spinner. Size via font-size / width+height on the element. */
+.spinner {
+  display: inline-block;
+  width: 1em;
+  height: 1em;
+  border: 2px solid var(--color-border, #d8dee6);
+  border-top-color: var(--color-primary, #2563eb);
+  border-radius: var(--radius-full, 9999px);
+  animation: awcms-spin 0.7s linear infinite;
+}
+
+.pulse {
+  animation: awcms-pulse 1.6s ease-in-out infinite;
+}
+
+/* ------------------------------------------------------------------ */
+/* Reduced-motion: strip ALL of the above.                            */
+/* Entrance utilities reset to their final, fully-visible state so no  */
+/* content is ever left hidden for reduced-motion users.               */
+/* ------------------------------------------------------------------ */
+@media (prefers-reduced-motion: reduce) {
+  .fade-in,
+  .fade-in-up,
+  .fade-in-down,
+  .scale-in,
+  .slide-in-left,
+  .stagger-children > *,
+  .pulse,
+  .spinner,
+  .skeleton {
+    animation: none !important;
+  }
+
+  .fade-in,
+  .fade-in-up,
+  .fade-in-down,
+  .scale-in,
+  .slide-in-left {
+    opacity: 1 !important;
+    transform: none !important;
+  }
+
+  .hover-lift,
+  .hover-grow,
+  .transition-base {
+    transition: none !important;
+  }
+  .hover-lift:hover,
+  .hover-grow:hover {
+    transform: none !important;
+  }
+
+  /* Skeleton stays as a static muted block (still communicates "loading"). */
+  .skeleton {
+    background-image: none;
+  }
+}

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -49,11 +49,23 @@
      already promises. Measured: 5.36:1 against white in both themes. */
   --color-info-strong: #0e7490;
 
+  /*
+   * Additive interaction / surface tints (UI/UX overhaul foundation). Purely
+   * NEW tokens — the doc-14 values above are untouched. `-hover` = the darker
+   * pressed/hovered fill of a solid control; `-soft` = a low-chroma tinted
+   * background for emphasis blocks (selected rows, info panels) that keeps
+   * `--color-text` legible on top; `--color-overlay` = the modal/drawer scrim.
+   */
+  --color-primary-hover: #1d4ed8;
+  --color-primary-soft: #e8effc;
+  --color-surface-hover: #f0f3f8;
+  --color-overlay: rgba(15, 23, 42, 0.5);
+
   /* Font */
   --font-sans: system-ui, -apple-system, "Inter", "Segoe UI", sans-serif;
   --font-mono: ui-monospace, "SFMono-Regular", "Menlo", monospace;
 
-  /* Font size (xs .. 2xl) */
+  /* Font size (xs .. 3xl) */
   --fs-xs: 12px;
   --fs-sm: 14px;
   --fs-base: 16px;
@@ -61,6 +73,24 @@
   --fs-lg: 20px;
   --fs-xl: 24px;
   --fs-2xl: 32px;
+  --fs-3xl: 40px;
+
+  /* Font weight */
+  --fw-normal: 400;
+  --fw-medium: 500;
+  --fw-semibold: 600;
+  --fw-bold: 700;
+
+  /* Line height */
+  --lh-tight: 1.2;
+  --lh-snug: 1.35;
+  --lh-normal: 1.5;
+  --lh-relaxed: 1.7;
+
+  /* Letter spacing */
+  --tracking-tight: -0.01em;
+  --tracking-normal: 0;
+  --tracking-wide: 0.02em;
 
   /* Spacing (1 .. 8) */
   --sp-1: 4px;
@@ -76,12 +106,37 @@
   --radius-sm: 4px;
   --radius-md: 8px;
   --radius-lg: 12px;
+  --radius-xl: 16px;
   --radius-full: 9999px;
 
-  /* Shadow */
+  /* Shadow / elevation */
+  --shadow-xs: 0 1px 1px rgba(15, 23, 42, 0.05);
   --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.08);
   --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.12);
   --shadow-lg: 0 12px 32px rgba(15, 23, 42, 0.18);
+
+  /*
+   * Motion tokens (UI/UX overhaul foundation). Standard durations + easing
+   * curves so every transition/animation in the app moves with the same
+   * rhythm. Consumed by `motion.css` utilities and component transitions.
+   *
+   * IMPORTANT: motion is always OPT-IN and every consumer MUST degrade under
+   * `@media (prefers-reduced-motion: reduce)` — `motion.css` and the layouts
+   * do this centrally, but any new consumer of these tokens must too.
+   */
+  --motion-instant: 80ms;
+  --motion-fast: 140ms;
+  --motion-base: 240ms;
+  --motion-slow: 400ms;
+  /* General-purpose UI easing (emphasized decelerate). */
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  /* Decelerate — for entrances (elements arriving on screen). */
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+  /* Accelerate — for exits (elements leaving screen). */
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);
+  /* Gentle overshoot — for playful affordances (toggles, chips). Tasteful,
+     never bouncy. */
+  --ease-spring: cubic-bezier(0.34, 1.56, 0.64, 1);
 
   /* Z-index */
   --z-nav: 100;
@@ -130,6 +185,15 @@
      against the constant white fill-text, not the page background. */
   --color-info-strong: #0e7490;
 
+  /* Dark-theme values for the additive interaction/surface tints — see the
+     :root block for what each is for. Overlay is darker so the scrim reads
+     over an already-dark page. */
+  --color-primary-hover: #2f6fd6;
+  --color-primary-soft: #16233b;
+  --color-surface-hover: #1c2430;
+  --color-overlay: rgba(0, 0, 0, 0.6);
+
+  --shadow-xs: 0 1px 1px rgba(0, 0, 0, 0.35);
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.45);
   --shadow-lg: 0 12px 32px rgba(0, 0, 0, 0.55);

--- a/tests/e2e/admin-abac-policies.e2e.ts
+++ b/tests/e2e/admin-abac-policies.e2e.ts
@@ -14,6 +14,7 @@
  * pass and the controls render.
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -31,7 +32,7 @@ test.describe("admin ABAC policies write (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-email-templates-create.e2e.ts
+++ b/tests/e2e/admin-email-templates-create.e2e.ts
@@ -21,6 +21,7 @@
  * through — guarding against a false green).
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -42,7 +43,7 @@ test.describe("admin email templates create (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-modules-toggle.e2e.ts
+++ b/tests/e2e/admin-modules-toggle.e2e.ts
@@ -25,6 +25,7 @@
  * the same catalog state.
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -51,7 +52,7 @@ test.describe("admin modules toggle (authenticated)", () => {
     page.on("dialog", (dialog) => dialog.accept("E2E toggle round-trip"));
 
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-offices-create.e2e.ts
+++ b/tests/e2e/admin-offices-create.e2e.ts
@@ -13,6 +13,7 @@
  * form renders.
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -30,7 +31,7 @@ test.describe("admin offices create (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-offices-edit.e2e.ts
+++ b/tests/e2e/admin-offices-edit.e2e.ts
@@ -15,6 +15,7 @@
  * gates pass and the controls render.
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -32,7 +33,7 @@ test.describe("admin offices edit/delete/restore (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-offices.e2e.ts
+++ b/tests/e2e/admin-offices.e2e.ts
@@ -13,6 +13,7 @@
  * `head_office` row is what the table must show.
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -31,7 +32,7 @@ test.describe("admin offices (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();
@@ -54,7 +55,7 @@ test.describe("admin offices (authenticated)", () => {
   }) => {
     // Log in first (fresh page/context per test).
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();
@@ -102,7 +103,7 @@ test.describe("admin offices (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill("definitely-the-wrong-password");
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-profiles-create.e2e.ts
+++ b/tests/e2e/admin-profiles-create.e2e.ts
@@ -12,6 +12,7 @@
  * the form passes.
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -29,7 +30,7 @@ test.describe("admin profiles create (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-roles.e2e.ts
+++ b/tests/e2e/admin-roles.e2e.ts
@@ -14,6 +14,7 @@
  * create form + action controls render.
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -31,7 +32,7 @@ test.describe("admin roles CRUD (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/admin-users.e2e.ts
+++ b/tests/e2e/admin-users.e2e.ts
@@ -17,6 +17,7 @@
  * without deactivating the owner (which would revoke the running session).
  */
 import { test, expect } from "@playwright/test";
+import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -34,7 +35,7 @@ test.describe("admin users write controls (authenticated)", () => {
     page
   }) => {
     await page.goto("/login");
-    await page.locator("#tenant-id").fill(tenantId!);
+    await provideTenant(page, tenantId!);
     await page.locator("#login-identifier").fill(loginIdentifier!);
     await page.locator("#password").fill(password!);
     await page.locator("#login-submit").click();

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -5,9 +5,12 @@
  * read-only SSR read of the active tenant registry to choose the tenant field
  * shape. That read is wrapped so any failure (a placeholder `DATABASE_URL` that
  * never connects, an unmigrated DB, an empty registry) degrades to the manual
- * `#tenant-id` TEXT input — so this spec still needs zero seeded data and
- * `#tenant-id` is still a visible field here (the "pick a target that needs no
- * fixtures" convention, skill #4). It proves the first `.astro` page renders in
+ * `#tenant-id` TEXT input. This spec needs no fixtures of its own, but the CI
+ * e2e-smoke job seeds one tenant before the whole suite runs — with exactly one
+ * tenant the picker renders `#tenant-id` as a HIDDEN prefilled input, so this
+ * spec asserts the field is ATTACHED (a stable DOM id) rather than visible; its
+ * visibility legitimately depends on tenant count. It proves the first `.astro`
+ * page renders in
  * a real browser AND that its client script executes under the middleware CSP
  * (`default-src 'self'`): if Astro had inlined the script, CSP would block it
  * and the form's stable ids would still be present but dead — so a follow-up
@@ -26,7 +29,10 @@ test.describe("login page", () => {
 
     expect(response?.status()).toBe(200);
     await expect(page.locator("#login-form")).toBeVisible();
-    await expect(page.locator("#tenant-id")).toBeVisible();
+    // `#tenant-id` is a stable id but its shape/visibility depends on tenant
+    // count (hidden+prefilled when exactly one tenant is seeded, as in CI
+    // e2e-smoke), so assert it is attached rather than visible.
+    await expect(page.locator("#tenant-id")).toBeAttached();
     await expect(page.locator("#login-identifier")).toBeVisible();
     await expect(page.locator("#password")).toBeVisible();
     await expect(page.locator("#login-submit")).toBeVisible();

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -1,18 +1,22 @@
 /**
  * Login page render spec (Issue #166) — see skill `awcms-browser-test`.
  *
- * `/login` renders the same form regardless of DB contents (it does no
- * server-side DB read of its own), so this needs zero seeded data — the
- * "pick a target that needs no fixtures" convention (skill #4). It proves the
- * first `.astro` page renders in a real browser AND that its client script
- * executes under the middleware CSP (`default-src 'self'`): if Astro had
- * inlined the script, CSP would block it and the form's stable ids would still
- * be present but dead — so a follow-up render assertion is not enough on its
- * own; the submit-behaviour path is covered by `admin-offices.e2e.ts` where a
- * seeded session exists.
+ * The auto tenant picker (UI/UX phase 2) makes `/login` do ONE best-effort,
+ * read-only SSR read of the active tenant registry to choose the tenant field
+ * shape. That read is wrapped so any failure (a placeholder `DATABASE_URL` that
+ * never connects, an unmigrated DB, an empty registry) degrades to the manual
+ * `#tenant-id` TEXT input — so this spec still needs zero seeded data and
+ * `#tenant-id` is still a visible field here (the "pick a target that needs no
+ * fixtures" convention, skill #4). It proves the first `.astro` page renders in
+ * a real browser AND that its client script executes under the middleware CSP
+ * (`default-src 'self'`): if Astro had inlined the script, CSP would block it
+ * and the form's stable ids would still be present but dead — so a follow-up
+ * render assertion is not enough on its own; the submit-behaviour path is
+ * covered by `admin-offices.e2e.ts` where a seeded session exists.
  *
  * Run: `bun run build && bun run start` (DATABASE_URL may be a placeholder —
- * this page never connects), then `bun run test:e2e`.
+ * the tenant read then fails closed to the manual field), then
+ * `bun run test:e2e`.
  */
 import { test, expect } from "@playwright/test";
 

--- a/tests/e2e/support/e2e-auth.ts
+++ b/tests/e2e/support/e2e-auth.ts
@@ -1,0 +1,37 @@
+import { expect, type Page } from "@playwright/test";
+
+/**
+ * Provide the tenant for `/login` regardless of the auto tenant-picker shape.
+ *
+ * The login page resolves the tenant field server-side by how many active
+ * tenants exist (see `src/pages/login.astro`):
+ *   - exactly 1  → `#tenant-id` is a HIDDEN input, already prefilled with that
+ *                  tenant's id (the user picks nothing). Playwright cannot
+ *                  `.fill()` a hidden input, so we assert the prefill instead —
+ *                  which also proves the auto-pick chose the right tenant.
+ *   - 2..50      → `#tenant-id` is a `<select>` of tenant names (value = id).
+ *   - 0 or >50   → `#tenant-id` is a visible TEXT input (manual entry).
+ *
+ * The CI e2e-smoke job seeds exactly one tenant, so the hidden-prefill branch
+ * is the one it exercises; the others keep the helper correct for local
+ * multi-tenant / pre-setup runs.
+ */
+export async function provideTenant(
+  page: Page,
+  tenantId: string
+): Promise<void> {
+  const field = page.locator("#tenant-id");
+  const tagName = await field.evaluate((el) => el.tagName.toLowerCase());
+
+  if (tagName === "select") {
+    await field.selectOption(tenantId);
+    return;
+  }
+
+  if ((await field.getAttribute("type")) === "hidden") {
+    await expect(field).toHaveValue(tenantId);
+    return;
+  }
+
+  await field.fill(tenantId);
+}


### PR DESCRIPTION
Overhaul UI/UX seluruh surface pengguna awcms: **mobile-first responsif, animasi profesional (CSS murni), dan aksesibilitas**, di dalam jaminan CSP single-owner "zero third-party origin di LAN/offline" (tanpa font CDN/library eksternal; styling di-serve same-origin; nol `<style>`/`<script>` inline).

Dikerjakan dengan orkestrasi multi-agen anti-konflik: 1 agen fondasi design-system (sequential), lalu 3 agen paralel di worktree terpisah (login/admin/blog) yang hanya mengonsumsi fondasi read-only — di-merge bersih tanpa konflik.

## Perubahan

**Fondasi design system** (`992007a0`)
- `tokens.css`: skala tipografi/spacing/radius/elevation, tint interaksi, token MOTION (durasi + easing).
- `motion.css` (baru): utility animasi reusable (fade/scale/slide/stagger/hover-lift/skeleton/spinner), semua di-guard `prefers-reduced-motion`.
- `AdminLayout.astro` + `PublicThemeLayout.astro`: shell responsif mobile-first, drawer mobile **CSS-only** (tanpa JS), skip-link.

**Login** — redesign + **auto tenant picker**: 1 tenant disembunyikan/prefilled, 2–50 dropdown nama tenant, >50 fallback manual (anti mass-enumeration), fail-closed ke input manual saat pre-setup/DB error. Query root-registry server-side (tanpa endpoint publik baru, tanpa perubahan OpenAPI). Kontrak DOM (`#login-form`/`#tenant-id`/…) dipertahankan.

**Admin** — 8 layar mobile-first: tabel lebar → pola kartu/stack (`data-label` per sel), stat/quick-link beranimasi, hierarki visual & empty state konsisten. Selektor/hook E2E + `admin-form-client.ts` dipertahankan.

**Blog publik** (`/blog/{tenantCode}/...`) — tipografi baca nyaman (~65ch), kartu post grid→stack, media/tabel/kode responsif dengan scroll-container sendiri, animasi entrance halus. Styling via stylesheet same-origin `public/css/public-content.css` (bukan inline `<style>` yang akan diblokir CSP). Renderer `content_json` whitelist-based **tidak dilonggarkan** (sanitasi XSS byte-for-byte sama).

## Verifikasi (DoD penuh hijau, pada hasil merge gabungan)

`bun run` lint / typecheck / **test (1721 pass, 206 skip, 0 fail)** / build / api:spec:check / check:docs / changesets:policy:check — semua hijau. `tests/security-headers-csp.test.ts` **12/12 pass** (jaminan CSP tak diregresi). Perubahan murni presentasi: nol perubahan migration/API/event/ABAC/audit.

## Catatan

- Halaman login render light-theme (tanpa theme-script; dark akan butuh perubahan fondasi) — dicatat sebagai follow-up.
- E2E Playwright env-gated tidak dieksekusi; kontrak DOM/selektor divalidasi statis + unit/build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
