### PR TITLE
fix(database): make a pool refusal impossible to mistake for data

### DIFF
--- a/.changeset/database-busy-typed-refusal.md
+++ b/.changeset/database-busy-typed-refusal.md
@@ -1,0 +1,45 @@
+---
+"awcms": minor
+---
+
+Buat penolakan pool database tak bisa lagi menyamar sebagai data, dan hentikan
+inversi backpressure yang sudah hidup di jalur job.
+
+`withTenant<T>(...): Promise<T>` mengembalikan `503 DATABASE_BUSY` (breaker
+open / work-class saturasi) dan `409` idempotency lewat `as T` — cast yang
+artinya persis "berhenti memeriksa". Header-nya menyatakan "in practice every
+real call site uses `T = Response`"; itu sudah lama tidak benar. **58 berkas di
+`src/`+`scripts/` yang bukan handler HTTP** (15 di antaranya `.astro`) dan 24
+berkas test memakainya untuk mengambil DATA; begitu tipe-nya dijujurkan,
+compiler membuktikan 30 di antaranya benar-benar membaca field dari nilai yang
+bisa berupa `Response`.
+
+Kerusakannya nyata, bukan teoretis. `purgeExpiredAuditEvents` berjanji
+`Promise<number>`; di bawah work-class `maintenance` (SATU slot) ia
+mengembalikan `Response`. `runBoundedBatches` berhenti "sampai satu pass
+mengembalikan `count: 0`" — dan `Response` tak pernah `=== 0`, sehingga job yang
+seluruh tujuannya mengalah justru menjalankan 50 pass penuh per tenant ke
+database yang baru saja menolak, lalu melaporkan `totalCount` sebagai string
+`"0[object Response]…"` (karena `number + Response` itu konkatenasi). Test
+mutasinya mereproduksi persis output itu.
+
+Sekarang ada dua bentuk, dan compiler yang memilihkan:
+
+- **`withTenant(...)` → `Promise<T | Response>`.** Jalur request meneruskan
+  `503`-nya apa adanya, lengkap dengan `Retry-After`; 275 pemanggilan di 204
+  berkas rute yang callback-nya memang sudah mengembalikan `Response` tidak
+  berubah satu baris pun (`Response | Response` itu `Response`).
+- **`withTenantOrThrow<T>(...)` → `Promise<T>`.** Untuk semua yang bukan handler
+  HTTP. Melempar `DatabaseBusyError` yang MEMBAWA response `503` yang sama
+  (jadi kedua bentuk tak bisa menyimpang), dan kini diklasifikasi `retryable`
+  oleh job runner alih-alih jatuh ke `unknown`.
+
+Tak ada lagi satu pun `as T` di modul itu.
+
+`db:tenant-context:check` (baru, di rantai `check`) menutup dua sisa yang tak
+terlihat compiler: hasil `withTenant` yang **dibuang** (`await withTenant(...)`
+sebagai statement — 503-nya lenyap tanpa jejak), dan pemanggilan dari `.astro`,
+yang tak pernah dibaca `tsc --noEmit`. Gate itu langsung menemukan tiga
+pembuangan nyata di jalur auth: dua di antaranya melewatkan audit event
+`sso_account_linked`/`mfa_challenge_issued` sambil tetap menjawab seolah sudah
+tertulis.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -130,6 +130,26 @@ membandingkan `tenant_id` dengan `current_setting('app.current_tenant_id')`.
 RLS adalah lapis kedua — query tetap wajib memfilter `tenant_id` secara
 eksplisit. State pool/breaker diekspos di `GET /api/v1/database/pool/health`.
 
+**Penolakan pool BUKAN sebuah nilai — dua bentuk, dipilih compiler.**
+`withTenant()` mengembalikan `T | Response`: pemanggil di jalur request
+meneruskan `503`-nya apa adanya (`if (result instanceof Response) return
+result;`), dan ~390 handler yang callback-nya memang mengembalikan `Response`
+tak berubah sama sekali. Segala sesuatu yang BUKAN handler HTTP — worker, job
+terjadwal, frontmatter SSR, resolver tenant, fixture test — memakai
+`withTenantOrThrow()`, yang melempar `DatabaseBusyError` (membawa `response`
+`503` yang identik, jadi kedua bentuk tak bisa menyimpang) dan diklasifikasi
+`retryable` oleh job runner. Sebelumnya satu fungsi generik meng-`as T`
+penolakan itu menjadi tipe apa pun yang diminta pemanggil: `purgeExpiredAuditEvents`
+berjanji `Promise<number>` tapi mengembalikan `Response`, `runBoundedBatches`
+berhenti pada `count === 0` yang tak pernah cocok, dan job yang seluruh tujuannya
+mengalah justru menjalankan 50 pass per tenant ke database yang baru saja
+menolak — lalu melaporkan sukses dengan total berupa string
+`"0[object Response]…"` (karena `number + Response` itu konkatenasi).
+`db:tenant-context:check` menutup dua sisa yang tak terlihat compiler: hasil
+`withTenant` yang **dibuang** (`await withTenant(...)` sebagai statement —
+`503`-nya hilang tanpa jejak) dan pemanggilan dari `.astro`, yang tak pernah
+dibaca `tsc --noEmit`.
+
 **Pengecualian RLS yang disengaja (allow-list eksplisit).** Dua tabel global
 sengaja tanpa RLS: `awcms_tenants` (root multi-tenant — endpoint wajib
 `WHERE id = <tenantId>` eksplisit) dan `awcms_setup_state` (singleton

--- a/docs/awcms/16_backend_data_access_integration.md
+++ b/docs/awcms/16_backend_data_access_integration.md
@@ -88,6 +88,24 @@ async function withTenant<T>(
 }
 ```
 
+Sketsa di atas sengaja minimal (tanpa work class/circuit breaker). Yang **tidak**
+boleh disederhanakan dari implementasi nyata (`src/lib/database/tenant-context.ts`):
+gate pool bisa **menolak sebelum `fn` jalan sama sekali**, dan penolakan itu
+bukan nilai yang boleh menyamar sebagai hasil. Karena itu ada dua bentuk:
+
+- **`withTenant(...)` → `Promise<T | Response>`** untuk jalur request. Penolakan
+  datang sebagai `503 DATABASE_BUSY` + `Retry-After` yang tinggal diteruskan
+  (`if (result instanceof Response) return result;`).
+- **`withTenantOrThrow<T>(...)` → `Promise<T>`** untuk semua yang bukan handler
+  HTTP — worker, job terjadwal, frontmatter SSR, resolver tenant, fixture test.
+  Melempar `DatabaseBusyError` (membawa response `503` yang identik), yang
+  diklasifikasi `retryable` oleh job runner.
+
+Aturannya bukan gaya: sebuah worker yang menerima `Response` sebagai "hasil"
+membacanya sebagai nol baris dan melaporkan sukses. `db:tenant-context:check`
+menegakkan dua sisa yang tak terlihat compiler — hasil `withTenant` yang dibuang,
+dan pemanggilan dari `.astro` (tak pernah dibaca `tsc --noEmit`).
+
 ## Transaction wrapper dan locking
 
 1. Transaction untuk semua mutation multi-table.

--- a/docs/awcms/database-capacity-runbook.md
+++ b/docs/awcms/database-capacity-runbook.md
@@ -288,9 +288,11 @@ without a reviewable diff to that file.
 **Two halves, two sources of truth.** Routes are GENERATED, because every route
 already declares its class inline — via `defineTenantRoute({ workClass })`
 (Issue #255, where omitting it is a compile error), via an explicit literal on
-`withTenant(...)`, or by relying on the documented `"interactive"` default. Jobs
-are DECLARED in `src/lib/database/work-class-registry.ts`, because worker
-scripts never call `withTenant` and there is nothing to generate from; the
+`withTenant(...)`/`withTenantOrThrow(...)`, or by relying on the documented
+`"interactive"` default. Jobs are DECLARED in
+`src/lib/database/work-class-registry.ts`, because a worker script's class is a
+property of the SCRIPT, not of any one transaction inside it, so there is
+nothing to generate from; the
 generator discovers them by ground truth (`getWorkerDatabaseClient(` /
 `getSetupDatabaseClient(` in `scripts/*.ts`) and **refuses to run** — not merely
 to check — when the declared map and the scripts on disk disagree.
@@ -303,7 +305,7 @@ repo (`social-publish-dispatch`, `organization-structure-metrics-snapshot`,
 `integration-hub-outbound-dispatch`, `data-exchange-worker`), carried over from
 awcms-mini with their ADR-accepted-but-unimplemented modules.
 
-**What the snapshot says today: 208 routes, 18 jobs.** Of the routes, **176 still
+**What the snapshot says today: 216 routes, 18 jobs.** Of the routes, **176 still
 rely on `withTenant`'s `"interactive"` default** — they share login's pool budget
 by omission rather than by decision. 28 pass an explicit literal and 4 go through
 `defineTenantRoute`. Shrinking that 176 is the migration tracked in Issue #255;

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -1105,13 +1105,13 @@
       "path": "scripts/data-lifecycle-archive-purge.ts",
       "workClass": "maintenance",
       "source": "registry",
-      "rationale": "Scheduled bounded archive/purge (data-lifecycle:archive-purge, Issue #745) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/form-draft-purge; every withTenant call inside archive-purge-job.ts already passes workClass: \"maintenance\" explicitly."
+      "rationale": "Scheduled bounded archive/purge (data-lifecycle:archive-purge, Issue #745) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/form-draft-purge; every withTenantOrThrow call inside archive-purge-job.ts already passes workClass: \"maintenance\" explicitly."
     },
     {
       "path": "scripts/domain-events-dispatch.ts",
       "workClass": "background_sync",
       "source": "registry",
-      "rationale": "Outbox dispatcher (domain-events:dispatch, Issue #742), recommended every 30-60 seconds — same recurring dispatcher profile as email/object-sync/social-publish dispatch; its own internal withTenant calls already pass workClass: \"background_sync\" explicitly."
+      "rationale": "Outbox dispatcher (domain-events:dispatch, Issue #742), recommended every 30-60 seconds — same recurring dispatcher profile as email/object-sync/social-publish dispatch; its own internal withTenantOrThrow calls already pass workClass: \"background_sync\" explicitly."
     },
     {
       "path": "scripts/edge-cache-purge.ts",
@@ -1135,7 +1135,7 @@
       "path": "scripts/identity-access-business-scope-expiry.ts",
       "workClass": "maintenance",
       "source": "registry",
-      "rationale": "Scheduled expiry sweep for business-scope assignments/SoD conflict exceptions (identity-access:business-scope:expiry, Issue #746) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenant call inside business-scope-expiry-job.ts already passes workClass: \"maintenance\" explicitly."
+      "rationale": "Scheduled expiry sweep for business-scope assignments/SoD conflict exceptions (identity-access:business-scope:expiry, Issue #746) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenantOrThrow call inside business-scope-expiry-job.ts already passes workClass: \"maintenance\" explicitly."
     },
     {
       "path": "scripts/news-media-r2-reconcile.ts",
@@ -1159,7 +1159,7 @@
       "path": "scripts/reporting-projections-refresh.ts",
       "workClass": "maintenance",
       "source": "registry",
-      "rationale": "Incremental cursor_table projection updates + rebuild-continuation sweep (reporting:projections:refresh, Issue #753), recommended every 2 minutes — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenant call inside projection-incremental-worker.ts/projection-rebuild.ts already passes workClass: \"maintenance\" explicitly."
+      "rationale": "Incremental cursor_table projection updates + rebuild-continuation sweep (reporting:projections:refresh, Issue #753), recommended every 2 minutes — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenantOrThrow call inside projection-incremental-worker.ts/projection-rebuild.ts already passes workClass: \"maintenance\" explicitly."
     },
     {
       "path": "scripts/site-search-reconcile.ts",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "modules:composition:inventory:check": "bun scripts/module-composition-inventory-check.ts",
     "logging:lint:check": "bun scripts/logging-lint-check.ts",
     "api:tenant-route:check": "bun scripts/tenant-route-factory-check.ts",
+    "db:tenant-context:check": "bun scripts/tenant-context-usage-check.ts",
     "db:work-class:generate": "bun scripts/work-class-registry-generate.ts",
     "db:work-class:check": "bun scripts/work-class-registry-check.ts",
     "config:validate": "bun scripts/validate-env.ts",
@@ -96,7 +97,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/comments-retention.ts
+++ b/scripts/comments-retention.ts
@@ -31,7 +31,7 @@
  * see nothing rather than crossing tenants.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { logScriptFailure } from "../src/lib/logging/error-log";
 import {
   COMMENTS_DEFAULT_ANONYMIZE_DAYS,
@@ -86,7 +86,7 @@ async function main() {
 
     for (const tenant of tenants) {
       for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
-        const result = await withTenant(sql, tenant.id, (tx) =>
+        const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
           anonymizeAgedComments(tx, tenant.id, legalHoldGuardPortAdapter, {
             retentionDays,
             now
@@ -108,7 +108,7 @@ async function main() {
       }
 
       for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
-        const result = await withTenant(sql, tenant.id, (tx) =>
+        const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
           purgeUnconfirmedReplySubscriptions(tx, tenant.id, { now })
         );
 

--- a/scripts/edge-cache-purge.ts
+++ b/scripts/edge-cache-purge.ts
@@ -25,7 +25,7 @@
  * unconditionally across deployments that have not adopted the edge cache.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { logScriptFailure } from "../src/lib/logging/error-log";
 import { loadEdgeCacheConfig } from "../src/lib/edge-cache/config";
 import {
@@ -74,7 +74,7 @@ async function main(): Promise<void> {
 
     for (const tenant of tenants) {
       for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
-        const claimed = await withTenant(sql, tenant.id, (tx) =>
+        const claimed = await withTenantOrThrow(sql, tenant.id, (tx) =>
           claimEdgeCachePurges(tx, tenant.id, config.purgeBatchSize, new Date())
         );
 
@@ -89,7 +89,7 @@ async function main(): Promise<void> {
 
           // Each outcome is committed on its own so a crash mid-batch loses at
           // most one row's status, not the whole pass's progress.
-          await withTenant(sql, tenant.id, (tx) =>
+          await withTenantOrThrow(sql, tenant.id, (tx) =>
             outcome.ok
               ? markEdgeCachePurgeDone(tx, row.id, new Date())
               : markEdgeCachePurgeFailed(
@@ -109,7 +109,7 @@ async function main(): Promise<void> {
         }
       }
 
-      pruned += await withTenant(sql, tenant.id, (tx) =>
+      pruned += await withTenantOrThrow(sql, tenant.id, (tx) =>
         pruneCompletedEdgeCachePurges(
           tx,
           tenant.id,

--- a/scripts/email-templates-seed-defaults.ts
+++ b/scripts/email-templates-seed-defaults.ts
@@ -18,7 +18,7 @@
  */
 import { getDatabaseClient } from "../src/lib/database/client";
 import { logScriptFailure } from "../src/lib/logging/error-log";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { recordAuditEvent } from "../src/modules/logging/application/audit-log";
 import { DEFAULT_EMAIL_TEMPLATES } from "../src/modules/email/domain/email-default-templates";
 import { seedDefaultEmailTemplates } from "../src/modules/email/application/email-template-directory";
@@ -44,7 +44,7 @@ async function main() {
   const correlationId = crypto.randomUUID();
 
   try {
-    const result = await withTenant(sql, tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, tenantId, async (tx) => {
       const seeded = await seedDefaultEmailTemplates(
         tx,
         tenantId,

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -45,7 +45,7 @@ import { execFileSync } from "node:child_process";
 import path from "node:path";
 
 import { getDatabaseClient } from "../src/lib/database/client";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { hashPassword } from "../src/lib/auth/password";
 import { listModules } from "../src/modules";
 import {
@@ -1980,7 +1980,7 @@ export async function checkSsoBreakGlassReady(): Promise<SecurityCheckResult> {
     const stranded: string[] = [];
 
     for (const tenant of tenants) {
-      const outcome = await withTenant(
+      const outcome = await withTenantOrThrow(
         sql,
         tenant.id,
         async (tx) => {

--- a/scripts/site-search-reconcile.ts
+++ b/scripts/site-search-reconcile.ts
@@ -16,7 +16,7 @@
  * never leaks. `--tenant=<uuid>` limits the run to a single tenant.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { logScriptFailure } from "../src/lib/logging/error-log";
 import { getRegisteredSearchSources } from "../src/modules/site-search/presentation/search-sources";
 import {
@@ -56,7 +56,7 @@ async function main(): Promise<void> {
     let totalFailures = 0;
 
     for (const tenant of tenants) {
-      const result = await withTenant(
+      const result = await withTenantOrThrow(
         sql,
         tenant.id,
         (tx) =>

--- a/scripts/tenant-context-usage-check.ts
+++ b/scripts/tenant-context-usage-check.ts
@@ -1,0 +1,180 @@
+/**
+ * `withTenant` may refuse. This gate covers the two ways that refusal can be
+ * lost that the TYPE SYSTEM cannot see.
+ *
+ * `withTenant(...)` returns `T | Response`, so anything that reads fields off
+ * the result is a compile error the day it is written. Two holes remain, and
+ * both are the shape that shipped:
+ *
+ * 1. **A discarded result.** `await withTenant(sql, id, async (tx) => { … })`
+ *    as a bare statement type-checks perfectly — the `503` is constructed,
+ *    returned, and dropped on the floor. The write never happened and nobody
+ *    is told. `withTenantOrThrow` is the form for a side-effect-only call: it
+ *    throws, so the caller's own `catch` (or the job runner) sees it.
+ *
+ * 2. **`.astro` frontmatter.** `bun run typecheck` is `tsc --noEmit`, which
+ *    does not read `.astro` files at all, so an admin page could assign a
+ *    `Response` to a variable it then maps over and no gate in the chain
+ *    would notice. Every one of the 15 admin screens calls this from
+ *    frontmatter that returns DATA, never a `Response`, so the rule for that
+ *    extension is simply "use `withTenantOrThrow`" — no judgement call, and
+ *    no need to teach this script what an Astro page returns.
+ *
+ * Pure text, no database, no AST: it runs in the `quality` job on every PR and
+ * fails at authoring time, the same shape as
+ * `migration-tenant-guc-consistency` and `table-write-ownership-check`.
+ */
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+const SOURCE_ROOTS = ["src", "scripts", "tests"];
+const SOURCE_EXTENSIONS = [".ts", ".astro"];
+
+/**
+ * The definition itself, plus the two gates that scan source text for this
+ * very call and would otherwise report their own regexes.
+ */
+const EXEMPT_FILES = new Set([
+  "src/lib/database/tenant-context.ts",
+  "scripts/tenant-context-usage-check.ts",
+  "scripts/tenant-route-factory-check.ts",
+  "scripts/work-class-registry-generate.ts"
+]);
+
+/** `withTenant(` / `withTenant<T>(` — and NOT `withTenantOrThrow(`, which is the fix. */
+const WITH_TENANT_CALL = /\bwithTenant\s*(?:<[^()]*>)?\s*\(/;
+
+/**
+ * A call whose value goes nowhere: the line starts the statement with `await`
+ * (or the bare call) rather than `return`, `=`, `const`, `(`, `?`, `,` …
+ *
+ * Anchored at the start of the trimmed line on purpose. `const x = await
+ * withTenant(` and `return withTenant(` both keep the value reachable, and
+ * whichever branch reads it is then the compiler's problem, not this gate's.
+ */
+const DISCARDED_CALL =
+  /^await\s+withTenant\s*(?:<[^()]*>)?\s*\(|^withTenant\s*(?:<[^()]*>)?\s*\(/;
+
+export type UsageViolation = {
+  file: string;
+  line: number;
+  kind: "discarded_result" | "astro_frontmatter";
+  text: string;
+};
+
+/**
+ * Comment lines are dropped so a docblock EXPLAINING this rule is not read as
+ * breaking it — the same self-report `table-write-ownership-check` hit, and
+ * this file's own header would trip it on the first run otherwise.
+ */
+export function findUsageViolations(
+  file: string,
+  source: string
+): UsageViolation[] {
+  if (EXEMPT_FILES.has(file)) return [];
+
+  const isAstro = file.endsWith(".astro");
+  const violations: UsageViolation[] = [];
+
+  source.split("\n").forEach((rawLine, index) => {
+    const line = rawLine.trim();
+
+    if (
+      line.startsWith("//") ||
+      line.startsWith("*") ||
+      line.startsWith("/*")
+    ) {
+      return;
+    }
+
+    if (!WITH_TENANT_CALL.test(line)) return;
+
+    if (isAstro) {
+      violations.push({
+        file,
+        line: index + 1,
+        kind: "astro_frontmatter",
+        text: line
+      });
+      return;
+    }
+
+    if (DISCARDED_CALL.test(line)) {
+      violations.push({
+        file,
+        line: index + 1,
+        kind: "discarded_result",
+        text: line
+      });
+    }
+  });
+
+  return violations;
+}
+
+async function* walk(directory: string): AsyncGenerator<string> {
+  const entries = await readdir(directory, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const full = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      yield* walk(full);
+      continue;
+    }
+
+    if (SOURCE_EXTENSIONS.some((extension) => entry.name.endsWith(extension))) {
+      yield full;
+    }
+  }
+}
+
+export async function collectUsageViolations(): Promise<UsageViolation[]> {
+  const violations: UsageViolation[] = [];
+
+  for (const root of SOURCE_ROOTS) {
+    for await (const file of walk(root)) {
+      violations.push(
+        ...findUsageViolations(file, await Bun.file(file).text())
+      );
+    }
+  }
+
+  return violations.sort((a, b) =>
+    a.file === b.file ? a.line - b.line : a.file.localeCompare(b.file)
+  );
+}
+
+const REASON: Record<UsageViolation["kind"], string> = {
+  discarded_result:
+    "hasil withTenant() dibuang. Saat pool menolak, 503-nya hilang tanpa jejak dan " +
+    "penulisan tak pernah terjadi — pakai withTenantOrThrow() supaya menjadi error.",
+  astro_frontmatter:
+    "frontmatter .astro tidak dicek `tsc --noEmit`, jadi Response yang bocor ke sini " +
+    "tak tertangkap siapa pun — pakai withTenantOrThrow()."
+};
+
+async function main(): Promise<void> {
+  const violations = await collectUsageViolations();
+
+  if (violations.length === 0) {
+    console.log(
+      "tenant-context usage OK — tidak ada hasil withTenant() yang dibuang, " +
+        "tidak ada pemanggilan dari .astro."
+    );
+    return;
+  }
+
+  for (const violation of violations) {
+    console.error(
+      `${violation.file}:${violation.line} — ${REASON[violation.kind]}\n    ${violation.text}`
+    );
+  }
+
+  process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/tenant-domain-dns-sync.ts
+++ b/scripts/tenant-domain-dns-sync.ts
@@ -28,7 +28,7 @@
  * says that. `--dry-run` reports what would change without writing.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { logScriptFailure } from "../src/lib/logging/error-log";
 import {
   reconcileServingRecords,
@@ -69,7 +69,7 @@ async function main(): Promise<void> {
     `) as TenantRow[];
 
     for (const tenant of tenants) {
-      const rows = await withTenant(
+      const rows = await withTenantOrThrow(
         sql,
         tenant.id,
         (tx) =>

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -46,8 +46,11 @@ import path from "node:path";
 
 const ROUTES_ROOT = "src/pages/api";
 
-/** Matches `withTenant(` AND `withTenant<T>(`. */
-const WITH_TENANT_CALL_PATTERN = /\bwithTenant\s*(?:<[^()]*>)?\s*\(/;
+/** Matches `withTenant(`, `withTenant<T>(` AND `withTenantOrThrow(` — a route
+ * that opens its own tenant transaction bypasses the factory under either
+ * name, so neither may slip past this gate. */
+const WITH_TENANT_CALL_PATTERN =
+  /\bwithTenant(?:OrThrow)?\s*(?:<[^()]*>)?\s*\(/;
 
 /**
  * Routes that still open their own transaction, measured at `b9931594`.

--- a/scripts/visitor-analytics-purge.ts
+++ b/scripts/visitor-analytics-purge.ts
@@ -25,7 +25,7 @@
  * deleting/clearing anything.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import {
   applyJobExitCode,
   formatJobOutcomeLine,
@@ -79,7 +79,7 @@ export async function runVisitorAnalyticsPurge(
       break;
     }
 
-    const result = await withTenant(sql, tenant.id, (tx) =>
+    const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
       purgeVisitorAnalyticsData(
         tx,
         tenant.id,

--- a/scripts/visitor-analytics-rollup.ts
+++ b/scripts/visitor-analytics-rollup.ts
@@ -20,7 +20,7 @@
  * `--dry-run` reports the tenant count without writing any rollup row.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import {
   applyJobExitCode,
   formatJobOutcomeLine,
@@ -94,7 +94,7 @@ export async function runVisitorAnalyticsRollup(
       break;
     }
 
-    const result = await withTenant(sql, tenant.id, (tx) =>
+    const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
       rollupVisitorAnalyticsForDate(tx, tenant.id, date)
     );
 

--- a/scripts/work-class-registry-generate.ts
+++ b/scripts/work-class-registry-generate.ts
@@ -50,8 +50,14 @@ const ROUTES_ROOT = "src/pages/api";
 const SCRIPTS_ROOT = "scripts";
 export const REGISTRY_PATH = "docs/awcms/work-class-registry.generated.json";
 
-/** `withTenant(` and `withTenant<T>(` — the generic form is what the factory itself writes. */
-const WITH_TENANT_CALL = /\bwithTenant\s*(?:<[^()]*>)?\s*\(/;
+/**
+ * `withTenant(`, `withTenant<T>(` (the generic form is what the factory itself
+ * writes), and `withTenantOrThrow(`. Both names open the same tenant
+ * transaction through the same pool gate, so both declare a work class and
+ * both belong in the registry — a pattern that matched only one of them would
+ * make a route or job disappear from the snapshot by renaming its call.
+ */
+const WITH_TENANT_CALL = /\bwithTenant(?:OrThrow)?\s*(?:<[^()]*>)?\s*\(/;
 const DEFINE_TENANT_ROUTE_CALL = /\bdefineTenantRoute\s*(?:<[^()]*>)?\s*\(/;
 const WORK_CLASS_LITERAL = /workClass\s*:\s*"([a-z_]+)"/g;
 

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -71,7 +71,7 @@ import ThemeToggle from "../components/ThemeToggle.astro";
 import SyncIndicator from "../components/SyncIndicator.astro";
 import LocaleBadge from "../components/LocaleBadge.astro";
 import { getDatabaseClient } from "../lib/database/client";
-import { withTenant } from "../lib/database/tenant-context";
+import { withTenantOrThrow } from "../lib/database/tenant-context";
 import { fetchSyncIndicatorActive } from "../modules/reporting/application/sync-indicator";
 import { fetchTenantModuleEntries } from "../modules/module-management/application/tenant-module-lifecycle";
 import {
@@ -146,7 +146,7 @@ let arrangement: SidebarArrangement = { types: [], items: [] };
 
 try {
   const sql = getDatabaseClient();
-  const chrome = await withTenant(sql, ssr.tenantId, async (tx) => {
+  const chrome = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
     const rows = (await tx`
       SELECT tenant_name FROM awcms_tenants WHERE id = ${ssr.tenantId}
     `) as Array<{ tenant_name: string | null }>;

--- a/src/lib/auth/ssr-session.ts
+++ b/src/lib/auth/ssr-session.ts
@@ -57,11 +57,12 @@ export async function resolveSsrContext(
     });
 
     // When the DB circuit breaker is open / a work-class queue is saturated,
-    // `withTenant` returns a `503` `Response` (cast to the callback's return
-    // type) instead of running the callback. For SSR session resolution that
-    // means "can't confirm the session right now" — degrade to unauthenticated
-    // (the SSR guard then redirects to /login) rather than leaking a Response
-    // where an SsrContext is expected.
+    // `withTenant` answers with a `503` `Response` instead of running the
+    // callback — which the return type now says out loud, so this branch is
+    // checked rather than remembered. For SSR session resolution it means
+    // "can't confirm the session right now": degrade to unauthenticated (the
+    // SSR guard then redirects to /login) rather than leak a `Response` where
+    // an `SsrContext` is expected.
     if (result instanceof Response) return null;
 
     return result;

--- a/src/lib/database/tenant-context.ts
+++ b/src/lib/database/tenant-context.ts
@@ -74,39 +74,93 @@ export type WithTenantOptions = {
 };
 
 /**
+ * Thrown by `withTenantOrThrow` when the transaction was REFUSED before `fn`
+ * ever ran — the circuit breaker was open, or the work class's bounded queue
+ * rejected/timed out. Carries everything the HTTP shape carries, so a caller
+ * that does sit on a request path can still answer `503` + `Retry-After`.
+ *
+ * The distinction that matters to a worker: this is "the database declined to
+ * start the work", never "the work ran and found nothing". Those two are the
+ * same value under the old `as T` cast, and that is the bug this type exists
+ * to make unrepresentable.
+ */
+export class DatabaseBusyError extends Error {
+  readonly code = "DATABASE_BUSY";
+  readonly workClass: WorkClass;
+  readonly retryAfterSeconds: number;
+  /**
+   * The very `503` {@link withTenant} would have returned for this refusal —
+   * carried rather than rebuilt, so a caller on a request path that catches
+   * this error answers with the identical status, body and `Retry-After` and
+   * the two forms cannot drift apart.
+   */
+  readonly response: Response;
+
+  constructor(
+    message: string,
+    workClass: WorkClass,
+    retryAfterSeconds: number,
+    response: Response
+  ) {
+    super(message);
+    this.name = "DatabaseBusyError";
+    this.workClass = workClass;
+    this.retryAfterSeconds = retryAfterSeconds;
+    this.response = response;
+  }
+}
+
+/**
+ * What the shared core produced. `rejected` covers every path that answers the
+ * CALLER without running `fn` to completion: the two saturation refusals and
+ * the idempotency race. Each carries both the HTTP form (for `withTenant`) and
+ * the cause (for `withTenantOrThrow`), so neither wrapper has to reconstruct
+ * what the other one knows.
+ */
+type TenantWorkOutcome<T> =
+  | { status: "ok"; value: T }
+  | { status: "rejected"; response: Response; cause: RejectionCause };
+
+type RejectionCause =
+  | { kind: "busy"; message: string; retryAfterSeconds: number }
+  | { kind: "idempotency"; error: IdempotencyRaceLostError };
+
+/**
  * Runs `fn` inside a tenant-scoped transaction, protected by the Issue 10.2
  * pool gate + circuit breaker (doc 16). This is the single highest-leverage
- * integration point: every existing endpoint already calls `withTenant`, so
- * extending it here protects all of them without touching ~25 route files.
+ * integration point: every existing endpoint already calls it, so extending it
+ * here protects all of them without touching ~25 route files.
  *
- * `T` is generic for backward compatibility, but in practice every real call
- * site uses `T = Response` (every existing endpoint returns the result of
- * `withTenant` directly from its handler, matching how Issue 8.1/9.1's
- * endpoints already implicitly assume this). The `fail(...)` calls below are
- * therefore cast to `T` — this is type-safe in practice, even though the
- * generic signature doesn't statically enforce `T = Response`.
+ * Private, because its return type is the honest one and therefore awkward:
+ * both public wrappers exist to turn `TenantWorkOutcome` into the shape their
+ * own callers can actually handle.
  */
-export async function withTenant<T>(
+async function runTenantWork<T>(
   sql: Bun.SQL,
   tenantId: string,
   fn: (tx: Bun.TransactionSQL) => Promise<T>,
   options?: WithTenantOptions
-): Promise<T> {
+): Promise<TenantWorkOutcome<T>> {
   const safeTenantId = assertUuid(tenantId);
   const workClass = options?.workClass ?? "interactive";
   const queueTimeoutMs = options?.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS;
   const breaker = getDatabaseCircuitBreaker();
   const now = new Date();
 
+  const busy = (message: string, retryAfterSeconds: number) =>
+    ({
+      status: "rejected",
+      response: fail(503, "DATABASE_BUSY", message, {}, undefined, {
+        "Retry-After": String(retryAfterSeconds)
+      }),
+      cause: { kind: "busy", message, retryAfterSeconds }
+    }) satisfies TenantWorkOutcome<T>;
+
   if (!breaker.canAttempt(now)) {
-    return fail(
-      503,
-      "DATABASE_BUSY",
+    return busy(
       "Database circuit breaker is open.",
-      {},
-      undefined,
-      { "Retry-After": String(CIRCUIT_OPEN_RETRY_AFTER_SECONDS) }
-    ) as T;
+      CIRCUIT_OPEN_RETRY_AFTER_SECONDS
+    );
   }
 
   let slot;
@@ -126,14 +180,10 @@ export async function withTenant<T>(
         saturation: getWorkClassSaturation()
       });
 
-      return fail(
-        503,
-        "DATABASE_BUSY",
+      return busy(
         `Database work-class "${workClass}" queue is full; rejected immediately.`,
-        {},
-        undefined,
-        { "Retry-After": String(WORK_CLASS_BUSY_RETRY_AFTER_SECONDS) }
-      ) as T;
+        WORK_CLASS_BUSY_RETRY_AFTER_SECONDS
+      );
     }
 
     if (error instanceof WorkClassTimeoutError) {
@@ -144,14 +194,10 @@ export async function withTenant<T>(
         saturation: getWorkClassSaturation()
       });
 
-      return fail(
-        503,
-        "DATABASE_BUSY",
+      return busy(
         `Database work-class "${workClass}" is saturated.`,
-        {},
-        undefined,
-        { "Retry-After": String(WORK_CLASS_BUSY_RETRY_AFTER_SECONDS) }
-      ) as T;
+        WORK_CLASS_BUSY_RETRY_AFTER_SECONDS
+      );
     }
 
     throw error;
@@ -166,7 +212,7 @@ export async function withTenant<T>(
 
     breaker.recordSuccess(new Date());
 
-    return result;
+    return { status: "ok", value: result };
   } catch (error) {
     if (error instanceof IdempotencyRaceLostError) {
       // Benign concurrency outcome, not a database/infra failure — skip the
@@ -179,21 +225,23 @@ export async function withTenant<T>(
         replayed: error.replay !== null
       });
 
-      if (error.replay) {
+      return {
+        status: "rejected",
         // Same key + same request hash as the winner — honor the ordinary
         // "hash sama -> replay" rule even under the race, instead of forcing
         // a same-payload retry into a 409 it wouldn't have gotten had it lost
         // the race by a few milliseconds less.
-        return jsonResponse(error.replay.responseBody, {
-          status: error.replay.responseStatus
-        }) as T;
-      }
-
-      return fail(
-        409,
-        "IDEMPOTENCY_CONFLICT",
-        "Idempotency-Key was already used with a different request."
-      ) as T;
+        response: error.replay
+          ? jsonResponse(error.replay.responseBody, {
+              status: error.replay.responseStatus
+            })
+          : fail(
+              409,
+              "IDEMPOTENCY_CONFLICT",
+              "Idempotency-Key was already used with a different request."
+            ),
+        cause: { kind: "idempotency", error }
+      };
     }
 
     if (isPostgresClientInputError(error)) {
@@ -210,4 +258,83 @@ export async function withTenant<T>(
   } finally {
     slot.release();
   }
+}
+
+/**
+ * The request-path form. A refusal comes back AS the `503`/`409` `Response` it
+ * should be sent as, so the ~390 handlers whose `fn` already returns a
+ * `Response` are unchanged: `Response | Response` is `Response`.
+ *
+ * ## Why the return type grew a `| Response`
+ *
+ * The signature used to be `Promise<T>`, and the header said "in practice
+ * every real call site uses `T = Response`". That stopped being true long
+ * before anyone noticed, and the `as T` casts handed a refusal back as a value
+ * of whatever type the caller asked for — invisibly, since a cast is precisely
+ * the instruction "stop checking".
+ *
+ * The damage was not hypothetical. `purgeExpiredAuditEvents` declares
+ * `Promise<number>`; under a saturated `maintenance` class (ONE slot) it
+ * returned a `Response`. `runBoundedBatches` loops "until a pass returns
+ * `count: 0`" — and a `Response` is never `=== 0`, so a job whose entire
+ * purpose is to back off ran its full 50 passes per tenant AGAINST AN
+ * ALREADY-REFUSING DATABASE, then reported `totalCount` as the string
+ * `"0[object Response]…"`, because `number + Response` is concatenation.
+ * Backpressure inverted into load, and the run reported success.
+ *
+ * A handler whose `fn` returns data now has to narrow, and narrowing is also
+ * the fix — `if (result instanceof Response) return result;` forwards the
+ * `503` with its `Retry-After` intact. Callers that are not serving a request
+ * want {@link withTenantOrThrow}: for them a `Response` is not an answer, and
+ * discarding an ignored return value would put the hole straight back.
+ */
+export async function withTenant<T>(
+  sql: Bun.SQL,
+  tenantId: string,
+  fn: (tx: Bun.TransactionSQL) => Promise<T>,
+  options?: WithTenantOptions
+): Promise<T | Response> {
+  const outcome = await runTenantWork(sql, tenantId, fn, options);
+
+  return outcome.status === "ok" ? outcome.value : outcome.response;
+}
+
+/**
+ * The form for everything that is not an HTTP handler — workers, scheduled
+ * jobs, SSR page frontmatter, tenant resolvers, test fixtures. `fn`'s value
+ * comes back as `T` and nothing else ever does: a refusal throws.
+ *
+ * Throwing is the correct shape for these callers, not a lesser one. A job
+ * runner already classifies a thrown error as a retryable failure with
+ * backoff, which is precisely what "the database is shedding load" should
+ * mean; the alternative — a value the caller silently mistakes for an empty
+ * result — is how a purge that ran zero times reports that it drained the
+ * backlog.
+ *
+ * `IdempotencyRaceLostError` is re-thrown rather than converted. Idempotency
+ * keys are a request-scoped concern; a caller that is not serving a request
+ * has no use for the `409` and should see the original error.
+ */
+export async function withTenantOrThrow<T>(
+  sql: Bun.SQL,
+  tenantId: string,
+  fn: (tx: Bun.TransactionSQL) => Promise<T>,
+  options?: WithTenantOptions
+): Promise<T> {
+  const outcome = await runTenantWork(sql, tenantId, fn, options);
+
+  if (outcome.status === "ok") {
+    return outcome.value;
+  }
+
+  if (outcome.cause.kind === "idempotency") {
+    throw outcome.cause.error;
+  }
+
+  throw new DatabaseBusyError(
+    outcome.cause.message,
+    options?.workClass ?? "interactive",
+    outcome.cause.retryAfterSeconds,
+    outcome.response
+  );
 }

--- a/src/lib/database/work-class-registry.ts
+++ b/src/lib/database/work-class-registry.ts
@@ -87,7 +87,7 @@ export const JOB_WORK_CLASS_REGISTRY: Readonly<
   "scripts/domain-events-dispatch.ts": {
     workClass: "background_sync",
     rationale:
-      'Outbox dispatcher (domain-events:dispatch, Issue #742), recommended every 30-60 seconds — same recurring dispatcher profile as email/object-sync/social-publish dispatch; its own internal withTenant calls already pass workClass: "background_sync" explicitly.'
+      'Outbox dispatcher (domain-events:dispatch, Issue #742), recommended every 30-60 seconds — same recurring dispatcher profile as email/object-sync/social-publish dispatch; its own internal withTenantOrThrow calls already pass workClass: "background_sync" explicitly.'
   },
   "scripts/blog-scheduled-publish.ts": {
     workClass: "background_sync",
@@ -102,12 +102,12 @@ export const JOB_WORK_CLASS_REGISTRY: Readonly<
   "scripts/data-lifecycle-archive-purge.ts": {
     workClass: "maintenance",
     rationale:
-      'Scheduled bounded archive/purge (data-lifecycle:archive-purge, Issue #745) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/form-draft-purge; every withTenant call inside archive-purge-job.ts already passes workClass: "maintenance" explicitly.'
+      'Scheduled bounded archive/purge (data-lifecycle:archive-purge, Issue #745) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/form-draft-purge; every withTenantOrThrow call inside archive-purge-job.ts already passes workClass: "maintenance" explicitly.'
   },
   "scripts/identity-access-business-scope-expiry.ts": {
     workClass: "maintenance",
     rationale:
-      'Scheduled expiry sweep for business-scope assignments/SoD conflict exceptions (identity-access:business-scope:expiry, Issue #746) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenant call inside business-scope-expiry-job.ts already passes workClass: "maintenance" explicitly.'
+      'Scheduled expiry sweep for business-scope assignments/SoD conflict exceptions (identity-access:business-scope:expiry, Issue #746) — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenantOrThrow call inside business-scope-expiry-job.ts already passes workClass: "maintenance" explicitly.'
   },
   "scripts/workflow-escalations-dispatch.ts": {
     workClass: "background_sync",
@@ -117,7 +117,7 @@ export const JOB_WORK_CLASS_REGISTRY: Readonly<
   "scripts/reporting-projections-refresh.ts": {
     workClass: "maintenance",
     rationale:
-      'Incremental cursor_table projection updates + rebuild-continuation sweep (reporting:projections:refresh, Issue #753), recommended every 2 minutes — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenant call inside projection-incremental-worker.ts/projection-rebuild.ts already passes workClass: "maintenance" explicitly.'
+      'Incremental cursor_table projection updates + rebuild-continuation sweep (reporting:projections:refresh, Issue #753), recommended every 2 minutes — same tolerant-of-delay, never-latency-sensitive profile as audit-log-purge/data-lifecycle-archive-purge; every withTenantOrThrow call inside projection-incremental-worker.ts/projection-rebuild.ts already passes workClass: "maintenance" explicitly.'
   },
   "scripts/reporting-exports-dispatch.ts": {
     workClass: "maintenance",

--- a/src/lib/jobs/retry-classification.ts
+++ b/src/lib/jobs/retry-classification.ts
@@ -25,7 +25,13 @@
  * (class `08`), insufficient-resources (class `53`), and operator
  * intervention (class `57`, e.g. `57P03` cannot_connect_now during a
  * restart) as retryable — transient infra conditions, not data problems.
+ *
+ * `DatabaseBusyError` is imported rather than duplicated, unlike the SQLSTATE
+ * lists above: it is an exported type with one construction site, so there is
+ * no internal detail to leak and nothing that could drift out of step.
  */
+import { DatabaseBusyError } from "../database/tenant-context";
+
 export type RetryClassification = "retryable" | "not_retryable" | "unknown";
 
 /** Specific SQLSTATEs known to be safe/expected to retry, regardless of class. */
@@ -57,6 +63,14 @@ const RETRYABLE_NETWORK_ERROR_PATTERN =
  * "we don't have a rule for this yet".
  */
 export function classifyError(error: unknown): RetryClassification {
+  // The database itself declined to start the work and named a `Retry-After`.
+  // Nothing about the job's own data is wrong, so this is the most clearly
+  // retryable condition the runner can see — and it must not fall through to
+  // `"unknown"`, which is what an operator reads as "no rule for this yet".
+  if (error instanceof DatabaseBusyError) {
+    return "retryable";
+  }
+
   if (error instanceof Bun.SQL.PostgresError) {
     const sqlstate = String(error.errno ?? error.code ?? "");
 

--- a/src/modules/blog-content/application/blog-scheduled-publish.ts
+++ b/src/modules/blog-content/application/blog-scheduled-publish.ts
@@ -1,5 +1,5 @@
 import { enqueueModuleContentPurge } from "../../../lib/edge-cache/content-purge";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
 import { recordAuditEvent } from "../../logging/application/audit-log";
 import { fetchPostTermIds } from "./blog-taxonomy-directory";
@@ -102,7 +102,7 @@ export async function publishDueScheduledPosts(
   const now = options.now ?? new Date();
   const correlationId = options.correlationId;
 
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {

--- a/src/modules/comments/application/public-comments-tenant-resolution.ts
+++ b/src/modules/comments/application/public-comments-tenant-resolution.ts
@@ -9,7 +9,7 @@
  * response by the caller — never leak WHY), cost-normalized against a timing
  * side-channel.
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   resolvePublicTenantFromRequest,
   type PublicHostResolverConfig,
@@ -57,7 +57,7 @@ export async function padUnresolvedCommentsTenantLatency(
   sql: Bun.SQL,
   _env: NodeJS.ProcessEnv = process.env
 ): Promise<void> {
-  await withTenant(sql, TIMING_PAD_TENANT_ID, async (tx) => {
+  await withTenantOrThrow(sql, TIMING_PAD_TENANT_ID, async (tx) => {
     await checkCommentsGate(tx, TIMING_PAD_TENANT_ID);
   });
 }
@@ -81,7 +81,7 @@ export async function withCommentsTenant<T>(
     return null;
   }
 
-  return withTenant(sql, tenant.tenantId, async (tx) => {
+  return withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
     const { enabled, settings } = await checkCommentsGate(tx, tenant.tenantId);
     if (!enabled) return null;
     return handler(tx, tenant, settings);

--- a/src/modules/data-lifecycle/application/archive-purge-job.ts
+++ b/src/modules/data-lifecycle/application/archive-purge-job.ts
@@ -60,7 +60,7 @@
  * hold created between passes takes effect on the very next pass, not just the
  * next invocation.
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   fetchActiveTenants,
   runBoundedBatches,
@@ -139,7 +139,7 @@ async function runGenericArchivePass(
   );
   const cursorColumn = assertSafeIdentifier(descriptor.cursorColumn, "column");
 
-  const selection = await withTenant(
+  const selection = await withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -183,7 +183,7 @@ async function runGenericArchivePass(
   }
 
   if (selection.rows.length === 0) {
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       (tx) =>
@@ -210,7 +210,7 @@ async function runGenericArchivePass(
     cursorRangeEnd: newCursorValue
   });
 
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -266,7 +266,7 @@ async function runGenericPurgePass(
   );
   const cursorColumn = assertSafeIdentifier(descriptor.cursorColumn, "column");
 
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -404,7 +404,7 @@ export async function runDataLifecycleArchivePurge(
       break;
     }
 
-    const activeHolds: LegalHoldRecord[] = await withTenant(
+    const activeHolds: LegalHoldRecord[] = await withTenantOrThrow(
       sql,
       tenant.id,
       (tx) => fetchActiveLegalHoldsForPlanning(tx, tenant.id),
@@ -413,7 +413,7 @@ export async function runDataLifecycleArchivePurge(
 
     for (const descriptor of delegatedDescriptors) {
       const startedAt = new Date();
-      const snapshot = await withTenant(
+      const snapshot = await withTenantOrThrow(
         sql,
         tenant.id,
         (tx) =>
@@ -422,7 +422,7 @@ export async function runDataLifecycleArchivePurge(
       );
       totalDryRunEligible += snapshot.eligibleCount;
 
-      await withTenant(
+      await withTenantOrThrow(
         sql,
         tenant.id,
         (tx) =>
@@ -456,7 +456,7 @@ export async function runDataLifecycleArchivePurge(
       // re-fetches holds fresh inside every single batch pass
       // (`runGenericArchivePass`/`runGenericPurgePass` themselves) — see the
       // TOCTOU fix comment on those functions.
-      const snapshot = await withTenant(
+      const snapshot = await withTenantOrThrow(
         sql,
         tenant.id,
         (tx) =>
@@ -507,7 +507,7 @@ export async function runDataLifecycleArchivePurge(
         tenantsHitPassLimit.push(tenant.id);
       }
 
-      await withTenant(
+      await withTenantOrThrow(
         sql,
         tenant.id,
         (tx) =>

--- a/src/modules/domain-event-runtime/application/dispatch-domain-events.ts
+++ b/src/modules/domain-event-runtime/application/dispatch-domain-events.ts
@@ -1,4 +1,4 @@
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { sanitizeErrorForLog } from "../../../lib/logging/error-sanitizer";
 import { log } from "../../../lib/logging/logger";
 import {
@@ -71,7 +71,7 @@ async function isConsumerPaused(
   tenantId: string,
   consumerName: string
 ): Promise<boolean> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -93,7 +93,7 @@ async function selectHeadOfLineDeliveries(
   now: Date,
   limit: number
 ): Promise<HeadOfLineCandidate[]> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -147,7 +147,7 @@ async function recordDeliveryFailure(
   now: Date,
   correlationId: string
 ): Promise<"retried" | "dead_letter" | "superseded"> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -233,7 +233,7 @@ async function processOneDelivery(
   fallbackCorrelationId: string
 ): Promise<ProcessDeliveryOutcome> {
   try {
-    const outcome = await withTenant(
+    const outcome = await withTenantOrThrow(
       sql,
       tenantId,
       async (tx) => {
@@ -430,7 +430,7 @@ export async function recordDomainEventBacklogGauges(
   sql: Bun.SQL,
   tenantId: string
 ): Promise<void> {
-  const rows = await withTenant(
+  const rows = await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => tx`

--- a/src/modules/email/application/email-dispatch.ts
+++ b/src/modules/email/application/email-dispatch.ts
@@ -33,7 +33,7 @@
  * feature-flag rule: provider off never touches the provider at all).
  */
 import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
 import { fetchActiveEmailTemplateByKey } from "./email-template-directory";
 import { resolveEmailSendMaxRetries } from "../domain/email-config";
@@ -131,7 +131,7 @@ async function claimEligibleEntries(
     now.getTime() + EMAIL_DISPATCH_LEASE_MINUTES * 60_000
   );
 
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -194,7 +194,7 @@ async function recordDeliveryAttempt(
   providerResponseSnippet: string | null,
   errorMessage: string | null
 ): Promise<void> {
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => tx`
@@ -218,7 +218,7 @@ async function finalizeSent(
   providerName: string,
   providerMessageId: string | undefined
 ): Promise<void> {
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => tx`
@@ -246,7 +246,7 @@ async function finalizeSuppressed(
   tenantId: string,
   id: string
 ): Promise<void> {
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => tx`
@@ -274,7 +274,7 @@ async function finalizeFailure(
     : { eligible: false as const };
 
   if (evaluation.eligible) {
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => tx`
@@ -289,7 +289,7 @@ async function finalizeFailure(
     return { eligible: true };
   }
 
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => tx`
@@ -329,7 +329,7 @@ function createTemplateLoader(
       return cached;
     }
 
-    const template = await withTenant(
+    const template = await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => fetchActiveEmailTemplateByKey(tx, tenantId, templateKey),
@@ -402,7 +402,7 @@ export async function dispatchEmailQueue(
   const fromName = options.fromName ?? env.EMAIL_FROM_NAME ?? "";
   const renderLocale = await fetchTenantDefaultLocale(sql, tenantId);
   const loadTemplate = createTemplateLoader(sql, tenantId);
-  const suppressedHashes = await withTenant(
+  const suppressedHashes = await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => fetchSuppressedRecipientHashes(tx, tenantId),

--- a/src/modules/form-drafts/application/form-draft-purge.ts
+++ b/src/modules/form-drafts/application/form-draft-purge.ts
@@ -1,4 +1,4 @@
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { recordAuditEvent } from "../../logging/application/audit-log";
 import { FORM_DRAFTS_LIFECYCLE_KEY } from "../module";
 import type { LegalHoldGuardPort } from "../../_shared/ports/legal-hold-guard-port";
@@ -65,7 +65,7 @@ export async function expireOverdueFormDrafts(
   const now = options.now ?? new Date();
   const batchLimit = options.batchLimit ?? FORM_DRAFT_PURGE_BATCH_LIMIT;
 
-  const expiredCount = await withTenant(
+  const expiredCount = await withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -130,7 +130,7 @@ export async function purgeExpiredFormDrafts(
   const now = options.now ?? new Date();
   const cutoff = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
 
-  const purgedCount = await withTenant(
+  const purgedCount = await withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {

--- a/src/modules/identity-access/application/business-scope-expiry-job.ts
+++ b/src/modules/identity-access/application/business-scope-expiry-job.ts
@@ -33,7 +33,7 @@
  * immediately regardless of when this job runs.
  */
 import { recordAuditEvent } from "../../logging/application/audit-log";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   recordCounter,
   recordGauge
@@ -56,7 +56,7 @@ async function expireAssignmentsPass(
   tenantId: string,
   now: Date
 ): Promise<ExpiryPassResult> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -110,7 +110,7 @@ async function expireSoDConflictExceptionsPass(
   tenantId: string,
   now: Date
 ): Promise<ExpiryPassResult> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -170,7 +170,7 @@ async function refreshAssignmentGauges(
   sql: Bun.SQL,
   tenantId: string
 ): Promise<void> {
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -215,7 +215,7 @@ async function countExpiredBacklogForTenant(
   tenantId: string,
   now: Date
 ): Promise<{ assignments: number; exceptions: number }> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {

--- a/src/modules/identity-access/application/tenant-sso.ts
+++ b/src/modules/identity-access/application/tenant-sso.ts
@@ -56,7 +56,7 @@ import {
   type OAuthRequestDenyReason
 } from "../domain/oidc-policy";
 import { isAutoLinkAllowedForProvider } from "../domain/tenant-sso-policy";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolveChallengeTtlSec } from "../../../lib/auth/mfa-config";
 import { createMfaChallenge, findActiveMfaFactor } from "./mfa";
 import {
@@ -629,7 +629,7 @@ export async function completeTenantSsoCallback(
 
   // Resolve the provider first (need its id to look up the state row keyed by
   // provider_id, and to re-check enabled).
-  const provider = await withTenant(sql, tenantId, (tx) =>
+  const provider = await withTenantOrThrow(sql, tenantId, (tx) =>
     fetchAuthProviderRowByKey(tx, tenantId, providerKey)
   );
 
@@ -639,7 +639,7 @@ export async function completeTenantSsoCallback(
 
   const providerId = provider.id;
 
-  const consumeResult = await withTenant(sql, tenantId, (tx) =>
+  const consumeResult = await withTenantOrThrow(sql, tenantId, (tx) =>
     consumeSsoOAuthRequest(tx, tenantId, providerId, token, now)
   );
 
@@ -701,7 +701,7 @@ export async function completeTenantSsoCallback(
     return { outcome: "error", code: verifyResult.code };
   }
 
-  const finalResult = await withTenant(sql, tenantId, async (tx) => {
+  const finalResult = await withTenantOrThrow(sql, tenantId, async (tx) => {
     if (consumeResult.purpose === "link") {
       const linkIdentityId = consumeResult.identityId;
 

--- a/src/modules/logging/application/audit-purge.ts
+++ b/src/modules/logging/application/audit-purge.ts
@@ -1,4 +1,4 @@
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { recordAuditEvent } from "./audit-log";
 import { LOGGING_AUDIT_EVENTS_LIFECYCLE_KEY } from "../module";
 import type { LegalHoldGuardPort } from "../../_shared/ports/legal-hold-guard-port";
@@ -122,7 +122,7 @@ export async function purgeExpiredAuditEvents(
   const now = options.now ?? new Date();
   const cutoff = resolveAuditRetentionCutoff(now, retentionDays);
 
-  const purgedCount = await withTenant(
+  const purgedCount = await withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -196,7 +196,7 @@ export async function countPurgeableAuditEvents(
   tenantId: string,
   cutoff: Date
 ): Promise<number> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {

--- a/src/modules/media-library/application/media-finalize-upload-session.ts
+++ b/src/modules/media-library/application/media-finalize-upload-session.ts
@@ -39,7 +39,10 @@
  * forever.
  */
 import { fail, jsonResponse, ok } from "../../_shared/api-response";
-import { withTenant } from "../../../lib/database/tenant-context";
+import {
+  withTenant,
+  withTenantOrThrow
+} from "../../../lib/database/tenant-context";
 import { authorizeInTransaction } from "../../identity-access/application/access-guard";
 import { log } from "../../../lib/logging/logger";
 import { recordAuditEvent } from "../../logging/application/audit-log";
@@ -234,6 +237,13 @@ export async function finalizeNewsMediaUploadSession(
     }
   );
 
+  // The pool gate refused before `fn` ever ran (`503 DATABASE_BUSY`, or the
+  // idempotency race's own answer). Forwarded as-is: it is already the exact
+  // response this endpoint should send, `Retry-After` included.
+  if (precheck instanceof Response) {
+    return precheck;
+  }
+
   if (precheck.kind === "response") {
     return precheck.response;
   }
@@ -255,7 +265,7 @@ export async function finalizeNewsMediaUploadSession(
   // fails, that failure is only logged — it never masks/replaces the
   // caller's own error path.
   const revertClaim = async () => {
-    await withTenant(sql, tenantId, (tx) =>
+    await withTenantOrThrow(sql, tenantId, (tx) =>
       revertNewsMediaObjectUploadClaim(tx, tenantId, precheck.objectId)
     ).catch((revertError) => {
       log("error", "news-portal.upload-session.finalize.revert_claim_failed", {

--- a/src/modules/media-library/application/media-reconciliation.ts
+++ b/src/modules/media-library/application/media-reconciliation.ts
@@ -72,7 +72,7 @@
  * for one candidate is deferred (counted, logged, left for the next run) —
  * it never aborts the rest of that tenant's cleanup loop.
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { fetchActiveTenants } from "../../../lib/jobs/batching";
 import {
   categorizeNewsMediaReconciliation,
@@ -235,7 +235,7 @@ async function cleanupExpiredPending(
       // already moved this row out of pending_upload/uploaded, the guarded
       // UPDATE matches zero rows and we skip it entirely: never touch R2
       // for a row that is genuinely still in flight.
-      const claimed = await withTenant(
+      const claimed = await withTenantOrThrow(
         sql,
         tenantId,
         (tx) =>
@@ -258,7 +258,7 @@ async function cleanupExpiredPending(
       continue;
     }
 
-    const purged = await withTenant(
+    const purged = await withTenantOrThrow(
       sql,
       tenantId,
       (tx) =>
@@ -304,7 +304,7 @@ async function cleanupStaleOrphaned(
       continue;
     }
 
-    const softDeleted = await withTenant(
+    const softDeleted = await withTenantOrThrow(
       sql,
       tenantId,
       (tx) =>
@@ -345,7 +345,7 @@ async function cleanupOrphanInR2(
     // `objectKeyExistsForTenant` header for exactly why this MUST be a
     // fresh, targeted point lookup immediately before deleting, not a reuse
     // of the earlier bulk snapshot.
-    const stillOrphan = !(await withTenant(
+    const stillOrphan = !(await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => objectKeyExistsForTenant(tx, tenantId, entry.objectKey),
@@ -390,7 +390,7 @@ export async function reconcileNewsMediaForTenant(
   const dryRun = options.dryRun ?? false;
   const signal = options.signal;
 
-  const snapshotRows = await withTenant(
+  const snapshotRows = await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => fetchNewsMediaObjectsForReconciliation(tx, tenantId),

--- a/src/modules/reporting/application/export-generation.ts
+++ b/src/modules/reporting/application/export-generation.ts
@@ -11,7 +11,7 @@
  * silence (same "freshness must reflect reality" principle this issue
  * applies to projections applies here too).
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import type { ProjectionDescriptor } from "../../_shared/module-contract";
 import { getProjectionMetrics } from "./projection-metric-store";
 import { recordExportRun, type ExportRunRow } from "./export-run-store";
@@ -48,7 +48,7 @@ export async function generateProjectionExport(
   input: GenerateExportInput,
   env: NodeJS.ProcessEnv = process.env
 ): Promise<ExportRunRow> {
-  const metrics = await withTenant(sql, input.tenantId, (tx) =>
+  const metrics = await withTenantOrThrow(sql, input.tenantId, (tx) =>
     getProjectionMetrics(tx, input.tenantId, input.descriptor.key)
   );
 
@@ -76,7 +76,7 @@ export async function generateProjectionExport(
       Date.now() + retentionDays * 24 * 60 * 60 * 1000
     );
 
-    return withTenant(sql, input.tenantId, (tx) =>
+    return withTenantOrThrow(sql, input.tenantId, (tx) =>
       recordExportRun(tx, input.tenantId, {
         scheduledExportId: input.scheduledExportId,
         projectionKey: input.descriptor.key,
@@ -94,7 +94,7 @@ export async function generateProjectionExport(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 
-    return withTenant(sql, input.tenantId, (tx) =>
+    return withTenantOrThrow(sql, input.tenantId, (tx) =>
       recordExportRun(tx, input.tenantId, {
         scheduledExportId: input.scheduledExportId,
         projectionKey: input.descriptor.key,

--- a/src/modules/reporting/application/projection-incremental-worker.ts
+++ b/src/modules/reporting/application/projection-incremental-worker.ts
@@ -74,7 +74,7 @@ import type {
   ProjectionCursorStream,
   ProjectionDescriptor
 } from "../../_shared/module-contract";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   fetchActiveTenants,
   runBoundedBatches
@@ -171,7 +171,7 @@ export async function runCursorStreamPass(
   );
   const selectColumns = Array.from(new Set([cursorColumn, ...matchColumns]));
 
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -303,7 +303,7 @@ export async function runIncrementalUpdateForTenant(
       };
     }
 
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => recordProjectionSuccess(tx, tenantId, descriptor.key),
@@ -320,7 +320,7 @@ export async function runIncrementalUpdateForTenant(
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
 
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => recordProjectionFailure(tx, tenantId, descriptor.key, message),

--- a/src/modules/reporting/application/projection-rebuild.ts
+++ b/src/modules/reporting/application/projection-rebuild.ts
@@ -63,7 +63,7 @@
  *    pass and both paths would apply the same delta. See
  *    `projection-lock.ts`'s header for the full argument.
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   fetchActiveTenants,
   runBoundedBatches
@@ -234,7 +234,7 @@ async function runRebuildStreamPass(
   );
   const selectColumns = Array.from(new Set([cursorColumn, ...matchColumns]));
 
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -335,7 +335,7 @@ export async function continueRebuildPasses(
   runId: string,
   maxPasses?: number
 ): Promise<ContinueRebuildResult> {
-  const run = await withTenant(
+  const run = await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => getRebuildRunById(tx, tenantId, runId),
@@ -380,7 +380,7 @@ export async function continueRebuildPasses(
       return { status: "in_progress", rowsProcessedThisInvocation };
     }
 
-    const stillRunning = await withTenant(
+    const stillRunning = await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => getRebuildRunById(tx, tenantId, runId),
@@ -394,7 +394,7 @@ export async function continueRebuildPasses(
       };
     }
 
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => completeRebuildRun(tx, tenantId, runId),
@@ -403,7 +403,7 @@ export async function continueRebuildPasses(
     return { status: "completed", rowsProcessedThisInvocation };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => failRebuildRun(tx, tenantId, runId, message),
@@ -432,7 +432,7 @@ export async function continueAllRunningRebuilds(
 
   for (const tenant of tenants) {
     for (const descriptor of descriptors) {
-      const running = await withTenant(
+      const running = await withTenantOrThrow(
         sql,
         tenant.id,
         (tx) => findRunningRebuild(tx, tenant.id, descriptor.key),

--- a/src/modules/reporting/application/scheduled-export-dispatch.ts
+++ b/src/modules/reporting/application/scheduled-export-dispatch.ts
@@ -7,7 +7,7 @@
  * `generateProjectionExport` a manual `POST .../export` API call uses —
  * no separate/divergent scheduled-only code path.
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { fetchActiveTenants } from "../../../lib/jobs/batching";
 import { generateProjectionExport } from "./export-generation";
 import { findProjectionDescriptor } from "./projection-directory";
@@ -28,7 +28,7 @@ export async function dispatchDueScheduledExports(
   let exportsFailed = 0;
 
   for (const tenant of tenants) {
-    const due = await withTenant(
+    const due = await withTenantOrThrow(
       sql,
       tenant.id,
       (tx) => listDueScheduledExports(tx, tenant.id, now),

--- a/src/modules/seo-distribution/application/public-seo-tenant-resolution.ts
+++ b/src/modules/seo-distribution/application/public-seo-tenant-resolution.ts
@@ -26,7 +26,7 @@
  * resolver — never `blog_content`/`news_portal` internals. The content providers
  * are injected at the route composition root (`src/lib/seo/discovery-providers.ts`).
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   resolvePublicTenantFromRequest,
   type PublicHostResolverConfig,
@@ -78,7 +78,7 @@ async function isSeoDistributionEnabled(
 export async function padUnresolvedSeoTenantLatency(
   sql: Bun.SQL
 ): Promise<void> {
-  await withTenant(sql, TIMING_PAD_TENANT_ID, async (tx) => {
+  await withTenantOrThrow(sql, TIMING_PAD_TENANT_ID, async (tx) => {
     await isSeoDistributionEnabled(tx, TIMING_PAD_TENANT_ID);
   });
 }
@@ -104,7 +104,7 @@ export async function withSeoPublicTenant<T>(
     return null;
   }
 
-  return withTenant(sql, tenant.tenantId, async (tx) => {
+  return withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
     if (!(await isSeoDistributionEnabled(tx, tenant.tenantId))) {
       return null;
     }

--- a/src/modules/seo-distribution/application/redirect-resolution-service.ts
+++ b/src/modules/seo-distribution/application/redirect-resolution-service.ts
@@ -36,7 +36,7 @@
  * never match a locale, only the all-locales (`locale_scope IS NULL`) rules do.
  */
 import { assertSafeRedirectTarget } from "../domain/redirect-target-classification";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
 import {
   normalizePublicHost,
@@ -112,7 +112,7 @@ async function resolveLegacyBlogRedirect(
   const tenant = await resolvePublicTenantByCode(sql, parsed.tenantCode);
   if (!tenant) return null;
 
-  return withTenant(sql, tenant.tenantId, async (tx) => {
+  return withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
     if (!(await isSeoDistributionEnabled(tx, tenant.tenantId))) return null;
 
     const settings = await fetchRedirectSettings(tx, tenant.tenantId);
@@ -164,7 +164,7 @@ async function resolveHostBasedRedirect(
   const requestHost = rawHost ? normalizePublicHost(rawHost) : null;
   const now = options.now ?? new Date();
 
-  return withTenant(sql, tenant.tenantId, async (tx) => {
+  return withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
     if (!(await isSeoDistributionEnabled(tx, tenant.tenantId))) {
       return { kind: "skip" };
     }

--- a/src/modules/seo-distribution/presentation/redirect-middleware.ts
+++ b/src/modules/seo-distribution/presentation/redirect-middleware.ts
@@ -14,7 +14,7 @@
  * SEO composition roots (`discovery-route.ts` / `discovery-providers.ts`).
  */
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
 import { isRedirectEligiblePath } from "../domain/redirect-eligibility";
 import {
@@ -121,7 +121,11 @@ export async function recordPublicNotFound(
       request.headers.get("referer")
     );
 
-    await withTenant(sql, capture.tenantId, async (tx) => {
+    // `withTenantOrThrow`, because this result is DISCARDED. `withTenant`
+    // would hand back a `503` that a bare `await` throws away, and the 404
+    // observation would go unrecorded with nothing said about it — the same
+    // silent-drop shape this whole change exists to remove.
+    await withTenantOrThrow(sql, capture.tenantId, async (tx) => {
       await recordNotFoundObservation(tx, capture.tenantId, {
         normalizedPath: capture.normalizedPath,
         referrerDomain,

--- a/src/modules/site-search/application/public-search-tenant-resolution.ts
+++ b/src/modules/site-search/application/public-search-tenant-resolution.ts
@@ -16,7 +16,7 @@
  * tenant lifecycle (the module registry authority), the neutral tenant resolver,
  * and `site_search`'s own settings table.
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   resolvePublicTenantFromRequest,
   type PublicHostResolverConfig,
@@ -77,7 +77,7 @@ async function checkSiteSearchGate(
 export async function padUnresolvedSearchTenantLatency(
   sql: Bun.SQL
 ): Promise<void> {
-  await withTenant(sql, TIMING_PAD_TENANT_ID, async (tx) => {
+  await withTenantOrThrow(sql, TIMING_PAD_TENANT_ID, async (tx) => {
     await checkSiteSearchGate(tx, TIMING_PAD_TENANT_ID);
   });
 }
@@ -103,7 +103,7 @@ export async function withSiteSearchTenant<T>(
     return null;
   }
 
-  return withTenant(sql, tenant.tenantId, async (tx) => {
+  return withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
     const { enabled, settings } = await checkSiteSearchGate(
       tx,
       tenant.tenantId

--- a/src/modules/sync-storage/application/object-dispatch.ts
+++ b/src/modules/sync-storage/application/object-dispatch.ts
@@ -36,7 +36,7 @@
  * "provider opsional... fitur off tidak menghentikan aplikasi").
  */
 import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
 import { evaluateObjectRetry } from "../domain/object-queue";
 import {
@@ -86,7 +86,7 @@ async function claimEligibleEntries(
     now.getTime() + OBJECT_DISPATCH_LEASE_MINUTES * 60_000
   );
 
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -138,7 +138,7 @@ async function finalizeSent(
   tenantId: string,
   id: string
 ): Promise<void> {
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => tx`
@@ -161,7 +161,7 @@ async function finalizeFailure(
   const evaluation = evaluateObjectRetry(currentRetryCount, now);
 
   if (evaluation.eligible) {
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       (tx) => tx`
@@ -176,7 +176,7 @@ async function finalizeFailure(
     return { eligible: true };
   }
 
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     (tx) => tx`

--- a/src/modules/theming/presentation/theme-preview.ts
+++ b/src/modules/theming/presentation/theme-preview.ts
@@ -13,7 +13,10 @@
  * resolution (unlike the public `/theming/{tenantCode}/tokens.css` stylesheet).
  */
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import {
+  withTenant,
+  withTenantOrThrow
+} from "../../../lib/database/tenant-context";
 import { fetchVersionById } from "../application/theme-config-directory";
 import { findActivePreviewSession } from "../application/theme-preview-directory";
 import { resolveVersionThemeCss } from "../application/theme-render-resolver";
@@ -49,7 +52,11 @@ export async function resolvePreviewContext(
   const sql = getDatabaseClient();
   const tokenHash = hashPreviewToken(parsed.rawToken);
 
-  return withTenant(sql, parsed.tenantId, async (tx) => {
+  // `withTenantOrThrow`, not a narrow-to-null: `null` here means "no such
+  // preview" and the page turns it into a 404. A refused transaction is not
+  // that, and telling an operator their draft expired when the database is
+  // shedding load sends them to debug the wrong thing.
+  return withTenantOrThrow(sql, parsed.tenantId, async (tx) => {
     const session = await findActivePreviewSession(tx, tokenHash, now);
     if (!session) return null;
     const version = await fetchVersionById(
@@ -106,6 +113,10 @@ export async function serveThemePreviewTokensCss(
     return resolveVersionThemeCss(version).css;
   });
 
+  // Same reasoning as `resolvePreviewContext`, expressed the other way: here
+  // the function DOES return a `Response`, so the 503 is simply forwarded
+  // rather than collapsed into the 404 that means "expired".
+  if (css instanceof Response) return css;
   if (css === null) return notFound();
 
   return new Response(css, {

--- a/src/modules/theming/presentation/theme-public-css.ts
+++ b/src/modules/theming/presentation/theme-public-css.ts
@@ -81,7 +81,7 @@ export async function serveActiveThemeTokensCss(
   if (!tenant) {
     resolved = defaultThemeCss();
   } else {
-    resolved = await withTenant(sql, tenant.tenantId, async (tx) => {
+    const lookup = await withTenant(sql, tenant.tenantId, async (tx) => {
       const entry = await fetchTenantModuleEntry(
         tx,
         tenant.tenantId,
@@ -90,6 +90,14 @@ export async function serveActiveThemeTokensCss(
       if (!(entry?.tenantEnabled ?? false)) return defaultThemeCss();
       return resolveActiveThemeCssForTenant(tx, tenant.tenantId);
     });
+
+    // A refused transaction must not become a stylesheet. Falling back to
+    // `defaultThemeCss()` here would be worse than the 503: this response is
+    // CACHEABLE, so one saturated moment would pin the wrong tokens in every
+    // downstream cache for the whole max-age.
+    if (lookup instanceof Response) return lookup;
+
+    resolved = lookup;
   }
 
   const ifNoneMatch = request.headers.get("if-none-match");

--- a/src/modules/visitor-analytics/application/collector.ts
+++ b/src/modules/visitor-analytics/application/collector.ts
@@ -22,7 +22,7 @@
  * created inside its own tenant-scoped transaction, never from a raw
  * client-supplied UUID — closing the cross-tenant existence-oracle risk.
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
 import { isTrackablePath, sanitizePath } from "../domain/path-sanitizer";
 import { extractReferrerDomain } from "../../_shared/referrer";
@@ -248,7 +248,7 @@ export async function collectVisitorTelemetry(
     const rawIpAddress = config.rawIpEnabled ? ipAddress : null;
     const referrerDomain = extractReferrerDomain(referrerHeader);
 
-    await withTenant(
+    await withTenantOrThrow(
       sql,
       tenantId,
       async (tx) => {

--- a/src/modules/workflow-approval/application/workflow-escalation.ts
+++ b/src/modules/workflow-approval/application/workflow-escalation.ts
@@ -15,7 +15,7 @@
  * this function skips it — never double-escalates, and never throws (a
  * lost race is an expected, silent no-op, not a failure).
  */
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   recordCounter,
   recordGauge
@@ -50,7 +50,7 @@ export async function escalateDueTasksForTenant(
   batchLimit: number = DEFAULT_ESCALATION_BATCH_LIMIT,
   correlationId?: string
 ): Promise<EscalateDueTasksResult> {
-  return withTenant(
+  return withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {
@@ -145,7 +145,7 @@ export async function recordWorkflowBacklogGauges(
   tenantId: string,
   now: Date
 ): Promise<void> {
-  await withTenant(
+  await withTenantOrThrow(
     sql,
     tenantId,
     async (tx) => {

--- a/src/pages/admin/abac-policies.astro
+++ b/src/pages/admin/abac-policies.astro
@@ -22,7 +22,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listAbacPolicies,
@@ -47,7 +47,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, (tx) =>
+    const result = await withTenantOrThrow(sql, ssr.tenantId, (tx) =>
       listAbacPolicies(tx, ssr.tenantId)
     );
     if (result instanceof Response) loadError = true;

--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -21,7 +21,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { evaluateFieldAccessInTransaction } from "../../modules/identity-access/application/access-guard";
 import { resolveVisitorAnalyticsConfig } from "../../modules/visitor-analytics/domain/visitor-analytics-config";
@@ -110,7 +110,7 @@ if (canView) {
     const now = new Date();
     const start = resolveRangeStart(range, now);
 
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
       // Resolve raw-detail visibility through ABAC (deny-overrides-allow),
       // reusing the SSR-resolved subject/permissions — only when sessions are
       // shown at all (the sole place raw detail renders). Fail-closed otherwise.

--- a/src/pages/admin/comments.astro
+++ b/src/pages/admin/comments.astro
@@ -31,7 +31,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { listModerationQueue } from "../../modules/comments/application/comment-moderation";
 import type { ModerationQueueItem } from "../../modules/comments/application/comment-moderation";
@@ -76,7 +76,7 @@ let loadFailed = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, (tx) =>
+    const result = await withTenantOrThrow(sql, ssr.tenantId, (tx) =>
       listModerationQueue(tx, ssr.tenantId, {
         status: activeStatus,
         limit: 50

--- a/src/pages/admin/email-templates.astro
+++ b/src/pages/admin/email-templates.astro
@@ -17,7 +17,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { listEmailTemplates } from "../../modules/email/application/email-template-directory";
 import { BASE_EMAIL_TEMPLATE_CATEGORIES } from "../../modules/email/domain/email-template-categories";
@@ -42,7 +42,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
       return (await listEmailTemplates(tx, ssr.tenantId, {
         includeInactive: true
       })) as TemplateRow[];

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -37,7 +37,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { fetchTenantActivityReport } from "../../modules/reporting/application/tenant-activity-report";
 import { fetchAccessAuditReport } from "../../modules/reporting/application/access-audit-report";
@@ -65,7 +65,7 @@ let loadError = false;
 
 if (hasDashboardAccess) {
   try {
-    const result = await withTenant(
+    const result = await withTenantOrThrow(
       getDatabaseClient(),
       ssr.tenantId,
       async (tx) => ({

--- a/src/pages/admin/modules.astro
+++ b/src/pages/admin/modules.astro
@@ -23,7 +23,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { fetchTenantModuleEntries } from "../../modules/module-management/application/tenant-module-lifecycle";
 
@@ -53,7 +53,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
       return (await fetchTenantModuleEntries(tx, ssr.tenantId)) as ModuleRow[];
     });
     if (result instanceof Response) loadError = true;

--- a/src/pages/admin/offices.astro
+++ b/src/pages/admin/offices.astro
@@ -25,7 +25,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listDeletedOffices,
@@ -66,7 +66,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
       const page = await listOffices(tx, ssr.tenantId, null);
       // Only fetch the deleted set for viewers who can act on it (restore is
       // gated on `update`); otherwise it is noise they cannot use.

--- a/src/pages/admin/profiles.astro
+++ b/src/pages/admin/profiles.astro
@@ -10,7 +10,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { listParties } from "../../modules/profile-identity/application/party-directory";
 
@@ -36,7 +36,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
       const page = await listParties(tx, ssr.tenantId, {});
       return page.items as PartyRow[];
     });

--- a/src/pages/admin/registrations.astro
+++ b/src/pages/admin/registrations.astro
@@ -19,7 +19,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { isSelfRegistrationEnabled } from "../../lib/auth/self-registration-config";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { listRoles } from "../../modules/identity-access/application/access-directory";
@@ -49,7 +49,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => ({
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => ({
       requests: await listPendingRegistrations(tx, ssr.tenantId),
       // Only needed to render the optional role picker on the approve control.
       roles: canApprove ? await listRoles(tx, ssr.tenantId) : []

--- a/src/pages/admin/roles.astro
+++ b/src/pages/admin/roles.astro
@@ -20,7 +20,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listRoles,
@@ -60,7 +60,7 @@ function permLabel(p: PermissionCatalogEntry): string {
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
       const liveRoles = await listRoles(tx, ssr.tenantId);
       if (!canConfigure) {
         return {

--- a/src/pages/admin/security.astro
+++ b/src/pages/admin/security.astro
@@ -34,7 +34,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { isMfaFeatureEnabled } from "../../lib/auth/mfa-config";
 import { isSsoEnabled } from "../../lib/auth/sso-config";
 import {
@@ -99,7 +99,7 @@ let loadError = false;
 if (canReadAnything) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => ({
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => ({
       // Each read is gated on its OWN permission, so a caller holding only one
       // of the three does not silently pull the other two into memory.
       policy: canReadPolicy

--- a/src/pages/admin/sidebar-menu.astro
+++ b/src/pages/admin/sidebar-menu.astro
@@ -21,7 +21,7 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { logAdminPageError } from "../../lib/logging/error-log";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
@@ -55,7 +55,7 @@ let loadFailed = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) =>
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) =>
       buildSidebarEditorModel(await fetchSidebarArrangement(tx, ssr.tenantId))
     );
 

--- a/src/pages/admin/tenant/domains.astro
+++ b/src/pages/admin/tenant/domains.astro
@@ -18,7 +18,7 @@
 import AdminLayout from "../../../layouts/AdminLayout.astro";
 import "../../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { permissionKey } from "../../../modules/identity-access/domain/access-control";
 import {
   listTenantDomains,
@@ -58,7 +58,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => {
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
       const page = await listTenantDomains(tx, ssr.tenantId);
       return page.domains;
     });

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -19,7 +19,7 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenant } from "../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
 import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listRoles,
@@ -46,7 +46,7 @@ let loadError = false;
 if (canRead) {
   try {
     const sql = getDatabaseClient();
-    const result = await withTenant(sql, ssr.tenantId, async (tx) => ({
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => ({
       users: await listTenantUsers(tx, ssr.tenantId),
       roles: await listRoles(tx, ssr.tenantId)
     }));

--- a/src/pages/api/v1/auth/login.ts
+++ b/src/pages/api/v1/auth/login.ts
@@ -10,7 +10,10 @@ import {
 } from "../../../../modules/identity-access/application/login-policy";
 import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
 import { getDatabaseClient } from "../../../../lib/database/client";
-import { withTenant } from "../../../../lib/database/tenant-context";
+import {
+  withTenant,
+  withTenantOrThrow
+} from "../../../../lib/database/tenant-context";
 import {
   generateSessionToken,
   hashSessionToken
@@ -188,7 +191,11 @@ async function recordLoginFailureOutOfBand(
   }
 ): Promise<void> {
   try {
-    await withTenant(sql, input.tenantId, async (tx) => {
+    // `withTenantOrThrow`: this whole helper is best-effort and already
+    // wrapped in the `catch` below. With `withTenant` a pool refusal would be
+    // returned as a `503` and then discarded by the bare `await`, so the
+    // failure audit would go unwritten with nothing logged about it.
+    await withTenantOrThrow(sql, input.tenantId, async (tx) => {
       // Re-checked here rather than threaded in: this runs after the login
       // transaction unwound, so nothing it computed can be trusted to still
       // hold. Without it an unknown-tenant header would trip the audit table's

--- a/src/pages/api/v1/auth/sso/[providerKey]/callback.ts
+++ b/src/pages/api/v1/auth/sso/[providerKey]/callback.ts
@@ -2,7 +2,10 @@ import type { APIRoute } from "astro";
 
 import { fail } from "../../../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../../../lib/database/client";
-import { withTenant } from "../../../../../../lib/database/tenant-context";
+import {
+  withTenant,
+  withTenantOrThrow
+} from "../../../../../../lib/database/tenant-context";
 import {
   createSessionWithAssurance,
   setSessionCookies
@@ -89,7 +92,11 @@ export const GET: APIRoute = async ({ cookies, url, params, locals }) => {
   }
 
   if (result.outcome === "mfa_required") {
-    await withTenant(sql, result.tenantId, (tx) =>
+    // `withTenantOrThrow` — a discarded `503` here would drop a security audit
+    // record and still answer as though it had been written. Any OTHER failure
+    // of this same write already propagates; a pool refusal now behaves the
+    // same way instead of being the one failure that passes silently.
+    await withTenantOrThrow(sql, result.tenantId, (tx) =>
       recordAuditEvent(tx, {
         tenantId: result.tenantId,
         moduleKey: "identity_access",
@@ -116,7 +123,7 @@ export const GET: APIRoute = async ({ cookies, url, params, locals }) => {
   }
 
   if (result.outcome === "linked") {
-    await withTenant(sql, result.tenantId, (tx) =>
+    await withTenantOrThrow(sql, result.tenantId, (tx) =>
       recordAuditEvent(tx, {
         tenantId: result.tenantId,
         moduleKey: "identity_access",

--- a/src/pages/api/v1/media/enforcement.ts
+++ b/src/pages/api/v1/media/enforcement.ts
@@ -123,6 +123,13 @@ export const GET: APIRoute = async ({ request, cookies }) => {
     };
   });
 
+  // The pool gate refused before the transaction ran — forward its own
+  // `503 DATABASE_BUSY` (`Retry-After` included) rather than reading fields
+  // off it. Narrowing here is what the widened return type is for.
+  if (result instanceof Response) {
+    return result;
+  }
+
   if (result.kind === "response") {
     return result.response;
   }

--- a/src/pages/api/v1/media/news-images/upload-sessions/index.ts
+++ b/src/pages/api/v1/media/news-images/upload-sessions/index.ts
@@ -135,6 +135,11 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     }
   );
 
+  // Pool-gate refusal — forwarded as-is (see the note on `withTenant`).
+  if (txResult instanceof Response) {
+    return txResult;
+  }
+
   if (txResult.kind === "response") {
     return txResult.response;
   }

--- a/src/pages/api/v1/reports/exports/runs/[id]/download.ts
+++ b/src/pages/api/v1/reports/exports/runs/[id]/download.ts
@@ -82,6 +82,11 @@ export const GET: APIRoute = async ({ request, cookies, params }) => {
     return { ok: true as const, run };
   });
 
+  // Pool-gate refusal — forwarded as-is (see the note on `withTenant`).
+  if (outcome instanceof Response) {
+    return outcome;
+  }
+
   if (!outcome.ok) {
     return outcome.response;
   }

--- a/src/pages/api/v1/reports/exports/trigger.ts
+++ b/src/pages/api/v1/reports/exports/trigger.ts
@@ -137,6 +137,11 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
     return { ok: true as const, actorTenantUserId: auth.context.tenantUserId };
   });
 
+  // Pool-gate refusal — forwarded as-is (see the note on `withTenant`).
+  if (preCheck instanceof Response) {
+    return preCheck;
+  }
+
   if (!preCheck.ok) {
     return preCheck.response;
   }

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import {
@@ -52,7 +52,7 @@ export const GET: APIRoute = async ({ params, url }) => {
       return notFoundHtmlResponse();
     }
 
-    return await withTenant(sql, tenant.tenantId, async (tx) => {
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
         return notFoundHtmlResponse();
       }

--- a/src/pages/blog/[tenantCode]/category/[slug].ts
+++ b/src/pages/blog/[tenantCode]/category/[slug].ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../../lib/database/client";
-import { withTenant } from "../../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../../lib/html/escape";
 import {
@@ -40,7 +40,7 @@ export const GET: APIRoute = async ({ params, url }) => {
 
     const page = parsePageParam(url.searchParams.get("page"));
 
-    return await withTenant(sql, tenant.tenantId, async (tx) => {
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
         return notFoundHtmlResponse();
       }

--- a/src/pages/blog/[tenantCode]/feed.xml.ts
+++ b/src/pages/blog/[tenantCode]/feed.xml.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import {
@@ -44,7 +44,7 @@ export const GET: APIRoute = async ({ params, url }) => {
       return notFoundXmlResponse();
     }
 
-    return await withTenant(sql, tenant.tenantId, async (tx) => {
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
         return notFoundXmlResponse();
       }

--- a/src/pages/blog/[tenantCode]/index.ts
+++ b/src/pages/blog/[tenantCode]/index.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import {
@@ -58,7 +58,7 @@ export const GET: APIRoute = async ({ params, url }) => {
 
     const page = parsePageParam(url.searchParams.get("page"));
 
-    return await withTenant(sql, tenant.tenantId, async (tx) => {
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
         return notFoundHtmlResponse();
       }

--- a/src/pages/blog/[tenantCode]/search.ts
+++ b/src/pages/blog/[tenantCode]/search.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import {
@@ -45,7 +45,7 @@ export const GET: APIRoute = async ({ params, url }) => {
     const cursorParam = url.searchParams.get("cursor");
     const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
 
-    return await withTenant(sql, tenant.tenantId, async (tx) => {
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
         return notFoundHtmlResponse();
       }

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenant } from "../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import {
@@ -39,7 +39,7 @@ export const GET: APIRoute = async ({ params, url }) => {
       return notFoundXmlResponse();
     }
 
-    return await withTenant(sql, tenant.tenantId, async (tx) => {
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
         return notFoundXmlResponse();
       }

--- a/src/pages/blog/[tenantCode]/tag/[slug].ts
+++ b/src/pages/blog/[tenantCode]/tag/[slug].ts
@@ -1,7 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../../lib/database/client";
-import { withTenant } from "../../../../lib/database/tenant-context";
+import { withTenantOrThrow } from "../../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../../lib/html/escape";
 import {
@@ -40,7 +40,7 @@ export const GET: APIRoute = async ({ params, url }) => {
 
     const page = parsePageParam(url.searchParams.get("page"));
 
-    return await withTenant(sql, tenant.tenantId, async (tx) => {
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
       if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
         return notFoundHtmlResponse();
       }

--- a/tests/database-busy-refusal.test.ts
+++ b/tests/database-busy-refusal.test.ts
@@ -1,0 +1,189 @@
+/**
+ * A pool refusal is not a value. This file pins the split between the two
+ * forms, and then reproduces the defect that made the split necessary.
+ *
+ * ## The defect, in the smallest form that still shows it
+ *
+ * `purgeExpiredAuditEvents` is declared `Promise<PurgeAuditEventsResult>` with
+ * a numeric `purgedCount`. Under the old `withTenant<T>(...): Promise<T>` the
+ * `maintenance` class — which has exactly ONE slot — could return a `503`
+ * `Response`, cast to `number` by an `as T` the compiler was instructed not to
+ * question.
+ *
+ * `runBoundedBatches` then loops "until a pass returns `count: 0`". A
+ * `Response` is never `=== 0`, so the loop ran its full `maxPasses` (50) per
+ * tenant against a database that had just refused — a job whose entire purpose
+ * is to back off amplifying load instead — and `totalCount += result.count`
+ * turned the total into the STRING `"0[object Response]…"`, because `number +
+ * Response` is concatenation. The run then reported success.
+ *
+ * The two tests at the bottom assert the numbers that make that concrete: ONE
+ * attempt, not fifty, and a thrown `DatabaseBusyError` rather than a result
+ * object. Both fail if `purgeExpiredAuditEvents` is moved back to `withTenant`.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getDatabaseCircuitBreaker,
+  resetDatabaseCircuitBreakerForTests
+} from "../src/lib/database/circuit-breaker";
+import { resetWorkClassGatesForTests } from "../src/lib/database/work-class";
+import {
+  DatabaseBusyError,
+  withTenant,
+  withTenantOrThrow
+} from "../src/lib/database/tenant-context";
+import { runBoundedBatches } from "../src/lib/jobs/batching";
+import { classifyError } from "../src/lib/jobs/retry-classification";
+import { purgeExpiredAuditEvents } from "../src/modules/logging/application/audit-purge";
+import type { LegalHoldGuardPort } from "../src/modules/_shared/ports/legal-hold-guard-port";
+
+const TENANT_ID = "11111111-1111-1111-1111-111111111111";
+
+/** Same shape as `tenant-context-circuit-breaker.test.ts` — `begin` + `unsafe` is all the primitive touches. */
+function fakeSql(): Bun.SQL {
+  const fakeTx = { unsafe: async () => [] } as unknown as Bun.TransactionSQL;
+
+  return {
+    begin: async (callback: (tx: Bun.TransactionSQL) => Promise<unknown>) =>
+      callback(fakeTx)
+  } as unknown as Bun.SQL;
+}
+
+/** Drives the breaker to open without touching a database. */
+async function openTheBreaker(sql: Bun.SQL): Promise<void> {
+  const boom = new Error("boom");
+
+  for (let i = 0; i < 5; i += 1) {
+    await withTenantOrThrow(sql, TENANT_ID, async () => {
+      throw boom;
+    }).catch(() => undefined);
+  }
+
+  expect(getDatabaseCircuitBreaker().canAttempt(new Date())).toBe(false);
+}
+
+const neverHeld: LegalHoldGuardPort = {
+  isDescriptorHeld: async () => false
+};
+
+describe("the two forms of a refusal", () => {
+  beforeEach(() => {
+    resetDatabaseCircuitBreakerForTests();
+    resetWorkClassGatesForTests();
+  });
+
+  afterEach(() => {
+    resetDatabaseCircuitBreakerForTests();
+    resetWorkClassGatesForTests();
+  });
+
+  test("withTenantOrThrow throws DatabaseBusyError instead of returning one", async () => {
+    const sql = fakeSql();
+    await openTheBreaker(sql);
+
+    let ran = false;
+    const error = await withTenantOrThrow(sql, TENANT_ID, async () => {
+      ran = true;
+      return 42;
+    }).catch((caught: unknown) => caught);
+
+    // The callback must not have run — this is a refusal, not a failed attempt.
+    expect(ran).toBe(false);
+    expect(error).toBeInstanceOf(DatabaseBusyError);
+    expect((error as DatabaseBusyError).code).toBe("DATABASE_BUSY");
+    expect((error as DatabaseBusyError).retryAfterSeconds).toBe(30);
+  });
+
+  test("withTenant still answers with the 503 — the request path is unchanged", async () => {
+    const sql = fakeSql();
+    await openTheBreaker(sql);
+
+    const response = await withTenant(
+      sql,
+      TENANT_ID,
+      async () => new Response("should never run")
+    );
+
+    expect(response).toBeInstanceOf(Response);
+    expect((response as Response).status).toBe(503);
+    expect((response as Response).headers.get("Retry-After")).toBe("30");
+  });
+
+  test("the thrown error carries the SAME response, so the two cannot drift", async () => {
+    const sql = fakeSql();
+    await openTheBreaker(sql);
+
+    const error = (await withTenantOrThrow(sql, TENANT_ID, async () => 1).catch(
+      (caught: unknown) => caught
+    )) as DatabaseBusyError;
+    const direct = (await withTenant(
+      sql,
+      TENANT_ID,
+      async () => new Response("x")
+    )) as Response;
+
+    expect(error.response.status).toBe(direct.status);
+    expect(error.response.headers.get("Retry-After")).toBe(
+      direct.headers.get("Retry-After")
+    );
+    expect(await error.response.json()).toEqual(await direct.json());
+  });
+
+  test("a job runner classifies it as retryable, not `unknown`", () => {
+    // `unknown` is what an operator reads as "we have no rule for this yet".
+    // A database that named its own `Retry-After` is the clearest retryable
+    // condition there is.
+    expect(
+      classifyError(
+        new DatabaseBusyError("busy", "maintenance", 2, new Response(null))
+      )
+    ).toBe("retryable");
+  });
+});
+
+describe("the purge job that the cast broke", () => {
+  beforeEach(() => {
+    resetDatabaseCircuitBreakerForTests();
+    resetWorkClassGatesForTests();
+  });
+
+  afterEach(() => {
+    resetDatabaseCircuitBreakerForTests();
+    resetWorkClassGatesForTests();
+  });
+
+  test("purgeExpiredAuditEvents fails loudly instead of returning a Response as purgedCount", async () => {
+    const sql = fakeSql();
+    await openTheBreaker(sql);
+
+    const outcome = await purgeExpiredAuditEvents(
+      sql,
+      TENANT_ID,
+      neverHeld
+    ).catch((caught: unknown) => caught);
+
+    expect(outcome).toBeInstanceOf(DatabaseBusyError);
+    // The old shape, spelled out so the regression is unmistakable: a result
+    // object whose `purgedCount` was neither a number nor zero.
+    expect(outcome).not.toHaveProperty("purgedCount");
+  });
+
+  test("a refused pass stops the batch loop at ONE attempt, not fifty", async () => {
+    const sql = fakeSql();
+    await openTheBreaker(sql);
+
+    let attempts = 0;
+    const outcome = await runBoundedBatches(async () => {
+      attempts += 1;
+      const result = await purgeExpiredAuditEvents(sql, TENANT_ID, neverHeld);
+      return { count: result.purgedCount };
+    }).catch((caught: unknown) => caught);
+
+    expect(outcome).toBeInstanceOf(DatabaseBusyError);
+    // The number that matters. `maxPasses` defaults to 50, and every one of
+    // those passes used to be a fresh queue attempt against a database that
+    // had already said no.
+    expect(attempts).toBe(1);
+  });
+});

--- a/tests/integration/abac-policy-evaluator.integration.test.ts
+++ b/tests/integration/abac-policy-evaluator.integration.test.ts
@@ -42,7 +42,7 @@ import {
   resetHandlerDatabase,
   teardownHandlerDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import { hashSessionToken } from "../../src/lib/auth/session-token";
 import { loadActivePolicies } from "../../src/modules/identity-access/application/policy-cache";
 import { resetPolicyCache } from "../../src/modules/identity-access/application/policy-cache";
@@ -394,7 +394,7 @@ suite("dynamic ABAC policy evaluator (Issue #179)", () => {
       // And the compiler/cache loads ZERO policies for the tenant — the flat row
       // is never even loaded.
       const client = getHandlerDatabaseClient();
-      const active = await withTenant(client, owner.tenantId, (tx) =>
+      const active = await withTenantOrThrow(client, owner.tenantId, (tx) =>
         loadActivePolicies(tx, owner.tenantId)
       );
       expect(active.length).toBe(0);
@@ -457,10 +457,10 @@ suite("dynamic ABAC policy evaluator (Issue #179)", () => {
       `;
 
       const client = getHandlerDatabaseClient();
-      const aPolicies = await withTenant(client, owner.tenantId, (tx) =>
+      const aPolicies = await withTenantOrThrow(client, owner.tenantId, (tx) =>
         loadActivePolicies(tx, owner.tenantId)
       );
-      const bPolicies = await withTenant(client, TENANT_B_ID, (tx) =>
+      const bPolicies = await withTenantOrThrow(client, TENANT_B_ID, (tx) =>
         loadActivePolicies(tx, TENANT_B_ID)
       );
 

--- a/tests/integration/admin-security-policy.integration.test.ts
+++ b/tests/integration/admin-security-policy.integration.test.ts
@@ -21,7 +21,7 @@ import {
 } from "bun:test";
 
 import { hashPassword } from "../../src/lib/auth/password";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   fetchEligibleBreakGlassIdentityIds,
   getTenantAuthPolicy,
@@ -86,13 +86,13 @@ async function seedAccount(
 }
 
 function candidates(tenantId: string) {
-  return withTenant(getRuntimeSql(), tenantId, (tx) =>
+  return withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
     listBreakGlassCandidates(tx, tenantId)
   );
 }
 
 function eligible(tenantId: string, identityIds: string[]) {
-  return withTenant(getRuntimeSql(), tenantId, (tx) =>
+  return withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
     fetchEligibleBreakGlassIdentityIds(tx, tenantId, identityIds)
   );
 }
@@ -148,7 +148,7 @@ suite("admin security break-glass picker (Wave 2 delta auth)", () => {
       identityStatus: "inactive"
     });
 
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       saveTenantAuthPolicy(tx, TENANT_A, active.tenantUserId, {
         breakGlassIdentityIds: [active.identityId, inactive.identityId]
       })
@@ -156,7 +156,7 @@ suite("admin security break-glass picker (Wave 2 delta auth)", () => {
 
     expect(result.outcome).toBe("saved");
 
-    const stored = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const stored = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       getTenantAuthPolicy(tx, TENANT_A)
     );
 
@@ -166,7 +166,7 @@ suite("admin security break-glass picker (Wave 2 delta auth)", () => {
   test("requiring SSO with no eligible break-glass account is refused", async () => {
     const active = await seedAccount(TENANT_A, "owner@example.com");
 
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       saveTenantAuthPolicy(tx, TENANT_A, active.tenantUserId, {
         ssoEnabled: true,
         ssoRequired: true,
@@ -179,7 +179,7 @@ suite("admin security break-glass picker (Wave 2 delta auth)", () => {
     // the server will never accept.
     expect(result.outcome).toBe("break_glass_required");
 
-    const stored = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const stored = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       getTenantAuthPolicy(tx, TENANT_A)
     );
     expect(stored.ssoRequired).toBe(false);
@@ -188,7 +188,7 @@ suite("admin security break-glass picker (Wave 2 delta auth)", () => {
   test("requiring SSO succeeds once an eligible account is named", async () => {
     const active = await seedAccount(TENANT_A, "owner@example.com");
 
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       saveTenantAuthPolicy(tx, TENANT_A, active.tenantUserId, {
         ssoEnabled: true,
         ssoRequired: true,

--- a/tests/integration/business-scope.integration.test.ts
+++ b/tests/integration/business-scope.integration.test.ts
@@ -38,7 +38,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   createBusinessScopeAssignment,
   listBusinessScopeAssignments,
@@ -144,7 +144,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     const now = new Date();
     const runtime = getRuntimeSql();
 
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -165,7 +165,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     );
     expect(created.ok).toBe(true);
 
-    const list = await withTenant(runtime, TENANT_A, (tx) =>
+    const list = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       listBusinessScopeAssignments(tx, TENANT_A, {})
     );
     expect(list.length).toBe(1);
@@ -180,7 +180,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     expect(events.map((e) => e.event_type)).toEqual(["granted"]);
 
     const assignmentId = list[0]!.id;
-    const revoked = await withTenant(runtime, TENANT_A, (tx) =>
+    const revoked = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       revokeBusinessScopeAssignment(tx, TENANT_A, A_ACTOR, assignmentId, {
         revokeReason: "left the office"
       })
@@ -191,7 +191,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
 
   test("self-grant is denied", async () => {
     const now = new Date();
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -219,7 +219,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     // The base no-op resolver returns resolved:false for OFFICE_A, so if the
     // self-grant check ran AFTER resolveScope the result would be
     // SCOPE_UNRESOLVED. It must be SELF_GRANT_DENIED (identity guard first).
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -247,7 +247,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
 
   test("F2: the reserved 'tenant' scope_type cannot be stored as an assignment", async () => {
     const now = new Date();
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -280,7 +280,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
   test("cross-tenant SCOPE reference is denied at the app layer (port resolves nothing for the wrong tenant)", async () => {
     const now = new Date();
     // tenant A subject, but a scope id that only exists under tenant B.
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -304,7 +304,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
   });
 
   test("cross-tenant SUBJECT reference is denied by the composite (tenant_id, tenant_user_id) FK (raw INSERT bypassing the app)", async () => {
-    const error = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const error = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       assertRejected(
         tx`
           INSERT INTO awcms_business_scope_assignments
@@ -320,7 +320,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
   });
 
   test("cross-tenant ROLE reference is denied by the composite (tenant_id, role_id) FK (raw INSERT bypassing the app)", async () => {
-    const error = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const error = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       assertRejected(
         tx`
           INSERT INTO awcms_business_scope_assignments
@@ -344,7 +344,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     }
     const now = new Date();
     // Seed one tenant-A assignment through the owner/app runtime.
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -366,7 +366,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
 
     const app = getAppRoleSql();
     // Control: with the GUC on tenant A, awcms_app sees the row.
-    const visible = await withTenant(app, TENANT_A, (tx) =>
+    const visible = await withTenantOrThrow(app, TENANT_A, (tx) =>
       tx`SELECT id FROM awcms_business_scope_assignments`.then(
         (r) => r as { id: string }[]
       )
@@ -374,7 +374,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     expect(visible.length).toBe(1);
 
     // Isolation: with the GUC on tenant B, awcms_app sees ZERO tenant-A rows.
-    const hidden = await withTenant(app, TENANT_B, (tx) =>
+    const hidden = await withTenantOrThrow(app, TENANT_B, (tx) =>
       tx`SELECT id FROM awcms_business_scope_assignments`.then(
         (r) => r as { id: string }[]
       )
@@ -386,7 +386,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     const now = new Date();
     const runtime = getRuntimeSql();
 
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -424,7 +424,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     const granted = new Set(["sales.orders.read"]);
 
     // Before revoke — the subject's facts cover the required scope.
-    const factsBefore = await withTenant(runtime, TENANT_A, (tx) =>
+    const factsBefore = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       resolveBusinessScopeFacts(
         tx,
         TENANT_A,
@@ -438,16 +438,16 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
     ).toBe(true);
 
     // Revoke, then re-resolve facts at the same instant — coverage is gone.
-    const list = await withTenant(runtime, TENANT_A, (tx) =>
+    const list = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       listBusinessScopeAssignments(tx, TENANT_A, {})
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       revokeBusinessScopeAssignment(tx, TENANT_A, A_ACTOR, list[0]!.id, {
         revokeReason: "immediate"
       })
     );
 
-    const factsAfter = await withTenant(runtime, TENANT_A, (tx) =>
+    const factsAfter = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       resolveBusinessScopeFacts(
         tx,
         TENANT_A,
@@ -469,7 +469,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
   test("descendant coverage resolves end-to-end through the dummy port (assigned parent office covers a child office)", async () => {
     const now = new Date();
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -489,7 +489,7 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
       )
     );
 
-    const facts = await withTenant(runtime, TENANT_A, (tx) =>
+    const facts = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       resolveBusinessScopeFacts(
         tx,
         TENANT_A,

--- a/tests/integration/comments.integration.test.ts
+++ b/tests/integration/comments.integration.test.ts
@@ -7,7 +7,7 @@ import {
   test
 } from "bun:test";
 
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import { getRegisteredCommentableResources } from "../../src/modules/comments/presentation/commentable-resources";
 import { resolvePublishedCommentableResource } from "../../src/modules/comments/application/commentable-resource-engine";
 import {
@@ -79,7 +79,7 @@ async function submit(
   postId: string,
   body: string
 ): Promise<string | null> {
-  return withTenant(getRuntimeSql(), tenantId, async (tx) => {
+  return withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
     const resolved = await resolvePublishedCommentableResource(
       tx,
       tenantId,
@@ -117,7 +117,7 @@ async function submit(
 }
 
 async function publicList(tenantId: string, postId: string): Promise<number> {
-  return withTenant(getRuntimeSql(), tenantId, async (tx) => {
+  return withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
     const resolved = await resolvePublishedCommentableResource(
       tx,
       tenantId,
@@ -159,7 +159,7 @@ suite("comments integration (ADR-0041)", () => {
     // Not public until approved.
     expect(await publicList(TENANT_A, post)).toBe(0);
 
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       moderateComment(
         tx,
         TENANT_A,
@@ -171,21 +171,30 @@ suite("comments integration (ADR-0041)", () => {
     );
 
     // Now visible, and body is escaped safe HTML (no raw <b>).
-    const items = await withTenant(getRuntimeSql(), TENANT_A, async (tx) => {
-      const resolved = await resolvePublishedCommentableResource(
-        tx,
-        TENANT_A,
-        {
-          resourceType: "blog_post",
-          resourceId: post,
-          locale: "en",
-          tenantCode: "tenant-a"
-        },
-        getRegisteredCommentableResources()
-      );
-      const thread = await getOrCreateThread(tx, TENANT_A, resolved!, settings);
-      return (await listApprovedComments(tx, TENANT_A, thread.id, {})).items;
-    });
+    const items = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT_A,
+      async (tx) => {
+        const resolved = await resolvePublishedCommentableResource(
+          tx,
+          TENANT_A,
+          {
+            resourceType: "blog_post",
+            resourceId: post,
+            locale: "en",
+            tenantCode: "tenant-a"
+          },
+          getRegisteredCommentableResources()
+        );
+        const thread = await getOrCreateThread(
+          tx,
+          TENANT_A,
+          resolved!,
+          settings
+        );
+        return (await listApprovedComments(tx, TENANT_A, thread.id, {})).items;
+      }
+    );
     expect(items).toHaveLength(1);
     expect(items[0]!.bodyHtml).toContain("&lt;b&gt;");
     expect(items[0]!.bodyHtml).not.toContain("<b>");
@@ -212,7 +221,7 @@ suite("comments integration (ADR-0041)", () => {
   test("RLS: tenant B cannot see tenant A's comments (IDOR/cross-tenant)", async () => {
     const postA = await insertPost(TENANT_A, { slug: "a1" });
     const commentId = await submit(TENANT_A, postA, "tenant a comment");
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       moderateComment(
         tx,
         TENANT_A,
@@ -223,19 +232,23 @@ suite("comments integration (ADR-0041)", () => {
       )
     );
     // Scoped to tenant B, the comment row is invisible under RLS.
-    const seenByB = await withTenant(getRuntimeSql(), TENANT_B, async (tx) => {
-      const rows = (await tx`
+    const seenByB = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT_B,
+      async (tx) => {
+        const rows = (await tx`
         SELECT count(*)::int AS count FROM awcms_comments_comments
       `) as { count: number }[];
-      return rows[0]!.count;
-    });
+        return rows[0]!.count;
+      }
+    );
     expect(seenByB).toBe(0);
   }, 20000);
 
   test("approve writes a same-commit domain-event outbox row", async () => {
     const post = await insertPost(TENANT_A, { slug: "evt" });
     const commentId = await submit(TENANT_A, post, "event body");
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       moderateComment(
         tx,
         TENANT_A,
@@ -245,20 +258,24 @@ suite("comments integration (ADR-0041)", () => {
         async () => {}
       )
     );
-    const events = await withTenant(getRuntimeSql(), TENANT_A, async (tx) => {
-      const rows = (await tx`
+    const events = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT_A,
+      async (tx) => {
+        const rows = (await tx`
         SELECT event_type FROM awcms_domain_events
         WHERE event_type = 'awcms.comments.comment.approved'
       `) as { event_type: string }[];
-      return rows.length;
-    });
+        return rows.length;
+      }
+    );
     expect(events).toBeGreaterThanOrEqual(1);
   }, 20000);
 
   test("author self-delete within window soft-deletes (row retained, hidden)", async () => {
     const post = await insertPost(TENANT_A, { slug: "sd" });
     const commentId = await submit(TENANT_A, post, "delete me");
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       moderateComment(
         tx,
         TENANT_A,
@@ -270,7 +287,7 @@ suite("comments integration (ADR-0041)", () => {
     );
     expect(await publicList(TENANT_A, post)).toBe(1);
 
-    const del = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const del = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       requestCommentDeletion(tx, TENANT_A, commentId!, {
         userId: null,
         ipHash: "iphash"
@@ -280,12 +297,16 @@ suite("comments integration (ADR-0041)", () => {
     expect(await publicList(TENANT_A, post)).toBe(0);
 
     // Row retained (soft delete), status = deleted.
-    const status = await withTenant(getRuntimeSql(), TENANT_A, async (tx) => {
-      const rows = (await tx`
+    const status = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT_A,
+      async (tx) => {
+        const rows = (await tx`
         SELECT status FROM awcms_comments_comments WHERE id = ${commentId}
       `) as { status: string }[];
-      return rows[0]?.status;
-    });
+        return rows[0]?.status;
+      }
+    );
     expect(status).toBe("deleted");
   }, 20000);
 });

--- a/tests/integration/data-lifecycle-tenant-state.integration.test.ts
+++ b/tests/integration/data-lifecycle-tenant-state.integration.test.ts
@@ -33,7 +33,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   createLegalHold,
   fetchActiveLegalHoldsForPlanning,
@@ -96,7 +96,7 @@ suite("data_lifecycle module (integration)", () => {
 
   test("create + list + fetchActive round-trip, tenant-scoped", async () => {
     const runtime = getRuntimeSql();
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createLegalHold(tx, TENANT_A, ACTOR, validHoldInput(null))
     );
     if (created instanceof Response || !created.ok) {
@@ -105,7 +105,7 @@ suite("data_lifecycle module (integration)", () => {
     expect(created.hold.status).toBe("active");
     expect(created.hold.tenantId).toBe(TENANT_A);
 
-    const active = await withTenant(runtime, TENANT_A, (tx) =>
+    const active = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchActiveLegalHoldsForPlanning(tx, TENANT_A)
     );
     if (active instanceof Response) throw new Error("unexpected 503");
@@ -119,7 +119,7 @@ suite("data_lifecycle module (integration)", () => {
       return;
     }
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createLegalHold(tx, TENANT_A, ACTOR, validHoldInput(null))
     );
 
@@ -131,7 +131,7 @@ suite("data_lifecycle module (integration)", () => {
     expect(noContext).toHaveLength(0);
 
     // Tenant B's context sees none of tenant A's holds.
-    const asB = await withTenant(app, TENANT_B, async (tx) => {
+    const asB = await withTenantOrThrow(app, TENANT_B, async (tx) => {
       const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_data_lifecycle_legal_holds
       `) as { n: number }[];
@@ -140,7 +140,7 @@ suite("data_lifecycle module (integration)", () => {
     expect(asB).toBe(0);
 
     // Tenant A's own context DOES see its hold.
-    const asA = await withTenant(app, TENANT_A, async (tx) => {
+    const asA = await withTenantOrThrow(app, TENANT_A, async (tx) => {
       const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_data_lifecycle_legal_holds
       `) as { n: number }[];
@@ -153,7 +153,7 @@ suite("data_lifecycle module (integration)", () => {
     const runtime = getRuntimeSql();
 
     // Seed one session + one old visit event for tenant A (past the 90d cutoff).
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const oldTs = daysAgo(200);
       const sessionRows = (await tx`
         INSERT INTO awcms_visitor_sessions
@@ -169,7 +169,7 @@ suite("data_lifecycle module (integration)", () => {
     });
 
     // Create an ACTIVE hold scoped to visitor_analytics.visit_events.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createLegalHold(
         tx,
         TENANT_A,
@@ -179,7 +179,7 @@ suite("data_lifecycle module (integration)", () => {
     );
 
     // Purge while held: step-1 events DELETE is skipped.
-    const held = await withTenant(runtime, TENANT_A, (tx) =>
+    const held = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       purgeVisitorAnalyticsData(
         tx,
         TENANT_A,
@@ -191,16 +191,20 @@ suite("data_lifecycle module (integration)", () => {
     if (held instanceof Response) throw new Error("unexpected 503 (held run)");
     expect(held.eventsDeleted).toBe(0);
 
-    const stillThere = await withTenant(runtime, TENANT_A, async (tx) => {
-      const rows = (await tx`
+    const stillThere = await withTenantOrThrow(
+      runtime,
+      TENANT_A,
+      async (tx) => {
+        const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_visit_events WHERE tenant_id = ${TENANT_A}
       `) as { n: number }[];
-      return rows[0]!.n;
-    });
+        return rows[0]!.n;
+      }
+    );
     expect(stillThere).toBe(1);
 
     // Release every active hold for A, then re-run: the event is now purged.
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const active = await fetchActiveLegalHoldsForPlanning(tx, TENANT_A);
       for (const hold of active) {
         await releaseLegalHold(tx, TENANT_A, ACTOR, hold.id, {
@@ -209,7 +213,7 @@ suite("data_lifecycle module (integration)", () => {
       }
     });
 
-    const unblocked = await withTenant(runtime, TENANT_A, (tx) =>
+    const unblocked = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       purgeVisitorAnalyticsData(
         tx,
         TENANT_A,
@@ -231,7 +235,7 @@ suite("data_lifecycle module (integration)", () => {
     // rollup — absent a hold, step 2 clears the PII, step 3 deletes the session,
     // step 4 deletes the rollup. (No event, so this is distinct from the prior
     // test where the event transitively protected the session.)
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await tx`
         INSERT INTO awcms_visitor_sessions
           (tenant_id, visitor_key_hash, area, first_seen_at, last_seen_at,
@@ -247,11 +251,11 @@ suite("data_lifecycle module (integration)", () => {
 
     // A TENANT-WIDE hold (descriptorKey null) must cover visit_events too, so
     // the whole purge is skipped.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createLegalHold(tx, TENANT_A, ACTOR, validHoldInput(null))
     );
 
-    const held = await withTenant(runtime, TENANT_A, (tx) =>
+    const held = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       purgeVisitorAnalyticsData(
         tx,
         TENANT_A,
@@ -269,7 +273,7 @@ suite("data_lifecycle module (integration)", () => {
     });
 
     // The PII column is physically untouched, and both rows still exist.
-    const preserved = await withTenant(runtime, TENANT_A, async (tx) => {
+    const preserved = await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const s = (await tx`
         SELECT ip_address, login_identifier_snapshot
         FROM awcms_visitor_sessions WHERE tenant_id = ${TENANT_A}
@@ -288,7 +292,7 @@ suite("data_lifecycle module (integration)", () => {
     expect(preserved.rollups).toBe(1);
 
     // Release → normal retention resumes: PII cleared, session + rollup deleted.
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const active = await fetchActiveLegalHoldsForPlanning(tx, TENANT_A);
       for (const hold of active) {
         await releaseLegalHold(tx, TENANT_A, ACTOR, hold.id, {
@@ -296,7 +300,7 @@ suite("data_lifecycle module (integration)", () => {
         });
       }
     });
-    const after = await withTenant(runtime, TENANT_A, (tx) =>
+    const after = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       purgeVisitorAnalyticsData(
         tx,
         TENANT_A,
@@ -316,7 +320,7 @@ suite("data_lifecycle module (integration)", () => {
     const oldTs = daysAgo(900); // past the 730d audit default cutoff
 
     // Seed 3 old audit events for tenant A.
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       for (let i = 0; i < 3; i += 1) {
         await tx`
           INSERT INTO awcms_audit_events
@@ -327,7 +331,7 @@ suite("data_lifecycle module (integration)", () => {
     });
 
     // A tenant-wide hold (descriptorKey null) covers logging.audit_events too.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createLegalHold(tx, TENANT_A, ACTOR, validHoldInput(null))
     );
 
@@ -339,17 +343,21 @@ suite("data_lifecycle module (integration)", () => {
     );
     expect(held.purgedCount).toBe(0);
 
-    const oldRemaining = await withTenant(runtime, TENANT_A, async (tx) => {
-      const rows = (await tx`
+    const oldRemaining = await withTenantOrThrow(
+      runtime,
+      TENANT_A,
+      async (tx) => {
+        const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_audit_events
         WHERE tenant_id = ${TENANT_A} AND created_at < ${held.cutoff}
       `) as { n: number }[];
-      return rows[0]!.n;
-    });
+        return rows[0]!.n;
+      }
+    );
     expect(oldRemaining).toBe(3);
 
     // Release the hold, then re-run: the 3 old events are purged.
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const active = await fetchActiveLegalHoldsForPlanning(tx, TENANT_A);
       for (const hold of active) {
         await releaseLegalHold(tx, TENANT_A, ACTOR, hold.id, {

--- a/tests/integration/db-role-separation.integration.test.ts
+++ b/tests/integration/db-role-separation.integration.test.ts
@@ -58,7 +58,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 
 const TENANT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const TENANT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -227,7 +227,7 @@ suite(
         await seedTwoTenants();
         const sql = getOwnerSql();
 
-        const asTenantA = await withTenant(sql, TENANT_A, async (tx) => {
+        const asTenantA = await withTenantOrThrow(sql, TENANT_A, async (tx) => {
           return (await tx`
           SELECT office_code FROM awcms_offices ORDER BY office_code
         `) as { office_code: string }[];
@@ -240,7 +240,7 @@ suite(
         // And an explicit, adversarial `WHERE tenant_id = <B>` — the shape a
         // buggy service layer or a parameter-injection would produce — still
         // yields nothing, because Postgres ANDs the policy in itself.
-        const targeted = await withTenant(sql, TENANT_A, async (tx) => {
+        const targeted = await withTenantOrThrow(sql, TENANT_A, async (tx) => {
           return (await tx`
           SELECT office_code FROM awcms_offices WHERE tenant_id = ${TENANT_B}
         `) as { office_code: string }[];
@@ -252,11 +252,15 @@ suite(
       test("CONTROL: the same OWNER connection DOES see both tenants in awcms_tenants (no RLS there), proving the zero-row results are RLS and not a dead connection", async () => {
         await seedTwoTenants();
 
-        const rows = await withTenant(getOwnerSql(), TENANT_A, async (tx) => {
-          return (await tx`
+        const rows = await withTenantOrThrow(
+          getOwnerSql(),
+          TENANT_A,
+          async (tx) => {
+            return (await tx`
           SELECT tenant_code FROM awcms_tenants ORDER BY tenant_code
         `) as { tenant_code: string }[];
-        });
+          }
+        );
 
         expect(rows.map((row) => row.tenant_code)).toEqual([
           "rls-tenant-a",
@@ -267,7 +271,7 @@ suite(
       test("cross-tenant UPDATE and DELETE are blocked too, not just SELECT", async () => {
         await seedTwoTenants();
 
-        await withTenant(getOwnerSql(), TENANT_A, async (tx) => {
+        await withTenantOrThrow(getOwnerSql(), TENANT_A, async (tx) => {
           const updated = await tx`
           UPDATE awcms_offices SET office_name = 'HIJACKED' WHERE tenant_id = ${TENANT_B}
         `;
@@ -293,14 +297,17 @@ suite(
       test("INSERTing a row for another tenant is rejected outright (the policy's USING supplies the WITH CHECK)", async () => {
         await seedTwoTenants();
 
-        const error = await withTenant(getOwnerSql(), TENANT_A, async (tx) =>
-          assertRejected(
-            tx`
+        const error = await withTenantOrThrow(
+          getOwnerSql(),
+          TENANT_A,
+          async (tx) =>
+            assertRejected(
+              tx`
             INSERT INTO awcms_offices (tenant_id, office_code, office_name)
             VALUES (${TENANT_B}, 'smuggled', 'Smuggled')
           `,
-            "an INSERT of a tenant-B row from tenant A's context"
-          )
+              "an INSERT of a tenant-B row from tenant A's context"
+            )
         );
 
         expect(error.message).toMatch(/row-level security/i);
@@ -416,11 +423,15 @@ suite(
         if (skipUnlessAppRole()) return;
         await seedTwoTenants();
 
-        const rows = await withTenant(getAppRoleSql(), TENANT_A, async (tx) => {
-          return (await tx`
+        const rows = await withTenantOrThrow(
+          getAppRoleSql(),
+          TENANT_A,
+          async (tx) => {
+            return (await tx`
           SELECT office_code FROM awcms_offices ORDER BY office_code
         `) as { office_code: string }[];
-        });
+          }
+        );
 
         expect(rows.map((row) => row.office_code)).toEqual(["hq-a"]);
       });

--- a/tests/integration/media-library-tenant-state.integration.test.ts
+++ b/tests/integration/media-library-tenant-state.integration.test.ts
@@ -39,7 +39,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   isManagedMediaEnforcedForTenant,
   markManagedMediaEnforced
@@ -88,7 +88,7 @@ suite("media_library tenant state (ADR-0036)", () => {
   test("markManagedMediaEnforced round-trips inside a tenant-scoped transaction", async () => {
     const tenantId = await provisionTenant("acme");
 
-    await withTenant(getRuntimeSql(), tenantId, async (tx) => {
+    await withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
       expect(await isManagedMediaEnforcedForTenant(tx, tenantId)).toBe(false);
       await markManagedMediaEnforced(tx, tenantId);
       expect(await isManagedMediaEnforcedForTenant(tx, tenantId)).toBe(true);
@@ -99,11 +99,11 @@ suite("media_library tenant state (ADR-0036)", () => {
     const enforcedTenantId = await provisionTenant("acme");
     const otherTenantId = await provisionTenant("globex");
 
-    await withTenant(getRuntimeSql(), enforcedTenantId, async (tx) => {
+    await withTenantOrThrow(getRuntimeSql(), enforcedTenantId, async (tx) => {
       await markManagedMediaEnforced(tx, enforcedTenantId);
     });
 
-    await withTenant(getRuntimeSql(), otherTenantId, async (tx) => {
+    await withTenantOrThrow(getRuntimeSql(), otherTenantId, async (tx) => {
       // Fail-closed for the tenant that never opted in — and, critically, asking
       // about ANOTHER tenant's id from inside this tenant's context must not leak
       // that tenant's state either.
@@ -124,7 +124,7 @@ suite("media_library tenant state (ADR-0036)", () => {
     }
 
     const enforcedTenantId = await provisionTenant("acme");
-    await withTenant(getRuntimeSql(), enforcedTenantId, async (tx) => {
+    await withTenantOrThrow(getRuntimeSql(), enforcedTenantId, async (tx) => {
       await markManagedMediaEnforced(tx, enforcedTenantId);
     });
 
@@ -195,7 +195,7 @@ suite("media_library tenant state (ADR-0036)", () => {
   test("a brochure-site tenant gets managed media with NO news_portal state at all — the product gap ADR-0036 closes", async () => {
     const tenantId = await provisionTenant("acme");
 
-    await withTenant(getRuntimeSql(), tenantId, async (tx) => {
+    await withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
       // Before opting in: enforcement off, even though the deployment's media R2
       // is fully configured. Deployment readiness alone must never opt a tenant in.
       expect(
@@ -231,7 +231,7 @@ suite("media_library tenant state (ADR-0036)", () => {
   test("enforcement fails closed when the deployment's media R2 is not configured, even for an opted-in tenant", async () => {
     const tenantId = await provisionTenant("acme");
 
-    await withTenant(getRuntimeSql(), tenantId, async (tx) => {
+    await withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
       await markManagedMediaEnforced(tx, tenantId);
 
       // The tenant flag alone must never enforce registry-backed references on a

--- a/tests/integration/module-tenant-lifecycle.integration.test.ts
+++ b/tests/integration/module-tenant-lifecycle.integration.test.ts
@@ -65,7 +65,7 @@ import { POST as enableModule } from "../../src/pages/api/v1/tenant/modules/[mod
 import { POST as disableModule } from "../../src/pages/api/v1/tenant/modules/[moduleKey]/disable";
 import { GET as listWorkflowTasks } from "../../src/pages/api/v1/workflows/tasks/index";
 import { fetchTenantModuleEntry } from "../../src/modules/module-management/application/tenant-module-lifecycle";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 
 const OWNER_PASSWORD = "integration-test-owner-password";
 const TENANT_B_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
@@ -351,7 +351,7 @@ suite("tenant module lifecycle (Issue #154)", () => {
       expect(result.status).toBe(200);
       expect(result.body.data!.tenantEnabled).toBe(false);
 
-      const entry = await withTenant(
+      const entry = await withTenantOrThrow(
         getHandlerDatabaseClient(),
         owner.tenantId,
         (tx) => fetchTenantModuleEntry(tx, owner.tenantId, DISABLABLE_MODULE)

--- a/tests/integration/password-reset.integration.test.ts
+++ b/tests/integration/password-reset.integration.test.ts
@@ -34,7 +34,7 @@ import {
 
 import { hashPassword, verifyPassword } from "../../src/lib/auth/password";
 import { hashResetToken } from "../../src/lib/auth/reset-token";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import type {
   AuthNotificationPort,
   AuthNotificationRequest
@@ -156,7 +156,7 @@ function request(
   notifications: AuthNotificationPort,
   now: Date = NOW
 ) {
-  return withTenant(getRuntimeSql(), tenantId, (tx) =>
+  return withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
     requestPasswordReset(tx, tenantId, loginIdentifier, now, {
       tokenTtlMinutes: 30,
       resetUrlBase: "https://awcms.test/reset-password",
@@ -166,7 +166,7 @@ function request(
 }
 
 function complete(tenantId: string, token: string, now: Date = NOW) {
-  return withTenant(getRuntimeSql(), tenantId, (tx) =>
+  return withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
     completePasswordReset(tx, tenantId, token, NEW_PASSWORD, now)
   );
 }
@@ -515,7 +515,7 @@ suite("password reset integration (Wave 2 delta auth)", () => {
       )
     `;
 
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       requestPasswordReset(tx, TENANT_A, IDENTIFIER, NOW, {
         tokenTtlMinutes: 30,
         resetUrlBase: "https://awcms.test/reset-password",
@@ -550,7 +550,7 @@ suite("password reset integration (Wave 2 delta auth)", () => {
     // told nothing, and the operator gets a distinct outcome to act on.
     await seedAccount(TENANT_A);
 
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       requestPasswordReset(tx, TENANT_A, IDENTIFIER, NOW, {
         tokenTtlMinutes: 30,
         resetUrlBase: "https://awcms.test/reset-password",

--- a/tests/integration/reporting-projections.integration.test.ts
+++ b/tests/integration/reporting-projections.integration.test.ts
@@ -55,7 +55,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import type {
   ProjectionCursorStream,
   ProjectionDescriptor
@@ -128,7 +128,7 @@ async function readMetric(
   projectionKey: string,
   metricKey: string
 ): Promise<number> {
-  const metrics = await withTenant(getRuntimeSql(), tenantId, (tx) =>
+  const metrics = await withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
     getProjectionMetrics(tx, tenantId, projectionKey)
   );
 
@@ -267,13 +267,17 @@ suite("reporting projections (Issue #154)", () => {
       // And prove the isolation is RLS, not just the application filter:
       // reading A's metric key from INSIDE B's tenant context returns
       // nothing, even though the admin connection can see both rows.
-      const leaked = await withTenant(getRuntimeSql(), TENANT_B, async (tx) => {
-        return (await tx`
+      const leaked = await withTenantOrThrow(
+        getRuntimeSql(),
+        TENANT_B,
+        async (tx) => {
+          return (await tx`
           SELECT tenant_id, metric_value
           FROM awcms_reporting_projection_metrics
           WHERE projection_key = ${PROJECTION_KEY}
         `) as { tenant_id: string; metric_value: number }[];
-      });
+        }
+      );
 
       expect(leaked.map((row) => row.tenant_id)).toEqual([TENANT_B]);
 
@@ -302,7 +306,7 @@ suite("reporting projections (Issue #154)", () => {
       tenantId: string,
       at: Date
     ): Promise<void> {
-      await withTenant(getRuntimeSql(), tenantId, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
         upsertStreamCursor(
           tx,
           tenantId,
@@ -314,7 +318,7 @@ suite("reporting projections (Issue #154)", () => {
     }
 
     test("with NO rebuild watermark, every event increments the metric (the ordinary steady state)", async () => {
-      await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
         applyEventActivityProjectionIncrement(tx, TENANT_A, new Date())
       );
 
@@ -327,14 +331,14 @@ suite("reporting projections (Issue #154)", () => {
 
       // Strictly before, and exactly at, the watermark: both are "already
       // covered by the rebuild" and must be dropped.
-      await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
         applyEventActivityProjectionIncrement(
           tx,
           TENANT_A,
           new Date(watermark.getTime() - 1000)
         )
       );
-      await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
         applyEventActivityProjectionIncrement(tx, TENANT_A, watermark)
       );
 
@@ -345,7 +349,7 @@ suite("reporting projections (Issue #154)", () => {
       const watermark = new Date();
       await setRebuildWatermark(TENANT_A, watermark);
 
-      await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
         applyEventActivityProjectionIncrement(
           tx,
           TENANT_A,
@@ -364,10 +368,10 @@ suite("reporting projections (Issue #154)", () => {
 
       // Same timestamp, two tenants: dropped for A (covered), counted for B
       // (B has no watermark of its own).
-      await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
         applyEventActivityProjectionIncrement(tx, TENANT_A, beforeWatermark)
       );
-      await withTenant(getRuntimeSql(), TENANT_B, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), TENANT_B, (tx) =>
         applyEventActivityProjectionIncrement(tx, TENANT_B, beforeWatermark)
       );
 

--- a/tests/integration/self-registration.integration.test.ts
+++ b/tests/integration/self-registration.integration.test.ts
@@ -24,7 +24,7 @@ import {
 } from "bun:test";
 
 import { verifyPassword } from "../../src/lib/auth/password";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import type {
   AuthNotificationPort,
   AuthNotificationRequest
@@ -99,7 +99,7 @@ function submit(
   loginIdentifier = APPLICANT,
   displayName = "Ada Lovelace"
 ) {
-  return withTenant(getRuntimeSql(), tenantId, (tx) =>
+  return withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
     submitRegistrationRequest(tx, tenantId, { loginIdentifier, displayName })
   );
 }
@@ -111,7 +111,7 @@ function approve(
   roleIds: string[] = [],
   enqueued = true
 ) {
-  return withTenant(getRuntimeSql(), tenantId, (tx) =>
+  return withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
     approveRegistrationRequest(tx, tenantId, requestId, REVIEWER, NOW, {
       roleIds,
       notifications: stubPort(sent, enqueued),
@@ -183,7 +183,7 @@ suite("self-registration integration (Wave 2 delta auth)", () => {
   test("the queue masks the address", async () => {
     await submit(TENANT_A);
 
-    const queue = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const queue = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       listPendingRegistrations(tx, TENANT_A)
     );
 
@@ -290,7 +290,7 @@ suite("self-registration integration (Wave 2 delta auth)", () => {
   test("rejection creates nothing and closes the queue entry", async () => {
     const request = await submit(TENANT_A);
 
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       rejectRegistrationRequest(tx, TENANT_A, request.requestId!, REVIEWER, NOW)
     );
 
@@ -302,7 +302,7 @@ suite("self-registration integration (Wave 2 delta auth)", () => {
     `) as { n: number }[];
     expect(identities[0]!.n).toBe(0);
 
-    const queue = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const queue = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       listPendingRegistrations(tx, TENANT_A)
     );
     expect(queue).toEqual([]);
@@ -311,7 +311,7 @@ suite("self-registration integration (Wave 2 delta auth)", () => {
   test("a rejected applicant can apply again", async () => {
     // The partial unique index covers PENDING rows only, and this is why.
     const first = await submit(TENANT_A);
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       rejectRegistrationRequest(tx, TENANT_A, first.requestId!, REVIEWER, NOW)
     );
 
@@ -324,7 +324,7 @@ suite("self-registration integration (Wave 2 delta auth)", () => {
   test("approving an already-reviewed request is a no-op", async () => {
     const sent: Sent = [];
     const request = await submit(TENANT_A);
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       rejectRegistrationRequest(tx, TENANT_A, request.requestId!, REVIEWER, NOW)
     );
 
@@ -339,7 +339,7 @@ suite("self-registration integration (Wave 2 delta auth)", () => {
     const sent: Sent = [];
 
     expect(
-      await withTenant(getRuntimeSql(), TENANT_B, (tx) =>
+      await withTenantOrThrow(getRuntimeSql(), TENANT_B, (tx) =>
         listPendingRegistrations(tx, TENANT_B)
       )
     ).toEqual([]);

--- a/tests/integration/seo-distribution.integration.test.ts
+++ b/tests/integration/seo-distribution.integration.test.ts
@@ -34,7 +34,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   fetchSeoTenantSettings,
   updateSeoTenantSettings
@@ -113,7 +113,7 @@ suite("seo_distribution module (integration)", () => {
 
   test("config round-trip: write then read is tenant-scoped", async () => {
     const runtime = getRuntimeSql();
-    const saved = await withTenant(runtime, TENANT_A, (tx) =>
+    const saved = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       updateSeoTenantSettings(
         tx,
         TENANT_A,
@@ -130,14 +130,14 @@ suite("seo_distribution module (integration)", () => {
     expect(saved.siteName).toBe("Tenant A Site");
     expect(saved.defaultRobotsNoindex).toBe(true);
 
-    const read = await withTenant(runtime, TENANT_A, (tx) =>
+    const read = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchSeoTenantSettings(tx, TENANT_A)
     );
     expect(read.siteName).toBe("Tenant A Site");
     expect(read.includedResourceTypes).toEqual(["blog_post"]);
 
     // Tenant B has no row → the neutral default object, not tenant A's config.
-    const readB = await withTenant(runtime, TENANT_B, (tx) =>
+    const readB = await withTenantOrThrow(runtime, TENANT_B, (tx) =>
       fetchSeoTenantSettings(tx, TENANT_B)
     );
     expect(readB.siteName).toBeNull();
@@ -151,7 +151,7 @@ suite("seo_distribution module (integration)", () => {
       return;
     }
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       updateSeoTenantSettings(
         tx,
         TENANT_A,
@@ -169,7 +169,7 @@ suite("seo_distribution module (integration)", () => {
     expect(noContext).toHaveLength(0);
 
     // Tenant B's context sees none of tenant A's config.
-    const asB = await withTenant(app, TENANT_B, async (tx) => {
+    const asB = await withTenantOrThrow(app, TENANT_B, async (tx) => {
       const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_seo_tenant_settings
       `) as { n: number }[];
@@ -178,7 +178,7 @@ suite("seo_distribution module (integration)", () => {
     expect(asB).toBe(0);
 
     // Tenant A's own context DOES see its config.
-    const asA = await withTenant(app, TENANT_A, async (tx) => {
+    const asA = await withTenantOrThrow(app, TENANT_A, async (tx) => {
       const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_seo_tenant_settings
       `) as { n: number }[];
@@ -190,7 +190,7 @@ suite("seo_distribution module (integration)", () => {
   test("public discovery build returns PUBLISHED blog facts (host-absolute) and never a draft", async () => {
     const runtime = getRuntimeSql();
 
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await seedPrimaryDomain(tx, TENANT_A, "example.com");
       await seedBlogPost(tx, TENANT_A, {
         slug: "public-post",
@@ -226,7 +226,7 @@ suite("seo_distribution module (integration)", () => {
       now: NOW
     });
 
-    const sitemap = await withTenant(runtime, TENANT_A, (tx) =>
+    const sitemap = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       buildSitemapPagePayload(ctx(tx), 1)
     );
     expect(sitemap).not.toBeNull();
@@ -241,7 +241,7 @@ suite("seo_distribution module (integration)", () => {
     expect(sitemap!.body).not.toContain("draft-post");
     expect(sitemap!.body).not.toContain("private-post");
 
-    const rss = await withTenant(runtime, TENANT_A, (tx) =>
+    const rss = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       buildFeedPayload(ctx(tx), "rss")
     );
     expect(rss).not.toBeNull();
@@ -255,7 +255,7 @@ suite("seo_distribution module (integration)", () => {
 
   test("tenant-wide default_robots_noindex suppresses sitemap AND feeds (auditor MEDIUM-1), not just robots.txt", async () => {
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await seedPrimaryDomain(tx, TENANT_A, "example.com");
       await seedBlogPost(tx, TENANT_A, {
         slug: "public-post",
@@ -286,15 +286,15 @@ suite("seo_distribution module (integration)", () => {
     // Even with a verified primary host + a published post, the machine-readable
     // discovery surfaces return null (route → 404), mirroring robots.txt's
     // `Disallow: /`. Non-compliant scrapers/aggregators get no URL enumeration.
-    const sitemap = await withTenant(runtime, TENANT_A, (tx) =>
+    const sitemap = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       buildSitemapPagePayload(ctx(tx), 1)
     );
     expect(sitemap).toBeNull();
-    const index = await withTenant(runtime, TENANT_A, (tx) =>
+    const index = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       buildSitemapIndexPayload(ctx(tx))
     );
     expect(index).toBeNull();
-    const rss = await withTenant(runtime, TENANT_A, (tx) =>
+    const rss = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       buildFeedPayload(ctx(tx), "rss")
     );
     expect(rss).toBeNull();
@@ -302,7 +302,7 @@ suite("seo_distribution module (integration)", () => {
 
   test("no primary domain: sitemap/feed 404 (null), but discovery does not crash", async () => {
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       seedBlogPost(tx, TENANT_A, {
         slug: "orphan",
         title: "Orphan",
@@ -324,12 +324,12 @@ suite("seo_distribution module (integration)", () => {
 
     // No verified primary host → a sitemap/feed's <loc>/<guid> MUST be absolute,
     // so the builders return null (the route maps that to a generic 404).
-    const sitemap = await withTenant(runtime, TENANT_A, (tx) =>
+    const sitemap = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       buildSitemapPagePayload(ctx(tx), 1)
     );
     expect(sitemap).toBeNull();
 
-    const rss = await withTenant(runtime, TENANT_A, (tx) =>
+    const rss = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       buildFeedPayload(ctx(tx), "rss")
     );
     expect(rss).toBeNull();

--- a/tests/integration/seo-redirect-governance.integration.test.ts
+++ b/tests/integration/seo-redirect-governance.integration.test.ts
@@ -42,7 +42,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import { validateRedirectInput } from "../../src/modules/seo-distribution/domain/redirect-rule";
 import {
   createRedirect,
@@ -121,7 +121,7 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
     const runtime = getRuntimeSql();
 
     // Seed one live rule + settings + a 404 observation for tenant A.
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await createRedirect(
         tx,
         TENANT_A,
@@ -155,7 +155,7 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
     }
 
     // Tenant B's context sees none of tenant A's redirect rules.
-    const asB = await withTenant(app, TENANT_B, async (tx) => {
+    const asB = await withTenantOrThrow(app, TENANT_B, async (tx) => {
       const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_seo_redirects
       `) as { n: number }[];
@@ -164,7 +164,7 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
     expect(asB).toBe(0);
 
     // Tenant A's own context DOES see its rule.
-    const asA = await withTenant(app, TENANT_A, async (tx) => {
+    const asA = await withTenantOrThrow(app, TENANT_A, async (tx) => {
       const rows = (await tx`
         SELECT count(*)::int AS n FROM awcms_seo_redirects
       `) as { n: number }[];
@@ -181,7 +181,7 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
     }
     const runtime = getRuntimeSql();
 
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await seedPrimaryDomain(tx, TENANT_A, HOST_A);
       await createRedirect(
         tx,
@@ -214,7 +214,7 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
     }
     const runtime = getRuntimeSql();
 
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await seedPrimaryDomain(tx, TENANT_A, HOST_A);
       // Insert a malicious rule DIRECTLY, bypassing write-time validation — this is
       // the "host removed / rule tampered after write" case the resolve-time
@@ -262,7 +262,7 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
       domainHost: HOST_A
     };
 
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await recordNotFoundObservation(tx, TENANT_A, { ...capture, at: NOW });
       await recordNotFoundObservation(tx, TENANT_A, {
         ...capture,
@@ -270,7 +270,7 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
       });
     });
 
-    const rows = await withTenant(runtime, TENANT_A, async (tx) => {
+    const rows = await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       return (await tx`
         SELECT normalized_path, hit_count::int AS hit_count
         FROM awcms_seo_not_found_observations
@@ -287,16 +287,16 @@ suite("seo_distribution redirect governance (ADR-0039, integration)", () => {
   test("a redirect created for tenant A is not readable by getRedirectById under tenant B's context", async () => {
     const runtime = getRuntimeSql();
 
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createRedirect(tx, TENANT_A, ACTOR, relativeRedirectInput("/a", "/b"))
     );
 
-    const seenByB = await withTenant(runtime, TENANT_B, (tx) =>
+    const seenByB = await withTenantOrThrow(runtime, TENANT_B, (tx) =>
       getRedirectById(tx, TENANT_B, created.id)
     );
     expect(seenByB).toBeNull();
 
-    const seenByA = await withTenant(runtime, TENANT_A, (tx) =>
+    const seenByA = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       getRedirectById(tx, TENANT_A, created.id)
     );
     expect(seenByA?.normalizedSourcePath).toBe("/a");

--- a/tests/integration/site-search.integration.test.ts
+++ b/tests/integration/site-search.integration.test.ts
@@ -37,7 +37,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import { getRegisteredSearchSources } from "../../src/modules/site-search/presentation/search-sources";
 import {
   rebuildTenantSearchIndex,
@@ -98,7 +98,7 @@ async function insertPost(tenantId: string, seed: PostSeed): Promise<string> {
 }
 
 async function docCount(tenantId: string): Promise<number> {
-  return withTenant(getRuntimeSql(), tenantId, async (tx) => {
+  return withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
     const rows = (await tx`
       SELECT count(*)::int AS count FROM awcms_site_search_documents
     `) as { count: number }[];
@@ -155,12 +155,12 @@ suite("site_search module (integration, ADR-0040)", () => {
       publishedAt: new Date(Date.now() + 86_400_000)
     });
 
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
 
     expect(await docCount(TENANT_A)).toBe(1);
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, { query: "fox", locale: "en", limit: 20 })
     );
     expect(result.items).toHaveLength(1);
@@ -177,10 +177,10 @@ suite("site_search module (integration, ADR-0040)", () => {
       slug: "draft",
       status: "draft"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "unpublishedwombat",
         locale: "en",
@@ -196,7 +196,7 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "panther body",
       slug: "rem"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
     expect(await docCount(TENANT_A)).toBe(1);
@@ -204,12 +204,12 @@ suite("site_search module (integration, ADR-0040)", () => {
     await getAdminSql()`
       UPDATE awcms_blog_posts SET status = 'draft', updated_at = now() WHERE id = ${id}
     `;
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
     expect(await docCount(TENANT_A)).toBe(0);
 
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "panther",
         locale: "en",
@@ -225,7 +225,7 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "lynx body",
       slug: "lynx"
     });
-    const first = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const first = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reindexSearchResource(tx, TENANT_A, SOURCES[0]!, id)
     );
     expect(first).toBe("indexed");
@@ -234,7 +234,7 @@ suite("site_search module (integration, ADR-0040)", () => {
     await getAdminSql()`
       UPDATE awcms_blog_posts SET status = 'archived', updated_at = now() WHERE id = ${id}
     `;
-    const second = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const second = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reindexSearchResource(tx, TENANT_A, SOURCES[0]!, id)
     );
     expect(second).toBe("removed");
@@ -249,7 +249,7 @@ suite("site_search module (integration, ADR-0040)", () => {
         slug: `p-${i}`
       });
     }
-    const first = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const first = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       rebuildTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
     expect(first.status).toBe("succeeded");
@@ -257,13 +257,13 @@ suite("site_search module (integration, ADR-0040)", () => {
     expect(await docCount(TENANT_A)).toBe(5);
 
     // Rebuild again — end state identical regardless of prior state.
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       rebuildTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
     expect(await docCount(TENANT_A)).toBe(5);
 
     // Reconcile a third time with no source change: every document unchanged.
-    const third = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const third = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
     expect(third.results[0]!.unchanged).toBe(5);
@@ -278,13 +278,13 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "marmot body",
       slug: "marmot"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
     await getAdminSql()`
       UPDATE awcms_blog_posts SET title = 'Renamed marmot', updated_at = now() WHERE id = ${id}
     `;
-    const run = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const run = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
     expect(run.results[0]!.updated).toBe(1);
@@ -303,14 +303,14 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "b body",
       slug: "b"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
-    await withTenant(getRuntimeSql(), TENANT_B, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_B, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_B, SOURCES)
     );
 
-    const aResult = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const aResult = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "aardvark",
         locale: "en",
@@ -322,12 +322,16 @@ suite("site_search module (integration, ADR-0040)", () => {
 
     // RLS also blocks a RAW cross-tenant read of the index table — the query
     // below has no tenant predicate at all.
-    const visible = await withTenant(getRuntimeSql(), TENANT_A, async (tx) => {
-      const rows = (await tx`
+    const visible = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT_A,
+      async (tx) => {
+        const rows = (await tx`
         SELECT count(*)::int AS c FROM awcms_site_search_documents
       `) as { c: number }[];
-      return rows[0]!.c;
-    });
+        return rows[0]!.c;
+      }
+    );
     expect(visible).toBe(1);
   });
 
@@ -344,11 +348,11 @@ suite("site_search module (integration, ADR-0040)", () => {
       slug: "en-cat",
       locale: "en"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
 
-    const enResult = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const enResult = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "kucing",
         locale: "en",
@@ -357,7 +361,7 @@ suite("site_search module (integration, ADR-0040)", () => {
     );
     expect(enResult.items).toHaveLength(0);
 
-    const idResult = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const idResult = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "kucing",
         locale: "id",
@@ -373,10 +377,10 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "hello <script>alert(document.cookie)</script> wolverine world",
       slug: "xss"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "wolverine",
         locale: "en",
@@ -398,10 +402,10 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "gopher body",
       slug: "g"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
-    const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "gopher'; DROP TABLE awcms_site_search_documents; --",
         locale: "en",
@@ -424,19 +428,22 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "secret",
       slug: "cham-b"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
-    await withTenant(getRuntimeSql(), TENANT_B, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_B, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_B, SOURCES)
     );
 
-    const suggestions = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
-      suggestSiteContent(tx, TENANT_A, {
-        query: "chamele",
-        locale: "en",
-        limit: 8
-      })
+    const suggestions = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT_A,
+      (tx) =>
+        suggestSiteContent(tx, TENANT_A, {
+          query: "chamele",
+          locale: "en",
+          limit: 8
+        })
     );
     expect(suggestions.length).toBeGreaterThanOrEqual(1);
     expect(suggestions.every((s) => s.title.includes("Chameleon"))).toBe(true);
@@ -449,11 +456,11 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "capybara body",
       slug: "cap"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
 
-    const included = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const included = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "capybara",
         locale: "en",
@@ -463,7 +470,7 @@ suite("site_search module (integration, ADR-0040)", () => {
     );
     expect(included.items).toHaveLength(1);
 
-    const excluded = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const excluded = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       searchSiteContent(tx, TENANT_A, {
         query: "capybara",
         locale: "en",
@@ -482,7 +489,7 @@ suite("site_search module (integration, ADR-0040)", () => {
         slug: `nb-${i}`
       });
     }
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
     );
 
@@ -491,7 +498,7 @@ suite("site_search module (integration, ADR-0040)", () => {
     for (let page = 0; page < 10; page += 1) {
       // The cursor is opaque to callers; a real client round-trips the string
       // through the query param, which is exactly what decodeSearchCursor does.
-      const result = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+      const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
         searchSiteContent(tx, TENANT_A, {
           query: "numbat",
           locale: "en",
@@ -513,13 +520,13 @@ suite("site_search module (integration, ADR-0040)", () => {
       body: "quokka body",
       slug: "quokka"
     });
-    await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       reconcileTenantSearchIndex(tx, TENANT_A, SOURCES, {
         trigger: "scheduled"
       })
     );
 
-    const status = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const status = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       fetchIndexStatus(tx, TENANT_A)
     );
     expect(status.documentCount).toBe(1);
@@ -531,7 +538,7 @@ suite("site_search module (integration, ADR-0040)", () => {
     expect(status.lastRun?.trigger).toBe("scheduled");
     expect(status.latestIndexedAt).not.toBeNull();
 
-    const runs = await withTenant(getRuntimeSql(), TENANT_A, (tx) =>
+    const runs = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
       fetchRecentRuns(tx, TENANT_A, 10)
     );
     expect(runs).toHaveLength(1);

--- a/tests/integration/sod.integration.test.ts
+++ b/tests/integration/sod.integration.test.ts
@@ -42,7 +42,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import { collectSoDRuleDescriptors } from "../../src/modules/identity-access/domain/sod-rule-registry";
 import { exampleDomainModules } from "../fixtures/example-domain-modules";
 import { createBusinessScopeAssignment } from "../../src/modules/identity-access/application/business-scope-assignment-service";
@@ -224,7 +224,7 @@ suite("segregation of duties (Issue #181)", () => {
       [["payment", "approve"]]
     );
 
-    const result = await withTenant(runtime, TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -253,7 +253,7 @@ suite("segregation of duties (Issue #181)", () => {
     ).toBe(true);
 
     // An append-only evaluation row was written.
-    const logged = await withTenant(
+    const logged = await withTenantOrThrow(
       runtime,
       TENANT_A,
       (tx) =>
@@ -272,7 +272,7 @@ suite("segregation of duties (Issue #181)", () => {
       [["payment", "approve"]]
     );
 
-    const result = await withTenant(runtime, TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createBusinessScopeAssignment(
         tx,
         TENANT_A,
@@ -306,7 +306,7 @@ suite("segregation of duties (Issue #181)", () => {
       A_SUBJECT
     );
 
-    const result = await withTenant(runtime, TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       checkHighRiskSoDConflicts(
         tx,
         TENANT_A,
@@ -327,7 +327,7 @@ suite("segregation of duties (Issue #181)", () => {
   test("ACTION-time mutation proof: without the conflicting fact, the action is NOT blocked", async () => {
     const runtime = getRuntimeSql();
     // Subject holds nothing conflicting.
-    const result = await withTenant(runtime, TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       checkHighRiskSoDConflicts(
         tx,
         TENANT_A,
@@ -381,7 +381,7 @@ suite("segregation of duties (Issue #181)", () => {
       VALUES (${TENANT_A}, ${identityRows[0]!.identity_id}, ${hashSessionToken(token)}, ${new Date(Date.now() + 3_600_000)})
     `;
 
-    const denied = await withTenant(runtime, TENANT_A, (tx) =>
+    const denied = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       authorizeInTransaction(
         tx,
         TENANT_A,
@@ -415,7 +415,7 @@ suite("segregation of duties (Issue #181)", () => {
     );
 
     // Blocked before any exception.
-    const before = await withTenant(runtime, TENANT_A, (tx) =>
+    const before = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       checkHighRiskSoDConflicts(
         tx,
         TENANT_A,
@@ -432,7 +432,7 @@ suite("segregation of duties (Issue #181)", () => {
     expect(before.blocked).toBe(true);
 
     // A_ACTOR requests an exception for the subject; blanket (null scope).
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createSoDConflictException(
         tx,
         TENANT_A,
@@ -455,7 +455,7 @@ suite("segregation of duties (Issue #181)", () => {
     const exceptionId = created.exception.id;
 
     // Self-approval (the requester A_ACTOR) is denied.
-    const selfApprove = await withTenant(runtime, TENANT_A, (tx) =>
+    const selfApprove = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       approveSoDConflictException(tx, TENANT_A, A_ACTOR, exceptionId, "self")
     );
     expect(selfApprove.ok).toBe(false);
@@ -467,15 +467,24 @@ suite("segregation of duties (Issue #181)", () => {
     // (A_ACTOR) filed the request (the create route accepts an arbitrary
     // subject). Without the subject!=approver guard, A_SUBJECT here holds the
     // conflicting permission AND could self-clear their own block.
-    const beneficiaryApprove = await withTenant(runtime, TENANT_A, (tx) =>
-      approveSoDConflictException(tx, TENANT_A, A_SUBJECT, exceptionId, "self")
+    const beneficiaryApprove = await withTenantOrThrow(
+      runtime,
+      TENANT_A,
+      (tx) =>
+        approveSoDConflictException(
+          tx,
+          TENANT_A,
+          A_SUBJECT,
+          exceptionId,
+          "self"
+        )
     );
     expect(beneficiaryApprove.ok).toBe(false);
     if (beneficiaryApprove.ok) throw new Error("unreachable");
     expect(beneficiaryApprove.reason).toBe("self_approval_denied");
 
     // A DIFFERENT user (A_APPROVER) approves.
-    const approved = await withTenant(runtime, TENANT_A, (tx) =>
+    const approved = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       approveSoDConflictException(
         tx,
         TENANT_A,
@@ -487,7 +496,7 @@ suite("segregation of duties (Issue #181)", () => {
     expect(approved.ok).toBe(true);
 
     // Now the conflict is covered.
-    const after = await withTenant(runtime, TENANT_A, (tx) =>
+    const after = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       checkHighRiskSoDConflicts(
         tx,
         TENANT_A,
@@ -514,7 +523,7 @@ suite("segregation of duties (Issue #181)", () => {
     );
 
     // Approved exception, then revoke -> immediately blocked again.
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createSoDConflictException(
         tx,
         TENANT_A,
@@ -532,7 +541,7 @@ suite("segregation of duties (Issue #181)", () => {
       )
     );
     if (!created.ok) throw new Error("unreachable");
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       approveSoDConflictException(
         tx,
         TENANT_A,
@@ -541,7 +550,7 @@ suite("segregation of duties (Issue #181)", () => {
         null
       )
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       revokeSoDConflictException(
         tx,
         TENANT_A,
@@ -552,7 +561,7 @@ suite("segregation of duties (Issue #181)", () => {
         }
       )
     );
-    const afterRevoke = await withTenant(runtime, TENANT_A, (tx) =>
+    const afterRevoke = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       checkHighRiskSoDConflicts(
         tx,
         TENANT_A,
@@ -577,7 +586,7 @@ suite("segregation of duties (Issue #181)", () => {
       VALUES (${TENANT_A}, ${RULE_VENDOR_PAYMENT}, ${A_SUBJECT}, 'expired override',
         ${A_ACTOR}, ${A_APPROVER}, 'approved', ${new Date(Date.now() - 100000)}, ${new Date(Date.now() - 1000)})
     `;
-    const afterExpired = await withTenant(runtime, TENANT_A, (tx) =>
+    const afterExpired = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       checkHighRiskSoDConflicts(
         tx,
         TENANT_A,
@@ -615,7 +624,7 @@ suite("segregation of duties (Issue #181)", () => {
 
     // Tenant B's subject, same rule, still blocked (the tenant-A exception is
     // invisible/inapplicable across the tenant boundary).
-    const blockedInB = await withTenant(runtime, TENANT_B, (tx) =>
+    const blockedInB = await withTenantOrThrow(runtime, TENANT_B, (tx) =>
       checkHighRiskSoDConflicts(
         tx,
         TENANT_B,
@@ -648,7 +657,7 @@ suite("segregation of duties (Issue #181)", () => {
 
     const app = getAppRoleSql();
     // Control: scoped to tenant A, the row IS visible.
-    const visibleInA = await withTenant(
+    const visibleInA = await withTenantOrThrow(
       app,
       TENANT_A,
       (tx) => tx`SELECT count(*)::int AS n FROM awcms_sod_conflict_exceptions`
@@ -656,7 +665,7 @@ suite("segregation of duties (Issue #181)", () => {
     expect((visibleInA[0] as { n: number }).n).toBe(1);
 
     // Scoped to tenant B, tenant A's row is INVISIBLE.
-    const visibleInB = await withTenant(
+    const visibleInB = await withTenantOrThrow(
       app,
       TENANT_B,
       (tx) => tx`SELECT count(*)::int AS n FROM awcms_sod_conflict_exceptions`
@@ -682,10 +691,10 @@ suite("segregation of duties (Issue #181)", () => {
     // status='pending', not by one racer being rejected at the self-approval
     // guard.
     const settled = await Promise.allSettled([
-      withTenant(runtime, TENANT_A, (tx) =>
+      withTenantOrThrow(runtime, TENANT_A, (tx) =>
         approveSoDConflictException(tx, TENANT_A, A_APPROVER, exceptionId, "r1")
       ),
-      withTenant(runtime, TENANT_A, (tx) =>
+      withTenantOrThrow(runtime, TENANT_A, (tx) =>
         approveSoDConflictException(
           tx,
           TENANT_A,
@@ -716,7 +725,7 @@ suite("segregation of duties (Issue #181)", () => {
     );
 
     const countQueries = async (subject: string): Promise<number> =>
-      withTenant(runtime, TENANT_A, async (tx) => {
+      withTenantOrThrow(runtime, TENANT_A, async (tx) => {
         let count = 0;
         const counting = new Proxy(tx, {
           apply(target, thisArg, args) {

--- a/tests/integration/sso-break-glass-readiness.integration.test.ts
+++ b/tests/integration/sso-break-glass-readiness.integration.test.ts
@@ -34,7 +34,7 @@ import {
 } from "bun:test";
 
 import { hashPassword } from "../../src/lib/auth/password";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import { saveTenantAuthPolicy } from "../../src/modules/identity-access/application/tenant-auth-policy";
 import { checkSsoBreakGlassReady } from "../../scripts/security-readiness";
 import {
@@ -108,7 +108,7 @@ async function lockDownTenant(
   // table's CHECK forbids a row with neither login method.
   mode: "sso_required" | "password_login_disabled" = "sso_required"
 ): Promise<void> {
-  const result = await withTenant(
+  const result = await withTenantOrThrow(
     getHandlerDatabaseClient(),
     tenantId,
     (tx) =>

--- a/tests/integration/tenant-domain.integration.test.ts
+++ b/tests/integration/tenant-domain.integration.test.ts
@@ -37,7 +37,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   createTenantDomain,
   fetchActiveTenantDomain,
@@ -95,7 +95,7 @@ suite("tenant_domain module (integration)", () => {
 
   test("create -> fetch -> list, verification_token_hash never returned", async () => {
     const runtime = getRuntimeSql();
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(tx, TENANT_A, ACTOR, createInput("A.Example.com"))
     );
     expect(created.hostname).toBe("A.Example.com");
@@ -103,12 +103,12 @@ suite("tenant_domain module (integration)", () => {
     expect(created.status).toBe("pending_verification");
     expect(created).not.toHaveProperty("verificationTokenHash");
 
-    const fetched = await withTenant(runtime, TENANT_A, (tx) =>
+    const fetched = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchActiveTenantDomain(tx, TENANT_A, created.id)
     );
     expect(fetched?.id).toBe(created.id);
 
-    const page = await withTenant(runtime, TENANT_A, (tx) =>
+    const page = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       listTenantDomains(tx, TENANT_A)
     );
     expect(page.domains).toHaveLength(1);
@@ -117,11 +117,11 @@ suite("tenant_domain module (integration)", () => {
 
   test("normalized_hostname is globally unique across tenants (case-insensitive)", async () => {
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(tx, TENANT_A, ACTOR, createInput("shared.example.com"))
     );
     const error = await assertRejected(
-      withTenant(runtime, TENANT_B, (tx) =>
+      withTenantOrThrow(runtime, TENANT_B, (tx) =>
         createTenantDomain(
           tx,
           TENANT_B,
@@ -138,22 +138,22 @@ suite("tenant_domain module (integration)", () => {
 
   test("soft delete frees the normalized hostname for reuse (even by another tenant)", async () => {
     const runtime = getRuntimeSql();
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(tx, TENANT_A, ACTOR, createInput("reuse.example.com"))
     );
-    const deleted = await withTenant(runtime, TENANT_A, (tx) =>
+    const deleted = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       softDeleteTenantDomain(tx, TENANT_A, ACTOR, created.id, "moved off")
     );
     expect(deleted).toBe(true);
 
     // A soft-deleted row no longer resolves through the directory.
-    const gone = await withTenant(runtime, TENANT_A, (tx) =>
+    const gone = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchActiveTenantDomain(tx, TENANT_A, created.id)
     );
     expect(gone).toBeNull();
 
     // The hostname is now reusable by a different tenant.
-    const recreated = await withTenant(runtime, TENANT_B, (tx) =>
+    const recreated = await withTenantOrThrow(runtime, TENANT_B, (tx) =>
       createTenantDomain(tx, TENANT_B, ACTOR, createInput("reuse.example.com"))
     );
     expect(recreated.tenantId).toBe(TENANT_B);
@@ -161,23 +161,23 @@ suite("tenant_domain module (integration)", () => {
 
   test("verify: needs a method, is idempotent at active, refuses suspended", async () => {
     const runtime = getRuntimeSql();
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(tx, TENANT_A, ACTOR, createInput("v.example.com"))
     );
 
     // No verification_method configured yet.
-    const noMethod = await withTenant(runtime, TENANT_A, (tx) =>
+    const noMethod = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
     );
     expect(noMethod.outcome).toBe("missing_verification_method");
 
     // Configure a method, then verify -> active.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       updateTenantDomain(tx, TENANT_A, ACTOR, created.id, {
         verificationMethod: "manual"
       })
     );
-    const verified = await withTenant(runtime, TENANT_A, (tx) =>
+    const verified = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
     );
     expect(verified.outcome).toBe("verified");
@@ -185,18 +185,18 @@ suite("tenant_domain module (integration)", () => {
     expect(verified.entry.status).toBe("active");
 
     // Idempotent at active.
-    const again = await withTenant(runtime, TENANT_A, (tx) =>
+    const again = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
     );
     expect(again.outcome).toBe("verified");
 
     // Suspended cannot be verified back to active.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       updateTenantDomain(tx, TENANT_A, ACTOR, created.id, {
         status: "suspended"
       })
     );
-    const suspended = await withTenant(runtime, TENANT_A, (tx) =>
+    const suspended = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
     );
     expect(suspended.outcome).toBe("not_verifiable");
@@ -204,7 +204,7 @@ suite("tenant_domain module (integration)", () => {
 
   test("set-primary: only an active domain, at most one primary per tenant", async () => {
     const runtime = getRuntimeSql();
-    const first = await withTenant(runtime, TENANT_A, (tx) =>
+    const first = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(
         tx,
         TENANT_A,
@@ -212,7 +212,7 @@ suite("tenant_domain module (integration)", () => {
         createInput("one.example.com", "manual")
       )
     );
-    const second = await withTenant(runtime, TENANT_A, (tx) =>
+    const second = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(
         tx,
         TENANT_A,
@@ -222,28 +222,28 @@ suite("tenant_domain module (integration)", () => {
     );
 
     // A pending domain cannot become primary.
-    const notActive = await withTenant(runtime, TENANT_A, (tx) =>
+    const notActive = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       setPrimaryTenantDomain(tx, TENANT_A, ACTOR, first.id)
     );
     expect(notActive.outcome).toBe("not_active");
 
     // Verify both, set first primary, then switch to second — only one primary.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       verifyTenantDomain(tx, TENANT_A, ACTOR, first.id)
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       verifyTenantDomain(tx, TENANT_A, ACTOR, second.id)
     );
-    const setFirst = await withTenant(runtime, TENANT_A, (tx) =>
+    const setFirst = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       setPrimaryTenantDomain(tx, TENANT_A, ACTOR, first.id)
     );
     expect(setFirst.outcome).toBe("set");
-    const setSecond = await withTenant(runtime, TENANT_A, (tx) =>
+    const setSecond = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       setPrimaryTenantDomain(tx, TENANT_A, ACTOR, second.id)
     );
     expect(setSecond.outcome).toBe("set");
 
-    const page = await withTenant(runtime, TENANT_A, (tx) =>
+    const page = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       listTenantDomains(tx, TENANT_A)
     );
     const primaries = page.domains.filter((d) => d.isPrimary);
@@ -253,10 +253,10 @@ suite("tenant_domain module (integration)", () => {
 
   test("cross-tenant isolation: tenant A cannot read tenant B's domain by id", async () => {
     const runtime = getRuntimeSql();
-    const bDomain = await withTenant(runtime, TENANT_B, (tx) =>
+    const bDomain = await withTenantOrThrow(runtime, TENANT_B, (tx) =>
       createTenantDomain(tx, TENANT_B, ACTOR, createInput("b-only.example.com"))
     );
-    const asA = await withTenant(runtime, TENANT_A, (tx) =>
+    const asA = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchActiveTenantDomain(tx, TENANT_A, bDomain.id)
     );
     expect(asA).toBeNull();
@@ -271,7 +271,7 @@ suite("tenant_domain module (integration)", () => {
 
     const runtime = getRuntimeSql();
     // Create an active, verified domain for the active tenant A.
-    const created = await withTenant(runtime, TENANT_A, (tx) =>
+    const created = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(
         tx,
         TENANT_A,
@@ -279,7 +279,7 @@ suite("tenant_domain module (integration)", () => {
         createInput("live.example.com", "manual")
       )
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       verifyTenantDomain(tx, TENANT_A, ACTOR, created.id)
     );
 
@@ -312,7 +312,7 @@ suite("tenant_domain module (integration)", () => {
     const runtime = getRuntimeSql();
 
     // Pending domain under an active tenant -> not resolved.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       createTenantDomain(
         tx,
         TENANT_A,
@@ -321,7 +321,7 @@ suite("tenant_domain module (integration)", () => {
       )
     );
     // Active domain under an INACTIVE tenant -> not resolved.
-    const onInactive = await withTenant(runtime, TENANT_INACTIVE, (tx) =>
+    const onInactive = await withTenantOrThrow(runtime, TENANT_INACTIVE, (tx) =>
       createTenantDomain(
         tx,
         TENANT_INACTIVE,
@@ -329,7 +329,7 @@ suite("tenant_domain module (integration)", () => {
         createInput("inactive-tenant.example.com", "manual")
       )
     );
-    await withTenant(runtime, TENANT_INACTIVE, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_INACTIVE, (tx) =>
       verifyTenantDomain(tx, TENANT_INACTIVE, ACTOR, onInactive.id)
     );
 

--- a/tests/integration/theming.integration.test.ts
+++ b/tests/integration/theming.integration.test.ts
@@ -36,7 +36,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   fetchThemeTenantState,
   insertPublishedVersion,
@@ -113,10 +113,10 @@ suite("theming module (integration)", () => {
     const runtime = getRuntimeSql();
 
     // Save a draft, then publish it (version 1).
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
     );
-    const pub1 = await withTenant(runtime, TENANT_A, (tx) =>
+    const pub1 = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
     );
     expect(pub1.ok).toBe(true);
@@ -124,7 +124,7 @@ suite("theming module (integration)", () => {
     expect(pub1.version.versionNumber).toBe(1);
 
     // A fresh draft + publish → version 2.
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       saveThemeDraft(
         tx,
         TENANT_A,
@@ -134,7 +134,7 @@ suite("theming module (integration)", () => {
         noAudit
       )
     );
-    const pub2 = await withTenant(runtime, TENANT_A, (tx) =>
+    const pub2 = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
     );
     expect(pub2.ok).toBe(true);
@@ -142,30 +142,30 @@ suite("theming module (integration)", () => {
     expect(pub2.version.versionNumber).toBe(2);
 
     // The active pointer is the latest published version.
-    const state = await withTenant(runtime, TENANT_A, (tx) =>
+    const state = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchThemeTenantState(tx, TENANT_A)
     );
     expect(state.activeThemeKey).toBe("aria");
     expect(state.activeVersionId).toBe(pub2.version.id);
 
     // rollback to v1, then retire.
-    const roll = await withTenant(runtime, TENANT_A, (tx) =>
+    const roll = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       rollbackThemeVersion(tx, TENANT_A, ACTOR, pub1.version.id, noAudit)
     );
     expect(roll.ok).toBe(true);
     if (!roll.ok) return;
     expect(roll.version.id).toBe(pub1.version.id);
 
-    const rolledState = await withTenant(runtime, TENANT_A, (tx) =>
+    const rolledState = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchThemeTenantState(tx, TENANT_A)
     );
     expect(rolledState.activeVersionId).toBe(pub1.version.id);
 
-    const retire = await withTenant(runtime, TENANT_A, (tx) =>
+    const retire = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       retireActiveTheme(tx, TENANT_A, ACTOR, noAudit)
     );
     expect(retire.previousThemeKey).toBe("aria");
-    const retiredState = await withTenant(runtime, TENANT_A, (tx) =>
+    const retiredState = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchThemeTenantState(tx, TENANT_A)
     );
     expect(retiredState.activeVersionId).toBeNull();
@@ -173,13 +173,13 @@ suite("theming module (integration)", () => {
 
   test("rollback to a foreign/nonexistent version id is refused (INVALID_TARGET)", async () => {
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
     );
-    const bad = await withTenant(runtime, TENANT_A, (tx) =>
+    const bad = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       rollbackThemeVersion(
         tx,
         TENANT_A,
@@ -193,10 +193,10 @@ suite("theming module (integration)", () => {
 
   test("a PUBLISHED version row is IMMUTABLE — UPDATE and DELETE both raise (sql/033 trigger)", async () => {
     const runtime = getRuntimeSql();
-    const versionNumber = await withTenant(runtime, TENANT_A, (tx) =>
+    const versionNumber = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       nextPublishedVersionNumber(tx, TENANT_A)
     );
-    const published = await withTenant(runtime, TENANT_A, (tx) =>
+    const published = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       insertPublishedVersion(
         tx,
         TENANT_A,
@@ -210,7 +210,7 @@ suite("theming module (integration)", () => {
     );
 
     await assertRejected(
-      withTenant(
+      withTenantOrThrow(
         runtime,
         TENANT_A,
         (tx) =>
@@ -219,7 +219,7 @@ suite("theming module (integration)", () => {
       "UPDATE of a published version row"
     );
     await assertRejected(
-      withTenant(
+      withTenantOrThrow(
         runtime,
         TENANT_A,
         (tx) =>
@@ -244,15 +244,15 @@ suite("theming module (integration)", () => {
     const app = getAppRoleSql();
 
     // Tenant A publishes a version (writes config_version + state rows).
-    await withTenant(app, TENANT_A, (tx) =>
+    await withTenantOrThrow(app, TENANT_A, (tx) =>
       saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
     );
-    await withTenant(app, TENANT_A, (tx) =>
+    await withTenantOrThrow(app, TENANT_A, (tx) =>
       publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
     );
 
     // A really did write its own rows.
-    const aVersions = (await withTenant(
+    const aVersions = (await withTenantOrThrow(
       app,
       TENANT_A,
       (tx) => tx`SELECT count(*)::int AS c FROM awcms_theming_config_versions`
@@ -260,13 +260,13 @@ suite("theming module (integration)", () => {
     expect(aVersions[0]!.c).toBeGreaterThan(0);
 
     // Under B's tenant context, A's version + state rows are simply not visible.
-    const bVersions = (await withTenant(
+    const bVersions = (await withTenantOrThrow(
       app,
       TENANT_B,
       (tx) => tx`SELECT count(*)::int AS c FROM awcms_theming_config_versions`
     )) as { c: number }[];
     expect(bVersions[0]!.c).toBe(0);
-    const bState = (await withTenant(
+    const bState = (await withTenantOrThrow(
       app,
       TENANT_B,
       (tx) => tx`SELECT count(*)::int AS c FROM awcms_theming_tenant_state`
@@ -279,7 +279,7 @@ suite("theming module (integration)", () => {
     const now = new Date();
 
     // A draft version to attach the preview to.
-    const draft = await withTenant(runtime, TENANT_A, (tx) =>
+    const draft = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       upsertDraftVersion(
         tx,
         TENANT_A,
@@ -294,7 +294,7 @@ suite("theming module (integration)", () => {
     // A live session resolves; an expired one is filtered out by `expires_at`.
     const liveRaw = "1".repeat(64);
     const expiredRaw = "2".repeat(64);
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       await createPreviewSession(
         tx,
         TENANT_A,
@@ -313,18 +313,18 @@ suite("theming module (integration)", () => {
       );
     });
 
-    const live = await withTenant(runtime, TENANT_A, (tx) =>
+    const live = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       findActivePreviewSession(tx, hashPreviewToken(liveRaw), now)
     );
     expect(live?.versionId).toBe(draft.id);
 
-    const expired = await withTenant(runtime, TENANT_A, (tx) =>
+    const expired = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       findActivePreviewSession(tx, hashPreviewToken(expiredRaw), now)
     );
     expect(expired).toBeNull();
 
     // A preview session created for A is invisible under B's tenant context.
-    const crossTenant = await withTenant(runtime, TENANT_B, (tx) =>
+    const crossTenant = await withTenantOrThrow(runtime, TENANT_B, (tx) =>
       findActivePreviewSession(tx, hashPreviewToken(liveRaw), now)
     );
     expect(crossTenant).toBeNull();
@@ -332,13 +332,13 @@ suite("theming module (integration)", () => {
 
   test("published version history lists newest-first and only published rows", async () => {
     const runtime = getRuntimeSql();
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       saveThemeDraft(tx, TENANT_A, ACTOR, defaultTheme, validConfig(), noAudit)
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       saveThemeDraft(
         tx,
         TENANT_A,
@@ -348,10 +348,10 @@ suite("theming module (integration)", () => {
         noAudit
       )
     );
-    await withTenant(runtime, TENANT_A, (tx) =>
+    await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       publishThemeDraft(tx, TENANT_A, ACTOR, noAudit)
     );
-    const history = await withTenant(runtime, TENANT_A, (tx) =>
+    const history = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       listPublishedVersions(tx, TENANT_A, 50)
     );
     expect(history.map((v) => v.versionNumber)).toEqual([2, 1]);

--- a/tests/integration/visitor-analytics.integration.test.ts
+++ b/tests/integration/visitor-analytics.integration.test.ts
@@ -37,7 +37,7 @@ import {
   setupIntegrationDatabase,
   teardownIntegrationDatabase
 } from "./harness";
-import { withTenant } from "../../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import { collectVisitorTelemetry } from "../../src/modules/visitor-analytics/application/collector";
 import {
   fetchAnalyticsSummary,
@@ -118,7 +118,7 @@ suite("visitor_analytics module (integration)", () => {
     const runtime = getRuntimeSql();
     await collectHuman(TENANT_A, "/blog/acme/post-1");
 
-    const counts = await withTenant(runtime, TENANT_A, async (tx) => {
+    const counts = await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const sessions = (await tx`
         SELECT count(*) AS n FROM awcms_visitor_sessions WHERE tenant_id = ${TENANT_A}
       `) as { n: string }[];
@@ -133,7 +133,7 @@ suite("visitor_analytics module (integration)", () => {
     expect(counts.sessions).toBe(1);
     expect(counts.events).toBe(1);
 
-    const summary = await withTenant(runtime, TENANT_A, (tx) =>
+    const summary = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchAnalyticsSummary(
         tx,
         TENANT_A,
@@ -145,7 +145,7 @@ suite("visitor_analytics module (integration)", () => {
     expect(summary.humanUniqueVisitors).toBe(1);
     expect(summary.botPageviews).toBe(0);
 
-    const realtime = await withTenant(runtime, TENANT_A, (tx) =>
+    const realtime = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       fetchRealtimeStats(tx, TENANT_A, CONFIG.onlineWindowSeconds)
     );
     expect(realtime.onlineHumanCount).toBe(1);
@@ -156,7 +156,7 @@ suite("visitor_analytics module (integration)", () => {
     const runtime = getRuntimeSql();
     await collectHuman(TENANT_A, "/");
 
-    const row = await withTenant(runtime, TENANT_A, async (tx) => {
+    const row = await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const rows = (await tx`
         SELECT ip_address, ip_hash, user_agent_hash, visitor_key_hash, identity_id
         FROM awcms_visitor_sessions WHERE tenant_id = ${TENANT_A} LIMIT 1
@@ -181,7 +181,7 @@ suite("visitor_analytics module (integration)", () => {
     const runtime = getRuntimeSql();
     await collectHuman(TENANT_A, "/only-a");
 
-    const asB = await withTenant(runtime, TENANT_B, async (tx) => {
+    const asB = await withTenantOrThrow(runtime, TENANT_B, async (tx) => {
       const rows = (await tx`
         SELECT count(*) AS n FROM awcms_visit_events
       `) as { n: string }[];
@@ -213,7 +213,7 @@ suite("visitor_analytics module (integration)", () => {
     const runtime = getRuntimeSql();
     await collectHuman(TENANT_A, "/");
 
-    const sessionId = await withTenant(runtime, TENANT_A, async (tx) => {
+    const sessionId = await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const rows = (await tx`
         SELECT id FROM awcms_visitor_sessions WHERE tenant_id = ${TENANT_A} LIMIT 1
       `) as { id: string }[];
@@ -224,7 +224,7 @@ suite("visitor_analytics module (integration)", () => {
     // (tenant_id, visitor_session_id) composite FK — (B, A_session) does not
     // exist in awcms_visitor_sessions(tenant_id, id).
     await assertRejected(
-      withTenant(
+      withTenantOrThrow(
         runtime,
         TENANT_B,
         (tx) =>
@@ -243,7 +243,7 @@ suite("visitor_analytics module (integration)", () => {
     const oldTs = "2000-01-01T00:00:00Z";
 
     // Seed one deliberately-ancient session + event directly.
-    await withTenant(runtime, TENANT_A, async (tx) => {
+    await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const sessionRows = (await tx`
         INSERT INTO awcms_visitor_sessions
           (tenant_id, visitor_key_hash, area, first_seen_at, last_seen_at)
@@ -258,7 +258,7 @@ suite("visitor_analytics module (integration)", () => {
       `;
     });
 
-    const result = await withTenant(runtime, TENANT_A, (tx) =>
+    const result = await withTenantOrThrow(runtime, TENANT_A, (tx) =>
       purgeVisitorAnalyticsData(tx, TENANT_A, CONFIG, new Date(), NEVER_HELD)
     );
     if (result instanceof Response)
@@ -267,7 +267,7 @@ suite("visitor_analytics module (integration)", () => {
     expect(result.eventsDeleted).toBe(1);
     expect(result.sessionsDeleted).toBe(1);
 
-    const remaining = await withTenant(runtime, TENANT_A, async (tx) => {
+    const remaining = await withTenantOrThrow(runtime, TENANT_A, async (tx) => {
       const rows = (await tx`
         SELECT count(*) AS n FROM awcms_visit_events WHERE tenant_id = ${TENANT_A}
       `) as { n: string }[];

--- a/tests/reporting-projection-rebuild-lock.test.ts
+++ b/tests/reporting-projection-rebuild-lock.test.ts
@@ -39,7 +39,7 @@ import type {
   ProjectionCursorStream,
   ProjectionDescriptor
 } from "../src/modules/_shared/module-contract";
-import { withTenant } from "../src/lib/database/tenant-context";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { runIncrementalUpdateForTenant } from "../src/modules/reporting/application/projection-incremental-worker";
 import { lockProjectionForWrite } from "../src/modules/reporting/application/projection-lock";
 import { getProjectionMetrics } from "../src/modules/reporting/application/projection-metric-store";
@@ -179,7 +179,7 @@ describeWithDatabase(
     }
 
     async function readMetric(): Promise<number> {
-      const metrics = await withTenant(sql, tenantId, (tx) =>
+      const metrics = await withTenantOrThrow(sql, tenantId, (tx) =>
         getProjectionMetrics(tx, tenantId, PROJECTION_KEY)
       );
 
@@ -320,7 +320,7 @@ describeWithDatabase(
       // its transaction (and, after the fix, the projection lock) open.
       await sleep(500);
 
-      const triggerRun = withTenant(sql, tenantId, (tx) =>
+      const triggerRun = withTenantOrThrow(sql, tenantId, (tx) =>
         triggerOrResumeRebuild(tx, tenantId, DESCRIPTOR, {
           requestedBy: null,
           reason: "Issue #151 reset-mid-pass probe"
@@ -348,7 +348,7 @@ describeWithDatabase(
 
       // Once everything drains, exactly one rebuild owns the projection and
       // the reset it performed is intact.
-      const running = await withTenant(sql, tenantId, (tx) =>
+      const running = await withTenantOrThrow(sql, tenantId, (tx) =>
         findRunningRebuild(tx, tenantId, PROJECTION_KEY)
       );
       expect(running).not.toBeNull();

--- a/tests/sso-break-glass-readiness-contract.test.ts
+++ b/tests/sso-break-glass-readiness-contract.test.ts
@@ -62,7 +62,7 @@ describe("the break-glass readiness check", () => {
     expect(check).not.toMatch(/\b(FROM|JOIN)\s+awcms_tenant_users\b/);
   });
 
-  test("reads policies through withTenant, so RLS is exercised rather than sidestepped", async () => {
+  test("reads policies through withTenantOrThrow, so RLS is exercised rather than sidestepped", async () => {
     const source = await readFile(SCRIPT, "utf8");
     const check = source.slice(
       source.indexOf("export async function checkSsoBreakGlassReady"),
@@ -72,7 +72,7 @@ describe("the break-glass readiness check", () => {
     // A direct `SELECT ... FROM awcms_tenant_auth_policies` would return zero
     // rows under FORCE RLS without the tenant GUC — and zero rows reads as
     // "no tenant is locked down", i.e. a silent unconditional PASS.
-    expect(check).toContain("withTenant(");
+    expect(check).toContain("withTenantOrThrow(");
     expect(check).not.toContain("FROM awcms_tenant_auth_policies");
   });
 

--- a/tests/tenant-context-circuit-breaker.test.ts
+++ b/tests/tenant-context-circuit-breaker.test.ts
@@ -8,7 +8,10 @@ import {
   acquireWorkClassSlot,
   resetWorkClassGatesForTests
 } from "../src/lib/database/work-class";
-import { withTenant } from "../src/lib/database/tenant-context";
+import {
+  withTenant,
+  withTenantOrThrow
+} from "../src/lib/database/tenant-context";
 
 const TENANT_ID = "11111111-1111-1111-1111-111111111111";
 
@@ -28,7 +31,7 @@ function fakeSql(): Bun.SQL {
   } as unknown as Bun.SQL;
 }
 
-describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () => {
+describe("tenant transaction circuit breaker (Issue #599, extended by Issue #601)", () => {
   beforeEach(() => {
     resetDatabaseCircuitBreakerForTests();
     resetWorkClassGatesForTests();
@@ -48,7 +51,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
 
     for (let i = 0; i < 10; i++) {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw violation;
         })
       ).rejects.toBe(violation);
@@ -71,7 +74,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
 
     for (let i = 0; i < 10; i++) {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw violation;
         })
       ).rejects.toBe(violation);
@@ -92,7 +95,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
 
     for (let i = 0; i < 10; i++) {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw violation;
         })
       ).rejects.toBe(violation);
@@ -110,7 +113,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
 
     for (let i = 0; i < 10; i++) {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw violation;
         })
       ).rejects.toBe(violation);
@@ -129,7 +132,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
     // Default failure threshold is 5 consecutive failures (circuit-breaker.ts).
     for (let i = 0; i < 5; i++) {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw connectionError;
         })
       ).rejects.toBe(connectionError);
@@ -144,7 +147,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
 
     for (let i = 0; i < 5; i++) {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw genericError;
         })
       ).rejects.toBe(genericError);
@@ -156,7 +159,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
   test("a success still resets recorded state (no regression)", async () => {
     const sql = fakeSql();
 
-    const result = await withTenant(sql, TENANT_ID, async () => "ok");
+    const result = await withTenantOrThrow(sql, TENANT_ID, async () => "ok");
 
     expect(result).toBe("ok");
     expect(getDatabaseCircuitBreaker().canAttempt(new Date())).toBe(true);
@@ -177,7 +180,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
 
     try {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw violation;
         })
       ).rejects.toBe(violation);
@@ -199,7 +202,7 @@ describe("withTenant circuit breaker (Issue #599, extended by Issue #601)", () =
 
 // Issue #743 — every 503 DATABASE_BUSY withTenant can return now carries a
 // Retry-After header ("controlled 503 instead of cascading timeouts").
-describe("withTenant graceful saturation and Retry-After (Issue #743)", () => {
+describe("graceful saturation and Retry-After (Issue #743)", () => {
   beforeEach(() => {
     resetDatabaseCircuitBreakerForTests();
     resetWorkClassGatesForTests();
@@ -216,7 +219,7 @@ describe("withTenant graceful saturation and Retry-After (Issue #743)", () => {
 
     for (let i = 0; i < 5; i++) {
       await expect(
-        withTenant(sql, TENANT_ID, async () => {
+        withTenantOrThrow(sql, TENANT_ID, async () => {
           throw genericError;
         })
       ).rejects.toBe(genericError);

--- a/tests/tenant-context-usage.test.ts
+++ b/tests/tenant-context-usage.test.ts
@@ -1,0 +1,133 @@
+/**
+ * `db:tenant-context:check` — the two ways a pool refusal escapes the type
+ * system.
+ *
+ * Every case feeds `findUsageViolations` source it must reject, and the two
+ * central ones reinstate the REAL defects this gate was written for, in the
+ * exact form they shipped:
+ *
+ * - `src/pages/api/v1/auth/sso/[providerKey]/callback.ts` discarded the result
+ *   of an audit-event write, so under a saturated pool an `sso_account_linked`
+ *   record was skipped and the endpoint still answered as though it had been
+ *   made.
+ * - the 15 admin `.astro` screens assign the result to a variable they then
+ *   read fields off, in files `tsc --noEmit` never opens.
+ *
+ * The last block runs the gate against the real repository, so this file is
+ * also the drift detector.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectUsageViolations,
+  findUsageViolations
+} from "../scripts/tenant-context-usage-check";
+
+describe("a discarded withTenant() result", () => {
+  test("flags the defect this gate exists for: an audit write whose 503 goes nowhere", () => {
+    const violations = findUsageViolations(
+      "src/pages/api/v1/auth/sso/[providerKey]/callback.ts",
+      [
+        'if (result.outcome === "linked") {',
+        "  await withTenant(sql, result.tenantId, (tx) =>",
+        "    recordAuditEvent(tx, { action: 'sso_account_linked' })",
+        "  );",
+        "}"
+      ].join("\n")
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.kind).toBe("discarded_result");
+    expect(violations[0]!.line).toBe(2);
+  });
+
+  test("the generic form is caught too", () => {
+    expect(
+      findUsageViolations("src/x.ts", "await withTenant<void>(sql, id, fn);")
+    ).toHaveLength(1);
+  });
+
+  test("a returned result is not discarded — the compiler owns it from there", () => {
+    expect(
+      findUsageViolations(
+        "src/pages/api/v1/offices/index.ts",
+        "return withTenant(sql, tenantId, async (tx) => ok(tx));"
+      )
+    ).toEqual([]);
+  });
+
+  test("an assigned result is not discarded", () => {
+    // `const x = await withTenant(...)` keeps the value reachable, so whichever
+    // branch reads it is a compile error rather than this gate's business.
+    expect(
+      findUsageViolations(
+        "src/x.ts",
+        "const precheck = await withTenant<PrecheckResult>(sql, id, fn);"
+      )
+    ).toEqual([]);
+  });
+
+  test("withTenantOrThrow — the fix — is never flagged", () => {
+    expect(
+      findUsageViolations(
+        "src/modules/logging/application/audit-purge.ts",
+        "await withTenantOrThrow(sql, tenantId, async (tx) => {"
+      )
+    ).toEqual([]);
+  });
+});
+
+describe("a .astro call", () => {
+  test("is flagged even when the result IS used, because tsc never reads the file", () => {
+    // The distinction that matters: this same line in a `.ts` file is fine,
+    // because `Response | Row[]` fails to compile at `rows.map`. In `.astro`
+    // nothing checks it, so the rule is the extension, not the shape.
+    const source = "const rows = await withTenant(sql, ssr.tenantId, load);";
+
+    expect(findUsageViolations("src/pages/admin/users.astro", source)).toEqual([
+      {
+        file: "src/pages/admin/users.astro",
+        line: 1,
+        kind: "astro_frontmatter",
+        text: source
+      }
+    ]);
+    expect(findUsageViolations("src/pages/admin/users.ts", source)).toEqual([]);
+  });
+});
+
+describe("comment handling", () => {
+  test("a file that DOCUMENTS the rule is not counted as breaking it", () => {
+    // Not hypothetical: this gate's own header, and `withTenant`'s docblock,
+    // both spell out the discarded-`await` shape. Without this the gate
+    // reports itself — the third time that has happened in this repository.
+    const source = [
+      "/**",
+      " * Historically this did `await withTenant(sql, id, fn);` and dropped it.",
+      " */",
+      "// see also: await withTenant(sql, id, fn)",
+      "await withTenantOrThrow(sql, id, fn);"
+    ].join("\n");
+
+    expect(findUsageViolations("src/x.ts", source)).toEqual([]);
+  });
+});
+
+describe("the real repository", () => {
+  test("has no discarded refusal and no .astro caller", async () => {
+    const violations = await collectUsageViolations();
+
+    expect(violations.map((v) => `${v.file}:${v.line} (${v.kind})`)).toEqual(
+      []
+    );
+  }, 60000);
+
+  test("is wired into `bun run check`", async () => {
+    const manifest = (await Bun.file("package.json").json()) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(manifest.scripts["db:tenant-context:check"]).toBeDefined();
+    expect(manifest.scripts.check).toContain("db:tenant-context:check");
+  });
+});


### PR DESCRIPTION
## Apa yang saya cari

Bukan "gate mana yang merah", melainkan **klaim mana di kode yang sudah tidak benar lagi**. `withTenant`'s header menyatakan:

> `T` is generic for backward compatibility, but in practice every real call site uses `T = Response` … The `fail(...)` calls below are therefore cast to `T` — this is type-safe in practice.

Saya uji klaim itu ke kode. **58 berkas di `src/`+`scripts/` yang bukan handler HTTP** (15 di antaranya `.astro`) dan 24 berkas test memakainya untuk mengambil DATA. Klaimnya sudah lama salah, dan `as T` adalah instruksi "berhenti memeriksa" — jadi tak ada yang memberi tahu.

## Kerusakannya sudah hidup

`purgeExpiredAuditEvents` berjanji `Promise<number>`. Di bawah work-class `maintenance` — yang punya **SATU** slot, jadi dua job terjadwal yang beririsan sudah cukup — ia mengembalikan `Response`.

`runBoundedBatches` berhenti "sampai satu pass mengembalikan `count: 0`". Sebuah `Response` tak pernah `=== 0`. Jadi:

1. Job yang **seluruh tujuannya mengalah** menjalankan 50 pass penuh per tenant ke database yang baru saja menolak — backpressure berbalik menjadi beban.
2. `totalCount += result.count` menghasilkan `"0[object Response]…"`, karena `number + Response` itu konkatenasi.
3. Run-nya melaporkan **sukses**.

Test mutasinya (mengembalikan `audit-purge.ts` ke `withTenant`) mereproduksi output itu persis, 50 kali berulang — bukan inferensi.

## Perbaikan: dua bentuk, compiler yang memilihkan

| | untuk | penolakan |
|---|---|---|
| `withTenant(...) → Promise<T \| Response>` | jalur request | diteruskan sebagai `503` + `Retry-After` |
| `withTenantOrThrow<T>(...) → Promise<T>` | worker, job, SSR, resolver, fixture | melempar `DatabaseBusyError` |

275 pemanggilan di 204 berkas rute **tidak berubah satu baris pun** — callback-nya memang mengembalikan `Response`, dan `Response | Response` itu `Response`. Handler yang callback-nya mengembalikan data kini wajib menyempitkan, dan penyempitannya sekaligus perbaikannya.

`DatabaseBusyError` **membawa** response `503`-nya, bukan membangun ulang — jadi kedua bentuk tak bisa menyimpang. Job runner kini mengklasifikasinya `retryable`, bukan `unknown` (yang dibaca operator sebagai "belum ada aturannya"). **Tak ada lagi satu pun `as T` di modul itu.**

## Gate untuk yang tak terlihat compiler

`db:tenant-context:check` (baru, di rantai `check`) menutup dua sisa:

- **Hasil yang dibuang.** `await withTenant(...)` sebagai statement lolos type-check sempurna — `503`-nya dibangun, dikembalikan, lalu jatuh ke lantai.
- **`.astro`.** `bun run typecheck` itu `tsc --noEmit`, yang tak pernah membuka berkas `.astro` sama sekali.

Gate ini **langsung menemukan tiga pembuangan nyata** di jalur auth pada run pertamanya. Dua di antaranya melewatkan audit event `sso_account_linked` / `mfa_challenge_issued` sambil tetap menjawab seolah sudah tertulis.

## Verifikasi

- **Mutasi dibuktikan merah 3×**, satu di antaranya dengan **defect asli dipasang ulang di source sungguhan** (bukan input sintetis).
- `bun run check` penuh hijau — semua 22 gate, lint, typecheck, build.
- **2578 unit test** (0 fail), **193 test integrasi** lawan PostgreSQL 18.4 nyata (0 fail), **64 test DB-gated legacy** (0 fail).
- `db:work-class:generate` diregenerasi; pola kedua scanner (`work-class-registry-generate`, `tenant-route-factory-check`) diperlebar agar mencakup kedua nama — kalau tidak, sebuah rute/job bisa hilang dari snapshot hanya dengan mengganti nama panggilannya.

## Catatan sisi

`docs/awcms/database-capacity-runbook.md` menyebut "208 routes" sementara snapshot ter-commit sudah 216 sebelum PR ini — drift lama, dikoreksi sekalian karena berkasnya memang tersentuh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)