### PR TITLE
feat(blog-content): tutup jalur tulis iklan free-URL, dan buat drop terbukti

### DIFF
--- a/.changeset/blog-ads-write-path-retired.md
+++ b/.changeset/blog-ads-write-path-retired.md
@@ -1,0 +1,47 @@
+---
+"awcms": minor
+---
+
+ADR-0044 §4 Fase 2, langkah ketiga: jalur TULIS iklan free-URL ditutup, dan
+gerbang kesiapan yang membuat penghapusan tabel bisa dibuktikan alih-alih
+dipercaya.
+
+`POST /api/v1/blog/ads` dan `PATCH /api/v1/blog/ads/{id}` sekarang menjawab
+**410 ENDPOINT_RETIRED**, tanpa auth dan tanpa sentuhan basis data. Keduanya
+menyimpan `imageUrl` teks bebas — URL apa pun yang diketik admin, dirender
+langsung ke `<img src>` halaman publik. Itulah bypass managed-media yang ditutup
+ADR-0036, dan ia terbuka selama masih ada rute yang bisa menulisnya.
+
+**Urutannya yang menjadi isi perubahan ini.** Job ingest memindahkan apa yang
+ada saat ia berjalan. Jalur tulis yang masih terbuka membiarkan editor membuat
+iklan free-URL di jendela antara ingest dan penghapusan — iklan yang tidak
+bermigrasi ke mana pun dan lenyap saat tabelnya hilang, tanpa satu pun laporan
+menyebut ia pernah ada.
+
+Menutup `POST` saja tidak cukup: `PATCH` bisa menulis ulang `imageUrl` pada
+iklan yang sudah ada — bypass yang sama lewat rute yang lebih senyap, dan yang
+tidak menghasilkan baris baru untuk diperhatikan siapa pun.
+
+`GET` dan `DELETE` sengaja bertahan. Operator yang menyelesaikan laporan residu
+harus bisa membaca baris yang disebut laporan itu, dan mempensiunkan yang tidak
+ingin ia buat ulang — `blog:ads:drop-readiness` menghitung iklan yang
+soft-delete sebagai sudah-diputuskan.
+
+**`bun run blog:ads:drop-readiness`** menjawab "bolehkah kedua tabel lama
+dihapus sekarang?" dari data, dan keluar non-nol selama jawabannya belum.
+Migrasi penghapusan tak bisa dibatalkan dan membawa serta iklan situs hidup;
+seluruh pengaman epik ini menjadi hiasan bila langkah terakhirnya diambil atas
+dasar ingatan seseorang bahwa ia sudah menjalankan ingest. Kolom
+`source_legacy_ad_id` (`sql/079`) membuatnya jadi sebuah join.
+
+Iklan lama terhitung sudah-diputuskan bila ada baris penerus yang menyebutnya,
+ATAU bila ia soft-delete. Selain itu memblokir. **Tidak ada flag override** —
+gerbang yang bisa disuruh lulus adalah gerbang yang tak perlu dipenuhi siapa
+pun.
+
+Catatan proses: mutasi pertama saya terhadap query kesiapan (menghapus predikat
+`p.tenant_id = a.tenant_id`) **lolos ketujuh test** — RLS diam-diam mengerjakan
+apa yang diklaim predikat itu. Dua mekanisme diklaim, dan test yang tak bisa
+membedakannya hanya membuktikan setidaknya satu ada. Test kedelapan menjalankan
+penilaian yang sama sebagai peran admin yang melewati RLS sepenuhnya, sehingga
+predikatnya menjadi satu-satunya penghalang — dan mutasi itu kini merah.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -5985,4 +5985,5 @@ for the full policy.
 **Currently deprecated** (derived from `deprecated: true` on any operation,
 schema, or event channel in the bundled contracts):
 
-_None — nothing in the bundled contracts is currently marked deprecated._
+- REST: `POST /api/v1/blog/ads` (`blogCreateAd`)
+- REST: `PATCH /api/v1/blog/ads/{id}` (`blogUpdateAd`)

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -30,7 +30,7 @@
       ],
       "permissionCount": 43,
       "navigationCount": 0,
-      "jobCount": 2,
+      "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,
       "deploymentProfiles": null

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -1090,6 +1090,12 @@
       "rationale": "Scheduled retention purge (logs:audit:purge) — tolerant of delay, never latency-sensitive."
     },
     {
+      "path": "scripts/blog-ads-drop-readiness.ts",
+      "workClass": "maintenance",
+      "source": "registry",
+      "rationale": "Read-only readiness report (blog:ads:drop-readiness, ADR-0044 §4 Fase 2) — issues no write at all and is run by an operator deciding whether the drop migration may be written, so it is as delay-tolerant as work gets."
+    },
+    {
       "path": "scripts/blog-ads-ingest.ts",
       "workClass": "maintenance",
       "source": "registry",

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -2468,61 +2468,18 @@ paths:
       tags:
         - Blog Content
       operationId: blogCreateAd
-      summary: Create an advertisement
-      description: Gated by blog_content.ads.configure. imageUrl/linkUrl must be absolute http(s) URLs (never raw HTML/embed markup). Optionally seeds its initial placements (global|widget|post|page; targetId required except for global).
+      summary: Create an advertisement (RETIRED — always 410)
+      deprecated: true
+      description: RETIRED by ADR-0044 §4. Always responds 410 ENDPOINT_RETIRED, without auth or any database access. This endpoint stored a free-text imageUrl — any URL an admin typed, rendered straight into a public img src — which is the managed-media bypass ADR-0036 closed. Upload the image through the media library, then use POST /api/v1/news-portal/ad-placements, which requires a verified media object. GET and DELETE on this resource still work, so the ingest job's residue report stays resolvable.
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required:
-                - name
-                - imageUrl
-              properties:
-                name:
-                  type: string
-                imageUrl:
-                  type: string
-                linkUrl:
-                  type: string
-                  nullable: true
-                isActive:
-                  type: boolean
-                startsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                endsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                placements:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/BlogAdPlacement"
       responses:
-        "200":
-          description: Ad created.
+        "410":
+          description: Endpoint retired. The successor is named in the error message.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    enum:
-                      - true
-                  data:
-                    type: object
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
+                $ref: "#/components/schemas/ApiError"
   /api/v1/blog/ads/{id}:
     parameters:
       - name: id
@@ -2535,60 +2492,18 @@ paths:
       tags:
         - Blog Content
       operationId: blogUpdateAd
-      summary: Update an advertisement (and/or its placements)
-      description: Gated by blog_content.ads.configure. Providing placements replaces the whole set.
+      summary: Update an advertisement (RETIRED — always 410)
+      deprecated: true
+      description: "RETIRED by ADR-0044 §4. Always responds 410 ENDPOINT_RETIRED, without auth or any database access. Closing POST alone would not have sufficed: this endpoint could rewrite imageUrl on an existing ad, the same free-URL bypass by a quieter route that creates no new row. Use PATCH /api/v1/news-portal/ad-placements/{id}, which requires a verified media object."
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                imageUrl:
-                  type: string
-                linkUrl:
-                  type: string
-                  nullable: true
-                isActive:
-                  type: boolean
-                startsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                endsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                placements:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/BlogAdPlacement"
       responses:
-        "200":
-          description: Ad updated.
+        "410":
+          description: Endpoint retired. The successor is named in the error message.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    enum:
-                      - true
-                  data:
-                    type: object
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "404":
-          $ref: "#/components/responses/NotFound"
+                $ref: "#/components/schemas/ApiError"
     delete:
       tags:
         - Blog Content

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -1802,58 +1802,18 @@ paths:
       tags:
         - Blog Content
       operationId: blogCreateAd
-      summary: Create an advertisement
-      description: "Gated by blog_content.ads.configure. imageUrl/linkUrl must be absolute http(s) URLs (never raw HTML/embed markup). Optionally seeds its initial placements (global|widget|post|page; targetId required except for global)."
+      summary: Create an advertisement (RETIRED — always 410)
+      deprecated: true
+      description: "RETIRED by ADR-0044 §4. Always responds 410 ENDPOINT_RETIRED, without auth or any database access. This endpoint stored a free-text imageUrl — any URL an admin typed, rendered straight into a public img src — which is the managed-media bypass ADR-0036 closed. Upload the image through the media library, then use POST /api/v1/news-portal/ad-placements, which requires a verified media object. GET and DELETE on this resource still work, so the ingest job's residue report stays resolvable."
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [name, imageUrl]
-              properties:
-                name:
-                  type: string
-                imageUrl:
-                  type: string
-                linkUrl:
-                  type: string
-                  nullable: true
-                isActive:
-                  type: boolean
-                startsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                endsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                placements:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/BlogAdPlacement"
       responses:
-        "200":
-          description: Ad created.
+        "410":
+          description: Endpoint retired. The successor is named in the error message.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    enum: [true]
-                  data:
-                    type: object
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
+                $ref: "#/components/schemas/ApiError"
   /api/v1/blog/ads/{id}:
     parameters:
       - name: id
@@ -1866,59 +1826,18 @@ paths:
       tags:
         - Blog Content
       operationId: blogUpdateAd
-      summary: Update an advertisement (and/or its placements)
-      description: Gated by blog_content.ads.configure. Providing placements replaces the whole set.
+      summary: Update an advertisement (RETIRED — always 410)
+      deprecated: true
+      description: "RETIRED by ADR-0044 §4. Always responds 410 ENDPOINT_RETIRED, without auth or any database access. Closing POST alone would not have sufficed: this endpoint could rewrite imageUrl on an existing ad, the same free-URL bypass by a quieter route that creates no new row. Use PATCH /api/v1/news-portal/ad-placements/{id}, which requires a verified media object."
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                imageUrl:
-                  type: string
-                linkUrl:
-                  type: string
-                  nullable: true
-                isActive:
-                  type: boolean
-                startsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                endsAt:
-                  type: string
-                  format: date-time
-                  nullable: true
-                placements:
-                  type: array
-                  items:
-                    $ref: "#/components/schemas/BlogAdPlacement"
       responses:
-        "200":
-          description: Ad updated.
+        "410":
+          description: Endpoint retired. The successor is named in the error message.
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                    enum: [true]
-                  data:
-                    type: object
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "401":
-          $ref: "#/components/responses/Unauthorized"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "404":
-          $ref: "#/components/responses/NotFound"
+                $ref: "#/components/schemas/ApiError"
     delete:
       tags:
         - Blog Content

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "identity-access:business-scope:expiry": "bun scripts/identity-access-business-scope-expiry.ts",
     "blog:publish:scheduled": "bun scripts/blog-scheduled-publish.ts",
     "blog:ads:ingest": "bun scripts/blog-ads-ingest.ts",
+    "blog:ads:drop-readiness": "bun scripts/blog-ads-drop-readiness.ts",
     "news-media:reconcile": "bun scripts/news-media-r2-reconcile.ts",
     "logs:audit:purge": "bun scripts/audit-log-purge.ts",
     "data-lifecycle:archive-purge": "bun scripts/data-lifecycle-archive-purge.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ lalu membangun duplikatnya.
 
 <!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-59 target menjalankan berkas di `scripts/`; 23 di antaranya
+60 target menjalankan berkas di `scripts/`; 23 di antaranya
 ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
 terjadwal, atau oleh workflow CI tertentu.
 
@@ -35,6 +35,7 @@ terjadwal, atau oleh workflow CI tertentu.
 | `api:docs:generate`                      | `api-docs-generate.ts`                     | —    |
 | `api:spec:check`                         | `api-spec-check.ts`                        | ✅   |
 | `api:tenant-route:check`                 | `tenant-route-factory-check.ts`            | ✅   |
+| `blog:ads:drop-readiness`                | `blog-ads-drop-readiness.ts`               | —    |
 | `blog:ads:ingest`                        | `blog-ads-ingest.ts`                       | —    |
 | `blog:publish:scheduled`                 | `blog-scheduled-publish.ts`                | —    |
 | `changesets:policy:check`                | `changeset-policy-check.ts`                | —    |

--- a/scripts/blog-ads-drop-readiness.ts
+++ b/scripts/blog-ads-drop-readiness.ts
@@ -1,0 +1,117 @@
+/**
+ * blog-ads-drop-readiness.ts — `bun run blog:ads:drop-readiness`.
+ *
+ * ADR-0044 §4 Fase 2, step three: answers "may `awcms_blog_ads` and
+ * `awcms_blog_ad_placements` be dropped yet?" from the data, and exits non-zero
+ * while the answer is no.
+ *
+ * The drop migration is irreversible and takes a live site's advertising with
+ * it. Every other safeguard in this epic is about not losing rows silently, and
+ * they all become decorative if the final step is taken on the strength of
+ * someone remembering they ran the ingest. Migration 079's
+ * `source_legacy_ad_id` exists so this can be a join instead: run this, read
+ * the number, and only then write the drop.
+ *
+ * A legacy ad is accounted for when a successor row names it, OR when it is
+ * soft-deleted — an operator read the residue report and decided it does not
+ * come along. Anything else blocks. There is deliberately no override flag: a
+ * check that can be told to pass is a check nobody has to satisfy.
+ *
+ * Read-only. It issues no UPDATE, INSERT or DELETE, so it is safe to run
+ * against production at any time, including before the ingest has ever run.
+ *
+ * Runs as the least-privilege `awcms_worker` role, which holds SELECT on both
+ * legacy tables and the successor (`sql/079`) and nothing more. RLS is FORCE'd
+ * for that role too, so every pass is wrapped in `withTenantOrThrow`.
+ */
+import { getWorkerDatabaseClient } from "../src/lib/database/client";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
+import { logScriptFailure } from "../src/lib/logging/error-log";
+import {
+  MAX_REPORTED_OUTSTANDING,
+  assessLegacyAdDropReadiness,
+  isReadyToDrop,
+  type LegacyAdDropReadiness
+} from "../src/modules/blog-content/application/legacy-ad-drop-readiness";
+
+type TenantRow = { id: string };
+
+async function main() {
+  const sql = getWorkerDatabaseClient();
+  const correlationId = crypto.randomUUID();
+
+  try {
+    const tenants = (await sql`
+      SELECT id FROM awcms_tenants WHERE status = 'active'
+    `) as TenantRow[];
+
+    const reports: LegacyAdDropReadiness[] = [];
+
+    for (const tenant of tenants) {
+      reports.push(
+        await withTenantOrThrow(sql, tenant.id, (tx) =>
+          assessLegacyAdDropReadiness(tx, tenant.id)
+        )
+      );
+    }
+
+    for (const report of reports) {
+      if (report.totalLegacyAds === 0 && report.retired === 0) {
+        continue;
+      }
+
+      console.log(
+        `blog:ads:drop-readiness tenant=${report.tenantId} ` +
+          `legacyAds=${report.totalLegacyAds} migrated=${report.migrated} ` +
+          `outstanding=${report.outstanding} retired=${report.retired}`
+      );
+
+      for (const adId of report.outstandingAdIds) {
+        console.log(
+          `blog:ads:drop-readiness OUTSTANDING — tenant=${report.tenantId} legacyAd=${adId}`
+        );
+      }
+
+      // Never let a truncated list of blockers read as a complete one.
+      if (report.outstanding > report.outstandingAdIds.length) {
+        console.log(
+          `blog:ads:drop-readiness — ${report.outstanding - report.outstandingAdIds.length} ` +
+            `further outstanding ad(s) in tenant ${report.tenantId} not listed ` +
+            `(cap ${MAX_REPORTED_OUTSTANDING}). The count above is exact.`
+        );
+      }
+    }
+
+    const totalOutstanding = reports.reduce(
+      (sum, report) => sum + report.outstanding,
+      0
+    );
+
+    if (isReadyToDrop(reports)) {
+      console.log(
+        `blog:ads:drop-readiness READY — correlationId=${correlationId} ` +
+          `tenants=${tenants.length}. Every legacy advertisement has either ` +
+          `migrated or been retired. The drop migration may be written.`
+      );
+      return;
+    }
+
+    console.error(
+      `blog:ads:drop-readiness NOT READY — correlationId=${correlationId} ` +
+        `tenants=${tenants.length} outstanding=${totalOutstanding}. Each ad ` +
+        `listed above has no successor row and is not soft-deleted, so ` +
+        `dropping the legacy tables now would destroy it with no record. Run ` +
+        `\`bun run blog:ads:ingest\`, resolve its residue, and re-run this.`
+    );
+    process.exitCode = 1;
+  } catch (error) {
+    logScriptFailure("blog:ads:drop-readiness FAILED", error);
+    process.exitCode = 1;
+  } finally {
+    await sql.close({ timeout: 1 });
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/src/lib/database/work-class-registry.ts
+++ b/src/lib/database/work-class-registry.ts
@@ -94,6 +94,11 @@ export const JOB_WORK_CLASS_REGISTRY: Readonly<
     rationale:
       "Scheduled-publish dispatcher (blog:publish:scheduled) — recurring, not latency-sensitive, but more time-relevant than a maintenance purge."
   },
+  "scripts/blog-ads-drop-readiness.ts": {
+    workClass: "maintenance",
+    rationale:
+      "Read-only readiness report (blog:ads:drop-readiness, ADR-0044 §4 Fase 2) — issues no write at all and is run by an operator deciding whether the drop migration may be written, so it is as delay-tolerant as work gets."
+  },
   "scripts/blog-ads-ingest.ts": {
     workClass: "maintenance",
     rationale:

--- a/src/modules/blog-content/application/legacy-ad-drop-readiness.ts
+++ b/src/modules/blog-content/application/legacy-ad-drop-readiness.ts
@@ -1,0 +1,115 @@
+/**
+ * "May the legacy advertisement tables be dropped yet?" — ADR-0044 §4 Fase 2,
+ * step three.
+ *
+ * The drop is irreversible and takes a live site's advertising with it, so the
+ * question has to be answerable from the data rather than from someone's
+ * recollection of having run the ingest. Migration 079's `source_legacy_ad_id`
+ * is what makes that possible: every successor row names the legacy row it came
+ * from, so "did everything move?" is a join.
+ *
+ * ## What counts as ready
+ *
+ * A legacy ad is ACCOUNTED FOR when either
+ *
+ *   - at least one `awcms_news_portal_ad_placements` row names it via
+ *     `source_legacy_ad_id` (it migrated), or
+ *   - it is soft-deleted (`deleted_at IS NOT NULL`) — an operator read the
+ *     residue report and decided this ad does not come along.
+ *
+ * Anything else is OUTSTANDING, and outstanding means not ready. There is no
+ * "close enough" threshold and no override flag: the whole point of the
+ * `source_legacy_ad_id` column is that this check cannot be satisfied by
+ * assertion.
+ *
+ * ## What this deliberately does NOT check
+ *
+ * Whether the successor rows are any good — right slot, right schedule, right
+ * image. That is editorial judgement, and a readiness check that pretended to
+ * validate it would be making a promise it cannot keep. This answers exactly
+ * one question: is there a legacy row whose fate nobody has decided?
+ *
+ * Runs inside the caller's own tenant-scoped transaction.
+ */
+
+export type LegacyAdDropReadiness = {
+  tenantId: string;
+  /** Every non-deleted legacy ad, whether or not it migrated. */
+  totalLegacyAds: number;
+  /** Non-deleted legacy ads with at least one successor row. */
+  migrated: number;
+  /**
+   * Non-deleted legacy ads with no successor. Each one either failed to
+   * migrate (it is in the residue report) or was created after the ingest ran.
+   */
+  outstanding: number;
+  /** Up to `MAX_REPORTED_OUTSTANDING` ids, so the report names rows rather than counting them. */
+  outstandingAdIds: string[];
+  /** Soft-deleted legacy ads — accounted for by an operator's decision, not by migration. */
+  retired: number;
+};
+
+/**
+ * A readiness report is read by a human, and a thousand ids is not a report.
+ * The COUNT is always exact and always the thing the ready/not-ready decision
+ * rests on; this only bounds how many are named. The script says explicitly
+ * when the list was truncated, because a silently shortened list of blockers
+ * reads as a complete one.
+ */
+export const MAX_REPORTED_OUTSTANDING = 50;
+
+export async function assessLegacyAdDropReadiness(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<LegacyAdDropReadiness> {
+  const rows = (await tx`
+    SELECT
+      count(*) FILTER (WHERE a.deleted_at IS NULL)::int AS total_legacy_ads,
+      count(*) FILTER (
+        WHERE a.deleted_at IS NULL AND s.source_legacy_ad_id IS NOT NULL
+      )::int AS migrated,
+      count(*) FILTER (WHERE a.deleted_at IS NOT NULL)::int AS retired
+    FROM awcms_blog_ads a
+    LEFT JOIN LATERAL (
+      SELECT p.source_legacy_ad_id
+      FROM awcms_news_portal_ad_placements p
+      WHERE p.tenant_id = a.tenant_id AND p.source_legacy_ad_id = a.id
+      LIMIT 1
+    ) s ON true
+    WHERE a.tenant_id = ${tenantId}
+  `) as {
+    total_legacy_ads: number;
+    migrated: number;
+    retired: number;
+  }[];
+
+  const summary = rows[0] ?? { total_legacy_ads: 0, migrated: 0, retired: 0 };
+
+  const outstandingRows = (await tx`
+    SELECT a.id
+    FROM awcms_blog_ads a
+    WHERE a.tenant_id = ${tenantId}
+      AND a.deleted_at IS NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM awcms_news_portal_ad_placements p
+        WHERE p.tenant_id = a.tenant_id AND p.source_legacy_ad_id = a.id
+      )
+    ORDER BY a.created_at ASC
+    LIMIT ${MAX_REPORTED_OUTSTANDING}
+  `) as { id: string }[];
+
+  return {
+    tenantId,
+    totalLegacyAds: summary.total_legacy_ads,
+    migrated: summary.migrated,
+    outstanding: summary.total_legacy_ads - summary.migrated,
+    outstandingAdIds: outstandingRows.map((row) => row.id),
+    retired: summary.retired
+  };
+}
+
+export function isReadyToDrop(
+  reports: readonly LegacyAdDropReadiness[]
+): boolean {
+  return reports.every((report) => report.outstanding === 0);
+}

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -477,6 +477,16 @@ export const blogContentModule = defineModule({
       environmentNotes:
         "Reads `NEWS_MEDIA_R2_PUBLIC_BASE_URL` to recognise this deployment's own media URLs; with it unset every ad is reported as residue rather than migrated, which is loud and lossless. Makes no network call of any kind — it never fetches an image, and deliberately so (see `domain/legacy-ad-ingest.ts`).",
       safeInOfflineLan: true
+    },
+    {
+      command: "bun run blog:ads:drop-readiness",
+      purpose:
+        "ADR-0044 §4 Fase 2: answers whether `awcms_blog_ads` and `awcms_blog_ad_placements` may be dropped yet, and exits non-zero while the answer is no. A legacy ad is accounted for when a successor row names it via `source_legacy_ad_id` (migration 079) or when it is soft-deleted — an operator read the residue report and decided it does not come along. Anything else blocks, and there is deliberately no override flag. Read-only: it issues no INSERT, UPDATE or DELETE, so it is safe to run against production at any time, including before the ingest has ever run.",
+      recommendedSchedule:
+        "NOT scheduled. Run it by hand before writing the drop migration, and re-run it after each round of `blog:ads:ingest`. Retired together with the legacy tables it inspects.",
+      environmentNotes:
+        "No configuration and no external call — a pure database read. Answers only 'is there a legacy row whose fate nobody has decided'; whether the successor rows are editorially correct is human judgement it does not pretend to check.",
+      safeInOfflineLan: true
     }
   ]
 });

--- a/src/pages/api/v1/blog/ads/[id].ts
+++ b/src/pages/api/v1/blog/ads/[id].ts
@@ -16,16 +16,8 @@ import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   fetchAdById,
-  fetchAdPlacements,
-  softDeleteAd,
-  syncAdPlacements,
-  updateAd
+  softDeleteAd
 } from "../../../../../modules/blog-content/application/ads-directory";
-import {
-  validateAdPlacementsInput,
-  validateUpdateAdInput,
-  type AdPlacementInput
-} from "../../../../../modules/blog-content/domain/ad-policy";
 import { validateDeleteReasonInput } from "../../../../../modules/blog-content/domain/content-validation";
 
 const CONFIGURE_GUARD = {
@@ -34,111 +26,20 @@ const CONFIGURE_GUARD = {
   action: "configure" as const
 };
 
-/** `PATCH /api/v1/blog/ads/{id}` (Issue #542). `placements` (full replace) may be sent independently of the other ad fields. */
-export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
-  const { tenantId, token } = resolveAuthInputs(request, cookies);
-  const id = params.id;
-
-  if (!tenantId) {
-    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  }
-
-  if (!id) {
-    return fail(400, "VALIDATION_ERROR", "Ad id is required.");
-  }
-
-  if (!token) {
-    return fail(401, "AUTH_REQUIRED", "Authentication required.");
-  }
-
-  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
-
-  if (bodyRead.tooLarge) {
-    return bodyTooLargeResponse(bodyRead.limitBytes);
-  }
-
-  const body = bodyRead.value;
-  const validation = validateUpdateAdInput(body);
-
-  if (!validation.valid) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "Ad update is invalid.",
-      {},
-      validation.errors
-    );
-  }
-
-  let placements: AdPlacementInput[] | undefined;
-
-  if (body && body.placements !== undefined) {
-    const placementsResult = validateAdPlacementsInput(body.placements);
-
-    if (!placementsResult.valid) {
-      return fail(
-        400,
-        "VALIDATION_ERROR",
-        "Ad placements are invalid.",
-        {},
-        placementsResult.errors
-      );
-    }
-
-    placements = placementsResult.value;
-  }
-
-  const input = validation.value;
-  const sql = getDatabaseClient();
-  const tokenHash = hashSessionToken(token);
-  const now = new Date();
-  const correlationId = locals.correlationId;
-
-  return withTenant(sql, tenantId, async (tx) => {
-    const auth = await authorizeInTransaction(
-      tx,
-      tenantId,
-      tokenHash,
-      now,
-      CONFIGURE_GUARD
-    );
-
-    if (!auth.allowed) {
-      return auth.denied;
-    }
-
-    const updated = await updateAd(tx, tenantId, id, input);
-
-    if (!updated) {
-      return fail(404, "RESOURCE_NOT_FOUND", "Ad not found.");
-    }
-
-    const currentPlacements = placements
-      ? await syncAdPlacements(tx, tenantId, id, placements)
-      : await fetchAdPlacements(tx, tenantId, id);
-
-    await recordAuditEvent(tx, {
-      tenantId,
-      actorTenantUserId: auth.context.tenantUserId,
-      moduleKey: "blog_content",
-      action: "blog.ad.updated",
-      resourceType: "blog_ad",
-      resourceId: id,
-      severity: "info",
-      message: `Blog ad updated: ${updated.name}.`,
-      correlationId
-    });
-
-    log("info", "blog-content.ad.updated", {
-      correlationId,
-      tenantId,
-      moduleKey: "blog_content",
-      adId: id
-    });
-
-    return ok({ ...updated, placements: currentPlacements });
-  });
-};
+/**
+ * `PATCH /api/v1/blog/ads/{id}` — **retired** (ADR-0044 §4 Fase 2, step three),
+ * for the same reason as `POST` on the collection: see that handler's comment.
+ *
+ * Closing `POST` alone would not have been enough. This endpoint could rewrite
+ * `imageUrl` on an existing ad, so it was a second, quieter route to the same
+ * free-URL bypass — and one that produces no new row for anyone to notice.
+ */
+export const PATCH: APIRoute = async () =>
+  fail(
+    410,
+    "ENDPOINT_RETIRED",
+    "Free-URL advertisements are retired (ADR-0044). Upload the image through the media library, then manage the advertisement via PATCH /api/v1/news-portal/ad-placements/{id}, which requires a verified media object instead of an arbitrary URL."
+  );
 
 /** `DELETE /api/v1/blog/ads/{id}` (Issue #542) — soft-delete. `reason` required. */
 export const DELETE: APIRoute = async ({

--- a/src/pages/api/v1/blog/ads/index.ts
+++ b/src/pages/api/v1/blog/ads/index.ts
@@ -8,32 +8,12 @@ import {
   resolveAuthInputs
 } from "../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../lib/auth/session-token";
-import {
-  bodyTooLargeResponse,
-  readJsonBody
-} from "../../../../../lib/security/request-body-limit";
-import { log } from "../../../../../lib/logging/logger";
-import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
-import {
-  createAd,
-  listAds,
-  syncAdPlacements
-} from "../../../../../modules/blog-content/application/ads-directory";
-import {
-  validateAdPlacementsInput,
-  validateCreateAdInput
-} from "../../../../../modules/blog-content/domain/ad-policy";
+import { listAds } from "../../../../../modules/blog-content/application/ads-directory";
 
 const READ_GUARD = {
   moduleKey: "blog_content",
   activityCode: "ads",
   action: "read" as const
-};
-
-const CONFIGURE_GUARD = {
-  moduleKey: "blog_content",
-  activityCode: "ads",
-  action: "configure" as const
 };
 
 /** `GET /api/v1/blog/ads` (Issue #542) — list this tenant's non-deleted ads. */
@@ -71,96 +51,34 @@ export const GET: APIRoute = async ({ request, cookies }) => {
   });
 };
 
-/** `POST /api/v1/blog/ads` (Issue #542) — create an ad, optionally with its initial `placements`. Not idempotent. */
-export const POST: APIRoute = async ({ request, cookies, locals }) => {
-  const { tenantId, token } = resolveAuthInputs(request, cookies);
-
-  if (!tenantId) {
-    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
-  }
-
-  if (!token) {
-    return fail(401, "AUTH_REQUIRED", "Authentication required.");
-  }
-
-  const bodyRead = await readJsonBody<Record<string, unknown>>(request);
-
-  if (bodyRead.tooLarge) {
-    return bodyTooLargeResponse(bodyRead.limitBytes);
-  }
-
-  const body = bodyRead.value;
-  const validation = validateCreateAdInput(body);
-
-  if (!validation.valid) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "Ad is invalid.",
-      {},
-      validation.errors
-    );
-  }
-
-  const placementsInput = (body ?? {}).placements ?? [];
-  const placementsResult = validateAdPlacementsInput(placementsInput);
-
-  if (!placementsResult.valid) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "Ad placements are invalid.",
-      {},
-      placementsResult.errors
-    );
-  }
-
-  const input = validation.value;
-  const sql = getDatabaseClient();
-  const tokenHash = hashSessionToken(token);
-  const now = new Date();
-  const correlationId = locals.correlationId;
-
-  return withTenant(sql, tenantId, async (tx) => {
-    const auth = await authorizeInTransaction(
-      tx,
-      tenantId,
-      tokenHash,
-      now,
-      CONFIGURE_GUARD
-    );
-
-    if (!auth.allowed) {
-      return auth.denied;
-    }
-
-    const ad = await createAd(tx, tenantId, input);
-    const placements = await syncAdPlacements(
-      tx,
-      tenantId,
-      ad.id,
-      placementsResult.value
-    );
-
-    await recordAuditEvent(tx, {
-      tenantId,
-      actorTenantUserId: auth.context.tenantUserId,
-      moduleKey: "blog_content",
-      action: "blog.ad.created",
-      resourceType: "blog_ad",
-      resourceId: ad.id,
-      severity: "info",
-      message: `Blog ad created: ${ad.name}.`,
-      correlationId
-    });
-
-    log("info", "blog-content.ad.created", {
-      correlationId,
-      tenantId,
-      moduleKey: "blog_content",
-      adId: ad.id
-    });
-
-    return ok({ ...ad, placements });
-  });
-};
+/**
+ * `POST /api/v1/blog/ads` — **retired** (ADR-0044 §4 Fase 2, step three).
+ *
+ * This endpoint created an advertisement from a free-text `imageUrl`: any URL
+ * an admin typed, stored verbatim and rendered into an `<img src>` on a public
+ * page. That is the managed-media bypass ADR-0036 inverted media ownership to
+ * close, and it is the reason the merged module keeps only the media-backed
+ * advertisement system.
+ *
+ * It is closed BEFORE the tables are dropped, not with them, and the ordering
+ * is the point: the ingest job (`bun run blog:ads:ingest`) moves what exists at
+ * the moment it runs. Leaving this open would let an editor create a free-URL
+ * ad in the window between the ingest and the drop — an ad that migrates
+ * nowhere and disappears when the table goes, with nothing in any report saying
+ * it ever existed.
+ *
+ * `GET` and `DELETE` deliberately survive. An operator has to be able to read
+ * the residue report's rows and retire the ones they do not want to re-create;
+ * removing the read path would leave them resolving a report against data they
+ * can no longer see.
+ *
+ * 410 rather than 404: the resource existed, its absence is permanent, and the
+ * successor is named in the message. Deliberately answered before any auth or
+ * database work — there is nothing left here to authorize.
+ */
+export const POST: APIRoute = async () =>
+  fail(
+    410,
+    "ENDPOINT_RETIRED",
+    "Free-URL advertisements are retired (ADR-0044). Upload the image through the media library, then create the advertisement via POST /api/v1/news-portal/ad-placements, which requires a verified media object instead of an arbitrary URL."
+  );

--- a/tests/integration/legacy-ad-drop-readiness.integration.test.ts
+++ b/tests/integration/legacy-ad-drop-readiness.integration.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Integration tests for ADR-0044 §4 Fase 2's drop-readiness check against a
+ * real PostgreSQL under the WORLD-1 ephemeral-database harness.
+ *
+ * This is the last gate before an irreversible migration takes a live site's
+ * advertising with it, so the failure that matters is the one where it says
+ * READY too early. A readiness check that under-reports blockers is worse than
+ * no check at all: it converts "I think we ran the ingest" into "the tool
+ * confirmed it".
+ *
+ * So the assertions here are mostly about what must NOT be counted as
+ * accounted-for, and they are exercised against real rows rather than against
+ * the query's shape.
+ *
+ * Skipped unless a real database is configured (see tests/integration/harness.ts).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import {
+  assessLegacyAdDropReadiness,
+  isReadyToDrop
+} from "../../src/modules/blog-content/application/legacy-ad-drop-readiness";
+
+async function provisionTenant(tenantCode: string): Promise<string> {
+  const admin = getAdminSql();
+  const tenantId = crypto.randomUUID();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${tenantId}, ${tenantCode}, ${tenantCode}, 'active')
+  `;
+
+  return tenantId;
+}
+
+async function provisionMediaObject(tenantId: string): Promise<string> {
+  const admin = getAdminSql();
+  const id = crypto.randomUUID();
+  const objectKey = `news-media/${tenantId}/2026/07/${id}.jpg`;
+
+  await admin`
+    INSERT INTO awcms_news_media_objects
+      (id, tenant_id, bucket_name, object_key, public_url, mime_type, status,
+       alt_text, created_by_tenant_user_id)
+    VALUES (
+      ${id}, ${tenantId}, 'test-bucket', ${objectKey},
+      ${`https://media.example.test/${objectKey}`}, 'image/jpeg', 'verified',
+      'Banner', ${crypto.randomUUID()}
+    )
+  `;
+
+  return id;
+}
+
+async function provisionLegacyAd(tenantId: string): Promise<string> {
+  const admin = getAdminSql();
+  const adId = crypto.randomUUID();
+
+  await admin`
+    INSERT INTO awcms_blog_ads (id, tenant_id, name, image_url)
+    VALUES (${adId}, ${tenantId}, 'Legacy banner', 'https://cdn.example/a.jpg')
+  `;
+
+  return adId;
+}
+
+async function provisionSuccessor(
+  tenantId: string,
+  mediaObjectId: string,
+  sourceLegacyAdId: string
+): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_news_portal_ad_placements
+      (tenant_id, placement_key, name, media_object_id, target_type,
+       source_legacy_ad_id)
+    VALUES (
+      ${tenantId}, 'sidebar_top', 'Migrated banner', ${mediaObjectId},
+      'global', ${sourceLegacyAdId}
+    )
+  `;
+}
+
+function assess(tenantId: string) {
+  return withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
+    assessLegacyAdDropReadiness(tx, tenantId)
+  );
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("legacy advertisement drop readiness (ADR-0044 §4)", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+  beforeEach(async () => {
+    await resetDatabase();
+  });
+
+  test("a tenant with no legacy ads at all is ready", async () => {
+    const tenantId = await provisionTenant("acme");
+    const report = await assess(tenantId);
+
+    expect(report).toMatchObject({
+      totalLegacyAds: 0,
+      migrated: 0,
+      outstanding: 0,
+      retired: 0
+    });
+    expect(isReadyToDrop([report])).toBe(true);
+  });
+
+  test("an un-migrated legacy ad BLOCKS, and is named", async () => {
+    const tenantId = await provisionTenant("acme");
+    const adId = await provisionLegacyAd(tenantId);
+
+    const report = await assess(tenantId);
+
+    expect(report.totalLegacyAds).toBe(1);
+    expect(report.migrated).toBe(0);
+    expect(report.outstanding).toBe(1);
+    expect(report.outstandingAdIds).toEqual([adId]);
+    expect(isReadyToDrop([report])).toBe(false);
+  });
+
+  test("a migrated legacy ad is accounted for", async () => {
+    const tenantId = await provisionTenant("acme");
+    const mediaObjectId = await provisionMediaObject(tenantId);
+    const adId = await provisionLegacyAd(tenantId);
+
+    await provisionSuccessor(tenantId, mediaObjectId, adId);
+
+    const report = await assess(tenantId);
+
+    expect(report.totalLegacyAds).toBe(1);
+    expect(report.migrated).toBe(1);
+    expect(report.outstanding).toBe(0);
+    expect(report.outstandingAdIds).toEqual([]);
+    expect(isReadyToDrop([report])).toBe(true);
+  });
+
+  test("one ad with several successors is counted ONCE, not once per row", async () => {
+    // A legacy ad with three placements becomes three successor rows. A plain
+    // JOIN would count it three times and report `migrated` above
+    // `totalLegacyAds` — which, subtracted, yields a NEGATIVE outstanding and a
+    // cheerful READY for a tenant that has un-migrated ads elsewhere.
+    const tenantId = await provisionTenant("acme");
+    const mediaObjectId = await provisionMediaObject(tenantId);
+    const migratedAdId = await provisionLegacyAd(tenantId);
+    const blockingAdId = await provisionLegacyAd(tenantId);
+
+    for (const [targetType, targetId] of [
+      ["global", null],
+      ["post", crypto.randomUUID()],
+      ["page", crypto.randomUUID()]
+    ] as const) {
+      await getAdminSql()`
+        INSERT INTO awcms_news_portal_ad_placements
+          (tenant_id, placement_key, name, media_object_id, target_type,
+           target_id, source_legacy_ad_id)
+        VALUES (
+          ${tenantId}, 'sidebar_top', 'Migrated banner', ${mediaObjectId},
+          ${targetType}, ${targetId}, ${migratedAdId}
+        )
+      `;
+    }
+
+    const report = await assess(tenantId);
+
+    expect(report.totalLegacyAds).toBe(2);
+    expect(report.migrated).toBe(1);
+    expect(report.outstanding).toBe(1);
+    expect(report.outstandingAdIds).toEqual([blockingAdId]);
+    expect(isReadyToDrop([report])).toBe(false);
+  });
+
+  test("a soft-deleted legacy ad is accounted for without migrating", async () => {
+    // The operator read the residue report and decided this ad does not come
+    // along. That is a decision, and the check has to accept decisions or
+    // there is no way to ever reach READY with residue that cannot migrate.
+    const tenantId = await provisionTenant("acme");
+    const adId = await provisionLegacyAd(tenantId);
+
+    await getAdminSql()`
+      UPDATE awcms_blog_ads SET deleted_at = now() WHERE id = ${adId}
+    `;
+
+    const report = await assess(tenantId);
+
+    expect(report.totalLegacyAds).toBe(0);
+    expect(report.retired).toBe(1);
+    expect(report.outstanding).toBe(0);
+    expect(isReadyToDrop([report])).toBe(true);
+  });
+
+  test("a successor belonging to ANOTHER tenant does not count", async () => {
+    // The most dangerous false READY available: a successor row that names this
+    // ad's id but lives in a different tenant. One tenant's migration must not
+    // silently clear another's blocker.
+    const acmeId = await provisionTenant("acme");
+    const globexId = await provisionTenant("globex");
+    const globexMediaId = await provisionMediaObject(globexId);
+    const acmeAdId = await provisionLegacyAd(acmeId);
+
+    await provisionSuccessor(globexId, globexMediaId, acmeAdId);
+
+    const report = await assess(acmeId);
+
+    expect(report.outstanding).toBe(1);
+    expect(report.outstandingAdIds).toEqual([acmeAdId]);
+    expect(isReadyToDrop([report])).toBe(false);
+  });
+
+  test("cross-tenant isolation survives WITHOUT RLS — the query's own predicate holds", async () => {
+    // The test above passes even if `p.tenant_id = a.tenant_id` is deleted from
+    // both queries, because the runtime role is subject to FORCE'd RLS and RLS
+    // silently does the work. Verified by mutation: removing the predicate left
+    // all seven other tests green.
+    //
+    // That is a gap worth closing rather than a reassurance. Two mechanisms are
+    // claimed here — RLS and an explicit predicate — and a test that cannot
+    // tell them apart proves only that at least one exists. So this runs the
+    // SAME assessment as the admin role, which bypasses RLS entirely, leaving
+    // the predicate as the only thing between one tenant's migration and
+    // another tenant's blocker.
+    const acmeId = await provisionTenant("acme");
+    const globexId = await provisionTenant("globex");
+    const globexMediaId = await provisionMediaObject(globexId);
+    const acmeAdId = await provisionLegacyAd(acmeId);
+
+    await provisionSuccessor(globexId, globexMediaId, acmeAdId);
+
+    const report = await assessLegacyAdDropReadiness(getAdminSql(), acmeId);
+
+    expect(report.outstanding).toBe(1);
+    expect(report.outstandingAdIds).toEqual([acmeAdId]);
+  });
+
+  test("readiness across tenants is AND, not majority", async () => {
+    const readyTenantId = await provisionTenant("acme");
+    const blockedTenantId = await provisionTenant("globex");
+    await provisionLegacyAd(blockedTenantId);
+
+    const reports = [
+      await assess(readyTenantId),
+      await assess(blockedTenantId)
+    ];
+
+    expect(isReadyToDrop([reports[0]!])).toBe(true);
+    expect(isReadyToDrop(reports)).toBe(false);
+  });
+});

--- a/tests/legacy-ad-write-path-retired.test.ts
+++ b/tests/legacy-ad-write-path-retired.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "bun:test";
+
+import { DELETE, PATCH } from "../src/pages/api/v1/blog/ads/[id]";
+import { GET, POST } from "../src/pages/api/v1/blog/ads/index";
+
+/**
+ * ADR-0044 §4 Fase 2, step three: the free-URL advertisement WRITE path is
+ * closed before the tables are dropped, not with them.
+ *
+ * `awcms_blog_ads.image_url` is free text rendered straight into a public
+ * `<img src>`. That is the managed-media bypass ADR-0036 inverted media
+ * ownership to close, and it stays open for as long as any route can write it.
+ *
+ * The ordering is the substance of this change. The ingest job moves what
+ * exists at the moment it runs; an open write path lets an editor create a
+ * free-URL ad in the window between the ingest and the drop — an ad that
+ * migrates nowhere and disappears when the table goes, with nothing in any
+ * report saying it existed.
+ *
+ * Both handlers answer before any auth or database work, which is what makes
+ * them testable here with a bare `Request` and no harness at all. That is a
+ * property worth pinning: if either ever starts touching the database, this
+ * file stops compiling into a meaningful test and someone has to look.
+ */
+function retiredRequest(method: string): Request {
+  return new Request("https://example.test/api/v1/blog/ads", { method });
+}
+
+async function callRetired(
+  handler: typeof POST,
+  method: string
+): Promise<Response> {
+  // Cast: these handlers ignore every argument by construction. Passing an
+  // empty context is the assertion, not a shortcut — a handler that reads
+  // `cookies` or `params` would throw here rather than quietly pass.
+  return (await handler({
+    request: retiredRequest(method)
+  } as unknown as Parameters<typeof POST>[0])) as Response;
+}
+
+describe("ADR-0044 §4 — the free-URL advertisement write path is retired", () => {
+  test("POST /api/v1/blog/ads is 410 Gone", async () => {
+    const response = await callRetired(POST, "POST");
+
+    // 410, not 404: the resource existed and its absence is permanent. A 404
+    // would read as "wrong URL" and send an integrator looking for a typo.
+    expect(response.status).toBe(410);
+
+    const body = (await response.json()) as {
+      success: boolean;
+      error: { code: string; message: string };
+    };
+
+    expect(body.success).toBe(false);
+    expect(body.error.code).toBe("ENDPOINT_RETIRED");
+    // The successor is named, or the caller is stuck.
+    expect(body.error.message).toContain("/api/v1/news-portal/ad-placements");
+  });
+
+  test("PATCH /api/v1/blog/ads/{id} is 410 Gone", async () => {
+    // Closing POST alone would not have been enough: PATCH could rewrite
+    // `imageUrl` on an existing ad, which is the same bypass by a quieter
+    // route — and one that creates no new row for anyone to notice.
+    const response = await callRetired(
+      PATCH as unknown as typeof POST,
+      "PATCH"
+    );
+
+    expect(response.status).toBe(410);
+
+    const body = (await response.json()) as {
+      error: { code: string; message: string };
+    };
+
+    expect(body.error.code).toBe("ENDPOINT_RETIRED");
+    expect(body.error.message).toContain("/api/v1/news-portal/ad-placements");
+  });
+
+  test("neither retired handler touches auth or the database", async () => {
+    // A `Request` and nothing else. `resolveAuthInputs` needs `cookies`,
+    // `getDatabaseClient` needs configuration, and `params.id` is read by the
+    // real DELETE handler — if a retired handler reached any of them it would
+    // throw rather than return, and this would fail.
+    for (const [handler, method] of [
+      [POST, "POST"],
+      [PATCH as unknown as typeof POST, "PATCH"]
+    ] as const) {
+      const response = await callRetired(handler, method);
+      expect(response.status).toBe(410);
+    }
+  });
+
+  test("GET and DELETE survive, so residue stays resolvable", () => {
+    // An operator resolving the ingest's residue report has to be able to read
+    // the rows it names, and to retire the ones they do not want to re-create.
+    // Removing the read path would leave them resolving a report against data
+    // they can no longer see; removing DELETE would leave "I do not want this
+    // ad" with no way to say so, and `blog:ads:drop-readiness` counts a
+    // soft-deleted ad as accounted for.
+    expect(typeof GET).toBe("function");
+    expect(typeof DELETE).toBe("function");
+  });
+});

--- a/tests/module-management-job-registry.test.ts
+++ b/tests/module-management-job-registry.test.ts
@@ -85,10 +85,12 @@ describe("fetchModuleJobs", () => {
       [
         "bun run analytics:purge",
         "bun run analytics:rollup",
-        // ADR-0044 §4 Fase 2. The only entry here that is NOT scheduled: a
-        // one-shot operator-run migration whose descriptor exists so the job is
-        // discoverable at all, and which is retired along with the legacy ad
-        // tables it reads.
+        // ADR-0044 §4 Fase 2. The only two entries here that are NOT scheduled:
+        // an operator-run migration and the read-only readiness check that
+        // gates its irreversible final step. Their descriptors exist so the
+        // jobs are discoverable at all, and both retire along with the legacy
+        // ad tables they read.
+        "bun run blog:ads:drop-readiness",
         "bun run blog:ads:ingest",
         "bun run blog:publish:scheduled",
         "bun run comments:retention",


### PR DESCRIPTION
ADR-0044 §4 Fase 2, **langkah ketiga**. Melanjutkan #302.

## Jalur tulis ditutup SEBELUM tabelnya dihapus

`POST /api/v1/blog/ads` dan `PATCH /api/v1/blog/ads/{id}` kini menjawab **410 `ENDPOINT_RETIRED`**, tanpa auth dan tanpa sentuhan basis data.

Keduanya menyimpan `imageUrl` teks bebas — URL apa pun yang diketik admin, dirender langsung ke `<img src>` halaman publik. Itulah bypass managed-media yang ditutup ADR-0036, dan ia terbuka selama masih ada rute yang bisa menulisnya.

**Urutannya yang menjadi isi perubahan ini.** Job ingest (#302) memindahkan apa yang ada saat ia berjalan. Jalur tulis yang masih terbuka membiarkan editor membuat iklan free-URL di jendela antara ingest dan penghapusan — iklan yang tidak bermigrasi ke mana pun dan lenyap saat tabelnya hilang, **tanpa satu pun laporan menyebut ia pernah ada**. Itu persis kegagalan yang dilarang ADR-0044 §4.

Menutup `POST` saja tidak cukup: `PATCH` bisa menulis ulang `imageUrl` pada iklan yang sudah ada — bypass yang sama lewat rute lebih senyap, dan yang tidak menghasilkan baris baru untuk diperhatikan siapa pun.

`GET` dan `DELETE` **sengaja bertahan**. Operator yang menyelesaikan laporan residu harus bisa membaca baris yang disebut laporan itu, dan mempensiunkan yang tidak ingin ia buat ulang — `blog:ads:drop-readiness` menghitung iklan soft-delete sebagai sudah-diputuskan. Menghapus jalur baca akan meninggalkan operator menyelesaikan laporan terhadap data yang tak lagi bisa ia lihat.

410, bukan 404: resource-nya pernah ada, ketiadaannya permanen, dan penggantinya disebut di pesan error. 404 akan terbaca "salah URL" dan mengirim integrator mencari salah ketik.

## Gerbang yang membuat penghapusan bisa dibuktikan

`bun run blog:ads:drop-readiness` menjawab "bolehkah kedua tabel lama dihapus sekarang?" **dari data**, dan keluar non-nol selama jawabannya belum.

Migrasi penghapusan tak bisa dibatalkan dan membawa serta iklan situs hidup. Seluruh pengaman epik ini menjadi hiasan bila langkah terakhirnya diambil atas dasar ingatan seseorang bahwa ia sudah menjalankan ingest. `source_legacy_ad_id` (`sql/079`) membuatnya jadi sebuah join.

Iklan lama terhitung sudah-diputuskan bila **ada baris penerus yang menyebutnya**, ATAU bila **ia soft-delete** (operator membaca residunya dan memutuskan iklan ini tidak ikut). Selain itu memblokir. **Tidak ada flag override** — gerbang yang bisa disuruh lulus adalah gerbang yang tak perlu dipenuhi siapa pun.

Read-only sepenuhnya: nol INSERT/UPDATE/DELETE, jadi aman dijalankan terhadap produksi kapan pun, termasuk sebelum ingest pernah berjalan.

## Satu mutasi lolos, dan itu temuan

Mutasi pertama terhadap query kesiapan — menghapus predikat `p.tenant_id = a.tenant_id` dari kedua query — **lolos ketujuh test**.

Penyebabnya: query berjalan di dalam `withTenantOrThrow`, jadi RLS yang di-FORCE diam-diam mengerjakan apa yang diklaim predikat itu. Dua mekanisme diklaim di sini, dan test yang tak bisa membedakannya hanya membuktikan **setidaknya satu** ada — bukan keduanya. Kalau query ini kelak dipanggil dari peran yang melewati RLS, predikatnya adalah satu-satunya yang tersisa.

Test kedelapan menjalankan penilaian yang **sama** sebagai peran admin yang melewati RLS sepenuhnya:

| Mutasi | Sebelum test #8 | Sesudah |
|---|---|---|
| predikat tenant dihapus dari join | 7 pass / **0 fail** | 7 pass / **1 fail** |
| `LATERAL`+`LIMIT 1` → JOIN polos (hitung ganda) | 6 pass / **1 fail** | — |
| `every` → `some` (satu tenant siap = semua siap) | 6 pass / **1 fail** | — |
| tanpa mutasi | 7 pass / 0 fail | **8 pass / 0 fail** |

Mutasi kedua layak disebut sendiri: satu iklan lama dengan tiga placement menjadi tiga baris penerus, dan JOIN polos menghitungnya tiga kali — `migrated` melampaui `totalLegacyAds`, selisihnya **negatif**, dan hasilnya READY yang ceria untuk tenant yang masih punya iklan belum bermigrasi.

## Verifikasi

```
bun test (tanpa Postgres)      2685 pass / 0 fail   (3049 test, 243 berkas)
bun test tests/integration/     213 pass / 0 fail   (23 berkas, PostgreSQL 16)
bun run check                   seluruh 26 gerbang OK
bun run build                   Complete
```

OpenAPI: kedua operasi ditandai `deprecated: true` dengan satu-satunya respons `410`, dan `docs/awcms/api-reference.md` diregenerasi.

## Yang tersisa

Migrasi `DROP TABLE` itu sendiri — dan ia **tidak boleh** mendarat sebelum `blog:ads:drop-readiness` melaporkan READY terhadap produksi. Itu langkah yang membutuhkan data produksi, bukan kode. Setelah PR ini di-merge dan di-deploy, urutan operatornya: jalankan ingest, baca residu, selesaikan, jalankan readiness, baru tulis migrasi drop-nya.