### PR TITLE
feat(tenant-domain): port tenant_domain module from awcms-micro (Wave 0)

### DIFF
--- a/.changeset/port-tenant-domain-module.md
+++ b/.changeset/port-tenant-domain-module.md
@@ -1,0 +1,33 @@
+---
+"awcms": minor
+---
+
+Port modul `tenant_domain` dari awcms-micro (epic #555): pemetaan
+hostname/subdomain → tenant untuk routing publik berbasis host (Wave-0 program
+penyerapan awcms-micro). Menambah tabel `awcms_tenant_domains` (migrasi 046, tenant-scoped
+`ENABLE`+`FORCE ROW LEVEL SECURITY`, unique hostname lintas-tenant, satu primary
+per tenant), seed permission `tenant_domain.domains.*` (migrasi 047), dan fungsi
+lookup host→tenant `awcms_resolve_tenant_domain_lookup` `SECURITY DEFINER`
+(migrasi 048, `EXECUTE` hanya ke `awcms_app`).
+
+API manajemen tenant-scoped di `/api/v1/tenant/domains` (list/create/read/
+update/soft-delete + `verify` dan `set-primary` yang ber-`Idempotency-Key` dan
+diaudit), layar admin `/admin/tenant/domains`, resolver host publik ADITIF
+(`lib/tenant/public-host-tenant-resolver.ts` — hidup berdampingan dengan
+routing berbasis path `/blog/{tenantCode}` ADR-0009, tidak meregresi), dan
+adapter Cloudflare DNS OPSIONAL (env-gated, aman tanpa kredensial, belum
+di-wire ke rute mana pun).
+
+Deferral yang didokumentasikan: rute konten publik ber-resolusi host belum
+di-wire (deferral yang sama seperti `/news/**` news_portal); `src/middleware.ts`
+tidak disentuh (jaminan login/Turnstile/CSP tak berubah). Union `AccessAction`
+identity-access diperluas dengan `set_primary`.
+
+**Risiko residual (harden sebelum go-live self-service custom domain).** `verify`
+saat ini mengaktifkan domain berdasarkan field in-row tanpa bukti kepemilikan
+outbound (model manual-first; adapter DNS ada tapi belum di-wire). Untuk mencegah
+pengambilalihan domain (dangling-DNS) pada custom domain bersama, aktivasi
+`custom_domain` **wajib digerbangi operator/manual** sampai bukti kepemilikan
+DNS-token (`verification_token_hash` + cek TXT/CNAME lewat adapter) di-wire.
+`verify` sudah default-deny + di-audit; risiko ini didokumentasikan di README modul
+dan skill `awcms-tenant-domain-routing`.

--- a/.changeset/port-tenant-domain-module.md
+++ b/.changeset/port-tenant-domain-module.md
@@ -8,7 +8,15 @@ penyerapan awcms-micro). Menambah tabel `awcms_tenant_domains` (migrasi 046, ten
 `ENABLE`+`FORCE ROW LEVEL SECURITY`, unique hostname lintas-tenant, satu primary
 per tenant), seed permission `tenant_domain.domains.*` (migrasi 047), dan fungsi
 lookup host→tenant `awcms_resolve_tenant_domain_lookup` `SECURITY DEFINER`
-(migrasi 048, `EXECUTE` hanya ke `awcms_app`).
+(migrasi 048). Fungsi ini di-own oleh role bootstrap khusus `awcms_domain_bootstrap`
+(`NOLOGIN`/`NOSUPERUSER`/`NOBYPASSRLS`, tanpa anggota) dengan policy `FOR SELECT`
+ter-scope (`USING (true)` khusus role itu) sehingga bootstrap host→tenant tetap
+resolve di deployment role-separated tempat owner migrasi **bukan** superuser
+(mis. `awcms_app`/`awcms_worker`/`awcms_setup` dari sql/019–022, dan harness
+integrasi yang men-demote owner-nya) — tanpa memberi `BYPASSRLS` ke role apa pun,
+tanpa melepas `FORCE ROW LEVEL SECURITY`, dan tanpa menyentuh policy
+`tenant_isolation`. `EXECUTE` hanya ke `awcms_app`; kolom sensitif
+(`verification_token_hash`/`verification_record_value`) tetap tak terbaca.
 
 API manajemen tenant-scoped di `/api/v1/tenant/domains` (list/create/read/
 update/soft-delete + `verify` dan `set-primary` yang ber-`Idempotency-Key` dan

--- a/.claude/skills/awcms-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-tenant-domain-routing/SKILL.md
@@ -71,16 +71,38 @@ hanya dari env `TENANT_DOMAIN_CLOUDFLARE_*`.
 
 `awcms_resolve_tenant_domain_lookup(p_normalized_hostname text)` — satu-satunya
 jalur baca bootstrap yang disahkan untuk resolusi host→tenant SEBELUM ada tenant
-context (`app.current_tenant_id` GUC). Kenapa aman:
+context (`app.current_tenant_id` GUC). Kenapa aman — **JANGAN** andalkan asumsi
+"owner migrasi superuser → fungsi bypass RLS": itu SALAH di posture hardened
+repo ini. Fungsi `SECURITY DEFINER` jalan dengan hak **owner-nya saat dipanggil**,
+dan sql/019–022 sengaja menjalankan runtime sebagai role NON-superuser
+NOBYPASSRLS; deployment role-separated (dan integration harness, yang men-demote
+owner migrasi ke `NOSUPERUSER NOBYPASSRLS` tepat setelah migrasi) tidak
+menyisakan superuser yang meng-own fungsi ini. Owner non-superuser tunduk penuh
+pada `FORCE RLS` → fungsi akan resolve **0 baris** untuk setiap host. Jadi
+keamanan bootstrap **bukan** dari bypass, melainkan:
 
-- Owner migrasi (`DATABASE_URL`) adalah superuser → bypass RLS unconditional;
-  `FORCE` hanya mencabut exemption owner NON-superuser. Jadi keamanan TIDAK
-  datang dari RLS di level fungsi ini.
-- Pagar sebenarnya: (1) badan fungsi SQL statis, hanya me-return 8 kolom
-  non-sensitif untuk satu `normalized_hostname` terparameterkan +
-  `deleted_at IS NULL` — tidak bisa membaca `verification_token_hash`/
-  `verification_record_value`/`hostname` mentah; (2) `EXECUTE` di-`REVOKE` dari
-  `PUBLIC`, di-`GRANT` hanya ke `awcms_app`. `awcms_app` tetap tidak bisa
+- **Owner role khusus `awcms_domain_bootstrap`** — `NOLOGIN NOSUPERUSER
+NOBYPASSRLS`, dibuat idempoten (pola sama sql/019/022, cluster-scoped). Fungsi
+  di-`ALTER FUNCTION ... OWNER TO awcms_domain_bootstrap` → eksekusi sebagai role
+  ini. NOLOGIN + **tanpa anggota** (khususnya `awcms_app` bukan anggota; reassign
+  owner memakai owner migrasi SUPERUSER, **tanpa** grant membership ke siapa pun)
+  → tak ada yang bisa `SET ROLE` ke situ; satu-satunya kode yang jalan sebagai
+  role ini adalah fungsi ini.
+- **Policy baca ter-scope** `awcms_tenant_domains_bootstrap_read` — permissive
+  `FOR SELECT TO awcms_domain_bootstrap USING (true)`, di-OR dengan (bukan ganti)
+  `tenant_isolation`. RLS mencocokkan role policy lewat membership, jadi policy
+  ini berlaku HANYA saat role adalah/anggota `awcms_domain_bootstrap` — yakni
+  HANYA di dalam fungsi ini. `SELECT` langsung `awcms_app` tetap cuma kena
+  `tenant_isolation` → fail-closed. `FORCE RLS` + policy `tenant_isolation`
+  sql/046 **tidak** disentuh. `awcms_domain_bootstrap` juga butuh `GRANT SELECT`
+  eksplisit di `awcms_tenant_domains` + `awcms_tenants` (privilege tabel terpisah
+  dari policy RLS).
+- Pagar tambahan (bukan sumber utama keamanan, tapi wajib): (1) badan fungsi SQL
+  statis, hanya me-return 8 kolom non-sensitif untuk satu `normalized_hostname`
+  terparameterkan + `deleted_at IS NULL` — **daftar kolom** itu batasnya, tak
+  bisa membaca `verification_token_hash`/`verification_record_value`/`hostname`
+  mentah walau policy mengizinkan SELECT seluruh tabel; (2) `EXECUTE` di-`REVOKE`
+  dari `PUBLIC`, di-`GRANT` hanya ke `awcms_app`. `awcms_app` tetap tidak bisa
   `SELECT` langsung dari tabel tanpa `withTenant`.
 - `SET search_path = public, pg_temp` + `STABLE`.
 - JOIN ke `awcms_tenants` (sudah RLS-free, ADR-0003) di dalam fungsi yang sama
@@ -88,9 +110,12 @@ context (`app.current_tenant_id` GUC). Kenapa aman:
   timing side-channel antara "host tak dikenal" vs "host ada tapi tenant
   non-aktif". **Jangan** memecah ini jadi query kedua bersyarat.
 
-Diverifikasi terhadap Postgres nyata (docker `psql` di dalam container): `SELECT`
-langsung `awcms_tenant_domains` di bawah `awcms_app` dengan GUC fail-closed → 0
-baris; `awcms_resolve_tenant_domain_lookup(...)` → 1 baris.
+Diverifikasi terhadap Postgres nyata (docker `psql`, mereplikasi owner
+ter-demote `NOSUPERUSER NOBYPASSRLS` seperti harness): `SELECT` langsung
+`awcms_tenant_domains` di bawah `awcms_app` dengan GUC fail-closed → 0 baris;
+`awcms_resolve_tenant_domain_lookup(...)` → 1 baris (owner fungsi non-superuser);
+drop policy bootstrap → fungsi balik 0 baris (bukti policy load-bearing);
+`awcms_app` tetap tak bisa baca `verification_token_hash`.
 
 ## Resolver publik (`public-host-tenant-resolver.ts`)
 

--- a/.claude/skills/awcms-tenant-domain-routing/SKILL.md
+++ b/.claude/skills/awcms-tenant-domain-routing/SKILL.md
@@ -1,897 +1,225 @@
 ---
 name: awcms-tenant-domain-routing
-description: BACAAN SAJA — modul tenant_domain routing BELUM di-port ke repo ini (ada di awcms-mini; `ls src/modules` tidak memuatnya, tidak ada migration/fungsi lookup-nya di `sql/`). Rujukan modul/tabel/`sql/NNN` di dalamnya adalah artefak awcms-mini, penomoran mini. Pakai sebagai spesifikasi target saat MEM-PORT (via `awcms-port-from-mini`), bukan panduan implementasi kode yang bisa dipanggil — verifikasi `ls src/modules` dulu. Routing publik yang ADA di repo ini `/blog/{tenantCode}` (ADR-0009). Konteks port (Issue #556-#567, epic #555). Gunakan saat menambah/mengubah PUBLIC_* env config, skema/API/UI tenant domain, resolver tenant berbasis host, rute publik `/news`, module presets, atau adapter Cloudflare DNS. Merangkum keputusan yang sudah dibuat supaya issue lanjutan tidak mengulang/kontradiksi.
+description: Modul tenant_domain SUDAH di-port ke repo ini (dari awcms-micro epic #555). Pemetaan hostname/subdomain → tenant untuk routing publik berbasis host, hidup berdampingan dengan routing berbasis path `/blog/{tenantCode}` (ADR-0009) tanpa meregresinya. Gunakan saat mengubah skema/API/UI tenant domain, resolver tenant berbasis host, fungsi lookup `SECURITY DEFINER`, adapter Cloudflare DNS opsional, atau saat mem-wire rute konten publik ber-resolusi host (masih deferred). Merangkum keputusan desain yang mengikat supaya perubahan lanjutan tidak mengulang/kontradiksi.
 ---
 
-# AWCMS — Online Public Tenant Routing & Tenant Domain Management
+# AWCMS — Tenant Domain & Host-Based Public Routing
 
-<!-- sql-refs: awcms-mini — modul belum di-port; setiap `sql/NNN` di file ini penomoran awcms-mini, bukan repo ini -->
+Modul `tenant_domain` memetakan hostname/subdomain publik ke sebuah tenant,
+membuktikan kepemilikan (manual-first), dan memilih satu domain **primary**
+aktif per tenant. Ia adalah seam data + resolver yang akan dibaca oleh rute
+konten publik ber-resolusi host di masa depan untuk menjawab "Host header ini
+milik tenant mana?" TANPA `tenantCode` di path.
 
-> **STATUS — BACAAN SAJA: modul ini BELUM di-port ke repo ini.**
-> `tenant_domain` routing ada di **awcms-mini**, bukan di sini:
-> `ls src/modules` TIDAK memuatnya, dan `sql/` tidak memuat migration-nya
-> (termasuk fungsi `SECURITY DEFINER` lookup host→tenant). Semua rujukan
-> `src/modules/...`, tabel `awcms_tenant_domain*`, dan `sql/NNN` di bawah
-> adalah artefak awcms-mini — **jangan `import`/`SELECT`/mengklaim ada** di
-> repo ini. Nomor `sql/NNN` memakai penomoran awcms-mini dan akan berubah
-> saat di-port (melanjutkan dari migration terakhir repo ini). Pakai skill
-> ini sebagai spesifikasi target port (via `awcms-port-from-mini`), bukan
-> peta kode yang bisa dipanggil. Verifikasi `ls src/modules` sebelum
-> mengklaim apa pun ada.
-
-Epic #555 menambah **mode routing publik online-primary** (domain/subdomain
-→ tenant, tanpa perlu `tenantCode` di path) sambil **mempertahankan**
-kapabilitas offline/LAN-first yang sudah ada (`/blog/{tenantCode}` tetap
-jalan — lihat ADR-0009 dan skill `awcms-blog-content`). Target model:
-
-```txt
-Domain/Subdomain -> Public Tenant Resolver -> Tenant Context -> /news Public Routes -> blog_content
-```
+**Additive, bukan pengganti.** Routing berbasis path `/blog/{tenantCode}`
+(ADR-0009) tetap utuh dan tetap jadi mekanisme untuk rute itu. `src/middleware.ts`
+TIDAK disentuh — resolusi host adalah urusan per-rute-publik, bukan middleware,
+jadi jaminan login/Turnstile/CSP tak berubah.
 
 ## Kapan pakai skill ini vs skill generik
 
-Skill ini melengkapi (bukan menggantikan) `awcms-new-endpoint`,
-`awcms-new-migration`, `awcms-new-module`,
-`awcms-blog-content` (untuk sisi `/news` di modul `blog_content`),
-dan `awcms-module-management` (untuk sisi module presets/matrix UI).
-Skill ini menyediakan konteks **cross-cutting epic #555 spesifik** yang
-menjembatani beberapa modul sekaligus (config, `tenant_domain` module baru,
-`blog_content`, `module_management`).
+Melengkapi (bukan menggantikan) `awcms-new-endpoint`, `awcms-new-migration`,
+`awcms-new-module`, `awcms-abac-guard`, `awcms-idempotency`. Skill ini
+menyediakan konteks lintas-file spesifik `tenant_domain` supaya perubahan
+lanjutan tidak meregresi keputusan desain yang mengikat.
 
-## Status per issue (jangan bangun ulang yang sudah ada)
+## Peta kode (yang SUDAH ada di repo ini — pakai ulang, jangan re-derive)
 
-| Issue | Scope                                                         | Status                                                                           |
-| ----- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
-| #556  | Online public mode config (`PUBLIC_*` env vars)               | **Selesai** — lihat §Config di bawah                                             |
-| #557  | Tenant domain/subdomain mapping schema                        | **Selesai** — lihat §Schema di bawah                                             |
-| #558  | Register module descriptor `tenant_domain`                    | **Selesai** — lihat §Module descriptor di bawah                                  |
-| #559  | Public host tenant resolver (dengan fallback)                 | **Selesai** — lihat §Resolver di bawah                                           |
-| #560  | Rute publik `/news` untuk `blog_content`                      | **Selesai** — lihat §Rute publik `/news` di bawah                                |
-| #561  | Dokumentasi legacy `/blog/{tenantCode}`                       | **Selesai** — lihat ADR-0010, `blog-content/README.md`, `deployment-profiles.md` |
-| #562  | Tenant domain management API                                  | **Selesai** — lihat §API di bawah                                                |
-| #563  | Admin UI domain/subdomain                                     | **Selesai** — lihat §Admin UI di bawah                                           |
-| #564  | Tenant settings untuk rute `/news` vs legacy (`blog_content`) | **Selesai** — lihat §Tenant settings public route di bawah                       |
-| #565  | Tenant module presets (online/news/LAN/minimal)               | **Selesai** — lihat §Tenant module presets di bawah                              |
-| #566  | Tenant-module matrix admin UI                                 | **Selesai** — lihat §Tenant-module matrix admin UI di bawah                      |
-| #567  | Cloudflare DNS adapter (opsional)                             | **Selesai** — lihat §Cloudflare DNS adapter di bawah                             |
+| Bagian          | Lokasi                                                                                         |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| Descriptor      | `src/modules/tenant-domain/module.ts` (`type: "domain"`, terdaftar di `src/modules/index.ts`)  |
+| Skema           | `sql/046_awcms_tenant_domain_schema.sql` — `awcms_tenant_domains`                              |
+| Permission seed | `sql/047_awcms_tenant_domain_permissions.sql` — `tenant_domain.domains.*`                      |
+| Fungsi lookup   | `sql/048_awcms_tenant_domain_lookup_function.sql` — `awcms_resolve_tenant_domain_lookup(text)` |
+| Validasi        | `src/modules/tenant-domain/domain/tenant-domain-validation.ts`                                 |
+| DNS config      | `src/modules/tenant-domain/domain/tenant-domain-dns-config.ts`                                 |
+| Directory       | `src/modules/tenant-domain/application/tenant-domain-directory.ts`                             |
+| Cloudflare      | `src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts` (opsional, belum di-wire) |
+| Resolver publik | `src/lib/tenant/public-host-tenant-resolver.ts`                                                |
+| API             | `src/pages/api/v1/tenant/domains/index.ts`, `[id].ts`, `[id]/verify.ts`, `[id]/set-primary.ts` |
+| Admin UI        | `src/pages/admin/tenant/domains.astro` (+ nav di `src/layouts/AdminLayout.astro`)              |
+| OpenAPI         | `openapi/modules/tenant-domain.openapi.yaml`                                                   |
 
-## Yang sudah ada — pakai ulang, jangan re-derive
+## Skema (`awcms_tenant_domains`, migrasi 046)
 
-### Config (Issue #556, `scripts/validate-env.ts`)
+- `hostname` (raw, case dipertahankan) + `normalized_hostname`
+  (`lower(btrim(hostname))`, dijaga CHECK
+  `awcms_tenant_domains_normalized_hostname_matches_check`). Unique index
+  `awcms_tenant_domains_normalized_hostname_dedup` pada `normalized_hostname
+WHERE deleted_at IS NULL` bersifat **GLOBAL (lintas-tenant)** — satu hostname
+  cuma boleh milik satu tenant. Soft delete membebaskannya untuk dipakai ulang.
+- `domain_type` (`subdomain`|`custom_domain`), `route_mode`
+  (`canonical`|`legacy_blog` — kolom disiapkan, belum dikonsumsi resolver).
+- `status` (`pending_verification`|`active`|`suspended`|`failed`); soft delete
+  (`deleted_at`/`deleted_by`/`delete_reason`) adalah state "tidak resolve"
+  terpisah, tidak digabung ke enum.
+- `is_primary` + `redirect_to_primary`; satu primary aktif per tenant
+  (`awcms_tenant_domains_primary_dedup`, partial unique index).
+- `verification_method` + `verification_record_name`/`verification_record_value`
+  (nilai DNS PUBLIK yang dipublish tenant — BUKAN secret).
+  `verification_token_hash` adalah hash bearer-token internal dan **tidak pernah**
+  di-`SELECT`/dikembalikan oleh kode modul manapun.
+- RLS `ENABLE` + `FORCE` + policy `tenant_isolation` standar. **Jangan lepas
+  FORCE** untuk menyiasati bootstrap gap resolver — itu tugas fungsi 048.
+- GRANT ke `awcms_app` otomatis lewat `ALTER DEFAULT PRIVILEGES` (sql/019); tidak
+  ada grant `<worker-role>` (modul ini tak punya background job).
 
-Enam env var baru, semuanya **opsional** dan backward-compatible — kalau
-tidak diset sama sekali, `config:validate` tetap PASS dan perilaku tetap
-offline/LAN-first (`tenant_code_legacy` implisit):
+**Tidak ada kolom yang menyimpan kredensial provider DNS.** Token/zone Cloudflare
+hanya dari env `TENANT_DOMAIN_CLOUDFLARE_*`.
 
-- `PUBLIC_TENANT_RESOLUTION_MODE` — enum `host_default | env_default | setup_default | tenant_code_legacy`. Divalidasi `isKnownPublicTenantResolutionMode` (`scripts/validate-env.ts`, cari nama fungsinya — nomor baris di file ini bergeser tiap ada penyisipan check baru di atasnya, jangan percaya angka baris statis); value lain gagal validasi dengan pesan daftar value yang sah.
-- `PUBLIC_DEFAULT_TENANT_ID` / `PUBLIC_DEFAULT_TENANT_CODE` — wajib **minimal salah satu** saat mode `env_default` (bukan keduanya).
-- `PUBLIC_PLATFORM_ROOT_DOMAIN` — wajib saat mode `host_default` (landasan untuk resolver berbasis host di Issue #559 — tanpa root domain, resolver tidak bisa membedakan subdomain tenant valid dari `Host` header sembarangan).
-- `PUBLIC_CANONICAL_BASE_PATH` — default `/news` (belum ada rute nyata di sana sampai #560), divalidasi `isValidCanonicalBasePath` (`scripts/validate-env.ts`, cari nama fungsinya): wajib absolute path (`/...`), tanpa whitespace, tanpa `//`, tanpa trailing slash kecuali `/` itu sendiri. Divalidasi **selalu**, independen dari mode.
-- `PUBLIC_TRUST_PROXY` — default `false` (aman). Kalau `true`, app **wajib** jalan di belakang reverse proxy tepercaya yang men-sanitize `X-Forwarded-Host` — jangan pernah percaya header itu tanpa proxy tepercaya di depan (catatan keamanan eksplisit epic #555, relevan untuk resolver #559).
+## Fungsi lookup `SECURITY DEFINER` (migrasi 048)
 
-Entry point: `checkPublicRoutingConfig()` (`scripts/validate-env.ts`, cari nama fungsinya),
-dipanggil dari `runEnvValidation()`. Semua pesan fail hanya menyebut nama
-var, tidak pernah value-nya (pola sama seperti check lain di file ini) —
-kecuali `PUBLIC_CANONICAL_BASE_PATH`/`PUBLIC_TENANT_RESOLUTION_MODE` yang
-memang bukan secret dan boleh echo value untuk debuggability operator.
+`awcms_resolve_tenant_domain_lookup(p_normalized_hostname text)` — satu-satunya
+jalur baca bootstrap yang disahkan untuk resolusi host→tenant SEBELUM ada tenant
+context (`app.current_tenant_id` GUC). Kenapa aman:
 
-Didokumentasikan di `docs/awcms/18_configuration_env_reference.md`
-§Public routing dan `docs/awcms/deployment-profiles.md` §Profil
-online. Test: `tests/validate-env.test.ts`'s
-`describe("checkPublicRoutingConfig", ...)`.
+- Owner migrasi (`DATABASE_URL`) adalah superuser → bypass RLS unconditional;
+  `FORCE` hanya mencabut exemption owner NON-superuser. Jadi keamanan TIDAK
+  datang dari RLS di level fungsi ini.
+- Pagar sebenarnya: (1) badan fungsi SQL statis, hanya me-return 8 kolom
+  non-sensitif untuk satu `normalized_hostname` terparameterkan +
+  `deleted_at IS NULL` — tidak bisa membaca `verification_token_hash`/
+  `verification_record_value`/`hostname` mentah; (2) `EXECUTE` di-`REVOKE` dari
+  `PUBLIC`, di-`GRANT` hanya ke `awcms_app`. `awcms_app` tetap tidak bisa
+  `SELECT` langsung dari tabel tanpa `withTenant`.
+- `SET search_path = public, pg_temp` + `STABLE`.
+- JOIN ke `awcms_tenants` (sudah RLS-free, ADR-0003) di dalam fungsi yang sama
+  supaya resolver butuh **tepat satu round-trip** untuk setiap outcome — hindari
+  timing side-channel antara "host tak dikenal" vs "host ada tapi tenant
+  non-aktif". **Jangan** memecah ini jadi query kedua bersyarat.
 
-### Schema (Issue #557, `sql/031`/`sql/032`)
+Diverifikasi terhadap Postgres nyata (docker `psql` di dalam container): `SELECT`
+langsung `awcms_tenant_domains` di bawah `awcms_app` dengan GUC fail-closed → 0
+baris; `awcms_resolve_tenant_domain_lookup(...)` → 1 baris.
 
-Tabel `awcms_tenant_domains` — pemetaan hostname/domain/subdomain →
-tenant. **Schema saja**, belum ada module descriptor (#558), resolver
-(#559), atau API (#562) yang mengonsumsinya.
+## Resolver publik (`public-host-tenant-resolver.ts`)
 
-- Migration di-split dua file mengikuti pola `blog_content` (026 schema /
-  027 permission, diulang lagi di 029/030): `sql/031_awcms_tenant_domain_schema.sql`
-  (tabel) dan `sql/032_awcms_tenant_domain_permissions.sql`
-  (permission seed).
-- Kolom kunci: `hostname` (raw, case asli) + `normalized_hostname` (kolom
-  terpisah, bukan functional index — `lower(btrim(hostname))`, dijaga
-  konsisten oleh CHECK constraint
-  `awcms_tenant_domains_normalized_hostname_matches_check`);
-  `domain_type` (`subdomain` | `custom_domain`); `route_mode`
-  (`canonical` → rute `/news` #560, | `legacy_blog` → rute
-  `/blog/{tenantCode}` ADR-0009 — kolom disiapkan, belum dikonsumsi
-  resolver manapun); `status` (`pending_verification` | `active` |
-  `suspended` | `failed` — soft delete via `deleted_at` adalah state
-  kelima "tidak resolve traffic", tidak digabung ke enum ini);
-  `verification_method` (`dns_txt` | `dns_cname` | `file` | `manual`,
-  nullable); `verification_token_hash` (sha256 hex, prefix `sha256:`,
-  konstruksi sama seperti `lib/auth/password-reset-token.ts`'s
-  `hashResetToken` — token CSPRNG high-entropy jadi fast hash sudah benar,
-  bukan bcrypt/argon2; raw token tidak pernah disimpan);
-  `verification_record_name`/`verification_record_value` (nilai DNS
-  publik yang dipublish tenant, BUKAN secret provider); `is_primary` +
-  `redirect_to_primary`.
-- Constraint kunci: `awcms_tenant_domains_normalized_hostname_dedup`
-  (unique index global — LINTAS tenant, bukan per-tenant — pada
-  `normalized_hostname` `WHERE deleted_at IS NULL`, karena satu hostname
-  cuma boleh milik satu tenant); `awcms_tenant_domains_primary_dedup`
-  (unique index pada `tenant_id` `WHERE is_primary = true AND deleted_at IS NULL`
-  — satu primary aktif per tenant); soft delete standar
-  (`deleted_at`/`deleted_by`/`delete_reason`) membebaskan
-  `normalized_hostname` untuk dipakai ulang.
-- RLS: `ENABLE` + `FORCE` + policy `tenant_isolation` standar (sama pola
-  semua tabel tenant-scoped lain) — ini menciptakan bootstrap gap
-  (query hostname→tenant_id butuh dijalankan SEBELUM tenant context ada,
-  sementara FORCE RLS + fail-closed GUC dari migration 013 membuat query
-  tanpa `withTenant` selalu 0 baris), yang **sudah diselesaikan Issue #559**
-  lewat fungsi `SECURITY DEFINER` — lihat §Resolver di bawah untuk mekanisme
-  lengkap. `FORCE ROW LEVEL SECURITY` **tidak** dilepas dari tabel ini.
-- Permission seed: `module_key` `tenant_domain`, `activity_code` `domains`
-  — `read`/`create`/`update`/`delete`/`verify`/`set_primary` (persis
-  §Seed permissions issue #557). Belum ada role/access assignment yang
-  memakainya (menunggu #562 dkk.).
-- Test: `tests/integration/tenant-domain-schema.integration.test.ts`
-  (idempotency, unique constraint case-insensitive, primary-per-tenant,
-  soft-delete-frees-hostname, RLS isolation, fail-closed tanpa GUC, tidak
-  ada kolom secret provider).
+`resolvePublicTenantFromRequest(sql, request|host, config, deps?)` — urutan:
 
-### Module descriptor (Issue #558, `src/modules/tenant-domain/module.ts`)
+0. `mode === "tenant_code_legacy"` → langsung `null` (operator eksplisit opt-out
+   dari tebakan tenant default). Mode `undefined` (default offline/LAN) **TIDAK**
+   sama — tetap jalankan fallback penuh.
+1. host lookup (`resolvePublicTenantByHost`) — HANYA saat
+   `mode === "host_default"`, lewat fungsi 048.
+2. `PUBLIC_DEFAULT_TENANT_ID` → 3. `PUBLIC_DEFAULT_TENANT_CODE` → 4.
+   `awcms_setup_state.tenant_id` → 5. `null` (404 generik).
 
-Modul `tenant_domain` terdaftar di `src/modules/index.ts`'s `listModules()`
-(lihat file itu untuk jumlah modul terdaftar saat ini — angka ini
-bertambah tiap modul baru terdaftar, jangan hardcode ulang di sini).
-**Hanya descriptor** — tidak ada API/UI/resolver di sini, itu semua issue
-lanjutan.
+Langkah 2-4 (safe fallback) jalan untuk setiap mode KECUALI
+`tenant_code_legacy`. Hanya `domain_status === 'active' &&
+tenant_status === 'active'` yang resolve — kombinasi lain return `null` identik.
+`X-Forwarded-Host` dibaca hanya saat `config.trustProxy === true`; header
+multi-value dianggap anomali → log + fallback ke `Host` biasa.
+`normalizePublicHost()` di-reuse oleh validasi API (bukan opini shape kedua) dan
+hanya throw untuk string kosong (pelanggaran kontrak pemanggil).
 
-- `key: "tenant_domain"`, `type: "system"` (bukan `"domain"`/`"integration"`)
-  — modul ini mengelola routing infrastructure yang dipakai bersama SEMUA
-  tenant (resolusi hostname→tenant), bukan fitur bisnis tenant-facing, dan
-  bukan didefinisikan oleh integrasi provider eksternal (Cloudflare adapter
-  #567 opsional/enhancement, bukan sifat inti modul). Alasan sama seperti
-  `module_management`'s `type: "system"`.
-- `dependencies: ["tenant_admin", "identity_access"]`. `isCore` **tidak**
-  di-set (beda dari `module_management`) — tidak ada yang wajib memakai
-  modul ini; tenant yang cuma pakai `/blog/{tenantCode}` legacy tidak
-  pernah butuh domain mapping.
-- `api: { basePath: "/api/v1/tenant/domains", openApiPath:
-"openapi/awcms-public-api.openapi.yaml" }` dan `navigation: [{
-path: "/admin/tenant/domains", requiredPermission:
-"tenant_domain.domains.read", ... }]` **dideklarasikan sekarang**
-  meski API (#562)/UI (#563) belum ada — permintaan eksplisit issue
-  #558's descriptor requirements. Konsekuensi: Module Management's
-  `openApiDocumentedSignal` (readiness check) akan melaporkan `fail`
-  untuk `tenant_domain` sampai #562 menambah path OpenAPI nyata di bawah
-  basePath itu — ini diharapkan, bukan regresi. Nav entry hanya muncul di
-  sidebar untuk pemegang `tenant_domain.domains.read` (belum ada role yang
-  punya izin ini sampai ada assignment eksplisit).
-- `permissions`: 6 entry `tenant_domain.domains.*` (`read`/`create`/
-  `update`/`delete`/`verify`/`set_primary`), match persis dengan seed
-  migration 032 (`activityCode`/`action`/`description` identik) — divalidasi
-  `tests/modules/tenant-domain-module.test.ts`.
-- `settings: { schemaVersion: 1, defaults: { defaultVerificationMethod:
-"manual" } }` — satu-satunya preferensi non-secret yang dideklarasikan;
-  **bukan** default ke `dns_txt`/`dns_cname`/provider otomatis apa pun.
-  Tidak ada field `jobs`/`health` (belum ada command/health-check nyata
-  untuk didokumentasikan, konsisten dengan konvensi
-  `module_management/README.md`).
-- Tidak ada folder `domain/`/`application/` yang dibuat untuk modul ini di
-  Issue #558 — belum ada logic apa pun untuk ditempatkan di sana sampai
-  issue yang benar-benar butuh (#559/#562/#563). Hanya `module.ts` +
-  `README.md`.
+## API manajemen (`/api/v1/tenant/domains`)
 
-### Resolver (Issue #559, `src/lib/tenant/public-host-tenant-resolver.ts`)
-
-**Dikonsumsi oleh `/news` sejak Issue #560** (lihat §Rute publik `/news` di
-bawah) lewat `withNewsTenant()`
-(`src/modules/blog-content/application/public-news-tenant-resolution.ts`).
-Lima fungsi: `normalizePublicHost`, `resolvePublicTenantByHost`,
-`resolveDefaultPublicTenantFromEnv`, `resolveDefaultPublicTenantFromSetupState`,
-`resolvePublicTenantFromRequest` (orkestrator).
-
-**Urutan resolusi**: (0) `config.mode === "tenant_code_legacy"` → langsung
-`null`, skip langkah 1-4 seluruhnya — lihat §Keputusan `tenant_code_legacy`
-di bawah — → (1) host/domain mapping — HANYA jalan kalau
-`config.mode === "host_default"` — → (2) `PUBLIC_DEFAULT_TENANT_ID` → (3)
-`PUBLIC_DEFAULT_TENANT_CODE` (2-3 satu fungsi,
-`resolveDefaultPublicTenantFromEnv`, coba ID dulu lalu CODE) → (4)
-`awcms_setup_state.tenant_id` → (5) `null` (404 generic). **Langkah
-2-4 SELALU jalan untuk setiap mode KECUALI `tenant_code_legacy` (langkah 0)** — itu "safe fallback" di judul issue #559; untuk mode lain (termasuk
-`undefined`/tidak diset), hanya langkah 1 (host lookup) yang digerbangi
-mode. Konsekuensi keamanan yang disengaja: deployment yang tidak pernah set
-`PUBLIC_TENANT_RESOLUTION_MODE=host_default` (termasuk semua deployment
-offline/LAN existing yang tidak set `PUBLIC_*` sama sekali) TIDAK PERNAH
-menyentuh fungsi bootstrap `awcms_tenant_domains` — permukaan lebih
-kecil, bukan cuma code path lebih pendek.
-
-#### Keputusan `tenant_code_legacy` (diputuskan Issue #560)
-
-Dua reviewer Issue #559 (awcms-reviewer dan awcms-security-auditor)
-menandai satu ambiguitas produk yang wajib diputuskan eksplisit sebelum
-`/news` dibangun: versi awal `resolvePublicTenantFromRequest()` menjalankan
-langkah 2-4 (fallback env→setup) untuk **SEMUA** mode, termasuk
-`tenant_code_legacy` — padahal mode itu secara semantik berarti "tidak ada
-tebakan tenant default, wajib `tenantCode` eksplisit di path", dan `/news`
-sama sekali tidak punya segmen `tenantCode` di path.
-
-**Keputusan final, diimplementasikan Issue #560**: ketika
-`config.mode === "tenant_code_legacy"`, `resolvePublicTenantFromRequest()`
-langsung `return null` — skip seluruh langkah 1-4, bukan cuma langkah 1
-seperti mode lain. Mode `undefined` (default offline/LAN hari ini, operator
-tidak pernah men-set var ini sama sekali) **TIDAK** diperlakukan sama
-dengan `tenant_code_legacy` eksplisit — `undefined` tetap menjalankan
-seluruh fallback chain 2-4, karena operator yang tidak pernah menyentuh
-`PUBLIC_TENANT_RESOLUTION_MODE` belum membuat pilihan eksplisit "tidak ada
-tebakan tenant default". Hanya operator yang benar-benar men-set
-`PUBLIC_TENANT_RESOLUTION_MODE=tenant_code_legacy` yang membuat pilihan itu
-secara sadar, dan `/news` menghormatinya dengan tidak pernah resolve tenant
-apa pun untuk mode tersebut.
-
-Test: `tests/unit/public-host-tenant-resolver.test.ts`'s
-`describe("mode=tenant_code_legacy (Issue #560 decision)", ...)` (termasuk
-bukti bahwa `undefined` mode tetap resolve lewat fallback chain, sementara
-`tenant_code_legacy` eksplisit tidak, bahkan saat `PUBLIC_DEFAULT_TENANT_ID`/
-`_CODE`/setup-state semuanya valid) dan
-`tests/integration/blog-content-public-news.integration.test.ts`'s dua test
-`mode=tenant_code_legacy`.
-
-**Fungsi `SECURITY DEFINER` bootstrap** — `sql/033_awcms_tenant_domain_lookup_function.sql`
-(pakai checklist umum `SECURITY DEFINER` di
-`docs/adr/0003-postgresql-rls-multi-tenant.md` §Checklist untuk fungsi baru
-lain di masa depan):
-
-```sql
-CREATE OR REPLACE FUNCTION awcms_resolve_tenant_domain_lookup(p_normalized_hostname text)
-RETURNS TABLE (
-  tenant_id uuid, domain_status text, is_primary boolean, route_mode text,
-  tenant_status text, tenant_code text, tenant_name text, default_locale text
-)
-LANGUAGE sql SECURITY DEFINER STABLE
-SET search_path = public, pg_temp
-AS $function$
-  SELECT d.tenant_id, d.status AS domain_status, d.is_primary, d.route_mode,
-         t.status AS tenant_status, t.tenant_code, t.tenant_name, t.default_locale
-  FROM awcms_tenant_domains AS d
-  JOIN awcms_tenants AS t ON t.id = d.tenant_id
-  WHERE d.normalized_hostname = p_normalized_hostname AND d.deleted_at IS NULL;
-$function$;
-
-REVOKE ALL ON FUNCTION awcms_resolve_tenant_domain_lookup(text) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION awcms_resolve_tenant_domain_lookup(text) TO awcms_app;
-```
-
-**Post-review fix (timing side-channel, Medium finding):** the first
-version of this function returned only `(tenant_id, status, is_primary,
-route_mode)`, and `resolvePublicTenantByHost()` issued a SECOND,
-conditional query against `awcms_tenants` only when the domain row
-was found `active` — an unknown/unmapped host returned after exactly one
-round trip, a host mapped to an active domain but an inactive tenant
-always cost two. That is an observable timing side-channel distinguishing
-"no such mapping" from "mapping exists, tenant just isn't active" purely
-by response latency. Fixed by joining `awcms_tenants` into this same
-function (safe — that table is already RLS-free/publicly `SELECT`-able,
-so the join exposes nothing not already unconditionally public; it only
-removes a round trip) so `resolvePublicTenantByHost()` now issues **exactly
-one query for every outcome**, proven by
-`tests/integration/public-tenant-resolution.integration.test.ts`'s
-round-trip-counting test (wraps the same `sql` client in a `Proxy` and
-asserts the call count is 1 for an unmapped host, a mapped-but-inactive-
-tenant host, and a fully active host alike).
-
-Kenapa ini aman — **diverifikasi empiris** (bukan diasumsikan dari
-dokumentasi PostgreSQL) terhadap DB yang jalan sebelum migration ini
-ditulis, lihat percobaan di riwayat implementasi Issue #559:
-
-- Migration jalan sebagai role pemilik schema (`POSTGRES_USER`,
-  `awcms` di `docker-compose.yml`), dan role itu adalah **Postgres
-  SUPERUSER sungguhan** (`SELECT rolsuper FROM pg_roles` → `true`).
-  Superuser bypass RLS **unconditional**, terlepas dari `FORCE ROW LEVEL
-SECURITY` — `FORCE` hanya menghapus exemption RLS milik _table owner_
-  ketika owner itu BUKAN superuser; tidak berefek pada owner yang memang
-  superuser. Jadi fungsi `SECURITY DEFINER` yang dimiliki role ini bypass
-  RLS dengan cara yang sama seperti DDL/DML migration lain di schema ini
-  — bukan mekanisme RLS-vs-FORCE yang berbeda.
-- Karena keamanan TIDAK datang dari RLS/FORCE di level fungsi ini, dua hal
-  lain yang justru jadi pagar sebenarnya: (1) badan fungsi adalah SQL
-  statis tetap (bukan dynamic SQL), hanya me-return 4 kolom non-sensitif
-  (`tenant_id`/`status`/`is_primary`/`route_mode`) untuk satu
-  `normalized_hostname` yang diparameterkan + `deleted_at IS NULL` — tidak
-  mungkin dipakai membaca `verification_token_hash`/
-  `verification_record_value`/`hostname` mentah/tabel lain; (2) `EXECUTE`
-  di-revoke dari `PUBLIC` lalu di-grant eksplisit hanya ke `awcms_app`
-  — tidak ada role non-superuser lain yang bisa memanggil fungsi ini, dan
-  `awcms_app` sendiri tetap tidak bisa `SELECT` langsung dari
-  `awcms_tenant_domains` tanpa `withTenant(...)` (dibuktikan di
-  integration test).
-- `SET search_path = public, pg_temp` mengunci resolusi nama di dalam
-  fungsi (defense-in-depth standar untuk `SECURITY DEFINER`, terlepas dari
-  fakta ownernya sudah superuser).
-- Diverifikasi di
-  `tests/integration/public-tenant-resolution.integration.test.ts`: fungsi
-  ini resolve rows lewat `awcms_app` TANPA `app.current_tenant_id`
-  GUC di-set; `SELECT` langsung ke tabel dari koneksi yang sama (tanpa
-  fungsi) tetap 0 baris; kolom yang dikembalikan fungsi tidak pernah
-  memuat `verification_token_hash`/`hostname`/`verification_record_value`.
-
-`resolvePublicTenantByHost()` sendiri masih menambah filter
-`domain_status === 'active' && tenant_status === 'active'` di sisi
-TypeScript (fungsi SQL sengaja tidak memfilter status — hanya
-`deleted_at IS NULL` — supaya keputusan "kombinasi status mana yang boleh
-resolve traffic publik" tetap satu tempat, di kode aplikasi yang lebih
-mudah diaudit/diubah daripada re-migrate SQL). Fungsi ini juga
-me-revalidasi _shape_ `normalizedHost` sendiri (`isValidHostnameShape`,
-Low finding — fungsi ini exported dan didokumentasikan bisa dipanggil
-langsung oleh #560, jadi tidak boleh hanya mengandalkan "caller sudah
-normalize duluan") sebelum query apa pun dijalankan — dibuktikan di
-`tests/unit/public-host-tenant-resolver.test.ts` dengan `sql` palsu yang
-throw kalau dipanggil sama sekali.
-
-Semua kegagalan — host tidak dikenal, domain non-`active`, domain
-soft-deleted, tenant inactive — return `null` yang identik, dalam **satu**
-round-trip DB (lihat perbaikan timing side-channel di atas); satu-satunya
-yang boleh throw adalah `normalizePublicHost()` dipanggil dengan string
-kosong (pelanggaran kontrak pemanggil, bukan hasil resolusi runtime).
-`resolvePublicTenantFromRequest()` tidak pernah memanggil
-`normalizePublicHost` dengan string kosong — request tanpa `Host` header
-cukup melewati langkah 1 seluruhnya.
-
-`X-Forwarded-Host` hanya dibaca kalau `config.trustProxy === true`
-(caller yang menentukan, bukan modul ini yang membaca `PUBLIC_TRUST_PROXY`
-langsung dari `process.env` — pemanggil bertanggung jawab membangun
-`config` dari env; lihat `resolveDefaultPublicTenantFromEnv`'s parameter
-`env` untuk satu-satunya fungsi di modul ini yang punya default
-`process.env` bawaan). **Aturan operasional mengikat (Medium finding,
-post-review):** deployment yang set `PUBLIC_TRUST_PROXY=true` WAJIB
-berada di belakang satu trusted edge proxy yang langsung bersebelahan
-(directly-adjacent) dan yang MENIMPA (overwrite) `X-Forwarded-Host` secara
-penuh di setiap request — tidak pernah append/forward nilai dari client.
-Topologi yang didokumentasikan repo ini tidak pernah menghasilkan lebih
-dari satu nilai `X-Forwarded-Host` secara sah. Kalau header tetap berisi
-lebih dari satu nilai comma-separated saat runtime, `extractHostHeader()`
-TIDAK menebak mana yang trustworthy (leftmost = persis yang bisa
-di-pre-seed penuh oleh attacker kalau proxy-nya append, bukan overwrite) —
-ia log anomali (`public_host_resolver.x_forwarded_host_multi_value`) dan
-fallback ke `Host` biasa, persis seperti `trustProxy: false`. Perilaku ini
-diuji di `tests/unit/public-host-tenant-resolver.test.ts`.
-
-Test: `tests/unit/public-host-tenant-resolver.test.ts` (murni,
-`normalizePublicHost` + percabangan `resolvePublicTenantFromRequest` lewat
-mocked `deps`, tanpa DB) dan
-`tests/integration/public-tenant-resolution.integration.test.ts` (Postgres
-nyata — setiap acceptance criterion issue #559, termasuk bukti RLS/bypass
-di atas).
-
-### Rute publik `/news` (Issue #560)
-
-Tujuh rute publik anonim di bawah `src/pages/news/` — persis analog rute
-`/blog/{tenantCode}/...` (Issue #540, skill `awcms-blog-content`),
-me-reuse SEMUA application/domain service yang sama
-(`public-blog-directory.ts`, `public-page-rendering.ts`, `seo-rendering.ts`,
-`content-block-rendering.ts`, `blog-search.ts`'s `searchPublicBlogContent`,
-`error-responses.ts`). **Satu-satunya perbedaan**: resolusi tenant.
-`/blog/{tenantCode}/...` memakai `resolvePublicTenantByCode(sql,
-tenantCode)` dari path segment (ADR-0009); `/news/...` memakai
-`resolvePublicTenantFromRequest(sql, request, config)` (Issue #559) — tanpa
-segmen `tenantCode` di path sama sekali.
+Authenticated, tenant-scoped, guard di chokepoint identity-access
+(`authorizeInTransaction`, default-deny ABAC) di dalam `withTenant`. Setiap query
+jalan di bawah RLS `FORCE` (defense-in-depth di atas filter `tenant_id`) —
+**tidak pernah** lewat fungsi `SECURITY DEFINER` (itu eksklusif resolver publik).
 
 ```txt
-GET /news                         -> index (paginated)
-GET /news/{slug}                  -> detail post
-GET /news/category/{slug}         -> arsip kategori
-GET /news/tag/{slug}              -> arsip tag
-GET /news/search?q=               -> search publik
-GET /news/feed.xml                -> RSS 2.0
-GET /news/sitemap-news.xml        -> sitemap protocol 0.9
-```
-
-Semua `.ts` `APIRoute` (bukan `.astro`), pola sama persis rute
-`/blog/{tenantCode}` — testable lewat `tests/integration/harness.ts`'s
-`invoke()`/`invokeRaw()`.
-
-**Helper bersama**:
-`src/modules/blog-content/application/public-news-tenant-resolution.ts`'s
-`withNewsTenant(sql, request, handler, env?)` — dipakai ketujuh rute,
-memusatkan dua langkah wajib sebelum query post apa pun:
-
-1. `buildPublicHostResolverConfigFromEnv(env)` membangun
-   `PublicHostResolverConfig` dari `process.env.PUBLIC_TENANT_RESOLUTION_MODE`/
-   `process.env.PUBLIC_TRUST_PROXY` (dua env var Issue #556 — resolver #559
-   sendiri sengaja tidak membaca `process.env` untuk keduanya, lihat
-   §Resolver), lalu memanggil `resolvePublicTenantFromRequest`. `null` →
-   seluruh helper return `null`.
-2. **Module-disabled gate (acceptance criterion eksplisit Issue #560, DAN
-   gap yang belum ada bahkan di `/blog/{tenantCode}` existing)**: setelah
-   tenant resolve, `fetchTenantModuleEntry(tx, tenantId, "blog_content")`
-   (`module-management/application/tenant-module-lifecycle.ts` — single-module
-   narrowing dari `fetchTenantModuleEntries`, lihat "Sudah diperbaiki" di
-   bawah untuk alasannya)
-   dipanggil **di dalam** `withTenant(...)` yang sama, **sebelum** `handler`
-   (yang query post) dijalankan. Kalau entry `blog_content`'s
-   `tenantEnabled === false`, helper return `null` — rute memetakannya ke
-   404 generic yang identik dengan tenant tidak resolve, tidak pernah
-   membedakan "module disabled" vs "tenant tidak ada" vs "host tidak
-   dikenal" dari luar.
-
-Setiap rute lalu: `const result = await withNewsTenant(sql, request, async
-(tx, tenant) => { ...; return new Response(...); }); return result ??
-notFoundHtmlResponse();` (atau `notFoundXmlResponse()` untuk feed/sitemap).
-Post-not-found di dalam `handler` juga cukup `return null` — collapse ke
-404 generic yang sama, tidak perlu dibedakan dari kasus tenant/module.
-
-**Catatan pre-existing gap, TIDAK diperbaiki di Issue #560 (di luar
-scope)**: rute `/blog/{tenantCode}` existing (Issue #540) **tidak** punya
-cek module-disabled sama sekali — tenant yang menonaktifkan `blog_content`
-lewat `/api/v1/tenant/modules/blog_content/disable` tetap bisa diakses
-publik lewat `/blog/{tenantCode}`. Follow-up yang disarankan: issue
-terpisah untuk retrofit cek yang sama ke `/blog/{tenantCode}` (reuse
-`withNewsTenant`'s pola module-disabled check, atau ekstrak helper yang
-lebih generik kalau retrofit itu dikerjakan).
-
-**Helper rendering yang diperluas** (refactor murni, tanpa perubahan
-behavior untuk `/blog/{tenantCode}`):
-`public-page-rendering.ts`'s `renderPostSummaryListHtml(tenantCode, ...)`
-sekarang delegasi ke `renderPostSummaryListHtmlAtBasePath(basePath, ...)`
-generik baru (`basePath` = `/blog/{tenantCode}` untuk wrapper lama, `/news`
-untuk rute baru) — byte-for-byte identik untuk pemanggil lama.
-`renderPaginationNavHtml` sudah generik sejak awal (parameter `basePath`),
-tidak perlu diubah.
-
-Canonical URL/feed/sitemap semua literal `/news` (bukan konsumsi
-`PUBLIC_CANONICAL_BASE_PATH` — var itu divalidasi sejak Issue #556 tapi
-belum dikonsumsi kode manapun; `/news` di issue ini adalah path file tetap,
-bukan basePath yang dikonfigurasi via env).
-
-Test: `tests/integration/blog-content-public-news.integration.test.ts` —
-setiap acceptance criterion (listing/detail/draft-review-scheduled-archived-
-private-unlisted-soft-deleted visibility, canonical URL, feed/sitemap link
-base, module-disabled 404, `tenant_code_legacy` 404, isolasi lintas tenant).
-
-### API tenant domain management (Issue #562, `src/pages/api/v1/tenant/domains/**`)
-
-Authenticated, tenant-scoped CRUD + lifecycle di atas
-`awcms_tenant_domains` — kode aplikasi PERTAMA yang pernah menulis baris
-ke tabel ini (resolver #559 hanya pernah membacanya). Tidak ada admin UI
-(#563), tidak ada panggilan Cloudflare DNS (#567) — API-only, persis scope
-issue.
-
-```txt
-GET    /api/v1/tenant/domains              list, keyset-paginated
+GET    /api/v1/tenant/domains              list, keyset-paginated (limit 100)
 POST   /api/v1/tenant/domains              create
 GET    /api/v1/tenant/domains/{id}         read one
 PATCH  /api/v1/tenant/domains/{id}         partial update
-DELETE /api/v1/tenant/domains/{id}         soft delete
-POST   /api/v1/tenant/domains/{id}/verify        manual-first verify
-POST   /api/v1/tenant/domains/{id}/set-primary   atomic primary swap
+DELETE /api/v1/tenant/domains/{id}         soft delete (reason wajib)
+POST   /api/v1/tenant/domains/{id}/verify        manual-first verify (Idempotency-Key)
+POST   /api/v1/tenant/domains/{id}/set-primary   atomic primary swap (Idempotency-Key)
 ```
 
-Pola akses data mengikuti aturan #10 di bawah dengan ketat: setiap query di
-`tenant-domain/application/tenant-domain-directory.ts` jalan di dalam
-`withTenant(...)` biasa (RLS `FORCE` sebagai defense-in-depth di atas filter
-`tenant_id` eksplisit) — **tidak pernah** lewat fungsi `SECURITY DEFINER`
-migration 033 (fungsi itu tetap eksklusif untuk resolver publik anonim
-#559). Validasi hostname (`tenant-domain/domain/tenant-domain-validation.ts`)
-me-reuse `normalizePublicHost()` (#559) langsung, bukan opini shape kedua.
+Keputusan mengikat:
 
-Union `AccessAction` (`identity-access/domain/access-control.ts`) diperluas
-dengan `verify`/`set_primary` di issue ini — migrasi 032 sudah menyeed kedua
-permission itu sejak #557, tapi tidak ada konsumen sampai sekarang. Keduanya
-**tidak** masuk `HIGH_RISK_ACTIONS` (pola sama seperti `retry`/`sync`/
-`enable`/`disable`/`check`/`publish` — lihat `identity-access/README.md`),
-tapi keduanya tetap **wajib** `Idempotency-Key` (skill
-`awcms-idempotency`, scope `tenant_domain_verify`/
-`tenant_domain_set_primary`) dan tetap diaudit eksplisit
-(`tenant_domain.domain.verified`/`.set_primary`) terlepas dari klasifikasi
-itu.
+- `hostname` **immutable** setelah create (re-point = delete + create ulang);
+  `is_primary` tak pernah settable lewat `PATCH` generik (satu-satunya jalur =
+  `set-primary`); `PATCH` tak pernah bisa set `status: "active"` (pakai verify).
+- Duplikat normalized hostname → `409 HOSTNAME_CONFLICT` generik, tak pernah
+  membocorkan apakah milik tenant lain. Unknown/cross-tenant/deleted id → `404`
+  generik (filter `tenant_id`/`deleted_at IS NULL` + RLS FORCE).
+- `verify`/`set_primary` wajib `Idempotency-Key` (scope
+  `tenant_domain_verify`/`tenant_domain_set_primary`) dan diaudit, meski
+  keduanya **tidak** `HIGH_RISK` (union `AccessAction` diperluas dengan
+  `set_primary`; `verify` sudah ada dari news_portal). `verify` manual-first,
+  tanpa panggilan DNS/HTTP keluar.
+- ⚠️ **RISIKO RESIDUAL M1 (dangling-DNS takeover) — gerbangi sebelum
+  self-service custom domain tak-tepercaya.** `verify` mengaktifkan domain tanpa
+  bukti kepemilikan outbound; hostname yang di-soft-delete bisa didaftar ulang
+  tenant lain (unique index `WHERE deleted_at IS NULL`). Untuk `custom_domain`
+  bersama: pertahankan aktivasi **digerbangi operator/manual**, ATAU wire bukti
+  DNS-token (`verification_token_hash` + cek TXT/CNAME via `checkVerificationStatus`)
+  sebelum mengizinkan verifikasi self-service. Lihat README modul §Security
+  residual risk + follow-up di `docs/awcms/absorb-awcms-micro-roadmap.md`.
+- `set-primary` atomic (unset-lama-lalu-set-baru dalam satu transaksi); race
+  first-time-primary konkuren dipetakan ke `409 CONCURRENT_UPDATE`
+  (`setPrimaryTenantDomain` menangkap pelanggaran
+  `awcms_tenant_domains_primary_dedup`).
 
-Constraint global `awcms_tenant_domains_normalized_hostname_dedup`
-(migration 031, LINTAS tenant) di-catch di `POST /api/v1/tenant/domains` dan
-selalu dipetakan ke `409 HOSTNAME_CONFLICT` generik — tidak pernah
-membedakan "hostname ini sudah milikmu sendiri" vs "hostname ini sudah
-dipakai tenant lain" (binding rule §Security notes issue #562, sejalan
-dengan aturan #5 di bawah). Unknown/cross-tenant/soft-deleted id semuanya
-jatuh ke 404 generik yang sama lewat filter `tenant_id`/`deleted_at IS NULL`
-eksplisit plus RLS `FORCE` di baliknya.
+## Keyset pagination — jebakan µs vs ms
 
-`set-primary` atomic karena `withTenant` sudah membuka satu transaksi
-`sql.begin(...)` per request, dan `setPrimaryTenantDomain` menjalankan dua
-UPDATE di transaksi yang sama dengan urutan tetap (unset primary lama
-DULU, baru set primary baru) — index unique parsial
-`awcms_tenant_domains_primary_dedup` tidak pernah dilanggar
-mid-transaction untuk swap sekuensial (tenant yang sudah punya primary).
-**Post-review fix (Medium finding, security audit #562):** untuk tenant
-yang belum PERNAH punya primary, dua request `set-primary` konkuren untuk
-dua domain berbeda sama-sama match nol baris di UPDATE "unset" (tidak ada
-yang perlu di-unset), jadi keduanya lolos ke UPDATE "set" tanpa saling
-memblokir — satu di antaranya kalah ke index unique saat commit.
-`setPrimaryTenantDomain` sekarang membungkus UPDATE kedua dengan
-`try/catch` yang menangkap pelanggaran `awcms_tenant_domains_primary_dedup`
-dan mengembalikan `{ outcome: "conflict" }` (pola sama seperti
-`createTenantDomain`'s catch untuk hostname-dedup), dipetakan rute ke
-`409 CONCURRENT_UPDATE` generik — bukan 500 dengan raw constraint error.
-Diuji `tests/integration/tenant-domain-api.integration.test.ts`'s
-"set-primary under concurrent first-time race" (dua request paralel via
-`Promise.all`, assert satu 200 + satu 409, dan DB akhirnya cuma satu baris
-`is_primary = true`). `verify` manual-first murni (tidak ada panggilan
-DNS/HTTP keluar di issue ini), hanya membalik `status` berdasarkan
-`verification_method` yang sudah ada di baris. `verification_token_hash`
-tidak pernah di-`SELECT` oleh `tenant-domain-directory.ts` sama sekali,
-apalagi dikembalikan di response manapun.
+`listTenantDomains` MEMBANGKITKAN cursor SENDIRI (bukan di rute) via
+`to_char(created_at AT TIME ZONE 'UTC', ...)` sebagai `created_at_cursor` lalu
+`encodeKeysetCursor(created_at_cursor, id)`. Ini karena `timestamptz` menyimpan
+MIKRODETIK tapi JS `Date` cuma milidetik — cursor dari `Date` melewatkan baris
+yang berbagi milidetik itu (Issue #158). Jangan membangun cursor dari
+`view.createdAt`.
 
-Detail lengkap (termasuk kenapa `hostname` immutable setelah create, kenapa
-`is_primary` tidak pernah settable lewat `PATCH` generik, dan daftar
-lengkap acceptance criterion) ada di
-`src/modules/tenant-domain/README.md` §Tenant domain management API. Test:
-`tests/integration/tenant-domain-api.integration.test.ts`.
+## Adapter Cloudflare DNS (opsional, BELUM di-wire)
 
-### Admin UI (Issue #563, `src/pages/admin/tenant/domains.astro`)
+`infrastructure/cloudflare-dns-adapter.ts` — `resolveTenantDomainDnsProvider(env)`
 
-Path/permission gate persis descriptor Issue #558:
-`/admin/tenant/domains`, `tenant_domain.domains.read`. **Binding split**
-yang wajib diikuti issue turunan manapun yang menambah aksi baru di
-halaman ini: SSR initial render boleh baca langsung lewat
-`listTenantDomains`/`withTenant` (read-only, sama pola
-`admin/blog/categories.astro`), tapi **setiap mutasi** (create/update/
-delete/verify/set-primary) **wajib** lewat `fetch` client-side ke
-`/api/v1/tenant/domains/**` (#562) — tidak ada shortcut SSR privileged
-untuk mutasi apa pun, itu acceptance criterion mengikat issue #563.
-`verify`/`set-primary` mengirim `Idempotency-Key` baru
-(`newIdempotencyKey()`) per klik, pola sama
-`admin/blog/posts/[id].astro`'s tombol lifecycle. Validasi hostname
-client-side (`looksLikeValidHostname()` di halaman ini) murni UX —
-`normalizePublicHost()` lewat API tetap satu-satunya enforcement.
-Badge status pakai enum DB asli (`pending_verification | active |
-suspended | failed`) — bukan daftar shorthand issue #563 sendiri yang
-menyebut "verified" sebagai status kelima (tidak ada di schema). Link
-preview `/news` hanya muncul untuk domain yang `active` **dan**
-`isPrimary` sekaligus. Test:
-`tests/integration/tenant-domain-admin.integration.test.ts`.
+- `createCloudflareDnsProvider`. Tak ada rute yang memanggilnya. Tanpa
+  `TENANT_DOMAIN_DNS_PROVIDER=cloudflare`, resolver mengembalikan provider
+  misconfigured-result yang bersih (tak pernah throw) — awcms build & jalan tanpa
+  kredensial Cloudflare. `validateDnsRecordInput` menolak recordName di luar
+  `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN`, CR/LF injection, dan CNAME target non-host.
+  `recordName` shape sengaja BUKAN reuse `normalizePublicHost()` (nama record DNS
+  lazim underscore-prefix, mis. `_acme-challenge.example.com`); `normalizePublicHost`
+  tetap dipakai untuk target CNAME. Timeout via `resolveTenantDomainCloudflareTimeoutMs`
+  (env `TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS`, default 8 detik, tak pernah gagalkan
+  boot). Secret Cloudflare hanya dari env — tak pernah di DB/response.
 
-### Tenant settings public route (Issue #564, `blog_content`)
+## Yang BELUM ada (deferred, terdokumentasi)
 
-Empat key baru di descriptor `blog_content`'s `settings.defaults`
-(`src/modules/blog-content/module.ts`, dibaca lewat
-`fetchEffectivePublicRouteSettings`/`isLegacyTenantRouteEnabled`,
-`src/modules/blog-content/application/public-route-settings.ts`):
-`publicRouteMode` (`domain_default` default, atau `disabled`),
-`publicBasePath` (default `/news`), `legacyTenantRouteEnabled` (default
-`true`), `publicLabel` (default `"News"`).
+- **Rute konten publik ber-resolusi host** (permukaan gaya `/news`). Resolver +
+  fungsi lookup + directory + admin API sudah lengkap & teruji, tapi belum ada
+  rute publik yang mengonsumsi `resolvePublicTenantFromRequest` — butuh rute
+  render publik blog_content/news_portal di-plumb lewatnya (news_portal
+  men-defer `/news/**`-nya sendiri dengan alasan sama). Wiring-nya follow-up
+  bersih; seam stabil. Env `PUBLIC_TENANT_RESOLUTION_MODE`/`PUBLIC_TRUST_PROXY`/
+  `PUBLIC_DEFAULT_TENANT_ID`/`PUBLIC_DEFAULT_TENANT_CODE` belum divalidasi
+  `scripts/validate-env.ts` (belum ada konsumen runtime) — tambahkan saat
+  mem-wire rute publik.
+- **Otomasi Cloudflare DNS** (lihat di atas).
 
-**Keputusan mengikat yang wajib diikuti issue lanjutan** (jangan
-diulang/dikontradiksi):
+## Aturan mengikat lintas-perubahan
 
-1. **`rssEnabled`/`sitemapEnabled` SENGAJA TIDAK** ada di store baru ini
-   meski muncul di contoh JSON issue #564 sendiri — keduanya sudah punya
-   rumah di `awcms_blog_settings`/`fetchBlogSettings()` sejak Issue
-   #543, sudah ditegakkan `/news/feed.xml`/`sitemap-news.xml` sejak Issue
-   #560. Menambahkannya ke store generik (`awcms_module_settings`,
-   framework Issue #516) akan membuat dua sumber kebenaran independen
-   untuk konsep yang sama — bug nyata, bukan kosmetik (admin toggle di
-   satu tempat, rute baca dari tempat lain). Test regresi eksplisit
-   membuktikan ini: `tests/integration/blog-content-settings.integration.test.ts`
-   PATCH `rssEnabled` ke store yang SALAH (baru) → tidak berpengaruh ke
-   `/news/feed.xml`; PATCH ke store yang BENAR (lama) → baru berpengaruh.
-2. **`publicBasePath` hanya memengaruhi link-generation (canonical
-   `<link>`, RSS `<link>`/`<guid>`, sitemap `<loc>`, pagination href,
-   cross-link)** — BUKAN routing fisik. `/news/**` tetap file-based route
-   Astro yang secara fisik hanya bisa diakses di `/news/*`; mengubah
-   `publicBasePath` tidak memindahkan endpoint yang benar-benar merespons.
-   Ini keterbatasan yang disengaja (retargeting routing fisik per-tenant
-   butuh dynamic catch-all route, jauh di luar scope #564), didokumentasikan
-   eksplisit di `blog-content/README.md` §Public route settings — jangan
-   "perbaiki" jadi routing dinamis tanpa issue baru yang eksplisit
-   membahasnya.
-3. **`publicRouteMode=disabled` adalah outcome ke-4 pada gate timing-parity
-   `withNewsTenant`** (menambah dari 3 outcome sebelumnya — lihat
-   "Timing side-channel" di §Belum ada di bawah). Ditegakkan struktural
-   lewat satu fungsi bersama `checkBlogContentAndRouteGate()`
-   (`public-news-tenant-resolution.ts`) yang dipanggil baik dari jalur
-   tenant resolve sungguhan maupun dari `padUnresolvedTenantLatency()` —
-   secara konstruksi tak bisa drift, bukan dua implementasi kebetulan
-   sama. **Follow-up non-blocking** (dicatat security audit #564): belum
-   ada test `wrapCountingSql`-based yang secara eksplisit membandingkan
-   round-trip count outcome `publicRouteMode=disabled` vs 3 outcome
-   lainnya (paritas berlaku by construction, tapi belum diuji langsung
-   seperti paritas module-disabled vs enabled) — tambahkan bila menyentuh
-   area ini lagi.
-4. **`legacyTenantRouteEnabled=false` → 404 identik di SEMUA 7 rute
-   `/blog/{tenantCode}/**`** (bukan redirect — pilihan eksplisit #564),
-   lewat `isLegacyTenantRouteEnabled()` dipanggil tepat setelah
-   `withTenant(...)` di ketujuh file, sebelum query lain apa pun. Default
-   `true` mempertahankan perilaku hari ini tanpa perubahan (menegakkan
-   aturan #3 di bawah — legacy route tidak pernah hilang secara default).
-5. **`publicLabel` hanya memengaruhi output `/news`** (heading, `<title>`,
-   RSS channel title) — `/blog/{tenantCode}` tetap pakai teks "Blog"
-   historis, tidak disentuh. Di-escape lewat `escapeHtml()` yang sudah
-   ada — **follow-up non-blocking** (security audit #564): belum ada test
-   regresi eksplisit yang mengirim payload `<script>` via `publicLabel`/
-   `publicBasePath` lalu assert output ter-escape (mitigasi sudah
-   diverifikasi lewat code review manual — `escapeHtml()` dipanggil di
-   setiap titik render — tapi belum jadi regression test otomatis).
+1. **Backward compatibility**: deployment offline/LAN yang tak pernah set
+   `PUBLIC_*` apa pun harus tetap jalan persis seperti sebelumnya — jangan buat
+   var config ini wajib secara default.
+2. **`X-Forwarded-Host` hanya saat `trustProxy` eksplisit true** — default aman
+   `false` di setiap lapisan baru.
+3. **`/blog/{tenantCode}` (ADR-0009) TIDAK dihapus** — host routing bersifat
+   tambahan, bukan pengganti.
+4. **Tenant existence tidak boleh bocor**: unknown/failed/suspended/inactive
+   harus menghasilkan respons identik (resolver sudah return `null` identik;
+   rute publik pemakainya wajib memetakan ke 404 generik yang sama).
+5. **Secret provider (Cloudflare token) tak pernah di DB/descriptor** — hanya
+   env, seperti Mailketing/R2.
+6. **Semua mutasi domain diaudit** (`tenant_domain.domain.<verb>`); resolver
+   publik read-only anonim TIDAK diaudit (sama seperti `resolvePublicTenantByCode`).
+7. **API manajemen #tenant-scoped pakai `withTenant` biasa**, TIDAK pernah fungsi
+   `SECURITY DEFINER` (itu murni bootstrap publik pra-tenant-context).
 
-Validasi nilai: `isPublicRouteMode`/`isValidBasePath`
-(`public-route-settings.ts`) — enum-checked untuk mode, absolute-path +
-no-whitespace + no-`//` + no-trailing-slash untuk base path; nilai tak
-valid jatuh ke default aman, tidak pernah dipakai mentah. `publicLabel`
-tidak divalidasi bentuk semantiknya (bebas string label, sama seperti
-`blogTitle` di `awcms_blog_settings`), tapi sejak perbaikan
-value-shape heuristic (lihat "Sudah diperbaiki" di bawah)
-`validateModuleSettingsPatch` tetap menolak kalau isinya credential-shaped
-(JWT/PEM/AWS key/Bearer/connection-string) — bebas-string hanya untuk
-konten label yang wajar, bukan celah untuk menyimpan secret mentah.
+## Test
 
-Test: `tests/integration/blog-content-settings.integration.test.ts` (12
-test) dan 3 test paritas round-trip di
-`tests/integration/blog-content-public-news.integration.test.ts`. Detail
-lengkap kelima keputusan di atas: `blog-content/README.md` §Public route
-settings.
-
-### Tenant module presets (Issue #565, `module_management`)
-
-Domain+application service layer saja (`src/modules/module-management/domain/module-presets.ts` +
-`application/module-presets.ts`) — **belum ada endpoint API/UI** (itu
-scope #566's matrix UI dan/atau setup wizard yang belum ada). Lima preset
-(`online_website`, `news_portal`, `saas_online`, `pos_lan`, `minimal`),
-`applyModulePreset()` bisa dipanggil issue lanjutan mana pun yang butuh
-"set tenant module state ke profil X" — jangan re-derive dependency-graph
-logic-nya, itu sudah 100% reuse `evaluateModuleEnable`/
-`evaluateModuleDisable`/`enableTenantModule`/`disableTenantModule` yang
-ada sejak Issue #515.
-
-**Koreksi kunci key modul** yang wajib diikuti issue lanjutan manapun yang
-menyebut modul workflow: key registry sungguhan adalah `workflow`
-(`src/modules/workflow-approval/module.ts`), **bukan**
-`workflow_approval` — issue #565 sendiri salah menyebutnya di contoh
-JSON-nya. Grep `key: "` di `src/modules/*/module.ts` sebelum menulis key
-modul apa pun secara manual, jangan asumsikan nama direktori = key.
-
-**Preset menerapkan enable DAN disable** (bukan cuma enable) — modul yang
-sedang enabled, tidak ada di daftar preset, dan bukan "protected"
-(`isCore: true` ditambah closure transitif dependency-nya — dihitung
-dinamis lewat `resolveProtectedModuleKeys`, bukan hardcoded; hari ini
-resolve ke `{module_management, tenant_admin, identity_access,
-profile_identity}`) akan di-disable. Disable leaves-first, skip (bukan
-force) untuk modul yang masih dibutuhkan modul lain yang tetap enabled —
-termasuk modul yang plan yang SAMA baru saja mau enable (bug post-review:
-versi awal cuma menghitung status enabled SEBELUM plan, bukan union
-dengan modul yang baru mau di-enable plan itu sendiri — sudah diperbaiki,
-lihat komentar `planDisableOrder` di `domain/module-presets.ts`).
-Idempotent: re-apply preset yang sama menghasilkan plan kosong (tidak ada
-audit event baru). Setiap perubahan modul (bukan satu event "preset
-applied" agregat) tetap diaudit lewat `recordAuditEvent` pola sama
-`enable.ts`/`disable.ts`.
-
-`applyModulePreset` **tidak** melakukan ABAC check sendiri (sama seperti
-`enableTenantModule`/`disableTenantModule` yang dibungkusnya) — pemanggil
-masa depan (API #566 atau setup wizard) wajib `authorizeInTransaction`
-sendiri sebelum memanggilnya, guard permission yang sesuai (pola sama
-`ENABLE_GUARD`/`DISABLE_GUARD` di `enable.ts`/`disable.ts`).
-
-Test: `tests/unit/module-presets.test.ts` (18 test, pure domain logic
-lewat synthetic registry) dan
-`tests/integration/module-presets.integration.test.ts` (7 test, real
-Postgres). Detail lengkap tiga keputusan desain di atas:
-`module-management/README.md` §Tenant module presets.
-
-### Tenant-module matrix admin UI (Issue #566, `module_management`)
-
-`/admin/modules/tenants` (`src/pages/admin/modules/tenants.astro` +
-`application/module-matrix.ts`'s `fetchModuleMatrix`) — layar admin yang
-menampilkan module x atribut relevan **untuk satu tenant**, di atas data
-yang sama yang sudah dibaca #521's list/detail (`fetchModuleCatalog`,
-`fetchTenantModuleEntries`, `fetchModuleHealthReport`) plus #565's
-`resolveProtectedModuleKeys`, dan `evaluateModuleEnable`/
-`evaluateModuleDisable` (#515) untuk dua peringatan baru
-(`dependencyWarning`/`reverseDependencyWarning`) — bukan graph baru.
-
-**Keputusan scope mengikat (single-tenant, BUKAN cross-tenant)**: kata-kata
-issue sendiri ("filter by tenant", "managing module availability across
-tenants") terbaca seperti matrix lintas-tenant sungguhan — tapi model
-identity repo ini strictly 1:1 tenant-scoped (`identity-access/README.md`,
-`TenantBadge.astro` — Issue #693, menggantikan `TenantSwitcher.astro` —
-merender badge non-interaktif untuk alasan yang sama). Sudah
-diputuskan bersama maintainer: layar ini scoped ke tenant admin sendiri
-(`context.tenantId`), sama seperti semua layar admin lain di app ini —
-**tidak ada** filter/selector tenant di mana pun di halaman ini. Alasan
-lengkap: docblock `tenants.astro` sendiri. Issue lanjutan manapun **jangan**
-"perbaiki" ini dengan menambah dropdown tenant satu-opsi palsu atau
-membangun filtering lintas-tenant sungguhan — itu butuh konsep
-identity/session platform-operator baru yang sama sekali di luar scope
-repo ini hari ini.
-
-**Nilai "matrix" konkret** (karena tidak ada sumbu tenant kedua untuk
-dijadikan grid sungguhan): (1) peringatan dependency/reverse-dependency
-untuk SEMUA modul sekaligus (100% reuse `evaluateModuleEnable`/
-`evaluateModuleDisable`, tidak pernah walk graph baru — `dependencyWarning`
-hanya dihitung untuk modul yang SEDANG disabled, `reverseDependencyWarning`
-hanya untuk modul yang SEDANG enabled, karena memanggil `evaluateModuleEnable`
-pada modul yang sudah enabled hanya akan short-circuit ke
-`MODULE_ALREADY_ENABLED` sebelum sempat mengecek dependency — bukan
-pertanyaan yang didesain untuk state itu); (2) visualisasi core/protected
-bulk (`isCore` + `isProtected` per baris, tombol disable disembunyikan untuk
-keduanya — protected non-core pun, karena disable-nya pasti ditolak server
-lewat `MODULE_REVERSE_DEPENDENCY_ACTIVE`); (3) filter client-side "hanya
-tampilkan modul dengan peringatan". Settings editing dan audit-event list
-**tidak** diduplikasi — tetap link ke `/admin/modules/{moduleKey}` yang
-sudah punya keduanya.
-
-**Preset (#565's `applyModulePreset`) SENGAJA TIDAK diwire ke layar ini** —
-butuh endpoint API + OpenAPI + guard + test baru, unit kerja tersendiri yang
-cukup besar; dicatat sebagai follow-up terpisah, bukan dipaksakan masuk
-issue ini.
-
-**Binding split sama seperti #563**: SSR baca langsung (`withTenant` +
-`fetchModuleMatrix`), setiap mutasi (enable/disable) lewat
-`/api/v1/tenant/modules/{moduleKey}/enable|disable` (#515) yang sudah ada —
-tidak ada shortcut SSR privileged. Kedua endpoint itu **tidak** butuh
-`Idempotency-Key` (dicek langsung dari `enable.ts`/`disable.ts`), jadi tidak
-dikirim di sini — beda dari `verify`/`set-primary` #563 yang butuh.
-
-Test: `tests/integration/module-tenant-matrix.integration.test.ts`. Detail
-lengkap: `module-management/README.md` §Tenant-module matrix admin UI.
-
-### Cloudflare DNS adapter (Issue #567, `tenant_domain`)
-
-Provider boundary saja — **belum ada rute apa pun** di repo ini yang
-memanggilnya (menyelesaikan `.../verify` dengan panggilan DNS nyata, atau
-"provision platform subdomain", tetap follow-up terbuka). Manual domain
-management (`POST /api/v1/tenant/domains/{id}/verify`, #562) tetap default
-MVP tanpa perubahan — tidak ada var baru yang wajib.
-
-**Env baru** (`domain/tenant-domain-dns-config.ts`,
-`scripts/validate-env.ts`'s `checkTenantDomainDnsConfig`), semuanya
-opsional/backward-compatible:
-
-- `TENANT_DOMAIN_DNS_PROVIDER` — `manual` (default) | `cloudflare`.
-- `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` — wajib bila `cloudflare`. **Var
-  terpisah** dari `PUBLIC_PLATFORM_ROOT_DOMAIN` (#556) meski keduanya
-  biasanya bernilai sama secara operasional: `PUBLIC_PLATFORM_ROOT_DOMAIN`
-  menggerbangi resolver host-based publik (#559, siapa yang boleh
-  di-_resolve_ jadi tenant); var ini menggerbangi hostname mana yang
-  boleh disentuh adapter Cloudflare (siapa yang boleh dibuatkan/dicek
-  record DNS-nya) — juga mencerminkan batasan nyata API Cloudflare (satu
-  zone id/token hanya bisa mengelola record di dalam zone-nya sendiri).
-  Jangan gabungkan kedua var ini di issue lanjutan mana pun.
-- `TENANT_DOMAIN_CLOUDFLARE_ZONE_ID` — wajib bila `cloudflare`.
-- `TENANT_DOMAIN_CLOUDFLARE_API_TOKEN` — wajib bila `cloudflare`, secret
-  sungguhan. Hanya dari env/secret manager — **tidak pernah** disimpan di
-  `awcms_tenant_domains`/`awcms_module_settings`/tabel lain, tidak
-  pernah dirender di admin UI mana pun (menegakkan §Aturan lintas-issue #7
-  di bawah).
-- `TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS` — selalu opsional, bahkan saat
-  `cloudflare` dipilih. Timeout per panggilan (ms); kosong/tidak valid
-  selalu jatuh ke default aman (8 detik), tidak pernah gagalkan boot —
-  bukan bagian `TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED`, dan tidak
-  dicek `checkTenantDomainDnsConfig` (pola sama `EMAIL_SEND_TIMEOUT_MS`).
-  Fix dari security audit follow-up PR #580 — sebelumnya hardcoded, lihat
-  "Sudah diperbaiki" di bawah.
-
-**Adapter** (`infrastructure/cloudflare-dns-adapter.ts`) — port
-`TenantDomainDnsProvider` dengan dua method, keduanya timeout-bounded
-(`withTimeout`, default 8 detik, tunable lewat
-`TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS`) dan digerbangi circuit breaker bersama
-(`getProviderCircuitBreaker("tenant-domain-cloudflare-dns")`), pola persis
-`email/infrastructure/mailketing-provider.ts` dan
-`sync-storage/infrastructure/object-storage-uploader.ts`. Keduanya dipanggil
-di luar transaksi DB mana pun (ADR-0006) — file ini tidak pernah membuka
-`sql.begin(...)`:
-
-- `createVerificationRecord({recordType, recordName, recordValue})` —
-  **idempotent by construction**: list dulu record yang match
-  type/name/content persis, return `{ok:true, alreadyExists:true}` tanpa
-  write kedua kalau sudah ada, bukan mengandalkan kode error duplicate
-  Cloudflare tertentu.
-- `checkVerificationStatus({recordType, recordName, expectedValue})` — list
-  record pada name/type itu, bandingkan content (CNAME dinormalisasi:
-  strip trailing dot + lowercase sebelum dibandingkan).
-
-**Validasi input mengikat** (`validateDnsRecordInput`, exported, pure):
-`recordName` wajib persis `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` atau
-subdomain-nya — ditolak SEBELUM panggilan network apa pun. Shape check
-`recordName` **sengaja bukan** reuse `normalizePublicHost()` (#559): nama
-record verifikasi DNS lazim berlabel underscore-prefix (mis.
-`_acme-challenge.example.com`, `_awcms-verify.tenant1.platform.example`)
-yang shape-check `Host` header (`normalizePublicHost`) menolaknya, padahal
-konvensi ini valid dan lazim untuk TXT record verifikasi — lihat
-`isValidDnsRecordNameShape` (fungsi baru, dedicated) di file adapter.
-`normalizePublicHost()` tetap dipakai ulang, tidak berubah, untuk
-memvalidasi _target_ CNAME (hostname sungguhan yang dituju, bukan label
-record).
-
-**Redaksi error mengikat**: error HTTP dari Cloudflare tidak pernah
-menyertakan `errors[].message` mentah — hanya kode numerik
-`errors[].code` yang disurfacekan (aman, tidak identifiable). Teks error
-apa pun yang di-throw (network failure, timeout) juga melewati `redact()`
-yang menghapus nilai `apiToken`/`zoneId` yang dikonfigurasi sebagai defense
-in depth (mis. error jaringan yang pesannya kebetulan menyertakan URL
-request, yang menyertakan zone id) sebelum dipotong ke 300 karakter. Tidak
-pernah stack trace.
-
-`resolveTenantDomainDnsProvider(env)` — resolver produksi (mirror
-`resolveEmailProvider`/`resolveObjectUploader`): membangun provider
-Cloudflare sungguhan kalau lengkap terkonfigurasi, atau stub aman yang
-selalu `{ok:false}` dengan pesan jelas (tidak pernah throw) untuk mode
-`manual`, provider tak dikenal, atau `cloudflare` yang kurang salah satu
-dari tiga var wajib. **Belum dipanggil dari mana pun** di issue ini — tidak
-ada route yang wire ke sini.
-
-Test: `tests/unit/cloudflare-dns-adapter.test.ts` (`validateDnsRecordInput`
-pure cases; lalu terhadap `Bun.serve` fake server lokal — sukses,
-idempotent re-create, provider error dengan bukti redaksi terhadap server
-yang sengaja meng-echo token/zone id di `errors[].message`, timeout,
-circuit breaker trip, dan `resolveTenantDomainDnsProvider`'s perilaku
-env hilang/tidak-dikenal/`cloudflare` tidak lengkap).
-`tests/validate-env.test.ts`'s `describe("checkTenantDomainDnsConfig", ...)`
-menguji aturan gating env di atas. Detail lengkap:
-`src/modules/tenant-domain/README.md` §Cloudflare DNS adapter.
-
-## Aturan lintas-issue yang wajib diikuti
-
-1. **Backward compatibility non-negotiable**: setiap deployment offline/LAN existing yang tidak pernah set `PUBLIC_*` apa pun harus tetap `config:validate` PASS dan berperilaku persis seperti sebelum epic ini — jangan pernah membuat salah satu dari enam var config ini menjadi wajib secara default.
-2. **`PUBLIC_TRUST_PROXY=false` harus tetap default aman** di setiap lapisan baru — jangan baca `X-Forwarded-Host`/`X-Forwarded-Proto` kecuali `PUBLIC_TRUST_PROXY=true` eksplisit diset. Resolver #559 sudah menegakkan ini (`resolvePublicTenantFromRequest`'s `config.trustProxy`, default `false`); API domain #562 manapun yang membaca header host langsung (bukan lewat resolver ini) wajib pola yang sama.
-3. **`/blog/{tenantCode}` (ADR-0009, skill `awcms-blog-content`) TIDAK dihapus** — epic #555 secara eksplisit out-of-scope untuk "removing legacy `/blog/{tenantCode}` routes in the MVP". `/news` (#560) adalah rute **tambahan**, bukan pengganti. Issue #561 (selesai — `docs/adr/0010-public-host-tenant-routing.md`) mendokumentasikan `/blog/{tenantCode}` sebagai legacy, bukan menghapusnya.
-4. **Jangan trust `X-Forwarded-Host` tanpa proxy tepercaya** — ulangi dari epic #555 §Security notes. Berlaku juga untuk API domain #562 manapun yang membaca header host secara independen dari resolver #559.
-5. **Tenant existence tidak boleh bocor**: domain/tenant yang unknown, failed, suspended, atau inactive harus menghasilkan respons yang identik/tidak bisa dibedakan (pola sama seperti ADR-0009's 404 identik untuk `tenantCode` tak dikenal vs tenant tidak aktif) — resolver #559 sudah menegakkan ini (`resolvePublicTenantByHost`/`resolveDefaultPublicTenantFromEnv`/`resolveDefaultPublicTenantFromSetupState`/`resolvePublicTenantFromRequest` semua return `null` identik). Rute publik `/news` #560 **wajib** memetakan `null` resolver ini ke 404 generic yang sama, tidak menambah pesan/status yang membedakan kasus.
-6. **Module disabled tetap diblokir server-side** — kalau tenant module presets (#565, selesai) atau tenant-module matrix (#566) menonaktifkan sebuah modul, endpoint modul itu wajib tetap menolak di server (guard ABAC/tenant-module lifecycle yang sudah ada dari `module_management`), bukan hanya disembunyikan di UI. Ditegakkan otomatis untuk #565 — `applyModulePreset` selalu lewat `disableTenantModule` yang sudah ada (tidak pernah menulis `awcms_tenant_modules` langsung), jadi enforcement server-side yang sudah ada sejak Issue #515 tidak pernah dilewati.
-7. **Provider secret (mis. Cloudflare API token, #567) tidak pernah disimpan di module descriptor atau kolom DB biasa** — pakai environment variable seperti provider lain (Mailketing, R2), dan `configure`-only permission gate seperti pola `email`/`sync-storage` provider config.
-8. **Semua mutasi domain/module (create/update/delete domain mapping, enable/disable module preset) wajib diaudit** — pola `recordAuditEvent` yang sama dipakai modul lain, action literal sesuai konvensi modul (`tenant_domain.<resource>.<verb>` mengikuti pola `blog.<resource>.<verb>` dari blog_content). Resolver #559 sendiri **bukan** mutasi (read-only, anonymous) — tidak diaudit, sama seperti `resolvePublicTenantByCode` (ADR-0009) tidak diaudit.
-9. **Cloudflare DNS adapter (#567) adalah opsional/enhancement**, bukan hard dependency — epic #555 §Out of scope eksplisit menyebut "making Cloudflare DNS automation a hard dependency" di luar scope. Tenant domain mapping (#557/#562) harus tetap berfungsi tanpa Cloudflare sama sekali (manual DNS setup oleh operator).
-10. **`/news` routes (Issue #560, selesai) reuse `resolvePublicTenantFromRequest()` (Issue #559) langsung** lewat `withNewsTenant()` helper — tidak re-derive hostname→tenant lookup logic lain. `config.mode` untuk panggilan itu dibangun dari `PUBLIC_TENANT_RESOLUTION_MODE`/`PUBLIC_TRUST_PROXY` di `process.env` (resolver sendiri tidak membaca `process.env` untuk keduanya — sengaja, untuk testability; lihat §Resolver). `#562`'s admin API (mutasi domain, tenant-scoped, authenticated) **TIDAK** boleh reuse resolver #559 (yang anonymous/pre-tenant-context) — API #562 memakai `withTenant(...)` biasa seperti endpoint tenant-scoped lain, RLS `awcms_tenant_domains` yang menjaga isolasinya, bukan fungsi `SECURITY DEFINER` (fungsi itu murni untuk bootstrap publik tanpa tenant context).
-
-## Residual follow-up — belum ada
-
-**Epic #555 (#556-#567) sekarang 100% selesai** — semua 12 issue sudah
-merge: config (#556), schema `awcms_tenant_domains` (#557), module
-descriptor `tenant_domain` (#558), resolver host-based (#559), rute publik
-`/news` (#560), dokumentasi legacy/ADR-0010 (#561), API tenant domain
-management (#562, §API di atas), admin UI (#563, §Admin UI di atas), tenant
-settings public route `blog_content` (#564, §Tenant settings public route di
-atas), tenant module presets (#565, §Tenant module presets di atas —
-service layer saja), tenant-module matrix admin UI (#566, §Tenant-module
-matrix admin UI di atas — single-tenant scope, lihat keputusan mengikat di
-bagian itu), dan adapter Cloudflare DNS opsional (#567, §Cloudflare DNS
-adapter di atas — provider boundary saja, **belum ada route yang
-memanggilnya**, lihat follow-up #4 di bawah).
-
-Tabel `awcms_tenant_domains` sekarang bisa ditulis lewat kode aplikasi
-(API #562 + admin UI #563) — bukan lagi schema-only. Operator yang
-benar-benar mengisi baris nyata lewat UI/API dan mengaktifkan
-`PUBLIC_TENANT_RESOLUTION_MODE=host_default` membuat resolver #559 langkah 1
-(host/domain mapping asli) benar-benar reachable di production untuk
-pertama kalinya — lihat konsekuensi keamanan di ADR-0010 §Konsekuensi
-sebelum mengaktifkan mode itu.
-
-**Follow-up non-blocking untuk issue lanjutan mana pun yang menyentuh area
-ini** (bukan gate merge #567, dicatat di sini supaya tidak di-re-derive):
-
-4. `infrastructure/cloudflare-dns-adapter.ts` (#567) belum di-wire ke rute
-   apa pun — `POST /api/v1/tenant/domains/{id}/verify` (#562) tetap
-   manual-first murni (tidak ada panggilan DNS/HTTP keluar). Issue lanjutan
-   yang ingin menambah verifikasi Cloudflare otomatis harus: (a) memanggil
-   `resolveTenantDomainDnsProvider(env)`/`createCloudflareDnsProvider` di
-   luar transaksi DB `withTenant` mana pun (ADR-0006 — adapter ini sendiri
-   tidak pernah membuka transaksi, tapi endpoint pemanggilnya wajib tetap
-   menjaga aturan itu), (b) tetap treat hasil provider sebagai _input_ ke
-   `verifyTenantDomain` yang sudah ada, bukan menggantikannya, dan (c) tetap
-   audit `tenant_domain.domain.verified` seperti sekarang — jangan tambah
-   audit event kedua khusus "cloudflare check" kecuali ada kebutuhan produk
-   eksplisit.
-
-**Follow-up non-blocking dari security audit #562** (verdict PASS, tidak ada Critical/High — item ini dicatat sebagai perbaikan lanjutan, bukan gate merge):
-
-3. **Klasifikasi `set_primary` di luar `HIGH_RISK_ACTIONS`** (`identity-access/domain/access-control.ts`) layak ditinjau ulang untuk konsistensi jangka panjang — `isHighRiskAction()` tidak dikonsumsi di mana pun hari ini (murni metadata, audit dan `Idempotency-Key` tetap ditegakkan eksplisit per-endpoint terlepas dari klasifikasi ini), tapi blast radius `set_primary` (mengubah tenant mana yang jadi canonical redirect target untuk traffic publik anonim) berpotensi lebih besar daripada `delete` (yang sudah masuk `HIGH_RISK_ACTIONS`). Tidak berdampak fungsional sekarang; pertimbangkan saat `isHighRiskAction()` mulai dikonsumsi (mis. rate limiting tambahan, step-up auth).
-
-Sudah diperbaiki (follow-up lintas-modul dari audit #562, bukan follow-up lagi): **race idempotency-store lintas-modul** (`src/modules/_shared/idempotency.ts`, dipakai `verify`/`set-primary` #562 dan setiap endpoint idempotent lain di repo) — dua request paralel dengan `Idempotency-Key` yang SAMA bisa sama-sama lolos `findIdempotencyRecord` di bawah READ COMMITTED sebelum salah satu commit; yang kalah dulu gagal pada unique index `awcms_idempotency_keys_scope_key` (migration 012) tanpa ditangkap (raw error/500). Fix: `saveIdempotencyRecord` sekarang `INSERT ... ON CONFLICT (tenant_id, request_scope, idempotency_key) DO NOTHING RETURNING id`; kalau kalah race, `SELECT` ulang row pemenang (dijamin sudah committed) dan bandingkan `request_hash` — hash sama (payload identik, retry jaringan murni) → lempar `IdempotencyRaceLostError` membawa `replay` (response pemenang), hash beda (genuine conflict) → `replay: null`. `withTenant` (`src/lib/database/tenant-context.ts`) menangkapnya di satu titik — rollback transaksi (mutation loser tidak pernah persist, "double submit paralel -> tidak dobel" tetap tegak), skip circuit breaker (bukan infra failure), log `idempotency.race_lost` (key di-hash, bukan raw), lalu **replay response pemenang** (bukan 409) kalau hash sama — menegakkan aturan "hash sama → replay" yang sudah ada bahkan saat kalah race — atau `409 IDEMPOTENCY_CONFLICT` bersih kalau hash beda. Berlaku otomatis untuk semua ~25 route pemakai `withTenant`, bukan spesifik `tenant_domain`. Test: `tests/integration/tenant-domain-api.integration.test.ts`'s "set-primary under concurrent SAME Idempotency-Key + SAME payload" (dua-duanya 200 lewat replay, tepat satu audit event + satu row idempotency key) dan "verify under concurrent SAME Idempotency-Key + DIFFERENT payload" (satu 200 satu 409 bersih; sengaja pakai `verify` pada dua domain berbeda, bukan `set-primary`, supaya tidak bercampur dengan race index primary-dedup `set-primary` sendiri yang sudah punya test terpisah). Detail: doc 16 §Idempotency store, skill `awcms-idempotency` §Verifikasi. (Ditemukan awcms-reviewer saat review PR ini: revisi awal hanya melempar 409 tanpa pengecekan hash, melanggar aturan "hash sama → replay" untuk kasus race; diperbaiki sebelum merge.)
-
-Sudah diperbaiki (follow-up dari security audit #560, bukan follow-up lagi): **`fetchTenantModuleEntries` membaca status SEMUA modul terdaftar**, bukan cuma `blog_content` (`public-news-tenant-resolution.ts`) — bukan risiko DoS nyata (satu query indexed murah, filtering di memori), tapi melanggar prinsip "read surface publik seminimal mungkin" resolver #559 untuk gate anonim yang cuma butuh status satu modul. Fix: `fetchTenantModuleEntry` (singular, baru — `module-management/application/tenant-module-lifecycle.ts`) — narrowing yang `SELECT`-nya di-filter `module_key = $2`, bukan membaca semua row tenant lalu filter di memori; dipakai `checkBlogContentAndRouteGate` (satu-satunya pemanggil, dipakai identik oleh jalur resolve sungguhan maupun `padUnresolvedTenantLatency`, jadi paritas round-trip timing #562 tidak berubah — sama-sama tetap 1 query untuk cek modul). `fetchTenantModuleEntries` (plural) tidak dihapus — 3 konsumen lain (`GET /api/v1/tenant/modules`, tenant module presets, tenant-module matrix UI) tetap butuh daftar lengkap dan tetap memakainya. Test: `tests/integration/module-tenant-lifecycle.integration.test.ts`'s "fetchTenantModuleEntry ... matches the plural function's per-entry result before and after a real disable" dan `tests/integration/blog-content-public-news.integration.test.ts`'s round-trip-parity test yang sudah ada (masih hijau tanpa perubahan — jumlah round trip tetap 1 baik pakai fungsi lama maupun baru).
-
-Sudah diperbaiki (follow-up dari security audit PR #580, bukan follow-up lagi): **timeout adapter Cloudflare hardcoded, tidak env-tunable** (`cloudflare-dns-adapter.ts`'s `DEFAULT_TIMEOUT_MS = 8_000`, tidak ada cara mengubahnya per-deployment). Fix: `resolveTenantDomainCloudflareTimeoutMs(env)` (baru, `domain/tenant-domain-dns-config.ts`) — pola persis `email/domain/email-config.ts`'s `resolveEmailSendTimeoutMs`: baca `TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS`, jatuh ke default kalau kosong/bukan angka positif, tidak pernah gagalkan boot (bukan bagian `TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED`, tidak dicek `checkTenantDomainDnsConfig`, sama seperti `EMAIL_SEND_TIMEOUT_MS`). `resolveTenantDomainDnsProvider(env)` sekarang memanggilnya untuk mengisi `timeoutMs` provider Cloudflare. Test: `tests/unit/cloudflare-dns-adapter.test.ts`'s `describe("resolveTenantDomainCloudflareTimeoutMs", ...)`.
-
-Sudah diperbaiki di #560 (bukan follow-up lagi): guard module-disabled sekarang fail-closed (`!blogContentEntry?.tenantEnabled`, bukan `blogContentEntry && !blogContentEntry.tenantEnabled`) — entry yang hilang dianggap disabled, bukan enabled by default.
-
-Sudah diperbaiki bersamaan dengan #562 (bukan follow-up lagi): **timing side-channel di `withNewsTenant`** (`public-news-tenant-resolution.ts`) — tiga outcome yang seharusnya identik (tenant tidak resolve / `tenant_code_legacy` / module `blog_content` disabled untuk tenant) dulu punya biaya latency berbeda (tenant tidak resolve = tidak buka transaksi sama sekali; tenant resolve tapi module disabled = buka `withTenant` + 1 query `fetchTenantModuleEntries`), sehingga prober eksternal dengan `Host` header berbeda-beda bisa membedakan "hostname termapping ke tenant aktif" dari "hostname tidak dikenal" murni lewat waktu respons begitu #562 mengisi `awcms_tenant_domains` dengan mapping nyata. Fix: `padUnresolvedTenantLatency()` (baru,
-`public-news-tenant-resolution.ts`) membebankan biaya round-trip yang SAMA pada jalur "tenant tidak resolve" — buka transaksi lewat `withTenant` yang sama, `SET LOCAL` GUC tenant ke UUID nol (sentinel fail-closed migration 013, tidak pernah cocok dengan tenant nyata), lalu satu `SELECT` ke `awcms_tenant_modules` — persis bentuk round-trip yang sudah dibayar jalur module-disabled lewat `fetchTenantModuleEntries`. Pola "tambahkan cost tetap di jalur tidak-resolve" (bukan "gabungkan jadi satu query" seperti migration 033/#559, karena jalur tidak-resolve secara struktural tidak punya `tenant_id` nyata untuk digabung ke query yang sama). Test:
-`tests/integration/blog-content-public-news.integration.test.ts`'s round-trip-counting test (pola Proxy yang sama seperti
-`tests/integration/public-tenant-resolution.integration.test.ts`, diperluas untuk mengintersep `sql.begin(...)`/method call pada `tx` juga, bukan cuma pemanggilan `sql` langsung).
-
-**Diperluas jadi EMPAT outcome bersamaan dengan #564** (bukan follow-up baru, perluasan mekanisme yang sudah ada): `publicRouteMode=disabled` (§Tenant settings public route di atas) adalah outcome ke-4 pada gate yang sama. Paritas ditegakkan struktural lewat `checkBlogContentAndRouteGate()` — dipanggil identik dari jalur resolve sungguhan maupun `padUnresolvedTenantLatency()`, jadi tak bisa drift secara desain. **Follow-up non-blocking dari security audit #564** (verdict PASS, tidak ada Critical/High):
-
-4. Belum ada test `wrapCountingSql`-based yang secara eksplisit membandingkan round-trip count outcome `publicRouteMode=disabled` vs 3 outcome lainnya — paritas berlaku by construction (diverifikasi manual saat audit #564) tapi belum diuji langsung seperti paritas module-disabled vs enabled sudah diuji. Tambahkan test pembanding eksplisit bila menyentuh `checkBlogContentAndRouteGate`/`padUnresolvedTenantLatency` lagi.
-5. Belum ada test regresi XSS eksplisit untuk `publicLabel`/`publicBasePath` di output `/news` (mitigasi sudah diverifikasi manual — `escapeHtml()` dipanggil di setiap titik render, tidak ada `set:html`/raw string concatenation — tapi belum jadi regression test otomatis yang mengirim payload `<script>` lalu assert output ter-escape). Tambahkan bila menyentuh rendering `/news` lagi.
-
-Sudah diperbaiki (follow-up dari security audit #564, bukan follow-up lagi): **`validateModuleSettingsPatch` hanya memeriksa nama key, bukan bentuk nilai** (framework generik Issue #516, `module-management/domain/module-settings.ts`) — admin tenant (atau siapa pun dengan sesi admin) bisa menulis nilai credential-shaped ke field non-sensitif-namanya seperti `publicLabel` dan itu tersimpan mentah, terbaca lewat GET yang sama. Bukan regresi #564 (identik untuk semua modul yang pakai framework ini), tidak spesifik `blog_content`. Fix: `_shared/redaction.ts`'s baru `findSecretShapedValues` — heuristik bentuk-value yang sengaja konservatif (JWT tiga segmen, blok PEM private key, AWS access key id, header `Bearer`/`Basic` mentah, connection string ber-`user:pass@`) supaya label/URL/flag biasa tidak pernah salah tertolak — dipanggil `validateModuleSettingsPatch` setelah cek nama key; kalau ada yang cocok, `400 SETTINGS_SECRET_SHAPED_VALUE_REJECTED` (pesan error hanya menyebut _path_ key, tidak pernah value-nya sendiri). Berlaku otomatis untuk semua konsumen `PATCH .../settings` (satu route file, `tenant/modules/{moduleKey}/settings.ts`, sudah generik terhadap `ModuleSettingsErrorCode` apa pun) tanpa ubah route atau modul manapun. Test: `tests/audit-log.test.ts`'s `findSecretShapedValues` (unit, semua pola + no-false-positive pada label/URL/flag biasa) dan `tests/integration/module-settings.integration.test.ts`'s "PATCH rejects a secret-shaped VALUE under an innocently-named key".
+- Unit (tanpa DB): `tests/tenant-domain-module.test.ts`,
+  `tests/tenant-domain-validation.test.ts`,
+  `tests/tenant-domain-dns-config.test.ts`,
+  `tests/cloudflare-dns-adapter.test.ts`,
+  `tests/public-host-tenant-resolver.test.ts`.
+- Integration (DB-gated): `tests/integration/tenant-domain.integration.test.ts`
+  — CRUD/verify/set-primary, unique lintas-tenant, soft-delete reuse,
+  satu-primary-per-tenant, dan **RLS dibuktikan di bawah `awcms_app`** (SELECT
+  langsung 0 baris tanpa tenant context; fungsi `SECURITY DEFINER` resolve
+  domain aktif tanpa membocorkan kolom secret).

--- a/docs/adr/0003-postgresql-rls-multi-tenant.md
+++ b/docs/adr/0003-postgresql-rls-multi-tenant.md
@@ -27,23 +27,26 @@ Kami memutuskan memakai **PostgreSQL** dengan **Row Level Security (RLS)** pada 
 
 RLS + `FORCE` (di atas) menutup akses tenant-scoped biasa, tapi beberapa
 query harus dijalankan **sebelum** tenant context ada sama sekali (mis.
-resolusi publik `hostname`/`tenantCode` -> `tenant_id`). Contoh ilustratif
-(prospektif): saat modul `tenant_domain` di-port dari `awcms-mini`, resolver
-lookup-nya (mis. fungsi `awcms_resolve_tenant_domain_lookup`, Issue #559,
-epic #555) akan memakai pola `SECURITY DEFINER` ini. **Catatan status:** modul
-`tenant_domain` **belum di-port** ke repo ini — belum ada migrasi lookup-nya
-dan **tidak ada satu pun fungsi `SECURITY DEFINER` di `sql/` saat ini**; nomor
-migrasi lookup-nya nanti **TBD (bukan `033`, yang kini dipakai skema
-`theming`)**. Setiap fungsi `SECURITY DEFINER` baru di repo ini wajib
-memenuhi checklist berikut sebelum dianggap aman (termasuk verifikasi empiris
-terhadap DB yang berjalan, bukan diasumsikan dari dokumentasi PostgreSQL
-semata):
+resolusi publik `hostname`/`tenantCode` -> `tenant_id`). **Contoh nyata:** modul
+`tenant_domain` (di-port dari `awcms-micro` epic #555) kini ada di repo ini;
+resolver lookup-nya `awcms_resolve_tenant_domain_lookup` (`sql/048`) adalah
+**fungsi `SECURITY DEFINER` pertama** di `sql/`. Setiap fungsi `SECURITY DEFINER`
+baru di repo ini wajib memenuhi checklist berikut sebelum dianggap aman
+(termasuk verifikasi empiris terhadap DB yang berjalan, bukan diasumsikan dari
+dokumentasi PostgreSQL semata):
 
-1. **Konfirmasi role pemilik benar-benar superuser (atau owner tabel yang
-   dituju)** — `SELECT rolsuper FROM pg_roles WHERE rolname = '<role>'`.
-   Migration di repo ini berjalan sebagai `POSTGRES_USER` (`awcms`),
-   yang memang superuser sungguhan — keamanan mekanisme ini TIDAK datang
-   dari interaksi RLS/`FORCE`, melainkan dari dua pagar di bawah.
+1. **Pastikan owner fungsi benar-benar bisa membaca di bawah `FORCE RLS`.** Ada
+   DUA posture owner yang valid: (a) owner adalah superuser sungguhan (bypass RLS
+   tanpa syarat); ATAU (b) **owner adalah role bootstrap khusus** `NOLOGIN
+NOSUPERUSER NOBYPASSRLS` **tanpa anggota**, ditambah policy `FOR SELECT TO
+<role> USING (true)` ter-scope ke role itu (pola `sql/048` —
+   `awcms_domain_bootstrap`). **PENTING — asumsi "owner superuser" TIDAK cukup**
+   di deployment role-separated/hardened (sql/019–022) dan di integration harness,
+   yang men-demote owner migrasi ke `NOSUPERUSER NOBYPASSRLS` setelah migrasi: di
+   sana fungsi `SECURITY DEFINER` yang di-own role non-superuser tunduk penuh
+   pada `FORCE RLS` dan resolve **0 baris**. **Pilih (b)** agar bootstrap tetap
+   bekerja lintas posture. Keamanan mekanisme TIDAK datang dari interaksi
+   RLS/`FORCE`, melainkan dari kepemilikan yang benar + dua pagar di bawah.
 2. **Body fungsi wajib SQL statis/tetap** — tidak ada dynamic SQL/string
    concatenation dari parameter. Parameter selalu lewat argumen fungsi yang
    diparameterkan (`p_<nama> text`, dst.), tidak pernah diselipkan ke query
@@ -68,11 +71,13 @@ semata):
    rows lewat role least-privilege TANPA `app.current_tenant_id` GUC
    di-set; (b) `SELECT` langsung ke tabel yang sama dari role/session yang
    sama (tanpa fungsi) tetap 0 baris; (c) kolom yang di-return persis
-   sesuai yang didokumentasikan, tidak lebih. `tests/integration/public-tenant-resolution.integration.test.ts`
-   adalah contoh test yang membuktikan ketiganya.
+   sesuai yang didokumentasikan, tidak lebih. `tests/integration/tenant-domain.integration.test.ts`
+   adalah contoh test yang membuktikan ketiganya (di bawah role `awcms_app`,
+   dengan harness yang men-demote owner migrasi — lihat checklist item 1).
 8. **Hindari timing side-channel** — kalau fungsi ini dipanggil lalu diikuti
    query kedua yang kondisional (mis. "kalau baris pertama ditemukan, query
    lagi ke tabel lain"), pertimbangkan apakah beda jumlah round-trip antar
    outcome bisa dieksploitasi sebagai side-channel — gabungkan jadi satu query
    via `JOIN` kalau tabel kedua sudah RLS-free/publicly readable, seperti
-   `awcms_tenants` (pola ini akan relevan saat resolver `tenant_domain` diport).
+   `awcms_tenants` (pola ini dipakai resolver `tenant_domain` `sql/048` — satu
+   `JOIN awcms_tenants` supaya tiap outcome butuh tepat satu round-trip).

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -1,5 +1,5 @@
 {
-  "moduleCount": 13,
+  "moduleCount": 14,
   "valid": true,
   "issueCount": 0,
   "modules": [
@@ -213,6 +213,22 @@
       "capabilitiesConsumed": [],
       "permissionCount": 6,
       "navigationCount": 0,
+      "jobCount": 0,
+      "hasHealthCheck": false,
+      "hasReadinessCheck": false,
+      "deploymentProfiles": null
+    },
+    {
+      "key": "tenant_domain",
+      "name": "Tenant Domain",
+      "version": "0.1.0",
+      "status": "active",
+      "type": "domain",
+      "dependencies": ["tenant_admin", "identity_access"],
+      "capabilitiesProvided": [],
+      "capabilitiesConsumed": [],
+      "permissionCount": 6,
+      "navigationCount": 1,
       "jobCount": 0,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -8700,6 +8700,314 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/tenant/domains:
+    get:
+      tags:
+        - Tenant Domains
+      summary: List this tenant's domain/subdomain mappings
+      description: Gated by tenant_domain.domains.read. Non-deleted mappings only, keyset-paginated newest first (limit 100).
+      operationId: tenantDomainsList
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous page's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: A page of tenant domain mappings.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      domains:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/TenantDomain"
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Tenant Domains
+      summary: Add a tenant domain/subdomain mapping
+      description: Gated by tenant_domain.domains.create. A duplicate normalized hostname always returns a generic 409 (never reveals whether the hostname belongs to another tenant). Audited.
+      operationId: tenantDomainsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTenantDomainRequest"
+      responses:
+        "200":
+          description: Mapping created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: The hostname is already mapped to a tenant (HOSTNAME_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/tenant/domains/{id}:
+    get:
+      tags:
+        - Tenant Domains
+      summary: Read one tenant domain mapping
+      description: Gated by tenant_domain.domains.read. Unknown/cross-tenant/soft-deleted id all return a generic 404.
+      operationId: tenantDomainsGet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The tenant domain mapping.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Tenant Domains
+      summary: Partially update a tenant domain mapping
+      description: Gated by tenant_domain.domains.update. Idempotent by construction. `hostname`/`is_primary` are immutable here and `status` can never be set to `active` (use POST .../verify). Audited.
+      operationId: tenantDomainsUpdate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTenantDomainRequest"
+      responses:
+        "200":
+          description: Mapping updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Tenant Domains
+      summary: Soft-delete a tenant domain mapping
+      description: Gated by tenant_domain.domains.delete. Reason-required soft delete; never hard-deletes, and frees the normalized hostname for reuse. Audited.
+      operationId: tenantDomainsDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteTenantDomainRequest"
+      responses:
+        "200":
+          description: Mapping soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      deleted:
+                        type: boolean
+                        enum:
+                          - true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/tenant/domains/{id}/set-primary:
+    post:
+      tags:
+        - Tenant Domains
+      summary: Set a tenant domain as the active primary
+      description: Gated by tenant_domain.domains.set_primary. Requires Idempotency-Key. Atomically makes the domain this tenant's single primary, unsetting any previous primary. Only an `active` (verified) domain is eligible. Audited.
+      operationId: tenantDomainsSetPrimary
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Domain set as primary, or replay of a prior identical request.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Domain is not `active` (INVALID_STATUS_TRANSITION), a concurrent request already changed the primary (CONCURRENT_UPDATE), or the Idempotency-Key was reused with a different request (IDEMPOTENCY_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/tenant/domains/{id}/verify:
+    post:
+      tags:
+        - Tenant Domains
+      summary: Verify a tenant domain (manual-first)
+      description: "Gated by tenant_domain.domains.verify. Requires Idempotency-Key. Manual-first: flips status to `active` based on the row's own `verification_method`/`verification_record_*` — no outbound DNS/HTTP call. Audited."
+      operationId: tenantDomainsVerify
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Domain verified (status `active`), or replay of a prior identical request.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Cannot verify from the current status (INVALID_STATUS_TRANSITION), or the Idempotency-Key was reused with a different request (IDEMPOTENCY_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/tenant/modules:
     get:
       operationId: listTenantModules
@@ -11353,6 +11661,52 @@ components:
         caption:
           type: string
           nullable: true
+    CreateTenantDomainRequest:
+      type: object
+      required:
+        - hostname
+      properties:
+        hostname:
+          type: string
+          description: DNS hostname (no port). Normalized to lowercase for uniqueness/lookup.
+        domainType:
+          type: string
+          enum:
+            - subdomain
+            - custom_domain
+          default: custom_domain
+        routeMode:
+          type: string
+          enum:
+            - canonical
+            - legacy_blog
+          default: canonical
+        verificationMethod:
+          type: string
+          nullable: true
+          enum:
+            - dns_txt
+            - dns_cname
+            - file
+            - manual
+            - null
+        verificationRecordName:
+          type: string
+          nullable: true
+        verificationRecordValue:
+          type: string
+          nullable: true
+        redirectToPrimary:
+          type: boolean
+          default: false
+    DeleteTenantDomainRequest:
+      type: object
+      required:
+        - reason
+      properties:
+        reason:
+          type: string
+          description: Non-empty soft-delete reason (audited).
     FinalizeNewsMediaUploadSessionRequest:
       type: object
       additionalProperties: false
@@ -11999,6 +12353,78 @@ components:
           type: string
           format: date-time
           nullable: true
+    TenantDomain:
+      type: object
+      description: A tenant hostname/subdomain mapping. `verification_token_hash` is never exposed.
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        hostname:
+          type: string
+        normalizedHostname:
+          type: string
+        domainType:
+          type: string
+          enum:
+            - subdomain
+            - custom_domain
+        routeMode:
+          type: string
+          enum:
+            - canonical
+            - legacy_blog
+        status:
+          type: string
+          enum:
+            - pending_verification
+            - active
+            - suspended
+            - failed
+        isPrimary:
+          type: boolean
+        redirectToPrimary:
+          type: boolean
+        verificationMethod:
+          type: string
+          nullable: true
+          enum:
+            - dns_txt
+            - dns_cname
+            - file
+            - manual
+            - null
+        verificationRecordName:
+          type: string
+          nullable: true
+        verificationRecordValue:
+          type: string
+          nullable: true
+        verifiedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastCheckedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+          format: uuid
+          nullable: true
+        updatedBy:
+          type: string
+          format: uuid
+          nullable: true
     TenantMfaPolicy:
       type: object
       properties:
@@ -12191,6 +12617,43 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/ThemeVersion"
+    UpdateTenantDomainRequest:
+      type: object
+      description: At least one field required. `status` may not be `active` (use verify); `hostname`/`is_primary` are immutable.
+      properties:
+        domainType:
+          type: string
+          enum:
+            - subdomain
+            - custom_domain
+        routeMode:
+          type: string
+          enum:
+            - canonical
+            - legacy_blog
+        status:
+          type: string
+          enum:
+            - pending_verification
+            - suspended
+            - failed
+        verificationMethod:
+          type: string
+          nullable: true
+          enum:
+            - dns_txt
+            - dns_cname
+            - file
+            - manual
+            - null
+        verificationRecordName:
+          type: string
+          nullable: true
+        verificationRecordValue:
+          type: string
+          nullable: true
+        redirectToPrimary:
+          type: boolean
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/openapi/modules/tenant-domain.openapi.yaml
+++ b/openapi/modules/tenant-domain.openapi.yaml
@@ -1,0 +1,440 @@
+# Source fragment for the "Tenant Domain" module — ported from awcms-micro
+# (epic #555). One file per MODULE (Issue #182 convention): this file owns every
+# path carrying the "Tenant Domains" tag and every schema referenced ONLY by
+# those operations.
+#
+# Adapted to this base's shared-component vocabulary: success responses are
+# modelled inline (no `ApiSuccess` schema here), the Idempotency-Key header is
+# declared inline where a mutation requires it, and only the shared components
+# this base defines (CorrelationId; BadRequest/Unauthorized/Forbidden/NotFound;
+# ApiError) are referenced. All operations inherit the global bearerAuth +
+# tenantHeader security requirement from the root fragment.
+#
+# NOT independently valid OpenAPI — $ref targets pointing at shared components
+# only resolve after `bun run openapi:bundle` merges this file with the root and
+# every sibling module fragment into openapi/awcms-public-api.openapi.yaml. Edit
+# this file (or the root for shared components), never the generated bundle.
+paths:
+  /api/v1/tenant/domains:
+    get:
+      tags:
+        - Tenant Domains
+      summary: List this tenant's domain/subdomain mappings
+      description: Gated by tenant_domain.domains.read. Non-deleted mappings only, keyset-paginated newest first (limit 100).
+      operationId: tenantDomainsList
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous page's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: A page of tenant domain mappings.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      domains:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/TenantDomain"
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      tags:
+        - Tenant Domains
+      summary: Add a tenant domain/subdomain mapping
+      description: Gated by tenant_domain.domains.create. A duplicate normalized hostname always returns a generic 409 (never reveals whether the hostname belongs to another tenant). Audited.
+      operationId: tenantDomainsCreate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateTenantDomainRequest"
+      responses:
+        "200":
+          description: Mapping created.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: The hostname is already mapped to a tenant (HOSTNAME_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/tenant/domains/{id}:
+    get:
+      tags:
+        - Tenant Domains
+      summary: Read one tenant domain mapping
+      description: Gated by tenant_domain.domains.read. Unknown/cross-tenant/soft-deleted id all return a generic 404.
+      operationId: tenantDomainsGet
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The tenant domain mapping.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Tenant Domains
+      summary: Partially update a tenant domain mapping
+      description: "Gated by tenant_domain.domains.update. Idempotent by construction. `hostname`/`is_primary` are immutable here and `status` can never be set to `active` (use POST .../verify). Audited."
+      operationId: tenantDomainsUpdate
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateTenantDomainRequest"
+      responses:
+        "200":
+          description: Mapping updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      tags:
+        - Tenant Domains
+      summary: Soft-delete a tenant domain mapping
+      description: Gated by tenant_domain.domains.delete. Reason-required soft delete; never hard-deletes, and frees the normalized hostname for reuse. Audited.
+      operationId: tenantDomainsDelete
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteTenantDomainRequest"
+      responses:
+        "200":
+          description: Mapping soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      deleted:
+                        type: boolean
+                        enum: [true]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/tenant/domains/{id}/verify:
+    post:
+      tags:
+        - Tenant Domains
+      summary: Verify a tenant domain (manual-first)
+      description: "Gated by tenant_domain.domains.verify. Requires Idempotency-Key. Manual-first: flips status to `active` based on the row's own `verification_method`/`verification_record_*` — no outbound DNS/HTTP call. Audited."
+      operationId: tenantDomainsVerify
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Domain verified (status `active`), or replay of a prior identical request.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Cannot verify from the current status (INVALID_STATUS_TRANSITION), or the Idempotency-Key was reused with a different request (IDEMPOTENCY_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/tenant/domains/{id}/set-primary:
+    post:
+      tags:
+        - Tenant Domains
+      summary: Set a tenant domain as the active primary
+      description: "Gated by tenant_domain.domains.set_primary. Requires Idempotency-Key. Atomically makes the domain this tenant's single primary, unsetting any previous primary. Only an `active` (verified) domain is eligible. Audited."
+      operationId: tenantDomainsSetPrimary
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Domain set as primary, or replay of a prior identical request.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/TenantDomain"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Domain is not `active` (INVALID_STATUS_TRANSITION), a concurrent request already changed the primary (CONCURRENT_UPDATE), or the Idempotency-Key was reused with a different request (IDEMPOTENCY_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+components:
+  schemas:
+    TenantDomain:
+      type: object
+      description: A tenant hostname/subdomain mapping. `verification_token_hash` is never exposed.
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        hostname:
+          type: string
+        normalizedHostname:
+          type: string
+        domainType:
+          type: string
+          enum: [subdomain, custom_domain]
+        routeMode:
+          type: string
+          enum: [canonical, legacy_blog]
+        status:
+          type: string
+          enum: [pending_verification, active, suspended, failed]
+        isPrimary:
+          type: boolean
+        redirectToPrimary:
+          type: boolean
+        verificationMethod:
+          type: string
+          nullable: true
+          enum: [dns_txt, dns_cname, file, manual, null]
+        verificationRecordName:
+          type: string
+          nullable: true
+        verificationRecordValue:
+          type: string
+          nullable: true
+        verifiedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastCheckedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        createdBy:
+          type: string
+          format: uuid
+          nullable: true
+        updatedBy:
+          type: string
+          format: uuid
+          nullable: true
+    CreateTenantDomainRequest:
+      type: object
+      required:
+        - hostname
+      properties:
+        hostname:
+          type: string
+          description: DNS hostname (no port). Normalized to lowercase for uniqueness/lookup.
+        domainType:
+          type: string
+          enum: [subdomain, custom_domain]
+          default: custom_domain
+        routeMode:
+          type: string
+          enum: [canonical, legacy_blog]
+          default: canonical
+        verificationMethod:
+          type: string
+          nullable: true
+          enum: [dns_txt, dns_cname, file, manual, null]
+        verificationRecordName:
+          type: string
+          nullable: true
+        verificationRecordValue:
+          type: string
+          nullable: true
+        redirectToPrimary:
+          type: boolean
+          default: false
+    UpdateTenantDomainRequest:
+      type: object
+      description: At least one field required. `status` may not be `active` (use verify); `hostname`/`is_primary` are immutable.
+      properties:
+        domainType:
+          type: string
+          enum: [subdomain, custom_domain]
+        routeMode:
+          type: string
+          enum: [canonical, legacy_blog]
+        status:
+          type: string
+          enum: [pending_verification, suspended, failed]
+        verificationMethod:
+          type: string
+          nullable: true
+          enum: [dns_txt, dns_cname, file, manual, null]
+        verificationRecordName:
+          type: string
+          nullable: true
+        verificationRecordValue:
+          type: string
+          nullable: true
+        redirectToPrimary:
+          type: boolean
+    DeleteTenantDomainRequest:
+      type: object
+      required:
+        - reason
+      properties:
+        reason:
+          type: string
+          description: Non-empty soft-delete reason (audited).

--- a/sql/046_awcms_tenant_domain_schema.sql
+++ b/sql/046_awcms_tenant_domain_schema.sql
@@ -1,0 +1,151 @@
+-- tenant_domain — database foundation for mapping a public hostname/domain/
+-- subdomain to a tenant. Ported from awcms-micro migrations 031 (schema).
+-- Adapted to this base: every `awcms_micro_` identifier renamed to `awcms_`
+-- (table name, tenant FK, constraint/index names), and the awcms-micro
+-- worker-role grant model does not apply here — no explicit GRANT block is
+-- needed (see §RLS / GRANT below).
+--
+-- This table is the input the host-based public tenant resolver reads to
+-- answer "hostname -> tenant_id" without requiring a `tenantCode` in the path
+-- (ADR-0009's existing `/blog/{tenantCode}` model stays intact; host-based
+-- routing is an additive path). The narrow SECURITY DEFINER bootstrap read
+-- for that anonymous, pre-tenant-context lookup lands in migration 048; the
+-- authenticated tenant-scoped management API reads/writes this table only
+-- inside `withTenant(...)` (RLS FORCE'd below).
+--
+-- Column design notes:
+--   - `hostname` is the raw value as entered/observed (case preserved for
+--     display); `normalized_hostname` is a separate stored column (not a
+--     functional index on `lower(hostname)`) holding the lowercase+trimmed
+--     form used for uniqueness and resolver lookups. A CHECK constraint keeps
+--     the two in sync at the DB layer as defense-in-depth (application code is
+--     still responsible for populating both correctly on insert/update).
+--   - `domain_type`: `subdomain` (under the operator's platform root domain)
+--     vs `custom_domain` (tenant-owned external domain requiring its own DNS
+--     verification).
+--   - `route_mode`: which public route family this domain resolves into —
+--     `canonical` (host-resolved public routes) vs `legacy_blog` (the existing
+--     `/blog/{tenantCode}` routes, ADR-0009, documented as legacy but not
+--     removed). Not consumed by any resolver yet — this column is laid down
+--     for forward compatibility.
+--   - `status`: `pending_verification` (default; newly added, not yet
+--     proven), `active` (verified and eligible to resolve tenant traffic),
+--     `suspended` (operator/tenant paused it), `failed` (verification failed
+--     or repeatedly errors on recheck). Soft delete
+--     (`deleted_at`/`deleted_by`/`delete_reason`) is the fourth "does not
+--     resolve traffic" state, not folded into this enum. Binding rule on
+--     whoever builds a public host resolver on top of this: suspended/failed/
+--     deleted rows must never resolve public tenant traffic, and an
+--     unknown/inactive host must look identical to any other non-resolving
+--     host, never revealing which case it is.
+--   - `is_primary` + `redirect_to_primary`: exactly one primary domain per
+--     tenant among non-deleted rows (enforced below by a partial unique index on
+--     `WHERE is_primary = true AND deleted_at IS NULL`; the application layer
+--     additionally requires `status = 'active'` before a domain may be set
+--     primary) is where canonical
+--     URLs/redirects point; non-primary active domains can optionally redirect
+--     to it (`redirect_to_primary`), enforcement of the actual HTTP redirect
+--     is application-layer, not this migration's concern.
+--   - `verification_method`: how ownership is being/was proven —
+--     `dns_txt`/`dns_cname` (public DNS record, `verification_record_name`/
+--     `verification_record_value` hold the record the tenant must publish,
+--     never a secret), `file` (well-known file upload), or `manual`
+--     (operator-attested, no automated check).
+--   - `verification_token_hash`: sha256 hex, `sha256:`-prefixed — same
+--     construction as `lib/auth/password-reset-token.ts`'s `hashResetToken`
+--     (a CSPRNG-generated verification token is high-entropy, so a fast hash
+--     is correct — no bcrypt/argon2 needed). The raw token itself is never
+--     persisted; token generation/hashing/comparison is application code for a
+--     later enhancement, out of scope here. `verification_record_value` is
+--     intentionally distinct: it is the PUBLIC DNS record value the tenant
+--     publishes (not a secret). Neither column, nor any other column on this
+--     table, ever stores a DNS provider API credential/secret — those belong
+--     only in env/secret manager (the optional Cloudflare adapter reads its
+--     token/zone only from `TENANT_DOMAIN_CLOUDFLARE_*` env vars).
+--
+-- ## RLS / GRANT
+--
+-- `ENABLE`+`FORCE ROW LEVEL SECURITY` with the standard `tenant_isolation`
+-- policy (`awcms_app` connects as a non-owner role since sql/019, so `ENABLE`
+-- alone would be inert — `FORCE` is required). No explicit `GRANT` for
+-- `awcms_app`: sql/019's `ALTER DEFAULT PRIVILEGES ... GRANT ... ON TABLES TO
+-- awcms_app` already covers every table the migration owner creates from here
+-- on (same reasoning sql/041 relied on). No `awcms_worker` grant is added —
+-- this module ships no background job that touches this table.
+--
+-- FORCE RLS creates a bootstrap gap the host resolver must handle: a query
+-- against this table with no `app.current_tenant_id` GUC set (awcms_app's
+-- fail-closed default, sql/019) returns zero rows. That is correct for
+-- tenant-authenticated access (the management API must never see another
+-- tenant's domains), but the public host resolver must discover tenant_id
+-- from a hostname BEFORE any tenant context exists. That gap is closed by the
+-- narrow SECURITY DEFINER function in migration 048, NOT by removing FORCE RLS
+-- here. Do not remove FORCE RLS from this table to work around it.
+
+CREATE TABLE IF NOT EXISTS awcms_tenant_domains (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  hostname text NOT NULL,
+  normalized_hostname text NOT NULL,
+  domain_type text NOT NULL DEFAULT 'custom_domain',
+  route_mode text NOT NULL DEFAULT 'canonical',
+  status text NOT NULL DEFAULT 'pending_verification',
+  is_primary boolean NOT NULL DEFAULT false,
+  redirect_to_primary boolean NOT NULL DEFAULT false,
+  verification_method text,
+  verification_token_hash text,
+  verification_record_name text,
+  verification_record_value text,
+  verified_at timestamptz,
+  last_checked_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by uuid,
+  updated_by uuid,
+  deleted_at timestamptz,
+  deleted_by uuid,
+  delete_reason text,
+  CONSTRAINT awcms_tenant_domains_domain_type_check
+    CHECK (domain_type IN ('subdomain', 'custom_domain')),
+  CONSTRAINT awcms_tenant_domains_route_mode_check
+    CHECK (route_mode IN ('canonical', 'legacy_blog')),
+  CONSTRAINT awcms_tenant_domains_status_check
+    CHECK (status IN ('pending_verification', 'active', 'suspended', 'failed')),
+  CONSTRAINT awcms_tenant_domains_verification_method_check
+    CHECK (verification_method IS NULL
+      OR verification_method IN ('dns_txt', 'dns_cname', 'file', 'manual')),
+  CONSTRAINT awcms_tenant_domains_hostname_not_blank_check
+    CHECK (btrim(hostname) <> ''),
+  CONSTRAINT awcms_tenant_domains_normalized_hostname_matches_check
+    CHECK (normalized_hostname = lower(btrim(hostname)))
+);
+
+-- Case-insensitive global uniqueness among active (non-deleted) rows — a
+-- hostname can only ever map to one tenant, so this is intentionally NOT
+-- scoped by tenant_id. Soft-deleting a row frees its normalized_hostname for
+-- reuse (e.g. a domain moved off this platform, then re-added later).
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_tenant_domains_normalized_hostname_dedup
+  ON awcms_tenant_domains (normalized_hostname)
+  WHERE deleted_at IS NULL;
+
+-- At most one active primary domain per tenant.
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_tenant_domains_primary_dedup
+  ON awcms_tenant_domains (tenant_id)
+  WHERE is_primary = true AND deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_tenant_domains_tenant_idx
+  ON awcms_tenant_domains (tenant_id);
+
+CREATE INDEX IF NOT EXISTS awcms_tenant_domains_tenant_status_idx
+  ON awcms_tenant_domains (tenant_id, status)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_tenant_domains_tenant_deleted_idx
+  ON awcms_tenant_domains (tenant_id, deleted_at);
+
+ALTER TABLE awcms_tenant_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_tenant_domains FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_tenant_domains_tenant_isolation
+  ON awcms_tenant_domains
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);

--- a/sql/047_awcms_tenant_domain_permissions.sql
+++ b/sql/047_awcms_tenant_domain_permissions.sql
@@ -1,0 +1,19 @@
+-- tenant_domain — permission catalog seed for the `awcms_tenant_domains` table
+-- (migration 046). Ported from awcms-micro migration 032. Exactly the six
+-- permissions this module's `module.ts` `permissions` array declares.
+-- `module_key` 'tenant_domain' and `activity_code' 'domains' are new — not
+-- used by any other module's permission seed in this repo. No endpoints/roles
+-- are wired to these here; this migration only extends the global ABAC
+-- permission catalog, same shape as sql/042. Only tenants created AFTER this
+-- migration runs pick these up automatically via the setup bootstrap's
+-- `INSERT INTO awcms_role_permissions ... SELECT ... FROM awcms_permissions`
+-- (same limitation every prior permission-seed migration has).
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('tenant_domain', 'domains', 'read', 'Read tenant domain/subdomain mappings'),
+  ('tenant_domain', 'domains', 'create', 'Add a tenant domain/subdomain mapping'),
+  ('tenant_domain', 'domains', 'update', 'Update a tenant domain/subdomain mapping'),
+  ('tenant_domain', 'domains', 'delete', 'Soft delete a tenant domain/subdomain mapping'),
+  ('tenant_domain', 'domains', 'verify', 'Verify ownership of a tenant domain/subdomain'),
+  ('tenant_domain', 'domains', 'set_primary', 'Set a tenant domain as the active primary domain')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/sql/048_awcms_tenant_domain_lookup_function.sql
+++ b/sql/048_awcms_tenant_domain_lookup_function.sql
@@ -1,0 +1,108 @@
+-- tenant_domain — narrow SECURITY DEFINER bootstrap read closing the RLS
+-- bootstrap gap flagged in sql/046's header: the public host resolver must
+-- discover `tenant_id` from a hostname in `awcms_tenant_domains` BEFORE any
+-- tenant context (`app.current_tenant_id` GUC) exists, but that table is
+-- intentionally `FORCE ROW LEVEL SECURITY` (it holds tenant-manageable fields
+-- like `verification_token_hash`), so a plain `SELECT` from the least-privilege
+-- `awcms_app` role always returns zero rows without `withTenant(...)`. This
+-- migration adds one narrowly-scoped SECURITY DEFINER function as the single
+-- sanctioned bootstrap read path. `FORCE ROW LEVEL SECURITY` is NOT removed
+-- from the table.
+--
+-- Ported from awcms-micro migration 033. Adapted: the source's table/role
+-- prefixes were renamed to this repo's `awcms_*` convention, and the app role
+-- is `awcms_app` (sql/019). This is the first SECURITY DEFINER function in this
+-- repo — it follows the checklist in
+-- docs/adr/0003-postgresql-rls-multi-tenant.md for a new bypass function.
+--
+-- How/why this is safe:
+--   - Migrations execute as the schema-owning role (`DATABASE_URL`, which on a
+--     typical deployment is a Postgres SUPERUSER — the same role that owns
+--     every FORCE-RLS table in this schema). Superusers bypass row security
+--     unconditionally, regardless of `FORCE ROW LEVEL SECURITY` (`FORCE` only
+--     removes the *table owner's* default RLS exemption when the owner is a
+--     non-superuser role; it has no effect on an actually-superuser owner). So
+--     a SECURITY DEFINER function owned by this role executes with the same
+--     unconditional RLS bypass as the migration's own DDL/DML already does.
+--   - Because the *role* running this function's body already has an
+--     unconditional bypass, the safety of this mechanism does not come from
+--     RLS/FORCE at all — it comes entirely from two narrower guarantees:
+--       1. The function body is fixed, static SQL (no dynamic SQL / string
+--          concatenation) returning exactly eight non-sensitive columns for
+--          rows matching one parameterized `normalized_hostname` argument and
+--          `deleted_at IS NULL`. It can never be used to read
+--          `verification_token_hash`, `verification_record_value`, `hostname`
+--          (raw/unnormalized), or any other column/table.
+--       2. `EXECUTE` on the function is revoked from `PUBLIC` and granted only
+--          to `awcms_app` — no other non-superuser role can invoke this
+--          bypass. `awcms_app` still cannot query `awcms_tenant_domains`
+--          directly without `withTenant(...)`; it can only go through this one
+--          fixed lookup shape.
+--   - `SET search_path = public, pg_temp` pins name resolution inside the
+--     function body so it cannot be redirected by a caller-controlled
+--     `search_path` (standard SECURITY DEFINER hardening).
+--   - `STABLE` (not `VOLATILE`): the function only reads.
+--
+-- Timing side-channel note (kept from awcms-micro's own hardening): the
+-- function JOINs `awcms_tenants` and returns the tenant's own status/code/
+-- name/locale alongside the domain row, so the TypeScript resolver
+-- (`resolvePublicTenantByHost`) needs exactly ONE query for every outcome
+-- (unknown host, inactive domain, inactive tenant, or a full resolution),
+-- rather than a conditional second round trip that would distinguish "no such
+-- mapping" from "mapping exists, tenant just isn't active" purely by latency.
+-- This join does not widen the bypass: `awcms_tenants` is already RLS-free by
+-- design (ADR-0003) and freely `SELECT`-able by `awcms_app` — joining it here
+-- only removes a round trip; it exposes nothing not already unconditionally
+-- public.
+--
+-- Consumer: `src/lib/tenant/public-host-tenant-resolver.ts`'s
+-- `resolvePublicTenantByHost()`. It still applies
+-- `domain_status = 'active' AND tenant_status = 'active'` itself (this function
+-- intentionally returns non-active, non-deleted domain rows too, so the
+-- resolver layer — not this SQL layer — decides which combination resolves
+-- public traffic).
+
+CREATE OR REPLACE FUNCTION awcms_resolve_tenant_domain_lookup(
+  p_normalized_hostname text
+)
+RETURNS TABLE (
+  tenant_id uuid,
+  domain_status text,
+  is_primary boolean,
+  route_mode text,
+  tenant_status text,
+  tenant_code text,
+  tenant_name text,
+  default_locale text
+)
+LANGUAGE sql
+SECURITY DEFINER
+STABLE
+SET search_path = public, pg_temp
+AS $function$
+  SELECT
+    d.tenant_id,
+    d.status AS domain_status,
+    d.is_primary,
+    d.route_mode,
+    t.status AS tenant_status,
+    t.tenant_code,
+    t.tenant_name,
+    t.default_locale
+  FROM awcms_tenant_domains AS d
+  JOIN awcms_tenants AS t ON t.id = d.tenant_id
+  WHERE d.normalized_hostname = p_normalized_hostname
+    AND d.deleted_at IS NULL;
+$function$;
+
+COMMENT ON FUNCTION awcms_resolve_tenant_domain_lookup(text) IS
+  'Narrow SECURITY DEFINER bootstrap read for hostname -> tenant lookup before tenant context exists. Joins the (already RLS-free) awcms_tenants row in the same call so the TypeScript resolver needs exactly one round trip regardless of outcome (avoids a timing side-channel between "unmapped host" and "mapped but inactive tenant"). Returns only tenant_id/domain_status/is_primary/route_mode/tenant_status/tenant_code/tenant_name/default_locale for non-deleted domain rows matching a normalized hostname. Never returns verification_token_hash, verification_record_value, or raw hostname. EXECUTE restricted to awcms_app.';
+
+-- Function EXECUTE privilege is a separate grant mechanism from the table
+-- GRANTs sql/019's `ALTER DEFAULT PRIVILEGES` covers (that clause only applies
+-- to tables/sequences, not functions/routines) — this explicit grant is
+-- required, it is not automatic. PostgreSQL grants EXECUTE to PUBLIC by default
+-- on function creation; revoke that first so only the least-privilege app role
+-- can call this bypass.
+REVOKE ALL ON FUNCTION awcms_resolve_tenant_domain_lookup(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION awcms_resolve_tenant_domain_lookup(text) TO awcms_app;

--- a/sql/048_awcms_tenant_domain_lookup_function.sql
+++ b/sql/048_awcms_tenant_domain_lookup_function.sql
@@ -7,41 +7,78 @@
 -- `awcms_app` role always returns zero rows without `withTenant(...)`. This
 -- migration adds one narrowly-scoped SECURITY DEFINER function as the single
 -- sanctioned bootstrap read path. `FORCE ROW LEVEL SECURITY` is NOT removed
--- from the table.
+-- from the table, and the `awcms_app` tenant-isolation policy is untouched.
 --
 -- Ported from awcms-micro migration 033. Adapted: the source's table/role
 -- prefixes were renamed to this repo's `awcms_*` convention, and the app role
 -- is `awcms_app` (sql/019). This is the first SECURITY DEFINER function in this
 -- repo — it follows the checklist in
--- docs/adr/0003-postgresql-rls-multi-tenant.md for a new bypass function.
+-- docs/adr/0003-postgresql-rls-multi-tenant.md for a new bootstrap function.
 --
--- How/why this is safe:
---   - Migrations execute as the schema-owning role (`DATABASE_URL`, which on a
---     typical deployment is a Postgres SUPERUSER — the same role that owns
---     every FORCE-RLS table in this schema). Superusers bypass row security
---     unconditionally, regardless of `FORCE ROW LEVEL SECURITY` (`FORCE` only
---     removes the *table owner's* default RLS exemption when the owner is a
---     non-superuser role; it has no effect on an actually-superuser owner). So
---     a SECURITY DEFINER function owned by this role executes with the same
---     unconditional RLS bypass as the migration's own DDL/DML already does.
---   - Because the *role* running this function's body already has an
---     unconditional bypass, the safety of this mechanism does not come from
---     RLS/FORCE at all — it comes entirely from two narrower guarantees:
---       1. The function body is fixed, static SQL (no dynamic SQL / string
---          concatenation) returning exactly eight non-sensitive columns for
---          rows matching one parameterized `normalized_hostname` argument and
---          `deleted_at IS NULL`. It can never be used to read
---          `verification_token_hash`, `verification_record_value`, `hostname`
---          (raw/unnormalized), or any other column/table.
---       2. `EXECUTE` on the function is revoked from `PUBLIC` and granted only
---          to `awcms_app` — no other non-superuser role can invoke this
---          bypass. `awcms_app` still cannot query `awcms_tenant_domains`
---          directly without `withTenant(...)`; it can only go through this one
---          fixed lookup shape.
---   - `SET search_path = public, pg_temp` pins name resolution inside the
---     function body so it cannot be redirected by a caller-controlled
---     `search_path` (standard SECURITY DEFINER hardening).
---   - `STABLE` (not `VOLATILE`): the function only reads.
+-- ## How/why this is safe (works under the HARDENED, role-separated posture)
+--
+-- A SECURITY DEFINER function executes with the privileges of its OWNER *at
+-- call time*. The naive assumption "the migration owner is a superuser, so the
+-- function bypasses RLS" is FALSE in this repo's supported posture: sql/019–022
+-- deliberately run the runtime as NON-superuser, NOBYPASSRLS roles, and a
+-- role-separated deployment (and the integration harness, which demotes its
+-- migration owner to `NOSUPERUSER NOBYPASSRLS` right after migrating —
+-- tests/integration/harness.ts) leaves NO superuser owning this function. Under
+-- `FORCE ROW LEVEL SECURITY`, a non-superuser function owner is fully subject to
+-- the table's policies, so a function owned by such a role would resolve ZERO
+-- rows for every hostname — host-based public routing would silently return
+-- nothing. The safety of this bootstrap therefore does NOT rest on any RLS
+-- bypass. It rests on a dedicated, minimal owner role plus an explicit, scoped
+-- read policy, hardened by a fixed column list and a locked-down EXECUTE grant:
+--
+--   1. DEDICATED NOLOGIN BOOTSTRAP-OWNER ROLE. `awcms_domain_bootstrap` is
+--      created `NOLOGIN NOSUPERUSER NOBYPASSRLS` (cluster-scoped, idempotent —
+--      same guarded pattern as sql/019/022). The function is `ALTER FUNCTION
+--      ... OWNER TO awcms_domain_bootstrap`, so it executes as this role — never
+--      as a superuser, never as `awcms_app`. Because the role is NOLOGIN and its
+--      membership is granted to NO ONE (in particular `awcms_app` is not a
+--      member, and the reassign below relies on the SUPERUSER migration owner
+--      rather than granting the role's membership to anyone — see the ordering
+--      note), nothing outside this one function can ever act as this role: it
+--      cannot log in, and no session can `SET ROLE` to it.
+--   2. EXPLICIT, SCOPED SELECT POLICY. `awcms_tenant_domains_bootstrap_read` is
+--      a permissive `FOR SELECT TO awcms_domain_bootstrap USING (true)` policy.
+--      RLS combines permissive policies with OR and matches a policy's role by
+--      membership, so it applies ONLY when the querying role IS (or is a member
+--      of) `awcms_domain_bootstrap` — i.e. ONLY inside this SECURITY DEFINER
+--      function. `awcms_app` is not a member, so its own direct SELECTs still
+--      see only the `tenant_isolation` policy and remain fail-closed (zero rows
+--      without `app.current_tenant_id`). `FORCE ROW LEVEL SECURITY` and the
+--      `tenant_isolation` policy are kept exactly as sql/046 shipped them.
+--   3. FIXED, NON-SENSITIVE COLUMN LIST. The function body is fixed, static SQL
+--      (no dynamic SQL / string concatenation) returning exactly eight
+--      non-sensitive columns for rows matching one parameterized
+--      `normalized_hostname` and `deleted_at IS NULL`. Even though the read
+--      policy lets the bootstrap role SELECT the whole table, this function can
+--      never return `verification_token_hash`, `verification_record_value`,
+--      `hostname` (raw/unnormalized), or any other column/table — the column
+--      list is the boundary, not RLS.
+--   4. EXECUTE LOCKED TO `awcms_app`. `EXECUTE` is revoked from `PUBLIC` and
+--      granted only to `awcms_app` — no other role can invoke this bootstrap.
+--      `awcms_app` still cannot query `awcms_tenant_domains` directly without
+--      `withTenant(...)`; it can only go through this one fixed lookup shape.
+--   5. `SET search_path = public, pg_temp` pins name resolution inside the
+--      function body so it cannot be redirected by a caller-controlled
+--      `search_path` (standard SECURITY DEFINER hardening).
+--   6. `STABLE` (not `VOLATILE`): the function only reads.
+--
+-- ORDERING / PRIVILEGE NOTE. `ALTER FUNCTION ... OWNER TO awcms_domain_bootstrap`
+-- reassigns ownership to a role the migration runner is NOT a member of. That is
+-- fine because the migration runner is a SUPERUSER at migration time — an
+-- invariant this repo ALREADY hard-requires (sql/019's
+-- `ALTER ROLE awcms_app SET app.current_tenant_id`, and sql/022's equivalents,
+-- can only be executed by a superuser; the integration harness models this by
+-- creating its migration owner `SUPERUSER`, migrating, then demoting). A
+-- superuser can reassign ownership to any role WITHOUT being granted that role's
+-- membership, so we deliberately do NOT `GRANT awcms_domain_bootstrap TO
+-- <owner>`: giving anyone that membership would let them satisfy the
+-- `USING (true)` policy and read across tenants, defeating the isolation this
+-- migration is careful to preserve.
 --
 -- Timing side-channel note (kept from awcms-micro's own hardening): the
 -- function JOINs `awcms_tenants` and returns the tenant's own status/code/
@@ -51,9 +88,9 @@
 -- rather than a conditional second round trip that would distinguish "no such
 -- mapping" from "mapping exists, tenant just isn't active" purely by latency.
 -- This join does not widen the bypass: `awcms_tenants` is already RLS-free by
--- design (ADR-0003) and freely `SELECT`-able by `awcms_app` — joining it here
--- only removes a round trip; it exposes nothing not already unconditionally
--- public.
+-- design (ADR-0003) and freely `SELECT`-able. `awcms_domain_bootstrap` still
+-- needs an explicit table-level `SELECT` privilege on both tables (grants
+-- below) — table privileges are separate from RLS policies.
 --
 -- Consumer: `src/lib/tenant/public-host-tenant-resolver.ts`'s
 -- `resolvePublicTenantByHost()`. It still applies
@@ -61,6 +98,51 @@
 -- intentionally returns non-active, non-deleted domain rows too, so the
 -- resolver layer — not this SQL layer — decides which combination resolves
 -- public traffic).
+--
+-- No explicit `BEGIN;`/`COMMIT;` wrapper: `scripts/db-migrate.ts` already runs
+-- each migration inside one managed transaction (`sql.begin`), so every
+-- statement below — the role, its grants, the policy, the function, and the
+-- ownership reassign — applies atomically or not at all. (An in-file `BEGIN;`
+-- here would sit AFTER this header comment, so the runner's leading-token
+-- stripper could not remove it and it would nest inside the managed
+-- transaction; omitting it is cleaner and keeps the same all-or-nothing
+-- guarantee.)
+
+-- 1. The dedicated NOLOGIN bootstrap-owner role. Created NOSUPERUSER,
+-- NOBYPASSRLS, NOLOGIN, passwordless — it never logs in and nobody is ever a
+-- member of it, so it is unreachable except as the definer of the one function
+-- below. Idempotent + cluster-scoped: roles survive the integration harness's
+-- ephemeral-database drops within one process (same guarded pattern as
+-- sql/019's `awcms_app` and sql/022's `awcms_worker`/`awcms_setup`).
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'awcms_domain_bootstrap') THEN
+    CREATE ROLE awcms_domain_bootstrap NOLOGIN NOSUPERUSER NOBYPASSRLS NOCREATEDB NOCREATEROLE;
+  END IF;
+END
+$$;
+
+-- 2. Minimum privileges the bootstrap-owner needs to run the function body:
+-- schema USAGE (so it can resolve objects in `public`) and table-level SELECT on
+-- the two tables the function reads. `awcms_tenants` is RLS-free but a
+-- table-level SELECT privilege is still required to read it under this role
+-- (sql/019's `ALTER DEFAULT PRIVILEGES` only grants to `awcms_app`, not this
+-- role). No INSERT/UPDATE/DELETE, no other tables.
+GRANT USAGE ON SCHEMA public TO awcms_domain_bootstrap;
+GRANT SELECT ON awcms_tenant_domains TO awcms_domain_bootstrap;
+GRANT SELECT ON awcms_tenants TO awcms_domain_bootstrap;
+
+-- 3. The explicit, scoped bootstrap read policy. Permissive + `FOR SELECT` +
+-- `TO awcms_domain_bootstrap`, so it is OR'd with (never replaces) sql/046's
+-- `awcms_tenant_domains_tenant_isolation` and applies ONLY to the bootstrap
+-- role — i.e. ONLY inside the SECURITY DEFINER function below. `awcms_app`'s own
+-- direct SELECTs are unaffected and stay fail-closed. `FORCE ROW LEVEL SECURITY`
+-- stays on; the tenant-isolation policy stays exactly as shipped.
+CREATE POLICY awcms_tenant_domains_bootstrap_read
+  ON awcms_tenant_domains
+  FOR SELECT
+  TO awcms_domain_bootstrap
+  USING (true);
 
 CREATE OR REPLACE FUNCTION awcms_resolve_tenant_domain_lookup(
   p_normalized_hostname text
@@ -96,13 +178,21 @@ AS $function$
 $function$;
 
 COMMENT ON FUNCTION awcms_resolve_tenant_domain_lookup(text) IS
-  'Narrow SECURITY DEFINER bootstrap read for hostname -> tenant lookup before tenant context exists. Joins the (already RLS-free) awcms_tenants row in the same call so the TypeScript resolver needs exactly one round trip regardless of outcome (avoids a timing side-channel between "unmapped host" and "mapped but inactive tenant"). Returns only tenant_id/domain_status/is_primary/route_mode/tenant_status/tenant_code/tenant_name/default_locale for non-deleted domain rows matching a normalized hostname. Never returns verification_token_hash, verification_record_value, or raw hostname. EXECUTE restricted to awcms_app.';
+  'Narrow SECURITY DEFINER bootstrap read for hostname -> tenant lookup before tenant context exists. Owned by the dedicated NOLOGIN awcms_domain_bootstrap role (NOT a superuser), which an explicit FOR SELECT TO awcms_domain_bootstrap USING (true) policy lets read awcms_tenant_domains under FORCE RLS; the same role has no login and no members, so nothing else can act as it. Joins the (already RLS-free) awcms_tenants row in the same call so the TypeScript resolver needs exactly one round trip regardless of outcome (avoids a timing side-channel between "unmapped host" and "mapped but inactive tenant"). Returns only tenant_id/domain_status/is_primary/route_mode/tenant_status/tenant_code/tenant_name/default_locale for non-deleted domain rows matching a normalized hostname. Never returns verification_token_hash, verification_record_value, or raw hostname. EXECUTE restricted to awcms_app.';
 
--- Function EXECUTE privilege is a separate grant mechanism from the table
+-- 4. Function EXECUTE privilege is a separate grant mechanism from the table
 -- GRANTs sql/019's `ALTER DEFAULT PRIVILEGES` covers (that clause only applies
 -- to tables/sequences, not functions/routines) — this explicit grant is
 -- required, it is not automatic. PostgreSQL grants EXECUTE to PUBLIC by default
 -- on function creation; revoke that first so only the least-privilege app role
--- can call this bypass.
+-- can call this bootstrap. Done while the migration owner still owns the
+-- function (before the OWNER reassign below), so the migration owner's
+-- authority to REVOKE/GRANT on it is unambiguous.
 REVOKE ALL ON FUNCTION awcms_resolve_tenant_domain_lookup(text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION awcms_resolve_tenant_domain_lookup(text) TO awcms_app;
+
+-- 5. Reassign the function to the bootstrap-owner so SECURITY DEFINER runs it as
+-- that role. Requires SUPERUSER (the migration runner is one; see the ORDERING
+-- note in the header) — a superuser reassigns ownership without needing the
+-- target role's membership, so `awcms_domain_bootstrap` stays memberless.
+ALTER FUNCTION awcms_resolve_tenant_domain_lookup(text) OWNER TO awcms_domain_bootstrap;

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -42,7 +42,8 @@ interface Props {
     | "roles"
     | "abac-policies"
     | "modules"
-    | "email-templates";
+    | "email-templates"
+    | "tenant-domains";
 }
 
 const { title, active } = Astro.props;
@@ -108,6 +109,12 @@ const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
             aria-current={active === "offices" ? "page" : undefined}
           >
             Offices
+          </a>
+          <a
+            href="/admin/tenant/domains"
+            aria-current={active === "tenant-domains" ? "page" : undefined}
+          >
+            Tenant domains
           </a>
           <a
             href="/admin/profiles"

--- a/src/lib/tenant/public-host-tenant-resolver.ts
+++ b/src/lib/tenant/public-host-tenant-resolver.ts
@@ -1,0 +1,466 @@
+import { assertUuid } from "../database/tenant-context";
+import { log } from "../logging/logger";
+import {
+  resolvePublicTenantByCode,
+  type PublicTenantResolution
+} from "./public-tenant-resolver";
+
+/**
+ * Public host-based tenant resolution — ported from awcms-micro (epic #555).
+ * Resolves the tenant for anonymous public routes from the request
+ * `Host`/domain/subdomain first, then falls back safely to the same env/setup
+ * defaults offline/LAN deployments already rely on for `/blog/{tenantCode}`
+ * (ADR-0009). This is an ADDITIVE path: it never regresses ADR-0009's
+ * path-based `resolvePublicTenantByCode` — that resolver stays the mechanism
+ * for `/blog/{tenantCode}`; this one is for host-resolved public routes, and
+ * the two coexist.
+ *
+ * This module never touches tenant content — only `awcms_tenant_domains` (via
+ * the SECURITY DEFINER bootstrap function, migration 048), `awcms_tenants`
+ * (RLS-free by design, ADR-0003, same as `resolvePublicTenantByCode`), and
+ * `awcms_setup_state` (RLS-free singleton, migration 006).
+ *
+ * Every exported function here returns `null` for *any* non-resolving case —
+ * unknown host, unmapped domain, non-`active` domain status
+ * (`pending_verification`/`suspended`/`failed`), soft-deleted domain, or an
+ * inactive tenant. Callers must treat `null` as a single generic "no tenant"
+ * outcome (404), exactly like `resolvePublicTenantByCode` (ADR-0009) — never
+ * branch on *why* resolution failed. The only function that ever throws is
+ * `normalizePublicHost()`, and only for a genuinely-empty input (a caller
+ * contract violation, not a runtime resolution outcome); a non-empty but
+ * malformed host still returns `null`, never throws.
+ *
+ * **`tenant_code_legacy` mode is a fifth, standalone `null` case**:
+ * `resolvePublicTenantFromRequest()` returns `null` unconditionally for this
+ * mode, without even attempting the env/setup fallback chain — see that
+ * function's own docblock and `PublicHostResolverConfig.mode`'s docblock for
+ * the full reasoning.
+ */
+
+export type { PublicTenantResolution };
+
+type TenantDomainLookupRow = {
+  tenant_id: string;
+  domain_status: string;
+  is_primary: boolean;
+  route_mode: string;
+  tenant_status: string;
+  tenant_code: string;
+  tenant_name: string;
+  default_locale: string;
+};
+
+type TenantRow = {
+  id: string;
+  tenant_code: string;
+  tenant_name: string;
+  status: string;
+  default_locale: string;
+};
+
+type SetupStateRow = {
+  tenant_id: string | null;
+};
+
+/** The four documented resolution modes (`PUBLIC_TENANT_RESOLUTION_MODE`). */
+export type PublicTenantResolutionMode =
+  "host_default" | "env_default" | "setup_default" | "tenant_code_legacy";
+
+export type PublicHostResolverConfig = {
+  /**
+   * `PUBLIC_TENANT_RESOLUTION_MODE`. Only `"host_default"` enables step 1
+   * (host/domain lookup) below — every other value, including `undefined`
+   * (not set at all, today's offline/LAN default) and any unrecognized
+   * string, skips straight to the env/setup fallback chain (steps 2-4). This
+   * keeps the `awcms_tenant_domains` bootstrap function entirely unreached by
+   * deployments that never opted into online/host-based routing — smaller
+   * attack surface, not just smaller code path, for the common offline/LAN
+   * case.
+   *
+   * The env/setup fallback chain (steps 2-4) always runs regardless of mode —
+   * that is the "safe fallback", matching the acceptance criterion that an
+   * unset/other mode still tries `PUBLIC_DEFAULT_TENANT_ID` ->
+   * `PUBLIC_DEFAULT_TENANT_CODE` -> `awcms_setup_state.tenant_id` before
+   * giving up.
+   *
+   * **Explicit exception**: `mode === "tenant_code_legacy"` skips the *entire*
+   * chain, steps 1-4 alike, and resolution always returns `null`. This mode
+   * means "no default tenant guess — every route must carry an explicit
+   * `tenantCode` in its own path", which is exactly what `/blog/{tenantCode}`
+   * (ADR-0009) does and what a host-resolved public route structurally cannot.
+   * `undefined` (not set at all) is deliberately NOT folded into this case and
+   * keeps running the full safe-fallback chain, because an operator who never
+   * touched `PUBLIC_TENANT_RESOLUTION_MODE` has not made any explicit "no
+   * default tenant" choice.
+   */
+  mode?: string;
+  /**
+   * `PUBLIC_TRUST_PROXY`, default `false`. Only when `true` is
+   * `X-Forwarded-Host` read at all; otherwise the plain `Host` header is
+   * always used, matching the binding security note ("never trust
+   * X-Forwarded-Host without a trusted proxy in front").
+   */
+  trustProxy?: boolean;
+};
+
+export type PublicHostResolverDeps = {
+  resolvePublicTenantByHost: typeof resolvePublicTenantByHost;
+  resolveDefaultPublicTenantFromEnv: typeof resolveDefaultPublicTenantFromEnv;
+  resolveDefaultPublicTenantFromSetupState: typeof resolveDefaultPublicTenantFromSetupState;
+};
+
+const MAX_HOST_LENGTH = 253; // RFC 1035 total hostname length limit.
+const MAX_LABEL_LENGTH = 63; // RFC 1035 per-label length limit.
+const HOST_LABEL_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+/**
+ * Shared DNS-hostname shape check (length + per-label charset), used by
+ * `normalizePublicHost()` (after it strips the port) and, as defense in depth,
+ * directly inside `resolvePublicTenantByHost()` — that function is exported and
+ * documented as directly callable, so it must not rely solely on "the caller
+ * already normalized this" as its only guard. Does not strip a port or
+ * lowercase — the input is expected to already be normalized; this only
+ * re-validates shape.
+ */
+function isValidHostnameShape(value: string): boolean {
+  if (
+    value.length === 0 ||
+    value.length > MAX_HOST_LENGTH ||
+    value.startsWith(".") ||
+    value.endsWith(".") ||
+    value.includes("..") ||
+    value.includes("_") ||
+    /\s/.test(value)
+  ) {
+    return false;
+  }
+
+  return value
+    .split(".")
+    .every(
+      (label) =>
+        label.length > 0 &&
+        label.length <= MAX_LABEL_LENGTH &&
+        HOST_LABEL_PATTERN.test(label)
+    );
+}
+
+/**
+ * Normalizes an untrusted `Host`/`X-Forwarded-Host` value for use as a lookup
+ * key: strips a trailing `:<port>`, lowercases, trims, and validates DNS
+ * hostname shape. Returns `null` for anything that doesn't look like a
+ * plausible hostname (defense in depth — the DB lookup this feeds is already
+ * parameterized, this is an additional reject-early gate against
+ * obviously-malformed/oversized/injected input before it ever reaches a query).
+ * IPv6 literals (`[::1]`) are rejected: tenant domain mappings are always by
+ * hostname, never by IP literal.
+ *
+ * Throws only when `rawHost` itself is empty/not a string — that is a caller
+ * contract violation (e.g. calling this directly with `""`), not a runtime
+ * resolution outcome, so it is intentionally distinguishable from every other
+ * "not a valid/known host" case, which returns `null`.
+ */
+export function normalizePublicHost(rawHost: string): string | null {
+  if (typeof rawHost !== "string" || rawHost.trim().length === 0) {
+    throw new Error("normalizePublicHost: rawHost must be a non-empty string.");
+  }
+
+  const trimmed = rawHost.trim().toLowerCase();
+
+  if (/\s/.test(trimmed)) {
+    return null;
+  }
+
+  if (trimmed.startsWith("[")) {
+    // IPv6 literal, e.g. "[::1]:4321" — not a supported tenant domain shape.
+    return null;
+  }
+
+  const colonIndex = trimmed.lastIndexOf(":");
+  const hostOnly = colonIndex === -1 ? trimmed : trimmed.slice(0, colonIndex);
+
+  return isValidHostnameShape(hostOnly) ? hostOnly : null;
+}
+
+/**
+ * Fetches an `active` tenant by id from `awcms_tenants` — RLS-free by design
+ * (ADR-0003, same as `resolvePublicTenantByCode`'s own table access), so this
+ * runs directly on the app-role connection, before any `withTenant(...)`
+ * transaction. Not exported: every exported resolution step here needs "look
+ * up a tenant by id and confirm it's active", so it is centralized here rather
+ * than duplicated per step.
+ */
+async function fetchActivePublicTenantById(
+  sql: Bun.SQL,
+  tenantId: string
+): Promise<PublicTenantResolution | null> {
+  const rows = (await sql`
+    SELECT id, tenant_code, tenant_name, status, default_locale
+    FROM awcms_tenants
+    WHERE id = ${tenantId}
+  `) as TenantRow[];
+
+  const tenant = rows[0];
+
+  if (!tenant || tenant.status !== "active") {
+    return null;
+  }
+
+  return {
+    tenantId: tenant.id,
+    tenantCode: tenant.tenant_code,
+    tenantName: tenant.tenant_name,
+    defaultLocale: tenant.default_locale
+  };
+}
+
+/**
+ * Step 1 of the resolution order: hostname -> tenant, via the narrow SECURITY
+ * DEFINER bootstrap function `awcms_resolve_tenant_domain_lookup` (migration
+ * 048). `normalizedHost` must already be normalized by `normalizePublicHost()`
+ * — this function re-validates hostname *shape* as defense in depth (it is
+ * exported and directly callable), but does not re-strip a port or
+ * re-lowercase; callers must still normalize first.
+ *
+ * Exactly one query runs for every outcome (unknown host, non-`active` domain,
+ * or non-`active` tenant) — the SQL function joins `awcms_tenants` in the same
+ * call and returns the tenant's own status/code/name/locale alongside the
+ * domain row, specifically so this function never needs a second, conditional
+ * round trip (a timing side-channel).
+ *
+ * Only `domain_status === 'active' AND tenant_status === 'active'` resolves;
+ * every other combination — `pending_verification`/`suspended`/`failed`
+ * domain, soft-deleted domain (already excluded by the SQL function itself), or
+ * a non-`active` tenant — falls through to `null` identically. `is_primary` and
+ * `route_mode` are read but not part of the return value: they are not needed
+ * for base resolution, and keeping the public resolver's read surface minimal
+ * is a binding security note.
+ */
+export async function resolvePublicTenantByHost(
+  sql: Bun.SQL,
+  normalizedHost: string
+): Promise<PublicTenantResolution | null> {
+  if (
+    typeof normalizedHost !== "string" ||
+    !isValidHostnameShape(normalizedHost)
+  ) {
+    return null;
+  }
+
+  const rows = (await sql`
+    SELECT
+      tenant_id, domain_status, is_primary, route_mode,
+      tenant_status, tenant_code, tenant_name, default_locale
+    FROM awcms_resolve_tenant_domain_lookup(${normalizedHost})
+  `) as TenantDomainLookupRow[];
+
+  const row = rows[0];
+
+  if (
+    !row ||
+    row.domain_status !== "active" ||
+    row.tenant_status !== "active"
+  ) {
+    return null;
+  }
+
+  return {
+    tenantId: row.tenant_id,
+    tenantCode: row.tenant_code,
+    tenantName: row.tenant_name,
+    defaultLocale: row.default_locale
+  };
+}
+
+/**
+ * Steps 2-3 of the resolution order: `PUBLIC_DEFAULT_TENANT_ID` first, then
+ * `PUBLIC_DEFAULT_TENANT_CODE`. A malformed `PUBLIC_DEFAULT_TENANT_ID` (not a
+ * UUID) is treated as "this step did not resolve" and falls through to the
+ * CODE check, rather than throwing — this runtime path never surfaces a parse
+ * error to a public caller.
+ */
+export async function resolveDefaultPublicTenantFromEnv(
+  sql: Bun.SQL,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<PublicTenantResolution | null> {
+  const tenantId = env.PUBLIC_DEFAULT_TENANT_ID?.trim();
+
+  if (tenantId) {
+    try {
+      assertUuid(tenantId);
+      const resolved = await fetchActivePublicTenantById(sql, tenantId);
+
+      if (resolved) {
+        return resolved;
+      }
+    } catch {
+      // Malformed PUBLIC_DEFAULT_TENANT_ID — fall through to the CODE check
+      // below, never throw out of a public resolution path.
+    }
+  }
+
+  const tenantCode = env.PUBLIC_DEFAULT_TENANT_CODE?.trim();
+
+  if (tenantCode) {
+    return resolvePublicTenantByCode(sql, tenantCode);
+  }
+
+  return null;
+}
+
+/**
+ * Step 4 of the resolution order: `awcms_setup_state.tenant_id` — the tenant
+ * chosen during the setup wizard. `awcms_setup_state` is a RLS-free singleton
+ * table (migration 006), so this also runs directly on the app-role connection
+ * with no tenant context needed.
+ */
+export async function resolveDefaultPublicTenantFromSetupState(
+  sql: Bun.SQL
+): Promise<PublicTenantResolution | null> {
+  const rows = (await sql`
+    SELECT tenant_id
+    FROM awcms_setup_state
+    WHERE id = true
+  `) as SetupStateRow[];
+
+  const tenantId = rows[0]?.tenant_id;
+
+  if (!tenantId) {
+    return null;
+  }
+
+  return fetchActivePublicTenantById(sql, tenantId);
+}
+
+const defaultDeps: PublicHostResolverDeps = {
+  resolvePublicTenantByHost,
+  resolveDefaultPublicTenantFromEnv,
+  resolveDefaultPublicTenantFromSetupState
+};
+
+/**
+ * Extracts the host to resolve from a `Request`. Reads the plain `Host` header
+ * by default; only reads `X-Forwarded-Host` when `trustProxy` is `true`
+ * (default `false`) — an untrusted client can set `X-Forwarded-Host` to
+ * anything, so it must never be read unless a trusted reverse proxy in front is
+ * guaranteed to sanitize/overwrite it.
+ *
+ * **Binding operational requirement**: a deployment that sets
+ * `PUBLIC_TRUST_PROXY=true` MUST run behind a single, directly-adjacent trusted
+ * edge proxy that fully OVERWRITES `X-Forwarded-Host` on every request, never
+ * appends to (or forwards) a client-supplied value. If the header nonetheless
+ * contains more than one comma-separated value at runtime, that is treated as a
+ * sign of a misconfigured proxy chain or a spoofing attempt — this function
+ * does NOT guess which of several values is trustworthy. It logs the anomaly
+ * and falls back to the plain `Host` header instead, exactly as if `trustProxy`
+ * were `false` for this one request.
+ */
+function extractHostHeader(
+  request: Request,
+  trustProxy: boolean
+): string | null {
+  if (trustProxy) {
+    const forwarded = request.headers.get("x-forwarded-host");
+
+    if (forwarded && forwarded.trim().length > 0) {
+      const parts = forwarded
+        .split(",")
+        .map((part) => part.trim())
+        .filter((part) => part.length > 0);
+
+      if (parts.length === 1) {
+        return parts[0] as string;
+      }
+
+      if (parts.length > 1) {
+        log("warning", "public_host_resolver.x_forwarded_host_multi_value", {
+          valueCount: parts.length,
+          // Not a secret, but capped defensively — this is an anomaly report,
+          // not a place to let an attacker-sized header balloon log storage.
+          firstValuePreview: parts[0]?.slice(0, 100)
+        });
+      }
+    }
+  }
+
+  return request.headers.get("host");
+}
+
+/**
+ * Orchestrates the full resolution order for a public request:
+ *
+ * 0. `config.mode === "tenant_code_legacy"` — short-circuits to `null`
+ *    immediately, before any of steps 1-4 run. This mode means the operator
+ *    explicitly opted OUT of any default-tenant guess, so a route with no
+ *    `tenantCode` path segment must never resolve a tenant under it, not even
+ *    via the env/setup fallback.
+ * 1. Host/domain mapping (`resolvePublicTenantByHost`) — only attempted when
+ *    `config.mode === "host_default"`.
+ * 2. `PUBLIC_DEFAULT_TENANT_ID`
+ * 3. `PUBLIC_DEFAULT_TENANT_CODE`
+ *    (2-3 are both handled inside `resolveDefaultPublicTenantFromEnv`)
+ * 4. `awcms_setup_state.tenant_id`
+ * 5. `null` (caller responds with a generic 404)
+ *
+ * Steps 2-4 always run for every mode EXCEPT `tenant_code_legacy` (step 0) —
+ * they are the "safe fallback", so an offline/LAN deployment that never sets
+ * `PUBLIC_TENANT_RESOLUTION_MODE` (`config.mode === undefined`) still gets a
+ * usable default tenant for routes that don't carry an explicit `tenantCode`.
+ * `undefined` is deliberately NOT treated the same as explicit
+ * `tenant_code_legacy` — only an operator who has actually set that value has
+ * made the "no default tenant" choice this step 0 enforces.
+ *
+ * `requestOrHost` accepts either a `Request` (host header extracted per
+ * `config.trustProxy`) or an already-known host string (bypasses header
+ * extraction entirely — used by callers that resolved the host some other way,
+ * and by tests). `deps` allows the three DB-touching steps to be swapped for
+ * test doubles without a database; production callers should omit it.
+ */
+export async function resolvePublicTenantFromRequest(
+  sql: Bun.SQL,
+  requestOrHost: Request | string,
+  config: PublicHostResolverConfig = {},
+  deps: PublicHostResolverDeps = defaultDeps
+): Promise<PublicTenantResolution | null> {
+  if (config.mode === "tenant_code_legacy") {
+    return null;
+  }
+
+  const trustProxy = config.trustProxy ?? false;
+
+  if (config.mode === "host_default") {
+    const rawHost =
+      typeof requestOrHost === "string"
+        ? requestOrHost
+        : extractHostHeader(requestOrHost, trustProxy);
+
+    if (rawHost && rawHost.trim().length > 0) {
+      const normalizedHost = normalizePublicHost(rawHost);
+
+      if (normalizedHost) {
+        const byHost = await deps.resolvePublicTenantByHost(
+          sql,
+          normalizedHost
+        );
+
+        if (byHost) {
+          return byHost;
+        }
+      }
+    }
+  }
+
+  const byEnv = await deps.resolveDefaultPublicTenantFromEnv(sql);
+
+  if (byEnv) {
+    return byEnv;
+  }
+
+  const bySetupState = await deps.resolveDefaultPublicTenantFromSetupState(sql);
+
+  if (bySetupState) {
+    return bySetupState;
+  }
+
+  return null;
+}

--- a/src/lib/ui/admin-form-client.ts
+++ b/src/lib/ui/admin-form-client.ts
@@ -48,17 +48,27 @@ export function lockElement(
  * `body` is optional so a bodyless mutation (e.g. `DELETE /roles/{id}`, a
  * restore/toggle) can be sent without an empty-object payload; when omitted no
  * request body and no `Content-Type` header are attached.
+ *
+ * `extraHeaders` is optional and merged onto the request headers — used by
+ * high-risk mutations that must carry an `Idempotency-Key` header (e.g. the
+ * tenant-domain verify/set-primary buttons). It never overrides the
+ * `Content-Type` a JSON body sets.
  */
 export async function sendJson(
   method: "POST" | "PATCH" | "PUT" | "DELETE",
   url: string,
-  body?: unknown
+  body?: unknown,
+  extraHeaders?: Record<string, string>
 ): Promise<{ ok: boolean; errorCode: string | null }> {
   try {
     const hasBody = body !== undefined;
+    const headers: Record<string, string> = { ...extraHeaders };
+    if (hasBody) {
+      headers["Content-Type"] = "application/json";
+    }
     const response = await fetch(url, {
       method,
-      headers: hasBody ? { "Content-Type": "application/json" } : undefined,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
       credentials: "same-origin",
       body: hasBody ? JSON.stringify(body) : undefined
     });

--- a/src/modules/identity-access/domain/access-control.ts
+++ b/src/modules/identity-access/domain/access-control.ts
@@ -84,7 +84,15 @@ export type AccessAction =
   // gate on idempotency/audit). (`attach`/`detach`/`delete`/`restore`/`purge`/
   // `cancel` are also seeded in the `news_portal.media` permission catalog but
   // reuse existing union members / are not yet authorized by any ported route.)
-  | "verify";
+  | "verify"
+  // Tenant domain (ported from awcms-micro epic #555): `set_primary` atomically
+  // makes a verified tenant domain the active primary. Deliberately NOT in
+  // `HIGH_RISK_ACTIONS` (same posture as `verify` — it only flips one row's
+  // primary flag, does not delete or irreversibly change data); the set-primary
+  // endpoint still requires `Idempotency-Key` and is audited regardless of this
+  // classification. (`read`/`create`/`update`/`delete`/`verify` for
+  // tenant_domain reuse existing union members.)
+  | "set_primary";
 
 export type AccessRequest = {
   moduleKey: string;

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -12,6 +12,7 @@ import { reportingModule } from "./reporting/module";
 import { themingModule } from "./theming/module";
 import { blogContentModule } from "./blog-content/module";
 import { newsPortalModule } from "./news-portal/module";
+import { tenantDomainModule } from "./tenant-domain/module";
 
 /**
  * The reviewed BASE registry. Every module below is reviewed, in-repo code.
@@ -45,7 +46,14 @@ const baseModules: ModuleDescriptor[] = [
   // blog_content's `public_content`, but capability edges are not DAG edges,
   // so the graph stays acyclic. See src/modules/news-portal/module.ts's
   // `description` for what was ported vs. dropped.
-  newsPortalModule
+  newsPortalModule,
+  // Ported from awcms-micro (epic #555): tenant hostname/subdomain -> tenant
+  // mapping for host-based public routing, plus a SECURITY DEFINER host-lookup
+  // bootstrap function and the additive public host resolver. Depends only on
+  // tenant_admin/identity_access (both above), so the DAG stays acyclic. See
+  // src/modules/tenant-domain/module.ts's `description` for what was ported vs.
+  // deferred.
+  tenantDomainModule
 ];
 
 /**

--- a/src/modules/tenant-domain/README.md
+++ b/src/modules/tenant-domain/README.md
@@ -1,0 +1,141 @@
+# tenant_domain
+
+Tenant hostname/subdomain → tenant mapping for **host-based public routing**,
+ported from awcms-micro (epic #555). Registered as a `type: "domain"` module in
+`src/modules/index.ts`.
+
+This module lets a tenant register the public hostnames/subdomains that resolve
+to it, prove ownership (manual-first), and choose one active **primary** domain.
+It is the data + resolver seam a future host-resolved public content route
+family (a `/news`-style surface) will read to answer "which tenant does this
+`Host` header belong to?" **without** a `tenantCode` in the path.
+
+It is **additive**: ADR-0009's existing path-based `/blog/{tenantCode}` routing
+is untouched and remains the mechanism for those routes. `src/middleware.ts` is
+not modified — host resolution is a per-public-route concern, so the login /
+Turnstile / CSP guarantees are unchanged.
+
+## What shipped
+
+| Area            | Detail                                                                                                                                                            |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Schema          | `awcms_tenant_domains` (migration **046**) — tenant-scoped, `ENABLE`+`FORCE ROW LEVEL SECURITY`, global case-insensitive hostname uniqueness, one primary/tenant. |
+| Permissions     | migration **047** — `tenant_domain.domains.{read,create,update,delete,verify,set_primary}`.                                                                       |
+| Host lookup     | migration **048** — `awcms_resolve_tenant_domain_lookup(text)` `SECURITY DEFINER`, `EXECUTE` revoked from `PUBLIC`, granted only to `awcms_app`.                  |
+| Management API  | `GET/POST /api/v1/tenant/domains`, `GET/PATCH/DELETE .../{id}`, `POST .../{id}/verify`, `POST .../{id}/set-primary`.                                              |
+| Admin screen    | `/admin/tenant/domains` (SSR read + client-side `fetch` mutations, `tenant_domain.domains.read`-gated).                                                           |
+| Public resolver | `src/lib/tenant/public-host-tenant-resolver.ts` (additive; coexists with ADR-0009).                                                                               |
+| Optional DNS    | `infrastructure/cloudflare-dns-adapter.ts` — env-gated, absent-safe, **not wired into any route**.                                                                |
+
+## Data model (`awcms_tenant_domains`)
+
+- `hostname` (raw, case preserved) + `normalized_hostname` (`lower(btrim(...))`,
+  kept in sync by a CHECK). The unique index on `normalized_hostname WHERE
+deleted_at IS NULL` is **global (cross-tenant)** — a hostname maps to at most
+  one tenant. A soft delete frees it for reuse.
+- `domain_type` (`subdomain`|`custom_domain`), `route_mode`
+  (`canonical`|`legacy_blog`, laid down for forward compatibility, not consumed
+  by any resolver yet).
+- `status` (`pending_verification`|`active`|`suspended`|`failed`); soft delete
+  (`deleted_at`/`deleted_by`/`delete_reason`) is a separate "does not resolve"
+  state, not folded into the enum.
+- `is_primary` + `redirect_to_primary`; one active primary per tenant (partial
+  unique index).
+- `verification_method` + `verification_record_name`/`verification_record_value`
+  (the **public** DNS record the tenant publishes — never a secret).
+  `verification_token_hash` is an internal bearer-token hash and is **never**
+  selected/returned by any code in this module.
+
+**No column ever stores a DNS provider API credential.** The Cloudflare
+adapter's token/zone come only from `TENANT_DOMAIN_CLOUDFLARE_*` env vars.
+
+## Tenant domain management API
+
+All endpoints are authenticated, tenant-scoped, and guarded at the
+identity-access chokepoint (`authorizeInTransaction`, default-deny ABAC) inside
+`withTenant`. Every query runs under RLS `FORCE` (defense in depth over the
+explicit `tenant_id` filter) — **never** through the `SECURITY DEFINER` function
+(that is reserved for the anonymous public resolver).
+
+- `hostname` is **immutable** after create (re-pointing means delete + recreate)
+  and `is_primary` is never settable through the generic `PATCH` — the only path
+  to primary is the atomic `POST .../set-primary`. `PATCH` can never set
+  `status: "active"` (use verify).
+- A duplicate normalized hostname → generic `409 HOSTNAME_CONFLICT`, never
+  revealing whether it belongs to another tenant. Unknown/cross-tenant/deleted
+  ids → generic `404`.
+- `verify` and `set-primary` require an `Idempotency-Key` and are audited, even
+  though neither is classified `HIGH_RISK` (same posture as other status-flip
+  actions). `verify` is manual-first — it flips `status` to `active` from the
+  row's own fields, with **no outbound DNS/HTTP call**.
+- `set-primary` is atomic (unset-old-then-set-new inside one transaction) and
+  maps the concurrent first-time-primary race to `409 CONCURRENT_UPDATE`.
+
+## Public host resolver (the seam)
+
+`resolvePublicTenantFromRequest(sql, request|host, config, deps?)` orchestrates:
+
+0. `mode === "tenant_code_legacy"` → `null` immediately (operator opted out of
+   any default-tenant guess).
+1. host lookup (`resolvePublicTenantByHost`) — only when `mode ===
+"host_default"`, via the migration 048 `SECURITY DEFINER` function.
+2. `PUBLIC_DEFAULT_TENANT_ID` → 3. `PUBLIC_DEFAULT_TENANT_CODE` → 4.
+   `awcms_setup_state.tenant_id` → 5. `null`.
+
+Steps 2–4 (the safe fallback) run for every mode **except**
+`tenant_code_legacy`; an unset mode (offline/LAN default) keeps the full
+fallback. Only `domain_status === 'active' && tenant_status === 'active'`
+resolves — every other case returns an identical `null`, in exactly one DB round
+trip (no timing side-channel). `X-Forwarded-Host` is read only when
+`config.trustProxy` is true.
+
+## Not yet available (deferred, documented)
+
+- **Host-resolved public content routes.** The resolver + lookup function +
+  directory + admin API are complete and tested, but no public route consumes
+  `resolvePublicTenantFromRequest` yet — that needs the blog_content/news_portal
+  public render routes plumbed through it (news_portal deferred its own
+  `/news/**` routes for the same reason). Wiring it is a clean follow-up; the
+  seam is stable.
+- **Cloudflare DNS automation.** `resolveTenantDomainDnsProvider(env)` and
+  `createCloudflareDnsProvider` exist and are unit-tested, but no route calls
+  them. With no `TENANT_DOMAIN_DNS_PROVIDER=cloudflare` configured the resolver
+  returns a clean misconfigured-result provider (never throws), so awcms builds
+  and runs with zero Cloudflare credentials.
+
+## Security residual risk — gate before untrusted self-service (M1)
+
+`verify` currently activates a domain from in-row fields **without an outbound
+ownership proof** (manual-first; the DNS-token machinery —
+`verification_token_hash` + the Cloudflare/DNS adapter — exists but is not wired).
+Because the global-unique hostname index is scoped `WHERE deleted_at IS NULL`, a
+soft-deleted hostname is re-registerable by another tenant. If untrusted
+multi-tenant self-service verification of shared **`custom_domain`s** is enabled,
+this combination allows a **dangling-DNS domain takeover**: tenant A deletes a
+mapping but leaves DNS pointed at the platform, tenant B re-registers and
+`verify`s the same hostname with no proof, and traffic to the dangling host now
+resolves to tenant B.
+
+Mitigations already in place: `verify` is **default-deny** (privileged, seeded)
+and **audited**; subdomains under the platform root are not affected (they are not
+delegated to tenants). **Required before go-live of untrusted self-service custom
+domains:** either keep `custom_domain` activation **operator/manual-gated**, or
+wire real DNS-token ownership proof (write a CSPRNG token to
+`verification_token_hash`, require the tenant to publish the matching TXT/CNAME,
+and confirm it in `verify` via `checkVerificationStatus`). Tracked as the
+tenant-domain hardening follow-up in `docs/awcms/absorb-awcms-micro-roadmap.md`.
+
+## Tests
+
+- `tests/tenant-domain-module.test.ts` — descriptor ↔ migration 047 parity.
+- `tests/tenant-domain-validation.test.ts` — create/update validation.
+- `tests/tenant-domain-dns-config.test.ts` — provider/timeout config.
+- `tests/cloudflare-dns-adapter.test.ts` — DNS-record input validation + the
+  absent-safe resolver.
+- `tests/public-host-tenant-resolver.test.ts` — `normalizePublicHost` +
+  resolution-order branching (mocked deps, no DB).
+- `tests/integration/tenant-domain.integration.test.ts` — DB-gated: directory
+  CRUD/verify/set-primary, cross-tenant global uniqueness, soft-delete reuse,
+  one-primary-per-tenant, and **RLS proven under `awcms_app`** (direct SELECT
+  returns 0 rows without tenant context; the `SECURITY DEFINER` lookup resolves
+  an active domain and never exposes a secret column).

--- a/src/modules/tenant-domain/README.md
+++ b/src/modules/tenant-domain/README.md
@@ -17,15 +17,15 @@ Turnstile / CSP guarantees are unchanged.
 
 ## What shipped
 
-| Area            | Detail                                                                                                                                                            |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Schema          | `awcms_tenant_domains` (migration **046**) — tenant-scoped, `ENABLE`+`FORCE ROW LEVEL SECURITY`, global case-insensitive hostname uniqueness, one primary/tenant. |
-| Permissions     | migration **047** — `tenant_domain.domains.{read,create,update,delete,verify,set_primary}`.                                                                       |
-| Host lookup     | migration **048** — `awcms_resolve_tenant_domain_lookup(text)` `SECURITY DEFINER`, `EXECUTE` revoked from `PUBLIC`, granted only to `awcms_app`.                  |
-| Management API  | `GET/POST /api/v1/tenant/domains`, `GET/PATCH/DELETE .../{id}`, `POST .../{id}/verify`, `POST .../{id}/set-primary`.                                              |
-| Admin screen    | `/admin/tenant/domains` (SSR read + client-side `fetch` mutations, `tenant_domain.domains.read`-gated).                                                           |
-| Public resolver | `src/lib/tenant/public-host-tenant-resolver.ts` (additive; coexists with ADR-0009).                                                                               |
-| Optional DNS    | `infrastructure/cloudflare-dns-adapter.ts` — env-gated, absent-safe, **not wired into any route**.                                                                |
+| Area            | Detail                                                                                                                                                                                                                                                                       |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Schema          | `awcms_tenant_domains` (migration **046**) — tenant-scoped, `ENABLE`+`FORCE ROW LEVEL SECURITY`, global case-insensitive hostname uniqueness, one primary/tenant.                                                                                                            |
+| Permissions     | migration **047** — `tenant_domain.domains.{read,create,update,delete,verify,set_primary}`.                                                                                                                                                                                  |
+| Host lookup     | migration **048** — `awcms_resolve_tenant_domain_lookup(text)` `SECURITY DEFINER`, owned by a dedicated `NOLOGIN`/`NOSUPERUSER`/`NOBYPASSRLS` `awcms_domain_bootstrap` role with a scoped `FOR SELECT` policy; `EXECUTE` revoked from `PUBLIC`, granted only to `awcms_app`. |
+| Management API  | `GET/POST /api/v1/tenant/domains`, `GET/PATCH/DELETE .../{id}`, `POST .../{id}/verify`, `POST .../{id}/set-primary`.                                                                                                                                                         |
+| Admin screen    | `/admin/tenant/domains` (SSR read + client-side `fetch` mutations, `tenant_domain.domains.read`-gated).                                                                                                                                                                      |
+| Public resolver | `src/lib/tenant/public-host-tenant-resolver.ts` (additive; coexists with ADR-0009).                                                                                                                                                                                          |
+| Optional DNS    | `infrastructure/cloudflare-dns-adapter.ts` — env-gated, absent-safe, **not wired into any route**.                                                                                                                                                                           |
 
 ## Data model (`awcms_tenant_domains`)
 

--- a/src/modules/tenant-domain/application/tenant-domain-directory.ts
+++ b/src/modules/tenant-domain/application/tenant-domain-directory.ts
@@ -1,0 +1,419 @@
+/**
+ * Tenant domain management data access over `awcms_tenant_domains` (migration
+ * 046). Every query here runs inside a caller-provided tenant transaction
+ * (`withTenant`, RLS `FORCE`d on this table since migration 046) — **not** the
+ * `SECURITY DEFINER` bootstrap function from migration 048
+ * (`awcms_resolve_tenant_domain_lookup`), which is reserved for the anonymous,
+ * pre-tenant-context public resolver.
+ *
+ * `verification_token_hash` is deliberately never selected/returned by any
+ * function in this file — API responses must never expose provider
+ * token/secret values, and this column (an internal bearer-token hash,
+ * migration 046) is exactly that kind of value even though nothing in this
+ * module ever writes it. The column list is repeated literally at each query
+ * site (not factored into a shared fragment) — same convention every other
+ * directory module in this repo uses, so every query stays a single
+ * self-contained tagged template.
+ */
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
+import type {
+  CreateTenantDomainInput,
+  UpdateTenantDomainInput
+} from "../domain/tenant-domain-validation";
+
+export const TENANT_DOMAIN_LIST_LIMIT = 100;
+
+export type TenantDomainView = {
+  id: string;
+  tenantId: string;
+  hostname: string;
+  normalizedHostname: string;
+  domainType: string;
+  routeMode: string;
+  status: string;
+  isPrimary: boolean;
+  redirectToPrimary: boolean;
+  verificationMethod: string | null;
+  verificationRecordName: string | null;
+  verificationRecordValue: string | null;
+  verifiedAt: string | null;
+  lastCheckedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string | null;
+  updatedBy: string | null;
+};
+
+type TenantDomainRow = {
+  id: string;
+  tenant_id: string;
+  hostname: string;
+  normalized_hostname: string;
+  domain_type: string;
+  route_mode: string;
+  status: string;
+  is_primary: boolean;
+  redirect_to_primary: boolean;
+  verification_method: string | null;
+  verification_record_name: string | null;
+  verification_record_value: string | null;
+  verified_at: Date | null;
+  last_checked_at: Date | null;
+  created_at: Date;
+  updated_at: Date;
+  created_by: string | null;
+  updated_by: string | null;
+};
+
+// Row shape for the list query only — carries the full-precision cursor text
+// (Issue #158) kept out of the response DTO; see `_shared/keyset-pagination`
+// for why a JS `Date` cannot carry it.
+type TenantDomainListRow = TenantDomainRow & { created_at_cursor: string };
+
+export type TenantDomainListPage = {
+  domains: TenantDomainView[];
+  nextCursor: string | null;
+};
+
+function toView(row: TenantDomainRow): TenantDomainView {
+  return {
+    id: row.id,
+    tenantId: row.tenant_id,
+    hostname: row.hostname,
+    normalizedHostname: row.normalized_hostname,
+    domainType: row.domain_type,
+    routeMode: row.route_mode,
+    status: row.status,
+    isPrimary: row.is_primary,
+    redirectToPrimary: row.redirect_to_primary,
+    verificationMethod: row.verification_method,
+    verificationRecordName: row.verification_record_name,
+    verificationRecordValue: row.verification_record_value,
+    verifiedAt: row.verified_at ? row.verified_at.toISOString() : null,
+    lastCheckedAt: row.last_checked_at
+      ? row.last_checked_at.toISOString()
+      : null,
+    createdAt: row.created_at.toISOString(),
+    updatedAt: row.updated_at.toISOString(),
+    createdBy: row.created_by,
+    updatedBy: row.updated_by
+  };
+}
+
+/**
+ * Throws on a constraint violation — the route layer catches this and maps
+ * `awcms_tenant_domains_normalized_hostname_dedup` to a generic 409. The unique
+ * index is global (not tenant-scoped, migration 046), so this can throw whether
+ * the conflicting row belongs to this tenant or another one — the route must
+ * not distinguish the two in its response (never reveal whether a hostname
+ * belongs to another tenant).
+ */
+export async function createTenantDomain(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: CreateTenantDomainInput
+): Promise<TenantDomainView> {
+  const rows = (await tx`
+    INSERT INTO awcms_tenant_domains
+      (tenant_id, hostname, normalized_hostname, domain_type, route_mode,
+       verification_method, verification_record_name, verification_record_value,
+       redirect_to_primary, created_by, updated_by)
+    VALUES (
+      ${tenantId}, ${input.hostname}, ${input.normalizedHostname}, ${input.domainType},
+      ${input.routeMode}, ${input.verificationMethod}, ${input.verificationRecordName},
+      ${input.verificationRecordValue}, ${input.redirectToPrimary},
+      ${actorTenantUserId}, ${actorTenantUserId}
+    )
+    RETURNING id, tenant_id, hostname, normalized_hostname, domain_type, route_mode, status,
+      is_primary, redirect_to_primary, verification_method, verification_record_name,
+      verification_record_value, verified_at, last_checked_at, created_at, updated_at,
+      created_by, updated_by
+  `) as TenantDomainRow[];
+
+  return toView(rows[0]!);
+}
+
+/** Only non-deleted rows are readable — matches the base soft-delete convention. Tenant isolation is enforced twice, defense in depth: the explicit `tenant_id` filter here, and RLS `FORCE`d on the table (migration 046). */
+export async function fetchActiveTenantDomain(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<TenantDomainView | null> {
+  const rows = (await tx`
+    SELECT id, tenant_id, hostname, normalized_hostname, domain_type, route_mode, status,
+      is_primary, redirect_to_primary, verification_method, verification_record_name,
+      verification_record_value, verified_at, last_checked_at, created_at, updated_at,
+      created_by, updated_by
+    FROM awcms_tenant_domains
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as TenantDomainRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * Keyset pagination (`(created_at, id) DESC`), bounded page size, opaque
+ * cursor, no `OFFSET`. The cursor is generated HERE (not in the route) so the
+ * full microsecond precision of `created_at` survives — a route that rebuilt
+ * the cursor from the response DTO's `createdAt` (a JS `Date`/ISO-ms string)
+ * would floor the microseconds and silently skip every row sharing that
+ * millisecond across the page boundary (Issue #158). `created_at_cursor`
+ * carries the full-precision text and never leaves this function.
+ */
+export async function listTenantDomains(
+  tx: Bun.SQL,
+  tenantId: string,
+  cursor?: KeysetCursor
+): Promise<TenantDomainListPage> {
+  const cursorCreatedAt = cursor?.createdAt ?? null;
+  const cursorId = cursor?.id ?? null;
+
+  const rows = (await tx`
+    SELECT id, tenant_id, hostname, normalized_hostname, domain_type, route_mode, status,
+      is_primary, redirect_to_primary, verification_method, verification_record_name,
+      verification_record_value, verified_at, last_checked_at, created_at, updated_at,
+      to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor,
+      created_by, updated_by
+    FROM awcms_tenant_domains
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (
+        ${cursorCreatedAt}::timestamptz IS NULL
+        OR (created_at, id) < (${cursorCreatedAt}, ${cursorId})
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${TENANT_DOMAIN_LIST_LIMIT}
+  `) as TenantDomainListRow[];
+
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === TENANT_DOMAIN_LIST_LIMIT && last
+      ? encodeKeysetCursor(last.created_at_cursor, last.id)
+      : null;
+
+  return { domains: rows.map(toView), nextCursor };
+}
+
+/**
+ * Partial update. `hostname`/`normalized_hostname` are intentionally immutable
+ * here (no field for either in `UpdateTenantDomainInput`) — a domain's identity
+ * should not silently change under an existing mapping; re-pointing a hostname
+ * to a different tenant means deleting the mapping and creating a new one.
+ * `is_primary` is also never settable here — the only path to becoming primary
+ * is the atomic `setPrimaryTenantDomain` below. `status` can only reach
+ * non-`active` values here — see `UpdateTenantDomainInput`'s own docblock.
+ */
+export async function updateTenantDomain(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  input: UpdateTenantDomainInput
+): Promise<TenantDomainView | null> {
+  const rows = (await tx`
+    UPDATE awcms_tenant_domains
+    SET domain_type = COALESCE(${input.domainType ?? null}, domain_type),
+        route_mode = COALESCE(${input.routeMode ?? null}, route_mode),
+        status = COALESCE(${input.status ?? null}, status),
+        redirect_to_primary = COALESCE(${input.redirectToPrimary ?? null}, redirect_to_primary),
+        verification_method = CASE
+          WHEN ${input.verificationMethod === undefined} THEN verification_method
+          ELSE ${input.verificationMethod ?? null}
+        END,
+        verification_record_name = CASE
+          WHEN ${input.verificationRecordName === undefined} THEN verification_record_name
+          ELSE ${input.verificationRecordName ?? null}
+        END,
+        verification_record_value = CASE
+          WHEN ${input.verificationRecordValue === undefined} THEN verification_record_value
+          ELSE ${input.verificationRecordValue ?? null}
+        END,
+        updated_by = ${actorTenantUserId},
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, hostname, normalized_hostname, domain_type, route_mode, status,
+      is_primary, redirect_to_primary, verification_method, verification_record_name,
+      verification_record_value, verified_at, last_checked_at, created_at, updated_at,
+      created_by, updated_by
+  `) as TenantDomainRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/**
+ * Soft delete only (never hard-delete). Also clears `is_primary` so a
+ * soft-deleted row never lingers as a tenant's "primary" (the partial unique
+ * index already excludes `deleted_at IS NOT NULL` rows from the
+ * one-primary-per-tenant constraint, so this is a cleanliness choice, not a
+ * constraint requirement).
+ */
+export async function softDeleteTenantDomain(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string,
+  reason: string
+): Promise<boolean> {
+  const rows = await tx`
+    UPDATE awcms_tenant_domains
+    SET deleted_at = now(), deleted_by = ${actorTenantUserId}, delete_reason = ${reason},
+        is_primary = false, updated_by = ${actorTenantUserId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id
+  `;
+
+  return rows.length > 0;
+}
+
+export type VerifyTenantDomainResult =
+  | { outcome: "verified"; entry: TenantDomainView }
+  | { outcome: "not_found" }
+  | { outcome: "missing_verification_method" }
+  | { outcome: "not_verifiable"; currentStatus: string };
+
+/**
+ * Manual-first verify (no outbound DNS/HTTP call): flips `status` to `active`
+ * based purely on fields already on the row. A domain with no
+ * `verification_method` configured cannot be verified (nothing to attest).
+ * `active` is idempotent — calling verify again just returns the current row,
+ * not an error, since the end state is identical (also what makes a same-key
+ * idempotency replay and a genuine second call with a fresh key behave the same
+ * way). `suspended` is the one non-`active` status this refuses to transition
+ * out of via verify — that state is an explicit operator/tenant pause, not
+ * something a "yes, DNS is fine" attestation should silently override.
+ */
+export async function verifyTenantDomain(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string
+): Promise<VerifyTenantDomainResult> {
+  const existingRows = (await tx`
+    SELECT status, verification_method
+    FROM awcms_tenant_domains
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as { status: string; verification_method: string | null }[];
+
+  const existing = existingRows[0];
+
+  if (!existing) {
+    return { outcome: "not_found" };
+  }
+
+  if (!existing.verification_method) {
+    return { outcome: "missing_verification_method" };
+  }
+
+  if (existing.status === "active") {
+    const rows = (await tx`
+      SELECT id, tenant_id, hostname, normalized_hostname, domain_type, route_mode, status,
+        is_primary, redirect_to_primary, verification_method, verification_record_name,
+        verification_record_value, verified_at, last_checked_at, created_at, updated_at,
+        created_by, updated_by
+      FROM awcms_tenant_domains
+      WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    `) as TenantDomainRow[];
+
+    return { outcome: "verified", entry: toView(rows[0]!) };
+  }
+
+  if (
+    existing.status !== "pending_verification" &&
+    existing.status !== "failed"
+  ) {
+    return { outcome: "not_verifiable", currentStatus: existing.status };
+  }
+
+  const rows = (await tx`
+    UPDATE awcms_tenant_domains
+    SET status = 'active', verified_at = now(), last_checked_at = now(),
+        updated_by = ${actorTenantUserId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, hostname, normalized_hostname, domain_type, route_mode, status,
+      is_primary, redirect_to_primary, verification_method, verification_record_name,
+      verification_record_value, verified_at, last_checked_at, created_at, updated_at,
+      created_by, updated_by
+  `) as TenantDomainRow[];
+
+  return { outcome: "verified", entry: toView(rows[0]!) };
+}
+
+export type SetPrimaryTenantDomainResult =
+  | { outcome: "set"; entry: TenantDomainView }
+  | { outcome: "not_found" }
+  | { outcome: "not_active"; currentStatus: string }
+  | { outcome: "conflict" };
+
+/**
+ * Atomically makes `id` this tenant's primary domain, unsetting any previous
+ * primary. "Atomic" here means: the caller already runs this inside
+ * `withTenant`'s single `sql.begin(...)` transaction, and this function
+ * performs both UPDATEs against that same `tx` in a fixed order — unset the old
+ * primary (if any) FIRST, set the new primary SECOND — so the partial unique
+ * index (`awcms_tenant_domains_primary_dedup`, `tenant_id WHERE is_primary AND
+ * deleted_at IS NULL`, migration 046) is never violated mid-transaction for a
+ * *sequential* swap. Only an `active` (i.e. verified) domain can become primary.
+ *
+ * Race case this does NOT prevent structurally: a tenant with **no** existing
+ * primary yet, hit by two concurrent `set-primary` calls for two different
+ * domains. Both transactions' "unset old primary" UPDATE matches zero rows, so
+ * neither blocks the other, and both proceed to the "set new primary" UPDATE —
+ * one loses to the unique index at commit time. That's caught here and mapped
+ * to `{ outcome: "conflict" }` (route maps it to a generic 409) instead of
+ * letting the raw constraint-violation error surface.
+ */
+export async function setPrimaryTenantDomain(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string
+): Promise<SetPrimaryTenantDomainResult> {
+  const existingRows = (await tx`
+    SELECT status
+    FROM awcms_tenant_domains
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+  `) as { status: string }[];
+
+  const existing = existingRows[0];
+
+  if (!existing) {
+    return { outcome: "not_found" };
+  }
+
+  if (existing.status !== "active") {
+    return { outcome: "not_active", currentStatus: existing.status };
+  }
+
+  await tx`
+    UPDATE awcms_tenant_domains
+    SET is_primary = false, updated_by = ${actorTenantUserId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND is_primary = true AND deleted_at IS NULL AND id <> ${id}
+  `;
+
+  let rows: TenantDomainRow[];
+
+  try {
+    rows = (await tx`
+      UPDATE awcms_tenant_domains
+      SET is_primary = true, updated_by = ${actorTenantUserId}, updated_at = now()
+      WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+      RETURNING id, tenant_id, hostname, normalized_hostname, domain_type, route_mode, status,
+        is_primary, redirect_to_primary, verification_method, verification_record_name,
+        verification_record_value, verified_at, last_checked_at, created_at, updated_at,
+        created_by, updated_by
+    `) as TenantDomainRow[];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+
+    if (message.includes("awcms_tenant_domains_primary_dedup")) {
+      return { outcome: "conflict" };
+    }
+
+    throw error;
+  }
+
+  return { outcome: "set", entry: toView(rows[0]!) };
+}

--- a/src/modules/tenant-domain/domain/tenant-domain-dns-config.ts
+++ b/src/modules/tenant-domain/domain/tenant-domain-dns-config.ts
@@ -1,0 +1,69 @@
+/**
+ * Tenant domain DNS provider configuration. Pure — no `process.env` reads
+ * here; the Cloudflare adapter's resolver
+ * (`../infrastructure/cloudflare-dns-adapter.ts`) passes in whatever `env` it
+ * was given, the same split every other provider-selecting module uses.
+ *
+ * `"manual"` (default, MVP) means the operator publishes DNS records
+ * themselves and verifies via `POST /api/v1/tenant/domains/{id}/verify`
+ * exactly as today — this module makes zero outbound DNS/HTTP calls in that
+ * mode, and none of the vars below are required. `"cloudflare"` is the one
+ * optional adapter that can create/check DNS records for platform-managed
+ * subdomains on a Cloudflare-managed zone. Choosing `cloudflare` never becomes
+ * a hard dependency — manual DNS setup must keep working whether this var is
+ * left unset or explicitly set to `"manual"`, and awcms must build and run
+ * without any Cloudflare credentials.
+ */
+export const KNOWN_TENANT_DOMAIN_DNS_PROVIDERS = [
+  "manual",
+  "cloudflare"
+] as const;
+
+export type TenantDomainDnsProviderKind =
+  (typeof KNOWN_TENANT_DOMAIN_DNS_PROVIDERS)[number];
+
+export function isKnownTenantDomainDnsProvider(
+  value: string | undefined
+): value is TenantDomainDnsProviderKind {
+  return (KNOWN_TENANT_DOMAIN_DNS_PROVIDERS as readonly string[]).includes(
+    value ?? ""
+  );
+}
+
+/**
+ * Env var names required only when `TENANT_DOMAIN_DNS_PROVIDER=cloudflare`.
+ *
+ * `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` is deliberately a *separate* variable
+ * from any public-routing root-domain var, even though the two will often hold
+ * the same value operationally: a public host resolver's root domain gates
+ * which subdomains are trusted to resolve a tenant; this one scopes which
+ * hostnames the Cloudflare adapter is allowed to create/query DNS records for
+ * (defense in depth — see `validateDnsRecordInput` in the adapter file, and
+ * note that this also reflects a real Cloudflare API constraint: a zone/token
+ * can only manage records within its own zone). Conflating the two would let a
+ * change meant for one concern silently change the other.
+ */
+export const TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED = [
+  "TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN",
+  "TENANT_DOMAIN_CLOUDFLARE_ZONE_ID",
+  "TENANT_DOMAIN_CLOUDFLARE_API_TOKEN"
+] as const;
+
+/**
+ * Default per-call timeout for the Cloudflare adapter's `withTimeout`-bounded
+ * network calls. Optional — `TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS` is *not* in
+ * `TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED` above; an unset or invalid
+ * value always falls back to this default ("never fail boot over an optional
+ * tuning knob").
+ */
+export const DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS = 8_000;
+
+export function resolveTenantDomainCloudflareTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const raw = Number(env.TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS);
+
+  return Number.isFinite(raw) && raw > 0
+    ? raw
+    : DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS;
+}

--- a/src/modules/tenant-domain/domain/tenant-domain-validation.ts
+++ b/src/modules/tenant-domain/domain/tenant-domain-validation.ts
@@ -1,0 +1,407 @@
+/**
+ * Pure validation for the tenant domain management API. No I/O here.
+ *
+ * Hostname validation deliberately does **not** invent a second hostname-shape
+ * opinion: it reuses `lib/tenant/public-host-tenant-resolver.ts`'s
+ * `normalizePublicHost()` — the exact same lowercase/trim/RFC-1035-shape check
+ * the public host resolver applies to an inbound `Host` header — so a hostname
+ * this API accepts is guaranteed to be a hostname the resolver could later
+ * match against. A raw hostname containing a port (`example.com:8443`) is
+ * rejected outright, *before* calling `normalizePublicHost` (which would
+ * silently strip the port for Host-header parsing) — a domain/subdomain mapping
+ * is a DNS name, never a `Host` header with a port suffix, and silently
+ * stripping one here would desync the stored `hostname` column from
+ * `normalized_hostname` (the migration 046 CHECK constraint requires
+ * `normalized_hostname = lower(btrim(hostname))` exactly).
+ */
+import { normalizePublicHost } from "../../../lib/tenant/public-host-tenant-resolver";
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+type Result<T> =
+  { valid: true; value: T } | { valid: false; errors: ValidationError[] };
+
+export type TenantDomainType = "subdomain" | "custom_domain";
+export type TenantDomainRouteMode = "canonical" | "legacy_blog";
+export type TenantDomainVerificationMethod =
+  "dns_txt" | "dns_cname" | "file" | "manual";
+/**
+ * PATCH-only status vocabulary — deliberately excludes `active`. A domain can
+ * only ever reach `active` through `POST .../verify` (DNS verification stays
+ * manual-first, but is still a distinct, audited, idempotent action — not a
+ * side effect of a generic field update).
+ */
+export type UpdatableTenantDomainStatus =
+  "pending_verification" | "suspended" | "failed";
+
+// Exported (admin UI): the create/edit forms build their `<select>` option
+// lists from these same arrays rather than re-declaring a second opinion of the
+// enum vocabulary — a value the UI can select is guaranteed to be a value this
+// validator accepts.
+export const TENANT_DOMAIN_TYPES: readonly TenantDomainType[] = [
+  "subdomain",
+  "custom_domain"
+];
+export const TENANT_DOMAIN_ROUTE_MODES: readonly TenantDomainRouteMode[] = [
+  "canonical",
+  "legacy_blog"
+];
+export const TENANT_DOMAIN_VERIFICATION_METHODS: readonly TenantDomainVerificationMethod[] =
+  ["dns_txt", "dns_cname", "file", "manual"];
+export const TENANT_DOMAIN_UPDATABLE_STATUSES: readonly UpdatableTenantDomainStatus[] =
+  ["pending_verification", "suspended", "failed"];
+
+const DOMAIN_TYPES = TENANT_DOMAIN_TYPES;
+const ROUTE_MODES = TENANT_DOMAIN_ROUTE_MODES;
+const VERIFICATION_METHODS = TENANT_DOMAIN_VERIFICATION_METHODS;
+const UPDATABLE_STATUSES = TENANT_DOMAIN_UPDATABLE_STATUSES;
+
+// DNS TXT record values can legitimately run long (concatenated multi-string
+// records); this is a generous defense-in-depth cap, not a DNS-protocol-
+// accurate limit — the field is never parsed/executed, only stored and echoed
+// back.
+const MAX_RECORD_LENGTH = 2000;
+
+export type CreateTenantDomainInput = {
+  hostname: string;
+  normalizedHostname: string;
+  domainType: TenantDomainType;
+  routeMode: TenantDomainRouteMode;
+  verificationMethod: TenantDomainVerificationMethod | null;
+  verificationRecordName: string | null;
+  verificationRecordValue: string | null;
+  redirectToPrimary: boolean;
+};
+
+export type UpdateTenantDomainInput = {
+  domainType?: TenantDomainType;
+  routeMode?: TenantDomainRouteMode;
+  status?: UpdatableTenantDomainStatus;
+  verificationMethod?: TenantDomainVerificationMethod | null;
+  verificationRecordName?: string | null;
+  verificationRecordValue?: string | null;
+  redirectToPrimary?: boolean;
+};
+
+function validateHostname(
+  record: Record<string, unknown>,
+  errors: ValidationError[]
+): { hostname: string; normalizedHostname: string } | undefined {
+  const raw = record.hostname;
+
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    errors.push({ field: "hostname", message: "hostname is required." });
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+
+  if (trimmed.includes(":")) {
+    errors.push({
+      field: "hostname",
+      message: "hostname must not include a port."
+    });
+    return undefined;
+  }
+
+  let normalized: string | null;
+
+  try {
+    normalized = normalizePublicHost(trimmed);
+  } catch {
+    // normalizePublicHost() only throws for an empty string, already ruled out
+    // above — unreachable in practice, kept as a safety net so this function
+    // never throws out of a request-validation path.
+    errors.push({
+      field: "hostname",
+      message: "hostname must be a valid DNS hostname."
+    });
+    return undefined;
+  }
+
+  if (!normalized) {
+    errors.push({
+      field: "hostname",
+      message:
+        "hostname must be a valid DNS hostname (RFC 1035 shape, no IPv6 literal)."
+    });
+    return undefined;
+  }
+
+  return { hostname: trimmed, normalizedHostname: normalized };
+}
+
+function validateRecordString(
+  field: string,
+  value: unknown,
+  errors: ValidationError[]
+): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    value.length > MAX_RECORD_LENGTH
+  ) {
+    errors.push({
+      field,
+      message: `${field} must be a non-empty string up to ${MAX_RECORD_LENGTH} characters, or null.`
+    });
+    return null;
+  }
+
+  return value.trim();
+}
+
+/** Tri-state helper for PATCH: field omitted -> leave unchanged; `null` -> clear; string -> validate + set. */
+function validateUpdateRecordString(
+  field: string,
+  value: unknown,
+  errors: ValidationError[]
+): { present: boolean; value: string | null } {
+  if (value === undefined) {
+    return { present: false, value: null };
+  }
+
+  if (value === null) {
+    return { present: true, value: null };
+  }
+
+  if (
+    typeof value !== "string" ||
+    value.trim().length === 0 ||
+    value.length > MAX_RECORD_LENGTH
+  ) {
+    errors.push({
+      field,
+      message: `${field} must be a non-empty string up to ${MAX_RECORD_LENGTH} characters, or null.`
+    });
+    return { present: false, value: null };
+  }
+
+  return { present: true, value: value.trim() };
+}
+
+export function validateCreateTenantDomainInput(
+  body: unknown
+): Result<CreateTenantDomainInput> {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+
+  const hostnameResult = validateHostname(record, errors);
+
+  let domainType: TenantDomainType = "custom_domain";
+  if (record.domainType !== undefined) {
+    if (
+      typeof record.domainType !== "string" ||
+      !DOMAIN_TYPES.includes(record.domainType as TenantDomainType)
+    ) {
+      errors.push({
+        field: "domainType",
+        message: `domainType must be one of ${DOMAIN_TYPES.join(", ")}.`
+      });
+    } else {
+      domainType = record.domainType as TenantDomainType;
+    }
+  }
+
+  let routeMode: TenantDomainRouteMode = "canonical";
+  if (record.routeMode !== undefined) {
+    if (
+      typeof record.routeMode !== "string" ||
+      !ROUTE_MODES.includes(record.routeMode as TenantDomainRouteMode)
+    ) {
+      errors.push({
+        field: "routeMode",
+        message: `routeMode must be one of ${ROUTE_MODES.join(", ")}.`
+      });
+    } else {
+      routeMode = record.routeMode as TenantDomainRouteMode;
+    }
+  }
+
+  let verificationMethod: TenantDomainVerificationMethod | null = null;
+  if (
+    record.verificationMethod !== undefined &&
+    record.verificationMethod !== null
+  ) {
+    if (
+      typeof record.verificationMethod !== "string" ||
+      !VERIFICATION_METHODS.includes(
+        record.verificationMethod as TenantDomainVerificationMethod
+      )
+    ) {
+      errors.push({
+        field: "verificationMethod",
+        message: `verificationMethod must be one of ${VERIFICATION_METHODS.join(", ")}, or null.`
+      });
+    } else {
+      verificationMethod =
+        record.verificationMethod as TenantDomainVerificationMethod;
+    }
+  }
+
+  const verificationRecordName = validateRecordString(
+    "verificationRecordName",
+    record.verificationRecordName,
+    errors
+  );
+  const verificationRecordValue = validateRecordString(
+    "verificationRecordValue",
+    record.verificationRecordValue,
+    errors
+  );
+
+  let redirectToPrimary = false;
+  if (record.redirectToPrimary !== undefined) {
+    if (typeof record.redirectToPrimary !== "boolean") {
+      errors.push({
+        field: "redirectToPrimary",
+        message: "redirectToPrimary must be a boolean."
+      });
+    } else {
+      redirectToPrimary = record.redirectToPrimary;
+    }
+  }
+
+  if (errors.length > 0 || !hostnameResult) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      hostname: hostnameResult.hostname,
+      normalizedHostname: hostnameResult.normalizedHostname,
+      domainType,
+      routeMode,
+      verificationMethod,
+      verificationRecordName,
+      verificationRecordValue,
+      redirectToPrimary
+    }
+  };
+}
+
+export function validateUpdateTenantDomainInput(
+  body: unknown
+): Result<UpdateTenantDomainInput> {
+  const errors: ValidationError[] = [];
+  const record = (body ?? {}) as Record<string, unknown>;
+  const value: UpdateTenantDomainInput = {};
+
+  if (record.domainType !== undefined) {
+    if (
+      typeof record.domainType !== "string" ||
+      !DOMAIN_TYPES.includes(record.domainType as TenantDomainType)
+    ) {
+      errors.push({
+        field: "domainType",
+        message: `domainType must be one of ${DOMAIN_TYPES.join(", ")}.`
+      });
+    } else {
+      value.domainType = record.domainType as TenantDomainType;
+    }
+  }
+
+  if (record.routeMode !== undefined) {
+    if (
+      typeof record.routeMode !== "string" ||
+      !ROUTE_MODES.includes(record.routeMode as TenantDomainRouteMode)
+    ) {
+      errors.push({
+        field: "routeMode",
+        message: `routeMode must be one of ${ROUTE_MODES.join(", ")}.`
+      });
+    } else {
+      value.routeMode = record.routeMode as TenantDomainRouteMode;
+    }
+  }
+
+  if (record.status !== undefined) {
+    if (record.status === "active") {
+      errors.push({
+        field: "status",
+        message:
+          'status cannot be set to "active" directly — use POST /api/v1/tenant/domains/{id}/verify to activate a domain.'
+      });
+    } else if (
+      typeof record.status !== "string" ||
+      !UPDATABLE_STATUSES.includes(record.status as UpdatableTenantDomainStatus)
+    ) {
+      errors.push({
+        field: "status",
+        message: `status must be one of ${UPDATABLE_STATUSES.join(", ")} (use POST .../verify to reach "active").`
+      });
+    } else {
+      value.status = record.status as UpdatableTenantDomainStatus;
+    }
+  }
+
+  if (record.verificationMethod !== undefined) {
+    if (record.verificationMethod === null) {
+      value.verificationMethod = null;
+    } else if (
+      typeof record.verificationMethod !== "string" ||
+      !VERIFICATION_METHODS.includes(
+        record.verificationMethod as TenantDomainVerificationMethod
+      )
+    ) {
+      errors.push({
+        field: "verificationMethod",
+        message: `verificationMethod must be one of ${VERIFICATION_METHODS.join(", ")}, or null.`
+      });
+    } else {
+      value.verificationMethod =
+        record.verificationMethod as TenantDomainVerificationMethod;
+    }
+  }
+
+  const verificationRecordName = validateUpdateRecordString(
+    "verificationRecordName",
+    record.verificationRecordName,
+    errors
+  );
+  if (verificationRecordName.present) {
+    value.verificationRecordName = verificationRecordName.value;
+  }
+
+  const verificationRecordValue = validateUpdateRecordString(
+    "verificationRecordValue",
+    record.verificationRecordValue,
+    errors
+  );
+  if (verificationRecordValue.present) {
+    value.verificationRecordValue = verificationRecordValue.value;
+  }
+
+  if (record.redirectToPrimary !== undefined) {
+    if (typeof record.redirectToPrimary !== "boolean") {
+      errors.push({
+        field: "redirectToPrimary",
+        message: "redirectToPrimary must be a boolean."
+      });
+    } else {
+      value.redirectToPrimary = record.redirectToPrimary;
+    }
+  }
+
+  if (errors.length === 0 && Object.keys(value).length === 0) {
+    errors.push({
+      field: "body",
+      message:
+        "Provide at least one of domainType, routeMode, status, verificationMethod, verificationRecordName, verificationRecordValue, redirectToPrimary."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return { valid: true, value };
+}

--- a/src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts
+++ b/src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts
@@ -1,0 +1,539 @@
+/**
+ * Optional Cloudflare DNS adapter. Manual domain management (`POST
+ * /api/v1/tenant/domains/{id}/verify`) remains the MVP default — this adapter
+ * is never called unless an operator explicitly sets
+ * `TENANT_DOMAIN_DNS_PROVIDER=cloudflare` (see
+ * `../domain/tenant-domain-dns-config.ts`). **No route in this repo calls it
+ * yet** — wiring it into `.../verify` or a "provision platform subdomain" flow
+ * is deferred (see the module README's §Not yet available); this file exists so
+ * that future work can depend on the `TenantDomainDnsProvider` port without
+ * inventing the provider boundary, config split, or redaction/timeout/
+ * idempotency behavior at that point. awcms builds and runs with no Cloudflare
+ * credentials configured — `resolveTenantDomainDnsProvider` degrades to a clean
+ * misconfigured-result provider rather than throwing.
+ *
+ * Capabilities: create a TXT/CNAME DNS verification record, and check whether a
+ * DNS record has propagated to the value expected. Both calls are
+ * timeout-bounded (`withTimeout`) and gated by a shared circuit breaker
+ * (`getProviderCircuitBreaker("tenant-domain-cloudflare-dns")`) — the same
+ * pattern the email/sync-storage outbound provider calls already use. Both
+ * methods are meant to be invoked OUTSIDE any DB transaction (ADR-0006) — this
+ * file never opens, or participates in, one.
+ *
+ * Security notes (binding):
+ * - `apiToken`/`zoneId` are read only from configuration
+ *   (`resolveTenantDomainDnsProvider(env)` below) — never persisted to
+ *   `awcms_tenant_domains`, never rendered in any response.
+ *   `verification_record_value` (migration 046) is the *public* DNS value a
+ *   tenant is told to publish, never this token.
+ * - Errors returned to callers are redacted: never the raw Cloudflare API
+ *   response `errors[].message` text (only the numeric `errors[].code` values
+ *   are surfaced — safe, non-identifying), never the configured token or zone
+ *   id, never a stack trace. `redact()` additionally strips the configured
+ *   secrets out of any thrown-error text as defense in depth.
+ * - `createVerificationRecord`/`checkVerificationStatus` reject any `recordName`
+ *   that is not `TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN` itself or a subdomain of it
+ *   (`isWithinPlatformRootDomain`) — this adapter refuses to create or query DNS
+ *   records for an arbitrary caller-supplied hostname outside the platform's own
+ *   managed zone. Record-name shape validation is a dedicated check, not a reuse
+ *   of `normalizePublicHost()` — DNS verification record names conventionally
+ *   use an underscore-prefixed label (e.g. `_acme-challenge.example.com`) that a
+ *   `Host`-header shape check rightly rejects but every DNS verification flow
+ *   needs to allow; see `isValidDnsRecordNameShape` below. `normalizePublicHost()`
+ *   is still reused for the CNAME *target value* (a real "points-to" hostname).
+ * - `createVerificationRecord` is idempotent: it first lists existing records
+ *   with the same type/name/content and returns `{ ok: true, alreadyExists:
+ *   true }` without a second write if a match is already present.
+ */
+import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
+import { withTimeout } from "../../../lib/integration/timeout";
+import { normalizePublicHost } from "../../../lib/tenant/public-host-tenant-resolver";
+import {
+  DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS,
+  isKnownTenantDomainDnsProvider,
+  resolveTenantDomainCloudflareTimeoutMs,
+  TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED
+} from "../domain/tenant-domain-dns-config";
+
+const PROVIDER_KEY = "tenant-domain-cloudflare-dns";
+const DEFAULT_TIMEOUT_MS = DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS;
+const MAX_ERROR_MESSAGE_LENGTH = 300;
+const DEFAULT_API_BASE_URL = "https://api.cloudflare.com/client/v4";
+const MAX_TXT_VALUE_LENGTH = 2048; // Cloudflare TXT record content limit.
+
+export type DnsRecordType = "TXT" | "CNAME";
+
+export type CreateVerificationRecordInput = {
+  recordType: DnsRecordType;
+  /** Fully-qualified DNS name, e.g. "_awcms-verify.tenant1.platform.example". Must equal or be a subdomain of the configured platform root domain. */
+  recordName: string;
+  /** TXT record content, or the CNAME target hostname. */
+  recordValue: string;
+};
+
+export type CreateVerificationRecordResult =
+  | { ok: true; providerRecordId?: string; alreadyExists: boolean }
+  | { ok: false; error: string; retryable: boolean };
+
+export type CheckVerificationStatusInput = {
+  recordType: DnsRecordType;
+  recordName: string;
+  expectedValue: string;
+};
+
+export type CheckVerificationStatusResult =
+  | { ok: true; verified: boolean }
+  | { ok: false; error: string; retryable: boolean };
+
+/**
+ * The port. A future issue that wires this into `.../verify` or a
+ * subdomain-provisioning endpoint should depend on this type, never on
+ * `createCloudflareDnsProvider` by name.
+ */
+export type TenantDomainDnsProvider = {
+  createVerificationRecord(
+    input: CreateVerificationRecordInput
+  ): Promise<CreateVerificationRecordResult>;
+  checkVerificationStatus(
+    input: CheckVerificationStatusInput
+  ): Promise<CheckVerificationStatusResult>;
+};
+
+export type CloudflareDnsProviderConfig = {
+  zoneId: string;
+  apiToken: string;
+  platformRootDomain: string;
+  /** Override for tests/dev only — a local fake HTTP server standing in for the Cloudflare API. Always supplied from configuration, never from request/user input (SSRF-safe). */
+  baseUrl?: string;
+  /** Defaults to `DEFAULT_TIMEOUT_MS` (8s) if omitted. `resolveTenantDomainDnsProvider` below always passes `resolveTenantDomainCloudflareTimeoutMs(env)` here, so production deployments tune this via `TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS`, not by editing code. */
+  timeoutMs?: number;
+};
+
+type CloudflareApiError = { code: number; message: string };
+
+type CloudflareApiResponse<T> = {
+  success: boolean;
+  errors?: CloudflareApiError[];
+  result?: T;
+};
+
+type CloudflareDnsRecord = {
+  id: string;
+  type: string;
+  name: string;
+  content: string;
+};
+
+function truncate(message: string): string {
+  return message.length > MAX_ERROR_MESSAGE_LENGTH
+    ? `${message.slice(0, MAX_ERROR_MESSAGE_LENGTH)}…`
+    : message;
+}
+
+/**
+ * Strips the configured secret/identifier values out of `message` before it is
+ * ever returned to a caller or logged — defense in depth against a thrown error
+ * accidentally echoing part of the request (e.g. a `fetch()` network-error
+ * message that includes the target URL, which embeds the zone id).
+ */
+function redact(message: string, secrets: readonly string[]): string {
+  let sanitized = message;
+
+  for (const secret of secrets) {
+    if (secret) {
+      sanitized = sanitized.split(secret).join("[redacted]");
+    }
+  }
+
+  return sanitized;
+}
+
+/**
+ * Only the numeric Cloudflare `errors[].code` values are surfaced — never
+ * `.message`, which can echo request content this adapter does not fully
+ * control.
+ */
+function summarizeApiErrors(errors: CloudflareApiError[] | undefined): string {
+  if (!errors || errors.length === 0) {
+    return "no error detail provided";
+  }
+
+  return `error code(s) ${errors.map((error) => error.code).join(", ")}`;
+}
+
+const MAX_RECORD_NAME_LENGTH = 253; // RFC 1035 total hostname length limit.
+const MAX_RECORD_NAME_LABEL_LENGTH = 63; // RFC 1035 per-label length limit.
+// Deliberately more permissive than `normalizePublicHost()`'s
+// `HOST_LABEL_PATTERN`: DNS verification record names conventionally use an
+// underscore-prefixed label (e.g. "_acme-challenge.example.com",
+// "_dmarc.example.com") that RFC 1035 technically disallows but every major DNS
+// verification flow uses and every public resolver accepts (RFC 2181 §11
+// relaxes the restriction). A `Host` header, by contrast, is never legitimately
+// underscore-prefixed — which is why this file does not reuse
+// `normalizePublicHost()` for `recordName` shape, only for the CNAME *target
+// value* below (a real "points-to" hostname, not a record label).
+const RECORD_NAME_LABEL_PATTERN = /^[a-z0-9_]([a-z0-9_-]{0,61}[a-z0-9_])?$/;
+
+function isValidDnsRecordNameShape(value: string): boolean {
+  const trimmed = value.trim().toLowerCase();
+
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > MAX_RECORD_NAME_LENGTH ||
+    trimmed.startsWith(".") ||
+    trimmed.endsWith(".") ||
+    trimmed.includes("..") ||
+    /\s/.test(trimmed)
+  ) {
+    return false;
+  }
+
+  return trimmed
+    .split(".")
+    .every(
+      (label) =>
+        label.length > 0 &&
+        label.length <= MAX_RECORD_NAME_LABEL_LENGTH &&
+        RECORD_NAME_LABEL_PATTERN.test(label)
+    );
+}
+
+/**
+ * `recordName` must equal `platformRootDomain` or be a subdomain of it —
+ * refuses to let this adapter touch a hostname outside the platform's own
+ * managed zone, even though the configured Cloudflare zone/token may technically
+ * be able to. `platformRootDomain` comes from trusted operator configuration
+ * (`TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN`), not request input.
+ */
+function isWithinPlatformRootDomain(
+  recordName: string,
+  platformRootDomain: string
+): boolean {
+  const normalizedRoot = platformRootDomain.trim().toLowerCase();
+
+  if (
+    normalizedRoot.length === 0 ||
+    !isValidDnsRecordNameShape(normalizedRoot)
+  ) {
+    return false;
+  }
+
+  if (!isValidDnsRecordNameShape(recordName)) {
+    return false;
+  }
+
+  const normalizedName = recordName.trim().toLowerCase();
+
+  return (
+    normalizedName === normalizedRoot ||
+    normalizedName.endsWith(`.${normalizedRoot}`)
+  );
+}
+
+function isValidRecordValue(
+  recordType: DnsRecordType,
+  value: unknown
+): value is string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return false;
+  }
+
+  if (/[\r\n]/.test(value)) {
+    return false;
+  }
+
+  if (recordType === "TXT") {
+    return value.length <= MAX_TXT_VALUE_LENGTH;
+  }
+
+  // CNAME target must itself look like a plausible hostname.
+  try {
+    return normalizePublicHost(value) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates a DNS-record request before any network call is attempted — "do not
+ * allow arbitrary DNS record creation from user-controlled input without
+ * validation". Pure, exported for unit testing without a network double.
+ */
+export function validateDnsRecordInput(
+  input: { recordType: unknown; recordName: unknown; recordValue: unknown },
+  platformRootDomain: string
+): string | null {
+  if (input.recordType !== "TXT" && input.recordType !== "CNAME") {
+    return 'recordType must be "TXT" or "CNAME".';
+  }
+
+  if (
+    typeof input.recordName !== "string" ||
+    !isWithinPlatformRootDomain(input.recordName, platformRootDomain)
+  ) {
+    return "recordName must equal the platform root domain or be a subdomain of it.";
+  }
+
+  if (!isValidRecordValue(input.recordType, input.recordValue)) {
+    return "recordValue is not a valid value for the given recordType.";
+  }
+
+  return null;
+}
+
+function normalizeRecordValueForComparison(
+  recordType: DnsRecordType,
+  value: string
+): string {
+  const trimmed = value.trim();
+
+  if (recordType === "CNAME") {
+    return trimmed.replace(/\.$/, "").toLowerCase();
+  }
+
+  return trimmed;
+}
+
+export function createCloudflareDnsProvider(
+  config: CloudflareDnsProviderConfig
+): TenantDomainDnsProvider {
+  const baseUrl = config.baseUrl ?? DEFAULT_API_BASE_URL;
+  const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const breaker = getProviderCircuitBreaker(PROVIDER_KEY);
+  const secrets = [config.apiToken, config.zoneId];
+
+  async function callApi<T>(
+    path: string,
+    init: RequestInit,
+    label: string
+  ): Promise<{ status: number; body: CloudflareApiResponse<T> | undefined }> {
+    const response = await withTimeout(
+      fetch(`${baseUrl}/zones/${config.zoneId}${path}`, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${config.apiToken}`,
+          "Content-Type": "application/json",
+          ...(init.headers ?? {})
+        }
+      }),
+      timeoutMs,
+      label
+    );
+
+    const rawBody = await response.text().catch(() => "");
+    let body: CloudflareApiResponse<T> | undefined;
+
+    try {
+      body = rawBody
+        ? (JSON.parse(rawBody) as CloudflareApiResponse<T>)
+        : undefined;
+    } catch {
+      body = undefined;
+    }
+
+    return { status: response.status, body };
+  }
+
+  async function listMatchingRecords(
+    recordType: DnsRecordType,
+    recordName: string
+  ): Promise<CloudflareDnsRecord[]> {
+    const query = new URLSearchParams({ type: recordType, name: recordName });
+    const { status, body } = await callApi<CloudflareDnsRecord[]>(
+      `/dns_records?${query.toString()}`,
+      { method: "GET" },
+      "cloudflare dns list records"
+    );
+
+    if (status < 200 || status >= 300 || !body?.success) {
+      throw new Error(
+        `Cloudflare DNS API list request failed (HTTP ${status}, ${summarizeApiErrors(body?.errors)}).`
+      );
+    }
+
+    return body.result ?? [];
+  }
+
+  return {
+    async createVerificationRecord(input) {
+      const attemptedAt = new Date();
+      const validationError = validateDnsRecordInput(
+        input,
+        config.platformRootDomain
+      );
+
+      if (validationError) {
+        return { ok: false, error: validationError, retryable: false };
+      }
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "Cloudflare DNS circuit breaker is open; skipping attempt.",
+          retryable: true
+        };
+      }
+
+      try {
+        const existing = await listMatchingRecords(
+          input.recordType,
+          input.recordName
+        );
+        const match = existing.find(
+          (record) => record.content === input.recordValue
+        );
+
+        if (match) {
+          breaker.recordSuccess(attemptedAt);
+          return { ok: true, providerRecordId: match.id, alreadyExists: true };
+        }
+
+        const { status, body } = await callApi<CloudflareDnsRecord>(
+          "/dns_records",
+          {
+            method: "POST",
+            body: JSON.stringify({
+              type: input.recordType,
+              name: input.recordName,
+              content: input.recordValue,
+              ttl: 300,
+              proxied: false
+            })
+          },
+          "cloudflare dns create record"
+        );
+
+        if (status < 200 || status >= 300 || !body?.success) {
+          breaker.recordFailure(attemptedAt);
+          return {
+            ok: false,
+            error: truncate(
+              redact(
+                `Cloudflare DNS API create request failed (HTTP ${status}, ${summarizeApiErrors(body?.errors)}).`,
+                secrets
+              )
+            ),
+            retryable: status >= 500 || status === 0
+          };
+        }
+
+        breaker.recordSuccess(attemptedAt);
+        return {
+          ok: true,
+          providerRecordId: body.result?.id,
+          alreadyExists: false
+        };
+      } catch (error) {
+        breaker.recordFailure(attemptedAt);
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          ok: false,
+          error: truncate(redact(message, secrets)),
+          retryable: true
+        };
+      }
+    },
+
+    async checkVerificationStatus(input) {
+      const attemptedAt = new Date();
+      const validationError = validateDnsRecordInput(
+        { ...input, recordValue: input.expectedValue },
+        config.platformRootDomain
+      );
+
+      if (validationError) {
+        return { ok: false, error: validationError, retryable: false };
+      }
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "Cloudflare DNS circuit breaker is open; skipping attempt.",
+          retryable: true
+        };
+      }
+
+      try {
+        const records = await listMatchingRecords(
+          input.recordType,
+          input.recordName
+        );
+        const verified = records.some(
+          (record) =>
+            normalizeRecordValueForComparison(
+              input.recordType,
+              record.content
+            ) ===
+            normalizeRecordValueForComparison(
+              input.recordType,
+              input.expectedValue
+            )
+        );
+
+        breaker.recordSuccess(attemptedAt);
+        return { ok: true, verified };
+      } catch (error) {
+        breaker.recordFailure(attemptedAt);
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          ok: false,
+          error: truncate(redact(message, secrets)),
+          retryable: true
+        };
+      }
+    }
+  };
+}
+
+function createMisconfiguredProvider(reason: string): TenantDomainDnsProvider {
+  return {
+    async createVerificationRecord() {
+      return { ok: false, error: reason, retryable: false };
+    },
+    async checkVerificationStatus() {
+      return { ok: false, error: reason, retryable: false };
+    }
+  };
+}
+
+/**
+ * Production resolver: builds the configured provider from `env`, degrading to
+ * a clean misconfigured-result provider — never throwing — whenever
+ * `TENANT_DOMAIN_DNS_PROVIDER=cloudflare` is missing required config, or the var
+ * is unset/`"manual"`/unrecognized. **Not called from anywhere yet** — no route
+ * wires it in; see the module README's §Not yet available.
+ */
+export function resolveTenantDomainDnsProvider(
+  env: NodeJS.ProcessEnv = process.env
+): TenantDomainDnsProvider {
+  const provider = env.TENANT_DOMAIN_DNS_PROVIDER ?? "manual";
+
+  if (!isKnownTenantDomainDnsProvider(provider)) {
+    return createMisconfiguredProvider(
+      "TENANT_DOMAIN_DNS_PROVIDER is not a known provider."
+    );
+  }
+
+  if (provider === "manual") {
+    return createMisconfiguredProvider(
+      'TENANT_DOMAIN_DNS_PROVIDER is "manual" — no automated DNS provider is configured; use manual verification (POST /api/v1/tenant/domains/{id}/verify).'
+    );
+  }
+
+  const zoneId = env.TENANT_DOMAIN_CLOUDFLARE_ZONE_ID;
+  const apiToken = env.TENANT_DOMAIN_CLOUDFLARE_API_TOKEN;
+  const platformRootDomain = env.TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN;
+
+  if (!zoneId || !apiToken || !platformRootDomain) {
+    return createMisconfiguredProvider(
+      `Cloudflare DNS provider is not configured (requires ${TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED.join(", ")}).`
+    );
+  }
+
+  return createCloudflareDnsProvider({
+    zoneId,
+    apiToken,
+    platformRootDomain,
+    timeoutMs: resolveTenantDomainCloudflareTimeoutMs(env)
+  });
+}

--- a/src/modules/tenant-domain/module.ts
+++ b/src/modules/tenant-domain/module.ts
@@ -1,0 +1,106 @@
+import { defineModule } from "../_shared/module-contract";
+
+/**
+ * `tenant_domain` — tenant hostname/subdomain -> tenant mapping for host-based
+ * public routing, ported from awcms-micro (epic #555). Ships: the
+ * `awcms_tenant_domains` schema (migration 046), its permission catalog seed
+ * (migration 047), the SECURITY DEFINER host-lookup bootstrap function
+ * (migration 048), the authenticated tenant-scoped management API
+ * (`/api/v1/tenant/domains/**`), an admin screen (`/admin/tenant/domains`), the
+ * additive public host resolver (`lib/tenant/public-host-tenant-resolver.ts`),
+ * and the optional Cloudflare DNS adapter (`infrastructure/
+ * cloudflare-dns-adapter.ts`, not wired into any route yet).
+ *
+ * `type: "domain"` — registered per the port instruction. (awcms-micro used
+ * `type: "system"` reasoning that hostname->tenant routing is shared platform
+ * infrastructure; in this base it is registered as a `"domain"` module like the
+ * other ported website modules, following the same directly-in-base convention
+ * blog_content/news_portal use. The DB `module_type` CHECK constraint accepts
+ * base/system/domain/integration.)
+ *
+ * PORT-TIME NOTES (documented, not silent):
+ *  - The optional Cloudflare DNS adapter is included as an OPTIONAL capability
+ *    with a safe absent default: with no `TENANT_DOMAIN_DNS_PROVIDER=cloudflare`
+ *    configured, `resolveTenantDomainDnsProvider` returns a clean
+ *    misconfigured-result provider (never throws), so awcms builds and runs
+ *    with zero Cloudflare credentials. No route calls it yet.
+ *  - The host-resolved public route family (a `/news`-style tenant content
+ *    surface) is NOT wired in this port — that needs blog_content/news_portal
+ *    public render routes plumbed through the resolver, deferred exactly as
+ *    news_portal's own port deferred its `/news/**` routes. The resolver +
+ *    lookup function + directory + admin API are a complete, tested seam ready
+ *    for that future wiring; `src/middleware.ts` is intentionally untouched
+ *    (host resolution is a per-public-route concern, not a middleware one, so
+ *    the login/Turnstile/CSP guarantees are unchanged).
+ *
+ * This module never stores a DNS provider API token/credential in the database:
+ * `verification_token_hash` (migration 046) is an internal bearer-token hash,
+ * `verification_record_value` is the public DNS record value the tenant
+ * publishes (not a secret), and the Cloudflare adapter's own API token/zone id
+ * are read only from `TENANT_DOMAIN_CLOUDFLARE_*` env vars, never persisted.
+ */
+export const tenantDomainModule = defineModule({
+  key: "tenant_domain",
+  name: "Tenant Domain",
+  version: "0.1.0",
+  status: "active",
+  description:
+    "Tenant domain/subdomain mapping for host-based public routing (ported from awcms-micro epic #555). Ships the awcms_tenant_domains schema (migration 046: hostname/normalized_hostname, domain_type subdomain|custom_domain, route_mode canonical|legacy_blog, status pending_verification|active|suspended|failed, verification_method dns_txt|dns_cname|file|manual, is_primary/redirect_to_primary, tenant-scoped RLS with FORCE), its permission catalog seed (migration 047: tenant_domain.domains.{read,create,update,delete,verify,set_primary}), the SECURITY DEFINER bootstrap host-lookup function (migration 048, EXECUTE restricted to awcms_app), the authenticated tenant-scoped management API (GET/POST /api/v1/tenant/domains, GET/PATCH/DELETE .../{id}, POST .../{id}/verify, POST .../{id}/set-primary), an admin screen (/admin/tenant/domains), the additive public host resolver (lib/tenant/public-host-tenant-resolver.ts — coexists with ADR-0009 path-based /blog/{tenantCode}, never regresses it), and the OPTIONAL Cloudflare DNS adapter (infrastructure/cloudflare-dns-adapter.ts, env-gated, absent-safe, not wired into any route). PORT DEFERRALS: the host-resolved public content route family is not wired here (same deferral news_portal made for its /news/** routes); src/middleware.ts is untouched. This module never stores a DNS provider API token/credential in the database.",
+  dependencies: ["tenant_admin", "identity_access"],
+  type: "domain",
+  api: {
+    openApiPath: "openapi/modules/tenant-domain.openapi.yaml",
+    basePath: "/api/v1/tenant/domains"
+  },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_tenant_domains",
+      path: "/admin/tenant/domains",
+      order: 60,
+      requiredPermission: "tenant_domain.domains.read"
+    }
+  ],
+  permissions: [
+    {
+      activityCode: "domains",
+      action: "read",
+      description: "Read tenant domain/subdomain mappings"
+    },
+    {
+      activityCode: "domains",
+      action: "create",
+      description: "Add a tenant domain/subdomain mapping"
+    },
+    {
+      activityCode: "domains",
+      action: "update",
+      description: "Update a tenant domain/subdomain mapping"
+    },
+    {
+      activityCode: "domains",
+      action: "delete",
+      description: "Soft delete a tenant domain/subdomain mapping"
+    },
+    {
+      activityCode: "domains",
+      action: "verify",
+      description: "Verify ownership of a tenant domain/subdomain"
+    },
+    {
+      activityCode: "domains",
+      action: "set_primary",
+      description: "Set a tenant domain as the active primary domain"
+    }
+  ],
+  settings: {
+    schemaVersion: 1,
+    // Non-secret operational preference only: the default domain verification
+    // mode is manual DNS attestation, never an automatic provider. "manual"
+    // means no automated check at all is assumed until a tenant/operator
+    // explicitly picks one of the other `verification_method` values. The
+    // optional Cloudflare adapter is selected purely via the
+    // `TENANT_DOMAIN_DNS_PROVIDER` env var (not this settings object, and not
+    // wired into any route yet) — it never defaults this value away from manual.
+    defaults: { defaultVerificationMethod: "manual" }
+  }
+});

--- a/src/pages/admin/tenant/domains.astro
+++ b/src/pages/admin/tenant/domains.astro
@@ -1,0 +1,436 @@
+---
+/**
+ * Tenant domains management screen — ported/adapted from awcms-micro
+ * (epic #555). Mirrors this base's SSR-read-then-render pattern (see
+ * `admin/offices.astro`): read the tenant's domain mappings server-side by
+ * calling the SAME application function the JSON endpoint uses
+ * (`listTenantDomains`) inside `withTenant`, then render a plain accessible
+ * table + status badges.
+ *
+ * ABAC is enforced server-side by the endpoints; this page additionally gates
+ * its own render on `tenant_domain.domains.read`. Every mutation
+ * (create/update/delete/verify/set-primary) goes through `fetch` to
+ * `/api/v1/tenant/domains/**` — there is no privileged SSR mutation shortcut.
+ * `verify`/`set-primary` send a fresh `Idempotency-Key` per click. Client-side
+ * hostname validation is UX-only — `normalizePublicHost()` via the API is the
+ * single enforcement point.
+ */
+import AdminLayout from "../../../layouts/AdminLayout.astro";
+import "../../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../../lib/database/client";
+import { withTenant } from "../../../lib/database/tenant-context";
+import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import {
+  listTenantDomains,
+  type TenantDomainView
+} from "../../../modules/tenant-domain/application/tenant-domain-directory";
+import {
+  TENANT_DOMAIN_TYPES,
+  TENANT_DOMAIN_ROUTE_MODES,
+  TENANT_DOMAIN_VERIFICATION_METHODS
+} from "../../../modules/tenant-domain/domain/tenant-domain-validation";
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("tenant_domain", "domains", "read")
+);
+const canCreate = ssr.permissions.has(
+  permissionKey("tenant_domain", "domains", "create")
+);
+const canUpdate = ssr.permissions.has(
+  permissionKey("tenant_domain", "domains", "update")
+);
+const canDelete = ssr.permissions.has(
+  permissionKey("tenant_domain", "domains", "delete")
+);
+const canVerify = ssr.permissions.has(
+  permissionKey("tenant_domain", "domains", "verify")
+);
+const canSetPrimary = ssr.permissions.has(
+  permissionKey("tenant_domain", "domains", "set_primary")
+);
+
+const showActions = canUpdate || canDelete || canVerify || canSetPrimary;
+
+let domains: TenantDomainView[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      const page = await listTenantDomains(tx, ssr.tenantId);
+      return page.domains;
+    });
+    if (result instanceof Response) {
+      loadError = true;
+    } else {
+      domains = result;
+    }
+  } catch {
+    loadError = true;
+  }
+}
+
+function statusVariant(status: string): string {
+  if (status === "active") return "success";
+  if (status === "failed") return "danger";
+  if (status === "suspended") return "warning";
+  return "neutral";
+}
+---
+
+<AdminLayout title="Tenant domains" active="tenant-domains">
+  <header class="page-header fade-in-up">
+    <h1 id="tenant-domains-heading">Tenant domains</h1>
+    <p class="page-description">
+      Hostname/subdomain mappings for this tenant. Add a mapping, verify
+      ownership (manual-first), and choose one active primary. Deleting a
+      mapping frees its hostname for reuse.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="tenant-domains-denied">
+        You do not have permission to view tenant domains.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="tenant-domains-error">
+        Tenant domains could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canCreate && (
+      <form id="domain-create-form" class="admin-create-form fade-in-up">
+        <p class="form-legend">Add a domain</p>
+        <p
+          id="domain-create-error"
+          class="admin-create-error"
+          role="alert"
+          hidden
+        />
+
+        <label for="domain-hostname">Hostname</label>
+        <input
+          id="domain-hostname"
+          name="hostname"
+          type="text"
+          required
+          autocomplete="off"
+          placeholder="tenant.example.com"
+        />
+
+        <label for="domain-type">Domain type</label>
+        <select id="domain-type" name="domainType">
+          {TENANT_DOMAIN_TYPES.map((value) => (
+            <option value={value} selected={value === "custom_domain"}>
+              {value}
+            </option>
+          ))}
+        </select>
+
+        <label for="domain-route-mode">Route mode</label>
+        <select id="domain-route-mode" name="routeMode">
+          {TENANT_DOMAIN_ROUTE_MODES.map((value) => (
+            <option value={value} selected={value === "canonical"}>
+              {value}
+            </option>
+          ))}
+        </select>
+
+        <label for="domain-verification-method">Verification method</label>
+        <select id="domain-verification-method" name="verificationMethod">
+          <option value="">(none yet)</option>
+          {TENANT_DOMAIN_VERIFICATION_METHODS.map((value) => (
+            <option value={value}>{value}</option>
+          ))}
+        </select>
+
+        <button type="submit" id="domain-create-submit">
+          Add domain
+        </button>
+      </form>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <p
+        id="domain-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <div class="data-table-scroll fade-in-up">
+        <table class="data-table data-table--stack" id="tenant-domains-table">
+          <caption>{domains.length} domain(s)</caption>
+          <thead>
+            <tr>
+              <th scope="col">Hostname</th>
+              <th scope="col">Type</th>
+              <th scope="col">Route mode</th>
+              <th scope="col">Status</th>
+              <th scope="col">Primary</th>
+              {showActions && <th scope="col">Actions</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {domains.length === 0 ? (
+              <tr>
+                <td class="data-table-empty" colspan={showActions ? 6 : 5}>
+                  <div class="empty-state">
+                    <span class="empty-state-icon" aria-hidden="true">
+                      ⌂
+                    </span>
+                    <span class="empty-state-title">No domains yet</span>
+                    <span class="empty-state-text">
+                      {canCreate
+                        ? "Add your first domain mapping using the form above."
+                        : "Domain mappings for this tenant will appear here."}
+                    </span>
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              domains.map((domain) => (
+                <tr data-domain-row={domain.id}>
+                  <td data-label="Hostname">
+                    <span class="cell-code">{domain.hostname}</span>
+                  </td>
+                  <td data-label="Type">
+                    <span class="cell-muted">{domain.domainType}</span>
+                  </td>
+                  <td data-label="Route mode">
+                    <span class="cell-muted">{domain.routeMode}</span>
+                  </td>
+                  <td data-label="Status">
+                    <span
+                      class="status-badge"
+                      data-variant={statusVariant(domain.status)}
+                    >
+                      <span class="status-dot" aria-hidden="true" />
+                      {domain.status}
+                    </span>
+                  </td>
+                  <td data-label="Primary">{domain.isPrimary ? "Yes" : "—"}</td>
+                  {showActions && (
+                    <td data-label="Actions" class="stacked-block">
+                      <div class="row-actions">
+                        {canVerify &&
+                          (domain.status === "pending_verification" ||
+                            domain.status === "failed") && (
+                            <button
+                              type="button"
+                              class="module-toggle domain-verify-btn"
+                              data-domain-id={domain.id}
+                            >
+                              Verify
+                            </button>
+                          )}
+                        {canSetPrimary &&
+                          domain.status === "active" &&
+                          !domain.isPrimary && (
+                            <button
+                              type="button"
+                              class="module-toggle domain-primary-btn"
+                              data-domain-id={domain.id}
+                            >
+                              Set primary
+                            </button>
+                          )}
+                        {canDelete && (
+                          <button
+                            type="button"
+                            class="module-toggle domain-delete-btn"
+                            data-domain-id={domain.id}
+                            data-domain-host={domain.hostname}
+                          >
+                            Delete
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  )}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import forces Astro to bundle this EXTERNAL (an import-free script is
+  // inlined, and inline scripts are blocked by the middleware CSP). See
+  // admin-form-client.ts.
+  import { lockElement, sendJson } from "../../../lib/ui/admin-form-client";
+
+  const form = document.getElementById(
+    "domain-create-form"
+  ) as HTMLFormElement | null;
+  const createError = document.getElementById("domain-create-error");
+  const submitButton = document.getElementById(
+    "domain-create-submit"
+  ) as HTMLButtonElement | null;
+
+  function showCreateError(message: string): void {
+    if (!createError) return;
+    createError.textContent = message;
+    createError.hidden = false;
+  }
+
+  form?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!submitButton || submitButton.disabled) return;
+    const unlock = lockElement(submitButton, "Please wait…");
+    if (createError) createError.hidden = true;
+
+    const formData = new FormData(form);
+    const hostname = String(formData.get("hostname") ?? "").trim();
+    const domainType = String(formData.get("domainType") ?? "").trim();
+    const routeMode = String(formData.get("routeMode") ?? "").trim();
+    const verificationMethodRaw = String(
+      formData.get("verificationMethod") ?? ""
+    ).trim();
+
+    const payload: Record<string, unknown> = {
+      hostname,
+      domainType,
+      routeMode
+    };
+    if (verificationMethodRaw) {
+      payload.verificationMethod = verificationMethodRaw;
+    }
+
+    const result = await sendJson("POST", "/api/v1/tenant/domains", payload);
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    showCreateError(
+      result.errorCode === "HOSTNAME_CONFLICT"
+        ? "That hostname is already mapped. Choose another."
+        : "Could not add the domain. Check the hostname and try again."
+    );
+    unlock();
+  });
+
+  const actionError = document.getElementById("domain-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  function clearActionError(): void {
+    if (actionError) actionError.hidden = true;
+  }
+
+  // Verify (high-risk — carries a fresh Idempotency-Key per click).
+  document
+    .querySelectorAll<HTMLButtonElement>(".domain-verify-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.domainId;
+        if (!id) return;
+        clearActionError();
+        const unlock = lockElement(button, "Verifying…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/tenant/domains/${id}/verify`,
+          undefined,
+          { "Idempotency-Key": crypto.randomUUID() }
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showActionError(
+          "Could not verify the domain. Set a verification method first, then retry."
+        );
+        unlock();
+      });
+    });
+
+  // Set primary (high-risk — carries a fresh Idempotency-Key per click).
+  document
+    .querySelectorAll<HTMLButtonElement>(".domain-primary-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.domainId;
+        if (!id) return;
+        clearActionError();
+        const unlock = lockElement(button, "Setting…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/tenant/domains/${id}/set-primary`,
+          undefined,
+          { "Idempotency-Key": crypto.randomUUID() }
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showActionError(
+          "Could not set the domain as primary. Only a verified domain can be primary."
+        );
+        unlock();
+      });
+    });
+
+  // Delete: reason-required soft delete after an explicit confirm.
+  document
+    .querySelectorAll<HTMLButtonElement>(".domain-delete-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.domainId;
+        if (!id) return;
+        const host = button.dataset.domainHost ?? "this domain";
+        const reason = window.prompt(
+          `Delete ${host}? Enter a reason (the hostname becomes reusable):`
+        );
+        if (reason === null || reason.trim().length === 0) {
+          return;
+        }
+        clearActionError();
+        const unlock = lockElement(button, "Deleting…");
+
+        const result = await sendJson(
+          "DELETE",
+          `/api/v1/tenant/domains/${id}`,
+          { reason: reason.trim() }
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showActionError("Could not delete the domain. Please try again.");
+        unlock();
+      });
+    });
+</script>

--- a/src/pages/api/v1/tenant/domains/[id].ts
+++ b/src/pages/api/v1/tenant/domains/[id].ts
@@ -1,0 +1,255 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  fetchActiveTenantDomain,
+  softDeleteTenantDomain,
+  updateTenantDomain
+} from "../../../../../modules/tenant-domain/application/tenant-domain-directory";
+import { validateUpdateTenantDomainInput } from "../../../../../modules/tenant-domain/domain/tenant-domain-validation";
+
+const READ_GUARD = {
+  moduleKey: "tenant_domain",
+  activityCode: "domains",
+  action: "read" as const
+};
+
+const UPDATE_GUARD = {
+  moduleKey: "tenant_domain",
+  activityCode: "domains",
+  action: "update" as const
+};
+
+const DELETE_GUARD = {
+  moduleKey: "tenant_domain",
+  activityCode: "domains",
+  action: "delete" as const
+};
+
+/**
+ * `GET /api/v1/tenant/domains/{id}`. Unknown id, another tenant's id, and a
+ * soft-deleted id all fall through to the same generic 404 —
+ * `fetchActiveTenantDomain` filters `tenant_id`/`deleted_at IS NULL` explicitly,
+ * and RLS `FORCE`s the same isolation underneath (defense in depth), so a
+ * cross-tenant id is invisible before it can ever be distinguished from
+ * "doesn't exist".
+ */
+export const GET: APIRoute = async ({ request, params, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const domainId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!domainId) {
+    return fail(400, "VALIDATION_ERROR", "Domain id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const domain = await fetchActiveTenantDomain(tx, tenantId, domainId);
+
+    if (!domain) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Tenant domain not found.");
+    }
+
+    return ok(domain);
+  });
+};
+
+/** `PATCH /api/v1/tenant/domains/{id}` — partial update. Idempotent by construction (same body -> same end state), no `Idempotency-Key` needed. `hostname`/`is_primary`/`status: "active"` are not reachable through this endpoint — see `updateTenantDomain`'s own docblock. */
+export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const domainId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!domainId) {
+    return fail(400, "VALIDATION_ERROR", "Domain id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateUpdateTenantDomainInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Tenant domain update is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const domain = await updateTenantDomain(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      domainId,
+      input
+    );
+
+    if (!domain) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Tenant domain not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "tenant_domain",
+      action: "tenant_domain.domain.updated",
+      resourceType: "tenant_domain",
+      resourceId: domainId,
+      severity: "info",
+      message: `Tenant domain mapping updated: ${domain.normalizedHostname}.`,
+      correlationId
+    });
+
+    return ok(domain);
+  });
+};
+
+/** `DELETE /api/v1/tenant/domains/{id}` — soft-delete only, `reason` required. Never hard-deletes; frees the normalized hostname for reuse (migration 046's partial unique index). */
+export const DELETE: APIRoute = async ({
+  request,
+  params,
+  cookies,
+  locals
+}) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const domainId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!domainId) {
+    return fail(400, "VALIDATION_ERROR", "Domain id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value;
+  const reasonRaw = (body as { reason?: unknown } | null)?.reason;
+
+  if (typeof reasonRaw !== "string" || reasonRaw.trim().length === 0) {
+    return fail(400, "VALIDATION_ERROR", "reason is required.");
+  }
+
+  const reason = reasonRaw.trim();
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DELETE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const deleted = await softDeleteTenantDomain(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      domainId,
+      reason
+    );
+
+    if (!deleted) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Tenant domain not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "tenant_domain",
+      action: "tenant_domain.domain.deleted",
+      resourceType: "tenant_domain",
+      resourceId: domainId,
+      severity: "warning",
+      message: "Tenant domain mapping deleted.",
+      attributes: { reason },
+      correlationId
+    });
+
+    return ok({ id: domainId, deleted: true });
+  });
+};

--- a/src/pages/api/v1/tenant/domains/[id]/set-primary.ts
+++ b/src/pages/api/v1/tenant/domains/[id]/set-primary.ts
@@ -1,0 +1,158 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { setPrimaryTenantDomain } from "../../../../../../modules/tenant-domain/application/tenant-domain-directory";
+
+const SET_PRIMARY_GUARD = {
+  moduleKey: "tenant_domain",
+  activityCode: "domains",
+  action: "set_primary" as const
+};
+
+const IDEMPOTENCY_SCOPE = "tenant_domain_set_primary";
+
+/**
+ * `POST /api/v1/tenant/domains/{id}/set-primary` — atomically makes `id` this
+ * tenant's primary domain, clearing any previous primary. Atomicity comes from
+ * `withTenant`'s single `sql.begin(...)` transaction plus
+ * `setPrimaryTenantDomain`'s fixed unset-then-set statement order. Only a
+ * verified (`active`) domain can become primary. Requires `Idempotency-Key`.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const domainId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!domainId) {
+    return fail(400, "VALIDATION_ERROR", "Domain id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ domainId, action: "set_primary" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      SET_PRIMARY_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const result = await setPrimaryTenantDomain(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      domainId
+    );
+
+    if (result.outcome === "not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "Tenant domain not found.");
+    }
+
+    if (result.outcome === "not_active") {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot set a domain as primary in status "${result.currentStatus}" — verify it first.`
+      );
+    }
+
+    if (result.outcome === "conflict") {
+      return fail(
+        409,
+        "CONCURRENT_UPDATE",
+        "Another request already changed this tenant's primary domain. Retry with a new Idempotency-Key."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "tenant_domain",
+      action: "tenant_domain.domain.set_primary",
+      resourceType: "tenant_domain",
+      resourceId: domainId,
+      severity: "info",
+      message: `Tenant domain mapping set as primary: ${result.entry.normalizedHostname}.`,
+      correlationId
+    });
+
+    const successResponse = ok(result.entry);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/tenant/domains/[id]/verify.ts
+++ b/src/pages/api/v1/tenant/domains/[id]/verify.ts
@@ -1,0 +1,158 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../../modules/identity-access/application/access-guard";
+import { hashSessionToken } from "../../../../../../lib/auth/session-token";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { verifyTenantDomain } from "../../../../../../modules/tenant-domain/application/tenant-domain-directory";
+
+const VERIFY_GUARD = {
+  moduleKey: "tenant_domain",
+  activityCode: "domains",
+  action: "verify" as const
+};
+
+const IDEMPOTENCY_SCOPE = "tenant_domain_verify";
+
+/**
+ * `POST /api/v1/tenant/domains/{id}/verify` — manual-first verification: flips
+ * `status` to `active` based purely on fields already on the row
+ * (`verification_method`/`verification_record_*`); no outbound DNS/HTTP call
+ * happens here. Requires `Idempotency-Key`, same replay/conflict semantics as
+ * other high-risk mutations.
+ */
+export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+  const domainId = params.id;
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!domainId) {
+    return fail(400, "VALIDATION_ERROR", "Domain id is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ domainId, action: "verify" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      VERIFY_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const result = await verifyTenantDomain(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      domainId
+    );
+
+    if (result.outcome === "not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "Tenant domain not found.");
+    }
+
+    if (result.outcome === "missing_verification_method") {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "This domain has no verification_method configured — set one via PATCH before verifying."
+      );
+    }
+
+    if (result.outcome === "not_verifiable") {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot verify a domain in status "${result.currentStatus}".`
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "tenant_domain",
+      action: "tenant_domain.domain.verified",
+      resourceType: "tenant_domain",
+      resourceId: domainId,
+      severity: "info",
+      message: `Tenant domain mapping verified: ${result.entry.normalizedHostname}.`,
+      correlationId
+    });
+
+    const successResponse = ok(result.entry);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/tenant/domains/index.ts
+++ b/src/pages/api/v1/tenant/domains/index.ts
@@ -1,0 +1,174 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  createTenantDomain,
+  listTenantDomains
+} from "../../../../../modules/tenant-domain/application/tenant-domain-directory";
+import { validateCreateTenantDomainInput } from "../../../../../modules/tenant-domain/domain/tenant-domain-validation";
+import { decodeKeysetCursor } from "../../../../../modules/_shared/keyset-pagination";
+
+const READ_GUARD = {
+  moduleKey: "tenant_domain",
+  activityCode: "domains",
+  action: "read" as const
+};
+
+const CREATE_GUARD = {
+  moduleKey: "tenant_domain",
+  activityCode: "domains",
+  action: "create" as const
+};
+
+/** `GET /api/v1/tenant/domains` — this tenant's non-deleted domain/subdomain mappings, keyset-paginated newest first (limit 100). */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const cursorParam = url.searchParams.get("cursor");
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam && !cursor) {
+    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const { domains, nextCursor } = await listTenantDomains(
+      tx,
+      tenantId,
+      cursor ?? undefined
+    );
+
+    return ok({ domains, nextCursor });
+  });
+};
+
+/**
+ * `POST /api/v1/tenant/domains` — add a domain/subdomain mapping. A duplicate
+ * normalized hostname is caught here and mapped to a generic 409 — never
+ * distinguishes "you already have this hostname" from "another tenant already
+ * has this hostname" (do not leak whether a hostname belongs to another
+ * tenant), because the unique index is global, not tenant-scoped (migration
+ * 046).
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateCreateTenantDomainInput(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Tenant domain is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const input = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      CREATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    let domain;
+
+    try {
+      domain = await createTenantDomain(
+        tx,
+        tenantId,
+        auth.context.tenantUserId,
+        input
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+
+      if (message.includes("awcms_tenant_domains_normalized_hostname_dedup")) {
+        return fail(
+          409,
+          "HOSTNAME_CONFLICT",
+          "This hostname is already mapped to a tenant."
+        );
+      }
+
+      throw error;
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "tenant_domain",
+      action: "tenant_domain.domain.created",
+      resourceType: "tenant_domain",
+      resourceId: domain.id,
+      severity: "info",
+      message: `Tenant domain mapping created: ${domain.normalizedHostname}.`,
+      correlationId
+    });
+
+    return ok(domain);
+  });
+};

--- a/tests/cloudflare-dns-adapter.test.ts
+++ b/tests/cloudflare-dns-adapter.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveTenantDomainDnsProvider,
+  validateDnsRecordInput
+} from "../src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter";
+
+const ROOT = "platform.example";
+
+describe("validateDnsRecordInput", () => {
+  test("rejects an unknown record type", () => {
+    expect(
+      validateDnsRecordInput(
+        { recordType: "MX", recordName: `_x.${ROOT}`, recordValue: "v" },
+        ROOT
+      )
+    ).toContain("recordType");
+  });
+
+  test("rejects a recordName outside the platform root domain", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: "_x.attacker.example",
+          recordValue: "v"
+        },
+        ROOT
+      )
+    ).toContain("root domain");
+  });
+
+  test("accepts an underscore-prefixed TXT record within the root", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: `_awcms-verify.${ROOT}`,
+          recordValue: "awcms-verify=abc"
+        },
+        ROOT
+      )
+    ).toBeNull();
+  });
+
+  test("rejects a TXT value with CR/LF (header/record injection)", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "TXT",
+          recordName: `_x.${ROOT}`,
+          recordValue: "line1\r\nline2"
+        },
+        ROOT
+      )
+    ).toContain("recordValue");
+  });
+
+  test("CNAME target must be a plausible hostname", () => {
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "CNAME",
+          recordName: `www.${ROOT}`,
+          recordValue: "not a host"
+        },
+        ROOT
+      )
+    ).toContain("recordValue");
+    expect(
+      validateDnsRecordInput(
+        {
+          recordType: "CNAME",
+          recordName: `www.${ROOT}`,
+          recordValue: "target.example.com"
+        },
+        ROOT
+      )
+    ).toBeNull();
+  });
+});
+
+describe("resolveTenantDomainDnsProvider (absent-safe, never throws)", () => {
+  test("unset provider degrades to a clean misconfigured-result provider", async () => {
+    const provider = resolveTenantDomainDnsProvider({});
+    const created = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: `_x.${ROOT}`,
+      recordValue: "v"
+    });
+    expect(created.ok).toBe(false);
+  });
+
+  test('"manual" is explicitly not an automated provider', async () => {
+    const provider = resolveTenantDomainDnsProvider({
+      TENANT_DOMAIN_DNS_PROVIDER: "manual"
+    });
+    const checked = await provider.checkVerificationStatus({
+      recordType: "TXT",
+      recordName: `_x.${ROOT}`,
+      expectedValue: "v"
+    });
+    expect(checked.ok).toBe(false);
+    if (checked.ok) return;
+    expect(checked.error).toContain("manual");
+  });
+
+  test("cloudflare selected but missing config still does not throw", async () => {
+    const provider = resolveTenantDomainDnsProvider({
+      TENANT_DOMAIN_DNS_PROVIDER: "cloudflare"
+    });
+    const created = await provider.createVerificationRecord({
+      recordType: "TXT",
+      recordName: `_x.${ROOT}`,
+      recordValue: "v"
+    });
+    expect(created.ok).toBe(false);
+    if (created.ok) return;
+    expect(created.error).toContain("not configured");
+  });
+});

--- a/tests/integration/tenant-domain.integration.test.ts
+++ b/tests/integration/tenant-domain.integration.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Integration tests for the `tenant_domain` module (ported from awcms-micro
+ * epic #555) against a real PostgreSQL under the WORLD-1 ephemeral-database
+ * harness. Proves, with real DDL/RLS/constraints (not mocks):
+ *
+ *   - the directory CRUD + verify + set-primary flows through the module's own
+ *     application services inside `withTenant`;
+ *   - the GLOBAL (cross-tenant) case-insensitive unique index on
+ *     `normalized_hostname` — a hostname can map to only one tenant, and a soft
+ *     delete frees it for reuse;
+ *   - at-most-one active primary per tenant, and the atomic unset-then-set swap;
+ *   - FORCE ROW LEVEL SECURITY tenant isolation, proven under the non-superuser
+ *     `awcms_app` role (a direct SELECT without tenant context returns zero
+ *     rows), AND that the SECURITY DEFINER bootstrap function (migration 048)
+ *     is the one sanctioned read path that resolves a hostname -> tenant BEFORE
+ *     any tenant context exists, never exposing verification_token_hash.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  appRoleActivated,
+  assertRejected,
+  getAdminSql,
+  getAppRoleSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import {
+  createTenantDomain,
+  fetchActiveTenantDomain,
+  listTenantDomains,
+  setPrimaryTenantDomain,
+  softDeleteTenantDomain,
+  updateTenantDomain,
+  verifyTenantDomain
+} from "../../src/modules/tenant-domain/application/tenant-domain-directory";
+import { resolvePublicTenantByHost } from "../../src/lib/tenant/public-host-tenant-resolver";
+
+const TENANT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const TENANT_INACTIVE = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const ACTOR = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+
+async function seedTenants(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'active'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'active'),
+      (${TENANT_INACTIVE}, 'tenant-x', 'Tenant X', 'inactive')
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+function createInput(hostname: string, method: string | null = null) {
+  return {
+    hostname,
+    normalizedHostname: hostname.toLowerCase(),
+    domainType: "custom_domain" as const,
+    routeMode: "canonical" as const,
+    verificationMethod: method as
+      "dns_txt" | "dns_cname" | "file" | "manual" | null,
+    verificationRecordName: null,
+    verificationRecordValue: null,
+    redirectToPrimary: false
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("tenant_domain module (integration)", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  test("create -> fetch -> list, verification_token_hash never returned", async () => {
+    const runtime = getRuntimeSql();
+    const created = await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(tx, TENANT_A, ACTOR, createInput("A.Example.com"))
+    );
+    expect(created.hostname).toBe("A.Example.com");
+    expect(created.normalizedHostname).toBe("a.example.com");
+    expect(created.status).toBe("pending_verification");
+    expect(created).not.toHaveProperty("verificationTokenHash");
+
+    const fetched = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchActiveTenantDomain(tx, TENANT_A, created.id)
+    );
+    expect(fetched?.id).toBe(created.id);
+
+    const page = await withTenant(runtime, TENANT_A, (tx) =>
+      listTenantDomains(tx, TENANT_A)
+    );
+    expect(page.domains).toHaveLength(1);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  test("normalized_hostname is globally unique across tenants (case-insensitive)", async () => {
+    const runtime = getRuntimeSql();
+    await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(tx, TENANT_A, ACTOR, createInput("shared.example.com"))
+    );
+    const error = await assertRejected(
+      withTenant(runtime, TENANT_B, (tx) =>
+        createTenantDomain(
+          tx,
+          TENANT_B,
+          ACTOR,
+          createInput("SHARED.example.com")
+        )
+      ),
+      "a duplicate normalized hostname in another tenant"
+    );
+    expect(error.message).toContain(
+      "awcms_tenant_domains_normalized_hostname_dedup"
+    );
+  });
+
+  test("soft delete frees the normalized hostname for reuse (even by another tenant)", async () => {
+    const runtime = getRuntimeSql();
+    const created = await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(tx, TENANT_A, ACTOR, createInput("reuse.example.com"))
+    );
+    const deleted = await withTenant(runtime, TENANT_A, (tx) =>
+      softDeleteTenantDomain(tx, TENANT_A, ACTOR, created.id, "moved off")
+    );
+    expect(deleted).toBe(true);
+
+    // A soft-deleted row no longer resolves through the directory.
+    const gone = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchActiveTenantDomain(tx, TENANT_A, created.id)
+    );
+    expect(gone).toBeNull();
+
+    // The hostname is now reusable by a different tenant.
+    const recreated = await withTenant(runtime, TENANT_B, (tx) =>
+      createTenantDomain(tx, TENANT_B, ACTOR, createInput("reuse.example.com"))
+    );
+    expect(recreated.tenantId).toBe(TENANT_B);
+  });
+
+  test("verify: needs a method, is idempotent at active, refuses suspended", async () => {
+    const runtime = getRuntimeSql();
+    const created = await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(tx, TENANT_A, ACTOR, createInput("v.example.com"))
+    );
+
+    // No verification_method configured yet.
+    const noMethod = await withTenant(runtime, TENANT_A, (tx) =>
+      verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
+    );
+    expect(noMethod.outcome).toBe("missing_verification_method");
+
+    // Configure a method, then verify -> active.
+    await withTenant(runtime, TENANT_A, (tx) =>
+      updateTenantDomain(tx, TENANT_A, ACTOR, created.id, {
+        verificationMethod: "manual"
+      })
+    );
+    const verified = await withTenant(runtime, TENANT_A, (tx) =>
+      verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
+    );
+    expect(verified.outcome).toBe("verified");
+    if (verified.outcome !== "verified") return;
+    expect(verified.entry.status).toBe("active");
+
+    // Idempotent at active.
+    const again = await withTenant(runtime, TENANT_A, (tx) =>
+      verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
+    );
+    expect(again.outcome).toBe("verified");
+
+    // Suspended cannot be verified back to active.
+    await withTenant(runtime, TENANT_A, (tx) =>
+      updateTenantDomain(tx, TENANT_A, ACTOR, created.id, {
+        status: "suspended"
+      })
+    );
+    const suspended = await withTenant(runtime, TENANT_A, (tx) =>
+      verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
+    );
+    expect(suspended.outcome).toBe("not_verifiable");
+  });
+
+  test("set-primary: only an active domain, at most one primary per tenant", async () => {
+    const runtime = getRuntimeSql();
+    const first = await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(
+        tx,
+        TENANT_A,
+        ACTOR,
+        createInput("one.example.com", "manual")
+      )
+    );
+    const second = await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(
+        tx,
+        TENANT_A,
+        ACTOR,
+        createInput("two.example.com", "manual")
+      )
+    );
+
+    // A pending domain cannot become primary.
+    const notActive = await withTenant(runtime, TENANT_A, (tx) =>
+      setPrimaryTenantDomain(tx, TENANT_A, ACTOR, first.id)
+    );
+    expect(notActive.outcome).toBe("not_active");
+
+    // Verify both, set first primary, then switch to second — only one primary.
+    await withTenant(runtime, TENANT_A, (tx) =>
+      verifyTenantDomain(tx, TENANT_A, ACTOR, first.id)
+    );
+    await withTenant(runtime, TENANT_A, (tx) =>
+      verifyTenantDomain(tx, TENANT_A, ACTOR, second.id)
+    );
+    const setFirst = await withTenant(runtime, TENANT_A, (tx) =>
+      setPrimaryTenantDomain(tx, TENANT_A, ACTOR, first.id)
+    );
+    expect(setFirst.outcome).toBe("set");
+    const setSecond = await withTenant(runtime, TENANT_A, (tx) =>
+      setPrimaryTenantDomain(tx, TENANT_A, ACTOR, second.id)
+    );
+    expect(setSecond.outcome).toBe("set");
+
+    const page = await withTenant(runtime, TENANT_A, (tx) =>
+      listTenantDomains(tx, TENANT_A)
+    );
+    const primaries = page.domains.filter((d) => d.isPrimary);
+    expect(primaries).toHaveLength(1);
+    expect(primaries[0]?.id).toBe(second.id);
+  });
+
+  test("cross-tenant isolation: tenant A cannot read tenant B's domain by id", async () => {
+    const runtime = getRuntimeSql();
+    const bDomain = await withTenant(runtime, TENANT_B, (tx) =>
+      createTenantDomain(tx, TENANT_B, ACTOR, createInput("b-only.example.com"))
+    );
+    const asA = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchActiveTenantDomain(tx, TENANT_A, bDomain.id)
+    );
+    expect(asA).toBeNull();
+  });
+
+  test("RLS: awcms_app cannot SELECT the table without tenant context, but the SECURITY DEFINER lookup resolves an active domain", async () => {
+    if (!appRoleActivated) {
+      // Without migration 019's awcms_app role the FORCE-RLS bypass proof is
+      // not meaningful (owner-superuser bypasses RLS unconditionally).
+      return;
+    }
+
+    const runtime = getRuntimeSql();
+    // Create an active, verified domain for the active tenant A.
+    const created = await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(
+        tx,
+        TENANT_A,
+        ACTOR,
+        createInput("live.example.com", "manual")
+      )
+    );
+    await withTenant(runtime, TENANT_A, (tx) =>
+      verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
+    );
+
+    const app = getAppRoleSql();
+
+    // A direct SELECT with NO app.current_tenant_id set returns zero rows
+    // (fail-closed default GUC + FORCE RLS).
+    const direct = (await app`
+      SELECT id FROM awcms_tenant_domains WHERE normalized_hostname = 'live.example.com'
+    `) as { id: string }[];
+    expect(direct).toHaveLength(0);
+
+    // The SECURITY DEFINER lookup function IS the sanctioned bootstrap read.
+    const resolved = await resolvePublicTenantByHost(app, "live.example.com");
+    expect(resolved?.tenantId).toBe(TENANT_A);
+    expect(resolved?.tenantCode).toBe("tenant-a");
+
+    // The lookup never exposes a secret column.
+    const lookupRows = (await app`
+      SELECT * FROM awcms_resolve_tenant_domain_lookup('live.example.com')
+    `) as Record<string, unknown>[];
+    expect(lookupRows).toHaveLength(1);
+    expect(lookupRows[0]).not.toHaveProperty("verification_token_hash");
+    expect(lookupRows[0]).not.toHaveProperty("verification_record_value");
+    expect(lookupRows[0]).not.toHaveProperty("hostname");
+  });
+
+  test("resolver does not resolve a non-active domain or an inactive tenant", async () => {
+    if (!appRoleActivated) return;
+    const runtime = getRuntimeSql();
+
+    // Pending domain under an active tenant -> not resolved.
+    await withTenant(runtime, TENANT_A, (tx) =>
+      createTenantDomain(
+        tx,
+        TENANT_A,
+        ACTOR,
+        createInput("pending.example.com")
+      )
+    );
+    // Active domain under an INACTIVE tenant -> not resolved.
+    const onInactive = await withTenant(runtime, TENANT_INACTIVE, (tx) =>
+      createTenantDomain(
+        tx,
+        TENANT_INACTIVE,
+        ACTOR,
+        createInput("inactive-tenant.example.com", "manual")
+      )
+    );
+    await withTenant(runtime, TENANT_INACTIVE, (tx) =>
+      verifyTenantDomain(tx, TENANT_INACTIVE, ACTOR, onInactive.id)
+    );
+
+    const app = getAppRoleSql();
+    expect(
+      await resolvePublicTenantByHost(app, "pending.example.com")
+    ).toBeNull();
+    expect(
+      await resolvePublicTenantByHost(app, "inactive-tenant.example.com")
+    ).toBeNull();
+    expect(
+      await resolvePublicTenantByHost(app, "never.example.com")
+    ).toBeNull();
+  });
+});

--- a/tests/public-host-tenant-resolver.test.ts
+++ b/tests/public-host-tenant-resolver.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  normalizePublicHost,
+  resolvePublicTenantFromRequest,
+  type PublicHostResolverDeps,
+  type PublicTenantResolution
+} from "../src/lib/tenant/public-host-tenant-resolver";
+
+const FAKE_SQL = {} as unknown as Bun.SQL;
+
+const HOST_TENANT: PublicTenantResolution = {
+  tenantId: "11111111-1111-4111-8111-111111111111",
+  tenantCode: "host-tenant",
+  tenantName: "Host Tenant",
+  defaultLocale: "en"
+};
+const ENV_TENANT: PublicTenantResolution = {
+  tenantId: "22222222-2222-4222-8222-222222222222",
+  tenantCode: "env-tenant",
+  tenantName: "Env Tenant",
+  defaultLocale: "en"
+};
+const SETUP_TENANT: PublicTenantResolution = {
+  tenantId: "33333333-3333-4333-8333-333333333333",
+  tenantCode: "setup-tenant",
+  tenantName: "Setup Tenant",
+  defaultLocale: "en"
+};
+
+function makeDeps(
+  overrides: Partial<PublicHostResolverDeps> = {}
+): PublicHostResolverDeps & { calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    async resolvePublicTenantByHost() {
+      calls.push("host");
+      return null;
+    },
+    async resolveDefaultPublicTenantFromEnv() {
+      calls.push("env");
+      return null;
+    },
+    async resolveDefaultPublicTenantFromSetupState() {
+      calls.push("setup");
+      return null;
+    },
+    ...overrides
+  };
+}
+
+describe("normalizePublicHost", () => {
+  test("lowercases, trims, strips a port", () => {
+    expect(normalizePublicHost("  Tenant.Example.COM:4321 ")).toBe(
+      "tenant.example.com"
+    );
+  });
+
+  test("rejects IPv6 literals and underscore/malformed shapes", () => {
+    expect(normalizePublicHost("[::1]:4321")).toBeNull();
+    expect(normalizePublicHost("_dmarc.example.com")).toBeNull();
+    expect(normalizePublicHost("a..b.com")).toBeNull();
+  });
+
+  test("throws only on empty input (caller contract violation)", () => {
+    expect(() => normalizePublicHost("")).toThrow();
+    expect(() => normalizePublicHost("   ")).toThrow();
+  });
+});
+
+describe("resolvePublicTenantFromRequest resolution order", () => {
+  test("host_default resolves via host first, no fallback needed", async () => {
+    const deps = makeDeps({
+      async resolvePublicTenantByHost() {
+        deps.calls.push("host");
+        return HOST_TENANT;
+      }
+    });
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      "tenant.example.com",
+      { mode: "host_default" },
+      deps
+    );
+    expect(result).toEqual(HOST_TENANT);
+    expect(deps.calls).toEqual(["host"]);
+  });
+
+  test("host miss falls through to env, then setup", async () => {
+    const deps = makeDeps({
+      async resolveDefaultPublicTenantFromSetupState() {
+        deps.calls.push("setup");
+        return SETUP_TENANT;
+      }
+    });
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      "unmapped.example.com",
+      { mode: "host_default" },
+      deps
+    );
+    expect(result).toEqual(SETUP_TENANT);
+    expect(deps.calls).toEqual(["host", "env", "setup"]);
+  });
+
+  test("non-host mode never calls the host lookup but still runs env fallback", async () => {
+    const deps = makeDeps({
+      async resolveDefaultPublicTenantFromEnv() {
+        deps.calls.push("env");
+        return ENV_TENANT;
+      }
+    });
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      "tenant.example.com",
+      { mode: "env_default" },
+      deps
+    );
+    expect(result).toEqual(ENV_TENANT);
+    expect(deps.calls).toEqual(["env"]);
+  });
+
+  test("undefined mode (offline/LAN default) still runs the safe fallback chain", async () => {
+    const deps = makeDeps({
+      async resolveDefaultPublicTenantFromEnv() {
+        deps.calls.push("env");
+        return ENV_TENANT;
+      }
+    });
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      "tenant.example.com",
+      {},
+      deps
+    );
+    expect(result).toEqual(ENV_TENANT);
+    // No host lookup for an unset mode.
+    expect(deps.calls).toEqual(["env"]);
+  });
+
+  test("tenant_code_legacy short-circuits to null, skipping ALL steps", async () => {
+    const deps = makeDeps({
+      async resolvePublicTenantByHost() {
+        deps.calls.push("host");
+        return HOST_TENANT;
+      },
+      async resolveDefaultPublicTenantFromEnv() {
+        deps.calls.push("env");
+        return ENV_TENANT;
+      },
+      async resolveDefaultPublicTenantFromSetupState() {
+        deps.calls.push("setup");
+        return SETUP_TENANT;
+      }
+    });
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      "tenant.example.com",
+      { mode: "tenant_code_legacy" },
+      deps
+    );
+    expect(result).toBeNull();
+    expect(deps.calls).toEqual([]);
+  });
+
+  test("everything missing resolves to null", async () => {
+    const deps = makeDeps();
+    const result = await resolvePublicTenantFromRequest(
+      FAKE_SQL,
+      "unmapped.example.com",
+      { mode: "host_default" },
+      deps
+    );
+    expect(result).toBeNull();
+    expect(deps.calls).toEqual(["host", "env", "setup"]);
+  });
+});

--- a/tests/tenant-domain-dns-config.test.ts
+++ b/tests/tenant-domain-dns-config.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS,
+  isKnownTenantDomainDnsProvider,
+  resolveTenantDomainCloudflareTimeoutMs
+} from "../src/modules/tenant-domain/domain/tenant-domain-dns-config";
+
+describe("tenant-domain DNS config", () => {
+  test("isKnownTenantDomainDnsProvider only accepts manual/cloudflare", () => {
+    expect(isKnownTenantDomainDnsProvider("manual")).toBe(true);
+    expect(isKnownTenantDomainDnsProvider("cloudflare")).toBe(true);
+    expect(isKnownTenantDomainDnsProvider("route53")).toBe(false);
+    expect(isKnownTenantDomainDnsProvider(undefined)).toBe(false);
+    expect(isKnownTenantDomainDnsProvider("")).toBe(false);
+  });
+
+  test("timeout falls back to the default for unset/invalid/non-positive values", () => {
+    expect(resolveTenantDomainCloudflareTimeoutMs({})).toBe(
+      DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS
+    );
+    expect(
+      resolveTenantDomainCloudflareTimeoutMs({
+        TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS: "not-a-number"
+      })
+    ).toBe(DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS);
+    expect(
+      resolveTenantDomainCloudflareTimeoutMs({
+        TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS: "-5"
+      })
+    ).toBe(DEFAULT_TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS);
+  });
+
+  test("timeout uses a valid positive override", () => {
+    expect(
+      resolveTenantDomainCloudflareTimeoutMs({
+        TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS: "12000"
+      })
+    ).toBe(12000);
+  });
+});

--- a/tests/tenant-domain-module.test.ts
+++ b/tests/tenant-domain-module.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+
+import { getModuleByKey, listModules } from "../src/modules";
+import { tenantDomainModule } from "../src/modules/tenant-domain/module";
+
+// The six permissions seeded by sql/047_awcms_tenant_domain_permissions.sql,
+// verbatim. The descriptor's `permissions` array must match this list exactly
+// (activityCode/action/description) or Module Management's permission
+// sync/status report will show `missing`/`mismatched_description`.
+const MIGRATION_047_PERMISSIONS = [
+  {
+    activityCode: "domains",
+    action: "read",
+    description: "Read tenant domain/subdomain mappings"
+  },
+  {
+    activityCode: "domains",
+    action: "create",
+    description: "Add a tenant domain/subdomain mapping"
+  },
+  {
+    activityCode: "domains",
+    action: "update",
+    description: "Update a tenant domain/subdomain mapping"
+  },
+  {
+    activityCode: "domains",
+    action: "delete",
+    description: "Soft delete a tenant domain/subdomain mapping"
+  },
+  {
+    activityCode: "domains",
+    action: "verify",
+    description: "Verify ownership of a tenant domain/subdomain"
+  },
+  {
+    activityCode: "domains",
+    action: "set_primary",
+    description: "Set a tenant domain as the active primary domain"
+  }
+];
+
+describe("tenant_domain module descriptor (ported from awcms-micro)", () => {
+  test("listModules() includes tenant_domain", () => {
+    expect(listModules().some((m) => m.key === "tenant_domain")).toBe(true);
+    expect(getModuleByKey("tenant_domain")).toBe(tenantDomainModule);
+  });
+
+  test("descriptor shape", () => {
+    expect(tenantDomainModule.key).toBe("tenant_domain");
+    expect(tenantDomainModule.status).toBe("active");
+    // Registered as "domain" in this base (the port instruction), like the
+    // other directly-in-base website modules.
+    expect(tenantDomainModule.type).toBe("domain");
+    expect(tenantDomainModule.dependencies).toEqual([
+      "tenant_admin",
+      "identity_access"
+    ]);
+  });
+
+  test("api points at the module fragment + management basePath", () => {
+    expect(tenantDomainModule.api?.basePath).toBe("/api/v1/tenant/domains");
+    expect(tenantDomainModule.api?.openApiPath).toBe(
+      "openapi/modules/tenant-domain.openapi.yaml"
+    );
+  });
+
+  test("navigation.path is permission-gated on read", () => {
+    expect(tenantDomainModule.navigation).toHaveLength(1);
+    expect(tenantDomainModule.navigation?.[0]?.path).toBe(
+      "/admin/tenant/domains"
+    );
+    expect(tenantDomainModule.navigation?.[0]?.requiredPermission).toBe(
+      "tenant_domain.domains.read"
+    );
+  });
+
+  test("permissions array matches migration 047's seed exactly", () => {
+    expect(tenantDomainModule.permissions).toEqual(MIGRATION_047_PERMISSIONS);
+  });
+
+  test("permission keys reproduce the six tenant_domain.domains.* keys", () => {
+    const permissionKeys = (tenantDomainModule.permissions ?? []).map(
+      (p) => `${tenantDomainModule.key}.${p.activityCode}.${p.action}`
+    );
+
+    expect(permissionKeys).toEqual([
+      "tenant_domain.domains.read",
+      "tenant_domain.domains.create",
+      "tenant_domain.domains.update",
+      "tenant_domain.domains.delete",
+      "tenant_domain.domains.verify",
+      "tenant_domain.domains.set_primary"
+    ]);
+  });
+
+  test("settings.defaults only sets manual DNS verification mode", () => {
+    expect(tenantDomainModule.settings?.defaults).toEqual({
+      defaultVerificationMethod: "manual"
+    });
+  });
+
+  test("settings.defaults never contains a secret-shaped key or value", () => {
+    const defaults = tenantDomainModule.settings?.defaults ?? {};
+    const serialized = JSON.stringify(defaults).toLowerCase();
+
+    for (const forbidden of [
+      "password",
+      "token",
+      "secret",
+      "credential",
+      "apikey",
+      "api_key"
+    ]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+
+    expect(defaults).not.toHaveProperty("provider");
+    expect(defaults).not.toHaveProperty("cloudflareApiToken");
+  });
+
+  test("the module declares no jobs or health", () => {
+    expect(tenantDomainModule.jobs).toBeUndefined();
+    expect(tenantDomainModule.health).toBeUndefined();
+  });
+});

--- a/tests/tenant-domain-validation.test.ts
+++ b/tests/tenant-domain-validation.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  validateCreateTenantDomainInput,
+  validateUpdateTenantDomainInput
+} from "../src/modules/tenant-domain/domain/tenant-domain-validation";
+
+describe("validateCreateTenantDomainInput", () => {
+  test("accepts a plain hostname and normalizes it", () => {
+    const result = validateCreateTenantDomainInput({
+      hostname: "Tenant.Example.COM"
+    });
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.hostname).toBe("Tenant.Example.COM");
+    expect(result.value.normalizedHostname).toBe("tenant.example.com");
+    // Defaults.
+    expect(result.value.domainType).toBe("custom_domain");
+    expect(result.value.routeMode).toBe("canonical");
+    expect(result.value.verificationMethod).toBeNull();
+    expect(result.value.redirectToPrimary).toBe(false);
+  });
+
+  test("rejects a missing/blank hostname", () => {
+    for (const hostname of [undefined, "", "   "]) {
+      const result = validateCreateTenantDomainInput({ hostname });
+      expect(result.valid).toBe(false);
+      if (result.valid) continue;
+      expect(result.errors.some((e) => e.field === "hostname")).toBe(true);
+    }
+  });
+
+  test("rejects a hostname carrying a port (never silently strips it)", () => {
+    const result = validateCreateTenantDomainInput({
+      hostname: "example.com:8443"
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(
+      result.errors.some(
+        (e) => e.field === "hostname" && e.message.includes("port")
+      )
+    ).toBe(true);
+  });
+
+  test("rejects an underscore/IPv6/malformed hostname shape", () => {
+    for (const hostname of ["_dmarc.example.com", "[::1]", "exa mple.com"]) {
+      const result = validateCreateTenantDomainInput({ hostname });
+      expect(result.valid).toBe(false);
+    }
+  });
+
+  test("rejects an unknown domainType / routeMode / verificationMethod", () => {
+    const result = validateCreateTenantDomainInput({
+      hostname: "a.example.com",
+      domainType: "apex",
+      routeMode: "nonsense",
+      verificationMethod: "carrier_pigeon"
+    });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    const fields = result.errors.map((e) => e.field);
+    expect(fields).toContain("domainType");
+    expect(fields).toContain("routeMode");
+    expect(fields).toContain("verificationMethod");
+  });
+
+  test("accepts a full valid record with dns_txt method", () => {
+    const result = validateCreateTenantDomainInput({
+      hostname: "shop.example.com",
+      domainType: "custom_domain",
+      routeMode: "canonical",
+      verificationMethod: "dns_txt",
+      verificationRecordName: "_awcms-verify.shop.example.com",
+      verificationRecordValue: "awcms-verify=abc123",
+      redirectToPrimary: true
+    });
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.verificationMethod).toBe("dns_txt");
+    expect(result.value.redirectToPrimary).toBe(true);
+  });
+});
+
+describe("validateUpdateTenantDomainInput", () => {
+  test("rejects an empty patch body", () => {
+    const result = validateUpdateTenantDomainInput({});
+    expect(result.valid).toBe(false);
+  });
+
+  test('refuses status: "active" (must go through verify)', () => {
+    const result = validateUpdateTenantDomainInput({ status: "active" });
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(
+      result.errors.some(
+        (e) => e.field === "status" && e.message.includes("verify")
+      )
+    ).toBe(true);
+  });
+
+  test("accepts an updatable status", () => {
+    for (const status of ["pending_verification", "suspended", "failed"]) {
+      const result = validateUpdateTenantDomainInput({ status });
+      expect(result.valid).toBe(true);
+    }
+  });
+
+  test("tri-state: null clears verification fields, omit leaves unchanged", () => {
+    const cleared = validateUpdateTenantDomainInput({
+      verificationMethod: null,
+      verificationRecordName: null
+    });
+    expect(cleared.valid).toBe(true);
+    if (!cleared.valid) return;
+    expect(cleared.value.verificationMethod).toBeNull();
+    expect(cleared.value.verificationRecordName).toBeNull();
+
+    const partial = validateUpdateTenantDomainInput({
+      routeMode: "legacy_blog"
+    });
+    expect(partial.valid).toBe(true);
+    if (!partial.valid) return;
+    expect(partial.value).not.toHaveProperty("verificationMethod");
+    expect(partial.value.routeMode).toBe("legacy_blog");
+  });
+
+  test("hostname is not an updatable field", () => {
+    const result = validateUpdateTenantDomainInput({
+      hostname: "new.example.com"
+    });
+    // hostname is ignored — with nothing else present this is an empty patch.
+    expect(result.valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Ringkasan

Port modul **`tenant_domain`** dari awcms-micro (epic #555) — **modul pertama Wave-0** program penyerapan awcms-micro (ADR-0035, lihat `docs/awcms/absorb-awcms-micro-roadmap.md`). Seam pemetaan **host→tenant**: registrasi hostname/subdomain, verifikasi kepemilikan (manual-first), satu primary domain per tenant, resolver host publik aditif, dan fungsi lookup bootstrap `SECURITY DEFINER`.

## Yang di-port

- **Migrasi** `sql/046` (schema, `FORCE RLS`), `047` (permissions), `048` (lookup `SECURITY DEFINER` — `search_path` dipin, `EXECUTE` hanya `awcms_app`, kolom minimal). Lanjutan sekuensial dari `sql/045`, tanpa gap.
- **Modul** `src/modules/tenant-domain` (domain/application/infrastructure), terdaftar `type:"domain"`; adapter Cloudflare DNS **opsional & aman-tanpa-kredensial**.
- **API** tenant-scoped `/api/v1/tenant/domains` (list/create/read/update/soft-delete + `verify`/`set-primary` ber-`Idempotency-Key` & diaudit), ABAC default-deny dengan aksi ter-seed; layar admin `/admin/tenant/domains`.
- **Resolver host publik** aditif (`src/lib/tenant/public-host-tenant-resolver.ts`) — `src/middleware.ts` **tak disentuh** (login/Turnstile/CSP tak berubah); routing path-based `/blog/{tenantCode}` (ADR-0009) tak diregresi.
- Union `AccessAction` += `set_primary` (bukan high-risk); fragment OpenAPI per-modul; tests unit + integration (RLS dibuktikan di bawah `awcms_app`); skill `awcms-tenant-domain-routing` → panduan kode nyata.

## Review

- **DoD review:** mergeable (kualitas tinggi; hanya rujukan ADR di changeset yang diperbaiki).
- **Security audit:** **PASS**, tanpa temuan Critical/High. `SECURITY DEFINER`, isolasi RLS/FORCE, ABAC default-deny 7 metode, trust model Host-header, SSRF/secret adapter DNS, idempotency — semua sound.

### ⚠️ Risiko residual M1 (didokumentasikan, bukan blocker)
`verify` mengaktifkan domain tanpa bukti kepemilikan outbound → potensi **dangling-DNS takeover** bila verifikasi self-service custom domain tak-tepercaya diaktifkan. **Gerbangi aktivasi `custom_domain` secara operator/manual** sampai bukti DNS-token di-wire. Didokumentasikan di README modul §Security residual risk, skill, dan changeset.

### Deferral (didokumentasikan)
Rute konten publik ber-resolusi host belum di-wire (sama seperti `/news/**` news_portal); wiring bukti kepemilikan DNS-token.

## Verifikasi

`bun run check` hijau (exit 0): lint + docs + kontrak + typecheck + test (1761 pass) + build. RLS divalidasi via Postgres 18.4 nyata (docker) di bawah role `awcms_app`.

> **Urutan merge:** disarankan merge **#218 (ADR-0035)** lebih dulu — PR ini merujuk ADR-0035 & roadmap. Tak ada overlap file antar-PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)