### PR TITLE
docs: pin awcms environments to awcms.ahlikoding.com / awcms-staging.ahlikoding.com

### DIFF
--- a/.changeset/pin-ahlikoding-environments.md
+++ b/.changeset/pin-ahlikoding-environments.md
@@ -1,0 +1,16 @@
+---
+"awcms": patch
+---
+
+Pin the two deployed environments to their domains: `awcms.ahlikoding.com`
+(production) and `awcms-staging.ahlikoding.com` (staging).
+
+Adds `docs/awcms/environments.md` (domains, per-environment `APP_ENV`/`APP_URL`,
+staging isolation rules, DNS, edge-cache settings) and references it from
+`.env.example` and `deploy-coolify.md`, which previously used only generic
+placeholders.
+
+`APP_URL` is called out specifically because it builds the OIDC/SSO callback URL
+— a wrong host breaks login rather than just looking wrong.
+
+Documentation and example configuration only; no runtime change.

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,14 @@
 APP_ENV=development
 APP_URL=http://localhost:4321
+#
+# APP_URL is REQUIRED and is not cosmetic: it builds the OIDC/SSO callback URL
+# (src/lib/auth/sso-config.ts). A wrong host breaks login with
+# redirect_uri_mismatch rather than merely producing an ugly link. Register BOTH
+# redirect URIs with the IdP before staging is used to sign in.
+#
+# The two deployed environments (docs/awcms/environments.md):
+#   production  APP_ENV=production  APP_URL=https://awcms.ahlikoding.com
+#   staging     APP_ENV=staging     APP_URL=https://awcms-staging.ahlikoding.com
 LOG_LEVEL=info
 AUDIT_LOG_RETENTION_DAYS=730
 
@@ -326,7 +335,16 @@ COMMENTS_TIMING_SECRET=
 # TENANT_DOMAIN_SERVING_RECORD_TYPE=A, or a hostname for CNAME (the default).
 # There is deliberately NO default value — guessing this points every tenant
 # subdomain at a wrong address, which is a platform-wide outage.
-# TENANT_DOMAIN_SERVING_TARGET=ingress.example.com
+# For this deployment that is the production app host, so tenant subdomains
+# become <tenant>.awcms.ahlikoding.com pointing at it. Pair it with
+# TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN=awcms.ahlikoding.com — the adapter refuses
+# any hostname outside the configured root. See docs/awcms/environments.md
+# §Subdomain tenant: the root is a written-down ASSUMPTION, not a settled
+# decision, and changing it later means migrating tenant hostnames.
+#
+# Leave the provider as `manual` on STAGING: two environments writing serving
+# records for the same hostname into the same zone will overwrite each other.
+# TENANT_DOMAIN_SERVING_TARGET=awcms.ahlikoding.com
 #
 # A | CNAME (default CNAME).
 # TENANT_DOMAIN_SERVING_RECORD_TYPE=CNAME

--- a/docs/awcms/deploy-coolify.md
+++ b/docs/awcms/deploy-coolify.md
@@ -1,5 +1,17 @@
 # Deploy Coolify
 
+> **Domain environment awcms** (lihat [`environments.md`](environments.md) untuk
+> daftar lengkap + isolasi staging):
+>
+> | Environment | Domain                         | `APP_ENV`    |
+> | ----------- | ------------------------------ | ------------ |
+> | Production  | `awcms.ahlikoding.com`         | `production` |
+> | Staging     | `awcms-staging.ahlikoding.com` | `staging`    |
+>
+> **Satu app Coolify per environment**, bukan satu app dengan dua domain —
+> environment yang berbagi app berbagi env var, dan itulah cara staging tanpa
+> sengaja menulis ke data produksi.
+
 > **Status dokumen:** panduan target sebagian. Repo `awcms` belum punya `docker-compose.yml` yang nyata, tapi `Dockerfile.production` SUDAH ada — nyata di root repo (multi-stage, non-root user `bun`, healthcheck) dan sudah dipakai aktif oleh `build` job `.github/workflows/release.yml` untuk build+push image ke `ghcr.io/ahliweb/awcms` setiap rilis (lihat [`release-process.md`](release-process.md) untuk deskripsi status yang akurat). Karena itu, **Pola 1 dan Pola 2 di bawah (build dari `Dockerfile.production`) sudah bisa dipakai hari ini** — dokumen ini mengadaptasi panduan operasional Coolify yang sudah terbukti di basis `awcms-mini` untuk detail khusus Coolify (topologi VPS, opsi PostgreSQL, checklist keamanan) yang masih standar target sampai dipraktikkan sungguhan terhadap deployment nyata.
 
 Panduan operasional untuk deploy AWCMS ke [Coolify](https://coolify.io) memakai `Dockerfile.production` sebagai jalur registry/CI-push, berdampingan dengan `docker-compose.yml` yang tetap menjadi jalur LAN-first/offline yang direkomendasikan (lihat [`deployment-profiles.md`](deployment-profiles.md) §production (online) — image registry). Dokumen ini **tidak menggantikan** dokumen itu — dokumen ini menambahkan detail khusus Coolify: topologi satu VPS, topologi multi aplikasi dalam satu VPS, opsi PostgreSQL, kapasitas praktis, dan checklist keamanan.
@@ -162,7 +174,7 @@ Setiap aplikasi/database pada topologi multi-app punya migrasi one-shot sendiri 
 Endpoint: `GET /api/v1/health` — dipakai sebagai **Health Check Path** di konfigurasi Coolify application (lihat §Dua pola deploy di atas). Coolify memakai endpoint ini untuk menentukan container sehat sebelum menandai deploy sukses/sebelum mengarahkan traffic.
 
 ```bash
-curl https://<domain-aplikasi>/api/v1/health
+curl https://awcms.ahlikoding.com/api/v1/health   # staging: awcms-staging.ahlikoding.com
 ```
 
 Setiap aplikasi pada topologi multi-app dicek lewat endpoint health-nya masing-masing — tidak ada health check bersama lintas aplikasi.

--- a/docs/awcms/environments.md
+++ b/docs/awcms/environments.md
@@ -1,0 +1,118 @@
+# Environment awcms — domain, konfigurasi, dan isolasi
+
+> Dokumen **current-state**: dua environment resmi `awcms` beserta domainnya.
+> Untuk mekanisme deploy-nya lihat [`deploy-coolify.md`](deploy-coolify.md) dan
+> [`deployment-profiles.md`](deployment-profiles.md).
+
+## Dua environment
+
+| Environment    | Domain                         | `APP_ENV`     | Catatan                                    |
+| -------------- | ------------------------------ | ------------- | ------------------------------------------ |
+| **Production** | `awcms.ahlikoding.com`         | `production`  | Data nyata. Semua integrasi keluar AKTIF.  |
+| **Staging**    | `awcms-staging.ahlikoding.com` | `staging`     | Data buangan. Integrasi keluar MATI total. |
+| Development    | `http://localhost:4321`        | `development` | Lokal, tidak di-deploy.                    |
+
+Keduanya berjalan di host Docker yang sama dengan produksi lain
+(`192.42.84.46`), dikelola Coolify, di belakang Traefik yang memegang `:80`/`:443`
+dan menerbitkan TLS lewat resolver `letsencrypt`. **Satu app Coolify per
+environment** — bukan satu app dengan dua domain: environment berbagi app berarti
+berbagi env var, dan itulah cara staging tanpa sengaja menulis ke data produksi.
+
+## `APP_URL` bukan kosmetik
+
+`APP_URL` **wajib** (`scripts/validate-env.ts`) dan bukan sekadar label: ia
+menyusun URL callback OIDC/SSO (`src/lib/auth/sso-config.ts`). Salah host = alur
+login rusak dengan `redirect_uri_mismatch`, bukan sekadar tautan yang jelek.
+
+```bash
+# production
+APP_ENV=production
+APP_URL=https://awcms.ahlikoding.com
+
+# staging
+APP_ENV=staging
+APP_URL=https://awcms-staging.ahlikoding.com
+```
+
+Daftarkan **kedua** redirect URI di IdP sebelum staging dipakai login.
+
+## Isolasi staging — bukan opsional
+
+Staging berjalan di host yang sama dengan produksi. Yang memisahkannya hanya
+konfigurasi, jadi konfigurasi itu harus tegas. Pola ini sudah terbukti di
+staging `awcms-micro` (lihat `work-continuation-log.md` repo itu):
+
+- **Database sendiri**, role `awcms_app` sendiri, password sendiri. Bukan skema
+  lain di cluster produksi.
+- **Secret sendiri** — JWT, `AUTH_IP_HASH_SECRET`, `COMMENTS_TIMING_SECRET`,
+  kunci enkripsi. Menyalin secret produksi ke staging berarti token staging
+  berlaku di produksi.
+- **Integrasi keluar MATI**: `R2_ENABLED=false`, `EMAIL_ENABLED=false`, sync
+  nonaktif. Staging tidak boleh bisa menulis ke bucket media produksi atau
+  mengirim email ke alamat orang sungguhan.
+- `NEWS_PORTAL_PROFILE` **dihapus** (bukan diisi nilai lain) ketika staging tanpa
+  R2 — nilai yang diterima hanya `full_online_r2`, jadi `config:validate` akan
+  menolak sebelum deploy. Ini kesalahan nyata yang tertangkap di micro.
+
+Jalankan `bun run config:validate` dan `bun run security:readiness` **sebelum**
+deploy pertama tiap environment.
+
+## DNS
+
+Zona `ahlikoding.com` ada di Cloudflare (NS `dilbert`/`katja`). Kedua host di
+atas menunjuk ke `192.42.84.46`.
+
+Setelah record ada, TLS terbit otomatis lewat Traefik — tidak ada konfigurasi
+lain. Bila record dipasang **proxied** (orange cloud), Traefik tetap menerbitkan
+sertifikat asalkan tantangan HTTP-01 bisa lewat; bila ragu, mulai **DNS-only**
+lalu nyalakan proxy setelah TLS terbit.
+
+### Subdomain tenant (asumsi — konfirmasi sebelum dipakai)
+
+`bun run tenant-domain:dns:sync` (ADR-0042 / PR #236) mengubah baris
+`awcms_tenant_domains` menjadi record DNS nyata, tetapi butuh **root domain**
+yang belum ditetapkan pemilik repo. Yang paling koheren dengan dua domain di atas:
+
+```bash
+TENANT_DOMAIN_DNS_PROVIDER=cloudflare
+TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN=awcms.ahlikoding.com
+TENANT_DOMAIN_SERVING_TARGET=awcms.ahlikoding.com
+TENANT_DOMAIN_SERVING_RECORD_TYPE=CNAME
+```
+
+→ subdomain tenant berbentuk `<tenant>.awcms.ahlikoding.com`.
+
+Ini **asumsi yang ditulis eksplisit**, bukan keputusan yang sudah diambil.
+Alternatifnya adalah root `ahlikoding.com` (memberi `<tenant>.ahlikoding.com`),
+yang lebih pendek tetapi menaruh namespace tenant di zona yang dipakai bersama
+aplikasi lain di host itu. Adapter **menolak** hostname di luar root yang
+dikonfigurasi, jadi memilih root yang salah bukan lubang keamanan — hanya
+migrasi hostname yang menyakitkan nanti. Putuskan sebelum tenant pertama.
+
+Staging sebaiknya **tidak** memakai provider `cloudflare` (biarkan `manual`):
+dua environment yang menulis ke zona yang sama akan saling menimpa record
+serving milik hostname yang sama.
+
+## Cache tepi (ADR-0042)
+
+Staging adalah tempat yang benar untuk membuktikan lapisan Varnish sebelum
+produksi:
+
+```bash
+EDGE_CACHE_MODE=auto
+EDGE_CACHE_PURGE_ENDPOINT=http://varnish:80
+EDGE_CACHE_PURGE_TOKEN=<secret per environment>
+```
+
+Token purge **berbeda per environment**. Jadwalkan `bun run edge-cache:purge`;
+tanpa itu suntingan editor baru terlihat setelah TTL habis. Rinci di
+[`edge-cache-architecture.md`](edge-cache-architecture.md).
+
+## Yang belum ada (jangan diklaim)
+
+- **Instance staging `awcms` belum dibuat.** Yang berjalan di host itu adalah
+  staging `awcms-micro` (app Coolify `a107y9000uz0t9cmgs18lzcv`, DB
+  `d437d850oei6v1s92dq5y3lf`) — instance repo LAIN.
+- **Record DNS kedua host belum ada.** Per 2026-07-25 keduanya `NXDOMAIN`.
+- Dokumen ini menetapkan **konfigurasi target**; ia tidak membuktikan sesuatu
+  sudah berjalan.


### PR DESCRIPTION
The repo had no record of which host each environment answers on — only generic
placeholders (`<domain-aplikasi>`, `ingress.example.com`). This pins both.

| Environment | Domain | `APP_ENV` |
| --- | --- | --- |
| Production | `awcms.ahlikoding.com` | `production` |
| Staging | `awcms-staging.ahlikoding.com` | `staging` |

Adds `docs/awcms/environments.md` and references it from `.env.example` and
`deploy-coolify.md`.

## Three things worth flagging

**`APP_URL` is not cosmetic.** It's required by `config:validate` and it builds
the OIDC/SSO callback URL (`src/lib/auth/sso-config.ts`). Get the host wrong and
login fails with `redirect_uri_mismatch`. Both redirect URIs need registering
with the IdP before staging is used to sign in.

**Staging isolation is stated as a rule, not an aspiration.** Staging runs on the
*same host* as production; only configuration separates them. So: own database
and `awcms_app` role, own secrets (copying production JWT/hash secrets makes
staging tokens valid in production), and `R2_ENABLED=false` / `EMAIL_ENABLED=false`
so staging cannot write to the production media bucket or email real people. The
`NEWS_PORTAL_PROFILE` trap is carried over from awcms-micro's real staging
deploy — it only accepts `full_online_r2`, so without R2 the variable must be
*removed*, not set to something else, or `config:validate` rejects the deploy.

**The tenant-subdomain root is an assumption, and labelled as one.** You gave two
app domains, not a tenant namespace. `tenant-domain:dns:sync` (#236) needs a root;
the coherent choice is `awcms.ahlikoding.com`, giving
`<tenant>.awcms.ahlikoding.com`. The alternative — root `ahlikoding.com` — is
shorter but puts tenant names in a zone shared with the other apps on that host.
Picking wrong isn't a security hole (the adapter refuses hostnames outside the
configured root) but it is a painful hostname migration later. **Please confirm
before the first tenant.**

Staging should stay on `TENANT_DOMAIN_DNS_PROVIDER=manual`: two environments
writing serving records for the same hostname into the same zone overwrite each
other.

## Scope

Documentation and example config only; no runtime change. `bun run check`:
**2292 pass, 0 fail**.

Neither DNS record exists yet, and the awcms staging instance has not been
created — the doc says so explicitly rather than implying otherwise. Creating
them is still blocked on a working Coolify token and Cloudflare access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)