### PR TITLE
fix(edge-cache): invalidation had never worked — literal spaces broke every ban

### DIFF
--- a/.changeset/edge-cache-ban-expression-fix.md
+++ b/.changeset/edge-cache-ban-expression-fix.md
@@ -1,0 +1,30 @@
+---
+"awcms": patch
+---
+
+Fix edge-cache invalidation, which had never worked.
+
+The ban expression built by `infra/varnish/default.vcl` used `(^| )key( |$)` to
+anchor a surrogate key to a whole token. Varnish parses a ban expression by
+splitting it on **whitespace** into `<field> <operator> <argument>`, so the
+literal spaces inside that regex produced the wrong token count and every ban
+was rejected with `Wrong number of arguments`.
+
+Nothing surfaced it. The VCL's BAN handler returns `200` regardless, so
+`sendEdgeCachePurge` recorded success, the queue row was marked done, and the
+object stayed cached until its TTL expired. The subsystem reported healthy
+invalidation while performing none — the precise failure mode ADR-0042 exists to
+prevent. It was found by putting Varnish in front of staging and watching
+`X-Cache` stay `HIT` after a purge.
+
+Both sides now emit `(^|[[:space:]])key([[:space:]]|$)`: same boundary semantics,
+no literal space. Quoting the regex is not an alternative — the split happens
+before quote handling (verified against Varnish 7.5).
+
+Also corrects `infra/varnish/docker-compose.varnish.yml`, which named
+`varnishcache/varnish:7.5`. No such Docker Hub repository exists, so adopting the
+overlay failed with `pull access denied`. The image is `varnish:7.5`.
+
+Guarded by two file-level assertions in `tests/edge-cache.test.ts`, because the
+runtime expression is built in VCL rather than TypeScript and no unit test of the
+origin can observe it.

--- a/.claude/skills/awcms-edge-cache/SKILL.md
+++ b/.claude/skills/awcms-edge-cache/SKILL.md
@@ -37,13 +37,31 @@ ketiga yang senyap.
    `ssr-session.ts` dan menegakkan nama cookie asli masih cocok prefix itu.
 5. **Key surrogate masuk ke REGEX.** Dibatasi `[A-Za-z0-9:._-]` saat dibangun DAN
    divalidasi ulang di VCL. Key `.*` = satu permintaan membuang seluruh cache ke
-   origin. Pencocokan di-anchor `(^| )key( |$)` agar ban `t:abc` tidak ikut
-   membuang `t:abcdef` milik tenant lain.
+   origin. Pencocokan di-anchor `(^|[[:space:]])key([[:space:]]|$)` agar ban
+   `t:abc` tidak ikut membuang `t:abcdef` milik tenant lain. **JANGAN** kembalikan
+   ke spasi literal `(^| )` — lihat jebakan di bawah.
 6. **Tenant tak ter-resolve = tidak di-cache.** Objek tanpa key tenant tak bisa
    dijangkau purge mana pun, jadi akan basi selamanya.
 
 ## Jebakan yang sudah ditemukan (jangan diulang)
 
+- **Spasi literal di ekspresi ban membuat invalidasi TIDAK PERNAH bekerja.**
+  Varnish memecah ekspresi ban pada whitespace menjadi
+  `<field> <operator> <argument>`. Bentuk pertama yang dikirim, `(^| )key( |$)`,
+  punya spasi di dalam regex → jumlah token salah → ban ditolak
+  `Wrong number of arguments`. Yang membuatnya berbahaya: handler BAN tetap
+  membalas **200**, jadi `sendEdgeCachePurge` mencatat sukses, baris antrean
+  ditandai selesai, dan konten tetap basi sampai TTL habis. Tidak ada test,
+  log, atau metrik yang merah. Ditemukan hanya dengan memasang Varnish di depan
+  staging dan melihat `X-Cache` tetap `HIT` sesudah purge. Bentuk benar:
+  `(^|[[:space:]])key([[:space:]]|$)`. **Mengutip regex tidak menolong** —
+  pemecahan token terjadi sebelum penanganan kutip (diverifikasi di Varnish 7.5).
+  Dijaga `tests/edge-cache.test.ts` yang membaca `infra/varnish/default.vcl`
+  langsung; unit test murni tidak bisa menangkap ini karena ekspresi dibangun
+  di VCL, bukan di TypeScript.
+- **`varnishcache/varnish` bukan repository Docker Hub.** Compose overlay awal
+  menamainya dan gagal `pull access denied` bagi siapa pun yang mencoba
+  memakainya. Image yang benar: `varnish:7.5` (Docker Official Image).
 - **`/blog/{code}/search` adalah TIGA segmen** sehingga cocok dengan pola
   `blog-post` — padahal dokumentasi menyatakan surface query-driven dikecualikan.
   Ditangkap oleh probe gate, bukan oleh review. Sub-rute reserved baru di bawah

--- a/docs/adr/0042-varnish-edge-cache-auto-activation.md
+++ b/docs/adr/0042-varnish-edge-cache-auto-activation.md
@@ -90,8 +90,18 @@ atas header itu.
 Karena key masuk ke **regex**, key dibatasi ke `[A-Za-z0-9:._-]` saat dibangun DAN
 divalidasi ulang di VCL: sebuah key `.*` akan mengubah satu invalidasi menjadi
 "buang seluruh cache ke origin" — denial-of-service satu permintaan. Pencocokan
-juga di-anchor `(^| )key( |$)` agar ban `t:abc` tidak ikut membuang `t:abcdef`
-milik tenant lain.
+juga di-anchor `(^|[[:space:]])key([[:space:]]|$)` agar ban `t:abc` tidak ikut
+membuang `t:abcdef` milik tenant lain.
+
+`[[:space:]]` bukan pilihan gaya. Varnish memecah ekspresi ban pada **whitespace**
+menjadi `<field> <operator> <argument>`; spasi literal di dalam regex — persis
+yang ditulis versi pertama, `(^| )` — membuat jumlah token salah dan ban ditolak
+`Wrong number of arguments`. Handler BAN tetap membalas `200`, sehingga origin
+mencatat purge terkirim, baris antrean ditandai selesai, dan objek tetap
+ter-cache sampai TTL habis: **invalidasi tidak pernah bekerja sama sekali**.
+Ditemukan hanya setelah Varnish benar-benar dipasang di depan staging dan
+`X-Cache` tetap `HIT` sesudah purge. Mengutip regex tidak menolong — pemecahan
+token terjadi lebih dulu.
 
 Enqueue terjadi di **transaksi konten yang sama** (pola outbox ADR-0006), bukan
 panggilan HTTP di dalam transaksi. Pengiriman dilakukan `bun run edge-cache:purge`

--- a/infra/varnish/default.vcl
+++ b/infra/varnish/default.vcl
@@ -70,9 +70,19 @@ sub vcl_recv {
             return (synth(400, "Bad purge key"));
         }
 
-        # `(^| )` / `( |$)` anchor the match to a whole space-separated token, so
-        # banning tenant `t:abc` cannot also ban `t:abcdef` — a different tenant.
-        ban("obj.http.Surrogate-Key ~ (^| )" + req.http.X-Edge-Purge-Key + "( |$)");
+        # `(^|[[:space:]])` / `([[:space:]]|$)` anchor the match to a whole
+        # space-separated token, so banning tenant `t:abc` cannot also ban
+        # `t:abcdef` — a different tenant.
+        #
+        # `[[:space:]]` rather than a literal space is NOT cosmetic. Varnish
+        # parses a ban expression by splitting it on whitespace into
+        # `<field> <operator> <argument>`; a literal space inside the regex
+        # yields the wrong token count and the ban is rejected with
+        # `Wrong number of arguments`. This handler still returns 200 in that
+        # case, so the origin records the purge as delivered and the object
+        # stays cached until its TTL — invalidation silently never happens.
+        # Quoting the regex does not help; the split happens first.
+        ban("obj.http.Surrogate-Key ~ (^|[[:space:]])" + req.http.X-Edge-Purge-Key + "([[:space:]]|$)");
 
         return (synth(200, "Banned"));
     }

--- a/infra/varnish/docker-compose.varnish.yml
+++ b/infra/varnish/docker-compose.varnish.yml
@@ -22,7 +22,10 @@
 
 services:
   varnish:
-    image: varnishcache/varnish:7.5
+    # Docker Official Image. (There is no `varnishcache/varnish` repository on
+    # Docker Hub — an earlier revision of this file named one, so `compose up`
+    # failed with `pull access denied` for anybody who tried to adopt it.)
+    image: varnish:7.5
     depends_on:
       - app
     # 80 is Varnish's own listener; publish it wherever your TLS terminator

--- a/src/lib/edge-cache/surrogate-keys.ts
+++ b/src/lib/edge-cache/surrogate-keys.ts
@@ -20,8 +20,9 @@
  *    Belt and braces, because these two steps can be reached independently.
  * 2. **Prefix collisions widening a ban.** A naive ban on `t:abc` also matches
  *    the key `t:abcdef` — a different tenant. Keys are matched with explicit
- *    space-or-anchor boundaries (`(^| )key( |$)`) so one tenant can never flush
- *    another's cache by having an id that happens to be a prefix.
+ *    whitespace-or-anchor boundaries (`(^|[[:space:]])key([[:space:]]|$)`) so
+ *    one tenant can never flush another's cache by having an id that happens to
+ *    be a prefix.
  *
  * Both hazards are cross-tenant, which is why the sanitizer REJECTS rather than
  * silently rewriting: a key that cannot be represented safely must not become a
@@ -110,13 +111,36 @@ export function escapeForBanRegex(literal: string): string {
 /**
  * Build the ban expression for one key.
  *
- * The `(^| )` / `( |$)` boundaries are load-bearing (see the prefix-collision
- * hazard above) — do not "simplify" them away.
+ * ## Why `[[:space:]]` and not a literal space
+ *
+ * Varnish parses a ban expression by splitting it on **whitespace** into
+ * `<field> <operator> <argument>` triplets. A literal space anywhere in the
+ * regex — including inside `(^| )` — therefore produces the wrong token count
+ * and the ban is rejected with `Wrong number of arguments`.
+ *
+ * The original form of this expression used `(^| )`/`( |$)` and was rejected
+ * every single time. Nothing surfaced it: the VCL's BAN handler still returned
+ * `200`, so `sendEdgeCachePurge` recorded success, the purge row was marked
+ * done, and the object stayed in cache until its TTL expired. Invalidation had
+ * simply never worked. It was caught only by putting Varnish in front of
+ * staging and watching `X-Cache` stay `HIT` after a purge.
+ *
+ * `[[:space:]]` is the same boundary with no literal space in it, so the
+ * expression survives the tokenizer. The boundaries themselves are load-bearing
+ * (see the prefix-collision hazard above) — do not "simplify" them away, and do
+ * not reintroduce a bare space.
+ *
+ * Quoting the regex does NOT fix it: the tokenizer splits before any quote
+ * handling, so `~ "(^| )x( |$)"` fails identically. Verified against Varnish
+ * 7.5.
+ *
+ * This must stay byte-compatible with the `ban(...)` call in
+ * `infra/varnish/default.vcl`; `tests/edge-cache.test.ts` asserts both.
  */
 export function buildBanExpression(key: string): string {
   const escaped = escapeForBanRegex(key);
 
-  return `obj.http.Surrogate-Key ~ "(^| )${escaped}( |$)"`;
+  return `obj.http.Surrogate-Key ~ (^|[[:space:]])${escaped}([[:space:]]|$)`;
 }
 
 /**

--- a/tests/edge-cache.test.ts
+++ b/tests/edge-cache.test.ts
@@ -242,8 +242,56 @@ describe("surrogate keys", () => {
     // Without the boundaries, banning t:abc would also ban t:abcdef — a
     // different tenant's entire cache.
     expect(buildBanExpression("t:abc")).toBe(
-      'obj.http.Surrogate-Key ~ "(^| )t:abc( |$)"'
+      "obj.http.Surrogate-Key ~ (^|[[:space:]])t:abc([[:space:]]|$)"
     );
+  });
+
+  test("the ban expression contains no literal whitespace in its regex", () => {
+    // Varnish splits a ban expression on whitespace into
+    // `<field> <operator> <argument>`. A literal space inside the regex — which
+    // is what `(^| )` is — makes the token count wrong and Varnish rejects the
+    // ban with `Wrong number of arguments`.
+    //
+    // Nothing else catches this. The VCL's BAN handler returns 200 regardless,
+    // so the origin marks the purge delivered and the object stays cached until
+    // its TTL. Invalidation silently never happens. That is exactly what
+    // shipped, and it was only found by running Varnish in front of staging.
+    const expression = buildBanExpression("t:abc");
+    const [field, operator, ...rest] = expression.split(/\s+/);
+
+    expect(field).toBe("obj.http.Surrogate-Key");
+    expect(operator).toBe("~");
+    expect(rest).toHaveLength(1);
+  });
+});
+
+describe("the shipped VCL agrees with the origin", () => {
+  test("default.vcl builds the same ban expression shape", async () => {
+    // A file-level assertion on purpose: the runtime ban expression is built by
+    // the VCL (the origin only sends the key in a header), so a divergence
+    // between these two is invisible to every other test in this suite — and
+    // its symptom is silent staleness rather than an error.
+    const vcl = await Bun.file("infra/varnish/default.vcl").text();
+    const banCall = vcl
+      .split("\n")
+      .find((line) => line.trim().startsWith("ban("));
+
+    expect(banCall).toBeDefined();
+    expect(banCall).toContain("(^|[[:space:]])");
+    expect(banCall).toContain("([[:space:]]|$)");
+    // The bug, stated as the thing that must never come back.
+    expect(banCall).not.toContain("(^| )");
+    expect(banCall).not.toContain("( |$)");
+  });
+
+  test("the compose overlay names an image that exists on Docker Hub", async () => {
+    // `varnishcache/varnish` is not a Docker Hub repository; the earlier value
+    // failed with `pull access denied` for anyone who tried to adopt the file.
+    const compose = await Bun.file(
+      "infra/varnish/docker-compose.varnish.yml"
+    ).text();
+
+    expect(compose).toMatch(/^\s*image:\s*varnish:\d+\.\d+\s*$/m);
   });
 
   test("regex metacharacters are escaped for the ban expression", () => {


### PR DESCRIPTION
Found by actually putting Varnish in front of staging. **Edge-cache invalidation has never worked**, in the way that is hardest to notice: it reported success.

## The bug

`infra/varnish/default.vcl` anchored a surrogate key to a whole token with `(^| )key( |$)`. Varnish parses a ban expression by splitting it **on whitespace** into `<field> <operator> <argument>` — so the literal spaces inside the regex produced the wrong token count and every ban was rejected:

```
$ varnishadm ban "obj.http.Surrogate-Key ~ (^| )t:<id>( |$)"
Wrong number of arguments
```

The BAN handler in the VCL returns `200` regardless of what `ban()` did. So `sendEdgeCachePurge` recorded success, the queue row was marked done, `failed` stayed at zero, and the object sat in cache until its TTL expired. The subsystem reported healthy invalidation while performing none — the precise failure ADR-0042 exists to prevent, shipped inside the mechanism meant to prevent it.

Quoting the regex is not an alternative: the split happens before quote handling. `~ "(^| )x( |$)"` fails identically. Verified against Varnish 7.5.

## Why no test caught it

The runtime ban expression is assembled **in VCL** — the origin only sends the key in `X-Edge-Purge-Key`. `buildBanExpression` in TypeScript was only ever asserted against its own output, so the two could disagree (and did: one quoted, one not) with nothing observing it.

## The fix

Both sides now emit `(^|[[:space:]])key([[:space:]]|$)` — identical boundary semantics, no literal space.

Verified live on staging:

| step | `X-Cache` |
| --- | --- |
| warm | HIT |
| BAN near-miss key `t:<id>x` | HIT — prefix-collision guard intact |
| BAN exact key `t:<id>` | **MISS** |
| next request | HIT |

## Guards

Two file-level assertions in `tests/edge-cache.test.ts`, following the precedent already set for purge emission:

- one reads `infra/varnish/default.vcl` and rejects the old shape outright;
- one tokenises `buildBanExpression` output and requires exactly three whitespace-separated tokens.

Both mutation-proven: restoring `(^| )` turns the first red, and it goes green again on revert.

## Also

`infra/varnish/docker-compose.varnish.yml` named `varnishcache/varnish:7.5`. There is no such Docker Hub repository — adopting the overlay failed with `pull access denied`. Corrected to the Official Image `varnish:7.5`, with a test asserting the shape.

`bun run check` green — 2572 tests, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)