### PR TITLE
fix(edge-cache): purge could not work on Bun — wrong RLS GUC, then an unsendable method

### DIFF
--- a/.changeset/edge-cache-purge-rls-guc-fix.md
+++ b/.changeset/edge-cache-purge-rls-guc-fix.md
@@ -1,0 +1,37 @@
+---
+"awcms": patch
+---
+
+Fix the edge-cache purge queue's tenant-isolation policy, which read a GUC the
+application never sets — breaking every blog write when the cache was enabled.
+
+`sql/068` created `awcms_edge_cache_purges_tenant_isolation` against
+`current_setting('awcms.tenant_id', true)`. `withTenant()` sets
+`app.current_tenant_id`, and so do the other 108 tenant policies in `sql/`.
+`sql/068` was the only outlier.
+
+The consequence was not a stale cache. `current_setting` returned NULL, so the
+`WITH CHECK` predicate was NULL and every INSERT was rejected with
+`new row violates row-level security policy`. `enqueueModuleContentPurge` is
+awaited **inside** the content transaction (ADR-0042 §9 / ADR-0006) and is not
+guarded, so that rejection aborted the publish: with `EDGE_CACHE_MODE` set to
+`auto` or `on`, blog create, update, delete, and scheduled publish all returned
+500. The `USING` side failed in the opposite, quieter direction — the purge
+worker matched zero rows and reported `sent=0`, which reads exactly like an empty
+queue.
+
+It could not surface earlier. The subsystem defaults to `off`, where the enqueue
+returns before touching the database, so no CI job, integration test, or
+deployment had ever written to this table. It appeared on the first request after
+the feature was switched on.
+
+`sql/070` replaces the policy. `sql/068` is left untouched — it is applied in a
+running deployment and rewriting it would change its checksum and block
+`db:migrate`.
+
+Adds `tests/migration-tenant-guc-consistency.test.ts`: a database-free gate that
+scans every migration's executable SQL (comments stripped, so a repair migration
+may name the wrong GUC while explaining itself) and fails on any
+`current_setting` that is not `app.current_tenant_id`. It runs in the `quality`
+job on every PR, which is where this class of typo needs to be caught — at
+authoring time, not on the day a flag is enabled in production.

--- a/.changeset/edge-cache-purge-transport-fix.md
+++ b/.changeset/edge-cache-purge-transport-fix.md
@@ -1,0 +1,28 @@
+---
+"awcms": patch
+---
+
+Fix the purge transport: Bun cannot send the `BAN` method, so no purge ever
+reached Varnish.
+
+`sendEdgeCachePurge` issued `fetch(endpoint, { method: "BAN" })`, the
+conventional Varnish idiom. **Bun does not transmit non-standard HTTP methods.**
+Both `fetch` and `node:http` deliver that request as `GET` — confirmed against
+Bun 1.3.14 with `varnishlog -i ReqMethod`, where the same request written
+byte-for-byte over a raw socket logs `BAN` and answers `200 Banned`.
+
+Every purge therefore fell past the VCL's ban branch to the origin, which 404s an
+unrouted path. On a Bun-only runtime (ADR-0002) no configuration makes the `BAN`
+method work.
+
+The wire protocol is now `POST /__edge-cache-purge`. The security model is
+unchanged — the method was never a control; the purge ACL, the shared token, and
+the key-charset re-validation at the edge all still apply, to both entry points.
+The VCL continues to accept a real `BAN`, so `curl -X BAN` remains available for
+operator debugging.
+
+Adds `tests/edge-cache-purge-client.test.ts`, the first tests this client has had.
+They run against a real `Bun.serve` and assert `request.method` **as received**,
+because that is the only formulation that can fail for the reason this failed: an
+injected `fetchImpl` observes the argument, not the wire, and would have asserted
+`method === "BAN"` and passed forever.

--- a/.claude/skills/awcms-edge-cache/SKILL.md
+++ b/.claude/skills/awcms-edge-cache/SKILL.md
@@ -45,6 +45,28 @@ ketiga yang senyap.
 
 ## Jebakan yang sudah ditemukan (jangan diulang)
 
+- **Bun TIDAK mengirim method HTTP non-standar.** `fetch`/`node:http` dengan
+  `method: "BAN"` tiba di Varnish sebagai **`GET`** (diverifikasi Bun 1.3.14 lewat
+  `varnishlog -i ReqMethod`; byte yang sama lewat raw socket tercatat `BAN` dan
+  dijawab `200 Banned`). Akibatnya setiap purge lolos dari cabang ban di VCL,
+  jatuh ke origin, dan 404. Repo ini Bun-only (ADR-0002) — tidak ada konfigurasi
+  yang membuat method `BAN` bekerja. Protokol kabel sekarang
+  **`POST /__edge-cache-purge`**; VCL tetap menerima `BAN` asli untuk
+  `curl -X BAN` manual. Method tidak pernah jadi kontrol keamanan — ACL, token,
+  dan validasi charset key yang menjaganya, dan ketiganya berlaku di kedua pintu.
+- **Mock `fetchImpl` TIDAK bisa menangkap kelas bug ini.** Ia memeriksa argumen,
+  bukan kabel, jadi ia akan menyatakan `method === "BAN"` dan lulus selamanya.
+  `tests/edge-cache-purge-client.test.ts` menegakkan `request.method` seperti
+  **DITERIMA** oleh `Bun.serve` sungguhan. Tulis test transport dengan server
+  nyata.
+- **GUC RLS salah nama = jalur tulis MATI, bukan sekadar cache basi.** `sql/068`
+  memakai `awcms.tenant_id` padahal `withTenant()` menyetel
+  `app.current_tenant_id` (108 policy lain memakai yang benar). `WITH CHECK`
+  jadi NULL → INSERT ditolak → dan karena `enqueueModuleContentPurge` di-`await`
+  DI DALAM transaksi konten tanpa guard, publish blog ikut gagal 500. Diperbaiki
+  `sql/070`; dijaga `tests/migration-tenant-guc-consistency.test.ts` (gate teks,
+  tanpa DB, jalan di job `quality`).
+
 - **Spasi literal di ekspresi ban membuat invalidasi TIDAK PERNAH bekerja.**
   Varnish memecah ekspresi ban pada whitespace menjadi
   `<field> <operator> <argument>`. Bentuk pertama yang dikirim, `(^| )key( |$)`,

--- a/infra/varnish/default.vcl
+++ b/infra/varnish/default.vcl
@@ -50,7 +50,20 @@ sub vcl_recv {
     # ---------------------------------------------------------------------
     # Invalidation
     # ---------------------------------------------------------------------
-    if (req.method == "BAN") {
+    # Two ways in, one code path.
+    #
+    # `BAN` is the conventional Varnish idiom and stays supported so an operator
+    # can `curl -X BAN` by hand. The application cannot use it: Bun does not
+    # transmit non-standard HTTP methods — `fetch`/`node:http` with
+    # `method: "BAN"` arrive here as `GET` (verified against Bun 1.3.14 via
+    # `varnishlog -i ReqMethod`; the same bytes over a raw socket log `BAN`).
+    # Every purge therefore fell through to the backend and 404'd.
+    #
+    # So the origin sends `POST /__edge-cache-purge`. The method was never a
+    # security control — the ACL, the token, and the key charset check below are,
+    # and they apply identically to both entry points.
+    if (req.method == "BAN"
+        || (req.method == "POST" && req.url == "/__edge-cache-purge")) {
         if (!client.ip ~ purge_clients) {
             return (synth(403, "Not allowed"));
         }

--- a/sql/070_awcms_edge_cache_purges_tenant_guc_fix.sql
+++ b/sql/070_awcms_edge_cache_purges_tenant_guc_fix.sql
@@ -1,0 +1,48 @@
+-- 070 — repair the edge-cache purge queue's tenant-isolation policy.
+--
+-- `sql/068` created the policy against the GUC `awcms.tenant_id`. Nothing in
+-- this codebase ever sets that name. `withTenant()` issues
+-- `SET LOCAL app.current_tenant_id = ...` (src/lib/database/tenant-context.ts),
+-- and all 108 other tenant policies read `app.current_tenant_id`. `sql/068` was
+-- the single outlier.
+--
+-- ## Why this was worse than a stale cache
+--
+-- `current_setting('awcms.tenant_id', true)` returns NULL, so the WITH CHECK
+-- expression evaluates to NULL — never true. Every INSERT was therefore rejected
+-- with `new row violates row-level security policy`.
+--
+-- `enqueueModuleContentPurge` is awaited **inside the content transaction**
+-- (ADR-0042 §9 / ADR-0006), unguarded, so that rejection aborted the publish
+-- itself. With `EDGE_CACHE_MODE` set to `auto` or `on`, every blog create,
+-- update, delete, and scheduled publish returned a 500. The write path was down,
+-- not merely uncached.
+--
+-- It stayed invisible because the subsystem defaults to `off`: with the cache
+-- disabled `enqueueModuleContentPurge` returns before touching the database, so
+-- CI, the integration suite, and every deployment to date exercised the guarded
+-- path only. The fault appeared the moment the feature was switched on in
+-- staging — the first time this table was ever written to.
+--
+-- The USING side was equally broken and failed quietly in the other direction:
+-- the worker's `claimEdgeCachePurges` matched zero rows for every tenant and
+-- reported `sent=0`, which is indistinguishable from an empty queue.
+--
+-- ## Shape of the fix
+--
+-- `CREATE POLICY` is not idempotent and the policy already exists, so this drops
+-- and recreates rather than altering — the same DROP-then-CREATE the original
+-- migration used. Editing `sql/068` in place is not an option: it is already
+-- applied in staging, and a checksum change would block `db:migrate` on any
+-- running deployment.
+--
+-- No DML, no data to migrate: the table is empty everywhere precisely because
+-- nothing could ever insert into it.
+
+DROP POLICY IF EXISTS awcms_edge_cache_purges_tenant_isolation
+  ON awcms_edge_cache_purges;
+
+CREATE POLICY awcms_edge_cache_purges_tenant_isolation
+  ON awcms_edge_cache_purges
+  USING (tenant_id = current_setting('app.current_tenant_id', true)::uuid)
+  WITH CHECK (tenant_id = current_setting('app.current_tenant_id', true)::uuid);

--- a/src/lib/edge-cache/varnish-client.ts
+++ b/src/lib/edge-cache/varnish-client.ts
@@ -1,8 +1,29 @@
 /**
  * Varnish invalidation client — ADR-0042 §10.
  *
- * Sends one `BAN` request per surrogate key. The bundled VCL turns it into
- * `ban(obj.http.Surrogate-Key ~ "(^| )<key>( |$)")`.
+ * Sends one purge request per surrogate key. The bundled VCL turns it into
+ * `ban(obj.http.Surrogate-Key ~ (^|[[:space:]])<key>([[:space:]]|$))`.
+ *
+ * ## Why `POST /__edge-cache-purge` and not the `BAN` method
+ *
+ * The conventional Varnish idiom is a custom `BAN` method, and that is what this
+ * client originally sent. **Bun does not transmit non-standard HTTP methods.**
+ * `fetch(url, { method: "BAN" })` and `node:http` with `method: "BAN"` both
+ * arrive at Varnish as `GET` — verified against Bun 1.3.14 by reading
+ * `varnishlog -i ReqMethod`, where the same request written byte-for-byte over a
+ * raw socket logs `BAN` and answers `200 Banned`.
+ *
+ * The effect was total: every purge fell through the VCL's BAN branch to the
+ * backend, which returned 404 for an unrouted path, and the queue recorded
+ * `Varnish rejected the BAN with status 404`. On a Bun-only runtime (ADR-0002)
+ * there is no configuration that makes the `BAN` method work.
+ *
+ * So the wire protocol is a `POST` to a reserved path instead. Nothing about the
+ * security model changes: the method was never a control. The three that matter
+ * — the purge ACL, the shared token, and the key charset re-validation — are
+ * unchanged and all still enforced at the edge. The VCL continues to accept a
+ * real `BAN` as well, so `curl -X BAN` still works for an operator debugging by
+ * hand.
  *
  * ## Why the key travels raw and the regex is assembled at the edge
  *
@@ -27,7 +48,21 @@ import { loadEdgeCacheConfig, type EdgeCacheConfig } from "./config";
 export const PURGE_TOKEN_HEADER = "X-Edge-Purge-Token";
 export const PURGE_KEY_HEADER = "X-Edge-Purge-Key";
 
-/** Bounds one BAN. Short: a healthy Varnish answers a ban in single-digit ms. */
+/**
+ * Reserved path the VCL intercepts. It must never reach the origin; if Varnish
+ * is absent or misconfigured the app has no such route, so the request 404s and
+ * the queue records a failure rather than doing something unintended.
+ */
+export const PURGE_PATH = "/__edge-cache-purge";
+
+/**
+ * The method actually put on the wire. Must stay a standard method — see the
+ * header note; an exotic one is silently rewritten to GET by Bun and every purge
+ * becomes a no-op that reports success at the HTTP layer.
+ */
+export const PURGE_METHOD = "POST";
+
+/** Bounds one purge. Short: a healthy Varnish answers a ban in single-digit ms. */
 const PURGE_TIMEOUT_MS = 5_000;
 
 export type PurgeOutcome =
@@ -46,6 +81,16 @@ export type FetchLike = (
  * future caller) still cannot inject a regex.
  */
 const SAFE_KEY = /^[A-Za-z0-9:._-]{1,512}$/;
+
+/**
+ * Join the configured endpoint with the reserved path, tolerating a trailing
+ * slash in configuration. `new URL` is deliberately avoided: the endpoint is an
+ * operator-supplied origin, and resolving a path against it would let a
+ * configured value with its own path silently drop that path.
+ */
+function buildPurgeUrl(endpoint: string): string {
+  return `${endpoint.replace(/\/+$/, "")}${PURGE_PATH}`;
+}
 
 export async function sendEdgeCachePurge(
   surrogateKey: string,
@@ -79,8 +124,8 @@ export async function sendEdgeCachePurge(
   const timeout = setTimeout(() => controller.abort(), PURGE_TIMEOUT_MS);
 
   try {
-    const response = await fetchImpl(config.purgeEndpoint, {
-      method: "BAN",
+    const response = await fetchImpl(buildPurgeUrl(config.purgeEndpoint), {
+      method: PURGE_METHOD,
       headers: {
         [PURGE_KEY_HEADER]: surrogateKey,
         ...(config.purgeToken
@@ -99,7 +144,7 @@ export async function sendEdgeCachePurge(
     // anything else is worth another pass.
     return {
       ok: false,
-      detail: `Varnish rejected the BAN with status ${response.status}.`,
+      detail: `Varnish rejected the purge with status ${response.status}.`,
       retryable: response.status >= 500
     };
   } catch (error) {
@@ -107,8 +152,8 @@ export async function sendEdgeCachePurge(
       ok: false,
       detail:
         error instanceof Error && error.name === "AbortError"
-          ? `BAN timed out after ${PURGE_TIMEOUT_MS}ms.`
-          : "BAN request failed before a response was received.",
+          ? `Purge timed out after ${PURGE_TIMEOUT_MS}ms.`
+          : "Purge request failed before a response was received.",
       retryable: true
     };
   } finally {

--- a/tests/edge-cache-purge-client.test.ts
+++ b/tests/edge-cache-purge-client.test.ts
@@ -1,0 +1,187 @@
+/**
+ * ADR-0042 §10 — the purge client, tested against a real HTTP server.
+ *
+ * ## Why a real server and not an injected `fetchImpl`
+ *
+ * This file exists because the client shipped with a defect that a mock cannot
+ * express. It sent `method: "BAN"`, the conventional Varnish idiom. **Bun does
+ * not transmit non-standard HTTP methods**: both `fetch` and `node:http` deliver
+ * that request as `GET` (Bun 1.3.14). Every purge fell through the VCL's ban
+ * branch to the origin, 404'd, and the queue recorded a rejection — while the
+ * code, read on its own, looked exactly right.
+ *
+ * An injected fake would have asserted `init.method === "BAN"` and passed
+ * forever, because it observes the *argument* rather than the wire. So the tests
+ * below stand up a `Bun.serve` and assert `request.method` as **received**. That
+ * is the only formulation that can fail for the reason this bug failed.
+ *
+ * The same reasoning applies to the URL: the reserved path has to arrive intact
+ * for the VCL to intercept it, and only the server can say whether it did.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+
+import type { EdgeCacheConfig } from "../src/lib/edge-cache/config";
+import {
+  PURGE_KEY_HEADER,
+  PURGE_PATH,
+  PURGE_TOKEN_HEADER,
+  sendEdgeCachePurge
+} from "../src/lib/edge-cache/varnish-client";
+
+type Received = {
+  method: string;
+  path: string;
+  token: string | null;
+  key: string | null;
+};
+
+let server: ReturnType<typeof Bun.serve>;
+let received: Received[] = [];
+/** Status the fake edge answers with; per-test. */
+let respondWith = 200;
+
+beforeAll(() => {
+  server = Bun.serve({
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+
+      received.push({
+        method: request.method,
+        path: url.pathname,
+        token: request.headers.get(PURGE_TOKEN_HEADER),
+        key: request.headers.get(PURGE_KEY_HEADER)
+      });
+
+      return new Response("", { status: respondWith });
+    }
+  });
+});
+
+afterAll(() => {
+  server.stop(true);
+});
+
+function configFor(endpoint: string): EdgeCacheConfig {
+  return {
+    mode: "on",
+    maxTtlSeconds: 300,
+    staleWhileRevalidateSeconds: 600,
+    purgeEndpoint: endpoint,
+    purgeToken: "test-token",
+    purgeBatchSize: 200,
+    autoRequestRateThreshold: 5,
+    autoLatencyThresholdMs: 250,
+    autoWindowSeconds: 60
+  };
+}
+
+function endpoint(): string {
+  return `http://127.0.0.1:${server.port}`;
+}
+
+describe("sendEdgeCachePurge on the wire", () => {
+  test("the method that ARRIVES is one Bun actually transmits", async () => {
+    received = [];
+    respondWith = 200;
+
+    const outcome = await sendEdgeCachePurge("t:abc", {
+      config: configFor(endpoint())
+    });
+
+    expect(outcome).toEqual({ ok: true });
+    expect(received).toHaveLength(1);
+
+    // The assertion the old code would have failed. `BAN` would arrive as `GET`.
+    expect(received[0]?.method).not.toBe("GET");
+    expect(received[0]?.method).toBe("POST");
+  });
+
+  test("the reserved path arrives intact so the VCL can intercept it", async () => {
+    received = [];
+    respondWith = 200;
+
+    await sendEdgeCachePurge("t:abc", { config: configFor(endpoint()) });
+
+    expect(received[0]?.path).toBe(PURGE_PATH);
+  });
+
+  test("a trailing slash on the configured endpoint does not double up", async () => {
+    received = [];
+    respondWith = 200;
+
+    await sendEdgeCachePurge("t:abc", {
+      config: configFor(`${endpoint()}/`)
+    });
+
+    expect(received[0]?.path).toBe(PURGE_PATH);
+  });
+
+  test("token and key travel as headers, key raw and unescaped", async () => {
+    received = [];
+    respondWith = 200;
+
+    await sendEdgeCachePurge("t:abc:m:blog_content", {
+      config: configFor(endpoint())
+    });
+
+    expect(received[0]?.token).toBe("test-token");
+    // Raw on purpose: the edge assembles the regex, so the app never hands a
+    // remote party a compiled pattern.
+    expect(received[0]?.key).toBe("t:abc:m:blog_content");
+  });
+
+  test("4xx is not retryable, 5xx is", async () => {
+    received = [];
+    respondWith = 403;
+
+    const rejected = await sendEdgeCachePurge("t:abc", {
+      config: configFor(endpoint())
+    });
+
+    expect(rejected).toMatchObject({ ok: false, retryable: false });
+
+    respondWith = 503;
+
+    const unavailable = await sendEdgeCachePurge("t:abc", {
+      config: configFor(endpoint())
+    });
+
+    expect(unavailable).toMatchObject({ ok: false, retryable: true });
+  });
+
+  test("an unsafe key is refused before anything is sent", async () => {
+    received = [];
+    respondWith = 200;
+
+    const outcome = await sendEdgeCachePurge(".*", {
+      config: configFor(endpoint())
+    });
+
+    expect(outcome).toMatchObject({ ok: false, retryable: false });
+    // Nothing on the wire at all: a regex must never reach the edge.
+    expect(received).toHaveLength(0);
+  });
+
+  test("an unconfigured endpoint fails without retrying", async () => {
+    const outcome = await sendEdgeCachePurge("t:abc", {
+      config: { ...configFor(endpoint()), purgeEndpoint: null }
+    });
+
+    expect(outcome).toMatchObject({ ok: false, retryable: false });
+  });
+});
+
+describe("the VCL accepts what the client sends", () => {
+  test("default.vcl intercepts the reserved POST path", async () => {
+    // File-level, for the same reason as the ban-expression gate: the two halves
+    // of this protocol live in different languages and nothing else compares
+    // them. A client/VCL mismatch is a silent no-op, not an error.
+    const vcl = await Bun.file("infra/varnish/default.vcl").text();
+
+    expect(vcl).toContain(PURGE_PATH);
+    expect(vcl).toMatch(/req\.method\s*==\s*"POST"/);
+    // The operator escape hatch stays.
+    expect(vcl).toMatch(/req\.method\s*==\s*"BAN"/);
+  });
+});

--- a/tests/migration-tenant-guc-consistency.test.ts
+++ b/tests/migration-tenant-guc-consistency.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Every tenant-isolation policy must read the GUC the application actually sets.
+ *
+ * `withTenant()` issues `SET LOCAL app.current_tenant_id = ...`
+ * (`src/lib/database/tenant-context.ts`). A policy that reads any other name
+ * gets NULL from `current_setting(..., true)`, so its predicate is NULL — never
+ * true — and the table becomes unusable rather than merely unfiltered.
+ *
+ * ## Why this file exists
+ *
+ * `sql/068` shipped a policy against `awcms.tenant_id`, a name nothing in this
+ * codebase sets. Two failures followed, in opposite directions and both quiet:
+ *
+ * - **USING** matched no rows, so the purge worker drained nothing and reported
+ *   `sent=0` — indistinguishable from an empty queue.
+ * - **WITH CHECK** rejected every INSERT. Because `enqueueModuleContentPurge` is
+ *   awaited inside the content transaction, that rejection aborted the publish.
+ *   With `EDGE_CACHE_MODE` enabled, every blog write returned 500.
+ *
+ * Neither surfaced in CI. The edge cache defaults to `off`, so the enqueue
+ * returns before touching the database and no suite had ever written to the
+ * table. It appeared the first time the feature was switched on.
+ *
+ * A pure text gate is the right shape here. It needs no database, so it runs in
+ * the `quality` job on every PR, and it fails at authoring time — when the
+ * migration is being written — rather than on the day someone enables a flag in
+ * production.
+ */
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+/** The one GUC `withTenant()` sets. Anything else in a policy is a typo with teeth. */
+const TENANT_GUC = "app.current_tenant_id";
+
+/**
+ * `current_setting('<name>'` inside any policy body. Deliberately matches the
+ * whole migration text rather than parsing `CREATE POLICY` blocks: a GUC read
+ * anywhere in a migration should use the same name, and a loose match cannot
+ * miss one by failing to model SQL syntax.
+ */
+const CURRENT_SETTING = /current_setting\(\s*'([^']+)'/g;
+
+/**
+ * Names that are legitimately not the tenant GUC. Empty today, and an addition
+ * here should be rare enough to argue for in review.
+ */
+const ALLOWED_OTHER_GUCS = new Set<string>([]);
+
+/**
+ * Strip `--` line comments and `/* *\/` block comments.
+ *
+ * Load-bearing, not tidiness: a migration that *repairs* a wrong GUC has to name
+ * the wrong GUC in its own header to explain itself. Scanning raw text would
+ * make the fix trip the gate that exists to catch the bug — so the gate would
+ * punish documenting it.
+ */
+function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+}
+
+async function readMigrations(): Promise<{ name: string; sql: string }[]> {
+  const dir = path.resolve(process.cwd(), "sql");
+  const names = (await readdir(dir))
+    .filter((name) => name.endsWith(".sql"))
+    .sort();
+
+  return Promise.all(
+    names.map(async (name) => ({
+      name,
+      sql: stripSqlComments(await readFile(path.join(dir, name), "utf8"))
+    }))
+  );
+}
+
+describe("migrations read the tenant GUC the application sets", () => {
+  test("no migration reads a GUC other than app.current_tenant_id", async () => {
+    const migrations = await readMigrations();
+    const offenders: string[] = [];
+
+    for (const migration of migrations) {
+      for (const match of migration.sql.matchAll(CURRENT_SETTING)) {
+        const guc = match[1];
+
+        if (!guc || guc === TENANT_GUC || ALLOWED_OTHER_GUCS.has(guc)) {
+          continue;
+        }
+
+        offenders.push(`${migration.name}: current_setting('${guc}')`);
+      }
+    }
+
+    // `sql/068` is expected to appear nowhere: `sql/070` replaces its policy,
+    // but 068 itself is applied and immutable, so its text still contains the
+    // wrong name. The assertion below therefore tolerates 068 by name only.
+    const unexpected = offenders.filter(
+      (entry) => !entry.startsWith("068_awcms_edge_cache_purge_queue.sql:")
+    );
+
+    expect(unexpected).toEqual([]);
+  });
+
+  test("the last policy on the purge queue uses the right GUC", async () => {
+    // Ordering matters: `sql/070` must come after `sql/068` and must be the
+    // definition that wins. Asserting on the final occurrence across the sorted
+    // migration set is what "the policy in effect" actually means.
+    const migrations = await readMigrations();
+    const policyDefinitions = migrations
+      .filter((migration) =>
+        migration.sql.includes("awcms_edge_cache_purges_tenant_isolation")
+      )
+      .filter((migration) => /CREATE\s+POLICY/i.test(migration.sql));
+
+    expect(policyDefinitions.length).toBeGreaterThanOrEqual(2);
+
+    const winning = policyDefinitions.at(-1);
+
+    expect(winning?.name).toBe(
+      "070_awcms_edge_cache_purges_tenant_guc_fix.sql"
+    );
+    expect(winning?.sql).toContain(`current_setting('${TENANT_GUC}'`);
+    expect(winning?.sql).not.toContain("current_setting('awcms.tenant_id'");
+  });
+});


### PR DESCRIPTION
Two more defects in the same subsystem, both found by running it rather than reading it. Follows #242. Each is invisible while `EDGE_CACHE_MODE` is `off` — which is every environment and every CI job to date.

## 1. The purge queue's RLS policy named a GUC nothing sets

`sql/068` wrote `current_setting('awcms.tenant_id', true)`. `withTenant()` sets `app.current_tenant_id`, and so do the **other 108** tenant policies in `sql/`. It was the only outlier.

This was not a stale-cache bug:

- `current_setting` returned NULL → `WITH CHECK` was NULL → **every INSERT rejected**.
- `enqueueModuleContentPurge` is awaited *inside* the content transaction (ADR-0042 §9 / ADR-0006), unguarded — so that rejection **aborted the publish**. With the cache enabled, blog create, update, delete and scheduled publish all returned 500. The write path was down, not merely uncached.
- The `USING` side failed the opposite, quieter way: the worker matched zero rows and reported `sent=0`, indistinguishable from an empty queue.

Reproduced on the exact code path:

```
BEGIN; SET LOCAL app.current_tenant_id = '<tenant>';
INSERT INTO awcms_edge_cache_purges ...
ERROR:  new row violates row-level security policy
```

`sql/070` replaces the policy. `sql/068` is untouched — it is applied in a running deployment and rewriting it would change its checksum and block `db:migrate`.

## 2. Bun does not transmit non-standard HTTP methods

`sendEdgeCachePurge` sent `method: "BAN"`, the conventional Varnish idiom. Both `fetch` and `node:http` deliver it as **`GET`**:

| transport | what Varnish logged | result |
| --- | --- | --- |
| Bun `fetch`, `method: "BAN"` | `ReqMethod GET` | 404 from origin |
| Bun `node:http`, `method: "BAN"` | `ReqMethod GET` | 404 from origin |
| raw socket, literal `BAN / HTTP/1.1` | `ReqMethod BAN` | **200 Banned** |

Every purge fell past the VCL's ban branch to the origin. On a Bun-only runtime (ADR-0002) no configuration fixes this.

Wire protocol is now `POST /__edge-cache-purge`. **The security model is unchanged** — the method was never a control. The purge ACL, the shared token, and the key-charset re-validation at the edge all still apply, to both entry points. The VCL keeps accepting a real `BAN` so `curl -X BAN` still works for operator debugging.

## Why none of this was caught

`sendEdgeCachePurge` had **no tests at all**. That is the root cause of all three defects across #242 and this PR.

The new `tests/edge-cache-purge-client.test.ts` runs against a real `Bun.serve` and asserts `request.method` **as received**. This matters more than it looks: an injected `fetchImpl` observes the *argument*, so it would have asserted `method === "BAN"` and passed forever. Only the wire can fail for the reason this failed.

`tests/migration-tenant-guc-consistency.test.ts` scans every migration's executable SQL — comments stripped, so a repair migration may name the wrong GUC while explaining itself — and rejects any `current_setting` that is not `app.current_tenant_id`. No database, so it runs in `quality` on every PR.

Both mutation-proven red, then restored.

## Verified end to end on staging

| step | result |
| --- | --- |
| warm | `X-Cache: HIT` |
| enqueue under tenant context (the publish path) | `INSERT 0 1` |
| worker pass | `sent=1 failed=0` |
| after purge | **`X-Cache: MISS`** |
| next request | `X-Cache: HIT` |
| queue row | `done attempts=1` |

`bun run check` green — 2305 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)