### PR TITLE
feat(edge-cache): emit invalidation from blog content changes

### DIFF
--- a/.changeset/edge-cache-content-purge.md
+++ b/.changeset/edge-cache-content-purge.md
@@ -1,0 +1,18 @@
+---
+"awcms": minor
+---
+
+Emit edge-cache invalidation from blog content changes (ADR-0042).
+
+`enqueueEdgeCachePurge` previously had no callers, so a published edit stayed
+visible at the edge until its TTL expired. The four blog write paths — create,
+update, soft-delete, and scheduled publish — now enqueue a purge inside the same
+transaction as the content change, so a rolled-back write leaves no stray purge
+and a committed one cannot lose its invalidation.
+
+Purges are module-scoped, not resource-scoped: cached responses carry
+tenant/surface/module surrogate keys only, so a resource-scoped ban would match
+no object and leave the page stale while reporting success.
+
+No-op when `EDGE_CACHE_MODE` is off, so deployments that have not adopted the
+edge cache do not accumulate queue rows.

--- a/docs/awcms/edge-cache-architecture.md
+++ b/docs/awcms/edge-cache-architecture.md
@@ -95,9 +95,11 @@ key masuk ke regex, jadi `.*` akan mengubah satu invalidasi menjadi
 
 ## Yang belum tersambung (jangan klaim ada)
 
-- **Emisi purge dari event konten.** `enqueueEdgeCachePurge` siap dipanggil;
-  belum ada pemanggil. Sampai itu ada, invalidasi bergantung TTL — dan TTL surface
-  sengaja pendek (120–600 detik) justru karena itu.
+- ~~Emisi purge dari event konten.~~ **SUDAH** untuk `blog_content`: keempat
+  jalur tulis (create, update, soft-delete, scheduled publish) memanggil
+  `enqueueModuleContentPurge` di transaksi yang sama. Modul konten lain
+  (`news_portal`, `theming`, `media_library`) **belum** — suntingan di sana masih
+  menunggu TTL.
 - **Surface discovery ber-resolusi-host** (`/robots.txt`, `/sitemap.xml`,
   `/feed.xml`, `/atom.xml`, `/feed.json`). Kandidat terbaik, tetapi
   `serveDiscovery(request, …)` tidak menerima `locals` sehingga rute tak bisa

--- a/src/lib/edge-cache/content-purge.ts
+++ b/src/lib/edge-cache/content-purge.ts
@@ -1,0 +1,60 @@
+/**
+ * Content-change → edge-cache invalidation (ADR-0042 §9), the caller side.
+ *
+ * Content modules call this **inside the transaction that changes the content**.
+ * That is the whole point: the invalidation commits with the change, so a
+ * rolled-back publish leaves no stray purge and a committed publish can never
+ * lose its purge.
+ *
+ * ## Why module scope and not the resource
+ *
+ * The obvious call is "purge exactly the post that changed". It would invalidate
+ * nothing. `buildScopesForSurface` tags cached responses with tenant, surface,
+ * and module keys — **not** resource keys, because the surface registry cannot
+ * know a route's resource ids. Enqueuing `t:<tenant>:r:blog_post:<id>` would
+ * therefore produce a ban that matches no object, and the stale page would sit
+ * there until its TTL expired while the queue reported success.
+ *
+ * So this purges the owning module for the tenant: every blog surface for that
+ * tenant at once. Slightly broader than necessary, and correct — which is the
+ * right trade for an invalidation path. A post edit also changes the index, the
+ * taxonomy listings, and the feed anyway, so the "narrow" purge would have had
+ * to fan out to most of those regardless.
+ *
+ * When routes start emitting resource keys, add the narrower scope here **and**
+ * in `buildScopesForSurface` in the same change — one without the other is a
+ * purge that silently misses.
+ *
+ * ## No-op when the edge cache is off
+ *
+ * Guarded on `EDGE_CACHE_MODE`. Without the guard every publish on every
+ * deployment would append rows to a queue no worker drains, growing forever for
+ * a feature the operator never enabled.
+ */
+import { loadEdgeCacheConfig } from "./config";
+import { enqueueEdgeCachePurge, type SqlExecutor } from "./purge-queue";
+import type { SurrogateKeyScope } from "./surrogate-keys";
+
+/**
+ * Enqueue invalidation for a module's cached surfaces for one tenant.
+ *
+ * Returns the number of keys enqueued (`0` when the subsystem is off), and never
+ * throws for a disabled subsystem — callers are content write paths, and a cache
+ * concern must not be able to fail a publish.
+ */
+export async function enqueueModuleContentPurge(
+  tx: SqlExecutor,
+  tenantId: string,
+  moduleKey: string,
+  reason: string
+): Promise<number> {
+  const config = loadEdgeCacheConfig();
+
+  if (config.mode === "off") {
+    return 0;
+  }
+
+  const scopes: SurrogateKeyScope[] = [{ kind: "module", tenantId, moduleKey }];
+
+  return enqueueEdgeCachePurge(tx, tenantId, scopes, reason);
+}

--- a/src/modules/blog-content/application/blog-scheduled-publish.ts
+++ b/src/modules/blog-content/application/blog-scheduled-publish.ts
@@ -1,3 +1,4 @@
+import { enqueueModuleContentPurge } from "../../../lib/edge-cache/content-purge";
 import { withTenant } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
 import { recordAuditEvent } from "../../logging/application/audit-log";
@@ -235,6 +236,17 @@ export async function publishDueScheduledPosts(
         `;
 
         publishedPostIds.push(post.id);
+
+        // ADR-0042: invalidate this tenant's cached blog surfaces in the SAME
+        // transaction as the publish, so a rolled-back publish leaves no stray
+        // purge and a committed one can never lose its invalidation. No-op when
+        // the edge cache is disabled.
+        await enqueueModuleContentPurge(
+          tx,
+          tenantId,
+          "blog_content",
+          "blog.post.published"
+        );
 
         await recordAuditEvent(tx, {
           tenantId,

--- a/src/pages/api/v1/blog/posts/[id].ts
+++ b/src/pages/api/v1/blog/posts/[id].ts
@@ -1,3 +1,4 @@
+import { enqueueModuleContentPurge } from "../../../../../lib/edge-cache/content-purge";
 import type { APIRoute } from "astro";
 
 import { fail, ok } from "../../../../../modules/_shared/api-response";
@@ -358,6 +359,16 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       correlationId
     });
 
+    // ADR-0042: same transaction as the content change, so the invalidation
+    // cannot be lost or left behind by a rollback. No-op when the edge
+    // cache is disabled.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.updated"
+    );
+
     log("info", "blog-content.post.updated", {
       correlationId,
       tenantId,
@@ -453,6 +464,16 @@ export const DELETE: APIRoute = async ({
       attributes: { reason },
       correlationId
     });
+
+    // ADR-0042: same transaction as the content change, so the invalidation
+    // cannot be lost or left behind by a rollback. No-op when the edge
+    // cache is disabled.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.deleted"
+    );
 
     log("info", "blog-content.post.deleted", {
       correlationId,

--- a/src/pages/api/v1/blog/posts/index.ts
+++ b/src/pages/api/v1/blog/posts/index.ts
@@ -1,3 +1,4 @@
+import { enqueueModuleContentPurge } from "../../../../../lib/edge-cache/content-purge";
 import type { APIRoute } from "astro";
 
 import { fail, ok } from "../../../../../modules/_shared/api-response";
@@ -284,6 +285,16 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
       message: `Blog post created: ${post.slug}.`,
       correlationId
     });
+
+    // ADR-0042: same transaction as the content change, so the invalidation
+    // cannot be lost or left behind by a rollback. No-op when the edge
+    // cache is disabled.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.created"
+    );
 
     log("info", "blog-content.post.created", {
       correlationId,

--- a/tests/edge-cache-content-purge.test.ts
+++ b/tests/edge-cache-content-purge.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ADR-0042 — content-change purge emission.
+ *
+ * The assertion that matters most here is the negative one: with the edge cache
+ * off, a publish must not append queue rows. Every deployment that has not opted
+ * in still runs these write paths, and an unguarded enqueue would grow a table
+ * no worker drains.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { enqueueModuleContentPurge } from "../src/lib/edge-cache/content-purge";
+import type { SqlExecutor } from "../src/lib/edge-cache/purge-queue";
+
+/** Records the parameter arrays passed to the tagged-template executor. */
+function recordingTx(): { tx: SqlExecutor; calls: unknown[][] } {
+  const calls: unknown[][] = [];
+  const tx = ((_strings: TemplateStringsArray, ...values: unknown[]) => {
+    calls.push(values);
+
+    return Promise.resolve([]);
+  }) as SqlExecutor;
+
+  return { tx, calls };
+}
+
+const TENANT = "11111111-1111-4111-8111-111111111111";
+
+describe("enqueueModuleContentPurge", () => {
+  test("is a no-op when the edge cache is disabled", async () => {
+    const { tx, calls } = recordingTx();
+    const previous = process.env.EDGE_CACHE_MODE;
+
+    delete process.env.EDGE_CACHE_MODE;
+
+    try {
+      const enqueued = await enqueueModuleContentPurge(
+        tx,
+        TENANT,
+        "blog_content",
+        "blog.post.published"
+      );
+
+      expect(enqueued).toBe(0);
+      expect(calls).toHaveLength(0);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.EDGE_CACHE_MODE;
+      } else {
+        process.env.EDGE_CACHE_MODE = previous;
+      }
+    }
+  });
+
+  test("enqueues exactly the module-scoped key when enabled", async () => {
+    const { tx, calls } = recordingTx();
+    const previous = process.env.EDGE_CACHE_MODE;
+
+    process.env.EDGE_CACHE_MODE = "auto";
+
+    try {
+      const enqueued = await enqueueModuleContentPurge(
+        tx,
+        TENANT,
+        "blog_content",
+        "blog.post.published"
+      );
+
+      expect(enqueued).toBe(1);
+      expect(calls).toHaveLength(1);
+
+      // Module scope, NOT a resource key: cached responses are tagged with
+      // tenant/surface/module only, so a resource-scoped ban would match no
+      // object and the page would stay stale until its TTL expired.
+      expect(calls[0]).toEqual([
+        TENANT,
+        [`t:${TENANT}:m:blog_content`],
+        "blog.post.published"
+      ]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.EDGE_CACHE_MODE;
+      } else {
+        process.env.EDGE_CACHE_MODE = previous;
+      }
+    }
+  });
+});
+
+describe("blog write paths emit a purge", () => {
+  test.each([
+    ["src/pages/api/v1/blog/posts/[id].ts", 2],
+    ["src/pages/api/v1/blog/posts/index.ts", 1],
+    ["src/modules/blog-content/application/blog-scheduled-publish.ts", 1]
+  ])(
+    "%s calls enqueueModuleContentPurge %i time(s)",
+    async (path, expected) => {
+      // A source-level assertion on purpose. These are the paths that make
+      // content change; if someone adds a fourth mutating handler without an
+      // enqueue, the edge cache silently serves stale content — a failure that
+      // no unit test of the handler itself would surface.
+      const source = await Bun.file(path).text();
+      const occurrences =
+        source.split("await enqueueModuleContentPurge(").length - 1;
+
+      expect(occurrences).toBe(expected);
+    }
+  );
+});


### PR DESCRIPTION
Closes the gap I flagged when landing ADR-0042: `enqueueEdgeCachePurge` shipped
with **no callers**, so a published edit stayed visible at the edge until its TTL
expired. Blog content now invalidates itself.

## What changed

`enqueueModuleContentPurge` (`src/lib/edge-cache/content-purge.ts`), called from
the four blog write paths, each **inside the transaction that changes the
content**:

| Path | Reason |
| --- | --- |
| `POST /api/v1/blog/posts` | `blog.post.created` |
| `PATCH /api/v1/blog/posts/{id}` | `blog.post.updated` |
| `DELETE /api/v1/blog/posts/{id}` | `blog.post.deleted` |
| `bun run blog:publish:scheduled` | `blog.post.published` |

Same-transaction is the point (ADR-0006's outbox discipline): a rolled-back write
leaves no stray purge, and a committed one cannot lose its invalidation.

## Module scope, not resource scope — deliberate

The obvious call is "purge exactly the post that changed". It would invalidate
**nothing**. `buildScopesForSurface` tags cached responses with tenant, surface,
and module keys only — the surface registry cannot know a route's resource ids.
A `t:<tenant>:r:blog_post:<id>` ban would match no object, and the stale page
would sit there until TTL while the queue reported success.

Module scope is slightly broader and correct. A post edit changes the index,
taxonomy listings and feed anyway, so a "narrow" purge would have had to fan out
to most of those regardless. Narrowing this later means changing both sides in
one commit, which the code says explicitly.

## Off means off

Guarded on `EDGE_CACHE_MODE`. Without it, every deployment that never adopted the
edge cache would append rows to a queue no worker drains, forever. There's a test
asserting zero rows when disabled.

## Verification

`bun run check`: **2292 pass, 0 fail**, build complete.

Includes a source-level test asserting each write path still calls the enqueue —
if someone adds a fifth mutating handler without one, the edge cache silently
serves stale content, which no unit test of that handler would catch.

## Still open

`news_portal`, `theming` and `media_library` do not emit purges yet; edits there
still wait out the TTL. Noted in `docs/awcms/edge-cache-architecture.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)