### PR TITLE
feat(module-contract): make route ownership derivable with api.routes

### DIFF
--- a/.changeset/module-route-ownership.md
+++ b/.changeset/module-route-ownership.md
@@ -1,0 +1,30 @@
+---
+"awcms": minor
+---
+
+Make route ownership derivable: `ModuleApiContract.routes` and
+`modules:routes:check`.
+
+`basePath` was the only ownership claim a descriptor could make, and
+`tenant_admin` declared `basePath: "/api/v1"` — a prefix of every route in the
+application. Resolving a route to its longest-matching `basePath` handed
+`tenant_admin` 36 routes it does not own (all of
+`/api/v1/{access,roles,users,abac,identity}`, which are `identity_access`, plus
+`/api/v1/tenant/modules`, which is `module_management`), while 30 public routes
+matched nothing at all.
+
+`api.routes` is a list of owned prefixes, longest-prefix wins — because
+ownership genuinely is not one prefix: `/api/v1/tenant` is split between
+`tenant_domain` and `module_management`, and public surfaces (`/blog`,
+`/robots.txt`, `/search`, `/theming`, `/login`) belong to modules too.
+
+`bun run modules:routes:check` (check chain + `ci.yml`) requires every file
+under `src/pages` outside `/admin/**` to resolve to exactly one module or be
+named in a reviewed `PLATFORM_ROUTES` allow-list. It also rejects `/`, `/api`
+and `/api/v1` as claims outright — a coverage-only rule cannot see them, since a
+prefix matching everything leaves nothing uncovered.
+
+`MODULE_CONTRACT_VERSION` 2.3.0 -> 2.4.0 (additive; `routes` omitted means
+`[basePath]`). `openapi_documented` readiness now checks every owned prefix
+rather than the display `basePath`, which for `tenant_admin` had been matching
+any path at all.

--- a/.claude/skills/awcms-module-management/SKILL.md
+++ b/.claude/skills/awcms-module-management/SKILL.md
@@ -235,6 +235,31 @@ hal yang justru tidak boleh dilakukan laporan drift. Tetap jangan hapus baris
 `missing`/`orphaned` diperbaiki dengan menyelaraskan descriptor ATAU menambah
 migrasi seed, bukan dengan DELETE.
 
+## Kepemilikan rute: `api.routes`, bukan `basePath`
+
+`basePath` adalah prefix **tampilan**. Yang mengklaim kepemilikan adalah
+`api.routes` — daftar prefix, longest-prefix menang.
+
+Kenapa daftar: kepemilikan memang bukan satu prefix. `tenant_admin` memiliki
+`/api/v1/{offices,settings,setup}`, dan `/api/v1/tenant` **terbelah** antara
+`tenant_domain` (`/domains`) dan `module_management` (`/modules`). Permukaan
+publik non-API juga masuk (`/blog`, `/robots.txt`, `/search`, `/theming`) —
+sebelum Issue #256 ada 30 rute nyata yang tak diklaim siapa pun.
+
+> **JANGAN pernah menulis `basePath: "/api/v1"`.** Itu prefix setiap rute di
+> aplikasi; `tenant_admin` dulu menulisnya dan mencaplok 36 rute milik modul
+> lain (seluruh `/api/v1/{access,roles,users,abac,identity}` = `identity_access`,
+> `/api/v1/tenant/modules` = `module_management`). Gate menolak `/`, `/api`,
+> dan `/api/v1` secara eksplisit — **cek cakupan saja tidak cukup**: prefix yang
+> cocok dengan segalanya membuat nol rute tak-terklaim, jadi gerbang cakupan
+> hijau sementara jawabannya salah.
+
+`bun run modules:routes:check` menuntut tiap berkas di `src/pages` (kecuali
+`/admin/**`) dipetakan ke tepat SATU modul, atau ada di `PLATFORM_ROUTES`
+berikut alasan. `/admin/**` sengaja tidak di sini — sudah diikat
+`tests/admin-navigation-registry.test.ts`; mengklaimnya dua kali berarti dua
+sumber kebenaran untuk fakta yang sama.
+
 ## `navigation` = SATU sumber; sidebar dirender dari registry
 
 `ModuleDescriptor.navigation` dikonsumsi **empat** cara sekarang:

--- a/.claude/skills/awcms-new-module/SKILL.md
+++ b/.claude/skills/awcms-new-module/SKILL.md
@@ -40,7 +40,17 @@ export const <camelCase>Module = defineModule({
   // Kontrak OpenAPI dipecah per modul (Issue #182, ADR-0026): modul ini MEMILIKI
   // fragmentnya sendiri; `openApiPath` menunjuk fragment, bukan bundle GENERATED.
   // Setelah edit fragment: `bun run openapi:bundle` + `bun run api:docs:generate`.
-  api: { openApiPath: "openapi/modules/<module>.openapi.yaml", basePath: "/api/v1" },
+  // `basePath` = prefix UTAMA modul (tampilan/dokumen). `routes` = SEMUA prefix
+  // yang dimilikinya, termasuk permukaan publik non-API. JANGAN pernah menulis
+  // `/api/v1` di sini: itu prefix SETIAP rute di aplikasi, dan `modules:routes:check`
+  // menolaknya (Issue #256 — `tenant_admin` dulu menulisnya dan mencaplok 36 rute
+  // milik modul lain). Boleh dihilangkan bila modul hanya punya satu prefix;
+  // absennya berarti `[basePath]`.
+  api: {
+    openApiPath: "openapi/modules/<module>.openapi.yaml",
+    basePath: "/api/v1/<module>",
+    routes: ["/api/v1/<module>"] // + prefix publik, mis. "/<module>"
+  },
   events: {
     // awcms memakai SATU berkas AsyncAPI (belum dipecah per modul seperti OpenAPI).
     asyncApiPath: "asyncapi/awcms-domain-events.asyncapi.yaml",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Module dependency graph check
         run: bun run modules:dag:check
 
+      - name: Module route ownership check (Issue #256)
+        run: bun run modules:routes:check
+
       - name: Module composition check (Issue #178)
         run: bun run modules:compose:check
 

--- a/awcms-family-compatibility.yaml
+++ b/awcms-family-compatibility.yaml
@@ -29,7 +29,7 @@ family:
 # FAMILY_OWNED_CONTRACT_VERSIONS in src/modules/_shared/family-contract.ts and
 # given teeth by a SEMANTIC contract test that goes RED if the control drifts.
 contracts:
-  moduleDescriptorContractVersion: "2.3.0"
+  moduleDescriptorContractVersion: "2.4.0"
   # Per-capability port SemVer for capabilities OWNED BY A BASE MODULE (matches
   # CAPABILITY_CONTRACT_VERSIONS). Only capabilities whose owning module actually
   # ships in this base belong here. `party_directory` is owned by the base

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "changesets:policy:check": "bun scripts/changeset-policy-check.ts",
     "release:verify": "bun scripts/release-verify.ts",
     "modules:dag:check": "bun scripts/validate-module-graph.ts",
+    "modules:routes:check": "bun scripts/validate-module-routes.ts",
     "modules:compose:check": "bun scripts/validate-module-composition.ts",
     "modules:composition:inventory:generate": "bun scripts/module-composition-inventory-generate.ts",
     "modules:composition:inventory:check": "bun scripts/module-composition-inventory-check.ts",
@@ -94,7 +95,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/validate-module-routes.ts
+++ b/scripts/validate-module-routes.ts
@@ -1,0 +1,252 @@
+#!/usr/bin/env bun
+/**
+ * `bun run modules:routes:check` — Issue #256.
+ *
+ * Every file under `src/pages` resolves to exactly ONE owning module, or is
+ * named in a reviewed allow-list. No route belongs to nobody; no route belongs
+ * to two modules.
+ *
+ * ## Why ownership was not derivable before
+ *
+ * `ModuleApiContract.basePath` was the only ownership claim in the descriptor,
+ * and `tenant_admin` declared `basePath: "/api/v1"` — a prefix of every route
+ * in the application. Resolving by longest-matching `basePath` handed it 36
+ * routes it does not own (all of `/api/v1/{access,roles,users,abac,identity}`,
+ * which are `identity_access`, plus `/api/v1/tenant/modules`, which is
+ * `module_management`), while 30 further routes — the public blog, the
+ * discovery endpoints, `/search`, the theming CSS — matched nothing at all.
+ *
+ * So `api.routes` (a LIST, longest-prefix wins) now carries ownership and this
+ * gate keeps the mapping total and unambiguous.
+ *
+ * ## What is deliberately not here
+ *
+ * `/admin/**` pages. `tests/admin-navigation-registry.test.ts` already binds
+ * every admin page to exactly one descriptor's `navigation` entry, in both
+ * directions. Claiming them here too would be a second, drifting source for the
+ * same fact — the defect that gate was written to remove.
+ *
+ * Pure: reads `listModules()` and walks `src/pages`. No database, no network.
+ */
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { listModules } from "../src/modules";
+
+const PAGES_ROOT = "src/pages";
+
+/**
+ * Prefixes that can never be an ownership claim because they prefix the whole
+ * application. Rejected explicitly: a coverage-only gate cannot see them, since
+ * a prefix that matches everything leaves nothing uncovered.
+ */
+const OVERBROAD_PREFIXES = new Set(["/", "/api", "/api/v1"]);
+
+/**
+ * Routes owned by the platform rather than by any module. Each needs a reason a
+ * reviewer can disagree with — an entry without one is worse than no gate.
+ */
+const PLATFORM_ROUTES: readonly { route: string; reason: string }[] = [
+  {
+    route: "/api/v1/health",
+    reason:
+      "Liveness for the process, not for a module. Unauthenticated by the same " +
+      "precedent as /api/v1/database/pool/health, and exposes only aggregate " +
+      "booleans — a module owning it would imply it can be disabled, which " +
+      "would take the health endpoint down with it."
+  },
+  {
+    route: "/api/v1/database/pool/health",
+    reason:
+      "Pool/circuit-breaker counters for THIS process. Belongs to the database " +
+      "subsystem in src/lib, which is infrastructure and deliberately not a module."
+  },
+  {
+    route: "/[...path]",
+    reason:
+      "Astro's lowest-ranked catch-all: it runs only when no real route matched, " +
+      "so by construction it is the absence of a module rather than one module's " +
+      "surface. Renders the generic 404 (HTML for browsers, the standard JSON " +
+      "envelope for /api/*)."
+  }
+];
+
+/** `src/pages/blog/[tenantCode]/[slug].ts` -> `/blog/[tenantCode]/[slug]`. */
+export function routeOf(filePath: string): string {
+  return (
+    "/" +
+    filePath
+      .replace(/^src\/pages\/?/, "")
+      .replace(/\.(ts|astro|js)$/, "")
+      .replace(/\/index$/, "")
+      .replace(/^\//, "")
+  );
+}
+
+export type RouteOwnership = {
+  /** Prefix -> owning module key. Longest prefix wins. */
+  claims: { prefix: string; moduleKey: string }[];
+  /** Two modules claiming the same prefix — always a defect. */
+  conflicts: string[];
+};
+
+export function collectClaims(
+  modules: readonly {
+    key: string;
+    api?: { basePath: string; routes?: string[]; openApiPath?: string };
+  }[]
+): RouteOwnership {
+  const byPrefix = new Map<string, string[]>();
+
+  for (const module of modules) {
+    if (!module.api) {
+      continue;
+    }
+
+    for (const prefix of module.api.routes ?? [module.api.basePath]) {
+      byPrefix.set(prefix, [...(byPrefix.get(prefix) ?? []), module.key]);
+    }
+  }
+
+  const conflicts: string[] = [];
+  const claims: { prefix: string; moduleKey: string }[] = [];
+
+  // An over-broad prefix is the ORIGINAL defect, and it is invisible to the
+  // "every route has an owner" rule: `/api/v1` gives every route an owner, so
+  // the coverage check goes green while the answers are wrong. It has to be
+  // rejected on its own terms.
+  for (const [prefix, owners] of byPrefix) {
+    if (OVERBROAD_PREFIXES.has(prefix)) {
+      conflicts.push(
+        `"${prefix}" (declared by ${owners.join(", ")}) is too broad to be an ` +
+          "ownership claim — it prefixes routes belonging to other modules, which " +
+          "is exactly how `tenant_admin` came to own 36 routes it does not. List " +
+          "the specific prefixes in `api.routes` instead."
+      );
+    }
+  }
+
+  for (const [prefix, owners] of byPrefix) {
+    if (owners.length > 1) {
+      conflicts.push(`"${prefix}" is claimed by ${owners.sort().join(", ")}.`);
+      continue;
+    }
+
+    claims.push({ prefix, moduleKey: owners[0]! });
+  }
+
+  // Longest first: `/api/v1/tenant/modules` must beat `/api/v1/tenant/domains`'
+  // sibling and any shorter prefix, which is what makes a SPLIT tree resolve
+  // without special cases.
+  claims.sort((a, b) => b.prefix.length - a.prefix.length);
+
+  return { claims, conflicts };
+}
+
+export function resolveOwner(
+  route: string,
+  claims: readonly { prefix: string; moduleKey: string }[]
+): string | null {
+  return (
+    claims.find((claim) => route.startsWith(claim.prefix))?.moduleKey ?? null
+  );
+}
+
+async function* walk(directory: string): AsyncGenerator<string> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      yield* walk(full);
+    } else if (/\.(ts|astro)$/.test(entry.name)) {
+      yield full;
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const modules = listModules();
+  const { claims, conflicts } = collectClaims(modules);
+  const platform = new Set(PLATFORM_ROUTES.map((entry) => entry.route));
+  const problems: string[] = [...conflicts];
+
+  for (const entry of PLATFORM_ROUTES) {
+    if (entry.reason.trim().length < 40) {
+      problems.push(`${entry.route} is exempt with no substantive reason.`);
+    }
+  }
+
+  let scanned = 0;
+  let unowned = 0;
+
+  for await (const file of walk(PAGES_ROOT)) {
+    const filePath = file.split(path.sep).join("/");
+    const route = routeOf(filePath);
+
+    // Admin pages are bound to descriptors by
+    // `tests/admin-navigation-registry.test.ts`; a second claim here would be a
+    // second source of truth for the same fact.
+    if (route === "/admin" || route.startsWith("/admin/")) {
+      continue;
+    }
+
+    scanned++;
+
+    if (platform.has(route)) {
+      continue;
+    }
+
+    if (!resolveOwner(route, claims)) {
+      unowned++;
+      problems.push(
+        `${filePath} (${route}) — no module claims this route. Add its prefix to ` +
+          "the owning module's `api.routes`, or add a PLATFORM_ROUTES entry with a reason."
+      );
+    }
+  }
+
+  if (scanned === 0) {
+    console.error(
+      `modules:routes:check GAGAL — 0 berkas dipindai di ${PAGES_ROOT}. Jalankan dari root repository.`
+    );
+    process.exit(1);
+  }
+
+  // A platform exemption for a route that no longer exists makes the list look
+  // considered while excusing nothing.
+  const allRoutes = new Set<string>();
+
+  for await (const file of walk(PAGES_ROOT)) {
+    allRoutes.add(routeOf(file.split(path.sep).join("/")));
+  }
+
+  for (const entry of PLATFORM_ROUTES) {
+    if (!allRoutes.has(entry.route)) {
+      problems.push(
+        `${entry.route} is in PLATFORM_ROUTES but no such route exists — remove it.`
+      );
+    }
+  }
+
+  if (problems.length === 0) {
+    console.log(
+      `modules:routes:check OK — ${scanned} rute non-admin dipetakan ke ${claims.length} ` +
+        `prefix milik modul, plus ${PLATFORM_ROUTES.length} rute platform beralasan. ` +
+        "Nol rute tak-terklaim, nol prefix diklaim ganda."
+    );
+    process.exit(0);
+  }
+
+  for (const problem of problems) {
+    console.error(problem);
+  }
+
+  console.error(
+    `\nmodules:routes:check GAGAL — ${problems.length} temuan (${unowned} rute tak-terklaim).`
+  );
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/modules/_shared/module-contract.ts
+++ b/src/modules/_shared/module-contract.ts
@@ -17,7 +17,40 @@ export type ModuleLifecycleStatus =
 
 export type ModuleApiContract = {
   openApiPath: string;
+  /**
+   * The module's primary API prefix — for display, docs and the
+   * `openapi_documented` readiness signal. NOT a claim of ownership on its own:
+   * see `routes`.
+   */
   basePath: string;
+  /**
+   * Every route prefix this module owns, API and public alike.
+   *
+   * Added by Issue #256. `basePath` alone could not express ownership, and one
+   * module proved it: `tenant_admin` declared `basePath: "/api/v1"`, which is a
+   * prefix of every route in the application. Resolve a route to the
+   * longest-matching `basePath` and `tenant_admin` swallowed 36 it does not own
+   * — all of `/api/v1/access`, `/api/v1/roles`, `/api/v1/users`, `/api/v1/abac`
+   * and `/api/v1/identity` (`identity_access`), plus `/api/v1/tenant/modules`
+   * (`module_management`). Ownership was therefore not derivable at all, and
+   * any gate built on it would have accused the wrong module.
+   *
+   * A list, because ownership genuinely is not one prefix: `tenant_admin` owns
+   * `/api/v1/{offices,settings,setup}`, and `/api/v1/tenant` is SPLIT between
+   * `tenant_domain` (`/domains`) and `module_management` (`/modules`).
+   * Longest-prefix wins, so a split like that resolves without special cases.
+   *
+   * Public non-API surfaces belong here too (`/blog/{tenantCode}`, `robots.txt`,
+   * `/search`, `/theming`) — they are routes a module owns just as much as its
+   * `/api/v1` ones, and leaving them out is what let 30 real routes belong to
+   * nobody.
+   *
+   * Omitted means "`[basePath]`", so every existing descriptor keeps working.
+   * `modules:routes:check` requires the resulting map to cover every file under
+   * `src/pages` exactly once, or name it in a reviewed platform/public
+   * allow-list.
+   */
+  routes?: string[];
 };
 
 export type ModuleEventContract = {
@@ -701,7 +734,7 @@ export type HighVolumeTableDescriptor = {
  * every base `module.ts` that omits `commentableResources` stays valid
  * unchanged.
  */
-export const MODULE_CONTRACT_VERSION = "2.3.0";
+export const MODULE_CONTRACT_VERSION = "2.4.0";
 
 export function defineModule(descriptor: ModuleDescriptor): ModuleDescriptor {
   return descriptor;

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -272,7 +272,10 @@ export const blogContentModule = defineModule({
   ],
   api: {
     openApiPath: "openapi/awcms-public-api.openapi.yaml",
-    basePath: "/api/v1/blog"
+    basePath: "/api/v1/blog",
+    // The public path-based tenant routes (ADR-0009) are this module's surface
+    // too; before Issue #256 no descriptor claimed them at all.
+    routes: ["/api/v1/blog", "/blog"]
   },
   // Public search-source contribution to `site_search` (ADR-0040 §3, ported
   // from awcms-micro Issue #270). Pure DATA — no executable extractor, no SQL:

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -10,7 +10,20 @@ export const identityAccessModule = defineModule({
   dependencies: ["tenant_admin", "profile_identity"],
   api: {
     openApiPath: "openapi/modules/identity-access.openapi.yaml",
-    basePath: "/api/v1/auth"
+    basePath: "/api/v1/auth",
+    // Reclaimed from `tenant_admin`'s former `/api/v1` catch-all (Issue #256):
+    // access control, roles, users, ABAC policies and identity/business-scope
+    // are this module's surfaces, and its permissions are what guard them.
+    // `/login` is the SSR page for the same session it issues.
+    routes: [
+      "/api/v1/auth",
+      "/api/v1/access",
+      "/api/v1/roles",
+      "/api/v1/users",
+      "/api/v1/abac",
+      "/api/v1/identity",
+      "/login"
+    ]
   },
   // Issue #180 — the generic business-scope layer CONSUMES a hierarchy
   // resolver from a DERIVED application (ADR-0011 capability port,

--- a/src/modules/media-library/module.ts
+++ b/src/modules/media-library/module.ts
@@ -67,7 +67,10 @@ export const mediaLibraryModule = defineModule({
   },
   api: {
     openApiPath: "openapi/awcms-public-api.openapi.yaml",
-    basePath: "/api/v1/media/news-images"
+    basePath: "/api/v1/media/news-images",
+    // The whole `/api/v1/media` tree, not just the news-images sub-path —
+    // `/api/v1/media/enforcement` was falling to `tenant_admin`'s catch-all.
+    routes: ["/api/v1/media"]
   },
   permissions: [
     {

--- a/src/modules/module-management/application/health-registry.ts
+++ b/src/modules/module-management/application/health-registry.ts
@@ -244,17 +244,22 @@ async function openApiDocumentedSignal(
     paths?: Record<string, unknown>;
   } | null;
   const paths = document?.paths ? Object.keys(document.paths) : [];
-  const hasBasePathEntry = paths.some((p) =>
-    p.startsWith(descriptor.api!.basePath)
+  // Issue #256: check every prefix the module OWNS, not just its display
+  // `basePath`. That distinction was invisible while `tenant_admin` declared
+  // `basePath: "/api/v1"` — a prefix every path in any fragment matches, so
+  // this signal passed for it no matter what the fragment contained.
+  const owned = descriptor.api.routes ?? [descriptor.api.basePath];
+  const hasOwnedEntry = paths.some((p) =>
+    owned.some((prefix) => p.startsWith(prefix))
   );
 
   return {
     name: "openapi_documented",
-    status: document && hasBasePathEntry ? "pass" : "fail",
+    status: document && hasOwnedEntry ? "pass" : "fail",
     detail:
-      document && hasBasePathEntry
+      document && hasOwnedEntry
         ? undefined
-        : "No OpenAPI path found under the module's declared basePath."
+        : "No OpenAPI path found under any route prefix the module declares."
   };
 }
 

--- a/src/modules/module-management/module.ts
+++ b/src/modules/module-management/module.ts
@@ -12,7 +12,10 @@ export const moduleManagementModule = defineModule({
   isCore: true,
   api: {
     openApiPath: "openapi/modules/module-management.openapi.yaml",
-    basePath: "/api/v1/modules"
+    basePath: "/api/v1/modules",
+    // `/api/v1/tenant` is SPLIT: `/modules` here, `/domains` in `tenant_domain`.
+    // Longest-prefix resolution handles that without a special case.
+    routes: ["/api/v1/modules", "/api/v1/tenant/modules"]
   },
   navigation: [
     {

--- a/src/modules/seo-distribution/module.ts
+++ b/src/modules/seo-distribution/module.ts
@@ -112,7 +112,18 @@ export const seoDistributionModule = defineModule({
   },
   api: {
     openApiPath: "openapi/modules/seo-distribution.openapi.yaml",
-    basePath: "/api/v1/seo"
+    basePath: "/api/v1/seo",
+    // The public discovery routes this module renders (ADR-0038). They are
+    // top-level by protocol convention, not under a prefix, so each is listed.
+    routes: [
+      "/api/v1/seo",
+      "/robots.txt",
+      "/sitemap.xml",
+      "/sitemap-",
+      "/feed.xml",
+      "/feed.json",
+      "/atom.xml"
+    ]
   },
   permissions: [
     {

--- a/src/modules/site-search/module.ts
+++ b/src/modules/site-search/module.ts
@@ -76,7 +76,8 @@ export const siteSearchModule = defineModule({
   type: "domain",
   api: {
     openApiPath: "openapi/modules/site-search.openapi.yaml",
-    basePath: "/api/v1/site-search"
+    basePath: "/api/v1/site-search",
+    routes: ["/api/v1/site-search", "/search"]
   },
   permissions: [
     {

--- a/src/modules/tenant-admin/module.ts
+++ b/src/modules/tenant-admin/module.ts
@@ -10,7 +10,12 @@ export const tenantAdminModule = defineModule({
   dependencies: [],
   api: {
     openApiPath: "openapi/modules/tenant-admin.openapi.yaml",
-    basePath: "/api/v1"
+    // `basePath` stays the primary display prefix; `routes` is what actually
+    // claims ownership. This descriptor used to say `basePath: "/api/v1"`,
+    // which is a prefix of EVERY route in the application — see
+    // `ModuleApiContract.routes` for the 36 routes that swallowed.
+    basePath: "/api/v1/offices",
+    routes: ["/api/v1/offices", "/api/v1/settings", "/api/v1/setup"]
   },
   navigation: [
     {

--- a/src/modules/theming/module.ts
+++ b/src/modules/theming/module.ts
@@ -87,7 +87,9 @@ export const themingModule = defineModule({
   },
   api: {
     openApiPath: "openapi/modules/theming.openapi.yaml",
-    basePath: "/api/v1/theming"
+    basePath: "/api/v1/theming",
+    // Public token CSS + preview surfaces.
+    routes: ["/api/v1/theming", "/theming"]
   },
   permissions: [
     {

--- a/tests/media-library-module.test.ts
+++ b/tests/media-library-module.test.ts
@@ -47,10 +47,18 @@ describe("media_library module descriptor (ADR-0036)", () => {
   });
 
   test("owns the media upload basePath that moved off news_portal", () => {
-    expect(mediaLibraryModule.api).toEqual({
-      openApiPath: "openapi/awcms-public-api.openapi.yaml",
-      basePath: "/api/v1/media/news-images"
-    });
+    expect(mediaLibraryModule.api?.openApiPath).toBe(
+      "openapi/awcms-public-api.openapi.yaml"
+    );
+    expect(mediaLibraryModule.api?.basePath).toBe("/api/v1/media/news-images");
+  });
+
+  test("claims the whole /api/v1/media tree, not just the news-images sub-path", () => {
+    // Issue #256. `basePath` is the display prefix; `routes` is the ownership
+    // claim. Before it existed, `/api/v1/media/enforcement` fell through to
+    // `tenant_admin`'s `/api/v1` catch-all — a route this module owns,
+    // attributed to a module that has nothing to do with media.
+    expect(mediaLibraryModule.api?.routes).toEqual(["/api/v1/media"]);
   });
 
   test("owns the news-media:reconcile job that moved off news_portal (command name kept, ADR-0036 §3)", () => {

--- a/tests/module-route-ownership.test.ts
+++ b/tests/module-route-ownership.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Route ownership resolves to exactly one module, and the resolution rule is
+ * the one that made it possible.
+ *
+ * ## What was broken
+ *
+ * `basePath` was the only ownership claim, and `tenant_admin` declared
+ * `basePath: "/api/v1"` — a prefix of every route in the application. Longest-
+ * prefix resolution therefore handed it 36 routes it does not own, including
+ * all of `/api/v1/{access,roles,users,abac,identity}` (`identity_access`) and
+ * `/api/v1/tenant/modules` (`module_management`), while 30 public routes — the
+ * blog, the discovery endpoints, `/search`, the theming CSS — matched nothing.
+ *
+ * Ownership was not merely wrong, it was *underivable*: any gate built on
+ * `basePath` would have accused the wrong module, which is worse than no gate.
+ *
+ * ## What these pin
+ *
+ * The two properties the fix depends on: longest-prefix wins (so a SPLIT tree
+ * like `/api/v1/tenant` resolves without a special case), and the map stays
+ * total and unambiguous against the real registry.
+ *
+ * Pure — no database, no network.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import {
+  collectClaims,
+  resolveOwner,
+  routeOf
+} from "../scripts/validate-module-routes";
+
+describe("prefix resolution", () => {
+  test("longest prefix wins, so a split tree resolves without a special case", () => {
+    // `/api/v1/tenant` is genuinely split in this repo: `/domains` belongs to
+    // `tenant_domain`, `/modules` to `module_management`.
+    const { claims } = collectClaims([
+      {
+        key: "tenant_domain",
+        api: { basePath: "/api/v1/tenant/domains", openApiPath: "x" }
+      },
+      {
+        key: "module_management",
+        api: {
+          basePath: "/api/v1/modules",
+          openApiPath: "x",
+          routes: ["/api/v1/modules", "/api/v1/tenant/modules"]
+        }
+      }
+    ]);
+
+    expect(resolveOwner("/api/v1/tenant/domains/abc", claims)).toBe(
+      "tenant_domain"
+    );
+    expect(resolveOwner("/api/v1/tenant/modules/abc/enable", claims)).toBe(
+      "module_management"
+    );
+  });
+
+  test("a module with no `routes` falls back to its basePath", () => {
+    const { claims } = collectClaims([
+      { key: "email", api: { basePath: "/api/v1/email", openApiPath: "x" } }
+    ]);
+
+    expect(resolveOwner("/api/v1/email/templates", claims)).toBe("email");
+  });
+
+  test("two modules claiming one prefix is reported, not silently resolved", () => {
+    const { conflicts } = collectClaims([
+      { key: "a", api: { basePath: "/api/v1/thing", openApiPath: "x" } },
+      { key: "b", api: { basePath: "/api/v1/thing", openApiPath: "x" } }
+    ]);
+
+    expect(conflicts).toEqual(['"/api/v1/thing" is claimed by a, b.']);
+  });
+
+  test("an unclaimed route resolves to nobody rather than to the nearest module", () => {
+    const { claims } = collectClaims([
+      { key: "email", api: { basePath: "/api/v1/email", openApiPath: "x" } }
+    ]);
+
+    expect(resolveOwner("/api/v1/unknown", claims)).toBeNull();
+  });
+});
+
+describe("file path to route", () => {
+  test.each([
+    ["src/pages/api/v1/offices/index.ts", "/api/v1/offices"],
+    ["src/pages/api/v1/offices/[id].ts", "/api/v1/offices/[id]"],
+    ["src/pages/blog/[tenantCode]/[slug].ts", "/blog/[tenantCode]/[slug]"],
+    ["src/pages/robots.txt.ts", "/robots.txt"],
+    ["src/pages/login.astro", "/login"],
+    ["src/pages/[...path].ts", "/[...path]"]
+  ])("%s -> %s", (file, expected) => {
+    expect(routeOf(file)).toBe(expected);
+  });
+});
+
+describe("the real registry", () => {
+  const modules = listModules();
+  const { claims, conflicts } = collectClaims(modules);
+
+  test("no two modules claim the same prefix", () => {
+    expect(conflicts).toEqual([]);
+  });
+
+  test("no module claims a bare `/api/v1` again", () => {
+    // The specific regression. A prefix this short cannot be an ownership claim
+    // — it matches everything, so it silently annexes every route no other
+    // module happens to claim more specifically.
+    const overbroad = claims.filter(
+      (claim) => claim.prefix === "/api/v1" || claim.prefix === "/"
+    );
+
+    expect(overbroad).toEqual([]);
+  });
+
+  test("the modules that were wrongly annexed now own their own routes", () => {
+    for (const [route, owner] of [
+      ["/api/v1/access/policies", "identity_access"],
+      ["/api/v1/roles/index", "identity_access"],
+      ["/api/v1/users/[id]", "identity_access"],
+      ["/api/v1/abac/policies", "identity_access"],
+      ["/api/v1/identity/business-scope", "identity_access"],
+      ["/api/v1/tenant/modules/x/enable", "module_management"],
+      ["/api/v1/tenant/domains/x", "tenant_domain"],
+      ["/api/v1/media/enforcement", "media_library"],
+      // ...and the three that genuinely are tenant_admin's.
+      ["/api/v1/offices/[id]", "tenant_admin"],
+      ["/api/v1/settings", "tenant_admin"],
+      ["/api/v1/setup/status", "tenant_admin"]
+    ] as const) {
+      expect(resolveOwner(route, claims)).toBe(owner);
+    }
+  });
+
+  test("the public surfaces that belonged to nobody now have owners", () => {
+    for (const [route, owner] of [
+      ["/blog/[tenantCode]/[slug]", "blog_content"],
+      ["/robots.txt", "seo_distribution"],
+      ["/sitemap.xml", "seo_distribution"],
+      ["/feed.json", "seo_distribution"],
+      ["/atom.xml", "seo_distribution"],
+      ["/search", "site_search"],
+      ["/theming/[tenantCode]/tokens.css", "theming"],
+      ["/login", "identity_access"]
+    ] as const) {
+      expect(resolveOwner(route, claims)).toBe(owner);
+    }
+  });
+
+  test("every module that declares `routes` also keeps a basePath inside them", () => {
+    // A `basePath` outside the module's own owned set would mean the displayed
+    // prefix and the claimed prefixes describe different modules.
+    const stray = modules
+      .filter((module) => module.api?.routes)
+      .filter(
+        (module) =>
+          !module.api!.routes!.some((prefix) =>
+            module.api!.basePath.startsWith(prefix)
+          )
+      )
+      .map((module) => module.key);
+
+    expect(stray).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #256. Membuka blokir bagian `src/pages` dari #257.

## Kepemilikan rute tidak sekadar salah — ia **tidak bisa diturunkan**

`basePath` adalah satu-satunya klaim kepemilikan yang bisa ditulis descriptor, dan `tenant_admin` menulis `basePath: "/api/v1"` — prefix dari **setiap** rute di aplikasi. Resolusi longest-prefix menyerahkan 36 rute yang bukan miliknya:

| rute | pemilik sebenarnya |
| --- | --- |
| `/api/v1/{access,roles,users,abac,identity}` | `identity_access` |
| `/api/v1/tenant/modules` | `module_management` |
| `/api/v1/media/enforcement` | `media_library` |

Sementara 30 rute publik — blog, discovery, `/search`, CSS theming, `/login` — tidak cocok dengan apa pun. Gate apa pun yang dibangun di atas `basePath` akan **menuduh modul yang salah**, dan itu lebih buruk daripada tidak ada gate.

## Kenapa `routes` berupa DAFTAR

Kepemilikan memang bukan satu prefix:

- `tenant_admin` memiliki `/api/v1/{offices,settings,setup}`;
- `/api/v1/tenant` **terbelah** — `/domains` milik `tenant_domain`, `/modules` milik `module_management`.

Longest-prefix menang, jadi pembelahan itu resolve tanpa kasus khusus. Permukaan publik non-API ikut masuk: itu rute yang dimiliki modul sama seperti `/api/v1`-nya.

Dihilangkan berarti `[basePath]` → descriptor yang tak disentuh tetap jalan. `MODULE_CONTRACT_VERSION` 2.3.0 → **2.4.0** (additive), manifest keluarga di-pin.

## Cakupan saja TIDAK menangkap cacat aslinya

Aturan "tiap rute punya pemilik" **lolos** dengan catch-all dikembalikan: `/api/v1` memberi pemilik pada semua rute, jadi nol yang tak-tercakup dan gate hijau padahal semua jawabannya salah. Saya buktikan lewat mutasi, lalu perbaiki — `/`, `/api`, dan `/api/v1` ditolak sebagai klaim atas dasarnya sendiri.

`/admin/**` sengaja di luar cakupan: sudah diikat `tests/admin-navigation-registry.test.ts` dua arah, dan klaim kedua berarti dua sumber kebenaran untuk satu fakta.

## Bukti gate

| mutasi | pesan |
| --- | --- |
| `basePath: "/api/v1"` dikembalikan | `too broad to be an ownership claim` |
| halaman publik baru tanpa pemilik | `no module claims this route` |
| dua modul klaim `/robots.txt` | `claimed by seo_distribution, site_search` |

## Ikut diperbaiki

- **Sinyal `openapi_documented` yang hampa.** Ia mencocokkan `basePath`, jadi untuk `tenant_admin` cocok dengan path apa pun di fragment mana pun dan selalu lulus. Kini mengecek tiap prefix yang dimiliki.
- **Skill `awcms-new-module` mencontohkan `basePath: "/api/v1"`** — cacatnya sendiri, sedang disalin ke tiap modul baru.

## Hasil atribusi

`tenant_admin` kini tepat 6 rute miliknya; `identity_access` 43; tiga sisanya (`/api/v1/health`, `/api/v1/database/pool/health`, `/[...path]`) rute platform ber-alasan tertulis.

Suite penuh kondisi CI: **2389 pass, 277 skip, 0 fail**. Semua gate, typecheck, build hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
