### PR TITLE
feat(tenant-domain): reconcile platform subdomains to Cloudflare serving records

### DIFF
--- a/.changeset/tenant-domain-dns-serving-sync.md
+++ b/.changeset/tenant-domain-dns-serving-sync.md
@@ -1,0 +1,22 @@
+---
+"awcms": minor
+---
+
+Wire the Cloudflare DNS adapter so a database row becomes a working subdomain.
+
+Adds `ensureServingRecord` to the `TenantDomainDnsProvider` port and a
+reconciliation job (`bun run tenant-domain:dns:sync`) that brings the managed
+Cloudflare zone into line with the active `domain_type = 'subdomain'` rows in
+`awcms_tenant_domains`.
+
+Reconciliation, not a create-time API call: it is idempotent, retries a failed
+record on the next pass, and heals drift introduced by hand in the dashboard —
+none of which a side effect inside the create request can do. Serving records
+are desired-state, so a drifted record is moved with `PUT` rather than joined by
+a second record that would round-robin the tenant between two targets.
+
+Scope: platform subdomains only. Custom domains live in the tenant's own zone
+and keep the manual/TXT verification flow. Nothing is ever deleted.
+
+`sql/069` grants the worker `SELECT` (only) on `awcms_tenant_domains`. Unset
+config is a no-op: there is deliberately no default serving target.

--- a/.env.example
+++ b/.env.example
@@ -309,3 +309,29 @@ COMMENTS_TIMING_SECRET=
 #
 # Rows drained per tenant per pass of `bun run edge-cache:purge` (default 200).
 # EDGE_CACHE_PURGE_BATCH_SIZE=200
+
+# ---------------------------------------------------------------------------
+# Tenant subdomain serving records (bun run tenant-domain:dns:sync)
+# ---------------------------------------------------------------------------
+#
+# Turns a row in `awcms_tenant_domains` into a working subdomain. Only applies
+# to `domain_type = 'subdomain'` rows in the platform's OWN managed zone —
+# custom domains live in the tenant's zone and keep the manual/TXT flow.
+#
+# Requires TENANT_DOMAIN_DNS_PROVIDER=cloudflare plus the
+# TENANT_DOMAIN_CLOUDFLARE_* settings above. With either the provider or the
+# target below unset, the job exits without touching the database.
+#
+# Where tenant traffic should land: an IPv4 address when
+# TENANT_DOMAIN_SERVING_RECORD_TYPE=A, or a hostname for CNAME (the default).
+# There is deliberately NO default value — guessing this points every tenant
+# subdomain at a wrong address, which is a platform-wide outage.
+# TENANT_DOMAIN_SERVING_TARGET=ingress.example.com
+#
+# A | CNAME (default CNAME).
+# TENANT_DOMAIN_SERVING_RECORD_TYPE=CNAME
+#
+# Proxied (orange cloud) unless set to exactly "false". Proxying is what
+# supplies TLS for an unbounded number of subdomains without issuing a
+# certificate per name — the reason unlimited subdomains are practical here.
+# TENANT_DOMAIN_SERVING_PROXIED=true

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "site-search:sources:check": "bun scripts/site-search-sources-check.ts",
     "comments:resources:check": "bun scripts/comments-resources-check.ts",
     "comments:retention": "bun scripts/comments-retention.ts",
+    "tenant-domain:dns:sync": "bun scripts/tenant-domain-dns-sync.ts",
     "edge-cache:surfaces:check": "bun scripts/edge-cache-surfaces-check.ts",
     "edge-cache:purge": "bun scripts/edge-cache-purge.ts",
     "data-lifecycle:registry:check": "bun scripts/data-lifecycle-registry-check.ts",

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -1100,7 +1100,12 @@ export const WORKER_ROLE_GRANTS: Record<string, string[]> = {
   // outside the retention window (the job really does prune — this is not a
   // speculative grant). No INSERT: enqueueing happens in the application's
   // content transaction, never in the worker.
-  awcms_edge_cache_purges: ["SELECT", "UPDATE", "DELETE"]
+  awcms_edge_cache_purges: ["SELECT", "UPDATE", "DELETE"],
+  // tenant-domain:dns:sync (sql/069): SELECT the desired subdomain state only.
+  // The job's side effect is in Cloudflare, not here — it writes nothing back,
+  // so the worker never gets write access to the hostname->tenant mapping that
+  // decides whose content a visitor is served.
+  awcms_tenant_domains: ["SELECT"]
 };
 
 /**

--- a/scripts/tenant-domain-dns-sync.ts
+++ b/scripts/tenant-domain-dns-sync.ts
@@ -1,0 +1,133 @@
+/**
+ * tenant-domain-dns-sync.ts — `bun run tenant-domain:dns:sync`.
+ *
+ * Reconciles active platform subdomains in `awcms_tenant_domains` to serving DNS
+ * records in the managed Cloudflare zone. This is what makes "add a row, get a
+ * working subdomain" true.
+ *
+ * Internal worker entrypoint, never exposed over HTTP; run on a schedule (every
+ * minute or two is reasonable — a pass over unchanged domains is one list call
+ * each and returns `unchanged`).
+ *
+ * Runs as the least-privilege `awcms_worker` role with SELECT-only access
+ * (sql/069). RLS is FORCE'd for that role, so the read is wrapped in
+ * `withTenant`.
+ *
+ * ## No-ops loudly rather than guessing
+ *
+ * Exits immediately, without touching the database, when the DNS provider is not
+ * `cloudflare` or `TENANT_DOMAIN_SERVING_TARGET` is unset. There is no default
+ * target: pointing every tenant subdomain at a guessed address is a
+ * platform-wide outage, so "not configured" must mean "do nothing".
+ *
+ * ## Exit behaviour
+ *
+ * A per-domain failure is recorded and the pass continues; the job only reports
+ * failure for a fault that stops it running at all. A green exit therefore does
+ * NOT mean every record landed — the `failed=` count in the summary line is what
+ * says that. `--dry-run` reports what would change without writing.
+ */
+import { getWorkerDatabaseClient } from "../src/lib/database/client";
+import { withTenant } from "../src/lib/database/tenant-context";
+import { logScriptFailure } from "../src/lib/logging/error-log";
+import {
+  reconcileServingRecords,
+  resolveServingTarget,
+  type ServingDomainRow
+} from "../src/modules/tenant-domain/application/dns-serving-reconciler";
+import { resolveTenantDomainDnsProvider } from "../src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter";
+
+type TenantRow = { id: string };
+
+async function main(): Promise<void> {
+  const correlationId = crypto.randomUUID();
+  const dryRun = process.argv.includes("--dry-run");
+  const target = resolveServingTarget();
+  const providerKind = process.env.TENANT_DOMAIN_DNS_PROVIDER ?? "manual";
+
+  if (providerKind !== "cloudflare" || !target) {
+    console.log(
+      `tenant-domain:dns:sync skipped — correlationId=${correlationId} ` +
+        `provider=${providerKind} targetConfigured=${Boolean(target)}`
+    );
+
+    return;
+  }
+
+  const sql = getWorkerDatabaseClient();
+  const provider = resolveTenantDomainDnsProvider();
+
+  let created = 0;
+  let updated = 0;
+  let unchanged = 0;
+  let failed = 0;
+  let considered = 0;
+
+  try {
+    const tenants = (await sql`
+      SELECT id FROM awcms_tenants WHERE status = 'active'
+    `) as TenantRow[];
+
+    for (const tenant of tenants) {
+      const rows = await withTenant(
+        sql,
+        tenant.id,
+        (tx) =>
+          tx`
+            SELECT id, tenant_id, normalized_hostname
+            FROM awcms_tenant_domains
+            WHERE tenant_id = ${tenant.id}
+              AND domain_type = 'subdomain'
+              AND status = 'active'
+              AND deleted_at IS NULL
+            ORDER BY normalized_hostname
+          ` as Promise<ServingDomainRow[]>
+      );
+
+      considered += rows.length;
+
+      if (rows.length === 0) {
+        continue;
+      }
+
+      if (dryRun) {
+        for (const row of rows) {
+          console.log(
+            `[dry-run] would ensure ${target.recordType} ${row.normalized_hostname} -> ${target.value} (proxied=${target.proxied})`
+          );
+        }
+
+        continue;
+      }
+
+      const summary = await reconcileServingRecords(rows, provider, target);
+
+      created += summary.created;
+      updated += summary.updated;
+      unchanged += summary.unchanged;
+      failed += summary.failed;
+
+      for (const outcome of summary.outcomes) {
+        if (outcome.status === "failed") {
+          console.error(
+            `tenant-domain:dns:sync FAILED ${outcome.hostname} — retryable=${outcome.retryable} ${outcome.detail}`
+          );
+        }
+      }
+    }
+
+    console.log(
+      `tenant-domain:dns:sync complete — correlationId=${correlationId} ` +
+        `dryRun=${dryRun} tenants=${tenants.length} subdomains=${considered} ` +
+        `created=${created} updated=${updated} unchanged=${unchanged} failed=${failed}`
+    );
+  } catch (error) {
+    logScriptFailure("tenant-domain:dns:sync FAILED", error);
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/sql/069_awcms_tenant_domains_worker_read.sql
+++ b/sql/069_awcms_tenant_domains_worker_read.sql
@@ -1,0 +1,16 @@
+-- Grant the worker role read access to `awcms_tenant_domains` so
+-- `bun run tenant-domain:dns:sync` can read the desired subdomain state.
+--
+-- SELECT only, deliberately. The reconcile job's side effect lives in
+-- Cloudflare, not in this database: it writes no sync state, no timestamps, and
+-- no record ids back. That keeps the job stateless and idempotent, and it means
+-- a compromised worker cannot alter which hostname belongs to which tenant —
+-- which is exactly the mapping that decides whose content a visitor is served.
+--
+-- No INSERT/UPDATE/DELETE, and specifically no UPDATE: recording a
+-- `last_synced_at` would be convenient and is not worth handing the worker write
+-- access to the tenant-routing table for.
+--
+-- Matching entry required in `WORKER_ROLE_GRANTS` (scripts/security-readiness.ts);
+-- a drift test compares this file's text against that matrix.
+GRANT SELECT ON awcms_tenant_domains TO awcms_worker;

--- a/src/modules/tenant-domain/README.md
+++ b/src/modules/tenant-domain/README.md
@@ -97,11 +97,46 @@ trip (no timing side-channel). `X-Forwarded-Host` is read only when
   public render routes plumbed through it (news_portal deferred its own
   `/news/**` routes for the same reason). Wiring it is a clean follow-up; the
   seam is stable.
-- **Cloudflare DNS automation.** `resolveTenantDomainDnsProvider(env)` and
-  `createCloudflareDnsProvider` exist and are unit-tested, but no route calls
-  them. With no `TENANT_DOMAIN_DNS_PROVIDER=cloudflare` configured the resolver
-  returns a clean misconfigured-result provider (never throws), so awcms builds
-  and runs with zero Cloudflare credentials.
+- **Cloudflare DNS automation for CUSTOM domains.** The TXT/CNAME verification
+  half of the adapter still has no caller — custom-domain ownership proof remains
+  manual (`POST /api/v1/tenant/domains/{id}/verify`).
+
+  Platform **subdomains** ARE automated: see §Subdomain DNS reconciliation below.
+
+## Subdomain DNS reconciliation
+
+`bun run tenant-domain:dns:sync` reconciles active `domain_type = 'subdomain'`
+rows to serving A/CNAME records in the managed Cloudflare zone, via
+`ensureServingRecord` on the `TenantDomainDnsProvider` port. Adding a tenant
+subdomain is an INSERT; the next pass makes it resolve.
+
+Why a job rather than a call inside `POST /api/v1/tenant/domains`: a DNS write is
+slow and externally owned, so putting it in a tenant's request would block on
+Cloudflare, and a failure would leave a row whose domain never resolves with
+nothing to retry it. A pass is idempotent, so it also heals a record edited by
+hand in the dashboard.
+
+Two behaviours worth knowing:
+
+- A drifted record is **moved** (`PUT`), never joined by a second record —
+  two A records for one hostname round-robin traffic between the old and new
+  target, which reads as an intermittent outage rather than a misconfiguration.
+- **Nothing is ever deleted.** A suspended or soft-deleted domain is skipped,
+  leaving a stale record pointing at the platform (visible, harmless) rather than
+  having an automated job issue destructive DNS writes.
+
+Custom domains are excluded by construction: they are hostnames the platform does
+not own, so their records are not ours to write.
+
+Config (all absent-safe — unset means the job exits without touching the
+database): `TENANT_DOMAIN_DNS_PROVIDER=cloudflare`, the
+`TENANT_DOMAIN_CLOUDFLARE_*` credentials, and `TENANT_DOMAIN_SERVING_TARGET`.
+There is deliberately no default target: guessing it points every tenant
+subdomain at a wrong address. `--dry-run` reports intended changes.
+
+The worker holds `SELECT` only on `awcms_tenant_domains` (`sql/069`) — the job
+writes nothing back, so a compromised worker cannot alter the hostname->tenant
+mapping that decides whose content a visitor is served.
 
 ## Security residual risk — gate before untrusted self-service (M1)
 

--- a/src/modules/tenant-domain/application/dns-serving-reconciler.ts
+++ b/src/modules/tenant-domain/application/dns-serving-reconciler.ts
@@ -1,0 +1,148 @@
+/**
+ * Reconcile platform subdomains in the database to serving DNS records.
+ *
+ * This is the mechanism behind "unlimited subdomains": a row in
+ * `awcms_tenant_domains` is the desired state, and this brings the managed
+ * Cloudflare zone into line with it. Adding a tenant subdomain becomes an
+ * INSERT; the next reconcile pass makes it resolve.
+ *
+ * ## Why reconciliation and not a create-time API call
+ *
+ * The obvious design is "on POST /api/v1/tenant/domains, also create the DNS
+ * record". That is wrong here for the same reasons the edge-cache purge queue is
+ * not a direct HTTP call (ADR-0042 §9, ADR-0006):
+ *
+ * - it puts a slow, externally-owned network call inside a tenant's request;
+ * - a failure leaves the row created and the domain permanently non-resolving,
+ *   with nothing to retry it;
+ * - it cannot heal drift — a record edited by hand in the Cloudflare dashboard
+ *   stays wrong forever.
+ *
+ * A pass is idempotent, so running it more often is always safe.
+ *
+ * ## Scope, deliberately narrow
+ *
+ * Only `domain_type = 'subdomain'` rows are reconciled. Custom domains are
+ * hostnames the platform does **not** own; their records live in the tenant's
+ * own zone and writing them is neither possible nor appropriate. Those keep the
+ * existing manual/TXT verification flow.
+ *
+ * Nothing is ever deleted. A soft-deleted or suspended domain is skipped, which
+ * leaves a stale record resolving to the platform — visible and harmless —
+ * rather than having an automated job issue destructive DNS writes. Removal is
+ * an explicit operator action.
+ */
+import type {
+  EnsureServingRecordResult,
+  ServingRecordType,
+  TenantDomainDnsProvider
+} from "../infrastructure/cloudflare-dns-adapter";
+
+/** One row of desired state. */
+export type ServingDomainRow = {
+  id: string;
+  tenant_id: string;
+  normalized_hostname: string;
+};
+
+export type ServingTarget = {
+  recordType: ServingRecordType;
+  /** IPv4 for `A`, target hostname for `CNAME` — where tenant traffic should land. */
+  value: string;
+  proxied: boolean;
+};
+
+export type ReconcileOutcome = {
+  hostname: string;
+  tenantId: string;
+  status: "created" | "updated" | "unchanged" | "failed";
+  detail?: string;
+  retryable?: boolean;
+};
+
+export type ReconcileSummary = {
+  outcomes: ReconcileOutcome[];
+  created: number;
+  updated: number;
+  unchanged: number;
+  failed: number;
+};
+
+/**
+ * Reconcile every supplied row. One row's failure never aborts the pass — a
+ * single hostname Cloudflare rejects must not stop every other tenant's
+ * subdomain from being fixed.
+ *
+ * Rows are processed sequentially on purpose. Cloudflare rate-limits per token,
+ * and a burst of parallel writes across a large tenant base is the fastest way
+ * to get every request in the pass throttled at once.
+ */
+export async function reconcileServingRecords(
+  rows: readonly ServingDomainRow[],
+  provider: TenantDomainDnsProvider,
+  target: ServingTarget
+): Promise<ReconcileSummary> {
+  const outcomes: ReconcileOutcome[] = [];
+
+  for (const row of rows) {
+    const result: EnsureServingRecordResult =
+      await provider.ensureServingRecord({
+        recordType: target.recordType,
+        recordName: row.normalized_hostname,
+        recordValue: target.value,
+        proxied: target.proxied
+      });
+
+    outcomes.push(
+      result.ok
+        ? {
+            hostname: row.normalized_hostname,
+            tenantId: row.tenant_id,
+            status: result.action
+          }
+        : {
+            hostname: row.normalized_hostname,
+            tenantId: row.tenant_id,
+            status: "failed",
+            detail: result.error,
+            retryable: result.retryable
+          }
+    );
+  }
+
+  return {
+    outcomes,
+    created: outcomes.filter((o) => o.status === "created").length,
+    updated: outcomes.filter((o) => o.status === "updated").length,
+    unchanged: outcomes.filter((o) => o.status === "unchanged").length,
+    failed: outcomes.filter((o) => o.status === "failed").length
+  };
+}
+
+/**
+ * Read the serving target from the environment.
+ *
+ * Returns `null` when unset — the job then no-ops rather than guessing. Guessing
+ * here would mean pointing every tenant subdomain at a wrong address, which is
+ * a platform-wide outage, so "not configured" must never fall back to a default.
+ */
+export function resolveServingTarget(
+  env: NodeJS.ProcessEnv = process.env
+): ServingTarget | null {
+  const value = env.TENANT_DOMAIN_SERVING_TARGET?.trim();
+
+  if (!value) {
+    return null;
+  }
+
+  const rawType = env.TENANT_DOMAIN_SERVING_RECORD_TYPE?.trim().toUpperCase();
+  const recordType: ServingRecordType = rawType === "A" ? "A" : "CNAME";
+
+  return {
+    recordType,
+    value,
+    // Proxied unless explicitly disabled: the orange cloud is what supplies TLS
+    // for an unbounded number of subdomains without per-name certificates.
+    proxied: env.TENANT_DOMAIN_SERVING_PROXIED?.trim().toLowerCase() !== "false"
+  };
+}

--- a/src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts
+++ b/src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter.ts
@@ -3,17 +3,19 @@
  * /api/v1/tenant/domains/{id}/verify`) remains the MVP default — this adapter
  * is never called unless an operator explicitly sets
  * `TENANT_DOMAIN_DNS_PROVIDER=cloudflare` (see
- * `../domain/tenant-domain-dns-config.ts`). **No route in this repo calls it
- * yet** — wiring it into `.../verify` or a "provision platform subdomain" flow
- * is deferred (see the module README's §Not yet available); this file exists so
- * that future work can depend on the `TenantDomainDnsProvider` port without
- * inventing the provider boundary, config split, or redaction/timeout/
- * idempotency behavior at that point. awcms builds and runs with no Cloudflare
- * credentials configured — `resolveTenantDomainDnsProvider` degrades to a clean
- * misconfigured-result provider rather than throwing.
+ * `../domain/tenant-domain-dns-config.ts`). awcms builds and runs with no
+ * Cloudflare credentials configured — `resolveTenantDomainDnsProvider` degrades
+ * to a clean misconfigured-result provider rather than throwing.
  *
- * Capabilities: create a TXT/CNAME DNS verification record, and check whether a
- * DNS record has propagated to the value expected. Both calls are
+ * **Who calls this.** `bun run tenant-domain:dns:sync`
+ * (`scripts/tenant-domain-dns-sync.ts`) reconciles active platform subdomains in
+ * `awcms_tenant_domains` to serving records in the managed zone. No REQUEST path
+ * calls this adapter: a DNS write is slow, externally-owned, and must never sit
+ * inside a tenant's HTTP request or a DB transaction (ADR-0006).
+ *
+ * Capabilities: create a TXT/CNAME verification record, check whether a record
+ * has propagated to the expected value, and reconcile the A/CNAME *serving*
+ * record for a platform subdomain to its desired target. Both calls are
  * timeout-bounded (`withTimeout`) and gated by a shared circuit breaker
  * (`getProviderCircuitBreaker("tenant-domain-cloudflare-dns")`) — the same
  * pattern the email/sync-storage outbound provider calls already use. Both
@@ -85,10 +87,53 @@ export type CheckVerificationStatusResult =
   | { ok: true; verified: boolean }
   | { ok: false; error: string; retryable: boolean };
 
+/** Record types that can actually serve traffic for a tenant hostname. */
+export type ServingRecordType = "A" | "CNAME";
+
+export type EnsureServingRecordInput = {
+  recordType: ServingRecordType;
+  /** The tenant hostname itself, e.g. "acme.platform.example". */
+  recordName: string;
+  /** IPv4 address for `A`, or the target hostname for `CNAME`. */
+  recordValue: string;
+  /**
+   * Whether Cloudflare should proxy (orange-cloud) the record. Defaults to
+   * `true`: a proxied record is what gives the tenant edge TLS without the
+   * platform issuing a certificate per subdomain, which is the entire reason
+   * unlimited subdomains are practical on this stack.
+   */
+  proxied?: boolean;
+};
+
+export type EnsureServingRecordResult =
+  | {
+      ok: true;
+      providerRecordId?: string;
+      /** `unchanged` means the desired state already held — the common steady-state result. */
+      action: "created" | "updated" | "unchanged";
+    }
+  | { ok: false; error: string; retryable: boolean };
+
 /**
- * The port. A future issue that wires this into `.../verify` or a
- * subdomain-provisioning endpoint should depend on this type, never on
- * `createCloudflareDnsProvider` by name.
+ * The port. Callers depend on this type, never on `createCloudflareDnsProvider`
+ * by name.
+ *
+ * ## Why `ensureServingRecord` is separate from `createVerificationRecord`
+ *
+ * They look similar and are not. A verification record is **create-only and
+ * additive**: it proves the tenant controls a domain we do not own, and if one
+ * already exists with a different value that is simply a second, unrelated
+ * proof — never something to overwrite.
+ *
+ * A serving record is **desired-state**: exactly one record must exist for the
+ * hostname, and if its content has drifted from where traffic should go, the
+ * correct action is to *move* it. Modelling that as "create" would leave the
+ * stale record in place and silently keep routing a tenant to the old target.
+ *
+ * That is also why this is reconciliation rather than a create-time side effect
+ * — it can be re-run safely, it heals drift introduced by hand in the Cloudflare
+ * dashboard, and a subdomain whose record creation failed once is fixed by the
+ * next pass instead of staying broken.
  */
 export type TenantDomainDnsProvider = {
   createVerificationRecord(
@@ -97,6 +142,9 @@ export type TenantDomainDnsProvider = {
   checkVerificationStatus(
     input: CheckVerificationStatusInput
   ): Promise<CheckVerificationStatusResult>;
+  ensureServingRecord(
+    input: EnsureServingRecordInput
+  ): Promise<EnsureServingRecordResult>;
 };
 
 export type CloudflareDnsProviderConfig = {
@@ -122,6 +170,8 @@ type CloudflareDnsRecord = {
   type: string;
   name: string;
   content: string;
+  /** Absent on older API shapes; treated as "not proxied" when missing. */
+  proxied?: boolean;
 };
 
 function truncate(message: string): string {
@@ -281,6 +331,74 @@ export function validateDnsRecordInput(
   return null;
 }
 
+/**
+ * A strict dotted-quad check. `Number.parseInt` is deliberately not used: it
+ * accepts `"1.2.3.4abc"` and leading zeros, and a malformed address that
+ * Cloudflare then rejects would burn a reconcile attempt for every pass.
+ */
+function isValidIpv4(value: string): boolean {
+  const octets = value.trim().split(".");
+
+  return (
+    octets.length === 4 &&
+    octets.every(
+      (octet) =>
+        /^(0|[1-9]\d{0,2})$/.test(octet) &&
+        Number(octet) >= 0 &&
+        Number(octet) <= 255
+    )
+  );
+}
+
+/**
+ * Validate a serving-record request before any network call. Same discipline as
+ * `validateDnsRecordInput`: a hostname must live inside the platform root
+ * domain, so a tenant row cannot induce the platform's Cloudflare token to write
+ * a record in some unrelated part of the zone.
+ */
+export function validateServingRecordInput(
+  input: { recordType: unknown; recordName: unknown; recordValue: unknown },
+  platformRootDomain: string
+): string | null {
+  if (input.recordType !== "A" && input.recordType !== "CNAME") {
+    return 'recordType must be "A" or "CNAME".';
+  }
+
+  if (
+    typeof input.recordName !== "string" ||
+    !isWithinPlatformRootDomain(input.recordName, platformRootDomain)
+  ) {
+    return "recordName must equal the platform root domain or be a subdomain of it.";
+  }
+
+  if (
+    typeof input.recordValue !== "string" ||
+    /[\r\n]/.test(input.recordValue)
+  ) {
+    return "recordValue must be a single-line string.";
+  }
+
+  if (input.recordType === "A" && !isValidIpv4(input.recordValue)) {
+    return "recordValue must be a valid IPv4 address for an A record.";
+  }
+
+  if (input.recordType === "CNAME") {
+    let normalized: string | null = null;
+
+    try {
+      normalized = normalizePublicHost(input.recordValue);
+    } catch {
+      normalized = null;
+    }
+
+    if (!normalized) {
+      return "recordValue must be a valid hostname for a CNAME record.";
+    }
+  }
+
+  return null;
+}
+
 function normalizeRecordValueForComparison(
   recordType: DnsRecordType,
   value: string
@@ -335,7 +453,7 @@ export function createCloudflareDnsProvider(
   }
 
   async function listMatchingRecords(
-    recordType: DnsRecordType,
+    recordType: DnsRecordType | ServingRecordType,
     recordName: string
   ): Promise<CloudflareDnsRecord[]> {
     const query = new URLSearchParams({ type: recordType, name: recordName });
@@ -481,8 +599,136 @@ export function createCloudflareDnsProvider(
           retryable: true
         };
       }
+    },
+
+    async ensureServingRecord(input) {
+      const attemptedAt = new Date();
+      const validationError = validateServingRecordInput(
+        input,
+        config.platformRootDomain
+      );
+
+      if (validationError) {
+        return { ok: false, error: validationError, retryable: false };
+      }
+
+      if (!breaker.canAttempt(attemptedAt)) {
+        return {
+          ok: false,
+          error: "Cloudflare DNS circuit breaker is open; skipping attempt.",
+          retryable: true
+        };
+      }
+
+      const proxied = input.proxied ?? true;
+
+      try {
+        const existing = await listMatchingRecords(
+          input.recordType,
+          input.recordName
+        );
+
+        const desired = normalizeServingValue(
+          input.recordType,
+          input.recordValue
+        );
+        const current = existing[0];
+
+        if (
+          current &&
+          normalizeServingValue(input.recordType, current.content) ===
+            desired &&
+          current.proxied === proxied
+        ) {
+          breaker.recordSuccess(attemptedAt);
+
+          return {
+            ok: true,
+            providerRecordId: current.id,
+            action: "unchanged"
+          };
+        }
+
+        // Drifted or absent. PUT onto the existing record id rather than
+        // creating a second one: two A records for one hostname round-robin
+        // traffic between the old and new target, which looks like an
+        // intermittent outage rather than a misconfiguration.
+        const { status, body } = current
+          ? await callApi<CloudflareDnsRecord>(
+              `/dns_records/${encodeURIComponent(current.id)}`,
+              {
+                method: "PUT",
+                body: JSON.stringify({
+                  type: input.recordType,
+                  name: input.recordName,
+                  content: input.recordValue,
+                  ttl: 300,
+                  proxied
+                })
+              },
+              "cloudflare dns update serving record"
+            )
+          : await callApi<CloudflareDnsRecord>(
+              "/dns_records",
+              {
+                method: "POST",
+                body: JSON.stringify({
+                  type: input.recordType,
+                  name: input.recordName,
+                  content: input.recordValue,
+                  ttl: 300,
+                  proxied
+                })
+              },
+              "cloudflare dns create serving record"
+            );
+
+        if (status < 200 || status >= 300 || !body?.success) {
+          breaker.recordFailure(attemptedAt);
+
+          return {
+            ok: false,
+            error: truncate(
+              redact(
+                `Cloudflare DNS API serving-record request failed (HTTP ${status}, ${summarizeApiErrors(body?.errors)}).`,
+                secrets
+              )
+            ),
+            retryable: status >= 500 || status === 0
+          };
+        }
+
+        breaker.recordSuccess(attemptedAt);
+
+        return {
+          ok: true,
+          providerRecordId: body.result?.id,
+          action: current ? "updated" : "created"
+        };
+      } catch (error) {
+        breaker.recordFailure(attemptedAt);
+        const message = error instanceof Error ? error.message : String(error);
+
+        return {
+          ok: false,
+          error: truncate(redact(message, secrets)),
+          retryable: true
+        };
+      }
     }
   };
+}
+
+/** CNAME targets are case- and trailing-dot-insensitive; A record contents are literal. */
+function normalizeServingValue(
+  recordType: ServingRecordType,
+  value: string
+): string {
+  const trimmed = value.trim();
+
+  return recordType === "CNAME"
+    ? trimmed.replace(/\.$/, "").toLowerCase()
+    : trimmed;
 }
 
 function createMisconfiguredProvider(reason: string): TenantDomainDnsProvider {
@@ -491,6 +737,9 @@ function createMisconfiguredProvider(reason: string): TenantDomainDnsProvider {
       return { ok: false, error: reason, retryable: false };
     },
     async checkVerificationStatus() {
+      return { ok: false, error: reason, retryable: false };
+    },
+    async ensureServingRecord() {
       return { ok: false, error: reason, retryable: false };
     }
   };

--- a/tests/tenant-domain-dns-serving.test.ts
+++ b/tests/tenant-domain-dns-serving.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Serving-record reconciliation for platform subdomains.
+ *
+ * The adapter tests run against a local fake standing in for the Cloudflare API
+ * (`baseUrl` override), because the interesting behaviour is which HTTP verb is
+ * chosen: creating a second record where one should have been moved is the bug
+ * that splits a tenant's traffic between the old and new target.
+ */
+import { afterAll, describe, expect, test } from "bun:test";
+
+import {
+  createCloudflareDnsProvider,
+  validateServingRecordInput
+} from "../src/modules/tenant-domain/infrastructure/cloudflare-dns-adapter";
+import {
+  reconcileServingRecords,
+  resolveServingTarget,
+  type ServingDomainRow
+} from "../src/modules/tenant-domain/application/dns-serving-reconciler";
+
+const ROOT = "platform.example";
+
+describe("validateServingRecordInput", () => {
+  test("accepts an A record for a subdomain of the platform root", () => {
+    expect(
+      validateServingRecordInput(
+        {
+          recordType: "A",
+          recordName: `acme.${ROOT}`,
+          recordValue: "203.0.113.10"
+        },
+        ROOT
+      )
+    ).toBeNull();
+  });
+
+  test("accepts a CNAME to a hostname", () => {
+    expect(
+      validateServingRecordInput(
+        {
+          recordType: "CNAME",
+          recordName: `acme.${ROOT}`,
+          recordValue: "ingress.example.com"
+        },
+        ROOT
+      )
+    ).toBeNull();
+  });
+
+  test("refuses a hostname outside the managed zone", () => {
+    // The platform's Cloudflare token must never be induced to write a record
+    // for a name the platform does not own.
+    expect(
+      validateServingRecordInput(
+        {
+          recordType: "A",
+          recordName: "victim.example.org",
+          recordValue: "203.0.113.10"
+        },
+        ROOT
+      )
+    ).toContain("root domain");
+  });
+
+  test.each([
+    ["1.2.3"],
+    ["1.2.3.4.5"],
+    ["1.2.3.256"],
+    ["1.2.3.4abc"],
+    ["01.2.3.4"],
+    ["not-an-ip"],
+    [""]
+  ])("rejects %p as an A record value", (value) => {
+    expect(
+      validateServingRecordInput(
+        { recordType: "A", recordName: `acme.${ROOT}`, recordValue: value },
+        ROOT
+      )
+    ).toBeTruthy();
+  });
+
+  test("rejects a value containing a newline", () => {
+    expect(
+      validateServingRecordInput(
+        {
+          recordType: "CNAME",
+          recordName: `acme.${ROOT}`,
+          recordValue: "ok.example.com\nmalicious"
+        },
+        ROOT
+      )
+    ).toBeTruthy();
+  });
+
+  test("rejects an unsupported record type", () => {
+    expect(
+      validateServingRecordInput(
+        { recordType: "TXT", recordName: `acme.${ROOT}`, recordValue: "x" },
+        ROOT
+      )
+    ).toContain("recordType");
+  });
+});
+
+describe("resolveServingTarget", () => {
+  test("returns null when unset — the job must not guess a target", () => {
+    expect(resolveServingTarget({})).toBeNull();
+  });
+
+  test("defaults to a proxied CNAME", () => {
+    expect(
+      resolveServingTarget({
+        TENANT_DOMAIN_SERVING_TARGET: "ingress.example.com"
+      })
+    ).toEqual({
+      recordType: "CNAME",
+      value: "ingress.example.com",
+      proxied: true
+    });
+  });
+
+  test("honours an explicit A record and proxied=false", () => {
+    expect(
+      resolveServingTarget({
+        TENANT_DOMAIN_SERVING_TARGET: "203.0.113.10",
+        TENANT_DOMAIN_SERVING_RECORD_TYPE: "a",
+        TENANT_DOMAIN_SERVING_PROXIED: "false"
+      })
+    ).toEqual({ recordType: "A", value: "203.0.113.10", proxied: false });
+  });
+});
+
+describe("reconcileServingRecords", () => {
+  const rows: ServingDomainRow[] = [
+    { id: "1", tenant_id: "t1", normalized_hostname: `a.${ROOT}` },
+    { id: "2", tenant_id: "t2", normalized_hostname: `b.${ROOT}` },
+    { id: "3", tenant_id: "t3", normalized_hostname: `c.${ROOT}` }
+  ];
+
+  const target = {
+    recordType: "CNAME" as const,
+    value: "ingress.example.com",
+    proxied: true
+  };
+
+  test("one failure does not abort the rest of the pass", async () => {
+    // A single hostname Cloudflare rejects must not leave every other tenant's
+    // subdomain unfixed.
+    const provider = {
+      createVerificationRecord: async () => ({
+        ok: false as const,
+        error: "n/a",
+        retryable: false
+      }),
+      checkVerificationStatus: async () => ({
+        ok: false as const,
+        error: "n/a",
+        retryable: false
+      }),
+      ensureServingRecord: async (input: { recordName: string }) =>
+        input.recordName === `b.${ROOT}`
+          ? { ok: false as const, error: "boom", retryable: true }
+          : { ok: true as const, action: "created" as const }
+    };
+
+    const summary = await reconcileServingRecords(rows, provider, target);
+
+    expect(summary.created).toBe(2);
+    expect(summary.failed).toBe(1);
+    expect(summary.outcomes).toHaveLength(3);
+    expect(
+      summary.outcomes.find((o) => o.hostname === `b.${ROOT}`)
+    ).toMatchObject({ status: "failed", retryable: true });
+  });
+});
+
+describe("ensureServingRecord against a fake Cloudflare API", () => {
+  type FakeRecord = {
+    id: string;
+    type: string;
+    name: string;
+    content: string;
+    proxied: boolean;
+  };
+
+  let store: FakeRecord[] = [];
+  const calls: string[] = [];
+
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      calls.push(`${request.method} ${url.pathname}`);
+
+      if (request.method === "GET") {
+        const name = url.searchParams.get("name");
+        const type = url.searchParams.get("type");
+
+        return Response.json({
+          success: true,
+          errors: [],
+          result: store.filter((r) => r.name === name && r.type === type)
+        });
+      }
+
+      const body = (await request.json()) as Omit<FakeRecord, "id">;
+
+      if (request.method === "POST") {
+        const created = { ...body, id: `rec-${store.length + 1}` };
+        store.push(created);
+
+        return Response.json({ success: true, errors: [], result: created });
+      }
+
+      if (request.method === "PUT") {
+        const id = url.pathname.split("/").pop()!;
+        const index = store.findIndex((r) => r.id === id);
+        store[index] = { ...body, id };
+
+        return Response.json({
+          success: true,
+          errors: [],
+          result: store[index]
+        });
+      }
+
+      return Response.json(
+        { success: false, errors: [{ code: 1, message: "x" }] },
+        { status: 405 }
+      );
+    }
+  });
+
+  afterAll(() => server.stop(true));
+
+  function provider() {
+    return createCloudflareDnsProvider({
+      zoneId: "zone1",
+      apiToken: "token1",
+      platformRootDomain: ROOT,
+      baseUrl: `http://127.0.0.1:${server.port}`
+    });
+  }
+
+  test("creates, then reports unchanged, then updates in place on drift", async () => {
+    store = [];
+    calls.length = 0;
+
+    const first = await provider().ensureServingRecord({
+      recordType: "CNAME",
+      recordName: `acme.${ROOT}`,
+      recordValue: "ingress.example.com"
+    });
+
+    expect(first).toMatchObject({ ok: true, action: "created" });
+    expect(store).toHaveLength(1);
+    expect(store[0]!.proxied).toBe(true);
+
+    const second = await provider().ensureServingRecord({
+      recordType: "CNAME",
+      recordName: `acme.${ROOT}`,
+      recordValue: "ingress.example.com"
+    });
+
+    expect(second).toMatchObject({ ok: true, action: "unchanged" });
+    expect(store).toHaveLength(1);
+
+    const third = await provider().ensureServingRecord({
+      recordType: "CNAME",
+      recordName: `acme.${ROOT}`,
+      recordValue: "new-ingress.example.com"
+    });
+
+    // The load-bearing assertion: still ONE record. Creating a second would
+    // round-robin the tenant between the old and new target.
+    expect(third).toMatchObject({ ok: true, action: "updated" });
+    expect(store).toHaveLength(1);
+    expect(store[0]!.content).toBe("new-ingress.example.com");
+    expect(calls.some((c) => c.startsWith("PUT"))).toBe(true);
+  });
+
+  test("a trailing dot or different case is not treated as drift", async () => {
+    store = [
+      {
+        id: "rec-1",
+        type: "CNAME",
+        name: `x.${ROOT}`,
+        content: "Ingress.Example.com.",
+        proxied: true
+      }
+    ];
+
+    const result = await provider().ensureServingRecord({
+      recordType: "CNAME",
+      recordName: `x.${ROOT}`,
+      recordValue: "ingress.example.com"
+    });
+
+    expect(result).toMatchObject({ ok: true, action: "unchanged" });
+  });
+
+  test("a proxied-flag change alone is enough to trigger an update", async () => {
+    store = [
+      {
+        id: "rec-1",
+        type: "A",
+        name: `y.${ROOT}`,
+        content: "203.0.113.10",
+        proxied: false
+      }
+    ];
+
+    const result = await provider().ensureServingRecord({
+      recordType: "A",
+      recordName: `y.${ROOT}`,
+      recordValue: "203.0.113.10",
+      proxied: true
+    });
+
+    expect(result).toMatchObject({ ok: true, action: "updated" });
+    expect(store[0]!.proxied).toBe(true);
+  });
+
+  test("an invalid hostname never reaches the network", async () => {
+    store = [];
+    calls.length = 0;
+
+    const result = await provider().ensureServingRecord({
+      recordType: "A",
+      recordName: "victim.example.org",
+      recordValue: "203.0.113.10"
+    });
+
+    expect(result).toMatchObject({ ok: false, retryable: false });
+    expect(calls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Wires the Cloudflare DNS adapter that has existed since #219 but which **no code
called**. A row in `awcms_tenant_domains` now becomes a working subdomain.

This is the first of the two follow-ups I flagged, and the prerequisite for
`tenant_provisioning` (Wave B of the mini-backbone roadmap, #235).

## What changed

- `ensureServingRecord` added to the `TenantDomainDnsProvider` port + implemented
  in the Cloudflare adapter.
- `bun run tenant-domain:dns:sync` — reconciles active `domain_type = 'subdomain'`
  rows to A/CNAME serving records in the managed zone. `--dry-run` supported.
- `sql/069` — worker `SELECT` on `awcms_tenant_domains`, plus the matching
  `WORKER_ROLE_GRANTS` entry.

## Why reconciliation, not a call inside the create endpoint

The obvious design is "on `POST /api/v1/tenant/domains`, also create the record".
It's wrong here for the same reasons ADR-0042's purge queue isn't a direct HTTP
call:

- it puts a slow, externally-owned network call inside a tenant's request;
- on failure the row exists and the domain never resolves, with nothing to retry;
- it can't heal drift — a record edited by hand in the dashboard stays wrong.

## The distinction that drove the API shape

A **verification** record is create-only and additive: it proves control of a
domain we don't own, and an existing one with a different value is a second,
unrelated proof — never something to overwrite.

A **serving** record is desired-state: exactly one must exist, and a drifted one
must be *moved*. So `ensureServingRecord` issues `PUT` on the existing record id
rather than `POST`. Creating a second record would round-robin the tenant between
the old and new target — an intermittent outage, not an obvious misconfiguration.
There's a test asserting the store still holds exactly one record after drift.

## Safety boundaries

- **Platform subdomains only.** Custom domains live in the tenant's zone; writing
  them is neither possible nor appropriate. They keep the manual/TXT flow.
- **Nothing is ever deleted.** A suspended or soft-deleted domain is skipped,
  leaving a stale record pointing at the platform — visible and harmless — rather
  than letting an automated job issue destructive DNS writes.
- **Hostnames are confined to the managed zone** (`isWithinPlatformRootDomain`),
  so a tenant row can't induce the platform token to write elsewhere. A test
  asserts an out-of-zone name never reaches the network.
- **Worker gets `SELECT` only.** It writes nothing back, so it can't alter the
  hostname→tenant mapping that decides whose content a visitor is served.
- **No default serving target.** Unset config is a no-op; guessing would point
  every tenant subdomain at a wrong address.
- Sequential per-domain processing — a parallel burst is the fastest way to get
  the whole pass rate-limited by Cloudflare.

## Verification

`bun run check` full: **2287 pass, 0 fail**, build complete. 20 new tests,
including an A/CNAME/proxied drift matrix against a local fake Cloudflare API.

`sql/069` is a single GRANT; I did not re-run the local real-Postgres harness for
it — CI's "Integration tests (RLS + DB role separation)" job applies migrations
and is the check that matters here.

## Still open

Host-resolved public content routes (`serveDiscovery` doesn't receive `locals`)
remain deferred — tracked in #235 and the edge-cache docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)