### PR TITLE
fix(ci): give the integration suite a real hook budget, and name SIGTERM for what it is

### DIFF
--- a/.changeset/integration-hook-timeout.md
+++ b/.changeset/integration-hook-timeout.md
@@ -1,0 +1,18 @@
+---
+"awcms": patch
+---
+
+Stop the DB-gated integration suite racing bun's 5s per-hook default, and stop
+it misreporting the result.
+
+`setupIntegrationDatabase()` creates an ephemeral database and applies every
+file in `sql/` as a subprocess, inside `beforeAll` — thirteen files each do
+that, and the cost grows with every migration added. The CI step now passes
+`--timeout 60000` (~30x the ~1-2s a warm setup takes, still far under the job
+timeout) in both `ci.yml` and `release.yml`.
+
+When it does get killed, the harness now says so. Exit 143 is 128 + SIGTERM: the
+migration did not fail, it was terminated. The old message read "db:migrate
+failed against the ephemeral integration database (exit 143)", which points a
+reader at `sql/` — the one place the problem is not. Observed on PR #259 (run
+30188228406), green on a re-run with no code change.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,7 +293,18 @@ jobs:
         # here made 26 of them fail (data collisions/ordering), while all 4
         # harness-based integration files passed cleanly. They run in their own
         # step below instead, in a fresh `bun test` process of their own.
-        run: bun test tests/integration/
+        #
+        # `--timeout 60000` is not decoration. `setupIntegrationDatabase()`
+        # creates an ephemeral database and applies EVERY file in `sql/` as a
+        # subprocess, inside `beforeAll` — which is subject to bun's 5000ms
+        # per-hook default. Thirteen files each do that, and the cost grows
+        # with every migration added, so the default is a deadline the suite
+        # was always going to cross: observed on PR #259 (run 30188228406),
+        # green on a re-run with no code change. Setup takes ~1-2s on an idle
+        # runner, so 60s is ~30x headroom and still far under the job timeout.
+        # Set here rather than per-hook in 13 files: one place to forget, not
+        # thirteen.
+        run: bun test tests/integration/ --timeout 60000
 
       - name: Run DB-gated integration tests (legacy ad-hoc suite)
         # These 9 files each open their own ad-hoc `Bun.SQL(DATABASE_URL)`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,18 @@ jobs:
         # ad-hoc DB-gated suite runs in its own step below, in a fresh
         # `bun test` process, to avoid the collision documented in
         # `.github/workflows/ci.yml`'s `integration-tests` job.
-        run: bun test tests/integration/
+        #
+        # `--timeout 60000` is not decoration. `setupIntegrationDatabase()`
+        # creates an ephemeral database and applies EVERY file in `sql/` as a
+        # subprocess, inside `beforeAll` — which is subject to bun's 5000ms
+        # per-hook default. Thirteen files each do that, and the cost grows
+        # with every migration added, so the default is a deadline the suite
+        # was always going to cross: observed on PR #259 (run 30188228406),
+        # green on a re-run with no code change. Setup takes ~1-2s on an idle
+        # runner, so 60s is ~30x headroom and still far under the job timeout.
+        # Set here rather than per-hook in 13 files: one place to forget, not
+        # thirteen.
+        run: bun test tests/integration/ --timeout 60000
 
       - name: Run DB-gated integration tests (legacy ad-hoc suite)
         # These 9 files each open their own ad-hoc `Bun.SQL(DATABASE_URL)`

--- a/tests/integration-harness-diagnostics.test.ts
+++ b/tests/integration-harness-diagnostics.test.ts
@@ -1,0 +1,74 @@
+/**
+ * A killed migration must not be reported as a failed one.
+ *
+ * ## What this is for
+ *
+ * PR #259's integration job failed with:
+ *
+ *     error: db:migrate failed against the ephemeral integration database (exit 143).
+ *
+ * `db:migrate` had not failed. 143 is 128 + SIGTERM: the subprocess was KILLED
+ * by bun's 5000ms per-hook default while `setupIntegrationDatabase()` was still
+ * applying 70 migrations inside `beforeAll`. The run went green on a re-run with
+ * no code change.
+ *
+ * The wording is the expensive part. "db:migrate failed" points a reader at
+ * `sql/`, which is the one place the problem is not. The `--timeout 60000` now
+ * on the CI step stops it happening; this branch makes the next occurrence —
+ * a slower runner, more migrations — diagnose itself.
+ *
+ * No database: `describeMigrationFailure` is pure over an exit code, which is
+ * exactly why it was extracted. A branch that only fires on an unattended CI
+ * runner is one nobody would otherwise ever see run.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { describeMigrationFailure } from "./integration/harness";
+
+describe("db:migrate failure diagnostics", () => {
+  test("exit 143 is reported as KILLED, names the hook timeout, and points at the fix", () => {
+    const message = describeMigrationFailure(143, 5001, "out", "err");
+
+    expect(message).toContain("KILLED (SIGTERM)");
+    expect(message).toContain("did NOT fail");
+    expect(message).toContain("5001ms");
+    // The three things a reader needs: what actually happened, where the budget
+    // lives, and which file to edit.
+    expect(message).toContain("per-hook timeout");
+    expect(message).toContain("setupIntegrationDatabase()");
+    expect(message).toContain("--timeout");
+    expect(message).toContain(".github/workflows/{ci,release}.yml");
+  });
+
+  test("exit 143 does NOT claim the migration failed", () => {
+    // The whole defect: the old message did. Asserting the absence is what
+    // makes this a regression test rather than a restatement.
+    const message = describeMigrationFailure(143, 5001, "", "");
+
+    expect(message).not.toMatch(/^db:migrate failed/);
+  });
+
+  test("a genuine non-zero exit still reads as a failure, with the elapsed time", () => {
+    const message = describeMigrationFailure(1, 812, "out", "syntax error");
+
+    expect(message).toStartWith("db:migrate failed");
+    expect(message).toContain("exit 1");
+    expect(message).toContain("812ms");
+    expect(message).toContain("syntax error");
+    expect(message).not.toContain("SIGTERM");
+  });
+
+  test("both branches carry the subprocess output through", () => {
+    for (const exitCode of [1, 143]) {
+      const message = describeMigrationFailure(
+        exitCode,
+        10,
+        "STDOUT-MARKER",
+        "STDERR-MARKER"
+      );
+
+      expect(message).toContain("STDOUT-MARKER");
+      expect(message).toContain("STDERR-MARKER");
+    }
+  });
+});

--- a/tests/integration/harness.ts
+++ b/tests/integration/harness.ts
@@ -286,6 +286,7 @@ export async function roleExists(roleName: string): Promise<boolean> {
  * header for why (migration 019's `ALTER ROLE ... SET app.current_tenant_id`).
  */
 async function applyMigrationsAsOwner(): Promise<void> {
+  const startedAt = Date.now();
   const proc = Bun.spawn(["bun", "scripts/db-migrate.ts"], {
     cwd: new URL("../..", import.meta.url).pathname,
     stdout: "pipe",
@@ -299,9 +300,48 @@ async function applyMigrationsAsOwner(): Promise<void> {
     const stderr = await new Response(proc.stderr).text();
 
     throw new Error(
-      `db:migrate failed against the ephemeral integration database (exit ${exitCode}).\n${stdout}\n${stderr}`
+      describeMigrationFailure(exitCode, Date.now() - startedAt, stdout, stderr)
     );
   }
+}
+
+/**
+ * Turns a non-zero `db:migrate` exit into a message that names the actual
+ * cause.
+ *
+ * Exported and pure so `tests/integration-harness-diagnostics.test.ts` can pin
+ * the SIGTERM branch without a database — the branch exists precisely because
+ * it fires on a CI runner nobody is watching.
+ */
+export function describeMigrationFailure(
+  exitCode: number,
+  elapsedMs: number,
+  stdout: string,
+  stderr: string
+): string {
+  // 143 = 128 + SIGTERM. The migration did NOT fail — it was KILLED, and in
+  // practice by exactly one thing: bun's per-hook timeout expiring while this
+  // subprocess was still applying migrations inside `beforeAll`.
+  //
+  // Worth its own branch because the generic message sent a reader hunting for
+  // a bug in `sql/` (observed on PR #259, run 30188228406: green on a re-run
+  // with no code change). Naming the real cause on the first line is most of
+  // the fix; the `--timeout` on the CI step is the rest.
+  if (exitCode === 143) {
+    return (
+      `db:migrate was KILLED (SIGTERM) after ${elapsedMs}ms against the ephemeral ` +
+      "integration database — it did NOT fail. Almost always bun's per-hook timeout " +
+      "expiring during setupIntegrationDatabase(): that applies every file in `sql/` " +
+      "to a fresh database inside `beforeAll`, and the cost grows with each migration " +
+      "added. Raise `--timeout` on the step that runs tests/integration/ " +
+      `(.github/workflows/{ci,release}.yml).\n${stdout}\n${stderr}`
+    );
+  }
+
+  return (
+    `db:migrate failed against the ephemeral integration database (exit ${exitCode}, ` +
+    `${elapsedMs}ms).\n${stdout}\n${stderr}`
+  );
 }
 
 async function dropEphemeralDatabase(): Promise<void> {


### PR DESCRIPTION
Closes #264.

## Bukan flake acak

PR #259 gagal dengan `db:migrate failed … (exit 143)`. **143 = 128 + SIGTERM**: migrasinya tidak gagal — ia **dibunuh** oleh timeout hook default bun 5000 ms, saat `setupIntegrationDatabase()` masih menerapkan 70 migrasi di dalam `beforeAll`. Hijau saat re-run tanpa perubahan kode.

Ini balapan dengan **tenggat tetap yang bebannya tumbuh**: 13 berkas integrasi masing-masing membuat DB ephemeral dan menerapkan seluruh `sql/`, jadi tiap migrasi baru mendekatkan ke-13-nya ke batas. Run yang sama mencatat satu test ABAC di 5091 ms — batas yang sama.

## Dua perubahan

**1. `--timeout 60000` di step**, bukan per-hook di 13 berkas. Satu tempat untuk lupa, bukan tiga belas. Setup hangat makan ~1–2 s, jadi ~30× margin dan tetap jauh di bawah timeout job. Di `ci.yml` DAN `release.yml`.

**2. Pesannya jujur.** `describeMigrationFailure` (diekstrak pure dari `applyMigrationsAsOwner`) memberi exit 143 pesannya sendiri: DIBUNUH, bukan gagal, plus durasi, penyebab, dan berkas yang harus disunting. Pesan lama mengarahkan pembaca menyisir `sql/` — satu-satunya tempat masalahnya tidak ada.

## Gate

`tests/integration-harness-diagnostics.test.ts` mem-pin kedua cabang tanpa database — justru alasan fungsinya diekstrak: cabang ini hanya menyala di runner tak berpenunggu. **Mutation-proven**: menetralkan `if (exitCode === 143)` memerahkan 2 dari 4 test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)