### PR TITLE
feat(blog-content): terbitkan kosakata blok konten sebagai kontrak ter-gerbang

### DIFF
--- a/.changeset/content-block-contract.md
+++ b/.changeset/content-block-contract.md
@@ -1,0 +1,37 @@
+---
+"awcms": minor
+---
+
+Terbitkan kosakata blok `content_json` sebagai kontrak yang bisa dibaca mesin,
+dan patok ketiga tempat ia dinyatakan agar tak bisa menyimpang diam-diam.
+
+Sampai perubahan ini kosakata itu hidup di dua tempat: tipe TypeScript
+`ContentBlock` (tak terlihat siapa pun di luar `tsc`) dan **satu kalimat prosa**
+di salah satu dari lima kemunculan `contentJson` di OpenAPI — empat sisanya
+hanya menyebut `type: object`. Konsumen yang membaca kontrak punya peluang empat
+dari lima untuk tidak mempelajari apa pun tentang isi field itu.
+
+Akibatnya nyata dan sudah terjadi: `awcms-astro` menurunkan ulang kosakata itu
+dengan membaca, lalu keliru dalam tiga hal sekaligus — mengarang tipe
+`ordered_list` yang tak ada, dan menjatuhkan `gallery` serta `video_news` karena
+keduanya tak punya field `text` sementara fallback-nya merender `text`. Tidak
+ada yang gagal di mana pun. Daftar bernomor keluar berbutir dan bagian bermedia
+lenyap dari halaman yang tayang.
+
+Kosakata yang hanya hidup di prosa akan diturunkan ulang, dan penurunan ulang
+itulah tempat ia patah.
+
+- `CONTENT_BLOCK_TYPES` — kosakata sebagai nilai RUNTIME, disatukan dengan union
+  `ContentBlock` lewat assertion saling-assignable. Menambah varian ke union
+  tanpa menambahnya ke konstanta (atau sebaliknya) **memerahkan typecheck**,
+  bukan sebuah test yang mungkin tak dijalankan orang. Terbukti dua arah.
+- Skema `BlogContentBlock` + `BlogContentJson` di OpenAPI: `oneOf` enam varian
+  lengkap dengan field-nya, dirujuk dari **kelima** kemunculan `contentJson`.
+  Dua bentuk yang paling mudah salah tebak diberi catatan eksplisit — urutan
+  adalah FIELD pada `list` (bukan tipe `ordered_list`), dan `gallery`/
+  `video_news` TIDAK punya field `text`.
+- `tests/content-block-contract.test.ts` memaku kontrak OpenAPI dan `switch`
+  renderer ke konstanta yang sama, plus menegaskan setiap tipe merender sesuatu
+  yang tak kosong dan tak ada varian HTML mentah. Diuji dengan mutasi: kontrak
+  menyebut tipe berbeda (1 merah), satu `contentJson` kembali `type: object`
+  polos (1 merah), renderer berhenti menangani `gallery` (2 merah).

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -14715,6 +14715,146 @@ components:
           type: string
           format: uuid
           nullable: true
+    BlogContentBlock:
+      description: |
+        One block of `content_json`. The vocabulary is closed: a value outside
+        the six variants below is not stored and not rendered.
+
+        This schema exists because the vocabulary previously lived only in a
+        TypeScript type and one prose sentence, so every consumer re-derived it
+        by reading. One did, and disagreed with it in three ways at once —
+        silently, because a wrong block type raises no error anywhere. It
+        renders wrongly, or the section disappears.
+
+        Held to `blog-content/domain/content-block-rendering.ts`'s
+        `CONTENT_BLOCK_TYPES` by `tests/content-block-contract.test.ts`, which
+        also holds that constant to the renderer's own switch.
+
+        Note two shapes that are easy to guess wrong:
+          - Ordering is a FIELD on `list` (`ordered: true`), not a separate
+            `ordered_list` type.
+          - `gallery` and `video_news` carry NO `text` field. A renderer that
+            falls back to "render `text` as a paragraph" drops them entirely.
+      oneOf:
+        - type: object
+          required:
+            - type
+            - text
+          properties:
+            type:
+              type: string
+              enum:
+                - paragraph
+            text:
+              type: string
+        - type: object
+          required:
+            - type
+            - level
+            - text
+          properties:
+            type:
+              type: string
+              enum:
+                - heading
+            level:
+              type: integer
+              minimum: 1
+              maximum: 6
+            text:
+              type: string
+        - type: object
+          required:
+            - type
+            - items
+          properties:
+            type:
+              type: string
+              enum:
+                - list
+            ordered:
+              description: Absent or false means an unordered list. There is no separate `ordered_list` type.
+              type: boolean
+            items:
+              type: array
+              items:
+                type: string
+        - type: object
+          required:
+            - type
+            - text
+          properties:
+            type:
+              type: string
+              enum:
+                - quote
+            text:
+              type: string
+        - type: object
+          required:
+            - type
+            - items
+          properties:
+            type:
+              type: string
+              enum:
+                - gallery
+            items:
+              type: array
+              items:
+                type: object
+                required:
+                  - mediaType
+                properties:
+                  mediaType:
+                    type: string
+                    enum:
+                      - image
+                      - video
+                  url:
+                    description: Direct absolute URL. Legacy shape — absent when the item uses `mediaObjectId`.
+                    type: string
+                  mediaObjectId:
+                    description: Verified media registry object id. Resolving it to a URL requires a media lookup; a consumer that cannot perform one must show a placeholder rather than dropping the item.
+                    type: string
+                    format: uuid
+                  caption:
+                    type: string
+        - type: object
+          required:
+            - type
+            - provider
+            - videoId
+          properties:
+            type:
+              type: string
+              enum:
+                - video_news
+            provider:
+              description: Allowlisted provider. Only `youtube` is recognised today; an unknown provider must not be turned into a URL by guesswork.
+              type: string
+            videoId:
+              description: Provider video id, validated server-side against the provider's own id shape before storage.
+              type: string
+            title:
+              type: string
+            caption:
+              type: string
+            thumbnailMediaObjectId:
+              type: string
+              format: uuid
+            durationSeconds:
+              type: integer
+            sourceLabel:
+              type: string
+    BlogContentJson:
+      description: "Structured post/page body. `{ blocks: BlogContentBlock[] }` — never raw HTML, by construction: there is no block variant that carries markup."
+      type: object
+      properties:
+        blocks:
+          type: array
+          items:
+            $ref: "#/components/schemas/BlogContentBlock"
     BlogInternalTagLinkSettings:
       type: object
       required:
@@ -14795,7 +14935,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         status:
@@ -14868,7 +15008,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         locale:
@@ -14936,7 +15076,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         status:
@@ -15011,8 +15151,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
-          description: "{ blocks: ContentBlock[] } — whitelisted block types only (paragraph, heading, list, quote, gallery, video_news); never raw HTML."
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         locale:
@@ -15084,7 +15223,7 @@ components:
         title:
           type: string
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         excerpt:

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -2026,8 +2026,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
-          description: "{ blocks: ContentBlock[] } — whitelisted block types only (paragraph, heading, list, quote, gallery, video_news); never raw HTML."
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         locale:
@@ -2098,7 +2097,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         status:
@@ -2165,7 +2164,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         locale:
@@ -2229,7 +2228,7 @@ components:
           type: string
           nullable: true
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         status:
@@ -2350,7 +2349,7 @@ components:
         title:
           type: string
         contentJson:
-          type: object
+          $ref: "#/components/schemas/BlogContentJson"
         contentText:
           type: string
         excerpt:
@@ -2435,6 +2434,123 @@ components:
           nullable: true
         sortOrder:
           type: integer
+    BlogContentBlock:
+      description: |
+        One block of `content_json`. The vocabulary is closed: a value outside
+        the six variants below is not stored and not rendered.
+
+        This schema exists because the vocabulary previously lived only in a
+        TypeScript type and one prose sentence, so every consumer re-derived it
+        by reading. One did, and disagreed with it in three ways at once —
+        silently, because a wrong block type raises no error anywhere. It
+        renders wrongly, or the section disappears.
+
+        Held to `blog-content/domain/content-block-rendering.ts`'s
+        `CONTENT_BLOCK_TYPES` by `tests/content-block-contract.test.ts`, which
+        also holds that constant to the renderer's own switch.
+
+        Note two shapes that are easy to guess wrong:
+          - Ordering is a FIELD on `list` (`ordered: true`), not a separate
+            `ordered_list` type.
+          - `gallery` and `video_news` carry NO `text` field. A renderer that
+            falls back to "render `text` as a paragraph" drops them entirely.
+      oneOf:
+        - type: object
+          required: [type, text]
+          properties:
+            type:
+              type: string
+              enum: [paragraph]
+            text:
+              type: string
+        - type: object
+          required: [type, level, text]
+          properties:
+            type:
+              type: string
+              enum: [heading]
+            level:
+              type: integer
+              minimum: 1
+              maximum: 6
+            text:
+              type: string
+        - type: object
+          required: [type, items]
+          properties:
+            type:
+              type: string
+              enum: [list]
+            ordered:
+              description: Absent or false means an unordered list. There is no separate `ordered_list` type.
+              type: boolean
+            items:
+              type: array
+              items:
+                type: string
+        - type: object
+          required: [type, text]
+          properties:
+            type:
+              type: string
+              enum: [quote]
+            text:
+              type: string
+        - type: object
+          required: [type, items]
+          properties:
+            type:
+              type: string
+              enum: [gallery]
+            items:
+              type: array
+              items:
+                type: object
+                required: [mediaType]
+                properties:
+                  mediaType:
+                    type: string
+                    enum: [image, video]
+                  url:
+                    description: Direct absolute URL. Legacy shape — absent when the item uses `mediaObjectId`.
+                    type: string
+                  mediaObjectId:
+                    description: Verified media registry object id. Resolving it to a URL requires a media lookup; a consumer that cannot perform one must show a placeholder rather than dropping the item.
+                    type: string
+                    format: uuid
+                  caption:
+                    type: string
+        - type: object
+          required: [type, provider, videoId]
+          properties:
+            type:
+              type: string
+              enum: [video_news]
+            provider:
+              description: Allowlisted provider. Only `youtube` is recognised today; an unknown provider must not be turned into a URL by guesswork.
+              type: string
+            videoId:
+              description: Provider video id, validated server-side against the provider's own id shape before storage.
+              type: string
+            title:
+              type: string
+            caption:
+              type: string
+            thumbnailMediaObjectId:
+              type: string
+              format: uuid
+            durationSeconds:
+              type: integer
+            sourceLabel:
+              type: string
+    BlogContentJson:
+      description: "Structured post/page body. `{ blocks: BlogContentBlock[] }` — never raw HTML, by construction: there is no block variant that carries markup."
+      type: object
+      properties:
+        blocks:
+          type: array
+          items:
+            $ref: "#/components/schemas/BlogContentBlock"
     BlogAdPlacement:
       type: object
       required: [placementType]

--- a/src/modules/blog-content/domain/content-block-rendering.ts
+++ b/src/modules/blog-content/domain/content-block-rendering.ts
@@ -58,6 +58,49 @@ export type ContentBlock =
   | { type: "gallery"; items: GalleryItem[] }
   | ({ type: "video_news" } & VideoNewsItem);
 
+/**
+ * The block vocabulary as a RUNTIME value.
+ *
+ * `ContentBlock` above is a type, and a type cannot be read by a test, a
+ * schema generator, or anything outside `tsc`. So every consumer of
+ * `content_json` — this repo's own renderer, the OpenAPI contract, and any
+ * separate front-end that fetches posts — has had to re-derive the vocabulary
+ * from prose. `awcms-astro` did exactly that and got it wrong in three ways at
+ * once, silently: it invented an `ordered_list` type this union does not have,
+ * and dropped `gallery` and `video_news` entirely because they carry no `text`
+ * field. Nothing failed. The pages simply rendered wrongly or lost a section.
+ *
+ * This constant is the single source those consumers can actually be held to.
+ * The assertion below makes it impossible for it to drift from the union: add
+ * a variant to `ContentBlock` without adding it here (or vice versa) and the
+ * TYPECHECK fails, not a test somebody might not run.
+ */
+export const CONTENT_BLOCK_TYPES = [
+  "paragraph",
+  "heading",
+  "list",
+  "quote",
+  "gallery",
+  "video_news"
+] as const;
+
+export type ContentBlockType = (typeof CONTENT_BLOCK_TYPES)[number];
+
+/**
+ * Mutual assignability between the union's discriminants and the constant.
+ * Either direction failing is a real defect: a type in the union but not the
+ * constant is a block no consumer knows to render; a type in the constant but
+ * not the union is a promise nothing here can keep.
+ */
+type ContentBlockTypesMatchUnion = ContentBlock["type"] extends ContentBlockType
+  ? ContentBlockType extends ContentBlock["type"]
+    ? true
+    : never
+  : never;
+
+const CONTENT_BLOCK_TYPES_MATCH_UNION: ContentBlockTypesMatchUnion = true;
+void CONTENT_BLOCK_TYPES_MATCH_UNION;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/tests/content-block-contract.test.ts
+++ b/tests/content-block-contract.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  CONTENT_BLOCK_TYPES,
+  renderContentJsonToHtml
+} from "../src/modules/blog-content/domain/content-block-rendering";
+
+/**
+ * `content_json`'s block vocabulary is stated in THREE places that have to
+ * agree, and until now only one of them was checked against anything:
+ *
+ *   1. `ContentBlock` — the TypeScript union. Enforced by `tsc`, but a type is
+ *      invisible to everything outside it.
+ *   2. `renderContentJsonToHtml`'s switch — what this repo actually renders.
+ *   3. `BlogContentBlock` in the OpenAPI contract — what every OTHER consumer
+ *      reads, including front-ends in separate repositories.
+ *
+ * (1) and the runtime constant are already welded together by a mutual
+ * assignability assertion in `content-block-rendering.ts`, so `bun run
+ * typecheck` fails if either drifts. This file welds (2) and (3) to the same
+ * constant.
+ *
+ * The reason is concrete rather than theoretical. `awcms-astro` re-derived this
+ * vocabulary by reading prose and got it wrong three ways at once: it invented
+ * an `ordered_list` type that does not exist, and dropped `gallery` and
+ * `video_news` because they carry no `text` field and its fallback rendered
+ * `text`. Nothing failed anywhere. Numbered lists came out bulleted and media
+ * sections vanished from live pages.
+ *
+ * A vocabulary that only exists in prose gets re-derived, and re-derivation is
+ * where it breaks.
+ */
+const FRAGMENT_PATH = "openapi/modules/blog-content.openapi.yaml";
+const FRAGMENT = readFileSync(FRAGMENT_PATH, "utf8");
+const RENDERER = readFileSync(
+  "src/modules/blog-content/domain/content-block-rendering.ts",
+  "utf8"
+);
+
+describe("content_json block vocabulary", () => {
+  test("the OpenAPI contract publishes exactly the declared block types", () => {
+    // Every `enum: [<type>]` inside the BlogContentBlock oneOf. Parsed from the
+    // fragment text rather than from a YAML object graph so this test keeps
+    // working regardless of how the bundler reshapes things downstream.
+    const schemaStart = FRAGMENT.indexOf("    BlogContentBlock:");
+    const schemaEnd = FRAGMENT.indexOf("    BlogContentJson:");
+
+    expect(schemaStart).toBeGreaterThan(-1);
+    expect(schemaEnd).toBeGreaterThan(schemaStart);
+
+    const schema = FRAGMENT.slice(schemaStart, schemaEnd);
+    const published = [...schema.matchAll(/enum: \[([a-z_]+)\]/g)]
+      .map((match) => match[1]!)
+      .sort();
+
+    expect(published).toEqual([...CONTENT_BLOCK_TYPES].sort());
+  });
+
+  test("every contentJson field in the contract points at the schema", () => {
+    // The vocabulary used to appear in ONE prose `description` on one of five
+    // `contentJson` occurrences; the other four said only `type: object`. A
+    // consumer reading the contract had a four-in-five chance of learning
+    // nothing at all about what the field contains.
+    const bareObjectFields = FRAGMENT.match(/contentJson:\n\s+type: object/g);
+
+    expect(bareObjectFields).toBeNull();
+
+    const references = FRAGMENT.match(
+      /contentJson:\n\s+\$ref: "#\/components\/schemas\/BlogContentJson"/g
+    );
+
+    expect(references).not.toBeNull();
+    expect(references!.length).toBeGreaterThanOrEqual(5);
+  });
+
+  test("the renderer handles exactly the declared block types", () => {
+    // A type in the vocabulary with no `case` renders as nothing — which is the
+    // exact shape of the bug this whole file exists because of, just on the
+    // other side of the wire.
+    const handled = [...RENDERER.matchAll(/^\s+case "([a-z_]+)":/gm)]
+      .map((match) => match[1]!)
+      .sort();
+
+    expect(handled).toEqual([...CONTENT_BLOCK_TYPES].sort());
+  });
+
+  test("every declared block type renders something non-empty", () => {
+    // The stronger form of the assertion above: not "there is a case" but "the
+    // case produces output". `gallery` and `video_news` are the two that carry
+    // no `text`, and they are exactly the two a text-shaped fallback loses.
+    const samples: Record<string, Record<string, unknown>> = {
+      paragraph: { type: "paragraph", text: "Halo" },
+      heading: { type: "heading", level: 2, text: "Judul" },
+      list: { type: "list", items: ["satu"] },
+      quote: { type: "quote", text: "Kutipan" },
+      gallery: {
+        type: "gallery",
+        items: [{ mediaType: "image", url: "https://media.test/a.jpg" }]
+      },
+      video_news: {
+        type: "video_news",
+        provider: "youtube",
+        videoId: "dQw4w9WgXcQ"
+      }
+    };
+
+    for (const type of CONTENT_BLOCK_TYPES) {
+      expect(samples[type]).toBeDefined();
+
+      const html = renderContentJsonToHtml({ blocks: [samples[type]!] });
+
+      expect(html.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("ordering is a field on list, not a separate block type", () => {
+    // The single most re-derivable mistake in this vocabulary, and the one a
+    // consumer already made. Pinned from both sides: `ordered` changes the tag,
+    // and `ordered_list` is not a type.
+    expect(
+      renderContentJsonToHtml({
+        blocks: [{ type: "list", ordered: true, items: ["a"] }]
+      })
+    ).toContain("<ol>");
+
+    expect(
+      renderContentJsonToHtml({
+        blocks: [{ type: "list", items: ["a"] }]
+      })
+    ).toContain("<ul>");
+
+    expect(CONTENT_BLOCK_TYPES).not.toContain(
+      "ordered_list" as (typeof CONTENT_BLOCK_TYPES)[number]
+    );
+
+    expect(
+      renderContentJsonToHtml({
+        blocks: [{ type: "ordered_list", items: ["a"] }]
+      })
+    ).toBe("");
+  });
+
+  test("there is no raw-HTML block variant in the contract", () => {
+    // The guarantee the whole structured-content arrangement rests on. A
+    // variant named html/raw/embed would let an editor ship markup through a
+    // path no reviewer of this repo ever sees.
+    for (const forbidden of ["html", "raw", "embed", "script", "iframe"]) {
+      expect(CONTENT_BLOCK_TYPES).not.toContain(
+        forbidden as (typeof CONTENT_BLOCK_TYPES)[number]
+      );
+    }
+  });
+});


### PR DESCRIPTION
Akar penyebab dari cacat yang baru saja saya perbaiki di `ahliweb/awcms-astro#6`.

## Kosakata yang hanya hidup di prosa akan diturunkan ulang

Sampai PR ini, kosakata blok `content_json` dinyatakan di dua tempat:

1. Tipe TypeScript `ContentBlock` — ditegakkan `tsc`, tetapi **tidak terlihat oleh apa pun di luar `tsc`**.
2. **Satu kalimat prosa** di salah satu dari lima kemunculan `contentJson` di OpenAPI. Empat sisanya hanya menyebut `type: object`.

Konsumen yang membaca kontrak punya peluang empat dari lima untuk tidak mempelajari apa pun tentang isi field itu.

Akibatnya bukan hipotesis. `awcms-astro` menurunkan ulang kosakata itu dengan membaca, lalu keliru **tiga hal sekaligus**:

| Kekeliruan | Akibat |
|---|---|
| Mengarang tipe `ordered_list` | awcms memancarkan `{ type: "list", ordered: true }` — setiap daftar bernomor keluar berbutir |
| `gallery` jatuh ke fallback `text` | Blok itu tak punya `text` — **hilang total dari halaman** |
| `video_news` sama | **Hilang total dari halaman** |

Tidak ada yang gagal di mana pun. Build hijau, `astro check` hijau, halaman tayang.

## Tiga pernyataan, satu sumber

| Tempat | Sebelum | Sekarang |
|---|---|---|
| Union `ContentBlock` | ditegakkan `tsc` | ditegakkan `tsc` **dan** disatukan dengan konstanta runtime |
| `switch` renderer | tak dicek terhadap apa pun | dipaku ke konstanta |
| Kontrak OpenAPI | prosa di 1 dari 5 tempat | skema `oneOf` penuh, dirujuk dari **kelima** tempat, dipaku ke konstanta |

**`CONTENT_BLOCK_TYPES`** adalah kosakata sebagai nilai runtime — sesuatu yang bisa dibaca test, generator skema, dan siapa pun. Ia disatukan dengan union lewat assertion saling-assignable, sehingga penyimpangan memerahkan **typecheck**, bukan sebuah test yang mungkin tak dijalankan orang:

```
# tambah varian ke union tanpa menambah ke konstanta
error TS2322: Type 'true' is not assignable to type 'never'.

# hapus satu dari konstanta tanpa menghapus dari union
error TS2322: Type 'true' is not assignable to type 'never'.
```

**Skema `BlogContentBlock`** memuat keenam varian beserta field-nya, dan menandai eksplisit dua bentuk yang paling mudah salah tebak — persis dua yang sudah salah ditebak:

- Urutan adalah **FIELD** pada `list` (`ordered: true`), bukan tipe `ordered_list` tersendiri.
- `gallery` dan `video_news` **tidak punya field `text`**. Renderer yang jatuh ke "render `text` sebagai paragraf" menjatuhkan keduanya.

Juga didokumentasikan: item galeri ber-`mediaObjectId` menuntut lookup media, dan konsumen yang tak bisa melakukannya **wajib menampilkan placeholder, bukan menjatuhkan item**.

## Verifikasi

Gerbangnya diuji dengan mutasi, bukan dengan pelanggaran karangan:

| Mutasi | Hasil |
|---|---|
| kontrak menyebut tipe berbeda dari konstanta | 5 pass / **1 fail** |
| satu `contentJson` kembali `type: object` polos | 5 pass / **1 fail** |
| renderer berhenti menangani `gallery` | 4 pass / **2 fail** |
| varian ditambah ke union saja | **typecheck merah** |
| varian dihapus dari konstanta saja | **typecheck merah** |
| tanpa mutasi | **6 pass / 0 fail** |

```
bun test (tanpa Postgres)      2691 pass / 0 fail   (3055 test, 244 berkas)
bun test tests/integration/     213 pass / 0 fail   (23 berkas, PostgreSQL 16)
bun run check                   seluruh 26 gerbang OK
bun run build                   Complete
```

## Yang tidak bisa dijangkau gerbang ini

Sisi konsumen di repo lain. `awcms-astro` kini memaku kosakatanya sendiri lewat test (#6), tetapi kedua pemakuan itu independen — tak ada CI yang melihat keduanya sekaligus. Yang berubah adalah kontraknya kini **bisa dibaca mesin**, jadi konsumen berikutnya menurunkan ulang dari skema, bukan dari prosa.