### PR TITLE
feat(module-management): tenant-module matrix and per-module audit summary

### DIFF
--- a/.changeset/module-matrix-audit-summary.md
+++ b/.changeset/module-matrix-audit-summary.md
@@ -1,0 +1,26 @@
+---
+"awcms": minor
+---
+
+Tenant-module matrix and per-module audit summary — the rest of #261.
+
+`GET /api/v1/tenant/modules/matrix` returns every module with this tenant's
+enabled state, its protected flag, and two lifecycle warnings computed by
+re-running the REAL `evaluateModuleEnable`/`evaluateModuleDisable` rather than a
+UI-side re-derivation that would drift from the endpoints. Two queries total;
+the rest is pure.
+
+The warnings are one-directional on purpose — `dependencyWarning` only for a
+disabled module, `reverseDependencyWarning` only for an enabled one. The other
+combinations cannot arise, and asking `evaluateModuleEnable` about an
+already-enabled module short-circuits to `MODULE_ALREADY_ENABLED`: an answer
+that looks like a check and is not one.
+
+No health column, unlike awcms-micro's matrix: that one is fed by a batched
+health reader this base does not have, and a per-row read would be 21 queries
+inside one transaction.
+
+`GET /api/v1/modules/{moduleKey}/audit` returns recent module-management
+activity for one module, guarded by `logging.audit_trail.read` — these are
+audit-log rows, so the audit-log permission governs them. The caller-supplied
+`?limit=` is clamped to 1..50, with NaN/Infinity falling back to the default.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -1715,6 +1715,29 @@ Database-backed module registry, tenant module lifecycle, settings, permission s
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/modules/{moduleKey}/audit` — Recent module-management activity for one module.
+
+- **operationId**: `getModuleAuditSummary`
+- **Security**: bearerAuth + tenantHeader
+
+Tenant enable/disable, settings updates, health checks and preset applies recorded against this module key. Guarded by `logging.audit_trail.read`, not a module-management permission: these are audit-log rows, and whoever may not read the audit log must not get a filtered view of it through another door. An unregistered `moduleKey` answers 404, because an empty list would read as "nothing happened".
+
+**Parameters**
+
+| Name        | In    | Required | Type    | Description |
+| ----------- | ----- | -------- | ------- | ----------- |
+| `moduleKey` | path  | yes      | string  |             |
+| `limit`     | query | no       | integer |             |
+
+**Responses**
+
+| Status | Description                    | Schema                                 |
+| ------ | ------------------------------ | -------------------------------------- |
+| 200    | Recent activity, newest first. | object                                 |
+| 401    | Missing or invalid session.    | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.    | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.            | [`ApiError`](#standard-error-envelope) |
+
 ### `GET /api/v1/modules/{moduleKey}/health` — Passive, bounded module readiness signals (no live provider call).
 
 - **operationId**: `getModuleHealth`
@@ -1915,6 +1938,21 @@ Database-backed module registry, tenant module lifecycle, settings, permission s
 | 401    | Missing or invalid session.   | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.   | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.           | [`ApiError`](#standard-error-envelope) |
+
+### `GET /api/v1/tenant/modules/matrix` — Every module by what matters for this tenant, in two queries.
+
+- **operationId**: `getTenantModuleMatrix`
+- **Security**: bearerAuth + tenantHeader
+
+Single-tenant scope, never cross-tenant. Adds two lifecycle warnings by re-running the real enable/disable validation for each module's actual current state: `dependencyWarning` only for a DISABLED module ("would enabling succeed now?") and `reverseDependencyWarning` only for an ENABLED one ("would disabling be blocked?"). No health column — this base has no batched health reader, and a per-row one would be an N+1.
+
+**Responses**
+
+| Status | Description                            | Schema                                 |
+| ------ | -------------------------------------- | -------------------------------------- |
+| 200    | Module matrix for the caller's tenant. | object                                 |
+| 401    | Missing or invalid session.            | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.            | [`ApiError`](#standard-error-envelope) |
 
 ### `GET /api/v1/tenant/modules/presets` — Named module profiles, and optionally a dry-run plan for one.
 

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -567,6 +567,11 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/modules/[moduleKey]/audit.ts",
+      "workClass": "reporting",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/modules/[moduleKey]/health.ts",
       "workClass": "interactive",
       "source": "default"
@@ -925,6 +930,11 @@
       "path": "src/pages/api/v1/tenant/modules/index.ts",
       "workClass": "interactive",
       "source": "default"
+    },
+    {
+      "path": "src/pages/api/v1/tenant/modules/matrix/index.ts",
+      "workClass": "interactive",
+      "source": "factory"
     },
     {
       "path": "src/pages/api/v1/tenant/modules/presets/[presetName]/apply.ts",

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -7542,6 +7542,68 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/modules/{moduleKey}/audit:
+    get:
+      operationId: getModuleAuditSummary
+      tags:
+        - Module Management
+      summary: Recent module-management activity for one module.
+      description: 'Tenant enable/disable, settings updates, health checks and preset applies recorded against this module key. Guarded by `logging.audit_trail.read`, not a module-management permission: these are audit-log rows, and whoever may not read the audit log must not get a filtered view of it through another door. An unregistered `moduleKey` answers 404, because an empty list would read as "nothing happened".'
+      parameters:
+        - name: moduleKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+      responses:
+        "200":
+          description: Recent activity, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      moduleKey:
+                        type: string
+                      limit:
+                        type: integer
+                      entries:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            action:
+                              type: string
+                            resourceType:
+                              type: string
+                            severity:
+                              type: string
+                            message:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/modules/{moduleKey}/health:
     get:
       operationId: getModuleHealth
@@ -12049,6 +12111,74 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/tenant/modules/matrix:
+    get:
+      operationId: getTenantModuleMatrix
+      tags:
+        - Module Management
+      summary: Every module by what matters for this tenant, in two queries.
+      description: 'Single-tenant scope, never cross-tenant. Adds two lifecycle warnings by re-running the real enable/disable validation for each module''s actual current state: `dependencyWarning` only for a DISABLED module ("would enabling succeed now?") and `reverseDependencyWarning` only for an ENABLED one ("would disabling be blocked?"). No health column — this base has no batched health reader, and a per-row one would be an N+1.'
+      responses:
+        "200":
+          description: Module matrix for the caller's tenant.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      modules:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            moduleKey:
+                              type: string
+                            name:
+                              type: string
+                            version:
+                              type: string
+                            status:
+                              type: string
+                            isCore:
+                              type: boolean
+                            isProtected:
+                              type: boolean
+                            tenantEnabled:
+                              type: boolean
+                            disableReason:
+                              type: string
+                              nullable: true
+                            dependencies:
+                              type: array
+                              items:
+                                type: string
+                            dependencyWarning:
+                              nullable: true
+                              type: object
+                              properties:
+                                code:
+                                  type: string
+                                message:
+                                  type: string
+                            reverseDependencyWarning:
+                              nullable: true
+                              type: object
+                              properties:
+                                code:
+                                  type: string
+                                message:
+                                  type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/tenant/modules/presets:
     get:
       operationId: listTenantModulePresets

--- a/openapi/modules/module-management.openapi.yaml
+++ b/openapi/modules/module-management.openapi.yaml
@@ -181,6 +181,74 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/modules/{moduleKey}/audit:
+    get:
+      operationId: getModuleAuditSummary
+      tags:
+        - Module Management
+      summary: Recent module-management activity for one module.
+      description: >-
+        Tenant enable/disable, settings updates, health checks and preset
+        applies recorded against this module key. Guarded by
+        `logging.audit_trail.read`, not a module-management permission: these
+        are audit-log rows, and whoever may not read the audit log must not get
+        a filtered view of it through another door. An unregistered `moduleKey`
+        answers 404, because an empty list would read as "nothing happened".
+      parameters:
+        - name: moduleKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+      responses:
+        "200":
+          description: Recent activity, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      moduleKey:
+                        type: string
+                      limit:
+                        type: integer
+                      entries:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            action:
+                              type: string
+                            resourceType:
+                              type: string
+                            severity:
+                              type: string
+                            message:
+                              type: string
+                            createdAt:
+                              type: string
+                              format: date-time
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/modules/{moduleKey}/jobs:
     get:
       operationId: listModuleJobs
@@ -416,6 +484,80 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/tenant/modules/matrix:
+    get:
+      operationId: getTenantModuleMatrix
+      tags:
+        - Module Management
+      summary: Every module by what matters for this tenant, in two queries.
+      description: >-
+        Single-tenant scope, never cross-tenant. Adds two lifecycle warnings by
+        re-running the real enable/disable validation for each module's actual
+        current state: `dependencyWarning` only for a DISABLED module ("would
+        enabling succeed now?") and `reverseDependencyWarning` only for an
+        ENABLED one ("would disabling be blocked?"). No health column — this
+        base has no batched health reader, and a per-row one would be an N+1.
+      responses:
+        "200":
+          description: Module matrix for the caller's tenant.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      modules:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            moduleKey:
+                              type: string
+                            name:
+                              type: string
+                            version:
+                              type: string
+                            status:
+                              type: string
+                            isCore:
+                              type: boolean
+                            isProtected:
+                              type: boolean
+                            tenantEnabled:
+                              type: boolean
+                            disableReason:
+                              type: string
+                              nullable: true
+                            dependencies:
+                              type: array
+                              items:
+                                type: string
+                            dependencyWarning:
+                              nullable: true
+                              type: object
+                              properties:
+                                code:
+                                  type: string
+                                message:
+                                  type: string
+                            reverseDependencyWarning:
+                              nullable: true
+                              type: object
+                              properties:
+                                code:
+                                  type: string
+                                message:
+                                  type: string
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/tenant/modules/presets:
     get:
       operationId: listTenantModulePresets

--- a/src/modules/module-management/README.md
+++ b/src/modules/module-management/README.md
@@ -64,6 +64,31 @@ Ported and adapted from the awcms-mini module-management module.
   underlying calls already need. A new action would need a seed migration, and
   an unseeded action denies even the owner.
 
+- **Tenant-module matrix** (`application/module-matrix.ts`) — every module ×
+  what matters for this tenant, in TWO queries (catalog + tenant entries; the
+  rest is pure). Adds two lifecycle warnings by re-running the REAL
+  `evaluateModuleEnable`/`evaluateModuleDisable` against each module's actual
+  state, never a UI-side re-derivation that can drift from the endpoints.
+
+  One-directional on purpose: `dependencyWarning` only for a DISABLED module,
+  `reverseDependencyWarning` only for an ENABLED one. The other two combinations
+  cannot arise, and asking `evaluateModuleEnable` about an enabled module
+  short-circuits to `MODULE_ALREADY_ENABLED` — an answer that looks like a check
+  and is not one.
+
+  **No health column.** awcms-micro's matrix has one, fed by a BATCHED health
+  reader this base does not have; a per-row `fetchModuleHealthReport` would be
+  21 reads in one transaction. Health stays at
+  `GET /api/v1/modules/{moduleKey}/health` until a batched reader exists.
+
+- **Module audit summary** (`application/module-audit-summary.ts`) — recent
+  activity recorded against one module key (`tenant_module`, `module_settings`,
+  `module_health`, `module_preset`). Guarded by `logging.audit_trail.read`, not
+  a module-management permission: these are audit-log rows, and whoever may not
+  read the audit log must not get a filtered view of it through another door.
+  `module_registry` is excluded — descriptor sync's `resource_id` is not a
+  module key, so it would match nothing while implying it might.
+
 - **Job registry** (`application/job-registry.ts`) — documentation-only
   metadata about each module's operational commands. Never an execution
   surface.

--- a/src/modules/module-management/application/module-audit-summary.ts
+++ b/src/modules/module-management/application/module-audit-summary.ts
@@ -1,0 +1,86 @@
+/**
+ * Recent module-management activity for ONE module (Issue #261, ported from
+ * awcms-micro).
+ *
+ * Read-only, bounded, tenant-scoped through RLS like every other audit query
+ * here. It answers the question an operator has on a module's detail panel —
+ * "what has been done to this module lately?" — which `listAuditEvents` cannot,
+ * because that filters by `resource_type`, not by which module a row is about.
+ *
+ * ## Which resource types count
+ *
+ * Exactly those the module-management write surfaces record against a MODULE
+ * KEY: tenant enable/disable, settings update, health check, and preset apply.
+ *
+ * `module_registry` is deliberately absent. Descriptor sync is a registry-wide
+ * operation whose `resource_id` is not a module key, so including it would
+ * match zero rows while implying to the next reader that it might match some.
+ */
+
+/**
+ * `resource_id` on these rows is the module key — that is what makes a
+ * per-module lookup possible at all.
+ */
+const RELEVANT_RESOURCE_TYPES = [
+  "tenant_module",
+  "module_settings",
+  "module_health",
+  "module_preset"
+] as const;
+
+/** Hard ceiling regardless of what the caller asks for: this feeds an admin panel, never an export. */
+export const MODULE_AUDIT_SUMMARY_MAX_LIMIT = 50;
+export const MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT = 20;
+
+export type ModuleAuditSummaryEntry = {
+  action: string;
+  resourceType: string;
+  severity: string;
+  message: string;
+  createdAt: string;
+};
+
+/** Clamps to `[1, MAX]`, and treats a non-finite or non-integer input as the default rather than trusting it. */
+export function boundAuditSummaryLimit(limit: unknown): number {
+  const parsed =
+    typeof limit === "number" && Number.isFinite(limit)
+      ? Math.trunc(limit)
+      : Number.NaN;
+
+  if (!Number.isFinite(parsed)) {
+    return MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT;
+  }
+
+  return Math.min(Math.max(parsed, 1), MODULE_AUDIT_SUMMARY_MAX_LIMIT);
+}
+
+export async function fetchModuleAuditSummary(
+  tx: Bun.SQL,
+  tenantId: string,
+  moduleKey: string,
+  limit: number = MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT
+): Promise<ModuleAuditSummaryEntry[]> {
+  const rows = (await tx`
+    SELECT action, resource_type, severity, message, created_at
+    FROM awcms_audit_events
+    WHERE tenant_id = ${tenantId}
+      AND resource_id = ${moduleKey}
+      AND resource_type = ANY(${[...RELEVANT_RESOURCE_TYPES]}::text[])
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${boundAuditSummaryLimit(limit)}
+  `) as {
+    action: string;
+    resource_type: string;
+    severity: string;
+    message: string;
+    created_at: Date;
+  }[];
+
+  return rows.map((row) => ({
+    action: row.action,
+    resourceType: row.resource_type,
+    severity: row.severity,
+    message: row.message,
+    createdAt: row.created_at.toISOString()
+  }));
+}

--- a/src/modules/module-management/application/module-matrix.ts
+++ b/src/modules/module-management/application/module-matrix.ts
@@ -1,0 +1,216 @@
+/**
+ * Tenant-module matrix (Issue #261, ported from awcms-micro) — module ×
+ * relevant-attribute for the ONE tenant already in the caller's context.
+ *
+ * Single-tenant scope, never a cross-tenant view: this repo's identity model is
+ * strictly 1:1 tenant-scoped and RLS would refuse the rows anyway.
+ *
+ * ## Zero re-derivation
+ *
+ * Every field comes from something that already exists:
+ *
+ * - `fetchModuleCatalog` — static/registry fields;
+ * - `fetchTenantModuleEntries` — this tenant's enabled state;
+ * - `resolveProtectedModuleKeys` — the core/protected flag (Issue #261's
+ *   preset work);
+ * - `evaluateModuleEnable`/`evaluateModuleDisable` — the two warnings, called
+ *   with each module's REAL current state.
+ *
+ * That last point is the one worth being strict about. The warnings are an
+ * honest re-application of the exact validation the real enable/disable
+ * endpoints run, not a parallel reimplementation that can drift from them. This
+ * function never forges a synthetic tenant state to coax an answer out of a
+ * function that would otherwise short-circuit.
+ *
+ * ## Why only two warning directions, not four
+ *
+ * `dependencyWarning` is computed ONLY for a currently-DISABLED module —
+ * "would enabling this succeed right now?" — filtered to the dependency and
+ * version rejection codes. Never `MODULE_ALREADY_ENABLED`, which is not a
+ * warning, just the wrong question.
+ *
+ * `reverseDependencyWarning` is computed ONLY for a currently-ENABLED module —
+ * "would disabling this be blocked?" — filtered to
+ * `MODULE_REVERSE_DEPENDENCY_ACTIVE`.
+ *
+ * The other two combinations cannot arise. An enabled module's dependencies are
+ * satisfied by construction, because `disableTenantModule` already refuses to
+ * disable a dependency while an active dependent remains. Asking
+ * `evaluateModuleEnable` about an already-enabled module would short-circuit to
+ * `MODULE_ALREADY_ENABLED` before reaching the dependency loop — an answer to a
+ * question the function is not designed for, which is exactly the kind of thing
+ * that looks like a check and is not one.
+ *
+ * ## No health column, deliberately
+ *
+ * awcms-micro's matrix carries a health pill, fed by a BATCHED
+ * `fetchModuleHealthReports` that shares one context across the whole registry.
+ * This base has only the single-module `fetchModuleHealthReport`, so a health
+ * column here would mean 21 separate reads inside one transaction — an N+1 this
+ * function would be introducing, not inheriting. Health stays available
+ * per-module at `GET /api/v1/modules/{moduleKey}/health`; a batched reader is a
+ * separate piece of work, and the column arrives with it.
+ */
+import packageJson from "../../../../package.json";
+import { listModules } from "../..";
+import { fetchModuleCatalog, type ModuleCatalogEntry } from "./module-catalog";
+import {
+  fetchTenantModuleEntries,
+  type TenantModuleListEntry
+} from "./tenant-module-lifecycle";
+import { resolveProtectedModuleKeys } from "../domain/module-presets";
+import {
+  evaluateModuleDisable,
+  evaluateModuleEnable,
+  type ModuleLifecycleErrorCode,
+  type ModuleTenantState
+} from "../domain/tenant-module-lifecycle";
+
+const CURRENT_APP_VERSION = packageJson.version;
+
+/** Rejection codes that are worth surfacing as a warning on a disabled row. */
+const DEPENDENCY_WARNING_CODES: ReadonlySet<ModuleLifecycleErrorCode> = new Set(
+  [
+    "MODULE_DEPENDENCY_MISSING",
+    "MODULE_DEPENDENCY_DISABLED",
+    "MODULE_DEPENDENCY_CYCLE",
+    "MODULE_VERSION_INCOMPATIBLE"
+  ]
+);
+
+export type ModuleMatrixWarning = {
+  code: ModuleLifecycleErrorCode;
+  message: string;
+};
+
+export type ModuleMatrixRow = {
+  moduleKey: string;
+  name: string;
+  version: string;
+  type: ModuleCatalogEntry["type"];
+  status: string;
+  isCore: boolean;
+  /**
+   * `isCore` unioned with the transitive dependency closure of every core
+   * module. A disable attempt on any of these is guaranteed to be rejected
+   * server-side, so a UI can decline to offer the control at all rather than
+   * offering one that always fails.
+   */
+  isProtected: boolean;
+  tenantEnabled: boolean;
+  disableReason: string | null;
+  dependencies: string[];
+  /** Only ever set for a currently-DISABLED module. */
+  dependencyWarning: ModuleMatrixWarning | null;
+  /** Only ever set for a currently-ENABLED module. */
+  reverseDependencyWarning: ModuleMatrixWarning | null;
+};
+
+function toTenantState(entry: TenantModuleListEntry): ModuleTenantState {
+  return { moduleKey: entry.moduleKey, tenantEnabled: entry.tenantEnabled };
+}
+
+export async function fetchModuleMatrix(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<ModuleMatrixRow[]> {
+  // Sequential, never Promise.all: `tx` is one reserved connection, and
+  // concurrent queries on it desync the transaction.
+  const catalog = await fetchModuleCatalog(tx);
+  const tenantEntries = await fetchTenantModuleEntries(tx, tenantId);
+
+  // Everything below is pure — two reads total, regardless of module count.
+  const allDescriptors = listModules();
+  const descriptorByKey = new Map(allDescriptors.map((d) => [d.key, d]));
+  const tenantEntryByKey = new Map(
+    tenantEntries.map((entry) => [entry.moduleKey, entry])
+  );
+  const protectedKeys = resolveProtectedModuleKeys(allDescriptors);
+
+  /** A module with no row is enabled — the same convention the lifecycle service uses. */
+  function resolveTenantState(moduleKey: string): ModuleTenantState {
+    const entry = tenantEntryByKey.get(moduleKey);
+
+    return entry ? toTenantState(entry) : { moduleKey, tenantEnabled: true };
+  }
+
+  return catalog.map((entry) => {
+    const descriptor = descriptorByKey.get(entry.moduleKey) ?? null;
+    const tenantState = resolveTenantState(entry.moduleKey);
+    const tenantEntry = tenantEntryByKey.get(entry.moduleKey) ?? null;
+
+    let dependencyWarning: ModuleMatrixRow["dependencyWarning"] = null;
+
+    if (!tenantState.tenantEnabled && descriptor) {
+      const validation = evaluateModuleEnable({
+        target: descriptor,
+        targetTenantState: tenantState,
+        dependencyStates: descriptor.dependencies.map((dependencyKey) => {
+          const dependencyDescriptor =
+            descriptorByKey.get(dependencyKey) ?? null;
+
+          return dependencyDescriptor
+            ? {
+                descriptor: dependencyDescriptor,
+                tenantState: resolveTenantState(dependencyKey)
+              }
+            : { descriptor: null, moduleKey: dependencyKey };
+        }),
+        allDescriptors,
+        currentAppVersion: CURRENT_APP_VERSION
+      });
+
+      if (!validation.valid && DEPENDENCY_WARNING_CODES.has(validation.code)) {
+        dependencyWarning = {
+          code: validation.code,
+          message: validation.message
+        };
+      }
+    }
+
+    let reverseDependencyWarning: ModuleMatrixRow["reverseDependencyWarning"] =
+      null;
+
+    if (tenantState.tenantEnabled && descriptor) {
+      const validation = evaluateModuleDisable({
+        target: descriptor,
+        targetTenantState: tenantState,
+        reverseDependencies: allDescriptors
+          .filter(
+            (candidate) =>
+              candidate.key !== entry.moduleKey &&
+              candidate.dependencies.includes(entry.moduleKey)
+          )
+          .map((candidate) => ({
+            descriptor: candidate,
+            tenantState: resolveTenantState(candidate.key)
+          }))
+      });
+
+      if (
+        !validation.valid &&
+        validation.code === "MODULE_REVERSE_DEPENDENCY_ACTIVE"
+      ) {
+        reverseDependencyWarning = {
+          code: validation.code,
+          message: validation.message
+        };
+      }
+    }
+
+    return {
+      moduleKey: entry.moduleKey,
+      name: entry.name,
+      version: entry.version,
+      type: entry.type,
+      status: entry.status,
+      isCore: entry.isCore,
+      isProtected: protectedKeys.has(entry.moduleKey),
+      tenantEnabled: tenantState.tenantEnabled,
+      disableReason: tenantEntry?.disableReason ?? null,
+      dependencies: entry.dependencies,
+      dependencyWarning,
+      reverseDependencyWarning
+    };
+  });
+}

--- a/src/pages/api/v1/modules/[moduleKey]/audit.ts
+++ b/src/pages/api/v1/modules/[moduleKey]/audit.ts
@@ -1,0 +1,61 @@
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import {
+  boundAuditSummaryLimit,
+  fetchModuleAuditSummary,
+  MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT
+} from "../../../../../modules/module-management/application/module-audit-summary";
+import { getModuleByKey } from "../../../../../modules";
+
+/**
+ * `GET /api/v1/modules/{moduleKey}/audit` — recent module-management activity
+ * for one module.
+ *
+ * Guarded by `logging.audit_trail.read`, NOT by a module-management permission.
+ * The rows are audit-log rows; whoever may read the audit log may read this
+ * slice of it, and whoever may not must not get a filtered view of the same
+ * data through a different door.
+ *
+ * A `moduleKey` that is not registered answers 404 rather than an empty list —
+ * an empty list for a typo reads as "nothing has happened to this module",
+ * which is a different and wrong statement.
+ */
+export const GET = defineTenantRoute<{ limit: number }>({
+  workClass: "reporting",
+  prepare: ({ url }) => {
+    const raw = url.searchParams.get("limit");
+
+    return {
+      limit: raw === null ? MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT : Number(raw)
+    };
+  },
+  authorize: {
+    // `audit_trail`, not `audit_log`. `logging` seeds exactly one permission
+    // (`logging.audit_trail.read`, sql/007) and `/api/v1/logs/audit` already
+    // guards on it. Naming a plausible-but-unseeded action here would deny
+    // every caller including the owner — the latent-authz trap this repo has
+    // hit before on the roles and ABAC write surfaces, and which is invisible
+    // in review because the guard reads perfectly well.
+    moduleKey: "logging",
+    activityCode: "audit_trail",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, params, prepared }) => {
+    const moduleKey = params.moduleKey ?? "";
+
+    if (!getModuleByKey(moduleKey)) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Module is not registered.");
+    }
+
+    return ok({
+      moduleKey,
+      limit: boundAuditSummaryLimit(prepared.limit),
+      entries: await fetchModuleAuditSummary(
+        tx,
+        tenantId,
+        moduleKey,
+        prepared.limit
+      )
+    });
+  }
+});

--- a/src/pages/api/v1/tenant/modules/matrix/index.ts
+++ b/src/pages/api/v1/tenant/modules/matrix/index.ts
@@ -1,0 +1,24 @@
+import { ok } from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import { fetchModuleMatrix } from "../../../../../../modules/module-management/application/module-matrix";
+
+/**
+ * `GET /api/v1/tenant/modules/matrix` — every module × what matters for this
+ * tenant, in two queries.
+ *
+ * A read over the module registry, so it guards on `tenant_modules.read`, the
+ * same permission `GET /api/v1/tenant/modules` already requires. It adds no
+ * data the caller could not assemble from existing endpoints; it assembles it
+ * without N round trips and, more usefully, adds the two lifecycle warnings by
+ * re-running the REAL validation rather than a UI's guess at it.
+ */
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "module_management",
+    activityCode: "tenant_modules",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId }) =>
+    ok({ modules: await fetchModuleMatrix(tx, tenantId) })
+});

--- a/tests/module-audit-summary.test.ts
+++ b/tests/module-audit-summary.test.ts
@@ -1,0 +1,63 @@
+/**
+ * The audit summary's limit is a ceiling, not a suggestion.
+ *
+ * This endpoint takes a caller-supplied `?limit=`, and the row source is the
+ * audit log — the highest-volume table a tenant owns. An unbounded or
+ * NaN-poisoned limit turns an admin panel into an export, so the clamp is the
+ * part worth pinning; everything else here is a `SELECT` with two predicates.
+ *
+ * Pure — no database.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  boundAuditSummaryLimit,
+  MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT,
+  MODULE_AUDIT_SUMMARY_MAX_LIMIT
+} from "../src/modules/module-management/application/module-audit-summary";
+
+describe("limit bounding", () => {
+  test.each([
+    [1, 1],
+    [20, 20],
+    [50, 50]
+  ])("passes a valid limit through (%i)", (input, expected) => {
+    expect(boundAuditSummaryLimit(input)).toBe(expected);
+  });
+
+  test.each([
+    [0, 1],
+    [-5, 1],
+    [51, MODULE_AUDIT_SUMMARY_MAX_LIMIT],
+    [10_000, MODULE_AUDIT_SUMMARY_MAX_LIMIT]
+  ])("clamps out-of-range %i to %i", (input, expected) => {
+    expect(boundAuditSummaryLimit(input)).toBe(expected);
+  });
+
+  test.each([
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+    ["-Infinity", Number.NEGATIVE_INFINITY],
+    ["a string", "20"],
+    ["null", null],
+    ["undefined", undefined],
+    ["an object", {}]
+  ])("falls back to the default for %s", (_label, input) => {
+    // `Number(url.searchParams.get("limit"))` yields NaN for `?limit=abc` and
+    // Infinity for a large enough literal. Neither may reach `LIMIT`.
+    expect(boundAuditSummaryLimit(input)).toBe(
+      MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT
+    );
+  });
+
+  test("a fractional limit truncates rather than reaching SQL as a float", () => {
+    expect(boundAuditSummaryLimit(7.9)).toBe(7);
+  });
+
+  test("the default is inside the allowed range", () => {
+    expect(MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT).toBeLessThanOrEqual(
+      MODULE_AUDIT_SUMMARY_MAX_LIMIT
+    );
+    expect(MODULE_AUDIT_SUMMARY_DEFAULT_LIMIT).toBeGreaterThan(0);
+  });
+});

--- a/tests/module-matrix.test.ts
+++ b/tests/module-matrix.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The matrix's warnings must be the REAL validation, asked the right question.
+ *
+ * ## The failure this guards against
+ *
+ * A matrix is a UI convenience, and the tempting way to build one is to
+ * re-derive "can this be enabled?" from the dependency array by hand. That
+ * derivation then drifts from what `enableTenantModule` actually does, and the
+ * admin screen starts promising outcomes the API refuses.
+ *
+ * So the rule is: only ever ask `evaluateModuleEnable`/`evaluateModuleDisable`
+ * the question they are designed to answer, for the module's real state — and
+ * never forge a synthetic state to get an answer out of them.
+ *
+ * That is why the warnings are one-directional. `evaluateModuleEnable` on an
+ * ALREADY-ENABLED module short-circuits to `MODULE_ALREADY_ENABLED` before it
+ * ever reaches the dependency loop: the answer looks like a check and is not
+ * one. These tests pin that asymmetry, because a future edit "improving" the
+ * matrix by computing all four combinations would reintroduce exactly the
+ * fiction it avoids.
+ *
+ * Pure: the row-building logic is exercised through the same domain functions
+ * `fetchModuleMatrix` calls, with no database. The two reads
+ * `fetchModuleMatrix` performs (catalog + tenant entries) are covered by their
+ * own DB-gated tests.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import { resolveProtectedModuleKeys } from "../src/modules/module-management/domain/module-presets";
+import {
+  evaluateModuleDisable,
+  evaluateModuleEnable
+} from "../src/modules/module-management/domain/tenant-module-lifecycle";
+
+const REGISTRY = listModules();
+
+describe("the question each evaluator is asked", () => {
+  test("evaluateModuleEnable on an ENABLED module short-circuits — it is not a dependency check", () => {
+    // The whole reason `dependencyWarning` is computed only for disabled rows.
+    // If the matrix asked this question of an enabled module it would get
+    // MODULE_ALREADY_ENABLED, which is not a warning about anything.
+    const target = REGISTRY.find((module) => module.dependencies.length > 0)!;
+    const validation = evaluateModuleEnable({
+      target,
+      targetTenantState: { moduleKey: target.key, tenantEnabled: true },
+      dependencyStates: target.dependencies.map((key) => ({
+        descriptor: REGISTRY.find((m) => m.key === key)!,
+        // Deliberately DISABLED dependencies: a naive check would report them.
+        tenantState: { moduleKey: key, tenantEnabled: false }
+      })),
+      allDescriptors: REGISTRY,
+      currentAppVersion: "9.9.9"
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.valid === false && validation.code).toBe(
+      "MODULE_ALREADY_ENABLED"
+    );
+  });
+
+  test("a DISABLED module with a disabled dependency reports MODULE_DEPENDENCY_DISABLED", () => {
+    const target = REGISTRY.find((module) => module.dependencies.length > 0)!;
+    const dependencyKey = target.dependencies[0]!;
+    const validation = evaluateModuleEnable({
+      target,
+      targetTenantState: { moduleKey: target.key, tenantEnabled: false },
+      dependencyStates: target.dependencies.map((key) => ({
+        descriptor: REGISTRY.find((m) => m.key === key)!,
+        tenantState: { moduleKey: key, tenantEnabled: key !== dependencyKey }
+      })),
+      allDescriptors: REGISTRY,
+      currentAppVersion: "9.9.9"
+    });
+
+    expect(validation.valid === false && validation.code).toBe(
+      "MODULE_DEPENDENCY_DISABLED"
+    );
+  });
+
+  test("an ENABLED module with an enabled dependent reports MODULE_REVERSE_DEPENDENCY_ACTIVE", () => {
+    const dependent = REGISTRY.find(
+      (module) => module.dependencies.length > 0
+    )!;
+    const targetKey = dependent.dependencies[0]!;
+    const target = REGISTRY.find((module) => module.key === targetKey)!;
+
+    const validation = evaluateModuleDisable({
+      target,
+      targetTenantState: { moduleKey: target.key, tenantEnabled: true },
+      reverseDependencies: [
+        {
+          descriptor: dependent,
+          tenantState: { moduleKey: dependent.key, tenantEnabled: true }
+        }
+      ]
+    });
+
+    expect(validation.valid).toBe(false);
+    expect(validation.valid === false && validation.code).toBe(
+      "MODULE_REVERSE_DEPENDENCY_ACTIVE"
+    );
+  });
+
+  test("the same module with the dependent DISABLED is disableable", () => {
+    const dependent = REGISTRY.find(
+      (module) => module.dependencies.length > 0 && !module.isCore
+    )!;
+    const targetKey = dependent.dependencies[0]!;
+    const target = REGISTRY.find((module) => module.key === targetKey)!;
+
+    const validation = evaluateModuleDisable({
+      target,
+      targetTenantState: { moduleKey: target.key, tenantEnabled: true },
+      reverseDependencies: REGISTRY.filter(
+        (m) => m.key !== target.key && m.dependencies.includes(target.key)
+      ).map((m) => ({
+        descriptor: m,
+        tenantState: { moduleKey: m.key, tenantEnabled: false }
+      }))
+    });
+
+    // `isCore` still wins over everything — that is a different rejection and
+    // the matrix reports it through `isProtected`, not a warning.
+    if (target.isCore) {
+      expect(validation.valid === false && validation.code).toBe(
+        "CORE_MODULE_CANNOT_BE_DISABLED"
+      );
+    } else {
+      expect(validation.valid).toBe(true);
+    }
+  });
+});
+
+describe("isProtected", () => {
+  test("covers core and its whole dependency closure, and nothing else", () => {
+    const protectedKeys = resolveProtectedModuleKeys(REGISTRY);
+    const core = REGISTRY.filter((module) => module.isCore).map((m) => m.key);
+
+    expect(core.length).toBeGreaterThan(0);
+
+    for (const key of core) {
+      expect(protectedKeys.has(key)).toBe(true);
+    }
+
+    // Every protected key is reachable from a core module — nothing is
+    // protected "just because", which would silently remove a tenant's ability
+    // to disable something they are entitled to disable.
+    for (const key of protectedKeys) {
+      const reachable = new Set<string>();
+      const walk = (from: string) => {
+        if (reachable.has(from)) return;
+        reachable.add(from);
+        for (const dependency of REGISTRY.find((m) => m.key === from)
+          ?.dependencies ?? []) {
+          walk(dependency);
+        }
+      };
+
+      core.forEach(walk);
+      expect(reachable.has(key)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #261 (bagian 1 = presets, PR #270).

## Matriks

`GET /api/v1/tenant/modules/matrix` — setiap modul dengan state tenant, flag protected, dan **dua peringatan lifecycle**. Total **dua query** (catalog + tenant entries); sisanya murni.

Peringatannya yang jadi intinya. Cara menggoda membangun matriks adalah menurunkan sendiri "apakah ini bisa diaktifkan?" dari array dependency — lalu turunan itu **melenceng** dari yang benar-benar dilakukan `enableTenantModule`, dan layar admin mulai menjanjikan hasil yang ditolak API. Jadi tiap peringatan **menjalankan ulang validasi ASLI** terhadap state nyata modul, tanpa pernah memalsukan state sintetis untuk memancing jawaban.

Akibatnya satu arah:

| peringatan | hanya untuk |
| --- | --- |
| `dependencyWarning` | modul **DISABLED** — "kalau diaktifkan sekarang, berhasil?" |
| `reverseDependencyWarning` | modul **ENABLED** — "kalau dinonaktifkan, terblokir?" |

Dua kombinasi lain tak bisa muncul. Dependency modul aktif pasti terpenuhi menurut konstruksi (`disableTenantModule` menolak menonaktifkan dependency selama dependent-nya aktif), dan menanyai `evaluateModuleEnable` tentang modul yang sudah aktif akan short-circuit ke `MODULE_ALREADY_ENABLED` sebelum mencapai loop dependency — **jawaban yang tampak seperti pemeriksaan padahal bukan**. `tests/module-matrix.test.ts` mem-pin asimetri itu, karena "menyempurnakan" matriks jadi menghitung keempatnya akan mengembalikan persis fiksi yang dihindarinya.

**TANPA kolom health**, berbeda dari awcms-micro. Milik mereka disuapi `fetchModuleHealthReports` yang batch dan berbagi satu context untuk seluruh registry; base ini hanya punya pembaca per-modul, jadi kolom health di sini berarti **21 pembacaan dalam satu transaksi** — N+1 yang akan saya ciptakan, bukan warisi. Health tetap di `GET /api/v1/modules/{moduleKey}/health` sampai pembaca batch-nya ada.

## Ringkasan audit

`GET /api/v1/modules/{moduleKey}/audit` — enable/disable tenant, update settings, health check, dan apply preset yang tercatat atas satu module key.

Digerbangi **`logging.audit_trail.read`**, bukan permission module-management: barisnya adalah baris audit-log, dan siapa pun yang tak boleh membaca audit log tak boleh mendapat pandangan tersaringnya lewat pintu lain.

> **Saya awalnya menulis `logging.audit_log.read`.** Permission itu tidak ada — yang ter-seed adalah `logging.audit_trail.read` (`sql/007`). Action yang masuk akal tapi tak-ter-seed **men-deny setiap pemanggil termasuk owner**, terbaca mulus saat review, dan merupakan jebakan latent-authz yang sudah pernah kena di surface tulis roles dan ABAC. Tertangkap sebelum commit dan dicatat di kode.

`module_registry` sengaja **dikecualikan** dari resource type: descriptor sync itu operasi registry-wide yang `resource_id`-nya bukan module key, jadi memasukkannya akan cocok nol baris sambil menyiratkan sebaliknya.

`?limit=` dari pemanggil di-clamp ke 1..50. `Number(searchParams.get())` menghasilkan `NaN` untuk `?limit=abc` dan `Infinity` untuk literal cukup besar; **keduanya tak boleh mencapai `LIMIT`** dan jatuh ke default.

`moduleKey` tak-terdaftar menjawab **404**, bukan daftar kosong — daftar kosong untuk salah ketik terbaca sebagai "tak ada yang pernah terjadi pada modul ini", pernyataan yang berbeda dan salah.

Suite penuh: **2714 test, 0 gagal**. Semua gate, typecheck, build hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
