### PR TITLE
test(edge-cache): make the surfaces gate testable, then test it

### DIFF
--- a/.changeset/edge-cache-gate-testable.md
+++ b/.changeset/edge-cache-gate-testable.md
@@ -1,0 +1,31 @@
+---
+"awcms": patch
+---
+
+Buat `edge-cache:surfaces:check` bisa diuji, lalu uji dia.
+
+Dari 21 gate di rantai `bun run check`, ini satu-satunya yang membawa logika
+substansial (278 baris) **tanpa satu pun test** — dan alasannya struktural,
+bukan kelalaian: berkasnya berakhir dengan `await main()` di scope modul, jadi
+meng-`import`-nya akan MENJALANKAN gate-nya, dan `process.exit(1)`-nya akan
+membawa serta test runner. Gate lain yang tak diuji semuanya pembungkus tipis
+(35–66 baris) di atas kolektor yang diuji terpisah.
+
+Itu penting justru di sini. Registry ini adalah **allow-list** yang memutuskan
+apa yang boleh disimpan shared cache; kesalahan di dalamnya adalah pengungkapan
+lintas-tenant, bukan halaman lambat. Header berkasnya sendiri menyebut daftar
+probe `MUST_NEVER_MATCH` sebagai "the check that earns this file's existence" —
+dan sampai sekarang tak ada apa pun yang pernah menyaksikan daftar itu menolak
+sesuatu.
+
+Perubahannya: entrypoint dijaga `import.meta.main`, tiga aturannya diekspor
+sebagai fungsi murni (`validateSurfaces`, `findCacheableForbiddenPaths`,
+`findOwnersWithoutPurges`), dan `process.exit(1)` diganti `process.exitCode`
+sehingga gate tak lagi mematikan proses pemanggilnya. 20 test menanam
+pelanggaran nyata untuk tiap aturan.
+
+Dibuktikan dengan menghapus **traversal guard** di `matchPublicCacheSurface` —
+persis cacat yang digambarkan header gate ini. Hasilnya: `/blog/../admin` dan
+`/blog/%2e%2e/admin` dilaporkan cocok dengan surface `blog-post`, gate exit 1,
+test merah. URL admin yang cacheable, ditangkap oleh check yang sebelumnya tak
+pernah diamati bekerja.

--- a/scripts/edge-cache-surfaces-check.ts
+++ b/scripts/edge-cache-surfaces-check.ts
@@ -33,7 +33,7 @@ const PURGE_CALLER_ROOTS = ["src/pages", "src/modules"];
  * statically, and a purge whose target is unknown at review time is exactly the
  * thing this gate exists to prevent.
  */
-async function collectPurgedModuleKeys(): Promise<Set<string>> {
+export async function collectPurgedModuleKeys(): Promise<Set<string>> {
   const keys = new Set<string>();
   const constants = new Map<string, string>();
   const pattern =
@@ -111,7 +111,7 @@ async function collectPurgedModuleKeys(): Promise<Set<string>> {
  * encoding shapes, because a pattern that is safe against a clean path is not
  * necessarily safe against a hostile one.
  */
-const MUST_NEVER_MATCH = [
+export const MUST_NEVER_MATCH = [
   "/admin",
   "/admin/",
   "/admin/users",
@@ -137,12 +137,30 @@ const SAFE_SURFACE_KEY = /^[A-Za-z0-9._-]{1,128}$/;
 
 const MAX_DECLARED_TTL_SECONDS = 86_400;
 
-async function main(): Promise<void> {
+/**
+ * Shape of one registry entry, kept structural so a test can plant a violation
+ * without constructing a whole `PublicCacheSurface`.
+ */
+export type SurfaceLike = {
+  key: string;
+  pattern: RegExp;
+  ttlSeconds: number;
+  requiresTenant: boolean;
+  allowedQueryParams: readonly string[];
+  /** `null` in the live registry for a surface no module owns. */
+  moduleKey?: string | null;
+  rationale?: string;
+};
+
+/** Every per-entry rule. Pure: no filesystem, no registry import. */
+export function validateSurfaces(
+  surfaces: readonly SurfaceLike[],
+  moduleKeys: ReadonlySet<string>
+): string[] {
   const failures: string[] = [];
   const seenKeys = new Set<string>();
-  const moduleKeys = new Set(listModules().map((module) => module.key));
 
-  for (const surface of PUBLIC_CACHE_SURFACES) {
+  for (const surface of surfaces) {
     if (!SAFE_SURFACE_KEY.test(surface.key)) {
       failures.push(
         `Surface key "${surface.key}" is not a safe surrogate-key segment (allowed: A-Z a-z 0-9 . _ -).`
@@ -215,8 +233,23 @@ async function main(): Promise<void> {
     }
   }
 
-  for (const path of MUST_NEVER_MATCH) {
-    const matched = matchPublicCacheSurface(path);
+  return failures;
+}
+
+/**
+ * The check that earns this file's existence. Takes the matcher as an argument
+ * so a test can drive it with a planted pattern instead of the live registry —
+ * without that seam, the only observable behaviour is "the current registry
+ * passes", which proves nothing about the rule.
+ */
+export function findCacheableForbiddenPaths(
+  paths: readonly string[],
+  match: (path: string) => { key: string } | null | undefined
+): string[] {
+  const failures: string[] = [];
+
+  for (const path of paths) {
+    const matched = match(path);
 
     if (matched) {
       failures.push(
@@ -225,38 +258,54 @@ async function main(): Promise<void> {
     }
   }
 
-  // ---------------------------------------------------------------------
-  // Every module that OWNS a cacheable surface must emit purges for it.
-  //
-  // This is the asymmetry that makes stale content silent. Declaring a surface
-  // is one line in the registry and takes effect immediately; wiring the
-  // invalidation is a separate edit in a different file that nothing forces.
-  // Miss it and the surface caches correctly, serves correctly, and never
-  // updates — with no error anywhere.
-  //
-  // Framed by OWNERSHIP rather than by module list on purpose. Modules with no
-  // declared surface (`news_portal`, `media_library` today) are correctly
-  // silent: a ban for a module key that tags no cached object matches nothing
-  // while the queue reports success, so demanding a purge from them would add
-  // ceremony that looks like coverage and provides none. The obligation appears
-  // by itself on the day they declare a surface.
-  // ---------------------------------------------------------------------
+  return failures;
+}
+
+/**
+ * Every module that OWNS a cacheable surface must emit purges for it.
+ *
+ * This is the asymmetry that makes stale content silent. Declaring a surface is
+ * one line in the registry and takes effect immediately; wiring the
+ * invalidation is a separate edit in a different file that nothing forces. Miss
+ * it and the surface caches correctly, serves correctly, and never updates —
+ * with no error anywhere.
+ *
+ * Framed by OWNERSHIP rather than by module list on purpose. Modules with no
+ * declared surface (`news_portal`, `media_library` today) are correctly silent:
+ * a ban for a module key that tags no cached object matches nothing while the
+ * queue reports success, so demanding a purge from them would add ceremony that
+ * looks like coverage and provides none. The obligation appears by itself on
+ * the day they declare a surface.
+ */
+export function findOwnersWithoutPurges(
+  surfaces: readonly SurfaceLike[],
+  purgedKeys: ReadonlySet<string>
+): string[] {
   const declaredOwners = new Set(
-    PUBLIC_CACHE_SURFACES.map((surface) => surface.moduleKey).filter(
-      (key): key is string => Boolean(key)
-    )
+    surfaces
+      .map((surface) => surface.moduleKey)
+      .filter((key): key is string => Boolean(key))
   );
+
+  return [...declaredOwners]
+    .filter((owner) => !purgedKeys.has(owner))
+    .map(
+      (owner) =>
+        `Module "${owner}" owns a cacheable surface but no code calls ` +
+        `enqueueModuleContentPurge(..., "${owner}", ...). Its cached pages ` +
+        `would go stale until TTL with nothing reporting a problem.`
+    );
+}
+
+async function main(): Promise<void> {
+  const moduleKeys = new Set(listModules().map((module) => module.key));
   const purgedKeys = await collectPurgedModuleKeys();
 
-  for (const owner of declaredOwners) {
-    if (!purgedKeys.has(owner)) {
-      failures.push(
-        `Module "${owner}" owns a cacheable surface but no code calls ` +
-          `enqueueModuleContentPurge(..., "${owner}", ...). Its cached pages ` +
-          `would go stale until TTL with nothing reporting a problem.`
-      );
-    }
-  }
+  const failures = [
+    ...validateSurfaces(PUBLIC_CACHE_SURFACES, moduleKeys),
+    ...findCacheableForbiddenPaths(MUST_NEVER_MATCH, matchPublicCacheSurface),
+    ...findOwnersWithoutPurges(PUBLIC_CACHE_SURFACES, purgedKeys)
+  ];
 
   if (failures.length > 0) {
     console.error("edge-cache:surfaces:check FAILED");
@@ -265,8 +314,13 @@ async function main(): Promise<void> {
       console.error(`  - ${failure}`);
     }
 
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
+
+  const declaredOwners = new Set(
+    PUBLIC_CACHE_SURFACES.map((surface) => surface.moduleKey).filter(Boolean)
+  );
 
   console.log(
     `edge-cache:surfaces:check OK — ${PUBLIC_CACHE_SURFACES.length} declared surfaces, ` +
@@ -275,4 +329,10 @@ async function main(): Promise<void> {
   );
 }
 
-await main();
+// Guarded so a test can import the pure validators above without executing the
+// gate — the reason this file had no tests: a bare `await main()` at module
+// scope ran the check on import, and its `process.exit(1)` would have taken the
+// test runner with it.
+if (import.meta.main) {
+  await main();
+}

--- a/tests/edge-cache-surfaces-check.test.ts
+++ b/tests/edge-cache-surfaces-check.test.ts
@@ -1,0 +1,211 @@
+/**
+ * `edge-cache:surfaces:check` — the gate that had none.
+ *
+ * Of the gates in `bun run check`, this was the only one carrying substantial
+ * logic (278 lines) with no test at all, and the reason was structural: the
+ * file ended in a bare `await main()`, so importing it ran the gate — and its
+ * `process.exit(1)` would have taken the test runner with it. The entrypoint is
+ * guarded now and the rules are exported, which is what makes this file
+ * possible.
+ *
+ * That matters more here than for most gates. This registry is an ALLOW-LIST
+ * deciding what a shared cache may store; a mistake in it is a cross-tenant
+ * disclosure, not a slow page. Its own header says the probe list is what earns
+ * the file's existence — and until now nothing had ever observed that probe
+ * list reject anything.
+ *
+ * Every case below plants a violation. A gate that has only ever been observed
+ * passing has not been observed at all.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  MUST_NEVER_MATCH,
+  collectPurgedModuleKeys,
+  findCacheableForbiddenPaths,
+  findOwnersWithoutPurges,
+  validateSurfaces,
+  type SurfaceLike
+} from "../scripts/edge-cache-surfaces-check";
+import {
+  PUBLIC_CACHE_SURFACES,
+  matchPublicCacheSurface
+} from "../src/lib/edge-cache/surface-registry";
+import { listModules } from "../src/modules";
+
+const SAFE: SurfaceLike = {
+  key: "blog-post",
+  pattern: /^\/blog\/[^/]+\/[^/]+$/,
+  ttlSeconds: 300,
+  requiresTenant: true,
+  allowedQueryParams: [],
+  moduleKey: "blog_content",
+  rationale: "Public blog post body, identical for every anonymous visitor."
+};
+
+const MODULE_KEYS = new Set(listModules().map((module) => module.key));
+
+describe("validateSurfaces", () => {
+  test("the clean entry passes, so every failure below is about the planted flaw", () => {
+    expect(validateSurfaces([SAFE], MODULE_KEYS)).toEqual([]);
+  });
+
+  test("an unanchored pattern is rejected", () => {
+    // `\/blog\/x` matches INSIDE `/admin/blog/x`, so an unanchored pattern
+    // silently widens the allow-list to paths nobody reviewed.
+    const failures = validateSurfaces(
+      [{ ...SAFE, pattern: /\/blog\/[^/]+/ }],
+      MODULE_KEYS
+    );
+
+    expect(failures.join(" ")).toContain("not fully anchored");
+  });
+
+  test("a greedy wildcard is rejected because it spans path separators", () => {
+    const failures = validateSurfaces(
+      [{ ...SAFE, pattern: /^\/blog\/.*$/ }],
+      MODULE_KEYS
+    );
+
+    expect(failures.join(" ")).toContain("greedy wildcard");
+  });
+
+  test("requiresTenant=false is rejected — such an object can never be purged", () => {
+    const failures = validateSurfaces(
+      [{ ...SAFE, requiresTenant: false }],
+      MODULE_KEYS
+    );
+
+    expect(failures.join(" ")).toContain("requiresTenant=false");
+  });
+
+  test("a duplicate key is rejected — surrogate keys would collide", () => {
+    const failures = validateSurfaces([SAFE, { ...SAFE }], MODULE_KEYS);
+
+    expect(failures.join(" ")).toContain("Duplicate surface key");
+  });
+
+  test("a key that is not a safe surrogate-key segment is rejected", () => {
+    const failures = validateSurfaces(
+      [{ ...SAFE, key: "blog post/../x" }],
+      MODULE_KEYS
+    );
+
+    expect(failures.join(" ")).toContain("not a safe surrogate-key segment");
+  });
+
+  test.each([
+    [0, "ttlSeconds=0"],
+    [86_401, "ttlSeconds=86401"]
+  ])("a TTL outside 1..86400 is rejected (%p)", (ttlSeconds, expected) => {
+    const failures = validateSurfaces([{ ...SAFE, ttlSeconds }], MODULE_KEYS);
+
+    expect(failures.join(" ")).toContain(expected);
+  });
+
+  test("a module key absent from the registry is rejected", () => {
+    // A module-scoped purge for a key nothing tags matches nothing, while the
+    // queue happily reports success.
+    const failures = validateSurfaces(
+      [{ ...SAFE, moduleKey: "not_a_module" }],
+      MODULE_KEYS
+    );
+
+    expect(failures.join(" ")).toContain("not in the base registry");
+  });
+
+  test("an empty rationale is rejected", () => {
+    const failures = validateSurfaces(
+      [{ ...SAFE, rationale: "" }],
+      MODULE_KEYS
+    );
+
+    expect(failures.join(" ")).toContain("no meaningful rationale");
+  });
+
+  test("an oversized query allow-list is rejected", () => {
+    const failures = validateSurfaces(
+      [{ ...SAFE, allowedQueryParams: ["a", "b", "c", "d", "e"] }],
+      MODULE_KEYS
+    );
+
+    expect(failures.join(" ")).toContain("query parameters");
+  });
+});
+
+describe("findCacheableForbiddenPaths — the check this gate exists for", () => {
+  test("a pattern that swallows /admin is caught", () => {
+    // The concrete failure the gate's own header describes: `/^\/blog\/.*$/`
+    // reads fine in a diff and matches `/blog/../admin/users`. Driving the
+    // matcher directly is the only way to observe the rule REJECT something.
+    const greedy = /^\/blog\/.*$/;
+    const failures = findCacheableForbiddenPaths(
+      ["/blog/../admin/users"],
+      (path) => (greedy.test(path) ? { key: "blog-greedy" } : null)
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("must never be cacheable");
+    expect(failures[0]).toContain("blog-greedy");
+  });
+
+  test("a matcher that refuses everything produces no findings", () => {
+    expect(findCacheableForbiddenPaths(MUST_NEVER_MATCH, () => null)).toEqual(
+      []
+    );
+  });
+
+  test("the probe list covers traversal, encoding, admin and API shapes", () => {
+    // A shrinking probe list is how this check quietly stops proving anything.
+    expect(MUST_NEVER_MATCH.length).toBeGreaterThanOrEqual(16);
+    expect(MUST_NEVER_MATCH).toContain("/blog/../admin/users");
+    expect(MUST_NEVER_MATCH).toContain("/blog/%2e%2e/admin");
+    expect(MUST_NEVER_MATCH).toContain("/admin/users");
+    expect(MUST_NEVER_MATCH).toContain("/api/v1/health");
+  });
+});
+
+describe("findOwnersWithoutPurges", () => {
+  test("an owner that emits no purge is caught", () => {
+    // The asymmetry that makes stale content silent: declaring a surface takes
+    // effect immediately, wiring the purge is a separate edit nothing forces.
+    const failures = findOwnersWithoutPurges([SAFE], new Set());
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toContain("blog_content");
+    expect(failures[0]).toContain("would go stale until TTL");
+  });
+
+  test("a surface owned by nobody creates no obligation", () => {
+    expect(
+      findOwnersWithoutPurges([{ ...SAFE, moduleKey: null }], new Set())
+    ).toEqual([]);
+  });
+
+  test("an owner that does emit a purge passes", () => {
+    expect(findOwnersWithoutPurges([SAFE], new Set(["blog_content"]))).toEqual(
+      []
+    );
+  });
+});
+
+describe("the real registry", () => {
+  test("passes every per-entry rule", () => {
+    expect(validateSurfaces(PUBLIC_CACHE_SURFACES, MODULE_KEYS)).toEqual([]);
+  });
+
+  test("caches none of the paths that must never be cacheable", () => {
+    expect(
+      findCacheableForbiddenPaths(MUST_NEVER_MATCH, matchPublicCacheSurface)
+    ).toEqual([]);
+  });
+
+  test("every surface-owning module emits a purge", async () => {
+    expect(
+      findOwnersWithoutPurges(
+        PUBLIC_CACHE_SURFACES,
+        await collectPurgedModuleKeys()
+      )
+    ).toEqual([]);
+  }, 60000);
+});


### PR DESCRIPTION
Closes #293.

## Kenapa gate ini tak punya test: strukturnya menghalangi

Baris terakhirnya:

```ts
await main();
```

Top-level `await main()` di scope modul, dan `main()` memanggil `process.exit(1)`. Meng-`import` berkas ini dari test akan **menjalankan gate-nya saat impor** dan mematikan test runner. Jadi ini bukan "belum sempat ditulis" — bentuk berkasnya membuat test tak mungkin ditulis tanpa restrukturisasi lebih dulu.

Dari 21 gate di rantai `check`, ini satu-satunya dengan logika substansial (278 baris) tanpa test. Sisanya yang tak diuji semuanya pembungkus tipis 35–66 baris di atas kolektor yang sudah diuji terpisah.

## Kenapa justru gate ini yang penting

Registry ini adalah **allow-list** yang memutuskan apa yang boleh disimpan shared cache. Kesalahan di dalamnya adalah **pengungkapan lintas-tenant**, bukan halaman lambat.

Header berkasnya sendiri sudah menyebut daftar probe `MUST_NEVER_MATCH` sebagai *"the check that earns this file's existence"* — dan sampai PR ini, tak ada apa pun yang pernah menyaksikan daftar itu **menolak** sesuatu. Persis kelas kegagalan yang sudah tercatat di repo ini: gate cakupan bisa hijau sambil seluruh jawabannya salah.

## Perubahan

- `import.meta.main` menjaga entrypoint.
- Tiga aturannya diekspor sebagai fungsi murni: `validateSurfaces`, `findCacheableForbiddenPaths`, `findOwnersWithoutPurges`.
- `process.exit(1)` → `process.exitCode`, jadi gate tak lagi mematikan proses pemanggilnya.
- **20 test**, masing-masing menanam pelanggaran nyata: pattern tak ter-anchor, greedy wildcard, `requiresTenant=false`, kunci duplikat, kunci tak aman sebagai segmen surrogate-key, TTL di luar rentang, module key hantu, rationale kosong, allow-list query berlebihan, owner tanpa purge.

`findCacheableForbiddenPaths` menerima matcher-nya sebagai argumen — tanpa seam itu, satu-satunya perilaku yang bisa diamati adalah "registry saat ini lolos", yang tak membuktikan apa pun tentang aturannya.

## Bukti terkuat yang tersedia

Saya hapus **traversal guard** dari `matchPublicCacheSurface` — persis cacat yang digambarkan header gate ini:

```
edge-cache:surfaces:check FAILED
  - Path "/blog/../admin" must never be cacheable but matched surface "blog-post".
  - Path "/blog/%2e%2e/admin" must never be cacheable but matched surface "blog-post".
exit=1
```

**URL admin yang cacheable**, ditangkap oleh check yang sebelumnya tak pernah diamati bekerja. Test ikut merah. Guard-nya dikembalikan setelahnya.

Mutasi kedua (greedy wildcard `/^\\/blog\\/.*$/` ditanam di surface `blog-post` nyata) juga merah.

## Verifikasi

`bun run check` penuh hijau, **2945 test** (0 fail), build. Exit code gate diverifikasi 1 saat gagal / 0 saat lolos setelah penggantian `process.exit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)