### PR TITLE
feat(config): require every env var the code reads to be in .env.example

### DIFF
--- a/.changeset/env-contract-coverage.md
+++ b/.changeset/env-contract-coverage.md
@@ -1,0 +1,36 @@
+---
+"awcms": minor
+---
+
+Tegakkan bahwa setiap variabel env yang dibaca kode ada di `.env.example`.
+
+`tests/env-required-vars-doc.test.ts` sudah membandingkan daftar var **WAJIB**
+yang didokumentasikan dengan yang ditegakkan. Separuh yang lebih besar tak
+terjaga: var yang opsional tapi **mengubah perilaku**. Sebelas menumpuk di sana,
+termasuk:
+
+- **`TENANT_DOMAIN_DNS_PROVIDER`** — dua nilainya adalah "tak melakukan panggilan
+  keluar sama sekali" dan "bicara ke API DNS sungguhan". Tak ada di
+  `.env.example`, doc 18, maupun `validate-env.ts`.
+- **`R2_ACCOUNT_ID`/`R2_BUCKET`/`R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`** —
+  `R2_ENABLED=false` dikirim sendirian, jadi operator yang menyalakannya tak
+  punya template untuk empat kredensial yang lalu diwajibkan uploader.
+- **Empat `SITE_SEARCH_*_RATE_LIMIT_*`** — kontrol penyalahgunaan pada dua
+  endpoint publik anonim, bukan sekadar tuning.
+- `FORM_DRAFT_RETENTION_DAYS`, `OBJECT_SYNC_UPLOAD_TIMEOUT_MS`, dan blok
+  `TENANT_DOMAIN_CLOUDFLARE_*`.
+
+Yang terakhir lebih buruk dari sekadar absen: `.env.example` merujuk "the
+`TENANT_DOMAIN_CLOUDFLARE_*` settings **above**" padahal tak ada satu pun di
+seluruh berkas itu.
+
+Nilai default yang dicatat diverifikasi ke kode, bukan ditebak — retensi form
+draft 30 hari (bukan 90) dan timeout object-sync 10000ms (bukan 30000).
+
+`config:env:coverage:check` (baru, di rantai `check`) menargetkan `.env.example`,
+bukan doc 18: berkas itulah yang **disalin** operator, sementara var yang hanya
+ada di prosa harus sudah diketahui lebih dulu untuk bisa dicari. Placeholder
+ber-komentar sudah cukup — pola yang sudah dipakai `EMAIL_MAILKETING_*` — jadi
+secret tetap tak masuk repo. Batas yang dinyatakan terbuka di header gate: ia
+hanya mencocokkan `process.env.X`, jadi modul config yang mengoper
+`env: NodeJS.ProcessEnv` lalu membaca `env.X` tak terlihat.

--- a/.env.example
+++ b/.env.example
@@ -202,6 +202,16 @@ SYNC_HMAC_ALLOW_LEGACY=true
 STORAGE_DRIVER=local
 LOCAL_STORAGE_PATH=./storage
 R2_ENABLED=false
+# Required as a set when R2_ENABLED=true — the object-storage uploader reads
+# all four and refuses to upload if any is missing. Placeholders only; a real
+# secret must never be committed.
+# R2_ACCOUNT_ID=replace-me
+# R2_BUCKET=replace-me
+# R2_ACCESS_KEY_ID=replace-me
+# R2_SECRET_ACCESS_KEY=replace-me
+#
+# Per-object upload timeout for `bun run sync:objects:dispatch` (default 10000).
+# OBJECT_SYNC_UPLOAD_TIMEOUT_MS=10000
 
 EMAIL_ENABLED=false
 # EMAIL_PROVIDER: "mailketing" (real adapter) or "log" (safe local/dev, no network).
@@ -351,6 +361,27 @@ COMMENTS_TIMING_SECRET=
 # COMMENTS_RETENTION_DAYS=365
 
 # ---------------------------------------------------------------------------
+# Site search (ADR-0040) — public endpoint rate limits
+# ---------------------------------------------------------------------------
+#
+# Per-IP limits on the two PUBLIC, anonymous endpoints. These are an abuse
+# control, not a tuning knob: raising them widens the amount of full-text work
+# an unauthenticated caller can force per IP.
+# SITE_SEARCH_RATE_LIMIT_MAX=60
+# SITE_SEARCH_RATE_LIMIT_WINDOW_SEC=60
+#
+# The typeahead endpoint is cheaper per call and allows more of them.
+# SITE_SEARCH_SUGGEST_RATE_LIMIT_MAX=120
+# SITE_SEARCH_SUGGEST_RATE_LIMIT_WINDOW_SEC=60
+
+# ---------------------------------------------------------------------------
+# Form drafts (retention)
+# ---------------------------------------------------------------------------
+#
+# Retention window for `bun run form-drafts:purge`. Default 30 days.
+# FORM_DRAFT_RETENTION_DAYS=30
+
+# ---------------------------------------------------------------------------
 # Edge cache / Varnish (ADR-0042)
 # ---------------------------------------------------------------------------
 #
@@ -412,9 +443,28 @@ COMMENTS_TIMING_SECRET=
 # to `domain_type = 'subdomain'` rows in the platform's OWN managed zone —
 # custom domains live in the tenant's zone and keep the manual/TXT flow.
 #
-# Requires TENANT_DOMAIN_DNS_PROVIDER=cloudflare plus the
-# TENANT_DOMAIN_CLOUDFLARE_* settings above. With either the provider or the
-# target below unset, the job exits without touching the database.
+# Which DNS adapter `bun run tenant-domain:dns:sync` uses. `manual` (the
+# default) makes NO outbound call at all — verification stays a TXT record the
+# tenant places themselves. `cloudflare` is the only other value, and it turns
+# the job into something that talks to a real DNS API.
+# TENANT_DOMAIN_DNS_PROVIDER=manual
+#
+# Required as a set WHEN (and only when) the provider above is `cloudflare` —
+# see TENANT_DOMAIN_CLOUDFLARE_REQUIRED_WHEN_SELECTED in
+# src/modules/tenant-domain/domain/tenant-domain-dns-config.ts. The adapter
+# refuses any hostname outside the configured root, so the root is a security
+# boundary and not just a convenience.
+# TENANT_DOMAIN_PLATFORM_ROOT_DOMAIN=awcms.example.com
+# TENANT_DOMAIN_CLOUDFLARE_ZONE_ID=replace-me
+# TENANT_DOMAIN_CLOUDFLARE_API_TOKEN=replace-me
+#
+# Optional per-call timeout for the adapter's bounded network calls (default
+# 8000). An unset or invalid value falls back to the default — never a boot
+# failure over a tuning knob.
+# TENANT_DOMAIN_CLOUDFLARE_TIMEOUT_MS=8000
+#
+# With either the provider or the target below unset, the job exits without
+# touching the database.
 #
 # Where tenant traffic should land: an IPv4 address when
 # TENANT_DOMAIN_SERVING_RECORD_TYPE=A, or a hostname for CNAME (the default).

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "db:tenant-context:check": "bun scripts/tenant-context-usage-check.ts",
     "db:work-class:generate": "bun scripts/work-class-registry-generate.ts",
     "db:work-class:check": "bun scripts/work-class-registry-check.ts",
+    "config:env:coverage:check": "bun scripts/env-contract-coverage-check.ts",
     "config:validate": "bun scripts/validate-env.ts",
     "security:readiness": "bun scripts/security-readiness.ts",
     "lint": "prettier --check \"**/*.md\" \"**/*.{json,yml,yaml}\" \"**/*.{ts,mjs,astro}\"",
@@ -97,7 +98,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/env-contract-coverage-check.ts
+++ b/scripts/env-contract-coverage-check.ts
@@ -1,0 +1,180 @@
+/**
+ * Every environment variable the code reads must appear in `.env.example`.
+ *
+ * ## What this closes
+ *
+ * `tests/env-required-vars-doc.test.ts` already compares the documented list of
+ * MANDATORY variables against the enforced one. That leaves the larger half
+ * unwatched: a variable that is optional but CHANGES BEHAVIOUR. Nothing looked
+ * at those, and eleven had accumulated — including
+ * `TENANT_DOMAIN_DNS_PROVIDER`, whose only two values are "make no outbound
+ * call" and "talk to a real DNS API", and the four `R2_*` credentials that
+ * `R2_ENABLED=true` requires but that no template offered.
+ *
+ * Worse than absent: `.env.example` referred to "the `TENANT_DOMAIN_CLOUDFLARE_*`
+ * settings above" when no such settings existed anywhere in the file.
+ *
+ * `.env.example` is the artefact an operator COPIES, which is why it is the
+ * target rather than doc 18: a variable documented only in prose is one an
+ * operator has to already know to go looking for. A commented placeholder is
+ * enough — that is how the `EMAIL_MAILKETING_*` credentials were already
+ * handled, and it keeps secrets out of the repo.
+ *
+ * ## Known limit, stated rather than hidden
+ *
+ * This matches `process.env.X` only. Config modules that thread
+ * `env: NodeJS.ProcessEnv = process.env` through a parameter and then read
+ * `env.X` are invisible here — `tenant-domain-dns-config.ts` does exactly that.
+ * Broadening the pattern to any `env.X` would swallow unrelated identifiers, so
+ * the gate stays precise and this comment records what it does not see.
+ *
+ * Pure text, no database, no network — runs in `quality` on every PR.
+ */
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+const SOURCE_ROOTS = ["src", "scripts"];
+const SOURCE_EXTENSIONS = [".ts", ".astro", ".mjs"];
+const ENV_EXAMPLE = ".env.example";
+
+/** `process.env.NAME` — the direct read. */
+const ENV_READ = /process\.env\.([A-Z][A-Z0-9_]*)/g;
+
+/**
+ * Variables that steer TOOLING rather than a deployment, so an operator copying
+ * `.env.example` has no use for them. Each needs a reason; "it felt noisy" is
+ * not one.
+ */
+export const TOOLING_ONLY: readonly { name: string; reason: string }[] = [
+  {
+    name: "CHANGESET_POLICY_BASE_REF",
+    reason:
+      "Overrides the base ref `changesets:policy:check` diffs against. Set by CI (and by a developer reproducing a PR check locally), never by a deployment."
+  },
+  {
+    name: "RELEASE_VERIFY_TAG",
+    reason:
+      "The tag `release:verify` validates. Meaningful only on a tagged release commit inside release.yml, never in a running environment."
+  },
+  {
+    name: "FAMILY_CONFORMANCE_REPORT_PATH",
+    reason:
+      "Where `family:conformance:check` writes its machine-readable report. A CI artefact path, not deployment configuration."
+  },
+  {
+    name: "CI",
+    reason:
+      "Set by the CI provider itself. Nothing in a deployment sets or reads it as configuration."
+  },
+  {
+    name: "NODE_ENV",
+    reason:
+      "Set by the runtime/toolchain. This codebase's own environment switch is APP_ENV, which IS in .env.example."
+  }
+];
+
+export type EnvCoverageViolation = { name: string; files: string[] };
+
+/**
+ * Comments are stripped so a docblock that MENTIONS `process.env.TOKEN` while
+ * explaining a rule is not read as a read — `security-readiness.ts` does
+ * exactly that, and without this the gate reports a variable that no code ever
+ * touches.
+ */
+export function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((line) => !/^\s*(?:\/\/|\*)/.test(line))
+    .join("\n");
+}
+
+/** Present whether assigned or left as a commented placeholder. */
+export function declaredInEnvExample(source: string): Set<string> {
+  const declared = new Set<string>();
+
+  for (const line of source.split("\n")) {
+    const match = line.match(/^\s*#?\s*([A-Z][A-Z0-9_]*)=/);
+    if (match) declared.add(match[1]!);
+  }
+
+  return declared;
+}
+
+export function findCoverageViolations(
+  reads: ReadonlyMap<string, string[]>,
+  declared: ReadonlySet<string>
+): EnvCoverageViolation[] {
+  const excused = new Set(TOOLING_ONLY.map((entry) => entry.name));
+
+  return [...reads.entries()]
+    .filter(([name]) => !declared.has(name) && !excused.has(name))
+    .map(([name, files]) => ({ name, files: [...files].sort() }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+async function* walk(directory: string): AsyncGenerator<string> {
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const full = path.join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules" || entry.name === "dist") continue;
+      yield* walk(full);
+      continue;
+    }
+
+    if (SOURCE_EXTENSIONS.some((extension) => entry.name.endsWith(extension))) {
+      yield full;
+    }
+  }
+}
+
+export async function collectEnvReads(): Promise<Map<string, string[]>> {
+  const reads = new Map<string, string[]>();
+
+  for (const root of SOURCE_ROOTS) {
+    for await (const file of walk(root)) {
+      const source = stripComments(await Bun.file(file).text());
+
+      for (const match of source.matchAll(ENV_READ)) {
+        const name = match[1]!;
+        const files = reads.get(name) ?? [];
+        if (!files.includes(file)) files.push(file);
+        reads.set(name, files);
+      }
+    }
+  }
+
+  return reads;
+}
+
+async function main(): Promise<void> {
+  const reads = await collectEnvReads();
+  const declared = declaredInEnvExample(await Bun.file(ENV_EXAMPLE).text());
+  const violations = findCoverageViolations(reads, declared);
+
+  if (violations.length === 0) {
+    console.log(
+      `config:env:coverage:check OK — ${reads.size} variabel env dibaca kode, ` +
+        `semuanya ada di ${ENV_EXAMPLE} atau tercatat sebagai tooling-only ` +
+        `(${TOOLING_ONLY.length}).`
+    );
+    return;
+  }
+
+  for (const violation of violations) {
+    console.error(
+      `${violation.name} — dibaca kode tapi tidak ada di ${ENV_EXAMPLE}. ` +
+        "Operator yang menyalin berkas itu tak punya cara menemukannya. " +
+        "Tambahkan (placeholder ber-komentar sudah cukup, dan wajib untuk secret) " +
+        "atau catat di TOOLING_ONLY dengan alasannya.\n    " +
+        violation.files.join("\n    ")
+    );
+  }
+
+  process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/env-contract-coverage.test.ts
+++ b/tests/env-contract-coverage.test.ts
@@ -1,0 +1,147 @@
+/**
+ * `config:env:coverage:check` — the half of the env contract nothing watched.
+ *
+ * `tests/env-required-vars-doc.test.ts` compares the documented MANDATORY list
+ * against the enforced one. Optional-but-behaviour-changing variables sat
+ * outside both, and eleven had accumulated. The one that matters most is
+ * reinstated below as the central case: `TENANT_DOMAIN_DNS_PROVIDER`, whose two
+ * values are "make no outbound call" and "talk to a real DNS API", and which
+ * appeared in neither `.env.example`, doc 18, nor `validate-env.ts`.
+ *
+ * The last block runs the gate against the real repository, so this file is
+ * also the drift detector.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  TOOLING_ONLY,
+  collectEnvReads,
+  declaredInEnvExample,
+  findCoverageViolations,
+  stripComments
+} from "../scripts/env-contract-coverage-check";
+
+describe("findCoverageViolations", () => {
+  test("flags the defect this gate exists for: a behaviour switch absent from .env.example", () => {
+    const violations = findCoverageViolations(
+      new Map([
+        ["TENANT_DOMAIN_DNS_PROVIDER", ["scripts/tenant-domain-dns-sync.ts"]]
+      ]),
+      new Set(["APP_ENV", "DATABASE_URL"])
+    );
+
+    expect(violations).toEqual([
+      {
+        name: "TENANT_DOMAIN_DNS_PROVIDER",
+        // Naming the file matters: otherwise an operator learns only that
+        // something somewhere reads an undocumented variable.
+        files: ["scripts/tenant-domain-dns-sync.ts"]
+      }
+    ]);
+  });
+
+  test("a documented variable passes", () => {
+    expect(
+      findCoverageViolations(
+        new Map([["DATABASE_URL", ["src/lib/database/client.ts"]]]),
+        new Set(["DATABASE_URL"])
+      )
+    ).toEqual([]);
+  });
+
+  test("a tooling-only variable is excused", () => {
+    expect(
+      findCoverageViolations(
+        new Map([["RELEASE_VERIFY_TAG", ["scripts/release-verify.ts"]]]),
+        new Set()
+      )
+    ).toEqual([]);
+  });
+
+  test("every tooling-only entry says why an operator would never set it", () => {
+    for (const entry of TOOLING_ONLY) {
+      expect(entry.name).toMatch(/^[A-Z][A-Z0-9_]*$/);
+      expect(entry.reason.length).toBeGreaterThan(60);
+    }
+  });
+});
+
+describe("declaredInEnvExample", () => {
+  test("a commented placeholder counts as declared", () => {
+    // Secrets must NOT carry a real value in the repo, so the commented form is
+    // the correct way to ship them — the `EMAIL_MAILKETING_*` precedent.
+    const declared = declaredInEnvExample(
+      ["APP_ENV=development", "# R2_SECRET_ACCESS_KEY=replace-me"].join("\n")
+    );
+
+    expect(declared.has("APP_ENV")).toBe(true);
+    expect(declared.has("R2_SECRET_ACCESS_KEY")).toBe(true);
+  });
+
+  test("prose mentioning a variable name does NOT count as declaring it", () => {
+    // `.env.example` referred to "the TENANT_DOMAIN_CLOUDFLARE_* settings
+    // above" when no such settings existed. A looser match would have called
+    // that documented.
+    const declared = declaredInEnvExample(
+      "# Requires TENANT_DOMAIN_CLOUDFLARE_ZONE_ID to be set somewhere."
+    );
+
+    expect(declared.has("TENANT_DOMAIN_CLOUDFLARE_ZONE_ID")).toBe(false);
+  });
+});
+
+describe("stripComments", () => {
+  test("a docblock mentioning process.env is not a read", () => {
+    // Real case: `security-readiness.ts` explains a rule using
+    // `token: process.env.TOKEN ?? "..."`. Without stripping, the gate demands
+    // an entry for a variable no code touches.
+    const source = [
+      "/**",
+      ' * e.g. `token: process.env.TOKEN ?? "x"` reads from env.',
+      " */",
+      "const url = process.env.DATABASE_URL;"
+    ].join("\n");
+
+    const stripped = stripComments(source);
+
+    expect(stripped).not.toContain("process.env.TOKEN");
+    expect(stripped).toContain("process.env.DATABASE_URL");
+  });
+});
+
+describe("the real repository", () => {
+  test("every variable the code reads is in .env.example", async () => {
+    const violations = findCoverageViolations(
+      await collectEnvReads(),
+      declaredInEnvExample(await Bun.file(".env.example").text())
+    );
+
+    expect(violations.map((v) => v.name)).toEqual([]);
+  }, 60000);
+
+  test("the R2 credentials R2_ENABLED=true needs are all templated", async () => {
+    // `R2_ENABLED=false` shipped alone: an operator flipping it on had no
+    // template for the four credentials the uploader then requires.
+    const declared = declaredInEnvExample(
+      await Bun.file(".env.example").text()
+    );
+
+    for (const name of [
+      "R2_ACCOUNT_ID",
+      "R2_BUCKET",
+      "R2_ACCESS_KEY_ID",
+      "R2_SECRET_ACCESS_KEY"
+    ]) {
+      expect(declared.has(name)).toBe(true);
+    }
+  });
+
+  test("is wired into `bun run check`", async () => {
+    const manifest = (await Bun.file("package.json").json()) as {
+      scripts: Record<string, string>;
+    };
+
+    expect(manifest.scripts["config:env:coverage:check"]).toBeDefined();
+    expect(manifest.scripts.check).toContain("config:env:coverage:check");
+  });
+});


### PR DESCRIPTION
Closes #290.

## Cakupan lebih luas dari yang dilaporkan isunya

Isu #290 menyebut satu variabel. Menjalankan pemindaian penuh menemukan **sebelas** — dan yang terburuk bukan sekadar absen:

`.env.example` merujuk **"the `TENANT_DOMAIN_CLOUDFLARE_*` settings above"** padahal tak ada satu pun di seluruh berkas itu. Operator yang mengikuti petunjuknya diarahkan ke tempat kosong.

| variabel | kenapa penting |
| --- | --- |
| `TENANT_DOMAIN_DNS_PROVIDER` | dua nilainya: "tak ada panggilan keluar" vs "bicara ke API DNS sungguhan" |
| `R2_ACCOUNT_ID`, `R2_BUCKET`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY` | `R2_ENABLED=false` dikirim sendirian — menyalakannya tanpa template untuk empat kredensial yang lalu diwajibkan uploader |
| 4× `SITE_SEARCH_*_RATE_LIMIT_*` | kontrol penyalahgunaan pada dua endpoint **publik anonim**; menaikkannya memperlebar kerja full-text yang bisa dipaksa pemanggil tak terautentikasi per IP |
| `TENANT_DOMAIN_CLOUDFLARE_*` (4) | blok yang dirujuk tapi tak pernah ada |
| `FORM_DRAFT_RETENTION_DAYS`, `OBJECT_SYNC_UPLOAD_TIMEOUT_MS` | di doc 18, tak di `.env.example` |

Nilai default yang saya catat **dibaca dari kode, bukan ditebak** — dan dua di antaranya berbeda dari yang saya asumsikan semula: retensi form draft **30** hari (bukan 90), timeout object-sync **10000**ms (bukan 30000).

## Kenapa `.env.example`, bukan doc 18

Itu berkas yang **disalin** operator. Variabel yang hanya ada di prosa adalah variabel yang harus sudah Anda ketahui untuk bisa dicari. Placeholder ber-komentar dihitung sebagai terdeklarasi — pola yang sudah dipakai `EMAIL_MAILKETING_*` — jadi tak ada secret masuk repo.

Batas gate dinyatakan terbuka di headernya, bukan disembunyikan: ia hanya mencocokkan `process.env.X`. Modul config yang mengoper `env: NodeJS.ProcessEnv = process.env` lalu membaca `env.X` tak terlihat — `tenant-domain-dns-config.ts` persis begitu. Melebarkan polanya ke sembarang `env.X` akan menelan identifier tak terkait.

## Satu test yang saya buang, dan alasannya

Saya sempat menulis pemindai nilai-secret di gate ini. Ia **gagal**, dan gagalnya benar: heuristik bentuk-nama menandai `AUTH_PASSWORD_RESET_TOKEN_TTL_MIN`, `TURNSTILE_MAX_TOKEN_AGE_SEC`, dan `VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS` — tiga angka, nol secret. Saya verifikasi dua nilai yang benar-benar berbentuk secret (`AUTH_IP_HASH_SECRET`, `AWCMS_SYNC_HMAC_SECRET`): keduanya `change-me`.

Testnya saya hapus, tidak saya longgarkan. GitGuardian dan job `Repo hygiene (no secrets)` sudah menutup ini; duplikat yang lebih lemah dari kontrol yang sudah ada justru lebih buruk daripada tidak ada — ia jadi sumber kebenaran kedua yang menghasilkan false positive lalu dibungkam.

## Verifikasi

**Mutasi dibuktikan merah dengan defect ASLI** — menghapus kembali baris `TENANT_DOMAIN_DNS_PROVIDER` dari `.env.example` membuat gate exit 1 dan test merah.

`bun run check` penuh hijau, plus `bun scripts/validate-env.ts --file .env.example` (kontrak env tetap terpenuhi setelah penambahan), **2588 test pass / 0 fail**, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)