### PR TITLE
docs(scripts): derive the README inventory, and reject false "not yet ported" claims

### DIFF
--- a/.changeset/scripts-inventory-generated.md
+++ b/.changeset/scripts-inventory-generated.md
@@ -1,0 +1,32 @@
+---
+"awcms": patch
+---
+
+Turunkan inventaris `scripts/README.md` dari `package.json`, dan tolak klaim
+"belum ada" untuk tooling yang sudah ada.
+
+README itu punya dua tabel dan keduanya salah. Yang pertama mendaftar **12 dari
+52** skrip sebagai aktif. Yang kedua menyebut lima belas tooling sebagai "belum
+diport" padahal semuanya sudah mendarat — dan sebagian sudah berada di rantai
+`bun run check`: `api:docs:check`, `modules:compose:check`,
+`db:work-class:check`, `modules:composition:inventory:*`, serta seluruh worker
+per-modul (`email:*`, `analytics:*`, `reporting:*`, `workflow:*`,
+`form-drafts:*`, `identity-access:*`).
+
+Keduanya butuh aturan berbeda, karena mode kegagalannya berbeda:
+
+- **Kelalaian** ditutup dengan menurunkan tabelnya. Blok bertanda di README kini
+  dihasilkan `bun run scripts:inventory:generate` dan diperiksa
+  `scripts:inventory:check` — pola generate/check yang sama dengan artefak
+  `.generated` lain, karena artefak generated TANPA pasangan itu adalah klaim
+  palsu yang justru lebih dipercaya daripada prosa.
+- **Klaim ABSENSI palsu** ditutup dengan aturan tersendiri: sebuah target yang
+  tercatat di §Ditunda tapi ADA di `package.json` memerahkan gate. Ini arah yang
+  berbahaya — klaim negatif makin salah seiring waktu dan tak pernah gagal
+  sendiri, jadi pembacanya menyimpulkan `db:work-class:check` masih perlu
+  dibangun lalu membangun duplikatnya.
+
+Pemindaian klaim absensi hanya membaca BARIS TABEL, bukan prosa: prosa di
+bagian itu menjelaskan aturannya sambil menyebut nama target nyata, dan
+memindainya utuh membuat gate melaporkan dirinya sendiri pada run pertama —
+kali keempat bentuk itu muncul di repo ini.

--- a/package.json
+++ b/package.json
@@ -91,6 +91,8 @@
     "db:work-class:check": "bun scripts/work-class-registry-check.ts",
     "config:env:coverage:check": "bun scripts/env-contract-coverage-check.ts",
     "config:validate": "bun scripts/validate-env.ts",
+    "scripts:inventory:generate": "bun scripts/scripts-inventory.ts",
+    "scripts:inventory:check": "bun scripts/scripts-inventory.ts --check",
     "security:readiness": "bun scripts/security-readiness.ts",
     "lint": "prettier --check \"**/*.md\" \"**/*.{json,yml,yaml}\" \"**/*.{ts,mjs,astro}\"",
     "format": "prettier --write \"**/*.md\" \"**/*.{json,yml,yaml}\" \"**/*.{ts,mjs,astro}\"",
@@ -99,7 +101,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,63 +1,139 @@
 # Scripts AWCMS
 
 Skrip tooling/ops repo, dijalankan lewat Bun (`bun scripts/<x>.ts` atau target
-`bun run <name>` di `package.json`). Basis dasar ini diadaptasi dari repo acuan
-[awcms-mini](https://github.com/ahliweb/awcms-mini) dan dipangkas ke apa yang
-**benar-benar bisa berjalan** di atas fondasi Sprint 1–2 saat ini — skrip
-worker per-modul menyusul begitu modul ERP-nya ada.
+`bun run <name>` di `package.json`).
 
-## Aktif (fondasi)
+## Inventaris
 
-| Target                    | Skrip                        | Fungsi                                                                                 | Di `check`?                                                  |
-| ------------------------- | ---------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| `db:migrate`              | `db-migrate.ts`              | Runner migration SQL (checksum + advisory lock)                                        | —                                                            |
-| `check:docs`              | `check-docs.mjs`             | Mermaid, tautan internal, penamaan (sisa `awcms_mini_`), nama service docker compose   | ✅                                                           |
-| `check:docs:translation`  | `check-docs-translation.mjs` | Staleness terjemahan docs: `*.id.md` (sumber ID) vs `*.md` (Inggris, ADR-0023)         | ✅                                                           |
-| `api:spec:check`          | `api-spec-check.ts`          | Validasi OpenAPI/AsyncAPI + route parity `src/pages/api/v1`                            | ✅                                                           |
-| `modules:dag:check`       | `validate-module-graph.ts`   | Validasi seluruh registry modul membentuk DAG (no cycle/self/dup/missing dependency)   | ✅                                                           |
-| `logging:lint:check`      | `logging-lint-check.ts`      | Gate: tak ada error/console.error mentah tanpa redaksi di `src/**`, `scripts/**`       | ✅                                                           |
-| `security:readiness`      | `security-readiness.ts`      | Gate go-live: RLS enabled+FORCED, role app tak bypass RLS, dll (butuh DB termigrasi)   | — (butuh DB)                                                 |
-| `logs:audit:purge`        | `audit-log-purge.ts`         | Purge `awcms_audit_events` melampaui `AUDIT_LOG_RETENTION_DAYS` (batched, self-audit)  | — (butuh DB)                                                 |
-| `config:validate`         | `validate-env.ts`            | Validasi kontrak env (`process.env` atau `--file <path>`) sebelum boot/deploy          | — (butuh env)                                                |
-| `db:pool:health`          | `db-pool-health.ts`          | Probe `GET /api/v1/database/pool/health` (pool/work-class/circuit-breaker)             | — (butuh server)                                             |
-| `changesets:policy:check` | `changeset-policy-check.ts`  | Wajibkan changeset baru untuk PR yang mengubah file non-docs/non-agent-tooling         | — (PR-diff-shaped, lihat `.github/workflows/changesets.yml`) |
-| `release:verify`          | `release-verify.ts`          | Tag rilis == versi package.json, CHANGELOG.md punya section, tak ada changeset pending | — (tag-shaped, lihat `.github/workflows/release.yml`)        |
+Tabel di bawah **dihasilkan dari `package.json`** oleh
+`bun run scripts:inventory:generate`, dan `bun run scripts:inventory:check`
+(di rantai `check`) menolak kalau ia basi.
 
-`bun run check` — untuk rantai lengkap & urutan yang otoritatif, lihat script
-`check` di `package.json` langsung; tidak diduplikasi di sini agar tidak drift.
+Alasannya bukan kerapian. Versi tulis-tangan sebelumnya mendaftar 12 dari 52
+skrip sebagai aktif, dan tabel pendampingnya menyebut lima belas tooling sebagai
+"belum diport" padahal semuanya sudah mendarat — sebagian bahkan sudah ada di
+rantai `bun run check` (`api:docs:check`, `modules:compose:check`,
+`db:work-class:check`, dan seluruh worker per-modul). Klaim **negatif** adalah
+jenis yang berbahaya: "X belum ada" makin salah seiring waktu dan tak pernah
+gagal sendiri, tak seperti klaim positif yang langsung pecah begitu kodenya
+berubah. Pembacanya akan menyimpulkan `db:work-class:check` masih perlu dibangun,
+lalu membangun duplikatnya.
 
-`config:validate` tidak masuk `check` karena membutuhkan environment nyata;
-jalankan manual sebelum deploy, mis. `bun run config:validate` (membaca
-`process.env`) atau `bun scripts/validate-env.ts --file .env.example`.
+<!-- BEGIN GENERATED: script-inventory -->
 
-`changesets:policy:check` tidak masuk `check` karena berbentuk PR-diff
-(membandingkan `origin/main...HEAD`) — dijalankan sebagai workflow CI
-terpisah (`.github/workflows/changesets.yml`), bukan bagian dari check yang
-aman dijalankan di satu checkout lokal mana pun.
+<!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-`release:verify` tidak masuk `check` karena hanya bermakna tepat pada
-commit yang di-tag `vX.Y.Z` (real release) — dijalankan sebagai bagian
-`validate` job `.github/workflows/release.yml`, bukan pada checkout biasa.
+58 target menjalankan berkas di `scripts/`; 23 di antaranya
+ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
+terjadwal, atau oleh workflow CI tertentu.
 
-## Ditunda (butuh infrastruktur yang belum ada)
+| Target                                   | Skrip                                      | Gate |
+| ---------------------------------------- | ------------------------------------------ | ---- |
+| `analytics:purge`                        | `visitor-analytics-purge.ts`               | —    |
+| `analytics:rollup`                       | `visitor-analytics-rollup.ts`              | —    |
+| `api:docs:check`                         | `api-docs-check.ts`                        | ✅   |
+| `api:docs:generate`                      | `api-docs-generate.ts`                     | —    |
+| `api:spec:check`                         | `api-spec-check.ts`                        | ✅   |
+| `api:tenant-route:check`                 | `tenant-route-factory-check.ts`            | ✅   |
+| `blog:publish:scheduled`                 | `blog-scheduled-publish.ts`                | —    |
+| `changesets:policy:check`                | `changeset-policy-check.ts`                | —    |
+| `check:docs`                             | `check-docs.mjs`                           | ✅   |
+| `check:docs:translation`                 | `check-docs-translation.mjs`               | ✅   |
+| `comments:resources:check`               | `comments-resources-check.ts`              | ✅   |
+| `comments:retention`                     | `comments-retention.ts`                    | —    |
+| `config:env:coverage:check`              | `env-contract-coverage-check.ts`           | ✅   |
+| `config:validate`                        | `validate-env.ts`                          | —    |
+| `data-lifecycle:archive-purge`           | `data-lifecycle-archive-purge.ts`          | —    |
+| `data-lifecycle:registry:check`          | `data-lifecycle-registry-check.ts`         | ✅   |
+| `db:migrate`                             | `db-migrate.ts`                            | —    |
+| `db:pool:health`                         | `db-pool-health.ts`                        | —    |
+| `db:tenant-context:check`                | `tenant-context-usage-check.ts`            | ✅   |
+| `db:work-class:check`                    | `work-class-registry-check.ts`             | ✅   |
+| `db:work-class:generate`                 | `work-class-registry-generate.ts`          | —    |
+| `domain-events:dispatch`                 | `domain-events-dispatch.ts`                | —    |
+| `edge-cache:purge`                       | `edge-cache-purge.ts`                      | —    |
+| `edge-cache:surfaces:check`              | `edge-cache-surfaces-check.ts`             | ✅   |
+| `email:dispatch`                         | `email-dispatch.ts`                        | —    |
+| `email:provider:health`                  | `email-provider-health.ts`                 | —    |
+| `email:templates:seed-defaults`          | `email-templates-seed-defaults.ts`         | —    |
+| `family:conformance:check`               | `family-conformance-check.ts`              | ✅   |
+| `form-drafts:purge`                      | `form-draft-purge.ts`                      | —    |
+| `identity-access:business-scope:expiry`  | `identity-access-business-scope-expiry.ts` | —    |
+| `identity-access:sod-registry:check`     | `identity-access-sod-registry-check.ts`    | ✅   |
+| `logging:lint:check`                     | `logging-lint-check.ts`                    | ✅   |
+| `logs:audit:purge`                       | `audit-log-purge.ts`                       | —    |
+| `memory:docs:check`                      | `sync-agent-memory.ts`                     | —    |
+| `memory:docs:restore`                    | `sync-agent-memory.ts`                     | —    |
+| `memory:docs:sync`                       | `sync-agent-memory.ts`                     | —    |
+| `modules:compose:check`                  | `validate-module-composition.ts`           | ✅   |
+| `modules:composition:inventory:check`    | `module-composition-inventory-check.ts`    | ✅   |
+| `modules:composition:inventory:generate` | `module-composition-inventory-generate.ts` | —    |
+| `modules:dag:check`                      | `validate-module-graph.ts`                 | ✅   |
+| `modules:jobs:check`                     | `module-job-registry-check.ts`             | ✅   |
+| `modules:routes:check`                   | `validate-module-routes.ts`                | ✅   |
+| `modules:table-writes:check`             | `table-write-ownership-check.ts`           | ✅   |
+| `news-media:reconcile`                   | `news-media-r2-reconcile.ts`               | —    |
+| `openapi:bundle`                         | `openapi-bundle.ts`                        | —    |
+| `redis:health`                           | `redis-health.ts`                          | —    |
+| `release:verify`                         | `release-verify.ts`                        | —    |
+| `reporting:exports:dispatch`             | `reporting-exports-dispatch.ts`            | —    |
+| `reporting:projections:refresh`          | `reporting-projections-refresh.ts`         | —    |
+| `reporting:projections:registry:check`   | `reporting-projection-registry-check.ts`   | ✅   |
+| `scripts:inventory:check`                | `scripts-inventory.ts`                     | ✅   |
+| `scripts:inventory:generate`             | `scripts-inventory.ts`                     | —    |
+| `security:readiness`                     | `security-readiness.ts`                    | —    |
+| `site-search:reconcile`                  | `site-search-reconcile.ts`                 | —    |
+| `site-search:sources:check`              | `site-search-sources-check.ts`             | ✅   |
+| `sync:objects:dispatch`                  | `object-sync-dispatch.ts`                  | —    |
+| `tenant-domain:dns:sync`                 | `tenant-domain-dns-sync.ts`                | —    |
+| `workflow:escalations:dispatch`          | `workflow-escalations-dispatch.ts`         | —    |
 
-Skrip acuan berikut belum diport karena bergantung pada arsitektur/modul yang
-belum dibangun di repo ini. Diadaptasi begitu prasyaratnya ada:
+<!-- END GENERATED: script-inventory -->
 
-| Target acuan                                                                                                                                                                                                                                                                            | Prasyarat yang belum ada                                                             |
-| --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| `openapi:bundle`, `api:docs:generate`, `api:docs:check`                                                                                                                                                                                                                                 | Pemecahan OpenAPI jadi fragment per-modul (`openapi/modules/*.yaml`) — kini 1 file   |
-| `repo:inventory:generate` / `:check`                                                                                                                                                                                                                                                    | Bergantung pada `openapi:bundle` + `module-composition` (Module Management)          |
-| `config:docs:check`                                                                                                                                                                                                                                                                     | Rekonsiliasi 3-arah `.env.example` ↔ doc 18 (butuh doc 18 disamakan ke env repo ini) |
-| `modules:sync`, `modules:compose:check`, `modules:composition:inventory:*`                                                                                                                                                                                                              | Modul Module Management (validasi registry base)                                     |
-| `db:work-class:generate` / `:check`                                                                                                                                                                                                                                                     | Tabel/registry work-class                                                            |
-| `database:capacity:check`                                                                                                                                                                                                                                                               | Validasi kapasitas lintas-instance (preflight)                                       |
-| `domain-events:dispatch`, `sync:objects:dispatch`                                                                                                                                                                                                                                       | Modul domain-event-runtime + outbox                                                  |
-| `i18n:extract` / `:pot:check` / `:parity:check`                                                                                                                                                                                                                                         | Setup i18n (`.po`/`.pot`) + UI                                                       |
-| `production:preflight`, `resilience:dr-drill`, `performance:*`                                                                                                                                                                                                                          | Mengagregasi gate/modul di atas + server berjalan                                    |
-| Worker per-modul (`email:*`, `blog:*`, `news-media:*`, `social-publishing:*`, `analytics:*`, `reporting:*`, `workflow:*`, `integration-hub:*`, `data-exchange:*`, `reference-data:*`, `organization-structure:*`, `form-drafts:*`, `identity-access:business-scope:*`/`sod-registry:*`) | Modul ERP/CMS terkait                                                                |
+## Yang tidak masuk `check`, dan kenapa
+
+Rantai `check` harus aman dijalankan di checkout lokal mana pun tanpa database,
+tanpa server, dan tanpa konteks PR. Yang di luar rantai ada karena melanggar
+salah satu syarat itu:
+
+| Target                                                                  | Kenapa di luar `check`                                                                                         |
+| ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `security:readiness`                                                    | Butuh database termigrasi — memeriksa RLS `FORCE`, role app non-superuser, grant worker/setup                  |
+| `config:validate`                                                       | Butuh environment nyata (`process.env`, atau `--file <path>`). Jalankan sebelum deploy                         |
+| `db:migrate`, `db:pool:health`, `redis:health`, `email:provider:health` | Butuh database/Redis/provider yang berjalan                                                                    |
+| Seluruh worker terjadwal                                                | Butuh database, dan dijalankan cron/systemd — lihat `ModuleDescriptor.jobs` + `GET /api/v1/modules/{key}/jobs` |
+| `changesets:policy:check`                                               | Berbentuk PR-diff (`origin/main...HEAD`); dijalankan `.github/workflows/changesets.yml`                        |
+| `release:verify`                                                        | Hanya bermakna pada commit ber-tag `vX.Y.Z`; dijalankan job `validate` di `.github/workflows/release.yml`      |
+| `*:generate`                                                            | Pasangan tulis dari sebuah `*:check`. Yang menggerbangi CI adalah `:check`-nya                                 |
+
+Urutan otoritatif rantai `check` ada di `package.json` langsung — sengaja tidak
+diduplikasi di sini supaya tidak drift.
+
+## Jadwal job
+
+Tidak didaftar di sini. Sumber kebenarannya `ModuleDescriptor.jobs` (per modul,
+membawa `purpose`, `recommendedSchedule`, `environmentNotes`,
+`safeInOfflineLan`), disajikan lewat `GET /api/v1/modules/{moduleKey}/jobs` dan
+digerbangi `bun run modules:jobs:check`. Lihat
+[`docs/awcms/deployment-profiles.md`](../docs/awcms/deployment-profiles.md)
+§Job registry.
+
+## Ditunda (belum ada di repo ini)
+
+Skrip acuan berikut belum diport karena bergantung pada arsitektur yang belum
+dibangun. `scripts:inventory:check` **menolak** kalau salah satu dari nama di
+bawah ternyata sudah terdaftar di `package.json` — itu tepat cara tabel
+sebelumnya membusuk.
+
+| Target acuan                                    | Prasyarat yang belum ada                                                    |
+| ----------------------------------------------- | --------------------------------------------------------------------------- |
+| `repo:inventory:generate` / `:check`            | Generator inventaris repo lintas-artefak (OpenAPI + komposisi modul + docs) |
+| `config:docs:check`                             | Rekonsiliasi tiga-arah `.env.example` ↔ doc 18 ↔ `validate-env.ts`          |
+| `i18n:extract` / `:pot:check` / `:parity:check` | Setup i18n (`.po`/`.pot`) + UI                                              |
+| `database:capacity:check`                       | Validasi kapasitas lintas-instance (preflight)                              |
+| `production:preflight`, `resilience:dr-drill`   | Mengagregasi gate di atas + server berjalan                                 |
+| `performance:*`                                 | Harness beban + environment berukuran produksi                              |
 
 Lihat peta sprint di
 [`docs/awcms/11_implementation_blueprint.md`](../docs/awcms/11_implementation_blueprint.md)
-dan skill terkait di [`.claude/skills/`](../.claude/skills/README.md)
-(`awcms-new-migration`, `awcms-new-endpoint`, `awcms-module-management`, dst.).
+dan skill terkait di [`.claude/skills/`](../.claude/skills/README.md).

--- a/scripts/scripts-inventory.ts
+++ b/scripts/scripts-inventory.ts
@@ -1,0 +1,230 @@
+/**
+ * The `scripts/README.md` inventory, derived from `package.json`.
+ *
+ * ## Why generated
+ *
+ * The table it replaces was hand-written, and it aged in the direction that
+ * does the most damage. It listed 12 of 52 scripts as "active", and its
+ * companion "not yet ported" table named fifteen tools that had not only
+ * landed but were IN the `bun run check` chain — `api:docs:check`,
+ * `modules:compose:check`, `db:work-class:check`, and every per-module worker.
+ *
+ * A negative claim is the dangerous kind: "X does not exist yet" gets more
+ * wrong with time and never fails on its own, unlike a positive claim that
+ * breaks the moment the code moves. Someone reading it would conclude
+ * `db:work-class:check` still needed building and build a second one.
+ *
+ * So the completeness half is derived and the prose half is not: this file
+ * generates target/script/in-check, which is exactly the part that goes stale,
+ * and leaves the rest of the README to a human.
+ *
+ * Two commands, one source: `bun run scripts:inventory:generate` rewrites the
+ * marked block, `bun run scripts:inventory:check` fails if it is out of date.
+ * A `.generated` artefact WITHOUT that pair is a false claim that reads more
+ * authoritative than prose.
+ *
+ * ## Why the check parses instead of comparing bytes
+ *
+ * Prettier owns markdown formatting here and pads table columns to align them.
+ * A byte-for-byte comparison would therefore fail immediately after every
+ * `bun run lint`, and the two would fight forever. So the check parses the
+ * block back into rows and compares CONTENT — which is the property worth
+ * asserting anyway. Padding is not drift.
+ */
+const README_PATH = "scripts/README.md";
+const BEGIN = "<!-- BEGIN GENERATED: script-inventory -->";
+const END = "<!-- END GENERATED: script-inventory -->";
+
+export type InventoryRow = {
+  target: string;
+  script: string;
+  inCheck: boolean;
+};
+
+export type PackageScripts = Record<string, string>;
+
+const SCRIPT_REFERENCE = /scripts\/([\w.-]+\.(?:ts|mjs))/;
+
+/**
+ * One row per `package.json` target that runs a file in `scripts/`. Targets
+ * that only compose other targets (`check` itself, `dev`, `build`) are not
+ * inventory entries — they run no script of their own.
+ */
+export function buildInventory(packageScripts: PackageScripts): InventoryRow[] {
+  const chain = packageScripts.check ?? "";
+
+  return Object.entries(packageScripts)
+    .flatMap(([target, command]) => {
+      const match = command.match(SCRIPT_REFERENCE);
+      if (!match) return [];
+
+      return [
+        {
+          target,
+          script: match[1]!,
+          inCheck:
+            chain.includes(`bun run ${target} `) ||
+            chain.endsWith(`bun run ${target}`)
+        }
+      ];
+    })
+    .sort((a, b) => a.target.localeCompare(b.target));
+}
+
+export function renderInventory(rows: readonly InventoryRow[]): string {
+  const gated = rows.filter((row) => row.inCheck).length;
+
+  return [
+    BEGIN,
+    "",
+    `<!-- Dihasilkan \`bun run scripts:inventory:generate\`. JANGAN diedit tangan. -->`,
+    "",
+    `${rows.length} target menjalankan berkas di \`scripts/\`; ${gated} di antaranya`,
+    "ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,",
+    "terjadwal, atau oleh workflow CI tertentu.",
+    "",
+    "| Target | Skrip | Gate |",
+    "| ------ | ----- | ---- |",
+    ...rows.map(
+      (row) =>
+        `| \`${row.target}\` | \`${row.script}\` | ${row.inCheck ? "✅" : "—"} |`
+    ),
+    "",
+    END
+  ].join("\n");
+}
+
+export function replaceInventoryBlock(
+  readme: string,
+  rendered: string
+): string {
+  const begin = readme.indexOf(BEGIN);
+  const end = readme.indexOf(END);
+
+  if (begin === -1 || end === -1) {
+    throw new Error(
+      `${README_PATH} is missing the ${BEGIN} / ${END} markers — the generated block has no home.`
+    );
+  }
+
+  return readme.slice(0, begin) + rendered + readme.slice(end + END.length);
+}
+
+/** Parses the rendered block back into rows, ignoring column padding. */
+export function parseInventoryBlock(block: string): InventoryRow[] {
+  return block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("| `"))
+    .map((line) => {
+      const cells = line
+        .split("|")
+        .slice(1, -1)
+        .map((cell) => cell.trim().replace(/^`|`$/g, ""));
+
+      return {
+        target: cells[0] ?? "",
+        script: cells[1] ?? "",
+        inCheck: cells[2] === "✅"
+      };
+    });
+}
+
+export function extractInventoryBlock(readme: string): string {
+  const begin = readme.indexOf(BEGIN);
+  const end = readme.indexOf(END);
+
+  if (begin === -1 || end === -1) {
+    throw new Error(`${README_PATH} is missing the generated-block markers.`);
+  }
+
+  return readme.slice(begin, end + END.length);
+}
+
+/**
+ * A target named as "not yet ported" that actually EXISTS. This is the exact
+ * shape of the failure: the claim is negative, so nothing breaks when it stops
+ * being true.
+ */
+export function findFalseAbsenceClaims(
+  readme: string,
+  packageScripts: PackageScripts
+): string[] {
+  const deferredHeading = readme.indexOf("## Ditunda");
+  if (deferredHeading === -1) return [];
+
+  // TABLE ROWS only. The prose in that section explains the rule and names a
+  // real target while doing so; scanning it wholesale made the gate report
+  // itself on its first run — the same self-report `table-write-ownership-check`
+  // and `tenant-context-usage-check` both hit.
+  const rows = readme
+    .slice(deferredHeading)
+    .split("\n")
+    .filter((line) => line.trimStart().startsWith("|"))
+    .join("\n");
+
+  return Object.keys(packageScripts)
+    .filter((target) => rows.includes(`\`${target}\``))
+    .sort();
+}
+
+export async function readPackageScripts(): Promise<PackageScripts> {
+  return (
+    (await Bun.file("package.json").json()) as { scripts: PackageScripts }
+  ).scripts;
+}
+
+async function main(): Promise<void> {
+  const mode = process.argv.includes("--check") ? "check" : "generate";
+  const packageScripts = await readPackageScripts();
+  const readme = await Bun.file(README_PATH).text();
+  const rendered = renderInventory(buildInventory(packageScripts));
+  const falseAbsences = findFalseAbsenceClaims(readme, packageScripts);
+
+  if (mode === "generate") {
+    await Bun.write(README_PATH, replaceInventoryBlock(readme, rendered));
+    console.log(
+      `Diperbarui: ${README_PATH} — blok inventaris skrip diregenerasi.`
+    );
+    return;
+  }
+
+  const failures: string[] = [];
+
+  const present = parseInventoryBlock(extractInventoryBlock(readme));
+  const expected = buildInventory(packageScripts);
+
+  if (JSON.stringify(present) !== JSON.stringify(expected)) {
+    failures.push(
+      `${README_PATH} tidak cocok dengan regenerasi segar dari package.json ` +
+        `(${present.length} baris tercatat vs ${expected.length} target nyata). ` +
+        "Jalankan `bun run scripts:inventory:generate` dan commit hasilnya."
+    );
+  }
+
+  for (const target of falseAbsences) {
+    failures.push(
+      `\`${target}\` tercatat di §Ditunda sebagai belum ada, padahal SUDAH ` +
+        "terdaftar di package.json. Klaim negatif menua ke arah berbahaya: " +
+        "pembacanya akan membangun duplikatnya."
+    );
+  }
+
+  if (failures.length === 0) {
+    console.log(
+      `scripts:inventory:check OK — blok inventaris ${README_PATH} sinkron, ` +
+        "tak ada klaim 'belum ada' untuk target yang sudah ada."
+    );
+    return;
+  }
+
+  for (const failure of failures) {
+    console.error(failure);
+  }
+
+  process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/scripts-inventory.test.ts
+++ b/tests/scripts-inventory.test.ts
@@ -1,0 +1,201 @@
+/**
+ * `scripts:inventory:check` — the two ways `scripts/README.md` went wrong.
+ *
+ * The table it replaces listed 12 of 52 scripts, and its companion "not yet
+ * ported" table named fifteen tools that had already landed — several of them
+ * IN the `bun run check` chain. Those are different failures and need different
+ * rules:
+ *
+ * 1. **Omission** — a target exists and the inventory does not mention it. The
+ *    block is generated, so any drift is a mismatch against a fresh render.
+ * 2. **A false ABSENCE claim** — the deferred table says a target does not
+ *    exist yet, and it does. This is the dangerous direction: a negative claim
+ *    gets more wrong with time and never fails on its own, so a reader
+ *    concludes `db:work-class:check` still needs building and builds a second.
+ *
+ * Every case plants a violation.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildInventory,
+  extractInventoryBlock,
+  findFalseAbsenceClaims,
+  parseInventoryBlock,
+  readPackageScripts,
+  renderInventory,
+  replaceInventoryBlock
+} from "../scripts/scripts-inventory";
+
+const SCRIPTS = {
+  check: "bun run lint && bun run modules:dag:check && bun run typecheck",
+  lint: "prettier --check .",
+  "modules:dag:check": "bun scripts/validate-module-graph.ts",
+  "db:migrate": "bun scripts/db-migrate.ts",
+  dev: "astro dev"
+};
+
+describe("buildInventory", () => {
+  test("lists only targets that run a file in scripts/", () => {
+    const rows = buildInventory(SCRIPTS);
+
+    expect(rows.map((row) => row.target)).toEqual([
+      "db:migrate",
+      "modules:dag:check"
+    ]);
+    // `lint` and `dev` run no script of their own; `check` only composes.
+    expect(rows.map((row) => row.script)).toEqual([
+      "db-migrate.ts",
+      "validate-module-graph.ts"
+    ]);
+  });
+
+  test("marks membership of the check chain", () => {
+    const rows = buildInventory(SCRIPTS);
+
+    expect(rows.find((r) => r.target === "modules:dag:check")!.inCheck).toBe(
+      true
+    );
+    expect(rows.find((r) => r.target === "db:migrate")!.inCheck).toBe(false);
+  });
+
+  test("the LAST entry in the chain still counts as gated", () => {
+    // `chain.includes("bun run x ")` alone misses the final entry, which has no
+    // trailing space — that would silently under-report the most recently
+    // appended gate.
+    const rows = buildInventory({
+      check: "bun run lint && bun run modules:dag:check",
+      "modules:dag:check": "bun scripts/validate-module-graph.ts"
+    });
+
+    expect(rows[0]!.inCheck).toBe(true);
+  });
+});
+
+describe("the generated block", () => {
+  test("parsing tolerates the column padding prettier adds", () => {
+    // Prettier owns markdown formatting and aligns table columns. A byte
+    // comparison would fail right after every `bun run lint`, so the check
+    // asserts CONTENT — padding is not drift.
+    const padded = [
+      "| Target             | Skrip                      | Gate |",
+      "| ------------------ | -------------------------- | ---- |",
+      "| `modules:dag:check`| `validate-module-graph.ts` | ✅   |"
+    ].join("\n");
+
+    expect(parseInventoryBlock(padded)).toEqual([
+      {
+        target: "modules:dag:check",
+        script: "validate-module-graph.ts",
+        inCheck: true
+      }
+    ]);
+  });
+
+  test("round-trips: replace then extract returns what was rendered", () => {
+    const rendered = renderInventory(buildInventory(SCRIPTS));
+    const readme = [
+      "# Scripts",
+      "<!-- BEGIN GENERATED: script-inventory -->",
+      "<!-- END GENERATED: script-inventory -->",
+      "## Ditunda"
+    ].join("\n");
+
+    expect(extractInventoryBlock(replaceInventoryBlock(readme, rendered))).toBe(
+      rendered
+    );
+  });
+
+  test("a README without markers fails loudly rather than silently doing nothing", () => {
+    expect(() => extractInventoryBlock("# Scripts\n")).toThrow(
+      /missing the generated-block markers/
+    );
+  });
+});
+
+describe("findFalseAbsenceClaims", () => {
+  test("flags the defect this gate exists for: a shipped tool listed as not-yet-ported", () => {
+    const readme = [
+      "## Ditunda",
+      "",
+      "| Target acuan | Prasyarat |",
+      "| --- | --- |",
+      "| `db:work-class:check` | Tabel/registry work-class |"
+    ].join("\n");
+
+    expect(findFalseAbsenceClaims(readme, SCRIPTS)).toEqual([]);
+    expect(
+      findFalseAbsenceClaims(readme, {
+        ...SCRIPTS,
+        "db:work-class:check": "bun scripts/work-class-registry-check.ts"
+      })
+    ).toEqual(["db:work-class:check"]);
+  });
+
+  test("prose in that section is not a claim — only table rows are", () => {
+    // Not hypothetical: the section explains the rule and names a real target
+    // while doing so, and scanning it wholesale made the gate report itself on
+    // its very first run.
+    const readme = [
+      "## Ditunda",
+      "",
+      "`scripts:inventory:check` menolak kalau nama di bawah sudah terdaftar.",
+      "",
+      "| Target acuan | Prasyarat |",
+      "| --- | --- |",
+      "| `i18n:extract` | Setup i18n |"
+    ].join("\n");
+
+    expect(
+      findFalseAbsenceClaims(readme, {
+        ...SCRIPTS,
+        "scripts:inventory:check": "bun scripts/scripts-inventory.ts --check"
+      })
+    ).toEqual([]);
+  });
+
+  test("a README with no deferred section makes no claims", () => {
+    expect(findFalseAbsenceClaims("# Scripts\n", SCRIPTS)).toEqual([]);
+  });
+});
+
+describe("the real repository", () => {
+  test("the inventory block matches a fresh regeneration", async () => {
+    const readme = await Bun.file("scripts/README.md").text();
+
+    expect(parseInventoryBlock(extractInventoryBlock(readme))).toEqual(
+      buildInventory(await readPackageScripts())
+    );
+  });
+
+  test("the deferred table names nothing that already exists", async () => {
+    expect(
+      findFalseAbsenceClaims(
+        await Bun.file("scripts/README.md").text(),
+        await readPackageScripts()
+      )
+    ).toEqual([]);
+  });
+
+  test("every target that runs a script is in the inventory", async () => {
+    // The omission half, stated directly rather than only implied by the
+    // round-trip: 12 of 52 was the state this replaced.
+    const readme = await Bun.file("scripts/README.md").text();
+    const rows = buildInventory(await readPackageScripts());
+    const listed = new Set(
+      parseInventoryBlock(extractInventoryBlock(readme)).map((r) => r.target)
+    );
+
+    expect(rows.length).toBeGreaterThan(50);
+    for (const row of rows) {
+      expect(listed.has(row.target)).toBe(true);
+    }
+  });
+
+  test("is wired into `bun run check`", async () => {
+    const scripts = await readPackageScripts();
+
+    expect(scripts["scripts:inventory:generate"]).toBeDefined();
+    expect(scripts.check).toContain("scripts:inventory:check");
+  });
+});


### PR DESCRIPTION
Closes #289.

## Dua tabel, dua mode kegagalan yang berbeda

`scripts/README.md` punya dua tabel dan keduanya salah — tapi salahnya tidak sama, jadi butuh aturan berbeda.

**Kelalaian.** Tabel "Aktif" mendaftar **12 dari 52** skrip.

**Klaim absensi palsu.** Tabel "Ditunda" menyebut lima belas tooling sebagai belum diport, padahal semuanya sudah mendarat — dan sebagian sudah ada **di rantai `bun run check`**: `api:docs:check`, `modules:compose:check`, `db:work-class:check`, `modules:composition:inventory:*`, plus seluruh worker per-modul.

Yang kedua jauh lebih berbahaya, dan itu bukan penilaian estetis: **klaim negatif makin salah seiring waktu dan tak pernah gagal sendiri**, tak seperti klaim positif yang langsung pecah begitu kodenya berubah. Pembacanya menyimpulkan `db:work-class:check` masih perlu dibangun, lalu membangunnya lagi.

## Perbaikan

| kegagalan | aturan |
| --- | --- |
| kelalaian | blok bertanda di README **dihasilkan** dari `package.json`; `scripts:inventory:check` menolak kalau basi |
| klaim absensi palsu | target yang tercatat di §Ditunda tapi ADA di `package.json` memerahkan gate |

Pasangan generate/check mengikuti pola artefak generated lain di repo ini — artefak generated **tanpa** pasangan itu adalah klaim palsu yang justru lebih dipercaya daripada prosa (pelajaran #263).

## Dua keputusan desain yang layak disebut

**Check-nya mem-parse, bukan membandingkan byte.** Prettier memiliki format markdown di sini dan memadatkan kolom tabel agar rata. Perbandingan byte akan gagal tepat setelah setiap `bun run lint`, dan keduanya bertengkar selamanya. Yang layak di-assert adalah **isinya**; padding bukan drift.

**Pemindai klaim absensi hanya membaca BARIS TABEL.** Prosa di bagian itu menjelaskan aturannya sambil menyebut nama target nyata — memindainya utuh membuat gate melaporkan **dirinya sendiri** pada run pertama. Kali keempat bentuk itu muncul di repo ini, jadi kali ini langsung diantisipasi dan diuji.

## Verifikasi

**Mutasi dibuktikan merah dengan klaim ASLI dipasang ulang** — menambahkan kembali baris `db:work-class:generate / :check` ke tabel §Ditunda membuat gate exit 1 dan test merah.

`bun run check` penuh hijau, **2956 test pass / 0 fail**, build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)