### PR TITLE
docs: pin the default tenant per environment, state the owner convention

### DIFF
--- a/.changeset/default-tenant-owner-convention.md
+++ b/.changeset/default-tenant-owner-convention.md
@@ -1,0 +1,32 @@
+---
+"awcms": patch
+---
+
+Pin the default tenant per environment, and state the owner-account convention
+for all three phases.
+
+`PUBLIC_DEFAULT_TENANT_ID`/`_CODE` are now set in staging and production rather
+than left to the end of the resolution chain. Unset still worked — the chain
+terminates at `awcms_setup_state.tenant_id` — but that makes "which tenant does
+an unmatched host resolve to?" an implicit answer living in a table rather than a
+stated one, and it silently becomes the wrong answer the moment a second tenant
+exists. The consumers are real: `seo_distribution` (`/robots.txt`, sitemap, feeds)
+and `site_search`.
+
+`PUBLIC_TENANT_RESOLUTION_MODE` is deliberately left unset. Production does have
+an `awcms_tenant_domains` row for `awcms.ahlikoding.com`, so `host_default` would
+work — but enabling host lookup widens the reachable surface and is its own
+decision, not part of "set the default tenant".
+
+Documents the owner convention across development, staging and production: the
+login identifier `admin@ahlikoding.com` is shared, the password never is.
+`awcms_identities` is unique on `(tenant_id, login_identifier)`, so one address in
+three environments is three unrelated accounts with three password hashes and
+three `AUTH_JWT_SECRET`s.
+
+Also records the permission-seed gap where it will actually be read, with the
+backfill SQL: a seed migration reaches only tenants created after it, so landing a
+module does not grant its permissions to an existing owner — the symptom is a 403
+on a module that is plainly installed. Plus the queries that show whether "full
+access" is genuinely full, since RBAC 197/197 means nothing if an ABAC deny, an
+SoD rule, or a business-scope constraint is in play.

--- a/.env.example
+++ b/.env.example
@@ -235,8 +235,47 @@ VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS=30
 #
 # Safe fallback tenant for host-resolved public routes when the host does not map
 # (or host lookup is off): tried in order ID -> CODE -> awcms_setup_state.tenant_id.
+#
+# PIN THESE PER ENVIRONMENT. Leaving them unset still works — the chain ends at
+# `awcms_setup_state.tenant_id`, which the setup wizard populated — but that
+# makes "which tenant does an unmatched host get?" an implicit answer buried in
+# a table rather than a stated one. Pinning them is also the only way a second
+# tenant can be added later without silently changing what the first host
+# resolves to.
+#
+# Every deployed environment sets its OWN tenant here; the value is deliberately
+# not shared between them:
+#   development  -> the tenant your local setup wizard created
+#   staging      -> tenant_code `staging`
+#   production   -> tenant_code `ahliweb`
 # PUBLIC_DEFAULT_TENANT_ID=
 # PUBLIC_DEFAULT_TENANT_CODE=
+
+# --- owner account convention (all phases) ---
+# The first account created by `POST /api/v1/setup/initialize` is the tenant
+# `owner`: a system role holding the ENTIRE permission catalog. Across
+# development, staging, and production the owner login identifier is
+# `admin@ahlikoding.com`.
+#
+# The identifier is shared; the PASSWORD IS NOT, and must never be. Identities
+# are tenant-scoped (`awcms_identities` is unique on `(tenant_id,
+# login_identifier)`), so the same address in three environments is three
+# unrelated accounts with three different password hashes and three different
+# `AUTH_JWT_SECRET`s. Copying a password between them would undo exactly the
+# isolation that separation buys.
+#
+# One trap that is invisible until someone hits a 403: a permission-seed
+# migration only reaches tenants created AFTER it runs. Landing a module that
+# seeds new permissions does NOT grant them to an existing owner. Backfill as a
+# deployment step:
+#
+#   INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+#   SELECT r.tenant_id, r.id, p.id
+#   FROM awcms_roles r CROSS JOIN awcms_permissions p
+#   LEFT JOIN awcms_role_permissions rp
+#     ON rp.role_id = r.id AND rp.permission_id = p.id
+#   WHERE r.role_code = 'owner' AND r.deleted_at IS NULL
+#     AND rp.permission_id IS NULL;
 
 # --- comments (ADR-0041) ---
 # Both secrets are OPTIONAL and both degrade to a strictly SAFE state, which is

--- a/docs/awcms/environments.md
+++ b/docs/awcms/environments.md
@@ -18,6 +18,68 @@ dan menerbitkan TLS lewat resolver `letsencrypt`. **Satu app Coolify per
 environment** — bukan satu app dengan dua domain: environment berbagi app berarti
 berbagi env var, dan itulah cara staging tanpa sengaja menulis ke data produksi.
 
+## Tenant default & akun owner — sama di tiga fase
+
+Ketiga fase memakai konvensi yang sama, dan perbedaannya justru yang penting:
+
+| Hal                       | Development               | Staging                   | Production                |
+| ------------------------- | ------------------------- | ------------------------- | ------------------------- |
+| `tenant_code`             | hasil setup wizard lokal  | `staging`                 | `ahliweb`                 |
+| `PUBLIC_DEFAULT_TENANT_*` | pin ke tenant lokal       | pin ke tenant `staging`   | pin ke tenant `ahliweb`   |
+| Login owner               | `admin@ahlikoding.com`    | `admin@ahlikoding.com`    | `admin@ahlikoding.com`    |
+| Password owner            | **sendiri**               | **sendiri**               | **sendiri**               |
+| Role                      | `owner` (system, 197/197) | `owner` (system, 197/197) | `owner` (system, 197/197) |
+
+**Identifier-nya sama, password-nya TIDAK PERNAH sama.** `awcms_identities` unik
+pada `(tenant_id, login_identifier)`, jadi satu alamat di tiga environment adalah
+**tiga akun terpisah** dengan tiga hash password dan tiga `AUTH_JWT_SECRET`
+berbeda. Menyalin password antar fase membatalkan isolasi yang justru jadi alasan
+memisahkan environment.
+
+### Kenapa `PUBLIC_DEFAULT_TENANT_*` di-pin, padahal tanpa itu pun jalan
+
+Rantai resolusinya `host` → `PUBLIC_DEFAULT_TENANT_ID` → `PUBLIC_DEFAULT_TENANT_CODE`
+→ `awcms_setup_state.tenant_id`. Tanpa dua var itu, jawaban atas "host yang tidak
+cocok jatuh ke tenant mana?" tetap ada — tapi tersembunyi di sebuah baris tabel,
+bukan dinyatakan. Dan begitu tenant kedua ditambahkan, jawaban implisit itu bisa
+berubah tanpa satu pun perubahan konfigurasi. Konsumennya nyata:
+`seo_distribution` (`/robots.txt`, sitemap, feed) dan `site_search`.
+
+`PUBLIC_TENANT_RESOLUTION_MODE` **tidak** di-set di mana pun. Produksi punya baris
+`awcms_tenant_domains` untuk `awcms.ahlikoding.com`, jadi `host_default` akan
+bekerja — tetapi itu keputusan perilaku tersendiri (mengaktifkan lookup host dan
+memperluas permukaan yang tersentuh), bukan bagian dari "tetapkan tenant
+default". Nyalakan terpisah bila memang diinginkan.
+
+### Jebakan: seed permission tidak menjangkau tenant lama
+
+Migrasi seed permission hanya berlaku untuk tenant yang dibuat **setelahnya**.
+Mendaratkan modul baru **tidak** memberi permission-nya ke owner yang sudah ada —
+gejalanya 403 `ACCESS_DENIED` pada modul yang "sudah terpasang". Terjadi nyata di
+produksi 2026-07-26: owner kehilangan 18 permission (`comments`, `site_search`,
+`form_drafts`) setelah migrasi 062–070. Backfill adalah langkah deployment:
+
+```sql
+INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+SELECT r.tenant_id, r.id, p.id
+FROM awcms_roles r CROSS JOIN awcms_permissions p
+LEFT JOIN awcms_role_permissions rp
+  ON rp.role_id = r.id AND rp.permission_id = p.id
+WHERE r.role_code = 'owner' AND r.deleted_at IS NULL
+  AND rp.permission_id IS NULL;
+```
+
+Verifikasi bahwa "akses penuh" memang penuh — RBAC 197/197 belum cukup bila ada
+ABAC deny, aturan SoD, atau batasan business-scope:
+
+```sql
+SELECT count(*) FROM awcms_abac_policies WHERE is_active AND is_dsl_managed;
+SELECT count(*) FROM awcms_business_scope_assignments;
+```
+
+Keduanya `0` di produksi dan staging per 2026-07-26, dan tidak ada rute base yang
+menyetel `requiredScopeType`, jadi RBAC benar-benar penentu tunggalnya.
+
 ## `APP_URL` bukan kosmetik
 
 `APP_URL` **wajib** (`scripts/validate-env.ts`) dan bukan sekadar label: ia


### PR DESCRIPTION
Applies the default-tenant / owner-account convention across **development, staging and production**.

## What was already true

Production needed almost nothing: the owner is already `admin@ahlikoding.com`, active, holding the `owner` system role with **197/197** permissions. Verified that "full access" is genuinely full rather than just RBAC-complete — 0 active ABAC policies, 0 business-scope assignments, 0 MFA factors, and no base route sets `requiredScopeType`, so nothing narrows it.

## What changed

| | Development | Staging | Production |
|---|---|---|---|
| `tenant_code` | local setup wizard | `staging` | `ahliweb` |
| `PUBLIC_DEFAULT_TENANT_*` | documented | **pinned** | **pinned** |
| Owner login | `admin@ahlikoding.com` | **renamed** from `owner@awcms-staging…` | already correct |
| Role | `owner` 197/197 | `owner` 197/197 | `owner` 197/197 |

Staging's owner was renamed in-place under tenant context as `awcms_app`, so RLS was exercised rather than bypassed. Verified after: login with `admin@ahlikoding.com` issues a token, and the old identifier is correctly rejected.

**The identifier is shared; the password never is.** `awcms_identities` is unique on `(tenant_id, login_identifier)`, so one address across three environments is three unrelated accounts with three password hashes and three `AUTH_JWT_SECRET`s. I did **not** touch production's password — I don't have it, and resetting it would lock out the real owner. Production's login is therefore verified by state, not by an actual sign-in; that limit is stated rather than papered over.

## Why pin the env at all

The chain is `host` → `PUBLIC_DEFAULT_TENANT_ID` → `PUBLIC_DEFAULT_TENANT_CODE` → `awcms_setup_state.tenant_id`. Unset already resolved correctly — but the answer to "which tenant does an unmatched host get?" lived in a table rather than being stated, and it silently becomes the *wrong* answer once a second tenant exists. Consumers are real: `seo_distribution` discovery routes and `site_search`.

`PUBLIC_TENANT_RESOLUTION_MODE` is deliberately **not** set. Production does have an `awcms_tenant_domains` row for `awcms.ahlikoding.com`, so `host_default` would work — but enabling host lookup widens the reachable surface and is its own decision, not part of "set the default tenant".

## The trap worth reading

A permission-seed migration reaches only tenants created *after* it runs. Landing a module does not grant its permissions to an existing owner, and the symptom is a 403 on a module that is visibly installed. It bit production today: 18 permissions missing across `comments`/`site_search`/`form_drafts` after 062–070. The backfill SQL is now in both `.env.example` and `environments.md`, next to the queries that check whether full access is actually full.

`bun run check` green — 2310 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)