### PR TITLE
feat(modules): cross-check the two job registries, so a worker cannot ship unscheduled

### DIFF
--- a/.changeset/module-job-registry-crosscheck.md
+++ b/.changeset/module-job-registry-crosscheck.md
@@ -1,0 +1,38 @@
+---
+"awcms": minor
+---
+
+Bandingkan dua registry job yang selama ini mendeskripsikan skrip yang sama tanpa
+ada yang membandingkannya.
+
+`JOB_WORK_CLASS_REGISTRY` menyatakan anggaran pool sebuah skrip, dan sudah
+ditegakkan ke ground truth — generatornya MENOLAK jalan saat peta dan disk
+berselisih. `ModuleDescriptor.jobs` menyatakan sebuah job untuk APA dan seberapa
+sering operator harus menjalankannya (`recommendedSchedule`), dan disajikan lewat
+`GET /api/v1/modules/{moduleKey}/jobs`. Yang pertama ditegakkan ke filesystem;
+yang kedua tidak ditegakkan ke apa pun.
+
+Akibatnya sebuah skrip worker bisa sepenuhnya masuk model kapasitas tapi tetap
+tak terlihat di satu-satunya permukaan yang dibaca operator untuk tahu bahwa job
+itu perlu dijadwalkan — dan dua memang begitu:
+
+- **`tenant-domain:dns:sync`** — modul `tenant_domain` tak mendeklarasikan `jobs`
+  sama sekali. Deskriptornya ditambahkan (jadwal: tiap 15 menit; `manual` sebagai
+  default tak melakukan panggilan keluar).
+- **`edge-cache:purge`** — tak ada modul `edge_cache` untuk menggantungkan
+  deskriptornya: edge cache adalah infrastruktur `src/lib/` (ADR-0043), sementara
+  `ModuleDescriptor.jobs` di-key per modul. Dicatat sebagai pengecualian dengan
+  alasan STRUKTURAL, bukan "belum sempat".
+
+`modules:jobs:check` (baru, di rantai `check`) menegakkan keduanya: tiap skrip di
+work-class registry wajib punya deskriptor dengan `recommendedSchedule` tak
+kosong. Job yang tak dijadwalkan tak pernah jalan dan tak ada yang memberi tahu —
+tak ada gate, tak ada health check, tak ada alarm.
+
+Tabel §Job registry di `deployment-profiles.md` dihapus alih-alih diperbarui: ia
+salinan tangan yang menua persis seperti yang diperkirakan, memuat tiga command
+ERP yang tak pernah ada sambil melewatkan sepuluh job yang benar-benar dikirim.
+§Shared worker runner juga dikoreksi — ia mengklaim ketujuh dispatcher memakai
+`runJob`, padahal `email:dispatch` dan `sync:objects:dispatch` memakai claim-lease
+per baris, yang justru MENGIZINKAN worker paralel; empat job lain belum memakai
+keduanya dan kini terdaftar apa adanya.

--- a/docs/awcms/deployment-profiles.md
+++ b/docs/awcms/deployment-profiles.md
@@ -214,19 +214,45 @@ Catatan operasional (standar wajib untuk setiap dispatcher yang dibangun):
 
 ## Job registry
 
-Setiap modul (ERP maupun fondasi) yang mendaftarkan command operasional terjadwal (dispatcher, purge retensi, rekonsiliasi) direncanakan mengikuti registry metadata trusted per modul (`ModuleDescriptor.jobs`), dibaca lewat `GET /api/v1/modules/{moduleKey}/jobs` — pola yang sama dipertahankan dari basis. Contoh kategori job yang direncanakan untuk ERP:
+Setiap modul yang mendaftarkan command operasional terjadwal (dispatcher, purge
+retensi, rekonsiliasi) mendeklarasikannya di `ModuleDescriptor.jobs`. **Itu
+sumber kebenarannya, bukan dokumen ini** — tiap entri membawa `purpose`,
+`recommendedSchedule`, `environmentNotes`, dan `safeInOfflineLan`, dan disajikan
+langsung ke operator lewat:
 
-| Command (contoh)               | Kategori                                               | Jadwal disarankan                         |
-| ------------------------------ | ------------------------------------------------------ | ----------------------------------------- |
-| `sync:objects:dispatch`        | Sync storage/object queue                              | Setiap 1-2 menit                          |
-| `logs:audit:purge`             | Audit retention                                        | Harian                                    |
-| `finance:posting:dispatch`     | Posting transaksi finansial ke ledger/Coretax (outbox) | Setiap 1-2 menit                          |
-| `payroll:run:dispatch`         | Eksekusi payroll run terjadwal                         | Sesuai periode payroll (bulanan/mingguan) |
-| `inventory:sync:dispatch`      | Sinkronisasi stok ke marketplace/warehouse eksternal   | Setiap 1-5 menit                          |
-| `domain-events:dispatch`       | Domain event runtime (fan-out lintas modul)            | Setiap 30-60 detik                        |
-| `data-lifecycle:archive-purge` | Arsip/purge retensi data lintas modul                  | Harian                                    |
+```
+GET /api/v1/modules/{moduleKey}/jobs
+```
 
-Semua bersifat operasi database murni kecuali yang secara eksplisit menyentuh provider eksternal (bila fiturnya aktif) — aman dijadwalkan di profil offline/LAN sekalipun untuk job yang murni internal (audit purge, domain events, data lifecycle).
+Dokumen ini sengaja TIDAK menyalin daftarnya. Versi sebelumnya menyalin, dan
+salinan itu menua persis seperti yang diperkirakan: memuat tiga command ERP yang
+tak pernah ada (`finance:posting:dispatch`, `payroll:run:dispatch`,
+`inventory:sync:dispatch`) sementara sepuluh job yang benar-benar dikirim tak
+disebut sama sekali. Satu-satunya perbaikan yang bertahan adalah berhenti
+menyalinnya.
+
+Yang dijamin gate, bukan kebiasaan:
+
+- **`modules:jobs:check`** — tiap skrip di `JOB_WORK_CLASS_REGISTRY` wajib punya
+  `ModuleJobDescriptor` dengan `recommendedSchedule` yang tak kosong, atau
+  pengecualian ber-alasan STRUKTURAL. Job worker baru yang lupa deskriptornya
+  memerahkan CI di PR yang menambahkannya — tak bisa lagi mendarat lalu tak
+  pernah dijadwalkan siapa pun.
+- **`db:work-class:check`** — tiap skrip yang membuka koneksi worker/setup wajib
+  punya work class terdeklarasi; generatornya MENOLAK jalan saat peta dan disk
+  berselisih.
+
+Satu pengecualian tercatat hari ini: **`edge-cache:purge`**. Tak ada modul
+`edge_cache` untuk menggantungkan deskriptornya — edge cache adalah infrastruktur
+di `src/lib/edge-cache/` (ADR-0043), dan `ModuleDescriptor.jobs` di-key per
+modul. Jadwalnya: **setiap 10–30 detik**, cukup rapat supaya publikasi editor
+segera terlihat di edge. Alasan lengkapnya ada di
+`scripts/module-job-registry-check.ts`.
+
+Semua job bersifat operasi database murni kecuali yang secara eksplisit menyentuh
+provider eksternal (bila fiturnya aktif) — `safeInOfflineLan` di tiap deskriptor
+yang menyatakannya per job, jadi profil offline/LAN bisa diperiksa lewat API yang
+sama alih-alih menebak dari nama command.
 
 **On-demand/manual (bukan cron berulang)** — dijalankan operator sesuai kebutuhan:
 
@@ -237,11 +263,25 @@ Semua bersifat operasi database murni kecuali yang secara eksplisit menyentuh pr
 
 `src/lib/jobs/` SUDAH ada dan dipakai nyata — `job-runner.ts`, `batching.ts`,
 `retry-classification.ts`, dan `advisory-lock.ts` adalah implementasi
-berjalan, bukan rencana. Ketujuh dispatcher script yang sudah ada di
-`package.json` (`domain-events:dispatch`, `sync:objects:dispatch`,
-`workflow:escalations:dispatch`, `logs:audit:purge`, `email:dispatch`,
-`reporting:projections:refresh`, `reporting:exports:dispatch`) semuanya
-dibangun di atas shared runner ini. Ia menyediakan:
+berjalan, bukan rencana.
+
+**Dua model konkurensi, keduanya sah — pilih menurut bentuk jobnya, bukan menurut
+tahap migrasi.**
+
+| model                                                | job                                                                                                                                                                                                                                                                                                            | mekanisme                                                                                                                                |
+| ---------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **`runJob`** — advisory lock per nama job            | `domain-events:dispatch`, `workflow:escalations:dispatch`, `logs:audit:purge`, `reporting:projections:refresh`, `reporting:exports:dispatch`, `data-lifecycle:archive-purge`, `analytics:rollup`, `analytics:purge`, `news-media:reconcile`, `blog:publish:scheduled`, `identity-access:business-scope:expiry` | satu instance sekali jalan; cocok untuk sapuan seluruh tenant yang tak punya klaim per-baris                                             |
+| **claim-lease per baris** (`FOR UPDATE SKIP LOCKED`) | `email:dispatch`, `sync:objects:dispatch`, `edge-cache:purge`                                                                                                                                                                                                                                                  | aman dijalankan paralel — lihat §Catatan operasional di atas; antrean baris-per-baris tak butuh kunci selebar job                        |
+| **belum bermigrasi — tanpa kunci lintas-instance**   | `comments:retention`, `form-drafts:purge`, `site-search:reconcile`, `tenant-domain:dns:sync`                                                                                                                                                                                                                   | jadwalkan dari **satu** entri cron saja; adopsi `runJob` untuk keempatnya dilacak di [#291](https://github.com/ahliweb/awcms/issues/291) |
+
+Versi sebelumnya dokumen ini menyatakan ketujuh dispatcher "semuanya dibangun di
+atas shared runner ini". Itu tidak benar untuk `email:dispatch` dan
+`sync:objects:dispatch`, dan salahnya ke arah yang menyesatkan: pembacanya akan
+menyimpulkan advisory lock sudah mencegah tumpang tindih di dalam aplikasi,
+padahal jaminannya datang dari klaim baris — mekanisme berbeda dengan sifat
+operasional berbeda (yang satu justru MENGIZINKAN worker paralel).
+
+`runJob` menyediakan:
 
 - **Advisory lock per nama job** (`pg_try_advisory_lock`, non-blocking, session-level, reserved connection terpisah dari handler) — mencegah dua instance job yang sama berjalan tumpang tindih.
 - **Bounded batching per tenant/entitas** (`iterateTenantsInBatches`/`runBoundedBatches`) dengan safety bound (`maxPasses`).

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -352,7 +352,7 @@
       "capabilitiesConsumed": [],
       "permissionCount": 6,
       "navigationCount": 1,
-      "jobCount": 0,
+      "jobCount": 1,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,
       "deploymentProfiles": null

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "modules:dag:check": "bun scripts/validate-module-graph.ts",
     "modules:routes:check": "bun scripts/validate-module-routes.ts",
     "modules:table-writes:check": "bun scripts/table-write-ownership-check.ts",
+    "modules:jobs:check": "bun scripts/module-job-registry-check.ts",
     "modules:compose:check": "bun scripts/validate-module-composition.ts",
     "modules:composition:inventory:generate": "bun scripts/module-composition-inventory-generate.ts",
     "modules:composition:inventory:check": "bun scripts/module-composition-inventory-check.ts",
@@ -97,7 +98,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/module-job-registry-check.ts
+++ b/scripts/module-job-registry-check.ts
@@ -1,0 +1,140 @@
+/**
+ * Two registries describe the same worker scripts, and nothing compared them.
+ *
+ * - `JOB_WORK_CLASS_REGISTRY` (`src/lib/database/work-class-registry.ts`) says
+ *   which pool budget a script spends. `db:work-class:check` already holds it
+ *   to ground truth: a script that opens `getWorkerDatabaseClient(` /
+ *   `getSetupDatabaseClient(` and is missing from the map makes the generator
+ *   REFUSE to run.
+ * - `ModuleDescriptor.jobs` says what a job is FOR and how often an operator
+ *   should run it (`recommendedSchedule`), and is served to operators over
+ *   `GET /api/v1/modules/{moduleKey}/jobs`.
+ *
+ * The first is enforced against the filesystem; the second was enforced
+ * against nothing. So a worker script could be fully wired into the capacity
+ * model and still be invisible to the one surface an operator actually reads
+ * to find out that it needs scheduling — and two were:
+ * `tenant-domain:dns:sync` (its module simply declared no `jobs`) and
+ * `edge-cache:purge` (see the exception below).
+ *
+ * A job nobody schedules never runs, and nothing says so: no gate, no health
+ * check, no alarm — the backlog just grows. That is the failure this closes.
+ *
+ * Pure — reads the registries and `package.json`, no database, no network. It
+ * runs in `quality` on every PR.
+ */
+import { JOB_WORK_CLASS_REGISTRY } from "../src/lib/database/work-class-registry";
+import { listModules } from "../src/modules";
+
+/**
+ * A worker script with no module able to own its descriptor. Each entry has to
+ * name a STRUCTURAL reason — "nobody got round to it" belongs in the registry,
+ * not here.
+ */
+export const DOCUMENTED_EXCEPTIONS: readonly {
+  target: string;
+  reason: string;
+}[] = [
+  {
+    target: "edge-cache:purge",
+    reason:
+      "There is no `edge_cache` MODULE to hang a descriptor on: edge cache is technical infrastructure and lives in `src/lib/edge-cache/` under ADR-0043, which forbids a `src/lib` namespace from carrying a module's name. `ModuleDescriptor.jobs` is keyed by module, so an infrastructure-owned job has nowhere to go. Its schedule is stated in the script header instead (every 10-30s) and in `docs/awcms/deployment-profiles.md`. Giving edge cache a module purely to hold one job descriptor would invert ADR-0042/ADR-0043 for a documentation convenience."
+  }
+];
+
+export type JobRegistryViolation = {
+  target: string;
+  script: string;
+  kind: "missing_descriptor" | "missing_schedule";
+};
+
+export type PackageScripts = Record<string, string>;
+
+/** Resolves `scripts/x.ts` back to the `bun run <target>` a descriptor names. */
+export function targetForScript(
+  script: string,
+  packageScripts: PackageScripts
+): string | null {
+  const entry = Object.entries(packageScripts).find(([, command]) =>
+    command.includes(script)
+  );
+
+  return entry ? entry[0] : null;
+}
+
+export function findJobRegistryViolations(
+  workClassScripts: readonly string[],
+  declaredJobs: readonly { command: string; recommendedSchedule?: string }[],
+  packageScripts: PackageScripts
+): JobRegistryViolation[] {
+  const excused = new Set(DOCUMENTED_EXCEPTIONS.map((e) => e.target));
+  const byTarget = new Map(
+    declaredJobs.map((job) => [job.command.replace(/^bun run /, ""), job])
+  );
+  const violations: JobRegistryViolation[] = [];
+
+  for (const script of workClassScripts) {
+    const target = targetForScript(script, packageScripts);
+    if (!target || excused.has(target)) continue;
+
+    const descriptor = byTarget.get(target);
+
+    if (!descriptor) {
+      violations.push({ target, script, kind: "missing_descriptor" });
+      continue;
+    }
+
+    // A descriptor without a schedule answers "what is this?" but not the only
+    // question an operator has to answer to make the job actually run.
+    if (!descriptor.recommendedSchedule?.trim()) {
+      violations.push({ target, script, kind: "missing_schedule" });
+    }
+  }
+
+  return violations.sort((a, b) => a.target.localeCompare(b.target));
+}
+
+const REASON: Record<JobRegistryViolation["kind"], string> = {
+  missing_descriptor:
+    "terdaftar di JOB_WORK_CLASS_REGISTRY tapi tak punya ModuleJobDescriptor — " +
+    "tak terlihat di GET /api/v1/modules/{key}/jobs, jadi operator tak punya cara " +
+    "menemukan bahwa job ini perlu dijadwalkan. Tambahkan ke `jobs` di module.ts " +
+    "pemiliknya, atau catat pengecualian ber-alasan STRUKTURAL di gate ini.",
+  missing_schedule:
+    "punya ModuleJobDescriptor tanpa recommendedSchedule — deskriptor menjawab " +
+    '"ini apa" tapi bukan "seberapa sering", satu-satunya hal yang membuat job ' +
+    "benar-benar jalan."
+};
+
+async function main(): Promise<void> {
+  const packageScripts = (
+    (await Bun.file("package.json").json()) as { scripts: PackageScripts }
+  ).scripts;
+  const declaredJobs = listModules().flatMap((module) => module.jobs ?? []);
+  const violations = findJobRegistryViolations(
+    Object.keys(JOB_WORK_CLASS_REGISTRY),
+    declaredJobs,
+    packageScripts
+  );
+
+  if (violations.length === 0) {
+    console.log(
+      `modules:jobs:check OK — ${Object.keys(JOB_WORK_CLASS_REGISTRY).length} skrip job ` +
+        `di work-class registry, ${declaredJobs.length} ModuleJobDescriptor, ` +
+        `${DOCUMENTED_EXCEPTIONS.length} pengecualian ber-alasan.`
+    );
+    return;
+  }
+
+  for (const violation of violations) {
+    console.error(
+      `${violation.target} (${violation.script}) — ${REASON[violation.kind]}`
+    );
+  }
+
+  process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/modules/tenant-domain/module.ts
+++ b/src/modules/tenant-domain/module.ts
@@ -52,6 +52,17 @@ export const tenantDomainModule = defineModule({
     openApiPath: "openapi/modules/tenant-domain.openapi.yaml",
     basePath: "/api/v1/tenant/domains"
   },
+  jobs: [
+    {
+      command: "bun run tenant-domain:dns:sync",
+      purpose:
+        "Reconciles pending/active domain rows against the configured DNS provider so a verification record that was created but never propagated does not leave a tenant stuck at pending_verification forever. Read-only against the provider unless TENANT_DOMAIN_DNS_PROVIDER names a real adapter; with the default 'manual' it makes no outbound call at all.",
+      recommendedSchedule: "Every 15 minutes via cron/systemd timer.",
+      environmentNotes:
+        "Reaches an external DNS provider ONLY when TENANT_DOMAIN_DNS_PROVIDER=cloudflare (plus TENANT_DOMAIN_CLOUDFLARE_*). Default 'manual' keeps it purely local.",
+      safeInOfflineLan: true
+    }
+  ],
   navigation: [
     {
       labelKey: "admin.layout.nav_tenant_domains",

--- a/tests/module-job-registry.test.ts
+++ b/tests/module-job-registry.test.ts
@@ -1,0 +1,150 @@
+/**
+ * `modules:jobs:check` — the cross-check between the two job registries.
+ *
+ * Every case feeds `findJobRegistryViolations` input it must reject, and the
+ * central one reinstates the REAL defect: `tenant-domain:dns:sync` sat in
+ * `JOB_WORK_CLASS_REGISTRY` (so it was fully inside the capacity model) while
+ * its module declared no `jobs` at all — so it never appeared in
+ * `GET /api/v1/modules/{key}/jobs`, the surface an operator reads to learn a
+ * job needs scheduling.
+ *
+ * The last block runs the gate against the real registries, so this file is
+ * also the drift detector: a new worker script whose module forgets its
+ * descriptor fails here on the PR that adds it.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  DOCUMENTED_EXCEPTIONS,
+  findJobRegistryViolations,
+  targetForScript
+} from "../scripts/module-job-registry-check";
+import { JOB_WORK_CLASS_REGISTRY } from "../src/lib/database/work-class-registry";
+import { listModules } from "../src/modules";
+
+const PACKAGE_SCRIPTS = {
+  "tenant-domain:dns:sync": "bun scripts/tenant-domain-dns-sync.ts",
+  "edge-cache:purge": "bun scripts/edge-cache-purge.ts",
+  "site-search:reconcile": "bun scripts/site-search-reconcile.ts"
+};
+
+describe("findJobRegistryViolations", () => {
+  test("flags the defect this gate exists for: a work-class job with no descriptor", () => {
+    const violations = findJobRegistryViolations(
+      ["scripts/tenant-domain-dns-sync.ts"],
+      [],
+      PACKAGE_SCRIPTS
+    );
+
+    expect(violations).toEqual([
+      {
+        target: "tenant-domain:dns:sync",
+        script: "scripts/tenant-domain-dns-sync.ts",
+        kind: "missing_descriptor"
+      }
+    ]);
+  });
+
+  test("a descriptor without a schedule is still a finding", () => {
+    // "What is this job" is not the question that gets it running.
+    const violations = findJobRegistryViolations(
+      ["scripts/site-search-reconcile.ts"],
+      [{ command: "bun run site-search:reconcile" }],
+      PACKAGE_SCRIPTS
+    );
+
+    expect(violations[0]!.kind).toBe("missing_schedule");
+  });
+
+  test("a whitespace-only schedule does not count as one", () => {
+    const violations = findJobRegistryViolations(
+      ["scripts/site-search-reconcile.ts"],
+      [{ command: "bun run site-search:reconcile", recommendedSchedule: "  " }],
+      PACKAGE_SCRIPTS
+    );
+
+    expect(violations[0]!.kind).toBe("missing_schedule");
+  });
+
+  test("a complete descriptor passes", () => {
+    expect(
+      findJobRegistryViolations(
+        ["scripts/site-search-reconcile.ts"],
+        [
+          {
+            command: "bun run site-search:reconcile",
+            recommendedSchedule: "every 15 minutes"
+          }
+        ],
+        PACKAGE_SCRIPTS
+      )
+    ).toEqual([]);
+  });
+
+  test("the documented exception excuses only its own target", () => {
+    // `edge-cache:purge` is excused; a second module-less job would not be.
+    expect(
+      findJobRegistryViolations(
+        ["scripts/edge-cache-purge.ts"],
+        [],
+        PACKAGE_SCRIPTS
+      )
+    ).toEqual([]);
+
+    expect(
+      findJobRegistryViolations(
+        ["scripts/tenant-domain-dns-sync.ts"],
+        [],
+        PACKAGE_SCRIPTS
+      )
+    ).toHaveLength(1);
+  });
+
+  test("every exception carries a structural reason a reviewer can disagree with", () => {
+    for (const entry of DOCUMENTED_EXCEPTIONS) {
+      expect(entry.target.length).toBeGreaterThan(0);
+      expect(entry.reason.length).toBeGreaterThan(120);
+      // The bar is "no module CAN own this", not "no module HAS owned it".
+      expect(entry.reason).toContain("ADR-0043");
+    }
+  });
+});
+
+describe("targetForScript", () => {
+  test("resolves a script path back to its bun run target", () => {
+    expect(
+      targetForScript("scripts/tenant-domain-dns-sync.ts", PACKAGE_SCRIPTS)
+    ).toBe("tenant-domain:dns:sync");
+  });
+
+  test("returns null for a script no target runs", () => {
+    expect(targetForScript("scripts/nope.ts", PACKAGE_SCRIPTS)).toBeNull();
+  });
+});
+
+describe("the real registries", () => {
+  test("every work-class job script has a scheduled descriptor", async () => {
+    const packageScripts = (
+      (await Bun.file("package.json").json()) as {
+        scripts: Record<string, string>;
+      }
+    ).scripts;
+
+    const violations = findJobRegistryViolations(
+      Object.keys(JOB_WORK_CLASS_REGISTRY),
+      listModules().flatMap((module) => module.jobs ?? []),
+      packageScripts
+    );
+
+    expect(violations.map((v) => `${v.target} (${v.kind})`)).toEqual([]);
+  });
+
+  test("is wired into `bun run check`", async () => {
+    const manifest = (await Bun.file("package.json").json()) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(manifest.scripts["modules:jobs:check"]).toBeDefined();
+    expect(manifest.scripts.check).toContain("modules:jobs:check");
+  });
+});

--- a/tests/module-management-job-registry.test.ts
+++ b/tests/module-management-job-registry.test.ts
@@ -101,6 +101,7 @@ describe("fetchModuleJobs", () => {
         "bun run reporting:projections:refresh",
         "bun run site-search:reconcile",
         "bun run sync:objects:dispatch",
+        "bun run tenant-domain:dns:sync",
         "bun run workflow:escalations:dispatch"
       ].sort()
     );

--- a/tests/tenant-domain-module.test.ts
+++ b/tests/tenant-domain-module.test.ts
@@ -119,8 +119,27 @@ describe("tenant_domain module descriptor (ported from awcms-micro)", () => {
     expect(defaults).not.toHaveProperty("cloudflareApiToken");
   });
 
-  test("the module declares no jobs or health", () => {
-    expect(tenantDomainModule.jobs).toBeUndefined();
+  test("the DNS sync job is declared, with a schedule an operator can act on", () => {
+    // This used to assert `jobs` was UNDEFINED, pinning the defect in place:
+    // `scripts/tenant-domain-dns-sync.ts` was already in
+    // `JOB_WORK_CLASS_REGISTRY` (so it was fully inside the capacity model)
+    // while `GET /api/v1/modules/tenant_domain/jobs` returned nothing — the
+    // one surface an operator reads to learn a job needs scheduling. A job
+    // nobody schedules never runs, and nothing says so. `modules:jobs:check`
+    // now compares the two registries; this pins the module's own half.
+    const job = tenantDomainModule.jobs?.find(
+      (entry) => entry.command === "bun run tenant-domain:dns:sync"
+    );
+
+    expect(job).toBeDefined();
+    expect(job!.recommendedSchedule?.trim()).toBeTruthy();
+    // The outbound-call condition belongs in the descriptor, not only in the
+    // script: `safeInOfflineLan` is how an offline/LAN operator decides.
+    expect(job!.environmentNotes).toContain("TENANT_DOMAIN_DNS_PROVIDER");
+    expect(job!.safeInOfflineLan).toBe(true);
+  });
+
+  test("the module declares no health contract", () => {
     expect(tenantDomainModule.health).toBeUndefined();
   });
 });


### PR DESCRIPTION
Closes #288. Closes #292.

## Koreksi lebih dulu

Isu #288 saya tulis dengan premis **"10 dari 18 job tak punya jadwal terdokumentasi"**. Sebelum mengimplementasi saya verifikasi ke kode, dan itu **salah** — jadwalnya sudah ada di `ModuleDescriptor.jobs` untuk 16 dari 18 job, lengkap dengan `recommendedSchedule`, dan sudah disajikan lewat `GET /api/v1/modules/{key}/jobs`. Isunya sudah saya koreksi dan turunkan p1→p2 sebelum mulai.

Temuan yang tersisa lebih sempit tapi tetap nyata.

## Dua registry, nol perbandingan

| | isi | ditegakkan ke |
| --- | --- | --- |
| `JOB_WORK_CLASS_REGISTRY` | 18 skrip + work class | **filesystem** — generator MENOLAK jalan saat peta dan disk berselisih |
| `ModuleDescriptor.jobs` | 20 entri + `recommendedSchedule`, disajikan lewat API | **tak ada apa pun** |

Akibatnya sebuah skrip worker bisa sepenuhnya masuk model kapasitas dan tetap tak terlihat di satu-satunya permukaan yang dibaca operator untuk tahu job itu perlu dijadwalkan. Dua memang begitu, dan alasannya berbeda:

- **`tenant-domain:dns:sync`** — modul `tenant_domain` tak mendeklarasikan `jobs` sama sekali. Kelalaian; deskriptornya ditambahkan.
- **`edge-cache:purge`** — **tak ada modul `edge_cache`**. Edge cache adalah infrastruktur `src/lib/` (ADR-0043, yang justru melarang namespace `src/lib` menyandang nama modul), sementara `ModuleDescriptor.jobs` di-key per modul. Ini batasan struktural, bukan kelalaian — dicatat sebagai pengecualian dengan alasan yang bisa dibantah reviewer, dan test menuntut alasannya menyebut ADR-0043 supaya "belum sempat" tak bisa menyelinap ke daftar itu.

## Dokumen: dihapus, bukan diperbarui

Tabel §Job registry di `deployment-profiles.md` adalah salinan tangan dari data yang sudah ada di kode DAN sudah disajikan lewat API. Ia menua persis seperti yang diperkirakan: tiga command ERP yang tak pernah ada, sepuluh job nyata tak disebut. Memperbaruinya hanya mengulang siklus yang sama — jadi tabelnya dihapus dan diganti penunjuk ke sumber kebenarannya plus gate yang menjaganya.

§Shared worker runner (#292) dikoreksi: ia mengklaim ketujuh dispatcher memakai `runJob`. `email:dispatch` dan `sync:objects:dispatch` memakai claim-lease per baris — yang justru **MENGIZINKAN** worker paralel, kebalikan sifat advisory lock. Empat job lain memakai keduanya-tidak, dan kini terdaftar apa adanya dengan tautan ke #291.

## Satu test yang justru mengunci cacatnya

`tests/tenant-domain-module.test.ts` punya test bernama `"the module declares no jobs or health"` yang meng-assert `jobs` **undefined**. Test itu mengunci cacatnya di tempat: ia akan gagal pada perbaikan apa pun. Sekarang ia mengunci deskriptornya, dan komentarnya mencatat kenapa absennya salah.

## Verifikasi

**Mutasi dibuktikan merah dengan defect ASLI** — menghapus kembali blok `jobs` dari `tenant-domain/module.ts` membuat gate exit 1 dan satu test merah, bukan input sintetis.

`bun run check` penuh hijau: seluruh 23 gate (termasuk `modules:jobs:check` baru), lint, typecheck, build, **2589 test pass / 0 fail**. Inventory komposisi diregenerasi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)