### PR TITLE
chore(actions)(deps): bump github/codeql-action init+analyze to 4.37.3

### DIFF
--- a/.changeset/codeql-action-4-37-3.md
+++ b/.changeset/codeql-action-4-37-3.md
@@ -1,0 +1,14 @@
+---
+"awcms": patch
+---
+
+Naikkan `github/codeql-action` 4.37.1 → 4.37.3 untuk `init` DAN `analyze` dalam
+satu perubahan.
+
+Dependabot memecah bump ini jadi dua PR (#284 `init`, #286 `analyze`) karena
+keduanya dilacak sebagai action terpisah. Dipecah, masing-masing PR menjalankan
+`init` dan `analyze` pada versi yang BERBEDA, dan job `Analyze` gagal dengan
+version mismatch — persis itu yang terjadi: kedua PR merah di `Analyze
+(actions)` dan `Analyze (javascript-typescript)` sementara seluruh check lain
+hijau. Keduanya menunjuk SHA yang sama (`e4fba868`), jadi digabung di sini dan
+kedua PR dependabot ditutup.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,13 +47,13 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Menggabungkan #284 (`init`) dan #286 (`analyze`) menjadi satu perubahan.

Dependabot melacak `codeql-action/init` dan `codeql-action/analyze` sebagai action terpisah, jadi memecah satu rilis jadi dua PR. Dipecah, tiap PR menjalankan `init` dan `analyze` pada versi berbeda dan job `Analyze` gagal version-mismatch — dan memang persis itu yang terjadi: **#284 dan #286 sama-sama merah** di `Analyze (actions)` + `Analyze (javascript-typescript)` sementara seluruh check lain hijau.

Keduanya menunjuk SHA yang sama (`e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`), jadi digabung di sini. #284 dan #286 ditutup setelah ini merge.

Changeset `patch` disertakan: `.github/workflows/*.yml` tidak dikecualikan gate changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)