### PR TITLE
feat(visitor-analytics): port visitor_analytics module from awcms-micro (Wave 1, additive)

### DIFF
--- a/.changeset/port-visitor-analytics-module.md
+++ b/.changeset/port-visitor-analytics-module.md
@@ -12,3 +12,10 @@ Port modul `visitor_analytics` dari awcms-micro (epic #617-#624) sebagai modul s
 - **Dashboard** `/admin/analytics` (SSR-render).
 
 Adaptasi port terdokumentasi: kopling `data_lifecycle`/`LegalHoldGuardPort` DI-DROP (modul belum ada di base — purge tanpa gerbang legal-hold), dan wiring preset `news_portal_full_online_r2` DEFERRED (modul `news_portal` tidak disentuh).
+
+**Security hardening (DoD + security review atas port ini):**
+
+- **Rate-limit backstop pada beacon publik.** `POST /api/v1/analytics/collect` (unauth DB write) kini digerbangi rate limit per-IP (`checkRateLimit` yang sama dengan login/setup) SEBELUM tulis DB — mencegah flooding baris/pencemaran agregat oleh pemegang `tenantCode` publik. Kunci berbasis IP saja (tak membocorkan eksistensi tenant); `path` dibatasi panjang sebelum disimpan. Tunable `VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_MAX`/`_WINDOW_SEC` (default 120/60s).
+- **Salt HMAC per-tenant (privacy-by-design).** `visitor_key_hash`/`ip_hash`/`user_agent_hash` kini di-key dengan salt deployment DAN `tenantId` (domain-separator `\0`), sehingga browser/IP/user-agent yang sama menghasilkan hash BERBEDA lintas tenant satu origin — menutup korelasi lintas-tenant di lapisan penyimpanan. Diterapkan mumpung belum ada data. `VISITOR_ANALYTICS_HASH_SALT` kini wajib ≥ 16 karakter saat modul aktif.
+- **raw_detail lewat ABAC, bukan hanya keanggotaan RBAC.** Field de-anonimisasi (`ipHash`/`ipAddress`/`userAgentHash`/`loginIdentifierSnapshot`) di `GET /sessions`, `GET /events`, dan `/admin/analytics` kini diputuskan lewat evaluator ABAC (`evaluateFieldAccessInTransaction`) sehingga kebijakan DSL `deny` atas `raw_detail.read` dihormati (deny-overrides-allow).
+- Log fragmen IP mentah pada header forwarded multi-nilai dihapus (`client-ip.ts` hanya mencatat `valueCount`, bukan nilai).

--- a/.changeset/port-visitor-analytics-module.md
+++ b/.changeset/port-visitor-analytics-module.md
@@ -1,0 +1,14 @@
+---
+"awcms": minor
+---
+
+Port modul `visitor_analytics` dari awcms-micro (epic #617-#624) sebagai modul standalone `type: "system"` (ADR-0035 Wave 1). Menambah statistik pengunjung manusia **privacy-first** untuk rute admin & publik, online maupun offline/LAN.
+
+- **Skema** (migrasi 049 permission, 050 schema, 051 session-lookup index): `awcms_visitor_sessions`/`awcms_visit_events`/`awcms_visitor_daily_rollups`, semua `FORCE ROW LEVEL SECURITY` + policy `tenant_isolation`, index tenant_id-first, composite FK `(tenant_id, visitor_session_id)` lintas-tenant, dan GRANT `awcms_worker` least-privilege untuk job terjadwal.
+- **Privasi:** off by default (`VISITOR_ANALYTICS_ENABLED=false`); visitor-key/IP/user-agent disimpan hanya sebagai HMAC-SHA256 bersalt (salt wajib saat enabled — ditegakkan `validate-env`); raw IP & login snapshot opt-in terpisah; query string sensitif di-strip fail-safe.
+- **Koleksi = endpoint ingest PUBLIK** `POST /api/v1/analytics/collect` (anonim, resolve tenant dari `tenantCode` tabel `awcms_tenants` yang RLS-free — TANPA SECURITY DEFINER), **bukan** middleware: `src/middleware.ts` tidak disentuh (jaminan login/Turnstile/CSP tetap).
+- **API terautentikasi ABAC:** `GET /api/v1/analytics/{summary,realtime,sessions,events,pages,devices,locations,security,settings}`, `PATCH .../settings`, dan `POST .../retention/purge` (Idempotency-Key + audit `critical`). Raw-detail digerbangi `visitor_analytics.raw_detail.read`.
+- **Job:** `bun run analytics:rollup` & `bun run analytics:purge` (worker role, offline-safe).
+- **Dashboard** `/admin/analytics` (SSR-render).
+
+Adaptasi port terdokumentasi: kopling `data_lifecycle`/`LegalHoldGuardPort` DI-DROP (modul belum ada di base — purge tanpa gerbang legal-hold), dan wiring preset `news_portal_full_online_r2` DEFERRED (modul `news_portal` tidak disentuh).

--- a/.claude/skills/awcms-visitor-analytics/SKILL.md
+++ b/.claude/skills/awcms-visitor-analytics/SKILL.md
@@ -1,628 +1,107 @@
 ---
 name: awcms-visitor-analytics
-description: BACAAN SAJA — modul visitor_analytics BELUM di-port ke repo ini (ada di awcms-mini; `ls src/modules` tidak memuat `visitor-analytics`, tidak ada migration-nya di `sql/`). Rujukan modul/tabel/`sql/NNN` di dalamnya adalah artefak awcms-mini, penomoran mini. Pakai sebagai spesifikasi target saat MEM-PORT (via `awcms-port-from-mini`), bukan panduan implementasi kode yang bisa dipanggil — verifikasi `ls src/modules` dulu. Konteks port (Issue #617-#624). Gunakan saat menambah/mengubah VISITOR_ANALYTICS_* env config, skema session/event/rollup, helper identity/UA/bot classification, middleware collector, API/dashboard `/admin/analytics`, enrichment geolokasi, atau job rollup/retention purge. Merangkum keputusan yang sudah dibuat supaya issue lanjutan tidak mengulang/kontradiksi.
+description: Modul visitor_analytics SUDAH di-port ke repo ini (dari awcms-micro epic #617-#624) sebagai modul standalone `type:"system"`. Gunakan saat menambah/mengubah `/api/v1/analytics/*`, skema session/event/rollup (`awcms_visitor_sessions`/`awcms_visit_events`/`awcms_visitor_daily_rollups`, migrasi 049/050/051), helper klasifikasi identity/UA/bot + sanitasi path, endpoint ingest publik `POST /api/v1/analytics/collect`, dashboard `/admin/analytics`, enrichment geolokasi, atau job `analytics:rollup`/`analytics:purge`. Merangkum keputusan port (kopling data_lifecycle DI-DROP, wiring news_portal preset DEFERRED, koleksi = endpoint ingest publik BUKAN middleware, TIDAK ada SECURITY DEFINER) supaya perubahan lanjutan tidak meregresi privasi/RLS.
 ---
 
-# AWCMS — Visitor Analytics
-
-<!-- sql-refs: awcms-mini — modul belum di-port; setiap `sql/NNN` di file ini penomoran awcms-mini, bukan repo ini -->
-
-> **STATUS — BACAAN SAJA: modul ini BELUM di-port ke repo ini.**
-> `visitor_analytics` ada di **awcms-mini**, bukan di sini: `ls src/modules`
-> TIDAK memuat `visitor-analytics`, dan `sql/` tidak memuat migration-nya.
-> Semua rujukan `src/modules/visitor-analytics/...`, tabel
-> `awcms_visitor_analytics_*`, dan `sql/NNN` di bawah adalah artefak
-> awcms-mini — **jangan `import`/`SELECT`/mengklaim ada** di repo ini.
-> Nomor `sql/NNN` memakai penomoran awcms-mini dan akan berubah saat
-> di-port (melanjutkan dari migration terakhir repo ini). Pakai skill ini
-> sebagai spesifikasi target port (via `awcms-port-from-mini`), bukan peta
-> kode yang bisa dipanggil. Verifikasi `ls src/modules` sebelum mengklaim
-> apa pun ada.
-
-Epic visitor analytics (#617-#624) menambah **statistik pengunjung manusia
-privacy-first** untuk rute admin dan publik, di konfigurasi online maupun
-offline/LAN. Modul baru `visitor_analytics` (`type: "system"`) — bukan
-diperluas dari `reporting`/`logging` yang sudah ada, karena volume,
-retensi, dan kontrol privasi visitor telemetry berbeda dari keduanya
-(lihat `src/modules/visitor-analytics/README.md` §Why a separate module).
-
-## Kapan pakai skill ini vs skill generik
-
-Skill ini melengkapi (bukan menggantikan) `awcms-new-endpoint`,
-`awcms-new-migration`, `awcms-new-module`,
-`awcms-abac-guard`, `awcms-sensitive-data` (IP/user-agent/geo
-adalah data sensitif), `awcms-ui-screen` (dashboard #622), dan
-`awcms-observability` (retensi/purge, korelasi dengan audit log yang
-sudah ada). Skill ini menyediakan konteks **cross-cutting epic
-spesifik** yang menjembatani beberapa issue sekaligus.
-
-## Status per issue (jangan bangun ulang yang sudah ada)
-
-| Issue | Scope                                                                                                                                             | Status                                                                                                                            |
-| ----- | ------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
-| #617  | Module descriptor, permission catalog, config gate                                                                                                | **Selesai** — lihat §Config di bawah                                                                                              |
-| #618  | Visitor session/event/rollup schema + RLS                                                                                                         | **Selesai** — lihat §Schema di bawah                                                                                              |
-| #619  | Visitor identity, user-agent, human/bot classification helpers                                                                                    | **Selesai** — lihat §Domain helpers di bawah                                                                                      |
-| #620  | Middleware telemetry collection (admin + public)                                                                                                  | **Selesai** — lihat §Collector di bawah                                                                                           |
-| #621  | Analytics API + OpenAPI contract (`/api/v1/analytics`)                                                                                            | **Selesai** — lihat §API di bawah                                                                                                 |
-| #623  | Trusted online geolocation enrichment                                                                                                             | **Selesai** — lihat §Geo enrichment di bawah                                                                                      |
-| #622  | Admin visitor analytics dashboard UI (`/admin/analytics`)                                                                                         | **Selesai** — lihat §Dashboard UI di bawah                                                                                        |
-| #624  | Rollup job, retention purge job, readiness checks, docs pass; REOPENED 2026-07-11 dengan repository audit addendum (default-off, cookie lifetime) | **Selesai** (termasuk addendum) — lihat §Rollup job, §Retention purge job, §Readiness checks, §Repository audit addendum di bawah |
-
-Urutan dependency (dari body issue masing-masing): 617 → 618 → 619 → 620 →
-621 → 622; 623 boleh setelah 620 (paralel dengan 621/622); 624 butuh
-617+618+620+621 dan melengkapi 622/623. **Epic #617-#624 selesai penuh**,
-termasuk repository audit addendum #624 (2026-07-11, epic
-platform-hardening #679) — lihat §Repository audit addendum di bawah
-sebelum menganggap default lama (`ENABLED=true`, cookie 2 tahun) masih
-berlaku.
-
-## Yang sudah ada — pakai ulang, jangan re-derive
-
-### Config (Issue #617, `src/modules/visitor-analytics/domain/visitor-analytics-config.ts`)
-
-Tujuh belas env var, semuanya **opsional** dan privacy-first — kalau tidak
-di-set sama sekali, `config:validate` tetap PASS, modul TIDAK aktif
-(§Repository audit addendum), dan tidak ada raw IP/raw user-agent/
-geolokasi yang tersimpan:
-
-- `VISITOR_ANALYTICS_ENABLED` (default `false` sejak Issue #624
-  repository audit addendum, 2026-07-11 — sebelumnya `true` di rilis
-  awal Issue #617) — master switch. Deployment existing yang sudah
-  men-set var ini `true` eksplisit tidak terdampak; lihat §Repository
-  audit addendum untuk migration note lengkap.
-- `VISITOR_ANALYTICS_MODE` (default `basic`) — enum `basic | detailed`
-  (`VISITOR_ANALYTICS_MODES`, `isKnownVisitorAnalyticsMode`). Nilai tak
-  dikenal jatuh ke `basic`, tidak pernah throw.
-- `VISITOR_ANALYTICS_COLLECT_ADMIN` / `_COLLECT_PUBLIC` / `_COLLECT_API` —
-  toggle per permukaan (default `true`/`true`/`false`).
-- `VISITOR_ANALYTICS_DETAILED_ENABLED` — cadangan mode `detailed` (default
-  `false`, belum dikonsumsi apa pun).
-- `VISITOR_ANALYTICS_RAW_IP_ENABLED` / `_RAW_USER_AGENT_ENABLED` /
-  `_GEO_ENABLED` — **default `false` semuanya**, ini inti privacy-first
-  gate-nya. Independen dari `VISITOR_ANALYTICS_MODE` — mode tidak pernah
-  menyalakan ketiganya secara implisit.
-- `VISITOR_ANALYTICS_TRUST_PROXY` / `_TRUST_CLOUDFLARE` — default `false`;
-  sama prinsip keamanan dengan `PUBLIC_TRUST_PROXY` (skill
-  `awcms-tenant-domain-routing`) — hanya `true` di belakang proxy
-  tepercaya yang benar-benar mengisi ulang header, bukan meneruskan nilai
-  klien.
-- Lima var retensi/jendela/TTL — `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS`
-  (300), `_EVENT_RETENTION_DAYS` (90), `_RAW_DETAIL_RETENTION_DAYS` (30),
-  `_ROLLUP_RETENTION_DAYS` (730), `_VISITOR_KEY_COOKIE_TTL_DAYS` (30,
-  Issue #624 repository audit addendum — sebelumnya hardcoded
-  ~2 tahun/`63_072_000` detik di `src/middleware.ts`, bukan env var sama
-  sekali) — divalidasi `parsePositiveInt`, wajib integer positif **bila
-  diisi**; tak diisi → default di atas, tidak pernah gagal validasi.
-- `VISITOR_ANALYTICS_HASH_SALT` (default `""`) — salt untuk fingerprint
-  visitor pseudonymous, dikonsumsi `domain/visitor-key.ts`'s
-  `hashVisitorKey`/`hashIpAddress`/`hashUserAgent` (Issue #619) — lihat
-  §Domain helpers di bawah. Belum ada caller yang benar-benar memanggil
-  fungsi hashing ini dengan nilai request nyata sampai middleware #620.
-
-Entry point: `resolveVisitorAnalyticsConfig(env)` — SATU fungsi yang
-harus dipanggil issue lanjutan (#619 helper, #620 middleware), jangan
-re-derive baca `process.env.VISITOR_ANALYTICS_*` langsung. Gate boolean
-tunggal: `isVisitorAnalyticsEnabled(env)`.
-
-Validasi: `checkVisitorAnalyticsConfig()` (`scripts/validate-env.ts`),
-dipanggil dari `runEnvValidation()`. Didokumentasikan di
-`docs/awcms/18_configuration_env_reference.md` §Visitor analytics.
-Test: `tests/unit/visitor-analytics-config.test.ts`,
-`tests/validate-env.test.ts`'s `describe("checkVisitorAnalyticsConfig", ...)`.
-
-### Module descriptor (Issue #617, `src/modules/visitor-analytics/module.ts`)
-
-Modul `visitor_analytics` terdaftar di `src/modules/index.ts`'s
-`listModules()`. **Hanya descriptor + config** — tidak ada tabel/API/UI/
-middleware di sini, itu semua issue lanjutan.
-
-- `key: "visitor_analytics"`, `type: "system"` (bukan `"domain"`) —
-  observability infrastructure yang dipakai bersama semua tenant, sama
-  alasan dengan `reporting`/`logging`/`tenant_domain`.
-- `dependencies: ["tenant_admin", "identity_access", "logging", "reporting"]`
-  (persis daftar di body issue #617).
-- `api: { basePath: "/api/v1/analytics", openApiPath:
-"openapi/awcms-public-api.openapi.yaml" }` dan `navigation: [{
-path: "/admin/analytics", requiredPermission:
-"visitor_analytics.dashboard.read", order: 70 }]` **dideklarasikan sejak
-  Issue #617** meski saat itu API (#621)/dashboard (#622) belum ada —
-  konvensi sama dengan `tenant_domain`'s descriptor sebelum #562. Kedua
-  issue itu sekarang sudah selesai (lihat §API dan §Dashboard UI di
-  bawah), jadi `navigation`/`api` di atas bukan lagi janji ke depan.
-- `permissions`: 8 entry (`dashboard.read`, `realtime.read`,
-  `sessions.read`, `events.read`, `raw_detail.read`, `settings.read`,
-  `settings.update`, `retention.purge`), match persis seed migration 038
-  — divalidasi `tests/modules/visitor-analytics-module.test.ts`.
-  `raw_detail.read` **sengaja terpisah** dari `dashboard.read` — operator
-  bisa memberi akses dashboard agregat tanpa memberi akses PII mentah
-  (IP/user-agent).
-- Tidak ada field `settings`/`jobs`/`health` — belum ada
-  settings-API/job/health-check nyata untuk didokumentasikan (konsisten
-  konvensi `module_management/README.md`, lihat juga precedent
-  `tenant_domain` Issue #558).
-- Tidak ada folder `application/`/`infrastructure`/`api` yang dibuat di
-  Issue #617 — hanya `module.ts` + `domain/visitor-analytics-config.ts` +
-  `README.md`. Folder lain menyusul issue yang benar-benar butuh
-  (#618 schema, #619 helpers, #620 middleware, #621 API).
-
-Permission migration: `sql/038_awcms_visitor_analytics_permissions.sql`
-— pola sama `sql/032_awcms_tenant_domain_permissions.sql` (`INSERT ...
-ON CONFLICT (module_key, activity_code, action) DO NOTHING`), belum ada
-role/access assignment yang memakainya.
-
-### Schema (Issue #618, `sql/039_awcms_visitor_analytics_schema.sql`)
-
-Tiga tabel tenant-scoped, semua `ENABLE`+`FORCE ROW LEVEL SECURITY` dengan
-policy standar `tenant_id = current_setting('app.current_tenant_id')::uuid`.
-**Schema saja — belum ada writer**: middleware (#620) belum menulis apa
-pun ke sini.
-
-- `awcms_visitor_sessions` — satu baris per sesi presence. `area IN
-('admin','public','api','auth','setup','unknown')`, `device_type IN
-('desktop','mobile','tablet','bot','unknown')` (nullable). `ip_address`
-  (raw `inet`) nullable, hanya diisi kalau
-  `VISITOR_ANALYTICS_RAW_IP_ENABLED=true`. `login_identifier_snapshot`
-  nullable, **tidak boleh** diisi untuk pengunjung publik anonim.
-- `awcms_visit_events` — satu baris per page-view/API call.
-  `human_status IN ('human','bot','unknown')`, `status_code` (nullable)
-  wajib 100-599 bila diisi. Dua kolom `jsonb` catch-all
-  (`user_agent_parsed`, `geo`) default `'{}'::jsonb` — hanya untuk nilai
-  hasil parse (Issue #619/#623), tidak pernah raw request data.
-- `awcms_visitor_daily_rollups` — `PRIMARY KEY (tenant_id, date,
-area)`, sekaligus target upsert job rollup (#624). Tidak ada index
-  terpisah `(tenant_id, date, area)` — PK sudah menyediakannya, index
-  redundan yang diminta issue sengaja tidak dibuat.
-
-Tidak ada `deleted_at`/soft delete di tiga tabel ini (bukan master/config
-data) — lifecycle-nya purge berbasis retensi (job Issue #624), pola sama
-`awcms_audit_events` (migration 011).
-
-Test: `tests/integration/visitor-analytics-schema.integration.test.ts` —
-constraint check per tabel, RLS isolation lintas tenant, fail-closed tanpa
-GUC, dan scan kolom memastikan tidak ada kolom berbentuk secret (password/
-token/cookie/authorization/request_body).
-
-Docs: `docs/awcms/04_erd_data_dictionary.md` §Visitor Analytics
-(ERD ringkas) dan §Retention awal (dua baris retensi baru).
-
-**Temuan security-auditor Issue #618 (Medium, DITUTUP di Issue #620 — lihat
-§Collector di bawah):** FK biasa
-(`identity_id uuid REFERENCES awcms_identities (id)`,
-`visitor_session_id uuid REFERENCES awcms_visitor_sessions (id)`)
-**tidak dilindungi RLS** — constraint-check FK PostgreSQL berjalan dengan
-privilege owner tabel, bukan role pemanggil (dokumentasi resmi
-`CREATE POLICY`: "foreign key references are not restricted by row
-security"). Kalau nilai `identity_id`/`visitor_session_id` yang ditulis
-Issue #620 pernah berasal dari input yang dikontrol client (bukan
-di-derive dari session/tenant context di server), ini jadi **existence
-oracle lintas tenant** (attacker bisa binary-search UUID buat tahu
-"row ini ada di suatu tenant" vs "row ini tidak ada sama sekali", lepas
-dari RLS). **Wajib dipertahankan Issue #620**: `identity_id` selalu
-di-derive dari identity sesi terautentikasi milik request itu sendiri
-(tidak pernah dari field yang bisa diisi client), `visitor_session_id`
-selalu di-resolve server-side dari cookie/token opaque yang di-lookup di
-dalam tenant context pemanggil sendiri (tidak pernah dari raw UUID
-client yang langsung dicocokkan ke FK). Tambahkan test integrasi di #620
-yang membuktikan UUID palsu/lintas-tenant di salah satu field ditolak
-sebelum sempat menyentuh FK.
-
-### Domain helpers (Issue #619, `src/modules/visitor-analytics/domain/`)
-
-Lima file, semua pure/hampir-pure. `application/collector.ts` (Issue
-#620) adalah caller pertama — jangan re-derive logic ini di issue
-lanjutan mana pun; import langsung.
-
-- `visitor-key.ts` — `generateVisitorKey`/`isValidVisitorKey`/
-  `resolveVisitorKey` (cookie anonim, tolak nilai forged/non-UUID) dan
-  `hashVisitorKey`/`hashIpAddress`/`hashUserAgent` (HMAC-SHA256 di-key
-  dengan `VISITOR_ANALYTICS_HASH_SALT` — beda dari `hashIdentifier`
-  profile-identity yang sengaja unsalted, lihat file ini untuk alasan
-  lengkap).
-- `user-agent.ts` — `parseUserAgent`/`isBotUserAgent`. Tabel regex
-  ringkas (bukan dependency npm) untuk browser (Chrome/Firefox/Safari/
-  Edge/Opera/Samsung Internet/IE), OS (Windows/macOS/iOS/Android/Chrome
-  OS/Linux — **urutan cek OS penting**: iOS/Android/CrOS dicek sebelum
-  Windows/macOS/Linux karena UA iPhone/iPad selalu membawa token
-  kompatibilitas "like Mac OS X" dan UA Android/CrOS dibangun di atas
-  string kernel Linux — cek yang lebih spesifik dulu mencegah salah
-  klasifikasi), device type, dan ~30 signature bot/crawler/social-preview/
-  automation-client. **Bukan titik keputusan otorisasi/keamanan** — UA
-  bisa dipalsukan trivial.
-- `human-classifier.ts` — `classifyHumanStatus` (tri-state
-  human/bot/unknown untuk `visit_events.human_status`: bot UA selalu
-  menang; sesi terautentikasi + UA apa pun non-bot = human; request
-  anonim + UA tak dikenal = **unknown**, tidak pernah default human) dan
-  `classifySessionHumanity` (boolean `is_human`/`bot_reason` untuk
-  `visitor_sessions`, yang tidak punya kolom tri-state).
-- `path-sanitizer.ts` — `sanitizePath` (buang 11 query param sensitif
-  minimum issue: token/code/password/secret/email/phone/authorization/
-  access_token/refresh_token/reset_token/mfaChallengeToken, case-
-  insensitive) dan `isTrackablePath` (exclude static asset, `/_astro/*`,
-  favicon, endpoint health, path spec OpenAPI/AsyncAPI dari hitungan
-  pageview). **Fail SAFE, bukan fail open** (post-review fix PR #627):
-  input yang gagal di-parse `URL()` membuang seluruh query string
-  (`rawPath.split("?")[0]`), bukan echo raw input — versi awal echo raw
-  input, yang bisa membocorkan query param sensitif yang justru gagal
-  di-parse (mis. IPv6 literal rusak).
-- `referrer.ts` — `extractReferrerDomain` (hostname saja, tidak pernah
-  path/query/fragment, `null` untuk scheme non-http(s)).
-
-Test: `tests/unit/visitor-analytics-{visitor-key,user-agent,human-classifier,path-sanitizer,referrer}.test.ts`
-— `user-agent.test.ts` mencakup 20+ contoh UA nyata (desktop/mobile/
-tablet/13 signature bot/unknown).
-
-### Collector (Issue #620, `application/collector.ts` + `src/middleware.ts`)
-
-Satu-satunya writer `awcms_visitor_sessions`/`awcms_visit_events`.
-`src/middleware.ts` memanggilnya setelah `next()` resolve (di kedua
-cabang pre-admin dan `/admin/*`), jadi `response.status` sudah diketahui.
-
-- **Gate**: `shouldCollectRequest` (pure, unit-tested) — cek
-  `config.enabled` → `isTrackablePath` → flag per-area
-  (`COLLECT_ADMIN`/`COLLECT_API`/`COLLECT_PUBLIC`). `/login` diklasifikasi
-  `public` (page render), bukan `auth` — `auth`/`setup` khusus untuk
-  `/api/v1/auth/*`/`/api/v1/setup/*`, sama-sama digerbangi `COLLECT_API`
-  (`domain/request-area.ts`'s `determineArea`).
-- **Resolusi tenant**: `/admin/*` pakai `ssrContext.tenantId` yang sudah
-  ada (redirect guard sudah jalan lebih dulu). Area lain pakai
-  `resolvePublicTenantFromRequest` (#559) — best-effort, tenant tidak
-  resolve = tidak dikoleksi, bukan hard failure.
-- **Cookie visitor**: `awcms_visitor_key`, `httpOnly`+`sameSite=lax`,
-  di-set hanya saat request benar-benar dikoleksi. **Diubah Issue #624
-  repository audit addendum**: maxAge sekarang configurable
-  (`VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS`, 30 hari default —
-  bukan lagi hardcoded 2 tahun), dan `src/middleware.ts` memanggil
-  `shouldRevokeVisitorKeyCookie`/`planVisitorKeyCookie`
-  (`domain/visitor-key-cookie.ts`, fungsi pure baru) SEBELUM gate
-  path/area: cookie yang sudah ada dihapus aktif begitu
-  `VISITOR_ANALYTICS_ENABLED` bukan `"true"`, dan tidak ada cookie/event
-  baru yang pernah ditulis selama modul nonaktif. Jangan re-derive logic
-  set/delete cookie langsung di `src/middleware.ts` lagi — kedua fungsi
-  pure itu satu-satunya tempat keputusannya.
-- **Session find-or-create**: lookup `(tenant_id, visitor_key_hash,
-area)` (index baru migration 040). Dalam window
-  `VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS` → reuse row, tapi UPDATE
-  hanya jika tulisan terakhir ≥30 detik lalu (write-throttle). Di luar
-  window → session baru. Event **tidak pernah** di-throttle — selalu satu
-  baris per request yang dikoleksi. `login_identifier_snapshot` sengaja
-  selalu `null` (deferred, bukan regresi — lihat README modul).
-- **Fail-open**: `collectVisitorTelemetry` tidak pernah throw — semua
-  error ditangkap, dicatat `log("warning", "visitor_analytics.collector.failed", ...)`
-  dengan `correlationId`, tidak pernah membocorkan data sensitif.
-  `withTenant` dipanggil dengan `workClass: "background_sync"` (prioritas
-  DB terendah, doc 16).
-- **FK-oracle DITUTUP** (temuan security-auditor #618 di atas):
-  `identityId` selalu dari `ssrContext.identityId` (server-derived,
-  hanya ada setelah redirect guard `/admin/*` lolos) atau `null` untuk
-  publik — tidak pernah dari input client. `visitor_session_id` selalu
-  dari row yang baru saja ditemukan/dibuat fungsi ini sendiri di dalam
-  transaksi tenant-scoped-nya sendiri — tidak pernah dari UUID mentah
-  client.
-- **Client IP**: `domain/client-ip.ts`'s `resolveAnalyticsClientIp` —
-  saudara `lib/security/rate-limit.ts`'s `resolveClientIp` yang lebih
-  konservatif; hanya percaya `CF-Connecting-IP`/`X-Forwarded-For` saat
-  `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`/`_TRUST_PROXY` eksplisit `true`.
-
-Test: `tests/unit/visitor-analytics-collector.test.ts` (`shouldCollectRequest`),
-`tests/unit/visitor-analytics-request-area.test.ts`,
-`tests/unit/visitor-analytics-client-ip.test.ts`,
-`tests/integration/visitor-analytics-collector.integration.test.ts` (9
-test: create, sanitize, bot classify, raw-IP opt-in, throttle+reuse,
-session rollover, non-trackable no-op, fail-open invalid tenant,
-authenticated admin). Juga smoke-test manual lewat dev server + Postgres
-nyata (setup wizard → login → `/admin` → row session/event benar; `/` →
-session publik; asset statis dan `/api/v1/health` default-off → nihil).
-
-### API (Issue #621, `src/pages/api/v1/analytics/*`)
-
-11 endpoint. Semua wajib bearer session + tenant context + `authorizeInTransaction`
-(ABAC default-deny) — deny selalu `403 ACCESS_DENIED`, tidak pernah data
-analytics kosong/nol diam-diam.
-
-- `GET /realtime` (`realtime.read`), `GET /summary|pages|devices|locations|security`
-  (`dashboard.read`, `range=24h|7d|30d|12m` divalidasi ketat →
-  `400 VALIDATION_ERROR` untuk nilai lain).
-- `GET /sessions` (`sessions.read`), `GET /events` (`events.read`) — keyset
-  pagination (limit 50), field raw detail (`ipHash`/`ipAddress`/
-  `userAgentHash`/`loginIdentifierSnapshot`) `null` kecuali caller **juga**
-  punya `raw_detail.read` (dicek via `auth.grantedPermissionKeys.has(...)`
-  setelah guard utama lolos — `domain/analytics-response-shaping.ts`).
-- `GET/PATCH /settings` (`settings.read`/`.update`) — **reuse langsung**
-  storage generik Module Management (`awcms_module_settings`, Issue
-  #516) via `fetchModuleSettingsView`/`updateModuleSettings`, tapi
-  di-gate permission `visitor_analytics.*` sendiri (bukan
-  `module_management.settings.*` yang dipakai endpoint generiknya). Jangan
-  bangun storage settings kedua untuk modul ini.
-- `POST /retention/purge` (`retention.purge`) — wajib `Idempotency-Key`,
-  audit `critical`. Logic nyata (bukan stub) di
-  `application/retention-purge.ts`: hapus event > `EVENT_RETENTION_DAYS`,
-  clear `ip_address`/`login_identifier_snapshot` sesi > `RAW_DETAIL_RETENTION_DAYS`
-  (row tetap), hapus sesi > `EVENT_RETENTION_DAYS` (aman dijalankan
-  setelah hapus event — `last_seen_at` sesi selalu >= `occurred_at`
-  event-nya sendiri, jadi FK `visit_events.visitor_session_id` sudah
-  bersih), hapus rollup > `ROLLUP_RETENTION_DAYS`. Issue #624's scheduled
-  job **selesai** — `bun run analytics:purge`
-  (`scripts/visitor-analytics-purge.ts`, via `purgeVisitorAnalyticsForAllTenants`)
-  memanggil `purgeVisitorAnalyticsData` ini langsung untuk setiap tenant
-  `active`, tidak re-derive. Lihat §Rollup job/§Retention purge job di
-  bawah untuk detail penuh.
-- Query agregat (`application/analytics-queries.ts`) baca langsung dari
-  `visit_events`/`visitor_sessions` mentah, **bukan** `visitor_daily_rollups`
-  — tetap begitu setelah #624: rollup job (di bawah) kini mengisi tabel
-  itu, tapi switch `fetchAnalyticsSummary` membaca rollup untuk rentang
-  lama tetap open future work (optimisasi performa, bukan bagian
-  acceptance criteria #624).
-
-Test: `tests/unit/visitor-analytics-{range,response-shaping}.test.ts`,
-`tests/integration/visitor-analytics-api.integration.test.ts` (13 test:
-auth guard, ABAC deny lintas endpoint, realtime, summary+range validation,
-raw-detail gating dua arah, keyset pagination 55-row, FK-straddle purge,
-geo/jsonb object shape lewat API nyata, settings GET/PATCH + secret-key
-rejection, retention purge idempotency+delete+audit).
-
-### Geo enrichment (Issue #623, `domain/geo-enrichment.ts`)
-
-Country code saja, dari header Cloudflare `CF-IPCountry` — **tidak
-pernah** external network call. Gate ganda: `VISITOR_ANALYTICS_GEO_ENABLED`
-**dan** `VISITOR_ANALYTICS_TRUST_CLOUDFLARE` harus `true` keduanya;
-salah satu `false` → semua field `null`. Region/city/timezone selalu
-`null` di issue ini (belum ada local GeoIP DB, out of scope).
-
-`src/middleware.ts` panggil `resolveGeoEnrichment` di samping
-`resolveAnalyticsClientIp`, hasilnya masuk `collectVisitorTelemetry`'s
-field baru `geo` (Issue #620's `collector.ts` di-extend, bukan file
-baru) — ditulis ke `visitor_sessions.country_code/region/city/timezone`
-DAN `visit_events.geo` (shape sama yang sudah dibaca
-`fetchTopCountries`, Issue #621 — `GET /api/v1/analytics/locations`
-otomatis dapat data nyata begitu geo enrichment aktif, tanpa ubah sisi
-API).
-
-**Hardening ambiguous-header** (`domain/client-ip.ts`, issue ini juga):
-`resolveAnalyticsClientIp` sekarang menolak `X-Forwarded-For`/
-`CF-Connecting-IP` yang punya >1 nilai comma-separated (anomali, log
-warning, fallback ke sumber berikutnya — sama persis pola
-`X-Forwarded-Host` di `public-host-tenant-resolver.ts`, epic
-tenant-domain-routing). Proxy tepercaya yang benar wajib **overwrite**,
-bukan **append**, header ini (kontrak sama `PUBLIC_TRUST_PROXY`, doc 18)
-— jadi proxy yang dikonfigurasi benar tidak pernah menghasilkan >1 nilai
-di sini juga.
-
-**Temuan post-review issue ini — bug jsonb laten sejak #620**:
-`collector.ts`'s `user_agent_parsed`/`geo` sebelumnya ditulis via
-`JSON.stringify(...)::jsonb` — bytes yang tersimpan identik dengan
-`${object}::jsonb`, TAPI Bun.SQL men-decode SELECT berikutnya dari
-kolom itu sebagai raw JSON **string**, bukan object ter-parse (lihat
-memory `bun-sql-jsonb-stringify-trap` untuk bukti empiris lengkap).
-Ini diam-diam memengaruhi response `GET /api/v1/analytics/events`'s
-`userAgentParsed`/`geo` sejak #621 rilis. **Wajib dipertahankan issue
-lanjutan**: selalu bind object JS polos sebagai parameter query untuk
-kolom jsonb (`${plainObject}::jsonb`), jangan pernah
-`JSON.stringify()` dulu — cek `grep -rn "JSON.stringify.*::jsonb"` di
-modul manapun yang disentuh sebelum menganggap kolom jsonb "sudah
-benar".
-
-Test: `tests/unit/visitor-analytics-{client-ip,geo-enrichment}.test.ts`,
-`tests/integration/visitor-analytics-collector.integration.test.ts`
-(geo tertulis ke session+event, geo kosong tetap null),
-`tests/integration/visitor-analytics-api.integration.test.ts` (geo/
-userAgentParsed object nyata lewat `/events` dan `/locations`).
-
-### Dashboard UI (Issue #622, `src/pages/admin/analytics.astro`)
-
-`/admin/analytics`, gate `visitor_analytics.dashboard.read`. **UI-only** —
-tidak menambah endpoint/permission baru, tidak pernah query
-`awcms_visitor_sessions`/`awcms_visit_events` langsung. Semua
-angka/tabel dimuat client-side dari `GET /api/v1/analytics/*` (#621) lewat
-helper baru `fetchJson` (`src/lib/ui/admin-form-client.ts`) — SENGAJA
-bukan konvensi SSR-panggil-application-layer-langsung yang dipakai
-`admin/security.astro`/`admin/sync.astro`, supaya ABAC server-side
-(`authorizeInTransaction`) tetap satu-satunya enforcement point nyata.
-
-- **Raw-detail gating tidak di-derive ulang** — dashboard render persis
-  apa yang API kembalikan (`domain/analytics-response-shaping.ts` sudah
-  men-null-kan `ipAddress`/`ipHash`/`userAgentHash`/
-  `loginIdentifierSnapshot` untuk caller tanpa `raw_detail.read`); logic
-  UI baru (`domain/dashboard-view.ts`'s `displayOrPlaceholder`/
-  `buildSessionRowCells`) cuma menerjemahkan `null` jadi placeholder
-  aman, tidak pernah membuat keputusan izin sendiri. `showRawDetailColumns`
-  cuma menyembunyikan 4 kolom tabel sebagai kosmetik (biar caller yang
-  memang tidak akan pernah lihat nilai asli tidak melihat tembok tanda
-  strip) — tidak bisa bocor karena nilai yang ditampilkan selalu berasal
-  dari respons API apa adanya.
-- **Filter area/visitor-type TIDAK menyentuh endpoint agregat** — tidak
-  ada endpoint #621 yang menerima parameter `area`/tipe pengunjung, jadi
-  kedua filter ini cuma menyaring baris tabel active-sessions yang sudah
-  ter-fetch (client-side, `matchesAreaFilter`/`matchesVisitorTypeFilter`).
-  Hanya `range` (`24h|7d|30d|12m`) yang benar-benar query parameter API
-  nyata (`/summary`, `/pages`, `/devices`, `/locations`, `/security`).
-  Jangan bangun ulang asumsi "semua filter berlaku ke semua section" di
-  issue lanjutan manapun tanpa lebih dulu menambah parameter itu ke API
-  (perubahan API, di luar scope #622).
-- **Geo gate** — Location section tampil sebagai `StateNotice` disabled
-  kalau `resolveVisitorAnalyticsConfig().geoEnabled &&
-.trustCloudflare` tidak keduanya `true` (baca config env langsung,
-  bukan akses DB, bukan gerbang keamanan kedua — cuma keputusan render).
-
-Test: `tests/unit/visitor-analytics-dashboard-view.test.ts` (raw-detail-
-null formatting, section-state loading/empty/error, filter predicate —
-semua pure), `tests/e2e/admin-analytics-access-denied.e2e.ts`,
-`tests/e2e/admin-analytics-dashboard.e2e.ts` (raw-detail gating end-to-end
-lewat render browser sungguhan — caller tanpa `raw_detail.read` melihat
-baris sesi tenant yang sama tanpa kolom raw-detail maupun nilai
-`sha256:`-prefixed apa pun).
-
-### Rollup job (Issue #624, `application/rollup.ts` + `scripts/visitor-analytics-rollup.ts`)
-
-`bun run analytics:rollup` — mengagregasi `awcms_visit_events`
-mentah menjadi `awcms_visitor_daily_rollups`, satu baris per
-`(tenant, date, area)`, untuk setiap tenant `active`.
-
-- **Idempotent by construction**: `rollupVisitorAnalyticsForDate`
-  merekomputasi PENUH dari event mentah untuk tanggal yang diminta dan
-  UPSERT (`ON CONFLICT (tenant_id, date, area) DO UPDATE SET ... =
-EXCLUDED...`) — rerun tanggal yang sama berkali-kali selalu konvergen
-  ke baris yang sama, tidak pernah menambah ke nilai lama. Jangan ubah
-  ini jadi logic increment/append apa pun.
-- **SENGAJA tidak reuse `application/analytics-queries.ts`'s top-N
-  helper verbatim** — fungsi-fungsi itu cumulative-since-`start` (tanpa
-  batas atas) dan tenant-wide (tanpa filter `area`), bentuk yang dipakai
-  dashboard live (#621). Rollup butuh jendela `[dayStart, dayEnd)`
-  tertutup DAN split per `area` (PK tabel rollup), jadi
-  `application/rollup.ts` mengimplementasikan query top-N sendiri yang
-  di-scope hari+area, mengikuti pola keamanan SQL yang sama
-  (allow-list kolom/key jsonb sebelum `tx.unsafe`).
-- Area tanpa event pada tanggal itu **tidak** mendapat baris rollup
-  (bukan baris bernilai nol).
-- CLI: `--date=YYYY-MM-DD` | `--start-date=.../--end-date=...` | default
-  "kemarin" (UTC).
-
-Test: `tests/integration/visitor-analytics-rollup.integration.test.ts`.
-
-### Retention purge job (Issue #624, `scripts/visitor-analytics-purge.ts`)
-
-`bun run analytics:purge` — mengiterasi setiap tenant `active` dan
-memanggil `purgeVisitorAnalyticsData` (§API di atas) LANGSUNG lewat
-fungsi yang diekspor `purgeVisitorAnalyticsForAllTenants`, TIDAK PERNAH
-re-derive empat cutoff-nya. Hanya tenant yang benar-benar ada
-baris terhapus/terbersihkan yang mendapat audit `critical`
-`retention_purged` (attributes: empat angka ringkasan saja) — tenant
-tanpa data kedaluwarsa tidak menghasilkan audit noise. Tidak ada lapisan
-batching tambahan di atas apa yang `purgeVisitorAnalyticsData` sudah
-lakukan.
-
-Test: `tests/integration/visitor-analytics-purge.integration.test.ts` —
-SENGAJA tidak menguji ulang empat aturan retensi (sudah dicakup
-`tests/integration/visitor-analytics-api.integration.test.ts` lewat
-`POST .../retention/purge`, fungsi yang sama persis); hanya menguji apa
-yang ditambahkan script ini — iterasi multi-tenant, jumlah total lintas
-tenant, dan audit hanya untuk tenant yang punya efek nyata.
-
-### Readiness checks (Issue #624, `scripts/security-readiness.ts`)
-
-`scripts/validate-env.ts`'s `checkVisitorAnalyticsConfig` (#617) TETAP
-shape-only (enum/positive-int). Lima check SAFETY cross-field baru ada
-di `security-readiness.ts` (bukan `validate-env.ts`) — pola yang sama
-`checkOnlineAuthSecurityConfig`/`Ready` dkk. sudah pakai (shape vs
-safety/severity). Semua reuse `resolveVisitorAnalyticsConfig`:
-
-| Check                                             | Severity | Gagal saat                                                                                                      |
-| ------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------- |
-| `checkVisitorAnalyticsRawIpRetentionReady`        | critical | Raw IP aktif + retensi raw detail > retensi event                                                               |
-| `checkVisitorAnalyticsRawUserAgentRetentionReady` | warning  | Raw user-agent aktif (masih no-op) + retensi sama tidak aman                                                    |
-| `checkVisitorAnalyticsGeoTrustedSourceReady`      | critical | Geo aktif tanpa `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`                                                            |
-| `checkVisitorAnalyticsRetentionOrderingReady`     | warning  | Retensi raw detail > event, ATAU rollup < event                                                                 |
-| `checkVisitorAnalyticsHashSaltReady`              | warning  | Modul aktif + `VISITOR_ANALYTICS_HASH_SALT` kosong                                                              |
-| `checkVisitorAnalyticsVisitorKeyCookieTtlReady`   | warning  | Modul aktif + `VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS` > 400 hari (Issue #624 repository audit addendum) |
-
-Default privacy-first (semua var tidak di-set) lulus BERSIH keenam
-check ini. Hanya `critical` yang memblokir go-live. Jangan re-derive
-aturan ini di `validate-env.ts` — kalau butuh dipakai script lain,
-import dari `security-readiness.ts` seperti check lain sudah lakukan.
-
-Test: `tests/security-readiness.test.ts`.
-
-### Repository audit addendum (Issue #624, reopened 2026-07-11, epic platform-hardening #679)
-
-Setelah Issue #624's scope asli (rollup/purge/readiness/docs) selesai,
-audit repositori 2026-07-11 menemukan dua celah default privasi dan
-menambah scope ke issue yang SAMA (bukan issue baru):
-
-1. **`.env.example` mengaktifkan analytics secara default** — DITUTUP:
-   `VISITOR_ANALYTICS_ENABLED` sekarang default `false` di
-   `VISITOR_ANALYTICS_DEFAULTS` (`domain/visitor-analytics-config.ts`),
-   `.env.example`, dan `src/lib/config/registry.ts` sekaligus (ketiganya
-   harus tetap sinkron — `tests/unit/config-docs-check.test.ts`'s
-   `runConfigDocsCheck` menegakkan kehadiran var yang sama di ketiganya,
-   BUKAN kesamaan nilai default). Deployment existing yang sudah men-set
-   var ini `true` eksplisit tidak terdampak — hanya deployment yang
-   mengandalkan default implisit lama yang perlu menambahkan var ini
-   secara eksplisit setelah upgrade. Tidak ada migration data — perubahan
-   murni di layer config.
-2. **Cookie visitor-key berumur ~2 tahun** — DITUTUP: field baru
-   `visitorKeyCookieTtlDays` (default 30, env
-   `VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS`) di
-   `VisitorAnalyticsConfig`, dikonsumsi
-   `resolveVisitorKeyCookieMaxAgeSeconds`. Dua fungsi pure baru di
-   `domain/visitor-key-cookie.ts` — `shouldRevokeVisitorKeyCookie`
-   (dipanggil SEBELUM gate `shouldCollectRequest`, true hanya saat modul
-   nonaktif DAN cookie valid masih ada → middleware menghapusnya) dan
-   `planVisitorKeyCookie` (dipanggil SESUDAH gate lolos, HANYA saat modul
-   aktif — selalu resolve nilai + tandai perlu `Set-Cookie` atau tidak,
-   mempertahankan invarian lama "cookie di-set hanya saat request
-   benar-benar dikoleksi", bukan di setiap request).
-3. **"Jangan set cookie / tulis event saat disabled"** — sudah otomatis
-   benar secara struktural: `collectRequestAnalytics`
-   (`src/middleware.ts`) mengecek `config.enabled` SEBELUM apa pun lain
-   (setelah revocation check di atas) dan `return` langsung bila mati —
-   tidak ada jalur kode yang bisa sampai ke `context.cookies.set`/
-   `collectVisitorTelemetry` saat modul nonaktif. Diverifikasi
-   `tests/unit/visitor-analytics-visitor-key-cookie.test.ts` dan
-   `tests/unit/visitor-analytics-collector.test.ts` (kasus
-   `VISITOR_ANALYTICS_DEFAULTS` disabled-by-default).
-4. **Dokumentasi data-subject deletion/anonymization + UU PDP/ISO
-   27701:2025** — ditambahkan ke
-   `docs/awcms/visitor-analytics.md` (§Default opt-in dan upgrade
-   path, §Cookie anonim, baris baru tabel UU PDP, bagian ISO/IEC
-   27701:2025 dimutakhirkan dari referensi 2019 sebelumnya).
-
-**Yang TIDAK berubah** (di luar scope addendum, jangan disentuh issue
-lanjutan tanpa alasan baru): raw IP/raw user-agent/geo tetap default
-mati (sudah begitu sejak #617, addendum hanya menegaskan ulang), tidak
-ada perubahan skema/tabel (migration baru TIDAK dibutuhkan — perubahan
-ini murni config + middleware), tidak ada endpoint API baru.
-
-Test baru: `tests/unit/visitor-analytics-visitor-key-cookie.test.ts`
-(pure, `shouldRevokeVisitorKeyCookie`/`planVisitorKeyCookie`). Test yang
-diperbarui (bukan baru) untuk mencerminkan default baru:
-`tests/unit/visitor-analytics-config.test.ts`,
-`tests/unit/visitor-analytics-collector.test.ts`,
-`tests/security-readiness.test.ts`.
-
-## Prinsip yang wajib dipertahankan di setiap issue lanjutan
-
-1. **Privacy-first default** — raw IP, raw user-agent, geolokasi selalu
-   default mati. Jangan pernah membuat issue lanjutan menyalakannya secara
-   implisit lewat `VISITOR_ANALYTICS_MODE=detailed` atau flag lain; wajib
-   opt-in eksplisit per flag masing-masing.
-2. **`raw_detail.read` terpisah dari `dashboard.read`** — endpoint/UI yang
-   menampilkan IP/user-agent mentah wajib cek permission `raw_detail.read`
-   secara eksplisit, bukan cukup `dashboard.read`.
-3. **Tenant isolation** — skema (#618, sudah selesai) tenant-scoped + RLS
-   `ENABLE`+`FORCE`, sama pola semua tabel tenant-scoped lain di repo ini
-   (lihat `docs/adr/0003-postgresql-rls-multi-tenant.md`). Issue
-   lanjutan yang menulis ke tabel ini (mis. #620) tetap wajib lewat
-   `withTenant`, tidak pernah query langsung tanpa tenant context.
-4. **Bukan dependency operasional** — koleksi telemetry tidak boleh
-   memblokir/memperlambat request admin/publik yang sebenarnya (mis. tulis
-   event lewat outbox/fire-and-forget, bukan inline blocking DB write di
-   jalur request kritis) — prinsip sama ADR-0006 untuk provider eksternal.
-5. **Retensi lebih pendek untuk data lebih sensitif** — raw detail (30
-   hari default) < event (90 hari default) < rollup agregat (730 hari
-   default). Jangan balik urutan ini di issue lanjutan tanpa alasan eksplisit.
-6. **`VISITOR_ANALYTICS_HASH_SALT` bukan credential provider** — dipakai
-   untuk fingerprint pseudonymous (dedup visitor tanpa cookie persisten),
-   bukan untuk autentikasi apa pun. Jangan expose di response/log/audit.
-7. **Default-off untuk instalasi baru** (Issue #624 repository audit
-   addendum) — `VISITOR_ANALYTICS_ENABLED` default `false`. Jangan
-   pernah membalik ini kembali ke `true` tanpa keputusan sadar yang
-   didokumentasikan ulang — ini adalah keputusan privasi/kepatuhan
-   eksplisit, bukan preferensi teknis.
-8. **Cookie visitor-key pendek + revocable** — jangan pernah
-   memperpanjang default `VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS`
-   kembali ke orde tahun tanpa justifikasi eksplisit, dan jangan
-   menghapus logic `shouldRevokeVisitorKeyCookie` (revocation saat modul
-   nonaktif) — keduanya bagian dari keputusan privasi addendum ini, bukan
-   detail implementasi yang bebas diubah.
-
-## Referensi
-
-- `src/modules/visitor-analytics/README.md` — detail per-issue di dalam modul.
-- `docs/awcms/visitor-analytics.md` — panduan operasional lengkap
-  (mode offline/LAN vs online vs trusted-proxy/Cloudflare, retensi,
-  rollup/purge, dan pemetaan kepatuhan UU PDP/PP PSTE/ISO
-  27001-27002-27005-27701/OWASP ASVS/Logging Cheat Sheet).
-- `docs/awcms/18_configuration_env_reference.md` §Visitor analytics.
-- `docs/awcms/20_threat_model_security_architecture.md` §Standar
-  tambahan dipicu epic visitor analytics.
-- `AGENTS.md` skill table.
+# AWCMS — Visitor Analytics (code guide)
+
+Modul **SUDAH ADA** di repo ini: `src/modules/visitor-analytics/`,
+migrasi `sql/049`–`sql/051`, terdaftar di `src/modules/index.ts`. Ini panduan
+kode yang bisa dipanggil — bukan spesifikasi target. Baca juga
+`src/modules/visitor-analytics/README.md`.
+
+## Bentuk modul (apa yang ada di kode)
+
+- **Descriptor** `module.ts`: `key: "visitor_analytics"`, `type: "system"`,
+  `dependencies: [tenant_admin, identity_access, logging, reporting]`, 8
+  permission, `navigation` `/admin/analytics`, `jobs` (rollup+purge),
+  `settings.schemaVersion:1`. TIDAK ada field `dataLifecycle` (di-drop, lihat
+  §Port).
+- **domain/** (murni, unit-tested tanpa DB): `visitor-analytics-config.ts`
+  (env resolver privacy-first), `visitor-key.ts` (HMAC-SHA256 bersalt +
+  visitor-key anonim), `user-agent.ts`, `human-classifier.ts`,
+  `path-sanitizer.ts`, `referrer.ts`, `request-area.ts`, `client-ip.ts`,
+  `geo-enrichment.ts`, `analytics-range.ts`, `analytics-response-shaping.ts`
+  (gerbang raw-detail), `dashboard-view.ts`, `visitor-key-cookie.ts`.
+- **application/**: `collector.ts` (satu-satunya penulis session/event, fail-open,
+  `workClass:"background_sync"` `queueTimeoutMs:200`), `analytics-queries.ts`,
+  `rollup.ts`, `retention-purge.ts`, `event-directory.ts`, `session-directory.ts`.
+- **api**: `src/pages/api/v1/analytics/{collect,summary,realtime,sessions,events,pages,devices,locations,security,settings}.ts`
+  - `retention/purge.ts`.
+- **admin**: `src/pages/admin/analytics.astro` (SSR-render).
+- **jobs**: `scripts/visitor-analytics-rollup.ts` (`bun run analytics:rollup`),
+  `scripts/visitor-analytics-purge.ts` (`bun run analytics:purge`).
+
+## Invarian privasi (JANGAN regresi)
+
+1. **Off by default.** `VISITOR_ANALYTICS_ENABLED=false`. `collector` &
+   endpoint ingest tidak menulis apa pun saat disabled.
+2. **Identifier di-hash bersalt, tidak pernah mentah.** visitor-key/IP/UA →
+   `hashVisitorKey/hashIpAddress/hashUserAgent` (`domain/visitor-key.ts`),
+   di-key oleh `VISITOR_ANALYTICS_HASH_SALT`. `scripts/validate-env.ts`
+   MEWAJIBKAN salt nyata saat modul enabled (cross-rule) — jangan longgarkan.
+3. **Raw detail opt-in ganda.** `ip_address` mentah hanya saat
+   `rawIpEnabled`; `login_identifier_snapshot` tak pernah untuk anonim.
+   API menutup raw field via `shapeVisitorSession/shapeVisitEvent(row,
+canSeeRawDetail)` — `canSeeRawDetail = grantedPermissionKeys.has(
+"visitor_analytics.raw_detail.read")`. Gerbang server-side SATU kali;
+   dashboard TIDAK boleh jadi gerbang kedua.
+4. **`sanitizePath` fail-safe** (path tak-terparse → buang seluruh query),
+   `extractReferrerDomain` hanya hostname. Jangan simpan raw path/query/referrer.
+5. **jsonb** `user_agent_parsed`/`geo` diisi OBJEK JS (bukan
+   `${JSON.stringify}::jsonb`) supaya SELECT balik jadi objek, bukan string.
+
+## Koleksi = endpoint ingest publik (BUKAN middleware)
+
+`POST /api/v1/analytics/collect` publik/anonim: body `{tenantCode, path, referrer?}`.
+Resolve tenant via `resolvePublicTenantByCode` (tabel `awcms_tenants` **RLS-free**,
+ADR-0009 — sama seperti rute `/blog/{tenantCode}`), lalu `collectVisitorTelemetry`.
+**`src/middleware.ts` sengaja TIDAK disentuh** (jaminan login/Turnstile/CSP tetap).
+IP/UA dari header request (bukan body). Fire-and-forget selalu `202`; hanya
+rekam area `public` (anonim tak bisa buktikan admin/api). **TIDAK ada SECURITY
+DEFINER** — karena `awcms_tenants` RLS-free (lain dari `tenant_domain` yang
+butuh sql/048). `operationId analyticsCollect` ada di `ALLOWED_PUBLIC_OPERATIONS`
+(`scripts/api-spec-check.ts`).
+
+## RLS & FK (migrasi 050)
+
+- Tiga tabel `ENABLE`+`FORCE RLS` + policy `tenant_isolation`. `awcms_worker`
+  DIBERI GRANT eksplisit (default privileges hanya `awcms_app`) — job jalan
+  sebagai worker; jangan hapus grant itu.
+- `awcms_visit_events` pakai **composite FK** `(tenant_id, visitor_session_id)`
+  → `awcms_visitor_sessions(tenant_id, id)` (ada `UNIQUE(tenant_id,id)`).
+  `identity_id` FK polos (selalu null di ingest).
+
+## Keyset (konvensi base ini, bukan micro)
+
+`event-directory.ts`/`session-directory.ts` mengembalikan `{rows, nextCursor}`
+dengan cursor teks presisi-penuh dari `to_char(occurred_at/last_seen_at ... US
+...)` — JANGAN pakai `encodeKeysetCursor(row.date_as_JS_Date, id)` (micro
+begitu; `encodeKeysetCursor` di sini menerima TEKS, dan `Date` JS membuang
+mikrodetik → lewatkan baris di batas halaman, Issue #158).
+
+## Port (keputusan yang sudah diambil)
+
+- **DROP** descriptor `dataLifecycle` + `LegalHoldGuardPort` (modul
+  `data_lifecycle` belum di-port). `purgeVisitorAnalyticsData(tx, tenantId,
+config, now)` — 4 langkah tanpa gerbang legal-hold. Kembalikan bila
+  `data_lifecycle` di-port.
+- **DEFER** wiring preset `news_portal_full_online_r2` → JANGAN sentuh modul
+  `news_portal`. Modul ini standalone.
+- **Admin** = SSR-render (`admin/offices.astro` pattern), bukan client-fetch
+  SPA micro (base ini tak punya i18n framework / `components/ui`).
+
+## Gate saat mengubah modul ini
+
+`bun run check` penuh. Yang paling relevan: `api:spec:check` (route-parity —
+setiap route file WAJIB punya path OpenAPI di
+`openapi/modules/visitor-analytics.openapi.yaml`, lalu `bun run openapi:bundle`
+
+- commit bundle); `modules:composition:inventory:check` (regen
+  `bun run modules:composition:inventory:generate`); `logging:lint:check` (log
+  pakai field terstruktur + `moduleKey`); `typecheck`; `test`. Fragment OpenAPI
+  hanya boleh menyumbang `paths` + `components.schemas` (parameter di-inline;
+  `ModuleSettingsView` di-`$ref` ke milik module-management, jangan didefinisikan
+  ulang). Tes: unit `tests/visitor-analytics-*.test.ts` + integrasi DB-gated
+  `tests/integration/visitor-analytics.integration.test.ts` (RLS bawah
+  `awcms_app`, composite FK, purge).

--- a/.env.example
+++ b/.env.example
@@ -162,3 +162,33 @@ EMAIL_SEND_MAX_RETRIES=5
 # EMAIL_MAILKETING_ACCOUNT_ID=operator-label
 # EMAIL_MAILKETING_API_TOKEN=replace-me
 # EMAIL_MAILKETING_API_BASE_URL=https://api.mailketing.co.id
+
+# ── Visitor Analytics (ported from awcms-micro epic #617-#624) ──────────────
+# Privacy-first human visitor statistics. OFF by default: a fresh install
+# collects nothing until VISITOR_ANALYTICS_ENABLED=true (a technical switch,
+# never itself the lawful-basis/consent decision required by UU PDP).
+VISITOR_ANALYTICS_ENABLED=false
+# When enabled, a REAL salt is REQUIRED (validate-env enforces it): visitor
+# identifiers (visitor-key cookie, IP, user-agent) are stored only as salted
+# HMAC-SHA256, never raw. Generate e.g. `openssl rand -base64 32`.
+# VISITOR_ANALYTICS_HASH_SALT=replace-me
+# aggregate-only "basic" (default) vs richer "detailed"
+VISITOR_ANALYTICS_MODE=basic
+VISITOR_ANALYTICS_COLLECT_ADMIN=true
+VISITOR_ANALYTICS_COLLECT_PUBLIC=true
+VISITOR_ANALYTICS_COLLECT_API=false
+VISITOR_ANALYTICS_DETAILED_ENABLED=false
+# Raw IP / raw user-agent collection are each an explicit, independent opt-in
+# (default off — privacy-first; the hashes above are used instead).
+VISITOR_ANALYTICS_RAW_IP_ENABLED=false
+VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED=false
+# Country-only geo enrichment from Cloudflare's CF-IPCountry header — needs
+# BOTH of the next two true, and never makes an external network call.
+VISITOR_ANALYTICS_GEO_ENABLED=false
+VISITOR_ANALYTICS_TRUST_PROXY=false
+VISITOR_ANALYTICS_TRUST_CLOUDFLARE=false
+VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS=300
+VISITOR_ANALYTICS_EVENT_RETENTION_DAYS=90
+VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS=30
+VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS=730
+VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS=30

--- a/.env.example
+++ b/.env.example
@@ -168,9 +168,9 @@ EMAIL_SEND_MAX_RETRIES=5
 # collects nothing until VISITOR_ANALYTICS_ENABLED=true (a technical switch,
 # never itself the lawful-basis/consent decision required by UU PDP).
 VISITOR_ANALYTICS_ENABLED=false
-# When enabled, a REAL salt is REQUIRED (validate-env enforces it): visitor
-# identifiers (visitor-key cookie, IP, user-agent) are stored only as salted
-# HMAC-SHA256, never raw. Generate e.g. `openssl rand -base64 32`.
+# When enabled, a REAL salt is REQUIRED (validate-env enforces it, min 16 chars):
+# visitor identifiers (visitor-key cookie, IP, user-agent) are stored only as
+# per-tenant salted HMAC-SHA256, never raw. Generate e.g. `openssl rand -base64 32`.
 # VISITOR_ANALYTICS_HASH_SALT=replace-me
 # aggregate-only "basic" (default) vs richer "detailed"
 VISITOR_ANALYTICS_MODE=basic
@@ -192,3 +192,8 @@ VISITOR_ANALYTICS_EVENT_RETENTION_DAYS=90
 VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS=30
 VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS=730
 VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS=30
+# Per-IP rate-limit backstop on the PUBLIC ingest beacon
+# (POST /api/v1/analytics/collect). Defaults 120 req / 60 s per client IP when
+# unset. Keyed on IP only (never the tenant), so it leaks no tenant existence.
+# VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_MAX=120
+# VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_WINDOW_SEC=60

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -256,12 +256,7 @@
       "version": "0.1.0",
       "status": "active",
       "type": "system",
-      "dependencies": [
-        "tenant_admin",
-        "identity_access",
-        "logging",
-        "reporting"
-      ],
+      "dependencies": ["tenant_admin", "identity_access", "logging"],
       "capabilitiesProvided": [],
       "capabilitiesConsumed": [],
       "permissionCount": 8,

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -1,5 +1,5 @@
 {
-  "moduleCount": 14,
+  "moduleCount": 15,
   "valid": true,
   "issueCount": 0,
   "modules": [
@@ -246,6 +246,27 @@
       "permissionCount": 6,
       "navigationCount": 0,
       "jobCount": 0,
+      "hasHealthCheck": false,
+      "hasReadinessCheck": false,
+      "deploymentProfiles": null
+    },
+    {
+      "key": "visitor_analytics",
+      "name": "Visitor Analytics",
+      "version": "0.1.0",
+      "status": "active",
+      "type": "system",
+      "dependencies": [
+        "tenant_admin",
+        "identity_access",
+        "logging",
+        "reporting"
+      ],
+      "capabilitiesProvided": [],
+      "capabilitiesConsumed": [],
+      "permissionCount": 8,
+      "navigationCount": 1,
+      "jobCount": 2,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,
       "deploymentProfiles": null

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -635,6 +635,508 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/collect:
+    post:
+      tags:
+        - Visitor Analytics
+      summary: Public visitor page-view beacon (anonymous)
+      description: "PUBLIC, unauthenticated visit-ingest beacon. Resolves the tenant from the request body's `tenantCode` (the RLS-free tenant root), records a privacy-preserving page-view for `public`-area paths only (IP/user-agent stored as salted hashes; anonymous — no identity). Fire-and-forget: always 202 for a well-formed request whether or not anything was recorded (module disabled, unknown tenant, non-public/non-trackable path all still return 202 without leaking tenant existence). Requires no auth."
+      operationId: analyticsCollect
+      security: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CollectVisitBeaconRequest"
+      responses:
+        "202":
+          description: Beacon accepted (recorded or intentionally ignored — never distinguished).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      accepted:
+                        type: boolean
+                        enum:
+                          - true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "413":
+          description: Request body exceeds the size limit (BODY_TOO_LARGE).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/analytics/devices:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Browser + device-type breakdown
+      description: Gated by visitor_analytics.dashboard.read.
+      operationId: analyticsDevices
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum:
+              - 24h
+              - 7d
+              - 30d
+              - 12m
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Browser and device breakdown.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      range:
+                        type: string
+                      browsers:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+                      devices:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/events:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: List visit events (keyset-paginated)
+      description: Gated by visitor_analytics.events.read. Newest first. Raw detail (ipHash/userAgentHash) is returned only when the caller ALSO holds visitor_analytics.raw_detail.read — otherwise those fields are null.
+      operationId: analyticsEventsList
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous page's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: A page of visit events.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      events:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/VisitEvent"
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/locations:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Country breakdown
+      description: Gated by visitor_analytics.dashboard.read. Empty until geolocation enrichment is enabled (VISITOR_ANALYTICS_GEO_ENABLED + VISITOR_ANALYTICS_TRUST_CLOUDFLARE) — not an error, just no data yet.
+      operationId: analyticsLocations
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum:
+              - 24h
+              - 7d
+              - 30d
+              - 12m
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Country breakdown.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      range:
+                        type: string
+                      countries:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/pages:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Top pages by human pageviews
+      description: Gated by visitor_analytics.dashboard.read.
+      operationId: analyticsPages
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum:
+              - 24h
+              - 7d
+              - 30d
+              - 12m
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Top pages.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      range:
+                        type: string
+                      pages:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/realtime:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Online-now presence counts
+      description: Gated by visitor_analytics.realtime.read. Sessions active within the online window (VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS), split by area.
+      operationId: analyticsRealtime
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Realtime presence.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/RealtimeStats"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/retention/purge:
+    post:
+      tags:
+        - Visitor Analytics
+      summary: Purge visitor analytics data past retention
+      description: "Gated by visitor_analytics.retention.purge. Destructive, high-risk: requires Idempotency-Key, audited `critical`. Deletes events past eventRetentionDays, clears session raw detail past rawDetailRetentionDays, deletes orphaned sessions, and deletes rollups past rollupRetentionDays."
+      operationId: analyticsRetentionPurge
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Purge complete (or replay of a prior identical request).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/RetentionPurgeResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: The Idempotency-Key was reused with a different request (IDEMPOTENCY_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/analytics/security:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Bot/crawler traffic breakdown
+      description: Gated by visitor_analytics.dashboard.read.
+      operationId: analyticsSecurity
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum:
+              - 24h
+              - 7d
+              - 30d
+              - 12m
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Bot traffic breakdown.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/SecurityView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/sessions:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: List visitor sessions (keyset-paginated)
+      description: Gated by visitor_analytics.sessions.read. Newest-active-first. Raw detail (ipAddress/ipHash/userAgentHash/loginIdentifierSnapshot) is returned only when the caller ALSO holds visitor_analytics.raw_detail.read — otherwise those fields are null.
+      operationId: analyticsSessionsList
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous page's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: A page of visitor sessions.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      sessions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/VisitorSession"
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/settings:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Read visitor analytics module settings
+      description: Gated by visitor_analytics.settings.read. Thin wrapper around Module Management's generic per-tenant settings storage under this module's own permission.
+      operationId: analyticsSettingsGet
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Effective module settings.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ModuleSettingsView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Visitor Analytics
+      summary: Update visitor analytics module settings
+      description: Gated by visitor_analytics.settings.update. Shallow JSON-merge patch. Secret-shaped keys/values are rejected before storage. Audited (changed key names only, never values).
+      operationId: analyticsSettingsUpdate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "200":
+          description: Settings updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ModuleSettingsView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "413":
+          description: Request body exceeds the size limit (BODY_TOO_LARGE).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/analytics/summary:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Aggregate visitor summary for a range
+      description: Gated by visitor_analytics.dashboard.read. Human unique visitors, pageviews, bot pageviews, and top paths/browsers/devices/countries over the selected range.
+      operationId: analyticsSummary
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum:
+              - 24h
+              - 7d
+              - 30d
+              - 12m
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Aggregate summary.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/AnalyticsSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/auth/login:
     post:
       operationId: postAuthLogin
@@ -10984,6 +11486,37 @@ components:
           type: string
           format: date-time
           nullable: true
+    AnalyticsSummary:
+      type: object
+      properties:
+        range:
+          type: string
+        humanUniqueVisitors:
+          type: integer
+        humanPageviews:
+          type: integer
+        botPageviews:
+          type: integer
+        adminUniqueUsers:
+          type: integer
+        publicUniqueVisitors:
+          type: integer
+        topPaths:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        topBrowsers:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        topDevices:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        topCountries:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
     ApiError:
       type: object
       required:
@@ -11608,6 +12141,22 @@ components:
         updatedAt:
           type: string
           format: date-time
+    CollectVisitBeaconRequest:
+      type: object
+      required:
+        - tenantCode
+        - path
+      properties:
+        tenantCode:
+          type: string
+          description: Public tenant code the beacon is reporting for.
+        path:
+          type: string
+          description: The page path being reported (must start with '/'). Sanitized server-side; sensitive query params are stripped.
+        referrer:
+          type: string
+          nullable: true
+          description: Optional referrer URL; only its bare hostname is ever stored.
     ContentQualityChecklistResult:
       type: object
       required:
@@ -11982,6 +12531,13 @@ components:
           type: array
           items:
             type: string
+    NamedCount:
+      type: object
+      properties:
+        name:
+          type: string
+        count:
+          type: integer
     NewsMediaObjectItem:
       type: object
       required:
@@ -12189,6 +12745,33 @@ components:
           type: string
           format: date-time
           nullable: true
+    RealtimeStats:
+      type: object
+      properties:
+        onlineHumanCount:
+          type: integer
+        onlineAdminCount:
+          type: integer
+        onlinePublicCount:
+          type: integer
+        onlineApiCount:
+          type: integer
+        onlineWindowSeconds:
+          type: integer
+        lastUpdatedAt:
+          type: string
+          format: date-time
+    RetentionPurgeResult:
+      type: object
+      properties:
+        eventsDeleted:
+          type: integer
+        sessionsRawDetailCleared:
+          type: integer
+        sessionsDeleted:
+          type: integer
+        rollupsDeleted:
+          type: integer
     Role:
       type: object
       properties:
@@ -12203,6 +12786,21 @@ components:
           type: boolean
         permissionCount:
           type: integer
+    SecurityView:
+      type: object
+      properties:
+        range:
+          type: string
+        botPageviews:
+          type: integer
+        topBotReasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        botPageviewsByArea:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
     SoDConflictEvaluation:
       type: object
       description: One append-only segregation-of-duties conflict-check decision log entry (Issue
@@ -12654,6 +13252,130 @@ components:
           nullable: true
         redirectToPrimary:
           type: boolean
+    VisitEvent:
+      type: object
+      description: A single page-view/API event. Raw-detail fields (ipHash/userAgentHash) are null unless the caller holds visitor_analytics.raw_detail.read.
+      properties:
+        id:
+          type: string
+          format: uuid
+        visitorSessionId:
+          type: string
+          format: uuid
+          nullable: true
+        identityId:
+          type: string
+          format: uuid
+          nullable: true
+        occurredAt:
+          type: string
+          format: date-time
+        method:
+          type: string
+        statusCode:
+          type: integer
+          nullable: true
+        area:
+          type: string
+        routePattern:
+          type: string
+          nullable: true
+        pathSanitized:
+          type: string
+        referrerDomain:
+          type: string
+          nullable: true
+        durationMs:
+          type: integer
+          nullable: true
+        userAgentParsed:
+          type: object
+          additionalProperties: true
+        geo:
+          type: object
+          additionalProperties: true
+        humanStatus:
+          type: string
+          enum:
+            - human
+            - bot
+            - unknown
+        correlationId:
+          type: string
+          nullable: true
+        ipHash:
+          type: string
+          nullable: true
+        userAgentHash:
+          type: string
+          nullable: true
+    VisitorSession:
+      type: object
+      description: A visitor session. Raw-detail fields (ipAddress/ipHash/userAgentHash/loginIdentifierSnapshot) are null unless the caller holds visitor_analytics.raw_detail.read.
+      properties:
+        id:
+          type: string
+          format: uuid
+        visitorKeyHash:
+          type: string
+        identityId:
+          type: string
+          format: uuid
+          nullable: true
+        isAuthenticated:
+          type: boolean
+        area:
+          type: string
+        currentPath:
+          type: string
+          nullable: true
+        firstSeenAt:
+          type: string
+          format: date-time
+        lastSeenAt:
+          type: string
+          format: date-time
+        browserName:
+          type: string
+          nullable: true
+        browserVersionMajor:
+          type: string
+          nullable: true
+        osName:
+          type: string
+          nullable: true
+        deviceType:
+          type: string
+          nullable: true
+        isHuman:
+          type: boolean
+        botReason:
+          type: string
+          nullable: true
+        countryCode:
+          type: string
+          nullable: true
+        region:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+        loginIdentifierSnapshot:
+          type: string
+          nullable: true
+        ipHash:
+          type: string
+          nullable: true
+        ipAddress:
+          type: string
+          nullable: true
+        userAgentHash:
+          type: string
+          nullable: true
 security:
   - bearerAuth: []
     tenantHeader: []

--- a/openapi/modules/visitor-analytics.openapi.yaml
+++ b/openapi/modules/visitor-analytics.openapi.yaml
@@ -1,0 +1,707 @@
+# Source fragment for the "Visitor Analytics" module — ported from awcms-micro
+# (epic #617-#624). One file per MODULE (Issue #182 convention): this file owns
+# every path carrying the "Visitor Analytics" tag and every schema referenced
+# ONLY by those operations.
+#
+# Adapted to this base's shared-component vocabulary: success responses are
+# modelled inline, the Idempotency-Key header is declared inline where a
+# mutation requires it, and only the shared components this base defines
+# (CorrelationId; BadRequest/Unauthorized/Forbidden/NotFound; ApiError) are
+# referenced. Authenticated operations inherit the global bearerAuth +
+# tenantHeader security requirement from the root fragment; the PUBLIC
+# visit-ingest beacon (`POST /api/v1/analytics/collect`) opts out with
+# `security: []`.
+#
+# NOT independently valid OpenAPI — $ref targets pointing at shared components
+# only resolve after `bun run openapi:bundle` merges this file with the root and
+# every sibling module fragment into openapi/awcms-public-api.openapi.yaml. Edit
+# this file (or the root for shared components), never the generated bundle.
+paths:
+  /api/v1/analytics/collect:
+    post:
+      tags:
+        - Visitor Analytics
+      summary: Public visitor page-view beacon (anonymous)
+      description: "PUBLIC, unauthenticated visit-ingest beacon. Resolves the tenant from the request body's `tenantCode` (the RLS-free tenant root), records a privacy-preserving page-view for `public`-area paths only (IP/user-agent stored as salted hashes; anonymous — no identity). Fire-and-forget: always 202 for a well-formed request whether or not anything was recorded (module disabled, unknown tenant, non-public/non-trackable path all still return 202 without leaking tenant existence). Requires no auth."
+      operationId: analyticsCollect
+      security: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CollectVisitBeaconRequest"
+      responses:
+        "202":
+          description: Beacon accepted (recorded or intentionally ignored — never distinguished).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      accepted:
+                        type: boolean
+                        enum: [true]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "413":
+          description: Request body exceeds the size limit (BODY_TOO_LARGE).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/analytics/summary:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Aggregate visitor summary for a range
+      description: Gated by visitor_analytics.dashboard.read. Human unique visitors, pageviews, bot pageviews, and top paths/browsers/devices/countries over the selected range.
+      operationId: analyticsSummary
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum: [24h, 7d, 30d, 12m]
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Aggregate summary.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/AnalyticsSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/realtime:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Online-now presence counts
+      description: Gated by visitor_analytics.realtime.read. Sessions active within the online window (VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS), split by area.
+      operationId: analyticsRealtime
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Realtime presence.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/RealtimeStats"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/sessions:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: List visitor sessions (keyset-paginated)
+      description: "Gated by visitor_analytics.sessions.read. Newest-active-first. Raw detail (ipAddress/ipHash/userAgentHash/loginIdentifierSnapshot) is returned only when the caller ALSO holds visitor_analytics.raw_detail.read — otherwise those fields are null."
+      operationId: analyticsSessionsList
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous page's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: A page of visitor sessions.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      sessions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/VisitorSession"
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/events:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: List visit events (keyset-paginated)
+      description: "Gated by visitor_analytics.events.read. Newest first. Raw detail (ipHash/userAgentHash) is returned only when the caller ALSO holds visitor_analytics.raw_detail.read — otherwise those fields are null."
+      operationId: analyticsEventsList
+      parameters:
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous page's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: A page of visit events.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      events:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/VisitEvent"
+                      nextCursor:
+                        type: string
+                        nullable: true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/pages:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Top pages by human pageviews
+      description: Gated by visitor_analytics.dashboard.read.
+      operationId: analyticsPages
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum: [24h, 7d, 30d, 12m]
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Top pages.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      range:
+                        type: string
+                      pages:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/devices:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Browser + device-type breakdown
+      description: Gated by visitor_analytics.dashboard.read.
+      operationId: analyticsDevices
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum: [24h, 7d, 30d, 12m]
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Browser and device breakdown.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      range:
+                        type: string
+                      browsers:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+                      devices:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/locations:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Country breakdown
+      description: "Gated by visitor_analytics.dashboard.read. Empty until geolocation enrichment is enabled (VISITOR_ANALYTICS_GEO_ENABLED + VISITOR_ANALYTICS_TRUST_CLOUDFLARE) — not an error, just no data yet."
+      operationId: analyticsLocations
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum: [24h, 7d, 30d, 12m]
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Country breakdown.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      range:
+                        type: string
+                      countries:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/NamedCount"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/security:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Bot/crawler traffic breakdown
+      description: Gated by visitor_analytics.dashboard.read.
+      operationId: analyticsSecurity
+      parameters:
+        - name: range
+          in: query
+          required: false
+          description: Time window for the aggregate. Defaults to 7d.
+          schema:
+            type: string
+            enum: [24h, 7d, 30d, 12m]
+            default: 7d
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Bot traffic breakdown.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/SecurityView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/analytics/settings:
+    get:
+      tags:
+        - Visitor Analytics
+      summary: Read visitor analytics module settings
+      description: "Gated by visitor_analytics.settings.read. Thin wrapper around Module Management's generic per-tenant settings storage under this module's own permission."
+      operationId: analyticsSettingsGet
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Effective module settings.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/ModuleSettingsView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    patch:
+      tags:
+        - Visitor Analytics
+      summary: Update visitor analytics module settings
+      description: "Gated by visitor_analytics.settings.update. Shallow JSON-merge patch. Secret-shaped keys/values are rejected before storage. Audited (changed key names only, never values)."
+      operationId: analyticsSettingsUpdate
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: true
+      responses:
+        "200":
+          description: Settings updated.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/ModuleSettingsView"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "413":
+          description: Request body exceeds the size limit (BODY_TOO_LARGE).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/analytics/retention/purge:
+    post:
+      tags:
+        - Visitor Analytics
+      summary: Purge visitor analytics data past retention
+      description: "Gated by visitor_analytics.retention.purge. Destructive, high-risk: requires Idempotency-Key, audited `critical`. Deletes events past eventRetentionDays, clears session raw detail past rawDetailRetentionDays, deletes orphaned sessions, and deletes rollups past rollupRetentionDays."
+      operationId: analyticsRetentionPurge
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Purge complete (or replay of a prior identical request).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/RetentionPurgeResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "409":
+          description: The Idempotency-Key was reused with a different request (IDEMPOTENCY_CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+components:
+  schemas:
+    CollectVisitBeaconRequest:
+      type: object
+      required:
+        - tenantCode
+        - path
+      properties:
+        tenantCode:
+          type: string
+          description: Public tenant code the beacon is reporting for.
+        path:
+          type: string
+          description: The page path being reported (must start with '/'). Sanitized server-side; sensitive query params are stripped.
+        referrer:
+          type: string
+          nullable: true
+          description: Optional referrer URL; only its bare hostname is ever stored.
+    NamedCount:
+      type: object
+      properties:
+        name:
+          type: string
+        count:
+          type: integer
+    RealtimeStats:
+      type: object
+      properties:
+        onlineHumanCount:
+          type: integer
+        onlineAdminCount:
+          type: integer
+        onlinePublicCount:
+          type: integer
+        onlineApiCount:
+          type: integer
+        onlineWindowSeconds:
+          type: integer
+        lastUpdatedAt:
+          type: string
+          format: date-time
+    AnalyticsSummary:
+      type: object
+      properties:
+        range:
+          type: string
+        humanUniqueVisitors:
+          type: integer
+        humanPageviews:
+          type: integer
+        botPageviews:
+          type: integer
+        adminUniqueUsers:
+          type: integer
+        publicUniqueVisitors:
+          type: integer
+        topPaths:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        topBrowsers:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        topDevices:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        topCountries:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+    SecurityView:
+      type: object
+      properties:
+        range:
+          type: string
+        botPageviews:
+          type: integer
+        topBotReasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+        botPageviewsByArea:
+          type: array
+          items:
+            $ref: "#/components/schemas/NamedCount"
+    VisitorSession:
+      type: object
+      description: A visitor session. Raw-detail fields (ipAddress/ipHash/userAgentHash/loginIdentifierSnapshot) are null unless the caller holds visitor_analytics.raw_detail.read.
+      properties:
+        id:
+          type: string
+          format: uuid
+        visitorKeyHash:
+          type: string
+        identityId:
+          type: string
+          format: uuid
+          nullable: true
+        isAuthenticated:
+          type: boolean
+        area:
+          type: string
+        currentPath:
+          type: string
+          nullable: true
+        firstSeenAt:
+          type: string
+          format: date-time
+        lastSeenAt:
+          type: string
+          format: date-time
+        browserName:
+          type: string
+          nullable: true
+        browserVersionMajor:
+          type: string
+          nullable: true
+        osName:
+          type: string
+          nullable: true
+        deviceType:
+          type: string
+          nullable: true
+        isHuman:
+          type: boolean
+        botReason:
+          type: string
+          nullable: true
+        countryCode:
+          type: string
+          nullable: true
+        region:
+          type: string
+          nullable: true
+        city:
+          type: string
+          nullable: true
+        timezone:
+          type: string
+          nullable: true
+        loginIdentifierSnapshot:
+          type: string
+          nullable: true
+        ipHash:
+          type: string
+          nullable: true
+        ipAddress:
+          type: string
+          nullable: true
+        userAgentHash:
+          type: string
+          nullable: true
+    VisitEvent:
+      type: object
+      description: A single page-view/API event. Raw-detail fields (ipHash/userAgentHash) are null unless the caller holds visitor_analytics.raw_detail.read.
+      properties:
+        id:
+          type: string
+          format: uuid
+        visitorSessionId:
+          type: string
+          format: uuid
+          nullable: true
+        identityId:
+          type: string
+          format: uuid
+          nullable: true
+        occurredAt:
+          type: string
+          format: date-time
+        method:
+          type: string
+        statusCode:
+          type: integer
+          nullable: true
+        area:
+          type: string
+        routePattern:
+          type: string
+          nullable: true
+        pathSanitized:
+          type: string
+        referrerDomain:
+          type: string
+          nullable: true
+        durationMs:
+          type: integer
+          nullable: true
+        userAgentParsed:
+          type: object
+          additionalProperties: true
+        geo:
+          type: object
+          additionalProperties: true
+        humanStatus:
+          type: string
+          enum: [human, bot, unknown]
+        correlationId:
+          type: string
+          nullable: true
+        ipHash:
+          type: string
+          nullable: true
+        userAgentHash:
+          type: string
+          nullable: true
+    RetentionPurgeResult:
+      type: object
+      properties:
+        eventsDeleted:
+          type: integer
+        sessionsRawDetailCleared:
+          type: integer
+        sessionsDeleted:
+          type: integer
+        rollupsDeleted:
+          type: integer

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
     "blog:publish:scheduled": "bun scripts/blog-scheduled-publish.ts",
     "news-media:reconcile": "bun scripts/news-media-r2-reconcile.ts",
     "logs:audit:purge": "bun scripts/audit-log-purge.ts",
+    "analytics:rollup": "bun scripts/visitor-analytics-rollup.ts",
+    "analytics:purge": "bun scripts/visitor-analytics-purge.ts",
     "email:dispatch": "bun scripts/email-dispatch.ts",
     "email:provider:health": "bun scripts/email-provider-health.ts",
     "email:templates:seed-defaults": "bun scripts/email-templates-seed-defaults.ts",

--- a/scripts/api-spec-check.ts
+++ b/scripts/api-spec-check.ts
@@ -24,7 +24,12 @@ const ALLOWED_PUBLIC_OPERATIONS = new Set([
   // rate-limited; the callback trusts nothing until state/nonce/PKCE/ID-token
   // all validate.
   "getAuthSsoStart",
-  "getAuthSsoCallback"
+  "getAuthSsoCallback",
+  // visitor_analytics (ported from awcms-micro epic #617-#624) — the public
+  // visit-ingest beacon is anonymous by design: it carries no session, resolves
+  // the tenant from a public tenant code, records only privacy-preserving,
+  // anonymized, public-area page views, and is fire-and-forget (always 202).
+  "analyticsCollect"
 ]);
 
 /**

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -1023,7 +1023,15 @@ export const WORKER_ROLE_GRANTS: Record<string, string[]> = {
   // snapshot, UPDATE claiming pending_upload/uploaded rows to `failed` and
   // soft-deleting stale `orphaned` rows, DELETE hard-deleting expired `failed`
   // rows. The job's own audit INSERT reuses awcms_audit_events above.
-  awcms_news_media_objects: ["SELECT", "UPDATE", "DELETE"]
+  awcms_news_media_objects: ["SELECT", "UPDATE", "DELETE"],
+  // visitor_analytics — analytics:rollup + analytics:purge (sql/050). Rollup
+  // SELECTs raw events and SELECT/INSERT/UPDATEs the daily rollups; purge
+  // DELETEs aged events, SELECT/UPDATE/DELETEs sessions (raw-detail clear +
+  // orphan delete), and DELETEs aged rollups. No audit INSERT (analytics is
+  // log-like, not an audited high-risk action from the scheduled path).
+  awcms_visit_events: ["SELECT", "DELETE"],
+  awcms_visitor_sessions: ["SELECT", "UPDATE", "DELETE"],
+  awcms_visitor_daily_rollups: ["SELECT", "INSERT", "UPDATE", "DELETE"]
 };
 
 /**

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -193,7 +193,69 @@ const RULES: readonly Rule[] = [
   { name: "EMAIL_ENABLED", required: false, type: "bool" },
   { name: "EMAIL_FROM_NAME", required: false, type: "string" },
   { name: "EMAIL_SEND_TIMEOUT_MS", required: false, type: "int", min: 1 },
-  { name: "EMAIL_SEND_MAX_RETRIES", required: false, type: "int", min: 0 }
+  { name: "EMAIL_SEND_MAX_RETRIES", required: false, type: "int", min: 0 },
+
+  // visitor_analytics (ported from awcms-micro epic #617-#624). All optional,
+  // privacy-first off-by-default; see
+  // src/modules/visitor-analytics/domain/visitor-analytics-config.ts. The
+  // HASH_SALT cross-rule below requires a real salt whenever the module is
+  // enabled (salted HMAC of visitor identifiers must not use an empty key).
+  { name: "VISITOR_ANALYTICS_ENABLED", required: false, type: "bool" },
+  {
+    name: "VISITOR_ANALYTICS_MODE",
+    required: false,
+    type: "enum",
+    values: ["basic", "detailed"]
+  },
+  { name: "VISITOR_ANALYTICS_COLLECT_ADMIN", required: false, type: "bool" },
+  { name: "VISITOR_ANALYTICS_COLLECT_PUBLIC", required: false, type: "bool" },
+  { name: "VISITOR_ANALYTICS_COLLECT_API", required: false, type: "bool" },
+  { name: "VISITOR_ANALYTICS_DETAILED_ENABLED", required: false, type: "bool" },
+  { name: "VISITOR_ANALYTICS_RAW_IP_ENABLED", required: false, type: "bool" },
+  {
+    name: "VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED",
+    required: false,
+    type: "bool"
+  },
+  { name: "VISITOR_ANALYTICS_GEO_ENABLED", required: false, type: "bool" },
+  { name: "VISITOR_ANALYTICS_TRUST_PROXY", required: false, type: "bool" },
+  { name: "VISITOR_ANALYTICS_TRUST_CLOUDFLARE", required: false, type: "bool" },
+  {
+    name: "VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS",
+    required: false,
+    type: "int",
+    min: 1
+  },
+  {
+    name: "VISITOR_ANALYTICS_EVENT_RETENTION_DAYS",
+    required: false,
+    type: "int",
+    min: 1
+  },
+  {
+    name: "VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS",
+    required: false,
+    type: "int",
+    min: 1
+  },
+  {
+    name: "VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS",
+    required: false,
+    type: "int",
+    min: 1
+  },
+  {
+    name: "VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS",
+    required: false,
+    type: "int",
+    min: 1
+  },
+  {
+    name: "VISITOR_ANALYTICS_HASH_SALT",
+    required: false,
+    type: "string",
+    secret: true
+  }
 ];
 
 /** Nilai placeholder yang aman di dev tapi dilarang di produksi. */
@@ -314,6 +376,20 @@ export function validateEnv(env: EnvBag): string[] {
 
   if (isProduction && env.AUTH_COOKIE_SECURE === "false") {
     problems.push("AUTH_COOKIE_SECURE harus true di produksi.");
+  }
+
+  // visitor_analytics: enabling collection REQUIRES a real hash salt. Visitor
+  // identifiers (visitor-key cookie, IP, user-agent) are stored only as salted
+  // HMAC-SHA256; an empty/placeholder salt would make those hashes trivially
+  // correlatable against a precomputed table. Enforced regardless of APP_ENV —
+  // an empty salt with the module enabled is a privacy defect at any tier.
+  if (env.VISITOR_ANALYTICS_ENABLED === "true") {
+    const salt = env.VISITOR_ANALYTICS_HASH_SALT?.trim() ?? "";
+    if (salt === "" || PLACEHOLDER_SECRETS.has(salt)) {
+      problems.push(
+        "VISITOR_ANALYTICS_HASH_SALT wajib berisi salt nyata saat VISITOR_ANALYTICS_ENABLED=true (hash identifier pengunjung tidak boleh memakai salt kosong)."
+      );
+    }
   }
 
   // MFA: enabling TOTP enrollment REQUIRES a real 32-byte AES-256 key (no

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -250,6 +250,21 @@ const RULES: readonly Rule[] = [
     type: "int",
     min: 1
   },
+  // Per-IP rate-limit backstop on the PUBLIC ingest beacon
+  // (`POST /api/v1/analytics/collect`). Optional; the endpoint applies safe
+  // defaults (120 req / 60 s per IP) when unset or invalid.
+  {
+    name: "VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_MAX",
+    required: false,
+    type: "int",
+    min: 1
+  },
+  {
+    name: "VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_WINDOW_SEC",
+    required: false,
+    type: "int",
+    min: 1
+  },
   {
     name: "VISITOR_ANALYTICS_HASH_SALT",
     required: false,
@@ -260,6 +275,14 @@ const RULES: readonly Rule[] = [
 
 /** Nilai placeholder yang aman di dev tapi dilarang di produksi. */
 const PLACEHOLDER_SECRETS = new Set(["change-me", "changeme", "secret", ""]);
+
+/**
+ * Panjang minimum `VISITOR_ANALYTICS_HASH_SALT` saat modul aktif. Salt inilah
+ * kunci HMAC yang menahan korelasi hash identifier pengunjung terhadap tabel
+ * pra-komputasi; salt 1-2 karakter praktis tak memberi perlindungan itu, jadi
+ * ditegakkan fail-closed di semua tier saat modul enabled.
+ */
+const VISITOR_ANALYTICS_HASH_SALT_MIN_LENGTH = 16;
 
 function parseEnvFile(source: string): EnvBag {
   const bag: EnvBag = {};
@@ -388,6 +411,10 @@ export function validateEnv(env: EnvBag): string[] {
     if (salt === "" || PLACEHOLDER_SECRETS.has(salt)) {
       problems.push(
         "VISITOR_ANALYTICS_HASH_SALT wajib berisi salt nyata saat VISITOR_ANALYTICS_ENABLED=true (hash identifier pengunjung tidak boleh memakai salt kosong)."
+      );
+    } else if (salt.length < VISITOR_ANALYTICS_HASH_SALT_MIN_LENGTH) {
+      problems.push(
+        `VISITOR_ANALYTICS_HASH_SALT harus minimal ${VISITOR_ANALYTICS_HASH_SALT_MIN_LENGTH} karakter saat VISITOR_ANALYTICS_ENABLED=true (salt terlalu pendek mudah ditebak/brute-force).`
       );
     }
   }

--- a/scripts/visitor-analytics-purge.ts
+++ b/scripts/visitor-analytics-purge.ts
@@ -1,0 +1,153 @@
+/**
+ * visitor-analytics-purge.ts — `bun run analytics:purge`.
+ *
+ * Scheduled worker entrypoint for `purgeVisitorAnalyticsData`
+ * (`src/modules/visitor-analytics/application/retention-purge.ts`) — the same
+ * function the on-demand `POST /api/v1/analytics/retention/purge` endpoint
+ * calls, run here for every active tenant so retention is enforced without a
+ * user action.
+ *
+ * Built on the shared job runner (`src/lib/jobs/job-runner.ts`): advisory
+ * lock, timeout, SIGTERM/SIGINT-aware cancellation, JSON telemetry, exit
+ * code. Pure PostgreSQL operation, safe in offline/LAN deployments. Runs as
+ * the least-privilege `awcms_worker` role (sql/022) when
+ * `WORKER_DATABASE_URL` is configured.
+ *
+ * Retention windows come from the module's env config
+ * (VISITOR_ANALYTICS_EVENT_RETENTION_DAYS / _RAW_DETAIL_RETENTION_DAYS /
+ * _ROLLUP_RETENTION_DAYS). `--dry-run` reports the tenant count without
+ * deleting/clearing anything.
+ */
+import { getWorkerDatabaseClient } from "../src/lib/database/client";
+import { withTenant } from "../src/lib/database/tenant-context";
+import {
+  applyJobExitCode,
+  formatJobOutcomeLine,
+  isJobResultOk,
+  parseJobCliArgs,
+  printJobTelemetry,
+  runJob,
+  writeJobTelemetry,
+  type JobContext
+} from "../src/lib/jobs/job-runner";
+import { fetchActiveTenants } from "../src/lib/jobs/batching";
+import { purgeVisitorAnalyticsData } from "../src/modules/visitor-analytics/application/retention-purge";
+import {
+  resolveVisitorAnalyticsConfig,
+  type VisitorAnalyticsConfig
+} from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
+
+export type VisitorAnalyticsPurgeResult = {
+  tenantsChecked: number;
+  eventsDeleted: number;
+  sessionsRawDetailCleared: number;
+  sessionsDeleted: number;
+  rollupsDeleted: number;
+  tenantsSkipped: number;
+};
+
+export async function runVisitorAnalyticsPurge(
+  sql: Bun.SQL,
+  ctx: Pick<JobContext, "dryRun"> & Partial<Pick<JobContext, "signal">>,
+  config: VisitorAnalyticsConfig,
+  now: Date = new Date()
+): Promise<VisitorAnalyticsPurgeResult> {
+  const tenants = await fetchActiveTenants(sql);
+
+  const totals: VisitorAnalyticsPurgeResult = {
+    tenantsChecked: tenants.length,
+    eventsDeleted: 0,
+    sessionsRawDetailCleared: 0,
+    sessionsDeleted: 0,
+    rollupsDeleted: 0,
+    tenantsSkipped: 0
+  };
+
+  if (ctx.dryRun) {
+    return totals;
+  }
+
+  for (const tenant of tenants) {
+    if (ctx.signal?.aborted) {
+      break;
+    }
+
+    const result = await withTenant(sql, tenant.id, (tx) =>
+      purgeVisitorAnalyticsData(tx, tenant.id, config, now)
+    );
+
+    if (result instanceof Response) {
+      totals.tenantsSkipped += 1;
+      continue;
+    }
+
+    totals.eventsDeleted += result.eventsDeleted;
+    totals.sessionsRawDetailCleared += result.sessionsRawDetailCleared;
+    totals.sessionsDeleted += result.sessionsDeleted;
+    totals.rollupsDeleted += result.rollupsDeleted;
+  }
+
+  return totals;
+}
+
+async function main() {
+  const sql = getWorkerDatabaseClient();
+  const cliOptions = parseJobCliArgs(process.argv.slice(2));
+  const config = resolveVisitorAnalyticsConfig();
+
+  try {
+    const result = await runJob(
+      {
+        name: "analytics:purge",
+        description:
+          "Deletes/clears visitor analytics data past its retention windows (events, session raw detail, sessions, rollups) for every active tenant.",
+        handler: async (ctx) => {
+          const purgeResult = await runVisitorAnalyticsPurge(sql, ctx, config);
+          const skipped = purgeResult.tenantsSkipped > 0;
+
+          console.log(
+            `analytics:purge complete — correlationId=${ctx.correlationId} ` +
+              `tenants=${purgeResult.tenantsChecked} eventsDeleted=${purgeResult.eventsDeleted} ` +
+              `sessionsRawDetailCleared=${purgeResult.sessionsRawDetailCleared} ` +
+              `sessionsDeleted=${purgeResult.sessionsDeleted} rollupsDeleted=${purgeResult.rollupsDeleted}` +
+              (ctx.dryRun ? " (dry-run: nothing was deleted)" : "") +
+              (skipped
+                ? ` (WARNING: ${purgeResult.tenantsSkipped} tenant(s) skipped — database busy)`
+                : "")
+          );
+
+          return {
+            status: skipped ? "partial" : "success",
+            itemCounts: {
+              tenantsChecked: purgeResult.tenantsChecked,
+              eventsDeleted: purgeResult.eventsDeleted,
+              sessionsRawDetailCleared: purgeResult.sessionsRawDetailCleared,
+              sessionsDeleted: purgeResult.sessionsDeleted,
+              rollupsDeleted: purgeResult.rollupsDeleted,
+              tenantsSkipped: purgeResult.tenantsSkipped
+            },
+            detail: skipped
+              ? `${purgeResult.tenantsSkipped} tenant(s) skipped due to database backpressure`
+              : undefined
+          };
+        }
+      },
+      { sql, dryRun: cliOptions.dryRun }
+    );
+
+    printJobTelemetry(result);
+    await writeJobTelemetry(result, cliOptions.jsonOutputPath);
+
+    if (!isJobResultOk(result)) {
+      console.error(formatJobOutcomeLine(result));
+    }
+
+    applyJobExitCode(result);
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/visitor-analytics-purge.ts
+++ b/scripts/visitor-analytics-purge.ts
@@ -13,6 +13,12 @@
  * the least-privilege `awcms_worker` role (sql/022) when
  * `WORKER_DATABASE_URL` is configured.
  *
+ * Audit note (accepted asymmetry, base-consistent): unlike the on-demand
+ * `POST /api/v1/analytics/retention/purge` endpoint (which writes a `critical`
+ * audit event), this SCHEDULED run is not audited to `awcms_audit_events` — its
+ * record of record is the job runner's JSON telemetry (job-telemetry-as-record),
+ * the same posture as the other scheduled retention/rollup jobs in this base.
+ *
  * Retention windows come from the module's env config
  * (VISITOR_ANALYTICS_EVENT_RETENTION_DAYS / _RAW_DETAIL_RETENTION_DAYS /
  * _ROLLUP_RETENTION_DAYS). `--dry-run` reports the tenant count without

--- a/scripts/visitor-analytics-rollup.ts
+++ b/scripts/visitor-analytics-rollup.ts
@@ -1,0 +1,178 @@
+/**
+ * visitor-analytics-rollup.ts — `bun run analytics:rollup`.
+ *
+ * Scheduled worker entrypoint for `rollupVisitorAnalyticsForDate`
+ * (`src/modules/visitor-analytics/application/rollup.ts`). Recomputes the
+ * target UTC date's `awcms_visitor_daily_rollups` from raw
+ * `awcms_visit_events`, for every active tenant. Idempotent by construction
+ * (full UPSERT recompute), so re-running a date never double-counts.
+ *
+ * Built on the shared job runner (`src/lib/jobs/job-runner.ts`): advisory
+ * lock (two concurrent runs cannot collide), timeout, SIGTERM/SIGINT-aware
+ * cancellation, JSON telemetry, meaningful exit code. Pure PostgreSQL
+ * operation, safe in offline/LAN deployments. Runs as the least-privilege
+ * `awcms_worker` role (sql/022) when `WORKER_DATABASE_URL` is configured.
+ *
+ * Target date resolution:
+ *   1. `--date=YYYY-MM-DD` CLI flag
+ *   2. yesterday (UTC) — the most recent fully-elapsed day
+ *
+ * `--dry-run` reports the tenant count without writing any rollup row.
+ */
+import { getWorkerDatabaseClient } from "../src/lib/database/client";
+import { withTenant } from "../src/lib/database/tenant-context";
+import {
+  applyJobExitCode,
+  formatJobOutcomeLine,
+  isJobResultOk,
+  parseJobCliArgs,
+  printJobTelemetry,
+  runJob,
+  writeJobTelemetry,
+  type JobContext
+} from "../src/lib/jobs/job-runner";
+import { fetchActiveTenants } from "../src/lib/jobs/batching";
+import { rollupVisitorAnalyticsForDate } from "../src/modules/visitor-analytics/application/rollup";
+
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Yesterday (UTC) as `YYYY-MM-DD` — the most recent fully-elapsed day. */
+export function resolveDefaultRollupDate(now: Date = new Date()): string {
+  const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  return yesterday.toISOString().slice(0, 10);
+}
+
+export function resolveRollupDate(
+  argv: string[] = process.argv,
+  now: Date = new Date()
+): string {
+  const flag = argv.find((arg) => arg.startsWith("--date="));
+  const value = flag?.split("=")[1];
+
+  if (
+    value &&
+    DATE_PATTERN.test(value) &&
+    !Number.isNaN(new Date(value).getTime())
+  ) {
+    return value;
+  }
+
+  return resolveDefaultRollupDate(now);
+}
+
+export type VisitorAnalyticsRollupResult = {
+  date: string;
+  tenantsChecked: number;
+  tenantsRolledUp: number;
+  areasProcessed: number;
+  tenantsSkipped: number;
+};
+
+export async function runVisitorAnalyticsRollup(
+  sql: Bun.SQL,
+  ctx: Pick<JobContext, "dryRun"> & Partial<Pick<JobContext, "signal">>,
+  date: string
+): Promise<VisitorAnalyticsRollupResult> {
+  const tenants = await fetchActiveTenants(sql);
+
+  if (ctx.dryRun) {
+    return {
+      date,
+      tenantsChecked: tenants.length,
+      tenantsRolledUp: 0,
+      areasProcessed: 0,
+      tenantsSkipped: 0
+    };
+  }
+
+  let tenantsRolledUp = 0;
+  let areasProcessed = 0;
+  let tenantsSkipped = 0;
+
+  for (const tenant of tenants) {
+    if (ctx.signal?.aborted) {
+      break;
+    }
+
+    const result = await withTenant(sql, tenant.id, (tx) =>
+      rollupVisitorAnalyticsForDate(tx, tenant.id, date)
+    );
+
+    // `withTenant` returns a 503 `Response` when the circuit breaker is open /
+    // a work-class queue is saturated — count it as skipped, not processed.
+    if (result instanceof Response) {
+      tenantsSkipped += 1;
+      continue;
+    }
+
+    tenantsRolledUp += 1;
+    areasProcessed += result.areasProcessed;
+  }
+
+  return {
+    date,
+    tenantsChecked: tenants.length,
+    tenantsRolledUp,
+    areasProcessed,
+    tenantsSkipped
+  };
+}
+
+async function main() {
+  const sql = getWorkerDatabaseClient();
+  const cliOptions = parseJobCliArgs(process.argv.slice(2));
+  const date = resolveRollupDate();
+
+  try {
+    const result = await runJob(
+      {
+        name: "analytics:rollup",
+        description:
+          "Recomputes awcms_visitor_daily_rollups for the target UTC date from raw awcms_visit_events, for every active tenant (idempotent UPSERT).",
+        handler: async (ctx) => {
+          const rollupResult = await runVisitorAnalyticsRollup(sql, ctx, date);
+          const skipped = rollupResult.tenantsSkipped > 0;
+
+          console.log(
+            `analytics:rollup complete — correlationId=${ctx.correlationId} ` +
+              `date=${rollupResult.date} tenants=${rollupResult.tenantsChecked} ` +
+              `rolledUp=${rollupResult.tenantsRolledUp} areas=${rollupResult.areasProcessed}` +
+              (ctx.dryRun ? " (dry-run: nothing was written)" : "") +
+              (skipped
+                ? ` (WARNING: ${rollupResult.tenantsSkipped} tenant(s) skipped — database busy)`
+                : "")
+          );
+
+          return {
+            status: skipped ? "partial" : "success",
+            itemCounts: {
+              tenantsChecked: rollupResult.tenantsChecked,
+              tenantsRolledUp: rollupResult.tenantsRolledUp,
+              areasProcessed: rollupResult.areasProcessed,
+              tenantsSkipped: rollupResult.tenantsSkipped
+            },
+            detail: skipped
+              ? `${rollupResult.tenantsSkipped} tenant(s) skipped due to database backpressure`
+              : undefined
+          };
+        }
+      },
+      { sql, dryRun: cliOptions.dryRun }
+    );
+
+    printJobTelemetry(result);
+    await writeJobTelemetry(result, cliOptions.jsonOutputPath);
+
+    if (!isJobResultOk(result)) {
+      console.error(formatJobOutcomeLine(result));
+    }
+
+    applyJobExitCode(result);
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/sql/049_awcms_visitor_analytics_permissions.sql
+++ b/sql/049_awcms_visitor_analytics_permissions.sql
@@ -1,0 +1,23 @@
+-- visitor_analytics — permission catalog seed for the new
+-- `visitor_analytics` module descriptor
+-- (src/modules/visitor-analytics/module.ts). Ported from awcms-micro
+-- migration 038 (rename `awcms_micro_` -> `awcms_`,
+-- `awcms_micro_permissions` -> `awcms_permissions`). Same shape as
+-- sql/047_awcms_tenant_domain_permissions.sql — extends the global ABAC
+-- permission catalog only, no roles/access-assignments wired here, no new
+-- tables (the visitor session/event/rollup schema lands in the next
+-- migration, 050). Only tenants created AFTER this migration runs pick
+-- these up automatically via the setup bootstrap's
+-- `INSERT INTO awcms_role_permissions ... SELECT ... FROM awcms_permissions`
+-- (same limitation every prior permission-seed migration has).
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('visitor_analytics', 'dashboard', 'read', 'Read the visitor analytics dashboard'),
+  ('visitor_analytics', 'realtime', 'read', 'Read real-time/online visitor counts'),
+  ('visitor_analytics', 'sessions', 'read', 'Read visitor session records'),
+  ('visitor_analytics', 'events', 'read', 'Read visitor page-view/event records'),
+  ('visitor_analytics', 'raw_detail', 'read', 'Read raw visitor detail (IP address, user-agent) separate from aggregate dashboard access'),
+  ('visitor_analytics', 'settings', 'read', 'Read visitor analytics module settings'),
+  ('visitor_analytics', 'settings', 'update', 'Update visitor analytics module settings'),
+  ('visitor_analytics', 'retention', 'purge', 'Purge visitor analytics data past its retention window')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/sql/050_awcms_visitor_analytics_schema.sql
+++ b/sql/050_awcms_visitor_analytics_schema.sql
@@ -1,0 +1,203 @@
+-- visitor_analytics — tenant-scoped schema for visitor presence
+-- (`awcms_visitor_sessions`), individual page view/API events
+-- (`awcms_visit_events`), and pre-aggregated daily statistics
+-- (`awcms_visitor_daily_rollups`). Ported from awcms-micro migration 039
+-- (rename `awcms_micro_` -> `awcms_`), adapted to this base's cross-tenant
+-- foreign-key convention (see the composite FK note below).
+--
+-- Deliberately NOT audit tables and NOT soft-deletable master/config data:
+-- these are high-volume, log-like analytics rows (same shape as
+-- `awcms_audit_events`) — no `deleted_at`/`deleted_by`/`delete_reason`
+-- columns. Lifecycle is retention-based purge
+-- (`application/retention-purge.ts`, `bun run analytics:purge`), not soft
+-- delete/restore.
+--
+-- Privacy notes (binding on every writer of these tables, see
+-- `src/modules/visitor-analytics/README.md`):
+--   - `ip_address` (raw) is nullable and must only ever be populated when
+--     `VISITOR_ANALYTICS_RAW_IP_ENABLED=true` (the module's config gate).
+--     Default privacy-first operation relies on `ip_hash`/
+--     `user_agent_hash`/`visitor_key_hash` (all salted HMAC-SHA256) plus
+--     already-parsed browser/device fields, never the raw values.
+--   - `login_identifier_snapshot` is nullable and must never be populated
+--     for anonymous public visitors — only for authenticated sessions, as
+--     a point-in-time display convenience. The public visit-ingest
+--     endpoint this base ships is anonymous-only, so it always leaves both
+--     `identity_id` and `login_identifier_snapshot` null.
+--   - No request body, cookie, Authorization header, password-reset token,
+--     OAuth code, or query-string secret is ever stored in any column,
+--     including the two `jsonb` catch-alls (`user_agent_parsed`, `geo`) —
+--     both are populated only from derived/parsed values, never raw
+--     request data.
+--
+-- CROSS-TENANT FOREIGN KEY (this base's convention, not awcms-micro's): a
+-- plain `REFERENCES awcms_visitor_sessions (id)` is checked by the FK owner
+-- and so silently crosses tenants (the referenced row could belong to any
+-- tenant). This base carries `tenant_id` into the reference as a composite
+-- `(tenant_id, id)` FK, which requires a matching `UNIQUE (tenant_id, id)`
+-- on the parent — same pattern the office/tenant-scoped tables use. The
+-- collector always resolves `visitor_session_id` from a session row it
+-- itself just found/created inside the SAME tenant transaction, so this
+-- composite FK is naturally satisfied and can never point across tenants.
+--
+-- `identity_id` stays a plain nullable FK to `awcms_identities (id)`: the
+-- public ingest endpoint never populates it (anonymous-only), so it is
+-- never fed a client-controlled value that a composite FK would need to
+-- defend — and adding a `UNIQUE (tenant_id, id)` to another module's
+-- `awcms_identities` table is out of scope for this port.
+--
+-- RLS: `ENABLE` + `FORCE ROW LEVEL SECURITY` + the standard
+-- `tenant_isolation` policy on all three tables (same pattern as
+-- sql/046). No explicit `GRANT` needed for `awcms_app` — sql/019's
+-- `ALTER DEFAULT PRIVILEGES` already covers every table the owning role
+-- creates from here on.
+
+CREATE TABLE IF NOT EXISTS awcms_visitor_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  visitor_key_hash text NOT NULL,
+  identity_id uuid REFERENCES awcms_identities (id),
+  login_identifier_snapshot text,
+  is_authenticated boolean NOT NULL DEFAULT false,
+  area text NOT NULL,
+  current_path text,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  ip_hash text,
+  ip_address inet,
+  user_agent_hash text,
+  browser_name text,
+  browser_version_major text,
+  os_name text,
+  device_type text,
+  is_human boolean NOT NULL DEFAULT true,
+  bot_reason text,
+  country_code text,
+  region text,
+  city text,
+  timezone text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_visitor_sessions_area_check
+    CHECK (area IN ('admin', 'public', 'api', 'auth', 'setup', 'unknown')),
+  CONSTRAINT awcms_visitor_sessions_device_type_check
+    CHECK (device_type IS NULL
+      OR device_type IN ('desktop', 'mobile', 'tablet', 'bot', 'unknown'))
+);
+
+-- Composite unique so `awcms_visit_events` can carry a cross-tenant-safe
+-- `(tenant_id, visitor_session_id)` FK (see file header). `id` is already
+-- unique via the PRIMARY KEY; this adds `(tenant_id, id)` as the FK target.
+CREATE UNIQUE INDEX IF NOT EXISTS awcms_visitor_sessions_tenant_id_key
+  ON awcms_visitor_sessions (tenant_id, id);
+
+CREATE INDEX IF NOT EXISTS awcms_visitor_sessions_tenant_last_seen_idx
+  ON awcms_visitor_sessions (tenant_id, last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_visitor_sessions_tenant_area_last_seen_idx
+  ON awcms_visitor_sessions (tenant_id, area, last_seen_at DESC);
+
+ALTER TABLE awcms_visitor_sessions ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_visitor_sessions FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_visitor_sessions_tenant_isolation
+  ON awcms_visitor_sessions
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+CREATE TABLE IF NOT EXISTS awcms_visit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  visitor_session_id uuid,
+  identity_id uuid REFERENCES awcms_identities (id),
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  method text NOT NULL,
+  status_code integer,
+  area text NOT NULL,
+  route_pattern text,
+  path_sanitized text NOT NULL,
+  referrer_domain text,
+  duration_ms integer,
+  ip_hash text,
+  user_agent_hash text,
+  user_agent_parsed jsonb NOT NULL DEFAULT '{}'::jsonb,
+  geo jsonb NOT NULL DEFAULT '{}'::jsonb,
+  human_status text NOT NULL,
+  correlation_id text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT awcms_visit_events_session_fk
+    FOREIGN KEY (tenant_id, visitor_session_id)
+    REFERENCES awcms_visitor_sessions (tenant_id, id),
+  CONSTRAINT awcms_visit_events_area_check
+    CHECK (area IN ('admin', 'public', 'api', 'auth', 'setup', 'unknown')),
+  CONSTRAINT awcms_visit_events_human_status_check
+    CHECK (human_status IN ('human', 'bot', 'unknown')),
+  CONSTRAINT awcms_visit_events_status_code_check
+    CHECK (status_code IS NULL OR (status_code >= 100 AND status_code <= 599))
+);
+
+CREATE INDEX IF NOT EXISTS awcms_visit_events_tenant_occurred_idx
+  ON awcms_visit_events (tenant_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_visit_events_tenant_area_occurred_idx
+  ON awcms_visit_events (tenant_id, area, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_visit_events_tenant_human_status_occurred_idx
+  ON awcms_visit_events (tenant_id, human_status, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_visit_events_session_occurred_idx
+  ON awcms_visit_events (visitor_session_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS awcms_visit_events_identity_occurred_idx
+  ON awcms_visit_events (identity_id, occurred_at DESC);
+
+ALTER TABLE awcms_visit_events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_visit_events FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_visit_events_tenant_isolation
+  ON awcms_visit_events
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- No `deleted_at`/soft delete (see file header) and no separate `id`
+-- primary key — `(tenant_id, date, area)` is both the natural key and the
+-- upsert target for the rollup job, so it is the PRIMARY KEY directly
+-- (Postgres creates its backing unique index automatically).
+CREATE TABLE IF NOT EXISTS awcms_visitor_daily_rollups (
+  tenant_id uuid NOT NULL REFERENCES awcms_tenants (id),
+  date date NOT NULL,
+  area text NOT NULL,
+  human_unique_visitors integer NOT NULL DEFAULT 0,
+  human_pageviews integer NOT NULL DEFAULT 0,
+  bot_pageviews integer NOT NULL DEFAULT 0,
+  authenticated_unique_users integer NOT NULL DEFAULT 0,
+  public_unique_visitors integer NOT NULL DEFAULT 0,
+  admin_unique_users integer NOT NULL DEFAULT 0,
+  top_paths jsonb NOT NULL DEFAULT '[]'::jsonb,
+  top_browsers jsonb NOT NULL DEFAULT '[]'::jsonb,
+  top_devices jsonb NOT NULL DEFAULT '[]'::jsonb,
+  top_countries jsonb NOT NULL DEFAULT '[]'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, date, area),
+  CONSTRAINT awcms_visitor_daily_rollups_area_check
+    CHECK (area IN ('admin', 'public', 'api', 'auth', 'setup', 'unknown'))
+);
+
+ALTER TABLE awcms_visitor_daily_rollups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE awcms_visitor_daily_rollups FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY awcms_visitor_daily_rollups_tenant_isolation
+  ON awcms_visitor_daily_rollups
+  USING (tenant_id = current_setting('app.current_tenant_id')::uuid);
+
+-- Least-privilege grants for the `awcms_worker` role (sql/022) — the
+-- scheduled rollup (`bun run analytics:rollup`) and retention-purge
+-- (`bun run analytics:purge`) jobs run as this role when
+-- WORKER_DATABASE_URL is set. sql/019's `ALTER DEFAULT PRIVILEGES` only
+-- covers `awcms_app`, so each table a worker job touches needs an explicit
+-- grant here (same pattern sql/035 blog / sql/041 news-media use). The
+-- worker is NOBYPASSRLS, so these tenant-scoped tables still enforce their
+-- `tenant_isolation` policy on top of these table privileges — every job
+-- opens `withTenant(...)` per tenant, which sets `app.current_tenant_id`.
+GRANT SELECT, DELETE ON awcms_visit_events TO awcms_worker;
+GRANT SELECT, UPDATE, DELETE ON awcms_visitor_sessions TO awcms_worker;
+GRANT SELECT, INSERT, UPDATE, DELETE ON awcms_visitor_daily_rollups TO awcms_worker;

--- a/sql/051_awcms_visitor_analytics_session_lookup_index.sql
+++ b/sql/051_awcms_visitor_analytics_session_lookup_index.sql
@@ -1,0 +1,18 @@
+-- visitor_analytics — supports the collector's session find-or-create
+-- lookup (`application/collector.ts`'s `upsertVisitorSession`). Ported from
+-- awcms-micro migration 040 (rename `awcms_micro_` -> `awcms_`):
+--
+--   SELECT id, last_seen_at FROM awcms_visitor_sessions
+--   WHERE tenant_id = $1 AND visitor_key_hash = $2 AND area = $3
+--   ORDER BY last_seen_at DESC LIMIT 1
+--
+-- Not added by migration 050 (schema-only, no writer existed yet to justify
+-- it) — this is the first index that supports querying the table by
+-- `visitor_key_hash`. Deliberately NOT a UNIQUE constraint: one visitor
+-- legitimately accumulates multiple session rows over time (a new row
+-- starts once the previous one falls outside
+-- VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS, see collector.ts's
+-- `upsertVisitorSession`) — a unique index would force reusing the same row
+-- forever, contradicting that intentional session-boundary design.
+CREATE INDEX IF NOT EXISTS awcms_visitor_sessions_lookup_idx
+  ON awcms_visitor_sessions (tenant_id, visitor_key_hash, area, last_seen_at DESC);

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -43,7 +43,8 @@ interface Props {
     | "abac-policies"
     | "modules"
     | "email-templates"
-    | "tenant-domains";
+    | "tenant-domains"
+    | "analytics";
 }
 
 const { title, active } = Astro.props;
@@ -151,6 +152,12 @@ const roles = ssr.roles.length > 0 ? ssr.roles.join(", ") : "no roles";
             aria-current={active === "email-templates" ? "page" : undefined}
           >
             Email templates
+          </a>
+          <a
+            href="/admin/analytics"
+            aria-current={active === "analytics" ? "page" : undefined}
+          >
+            Visitor analytics
           </a>
         </nav>
       </aside>

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -211,3 +211,45 @@ export async function authorizeInTransaction(
 
   return { allowed: true, context, grantedPermissionKeys };
 }
+
+/**
+ * Secondary FIELD-level access check, reusing a context already authorized by
+ * `authorizeInTransaction`.
+ *
+ * The primary guard decides whether a caller may reach an endpoint at all; some
+ * endpoints then expose extra DE-ANONYMIZING fields behind a SEPARATE permission
+ * (e.g. `visitor_analytics.raw_detail.read`). Gating those on
+ * `grantedPermissionKeys.has(fieldKey)` alone checks only RBAC membership and
+ * silently ignores the ABAC layer — so a `deny` DSL policy on the field key would
+ * NOT be honored (deny-overrides-allow bypassed for the field). This routes the
+ * field decision through the SAME `evaluateAccess` used for the primary action,
+ * so RBAC grant AND no applicable ABAC deny are both required. Returns a plain
+ * boolean (never a Response): a denied field is omitted from the response, not an
+ * endpoint-level 403.
+ *
+ * Reuses the caller's already-resolved `context`/`grantedPermissionKeys` and the
+ * tenant's active policies (tenant-keyed cache — no extra session/permission
+ * round-trips). It deliberately records NO decision log: this is a projection
+ * refinement of an already-logged allowed decision, not a separate
+ * resource-access decision. `fieldGuard.action` must be a read-only action (this
+ * never runs the high-risk SoD chokepoint).
+ */
+export async function evaluateFieldAccessInTransaction(
+  tx: Bun.SQL,
+  tenantId: string,
+  context: TenantContext,
+  grantedPermissionKeys: ReadonlySet<string>,
+  fieldGuard: AccessRequest,
+  now: Date
+): Promise<boolean> {
+  const policies = await loadActivePolicies(tx, tenantId);
+  const decision = evaluateAccess(
+    context,
+    fieldGuard,
+    grantedPermissionKeys,
+    undefined,
+    { policies, env: { now, ipTrusted: false } }
+  );
+
+  return decision.allowed;
+}

--- a/src/modules/index.ts
+++ b/src/modules/index.ts
@@ -13,6 +13,7 @@ import { themingModule } from "./theming/module";
 import { blogContentModule } from "./blog-content/module";
 import { newsPortalModule } from "./news-portal/module";
 import { tenantDomainModule } from "./tenant-domain/module";
+import { visitorAnalyticsModule } from "./visitor-analytics/module";
 
 /**
  * The reviewed BASE registry. Every module below is reviewed, in-repo code.
@@ -53,7 +54,15 @@ const baseModules: ModuleDescriptor[] = [
   // tenant_admin/identity_access (both above), so the DAG stays acyclic. See
   // src/modules/tenant-domain/module.ts's `description` for what was ported vs.
   // deferred.
-  tenantDomainModule
+  tenantDomainModule,
+  // Ported from awcms-micro (epic #617-#624): privacy-first human visitor
+  // analytics. Standalone/additive — depends only on
+  // tenant_admin/identity_access/logging/reporting (all above), so the DAG
+  // stays acyclic. Collection is an additive PUBLIC ingest endpoint (not
+  // middleware); the data_lifecycle legal-hold coupling and the news_portal
+  // preset wiring are dropped/deferred. See
+  // src/modules/visitor-analytics/module.ts's `description`.
+  visitorAnalyticsModule
 ];
 
 /**

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -15,18 +15,28 @@ needs than `reporting`/`logging` are exactly why it is its own module.
   `VISITOR_ANALYTICS_ENABLED=true`. That software switch is never itself the
   lawful-basis/consent decision required by UU PDP — it only enables the
   mechanism.
-- **Identifiers are salted-hashed, never raw.** The anonymous visitor-key
-  cookie, IP address, and user-agent are stored only as `HMAC-SHA256`
-  (`domain/visitor-key.ts`), keyed by `VISITOR_ANALYTICS_HASH_SALT`. A real
-  salt is **required** when the module is enabled (`scripts/validate-env.ts`
-  enforces it) — the salt is what defeats correlation against a precomputed
-  hash table.
-- **Raw detail is an explicit, independent opt-in.** `ip_address` (raw) and
-  `login_identifier_snapshot` are only ever populated when
-  `VISITOR_ANALYTICS_RAW_IP_ENABLED=true` / for authenticated sessions; the
+- **Identifiers are per-tenant salted-hashed, never raw.** The anonymous
+  visitor-key cookie, IP address, and user-agent are stored only as
+  `HMAC-SHA256` (`domain/visitor-key.ts`), keyed by `VISITOR_ANALYTICS_HASH_SALT`
+  **and bound to the tenant id** (a `\0` domain separator folds `tenantId` into
+  the HMAC). Two properties fall out: cross-DEPLOYMENT rainbow-table resistance
+  (the salt), and cross-TENANT unlinkability (the tenant binding) — the same
+  browser/IP/user-agent yields DIFFERENT hashes across tenants sharing one
+  origin, so the raw hash columns of two tenants cannot be correlated at the
+  storage layer. A real salt of **≥ 16 chars** is **required** when the module
+  is enabled (`scripts/validate-env.ts` enforces both non-placeholder and the
+  minimum length).
+- **Raw detail is an explicit, independent opt-in, gated through ABAC.**
+  `ip_address` (raw) and `login_identifier_snapshot` are only ever populated
+  when `VISITOR_ANALYTICS_RAW_IP_ENABLED=true` / for authenticated sessions; the
   public ingest path here never populates either (anonymous-only). Reading raw
-  detail over the API needs the separate `visitor_analytics.raw_detail.read`
-  permission — gated once, server-side, in `domain/analytics-response-shaping.ts`.
+  detail over the API / dashboard needs the separate
+  `visitor_analytics.raw_detail.read` permission, and that field decision is
+  routed through the **ABAC evaluator** (`evaluateFieldAccessInTransaction`),
+  not a bare permission-set membership check — so a `deny` DSL policy on
+  `raw_detail.read` is honored (deny-overrides-allow). Applied uniformly across
+  `GET /sessions`, `GET /events`, and `/admin/analytics`; the actual field
+  omission happens once, server-side, in `domain/analytics-response-shaping.ts`.
 - **Nothing sensitive is ever persisted.** `domain/path-sanitizer.ts` strips
   token/secret query params (fail-safe: an unparseable path drops its whole
   query string) before a path reaches `path_sanitized`; `domain/referrer.ts`
@@ -70,6 +80,16 @@ needed), then records a privacy-preserving page view via
 (never the body). It is fire-and-forget (always `202`) and records **public-area
 page views only** — an anonymous beacon cannot prove an admin/API request, so it
 is not allowed to pollute admin/api analytics.
+
+**Abuse backstop.** Because it is an unauthenticated DB write, the beacon is
+fronted by a **per-IP rate limit** (the shared `checkRateLimit` in-process
+fixed-window limiter, the same one `auth/login.ts` and `setup/initialize.ts`
+use) before any database work — so a client holding a public `tenantCode`
+cannot flood unbounded session/event rows or poison a tenant's aggregates. The
+key is the client IP only (never the tenant), so a `429` reveals nothing about
+tenant existence; a `path` over `MAX_PATH_LENGTH` (2048) is rejected before
+storage. Tunable via `VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_MAX` /
+`_WINDOW_SEC` (defaults 120 req / 60 s per IP).
 
 ## API (authenticated, ABAC-guarded)
 

--- a/src/modules/visitor-analytics/README.md
+++ b/src/modules/visitor-analytics/README.md
@@ -1,0 +1,132 @@
+# visitor_analytics
+
+Privacy-first human visitor statistics for admin and public routes, in both
+online and offline/LAN configurations. Ported from **awcms-micro** (epic
+#617-#624) as a standalone, additive module.
+
+`type: "system"` — like `reporting`/`logging`, human visitor telemetry is
+platform/observability infrastructure every tenant shares the mechanism of, not
+a tenant-facing business feature. Higher volume and different retention/privacy
+needs than `reporting`/`logging` are exactly why it is its own module.
+
+## Privacy posture (the whole point of this module)
+
+- **Off by default.** A fresh install collects nothing until an operator sets
+  `VISITOR_ANALYTICS_ENABLED=true`. That software switch is never itself the
+  lawful-basis/consent decision required by UU PDP — it only enables the
+  mechanism.
+- **Identifiers are salted-hashed, never raw.** The anonymous visitor-key
+  cookie, IP address, and user-agent are stored only as `HMAC-SHA256`
+  (`domain/visitor-key.ts`), keyed by `VISITOR_ANALYTICS_HASH_SALT`. A real
+  salt is **required** when the module is enabled (`scripts/validate-env.ts`
+  enforces it) — the salt is what defeats correlation against a precomputed
+  hash table.
+- **Raw detail is an explicit, independent opt-in.** `ip_address` (raw) and
+  `login_identifier_snapshot` are only ever populated when
+  `VISITOR_ANALYTICS_RAW_IP_ENABLED=true` / for authenticated sessions; the
+  public ingest path here never populates either (anonymous-only). Reading raw
+  detail over the API needs the separate `visitor_analytics.raw_detail.read`
+  permission — gated once, server-side, in `domain/analytics-response-shaping.ts`.
+- **Nothing sensitive is ever persisted.** `domain/path-sanitizer.ts` strips
+  token/secret query params (fail-safe: an unparseable path drops its whole
+  query string) before a path reaches `path_sanitized`; `domain/referrer.ts`
+  keeps only a bare hostname. No request body, cookie, Authorization header, or
+  query-string secret is stored, including the two `jsonb` catch-alls
+  (`user_agent_parsed`, `geo`), which hold only derived/parsed values.
+- **Retention-based lifecycle.** These are log-like, high-volume rows (no soft
+  delete). Retention purge (`application/retention-purge.ts`) deletes events
+  past `eventRetentionDays`, clears session raw detail past
+  `rawDetailRetentionDays`, deletes orphaned sessions, and deletes rollups past
+  `rollupRetentionDays`.
+
+## Schema (migrations 049 / 050 / 051)
+
+- `049` — permission catalog seed (8 permissions).
+- `050` — `awcms_visitor_sessions`, `awcms_visit_events`,
+  `awcms_visitor_daily_rollups`. All `ENABLE`+`FORCE ROW LEVEL SECURITY` with a
+  `tenant_isolation` policy, tenant_id-first composite indexes, and least-
+  privilege `awcms_worker` grants for the scheduled jobs. `awcms_visit_events`
+  carries a **cross-tenant-safe composite FK** `(tenant_id, visitor_session_id)`
+  → `awcms_visitor_sessions (tenant_id, id)` (a plain `id` FK would silently
+  cross tenants). `identity_id` stays a plain nullable FK — the public ingest
+  never populates it.
+- `051` — the `(tenant_id, visitor_key_hash, area, last_seen_at)` session
+  find-or-create lookup index (deliberately NOT unique: one visitor accumulates
+  multiple sessions over time).
+
+## Collection: a PUBLIC ingest endpoint (not middleware)
+
+**Port adaptation.** awcms-micro collected telemetry from `src/middleware.ts`
+(observing every server request). This base keeps `src/middleware.ts`
+**untouched** (its login/Turnstile/CSP guarantees are unchanged) and exposes the
+same collector logic as an additive, opt-in **public beacon**:
+
+`POST /api/v1/analytics/collect` (anonymous, no auth) — the client posts
+`{ tenantCode, path, referrer? }`. The endpoint resolves the tenant from
+`tenantCode` against the **RLS-free** `awcms_tenants` root (ADR-0009, exactly
+like the `/blog/{tenantCode}` public routes — so **no SECURITY DEFINER** is
+needed), then records a privacy-preserving page view via
+`application/collector.ts`. IP/user-agent come from the request's own headers
+(never the body). It is fire-and-forget (always `202`) and records **public-area
+page views only** — an anonymous beacon cannot prove an admin/API request, so it
+is not allowed to pollute admin/api analytics.
+
+## API (authenticated, ABAC-guarded)
+
+All under `/api/v1/analytics`, gated at the identity-access chokepoint
+(`authorizeInTransaction`):
+
+| Endpoint                                            | Permission                                                              |
+| --------------------------------------------------- | ----------------------------------------------------------------------- |
+| `GET /summary\|pages\|devices\|locations\|security` | `visitor_analytics.dashboard.read`                                      |
+| `GET /realtime`                                     | `visitor_analytics.realtime.read`                                       |
+| `GET /sessions`                                     | `visitor_analytics.sessions.read` (+ `raw_detail.read` for raw fields)  |
+| `GET /events`                                       | `visitor_analytics.events.read` (+ `raw_detail.read` for raw fields)    |
+| `GET\|PATCH /settings`                              | `visitor_analytics.settings.read` / `.update`                           |
+| `POST /retention/purge`                             | `visitor_analytics.retention.purge` (Idempotency-Key, `critical` audit) |
+
+List endpoints use this base's full-precision text keyset cursor
+(`_shared/keyset-pagination.ts`) — the directories build the cursor from the
+row's own `to_char(... US ...)` microsecond text, never a floored JS `Date`.
+
+## Jobs
+
+- `bun run analytics:rollup` (`scripts/visitor-analytics-rollup.ts`) —
+  idempotently recomputes the previous UTC day's `awcms_visitor_daily_rollups`
+  per active tenant.
+- `bun run analytics:purge` (`scripts/visitor-analytics-purge.ts`) — enforces
+  retention per active tenant.
+
+Both run on the shared job runner (advisory lock, timeout, cancellation, JSON
+telemetry) as the least-privilege `awcms_worker` role; pure PostgreSQL, safe in
+offline/LAN. Use `--dry-run` first for the purge.
+
+## Admin screen
+
+`/admin/analytics` (`visitor_analytics.dashboard.read`). **Port adaptation:**
+awcms-micro's client-`fetch` SPA dashboard is rendered **server-side** here (the
+same SSR-read-then-render pattern `admin/offices.astro` uses) — this base has no
+i18n framework or `components/ui/` library. No client script, no CSP surface.
+
+## Port drops / deferrals (documented, not silent)
+
+- **data_lifecycle coupling DROPPED.** awcms-micro registered a `dataLifecycle`
+  descriptor and gated the events purge behind a `LegalHoldGuardPort` from its
+  `data_lifecycle` module — not ported to this base, so the descriptor and the
+  legal-hold guard are removed and the purge is unconditional. Re-introduce both
+  if/when `data_lifecycle` is ported.
+- **news_portal preset wiring DEFERRED.** awcms-micro's
+  `news_portal_full_online_r2` preset enables this module. This base's
+  `news_portal` was ported without that wiring and is **not modified** here;
+  this module ships standalone.
+- **Geolocation** is country-only from Cloudflare's `CF-IPCountry`
+  (`domain/geo-enrichment.ts`), only when both `VISITOR_ANALYTICS_GEO_ENABLED`
+  and `VISITOR_ANALYTICS_TRUST_CLOUDFLARE` are true; region/city/timezone are
+  always null (no paid/local GeoIP source). Never makes an external network
+  call.
+
+## Configuration
+
+See `domain/visitor-analytics-config.ts` and the `# Visitor Analytics` block in
+`.env.example`. All vars are `VISITOR_ANALYTICS_*`, optional, privacy-first
+off-by-default.

--- a/src/modules/visitor-analytics/application/analytics-queries.ts
+++ b/src/modules/visitor-analytics/application/analytics-queries.ts
@@ -1,0 +1,278 @@
+/**
+ * Aggregate analytics read queries (ported from awcms-micro epic #617-#624).
+ * All queries run inside the caller's own tenant-scoped transaction
+ * (`withTenant`) — RLS on `awcms_visitor_sessions`/`awcms_visit_events` is
+ * defense in depth on top of the explicit `tenant_id = ${tenantId}` filter
+ * every query below already carries.
+ *
+ * Computed directly from raw `visit_events`/`visitor_sessions` rows, not
+ * `awcms_visitor_daily_rollups` — the rollup table feeds long-range
+ * historical reporting; the live dashboard reads current raw data so it is
+ * never stale relative to the most recent visits.
+ */
+import type { AnalyticsRange } from "../domain/analytics-range";
+
+export type RealtimeStats = {
+  onlineHumanCount: number;
+  onlineAdminCount: number;
+  onlinePublicCount: number;
+  onlineApiCount: number;
+  onlineWindowSeconds: number;
+  lastUpdatedAt: string;
+};
+
+export async function fetchRealtimeStats(
+  tx: Bun.SQL,
+  tenantId: string,
+  onlineWindowSeconds: number
+): Promise<RealtimeStats> {
+  const rows = (await tx`
+    SELECT
+      count(*) FILTER (WHERE is_human) AS online_human_count,
+      count(*) FILTER (WHERE area = 'admin') AS online_admin_count,
+      count(*) FILTER (WHERE area = 'public') AS online_public_count,
+      count(*) FILTER (WHERE area IN ('api', 'auth', 'setup')) AS online_api_count
+    FROM awcms_visitor_sessions
+    WHERE tenant_id = ${tenantId}
+      AND last_seen_at >= now() - make_interval(secs => ${onlineWindowSeconds})
+  `) as {
+    online_human_count: string;
+    online_admin_count: string;
+    online_public_count: string;
+    online_api_count: string;
+  }[];
+
+  const row = rows[0];
+
+  return {
+    onlineHumanCount: Number(row?.online_human_count ?? 0),
+    onlineAdminCount: Number(row?.online_admin_count ?? 0),
+    onlinePublicCount: Number(row?.online_public_count ?? 0),
+    onlineApiCount: Number(row?.online_api_count ?? 0),
+    onlineWindowSeconds,
+    lastUpdatedAt: new Date().toISOString()
+  };
+}
+
+export type NamedCount = { name: string; count: number };
+
+async function topPathCounts(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit: number
+): Promise<NamedCount[]> {
+  const rows = (await tx`
+    SELECT path_sanitized AS name, count(*) AS count
+    FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start} AND human_status = 'human'
+    GROUP BY path_sanitized
+    ORDER BY count DESC, name ASC
+    LIMIT ${limit}
+  `) as { name: string; count: string }[];
+
+  return rows.map((row) => ({ name: row.name, count: Number(row.count) }));
+}
+
+/** The only two `jsonColumn` values `topJsonFieldCounts` may ever interpolate into SQL text. */
+const ALLOWED_JSON_COLUMNS = new Set(["user_agent_parsed", "geo"]);
+/** The only three `jsonKey` values `topJsonFieldCounts` may ever interpolate into SQL text. */
+const ALLOWED_JSON_KEYS = new Set(["browserName", "deviceType", "countryCode"]);
+
+async function topJsonFieldCounts(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  jsonColumn: "user_agent_parsed" | "geo",
+  jsonKey: "browserName" | "deviceType" | "countryCode",
+  limit: number
+): Promise<NamedCount[]> {
+  // `jsonColumn`/`jsonKey` are never user input — always one of the fixed
+  // literal values this file's own call sites pass — so interpolating them
+  // directly into the SQL text is safe. `tenantId`/`start`/`limit` remain
+  // real bound parameters via `tx.unsafe`'s `$1`/`$2`/`$3` placeholders,
+  // never string-concatenated. Defense in depth: a runtime allow-list assert
+  // means a future caller that bypasses the TS union type fails loudly
+  // instead of silently building unsafe SQL text.
+  if (
+    !ALLOWED_JSON_COLUMNS.has(jsonColumn) ||
+    !ALLOWED_JSON_KEYS.has(jsonKey)
+  ) {
+    throw new Error(
+      `topJsonFieldCounts: unexpected jsonColumn/jsonKey ("${jsonColumn}"/"${jsonKey}") — refusing to build SQL from an unvalidated identifier.`
+    );
+  }
+
+  const rows = (await tx.unsafe(
+    `SELECT ${jsonColumn}->>'${jsonKey}' AS name, count(*) AS count
+     FROM awcms_visit_events
+     WHERE tenant_id = $1 AND occurred_at >= $2 AND human_status = 'human'
+       AND ${jsonColumn}->>'${jsonKey}' IS NOT NULL
+     GROUP BY name
+     ORDER BY count DESC, name ASC
+     LIMIT $3`,
+    [tenantId, start, limit]
+  )) as { name: string; count: string }[];
+
+  return rows.map((row) => ({ name: row.name, count: Number(row.count) }));
+}
+
+export async function fetchTopPaths(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topPathCounts(tx, tenantId, start, limit);
+}
+
+export async function fetchTopBrowsers(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topJsonFieldCounts(
+    tx,
+    tenantId,
+    start,
+    "user_agent_parsed",
+    "browserName",
+    limit
+  );
+}
+
+export async function fetchTopDevices(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topJsonFieldCounts(
+    tx,
+    tenantId,
+    start,
+    "user_agent_parsed",
+    "deviceType",
+    limit
+  );
+}
+
+export async function fetchTopCountries(
+  tx: Bun.SQL,
+  tenantId: string,
+  start: Date,
+  limit = 50
+): Promise<NamedCount[]> {
+  return topJsonFieldCounts(tx, tenantId, start, "geo", "countryCode", limit);
+}
+
+export type AnalyticsSummary = {
+  range: AnalyticsRange;
+  humanUniqueVisitors: number;
+  humanPageviews: number;
+  botPageviews: number;
+  adminUniqueUsers: number;
+  publicUniqueVisitors: number;
+  topPaths: NamedCount[];
+  topBrowsers: NamedCount[];
+  topDevices: NamedCount[];
+  topCountries: NamedCount[];
+};
+
+export async function fetchAnalyticsSummary(
+  tx: Bun.SQL,
+  tenantId: string,
+  range: AnalyticsRange,
+  start: Date
+): Promise<AnalyticsSummary> {
+  const countRows = (await tx`
+    SELECT
+      count(DISTINCT visitor_session_id) FILTER (WHERE human_status = 'human') AS human_unique_visitors,
+      count(*) FILTER (WHERE human_status = 'human') AS human_pageviews,
+      count(*) FILTER (WHERE human_status = 'bot') AS bot_pageviews,
+      count(DISTINCT identity_id) FILTER (WHERE area = 'admin' AND identity_id IS NOT NULL) AS admin_unique_users,
+      count(DISTINCT visitor_session_id) FILTER (WHERE area = 'public') AS public_unique_visitors
+    FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start}
+  `) as {
+    human_unique_visitors: string;
+    human_pageviews: string;
+    bot_pageviews: string;
+    admin_unique_users: string;
+    public_unique_visitors: string;
+  }[];
+
+  const counts = countRows[0];
+
+  // Sequential, not Promise.all: concurrent queries on one tx connection leak it (idle in transaction).
+  const topPaths = await fetchTopPaths(tx, tenantId, start, 10);
+  const topBrowsers = await fetchTopBrowsers(tx, tenantId, start, 10);
+  const topDevices = await fetchTopDevices(tx, tenantId, start, 10);
+  const topCountries = await fetchTopCountries(tx, tenantId, start, 10);
+
+  return {
+    range,
+    humanUniqueVisitors: Number(counts?.human_unique_visitors ?? 0),
+    humanPageviews: Number(counts?.human_pageviews ?? 0),
+    botPageviews: Number(counts?.bot_pageviews ?? 0),
+    adminUniqueUsers: Number(counts?.admin_unique_users ?? 0),
+    publicUniqueVisitors: Number(counts?.public_unique_visitors ?? 0),
+    topPaths,
+    topBrowsers,
+    topDevices,
+    topCountries
+  };
+}
+
+export type SecurityView = {
+  range: AnalyticsRange;
+  botPageviews: number;
+  topBotReasons: NamedCount[];
+  botPageviewsByArea: NamedCount[];
+};
+
+export async function fetchSecurityView(
+  tx: Bun.SQL,
+  tenantId: string,
+  range: AnalyticsRange,
+  start: Date
+): Promise<SecurityView> {
+  const totalRows = (await tx`
+    SELECT count(*) AS bot_pageviews
+    FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start} AND human_status = 'bot'
+  `) as { bot_pageviews: string }[];
+
+  const reasonRows = (await tx`
+    SELECT s.bot_reason AS name, count(*) AS count
+    FROM awcms_visit_events e
+    JOIN awcms_visitor_sessions s ON s.id = e.visitor_session_id
+    WHERE e.tenant_id = ${tenantId} AND e.occurred_at >= ${start}
+      AND e.human_status = 'bot' AND s.bot_reason IS NOT NULL
+    GROUP BY s.bot_reason
+    ORDER BY count DESC, name ASC
+    LIMIT 20
+  `) as { name: string; count: string }[];
+
+  const areaRows = (await tx`
+    SELECT area AS name, count(*) AS count
+    FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${start} AND human_status = 'bot'
+    GROUP BY area
+    ORDER BY count DESC, name ASC
+  `) as { name: string; count: string }[];
+
+  return {
+    range,
+    botPageviews: Number(totalRows[0]?.bot_pageviews ?? 0),
+    topBotReasons: reasonRows.map((row) => ({
+      name: row.name,
+      count: Number(row.count)
+    })),
+    botPageviewsByArea: areaRows.map((row) => ({
+      name: row.name,
+      count: Number(row.count)
+    }))
+  };
+}

--- a/src/modules/visitor-analytics/application/collector.ts
+++ b/src/modules/visitor-analytics/application/collector.ts
@@ -230,10 +230,20 @@ export async function collectVisitorTelemetry(
       isAuthenticated,
       parsedUserAgent
     });
-    const visitorKeyHash = hashVisitorKey(visitorKey, config.hashSalt);
-    const ipHash = ipAddress ? hashIpAddress(ipAddress, config.hashSalt) : null;
+    // Visitor identifiers are keyed by BOTH the deployment salt AND `tenantId`
+    // (see `visitor-key.ts`) so the same browser/IP/user-agent yields different
+    // hashes across tenants sharing one origin — cross-tenant unlinkability at
+    // the storage layer.
+    const visitorKeyHash = hashVisitorKey(
+      visitorKey,
+      config.hashSalt,
+      tenantId
+    );
+    const ipHash = ipAddress
+      ? hashIpAddress(ipAddress, config.hashSalt, tenantId)
+      : null;
     const userAgentHash = userAgent
-      ? hashUserAgent(userAgent, config.hashSalt)
+      ? hashUserAgent(userAgent, config.hashSalt, tenantId)
       : null;
     const rawIpAddress = config.rawIpEnabled ? ipAddress : null;
     const referrerDomain = extractReferrerDomain(referrerHeader);

--- a/src/modules/visitor-analytics/application/collector.ts
+++ b/src/modules/visitor-analytics/application/collector.ts
@@ -1,0 +1,312 @@
+/**
+ * Visitor telemetry collector (ported from awcms-micro epic #617-#624). The
+ * only writer of `awcms_visitor_sessions`/`awcms_visit_events`. In
+ * awcms-micro `src/middleware.ts` was the sole caller; this base does NOT
+ * wire collection into middleware (kept untouched so login/Turnstile/CSP
+ * guarantees are unchanged) — instead the additive public visit-ingest
+ * endpoint (`src/pages/api/v1/analytics/collect.ts`) is the sole caller,
+ * invoking this after resolving the tenant from the beacon's `tenantCode`.
+ *
+ * BINDING (fail-open): `collectVisitorTelemetry` never throws — every
+ * failure is caught, logged as a `warning` with `correlationId` and no
+ * sensitive data, and the request always proceeds. Analytics must never
+ * become a critical availability dependency (reinforced by `withTenant`'s
+ * own `workClass: "background_sync"` — the lowest-priority DB work class, so
+ * a saturated pool queues real interactive/reporting work ahead of telemetry
+ * writes, never the reverse).
+ *
+ * BINDING: `identityId` must always be the caller's own server-derived
+ * authenticated identity — never a client-supplied value. The public ingest
+ * endpoint is anonymous-only, so it always passes `null`. `visitor_session_id`
+ * is always resolved from a session row this function itself just found or
+ * created inside its own tenant-scoped transaction, never from a raw
+ * client-supplied UUID — closing the cross-tenant existence-oracle risk.
+ */
+import { withTenant } from "../../../lib/database/tenant-context";
+import { log } from "../../../lib/logging/logger";
+import { isTrackablePath, sanitizePath } from "../domain/path-sanitizer";
+import { extractReferrerDomain } from "../domain/referrer";
+import { determineArea, type RequestArea } from "../domain/request-area";
+import {
+  classifyHumanStatus,
+  classifySessionHumanity
+} from "../domain/human-classifier";
+import { parseUserAgent, type ParsedUserAgent } from "../domain/user-agent";
+import {
+  hashIpAddress,
+  hashUserAgent,
+  hashVisitorKey
+} from "../domain/visitor-key";
+import type { GeoEnrichment } from "../domain/geo-enrichment";
+import type { VisitorAnalyticsConfig } from "../domain/visitor-analytics-config";
+
+/**
+ * A session row already updated within this many seconds is left alone —
+ * `last_seen_at` still reflects "recently active" for realtime-presence
+ * purposes without a write on every single request from the same visitor.
+ * Not env-tunable — a small, fixed constant.
+ */
+const SESSION_UPDATE_THROTTLE_MS = 30_000;
+
+/**
+ * Gates whether the collector should do anything at all for this request —
+ * pure, so it's independently unit-testable without a database. `pathname`
+ * must be the RAW (unsanitized) path; static/internal/health/spec paths are
+ * excluded regardless of every other flag.
+ */
+export function shouldCollectRequest(input: {
+  pathname: string;
+  area: RequestArea;
+  config: VisitorAnalyticsConfig;
+}): boolean {
+  const { pathname, area, config } = input;
+
+  if (!config.enabled) return false;
+  if (!isTrackablePath(pathname)) return false;
+  if (area === "admin") return config.collectAdmin;
+  if (pathname.startsWith("/api")) return config.collectApi;
+
+  return config.collectPublic;
+}
+
+export type CollectVisitorTelemetryInput = {
+  sql: Bun.SQL;
+  tenantId: string;
+  correlationId: string;
+  config: VisitorAnalyticsConfig;
+  method: string;
+  /** Raw path (with query string), NOT yet sanitized — this function sanitizes it. */
+  rawPath: string;
+  statusCode: number | null;
+  /** Resolved by the caller from the visitor cookie (`resolveVisitorKey`). */
+  visitorKey: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  referrerHeader: string | null;
+  isAuthenticated: boolean;
+  /** Server-derived from the caller's own authenticated session — see file header note. */
+  identityId: string | null;
+  /** Resolved by the caller from trusted headers only — always all-null when geo enrichment is disabled/untrusted. */
+  geo: GeoEnrichment;
+};
+
+type SessionRow = { id: string; last_seen_at: string };
+
+/**
+ * Known, benign limitation: two concurrent requests from the same visitor
+ * that both observe "no session yet" can each `INSERT` a new row — session-
+ * count fragmentation, not a correctness/security bug (tenant isolation and
+ * RLS are unaffected, `visit_events` FK integrity holds either way). Not
+ * worth a `SELECT ... FOR UPDATE`/advisory-lock fix for an analytics table.
+ */
+async function upsertVisitorSession(
+  tx: Bun.SQL,
+  input: {
+    tenantId: string;
+    area: RequestArea;
+    visitorKeyHash: string;
+    pathSanitized: string;
+    ipHash: string | null;
+    rawIpAddress: string | null;
+    userAgentHash: string | null;
+    parsedUserAgent: ParsedUserAgent;
+    isHuman: boolean;
+    botReason: string | null;
+    isAuthenticated: boolean;
+    identityId: string | null;
+    onlineWindowSeconds: number;
+    geo: GeoEnrichment;
+  }
+): Promise<string> {
+  const existingRows = (await tx`
+    SELECT id, last_seen_at FROM awcms_visitor_sessions
+    WHERE tenant_id = ${input.tenantId}
+      AND visitor_key_hash = ${input.visitorKeyHash}
+      AND area = ${input.area}
+    ORDER BY last_seen_at DESC
+    LIMIT 1
+  `) as SessionRow[];
+
+  const existing = existingRows[0];
+  const nowMs = Date.now();
+  const lastSeenMs = existing
+    ? new Date(existing.last_seen_at).getTime()
+    : null;
+  const withinSameSession =
+    lastSeenMs !== null &&
+    nowMs - lastSeenMs <= input.onlineWindowSeconds * 1000;
+
+  if (existing && withinSameSession) {
+    const dueForWrite =
+      lastSeenMs === null || nowMs - lastSeenMs >= SESSION_UPDATE_THROTTLE_MS;
+
+    if (dueForWrite) {
+      await tx`
+        UPDATE awcms_visitor_sessions
+        SET last_seen_at = now(),
+            current_path = ${input.pathSanitized},
+            is_human = ${input.isHuman},
+            bot_reason = ${input.botReason},
+            browser_name = ${input.parsedUserAgent.browserName},
+            browser_version_major = ${input.parsedUserAgent.browserVersionMajor},
+            os_name = ${input.parsedUserAgent.osName},
+            device_type = ${input.parsedUserAgent.deviceType},
+            country_code = ${input.geo.countryCode},
+            region = ${input.geo.region},
+            city = ${input.geo.city},
+            timezone = ${input.geo.timezone},
+            updated_at = now()
+        WHERE id = ${existing.id}
+      `;
+    }
+
+    return existing.id;
+  }
+
+  // No recent session for this visitor+area — start a new one.
+  // login_identifier_snapshot is deliberately always null here: it's a
+  // nullable display convenience, never populated for anonymous visitors
+  // (the only kind the public ingest endpoint produces).
+  const insertedRows = (await tx`
+    INSERT INTO awcms_visitor_sessions
+      (tenant_id, visitor_key_hash, identity_id, login_identifier_snapshot,
+       is_authenticated, area, current_path, ip_hash, ip_address,
+       user_agent_hash, browser_name, browser_version_major, os_name,
+       device_type, is_human, bot_reason, country_code, region, city, timezone)
+    VALUES (
+      ${input.tenantId}, ${input.visitorKeyHash}, ${input.identityId}, null,
+      ${input.isAuthenticated}, ${input.area}, ${input.pathSanitized},
+      ${input.ipHash}, ${input.rawIpAddress}, ${input.userAgentHash},
+      ${input.parsedUserAgent.browserName}, ${input.parsedUserAgent.browserVersionMajor},
+      ${input.parsedUserAgent.osName}, ${input.parsedUserAgent.deviceType},
+      ${input.isHuman}, ${input.botReason}, ${input.geo.countryCode},
+      ${input.geo.region}, ${input.geo.city}, ${input.geo.timezone}
+    )
+    RETURNING id
+  `) as { id: string }[];
+
+  return insertedRows[0]!.id;
+}
+
+/**
+ * Writes one `awcms_visit_events` row and creates/refreshes the matching
+ * `awcms_visitor_sessions` row. Never throws — see the file header's
+ * fail-open note. Callers should still check `shouldCollectRequest` first
+ * (cheap, no DB) to avoid the function-call overhead for requests that will
+ * be skipped anyway, but this function re-checks `isTrackablePath` itself as
+ * defense in depth.
+ */
+export async function collectVisitorTelemetry(
+  input: CollectVisitorTelemetryInput
+): Promise<void> {
+  const {
+    sql,
+    tenantId,
+    correlationId,
+    config,
+    method,
+    rawPath,
+    statusCode,
+    visitorKey,
+    ipAddress,
+    userAgent,
+    referrerHeader,
+    isAuthenticated,
+    identityId,
+    geo
+  } = input;
+
+  try {
+    if (!isTrackablePath(rawPath)) return;
+
+    const area = determineArea(rawPath.split("?")[0] ?? rawPath);
+    const pathSanitized = sanitizePath(rawPath);
+    const parsedUserAgent = parseUserAgent(userAgent);
+    const humanStatus = classifyHumanStatus({
+      isAuthenticated,
+      parsedUserAgent
+    });
+    const sessionHumanity = classifySessionHumanity({
+      isAuthenticated,
+      parsedUserAgent
+    });
+    const visitorKeyHash = hashVisitorKey(visitorKey, config.hashSalt);
+    const ipHash = ipAddress ? hashIpAddress(ipAddress, config.hashSalt) : null;
+    const userAgentHash = userAgent
+      ? hashUserAgent(userAgent, config.hashSalt)
+      : null;
+    const rawIpAddress = config.rawIpEnabled ? ipAddress : null;
+    const referrerDomain = extractReferrerDomain(referrerHeader);
+
+    await withTenant(
+      sql,
+      tenantId,
+      async (tx) => {
+        const sessionId = await upsertVisitorSession(tx, {
+          tenantId,
+          area,
+          visitorKeyHash,
+          pathSanitized,
+          ipHash,
+          rawIpAddress,
+          userAgentHash,
+          parsedUserAgent,
+          isHuman: sessionHumanity.isHuman,
+          botReason: sessionHumanity.botReason,
+          isAuthenticated,
+          identityId,
+          onlineWindowSeconds: config.onlineWindowSeconds,
+          geo
+        });
+
+        // Pass a plain JS object as the jsonb query parameter, never a
+        // pre-`JSON.stringify`'d string. Bun.SQL only decodes a `jsonb`
+        // column back into a parsed object on SELECT when the matching INSERT
+        // parameter was itself passed as an object — `${JSON.stringify(x)}::jsonb`
+        // stores the same bytes but every later SELECT returns a raw JSON
+        // string, breaking `VisitEventRow.user_agent_parsed`/`geo`'s
+        // `Record<string, unknown>` type.
+        const userAgentParsed = {
+          browserName: parsedUserAgent.browserName,
+          browserVersionMajor: parsedUserAgent.browserVersionMajor,
+          osName: parsedUserAgent.osName,
+          deviceType: parsedUserAgent.deviceType
+        };
+        const geoJson = {
+          countryCode: geo.countryCode,
+          region: geo.region,
+          city: geo.city,
+          timezone: geo.timezone
+        };
+
+        await tx`
+          INSERT INTO awcms_visit_events
+            (tenant_id, visitor_session_id, identity_id, method, status_code,
+             area, path_sanitized, referrer_domain, ip_hash, user_agent_hash,
+             user_agent_parsed, geo, human_status, correlation_id)
+          VALUES (
+            ${tenantId}, ${sessionId}, ${identityId}, ${method}, ${statusCode},
+            ${area}, ${pathSanitized}, ${referrerDomain}, ${ipHash}, ${userAgentHash},
+            ${userAgentParsed}::jsonb, ${geoJson}::jsonb, ${humanStatus}, ${correlationId}
+          )
+        `;
+      },
+      // `queueTimeoutMs` deliberately far below `withTenant`'s own 2000ms
+      // default: this collector is a synchronous, per-request caller of
+      // `background_sync`. Awaiting the 2000ms default here would mean every
+      // collected request could pick up up to two seconds of added latency
+      // under pool saturation before the fail-open path even triggers —
+      // exactly the "critical availability dependency" this module forbids.
+      // 200ms bounds the worst case to something a caller never notices,
+      // while still giving the write a fair shot under ordinary load.
+      { workClass: "background_sync", queueTimeoutMs: 200 }
+    );
+  } catch (error) {
+    log("warning", "visitor_analytics.collector.failed", {
+      correlationId,
+      tenantId,
+      moduleKey: "visitor_analytics",
+      error: error instanceof Error ? error.message : "unknown error"
+    });
+  }
+}

--- a/src/modules/visitor-analytics/application/event-directory.ts
+++ b/src/modules/visitor-analytics/application/event-directory.ts
@@ -1,0 +1,56 @@
+/**
+ * Keyset-paginated `awcms_visit_events` listing (ported from awcms-micro epic
+ * #617-#624). Ordered `occurred_at DESC, id DESC`.
+ *
+ * PORT ADAPTATION (this base's keyset convention, Issue #158): the cursor is
+ * built HERE from the row's full-microsecond-precision `occurred_at`
+ * (`KEYSET_CURSOR_CREATED_AT_SQL`-style `to_char`), never from a JS `Date`
+ * that has already floored the microseconds — a route that rebuilt the cursor
+ * from `occurred_at.toISOString()` would silently skip every row sharing that
+ * millisecond across the page boundary. `occurred_at_cursor` carries the
+ * full-precision text and never leaves this function.
+ */
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
+import type { VisitEventRow } from "../domain/analytics-response-shaping";
+
+export const VISIT_EVENT_LIST_LIMIT = 50;
+
+type VisitEventListRow = VisitEventRow & { occurred_at_cursor: string };
+
+export type VisitEventListPage = {
+  rows: VisitEventRow[];
+  nextCursor: string | null;
+};
+
+export async function listVisitEvents(
+  tx: Bun.SQL,
+  tenantId: string,
+  cursor?: KeysetCursor
+): Promise<VisitEventListPage> {
+  const cursorOccurredAt = cursor?.createdAt ?? null;
+  const cursorId = cursor?.id ?? null;
+
+  const rows = (await tx`
+    SELECT *,
+      to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS occurred_at_cursor
+    FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId}
+      AND (
+        ${cursorOccurredAt}::timestamptz IS NULL
+        OR (occurred_at, id) < (${cursorOccurredAt}, ${cursorId})
+      )
+    ORDER BY occurred_at DESC, id DESC
+    LIMIT ${VISIT_EVENT_LIST_LIMIT}
+  `) as VisitEventListRow[];
+
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === VISIT_EVENT_LIST_LIMIT && last
+      ? encodeKeysetCursor(last.occurred_at_cursor, last.id)
+      : null;
+
+  return { rows, nextCursor };
+}

--- a/src/modules/visitor-analytics/application/retention-purge.ts
+++ b/src/modules/visitor-analytics/application/retention-purge.ts
@@ -1,0 +1,93 @@
+/**
+ * Visitor analytics retention purge (ported from awcms-micro epic
+ * #617-#624), triggered by `POST /api/v1/analytics/retention/purge`
+ * (on-demand) and `bun run analytics:purge` (scheduled worker, via
+ * `purgeVisitorAnalyticsForAllTenants`).
+ *
+ * PORT NOTE: awcms-micro guarded step 1's DELETE behind a `LegalHoldGuardPort`
+ * from its `data_lifecycle` module. That module is NOT ported to this base
+ * (`ls src/modules` has no `data-lifecycle`, and `_shared/ports/
+ * legal-hold-guard-port.ts` does not exist here), so the legal-hold gate is
+ * DROPPED and step 1 is an unconditional DELETE. If/when `data_lifecycle` is
+ * ported, re-introduce the guard here exactly as awcms-micro does.
+ *
+ * Four independent cutoffs, each from the module's config
+ * (`VisitorAnalyticsConfig`):
+ *   1. `awcms_visit_events` older than `eventRetentionDays` — hard deleted.
+ *   2. `awcms_visitor_sessions.ip_address`/`login_identifier_snapshot` (the
+ *      two genuinely "raw detail" columns) older than `rawDetailRetentionDays`
+ *      — cleared in place, row kept (device/browser aggregate fields remain
+ *      useful long after raw detail should be gone).
+ *   3. `awcms_visitor_sessions` rows older than `eventRetentionDays` — hard
+ *      deleted, but only ones with no remaining `visit_events` row
+ *      (`NOT EXISTS`): the collector's own write-throttle (30s) can leave
+ *      `last_seen_at` trailing a session's newest event, so a purge landing
+ *      inside that straddle window could otherwise hit the
+ *      `visit_events.visitor_session_id` FK and abort the transaction. The
+ *      `NOT EXISTS` guard makes the delete self-defending.
+ *   4. `awcms_visitor_daily_rollups` older than `rollupRetentionDays` — hard
+ *      deleted.
+ */
+import type { VisitorAnalyticsConfig } from "../domain/visitor-analytics-config";
+
+export type RetentionPurgeResult = {
+  eventsDeleted: number;
+  sessionsRawDetailCleared: number;
+  sessionsDeleted: number;
+  rollupsDeleted: number;
+};
+
+function daysAgo(now: Date, days: number): Date {
+  return new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
+}
+
+export async function purgeVisitorAnalyticsData(
+  tx: Bun.SQL,
+  tenantId: string,
+  config: VisitorAnalyticsConfig,
+  now: Date
+): Promise<RetentionPurgeResult> {
+  const eventCutoff = daysAgo(now, config.eventRetentionDays);
+  const rawDetailCutoff = daysAgo(now, config.rawDetailRetentionDays);
+  const rollupCutoff = daysAgo(now, config.rollupRetentionDays)
+    .toISOString()
+    .slice(0, 10);
+
+  const deletedEvents = await tx`
+    DELETE FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at < ${eventCutoff}
+    RETURNING id
+  `;
+
+  const clearedSessions = await tx`
+    UPDATE awcms_visitor_sessions
+    SET ip_address = NULL, login_identifier_snapshot = NULL, updated_at = now()
+    WHERE tenant_id = ${tenantId}
+      AND last_seen_at < ${rawDetailCutoff}
+      AND (ip_address IS NOT NULL OR login_identifier_snapshot IS NOT NULL)
+    RETURNING id
+  `;
+
+  const deletedSessions = await tx`
+    DELETE FROM awcms_visitor_sessions s
+    WHERE s.tenant_id = ${tenantId} AND s.last_seen_at < ${eventCutoff}
+      AND NOT EXISTS (
+        SELECT 1 FROM awcms_visit_events e
+        WHERE e.visitor_session_id = s.id
+      )
+    RETURNING id
+  `;
+
+  const deletedRollups = await tx`
+    DELETE FROM awcms_visitor_daily_rollups
+    WHERE tenant_id = ${tenantId} AND date < ${rollupCutoff}
+    RETURNING tenant_id
+  `;
+
+  return {
+    eventsDeleted: deletedEvents.length,
+    sessionsRawDetailCleared: clearedSessions.length,
+    sessionsDeleted: deletedSessions.length,
+    rollupsDeleted: deletedRollups.length
+  };
+}

--- a/src/modules/visitor-analytics/application/rollup.ts
+++ b/src/modules/visitor-analytics/application/rollup.ts
@@ -1,0 +1,290 @@
+/**
+ * Daily rollup aggregation (ported from awcms-micro epic #617-#624),
+ * scheduled via `bun run analytics:rollup`
+ * (`scripts/visitor-analytics-rollup.ts`). Aggregates `awcms_visit_events`
+ * into `awcms_visitor_daily_rollups` (migration 050).
+ *
+ * Idempotent by construction: every run fully RECOMPUTES a (tenant, date,
+ * area) row from raw events and UPSERTs it (`ON CONFLICT (tenant_id, date,
+ * area) DO UPDATE SET ... = EXCLUDED...`), never increments an existing
+ * value. Re-running the same date any number of times converges on the same
+ * row, it never double-counts.
+ *
+ * Uses the same SQL-safety pattern as `application/analytics-queries.ts`
+ * (allow-listed jsonb column/key before any `tx.unsafe` string
+ * interpolation, real bound parameters for every value) scoped to a closed
+ * `[dayStart, dayEnd)` window AND a per-`area` split (the rollup table's own
+ * primary key is `(tenant_id, date, area)`).
+ */
+
+export type NamedCount = { name: string; count: number };
+
+export type DailyAreaRollup = {
+  area: string;
+  humanUniqueVisitors: number;
+  humanPageviews: number;
+  botPageviews: number;
+  authenticatedUniqueUsers: number;
+  publicUniqueVisitors: number;
+  adminUniqueUsers: number;
+  topPaths: NamedCount[];
+  topBrowsers: NamedCount[];
+  topDevices: NamedCount[];
+  topCountries: NamedCount[];
+};
+
+export type RollupDateResult = {
+  date: string;
+  areasProcessed: number;
+  areas: string[];
+};
+
+/** Top-N size for each rollup's jsonb array columns — matches
+ * `fetchAnalyticsSummary`'s own top-10 default. */
+const ROLLUP_TOP_N_LIMIT = 10;
+
+type AreaCountRow = {
+  area: string;
+  human_unique_visitors: string;
+  human_pageviews: string;
+  bot_pageviews: string;
+  authenticated_unique_users: string;
+  all_unique_visitors: string;
+};
+
+async function fetchDailyAreaCounts(
+  tx: Bun.SQL,
+  tenantId: string,
+  dayStart: Date,
+  dayEnd: Date
+): Promise<AreaCountRow[]> {
+  return (await tx`
+    SELECT
+      area,
+      count(DISTINCT visitor_session_id) FILTER (WHERE human_status = 'human') AS human_unique_visitors,
+      count(*) FILTER (WHERE human_status = 'human') AS human_pageviews,
+      count(*) FILTER (WHERE human_status = 'bot') AS bot_pageviews,
+      count(DISTINCT identity_id) FILTER (WHERE identity_id IS NOT NULL) AS authenticated_unique_users,
+      count(DISTINCT visitor_session_id) AS all_unique_visitors
+    FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId} AND occurred_at >= ${dayStart} AND occurred_at < ${dayEnd}
+    GROUP BY area
+  `) as AreaCountRow[];
+}
+
+async function fetchTopPathsForDay(
+  tx: Bun.SQL,
+  tenantId: string,
+  area: string,
+  dayStart: Date,
+  dayEnd: Date,
+  limit: number
+): Promise<NamedCount[]> {
+  const rows = (await tx`
+    SELECT path_sanitized AS name, count(*) AS count
+    FROM awcms_visit_events
+    WHERE tenant_id = ${tenantId} AND area = ${area}
+      AND occurred_at >= ${dayStart} AND occurred_at < ${dayEnd}
+      AND human_status = 'human'
+    GROUP BY path_sanitized
+    ORDER BY count DESC, name ASC
+    LIMIT ${limit}
+  `) as { name: string; count: string }[];
+
+  return rows.map((row) => ({ name: row.name, count: Number(row.count) }));
+}
+
+/** The only two `jsonColumn` values this function may ever interpolate into SQL text. */
+const ALLOWED_JSON_COLUMNS = new Set(["user_agent_parsed", "geo"]);
+/** The only three `jsonKey` values this function may ever interpolate into SQL text. */
+const ALLOWED_JSON_KEYS = new Set(["browserName", "deviceType", "countryCode"]);
+
+async function fetchTopJsonFieldForDay(
+  tx: Bun.SQL,
+  tenantId: string,
+  area: string,
+  dayStart: Date,
+  dayEnd: Date,
+  jsonColumn: "user_agent_parsed" | "geo",
+  jsonKey: "browserName" | "deviceType" | "countryCode",
+  limit: number
+): Promise<NamedCount[]> {
+  // Same defense-in-depth convention as `analytics-queries.ts`'s
+  // `topJsonFieldCounts`: `jsonColumn`/`jsonKey` are never user input, only
+  // ever one of this file's own fixed literal call-site values, but a runtime
+  // allow-list check means a future caller that bypasses the TS union type
+  // still fails loudly instead of building unsafe SQL text.
+  if (
+    !ALLOWED_JSON_COLUMNS.has(jsonColumn) ||
+    !ALLOWED_JSON_KEYS.has(jsonKey)
+  ) {
+    throw new Error(
+      `fetchTopJsonFieldForDay: unexpected jsonColumn/jsonKey ("${jsonColumn}"/"${jsonKey}") — refusing to build SQL from an unvalidated identifier.`
+    );
+  }
+
+  const rows = (await tx.unsafe(
+    `SELECT ${jsonColumn}->>'${jsonKey}' AS name, count(*) AS count
+     FROM awcms_visit_events
+     WHERE tenant_id = $1 AND area = $2
+       AND occurred_at >= $3 AND occurred_at < $4
+       AND human_status = 'human'
+       AND ${jsonColumn}->>'${jsonKey}' IS NOT NULL
+     GROUP BY name
+     ORDER BY count DESC, name ASC
+     LIMIT $5`,
+    [tenantId, area, dayStart, dayEnd, limit]
+  )) as { name: string; count: string }[];
+
+  return rows.map((row) => ({ name: row.name, count: Number(row.count) }));
+}
+
+/**
+ * Computes the full rollup row for a single `(tenantId, date, area)`. Reads
+ * only — callers are responsible for persisting via `upsertDailyRollup`.
+ */
+async function computeDailyAreaRollup(
+  tx: Bun.SQL,
+  tenantId: string,
+  area: string,
+  dayStart: Date,
+  dayEnd: Date,
+  counts: AreaCountRow
+): Promise<DailyAreaRollup> {
+  // Sequential, not Promise.all: concurrent queries on one tx connection leak it (idle in transaction).
+  const topPaths = await fetchTopPathsForDay(
+    tx,
+    tenantId,
+    area,
+    dayStart,
+    dayEnd,
+    ROLLUP_TOP_N_LIMIT
+  );
+  const topBrowsers = await fetchTopJsonFieldForDay(
+    tx,
+    tenantId,
+    area,
+    dayStart,
+    dayEnd,
+    "user_agent_parsed",
+    "browserName",
+    ROLLUP_TOP_N_LIMIT
+  );
+  const topDevices = await fetchTopJsonFieldForDay(
+    tx,
+    tenantId,
+    area,
+    dayStart,
+    dayEnd,
+    "user_agent_parsed",
+    "deviceType",
+    ROLLUP_TOP_N_LIMIT
+  );
+  const topCountries = await fetchTopJsonFieldForDay(
+    tx,
+    tenantId,
+    area,
+    dayStart,
+    dayEnd,
+    "geo",
+    "countryCode",
+    ROLLUP_TOP_N_LIMIT
+  );
+
+  const authenticatedUniqueUsers = Number(counts.authenticated_unique_users);
+  const allUniqueVisitors = Number(counts.all_unique_visitors);
+
+  return {
+    area,
+    humanUniqueVisitors: Number(counts.human_unique_visitors),
+    humanPageviews: Number(counts.human_pageviews),
+    botPageviews: Number(counts.bot_pageviews),
+    authenticatedUniqueUsers,
+    // Matches `fetchAnalyticsSummary`'s semantics: `publicUniqueVisitors`/
+    // `adminUniqueUsers` are each only meaningful for their own area's row;
+    // every other area's row carries 0 for both, so summing a date's rollup
+    // rows across areas reproduces the same tenant-wide totals
+    // `fetchAnalyticsSummary` computes directly from raw events.
+    publicUniqueVisitors: area === "public" ? allUniqueVisitors : 0,
+    adminUniqueUsers: area === "admin" ? authenticatedUniqueUsers : 0,
+    topPaths,
+    topBrowsers,
+    topDevices,
+    topCountries
+  };
+}
+
+/**
+ * Idempotent UPSERT into `awcms_visitor_daily_rollups`. `ON CONFLICT
+ * (tenant_id, date, area) DO UPDATE SET ... = EXCLUDED...` — a rerun for a
+ * date/area already rolled up overwrites every aggregate column with the
+ * freshly recomputed value, it never adds to the existing one.
+ */
+export async function upsertDailyRollup(
+  tx: Bun.SQL,
+  tenantId: string,
+  date: string,
+  rollup: DailyAreaRollup
+): Promise<void> {
+  await tx`
+    INSERT INTO awcms_visitor_daily_rollups (
+      tenant_id, date, area,
+      human_unique_visitors, human_pageviews, bot_pageviews,
+      authenticated_unique_users, public_unique_visitors, admin_unique_users,
+      top_paths, top_browsers, top_devices, top_countries, updated_at
+    ) VALUES (
+      ${tenantId}, ${date}, ${rollup.area},
+      ${rollup.humanUniqueVisitors}, ${rollup.humanPageviews}, ${rollup.botPageviews},
+      ${rollup.authenticatedUniqueUsers}, ${rollup.publicUniqueVisitors}, ${rollup.adminUniqueUsers},
+      ${rollup.topPaths}::jsonb, ${rollup.topBrowsers}::jsonb, ${rollup.topDevices}::jsonb, ${rollup.topCountries}::jsonb,
+      now()
+    )
+    ON CONFLICT (tenant_id, date, area) DO UPDATE SET
+      human_unique_visitors = EXCLUDED.human_unique_visitors,
+      human_pageviews = EXCLUDED.human_pageviews,
+      bot_pageviews = EXCLUDED.bot_pageviews,
+      authenticated_unique_users = EXCLUDED.authenticated_unique_users,
+      public_unique_visitors = EXCLUDED.public_unique_visitors,
+      admin_unique_users = EXCLUDED.admin_unique_users,
+      top_paths = EXCLUDED.top_paths,
+      top_browsers = EXCLUDED.top_browsers,
+      top_devices = EXCLUDED.top_devices,
+      top_countries = EXCLUDED.top_countries,
+      updated_at = now()
+  `;
+}
+
+/**
+ * Rolls up ONE calendar date (UTC day boundary — `date` is a plain
+ * `YYYY-MM-DD` string) for one tenant. Only areas that actually had at least
+ * one event that day get a row. Called from
+ * `scripts/visitor-analytics-rollup.ts` inside the caller's own `withTenant`
+ * transaction — this function does not open its own tenant context.
+ */
+export async function rollupVisitorAnalyticsForDate(
+  tx: Bun.SQL,
+  tenantId: string,
+  date: string
+): Promise<RollupDateResult> {
+  const dayStart = new Date(`${date}T00:00:00.000Z`);
+  const dayEnd = new Date(dayStart.getTime() + 24 * 60 * 60 * 1000);
+
+  const countRows = await fetchDailyAreaCounts(tx, tenantId, dayStart, dayEnd);
+  const areas: string[] = [];
+
+  for (const row of countRows) {
+    const rollup = await computeDailyAreaRollup(
+      tx,
+      tenantId,
+      row.area,
+      dayStart,
+      dayEnd,
+      row
+    );
+
+    await upsertDailyRollup(tx, tenantId, date, rollup);
+    areas.push(row.area);
+  }
+
+  return { date, areasProcessed: areas.length, areas };
+}

--- a/src/modules/visitor-analytics/application/session-directory.ts
+++ b/src/modules/visitor-analytics/application/session-directory.ts
@@ -1,0 +1,58 @@
+/**
+ * Keyset-paginated `awcms_visitor_sessions` listing (ported from awcms-micro
+ * epic #617-#624). Ordered `last_seen_at DESC, id DESC` — the generic
+ * `(timestamp, id)` cursor is reused even though the sort column here is
+ * `last_seen_at`, not literally `created_at`.
+ *
+ * PORT ADAPTATION (this base's keyset convention, Issue #158): the cursor is
+ * built HERE from the row's full-microsecond-precision `last_seen_at`, never
+ * from a JS `Date` (which has already floored the microseconds and would
+ * resurrect the row-skipping bug across the page boundary). `last_seen_at_cursor`
+ * carries the full-precision text and never leaves this function.
+ */
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
+import type { VisitorSessionRow } from "../domain/analytics-response-shaping";
+
+export const VISITOR_SESSION_LIST_LIMIT = 50;
+
+type VisitorSessionListRow = VisitorSessionRow & {
+  last_seen_at_cursor: string;
+};
+
+export type VisitorSessionListPage = {
+  rows: VisitorSessionRow[];
+  nextCursor: string | null;
+};
+
+export async function listVisitorSessions(
+  tx: Bun.SQL,
+  tenantId: string,
+  cursor?: KeysetCursor
+): Promise<VisitorSessionListPage> {
+  const cursorLastSeenAt = cursor?.createdAt ?? null;
+  const cursorId = cursor?.id ?? null;
+
+  const rows = (await tx`
+    SELECT *,
+      to_char(last_seen_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS last_seen_at_cursor
+    FROM awcms_visitor_sessions
+    WHERE tenant_id = ${tenantId}
+      AND (
+        ${cursorLastSeenAt}::timestamptz IS NULL
+        OR (last_seen_at, id) < (${cursorLastSeenAt}, ${cursorId})
+      )
+    ORDER BY last_seen_at DESC, id DESC
+    LIMIT ${VISITOR_SESSION_LIST_LIMIT}
+  `) as VisitorSessionListRow[];
+
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === VISITOR_SESSION_LIST_LIMIT && last
+      ? encodeKeysetCursor(last.last_seen_at_cursor, last.id)
+      : null;
+
+  return { rows, nextCursor };
+}

--- a/src/modules/visitor-analytics/domain/analytics-range.ts
+++ b/src/modules/visitor-analytics/domain/analytics-range.ts
@@ -1,0 +1,37 @@
+/**
+ * `range` query parameter validation for analytics aggregate endpoints
+ * (ported from awcms-micro epic #617-#624). Pure — the four values
+ * `24h|7d|30d|12m`.
+ */
+export const ANALYTICS_RANGES = ["24h", "7d", "30d", "12m"] as const;
+
+export type AnalyticsRange = (typeof ANALYTICS_RANGES)[number];
+
+export function isKnownAnalyticsRange(
+  value: string | null | undefined
+): value is AnalyticsRange {
+  return (ANALYTICS_RANGES as readonly string[]).includes(value ?? "");
+}
+
+/** `range=7d` (default) when the query param is omitted entirely. */
+export const DEFAULT_ANALYTICS_RANGE: AnalyticsRange = "7d";
+
+/** The start of the window for `range`, relative to `now`. Never throws. */
+export function resolveRangeStart(range: AnalyticsRange, now: Date): Date {
+  const start = new Date(now);
+
+  switch (range) {
+    case "24h":
+      start.setUTCHours(start.getUTCHours() - 24);
+      return start;
+    case "7d":
+      start.setUTCDate(start.getUTCDate() - 7);
+      return start;
+    case "30d":
+      start.setUTCDate(start.getUTCDate() - 30);
+      return start;
+    case "12m":
+      start.setUTCMonth(start.getUTCMonth() - 12);
+      return start;
+  }
+}

--- a/src/modules/visitor-analytics/domain/analytics-response-shaping.ts
+++ b/src/modules/visitor-analytics/domain/analytics-response-shaping.ts
@@ -1,0 +1,158 @@
+/**
+ * Raw-detail field omission for the `sessions`/`events` list endpoints
+ * (ported from awcms-micro epic #617-#624). Pure — the caller (route
+ * handler) decides `canSeeRawDetail` from whether the requester holds
+ * `visitor_analytics.raw_detail.read`; this module only shapes the response
+ * once that decision is made. Never the other way around — these functions
+ * must never themselves make an authorization decision.
+ *
+ * `*Row` types mirror the raw DB column names (snake_case); `*Dto` types are
+ * the actual HTTP response shape and are fully camelCase.
+ */
+
+export type VisitorSessionRow = {
+  id: string;
+  visitor_key_hash: string;
+  identity_id: string | null;
+  login_identifier_snapshot: string | null;
+  is_authenticated: boolean;
+  area: string;
+  current_path: string | null;
+  first_seen_at: Date;
+  last_seen_at: Date;
+  ip_hash: string | null;
+  ip_address: string | null;
+  user_agent_hash: string | null;
+  browser_name: string | null;
+  browser_version_major: string | null;
+  os_name: string | null;
+  device_type: string | null;
+  is_human: boolean;
+  bot_reason: string | null;
+  country_code: string | null;
+  region: string | null;
+  city: string | null;
+  timezone: string | null;
+};
+
+export type VisitorSessionDto = {
+  id: string;
+  visitorKeyHash: string;
+  identityId: string | null;
+  isAuthenticated: boolean;
+  area: string;
+  currentPath: string | null;
+  firstSeenAt: string;
+  lastSeenAt: string;
+  browserName: string | null;
+  browserVersionMajor: string | null;
+  osName: string | null;
+  deviceType: string | null;
+  isHuman: boolean;
+  botReason: string | null;
+  countryCode: string | null;
+  region: string | null;
+  city: string | null;
+  timezone: string | null;
+  loginIdentifierSnapshot: string | null;
+  ipHash: string | null;
+  ipAddress: string | null;
+  userAgentHash: string | null;
+};
+
+export function shapeVisitorSession(
+  row: VisitorSessionRow,
+  canSeeRawDetail: boolean
+): VisitorSessionDto {
+  return {
+    id: row.id,
+    visitorKeyHash: row.visitor_key_hash,
+    identityId: row.identity_id,
+    isAuthenticated: row.is_authenticated,
+    area: row.area,
+    currentPath: row.current_path,
+    firstSeenAt: row.first_seen_at.toISOString(),
+    lastSeenAt: row.last_seen_at.toISOString(),
+    browserName: row.browser_name,
+    browserVersionMajor: row.browser_version_major,
+    osName: row.os_name,
+    deviceType: row.device_type,
+    isHuman: row.is_human,
+    botReason: row.bot_reason,
+    countryCode: row.country_code,
+    region: row.region,
+    city: row.city,
+    timezone: row.timezone,
+    loginIdentifierSnapshot: canSeeRawDetail
+      ? row.login_identifier_snapshot
+      : null,
+    ipHash: canSeeRawDetail ? row.ip_hash : null,
+    ipAddress: canSeeRawDetail ? row.ip_address : null,
+    userAgentHash: canSeeRawDetail ? row.user_agent_hash : null
+  };
+}
+
+export type VisitEventRow = {
+  id: string;
+  visitor_session_id: string | null;
+  identity_id: string | null;
+  occurred_at: Date;
+  method: string;
+  status_code: number | null;
+  area: string;
+  route_pattern: string | null;
+  path_sanitized: string;
+  referrer_domain: string | null;
+  duration_ms: number | null;
+  ip_hash: string | null;
+  user_agent_hash: string | null;
+  user_agent_parsed: Record<string, unknown>;
+  geo: Record<string, unknown>;
+  human_status: string;
+  correlation_id: string | null;
+};
+
+export type VisitEventDto = {
+  id: string;
+  visitorSessionId: string | null;
+  identityId: string | null;
+  occurredAt: string;
+  method: string;
+  statusCode: number | null;
+  area: string;
+  routePattern: string | null;
+  pathSanitized: string;
+  referrerDomain: string | null;
+  durationMs: number | null;
+  userAgentParsed: Record<string, unknown>;
+  geo: Record<string, unknown>;
+  humanStatus: string;
+  correlationId: string | null;
+  ipHash: string | null;
+  userAgentHash: string | null;
+};
+
+export function shapeVisitEvent(
+  row: VisitEventRow,
+  canSeeRawDetail: boolean
+): VisitEventDto {
+  return {
+    id: row.id,
+    visitorSessionId: row.visitor_session_id,
+    identityId: row.identity_id,
+    occurredAt: row.occurred_at.toISOString(),
+    method: row.method,
+    statusCode: row.status_code,
+    area: row.area,
+    routePattern: row.route_pattern,
+    pathSanitized: row.path_sanitized,
+    referrerDomain: row.referrer_domain,
+    durationMs: row.duration_ms,
+    userAgentParsed: row.user_agent_parsed,
+    geo: row.geo,
+    humanStatus: row.human_status,
+    correlationId: row.correlation_id,
+    ipHash: canSeeRawDetail ? row.ip_hash : null,
+    userAgentHash: canSeeRawDetail ? row.user_agent_hash : null
+  };
+}

--- a/src/modules/visitor-analytics/domain/client-ip.ts
+++ b/src/modules/visitor-analytics/domain/client-ip.ts
@@ -44,12 +44,13 @@ function extractSingleTrustedHeaderValue(
   }
 
   if (parts.length > 1) {
+    // Log ONLY anomaly metadata — never the header value itself. A forwarded
+    // header's first entry is a raw client IP; emitting even a fragment of it
+    // would write an unhashed IP to logs, bypassing the `rawIpEnabled` opt-in
+    // that the storage path honors. `valueCount` is enough to spot the anomaly.
     log("warning", warningEvent, {
       moduleKey: "visitor_analytics",
-      valueCount: parts.length,
-      // Not a secret, but capped defensively — an anomaly report, not a
-      // place to let an attacker-sized header balloon log storage.
-      firstValuePreview: parts[0]?.slice(0, 100)
+      valueCount: parts.length
     });
   }
 

--- a/src/modules/visitor-analytics/domain/client-ip.ts
+++ b/src/modules/visitor-analytics/domain/client-ip.ts
@@ -1,0 +1,83 @@
+/**
+ * Client IP resolution for visitor analytics (ported from awcms-micro epic
+ * #617-#624). Pure — only ever trusts a forwarded header when the deployment
+ * has explicitly opted in via
+ * `VISITOR_ANALYTICS_TRUST_PROXY`/`VISITOR_ANALYTICS_TRUST_CLOUDFLARE` (the
+ * module's config gate) — never trust a spoofable client-supplied header
+ * without a trusted proxy in front that actually overwrites it.
+ *
+ * Returns `null` (never a fake "unknown" placeholder) when no IP is
+ * resolvable — `null` correctly hashes to nothing and stores as SQL `NULL`
+ * in `ip_hash`/`ip_address`, rather than a meaningless-but-real-looking hash
+ * of the literal string `"unknown"`.
+ *
+ * Ambiguous-header fail-safe: a forwarded header carrying more than one
+ * comma-separated value is treated as an anomaly, not "just proxy chaining"
+ * — this base has no "N trusted hops" configuration to anchor a "take the
+ * Nth value from the right" rule on (same reasoning
+ * `lib/tenant/public-host-tenant-resolver.ts`'s `extractHostHeader` uses for
+ * `X-Forwarded-Host`), so an ambiguous header is logged as a warning and
+ * never trusted, falling through to the next source in the chain exactly as
+ * if that trust flag were `false` for this one request.
+ */
+import { log } from "../../../lib/logging/logger";
+
+/** `null` if the header is absent/blank, the single value if unambiguous, `null` (with a warning logged) if it carries more than one comma-separated value. */
+function extractSingleTrustedHeaderValue(
+  request: Request,
+  headerName: string,
+  warningEvent: string
+): string | null {
+  const raw = request.headers.get(headerName);
+
+  if (!raw || raw.trim().length === 0) {
+    return null;
+  }
+
+  const parts = raw
+    .split(",")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+
+  if (parts.length === 1) {
+    return parts[0] as string;
+  }
+
+  if (parts.length > 1) {
+    log("warning", warningEvent, {
+      moduleKey: "visitor_analytics",
+      valueCount: parts.length,
+      // Not a secret, but capped defensively — an anomaly report, not a
+      // place to let an attacker-sized header balloon log storage.
+      firstValuePreview: parts[0]?.slice(0, 100)
+    });
+  }
+
+  return null;
+}
+
+export function resolveAnalyticsClientIp(
+  request: Request,
+  clientAddress: string | undefined,
+  trustConfig: { trustProxy: boolean; trustCloudflare: boolean }
+): string | null {
+  if (trustConfig.trustCloudflare) {
+    const cfIp = extractSingleTrustedHeaderValue(
+      request,
+      "cf-connecting-ip",
+      "visitor_analytics.client_ip.cf_connecting_ip_multi_value"
+    );
+    if (cfIp) return cfIp;
+  }
+
+  if (trustConfig.trustProxy) {
+    const forwardedFor = extractSingleTrustedHeaderValue(
+      request,
+      "x-forwarded-for",
+      "visitor_analytics.client_ip.x_forwarded_for_multi_value"
+    );
+    if (forwardedFor) return forwardedFor;
+  }
+
+  return clientAddress?.trim() || null;
+}

--- a/src/modules/visitor-analytics/domain/dashboard-view.ts
+++ b/src/modules/visitor-analytics/domain/dashboard-view.ts
@@ -1,0 +1,174 @@
+/**
+ * Pure view-model helpers for the `/admin/analytics` dashboard (ported from
+ * awcms-micro epic #617-#624). No DOM, no `fetch`, no `process.env` here —
+ * these functions are imported both by `src/pages/admin/analytics.astro`
+ * (server-side render) and by this module's own unit tests, so the
+ * dashboard's empty-state decisions and raw-detail-null formatting are
+ * testable without a browser or a live server.
+ *
+ * **Never a second authorization gate.** `visitor_analytics.raw_detail.read`
+ * is checked exactly once, server-side, in
+ * `domain/analytics-response-shaping.ts`'s `shapeVisitorSession`/
+ * `shapeVisitEvent` — a caller without that permission always receives `null`
+ * for `ipAddress`/`ipHash`/`userAgentHash`/`loginIdentifierSnapshot`,
+ * regardless of anything this file does. `buildSessionRowCells`'s
+ * `showRawDetailColumns` option only decides whether the dashboard bothers to
+ * render four columns that would otherwise be a wall of placeholder dashes —
+ * a presentation nicety, not a security decision. It can never cause a leak.
+ */
+
+export const DASHBOARD_VALUE_PLACEHOLDER = "—"; // em dash — never render the literal "null"/"undefined".
+
+/**
+ * Renders a possibly-null/blank field as-is, or the shared placeholder. The
+ * one place every raw-detail column (and every other nullable display field)
+ * funnels through.
+ */
+export function displayOrPlaceholder(value: string | null | undefined): string {
+  if (value === null || value === undefined) return DASHBOARD_VALUE_PLACEHOLDER;
+  const trimmed = value.trim();
+  return trimmed.length === 0 ? DASHBOARD_VALUE_PLACEHOLDER : value;
+}
+
+export type NamedCountLike = { name: string; count: number };
+
+/** A "top N" list section is empty when there is nothing to show, or every count is zero. */
+export function isNamedCountListEmpty(list: NamedCountLike[]): boolean {
+  return list.length === 0 || list.every((item) => item.count === 0);
+}
+
+export type RealtimeStatsLike = {
+  onlineHumanCount: number;
+  onlineAdminCount: number;
+  onlinePublicCount: number;
+  onlineApiCount: number;
+};
+
+export function isRealtimeAllZero(stats: RealtimeStatsLike): boolean {
+  return (
+    stats.onlineHumanCount === 0 &&
+    stats.onlineAdminCount === 0 &&
+    stats.onlinePublicCount === 0 &&
+    stats.onlineApiCount === 0
+  );
+}
+
+export type SummaryLike = {
+  humanUniqueVisitors: number;
+  humanPageviews: number;
+  botPageviews: number;
+};
+
+export function isSummaryEmpty(summary: SummaryLike): boolean {
+  return (
+    summary.humanUniqueVisitors === 0 &&
+    summary.humanPageviews === 0 &&
+    summary.botPageviews === 0
+  );
+}
+
+export type SecurityViewLike = { botPageviews: number };
+
+export function isSecurityViewEmpty(view: SecurityViewLike): boolean {
+  return view.botPageviews === 0;
+}
+
+export const ANALYTICS_AREA_FILTERS = [
+  "all",
+  "admin",
+  "public",
+  "api"
+] as const;
+export type AnalyticsAreaFilter = (typeof ANALYTICS_AREA_FILTERS)[number];
+
+export const ANALYTICS_VISITOR_TYPE_FILTERS = ["all", "human", "bot"] as const;
+export type AnalyticsVisitorTypeFilter =
+  (typeof ANALYTICS_VISITOR_TYPE_FILTERS)[number];
+
+/**
+ * Row filter for the active-sessions table (Area / Visitor type filters).
+ * This is a display filter over rows the caller is ALREADY authorized to see
+ * in full — never a substitute for, or a second copy of, the server's own
+ * ABAC/raw-detail gating.
+ */
+export function matchesAreaFilter(
+  area: string,
+  filter: AnalyticsAreaFilter
+): boolean {
+  if (filter === "all") return true;
+  if (filter === "api")
+    return area === "api" || area === "auth" || area === "setup";
+  return area === filter;
+}
+
+export function matchesVisitorTypeFilter(
+  isHuman: boolean,
+  filter: AnalyticsVisitorTypeFilter
+): boolean {
+  if (filter === "all") return true;
+  return filter === "human" ? isHuman : !isHuman;
+}
+
+/** Structural subset of `VisitorSessionDto` this file actually reads. */
+export type SessionRowLike = {
+  area: string;
+  currentPath: string | null;
+  browserName: string | null;
+  osName: string | null;
+  deviceType: string | null;
+  isHuman: boolean;
+  countryCode: string | null;
+  ipAddress: string | null;
+  ipHash: string | null;
+  userAgentHash: string | null;
+  loginIdentifierSnapshot: string | null;
+};
+
+export type SessionRowCells = {
+  area: string;
+  currentPath: string;
+  browser: string;
+  os: string;
+  device: string;
+  visitorType: string;
+  country: string;
+  raw: {
+    ipAddress: string;
+    ipHash: string;
+    userAgentHash: string;
+    loginIdentifier: string;
+  } | null;
+};
+
+/**
+ * Turns one already-shaped session row into display-ready strings for the
+ * active-sessions table. `raw` is `null` when `showRawDetailColumns` is
+ * `false`; when non-null, every one of its four fields still goes through
+ * `displayOrPlaceholder`.
+ */
+export function buildSessionRowCells(
+  session: SessionRowLike,
+  options: {
+    showRawDetailColumns: boolean;
+    humanLabel: string;
+    botLabel: string;
+  }
+): SessionRowCells {
+  return {
+    area: session.area,
+    currentPath: displayOrPlaceholder(session.currentPath),
+    browser: displayOrPlaceholder(session.browserName),
+    os: displayOrPlaceholder(session.osName),
+    device: displayOrPlaceholder(session.deviceType),
+    visitorType: session.isHuman ? options.humanLabel : options.botLabel,
+    country: displayOrPlaceholder(session.countryCode),
+    raw: options.showRawDetailColumns
+      ? {
+          ipAddress: displayOrPlaceholder(session.ipAddress),
+          ipHash: displayOrPlaceholder(session.ipHash),
+          userAgentHash: displayOrPlaceholder(session.userAgentHash),
+          loginIdentifier: displayOrPlaceholder(session.loginIdentifierSnapshot)
+        }
+      : null
+  };
+}

--- a/src/modules/visitor-analytics/domain/geo-enrichment.ts
+++ b/src/modules/visitor-analytics/domain/geo-enrichment.ts
@@ -1,0 +1,62 @@
+/**
+ * Trusted online geolocation enrichment (ported from awcms-micro epic
+ * #617-#624). Pure — reads only already-present, trusted request headers;
+ * never makes an external network call (binding constraint — no third-party
+ * geolocation API is ever called from the request path).
+ *
+ * Country code only, from Cloudflare's `CF-IPCountry` header, and only when
+ * both `VISITOR_ANALYTICS_GEO_ENABLED` and `VISITOR_ANALYTICS_TRUST_CLOUDFLARE`
+ * are `true` — Cloudflare's free tier reliably provides country via that
+ * header; region/city/timezone require either Cloudflare's paid IP
+ * Geolocation add-on or a local/offline GeoIP database (neither implemented
+ * here). Those three fields are always `null`; this is a documented gap, not
+ * a bug — `resolveGeoEnrichment` never fabricates a value.
+ *
+ * BINDING: never used for authorization, rate-limiting, or tenant resolution
+ * — analytics-only, same rule `domain/user-agent.ts`'s human/bot
+ * classification follows.
+ */
+export type GeoEnrichment = {
+  countryCode: string | null;
+  region: string | null;
+  city: string | null;
+  timezone: string | null;
+};
+
+const EMPTY_GEO: GeoEnrichment = {
+  countryCode: null,
+  region: null,
+  city: null,
+  timezone: null
+};
+
+/**
+ * Cloudflare's `CF-IPCountry` is a 2-letter ISO 3166-1 alpha-2 code, or one
+ * of a small set of non-country sentinels (`XX` unknown, `T1` Tor exit node,
+ * `EU` region-only edge case) — all still short alphanumeric codes, so this
+ * only guards against something obviously not a country-code-shaped value
+ * ever being stored (e.g. an empty string, or a header some misbehaving
+ * intermediary stuffed with unrelated text).
+ */
+const COUNTRY_CODE_PATTERN = /^[A-Z0-9]{2,3}$/i;
+
+function normalizeCountryCode(raw: string | null): string | null {
+  if (!raw) return null;
+
+  const trimmed = raw.trim().toUpperCase();
+
+  return COUNTRY_CODE_PATTERN.test(trimmed) ? trimmed : null;
+}
+
+export function resolveGeoEnrichment(
+  request: Request,
+  config: { geoEnabled: boolean; trustCloudflare: boolean }
+): GeoEnrichment {
+  if (!config.geoEnabled || !config.trustCloudflare) {
+    return EMPTY_GEO;
+  }
+
+  const countryCode = normalizeCountryCode(request.headers.get("cf-ipcountry"));
+
+  return { ...EMPTY_GEO, countryCode };
+}

--- a/src/modules/visitor-analytics/domain/human-classifier.ts
+++ b/src/modules/visitor-analytics/domain/human-classifier.ts
@@ -1,0 +1,65 @@
+/**
+ * Human/bot classification (ported from awcms-micro epic #617-#624). Pure —
+ * combines `user-agent.ts`'s parse result with whether the request is on an
+ * authenticated session to decide the `human_status`/`is_human` values
+ * migration 050's tables expect.
+ *
+ * BINDING (repeated from `user-agent.ts`): this classification is for
+ * ANALYTICS ONLY — never wire its output into an authorization, rate-limit,
+ * or security decision. A spoofed UA trivially defeats it, and that is an
+ * acceptable trade-off for analytics but not for access control.
+ */
+import type { ParsedUserAgent } from "./user-agent";
+
+/** Matches `awcms_visit_events.human_status`'s CHECK constraint exactly. */
+export type HumanStatus = "human" | "bot" | "unknown";
+
+export type ClassifyHumanInput = {
+  isAuthenticated: boolean;
+  parsedUserAgent: ParsedUserAgent;
+};
+
+/**
+ * `bot` wins regardless of authentication (a clearly-bot UA is never
+ * reclassified as human just because it presented a valid session). An
+ * authenticated session with a non-bot but unparseable UA is still `human`.
+ * Everything else with an unrecognized device type is `unknown`, never
+ * defaulted to `human` — unknown/ambiguous user-agents must not be blindly
+ * trusted.
+ */
+export function classifyHumanStatus(input: ClassifyHumanInput): HumanStatus {
+  const { isAuthenticated, parsedUserAgent } = input;
+
+  if (parsedUserAgent.isBot) return "bot";
+  if (isAuthenticated) return "human";
+  if (parsedUserAgent.deviceType === "unknown") return "unknown";
+  return "human";
+}
+
+export type ClassifySessionHumanityInput = {
+  isAuthenticated: boolean;
+  parsedUserAgent: ParsedUserAgent;
+};
+
+export type SessionHumanity = {
+  isHuman: boolean;
+  botReason: string | null;
+};
+
+/**
+ * `awcms_visitor_sessions.is_human` is a plain boolean (no `unknown`
+ * tri-state, and defaults `true`) — an unparseable/unknown UA on a session
+ * stays `is_human: true` unless the UA is clearly a bot, matching the
+ * table's own privacy-first default rather than inventing a third state the
+ * schema has no column for.
+ */
+export function classifySessionHumanity(
+  input: ClassifySessionHumanityInput
+): SessionHumanity {
+  const { parsedUserAgent } = input;
+
+  return {
+    isHuman: !parsedUserAgent.isBot,
+    botReason: parsedUserAgent.isBot ? parsedUserAgent.botReason : null
+  };
+}

--- a/src/modules/visitor-analytics/domain/path-sanitizer.ts
+++ b/src/modules/visitor-analytics/domain/path-sanitizer.ts
@@ -1,0 +1,137 @@
+/**
+ * Path/query sanitization and pageview-eligibility helpers (ported from
+ * awcms-micro epic #617-#624). Pure — no request I/O; the collector calls
+ * these with the request's own pathname+query before anything is stored in
+ * `awcms_visit_events`.
+ *
+ * BINDING: `sanitizePath`'s output is the ONLY form a path may take before
+ * it reaches `path_sanitized` (migration 050) — a raw, un-sanitized
+ * path/query string must never be persisted, since query strings routinely
+ * carry tokens/secrets (password reset links, OAuth codes, MFA challenge
+ * tokens) that must never land in an analytics table.
+ */
+
+/**
+ * Matched case-insensitively against query parameter names. `mfaChallengeToken`
+ * is included verbatim (its lowercase form is what's actually compared).
+ */
+const SENSITIVE_QUERY_PARAM_NAMES = new Set([
+  "token",
+  "code",
+  "password",
+  "secret",
+  "email",
+  "phone",
+  "authorization",
+  "access_token",
+  "refresh_token",
+  "reset_token",
+  "mfachallengetoken"
+]);
+
+/**
+ * Strips every sensitive query parameter and returns `pathname` (+ remaining
+ * safe query string, if any). Never throws.
+ *
+ * Fail SAFE, not fail open: a `rawPath` that `URL` cannot parse degrades to
+ * its path portion only (query string dropped entirely), never to the raw,
+ * un-sanitized input — the very thing this function exists to prevent from
+ * reaching `path_sanitized`. A pageview with a stripped query string is
+ * still useful analytics signal; echoing an unparseable-and-therefore-
+ * unstrippable query string is a real leak path.
+ */
+export function sanitizePath(rawPath: string): string {
+  let url: URL;
+
+  try {
+    url = new URL(rawPath, "http://internal.invalid");
+  } catch {
+    return rawPath.split("?")[0] ?? rawPath;
+  }
+
+  for (const key of [...url.searchParams.keys()]) {
+    if (SENSITIVE_QUERY_PARAM_NAMES.has(key.toLowerCase())) {
+      url.searchParams.delete(key);
+    }
+  }
+
+  const query = url.searchParams.toString();
+
+  return query ? `${url.pathname}?${query}` : url.pathname;
+}
+
+const STATIC_ASSET_EXTENSIONS = new Set([
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "avif",
+  "ico",
+  "css",
+  "js",
+  "mjs",
+  "woff",
+  "woff2",
+  "ttf",
+  "eot",
+  "otf",
+  "map"
+]);
+
+/** Path prefixes that are always internal build/runtime assets, never a pageview. */
+const SKIPPED_PATH_PREFIXES = ["/_astro/", "/_actions/", "/_image"];
+
+/** Any path segment (case-insensitive) that marks the whole path as non-trackable. */
+const SKIPPED_PATH_SEGMENTS = new Set(["health"]);
+
+function fileExtension(pathname: string): string | null {
+  const match = pathname.match(/\.([a-z0-9]+)$/i);
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+/**
+ * `false` for static assets, internal framework/build paths, health
+ * endpoints, and OpenAPI/AsyncAPI spec files — none of these represent a
+ * human/bot visiting a page, so the collector must skip writing a
+ * `visit_events` row for them. `pathname` should already be the sanitized
+ * form from `sanitizePath` (or any plain path) — this function never
+ * inspects the query string.
+ */
+export function isTrackablePath(pathname: string): boolean {
+  const normalized = pathname.split("?")[0] ?? pathname;
+
+  if (SKIPPED_PATH_PREFIXES.some((prefix) => normalized.startsWith(prefix))) {
+    return false;
+  }
+
+  if (normalized.toLowerCase().includes("favicon")) {
+    return false;
+  }
+
+  const extension = fileExtension(normalized);
+  if (extension && STATIC_ASSET_EXTENSIONS.has(extension)) {
+    return false;
+  }
+
+  if (/^\/(openapi|asyncapi)(\/|$)/i.test(normalized)) {
+    return false;
+  }
+
+  if (
+    (extension === "yaml" || extension === "yml") &&
+    /spec/i.test(normalized)
+  ) {
+    return false;
+  }
+
+  const segments = normalized.split("/").filter(Boolean);
+  if (
+    segments.some((segment) => SKIPPED_PATH_SEGMENTS.has(segment.toLowerCase()))
+  ) {
+    return false;
+  }
+
+  return true;
+}

--- a/src/modules/visitor-analytics/domain/referrer.ts
+++ b/src/modules/visitor-analytics/domain/referrer.ts
@@ -1,0 +1,32 @@
+/**
+ * Safe referrer-domain extraction (ported from awcms-micro epic #617-#624).
+ * Pure — never throws, never returns anything beyond a bare hostname (no
+ * path, query, or fragment, which routinely carry the referring page's own
+ * tokens/PII — must never be copied into
+ * `awcms_visit_events.referrer_domain`).
+ */
+
+/**
+ * `null` for a missing/empty/unparseable `Referer` header, or any non-http(s)
+ * scheme (e.g. `javascript:`, `data:` — never worth trusting as a referrer
+ * domain).
+ */
+export function extractReferrerDomain(
+  rawReferrer: string | null | undefined
+): string | null {
+  if (!rawReferrer) return null;
+
+  let url: URL;
+
+  try {
+    url = new URL(rawReferrer);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    return null;
+  }
+
+  return url.hostname ? url.hostname.toLowerCase() : null;
+}

--- a/src/modules/visitor-analytics/domain/request-area.ts
+++ b/src/modules/visitor-analytics/domain/request-area.ts
@@ -1,0 +1,27 @@
+/**
+ * Request area classification (ported from awcms-micro epic #617-#624).
+ * Pure — matches `awcms_visitor_sessions`/`awcms_visit_events`'s own `area`
+ * CHECK constraint (`admin|public|api|auth|setup|unknown`, migration 050)
+ * exactly.
+ *
+ * `auth`/`setup` are sub-classifications of API space (`/api/v1/auth/*`,
+ * `/api/v1/setup/*`), not page renders — a real page like `/login` is
+ * `public`, same as any other rendered page, since it is gated by
+ * `VISITOR_ANALYTICS_COLLECT_PUBLIC` (page-render volume), not
+ * `VISITOR_ANALYTICS_COLLECT_API` (JSON-endpoint-call volume).
+ */
+export type RequestArea =
+  "admin" | "public" | "api" | "auth" | "setup" | "unknown";
+
+export function determineArea(pathname: string): RequestArea {
+  if (pathname.startsWith("/admin")) return "admin";
+  if (pathname.startsWith("/api/v1/setup")) return "setup";
+  if (pathname.startsWith("/api/v1/auth")) return "auth";
+  if (pathname.startsWith("/api")) return "api";
+  return "public";
+}
+
+/** True for every area gated by `VISITOR_ANALYTICS_COLLECT_API` (anything under `/api`). */
+export function isApiArea(area: RequestArea): boolean {
+  return area === "api" || area === "auth" || area === "setup";
+}

--- a/src/modules/visitor-analytics/domain/user-agent.ts
+++ b/src/modules/visitor-analytics/domain/user-agent.ts
@@ -1,0 +1,196 @@
+/**
+ * Lightweight, dependency-free user-agent parsing and bot detection (ported
+ * from awcms-micro epic #617-#624). Pure string parsing — no external
+ * bot-intelligence provider, no fingerprinting beyond ordinary
+ * browser/OS/device-type detection from the UA string itself.
+ *
+ * Deliberately does NOT pull in a UA-parsing library (`ua-parser-js` and
+ * similar are large, frequently-updated-for-new-devices dependencies that
+ * would need Bun-compatibility verification per AGENTS.md's Bun-only rule) —
+ * a compact regex table covering the handful of browser/OS/bot families that
+ * matter for aggregate analytics is enough; this is not a security or
+ * billing decision point (see file header note below), so occasionally
+ * missing an exotic UA and falling back to `"unknown"` is an acceptable
+ * trade-off, not a defect.
+ *
+ * BINDING: human/bot classification here is for ANALYTICS ONLY. Never wire
+ * `isBotUserAgent`/`parseUserAgent`'s output into an authorization,
+ * rate-limit, or security decision — a spoofed UA trivially defeats it.
+ */
+
+export type DeviceType = "desktop" | "mobile" | "tablet" | "bot" | "unknown";
+
+export type ParsedUserAgent = {
+  browserName: string | null;
+  browserVersionMajor: string | null;
+  osName: string | null;
+  deviceType: DeviceType;
+  isBot: boolean;
+  botReason: string | null;
+};
+
+/**
+ * Common crawler/bot/preview-fetcher signatures — search engines
+ * (Googlebot, Bingbot, Slurp, DuckDuckBot, Baiduspider, YandexBot,
+ * Applebot), social link-preview fetchers (facebookexternalhit, Twitterbot,
+ * LinkedInBot, Slackbot, WhatsApp, TelegramBot, Discordbot), SEO/monitoring
+ * crawlers (AhrefsBot, SemrushBot, MJ12bot, PetalBot, DotBot, UptimeRobot),
+ * and generic script/automation clients (curl, wget, python-requests,
+ * Go-http-client, PostmanRuntime, HeadlessChrome, PhantomJS, Selenium).
+ * Matched case-insensitively against the raw UA string.
+ */
+const BOT_SIGNATURES: readonly { pattern: RegExp; name: string }[] = [
+  { pattern: /googlebot/i, name: "Googlebot" },
+  { pattern: /bingbot/i, name: "Bingbot" },
+  { pattern: /slurp/i, name: "Yahoo Slurp" },
+  { pattern: /duckduckbot/i, name: "DuckDuckBot" },
+  { pattern: /baiduspider/i, name: "Baiduspider" },
+  { pattern: /yandexbot/i, name: "YandexBot" },
+  { pattern: /applebot/i, name: "Applebot" },
+  { pattern: /facebookexternalhit/i, name: "Facebook" },
+  { pattern: /twitterbot/i, name: "Twitterbot" },
+  { pattern: /linkedinbot/i, name: "LinkedInBot" },
+  { pattern: /slackbot/i, name: "Slackbot" },
+  { pattern: /whatsapp/i, name: "WhatsApp" },
+  { pattern: /telegrambot/i, name: "TelegramBot" },
+  { pattern: /discordbot/i, name: "Discordbot" },
+  { pattern: /ahrefsbot/i, name: "AhrefsBot" },
+  { pattern: /semrushbot/i, name: "SemrushBot" },
+  { pattern: /mj12bot/i, name: "MJ12bot" },
+  { pattern: /petalbot/i, name: "PetalBot" },
+  { pattern: /dotbot/i, name: "DotBot" },
+  { pattern: /uptimerobot/i, name: "UptimeRobot" },
+  { pattern: /curl\//i, name: "curl" },
+  { pattern: /wget\//i, name: "Wget" },
+  { pattern: /python-requests/i, name: "python-requests" },
+  { pattern: /go-http-client/i, name: "Go-http-client" },
+  { pattern: /postmanruntime/i, name: "PostmanRuntime" },
+  { pattern: /headlesschrome/i, name: "HeadlessChrome" },
+  { pattern: /phantomjs/i, name: "PhantomJS" },
+  { pattern: /selenium/i, name: "Selenium" },
+  { pattern: /\bbot\b/i, name: "generic bot" },
+  { pattern: /crawler/i, name: "generic crawler" },
+  { pattern: /spider/i, name: "generic spider" }
+];
+
+export function isBotUserAgent(userAgent: string | null | undefined): {
+  isBot: boolean;
+  botReason: string | null;
+} {
+  if (!userAgent) {
+    return { isBot: false, botReason: null };
+  }
+
+  const match = BOT_SIGNATURES.find(({ pattern }) => pattern.test(userAgent));
+
+  return match
+    ? { isBot: true, botReason: match.name }
+    : { isBot: false, botReason: null };
+}
+
+const BROWSER_PATTERNS: readonly { pattern: RegExp; name: string }[] = [
+  // Order matters — many browser UAs include multiple engine tokens
+  // (Chrome/Safari/Edge all include "Safari"; Edge/Opera include "Chrome"),
+  // so more specific tokens are checked first.
+  { pattern: /edg\//i, name: "Edge" },
+  { pattern: /opr\//i, name: "Opera" },
+  { pattern: /samsungbrowser\//i, name: "Samsung Internet" },
+  { pattern: /firefox\//i, name: "Firefox" },
+  { pattern: /chrome\//i, name: "Chrome" },
+  { pattern: /crios\//i, name: "Chrome" },
+  { pattern: /fxios\//i, name: "Firefox" },
+  { pattern: /version\/.*safari/i, name: "Safari" },
+  { pattern: /safari\//i, name: "Safari" },
+  { pattern: /msie |trident\//i, name: "Internet Explorer" }
+];
+
+const BROWSER_VERSION_PATTERNS: Record<string, RegExp> = {
+  Edge: /edg\/(\d+)/i,
+  Opera: /opr\/(\d+)/i,
+  "Samsung Internet": /samsungbrowser\/(\d+)/i,
+  Firefox: /(?:firefox|fxios)\/(\d+)/i,
+  Chrome: /(?:chrome|crios)\/(\d+)/i,
+  Safari: /version\/(\d+)/i,
+  "Internet Explorer": /(?:msie |rv:)(\d+)/i
+};
+
+function detectBrowser(userAgent: string): {
+  name: string | null;
+  versionMajor: string | null;
+} {
+  const match = BROWSER_PATTERNS.find(({ pattern }) => pattern.test(userAgent));
+
+  if (!match) {
+    return { name: null, versionMajor: null };
+  }
+
+  const versionPattern = BROWSER_VERSION_PATTERNS[match.name];
+  const versionMatch = versionPattern ? userAgent.match(versionPattern) : null;
+
+  return { name: match.name, versionMajor: versionMatch?.[1] ?? null };
+}
+
+const OS_PATTERNS: readonly { pattern: RegExp; name: string }[] = [
+  // iOS/Android/CrOS checked before Windows/macOS/Linux: iPhone/iPad UAs
+  // always carry a "like Mac OS X" compatibility token, and Android/CrOS UAs
+  // are built on a Linux kernel string — checking the more specific
+  // mobile/OS tokens first avoids misclassifying them as macOS/Linux.
+  { pattern: /iphone|ipad|ipod/i, name: "iOS" },
+  { pattern: /android/i, name: "Android" },
+  { pattern: /cros/i, name: "Chrome OS" },
+  { pattern: /windows nt/i, name: "Windows" },
+  { pattern: /mac os x/i, name: "macOS" },
+  { pattern: /linux/i, name: "Linux" }
+];
+
+function detectOs(userAgent: string): string | null {
+  return (
+    OS_PATTERNS.find(({ pattern }) => pattern.test(userAgent))?.name ?? null
+  );
+}
+
+function detectDeviceType(userAgent: string, isBot: boolean): DeviceType {
+  if (isBot) return "bot";
+  if (/ipad|tablet/i.test(userAgent)) return "tablet";
+  // Android tablets omit "Mobile" in their UA; Android phones include it.
+  if (/android/i.test(userAgent) && !/mobile/i.test(userAgent)) return "tablet";
+  if (/mobi|iphone|ipod/i.test(userAgent)) return "mobile";
+  if (/android/i.test(userAgent)) return "mobile";
+  if (/windows nt|mac os x|linux|cros/i.test(userAgent)) return "desktop";
+  return "unknown";
+}
+
+/**
+ * Never throws. Empty/missing UA and completely unrecognized UAs both
+ * resolve to `deviceType: "unknown"` with null browser/OS fields —
+ * "unknown" is deliberately never conflated with "human" or "bot"
+ * (unknown/ambiguous user-agents must not be blindly trusted as human).
+ */
+export function parseUserAgent(
+  userAgent: string | null | undefined
+): ParsedUserAgent {
+  const { isBot, botReason } = isBotUserAgent(userAgent);
+
+  if (!userAgent) {
+    return {
+      browserName: null,
+      browserVersionMajor: null,
+      osName: null,
+      deviceType: "unknown",
+      isBot,
+      botReason
+    };
+  }
+
+  const { name: browserName, versionMajor: browserVersionMajor } =
+    detectBrowser(userAgent);
+
+  return {
+    browserName,
+    browserVersionMajor,
+    osName: detectOs(userAgent),
+    deviceType: detectDeviceType(userAgent, isBot),
+    isBot,
+    botReason
+  };
+}

--- a/src/modules/visitor-analytics/domain/visitor-analytics-config.ts
+++ b/src/modules/visitor-analytics/domain/visitor-analytics-config.ts
@@ -1,0 +1,218 @@
+/**
+ * Privacy-first configuration gate for the `visitor_analytics` module
+ * (ported from awcms-micro epic #617-#624). Pure — no `process.env` reads
+ * outside `resolveVisitorAnalyticsConfig`/`isVisitorAnalyticsEnabled`;
+ * `scripts/validate-env.ts` validates the raw env-var shape separately.
+ *
+ * This file only resolves/validates the env-var shape. It does not
+ * collect, store, or process any visitor data — that is the collector
+ * (`application/collector.ts`), the analytics queries, and the
+ * rollup/retention jobs.
+ *
+ * `VISITOR_ANALYTICS_MODE=basic` is the privacy-first default: raw IP, raw
+ * user-agent, and geolocation collection are all disabled by default and
+ * require an explicit opt-in env var, independent of
+ * `VISITOR_ANALYTICS_MODE` itself (the mode only distinguishes
+ * aggregate-only `basic` collection from a future `detailed` mode with
+ * richer session/event granularity — it never implies the raw-detail flags
+ * below turn on by itself).
+ *
+ * The module's master switch (`enabled`) defaults to `false` — a fresh
+ * installation collects nothing until an operator explicitly sets
+ * `VISITOR_ANALYTICS_ENABLED=true` after making their own lawful-
+ * purpose/consent decision (this software setting is a technical switch,
+ * never itself the legal basis required by UU PDP). An operator that sets
+ * the flag explicitly is unaffected; explicit values always win over the
+ * default here.
+ */
+export const VISITOR_ANALYTICS_MODES = ["basic", "detailed"] as const;
+
+export type VisitorAnalyticsMode = (typeof VISITOR_ANALYTICS_MODES)[number];
+
+export function isKnownVisitorAnalyticsMode(
+  value: string | undefined
+): value is VisitorAnalyticsMode {
+  return (VISITOR_ANALYTICS_MODES as readonly string[]).includes(value ?? "");
+}
+
+export type VisitorAnalyticsConfig = {
+  enabled: boolean;
+  mode: VisitorAnalyticsMode;
+  collectAdmin: boolean;
+  collectPublic: boolean;
+  collectApi: boolean;
+  detailedEnabled: boolean;
+  rawIpEnabled: boolean;
+  rawUserAgentEnabled: boolean;
+  geoEnabled: boolean;
+  trustProxy: boolean;
+  trustCloudflare: boolean;
+  onlineWindowSeconds: number;
+  eventRetentionDays: number;
+  rawDetailRetentionDays: number;
+  rollupRetentionDays: number;
+  hashSalt: string;
+  /**
+   * Lifetime (days) of the anonymous `awcms_visitor_key` cookie.
+   * Deliberately short — the cookie is a persistent anonymous identifier,
+   * so its lifetime is bounded to the same order of magnitude as the
+   * module's *shortest* sensitive-data retention window
+   * (`rawDetailRetentionDays`, 30 days default) rather than a multi-year
+   * constant.
+   */
+  visitorKeyCookieTtlDays: number;
+};
+
+/** Safe defaults matching the module's `.env.example` block exactly. */
+export const VISITOR_ANALYTICS_DEFAULTS: VisitorAnalyticsConfig = {
+  enabled: false,
+  mode: "basic",
+  collectAdmin: true,
+  collectPublic: true,
+  collectApi: false,
+  detailedEnabled: false,
+  rawIpEnabled: false,
+  rawUserAgentEnabled: false,
+  geoEnabled: false,
+  trustProxy: false,
+  trustCloudflare: false,
+  onlineWindowSeconds: 300,
+  eventRetentionDays: 90,
+  rawDetailRetentionDays: 30,
+  rollupRetentionDays: 730,
+  hashSalt: "",
+  visitorKeyCookieTtlDays: 30
+};
+
+/**
+ * The env var names whose value must parse as a positive integer when set —
+ * checked by `validateEnv` in `scripts/validate-env.ts` and reused here so
+ * both files agree on exactly which keys are "positive integer" shaped.
+ */
+export const VISITOR_ANALYTICS_POSITIVE_INT_VARS = [
+  "VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS",
+  "VISITOR_ANALYTICS_EVENT_RETENTION_DAYS",
+  "VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS",
+  "VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS",
+  "VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS"
+] as const;
+
+function isSet(value: string | undefined): boolean {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function parseBoolean(value: string | undefined, fallback: boolean): boolean {
+  if (!isSet(value)) return fallback;
+  return value === "true";
+}
+
+/** `undefined` when unset/blank/non-positive-integer — never throws, never NaN. */
+export function parsePositiveInt(
+  value: string | undefined
+): number | undefined {
+  if (!isSet(value)) return undefined;
+
+  const trimmed = (value as string).trim();
+
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const parsed = Number.parseInt(trimmed, 10);
+
+  return parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * Resolves the full config from `env`, falling back to
+ * `VISITOR_ANALYTICS_DEFAULTS` for anything unset or malformed. Never
+ * throws — malformed numeric values are reported by `scripts/validate-env.ts`,
+ * not here; this resolver always returns a usable config.
+ */
+export function resolveVisitorAnalyticsConfig(
+  env: NodeJS.ProcessEnv = process.env
+): VisitorAnalyticsConfig {
+  const modeRaw = env.VISITOR_ANALYTICS_MODE;
+
+  return {
+    enabled: parseBoolean(
+      env.VISITOR_ANALYTICS_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.enabled
+    ),
+    mode: isKnownVisitorAnalyticsMode(modeRaw)
+      ? modeRaw
+      : VISITOR_ANALYTICS_DEFAULTS.mode,
+    collectAdmin: parseBoolean(
+      env.VISITOR_ANALYTICS_COLLECT_ADMIN,
+      VISITOR_ANALYTICS_DEFAULTS.collectAdmin
+    ),
+    collectPublic: parseBoolean(
+      env.VISITOR_ANALYTICS_COLLECT_PUBLIC,
+      VISITOR_ANALYTICS_DEFAULTS.collectPublic
+    ),
+    collectApi: parseBoolean(
+      env.VISITOR_ANALYTICS_COLLECT_API,
+      VISITOR_ANALYTICS_DEFAULTS.collectApi
+    ),
+    detailedEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_DETAILED_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.detailedEnabled
+    ),
+    rawIpEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_RAW_IP_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.rawIpEnabled
+    ),
+    rawUserAgentEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_RAW_USER_AGENT_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.rawUserAgentEnabled
+    ),
+    geoEnabled: parseBoolean(
+      env.VISITOR_ANALYTICS_GEO_ENABLED,
+      VISITOR_ANALYTICS_DEFAULTS.geoEnabled
+    ),
+    trustProxy: parseBoolean(
+      env.VISITOR_ANALYTICS_TRUST_PROXY,
+      VISITOR_ANALYTICS_DEFAULTS.trustProxy
+    ),
+    trustCloudflare: parseBoolean(
+      env.VISITOR_ANALYTICS_TRUST_CLOUDFLARE,
+      VISITOR_ANALYTICS_DEFAULTS.trustCloudflare
+    ),
+    onlineWindowSeconds:
+      parsePositiveInt(env.VISITOR_ANALYTICS_ONLINE_WINDOW_SECONDS) ??
+      VISITOR_ANALYTICS_DEFAULTS.onlineWindowSeconds,
+    eventRetentionDays:
+      parsePositiveInt(env.VISITOR_ANALYTICS_EVENT_RETENTION_DAYS) ??
+      VISITOR_ANALYTICS_DEFAULTS.eventRetentionDays,
+    rawDetailRetentionDays:
+      parsePositiveInt(env.VISITOR_ANALYTICS_RAW_DETAIL_RETENTION_DAYS) ??
+      VISITOR_ANALYTICS_DEFAULTS.rawDetailRetentionDays,
+    rollupRetentionDays:
+      parsePositiveInt(env.VISITOR_ANALYTICS_ROLLUP_RETENTION_DAYS) ??
+      VISITOR_ANALYTICS_DEFAULTS.rollupRetentionDays,
+    hashSalt:
+      env.VISITOR_ANALYTICS_HASH_SALT ?? VISITOR_ANALYTICS_DEFAULTS.hashSalt,
+    visitorKeyCookieTtlDays:
+      parsePositiveInt(env.VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS) ??
+      VISITOR_ANALYTICS_DEFAULTS.visitorKeyCookieTtlDays
+  };
+}
+
+/**
+ * The single boolean every real-work caller (collector, ingest endpoint)
+ * should gate on.
+ */
+export function isVisitorAnalyticsEnabled(
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return resolveVisitorAnalyticsConfig(env).enabled;
+}
+
+/**
+ * Converts `visitorKeyCookieTtlDays` into the `maxAge` seconds value the
+ * cookie API expects — the single place that does this conversion so no
+ * caller ever hardcodes a TTL constant.
+ */
+export function resolveVisitorKeyCookieMaxAgeSeconds(
+  config: Pick<VisitorAnalyticsConfig, "visitorKeyCookieTtlDays">
+): number {
+  return config.visitorKeyCookieTtlDays * 86_400;
+}

--- a/src/modules/visitor-analytics/domain/visitor-key-cookie.ts
+++ b/src/modules/visitor-analytics/domain/visitor-key-cookie.ts
@@ -1,0 +1,62 @@
+/**
+ * Anonymous visitor-key cookie lifecycle policy (ported from awcms-micro
+ * epic #617-#624). Pure — no actual cookie/request I/O here; the public
+ * visit-ingest endpoint (`src/pages/api/v1/analytics/collect.ts`) is the
+ * sole caller and translates these decisions into real
+ * `cookies.set`/`.delete` calls.
+ *
+ * In awcms-micro these two functions were driven from `src/middleware.ts`
+ * (which observed every request). This base collects via an additive public
+ * ingest endpoint instead (`src/middleware.ts` is intentionally untouched),
+ * so the endpoint itself is the single caller:
+ *
+ * 1. `shouldRevokeVisitorKeyCookie` — true only when the module's master
+ *    switch is off AND a (previously valid) cookie is still present. A
+ *    browser that already carries the old persistent identifier (e.g. from
+ *    before the module was disabled) has it actively cleared rather than
+ *    left to linger.
+ * 2. `planVisitorKeyCookie` — called after the enabled/collect gate has
+ *    passed. Always resolves a usable visitor key (reusing a valid existing
+ *    one, minting a fresh one otherwise) and reports whether a `Set-Cookie`
+ *    is actually needed. The `maxAgeSeconds` is operator-configurable
+ *    (`VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS`, 30 days by default).
+ *    Once the browser expires the cookie, the next request mints a fresh key
+ *    — natural rotation without any additional server-side bookkeeping.
+ */
+import { resolveVisitorKey, isValidVisitorKey } from "./visitor-key";
+import {
+  resolveVisitorKeyCookieMaxAgeSeconds,
+  type VisitorAnalyticsConfig
+} from "./visitor-analytics-config";
+
+export function shouldRevokeVisitorKeyCookie(input: {
+  config: Pick<VisitorAnalyticsConfig, "enabled">;
+  existingValue: string | undefined;
+}): boolean {
+  return !input.config.enabled && isValidVisitorKey(input.existingValue);
+}
+
+export type VisitorKeyCookiePlan = {
+  value: string;
+  shouldSetCookie: boolean;
+  maxAgeSeconds: number;
+};
+
+/**
+ * Only meaningful (and only ever called) when the module is enabled and this
+ * request is being collected — callers must check
+ * `shouldRevokeVisitorKeyCookie` and the collect gate first.
+ */
+export function planVisitorKeyCookie(input: {
+  config: Pick<VisitorAnalyticsConfig, "visitorKeyCookieTtlDays">;
+  existingValue: string | undefined;
+}): VisitorKeyCookiePlan {
+  const { config, existingValue } = input;
+  const value = resolveVisitorKey(existingValue);
+
+  return {
+    value,
+    shouldSetCookie: value !== existingValue,
+    maxAgeSeconds: resolveVisitorKeyCookieMaxAgeSeconds(config)
+  };
+}

--- a/src/modules/visitor-analytics/domain/visitor-key.ts
+++ b/src/modules/visitor-analytics/domain/visitor-key.ts
@@ -1,0 +1,64 @@
+/**
+ * Anonymous visitor key + salted hashing helpers (ported from awcms-micro
+ * epic #617-#624). Pure — no cookie/request I/O here; the ingest endpoint
+ * reads/writes the actual cookie and calls `resolveVisitorKey` with whatever
+ * raw value it found (or `undefined`).
+ *
+ * All three hash functions here are HMAC-SHA256 keyed by
+ * `VISITOR_ANALYTICS_HASH_SALT` (`resolveVisitorAnalyticsConfig().hashSalt`),
+ * not plain SHA256 — unlike `profile-identity/domain/identifier.ts`'s
+ * `hashIdentifier` (deliberately unsalted), a deployment salt here prevents
+ * an external party from correlating these hashes against a precomputed
+ * table of `sha256(ip)`/`sha256(userAgent)` values computed for some *other*
+ * deployment or purpose — IP addresses and user-agents are far lower-entropy
+ * and more universally observable than the identifiers `hashIdentifier`
+ * hashes. These remain lookup/dedup hashes, not credential storage:
+ * enumeration risk is mitigated by RLS on the tables that store them
+ * (migration 050), not by hash cost, so a fast keyed hash (not
+ * bcrypt/argon2) is correct here too.
+ */
+import { createHmac, randomUUID } from "node:crypto";
+
+const VISITOR_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/** A fresh, cryptographically random anonymous visitor key (cookie value). */
+export function generateVisitorKey(): string {
+  return randomUUID();
+}
+
+/** True only for a value shaped like something `generateVisitorKey` produced. */
+export function isValidVisitorKey(
+  value: string | undefined | null
+): value is string {
+  return typeof value === "string" && VISITOR_KEY_PATTERN.test(value);
+}
+
+/**
+ * Reuses `existingValue` if it looks like a real visitor key, otherwise
+ * mints a new one — never trusts an arbitrary client-supplied string (e.g. a
+ * forged non-UUID cookie value) as-is.
+ */
+export function resolveVisitorKey(
+  existingValue: string | undefined | null
+): string {
+  return isValidVisitorKey(existingValue)
+    ? existingValue
+    : generateVisitorKey();
+}
+
+function hmacSha256(value: string, salt: string): string {
+  return `sha256:${createHmac("sha256", salt).update(value).digest("hex")}`;
+}
+
+export function hashVisitorKey(visitorKey: string, salt: string): string {
+  return hmacSha256(visitorKey, salt);
+}
+
+export function hashIpAddress(ipAddress: string, salt: string): string {
+  return hmacSha256(ipAddress, salt);
+}
+
+export function hashUserAgent(userAgent: string, salt: string): string {
+  return hmacSha256(userAgent, salt);
+}

--- a/src/modules/visitor-analytics/domain/visitor-key.ts
+++ b/src/modules/visitor-analytics/domain/visitor-key.ts
@@ -5,17 +5,28 @@
  * raw value it found (or `undefined`).
  *
  * All three hash functions here are HMAC-SHA256 keyed by
- * `VISITOR_ANALYTICS_HASH_SALT` (`resolveVisitorAnalyticsConfig().hashSalt`),
- * not plain SHA256 — unlike `profile-identity/domain/identifier.ts`'s
- * `hashIdentifier` (deliberately unsalted), a deployment salt here prevents
- * an external party from correlating these hashes against a precomputed
- * table of `sha256(ip)`/`sha256(userAgent)` values computed for some *other*
- * deployment or purpose — IP addresses and user-agents are far lower-entropy
- * and more universally observable than the identifiers `hashIdentifier`
- * hashes. These remain lookup/dedup hashes, not credential storage:
- * enumeration risk is mitigated by RLS on the tables that store them
- * (migration 050), not by hash cost, so a fast keyed hash (not
- * bcrypt/argon2) is correct here too.
+ * `VISITOR_ANALYTICS_HASH_SALT` (`resolveVisitorAnalyticsConfig().hashSalt`)
+ * AND bound to the tenant id, not plain SHA256 — unlike
+ * `profile-identity/domain/identifier.ts`'s `hashIdentifier` (deliberately
+ * unsalted). Two independent properties fall out of this construction:
+ *
+ *  - cross-DEPLOYMENT rainbow-table resistance: the deployment salt prevents
+ *    an external party from correlating these hashes against a precomputed
+ *    table of `sha256(ip)`/`sha256(userAgent)` values computed for some *other*
+ *    deployment or purpose — IP addresses and user-agents are far lower-entropy
+ *    and more universally observable than the identifiers `hashIdentifier`
+ *    hashes.
+ *  - cross-TENANT unlinkability (privacy-by-design): the tenant id is folded
+ *    into the HMAC (`update(tenantId)` + a `\0` domain separator, so a
+ *    value/tenant boundary can never be ambiguous), so the SAME browser/IP/
+ *    user-agent yields DIFFERENT hashes for different tenants sharing one
+ *    origin. Without this, identical hashes across tenants would let anyone who
+ *    can read the raw hash columns of two tenants correlate a visitor between
+ *    them at the storage layer. Cheap to require now while no data exists.
+ *
+ * These remain lookup/dedup hashes, not credential storage: enumeration risk is
+ * mitigated by RLS on the tables that store them (migration 050), not by hash
+ * cost, so a fast keyed hash (not bcrypt/argon2) is correct here too.
  */
 import { createHmac, randomUUID } from "node:crypto";
 
@@ -47,18 +58,40 @@ export function resolveVisitorKey(
     : generateVisitorKey();
 }
 
-function hmacSha256(value: string, salt: string): string {
-  return `sha256:${createHmac("sha256", salt).update(value).digest("hex")}`;
+/**
+ * HMAC-SHA256 keyed by the deployment `salt` and bound to `tenantId`. The
+ * tenant id is fed FIRST, followed by a `\0` domain separator, so the boundary
+ * between the tenant id and the hashed value is unambiguous (e.g. tenant `"ab"`
+ * + value `"c"` can never collide with tenant `"a"` + value `"bc"`).
+ */
+function hmacSha256(value: string, salt: string, tenantId: string): string {
+  return `sha256:${createHmac("sha256", salt)
+    .update(tenantId)
+    .update("\0")
+    .update(value)
+    .digest("hex")}`;
 }
 
-export function hashVisitorKey(visitorKey: string, salt: string): string {
-  return hmacSha256(visitorKey, salt);
+export function hashVisitorKey(
+  visitorKey: string,
+  salt: string,
+  tenantId: string
+): string {
+  return hmacSha256(visitorKey, salt, tenantId);
 }
 
-export function hashIpAddress(ipAddress: string, salt: string): string {
-  return hmacSha256(ipAddress, salt);
+export function hashIpAddress(
+  ipAddress: string,
+  salt: string,
+  tenantId: string
+): string {
+  return hmacSha256(ipAddress, salt, tenantId);
 }
 
-export function hashUserAgent(userAgent: string, salt: string): string {
-  return hmacSha256(userAgent, salt);
+export function hashUserAgent(
+  userAgent: string,
+  salt: string,
+  tenantId: string
+): string {
+  return hmacSha256(userAgent, salt, tenantId);
 }

--- a/src/modules/visitor-analytics/module.ts
+++ b/src/modules/visitor-analytics/module.ts
@@ -1,0 +1,133 @@
+import { defineModule } from "../_shared/module-contract";
+
+/**
+ * `visitor_analytics` — privacy-first human visitor statistics, ported from
+ * awcms-micro (epic #617-#624) as a standalone, additive module. Ships: the
+ * tenant-scoped session/event/rollup schema (migrations 049 permissions, 050
+ * schema, 051 session-lookup index), the identity/UA/bot classification +
+ * path-sanitization + salted-hashing domain helpers, the additive PUBLIC
+ * visit-ingest endpoint (`POST /api/v1/analytics/collect`), the authenticated
+ * `/api/v1/analytics/*` read API (ABAC-guarded), the on-demand retention
+ * purge endpoint (`POST /api/v1/analytics/retention/purge`), the scheduled
+ * rollup + retention-purge jobs (`bun run analytics:rollup` /
+ * `analytics:purge`), and the `/admin/analytics` dashboard.
+ *
+ * `type: "system"` (mirrors awcms-micro, NOT `"domain"`): human visitor
+ * telemetry is platform/observability infrastructure every tenant shares the
+ * mechanism of (same reasoning as `reporting`/`logging`), not a tenant-facing
+ * business feature. Higher volume and different retention/privacy needs than
+ * `reporting`/`logging` is exactly why it is its own module.
+ *
+ * PORT ADAPTATIONS (documented, not silent):
+ *  - COLLECTION IS A PUBLIC INGEST ENDPOINT, NOT MIDDLEWARE. awcms-micro
+ *    collected via `src/middleware.ts` (observing every request). This base
+ *    keeps `src/middleware.ts` UNTOUCHED (login/Turnstile/CSP guarantees
+ *    unchanged) and exposes the same collector logic via an additive public
+ *    beacon endpoint that resolves the tenant from the request's `tenantCode`
+ *    (the RLS-free `awcms_tenants` table, ADR-0009 — same as the existing
+ *    `/blog/{tenantCode}` public routes, so NO SECURITY DEFINER is needed).
+ *    The beacon is anonymous-only: `identity_id`/`login_identifier_snapshot`
+ *    are always null.
+ *  - NO data_lifecycle COUPLING. awcms-micro registered a `dataLifecycle`
+ *    descriptor and gated the events purge behind a `LegalHoldGuardPort` from
+ *    its `data_lifecycle` module. That module is not ported to this base, so
+ *    the descriptor and the legal-hold guard are dropped; the purge is
+ *    unconditional. Re-introduce both if/when `data_lifecycle` is ported.
+ *  - NEWS PORTAL PRESET WIRING DEFERRED. awcms-micro's
+ *    `news_portal_full_online_r2` preset enables this module. This base's
+ *    `news_portal` was ported without that wiring and is NOT modified here
+ *    (this module ships standalone).
+ */
+export const visitorAnalyticsModule = defineModule({
+  key: "visitor_analytics",
+  name: "Visitor Analytics",
+  version: "0.1.0",
+  status: "active",
+  description:
+    "Privacy-first human visitor statistics for admin and public routes, in both online and offline/LAN configurations (ported from awcms-micro epic #617-#624). VISITOR_ANALYTICS_ENABLED=false by default — a fresh install collects nothing until an operator opts in; raw IP, raw user-agent, and geolocation collection are each independently disabled unless explicitly enabled (see domain/visitor-analytics-config.ts). Visitor identifiers (visitor-key cookie, IP, user-agent) are stored only as salted HMAC-SHA256 hashes, never raw, unless the operator explicitly opts into raw collection. Ships the tenant-scoped awcms_visitor_sessions/awcms_visit_events/awcms_visitor_daily_rollups schema (migrations 049/050/051, RLS FORCE), the additive PUBLIC visit-ingest endpoint POST /api/v1/analytics/collect (anonymous beacon, resolves tenant from tenantCode, src/middleware.ts untouched), the authenticated ABAC-guarded read API (GET /api/v1/analytics/summary|realtime|sessions|events|pages|devices|locations|security|settings, PATCH .../settings), the high-risk POST /api/v1/analytics/retention/purge (Idempotency-Key + critical audit), the scheduled rollup and retention-purge jobs (bun run analytics:rollup / analytics:purge), and the /admin/analytics dashboard. PORT DROPS: the awcms-micro dataLifecycle descriptor and data_lifecycle LegalHoldGuardPort (that module is not ported here) — purge is unconditional. PORT DEFERRAL: the news_portal preset that enables this module in awcms-micro is not wired here.",
+  dependencies: ["tenant_admin", "identity_access", "logging", "reporting"],
+  type: "system",
+  api: {
+    openApiPath: "openapi/modules/visitor-analytics.openapi.yaml",
+    basePath: "/api/v1/analytics"
+  },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_visitor_analytics",
+      path: "/admin/analytics",
+      order: 70,
+      requiredPermission: "visitor_analytics.dashboard.read"
+    }
+  ],
+  permissions: [
+    {
+      activityCode: "dashboard",
+      action: "read",
+      description: "Read the visitor analytics dashboard"
+    },
+    {
+      activityCode: "realtime",
+      action: "read",
+      description: "Read real-time/online visitor counts"
+    },
+    {
+      activityCode: "sessions",
+      action: "read",
+      description: "Read visitor session records"
+    },
+    {
+      activityCode: "events",
+      action: "read",
+      description: "Read visitor page-view/event records"
+    },
+    {
+      activityCode: "raw_detail",
+      action: "read",
+      description:
+        "Read raw visitor detail (IP address, user-agent) separate from aggregate dashboard access"
+    },
+    {
+      activityCode: "settings",
+      action: "read",
+      description: "Read visitor analytics module settings"
+    },
+    {
+      activityCode: "settings",
+      action: "update",
+      description: "Update visitor analytics module settings"
+    },
+    {
+      activityCode: "retention",
+      action: "purge",
+      description: "Purge visitor analytics data past its retention window"
+    }
+  ],
+  settings: {
+    schemaVersion: 1,
+    // No non-secret operational default preferences yet — collection
+    // behaviour is env-driven (VISITOR_ANALYTICS_*), not per-tenant settings.
+    // The settings endpoints exist to reuse Module Management's generic
+    // per-tenant settings storage under this module's own permission gate.
+    defaults: {}
+  },
+  jobs: [
+    {
+      command: "bun run analytics:rollup",
+      purpose:
+        "Recompute the previous day's awcms_visitor_daily_rollups from raw awcms_visit_events, per active tenant. Idempotent (full UPSERT recompute).",
+      recommendedSchedule: "daily (shortly after UTC midnight)",
+      environmentNotes:
+        "Runs as the least-privilege awcms_worker role when WORKER_DATABASE_URL is set; pure PostgreSQL, no external provider.",
+      safeInOfflineLan: true
+    },
+    {
+      command: "bun run analytics:purge",
+      purpose:
+        "Delete/clear visitor analytics data past its retention windows (events, session raw detail, sessions, rollups), per active tenant.",
+      recommendedSchedule: "daily",
+      environmentNotes:
+        "Runs as the least-privilege awcms_worker role when WORKER_DATABASE_URL is set; pure PostgreSQL, no external provider. Destructive — use --dry-run first.",
+      safeInOfflineLan: true
+    }
+  ]
+});

--- a/src/modules/visitor-analytics/module.ts
+++ b/src/modules/visitor-analytics/module.ts
@@ -37,6 +37,17 @@ import { defineModule } from "../_shared/module-contract";
  *    `news_portal_full_online_r2` preset enables this module. This base's
  *    `news_portal` was ported without that wiring and is NOT modified here
  *    (this module ships standalone).
+ *  - NO `reporting` LIFECYCLE DEPENDENCY. awcms-micro lists `reporting` in
+ *    `dependencies`, but `dependencies` governs enable/disable LIFECYCLE
+ *    ORDERING only (see `_shared/module-contract.ts`) and neither micro nor
+ *    this base consumes any `reporting` capability, port, table, or projection
+ *    from `visitor_analytics` (no `capabilities.consumes` entry, no import).
+ *    `reporting` is a conceptual PEER (both `type: "system"` observability),
+ *    not a runtime prerequisite — visitor telemetry has its own schema and
+ *    rollup and functions with `reporting` disabled. Declaring the edge would
+ *    force `reporting` to stay enabled for no functional reason and wrongly
+ *    make it a non-leaf. Dropped here (kept `tenant_admin`/`identity_access`/
+ *    `logging`, which ARE used for tenant context, ABAC, and audit).
  */
 export const visitorAnalyticsModule = defineModule({
   key: "visitor_analytics",
@@ -45,7 +56,7 @@ export const visitorAnalyticsModule = defineModule({
   status: "active",
   description:
     "Privacy-first human visitor statistics for admin and public routes, in both online and offline/LAN configurations (ported from awcms-micro epic #617-#624). VISITOR_ANALYTICS_ENABLED=false by default — a fresh install collects nothing until an operator opts in; raw IP, raw user-agent, and geolocation collection are each independently disabled unless explicitly enabled (see domain/visitor-analytics-config.ts). Visitor identifiers (visitor-key cookie, IP, user-agent) are stored only as salted HMAC-SHA256 hashes, never raw, unless the operator explicitly opts into raw collection. Ships the tenant-scoped awcms_visitor_sessions/awcms_visit_events/awcms_visitor_daily_rollups schema (migrations 049/050/051, RLS FORCE), the additive PUBLIC visit-ingest endpoint POST /api/v1/analytics/collect (anonymous beacon, resolves tenant from tenantCode, src/middleware.ts untouched), the authenticated ABAC-guarded read API (GET /api/v1/analytics/summary|realtime|sessions|events|pages|devices|locations|security|settings, PATCH .../settings), the high-risk POST /api/v1/analytics/retention/purge (Idempotency-Key + critical audit), the scheduled rollup and retention-purge jobs (bun run analytics:rollup / analytics:purge), and the /admin/analytics dashboard. PORT DROPS: the awcms-micro dataLifecycle descriptor and data_lifecycle LegalHoldGuardPort (that module is not ported here) — purge is unconditional. PORT DEFERRAL: the news_portal preset that enables this module in awcms-micro is not wired here.",
-  dependencies: ["tenant_admin", "identity_access", "logging", "reporting"],
+  dependencies: ["tenant_admin", "identity_access", "logging"],
   type: "system",
   api: {
     openApiPath: "openapi/modules/visitor-analytics.openapi.yaml",

--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -23,6 +23,7 @@ import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
 import { withTenant } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { evaluateFieldAccessInTransaction } from "../../modules/identity-access/application/access-guard";
 import { resolveVisitorAnalyticsConfig } from "../../modules/visitor-analytics/domain/visitor-analytics-config";
 import {
   DEFAULT_ANALYTICS_RANGE,
@@ -64,9 +65,25 @@ const canRealtime = ssr.permissions.has(
 const canSessions = ssr.permissions.has(
   permissionKey("visitor_analytics", "sessions", "read")
 );
-const canRawDetail = ssr.permissions.has(
-  permissionKey("visitor_analytics", "raw_detail", "read")
-);
+
+// Raw-detail (IP/user-agent/login snapshot) visibility is resolved through the
+// ABAC evaluator inside `withTenant` below (see `rawDetailAllowed`), NOT a bare
+// `ssr.permissions.has(...)` membership check — so a `deny` DSL policy on
+// `visitor_analytics.raw_detail.read` is honored (deny-overrides-allow),
+// matching the `/api/v1/analytics/{sessions,events}` endpoints. Defaults false
+// (fail-closed) until that resolution runs.
+const RAW_DETAIL_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "raw_detail",
+  action: "read" as const
+};
+const subjectContext = {
+  tenantId: ssr.tenantId,
+  tenantUserId: ssr.tenantUserId,
+  identityId: ssr.identityId,
+  roles: ssr.roles
+};
+let canRawDetail = false;
 
 const config = resolveVisitorAnalyticsConfig();
 const geoActive = config.geoEnabled && config.trustCloudflare;
@@ -94,6 +111,20 @@ if (canView) {
     const start = resolveRangeStart(range, now);
 
     const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      // Resolve raw-detail visibility through ABAC (deny-overrides-allow),
+      // reusing the SSR-resolved subject/permissions — only when sessions are
+      // shown at all (the sole place raw detail renders). Fail-closed otherwise.
+      const rawDetailAllowed = canSessions
+        ? await evaluateFieldAccessInTransaction(
+            tx,
+            ssr.tenantId,
+            subjectContext,
+            ssr.permissions,
+            RAW_DETAIL_GUARD,
+            now
+          )
+        : false;
+
       // Sequential (one tx connection): concurrent queries would leak it.
       const rt = canRealtime
         ? await fetchRealtimeStats(tx, ssr.tenantId, config.onlineWindowSeconds)
@@ -108,7 +139,7 @@ if (canView) {
       const sec = await fetchSecurityView(tx, ssr.tenantId, range, start);
       const sess = canSessions
         ? (await listVisitorSessions(tx, ssr.tenantId)).rows.map((row) =>
-            shapeVisitorSession(row, canRawDetail)
+            shapeVisitorSession(row, rawDetailAllowed)
           )
         : [];
 
@@ -120,7 +151,8 @@ if (canView) {
         topDevices,
         topCountries,
         sec,
-        sess
+        sess,
+        rawDetailAllowed
       };
     });
 
@@ -137,6 +169,7 @@ if (canView) {
       countries = result.topCountries;
       security = result.sec;
       sessions = result.sess;
+      canRawDetail = result.rawDetailAllowed;
     }
   } catch {
     loadError = true;

--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -1,0 +1,524 @@
+---
+/**
+ * Visitor analytics dashboard (ported from awcms-micro epic #617-#624).
+ *
+ * PORT ADAPTATION: awcms-micro's dashboard was a client-side `fetch`-driven
+ * SPA over the `/api/v1/analytics/*` endpoints, built on an i18n framework and
+ * a `components/ui/` library this base does not have. This base renders the
+ * dashboard SERVER-SIDE (the same SSR-read-then-render pattern
+ * `admin/offices.astro` uses): it reads the analytics application-layer query
+ * functions directly inside `withTenant`, then renders plain accessible
+ * tables. No client script, no CSP surface, no i18n dependency.
+ *
+ * ABAC is enforced server-side by the `/api/v1/analytics/*` endpoints; this
+ * page additionally gates its own render on the same permissions (from
+ * `Astro.locals.ssrContext.permissions`) so a user without them gets a clean
+ * notice instead of an empty page. Raw detail (IP/user-agent/login snapshot)
+ * is gated by the separate `visitor_analytics.raw_detail.read`: rows are
+ * shaped through `shapeVisitorSession(row, canRawDetail)` (same server-side
+ * gate the API uses), so a caller without it never receives those values.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { resolveVisitorAnalyticsConfig } from "../../modules/visitor-analytics/domain/visitor-analytics-config";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart,
+  type AnalyticsRange
+} from "../../modules/visitor-analytics/domain/analytics-range";
+import {
+  fetchAnalyticsSummary,
+  fetchRealtimeStats,
+  fetchSecurityView,
+  fetchTopBrowsers,
+  fetchTopCountries,
+  fetchTopDevices,
+  fetchTopPaths,
+  type AnalyticsSummary,
+  type NamedCount,
+  type RealtimeStats,
+  type SecurityView
+} from "../../modules/visitor-analytics/application/analytics-queries";
+import { listVisitorSessions } from "../../modules/visitor-analytics/application/session-directory";
+import {
+  shapeVisitorSession,
+  type VisitorSessionDto
+} from "../../modules/visitor-analytics/domain/analytics-response-shaping";
+import {
+  buildSessionRowCells,
+  displayOrPlaceholder,
+  isNamedCountListEmpty
+} from "../../modules/visitor-analytics/domain/dashboard-view";
+
+const ssr = Astro.locals.ssrContext!;
+const canView = ssr.permissions.has(
+  permissionKey("visitor_analytics", "dashboard", "read")
+);
+const canRealtime = ssr.permissions.has(
+  permissionKey("visitor_analytics", "realtime", "read")
+);
+const canSessions = ssr.permissions.has(
+  permissionKey("visitor_analytics", "sessions", "read")
+);
+const canRawDetail = ssr.permissions.has(
+  permissionKey("visitor_analytics", "raw_detail", "read")
+);
+
+const config = resolveVisitorAnalyticsConfig();
+const geoActive = config.geoEnabled && config.trustCloudflare;
+
+const rangeParam = Astro.url.searchParams.get("range");
+const range: AnalyticsRange = isKnownAnalyticsRange(rangeParam)
+  ? rangeParam
+  : DEFAULT_ANALYTICS_RANGE;
+const RANGE_OPTIONS: AnalyticsRange[] = ["24h", "7d", "30d", "12m"];
+
+let realtime: RealtimeStats | null = null;
+let summary: AnalyticsSummary | null = null;
+let pages: NamedCount[] = [];
+let browsers: NamedCount[] = [];
+let devices: NamedCount[] = [];
+let countries: NamedCount[] = [];
+let security: SecurityView | null = null;
+let sessions: VisitorSessionDto[] = [];
+let loadError = false;
+
+if (canView) {
+  try {
+    const sql = getDatabaseClient();
+    const now = new Date();
+    const start = resolveRangeStart(range, now);
+
+    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+      // Sequential (one tx connection): concurrent queries would leak it.
+      const rt = canRealtime
+        ? await fetchRealtimeStats(tx, ssr.tenantId, config.onlineWindowSeconds)
+        : null;
+      const sum = await fetchAnalyticsSummary(tx, ssr.tenantId, range, start);
+      const topPaths = await fetchTopPaths(tx, ssr.tenantId, start);
+      const topBrowsers = await fetchTopBrowsers(tx, ssr.tenantId, start);
+      const topDevices = await fetchTopDevices(tx, ssr.tenantId, start);
+      const topCountries = geoActive
+        ? await fetchTopCountries(tx, ssr.tenantId, start)
+        : [];
+      const sec = await fetchSecurityView(tx, ssr.tenantId, range, start);
+      const sess = canSessions
+        ? (await listVisitorSessions(tx, ssr.tenantId)).rows.map((row) =>
+            shapeVisitorSession(row, canRawDetail)
+          )
+        : [];
+
+      return {
+        rt,
+        sum,
+        topPaths,
+        topBrowsers,
+        topDevices,
+        topCountries,
+        sec,
+        sess
+      };
+    });
+
+    // `withTenant` returns a 503 `Response` when the DB circuit breaker is open
+    // / a work-class queue is saturated — degrade to an error notice.
+    if (result instanceof Response) {
+      loadError = true;
+    } else {
+      realtime = result.rt;
+      summary = result.sum;
+      pages = result.topPaths;
+      browsers = result.topBrowsers;
+      devices = result.topDevices;
+      countries = result.topCountries;
+      security = result.sec;
+      sessions = result.sess;
+    }
+  } catch {
+    loadError = true;
+  }
+}
+
+const sessionCells = sessions.map((s) =>
+  buildSessionRowCells(s, {
+    showRawDetailColumns: canRawDetail,
+    humanLabel: "Human",
+    botLabel: "Bot"
+  })
+);
+---
+
+<AdminLayout title="Visitor Analytics" active="analytics">
+  <header class="page-header fade-in-up">
+    <h1 id="analytics-heading">Visitor analytics</h1>
+    <p class="page-description">
+      Privacy-first human visitor statistics. Visitor identifiers are stored as
+      salted hashes, never raw, unless explicitly enabled. Figures are
+      server-rendered from this tenant's own data.
+    </p>
+  </header>
+
+  {
+    !canView && (
+      <p class="state-notice fade-in-up" id="analytics-denied">
+        You do not have permission to view visitor analytics.
+      </p>
+    )
+  }
+
+  {
+    canView && !config.enabled && (
+      <p class="state-notice fade-in-up" id="analytics-disabled">
+        Visitor analytics collection is disabled
+        (VISITOR_ANALYTICS_ENABLED=false). Figures below reflect only data
+        collected while it was enabled.
+      </p>
+    )
+  }
+
+  {
+    canView && loadError && (
+      <p class="state-notice fade-in-up" id="analytics-error">
+        Analytics could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canView && !loadError && (
+      <>
+        {canRealtime && realtime && (
+          <section
+            class="admin-section fade-in-up"
+            aria-labelledby="realtime-title"
+          >
+            <h2 class="admin-section-title" id="realtime-title">
+              Online now
+            </h2>
+            <div class="stat-grid">
+              <div class="stat-card">
+                <span class="stat-label">Humans online</span>
+                <span class="stat-value">{realtime.onlineHumanCount}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Admin</span>
+                <span class="stat-value">{realtime.onlineAdminCount}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Public</span>
+                <span class="stat-value">{realtime.onlinePublicCount}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">API</span>
+                <span class="stat-value">{realtime.onlineApiCount}</span>
+              </div>
+            </div>
+          </section>
+        )}
+
+        <section class="admin-section fade-in-up" aria-labelledby="range-title">
+          <h2 class="admin-section-title" id="range-title">
+            Summary
+          </h2>
+          <form method="get" class="admin-toolbar" id="range-form">
+            <label for="range-select">Time range</label>
+            <select id="range-select" name="range">
+              {RANGE_OPTIONS.map((value) => (
+                <option value={value} selected={value === range}>
+                  {value}
+                </option>
+              ))}
+            </select>
+            <button type="submit">Apply</button>
+          </form>
+          {summary && (
+            <div class="stat-grid">
+              <div class="stat-card">
+                <span class="stat-label">Human unique visitors</span>
+                <span class="stat-value">{summary.humanUniqueVisitors}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Human pageviews</span>
+                <span class="stat-value">{summary.humanPageviews}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Bot pageviews</span>
+                <span class="stat-value">{summary.botPageviews}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Public unique visitors</span>
+                <span class="stat-value">{summary.publicUniqueVisitors}</span>
+              </div>
+              <div class="stat-card">
+                <span class="stat-label">Admin unique users</span>
+                <span class="stat-value">{summary.adminUniqueUsers}</span>
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section class="admin-section fade-in-up" aria-labelledby="pages-title">
+          <h2 class="admin-section-title" id="pages-title">
+            Top pages
+          </h2>
+          <div class="data-table-scroll">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th scope="col">Path</th>
+                  <th scope="col">Views</th>
+                </tr>
+              </thead>
+              <tbody>
+                {isNamedCountListEmpty(pages) ? (
+                  <tr>
+                    <td class="data-table-empty" colspan={2}>
+                      No data yet.
+                    </td>
+                  </tr>
+                ) : (
+                  pages.map((row) => (
+                    <tr>
+                      <td>
+                        <span class="cell-code">{row.name}</span>
+                      </td>
+                      <td>{row.count}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section
+          class="admin-section fade-in-up"
+          aria-labelledby="devices-title"
+        >
+          <h2 class="admin-section-title" id="devices-title">
+            Browsers &amp; devices
+          </h2>
+          <div class="data-table-scroll">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th scope="col">Browser</th>
+                  <th scope="col">Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {isNamedCountListEmpty(browsers) ? (
+                  <tr>
+                    <td class="data-table-empty" colspan={2}>
+                      No data yet.
+                    </td>
+                  </tr>
+                ) : (
+                  browsers.map((row) => (
+                    <tr>
+                      <td>{row.name}</td>
+                      <td>{row.count}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+          <div class="data-table-scroll">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th scope="col">Device type</th>
+                  <th scope="col">Count</th>
+                </tr>
+              </thead>
+              <tbody>
+                {isNamedCountListEmpty(devices) ? (
+                  <tr>
+                    <td class="data-table-empty" colspan={2}>
+                      No data yet.
+                    </td>
+                  </tr>
+                ) : (
+                  devices.map((row) => (
+                    <tr>
+                      <td>{row.name}</td>
+                      <td>{row.count}</td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        {geoActive && (
+          <section
+            class="admin-section fade-in-up"
+            aria-labelledby="locations-title"
+          >
+            <h2 class="admin-section-title" id="locations-title">
+              Countries
+            </h2>
+            <div class="data-table-scroll">
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Country</th>
+                    <th scope="col">Count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isNamedCountListEmpty(countries) ? (
+                    <tr>
+                      <td class="data-table-empty" colspan={2}>
+                        No data yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    countries.map((row) => (
+                      <tr>
+                        <td>{row.name}</td>
+                        <td>{row.count}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {security && (
+          <section
+            class="admin-section fade-in-up"
+            aria-labelledby="security-title"
+          >
+            <h2 class="admin-section-title" id="security-title">
+              Bot traffic
+            </h2>
+            <div class="stat-grid">
+              <div class="stat-card">
+                <span class="stat-label">Bot pageviews</span>
+                <span class="stat-value">{security.botPageviews}</span>
+              </div>
+            </div>
+            <div class="data-table-scroll">
+              <table class="data-table">
+                <thead>
+                  <tr>
+                    <th scope="col">Bot reason</th>
+                    <th scope="col">Count</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {isNamedCountListEmpty(security.topBotReasons) ? (
+                    <tr>
+                      <td class="data-table-empty" colspan={2}>
+                        No data yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    security.topBotReasons.map((row) => (
+                      <tr>
+                        <td>{row.name}</td>
+                        <td>{row.count}</td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {canSessions && (
+          <section
+            class="admin-section fade-in-up"
+            aria-labelledby="sessions-title"
+          >
+            <h2 class="admin-section-title">
+              <span id="sessions-title">Recent sessions</span>
+              <span class="count-pill">{sessionCells.length}</span>
+            </h2>
+            <div class="data-table-scroll">
+              <table class="data-table data-table--stack">
+                <thead>
+                  <tr>
+                    <th scope="col">Area</th>
+                    <th scope="col">Path</th>
+                    <th scope="col">Browser</th>
+                    <th scope="col">OS</th>
+                    <th scope="col">Device</th>
+                    <th scope="col">Type</th>
+                    <th scope="col">Country</th>
+                    {canRawDetail && (
+                      <>
+                        <th scope="col">IP</th>
+                        <th scope="col">IP hash</th>
+                        <th scope="col">UA hash</th>
+                        <th scope="col">Login</th>
+                      </>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {sessionCells.length === 0 ? (
+                    <tr>
+                      <td
+                        class="data-table-empty"
+                        colspan={canRawDetail ? 11 : 7}
+                      >
+                        No sessions yet.
+                      </td>
+                    </tr>
+                  ) : (
+                    sessionCells.map((cells) => (
+                      <tr>
+                        <td data-label="Area">{cells.area}</td>
+                        <td data-label="Path">
+                          <span class="cell-code">{cells.currentPath}</span>
+                        </td>
+                        <td data-label="Browser">{cells.browser}</td>
+                        <td data-label="OS">{cells.os}</td>
+                        <td data-label="Device">{cells.device}</td>
+                        <td data-label="Type">{cells.visitorType}</td>
+                        <td data-label="Country">{cells.country}</td>
+                        {canRawDetail && cells.raw && (
+                          <>
+                            <td data-label="IP">
+                              <span class="cell-muted">
+                                {displayOrPlaceholder(cells.raw.ipAddress)}
+                              </span>
+                            </td>
+                            <td data-label="IP hash">
+                              <span class="cell-muted">{cells.raw.ipHash}</span>
+                            </td>
+                            <td data-label="UA hash">
+                              <span class="cell-muted">
+                                {cells.raw.userAgentHash}
+                              </span>
+                            </td>
+                            <td data-label="Login">
+                              <span class="cell-muted">
+                                {cells.raw.loginIdentifier}
+                              </span>
+                            </td>
+                          </>
+                        )}
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+      </>
+    )
+  }
+</AdminLayout>

--- a/src/pages/api/v1/analytics/collect.ts
+++ b/src/pages/api/v1/analytics/collect.ts
@@ -3,6 +3,10 @@ import type { APIRoute } from "astro";
 import { fail, jsonResponse } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import {
+  checkRateLimit,
+  resolveClientIp
+} from "../../../../lib/security/rate-limit";
+import {
   bodyTooLargeResponse,
   readJsonBody
 } from "../../../../lib/security/request-body-limit";
@@ -19,6 +23,35 @@ import {
 } from "../../../../modules/visitor-analytics/domain/visitor-key-cookie";
 
 const VISITOR_KEY_COOKIE_NAME = "awcms_visitor_key";
+
+/**
+ * Defensive upper bound on the reported `path` before it is stored. The
+ * `path_sanitized`/`current_path` columns are unbounded `text` and the request
+ * body limit already caps the whole payload, but this bounds the single field
+ * independently — a real navigable URL path is far shorter, and an oversized
+ * value is only ever storage/log bloat on an anonymous, unauthenticated write.
+ */
+const MAX_PATH_LENGTH = 2048;
+
+/**
+ * Per-IP rate-limit backstop for this PUBLIC, unauthenticated beacon — the same
+ * `checkRateLimit` in-process fixed-window limiter `auth/login.ts` and
+ * `setup/initialize.ts` use. Without it, anyone holding a public `tenantCode`
+ * could flood the endpoint with unbounded session/event writes and poison a
+ * tenant's aggregates. The key is IP-only (never the tenant): a 429 is driven
+ * purely by request volume from one source and reveals nothing about whether
+ * any given tenant exists — the beacon's no-oracle contract is preserved.
+ *
+ * Env-tunable with defensive defaults (same pattern as `SETUP_RATE_LIMIT_*`):
+ * a page view fires one beacon per navigation, so 120/min per IP is generous
+ * for a real human while still bounding an abusive client.
+ */
+const COLLECT_RATE_LIMIT_MAX = Number(
+  process.env.VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_MAX ?? 120
+);
+const COLLECT_RATE_LIMIT_WINDOW_SEC = Number(
+  process.env.VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_WINDOW_SEC ?? 60
+);
 
 /**
  * `POST /api/v1/analytics/collect` — additive, PUBLIC (anonymous, no auth)
@@ -39,7 +72,11 @@ const VISITOR_KEY_COOKIE_NAME = "awcms_visitor_key";
  * HARDENING beyond awcms-micro: an anonymous beacon cannot prove it is an
  * admin/API request, so this endpoint records `public`-area page views ONLY
  * — a beacon reporting an `/admin` or `/api` path is accepted but not
- * recorded (prevents an anonymous client polluting admin/api analytics).
+ * recorded (prevents an anonymous client polluting admin/api analytics). A
+ * per-IP fixed-window rate limit (the shared `checkRateLimit` backstop, keyed
+ * on the client IP only) fronts every database write, so a client holding a
+ * public `tenantCode` cannot flood unbounded rows or poison a tenant's
+ * aggregates; a `path` longer than `MAX_PATH_LENGTH` is rejected before storage.
  *
  * Always returns 202 for a well-formed request whether or not anything was
  * actually recorded (module disabled, unknown/inactive tenant, non-public or
@@ -75,11 +112,16 @@ export const POST: APIRoute = async ({
   const path = typeof body?.path === "string" ? body.path.trim() : "";
   const referrer = typeof body?.referrer === "string" ? body.referrer : null;
 
-  if (tenantCode.length === 0 || !path.startsWith("/")) {
+  if (
+    tenantCode.length === 0 ||
+    tenantCode.length > 128 ||
+    !path.startsWith("/") ||
+    path.length > MAX_PATH_LENGTH
+  ) {
     return fail(
       400,
       "VALIDATION_ERROR",
-      "tenantCode (non-empty) and path (must start with '/') are required."
+      "tenantCode (non-empty, <=128 chars) and path (must start with '/', <=2048 chars) are required."
     );
   }
 
@@ -97,6 +139,35 @@ export const POST: APIRoute = async ({
   const area = determineArea(path.split("?")[0] ?? path);
   if (area !== "public" || !config.collectPublic || !isTrackablePath(path)) {
     return accepted;
+  }
+
+  // Per-IP rate-limit backstop — checked here, AFTER the free (no-DB) filters
+  // above but BEFORE any database work (the tenant lookup and the session/event
+  // write below). Keyed on the client IP only, so it can never distinguish an
+  // existing tenant from an unknown one (no enumeration oracle); a source that
+  // exceeds the window is refused with 429 before it can touch the database.
+  const clientIp = resolveClientIp(request, clientAddress);
+  const rateLimit = checkRateLimit(`analytics-collect:${clientIp}`, {
+    maxAttempts:
+      Number.isFinite(COLLECT_RATE_LIMIT_MAX) && COLLECT_RATE_LIMIT_MAX > 0
+        ? COLLECT_RATE_LIMIT_MAX
+        : 120,
+    windowMs:
+      (Number.isFinite(COLLECT_RATE_LIMIT_WINDOW_SEC) &&
+      COLLECT_RATE_LIMIT_WINDOW_SEC > 0
+        ? COLLECT_RATE_LIMIT_WINDOW_SEC
+        : 60) * 1000
+  });
+
+  if (!rateLimit.allowed) {
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many analytics beacons from this source. Try again later.",
+      {},
+      undefined,
+      { "retry-after": String(rateLimit.retryAfterSec) }
+    );
   }
 
   const sql = getDatabaseClient();

--- a/src/pages/api/v1/analytics/collect.ts
+++ b/src/pages/api/v1/analytics/collect.ts
@@ -1,0 +1,154 @@
+import type { APIRoute } from "astro";
+
+import { fail, jsonResponse } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
+import { collectVisitorTelemetry } from "../../../../modules/visitor-analytics/application/collector";
+import { resolveVisitorAnalyticsConfig } from "../../../../modules/visitor-analytics/domain/visitor-analytics-config";
+import { resolveAnalyticsClientIp } from "../../../../modules/visitor-analytics/domain/client-ip";
+import { resolveGeoEnrichment } from "../../../../modules/visitor-analytics/domain/geo-enrichment";
+import { determineArea } from "../../../../modules/visitor-analytics/domain/request-area";
+import { isTrackablePath } from "../../../../modules/visitor-analytics/domain/path-sanitizer";
+import {
+  planVisitorKeyCookie,
+  shouldRevokeVisitorKeyCookie
+} from "../../../../modules/visitor-analytics/domain/visitor-key-cookie";
+
+const VISITOR_KEY_COOKIE_NAME = "awcms_visitor_key";
+
+/**
+ * `POST /api/v1/analytics/collect` — additive, PUBLIC (anonymous, no auth)
+ * visit-ingest beacon. This is this base's replacement for awcms-micro's
+ * middleware collector: `src/middleware.ts` is intentionally UNTOUCHED (its
+ * login/Turnstile/CSP guarantees are unchanged), so collection is an opt-in,
+ * client-driven beacon instead of a server-side per-request hook.
+ *
+ * The beacon carries the public tenant code (resolved against the RLS-free
+ * `awcms_tenants` table, ADR-0009 — exactly like the `/blog/{tenantCode}`
+ * public routes, so no SECURITY DEFINER is needed) plus the page path it is
+ * reporting. Every identifier stored is derived server-side and privacy-
+ * preserving: IP/user-agent come from the request's own headers (never the
+ * body) and are stored only as salted HMAC hashes; the visitor key is an
+ * anonymous cookie; `identity_id`/`login_identifier_snapshot` are always
+ * null (anonymous-only).
+ *
+ * HARDENING beyond awcms-micro: an anonymous beacon cannot prove it is an
+ * admin/API request, so this endpoint records `public`-area page views ONLY
+ * — a beacon reporting an `/admin` or `/api` path is accepted but not
+ * recorded (prevents an anonymous client polluting admin/api analytics).
+ *
+ * Always returns 202 for a well-formed request whether or not anything was
+ * actually recorded (module disabled, unknown/inactive tenant, non-public or
+ * non-trackable path) — fire-and-forget beacon semantics that never leak
+ * tenant existence. `collectVisitorTelemetry` is itself fail-open.
+ */
+export const POST: APIRoute = async ({
+  request,
+  cookies,
+  clientAddress,
+  locals
+}) => {
+  const config = resolveVisitorAnalyticsConfig();
+  const existingVisitorKey = cookies.get(VISITOR_KEY_COOKIE_NAME)?.value;
+
+  // Revoke a lingering anonymous identifier when the module is disabled —
+  // before doing anything else, on every request, regardless of body shape.
+  if (
+    shouldRevokeVisitorKeyCookie({ config, existingValue: existingVisitorKey })
+  ) {
+    cookies.delete(VISITOR_KEY_COOKIE_NAME, { path: "/" });
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const body = bodyRead.value as Record<string, unknown> | null;
+  const tenantCode =
+    typeof body?.tenantCode === "string" ? body.tenantCode.trim() : "";
+  const path = typeof body?.path === "string" ? body.path.trim() : "";
+  const referrer = typeof body?.referrer === "string" ? body.referrer : null;
+
+  if (tenantCode.length === 0 || !path.startsWith("/")) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "tenantCode (non-empty) and path (must start with '/') are required."
+    );
+  }
+
+  const accepted = jsonResponse(
+    { success: true, data: { accepted: true }, meta: {} },
+    { status: 202 }
+  );
+
+  // Nothing to record: module off, non-public area, or a non-trackable path.
+  // Still 202 (accepted) — never distinguish these cases to the caller.
+  if (!config.enabled) {
+    return accepted;
+  }
+
+  const area = determineArea(path.split("?")[0] ?? path);
+  if (area !== "public" || !config.collectPublic || !isTrackablePath(path)) {
+    return accepted;
+  }
+
+  const sql = getDatabaseClient();
+  const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+  if (!tenant) {
+    return accepted;
+  }
+
+  // Anonymous visitor key: reuse a valid existing cookie or mint a fresh one,
+  // and (re)set the cookie so it persists for dedup.
+  const cookiePlan = planVisitorKeyCookie({
+    config,
+    existingValue: existingVisitorKey
+  });
+
+  if (cookiePlan.shouldSetCookie) {
+    cookies.set(VISITOR_KEY_COOKIE_NAME, cookiePlan.value, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.AUTH_COOKIE_SECURE === "true",
+      path: "/",
+      maxAge: cookiePlan.maxAgeSeconds
+    });
+  }
+
+  const ipAddress = resolveAnalyticsClientIp(request, clientAddress, {
+    trustProxy: config.trustProxy,
+    trustCloudflare: config.trustCloudflare
+  });
+  const geo = resolveGeoEnrichment(request, {
+    geoEnabled: config.geoEnabled,
+    trustCloudflare: config.trustCloudflare
+  });
+
+  await collectVisitorTelemetry({
+    sql,
+    tenantId: tenant.tenantId,
+    correlationId: locals.correlationId,
+    config,
+    // A page view is a navigation (GET); the beacon POST itself is transport.
+    method: "GET",
+    rawPath: path,
+    statusCode: null,
+    visitorKey: cookiePlan.value,
+    ipAddress,
+    userAgent: request.headers.get("user-agent"),
+    referrerHeader: referrer ?? request.headers.get("referer"),
+    isAuthenticated: false,
+    identityId: null,
+    geo
+  });
+
+  return accepted;
+};

--- a/src/pages/api/v1/analytics/devices.ts
+++ b/src/pages/api/v1/analytics/devices.ts
@@ -1,0 +1,74 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import {
+  fetchTopBrowsers,
+  fetchTopDevices
+} from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/devices?range=24h|7d|30d|12m` — browser + device-type breakdown. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    // Sequential, not Promise.all: concurrent queries on one tx connection leak it (idle in transaction).
+    const browsers = await fetchTopBrowsers(tx, tenantId, start);
+    const devices = await fetchTopDevices(tx, tenantId, start);
+
+    return ok({ range, browsers, devices });
+  });
+};

--- a/src/pages/api/v1/analytics/events.ts
+++ b/src/pages/api/v1/analytics/events.ts
@@ -6,6 +6,7 @@ import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
   authorizeInTransaction,
+  evaluateFieldAccessInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
 import { decodeKeysetCursor } from "../../../../modules/_shared/keyset-pagination";
@@ -18,12 +19,22 @@ const EVENTS_GUARD = {
   action: "read" as const
 };
 
-const RAW_DETAIL_PERMISSION_KEY = "visitor_analytics.raw_detail.read";
+/**
+ * Field-level guard for the de-anonymizing raw-detail columns. Routed through
+ * the ABAC evaluator (not a bare permission-set membership check) so a `deny`
+ * DSL policy on `visitor_analytics.raw_detail.read` is honored
+ * (deny-overrides-allow) — see `evaluateFieldAccessInTransaction`.
+ */
+const RAW_DETAIL_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "raw_detail",
+  action: "read" as const
+};
 
 /**
  * `GET /api/v1/analytics/events` — keyset-paginated, newest first. Raw detail
  * (`ipHash`/`userAgentHash`) included only when the caller also holds
- * `visitor_analytics.raw_detail.read`.
+ * `visitor_analytics.raw_detail.read` AND no ABAC policy denies it.
  */
 export const GET: APIRoute = async ({ request, cookies, url }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
@@ -60,8 +71,13 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
       return auth.denied;
     }
 
-    const canSeeRawDetail = auth.grantedPermissionKeys.has(
-      RAW_DETAIL_PERMISSION_KEY
+    const canSeeRawDetail = await evaluateFieldAccessInTransaction(
+      tx,
+      tenantId,
+      auth.context,
+      auth.grantedPermissionKeys,
+      RAW_DETAIL_GUARD,
+      now
     );
 
     const page = await listVisitEvents(tx, tenantId, cursor ?? undefined);

--- a/src/pages/api/v1/analytics/events.ts
+++ b/src/pages/api/v1/analytics/events.ts
@@ -1,0 +1,74 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { decodeKeysetCursor } from "../../../../modules/_shared/keyset-pagination";
+import { listVisitEvents } from "../../../../modules/visitor-analytics/application/event-directory";
+import { shapeVisitEvent } from "../../../../modules/visitor-analytics/domain/analytics-response-shaping";
+
+const EVENTS_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "events",
+  action: "read" as const
+};
+
+const RAW_DETAIL_PERMISSION_KEY = "visitor_analytics.raw_detail.read";
+
+/**
+ * `GET /api/v1/analytics/events` — keyset-paginated, newest first. Raw detail
+ * (`ipHash`/`userAgentHash`) included only when the caller also holds
+ * `visitor_analytics.raw_detail.read`.
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const cursorParam = url.searchParams.get("cursor");
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam && !cursor) {
+    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      EVENTS_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const canSeeRawDetail = auth.grantedPermissionKeys.has(
+      RAW_DETAIL_PERMISSION_KEY
+    );
+
+    const page = await listVisitEvents(tx, tenantId, cursor ?? undefined);
+    const events = page.rows.map((row) =>
+      shapeVisitEvent(row, canSeeRawDetail)
+    );
+
+    return ok({ events, nextCursor: page.nextCursor });
+  });
+};

--- a/src/pages/api/v1/analytics/locations.ts
+++ b/src/pages/api/v1/analytics/locations.ts
@@ -1,0 +1,74 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchTopCountries } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/**
+ * `GET /api/v1/analytics/locations?range=24h|7d|30d|12m` — country breakdown
+ * from `visit_events.geo->>'countryCode'`. Empty until geolocation enrichment
+ * is enabled (VISITOR_ANALYTICS_GEO_ENABLED + VISITOR_ANALYTICS_TRUST_CLOUDFLARE)
+ * — not an error, just no data yet.
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const countries = await fetchTopCountries(tx, tenantId, start);
+
+    return ok({ range, countries });
+  });
+};

--- a/src/pages/api/v1/analytics/pages.ts
+++ b/src/pages/api/v1/analytics/pages.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchTopPaths } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/pages?range=24h|7d|30d|12m` — top pages by human pageviews. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const pages = await fetchTopPaths(tx, tenantId, start);
+
+    return ok({ range, pages });
+  });
+};

--- a/src/pages/api/v1/analytics/realtime.ts
+++ b/src/pages/api/v1/analytics/realtime.ts
@@ -1,0 +1,58 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchRealtimeStats } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import { resolveVisitorAnalyticsConfig } from "../../../../modules/visitor-analytics/domain/visitor-analytics-config";
+
+const REALTIME_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "realtime",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/realtime` — online-now presence counts. */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const config = resolveVisitorAnalyticsConfig();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      REALTIME_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const stats = await fetchRealtimeStats(
+      tx,
+      tenantId,
+      config.onlineWindowSeconds
+    );
+
+    return ok(stats);
+  });
+};

--- a/src/pages/api/v1/analytics/retention/purge.ts
+++ b/src/pages/api/v1/analytics/retention/purge.ts
@@ -1,0 +1,131 @@
+import type { APIRoute } from "astro";
+
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import { withTenant } from "../../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../modules/_shared/idempotency";
+import { purgeVisitorAnalyticsData } from "../../../../../modules/visitor-analytics/application/retention-purge";
+import { resolveVisitorAnalyticsConfig } from "../../../../../modules/visitor-analytics/domain/visitor-analytics-config";
+
+const PURGE_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "retention",
+  action: "purge" as const
+};
+
+const IDEMPOTENCY_SCOPE = "visitor_analytics_retention_purge";
+
+/**
+ * `POST /api/v1/analytics/retention/purge` — on-demand purge using the
+ * module's retention config (VISITOR_ANALYTICS_EVENT_RETENTION_DAYS /
+ * _RAW_DETAIL_RETENTION_DAYS / _ROLLUP_RETENTION_DAYS). Destructive,
+ * high-risk mutation: requires `Idempotency-Key` and is audited `critical`.
+ * See `application/retention-purge.ts` for the exact purge rules.
+ */
+export const POST: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const idempotencyKey = request.headers.get("idempotency-key");
+
+  if (!idempotencyKey) {
+    return fail(
+      400,
+      "IDEMPOTENCY_REQUIRED",
+      "Idempotency-Key header is required."
+    );
+  }
+
+  const requestHash = computeRequestHash({ action: "retention_purge" });
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+  const config = resolveVisitorAnalyticsConfig();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      PURGE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const existingIdempotency = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey
+    );
+
+    if (existingIdempotency) {
+      if (existingIdempotency.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+
+      return jsonResponse(existingIdempotency.responseBody, {
+        status: existingIdempotency.responseStatus
+      });
+    }
+
+    const result = await purgeVisitorAnalyticsData(tx, tenantId, config, now);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "visitor_analytics",
+      action: "retention_purged",
+      resourceType: "visitor_analytics_data",
+      resourceId: tenantId,
+      severity: "critical",
+      message: "Visitor analytics data purged past retention window.",
+      attributes: result,
+      correlationId
+    });
+
+    const successResponse = ok(result);
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  });
+};

--- a/src/pages/api/v1/analytics/security.ts
+++ b/src/pages/api/v1/analytics/security.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchSecurityView } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/security?range=24h|7d|30d|12m` — bot/crawler traffic breakdown. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const view = await fetchSecurityView(tx, tenantId, range, start);
+
+    return ok(view);
+  });
+};

--- a/src/pages/api/v1/analytics/sessions.ts
+++ b/src/pages/api/v1/analytics/sessions.ts
@@ -6,6 +6,7 @@ import { withTenant } from "../../../../lib/database/tenant-context";
 import { hashSessionToken } from "../../../../lib/auth/session-token";
 import {
   authorizeInTransaction,
+  evaluateFieldAccessInTransaction,
   resolveAuthInputs
 } from "../../../../modules/identity-access/application/access-guard";
 import { decodeKeysetCursor } from "../../../../modules/_shared/keyset-pagination";
@@ -18,13 +19,24 @@ const SESSIONS_GUARD = {
   action: "read" as const
 };
 
-const RAW_DETAIL_PERMISSION_KEY = "visitor_analytics.raw_detail.read";
+/**
+ * Field-level guard for the de-anonymizing raw-detail columns. Routed through
+ * the ABAC evaluator (not a bare permission-set membership check) so a `deny`
+ * DSL policy on `visitor_analytics.raw_detail.read` is honored
+ * (deny-overrides-allow) — see `evaluateFieldAccessInTransaction`.
+ */
+const RAW_DETAIL_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "raw_detail",
+  action: "read" as const
+};
 
 /**
  * `GET /api/v1/analytics/sessions` — keyset-paginated, newest-active-first.
  * Raw detail (`ipHash`/`ipAddress`/`userAgentHash`/`loginIdentifierSnapshot`)
  * is included only when the caller also holds
- * `visitor_analytics.raw_detail.read`, independent of `sessions.read`.
+ * `visitor_analytics.raw_detail.read` AND no ABAC policy denies it, independent
+ * of `sessions.read`.
  */
 export const GET: APIRoute = async ({ request, cookies, url }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
@@ -61,8 +73,13 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
       return auth.denied;
     }
 
-    const canSeeRawDetail = auth.grantedPermissionKeys.has(
-      RAW_DETAIL_PERMISSION_KEY
+    const canSeeRawDetail = await evaluateFieldAccessInTransaction(
+      tx,
+      tenantId,
+      auth.context,
+      auth.grantedPermissionKeys,
+      RAW_DETAIL_GUARD,
+      now
     );
 
     const page = await listVisitorSessions(tx, tenantId, cursor ?? undefined);

--- a/src/pages/api/v1/analytics/sessions.ts
+++ b/src/pages/api/v1/analytics/sessions.ts
@@ -1,0 +1,75 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { decodeKeysetCursor } from "../../../../modules/_shared/keyset-pagination";
+import { listVisitorSessions } from "../../../../modules/visitor-analytics/application/session-directory";
+import { shapeVisitorSession } from "../../../../modules/visitor-analytics/domain/analytics-response-shaping";
+
+const SESSIONS_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "sessions",
+  action: "read" as const
+};
+
+const RAW_DETAIL_PERMISSION_KEY = "visitor_analytics.raw_detail.read";
+
+/**
+ * `GET /api/v1/analytics/sessions` — keyset-paginated, newest-active-first.
+ * Raw detail (`ipHash`/`ipAddress`/`userAgentHash`/`loginIdentifierSnapshot`)
+ * is included only when the caller also holds
+ * `visitor_analytics.raw_detail.read`, independent of `sessions.read`.
+ */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const cursorParam = url.searchParams.get("cursor");
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam && !cursor) {
+    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      SESSIONS_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const canSeeRawDetail = auth.grantedPermissionKeys.has(
+      RAW_DETAIL_PERMISSION_KEY
+    );
+
+    const page = await listVisitorSessions(tx, tenantId, cursor ?? undefined);
+    const sessions = page.rows.map((row) =>
+      shapeVisitorSession(row, canSeeRawDetail)
+    );
+
+    return ok({ sessions, nextCursor: page.nextCursor });
+  });
+};

--- a/src/pages/api/v1/analytics/settings.ts
+++ b/src/pages/api/v1/analytics/settings.ts
@@ -1,0 +1,160 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  fetchModuleSettingsView,
+  updateModuleSettings
+} from "../../../../modules/module-management/application/module-settings";
+import { validateModuleSettingsPatch } from "../../../../modules/module-management/domain/module-settings";
+
+const MODULE_KEY = "visitor_analytics";
+
+const READ_GUARD = {
+  moduleKey: MODULE_KEY,
+  activityCode: "settings",
+  action: "read" as const
+};
+
+const UPDATE_GUARD = {
+  moduleKey: MODULE_KEY,
+  activityCode: "settings",
+  action: "update" as const
+};
+
+/**
+ * `GET /api/v1/analytics/settings` — a thin,
+ * `visitor_analytics`-permission-gated wrapper around Module Management's
+ * generic per-tenant settings storage (`awcms_module_settings`), reusing its
+ * storage/validation rather than inventing a second mechanism. Distinct from
+ * the generic `GET /api/v1/tenant/modules/{moduleKey}/settings` (which
+ * requires `module_management.settings.read`) — this endpoint requires the
+ * module's own already-seeded `visitor_analytics.settings.read`/`.update`
+ * (migration 049) instead.
+ */
+export const GET: APIRoute = async ({ request, cookies }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      READ_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const view = await fetchModuleSettingsView(tx, tenantId, MODULE_KEY);
+
+    if (!view) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module is not registered.");
+    }
+
+    return ok(view);
+  });
+};
+
+/**
+ * `PATCH /api/v1/analytics/settings` — shallow JSON-merge patch, same
+ * semantics as the generic module-settings endpoint.
+ * `validateModuleSettingsPatch` rejects any secret-shaped key or value
+ * before this ever reaches storage. Audited (`settings_updated`, diff of
+ * changed key *names* only, never values).
+ */
+export const PATCH: APIRoute = async ({ request, cookies, locals }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const bodyRead = await readJsonBody(request);
+
+  if (bodyRead.tooLarge) {
+    return bodyTooLargeResponse(bodyRead.limitBytes);
+  }
+
+  const validation = validateModuleSettingsPatch(bodyRead.value);
+
+  if (!validation.valid) {
+    return fail(400, validation.code, validation.message);
+  }
+
+  const patch = validation.value;
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+  const correlationId = locals.correlationId;
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      UPDATE_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const result = await updateModuleSettings(
+      tx,
+      tenantId,
+      MODULE_KEY,
+      patch,
+      auth.context.tenantUserId
+    );
+
+    if (result.outcome === "not_found") {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module is not registered.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: MODULE_KEY,
+      action: "settings_updated",
+      resourceType: "module_settings",
+      resourceId: MODULE_KEY,
+      severity: "info",
+      message: "Visitor analytics settings updated.",
+      attributes: { diff: result.diff },
+      correlationId
+    });
+
+    return ok(result.view);
+  });
+};

--- a/src/pages/api/v1/analytics/summary.ts
+++ b/src/pages/api/v1/analytics/summary.ts
@@ -1,0 +1,69 @@
+import type { APIRoute } from "astro";
+
+import { fail, ok } from "../../../../modules/_shared/api-response";
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenant } from "../../../../lib/database/tenant-context";
+import { hashSessionToken } from "../../../../lib/auth/session-token";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs
+} from "../../../../modules/identity-access/application/access-guard";
+import { fetchAnalyticsSummary } from "../../../../modules/visitor-analytics/application/analytics-queries";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../../../../modules/visitor-analytics/domain/analytics-range";
+
+const DASHBOARD_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+/** `GET /api/v1/analytics/summary?range=24h|7d|30d|12m`. */
+export const GET: APIRoute = async ({ request, cookies, url }) => {
+  const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  if (!token) {
+    return fail(401, "AUTH_REQUIRED", "Authentication required.");
+  }
+
+  const rangeParam = url.searchParams.get("range");
+  const range = rangeParam ?? DEFAULT_ANALYTICS_RANGE;
+
+  if (!isKnownAnalyticsRange(range)) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "range must be one of 24h, 7d, 30d, 12m."
+    );
+  }
+
+  const sql = getDatabaseClient();
+  const tokenHash = hashSessionToken(token);
+  const now = new Date();
+
+  return withTenant(sql, tenantId, async (tx) => {
+    const auth = await authorizeInTransaction(
+      tx,
+      tenantId,
+      tokenHash,
+      now,
+      DASHBOARD_GUARD
+    );
+
+    if (!auth.allowed) {
+      return auth.denied;
+    }
+
+    const start = resolveRangeStart(range, now);
+    const summary = await fetchAnalyticsSummary(tx, tenantId, range, start);
+
+    return ok(summary);
+  });
+};

--- a/tests/access-guard-field-access.test.ts
+++ b/tests/access-guard-field-access.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for `evaluateFieldAccessInTransaction` (FIX 5) — the secondary,
+ * FIELD-level access gate that routes a de-anonymizing field decision (e.g.
+ * `visitor_analytics.raw_detail.read`) through the ABAC evaluator instead of a
+ * bare `grantedPermissionKeys.has(fieldKey)` membership check.
+ *
+ * The regression this closes: a membership check ignores the ABAC layer, so a
+ * `deny` DSL policy on the field key would be silently bypassed
+ * (deny-overrides-allow not honored for the field). These tests prove the deny
+ * is now honored, while RBAC is still required (default deny).
+ *
+ * No real database: the only query the helper runs is the policy-cache SELECT,
+ * driven here by a fake tagged-template `tx`. The policy cache is reset per test.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { evaluateFieldAccessInTransaction } from "../src/modules/identity-access/application/access-guard";
+import { resetPolicyCache } from "../src/modules/identity-access/application/policy-cache";
+import type { TenantContext } from "../src/modules/identity-access/domain/access-control";
+
+const RAW_DETAIL_GUARD = {
+  moduleKey: "visitor_analytics",
+  activityCode: "raw_detail",
+  action: "read" as const
+};
+
+const GRANTED = new Set(["visitor_analytics.raw_detail.read"]);
+const NOW = new Date("2026-07-24T00:00:00Z");
+
+function context(tenantId: string): TenantContext {
+  return {
+    tenantId,
+    tenantUserId: "22222222-2222-4222-8222-222222222222",
+    identityId: "33333333-3333-4333-8333-333333333333",
+    roles: ["analyst"]
+  };
+}
+
+/**
+ * A fake tagged-template `tx` returning `rows` for the single policy-cache
+ * SELECT `evaluateFieldAccessInTransaction` runs (via `loadActivePolicies`).
+ */
+function fakeTx(rows: unknown[]): Bun.SQL {
+  return (() => Promise.resolve(rows)) as unknown as Bun.SQL;
+}
+
+/** A DSL-managed DENY policy scoped to `raw_detail.read`, always-true condition. */
+function denyRawDetailRow() {
+  return {
+    policy_code: "deny-raw-detail",
+    effect: "deny",
+    module_key: "visitor_analytics",
+    activity_code: "raw_detail",
+    action: "read",
+    resource_type: null,
+    dsl_version: 1,
+    priority: 100,
+    conditions: { allOf: [] } // vacuously true → always matches
+  };
+}
+
+describe("evaluateFieldAccessInTransaction — raw_detail routed through ABAC (FIX 5)", () => {
+  beforeEach(() => resetPolicyCache());
+  afterEach(() => resetPolicyCache());
+
+  test("RBAC grant + NO policy → field allowed", async () => {
+    const tenantId = "aaaaaaaa-0000-4000-8000-000000000001";
+    const allowed = await evaluateFieldAccessInTransaction(
+      fakeTx([]),
+      tenantId,
+      context(tenantId),
+      GRANTED,
+      RAW_DETAIL_GUARD,
+      NOW
+    );
+    expect(allowed).toBe(true);
+  });
+
+  test("RBAC grant BUT a deny DSL policy on raw_detail.read → field DENIED (deny-overrides-allow)", async () => {
+    const tenantId = "aaaaaaaa-0000-4000-8000-000000000002";
+    // A bare `GRANTED.has("visitor_analytics.raw_detail.read")` membership check
+    // would still be TRUE here — routing through ABAC is what honors the deny.
+    const allowed = await evaluateFieldAccessInTransaction(
+      fakeTx([denyRawDetailRow()]),
+      tenantId,
+      context(tenantId),
+      GRANTED,
+      RAW_DETAIL_GUARD,
+      NOW
+    );
+    expect(allowed).toBe(false);
+  });
+
+  test("NO RBAC grant → field denied regardless (default deny)", async () => {
+    const tenantId = "aaaaaaaa-0000-4000-8000-000000000003";
+    const allowed = await evaluateFieldAccessInTransaction(
+      fakeTx([]),
+      tenantId,
+      context(tenantId),
+      new Set<string>(),
+      RAW_DETAIL_GUARD,
+      NOW
+    );
+    expect(allowed).toBe(false);
+  });
+});

--- a/tests/integration/visitor-analytics.integration.test.ts
+++ b/tests/integration/visitor-analytics.integration.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Integration tests for `visitor_analytics` against a real PostgreSQL under the
+ * WORLD-1 ephemeral-database harness. Proves, with real DDL/RLS/constraints
+ * (not mocks):
+ *
+ *   - the collector writes a session + event inside `withTenant`, and the
+ *     aggregate/realtime queries read them back correctly;
+ *   - FORCE ROW LEVEL SECURITY tenant isolation: tenant A's rows are invisible
+ *     to tenant B's context, AND a direct SELECT by the non-superuser
+ *     `awcms_app` role with NO tenant context returns zero rows (fail-closed);
+ *   - the cross-tenant composite FK `(tenant_id, visitor_session_id)` refuses a
+ *     visit_event that points at another tenant's session;
+ *   - retention purge hard-deletes events past the cutoff and the now-orphaned
+ *     sessions.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating). The privacy of stored identifiers
+ * (salted hashing) is covered by the pure unit tests
+ * (`tests/visitor-analytics-privacy.test.ts`).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  appRoleActivated,
+  assertRejected,
+  getAdminSql,
+  getAppRoleSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenant } from "../../src/lib/database/tenant-context";
+import { collectVisitorTelemetry } from "../../src/modules/visitor-analytics/application/collector";
+import {
+  fetchAnalyticsSummary,
+  fetchRealtimeStats
+} from "../../src/modules/visitor-analytics/application/analytics-queries";
+import { purgeVisitorAnalyticsData } from "../../src/modules/visitor-analytics/application/retention-purge";
+import {
+  VISITOR_ANALYTICS_DEFAULTS,
+  type VisitorAnalyticsConfig
+} from "../../src/modules/visitor-analytics/domain/visitor-analytics-config";
+
+const TENANT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+const CONFIG: VisitorAnalyticsConfig = {
+  ...VISITOR_ANALYTICS_DEFAULTS,
+  enabled: true,
+  hashSalt: "integration-salt"
+};
+
+async function seedTenants(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES
+      (${TENANT_A}, 'tenant-a', 'Tenant A', 'active'),
+      (${TENANT_B}, 'tenant-b', 'Tenant B', 'active')
+    ON CONFLICT (id) DO NOTHING
+  `;
+}
+
+async function collectHuman(tenantId: string, path: string): Promise<void> {
+  await collectVisitorTelemetry({
+    sql: getRuntimeSql(),
+    tenantId,
+    correlationId: "corr-int",
+    config: CONFIG,
+    method: "GET",
+    rawPath: path,
+    statusCode: 200,
+    visitorKey: "11111111-1111-4111-8111-111111111111",
+    ipAddress: "203.0.113.5",
+    userAgent:
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36",
+    referrerHeader: "https://ref.example.com/x",
+    isAuthenticated: false,
+    identityId: null,
+    geo: { countryCode: null, region: null, city: null, timezone: null }
+  });
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("visitor_analytics module (integration)", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  test("collector writes a session + event, queries read them back", async () => {
+    const runtime = getRuntimeSql();
+    await collectHuman(TENANT_A, "/blog/acme/post-1");
+
+    const counts = await withTenant(runtime, TENANT_A, async (tx) => {
+      const sessions = (await tx`
+        SELECT count(*) AS n FROM awcms_visitor_sessions WHERE tenant_id = ${TENANT_A}
+      `) as { n: string }[];
+      const events = (await tx`
+        SELECT count(*) AS n FROM awcms_visit_events WHERE tenant_id = ${TENANT_A}
+      `) as { n: string }[];
+      return {
+        sessions: Number(sessions[0]?.n ?? 0),
+        events: Number(events[0]?.n ?? 0)
+      };
+    });
+    expect(counts.sessions).toBe(1);
+    expect(counts.events).toBe(1);
+
+    const summary = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchAnalyticsSummary(
+        tx,
+        TENANT_A,
+        "7d",
+        new Date(Date.now() - 86_400_000)
+      )
+    );
+    expect(summary.humanPageviews).toBe(1);
+    expect(summary.humanUniqueVisitors).toBe(1);
+    expect(summary.botPageviews).toBe(0);
+
+    const realtime = await withTenant(runtime, TENANT_A, (tx) =>
+      fetchRealtimeStats(tx, TENANT_A, CONFIG.onlineWindowSeconds)
+    );
+    expect(realtime.onlineHumanCount).toBe(1);
+    expect(realtime.onlinePublicCount).toBe(1);
+  });
+
+  test("stored detail is anonymized: raw IP is null by default, hashes are present", async () => {
+    const runtime = getRuntimeSql();
+    await collectHuman(TENANT_A, "/");
+
+    const row = await withTenant(runtime, TENANT_A, async (tx) => {
+      const rows = (await tx`
+        SELECT ip_address, ip_hash, user_agent_hash, visitor_key_hash, identity_id
+        FROM awcms_visitor_sessions WHERE tenant_id = ${TENANT_A} LIMIT 1
+      `) as {
+        ip_address: string | null;
+        ip_hash: string | null;
+        user_agent_hash: string | null;
+        visitor_key_hash: string | null;
+        identity_id: string | null;
+      }[];
+      return rows[0];
+    });
+    // rawIpEnabled defaults false -> raw IP not stored; salted hashes are.
+    expect(row?.ip_address).toBeNull();
+    expect(row?.identity_id).toBeNull();
+    expect(row?.ip_hash?.startsWith("sha256:")).toBe(true);
+    expect(row?.user_agent_hash?.startsWith("sha256:")).toBe(true);
+    expect(row?.visitor_key_hash?.startsWith("sha256:")).toBe(true);
+  });
+
+  test("cross-tenant isolation: tenant B's context sees none of tenant A's rows", async () => {
+    const runtime = getRuntimeSql();
+    await collectHuman(TENANT_A, "/only-a");
+
+    const asB = await withTenant(runtime, TENANT_B, async (tx) => {
+      const rows = (await tx`
+        SELECT count(*) AS n FROM awcms_visit_events
+      `) as { n: string }[];
+      return Number(rows[0]?.n ?? 0);
+    });
+    expect(asB).toBe(0);
+  });
+
+  test("RLS: awcms_app cannot SELECT without tenant context (fail-closed FORCE RLS)", async () => {
+    if (!appRoleActivated) {
+      // Without migration 019's awcms_app role the FORCE-RLS proof is not
+      // meaningful (an owner-superuser bypasses RLS unconditionally).
+      return;
+    }
+    await collectHuman(TENANT_A, "/rls-probe");
+
+    const app = getAppRoleSql();
+    const sessions = (await app`SELECT id FROM awcms_visitor_sessions`) as {
+      id: string;
+    }[];
+    const events = (await app`SELECT id FROM awcms_visit_events`) as {
+      id: string;
+    }[];
+    expect(sessions).toHaveLength(0);
+    expect(events).toHaveLength(0);
+  });
+
+  test("cross-tenant composite FK refuses an event pointing at another tenant's session", async () => {
+    const runtime = getRuntimeSql();
+    await collectHuman(TENANT_A, "/");
+
+    const sessionId = await withTenant(runtime, TENANT_A, async (tx) => {
+      const rows = (await tx`
+        SELECT id FROM awcms_visitor_sessions WHERE tenant_id = ${TENANT_A} LIMIT 1
+      `) as { id: string }[];
+      return rows[0]!.id;
+    });
+
+    // Under tenant B's context, referencing tenant A's session id violates the
+    // (tenant_id, visitor_session_id) composite FK — (B, A_session) does not
+    // exist in awcms_visitor_sessions(tenant_id, id).
+    await assertRejected(
+      withTenant(
+        runtime,
+        TENANT_B,
+        (tx) =>
+          tx`
+          INSERT INTO awcms_visit_events
+            (tenant_id, visitor_session_id, method, area, path_sanitized, human_status)
+          VALUES (${TENANT_B}, ${sessionId}, 'GET', 'public', '/x', 'human')
+        `
+      ),
+      "a visit_event referencing another tenant's session"
+    );
+  });
+
+  test("retention purge hard-deletes events + orphaned sessions past the cutoff", async () => {
+    const runtime = getRuntimeSql();
+    const oldTs = "2000-01-01T00:00:00Z";
+
+    // Seed one deliberately-ancient session + event directly.
+    await withTenant(runtime, TENANT_A, async (tx) => {
+      const sessionRows = (await tx`
+        INSERT INTO awcms_visitor_sessions
+          (tenant_id, visitor_key_hash, area, first_seen_at, last_seen_at)
+        VALUES (${TENANT_A}, 'sha256:old', 'public', ${oldTs}, ${oldTs})
+        RETURNING id
+      `) as { id: string }[];
+      const sessionId = sessionRows[0]!.id;
+      await tx`
+        INSERT INTO awcms_visit_events
+          (tenant_id, visitor_session_id, occurred_at, method, area, path_sanitized, human_status)
+        VALUES (${TENANT_A}, ${sessionId}, ${oldTs}, 'GET', 'public', '/old', 'human')
+      `;
+    });
+
+    const result = await withTenant(runtime, TENANT_A, (tx) =>
+      purgeVisitorAnalyticsData(tx, TENANT_A, CONFIG, new Date())
+    );
+    if (result instanceof Response)
+      throw new Error("unexpected 503 during purge");
+
+    expect(result.eventsDeleted).toBe(1);
+    expect(result.sessionsDeleted).toBe(1);
+
+    const remaining = await withTenant(runtime, TENANT_A, async (tx) => {
+      const rows = (await tx`
+        SELECT count(*) AS n FROM awcms_visit_events WHERE tenant_id = ${TENANT_A}
+      `) as { n: string }[];
+      return Number(rows[0]?.n ?? 0);
+    });
+    expect(remaining).toBe(0);
+  });
+});

--- a/tests/module-management-job-registry.test.ts
+++ b/tests/module-management-job-registry.test.ts
@@ -83,6 +83,8 @@ describe("fetchModuleJobs", () => {
 
     expect(commands).toEqual(
       [
+        "bun run analytics:purge",
+        "bun run analytics:rollup",
         "bun run blog:publish:scheduled",
         "bun run config:validate",
         "bun run domain-events:dispatch",

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -74,4 +74,33 @@ describe("validateEnv", () => {
       0
     );
   });
+
+  test("visitor analytics hash salt is required only when the module is enabled", () => {
+    // Disabled (default) -> no salt required.
+    expect(
+      validateEnv({ ...base, VISITOR_ANALYTICS_ENABLED: "false" }).length
+    ).toBe(0);
+    // Enabled without a real salt -> problem.
+    expect(
+      validateEnv({ ...base, VISITOR_ANALYTICS_ENABLED: "true" }).some((p) =>
+        p.startsWith("VISITOR_ANALYTICS_HASH_SALT")
+      )
+    ).toBe(true);
+    // Enabled with a placeholder salt -> still a problem.
+    expect(
+      validateEnv({
+        ...base,
+        VISITOR_ANALYTICS_ENABLED: "true",
+        VISITOR_ANALYTICS_HASH_SALT: "change-me"
+      }).some((p) => p.startsWith("VISITOR_ANALYTICS_HASH_SALT"))
+    ).toBe(true);
+    // Enabled with a real salt -> clean.
+    expect(
+      validateEnv({
+        ...base,
+        VISITOR_ANALYTICS_ENABLED: "true",
+        VISITOR_ANALYTICS_HASH_SALT: "a-real-deployment-salt"
+      }).length
+    ).toBe(0);
+  });
 });

--- a/tests/validate-env.test.ts
+++ b/tests/validate-env.test.ts
@@ -94,7 +94,17 @@ describe("validateEnv", () => {
         VISITOR_ANALYTICS_HASH_SALT: "change-me"
       }).some((p) => p.startsWith("VISITOR_ANALYTICS_HASH_SALT"))
     ).toBe(true);
-    // Enabled with a real salt -> clean.
+    // Enabled with a too-short salt (< 16 chars) -> a problem (FIX 4).
+    expect(
+      validateEnv({
+        ...base,
+        VISITOR_ANALYTICS_ENABLED: "true",
+        VISITOR_ANALYTICS_HASH_SALT: "short-salt"
+      }).some(
+        (p) => p.startsWith("VISITOR_ANALYTICS_HASH_SALT") && p.includes("16")
+      )
+    ).toBe(true);
+    // Enabled with a real, long-enough salt -> clean.
     expect(
       validateEnv({
         ...base,

--- a/tests/visitor-analytics-classification.test.ts
+++ b/tests/visitor-analytics-classification.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for the pure classification/sanitization helpers of
+ * `visitor_analytics`: user-agent parsing + bot detection, human
+ * classification, path sanitization (the leak-prevention boundary), referrer
+ * extraction, and request-area classification.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  isBotUserAgent,
+  parseUserAgent
+} from "../src/modules/visitor-analytics/domain/user-agent";
+import {
+  classifyHumanStatus,
+  classifySessionHumanity
+} from "../src/modules/visitor-analytics/domain/human-classifier";
+import {
+  isTrackablePath,
+  sanitizePath
+} from "../src/modules/visitor-analytics/domain/path-sanitizer";
+import { extractReferrerDomain } from "../src/modules/visitor-analytics/domain/referrer";
+import { determineArea } from "../src/modules/visitor-analytics/domain/request-area";
+
+describe("user-agent parsing + bot detection", () => {
+  test("detects a common desktop browser + OS", () => {
+    const ua =
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+    const parsed = parseUserAgent(ua);
+    expect(parsed.browserName).toBe("Chrome");
+    expect(parsed.browserVersionMajor).toBe("120");
+    expect(parsed.osName).toBe("Windows");
+    expect(parsed.deviceType).toBe("desktop");
+    expect(parsed.isBot).toBe(false);
+  });
+
+  test("detects a mobile device", () => {
+    const ua =
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1";
+    const parsed = parseUserAgent(ua);
+    expect(parsed.osName).toBe("iOS");
+    expect(parsed.deviceType).toBe("mobile");
+  });
+
+  test("flags known crawlers as bots with a reason", () => {
+    const bot = isBotUserAgent(
+      "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+    );
+    expect(bot.isBot).toBe(true);
+    expect(bot.botReason).toBe("Googlebot");
+    expect(parseUserAgent("curl/8.0.1").deviceType).toBe("bot");
+  });
+
+  test("empty/unknown UA resolves to deviceType 'unknown', never blindly human", () => {
+    expect(parseUserAgent(null).deviceType).toBe("unknown");
+    expect(parseUserAgent("").deviceType).toBe("unknown");
+    expect(parseUserAgent("something-weird").deviceType).toBe("unknown");
+  });
+});
+
+describe("human/bot classification", () => {
+  test("a clear bot is 'bot' regardless of authentication", () => {
+    const parsed = parseUserAgent("Googlebot/2.1");
+    expect(
+      classifyHumanStatus({ isAuthenticated: true, parsedUserAgent: parsed })
+    ).toBe("bot");
+  });
+
+  test("an authenticated non-bot session is 'human' even with an odd UA", () => {
+    const parsed = parseUserAgent("weird-ua");
+    expect(
+      classifyHumanStatus({ isAuthenticated: true, parsedUserAgent: parsed })
+    ).toBe("human");
+  });
+
+  test("an anonymous unknown-device UA is 'unknown', not 'human'", () => {
+    const parsed = parseUserAgent("weird-ua");
+    expect(
+      classifyHumanStatus({ isAuthenticated: false, parsedUserAgent: parsed })
+    ).toBe("unknown");
+  });
+
+  test("session humanity: bot => is_human false with reason", () => {
+    const parsed = parseUserAgent("AhrefsBot/7.0");
+    const humanity = classifySessionHumanity({
+      isAuthenticated: false,
+      parsedUserAgent: parsed
+    });
+    expect(humanity.isHuman).toBe(false);
+    expect(humanity.botReason).toBe("AhrefsBot");
+  });
+});
+
+describe("path sanitization (leak-prevention boundary)", () => {
+  test("strips sensitive query params, keeps safe ones", () => {
+    const out = sanitizePath("/reset?token=SECRET123&lang=id&code=abc");
+    expect(out).toContain("/reset");
+    expect(out).toContain("lang=id");
+    expect(out).not.toContain("SECRET123");
+    expect(out).not.toContain("code=abc");
+  });
+
+  test("fails SAFE: an unparseable path degrades to its path portion, never echoes the raw query", () => {
+    const out = sanitizePath("/x?token=abc%ZZ%");
+    expect(out).not.toContain("token=abc");
+  });
+
+  test("isTrackablePath excludes assets, framework paths, health, and specs", () => {
+    expect(isTrackablePath("/_astro/app.js")).toBe(false);
+    expect(isTrackablePath("/logo.png")).toBe(false);
+    expect(isTrackablePath("/favicon.ico")).toBe(false);
+    expect(isTrackablePath("/api/v1/health")).toBe(false);
+    expect(isTrackablePath("/openapi/spec.yaml")).toBe(false);
+    expect(isTrackablePath("/blog/acme/my-post")).toBe(true);
+    expect(isTrackablePath("/")).toBe(true);
+  });
+});
+
+describe("referrer extraction", () => {
+  test("returns bare hostname only, lowercased", () => {
+    expect(extractReferrerDomain("https://News.Example.com/path?x=1")).toBe(
+      "news.example.com"
+    );
+  });
+
+  test("null for non-http(s) schemes and garbage", () => {
+    expect(extractReferrerDomain("javascript:alert(1)")).toBeNull();
+    expect(extractReferrerDomain("not a url")).toBeNull();
+    expect(extractReferrerDomain(null)).toBeNull();
+  });
+});
+
+describe("request-area classification", () => {
+  test("maps paths to the constrained area set", () => {
+    expect(determineArea("/admin/analytics")).toBe("admin");
+    expect(determineArea("/api/v1/setup/status")).toBe("setup");
+    expect(determineArea("/api/v1/auth/login")).toBe("auth");
+    expect(determineArea("/api/v1/analytics/collect")).toBe("api");
+    expect(determineArea("/blog/acme")).toBe("public");
+  });
+});

--- a/tests/visitor-analytics-collect-rate-limit.test.ts
+++ b/tests/visitor-analytics-collect-rate-limit.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Route-level test for the public visit-ingest beacon's per-IP rate limit
+ * (FIX 1). Drives the ACTUAL `analytics/collect.ts` handler with a fake Astro
+ * context and no database: the shared in-process `checkRateLimit` bucket for
+ * the beacon's IP is exhausted first, so the handler's own limiter returns 429
+ * BEFORE it reaches any DB work — proving the backstop fronts the unauthenticated
+ * write. The limiter key is IP-only, so this never depends on tenant existence.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { APIRoute } from "astro";
+
+import { POST as collectPOST } from "../src/pages/api/v1/analytics/collect";
+import {
+  checkRateLimit,
+  resetRateLimitForTests
+} from "../src/lib/security/rate-limit";
+
+// Must mirror collect.ts's DEFAULT rate-limit config exactly (120 req / 60 s).
+// If those defaults change, update this pair — the whole test hinges on the
+// pre-fill config matching the handler's.
+const COLLECT_LIMIT = { maxAttempts: 120, windowMs: 60_000 };
+const CLIENT_IP = "203.0.113.77";
+const KEY = `analytics-collect:${CLIENT_IP}`;
+
+/** Minimal AstroCookies stub — the 429 path only ever reads `.get`. */
+function fakeCookies() {
+  const store = new Map<string, string>();
+  return {
+    get(name: string) {
+      return store.has(name) ? { value: store.get(name)! } : undefined;
+    },
+    set(name: string, value: string) {
+      store.set(name, value);
+    },
+    delete(name: string) {
+      store.delete(name);
+    },
+    has(name: string) {
+      return store.has(name);
+    }
+  };
+}
+
+async function callCollect(opts: {
+  clientAddress: string;
+  body: unknown;
+}): Promise<Response> {
+  const request = new Request("http://localhost/api/v1/analytics/collect", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(opts.body)
+  });
+  return (await (collectPOST as APIRoute)({
+    request,
+    cookies: fakeCookies(),
+    clientAddress: opts.clientAddress,
+    locals: { correlationId: "test-corr" }
+  } as never)) as Response;
+}
+
+describe("public beacon per-IP rate limit (FIX 1)", () => {
+  const savedEnabled = process.env.VISITOR_ANALYTICS_ENABLED;
+
+  beforeEach(() => {
+    process.env.VISITOR_ANALYTICS_ENABLED = "true";
+    resetRateLimitForTests();
+  });
+
+  afterEach(() => {
+    resetRateLimitForTests();
+    if (savedEnabled === undefined)
+      delete process.env.VISITOR_ANALYTICS_ENABLED;
+    else process.env.VISITOR_ANALYTICS_ENABLED = savedEnabled;
+  });
+
+  test("a source over the window gets 429 with Retry-After, before any DB work", async () => {
+    // Exhaust the exact per-IP bucket the handler will use so its own
+    // checkRateLimit sees the window already over the limit.
+    let guard = 0;
+    while (checkRateLimit(KEY, COLLECT_LIMIT).allowed) {
+      guard += 1;
+      if (guard > 1000) throw new Error("bucket never tripped");
+    }
+
+    const res = await callCollect({
+      clientAddress: CLIENT_IP,
+      // A well-formed, trackable public beacon: it passes every free (no-DB)
+      // filter and would otherwise reach the tenant lookup + write.
+      body: { tenantCode: "any-public-code", path: "/a-public-page" }
+    });
+
+    expect(res.status).toBe(429);
+    const json = (await res.json()) as { error?: { code?: string } };
+    expect(json.error?.code).toBe("RATE_LIMITED");
+    expect(res.headers.get("retry-after")).toBeTruthy();
+  });
+
+  test("the limiter only fronts DB-bound writes: a non-public beacon still returns 202 even with a tripped bucket", async () => {
+    // Exhaust the CLIENT_IP bucket, then hit the endpoint from the SAME IP with
+    // an admin-area path. `determineArea` classifies it non-public, so the
+    // handler short-circuits to 202 (fire-and-forget) BEFORE the rate-limit
+    // check — proving the limiter guards only the path that reaches the DB, and
+    // is not a global kill switch that would 429 requests doing no DB work.
+    let guard = 0;
+    while (checkRateLimit(KEY, COLLECT_LIMIT).allowed) {
+      guard += 1;
+      if (guard > 1000) throw new Error("bucket never tripped");
+    }
+
+    const res = await callCollect({
+      clientAddress: CLIENT_IP,
+      body: { tenantCode: "any-public-code", path: "/admin/dashboard" }
+    });
+
+    expect(res.status).toBe(202);
+  });
+});

--- a/tests/visitor-analytics-contract.test.ts
+++ b/tests/visitor-analytics-contract.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Contract/parity tests for `visitor_analytics` — cheap guards that keep the
+ * three sources of truth aligned: the module descriptor's permission catalog,
+ * the permission-seed migration (sql/049), and the OpenAPI contract. No DB.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { visitorAnalyticsModule } from "../src/modules/visitor-analytics/module";
+
+const ROOT = join(import.meta.dir, "..");
+
+function permKey(activityCode: string, action: string): string {
+  return `${visitorAnalyticsModule.key}.${activityCode}.${action}`;
+}
+
+describe("descriptor <-> permission seed parity", () => {
+  test("module.ts permissions exactly match sql/049 seed", () => {
+    const seed = readFileSync(
+      join(ROOT, "sql/049_awcms_visitor_analytics_permissions.sql"),
+      "utf8"
+    );
+    // Extract every ('visitor_analytics', '<activity>', '<action>', ...) tuple.
+    const seededKeys = new Set(
+      [
+        ...seed.matchAll(/\('visitor_analytics',\s*'([^']+)',\s*'([^']+)'/g)
+      ].map((m) => permKey(m[1]!, m[2]!))
+    );
+    const descriptorKeys = new Set(
+      (visitorAnalyticsModule.permissions ?? []).map((p) =>
+        permKey(p.activityCode, p.action)
+      )
+    );
+
+    expect([...descriptorKeys].sort()).toEqual([...seededKeys].sort());
+    // Sanity: the exact set expected (protects against silent drift both ways).
+    expect(descriptorKeys.has("visitor_analytics.raw_detail.read")).toBe(true);
+    expect(descriptorKeys.has("visitor_analytics.retention.purge")).toBe(true);
+    expect(descriptorKeys.size).toBe(8);
+  });
+
+  test("navigation requiredPermission is a declared permission key", () => {
+    const declared = new Set(
+      (visitorAnalyticsModule.permissions ?? []).map((p) =>
+        permKey(p.activityCode, p.action)
+      )
+    );
+    for (const nav of visitorAnalyticsModule.navigation ?? []) {
+      if (nav.requiredPermission) {
+        expect(declared.has(nav.requiredPermission)).toBe(true);
+      }
+    }
+  });
+
+  test("descriptor is a standalone system module with the expected deps", () => {
+    expect(visitorAnalyticsModule.type).toBe("system");
+    expect(visitorAnalyticsModule.dependencies).toEqual([
+      "tenant_admin",
+      "identity_access",
+      "logging",
+      "reporting"
+    ]);
+    expect(visitorAnalyticsModule.api?.basePath).toBe("/api/v1/analytics");
+  });
+});
+
+describe("OpenAPI contract", () => {
+  const bundle = readFileSync(
+    join(ROOT, "openapi/awcms-public-api.openapi.yaml"),
+    "utf8"
+  );
+
+  test("the bundled spec declares every analytics route path", () => {
+    for (const path of [
+      "/api/v1/analytics/collect",
+      "/api/v1/analytics/summary",
+      "/api/v1/analytics/realtime",
+      "/api/v1/analytics/sessions",
+      "/api/v1/analytics/events",
+      "/api/v1/analytics/pages",
+      "/api/v1/analytics/devices",
+      "/api/v1/analytics/locations",
+      "/api/v1/analytics/security",
+      "/api/v1/analytics/settings",
+      "/api/v1/analytics/retention/purge"
+    ]) {
+      expect(bundle).toContain(`${path}:`);
+    }
+  });
+
+  test("the public ingest beacon declares an operationId + the module job commands exist", () => {
+    expect(bundle).toContain("operationId: analyticsCollect");
+    const commands = (visitorAnalyticsModule.jobs ?? []).map((j) => j.command);
+    expect(commands).toContain("bun run analytics:rollup");
+    expect(commands).toContain("bun run analytics:purge");
+  });
+});

--- a/tests/visitor-analytics-contract.test.ts
+++ b/tests/visitor-analytics-contract.test.ts
@@ -55,12 +55,18 @@ describe("descriptor <-> permission seed parity", () => {
 
   test("descriptor is a standalone system module with the expected deps", () => {
     expect(visitorAnalyticsModule.type).toBe("system");
+    // `reporting` is intentionally NOT a lifecycle dependency: `dependencies`
+    // governs enable/disable ORDERING only and this module consumes no
+    // `reporting` capability/port/table/projection (it is a conceptual peer,
+    // not a runtime prerequisite). Declaring it would force `reporting` to stay
+    // enabled for no functional reason and wrongly make it a non-leaf. See the
+    // PORT ADAPTATIONS block in the module descriptor.
     expect(visitorAnalyticsModule.dependencies).toEqual([
       "tenant_admin",
       "identity_access",
-      "logging",
-      "reporting"
+      "logging"
     ]);
+    expect(visitorAnalyticsModule.dependencies).not.toContain("reporting");
     expect(visitorAnalyticsModule.api?.basePath).toBe("/api/v1/analytics");
   });
 });

--- a/tests/visitor-analytics-domain.test.ts
+++ b/tests/visitor-analytics-domain.test.ts
@@ -21,6 +21,7 @@ import {
 } from "../src/modules/visitor-analytics/domain/analytics-range";
 import { resolveGeoEnrichment } from "../src/modules/visitor-analytics/domain/geo-enrichment";
 import { resolveAnalyticsClientIp } from "../src/modules/visitor-analytics/domain/client-ip";
+import { setLogSink, type LogEntry } from "../src/lib/logging/logger";
 import {
   planVisitorKeyCookie,
   shouldRevokeVisitorKeyCookie
@@ -143,6 +144,34 @@ describe("client-IP trust gate", () => {
         trustCloudflare: false
       })
     ).toBe("9.9.9.9");
+  });
+
+  test("the multi-value anomaly log records ONLY valueCount — never a raw IP fragment (FIX 3)", () => {
+    // Capture the structured log via the logger's own sink extension point so
+    // this asserts on the exact payload, no console/mock plumbing.
+    const captured: LogEntry[] = [];
+    setLogSink((entry) => captured.push(entry));
+    try {
+      const req = new Request("http://x/", {
+        headers: { "x-forwarded-for": "1.1.1.1, 2.2.2.2" }
+      });
+      resolveAnalyticsClientIp(req, "9.9.9.9", {
+        trustProxy: true,
+        trustCloudflare: false
+      });
+    } finally {
+      setLogSink(null);
+    }
+
+    const anomaly = captured.find((e) =>
+      e.message.endsWith("x_forwarded_for_multi_value")
+    );
+    expect(anomaly).toBeDefined();
+    expect(anomaly!.valueCount).toBe(2);
+    // The raw header value (and any fragment of it) must NOT appear anywhere in
+    // the log line — the old `firstValuePreview` leaked an unhashed client IP.
+    expect("firstValuePreview" in anomaly!).toBe(false);
+    expect(JSON.stringify(anomaly)).not.toContain("1.1.1.1");
   });
 });
 

--- a/tests/visitor-analytics-domain.test.ts
+++ b/tests/visitor-analytics-domain.test.ts
@@ -1,0 +1,296 @@
+/**
+ * Unit tests for the remaining pure `visitor_analytics` domain/application
+ * logic: the env config resolver (privacy-first defaults), range windows, geo
+ * enrichment + client-IP trust gates, the visitor-key cookie plan, the
+ * collect-gate, the dashboard view-model helpers, and rollup date resolution.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  resolveVisitorAnalyticsConfig,
+  isVisitorAnalyticsEnabled,
+  parsePositiveInt,
+  resolveVisitorKeyCookieMaxAgeSeconds,
+  VISITOR_ANALYTICS_DEFAULTS,
+  type VisitorAnalyticsConfig
+} from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
+import {
+  DEFAULT_ANALYTICS_RANGE,
+  isKnownAnalyticsRange,
+  resolveRangeStart
+} from "../src/modules/visitor-analytics/domain/analytics-range";
+import { resolveGeoEnrichment } from "../src/modules/visitor-analytics/domain/geo-enrichment";
+import { resolveAnalyticsClientIp } from "../src/modules/visitor-analytics/domain/client-ip";
+import {
+  planVisitorKeyCookie,
+  shouldRevokeVisitorKeyCookie
+} from "../src/modules/visitor-analytics/domain/visitor-key-cookie";
+import { shouldCollectRequest } from "../src/modules/visitor-analytics/application/collector";
+import {
+  buildSessionRowCells,
+  displayOrPlaceholder,
+  isNamedCountListEmpty,
+  isSummaryEmpty
+} from "../src/modules/visitor-analytics/domain/dashboard-view";
+import {
+  resolveDefaultRollupDate,
+  resolveRollupDate
+} from "../scripts/visitor-analytics-rollup";
+
+describe("config resolver (privacy-first defaults)", () => {
+  test("defaults to disabled with an empty salt and privacy flags off", () => {
+    const config = resolveVisitorAnalyticsConfig({});
+    expect(config.enabled).toBe(false);
+    expect(config.hashSalt).toBe("");
+    expect(config.rawIpEnabled).toBe(false);
+    expect(config.rawUserAgentEnabled).toBe(false);
+    expect(config.geoEnabled).toBe(false);
+    expect(config.mode).toBe("basic");
+    expect(isVisitorAnalyticsEnabled({})).toBe(false);
+  });
+
+  test("explicit env values win over defaults", () => {
+    const config = resolveVisitorAnalyticsConfig({
+      VISITOR_ANALYTICS_ENABLED: "true",
+      VISITOR_ANALYTICS_HASH_SALT: "real-salt",
+      VISITOR_ANALYTICS_EVENT_RETENTION_DAYS: "45"
+    });
+    expect(config.enabled).toBe(true);
+    expect(config.hashSalt).toBe("real-salt");
+    expect(config.eventRetentionDays).toBe(45);
+  });
+
+  test("parsePositiveInt rejects non-positive / malformed values", () => {
+    expect(parsePositiveInt("30")).toBe(30);
+    expect(parsePositiveInt("0")).toBeUndefined();
+    expect(parsePositiveInt("-5")).toBeUndefined();
+    expect(parsePositiveInt("abc")).toBeUndefined();
+    expect(parsePositiveInt(undefined)).toBeUndefined();
+  });
+
+  test("cookie TTL days -> maxAge seconds", () => {
+    expect(
+      resolveVisitorKeyCookieMaxAgeSeconds({ visitorKeyCookieTtlDays: 30 })
+    ).toBe(2_592_000);
+  });
+});
+
+describe("analytics range windows", () => {
+  test("known-range guard + default", () => {
+    expect(isKnownAnalyticsRange("7d")).toBe(true);
+    expect(isKnownAnalyticsRange("99y")).toBe(false);
+    expect(DEFAULT_ANALYTICS_RANGE).toBe("7d");
+  });
+
+  test("resolveRangeStart moves back the right amount", () => {
+    const now = new Date("2026-07-24T12:00:00Z");
+    expect(resolveRangeStart("24h", now).toISOString()).toBe(
+      "2026-07-23T12:00:00.000Z"
+    );
+    expect(resolveRangeStart("7d", now).toISOString()).toBe(
+      "2026-07-17T12:00:00.000Z"
+    );
+  });
+});
+
+describe("geo enrichment double-gate", () => {
+  const req = new Request("http://x/", { headers: { "cf-ipcountry": "ID" } });
+
+  test("returns country only when BOTH geoEnabled and trustCloudflare are true", () => {
+    expect(
+      resolveGeoEnrichment(req, { geoEnabled: true, trustCloudflare: true })
+        .countryCode
+    ).toBe("ID");
+    expect(
+      resolveGeoEnrichment(req, { geoEnabled: true, trustCloudflare: false })
+        .countryCode
+    ).toBeNull();
+    expect(
+      resolveGeoEnrichment(req, { geoEnabled: false, trustCloudflare: true })
+        .countryCode
+    ).toBeNull();
+  });
+});
+
+describe("client-IP trust gate", () => {
+  test("never trusts forwarded headers unless explicitly opted in", () => {
+    const req = new Request("http://x/", {
+      headers: { "x-forwarded-for": "1.2.3.4", "cf-connecting-ip": "5.6.7.8" }
+    });
+    // No trust -> falls back to the socket address.
+    expect(
+      resolveAnalyticsClientIp(req, "9.9.9.9", {
+        trustProxy: false,
+        trustCloudflare: false
+      })
+    ).toBe("9.9.9.9");
+    // Trust CF -> uses the CF header.
+    expect(
+      resolveAnalyticsClientIp(req, "9.9.9.9", {
+        trustProxy: false,
+        trustCloudflare: true
+      })
+    ).toBe("5.6.7.8");
+  });
+
+  test("an ambiguous multi-value forwarded header is NOT trusted (falls through)", () => {
+    const req = new Request("http://x/", {
+      headers: { "x-forwarded-for": "1.1.1.1, 2.2.2.2" }
+    });
+    expect(
+      resolveAnalyticsClientIp(req, "9.9.9.9", {
+        trustProxy: true,
+        trustCloudflare: false
+      })
+    ).toBe("9.9.9.9");
+  });
+});
+
+describe("visitor-key cookie lifecycle", () => {
+  test("revokes a lingering cookie only when disabled + a valid cookie exists", () => {
+    const valid = "11111111-1111-4111-8111-111111111111";
+    expect(
+      shouldRevokeVisitorKeyCookie({
+        config: { enabled: false },
+        existingValue: valid
+      })
+    ).toBe(true);
+    expect(
+      shouldRevokeVisitorKeyCookie({
+        config: { enabled: true },
+        existingValue: valid
+      })
+    ).toBe(false);
+    expect(
+      shouldRevokeVisitorKeyCookie({
+        config: { enabled: false },
+        existingValue: undefined
+      })
+    ).toBe(false);
+  });
+
+  test("plan reuses a valid cookie (no re-set) and mints one otherwise", () => {
+    const valid = "11111111-1111-4111-8111-111111111111";
+    const reuse = planVisitorKeyCookie({
+      config: { visitorKeyCookieTtlDays: 30 },
+      existingValue: valid
+    });
+    expect(reuse.value).toBe(valid);
+    expect(reuse.shouldSetCookie).toBe(false);
+
+    const fresh = planVisitorKeyCookie({
+      config: { visitorKeyCookieTtlDays: 30 },
+      existingValue: undefined
+    });
+    expect(fresh.shouldSetCookie).toBe(true);
+    expect(fresh.maxAgeSeconds).toBe(2_592_000);
+  });
+});
+
+describe("collect gate", () => {
+  function cfg(
+    overrides: Partial<VisitorAnalyticsConfig>
+  ): VisitorAnalyticsConfig {
+    return { ...VISITOR_ANALYTICS_DEFAULTS, ...overrides };
+  }
+
+  test("disabled module never collects", () => {
+    expect(
+      shouldCollectRequest({
+        pathname: "/",
+        area: "public",
+        config: cfg({ enabled: false })
+      })
+    ).toBe(false);
+  });
+
+  test("respects per-area toggles and skips non-trackable paths", () => {
+    const enabled = cfg({
+      enabled: true,
+      collectPublic: true,
+      collectApi: false,
+      collectAdmin: false
+    });
+    expect(
+      shouldCollectRequest({ pathname: "/", area: "public", config: enabled })
+    ).toBe(true);
+    expect(
+      shouldCollectRequest({
+        pathname: "/admin/x",
+        area: "admin",
+        config: enabled
+      })
+    ).toBe(false);
+    expect(
+      shouldCollectRequest({
+        pathname: "/logo.png",
+        area: "public",
+        config: enabled
+      })
+    ).toBe(false);
+  });
+});
+
+describe("dashboard view-model helpers", () => {
+  test("displayOrPlaceholder never renders literal null/blank", () => {
+    expect(displayOrPlaceholder(null)).toBe("—");
+    expect(displayOrPlaceholder("  ")).toBe("—");
+    expect(displayOrPlaceholder("Chrome")).toBe("Chrome");
+  });
+
+  test("empty-state detectors", () => {
+    expect(isNamedCountListEmpty([])).toBe(true);
+    expect(isNamedCountListEmpty([{ name: "x", count: 0 }])).toBe(true);
+    expect(isNamedCountListEmpty([{ name: "x", count: 3 }])).toBe(false);
+    expect(
+      isSummaryEmpty({
+        humanUniqueVisitors: 0,
+        humanPageviews: 0,
+        botPageviews: 0
+      })
+    ).toBe(true);
+  });
+
+  test("buildSessionRowCells hides raw block when not permitted", () => {
+    const base = {
+      area: "public",
+      currentPath: "/",
+      browserName: "Chrome",
+      osName: "Windows",
+      deviceType: "desktop",
+      isHuman: true,
+      countryCode: "ID",
+      ipAddress: "203.0.113.5",
+      ipHash: "sha256:h",
+      userAgentHash: "sha256:u",
+      loginIdentifierSnapshot: null
+    };
+    expect(
+      buildSessionRowCells(base, {
+        showRawDetailColumns: false,
+        humanLabel: "H",
+        botLabel: "B"
+      }).raw
+    ).toBeNull();
+    expect(
+      buildSessionRowCells(base, {
+        showRawDetailColumns: true,
+        humanLabel: "H",
+        botLabel: "B"
+      }).raw?.ipAddress
+    ).toBe("203.0.113.5");
+  });
+});
+
+describe("rollup date resolution", () => {
+  test("defaults to yesterday (UTC)", () => {
+    const now = new Date("2026-07-24T03:00:00Z");
+    expect(resolveDefaultRollupDate(now)).toBe("2026-07-23");
+  });
+
+  test("honors a valid --date flag, ignores a malformed one", () => {
+    const now = new Date("2026-07-24T03:00:00Z");
+    expect(resolveRollupDate(["--date=2026-01-15"], now)).toBe("2026-01-15");
+    expect(resolveRollupDate(["--date=nope"], now)).toBe("2026-07-23");
+  });
+});

--- a/tests/visitor-analytics-privacy.test.ts
+++ b/tests/visitor-analytics-privacy.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Unit tests for the privacy-critical core of `visitor_analytics`: the salted
+ * hashing of visitor identifiers, the anonymous visitor-key handling, and the
+ * raw-detail response gating. These are the guarantees the module's whole
+ * privacy posture rests on, so they are pure/unit-tested with no DB.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  generateVisitorKey,
+  hashIpAddress,
+  hashUserAgent,
+  hashVisitorKey,
+  isValidVisitorKey,
+  resolveVisitorKey
+} from "../src/modules/visitor-analytics/domain/visitor-key";
+import {
+  shapeVisitEvent,
+  shapeVisitorSession,
+  type VisitEventRow,
+  type VisitorSessionRow
+} from "../src/modules/visitor-analytics/domain/analytics-response-shaping";
+
+describe("visitor-key hashing (salted HMAC-SHA256)", () => {
+  test("is deterministic for the same value + salt", () => {
+    expect(hashVisitorKey("visitor-1", "salt")).toBe(
+      hashVisitorKey("visitor-1", "salt")
+    );
+  });
+
+  test("is salt-sensitive: a different salt yields a different hash", () => {
+    expect(hashIpAddress("203.0.113.5", "salt-a")).not.toBe(
+      hashIpAddress("203.0.113.5", "salt-b")
+    );
+  });
+
+  test("is keyed HMAC, not the plain sha256 of the value", async () => {
+    const value = "Mozilla/5.0";
+    const salt = "deployment-salt";
+    const keyed = hashUserAgent(value, salt);
+    // A plain unsalted SHA-256 of the value must NOT equal the keyed hash —
+    // the salt is what defeats a precomputed rainbow table.
+    const plain = `sha256:${new Bun.CryptoHasher("sha256").update(value).digest("hex")}`;
+    expect(keyed).not.toBe(plain);
+    expect(keyed.startsWith("sha256:")).toBe(true);
+  });
+
+  test("all three hashers share the same HMAC construction", () => {
+    // Same salt + same input across the three helpers -> same digest (they are
+    // the same keyed function, only named per call site for readability).
+    const salt = "s";
+    expect(hashVisitorKey("x", salt)).toBe(hashIpAddress("x", salt));
+    expect(hashIpAddress("x", salt)).toBe(hashUserAgent("x", salt));
+  });
+});
+
+describe("anonymous visitor key", () => {
+  test("generateVisitorKey produces a valid UUID key", () => {
+    expect(isValidVisitorKey(generateVisitorKey())).toBe(true);
+  });
+
+  test("resolveVisitorKey reuses a valid key but never trusts a forged one", () => {
+    const valid = generateVisitorKey();
+    expect(resolveVisitorKey(valid)).toBe(valid);
+
+    // A non-UUID forged cookie value is discarded; a fresh valid key is minted.
+    const forged = "'; DROP TABLE awcms_visit_events; --";
+    const resolved = resolveVisitorKey(forged);
+    expect(resolved).not.toBe(forged);
+    expect(isValidVisitorKey(resolved)).toBe(true);
+  });
+
+  test("isValidVisitorKey rejects null/undefined/blank/non-uuid", () => {
+    expect(isValidVisitorKey(null)).toBe(false);
+    expect(isValidVisitorKey(undefined)).toBe(false);
+    expect(isValidVisitorKey("")).toBe(false);
+    expect(isValidVisitorKey("not-a-uuid")).toBe(false);
+  });
+});
+
+function sessionRow(
+  overrides: Partial<VisitorSessionRow> = {}
+): VisitorSessionRow {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    visitor_key_hash: "sha256:abc",
+    identity_id: null,
+    login_identifier_snapshot: "user@example.com",
+    is_authenticated: false,
+    area: "public",
+    current_path: "/",
+    first_seen_at: new Date("2026-01-01T00:00:00Z"),
+    last_seen_at: new Date("2026-01-01T00:05:00Z"),
+    ip_hash: "sha256:iphash",
+    ip_address: "203.0.113.5",
+    user_agent_hash: "sha256:uahash",
+    browser_name: "Chrome",
+    browser_version_major: "120",
+    os_name: "Windows",
+    device_type: "desktop",
+    is_human: true,
+    bot_reason: null,
+    country_code: "ID",
+    region: null,
+    city: null,
+    timezone: null,
+    ...overrides
+  };
+}
+
+function eventRow(overrides: Partial<VisitEventRow> = {}): VisitEventRow {
+  return {
+    id: "22222222-2222-4222-8222-222222222222",
+    visitor_session_id: "11111111-1111-4111-8111-111111111111",
+    identity_id: null,
+    occurred_at: new Date("2026-01-01T00:00:00Z"),
+    method: "GET",
+    status_code: 200,
+    area: "public",
+    route_pattern: null,
+    path_sanitized: "/",
+    referrer_domain: "example.com",
+    duration_ms: null,
+    ip_hash: "sha256:iphash",
+    user_agent_hash: "sha256:uahash",
+    user_agent_parsed: { browserName: "Chrome" },
+    geo: { countryCode: "ID" },
+    human_status: "human",
+    correlation_id: "corr-1",
+    ...overrides
+  };
+}
+
+describe("raw-detail response gating (server-side, single gate)", () => {
+  test("a session WITHOUT raw_detail.read has all raw fields nulled", () => {
+    const dto = shapeVisitorSession(sessionRow(), false);
+    expect(dto.ipAddress).toBeNull();
+    expect(dto.ipHash).toBeNull();
+    expect(dto.userAgentHash).toBeNull();
+    expect(dto.loginIdentifierSnapshot).toBeNull();
+    // Non-raw aggregate fields are still present.
+    expect(dto.browserName).toBe("Chrome");
+    expect(dto.countryCode).toBe("ID");
+  });
+
+  test("a session WITH raw_detail.read receives the raw fields", () => {
+    const dto = shapeVisitorSession(sessionRow(), true);
+    expect(dto.ipAddress).toBe("203.0.113.5");
+    expect(dto.ipHash).toBe("sha256:iphash");
+    expect(dto.userAgentHash).toBe("sha256:uahash");
+    expect(dto.loginIdentifierSnapshot).toBe("user@example.com");
+  });
+
+  test("an event WITHOUT raw_detail.read nulls ipHash/userAgentHash but keeps aggregates", () => {
+    const dto = shapeVisitEvent(eventRow(), false);
+    expect(dto.ipHash).toBeNull();
+    expect(dto.userAgentHash).toBeNull();
+    expect(dto.humanStatus).toBe("human");
+    expect(dto.userAgentParsed).toEqual({ browserName: "Chrome" });
+  });
+
+  test("an event WITH raw_detail.read receives the hashes", () => {
+    const dto = shapeVisitEvent(eventRow(), true);
+    expect(dto.ipHash).toBe("sha256:iphash");
+    expect(dto.userAgentHash).toBe("sha256:uahash");
+  });
+});

--- a/tests/visitor-analytics-privacy.test.ts
+++ b/tests/visitor-analytics-privacy.test.ts
@@ -21,23 +21,49 @@ import {
   type VisitorSessionRow
 } from "../src/modules/visitor-analytics/domain/analytics-response-shaping";
 
-describe("visitor-key hashing (salted HMAC-SHA256)", () => {
-  test("is deterministic for the same value + salt", () => {
-    expect(hashVisitorKey("visitor-1", "salt")).toBe(
-      hashVisitorKey("visitor-1", "salt")
+const TENANT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+describe("visitor-key hashing (per-tenant salted HMAC-SHA256)", () => {
+  test("is deterministic for the same value + salt + tenant", () => {
+    expect(hashVisitorKey("visitor-1", "salt", TENANT_A)).toBe(
+      hashVisitorKey("visitor-1", "salt", TENANT_A)
     );
   });
 
   test("is salt-sensitive: a different salt yields a different hash", () => {
-    expect(hashIpAddress("203.0.113.5", "salt-a")).not.toBe(
-      hashIpAddress("203.0.113.5", "salt-b")
+    expect(hashIpAddress("203.0.113.5", "salt-a", TENANT_A)).not.toBe(
+      hashIpAddress("203.0.113.5", "salt-b", TENANT_A)
+    );
+  });
+
+  test("is tenant-sensitive: the same value + salt under a DIFFERENT tenant yields a DIFFERENT hash (cross-tenant unlinkability)", () => {
+    // The whole point of FIX 2: the same browser/IP/user-agent must NOT hash to
+    // the same value across tenants sharing one origin — otherwise the raw hash
+    // columns would let two tenants' data be correlated at the storage layer.
+    expect(hashIpAddress("203.0.113.5", "salt", TENANT_A)).not.toBe(
+      hashIpAddress("203.0.113.5", "salt", TENANT_B)
+    );
+    expect(hashVisitorKey("visitor-1", "salt", TENANT_A)).not.toBe(
+      hashVisitorKey("visitor-1", "salt", TENANT_B)
+    );
+    expect(hashUserAgent("Mozilla/5.0", "salt", TENANT_A)).not.toBe(
+      hashUserAgent("Mozilla/5.0", "salt", TENANT_B)
+    );
+  });
+
+  test("the tenant/value boundary is unambiguous (domain separator)", () => {
+    // Without the `\0` domain separator, tenant "ab" + value "c" would collide
+    // with tenant "a" + value "bc". They must not.
+    expect(hashIpAddress("c", "salt", "ab")).not.toBe(
+      hashIpAddress("bc", "salt", "a")
     );
   });
 
   test("is keyed HMAC, not the plain sha256 of the value", async () => {
     const value = "Mozilla/5.0";
     const salt = "deployment-salt";
-    const keyed = hashUserAgent(value, salt);
+    const keyed = hashUserAgent(value, salt, TENANT_A);
     // A plain unsalted SHA-256 of the value must NOT equal the keyed hash —
     // the salt is what defeats a precomputed rainbow table.
     const plain = `sha256:${new Bun.CryptoHasher("sha256").update(value).digest("hex")}`;
@@ -46,11 +72,15 @@ describe("visitor-key hashing (salted HMAC-SHA256)", () => {
   });
 
   test("all three hashers share the same HMAC construction", () => {
-    // Same salt + same input across the three helpers -> same digest (they are
-    // the same keyed function, only named per call site for readability).
+    // Same salt + same tenant + same input across the three helpers -> same
+    // digest (they are the same keyed function, only named per call site).
     const salt = "s";
-    expect(hashVisitorKey("x", salt)).toBe(hashIpAddress("x", salt));
-    expect(hashIpAddress("x", salt)).toBe(hashUserAgent("x", salt));
+    expect(hashVisitorKey("x", salt, TENANT_A)).toBe(
+      hashIpAddress("x", salt, TENANT_A)
+    );
+    expect(hashIpAddress("x", salt, TENANT_A)).toBe(
+      hashUserAgent("x", salt, TENANT_A)
+    );
   });
 });
 


### PR DESCRIPTION
Port modul **`visitor_analytics`** dari awcms-micro (epic #617–#624) sebagai modul standalone `type: "system"` — bagian **ADR-0035 Wave 1** (penyerapan awcms-micro). Menambah statistik pengunjung manusia **privacy-first** untuk rute admin & publik, online maupun offline/LAN. **Aditif** — `src/middleware.ts` tak disentuh (jaminan login/Turnstile/CSP tetap), tak ada modul lama yang diregresi.

## Yang di-ship

- **Skema** (migrasi **049** permission, **050** schema, **051** session-lookup index): `awcms_visitor_sessions` / `awcms_visit_events` / `awcms_visitor_daily_rollups` — semua `ENABLE`+`FORCE ROW LEVEL SECURITY` + policy `tenant_isolation`, index tenant_id-first, composite FK `(tenant_id, visitor_session_id)` lintas-tenant, GRANT `awcms_worker` least-privilege untuk job terjadwal.
- **Koleksi = endpoint ingest PUBLIK** `POST /api/v1/analytics/collect` (anonim; resolve tenant dari `tenantCode` via tabel `awcms_tenants` yang RLS-free — **tanpa** `SECURITY DEFINER**`), **bukan** middleware.
- **API terautentikasi ABAC:** `GET /api/v1/analytics/{summary,realtime,sessions,events,pages,devices,locations,security,settings}`, `PATCH .../settings`, `POST .../retention/purge` (Idempotency-Key + audit `critical`).
- **Job:** `bun run analytics:rollup` & `bun run analytics:purge` (worker role, offline-safe). **Dashboard** `/admin/analytics` (SSR).

## Privasi (by design)

Off by default (`VISITOR_ANALYTICS_ENABLED=false`). Visitor-key / IP / user-agent disimpan **hanya sebagai HMAC-SHA256 bersalt** (salt wajib saat aktif — ditegakkan `validate-env`); raw IP & login snapshot opt-in terpisah; query string sensitif di-strip fail-safe.

## Security hardening (hasil DoD + security review atas port ini)

- **Rate-limit backstop pada beacon publik.** `POST .../collect` (unauth DB write) digerbangi rate limit per-IP (`checkRateLimit` yang sama dengan login/setup) **sebelum** tulis DB — mencegah flooding baris / pencemaran agregat oleh pemegang `tenantCode` publik. Kunci berbasis IP saja (tak membocorkan eksistensi tenant). Tunable `VISITOR_ANALYTICS_COLLECT_RATE_LIMIT_MAX`/`_WINDOW_SEC` (default 120/60s).
- **Salt HMAC per-tenant.** `visitor_key_hash`/`ip_hash`/`user_agent_hash` di-key dengan salt deployment **DAN** `tenantId` (domain-separator `\0`) → browser/IP/UA sama menghasilkan hash **berbeda** lintas tenant satu origin (menutup korelasi lintas-tenant di lapisan penyimpanan). `VISITOR_ANALYTICS_HASH_SALT` wajib ≥ 16 karakter saat aktif.
- **`raw_detail` lewat ABAC, bukan hanya RBAC.** Field de-anonimisasi (`ipHash`/`ipAddress`/`userAgentHash`/`loginIdentifierSnapshot`) di `GET /sessions`, `GET /events`, `/admin/analytics` diputuskan lewat evaluator ABAC (`evaluateFieldAccessInTransaction`) → kebijakan DSL `deny` atas `raw_detail.read` dihormati (deny-overrides-allow).

## Adaptasi port terdokumentasi

Kopling `data_lifecycle`/`LegalHoldGuardPort` **di-drop** (modul belum ada di base — purge tanpa gerbang legal-hold); wiring preset `news_portal_full_online_r2` **deferred** (modul `news_portal` tak disentuh).

## Migrasi

Di-rebase bersih ke atas `main` pasca merge #219 (tenant-domain) → migrasi **049–051**, nyambung mulus dari 046–048 tanpa gap. `bun run check` hijau lokal (2042 tests, 0 fail, build complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
