### PR TITLE
docs: record the real deployed-environment state (staging live)

### DIFF
--- a/.changeset/staging-environment-live.md
+++ b/.changeset/staging-environment-live.md
@@ -1,0 +1,14 @@
+---
+"awcms": patch
+---
+
+Record the real state of the deployed environments: staging is live at
+`awcms-staging.ahlikoding.com` (own Coolify app and database, R2/email/sync off),
+production DNS and app already existed, and `awcms-micro-staging` has been
+removed.
+
+Also documents why `db:migrate` cannot run via `docker exec` on the production
+image — it is runtime-only and does not ship `scripts/` — and gives the one-shot
+container command instead. Staging has no schema until that is run.
+
+Documentation only.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -168,6 +168,12 @@ Modul (21): `tenant-admin`, `identity-access`, `profile-identity`, `logging`,
     `comments` ([ADR-0041](adr/0041-comments-module-admission.md), `sql/066`–`067`).
     **BELUM:** `newsletter`, `social-publishing` (mengaktifkan hook publish yang
     kini no-op di `blog-content`).
+- **Environment ter-deploy.** Produksi `awcms.ahlikoding.com` dan staging
+  `awcms-staging.ahlikoding.com` (dibuat 2026-07-25, app Coolify
+  `n3gg3qudm91kqdy62znmyxuq`, DB sendiri, R2/email/sync MATI). Health staging 200.
+  **BELUM:** migrasi DB staging — image produksi runtime-only sehingga
+  `db:migrate` harus dijalankan sebagai container one-shot; langkahnya ada di
+  [`awcms/environments.md`](awcms/environments.md).
 - **Cache tepi Varnish ([ADR-0042](adr/0042-varnish-edge-cache-auto-activation.md), `sql/068`).**
   Tier cache OPSIONAL di depan aplikasi, default MATI dan no-op saat mati. Allow-list
   surface fail-closed (`src/lib/edge-cache/`), aktivasi otomatis berbasis tekanan origin,

--- a/docs/awcms/environments.md
+++ b/docs/awcms/environments.md
@@ -108,11 +108,46 @@ Token purge **berbeda per environment**. Jadwalkan `bun run edge-cache:purge`;
 tanpa itu suntingan editor baru terlihat setelah TTL habis. Rinci di
 [`edge-cache-architecture.md`](edge-cache-architecture.md).
 
-## Yang belum ada (jangan diklaim)
+## Status nyata (2026-07-25)
 
-- **Instance staging `awcms` belum dibuat.** Yang berjalan di host itu adalah
-  staging `awcms-micro` (app Coolify `a107y9000uz0t9cmgs18lzcv`, DB
-  `d437d850oei6v1s92dq5y3lf`) — instance repo LAIN.
-- **Record DNS kedua host belum ada.** Per 2026-07-25 keduanya `NXDOMAIN`.
-- Dokumen ini menetapkan **konfigurasi target**; ia tidak membuktikan sesuatu
-  sudah berjalan.
+| Hal                                | Status                                                              |
+| ---------------------------------- | ------------------------------------------------------------------- |
+| DNS `awcms.ahlikoding.com`         | ✅ A → `192.42.84.46`, DNS-only                                     |
+| DNS `awcms-staging.ahlikoding.com` | ✅ A → `192.42.84.46`, DNS-only (dibuat 2026-07-25)                 |
+| App Coolify produksi               | ✅ `got4etcblum9kowdv4mrixqo` + DB `eel59mczdlkidkm5a6fhbdeh`       |
+| App Coolify staging                | ✅ `n3gg3qudm91kqdy62znmyxuq` + DB `my85c1xd4txesedhic72maeu`       |
+| TLS staging                        | ✅ terbit otomatis (Traefik/letsencrypt) beberapa menit setelah DNS |
+| Health staging                     | ✅ `GET /api/v1/health` → 200, 21 modul                             |
+| **Migrasi DB staging**             | ❌ **BELUM dijalankan** — lihat di bawah                            |
+
+Staging memakai `--ip 10.0.1.61` (produksi `10.0.1.51`); Coolify tidak bisa
+mem-publish port, jadi alamat container ditetapkan lewat
+`custom_docker_run_options`.
+
+### Migrasi staging belum jalan — dan kenapa
+
+`Dockerfile.production` menghasilkan image **runtime saja**: `scripts/` tidak
+ikut, jadi `docker exec <app> bun run db:migrate` gagal dengan
+`Module not found "scripts/db-migrate.ts"`. Ini bukan kesalahan konfigurasi
+staging; itu memang bentuk image-nya.
+
+Jalankan migrasi sebagai **container one-shot** dari repo, berbagi network
+container DB supaya DSN-nya `127.0.0.1` (pola yang sama dipakai staging
+`awcms-micro`):
+
+```bash
+docker run --rm --network container:my85c1xd4txesedhic72maeu \
+  -v "$PWD":/app -w /app \
+  -e DATABASE_URL="postgres://awcms_staging:<pw>@127.0.0.1:5432/awcms_staging" \
+  oven/bun:1.3.14-alpine sh -c "bun install --frozen-lockfile && bun run db:migrate"
+```
+
+Sampai itu dijalankan, staging **belum punya skema** — endpoint health tetap 200
+karena tidak menyentuh database.
+
+## Yang masih terbuka
+
+- Migrasi + seed tenant pertama di staging (di atas).
+- `awcms-micro-staging` sudah **dihapus** (app + DB) pada 2026-07-25; DNS-nya
+  memang tidak pernah ada.
+- Varnish belum dipasang di depan staging; `EDGE_CACHE_MODE=off` sampai itu ada.


### PR DESCRIPTION
Staging is up at https://awcms-staging.ahlikoding.com — health returns 200 with 21 modules.

`environments.md` said neither DNS record existed and staging had not been created. Both were false as of today, so the doc was actively misleading rather than merely stale.

## Now recorded

| | |
|---|---|
| DNS production / staging | both A → `192.42.84.46`, DNS-only |
| Coolify production | `got4etcblum9kowdv4mrixqo` + `eel59mczdlkidkm5a6fhbdeh` |
| Coolify staging | `n3gg3qudm91kqdy62znmyxuq` + `my85c1xd4txesedhic72maeu` |
| Staging isolation | own DB + own secrets; `R2_ENABLED=false`, `EMAIL_ENABLED=false`, `SYNC_ENABLED=false`, `TENANT_DOMAIN_DNS_PROVIDER=manual`, `EDGE_CACHE_MODE=off` |
| `awcms-micro-staging` | app + DB deleted |

## The gap this documents rather than hides

`db:migrate` **cannot** run via `docker exec` on the deployed container:
`Dockerfile.production` builds a runtime-only image that does not ship
`scripts/`, so it fails with `Module not found "scripts/db-migrate.ts"`.
That's the image's shape, not a staging misconfiguration.

**Staging therefore has no schema yet.** The health endpoint returns 200 anyway
because it never touches the database — which is exactly the kind of green light
that misleads. The one-shot container command (sharing the DB container's network
namespace, same pattern awcms-micro used) is documented in `environments.md`.

Documentation only. `bun run check`: 2292 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)