### PR TITLE
docs(site-search): correct the CSP rationale on the /search page renderer

### DIFF
--- a/.changeset/site-search-csp-comment-precision.md
+++ b/.changeset/site-search-csp-comment-precision.md
@@ -1,0 +1,16 @@
+---
+"awcms": patch
+---
+
+docs(site-search): correct the CSP rationale on the `/search` page renderer
+
+PR #229 landed between the site_search port and this change: `script-src` is now
+always emitted, carrying `'self'` plus the SHA-256 of the admin theme-init
+script. The renderer's comment still described the policy as `default-src 'self'`
+and implied inline scripts are categorically impossible.
+
+The no-`'unsafe-inline'` guarantee is unchanged, and the page's behaviour is
+unchanged — but a reader would now find a sanctioned hashed-inline script in the
+tree and conclude the comment was simply out of date. It names that pattern
+explicitly and states the reason it does not apply here: this route is a plain
+APIRoute with no build step to compute or keep such a hash in sync.

--- a/src/modules/site-search/domain/search-page-rendering.ts
+++ b/src/modules/site-search/domain/search-page-rendering.ts
@@ -8,13 +8,16 @@
  * ## Two deliberate port-time adaptations (not oversights)
  *
  * 1. **No inline typeahead script.** awcms-micro's page shipped the suggestion
- *    combobox as an inline `<script>`. This base's CSP is `default-src 'self'`
- *    with NO `'unsafe-inline'` for scripts (`lib/security/security-headers.ts`),
- *    so an inline script would simply be blocked — and this route is a plain
- *    `.ts` APIRoute emitting an HTML string (the established convention for every
- *    public page here, e.g. `/blog/{tenantCode}`), so there is no Astro component
- *    to bundle an external script from. The page therefore renders the no-JS core
- *    search only: a native `<form>` + result links, fully keyboard accessible.
+ *    combobox as an inline `<script>`. This base's CSP never carries
+ *    `'unsafe-inline'` for scripts (`lib/security/security-headers.ts`), so an
+ *    arbitrary inline script is blocked outright. The admin shell's theme-init
+ *    script shows the one sanctioned way around that — naming a script's exact
+ *    SHA-256 in `script-src` — but that is not available here: this route is a
+ *    plain `.ts` APIRoute emitting an HTML string (the established convention for
+ *    every public page, e.g. `/blog/{tenantCode}`), so there is neither an Astro
+ *    component to bundle an external script from nor a build step to compute and
+ *    keep that hash in sync. The page therefore renders the no-JS core search
+ *    only: a native `<form>` + result links, fully keyboard accessible.
  *    `GET /api/v1/site-search/suggest` still ships and is what a theme's own
  *    bundled client (or a future `.astro` page) consumes — see README §Follow-up.
  * 2. **Labels are supplied by the caller** (`DEFAULT_SEARCH_PAGE_LABELS` here)


### PR DESCRIPTION
#229 landed between the `site_search` port (#231) and this change: `script-src` is now **always** emitted, carrying `'self'` plus the SHA-256 of the admin theme-init script. The `/search` renderer's comment still described the policy as `default-src 'self'` and implied an inline script is categorically impossible.

No behaviour change, and the no-`'unsafe-inline'` guarantee is fully intact. But a reader would now find a sanctioned hashed-inline script in the tree and reasonably conclude the comment was just stale. The comment now names that pattern and gives the reason it does not apply to this route: a plain APIRoute has no build step to compute such a hash or keep it in sync — that, not the policy alone, is the actual blocker.

Comment-only; the shipped HTML is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)