### PR TITLE
feat(_shared): close the authorization chokepoint with defineTenantRoute

### DIFF
--- a/.changeset/tenant-route-factory.md
+++ b/.changeset/tenant-route-factory.md
@@ -1,0 +1,23 @@
+---
+"awcms": minor
+---
+
+Close the authorization chokepoint: `defineTenantRoute` + `api:tenant-route:check`.
+
+The auth/tenant opening that 204 route files copy verbatim now lives once in
+`src/modules/_shared/tenant-route.ts`. `workClass` is REQUIRED in the factory
+type with no default — 176 of those 204 files pass none today, so they share
+login's pool budget by omission rather than by decision.
+
+The four `/api/v1/reports/*` routes are migrated. They had hand-rolled the guard
+chain and called `evaluateAccess` with three arguments of five, which skipped
+`resolveModuleEnabled` and dynamic ABAC entirely: a tenant that disabled
+`reporting` was still served, and a `deny` policy authored through
+`/api/v1/access/policies` was silently inert. Both are now enforced, so those
+endpoints newly return `403 MODULE_DISABLED` when the module is off and honour
+ABAC. They also accept a session cookie as well as a bearer token, because
+`resolveAuthInputs` reads both.
+
+`bun run api:tenant-route:check` rejects any NEW route that calls `withTenant`
+directly. The 204 pre-existing routes are listed in a `NOT_YET_MIGRATED` ledger
+that can only shrink: a stale entry fails the gate too.

--- a/.claude/skills/awcms-new-endpoint/SKILL.md
+++ b/.claude/skills/awcms-new-endpoint/SKILL.md
@@ -15,6 +15,38 @@ flowchart LR
   Idem -->|Tidak| Svc
 ```
 
+## Pembukaan rute: `defineTenantRoute` WAJIB untuk rute baru
+
+Rute tenant-scoped **tidak lagi** menulis sendiri
+`resolveAuthInputs → cek tenant/token → getDatabaseClient → hashSessionToken →
+withTenant → authorizeInTransaction → auth.denied`. Semua itu hidup satu kali di
+`src/modules/_shared/tenant-route.ts`.
+
+```ts
+export const GET = defineTenantRoute({
+  workClass: "reporting", // WAJIB — tanpa default, lihat di bawah
+  authorize: { moduleKey: "reporting", activityCode: "dashboard", action: "read" },
+  prepare: async ({ request, url }) => {
+    // body/query/cursor — SEBELUM koneksi diambil, jadi request cacat
+    // tidak memakan slot pool. Kembalikan `Response` untuk short-circuit.
+  },
+  handler: async ({ tx, auth, tenantId, prepared }) => ok(...)
+});
+```
+
+- **`workClass` wajib, tanpa default.** 176 dari 204 berkas rute lama tidak
+  meneruskannya, jadi berbagi budget pool dengan login karena kelalaian, bukan
+  keputusan. Menegaskan ulang `"interactive"` jawaban yang sah.
+- **Bentuk callback `authorize`:** tulis `prepare` SEBELUM `authorize` di object
+  literal. TypeScript menyimpulkan `TPrepared` menurut urutan sumber; `authorize`
+  duluan mem-pin-nya ke `undefined` dan errornya menyesatkan.
+- **Gate `bun run api:tenant-route:check`** menolak rute BARU yang memanggil
+  `withTenant` langsung. 204 rute lama ada di `NOT_YET_MIGRATED` — daftar yang
+  **hanya boleh menyusut**; entri basi juga menggagalkan gate. **Jangan pernah
+  menambah baris ke daftar itu.**
+- Migrasi rute lama: satu modul per PR, tanpa perubahan perilaku, hapus barisnya
+  dari daftar.
+
 ## Aturan
 
 1. Route hanya orkestrasi; business logic di service, query di repository.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,9 @@ jobs:
       - name: Logging redaction lint check
         run: bun run logging:lint:check
 
+      - name: Tenant-route factory check (Issue #255)
+        run: bun run api:tenant-route:check
+
       - name: Typecheck (tsc --noEmit)
         run: bun run typecheck
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "modules:composition:inventory:generate": "bun scripts/module-composition-inventory-generate.ts",
     "modules:composition:inventory:check": "bun scripts/module-composition-inventory-check.ts",
     "logging:lint:check": "bun scripts/logging-lint-check.ts",
+    "api:tenant-route:check": "bun scripts/tenant-route-factory-check.ts",
     "config:validate": "bun scripts/validate-env.ts",
     "security:readiness": "bun scripts/security-readiness.ts",
     "lint": "prettier --check \"**/*.md\" \"**/*.{json,yml,yaml}\" \"**/*.{ts,mjs,astro}\"",
@@ -91,7 +92,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -1,0 +1,390 @@
+#!/usr/bin/env bun
+/**
+ * `bun run api:tenant-route:check` — Issue #255.
+ *
+ * Every NEW route under `src/pages/api` must open its tenant transaction
+ * through `defineTenantRoute` (`src/modules/_shared/tenant-route.ts`), not by
+ * calling `withTenant` directly.
+ *
+ * ## Why a gate
+ *
+ * Because the hand-copied opening was already wrong in four places and nothing
+ * noticed. `/api/v1/reports/*` reimplemented the guard chain and called
+ * `evaluateAccess` with three arguments of five, skipping the module-enabled
+ * check and dynamic ABAC entirely — a tenant that disabled `reporting` was
+ * still served, and a `deny` policy authored through the supported surface was
+ * silently inert. Copy-paste was the only enforcement there was; it worked 184
+ * times and failed 4, indistinguishably from a diff.
+ *
+ * The same duplication is why **176 of the 204 route files** that call
+ * `withTenant` directly pass no work class at all: they share login's pool
+ * budget by omission, not by decision. `defineTenantRoute` makes `workClass` a
+ * compile error to omit; this gate is what keeps the count of hand-rolled
+ * openings going DOWN while the migration proceeds module by module.
+ *
+ * ## The allowlist is a debt ledger, not an off switch
+ *
+ * Migration is deliberately incremental (one module per PR, no behaviour
+ * change), so routes predating the factory are listed verbatim. Two rules make
+ * the list one-directional:
+ *
+ * 1. A route under `src/pages/api` that calls `withTenant` directly and is NOT
+ *    listed fails — that is a NEW hand-rolled opening, and new routes have no
+ *    excuse.
+ * 2. A listed route that no longer calls `withTenant` directly (migrated, or
+ *    deleted) ALSO fails, with an instruction to delete the line. The list can
+ *    only shrink; it can never quietly absorb a regression.
+ *
+ * Regex over comment-stripped lines rather than an AST, matching the idiom of
+ * the other pure gates in `scripts/` — auditable in review, no new dependency.
+ * The pattern deliberately matches `withTenant<T>(` as well as `withTenant(`:
+ * `_shared/tenant-route.ts` itself writes the generic form, and a pattern that
+ * missed it would let a copy of the factory's own body through.
+ */
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+const ROUTES_ROOT = "src/pages/api";
+
+/** Matches `withTenant(` AND `withTenant<T>(`. */
+const WITH_TENANT_CALL_PATTERN = /\bwithTenant\s*(?:<[^()]*>)?\s*\(/;
+
+/**
+ * Routes that still open their own transaction, measured at `b9931594`.
+ * ONLY REMOVE LINES FROM THIS LIST. Never add one: a new entry means a new
+ * route skipped `defineTenantRoute`, which is what this gate exists to
+ * prevent.
+ */
+const NOT_YET_MIGRATED: readonly string[] = [
+  "src/pages/api/v1/abac/policies/[id].ts",
+  "src/pages/api/v1/abac/policies/index.ts",
+  "src/pages/api/v1/access/assignments.ts",
+  "src/pages/api/v1/access/evaluate.ts",
+  "src/pages/api/v1/access/modules.ts",
+  "src/pages/api/v1/access/policies/[id].ts",
+  "src/pages/api/v1/access/policies/[id]/disable.ts",
+  "src/pages/api/v1/access/policies/[id]/enable.ts",
+  "src/pages/api/v1/access/policies/index.ts",
+  "src/pages/api/v1/access/policies/simulate.ts",
+  "src/pages/api/v1/analytics/devices.ts",
+  "src/pages/api/v1/analytics/events.ts",
+  "src/pages/api/v1/analytics/locations.ts",
+  "src/pages/api/v1/analytics/pages.ts",
+  "src/pages/api/v1/analytics/realtime.ts",
+  "src/pages/api/v1/analytics/retention/purge.ts",
+  "src/pages/api/v1/analytics/security.ts",
+  "src/pages/api/v1/analytics/sessions.ts",
+  "src/pages/api/v1/analytics/settings.ts",
+  "src/pages/api/v1/analytics/summary.ts",
+  "src/pages/api/v1/auth/login.ts",
+  "src/pages/api/v1/auth/logout.ts",
+  "src/pages/api/v1/auth/me.ts",
+  "src/pages/api/v1/auth/mfa/admin/reset.ts",
+  "src/pages/api/v1/auth/mfa/policy.ts",
+  "src/pages/api/v1/auth/mfa/recovery-codes/regenerate.ts",
+  "src/pages/api/v1/auth/mfa/status.ts",
+  "src/pages/api/v1/auth/mfa/step-up.ts",
+  "src/pages/api/v1/auth/mfa/totp/disable.ts",
+  "src/pages/api/v1/auth/mfa/totp/enroll/start.ts",
+  "src/pages/api/v1/auth/mfa/totp/enroll/verify.ts",
+  "src/pages/api/v1/auth/mfa/totp/verify.ts",
+  "src/pages/api/v1/auth/sso-policy.ts",
+  "src/pages/api/v1/auth/sso-providers/[id].ts",
+  "src/pages/api/v1/auth/sso-providers/index.ts",
+  "src/pages/api/v1/auth/sso/[providerKey]/callback.ts",
+  "src/pages/api/v1/auth/sso/[providerKey]/link.ts",
+  "src/pages/api/v1/auth/sso/[providerKey]/start.ts",
+  "src/pages/api/v1/auth/sso/[providerKey]/unlink.ts",
+  "src/pages/api/v1/blog/ads/[id].ts",
+  "src/pages/api/v1/blog/ads/index.ts",
+  "src/pages/api/v1/blog/internal-tag-links/settings.ts",
+  "src/pages/api/v1/blog/menus/[id].ts",
+  "src/pages/api/v1/blog/menus/index.ts",
+  "src/pages/api/v1/blog/pages/[id].ts",
+  "src/pages/api/v1/blog/pages/[id]/quality-checklist.ts",
+  "src/pages/api/v1/blog/pages/index.ts",
+  "src/pages/api/v1/blog/posts/[id].ts",
+  "src/pages/api/v1/blog/posts/[id]/archive.ts",
+  "src/pages/api/v1/blog/posts/[id]/internal-links/preview.ts",
+  "src/pages/api/v1/blog/posts/[id]/publish.ts",
+  "src/pages/api/v1/blog/posts/[id]/purge.ts",
+  "src/pages/api/v1/blog/posts/[id]/quality-checklist.ts",
+  "src/pages/api/v1/blog/posts/[id]/restore.ts",
+  "src/pages/api/v1/blog/posts/[id]/revisions/[revisionId].ts",
+  "src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts",
+  "src/pages/api/v1/blog/posts/[id]/revisions/index.ts",
+  "src/pages/api/v1/blog/posts/[id]/schedule.ts",
+  "src/pages/api/v1/blog/posts/[id]/submit-review.ts",
+  "src/pages/api/v1/blog/posts/index.ts",
+  "src/pages/api/v1/blog/search/index.ts",
+  "src/pages/api/v1/blog/settings/index.ts",
+  "src/pages/api/v1/blog/templates/[id].ts",
+  "src/pages/api/v1/blog/templates/index.ts",
+  "src/pages/api/v1/blog/terms/[id].ts",
+  "src/pages/api/v1/blog/terms/index.ts",
+  "src/pages/api/v1/blog/theme/index.ts",
+  "src/pages/api/v1/blog/widgets/[id].ts",
+  "src/pages/api/v1/blog/widgets/index.ts",
+  "src/pages/api/v1/comments/admin/[id]/archive.ts",
+  "src/pages/api/v1/comments/admin/[id]/moderate.ts",
+  "src/pages/api/v1/comments/admin/[id]/restore.ts",
+  "src/pages/api/v1/comments/admin/bulk-moderate.ts",
+  "src/pages/api/v1/comments/admin/queue.ts",
+  "src/pages/api/v1/comments/admin/settings.ts",
+  "src/pages/api/v1/data-lifecycle/dry-run.ts",
+  "src/pages/api/v1/data-lifecycle/legal-holds.ts",
+  "src/pages/api/v1/data-lifecycle/legal-holds/[id]/release.ts",
+  "src/pages/api/v1/data-lifecycle/registry.ts",
+  "src/pages/api/v1/data-lifecycle/runs.ts",
+  "src/pages/api/v1/domain-events/consumers/[name]/pause.ts",
+  "src/pages/api/v1/domain-events/consumers/[name]/resume.ts",
+  "src/pages/api/v1/domain-events/consumers/index.ts",
+  "src/pages/api/v1/domain-events/deliveries/[id].ts",
+  "src/pages/api/v1/domain-events/deliveries/[id]/replay.ts",
+  "src/pages/api/v1/domain-events/deliveries/index.ts",
+  "src/pages/api/v1/domain-events/events/[id].ts",
+  "src/pages/api/v1/domain-events/events/index.ts",
+  "src/pages/api/v1/email/announcements/index.ts",
+  "src/pages/api/v1/email/announcements/preview.ts",
+  "src/pages/api/v1/email/messages/[id]/cancel.ts",
+  "src/pages/api/v1/email/messages/index.ts",
+  "src/pages/api/v1/email/suppressions/[id].ts",
+  "src/pages/api/v1/email/suppressions/index.ts",
+  "src/pages/api/v1/email/templates/[id].ts",
+  "src/pages/api/v1/email/templates/[id]/preview.ts",
+  "src/pages/api/v1/email/templates/[id]/restore.ts",
+  "src/pages/api/v1/email/templates/index.ts",
+  "src/pages/api/v1/form-drafts/[id].ts",
+  "src/pages/api/v1/form-drafts/[id]/submit.ts",
+  "src/pages/api/v1/form-drafts/index.ts",
+  "src/pages/api/v1/identity/business-scope/assignments/[id]/revoke.ts",
+  "src/pages/api/v1/identity/business-scope/assignments/index.ts",
+  "src/pages/api/v1/identity/business-scope/conflicts/index.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/[id]/approve.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/[id]/reject.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/[id]/revoke.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/index.ts",
+  "src/pages/api/v1/logs/audit.ts",
+  "src/pages/api/v1/media/enforcement.ts",
+  "src/pages/api/v1/media/news-images/upload-sessions/[id]/cancel.ts",
+  "src/pages/api/v1/media/news-images/upload-sessions/index.ts",
+  "src/pages/api/v1/modules/[moduleKey].ts",
+  "src/pages/api/v1/modules/[moduleKey]/health.ts",
+  "src/pages/api/v1/modules/[moduleKey]/health/check.ts",
+  "src/pages/api/v1/modules/[moduleKey]/jobs.ts",
+  "src/pages/api/v1/modules/[moduleKey]/permissions.ts",
+  "src/pages/api/v1/modules/index.ts",
+  "src/pages/api/v1/modules/sync.ts",
+  "src/pages/api/v1/news-portal/ad-placements/[id].ts",
+  "src/pages/api/v1/news-portal/ad-placements/index.ts",
+  "src/pages/api/v1/news-portal/homepage-sections/[id].ts",
+  "src/pages/api/v1/news-portal/homepage-sections/index.ts",
+  "src/pages/api/v1/offices/[id].ts",
+  "src/pages/api/v1/offices/[id]/restore.ts",
+  "src/pages/api/v1/offices/index.ts",
+  "src/pages/api/v1/profiles/[id].ts",
+  "src/pages/api/v1/profiles/[id]/identifiers.ts",
+  "src/pages/api/v1/profiles/[id]/links.ts",
+  "src/pages/api/v1/profiles/index.ts",
+  "src/pages/api/v1/profiles/resolve.ts",
+  "src/pages/api/v1/reports/email-health.ts",
+  "src/pages/api/v1/reports/exports/[id]/disable.ts",
+  "src/pages/api/v1/reports/exports/index.ts",
+  "src/pages/api/v1/reports/exports/runs.ts",
+  "src/pages/api/v1/reports/exports/runs/[id]/download.ts",
+  "src/pages/api/v1/reports/exports/trigger.ts",
+  "src/pages/api/v1/reports/projections/[key]/index.ts",
+  "src/pages/api/v1/reports/projections/[key]/rebuild/cancel.ts",
+  "src/pages/api/v1/reports/projections/[key]/rebuild/index.ts",
+  "src/pages/api/v1/reports/projections/[key]/reconcile.ts",
+  "src/pages/api/v1/reports/projections/index.ts",
+  "src/pages/api/v1/roles/[id].ts",
+  "src/pages/api/v1/roles/[id]/permissions.ts",
+  "src/pages/api/v1/roles/[id]/restore.ts",
+  "src/pages/api/v1/roles/index.ts",
+  "src/pages/api/v1/seo/config.ts",
+  "src/pages/api/v1/seo/not-found/[id].ts",
+  "src/pages/api/v1/seo/not-found/index.ts",
+  "src/pages/api/v1/seo/redirects/[id].ts",
+  "src/pages/api/v1/seo/redirects/[id]/lifecycle.ts",
+  "src/pages/api/v1/seo/redirects/capture-url-change.ts",
+  "src/pages/api/v1/seo/redirects/import.ts",
+  "src/pages/api/v1/seo/redirects/index.ts",
+  "src/pages/api/v1/seo/redirects/settings.ts",
+  "src/pages/api/v1/seo/redirects/validate.ts",
+  "src/pages/api/v1/settings/index.ts",
+  "src/pages/api/v1/site-search/index/failures.ts",
+  "src/pages/api/v1/site-search/index/rebuild.ts",
+  "src/pages/api/v1/site-search/index/reconcile.ts",
+  "src/pages/api/v1/site-search/index/status.ts",
+  "src/pages/api/v1/site-search/settings.ts",
+  "src/pages/api/v1/sync/conflicts/[id]/resolve.ts",
+  "src/pages/api/v1/sync/conflicts/index.ts",
+  "src/pages/api/v1/sync/nodes/[id].ts",
+  "src/pages/api/v1/sync/nodes/index.ts",
+  "src/pages/api/v1/sync/object-queue/[id]/retry.ts",
+  "src/pages/api/v1/sync/object-queue/index.ts",
+  "src/pages/api/v1/sync/objects/index.ts",
+  "src/pages/api/v1/sync/objects/status.ts",
+  "src/pages/api/v1/sync/pull.ts",
+  "src/pages/api/v1/sync/push.ts",
+  "src/pages/api/v1/sync/status.ts",
+  "src/pages/api/v1/tenant/domains/[id].ts",
+  "src/pages/api/v1/tenant/domains/[id]/set-primary.ts",
+  "src/pages/api/v1/tenant/domains/[id]/verify.ts",
+  "src/pages/api/v1/tenant/domains/index.ts",
+  "src/pages/api/v1/tenant/modules/[moduleKey]/disable.ts",
+  "src/pages/api/v1/tenant/modules/[moduleKey]/enable.ts",
+  "src/pages/api/v1/tenant/modules/[moduleKey]/settings.ts",
+  "src/pages/api/v1/tenant/modules/index.ts",
+  "src/pages/api/v1/theming/draft.ts",
+  "src/pages/api/v1/theming/index.ts",
+  "src/pages/api/v1/theming/preview.ts",
+  "src/pages/api/v1/theming/publish.ts",
+  "src/pages/api/v1/theming/retire.ts",
+  "src/pages/api/v1/theming/rollback.ts",
+  "src/pages/api/v1/theming/validate.ts",
+  "src/pages/api/v1/users/[id].ts",
+  "src/pages/api/v1/users/index.ts",
+  "src/pages/api/v1/workflows/definitions/[id].ts",
+  "src/pages/api/v1/workflows/definitions/[id]/new-version.ts",
+  "src/pages/api/v1/workflows/definitions/[id]/publish.ts",
+  "src/pages/api/v1/workflows/definitions/[id]/retire.ts",
+  "src/pages/api/v1/workflows/definitions/[id]/validate.ts",
+  "src/pages/api/v1/workflows/definitions/index.ts",
+  "src/pages/api/v1/workflows/delegations/[id]/revoke.ts",
+  "src/pages/api/v1/workflows/delegations/index.ts",
+  "src/pages/api/v1/workflows/instances/[id].ts",
+  "src/pages/api/v1/workflows/instances/[id]/cancel.ts",
+  "src/pages/api/v1/workflows/tasks/[id]/decisions.ts",
+  "src/pages/api/v1/workflows/tasks/[id]/force-decision.ts",
+  "src/pages/api/v1/workflows/tasks/[id]/reassign.ts",
+  "src/pages/api/v1/workflows/tasks/index.ts"
+];
+
+async function* walk(directory: string): AsyncGenerator<string> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (entry.name.endsWith(".ts")) {
+      yield full;
+    }
+  }
+}
+
+/** Comment lines are skipped so a docblock MENTIONING `withTenant(` is not a call. */
+function callsWithTenantDirectly(content: string): boolean {
+  return content.split("\n").some((line) => {
+    const trimmed = line.trim();
+
+    if (
+      trimmed.startsWith("*") ||
+      trimmed.startsWith("//") ||
+      trimmed.startsWith("/*")
+    ) {
+      return false;
+    }
+
+    return WITH_TENANT_CALL_PATTERN.test(line);
+  });
+}
+
+export type TenantRouteMigrationResult = {
+  /** Calls `withTenant` directly and is NOT on the allowlist — a newly hand-rolled opening. */
+  unlisted: string[];
+  /** Allowlist entries that no longer call `withTenant` directly — the list must only shrink. */
+  stale: string[];
+};
+
+/** Pure over already-read contents, so both failure directions are unit-testable without a synthetic file tree. */
+export function evaluateTenantRouteMigration(
+  files: readonly { path: string; content: string }[],
+  allowlist: readonly string[]
+): TenantRouteMigrationResult {
+  const allowed = new Set(allowlist);
+  const unlisted: string[] = [];
+  const stillDirect = new Set<string>();
+
+  for (const file of files) {
+    if (!callsWithTenantDirectly(file.content)) {
+      continue;
+    }
+
+    if (allowed.has(file.path)) {
+      stillDirect.add(file.path);
+      continue;
+    }
+
+    unlisted.push(file.path);
+  }
+
+  return {
+    unlisted,
+    stale: allowlist.filter((entry) => !stillDirect.has(entry))
+  };
+}
+
+async function main(): Promise<void> {
+  const files: { path: string; content: string }[] = [];
+
+  for await (const file of walk(ROUTES_ROOT)) {
+    files.push({
+      path: file.split(path.sep).join("/"),
+      content: await Bun.file(file).text()
+    });
+  }
+
+  // `ROUTES_ROOT` is repo-relative, so a run from the wrong working directory
+  // would walk nothing and report a cheerful, meaningless OK. This repo has
+  // already shipped gates that passed while scanning zero files.
+  if (files.length === 0) {
+    console.error(
+      `api:tenant-route:check GAGAL — scanned 0 files under ${ROUTES_ROOT}. ` +
+        "Run this from the repository root."
+    );
+    process.exit(1);
+  }
+
+  const { unlisted, stale } = evaluateTenantRouteMigration(
+    files,
+    NOT_YET_MIGRATED
+  );
+
+  if (unlisted.length === 0 && stale.length === 0) {
+    console.log(
+      `api:tenant-route:check OK — ${files.length} rute di ${ROUTES_ROOT}: memakai ` +
+        `defineTenantRoute, atau salah satu dari ${NOT_YET_MIGRATED.length} rute yang masih ` +
+        "antre migrasi (Issue #255)."
+    );
+    process.exit(0);
+  }
+
+  for (const file of unlisted) {
+    console.error(
+      `${file} — memanggil withTenant() langsung. Rute baru WAJIB memakai defineTenantRoute ` +
+        "(src/modules/_shared/tenant-route.ts), yang membawa gerbang tenant/token, rantai " +
+        "guard penuh, dan work class yang WAJIB ditulis. Jangan tambahkan berkas ini ke " +
+        "NOT_YET_MIGRATED."
+    );
+  }
+
+  for (const file of stale) {
+    console.error(
+      `${file} — terdaftar di NOT_YET_MIGRATED tapi sudah tidak memanggil withTenant() ` +
+        "langsung (ter-migrasi atau terhapus). Hapus barisnya: daftar ini hanya boleh menyusut."
+    );
+  }
+
+  console.error(
+    `\napi:tenant-route:check GAGAL — ${unlisted.length} rute belum lewat factory, ` +
+      `${stale.length} entri allowlist basi.`
+  );
+
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/modules/_shared/tenant-route.ts
+++ b/src/modules/_shared/tenant-route.ts
@@ -1,0 +1,230 @@
+import type { APIContext, APIRoute, AstroCookies } from "astro";
+
+import { fail } from "./api-response";
+import type { BusinessScopeHierarchyPort } from "./ports/business-scope-hierarchy-port";
+import type { SoDRuleDescriptor } from "./module-contract";
+import { hashSessionToken } from "../../lib/auth/session-token";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenant } from "../../lib/database/tenant-context";
+import type { WorkClass } from "../../lib/database/work-class";
+import {
+  authorizeInTransaction,
+  resolveAuthInputs,
+  type AuthorizeResult
+} from "../identity-access/application/access-guard";
+import type { AccessRequest } from "../identity-access/domain/access-control";
+
+/**
+ * `defineTenantRoute` (Issue #255) — the ONE place the auth/tenant opening that
+ * 184 of 221 `src/pages/api` route files copy verbatim is written down:
+ *
+ * ```
+ * resolveAuthInputs → tenantId? (400 TENANT_REQUIRED) → token? (401 AUTH_REQUIRED)
+ *   → getDatabaseClient → hashSessionToken → withTenant(workClass)
+ *   → authorizeInTransaction → short-circuit auth.denied → handler
+ * ```
+ *
+ * Ported from awcms-micro's `_shared/tenant-route.ts`, adapted where this
+ * repo's `withTenant` differs (see "One difference from micro" below).
+ *
+ * ## Why a factory and not "just a helper"
+ *
+ * Because the copy was already wrong in four places and nothing noticed.
+ * `/api/v1/reports/{module-usage,access-audit,sync-health,tenant-activity}.ts`
+ * hand-rolled the chain and called `evaluateAccess` with **three arguments of
+ * five**, so those endpoints skipped `resolveModuleEnabled` (a tenant that
+ * disabled `reporting` was still served) and skipped dynamic ABAC policies (a
+ * `deny` authored through `/api/v1/access/policies` was silently inert).
+ *
+ * Copy-paste was the only enforcement mechanism there was. It worked 184 times
+ * and failed 4, and no type, gate or reviewer could tell the difference from a
+ * diff. Everything below is stated once so the NEXT invariant does not have to
+ * be copied 293 times.
+ *
+ * ## `workClass` is REQUIRED, deliberately
+ *
+ * `withTenant`'s own `workClass` is optional and defaults to `"interactive"`.
+ * Measured over `src/pages/api` at the time of writing: **176 of the 204 route
+ * files** that call `withTenant` directly pass no work class at all. Only 28 do
+ * (19 `interactive`, 7 `background_sync`, 6 `reporting`). So 176 routes share
+ * login's pool budget because nobody passed the argument, not because anybody
+ * decided.
+ *
+ * Here it has no default: omitting it is a compile error. Re-affirming
+ * `"interactive"` is a perfectly good answer; leaving it unsaid is not.
+ *
+ * Do NOT cite `docs/awcms/work-class-registry.generated.json` for this. That
+ * file is a copied awcms-mini artifact — its own `_disclaimer` says so, listing
+ * ghost routes and a route count that was already wrong. There is no generator
+ * and no freshness gate behind it in this repo, so it can only rot.
+ *
+ * ## One difference from micro: no `unavailableBehavior`
+ *
+ * micro's factory pins `unavailableBehavior: "response"` because its
+ * `withTenant` can be told to throw instead. This repo's cannot — `withTenant`
+ * ALWAYS returns the 503 `DATABASE_BUSY` `Response`, cast to the caller's `T`
+ * (see its header: "type-safe in practice, even though the generic signature
+ * doesn't statically enforce `T = Response`").
+ *
+ * For a route that is exactly right, and pinning `withTenant<Response>` below
+ * makes the assumption explicit rather than inferred. For NON-`Response`
+ * callers it is a live hazard in this repo, which is why
+ * `layouts/AdminLayout.astro` shape-checks the result instead of trusting it.
+ * Nothing here fixes that; a route is simply never the caller that suffers it.
+ */
+
+/** Everything available BEFORE the transaction opens. */
+export type TenantRouteRequestContext = {
+  request: Request;
+  cookies: AstroCookies;
+  url: URL;
+  params: APIContext["params"];
+  locals: APIContext["locals"];
+  /** Already validated non-null (a missing one produced `400 TENANT_REQUIRED`). */
+  tenantId: string;
+  /** One clock for the whole request — the same instant the guard chain sees. */
+  now: Date;
+};
+
+/** The `allowed: true` half of {@link AuthorizeResult}, so `auth.context.tenantUserId` reads exactly as in a hand-written route. */
+export type AuthorizedAccess = Extract<AuthorizeResult, { allowed: true }>;
+
+export type TenantRouteHandlerContext<TPrepared> = TenantRouteRequestContext & {
+  /**
+   * The tenant transaction, with `app.current_tenant_id` already set.
+   *
+   * `tx` is ONE reserved connection. Never run two queries on it concurrently
+   * — no `Promise.all([queryA(tx), queryB(tx)])` and no
+   * `Promise.all(items.map((item) => query(tx, item)))`. Concurrent queries on
+   * one connection desync it, the transaction never commits, and the session
+   * is stranded holding its work-class slot. `await` in sequence, or use a
+   * plain `for` loop.
+   */
+  tx: Bun.TransactionSQL;
+  /** Already narrowed to allowed — a deny was returned before `handler` ran. */
+  auth: AuthorizedAccess;
+  /** Whatever `prepare` returned (`undefined` when there is no `prepare`). */
+  prepared: TPrepared;
+};
+
+export type TenantRouteConfig<TPrepared> = {
+  /**
+   * REQUIRED — no default. See this file's header: the whole point is that an
+   * implicit `"interactive"` becomes a written, reviewable classification.
+   */
+  workClass: WorkClass;
+  /** Forwarded verbatim to `withTenant` (which defaults to its own 2000ms). */
+  queueTimeoutMs?: number;
+  /**
+   * The guard. A plain `AccessRequest` for the usual static case, or a function
+   * when it depends on what `prepare` parsed (e.g. an action that differs by
+   * request body).
+   *
+   * INFERENCE ORDER, when using the callback form: write `prepare` BEFORE
+   * `authorize` in the object literal. TypeScript infers `TPrepared` from
+   * object-literal properties in source order, so an unannotated `authorize`
+   * callback appearing first pins `TPrepared` to its `undefined` default before
+   * `prepare` is looked at. The symptom is a confusing "`prepare` is not
+   * assignable to ..." error, not a silent wrong type.
+   */
+  authorize:
+    | AccessRequest
+    | ((
+        context: TenantRouteRequestContext & { prepared: TPrepared }
+      ) => AccessRequest);
+  /** Forwarded verbatim to `authorizeInTransaction`. */
+  authorizeOptions?: {
+    hierarchyPort?: BusinessScopeHierarchyPort;
+    sodRules?: readonly SoDRuleDescriptor[];
+  };
+  /**
+   * Runs AFTER the tenant/token checks and BEFORE any database work — the slot
+   * for everything hand-written routes do between the 401 guard and
+   * `withTenant`: body parsing, query-parameter validation, cursor decoding,
+   * `Idempotency-Key` handling. Returning a `Response` short-circuits with it,
+   * so a malformed request still costs no connection and no pool slot;
+   * returning anything else hands that value to `handler` as `prepared`.
+   */
+  prepare?: (
+    context: TenantRouteRequestContext
+  ) => TPrepared | Response | Promise<TPrepared | Response>;
+  /** Runs inside the tenant transaction, only when access was ALLOWED. */
+  handler: (
+    context: TenantRouteHandlerContext<TPrepared>
+  ) => Response | Promise<Response>;
+};
+
+export function defineTenantRoute<TPrepared = undefined>(
+  config: TenantRouteConfig<TPrepared>
+): APIRoute {
+  return async ({ request, cookies, url, params, locals }) => {
+    const { tenantId, token } = resolveAuthInputs(request, cookies);
+
+    if (!tenantId) {
+      return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+    }
+
+    if (!token) {
+      return fail(401, "AUTH_REQUIRED", "Authentication required.");
+    }
+
+    const requestContext: TenantRouteRequestContext = {
+      request,
+      cookies,
+      url,
+      params,
+      locals,
+      tenantId,
+      now: new Date()
+    };
+
+    let prepared = undefined as TPrepared;
+
+    if (config.prepare) {
+      const prepareResult = await config.prepare(requestContext);
+
+      if (prepareResult instanceof Response) {
+        return prepareResult;
+      }
+
+      prepared = prepareResult;
+    }
+
+    const guard =
+      typeof config.authorize === "function"
+        ? config.authorize({ ...requestContext, prepared })
+        : config.authorize;
+
+    const sql = getDatabaseClient();
+    const tokenHash = hashSessionToken(token);
+
+    // `withTenant<Response>` — pinned, not inferred. This repo's `withTenant`
+    // returns its 503 `DATABASE_BUSY` cast to `T` on breaker-open / queue-full,
+    // so `T = Response` is the assumption that makes that correct. Stated here
+    // so a future edit has to break it on purpose.
+    return withTenant<Response>(
+      sql,
+      tenantId,
+      async (tx) => {
+        const auth = await authorizeInTransaction(
+          tx,
+          tenantId,
+          tokenHash,
+          requestContext.now,
+          guard,
+          config.authorizeOptions
+        );
+
+        if (!auth.allowed) {
+          return auth.denied;
+        }
+
+        return config.handler({ ...requestContext, tx, auth, prepared });
+      },
+      {
+        workClass: config.workClass,
+        queueTimeoutMs: config.queueTimeoutMs
+      }
+    );
+  };
+}

--- a/src/pages/api/v1/reports/access-audit.ts
+++ b/src/pages/api/v1/reports/access-audit.ts
@@ -1,77 +1,36 @@
-import type { APIRoute } from "astro";
-import { fail, ok } from "../../../../modules/_shared/api-response";
-import { getDatabaseClient } from "../../../../lib/database/client";
-import { withTenant } from "../../../../lib/database/tenant-context";
-import { hashSessionToken } from "../../../../lib/auth/session-token";
-import { extractBearerToken } from "../../../../modules/identity-access/application/session-lookup";
-import {
-  fetchGrantedPermissionKeys,
-  resolveTenantContext
-} from "../../../../modules/identity-access/application/auth-context";
-import { recordDecisionLog } from "../../../../modules/identity-access/application/decision-log";
-import { evaluateAccess } from "../../../../modules/identity-access/domain/access-control";
+import { ok } from "../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../modules/_shared/tenant-route";
 import { fetchAccessAuditReport } from "../../../../modules/reporting/application/access-audit-report";
 
-const GUARD_REQUEST = {
-  moduleKey: "reporting",
-  activityCode: "dashboard",
-  action: "read" as const
-};
-
-export const GET: APIRoute = async ({ request }) => {
-  const tenantId = request.headers.get("x-awcms-tenant-id");
-
-  if (!tenantId) {
-    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  }
-
-  const token = extractBearerToken(request.headers.get("authorization"));
-
-  if (!token) {
-    return fail(401, "AUTH_REQUIRED", "Authentication required.");
-  }
-
-  const sql = getDatabaseClient();
-  const tokenHash = hashSessionToken(token);
-  const now = new Date();
-
-  return withTenant(
-    sql,
-    tenantId,
-    async (tx) => {
-      const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
-
-      if (!context) {
-        return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
-      }
-
-      const grantedPermissionKeys = await fetchGrantedPermissionKeys(
-        tx,
-        tenantId,
-        context.tenantUserId
-      );
-      const decision = evaluateAccess(
-        context,
-        GUARD_REQUEST,
-        grantedPermissionKeys
-      );
-
-      await recordDecisionLog(
-        tx,
-        tenantId,
-        context.tenantUserId,
-        GUARD_REQUEST,
-        decision
-      );
-
-      if (!decision.allowed) {
-        return fail(403, "ACCESS_DENIED", decision.reason);
-      }
-
-      const report = await fetchAccessAuditReport(tx, tenantId);
-
-      return ok(report);
-    },
-    { workClass: "reporting" }
-  );
-};
+/**
+ * Migrated to `defineTenantRoute` (Issue #255).
+ *
+ * This route used to hand-roll the guard chain: `resolveTenantContext` ->
+ * `fetchGrantedPermissionKeys` -> `evaluateAccess(context, GUARD, keys)` ->
+ * `recordDecisionLog`. Three arguments where `evaluateAccess` takes five, and
+ * two links of the real chain simply absent:
+ *
+ *   1. no `resolveModuleEnabled` — a tenant that disabled `reporting` was
+ *      still served this endpoint;
+ *   2. no `loadActivePolicies` — a dynamic ABAC `deny` authored through
+ *      `/api/v1/access/policies` was silently inert here.
+ *
+ * Both now come from `authorizeInTransaction`, which the factory calls for
+ * every route. BEHAVIOUR CHANGES, deliberately: this returns
+ * `403 MODULE_DISABLED` when `reporting` is off for the tenant, and honours
+ * ABAC policy. It also accepts a session cookie as well as a bearer token,
+ * because `resolveAuthInputs` reads both — the same sessions, resolved the
+ * same way, no longer rejected purely by where the caller put them.
+ */
+export const GET = defineTenantRoute({
+  // Unchanged from the hand-written version's `{ workClass: "reporting" }` —
+  // aggregate reads must not compete with interactive traffic for pool slots.
+  workClass: "reporting",
+  authorize: {
+    moduleKey: "reporting",
+    activityCode: "dashboard",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId }) =>
+    ok(await fetchAccessAuditReport(tx, tenantId))
+});

--- a/src/pages/api/v1/reports/module-usage.ts
+++ b/src/pages/api/v1/reports/module-usage.ts
@@ -1,77 +1,36 @@
-import type { APIRoute } from "astro";
-import { fail, ok } from "../../../../modules/_shared/api-response";
-import { getDatabaseClient } from "../../../../lib/database/client";
-import { withTenant } from "../../../../lib/database/tenant-context";
-import { hashSessionToken } from "../../../../lib/auth/session-token";
-import { extractBearerToken } from "../../../../modules/identity-access/application/session-lookup";
-import {
-  fetchGrantedPermissionKeys,
-  resolveTenantContext
-} from "../../../../modules/identity-access/application/auth-context";
-import { recordDecisionLog } from "../../../../modules/identity-access/application/decision-log";
-import { evaluateAccess } from "../../../../modules/identity-access/domain/access-control";
+import { ok } from "../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../modules/_shared/tenant-route";
 import { fetchModuleUsageReport } from "../../../../modules/reporting/application/module-usage-report";
 
-const GUARD_REQUEST = {
-  moduleKey: "reporting",
-  activityCode: "dashboard",
-  action: "read" as const
-};
-
-export const GET: APIRoute = async ({ request }) => {
-  const tenantId = request.headers.get("x-awcms-tenant-id");
-
-  if (!tenantId) {
-    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  }
-
-  const token = extractBearerToken(request.headers.get("authorization"));
-
-  if (!token) {
-    return fail(401, "AUTH_REQUIRED", "Authentication required.");
-  }
-
-  const sql = getDatabaseClient();
-  const tokenHash = hashSessionToken(token);
-  const now = new Date();
-
-  return withTenant(
-    sql,
-    tenantId,
-    async (tx) => {
-      const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
-
-      if (!context) {
-        return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
-      }
-
-      const grantedPermissionKeys = await fetchGrantedPermissionKeys(
-        tx,
-        tenantId,
-        context.tenantUserId
-      );
-      const decision = evaluateAccess(
-        context,
-        GUARD_REQUEST,
-        grantedPermissionKeys
-      );
-
-      await recordDecisionLog(
-        tx,
-        tenantId,
-        context.tenantUserId,
-        GUARD_REQUEST,
-        decision
-      );
-
-      if (!decision.allowed) {
-        return fail(403, "ACCESS_DENIED", decision.reason);
-      }
-
-      const modules = await fetchModuleUsageReport(tx, tenantId);
-
-      return ok({ modules });
-    },
-    { workClass: "reporting" }
-  );
-};
+/**
+ * Migrated to `defineTenantRoute` (Issue #255).
+ *
+ * This route used to hand-roll the guard chain: `resolveTenantContext` ->
+ * `fetchGrantedPermissionKeys` -> `evaluateAccess(context, GUARD, keys)` ->
+ * `recordDecisionLog`. Three arguments where `evaluateAccess` takes five, and
+ * two links of the real chain simply absent:
+ *
+ *   1. no `resolveModuleEnabled` — a tenant that disabled `reporting` was
+ *      still served this endpoint;
+ *   2. no `loadActivePolicies` — a dynamic ABAC `deny` authored through
+ *      `/api/v1/access/policies` was silently inert here.
+ *
+ * Both now come from `authorizeInTransaction`, which the factory calls for
+ * every route. BEHAVIOUR CHANGES, deliberately: this returns
+ * `403 MODULE_DISABLED` when `reporting` is off for the tenant, and honours
+ * ABAC policy. It also accepts a session cookie as well as a bearer token,
+ * because `resolveAuthInputs` reads both — the same sessions, resolved the
+ * same way, no longer rejected purely by where the caller put them.
+ */
+export const GET = defineTenantRoute({
+  // Unchanged from the hand-written version's `{ workClass: "reporting" }` —
+  // aggregate reads must not compete with interactive traffic for pool slots.
+  workClass: "reporting",
+  authorize: {
+    moduleKey: "reporting",
+    activityCode: "dashboard",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId }) =>
+    ok({ modules: await fetchModuleUsageReport(tx, tenantId) })
+});

--- a/src/pages/api/v1/reports/sync-health.ts
+++ b/src/pages/api/v1/reports/sync-health.ts
@@ -1,77 +1,36 @@
-import type { APIRoute } from "astro";
-import { fail, ok } from "../../../../modules/_shared/api-response";
-import { getDatabaseClient } from "../../../../lib/database/client";
-import { withTenant } from "../../../../lib/database/tenant-context";
-import { hashSessionToken } from "../../../../lib/auth/session-token";
-import { extractBearerToken } from "../../../../modules/identity-access/application/session-lookup";
-import {
-  fetchGrantedPermissionKeys,
-  resolveTenantContext
-} from "../../../../modules/identity-access/application/auth-context";
-import { recordDecisionLog } from "../../../../modules/identity-access/application/decision-log";
-import { evaluateAccess } from "../../../../modules/identity-access/domain/access-control";
+import { ok } from "../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../modules/_shared/tenant-route";
 import { fetchSyncHealthReport } from "../../../../modules/reporting/application/sync-health-report";
 
-const GUARD_REQUEST = {
-  moduleKey: "reporting",
-  activityCode: "dashboard",
-  action: "read" as const
-};
-
-export const GET: APIRoute = async ({ request }) => {
-  const tenantId = request.headers.get("x-awcms-tenant-id");
-
-  if (!tenantId) {
-    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  }
-
-  const token = extractBearerToken(request.headers.get("authorization"));
-
-  if (!token) {
-    return fail(401, "AUTH_REQUIRED", "Authentication required.");
-  }
-
-  const sql = getDatabaseClient();
-  const tokenHash = hashSessionToken(token);
-  const now = new Date();
-
-  return withTenant(
-    sql,
-    tenantId,
-    async (tx) => {
-      const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
-
-      if (!context) {
-        return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
-      }
-
-      const grantedPermissionKeys = await fetchGrantedPermissionKeys(
-        tx,
-        tenantId,
-        context.tenantUserId
-      );
-      const decision = evaluateAccess(
-        context,
-        GUARD_REQUEST,
-        grantedPermissionKeys
-      );
-
-      await recordDecisionLog(
-        tx,
-        tenantId,
-        context.tenantUserId,
-        GUARD_REQUEST,
-        decision
-      );
-
-      if (!decision.allowed) {
-        return fail(403, "ACCESS_DENIED", decision.reason);
-      }
-
-      const report = await fetchSyncHealthReport(tx, tenantId);
-
-      return ok(report);
-    },
-    { workClass: "reporting" }
-  );
-};
+/**
+ * Migrated to `defineTenantRoute` (Issue #255).
+ *
+ * This route used to hand-roll the guard chain: `resolveTenantContext` ->
+ * `fetchGrantedPermissionKeys` -> `evaluateAccess(context, GUARD, keys)` ->
+ * `recordDecisionLog`. Three arguments where `evaluateAccess` takes five, and
+ * two links of the real chain simply absent:
+ *
+ *   1. no `resolveModuleEnabled` — a tenant that disabled `reporting` was
+ *      still served this endpoint;
+ *   2. no `loadActivePolicies` — a dynamic ABAC `deny` authored through
+ *      `/api/v1/access/policies` was silently inert here.
+ *
+ * Both now come from `authorizeInTransaction`, which the factory calls for
+ * every route. BEHAVIOUR CHANGES, deliberately: this returns
+ * `403 MODULE_DISABLED` when `reporting` is off for the tenant, and honours
+ * ABAC policy. It also accepts a session cookie as well as a bearer token,
+ * because `resolveAuthInputs` reads both — the same sessions, resolved the
+ * same way, no longer rejected purely by where the caller put them.
+ */
+export const GET = defineTenantRoute({
+  // Unchanged from the hand-written version's `{ workClass: "reporting" }` —
+  // aggregate reads must not compete with interactive traffic for pool slots.
+  workClass: "reporting",
+  authorize: {
+    moduleKey: "reporting",
+    activityCode: "dashboard",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId }) =>
+    ok(await fetchSyncHealthReport(tx, tenantId))
+});

--- a/src/pages/api/v1/reports/tenant-activity.ts
+++ b/src/pages/api/v1/reports/tenant-activity.ts
@@ -1,77 +1,36 @@
-import type { APIRoute } from "astro";
-import { fail, ok } from "../../../../modules/_shared/api-response";
-import { getDatabaseClient } from "../../../../lib/database/client";
-import { withTenant } from "../../../../lib/database/tenant-context";
-import { hashSessionToken } from "../../../../lib/auth/session-token";
-import { extractBearerToken } from "../../../../modules/identity-access/application/session-lookup";
-import {
-  fetchGrantedPermissionKeys,
-  resolveTenantContext
-} from "../../../../modules/identity-access/application/auth-context";
-import { recordDecisionLog } from "../../../../modules/identity-access/application/decision-log";
-import { evaluateAccess } from "../../../../modules/identity-access/domain/access-control";
+import { ok } from "../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../modules/_shared/tenant-route";
 import { fetchTenantActivityReport } from "../../../../modules/reporting/application/tenant-activity-report";
 
-const GUARD_REQUEST = {
-  moduleKey: "reporting",
-  activityCode: "dashboard",
-  action: "read" as const
-};
-
-export const GET: APIRoute = async ({ request }) => {
-  const tenantId = request.headers.get("x-awcms-tenant-id");
-
-  if (!tenantId) {
-    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  }
-
-  const token = extractBearerToken(request.headers.get("authorization"));
-
-  if (!token) {
-    return fail(401, "AUTH_REQUIRED", "Authentication required.");
-  }
-
-  const sql = getDatabaseClient();
-  const tokenHash = hashSessionToken(token);
-  const now = new Date();
-
-  return withTenant(
-    sql,
-    tenantId,
-    async (tx) => {
-      const context = await resolveTenantContext(tx, tenantId, tokenHash, now);
-
-      if (!context) {
-        return fail(401, "AUTH_REQUIRED", "Session is invalid or expired.");
-      }
-
-      const grantedPermissionKeys = await fetchGrantedPermissionKeys(
-        tx,
-        tenantId,
-        context.tenantUserId
-      );
-      const decision = evaluateAccess(
-        context,
-        GUARD_REQUEST,
-        grantedPermissionKeys
-      );
-
-      await recordDecisionLog(
-        tx,
-        tenantId,
-        context.tenantUserId,
-        GUARD_REQUEST,
-        decision
-      );
-
-      if (!decision.allowed) {
-        return fail(403, "ACCESS_DENIED", decision.reason);
-      }
-
-      const report = await fetchTenantActivityReport(tx, tenantId);
-
-      return ok(report);
-    },
-    { workClass: "reporting" }
-  );
-};
+/**
+ * Migrated to `defineTenantRoute` (Issue #255).
+ *
+ * This route used to hand-roll the guard chain: `resolveTenantContext` ->
+ * `fetchGrantedPermissionKeys` -> `evaluateAccess(context, GUARD, keys)` ->
+ * `recordDecisionLog`. Three arguments where `evaluateAccess` takes five, and
+ * two links of the real chain simply absent:
+ *
+ *   1. no `resolveModuleEnabled` — a tenant that disabled `reporting` was
+ *      still served this endpoint;
+ *   2. no `loadActivePolicies` — a dynamic ABAC `deny` authored through
+ *      `/api/v1/access/policies` was silently inert here.
+ *
+ * Both now come from `authorizeInTransaction`, which the factory calls for
+ * every route. BEHAVIOUR CHANGES, deliberately: this returns
+ * `403 MODULE_DISABLED` when `reporting` is off for the tenant, and honours
+ * ABAC policy. It also accepts a session cookie as well as a bearer token,
+ * because `resolveAuthInputs` reads both — the same sessions, resolved the
+ * same way, no longer rejected purely by where the caller put them.
+ */
+export const GET = defineTenantRoute({
+  // Unchanged from the hand-written version's `{ workClass: "reporting" }` —
+  // aggregate reads must not compete with interactive traffic for pool slots.
+  workClass: "reporting",
+  authorize: {
+    moduleKey: "reporting",
+    activityCode: "dashboard",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId }) =>
+    ok(await fetchTenantActivityReport(tx, tenantId))
+});

--- a/tests/tenant-route-factory-check.test.ts
+++ b/tests/tenant-route-factory-check.test.ts
@@ -1,0 +1,114 @@
+/**
+ * The migration ledger only shrinks — proven in BOTH directions.
+ *
+ * `api:tenant-route:check` is only useful if it fails. Two failure directions
+ * matter and they fail for opposite reasons:
+ *
+ * - a NEW route hand-rolls the opening and is not on the list (the regression
+ *   the gate exists to stop);
+ * - a listed route was migrated but the line stayed (the list rotting into an
+ *   off-switch that excuses routes which no longer need excusing).
+ *
+ * `evaluateTenantRouteMigration` is exported pure precisely so both can be
+ * asserted over synthetic contents, without a file tree and without a database.
+ * The zero-files guard is exercised through the real filesystem walk in
+ * `scripts/`, which the script's own `main()` covers.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { evaluateTenantRouteMigration } from "../scripts/tenant-route-factory-check";
+
+const DIRECT = `
+import { withTenant } from "../../../../lib/database/tenant-context";
+export const GET = async () => withTenant(sql, tenantId, async (tx) => ok(tx));
+`;
+
+const MIGRATED = `
+import { defineTenantRoute } from "../../../../modules/_shared/tenant-route";
+export const GET = defineTenantRoute({ workClass: "interactive", authorize: g, handler: h });
+`;
+
+describe("tenant-route migration ledger", () => {
+  test("a new hand-rolled route that is not listed FAILS", () => {
+    const result = evaluateTenantRouteMigration(
+      [{ path: "src/pages/api/v1/thing/index.ts", content: DIRECT }],
+      []
+    );
+
+    expect(result.unlisted).toEqual(["src/pages/api/v1/thing/index.ts"]);
+    expect(result.stale).toEqual([]);
+  });
+
+  test("a listed route that still hand-rolls PASSES — that is the debt, not a defect", () => {
+    const result = evaluateTenantRouteMigration(
+      [{ path: "src/pages/api/v1/thing/index.ts", content: DIRECT }],
+      ["src/pages/api/v1/thing/index.ts"]
+    );
+
+    expect(result.unlisted).toEqual([]);
+    expect(result.stale).toEqual([]);
+  });
+
+  test("a listed route that was MIGRATED fails until its line is deleted", () => {
+    const result = evaluateTenantRouteMigration(
+      [{ path: "src/pages/api/v1/thing/index.ts", content: MIGRATED }],
+      ["src/pages/api/v1/thing/index.ts"]
+    );
+
+    expect(result.unlisted).toEqual([]);
+    expect(result.stale).toEqual(["src/pages/api/v1/thing/index.ts"]);
+  });
+
+  test("a listed route that was DELETED fails the same way", () => {
+    const result = evaluateTenantRouteMigration(
+      [],
+      ["src/pages/api/v1/gone.ts"]
+    );
+
+    expect(result.stale).toEqual(["src/pages/api/v1/gone.ts"]);
+  });
+
+  test("a migrated, unlisted route is simply fine", () => {
+    const result = evaluateTenantRouteMigration(
+      [{ path: "src/pages/api/v1/thing/index.ts", content: MIGRATED }],
+      []
+    );
+
+    expect(result).toEqual({ unlisted: [], stale: [] });
+  });
+});
+
+describe("detection is not fooled by prose or by generics", () => {
+  test("a docblock mentioning withTenant() is not a call", () => {
+    const content = `
+/**
+ * Historically this called withTenant(sql, tenantId, fn) directly.
+ * // withTenant(...) — also not a call
+ */
+${MIGRATED}
+`;
+
+    expect(
+      evaluateTenantRouteMigration(
+        [{ path: "src/pages/api/v1/thing.ts", content }],
+        []
+      ).unlisted
+    ).toEqual([]);
+  });
+
+  test("`withTenant<Response>(` IS detected", () => {
+    // Not hypothetical: `_shared/tenant-route.ts` itself writes the generic
+    // form, so a pattern that missed it would wave through a copy of the
+    // factory's own body pasted into a route.
+    const content = `
+export const GET = async () => withTenant<Response>(sql, tenantId, async (tx) => ok(tx));
+`;
+
+    expect(
+      evaluateTenantRouteMigration(
+        [{ path: "src/pages/api/v1/thing.ts", content }],
+        []
+      ).unlisted
+    ).toEqual(["src/pages/api/v1/thing.ts"]);
+  });
+});

--- a/tests/tenant-route-factory.test.ts
+++ b/tests/tenant-route-factory.test.ts
@@ -1,0 +1,302 @@
+/**
+ * `defineTenantRoute` carries the whole opening, in order, and short-circuits
+ * at every point a hand-written route does.
+ *
+ * ## What this replaces
+ *
+ * Nothing — that is the point. The opening it encapsulates was copied into 204
+ * route files and had no test anywhere, because there was no single thing to
+ * test. Its correctness was asserted only indirectly, by whichever integration
+ * test happened to exercise a route that had copied it correctly.
+ *
+ * Four routes had copied it INcorrectly (`/api/v1/reports/*`, Issue #255) and
+ * every integration test still passed, because each one asserted its own
+ * route's happy path and none asserted the chain.
+ *
+ * ## No database
+ *
+ * The factory's job is sequencing and short-circuiting: which checks run,
+ * in what order, and what stops the request. Every collaborator is injected
+ * through `mock.module`, so a fake can record the call order and a fake can
+ * refuse. The real guard chain has its own DB-backed integration tests; what
+ * has never been covered is the wiring between them.
+ */
+import { afterEach, describe, expect, mock, test } from "bun:test";
+
+const GUARD = {
+  moduleKey: "reporting",
+  activityCode: "dashboard",
+  action: "read" as const
+};
+
+const TENANT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+type Calls = string[];
+
+/**
+ * Rebuilds the module graph per test with the given fakes.
+ *
+ * `mock.module` mutates the LIVE namespace for the whole process, so the
+ * factory is re-imported after each set of mocks is installed and the mocks are
+ * restored in `afterEach`. Without the restore, a later test file importing
+ * `tenant-route.ts` would silently get this file's fakes.
+ */
+async function loadFactory(options: {
+  calls: Calls;
+  authInputs?: { tenantId: string | null; token: string | null };
+  authorize?: (guard: unknown) => unknown;
+}) {
+  const { calls } = options;
+
+  mock.module(
+    "../src/modules/identity-access/application/access-guard",
+    () => ({
+      resolveAuthInputs: () => {
+        calls.push("resolveAuthInputs");
+        return options.authInputs ?? { tenantId: TENANT, token: "tok" };
+      },
+      authorizeInTransaction: async (
+        _tx: unknown,
+        _tenantId: string,
+        _tokenHash: string,
+        _now: Date,
+        guard: unknown
+      ) => {
+        calls.push("authorizeInTransaction");
+        return (
+          options.authorize?.(guard) ?? {
+            allowed: true,
+            context: { tenantUserId: "user-1" },
+            grantedPermissionKeys: new Set<string>()
+          }
+        );
+      }
+    })
+  );
+
+  mock.module("../src/lib/auth/session-token", () => ({
+    hashSessionToken: () => {
+      calls.push("hashSessionToken");
+      return "hash";
+    }
+  }));
+
+  mock.module("../src/lib/database/client", () => ({
+    getDatabaseClient: () => {
+      calls.push("getDatabaseClient");
+      return {} as Bun.SQL;
+    }
+  }));
+
+  mock.module("../src/lib/database/tenant-context", () => ({
+    withTenant: async (
+      _sql: unknown,
+      _tenantId: string,
+      fn: (tx: unknown) => Promise<Response>,
+      opts?: { workClass?: string; queueTimeoutMs?: number }
+    ) => {
+      calls.push(`withTenant:${opts?.workClass}:${opts?.queueTimeoutMs}`);
+      return fn({} as Bun.TransactionSQL);
+    }
+  }));
+
+  return (await import("../src/modules/_shared/tenant-route"))
+    .defineTenantRoute;
+}
+
+function invoke(route: ReturnType<Awaited<ReturnType<typeof loadFactory>>>) {
+  return route({
+    request: new Request("https://example.test/api/v1/reports/module-usage"),
+    cookies: {} as never,
+    url: new URL("https://example.test/api/v1/reports/module-usage"),
+    params: {},
+    locals: {}
+  } as never) as Promise<Response>;
+}
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("defineTenantRoute sequencing", () => {
+  test("runs the opening in order and hands the handler an allowed auth", async () => {
+    const calls: Calls = [];
+    const defineTenantRoute = await loadFactory({ calls });
+
+    const route = defineTenantRoute({
+      workClass: "reporting",
+      authorize: GUARD,
+      handler: async ({ auth, tenantId, tx }) => {
+        calls.push("handler");
+        expect(auth.allowed).toBe(true);
+        expect(auth.context.tenantUserId).toBe("user-1");
+        expect(tenantId).toBe(TENANT);
+        expect(tx).toBeDefined();
+        return new Response("ok", { status: 200 });
+      }
+    });
+
+    const response = await invoke(route);
+
+    expect(response.status).toBe(200);
+    // The order IS the contract: no connection is taken before the token
+    // check, and the guard always runs before the handler.
+    expect(calls).toEqual([
+      "resolveAuthInputs",
+      "getDatabaseClient",
+      "hashSessionToken",
+      "withTenant:reporting:undefined",
+      "authorizeInTransaction",
+      "handler"
+    ]);
+  });
+
+  test("a missing tenant is 400 and never touches the database", async () => {
+    const calls: Calls = [];
+    const defineTenantRoute = await loadFactory({
+      calls,
+      authInputs: { tenantId: null, token: "tok" }
+    });
+
+    const response = await invoke(
+      defineTenantRoute({
+        workClass: "interactive",
+        authorize: GUARD,
+        handler: async () => {
+          calls.push("handler");
+          return new Response("unreachable");
+        }
+      })
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({
+      error: { code: "TENANT_REQUIRED" }
+    });
+    expect(calls).toEqual(["resolveAuthInputs"]);
+  });
+
+  test("a missing token is 401 and never touches the database", async () => {
+    const calls: Calls = [];
+    const defineTenantRoute = await loadFactory({
+      calls,
+      authInputs: { tenantId: TENANT, token: null }
+    });
+
+    const response = await invoke(
+      defineTenantRoute({
+        workClass: "interactive",
+        authorize: GUARD,
+        handler: async () => new Response("unreachable")
+      })
+    );
+
+    expect(response.status).toBe(401);
+    expect(await response.json()).toMatchObject({
+      error: { code: "AUTH_REQUIRED" }
+    });
+    expect(calls).toEqual(["resolveAuthInputs"]);
+  });
+
+  test("a denied guard returns the guard's own response, handler never runs", async () => {
+    const calls: Calls = [];
+    const denied = new Response("denied", { status: 403 });
+    const defineTenantRoute = await loadFactory({
+      calls,
+      authorize: () => ({ allowed: false, denied })
+    });
+
+    const response = await invoke(
+      defineTenantRoute({
+        workClass: "reporting",
+        authorize: GUARD,
+        handler: async () => {
+          calls.push("handler");
+          return new Response("unreachable");
+        }
+      })
+    );
+
+    // The SAME response object — the factory must not re-wrap or re-word a
+    // denial, because `authorizeInTransaction` distinguishes 401 from 403 and
+    // MODULE_DISABLED from ACCESS_DENIED, and that detail is load-bearing.
+    expect(response).toBe(denied);
+    expect(calls).not.toContain("handler");
+  });
+});
+
+describe("defineTenantRoute prepare phase", () => {
+  test("a Response from prepare short-circuits before any connection is taken", async () => {
+    const calls: Calls = [];
+    const defineTenantRoute = await loadFactory({ calls });
+
+    const response = await invoke(
+      defineTenantRoute<{ parsed: string }>({
+        workClass: "interactive",
+        prepare: () => {
+          calls.push("prepare");
+          return new Response("bad request", { status: 400 });
+        },
+        authorize: GUARD,
+        handler: async () => {
+          calls.push("handler");
+          return new Response("unreachable");
+        }
+      })
+    );
+
+    expect(response.status).toBe(400);
+    // The whole reason `prepare` runs before `getDatabaseClient`: a malformed
+    // body must not cost a pool slot.
+    expect(calls).toEqual(["resolveAuthInputs", "prepare"]);
+  });
+
+  test("prepare's value reaches the handler and the authorize callback", async () => {
+    const calls: Calls = [];
+    const defineTenantRoute = await loadFactory({ calls });
+    let seenByAuthorize: unknown;
+
+    const response = await invoke(
+      defineTenantRoute<{ action: "read" | "update" }>({
+        workClass: "interactive",
+        prepare: () => ({ action: "update" as const }),
+        authorize: ({ prepared }) => {
+          seenByAuthorize = prepared;
+          return { ...GUARD, action: prepared.action };
+        },
+        handler: async ({ prepared }) => {
+          expect(prepared).toEqual({ action: "update" });
+          return new Response("ok");
+        }
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(seenByAuthorize).toEqual({ action: "update" });
+  });
+});
+
+describe("work class is a decision, not a default", () => {
+  test("the declared work class reaches withTenant verbatim", async () => {
+    for (const workClass of [
+      "reporting",
+      "maintenance",
+      "interactive"
+    ] as const) {
+      const calls: Calls = [];
+      const defineTenantRoute = await loadFactory({ calls });
+
+      await invoke(
+        defineTenantRoute({
+          workClass,
+          queueTimeoutMs: 1234,
+          authorize: GUARD,
+          handler: async () => new Response("ok")
+        })
+      );
+
+      expect(calls).toContain(`withTenant:${workClass}:1234`);
+      mock.restore();
+    }
+  });
+});

--- a/tests/tenant-route-factory.test.ts
+++ b/tests/tenant-route-factory.test.ts
@@ -1,189 +1,188 @@
 /**
- * `defineTenantRoute` carries the whole opening, in order, and short-circuits
- * at every point a hand-written route does.
+ * `defineTenantRoute` runs the opening in order and short-circuits at every
+ * point a hand-written route does.
  *
- * ## What this replaces
+ * ## Why there are no module mocks here
  *
- * Nothing — that is the point. The opening it encapsulates was copied into 204
- * route files and had no test anywhere, because there was no single thing to
- * test. Its correctness was asserted only indirectly, by whichever integration
- * test happened to exercise a route that had copied it correctly.
+ * The first version of this file mocked `tenant-context`, `client`,
+ * `session-token` and `access-guard` through `mock.module`, and restored them
+ * with `mock.restore()`. It passed locally and turned CI red in twelve places:
+ * `mock.restore()` does NOT undo `mock.module`, so the fake `withTenant` leaked
+ * into every later file in the process. `tests/tenant-context-circuit-breaker.
+ * test.ts` asked for a 503 and got the fake's 200.
  *
- * Four routes had copied it INcorrectly (`/api/v1/reports/*`, Issue #255) and
- * every integration test still passed, because each one asserted its own
- * route's happy path and none asserted the chain.
+ * It passed locally only because `tenant-context-circuit-breaker` sorts before
+ * `tenant-route-factory` on this filesystem and had already run. That is luck,
+ * not isolation — and a test whose correctness depends on readdir order is not
+ * a test.
  *
- * ## No database
+ * So: real modules throughout, following awcms-micro's own factory test. The
+ * circuit breaker is forced OPEN, which makes `withTenant` return its 503
+ * before it ever calls `sql.begin` — every assertion below therefore exercises
+ * the genuine `withTenant`, the genuine `resolveAuthInputs`, and the genuine
+ * pool gate, and no connection is ever opened.
  *
- * The factory's job is sequencing and short-circuiting: which checks run,
- * in what order, and what stops the request. Every collaborator is injected
- * through `mock.module`, so a fake can record the call order and a fake can
- * refuse. The real guard chain has its own DB-backed integration tests; what
- * has never been covered is the wiring between them.
+ * ## What this deliberately does NOT cover
+ *
+ * The allowed path — handler running inside a real transaction with a resolved
+ * `auth.context`. That needs a session row, a permission grant and a database;
+ * faking it is what produced the leak above. It belongs in the DB-gated suite,
+ * and the four migrated `/api/v1/reports/*` routes are covered there through
+ * their own endpoints.
  */
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+import type { APIContext, APIRoute, AstroCookies } from "astro";
+
+import {
+  getDatabaseCircuitBreaker,
+  resetDatabaseCircuitBreakerForTests
+} from "../src/lib/database/circuit-breaker";
+import {
+  acquireWorkClassSlot,
+  resetWorkClassGatesForTests,
+  type WorkClassSlot
+} from "../src/lib/database/work-class";
+import { defineTenantRoute } from "../src/modules/_shared/tenant-route";
+
+const TENANT_ID = "11111111-1111-1111-1111-111111111111";
 
 const GUARD = {
   moduleKey: "reporting",
   activityCode: "dashboard",
-  action: "read" as const
-};
+  action: "read"
+} as const;
 
-const TENANT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+/** `resolveAuthInputs` only ever reads `cookies.get(name)?.value`. */
+const EMPTY_COOKIES = { get: () => undefined } as unknown as AstroCookies;
 
-type Calls = string[];
+async function call(
+  route: APIRoute,
+  headers: Record<string, string> = {}
+): Promise<{
+  status: number;
+  body: { error?: { code: string } };
+  response: Response;
+}> {
+  const url = new URL("http://unit.test/api/v1/reports/module-usage?x=1");
+  const response = (await route({
+    request: new Request(url.toString(), { method: "GET", headers }),
+    url,
+    params: {},
+    locals: {},
+    cookies: EMPTY_COOKIES
+  } as unknown as APIContext)) as Response;
+  const text = await response.text();
+
+  return {
+    status: response.status,
+    body: text.length > 0 ? JSON.parse(text) : {},
+    response
+  };
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    "x-awcms-tenant-id": TENANT_ID,
+    authorization: "Bearer unit-test-session-token"
+  };
+}
 
 /**
- * Rebuilds the module graph per test with the given fakes.
+ * The factory calls `getDatabaseClient()` before `withTenant`, and that needs a
+ * connection string to exist even though nothing ever connects (an open breaker
+ * short-circuits inside `withTenant`, before `sql.begin`).
  *
- * `mock.module` mutates the LIVE namespace for the whole process, so the
- * factory is re-imported after each set of mocks is installed and the mocks are
- * restored in `afterEach`. Without the restore, a later test file importing
- * `tenant-route.ts` would silently get this file's fakes.
+ * Only set when absent: a run WITH a real `DATABASE_URL` must keep using it,
+ * because the client is memoized per process — overwriting it here would hand a
+ * dead client to every later test in the run.
  */
-async function loadFactory(options: {
-  calls: Calls;
-  authInputs?: { tenantId: string | null; token: string | null };
-  authorize?: (guard: unknown) => unknown;
-}) {
-  const { calls } = options;
+const HAD_DATABASE_URL = Boolean(process.env.DATABASE_URL);
 
-  mock.module(
-    "../src/modules/identity-access/application/access-guard",
-    () => ({
-      resolveAuthInputs: () => {
-        calls.push("resolveAuthInputs");
-        return options.authInputs ?? { tenantId: TENANT, token: "tok" };
-      },
-      authorizeInTransaction: async (
-        _tx: unknown,
-        _tenantId: string,
-        _tokenHash: string,
-        _now: Date,
-        guard: unknown
-      ) => {
-        calls.push("authorizeInTransaction");
-        return (
-          options.authorize?.(guard) ?? {
-            allowed: true,
-            context: { tenantUserId: "user-1" },
-            grantedPermissionKeys: new Set<string>()
-          }
-        );
-      }
-    })
-  );
+/** Forces `withTenant` to return 503 before touching the connection. */
+function openTheBreaker(): void {
+  const breaker = getDatabaseCircuitBreaker();
 
-  mock.module("../src/lib/auth/session-token", () => ({
-    hashSessionToken: () => {
-      calls.push("hashSessionToken");
-      return "hash";
-    }
-  }));
+  for (let attempt = 0; attempt < 20; attempt++) {
+    breaker.recordFailure(new Date());
+  }
 
-  mock.module("../src/lib/database/client", () => ({
-    getDatabaseClient: () => {
-      calls.push("getDatabaseClient");
-      return {} as Bun.SQL;
-    }
-  }));
-
-  mock.module("../src/lib/database/tenant-context", () => ({
-    withTenant: async (
-      _sql: unknown,
-      _tenantId: string,
-      fn: (tx: unknown) => Promise<Response>,
-      opts?: { workClass?: string; queueTimeoutMs?: number }
-    ) => {
-      calls.push(`withTenant:${opts?.workClass}:${opts?.queueTimeoutMs}`);
-      return fn({} as Bun.TransactionSQL);
-    }
-  }));
-
-  return (await import("../src/modules/_shared/tenant-route"))
-    .defineTenantRoute;
+  expect(breaker.canAttempt(new Date())).toBe(false);
 }
 
-function invoke(route: ReturnType<Awaited<ReturnType<typeof loadFactory>>>) {
-  return route({
-    request: new Request("https://example.test/api/v1/reports/module-usage"),
-    cookies: {} as never,
-    url: new URL("https://example.test/api/v1/reports/module-usage"),
-    params: {},
-    locals: {}
-  } as never) as Promise<Response>;
-}
-
-afterEach(() => {
-  mock.restore();
+beforeAll(() => {
+  if (!HAD_DATABASE_URL) {
+    process.env.DATABASE_URL =
+      "postgres://unit:unit@127.0.0.1:1/unit-test-never-connected";
+  }
 });
 
-describe("defineTenantRoute sequencing", () => {
-  test("runs the opening in order and hands the handler an allowed auth", async () => {
-    const calls: Calls = [];
-    const defineTenantRoute = await loadFactory({ calls });
+afterAll(() => {
+  if (!HAD_DATABASE_URL) {
+    delete process.env.DATABASE_URL;
+  }
+});
 
-    const route = defineTenantRoute({
-      workClass: "reporting",
-      authorize: GUARD,
-      handler: async ({ auth, tenantId, tx }) => {
-        calls.push("handler");
-        expect(auth.allowed).toBe(true);
-        expect(auth.context.tenantUserId).toBe("user-1");
-        expect(tenantId).toBe(TENANT);
-        expect(tx).toBeDefined();
-        return new Response("ok", { status: 200 });
-      }
-    });
+beforeEach(() => {
+  resetDatabaseCircuitBreakerForTests();
+  resetWorkClassGatesForTests();
+});
 
-    const response = await invoke(route);
+afterEach(() => {
+  resetDatabaseCircuitBreakerForTests();
+  resetWorkClassGatesForTests();
+});
 
-    expect(response.status).toBe(200);
-    // The order IS the contract: no connection is taken before the token
-    // check, and the guard always runs before the handler.
-    expect(calls).toEqual([
-      "resolveAuthInputs",
-      "getDatabaseClient",
-      "hashSessionToken",
-      "withTenant:reporting:undefined",
-      "authorizeInTransaction",
-      "handler"
-    ]);
-  });
+describe("defineTenantRoute — the opening it replaces", () => {
+  test("a missing tenant header is 400 TENANT_REQUIRED", async () => {
+    let reached = false;
 
-  test("a missing tenant is 400 and never touches the database", async () => {
-    const calls: Calls = [];
-    const defineTenantRoute = await loadFactory({
-      calls,
-      authInputs: { tenantId: null, token: "tok" }
-    });
-
-    const response = await invoke(
+    const result = await call(
       defineTenantRoute({
         workClass: "interactive",
         authorize: GUARD,
         handler: async () => {
-          calls.push("handler");
+          reached = true;
           return new Response("unreachable");
         }
-      })
+      }),
+      { authorization: "Bearer t" }
     );
 
-    expect(response.status).toBe(400);
-    expect(await response.json()).toMatchObject({
-      error: { code: "TENANT_REQUIRED" }
-    });
-    expect(calls).toEqual(["resolveAuthInputs"]);
+    expect(result.status).toBe(400);
+    expect(result.body.error?.code).toBe("TENANT_REQUIRED");
+    expect(reached).toBe(false);
   });
 
-  test("a missing token is 401 and never touches the database", async () => {
-    const calls: Calls = [];
-    const defineTenantRoute = await loadFactory({
-      calls,
-      authInputs: { tenantId: TENANT, token: null }
-    });
+  test("a missing token is 401 AUTH_REQUIRED", async () => {
+    const result = await call(
+      defineTenantRoute({
+        workClass: "interactive",
+        authorize: GUARD,
+        handler: async () => new Response("unreachable")
+      }),
+      { "x-awcms-tenant-id": TENANT_ID }
+    );
 
-    const response = await invoke(
+    expect(result.status).toBe(401);
+    expect(result.body.error?.code).toBe("AUTH_REQUIRED");
+  });
+
+  test("both guards run before anything else — an unauthenticated call never reaches the pool", async () => {
+    // Proven by the breaker: it is OPEN, so ANY call that got as far as
+    // `withTenant` would come back 503. A 401 therefore means the request
+    // stopped earlier — which is the property that keeps unauthenticated
+    // traffic off the connection pool entirely.
+    openTheBreaker();
+
+    const result = await call(
       defineTenantRoute({
         workClass: "interactive",
         authorize: GUARD,
@@ -191,112 +190,117 @@ describe("defineTenantRoute sequencing", () => {
       })
     );
 
-    expect(response.status).toBe(401);
-    expect(await response.json()).toMatchObject({
-      error: { code: "AUTH_REQUIRED" }
-    });
-    expect(calls).toEqual(["resolveAuthInputs"]);
-  });
-
-  test("a denied guard returns the guard's own response, handler never runs", async () => {
-    const calls: Calls = [];
-    const denied = new Response("denied", { status: 403 });
-    const defineTenantRoute = await loadFactory({
-      calls,
-      authorize: () => ({ allowed: false, denied })
-    });
-
-    const response = await invoke(
-      defineTenantRoute({
-        workClass: "reporting",
-        authorize: GUARD,
-        handler: async () => {
-          calls.push("handler");
-          return new Response("unreachable");
-        }
-      })
-    );
-
-    // The SAME response object — the factory must not re-wrap or re-word a
-    // denial, because `authorizeInTransaction` distinguishes 401 from 403 and
-    // MODULE_DISABLED from ACCESS_DENIED, and that detail is load-bearing.
-    expect(response).toBe(denied);
-    expect(calls).not.toContain("handler");
+    expect(result.status).toBe(400);
+    expect(result.body.error?.code).toBe("TENANT_REQUIRED");
   });
 });
 
-describe("defineTenantRoute prepare phase", () => {
-  test("a Response from prepare short-circuits before any connection is taken", async () => {
-    const calls: Calls = [];
-    const defineTenantRoute = await loadFactory({ calls });
+describe("defineTenantRoute — prepare runs before any database work", () => {
+  test("a Response from prepare short-circuits with that exact response", async () => {
+    openTheBreaker();
+    let authorizeCalled = false;
 
-    const response = await invoke(
+    const result = await call(
       defineTenantRoute<{ parsed: string }>({
         workClass: "interactive",
-        prepare: () => {
-          calls.push("prepare");
-          return new Response("bad request", { status: 400 });
+        prepare: () =>
+          new Response(
+            JSON.stringify({ error: { code: "VALIDATION_ERROR" } }),
+            {
+              status: 400
+            }
+          ),
+        authorize: () => {
+          authorizeCalled = true;
+          return GUARD;
         },
-        authorize: GUARD,
-        handler: async () => {
-          calls.push("handler");
-          return new Response("unreachable");
-        }
-      })
+        handler: async () => new Response("unreachable")
+      }),
+      authHeaders()
     );
 
-    expect(response.status).toBe(400);
-    // The whole reason `prepare` runs before `getDatabaseClient`: a malformed
-    // body must not cost a pool slot.
-    expect(calls).toEqual(["resolveAuthInputs", "prepare"]);
+    // 400, not the 503 an open breaker would produce: `prepare` short-circuited
+    // before the pool was ever consulted. That ordering is the whole point — a
+    // malformed body must not cost a connection.
+    expect(result.status).toBe(400);
+    expect(result.body.error?.code).toBe("VALIDATION_ERROR");
+    expect(authorizeCalled).toBe(false);
   });
 
-  test("prepare's value reaches the handler and the authorize callback", async () => {
-    const calls: Calls = [];
-    const defineTenantRoute = await loadFactory({ calls });
-    let seenByAuthorize: unknown;
+  test("prepare's value reaches the authorize callback", async () => {
+    openTheBreaker();
+    let seen: unknown;
 
-    const response = await invoke(
+    const result = await call(
       defineTenantRoute<{ action: "read" | "update" }>({
         workClass: "interactive",
         prepare: () => ({ action: "update" as const }),
         authorize: ({ prepared }) => {
-          seenByAuthorize = prepared;
+          seen = prepared;
           return { ...GUARD, action: prepared.action };
         },
-        handler: async ({ prepared }) => {
-          expect(prepared).toEqual({ action: "update" });
-          return new Response("ok");
-        }
-      })
+        handler: async () => new Response("unreachable")
+      }),
+      authHeaders()
     );
 
-    expect(response.status).toBe(200);
-    expect(seenByAuthorize).toEqual({ action: "update" });
+    expect(seen).toEqual({ action: "update" });
+    // The guard was built, then the open breaker stopped the request at the
+    // pool — the furthest a test can go here without a database.
+    expect(result.status).toBe(503);
   });
 });
 
-describe("work class is a decision, not a default", () => {
-  test("the declared work class reaches withTenant verbatim", async () => {
-    for (const workClass of [
-      "reporting",
-      "maintenance",
-      "interactive"
-    ] as const) {
-      const calls: Calls = [];
-      const defineTenantRoute = await loadFactory({ calls });
+describe("defineTenantRoute — the declared work class is really used", () => {
+  test("an open breaker yields 503 DATABASE_BUSY with Retry-After: 30", async () => {
+    openTheBreaker();
 
-      await invoke(
+    const result = await call(
+      defineTenantRoute({
+        workClass: "reporting",
+        authorize: GUARD,
+        handler: async () => new Response("unreachable")
+      }),
+      authHeaders()
+    );
+
+    expect(result.status).toBe(503);
+    expect(result.body.error?.code).toBe("DATABASE_BUSY");
+    expect(result.response.headers.get("Retry-After")).toBe("30");
+  });
+
+  test("the declared class picks the gate: a saturated `maintenance` stops a `maintenance` route at the pool", async () => {
+    // Breaker CLOSED here, deliberately. `withTenant` checks the breaker
+    // BEFORE the work-class gate, so an open breaker returns Retry-After 30 for
+    // every class and would make this assertion pass no matter what `workClass`
+    // said — the first draft of this test did exactly that and proved nothing.
+    //
+    // With the breaker closed and `maintenance`'s only slot (concurrency 1)
+    // held, a route that DECLARED `maintenance` fails at the gate with the
+    // work-class Retry-After of 2. Delete `workClass` from the route below and
+    // it defaults to `interactive`, whose gate is wide open — a different
+    // outcome entirely. That is what makes this a test of forwarding rather
+    // than a test of "some 503 happened".
+    let held: WorkClassSlot | undefined;
+
+    try {
+      held = await acquireWorkClassSlot("maintenance", 50);
+
+      const result = await call(
         defineTenantRoute({
-          workClass,
-          queueTimeoutMs: 1234,
+          workClass: "maintenance",
+          queueTimeoutMs: 20,
           authorize: GUARD,
-          handler: async () => new Response("ok")
-        })
+          handler: async () => new Response("unreachable")
+        }),
+        authHeaders()
       );
 
-      expect(calls).toContain(`withTenant:${workClass}:1234`);
-      mock.restore();
+      expect(result.status).toBe(503);
+      expect(result.body.error?.code).toBe("DATABASE_BUSY");
+      expect(result.response.headers.get("Retry-After")).toBe("2");
+    } finally {
+      held?.release();
     }
   });
 });


### PR DESCRIPTION
Closes #255. Port `defineTenantRoute` dari awcms-micro (`187e9631`, Refs #370),
diadaptasi ke bentuk `withTenant` repo ini.

## Bug-nya

Empat rute `/api/v1/reports/*` merangkai sendiri rantai guard dan memanggil
`evaluateAccess` dengan **tiga argumen dari lima**:

```ts
evaluateAccess(context, request, grantedPermissionKeys,
               businessScopeFacts?, abac?)
```

Dua mata rantai hilang di keempat endpoint itu:

| hilang | akibat |
| --- | --- |
| `resolveModuleEnabled` | tenant yang men-disable `reporting` **tetap dilayani** keempatnya |
| `loadActivePolicies` | policy ABAC `deny` yang dibuat lewat `/api/v1/access/policies` **diam-diam inert** |

Keduanya gagal ke arah yang melapor sukses sambil tidak menegakkan apa pun.

## Mekanismenya, bukan sekadar empat rute

Salin-tempel adalah satu-satunya penegakan yang ada: berhasil 184 kali, gagal 4,
dan tak ada tipe, gate, atau reviewer yang bisa membedakannya dari diff.
`defineTenantRoute` menuliskan pembukaannya sekali.

**`workClass` WAJIB di tipe, tanpa default.** Diukur dari `src/pages/api`:

| | jumlah |
| --- | --- |
| berkas rute memanggil `withTenant` langsung | 204 |
| dengan `workClass` eksplisit | **28** (19 `interactive`, 7 `background_sync`, 6 `reporting`) |
| mengandalkan default | **176** |

176 rute berbagi budget pool dengan login karena kelalaian, bukan keputusan.
Menghilangkannya kini error kompilasi.

`prepare` jalan **sebelum** `getDatabaseClient`, jadi request cacat tetap tak
memakan slot pool.

**Satu perbedaan dari micro:** repo ini tak punya `unavailableBehavior` —
`withTenant` SELALU mengembalikan 503-nya sebagai `T`. Untuk rute itu benar, dan
`withTenant<Response>` di-pin agar asumsinya tertulis. Untuk pemanggil
non-`Response` itu tetap hazard hidup (sebabnya `AdminLayout.astro`
shape-check hasilnya); PR ini tidak mengubahnya.

## Gate

`bun run api:tenant-route:check` — di rantai `check` dan step `quality` `ci.yml`.
Menolak rute **BARU** yang memanggil `withTenant` langsung. 204 rute lama ada di
`NOT_YET_MIGRATED`, daftar yang **hanya boleh menyusut**: entri basi juga
menggagalkan gate, jadi ia tak bisa membusuk jadi tombol-mati.

**Mutation-proven terhadap repo nyata**, tiap mutasi dibuktikan MERAH lalu revert:

| mutasi | pesan |
| --- | --- |
| rute baru hand-roll, tak terdaftar | `memanggil withTenant() langsung … Jangan tambahkan berkas ini ke NOT_YET_MIGRATED` |
| rute ter-migrasi masih terdaftar | `Hapus barisnya: daftar ini hanya boleh menyusut` |
| rute ter-migrasi dikembalikan ke pola lama | tertangkap sebagai unlisted |

`evaluateTenantRouteMigration` diekspor pure sehingga kedua arah diuji tanpa
pohon berkas. Deteksinya mencocokkan `withTenant<T>(` **dan** `withTenant(` —
factory-nya sendiri menulis bentuk generik, jadi pola yang melewatkannya akan
meloloskan salinan badan factory yang ditempel ke rute.

## Koreksi yang ikut mendarat di kode

Komentar analisis saya sebelumnya mengutip "254 dari 302 `default`" dari
`docs/awcms/work-class-registry.generated.json`. **Itu salah.** Berkas itu
artefak salinan awcms-mini — `_disclaimer`-nya sendiri menyatakannya, memuat
rute HANTU dan jumlah rute yang sudah basi ("96 route nyata" vs 221). Tidak ada
generator dan tidak ada gate kesegaran di belakangnya. Angka di atas diukur dari
sumber; berkasnya kini ditandai eksplisit sebagai tidak-boleh-dikutip. Isu
terpisah menyusul untuk berkas itu sendiri.

## Perubahan perilaku, disengaja

`/api/v1/reports/*` kini mengembalikan `403 MODULE_DISABLED` saat modul mati,
menghormati policy ABAC, dan menerima cookie sesi selain bearer token
(`resolveAuthInputs` membaca keduanya — sesi yang sama, di-resolve dengan cara
yang sama, tak lagi ditolak semata karena pemanggil menaruhnya di tempat lain).

## Verifikasi

| | pass | fail | file |
| --- | --- | --- | --- |
| baseline (`main`) | 2339 | 93 | 208 |
| cabang ini | 2353 | 93 | 210 |

Delta persis **+14** (jumlah test baru), kegagalan **identik** — seluruhnya
DB-gated, `awcms_app is not permitted to log in` di container lokal, dijalankan
lewat pola netns yang sama untuk kedua sisi. 16 gate, `typecheck`, dan `build`
hijau.

## Sisa #255

204 rute masih di ledger. Migrasi lanjut satu modul per PR, tanpa perubahan
perilaku, hapus barisnya. Gate menjaga jumlahnya hanya turun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
