### PR TITLE
feat(module-management): tenant module presets

### DIFF
--- a/.changeset/module-presets.md
+++ b/.changeset/module-presets.md
@@ -1,0 +1,25 @@
+---
+"awcms": minor
+---
+
+Tenant module presets: named profiles a tenant can be brought to in one action.
+
+`minimal`, `website`, `news_portal` and `back_office`. A preset ENABLES what it
+lists and DISABLES every enabled, unlisted, unprotected module — enable-only
+would make presets useless as a way to REACH a profile, since a tenant that once
+enabled `blog_content` and then applied `minimal` would stay non-minimal
+forever.
+
+Ported from awcms-micro (Issue #261) with its planning logic intact, but not its
+preset set: `back_office` has no counterpart there, and micro's R2/SaaS presets
+are not reproduced because the subsystems that distinguished them do not exist
+in this base — a preset naming an absent module is a dead profile.
+
+`GET /api/v1/tenant/modules/presets?preset=<name>` returns a dry-run plan,
+because applying one disables things and an operator should see that list first.
+`POST /api/v1/tenant/modules/presets/{presetName}/apply` executes it through the
+existing lifecycle primitives, so each change runs the real validation and a
+rejection is reported per module rather than swallowed.
+
+No migration and no new permission: an apply is a sequence of enables and
+disables, so it guards on `module_management.tenant_modules.disable`.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -1916,6 +1916,50 @@ Database-backed module registry, tenant module lifecycle, settings, permission s
 | 403    | Access denied by RBAC/ABAC.   | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.           | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/tenant/modules/presets` — Named module profiles, and optionally a dry-run plan for one.
+
+- **operationId**: `listTenantModulePresets`
+- **Security**: bearerAuth + tenantHeader
+
+Applying a preset DISABLES every enabled, unlisted, unprotected module, so `?preset=<name>` returns the plan without writing anything — an operator switching a live tenant's profile sees the disable list before it happens. An unknown name returns the catalog with `plan: null`.
+
+**Parameters**
+
+| Name     | In    | Required | Type   | Description |
+| -------- | ----- | -------- | ------ | ----------- |
+| `preset` | query | no       | string |             |
+
+**Responses**
+
+| Status | Description                                             | Schema                                 |
+| ------ | ------------------------------------------------------- | -------------------------------------- |
+| 200    | Preset catalog, plus a plan when `preset` was supplied. | object                                 |
+| 400    | Validation error.                                       | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                             | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                             | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/tenant/modules/presets/{presetName}/apply` — Bring the tenant's module state to a named profile.
+
+- **operationId**: `applyTenantModulePreset`
+- **Security**: bearerAuth + tenantHeader
+
+Enables every module the preset lists and disables every enabled, unlisted, unprotected module. Each change runs the real lifecycle validation, so a change can be rejected: `complete: false` with per-module reasons is a real outcome, not an error.
+
+**Parameters**
+
+| Name         | In   | Required | Type   | Description |
+| ------------ | ---- | -------- | ------ | ----------- |
+| `presetName` | path | yes      | string |             |
+
+**Responses**
+
+| Status | Description                              | Schema                                 |
+| ------ | ---------------------------------------- | -------------------------------------- |
+| 200    | Preset applied, completely or partially. | object                                 |
+| 401    | Missing or invalid session.              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.              | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                      | [`ApiError`](#standard-error-envelope) |
+
 ## Sync Storage
 
 Offline-first sync node registration, HMAC-signed push/pull, conflict tracking, and the object sync upload queue.

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -927,6 +927,16 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/tenant/modules/presets/[presetName]/apply.ts",
+      "workClass": "maintenance",
+      "source": "factory"
+    },
+    {
+      "path": "src/pages/api/v1/tenant/modules/presets/index.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/theming/draft.ts",
       "workClass": "interactive",
       "source": "default"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -12049,6 +12049,119 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/tenant/modules/presets:
+    get:
+      operationId: listTenantModulePresets
+      tags:
+        - Module Management
+      summary: Named module profiles, and optionally a dry-run plan for one.
+      description: "Applying a preset DISABLES every enabled, unlisted, unprotected module, so `?preset=<name>` returns the plan without writing anything — an operator switching a live tenant's profile sees the disable list before it happens. An unknown name returns the catalog with `plan: null`."
+      parameters:
+        - name: preset
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Preset catalog, plus a plan when `preset` was supplied.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      presets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            label:
+                              type: string
+                            description:
+                              type: string
+                            enabledModuleKeys:
+                              type: array
+                              items:
+                                type: string
+                      plan:
+                        nullable: true
+                        type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/tenant/modules/presets/{presetName}/apply:
+    post:
+      operationId: applyTenantModulePreset
+      tags:
+        - Module Management
+      summary: Bring the tenant's module state to a named profile.
+      description: "Enables every module the preset lists and disables every enabled, unlisted, unprotected module. Each change runs the real lifecycle validation, so a change can be rejected: `complete: false` with per-module reasons is a real outcome, not an error."
+      parameters:
+        - name: presetName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Preset applied, completely or partially.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      presetName:
+                        type: string
+                      complete:
+                        type: boolean
+                      plan:
+                        type: object
+                      changes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            moduleKey:
+                              type: string
+                            action:
+                              type: string
+                              enum:
+                                - enable
+                                - disable
+                            outcome:
+                              type: string
+                              enum:
+                                - applied
+                                - rejected
+                            code:
+                              type: string
+                            message:
+                              type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/theming:
     get:
       tags:

--- a/openapi/modules/module-management.openapi.yaml
+++ b/openapi/modules/module-management.openapi.yaml
@@ -416,6 +416,127 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/tenant/modules/presets:
+    get:
+      operationId: listTenantModulePresets
+      tags:
+        - Module Management
+      summary: Named module profiles, and optionally a dry-run plan for one.
+      description: >-
+        Applying a preset DISABLES every enabled, unlisted, unprotected module,
+        so `?preset=<name>` returns the plan without writing anything — an
+        operator switching a live tenant's profile sees the disable list before
+        it happens. An unknown name returns the catalog with `plan: null`.
+      parameters:
+        - name: preset
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Preset catalog, plus a plan when `preset` was supplied.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      presets:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                            label:
+                              type: string
+                            description:
+                              type: string
+                            enabledModuleKeys:
+                              type: array
+                              items:
+                                type: string
+                      plan:
+                        nullable: true
+                        type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/tenant/modules/presets/{presetName}/apply:
+    post:
+      operationId: applyTenantModulePreset
+      tags:
+        - Module Management
+      summary: Bring the tenant's module state to a named profile.
+      description: >-
+        Enables every module the preset lists and disables every enabled,
+        unlisted, unprotected module. Each change runs the real lifecycle
+        validation, so a change can be rejected: `complete: false` with
+        per-module reasons is a real outcome, not an error.
+      parameters:
+        - name: presetName
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Preset applied, completely or partially.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      presetName:
+                        type: string
+                      complete:
+                        type: boolean
+                      plan:
+                        type: object
+                      changes:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            moduleKey:
+                              type: string
+                            action:
+                              type: string
+                              enum:
+                                - enable
+                                - disable
+                            outcome:
+                              type: string
+                              enum:
+                                - applied
+                                - rejected
+                            code:
+                              type: string
+                            message:
+                              type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/tenant/modules/{moduleKey}/settings:
     get:
       operationId: getTenantModuleSettings

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -45,6 +45,25 @@ Ported and adapted from the awcms-mini module-management module.
   needs a migration and is a separate increment; the model here is the default
   those overrides apply on top of, so it arrives without rework.
 
+- **Module presets** (`domain/module-presets.ts`, `application/module-presets.ts`)
+  — named profiles (`minimal`, `website`, `news_portal`, `back_office`) a tenant
+  can be brought TO in one action. A preset ENABLES what it lists and DISABLES
+  every enabled, unlisted, unprotected module; enable-only would make presets
+  useless as a way to reach a profile. Executed through the existing
+  `enableTenantModule`/`disableTenantModule` primitives, one call per planned
+  change, so a change can still be rejected and is reported rather than
+  swallowed (`complete: false` with per-module reasons).
+
+  "Protected" is not `isCore`: only `module_management` sets that flag, and the
+  rest are protected indirectly by the reverse-dependency check.
+  `resolveProtectedModuleKeys` makes that explicit for planning.
+
+  No new permission: an apply IS a sequence of enables and disables, so
+  `POST .../presets/{name}/apply` guards on
+  `module_management.tenant_modules.disable` — the stronger of the two the
+  underlying calls already need. A new action would need a seed migration, and
+  an unseeded action denies even the owner.
+
 - **Job registry** (`application/job-registry.ts`) — documentation-only
   metadata about each module's operational commands. Never an execution
   surface.

--- a/src/modules/module-management/application/module-presets.ts
+++ b/src/modules/module-management/application/module-presets.ts
@@ -1,0 +1,181 @@
+/**
+ * Preset execution (Issue #261, ported from awcms-micro).
+ *
+ * Resolves the tenant's current module state, asks
+ * `domain/module-presets.ts` what to do, then executes that plan through the
+ * EXISTING `enableTenantModule`/`disableTenantModule` primitives — one call per
+ * planned change, in the planned order.
+ *
+ * ## Zero re-derivation
+ *
+ * Nothing here re-implements lifecycle validation. Every enable and disable
+ * runs the real thing against live state, so a planned change can still be
+ * rejected. Rejections are REPORTED, never swallowed and never worked around:
+ * a preset that cannot be fully reached says so, item by item, rather than
+ * reporting success over a half-applied profile.
+ *
+ * ## Why there is no new permission
+ *
+ * Applying a preset is exactly a sequence of enables and disables, so it is
+ * guarded by BOTH `module_management.tenant_modules.enable` and
+ * `.disable` — the permissions those operations already require. A new
+ * `presets.apply` action would need a seed migration, and an unseeded action
+ * denies even the owner: the latent-authz trap this repo has already hit on the
+ * roles and ABAC write surfaces. Reusing both is also the honest guard — a
+ * preset can disable a module, so holding only `enable` must not be enough.
+ */
+import type { ModulePresetName } from "../domain/module-presets";
+import {
+  computeModulePresetPlan,
+  findModulePreset,
+  MODULE_PRESETS,
+  type ModulePresetPlan
+} from "../domain/module-presets";
+import { listModules } from "../..";
+import {
+  disableTenantModule,
+  enableTenantModule,
+  fetchTenantModuleEntries
+} from "./tenant-module-lifecycle";
+
+export type ModulePresetChangeOutcome =
+  | { moduleKey: string; action: "enable" | "disable"; outcome: "applied" }
+  | {
+      moduleKey: string;
+      action: "enable" | "disable";
+      outcome: "rejected";
+      code: string;
+      message: string;
+    };
+
+export type ModulePresetApplyResult = {
+  presetName: ModulePresetName;
+  plan: ModulePresetPlan;
+  changes: ModulePresetChangeOutcome[];
+  /** True when every planned change applied. A preset with an empty plan is trivially complete. */
+  complete: boolean;
+};
+
+/** The catalog, for `GET`. Pure metadata — no tenant state involved. */
+export function listModulePresets() {
+  return MODULE_PRESETS.map((preset) => ({
+    name: preset.name,
+    label: preset.label,
+    description: preset.description,
+    enabledModuleKeys: [...preset.enabledModuleKeys]
+  }));
+}
+
+async function currentTenantState(tx: Bun.SQL, tenantId: string) {
+  return (await fetchTenantModuleEntries(tx, tenantId)).map((entry) => ({
+    moduleKey: entry.moduleKey,
+    tenantEnabled: entry.tenantEnabled
+  }));
+}
+
+/**
+ * What applying `presetName` WOULD do, without writing anything.
+ *
+ * Worth its own entry point: a preset both enables and disables, so an operator
+ * about to switch a live tenant's profile deserves to see the disable list
+ * before it happens rather than after.
+ */
+export async function planModulePreset(
+  tx: Bun.SQL,
+  tenantId: string,
+  presetName: string
+): Promise<ModulePresetPlan | null> {
+  const preset = findModulePreset(presetName);
+
+  if (!preset) {
+    return null;
+  }
+
+  return computeModulePresetPlan({
+    preset,
+    allDescriptors: listModules(),
+    currentState: await currentTenantState(tx, tenantId)
+  });
+}
+
+/**
+ * Apply a preset. Returns `null` for an unknown preset name so the route can
+ * answer 404 rather than inventing an empty plan.
+ *
+ * Order matters and is the plan's: enables first (dependency-safe), then
+ * disables (leaves-first). Enabling before disabling means a module moving from
+ * "needed by A" to "needed by B" never passes through a moment where neither
+ * holds it.
+ *
+ * Sequential `await`s, never `Promise.all`: `tx` is one reserved connection,
+ * and concurrent queries on it desync the transaction.
+ */
+export async function applyModulePreset(
+  tx: Bun.SQL,
+  tenantId: string,
+  presetName: string,
+  actorTenantUserId: string
+): Promise<ModulePresetApplyResult | null> {
+  const preset = findModulePreset(presetName);
+
+  if (!preset) {
+    return null;
+  }
+
+  const plan = computeModulePresetPlan({
+    preset,
+    allDescriptors: listModules(),
+    currentState: await currentTenantState(tx, tenantId)
+  });
+  const changes: ModulePresetChangeOutcome[] = [];
+
+  for (const moduleKey of plan.toEnable) {
+    const result = await enableTenantModule(
+      tx,
+      tenantId,
+      moduleKey,
+      actorTenantUserId
+    );
+
+    changes.push(
+      result.outcome === "applied"
+        ? { moduleKey, action: "enable", outcome: "applied" }
+        : {
+            moduleKey,
+            action: "enable",
+            outcome: "rejected",
+            code: result.validation.code,
+            message: result.validation.message
+          }
+    );
+  }
+
+  for (const moduleKey of plan.toDisable) {
+    const result = await disableTenantModule(
+      tx,
+      tenantId,
+      moduleKey,
+      actorTenantUserId,
+      `Applied module preset "${preset.name}".`
+    );
+
+    changes.push(
+      result.outcome === "applied"
+        ? { moduleKey, action: "disable", outcome: "applied" }
+        : {
+            moduleKey,
+            action: "disable",
+            outcome: "rejected",
+            code: result.validation.code,
+            message: result.validation.message
+          }
+    );
+  }
+
+  return {
+    presetName: preset.name,
+    plan,
+    changes,
+    complete: changes.every((change) => change.outcome === "applied")
+  };
+}

--- a/src/modules/module-management/domain/module-presets.ts
+++ b/src/modules/module-management/domain/module-presets.ts
@@ -1,0 +1,384 @@
+/**
+ * Tenant module presets — named profiles a tenant can be brought to in one
+ * action. Pure planning; no I/O.
+ *
+ * Ported from awcms-micro's `module-management/domain/module-presets.ts`
+ * (Issue #261). The planning logic is unchanged; the PRESET SET is not — see
+ * "Presets for this template" below.
+ *
+ * The application layer resolves current state, hands it here, then executes
+ * the plan through the existing `enableTenantModule`/`disableTenantModule`
+ * primitives. Nothing in this file re-implements lifecycle validation.
+ *
+ * ## Design decision 1 — a preset ENABLES and DISABLES
+ *
+ * Applying a preset enables every module it lists and disables every currently
+ * enabled module that is neither listed nor protected. Enable-only would make
+ * presets useless as a way to REACH a profile: a tenant that once enabled
+ * `blog_content` and then applies `minimal` would stay non-minimal forever.
+ *
+ * A preset apply is therefore "make tenant module state match this profile",
+ * best-effort — not a purely additive grant.
+ *
+ * ## Design decision 2 — "protected" is not the same as `isCore`
+ *
+ * Only `module_management` sets `isCore: true` in this registry. The other
+ * foundational modules (`tenant_admin`, `identity_access`) are protected
+ * INDIRECTLY, by the reverse-dependency check
+ * (`MODULE_REVERSE_DEPENDENCY_ACTIVE`): nothing can disable them while
+ * `module_management` — which depends on them and can never itself be disabled
+ * — stays enabled.
+ *
+ * `resolveProtectedModuleKeys` makes that implicit protection explicit for
+ * planning: `isCore` keys plus their full transitive dependency closure. It
+ * does NOT duplicate the reverse-dependency check — the real
+ * `enable`/`disableTenantModule` still validate against live state. It exists
+ * so `minimal` can concretely mean "keep only what cannot be given up" instead
+ * of an empty enable list that would silently leave everything as it was.
+ *
+ * ## Design decision 3 — a preset does not silently pull in dependencies
+ *
+ * If a preset lists a module whose dependency is neither listed nor already
+ * enabled, this planner does not invent it. The existing
+ * `MODULE_DEPENDENCY_MISSING`/`MODULE_DEPENDENCY_DISABLED` semantics are reused:
+ * the enable fails and the application layer reports that failure. A planner
+ * that quietly repaired the preset would hide a mistake in the preset.
+ *
+ * ## Presets for this template
+ *
+ * awcms is the ERP/back-office line and, since ADR-0035, the family superset
+ * that absorbs the website/e-commerce cluster. Its presets are therefore not
+ * micro's: `back_office` has no counterpart there, and micro's
+ * `news_portal_full_online_r2` and `saas_online` are not reproduced because the
+ * subsystems that distinguished them (an R2 activation preset subsystem, the
+ * SaaS control plane) are not in this base. A preset naming a module this
+ * registry does not have would be a dead profile, which
+ * `computeModulePresetPlan` would have to report as `unknownModuleKeys` on
+ * every single apply.
+ */
+import type { ModuleDescriptor } from "../../_shared/module-contract";
+import type { ModuleTenantState } from "./tenant-module-lifecycle";
+
+export type ModulePresetName =
+  "minimal" | "website" | "news_portal" | "back_office";
+
+export type ModulePresetDefinition = {
+  name: ModulePresetName;
+  label: string;
+  description: string;
+  /**
+   * Keys this preset wants enabled, beyond what `resolveProtectedModuleKeys`
+   * already keeps. `minimal` is deliberately empty — "protected modules only".
+   */
+  enabledModuleKeys: readonly string[];
+};
+
+export const MODULE_PRESETS: readonly ModulePresetDefinition[] = [
+  {
+    name: "minimal",
+    label: "Minimal",
+    description:
+      "Protected modules only. Everything the tenant can safely give up is disabled.",
+    enabledModuleKeys: []
+  },
+  {
+    name: "website",
+    label: "Public website",
+    description:
+      "Public site with a custom domain, content, managed media, search, SEO, theming, comments and transactional email.",
+    // `media_library` is listed next to `blog_content` deliberately (ADR-0036).
+    // It is a non-protected System Foundation module, so a preset that enabled
+    // content WITHOUT it would DISABLE it — presets disable every enabled,
+    // non-protected, unlisted module — producing exactly the "website with no
+    // media management" gap that ADR-0036's ownership inversion closed.
+    // Dependency-CLOSED, deliberately. A preset does not auto-add a listed
+    // module's dependencies (design decision 3), and it DISABLES anything
+    // enabled and unlisted — so an unlisted dependency would be disabled and
+    // then block the module that needs it. `logging`, `sync_storage` and
+    // `domain_event_runtime` are here for that reason, not because a website
+    // "uses" them directly. `tests/module-presets.test.ts` fails on any preset
+    // whose closure is incomplete.
+    enabledModuleKeys: [
+      "tenant_domain",
+      "blog_content",
+      "media_library",
+      "seo_distribution",
+      "site_search",
+      "theming",
+      "comments",
+      "email",
+      "reporting",
+      "logging",
+      "sync_storage",
+      "domain_event_runtime"
+    ]
+  },
+  {
+    name: "news_portal",
+    label: "News portal",
+    description:
+      "The public website profile plus the editorial news portal and visitor analytics.",
+    enabledModuleKeys: [
+      "tenant_domain",
+      "blog_content",
+      "media_library",
+      "news_portal",
+      "seo_distribution",
+      "site_search",
+      "theming",
+      "comments",
+      "email",
+      "reporting",
+      "visitor_analytics",
+      "logging",
+      "sync_storage",
+      "domain_event_runtime",
+      "data_lifecycle"
+    ]
+  },
+  {
+    name: "back_office",
+    label: "ERP back office",
+    description:
+      "Back-office operation with no public site: approvals, reporting, retention/lifecycle, form drafts, offline sync and the domain-event runtime.",
+    // No counterpart in awcms-micro — this is the line awcms actually is
+    // (ADR-0035). Deliberately omits every public surface, so applying it to a
+    // tenant that had a website disables that website. That is the point of a
+    // profile.
+    enabledModuleKeys: [
+      "workflow",
+      "reporting",
+      "data_lifecycle",
+      "form_drafts",
+      "email",
+      "sync_storage",
+      "domain_event_runtime",
+      "logging"
+    ]
+  }
+];
+
+export function findModulePreset(
+  name: string
+): ModulePresetDefinition | undefined {
+  return MODULE_PRESETS.find((preset) => preset.name === name);
+}
+
+/**
+ * `isCore` keys plus their full transitive dependency closure — the set a
+ * preset never even attempts to disable, because the attempt would always be
+ * rejected.
+ */
+export function resolveProtectedModuleKeys(
+  allDescriptors: readonly ModuleDescriptor[]
+): Set<string> {
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const protectedKeys = new Set<string>();
+
+  function includeWithDependencies(key: string): void {
+    if (protectedKeys.has(key)) {
+      return;
+    }
+
+    protectedKeys.add(key);
+
+    for (const dependency of descriptorByKey.get(key)?.dependencies ?? []) {
+      includeWithDependencies(dependency);
+    }
+  }
+
+  for (const descriptor of allDescriptors) {
+    if (descriptor.isCore) {
+      includeWithDependencies(descriptor.key);
+    }
+  }
+
+  return protectedKeys;
+}
+
+/** `moduleKey -> modules that declare it as a dependency`. */
+function buildDependentsIndex(
+  allDescriptors: readonly ModuleDescriptor[]
+): Map<string, string[]> {
+  const dependents = new Map<string, string[]>();
+
+  for (const descriptor of allDescriptors) {
+    for (const dependency of descriptor.dependencies ?? []) {
+      dependents.set(dependency, [
+        ...(dependents.get(dependency) ?? []),
+        descriptor.key
+      ]);
+    }
+  }
+
+  return dependents;
+}
+
+/**
+ * Orders enable candidates so each module's dependencies come first, given
+ * `alreadyEnabled` as the satisfied base.
+ *
+ * Anything whose dependency can never be satisfied within this plan is still
+ * appended at the end. Best-effort on purpose: the real `enableTenantModule`
+ * then reports the exact rejection reason, instead of this planner silently
+ * dropping the module and producing a plan that looks complete.
+ */
+function planEnableOrder(
+  candidates: ReadonlySet<string>,
+  allDescriptors: readonly ModuleDescriptor[],
+  alreadyEnabled: ReadonlySet<string>
+): string[] {
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const remaining = new Set(candidates);
+  const ordered: string[] = [];
+  const satisfied = new Set(alreadyEnabled);
+
+  let changed = true;
+
+  while (remaining.size > 0 && changed) {
+    changed = false;
+
+    for (const key of remaining) {
+      const dependencies = descriptorByKey.get(key)?.dependencies ?? [];
+
+      if (dependencies.every((dependency) => satisfied.has(dependency))) {
+        ordered.push(key);
+        satisfied.add(key);
+        remaining.delete(key);
+        changed = true;
+      }
+    }
+  }
+
+  return [...ordered, ...remaining];
+}
+
+export type ModulePresetDisableSkip = {
+  moduleKey: string;
+  reason: "reverse_dependency_active";
+};
+
+type ModulePresetDisablePlan = {
+  ordered: string[];
+  skipped: ModulePresetDisableSkip[];
+};
+
+/**
+ * Orders disable candidates leaves-first, so a module is only disabled once
+ * nothing still enabled depends on it — mirroring what the real, sequential
+ * `disableTenantModule` calls will see as each lands.
+ *
+ * A candidate that can never become disableable is reported in `skipped`,
+ * never silently dropped and never force-disabled.
+ *
+ * `stillEnabledBase` must include both what is already enabled AND what this
+ * same plan is about to enable. A disable candidate that only a
+ * freshly-enabling module depends on has to be skipped pre-emptively; passing
+ * only the pre-plan set schedules it for disable and turns a clean skip into a
+ * spurious rejection from the real call. (awcms-micro hit exactly that and
+ * fixed it post-review; the fix is carried over rather than rediscovered.)
+ */
+function planDisableOrder(
+  candidates: ReadonlySet<string>,
+  allDescriptors: readonly ModuleDescriptor[],
+  stillEnabledBase: ReadonlySet<string>
+): ModulePresetDisablePlan {
+  const dependentsOf = buildDependentsIndex(allDescriptors);
+  const remaining = new Set(candidates);
+  const ordered: string[] = [];
+  const stillEnabled = new Set(stillEnabledBase);
+
+  let changed = true;
+
+  while (remaining.size > 0 && changed) {
+    changed = false;
+
+    for (const key of remaining) {
+      const blocked = (dependentsOf.get(key) ?? []).some((dependent) =>
+        stillEnabled.has(dependent)
+      );
+
+      if (!blocked) {
+        ordered.push(key);
+        stillEnabled.delete(key);
+        remaining.delete(key);
+        changed = true;
+      }
+    }
+  }
+
+  return {
+    ordered,
+    skipped: [...remaining].map((moduleKey) => ({
+      moduleKey,
+      reason: "reverse_dependency_active" as const
+    }))
+  };
+}
+
+export type ModulePresetPlan = {
+  presetName: ModulePresetName;
+  /** Keys to enable, dependency-safe order. */
+  toEnable: readonly string[];
+  /** Keys to disable, leaves-first order. */
+  toDisable: readonly string[];
+  /** Enabled, unlisted modules left alone because something still enabled depends on them. */
+  skippedDisable: readonly ModulePresetDisableSkip[];
+  /** Never considered for disabling (core plus its dependency closure). */
+  protectedModuleKeys: readonly string[];
+  /** Preset-listed keys that resolve to no registered descriptor. */
+  unknownModuleKeys: readonly string[];
+};
+
+/**
+ * Decide what a preset apply would do. Pure — no I/O, and it calls neither
+ * `evaluateModuleEnable` nor `evaluateModuleDisable`.
+ *
+ * The result is an INTENT, not a guarantee: the application layer runs the real
+ * lifecycle primitives for every planned change and surfaces their rejections
+ * rather than this function pre-empting them.
+ */
+export function computeModulePresetPlan(input: {
+  preset: ModulePresetDefinition;
+  allDescriptors: readonly ModuleDescriptor[];
+  currentState: readonly ModuleTenantState[];
+}): ModulePresetPlan {
+  const { preset, allDescriptors, currentState } = input;
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const currentlyEnabled = new Set(
+    currentState.filter((state) => state.tenantEnabled).map((s) => s.moduleKey)
+  );
+  const protectedKeys = resolveProtectedModuleKeys(allDescriptors);
+
+  const unknownModuleKeys = preset.enabledModuleKeys.filter(
+    (key) => !descriptorByKey.has(key)
+  );
+  const wantEnabled = new Set(
+    preset.enabledModuleKeys.filter((key) => descriptorByKey.has(key))
+  );
+
+  const toEnable = planEnableOrder(
+    new Set([...wantEnabled].filter((key) => !currentlyEnabled.has(key))),
+    allDescriptors,
+    currentlyEnabled
+  );
+
+  const disablePlan = planDisableOrder(
+    new Set(
+      [...currentlyEnabled].filter(
+        (key) => !protectedKeys.has(key) && !wantEnabled.has(key)
+      )
+    ),
+    allDescriptors,
+    new Set([...currentlyEnabled, ...wantEnabled])
+  );
+
+  return {
+    presetName: preset.name,
+    toEnable,
+    toDisable: disablePlan.ordered,
+    skippedDisable: disablePlan.skipped,
+    protectedModuleKeys: [...protectedKeys].sort(),
+    unknownModuleKeys
+  };
+}

--- a/src/pages/api/v1/tenant/modules/presets/[presetName]/apply.ts
+++ b/src/pages/api/v1/tenant/modules/presets/[presetName]/apply.ts
@@ -1,0 +1,71 @@
+import { fail, ok } from "../../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../../modules/_shared/tenant-route";
+import { applyModulePreset } from "../../../../../../../modules/module-management/application/module-presets";
+import { recordAuditEvent } from "../../../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/tenant/modules/{presetName}/apply` — bring the tenant's module
+ * state to a named profile.
+ *
+ * Guarded by `tenant_modules.disable`, not a new `presets.apply` action. A
+ * preset apply IS a sequence of enables and disables, and `disable` is the
+ * stronger of the two permissions the underlying primitives require — so the
+ * guard here can never be weaker than doing the same thing by hand. A new
+ * action would need a seed migration, and an unseeded action denies even the
+ * owner (the latent-authz trap already hit on the roles and ABAC write
+ * surfaces).
+ *
+ * Partial application is a real outcome, not an error: each planned change runs
+ * the real lifecycle validation and can be rejected. `complete: false` with the
+ * per-module reasons is more useful than a 500 that hides which half landed.
+ */
+export const POST = defineTenantRoute({
+  // Not "interactive": a preset can touch every module in the registry, each
+  // with its own descriptor sync. It is an administrative batch, and must not
+  // compete with request traffic for the interactive pool.
+  workClass: "maintenance",
+  authorize: {
+    moduleKey: "module_management",
+    activityCode: "tenant_modules",
+    action: "disable"
+  },
+  handler: async ({ tx, tenantId, auth, params, locals }) => {
+    const presetName = params.presetName ?? "";
+    const result = await applyModulePreset(
+      tx,
+      tenantId,
+      presetName,
+      auth.context.tenantUserId
+    );
+
+    if (!result) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Unknown module preset.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "module_management",
+      action: "tenant_module_preset_applied",
+      resourceType: "module_preset",
+      resourceId: result.presetName,
+      correlationId: locals.correlationId,
+      message: `Applied module preset "${result.presetName}" (${result.complete ? "complete" : "partial"}).`,
+      severity: result.complete ? "info" : "warning",
+      attributes: {
+        enabled: result.changes
+          .filter((c) => c.action === "enable" && c.outcome === "applied")
+          .map((c) => c.moduleKey),
+        disabled: result.changes
+          .filter((c) => c.action === "disable" && c.outcome === "applied")
+          .map((c) => c.moduleKey),
+        rejected: result.changes
+          .filter((c) => c.outcome === "rejected")
+          .map((c) => c.moduleKey),
+        complete: result.complete
+      }
+    });
+
+    return ok(result);
+  }
+});

--- a/src/pages/api/v1/tenant/modules/presets/index.ts
+++ b/src/pages/api/v1/tenant/modules/presets/index.ts
@@ -1,0 +1,36 @@
+import { ok } from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import { listModulePresets } from "../../../../../../modules/module-management/application/module-presets";
+import { planModulePreset } from "../../../../../../modules/module-management/application/module-presets";
+
+/**
+ * `GET /api/v1/tenant/modules/presets` — the preset catalog, and optionally a
+ * dry-run plan for one of them (`?preset=<name>`).
+ *
+ * The plan is a GET on purpose. Applying a preset DISABLES every enabled,
+ * unlisted, unprotected module, so an operator switching a live tenant's
+ * profile needs to see that list before it happens, not after. Read-only, so it
+ * guards on `tenant_modules.read`.
+ */
+export const GET = defineTenantRoute<{ preset: string | null }>({
+  workClass: "interactive",
+  prepare: ({ url }) => ({ preset: url.searchParams.get("preset") }),
+  authorize: {
+    moduleKey: "module_management",
+    activityCode: "tenant_modules",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, prepared }) => {
+    if (!prepared.preset) {
+      return ok({ presets: listModulePresets() });
+    }
+
+    const plan = await planModulePreset(tx, tenantId, prepared.preset);
+
+    if (!plan) {
+      return ok({ presets: listModulePresets(), plan: null });
+    }
+
+    return ok({ presets: listModulePresets(), plan });
+  }
+});

--- a/tests/module-presets.test.ts
+++ b/tests/module-presets.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Preset planning: what a named profile would actually do to a tenant.
+ *
+ * The two properties that carry the risk are both about DISABLING, because a
+ * preset does not merely add:
+ *
+ * 1. it disables every enabled, unlisted, unprotected module — without that,
+ *    a preset can never bring a tenant TO a profile, only add to whatever it
+ *    already had;
+ * 2. it never schedules a disable that the real `disableTenantModule` would
+ *    reject, and never force-disables — a blocked module is reported as
+ *    skipped.
+ *
+ * Pure: `computeModulePresetPlan` does no I/O and calls no lifecycle
+ * validation. The application layer runs the real primitives for every planned
+ * change, and their rejections are surfaced rather than pre-empted here.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import {
+  computeModulePresetPlan,
+  findModulePreset,
+  MODULE_PRESETS,
+  resolveProtectedModuleKeys,
+  type ModulePresetDefinition
+} from "../src/modules/module-management/domain/module-presets";
+import type { ModuleTenantState } from "../src/modules/module-management/domain/tenant-module-lifecycle";
+
+const REGISTRY = listModules();
+
+function allEnabled(): ModuleTenantState[] {
+  // A fresh tenant: a missing `awcms_tenant_modules` row means enabled, so this
+  // is the state every preset first meets.
+  return REGISTRY.map((module) => ({
+    moduleKey: module.key,
+    tenantEnabled: true
+  }));
+}
+
+function stateWith(enabled: readonly string[]): ModuleTenantState[] {
+  return REGISTRY.map((module) => ({
+    moduleKey: module.key,
+    tenantEnabled: enabled.includes(module.key)
+  }));
+}
+
+function plan(preset: ModulePresetDefinition, state: ModuleTenantState[]) {
+  return computeModulePresetPlan({
+    preset,
+    allDescriptors: REGISTRY,
+    currentState: state
+  });
+}
+
+describe("protected set", () => {
+  test("is isCore plus its full transitive dependency closure", () => {
+    const protectedKeys = resolveProtectedModuleKeys(REGISTRY);
+
+    // `module_management` is the only isCore module in this registry; the rest
+    // are protected INDIRECTLY, via the reverse-dependency check.
+    expect(REGISTRY.filter((m) => m.isCore).map((m) => m.key)).toEqual([
+      "module_management"
+    ]);
+    expect(protectedKeys.has("module_management")).toBe(true);
+
+    for (const dependency of REGISTRY.find(
+      (m) => m.key === "module_management"
+    )!.dependencies) {
+      expect(protectedKeys.has(dependency)).toBe(true);
+    }
+  });
+
+  test("no preset can ever schedule a protected module for disable", () => {
+    const protectedKeys = resolveProtectedModuleKeys(REGISTRY);
+
+    for (const preset of MODULE_PRESETS) {
+      const result = plan(preset, allEnabled());
+
+      for (const key of result.toDisable) {
+        expect(protectedKeys.has(key)).toBe(false);
+      }
+    }
+  });
+});
+
+describe("a preset both enables and disables", () => {
+  test("`minimal` on a fully-enabled tenant disables everything giveable-up", () => {
+    // The property that makes presets useful. An enable-only design would
+    // produce an empty plan here and leave the tenant exactly as it was.
+    const result = plan(findModulePreset("minimal")!, allEnabled());
+    const protectedKeys = resolveProtectedModuleKeys(REGISTRY);
+
+    expect(result.toEnable).toEqual([]);
+    expect(result.toDisable.length).toBeGreaterThan(5);
+
+    const untouched = REGISTRY.map((m) => m.key).filter(
+      (key) =>
+        !result.toDisable.includes(key) &&
+        !result.skippedDisable.some((s) => s.moduleKey === key)
+    );
+
+    expect(untouched.sort()).toEqual([...protectedKeys].sort());
+  });
+
+  test("switching profiles disables the outgoing profile's modules", () => {
+    // `back_office` names no public surface, so applying it to a website
+    // tenant must take the website down. That is what a profile means.
+    const website = plan(findModulePreset("website")!, allEnabled());
+    const afterWebsite = stateWith([
+      ...resolveProtectedModuleKeys(REGISTRY),
+      ...findModulePreset("website")!.enabledModuleKeys
+    ]);
+    const backOffice = plan(findModulePreset("back_office")!, afterWebsite);
+
+    expect(website.toDisable).toContain("workflow");
+    expect(backOffice.toDisable).toContain("blog_content");
+    expect(backOffice.toEnable).toContain("workflow");
+  });
+
+  test("a preset already satisfied plans nothing", () => {
+    const preset = findModulePreset("website")!;
+    const satisfied = stateWith([
+      ...resolveProtectedModuleKeys(REGISTRY),
+      ...preset.enabledModuleKeys
+    ]);
+    const result = plan(preset, satisfied);
+
+    expect(result.toEnable).toEqual([]);
+    expect(result.toDisable).toEqual([]);
+  });
+});
+
+describe("ordering is safe for the real sequential calls", () => {
+  test("every preset is dependency-CLOSED", () => {
+    // Not a style rule. A preset disables everything enabled and unlisted, so
+    // an unlisted dependency gets disabled and then blocks the module that
+    // needs it — the plan would enable `comments` and disable
+    // `domain_event_runtime` in the same pass. All four presets failed this on
+    // first run; the fix was to close them, not to relax the test.
+    const protectedKeys = resolveProtectedModuleKeys(REGISTRY);
+
+    for (const preset of MODULE_PRESETS) {
+      const listed = new Set([...protectedKeys, ...preset.enabledModuleKeys]);
+      const missing: string[] = [];
+
+      for (const key of preset.enabledModuleKeys) {
+        for (const dependency of REGISTRY.find((m) => m.key === key)
+          ?.dependencies ?? []) {
+          if (!listed.has(dependency)) {
+            missing.push(`${key} needs ${dependency}`);
+          }
+        }
+      }
+
+      expect({ preset: preset.name, missing }).toEqual({
+        preset: preset.name,
+        missing: []
+      });
+    }
+  });
+
+  test("enables come dependency-first", () => {
+    const preset = findModulePreset("website")!;
+    const fromMinimal = stateWith([...resolveProtectedModuleKeys(REGISTRY)]);
+    const result = plan(preset, fromMinimal);
+    const satisfied = new Set(resolveProtectedModuleKeys(REGISTRY));
+
+    for (const key of result.toEnable) {
+      const dependencies =
+        REGISTRY.find((m) => m.key === key)?.dependencies ?? [];
+
+      for (const dependency of dependencies) {
+        // Either already satisfied, or scheduled earlier in this same list.
+        expect(satisfied.has(dependency)).toBe(true);
+      }
+
+      satisfied.add(key);
+    }
+  });
+
+  test("disables come leaves-first — nothing still enabled depends on them", () => {
+    const result = plan(findModulePreset("minimal")!, allEnabled());
+    const stillEnabled = new Set(REGISTRY.map((m) => m.key));
+
+    for (const key of result.toDisable) {
+      const dependents = REGISTRY.filter(
+        (m) => m.key !== key && m.dependencies.includes(key)
+      ).map((m) => m.key);
+
+      for (const dependent of dependents) {
+        expect(stillEnabled.has(dependent)).toBe(false);
+      }
+
+      stillEnabled.delete(key);
+    }
+  });
+
+  test("a module blocked by one the plan is about to ENABLE is skipped, not scheduled", () => {
+    // The post-review fix carried over from awcms-micro. Seeding the blocking
+    // check with only the pre-plan enabled set schedules such a module for
+    // disable; the real call would then reject it as
+    // MODULE_REVERSE_DEPENDENCY_ACTIVE — a spurious rejection where the plan
+    // promised a clean skip.
+    const synthetic: ModuleDescriptorLike[] = [
+      { key: "core", dependencies: [], isCore: true },
+      { key: "shared", dependencies: [] },
+      { key: "incoming", dependencies: ["shared"] }
+    ];
+    const result = computeModulePresetPlan({
+      preset: {
+        name: "minimal",
+        label: "x",
+        description: "x",
+        enabledModuleKeys: ["incoming"]
+      },
+      allDescriptors: synthetic as never,
+      currentState: [
+        { moduleKey: "core", tenantEnabled: true },
+        { moduleKey: "shared", tenantEnabled: true },
+        { moduleKey: "incoming", tenantEnabled: false }
+      ]
+    });
+
+    expect(result.toEnable).toEqual(["incoming"]);
+    // `shared` is enabled and unlisted, so it looks like a disable candidate —
+    // but `incoming`, which this same plan enables, depends on it.
+    expect(result.toDisable).not.toContain("shared");
+    expect(result.skippedDisable).toEqual([
+      { moduleKey: "shared", reason: "reverse_dependency_active" }
+    ]);
+  });
+});
+
+type ModuleDescriptorLike = {
+  key: string;
+  dependencies: string[];
+  isCore?: boolean;
+};
+
+describe("preset definitions are real", () => {
+  test("every listed module key exists in the registry", () => {
+    // A preset naming a module this base does not have is a dead profile that
+    // reports `unknownModuleKeys` on every single apply.
+    const keys = new Set(REGISTRY.map((m) => m.key));
+
+    for (const preset of MODULE_PRESETS) {
+      const unknown = preset.enabledModuleKeys.filter((key) => !keys.has(key));
+
+      expect({ preset: preset.name, unknown }).toEqual({
+        preset: preset.name,
+        unknown: []
+      });
+    }
+  });
+
+  test("`unknownModuleKeys` still reports a key that vanishes", () => {
+    const result = computeModulePresetPlan({
+      preset: {
+        name: "minimal",
+        label: "x",
+        description: "x",
+        enabledModuleKeys: ["module_that_does_not_exist"]
+      },
+      allDescriptors: REGISTRY,
+      currentState: allEnabled()
+    });
+
+    expect(result.unknownModuleKeys).toEqual(["module_that_does_not_exist"]);
+  });
+
+  test("any preset enabling content also enables media_library", () => {
+    // ADR-0036's ownership inversion. `media_library` is not protected, so a
+    // content preset that omitted it would DISABLE it — reintroducing exactly
+    // the "website with no media management" gap that ADR closed.
+    for (const preset of MODULE_PRESETS) {
+      const enablesContent = ["blog_content", "news_portal"].some((key) =>
+        preset.enabledModuleKeys.includes(key)
+      );
+
+      if (enablesContent) {
+        expect(preset.enabledModuleKeys).toContain("media_library");
+      }
+    }
+  });
+
+  test("preset names are unique", () => {
+    const names = MODULE_PRESETS.map((preset) => preset.name);
+
+    expect(new Set(names).size).toBe(names.length);
+  });
+});


### PR DESCRIPTION
Bagian dari #261 (presets; matriks + ringkasan audit menyusul terpisah).

Profil bernama yang bisa membawa tenant KE suatu bentuk dalam satu aksi: `minimal`, `website`, `news_portal`, `back_office`.

## Preset MENGAKTIFKAN dan MENONAKTIFKAN

Kalau hanya menambah, preset tak berguna sebagai cara **mencapai** profil — tenant yang pernah mengaktifkan `blog_content` lalu menerapkan `minimal` akan selamanya tidak minimal.

"Protected" bukan `isCore`. Hanya `module_management` yang menyetel flag itu; modul fondasi lain terlindungi **tidak langsung** lewat cek reverse-dependency. `resolveProtectedModuleKeys` membuat perlindungan implisit itu eksplisit untuk perencanaan, tanpa menduplikasi ceknya — `enable`/`disableTenantModule` asli tetap memvalidasi terhadap state hidup.

## Logika di-port, himpunan preset lokal

Planner-nya dari awcms-micro tanpa perubahan, termasuk satu perbaikan pasca-review yang layak dibawa alih-alih ditemukan ulang: planner disable di-seed dengan `currentlyEnabled ∪ wantEnabled`, sehingga modul yang hanya diblokir oleh sesuatu yang **rencana ini sendiri akan aktifkan** di-skip lebih dulu, bukan dijadwalkan lalu ditolak secara spurious.

Presetnya bukan milik micro. `back_office` tak punya padanan di sana — itu lini yang awcms sebenarnya (ADR-0035). `news_portal_full_online_r2` dan `saas_online` tidak direproduksi: subsistem pembedanya tidak ada di base ini, dan preset yang menamai modul absen adalah profil mati yang melaporkan `unknownModuleKeys` setiap kali diterapkan.

## Keempat preset SALAH pada eksekusi pertama

Asersi dependency-closure di `tests/module-presets.test.ts` merah untuk semuanya. Karena preset menonaktifkan segala yang aktif-dan-tak-terdaftar, **dependensi yang tak terdaftar akan dinonaktifkan lalu memblokir modul yang membutuhkannya** — rencana `website` akan mengaktifkan `comments` sambil menonaktifkan `domain_event_runtime` di pass yang sama. Presetnya kini tertutup; test-nya yang menjaga.

Ikut digerbangi: preset apa pun yang mengaktifkan konten WAJIB mengaktifkan `media_library`, atau inversi kepemilikan ADR-0036 terbuka lagi sebagai "website tanpa manajemen media".

## Tanpa migrasi, tanpa permission baru

Apply preset **adalah** rangkaian enable dan disable, jadi `POST .../presets/{presetName}/apply` menggerbangi `module_management.tenant_modules.disable` — yang lebih kuat dari dua permission yang memang sudah dibutuhkan primitifnya, sehingga guard-nya tak mungkin lebih lemah daripada melakukannya manual. Action `presets.apply` baru butuh seed migration, dan action tak-ter-seed men-deny bahkan owner (jebakan latent-authz yang sudah kena di surface tulis roles dan ABAC).

Kedua rute memakai `defineTenantRoute` (#255). Rute apply mendeklarasikan `workClass: "maintenance"` — ia bisa menyentuh setiap modul di registry dan tak boleh berebut dengan trafik request. `db:work-class:check` (#263) menangkap kedua rute baru pada eksekusi pertama dan kini mencatatnya sebagai `source: "factory"`.

Suite penuh: **2693 test, 0 gagal**. Semua gate, typecheck, build hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)