### PR TITLE
fix(docs): perbaiki dua diagram mermaid rusak dan gerbangi kelas cacatnya

### DIFF
--- a/.changeset/mermaid-unquoted-parenthesis-gate.md
+++ b/.changeset/mermaid-unquoted-parenthesis-gate.md
@@ -1,0 +1,39 @@
+---
+"awcms": patch
+---
+
+Perbaiki dua diagram mermaid yang gagal di-render GitHub, dan gerbangi kelas
+cacatnya di `check:docs`.
+
+Saat parse gagal, GitHub tidak merender sebagian — ia mengganti **seluruh**
+diagram dengan kotak "Unable to render rich display". Dua diagram di repo ini
+gagal parse sementara `bun run check` tetap hijau, karena `checkMermaid` hanya
+memvalidasi pagar blok dan tipe diagram, tak pernah isinya.
+
+Grammar flowchart mermaid memperlakukan `(` sebagai token pembuka bentuk node,
+jadi kurung di posisi TEKS mematikan diagram:
+
+- `README.md`/`README.id.md` — label SISI `-->|online (primary)|`, yang dilihat
+  langsung di halaman depan GitHub;
+- `docs/awcms/21_module_admission_governance.md` — empat label NODE rhombus
+  (`Q2{... (bukan fitur produk berdiri sendiri)?}` dst.). Diagram ini rusak
+  diam-diam dan tak pernah dilaporkan.
+
+Perbaikannya sama untuk keduanya: kutip labelnya. Bentuk silinder `[( )]` di
+README TIDAK diubah — di sana kurung adalah sintaks bentuk, bukan teks.
+
+Gerbangnya diperluas: untuk blok `flowchart`/`graph`, setiap `(`/`)` yang
+tersisa setelah teks ber-kutip dan pembatas bentuk (`[( )]`, `([ ])`, `(( ))`,
+`[[ ]]`, `{{ }}`) dibuang = temuan, dengan pesan yang menyebut perbaikannya.
+Aturan ini sengaja TIDAK berlaku untuk `sequenceDiagram` dkk., tempat kurung
+dalam teks memang sah.
+
+Setiap klaim di atas diverifikasi terhadap parser mermaid 11 NYATA — engine yang
+sama dengan yang dipakai GitHub — bukan disimpulkan dari dokumentasi: tanpa
+kutip GAGAL, dengan kutip LOLOS, bentuk ber-kurung LOLOS apa adanya, dan kurung
+di `sequenceDiagram` LOLOS. Sesudah perbaikan, 85 blok mermaid di seluruh
+markdown ter-track di-parse dengan nol rusak, dan gerbangnya menandai tepat lima
+baris cacat itu — nol temuan palsu di 85 blok tersebut.
+
+Cakupan gerbang dinyatakan terbuka di kode: ini pemeriksa sintaksis satu kelas
+cacat, bukan parser mermaid.

--- a/README.id.md
+++ b/README.id.md
@@ -103,7 +103,7 @@ Mode operasi `awcms` adalah **hybrid online + offline dengan prioritas online-fi
 
 ```mermaid
 flowchart LR
-  Tx[Aksi operasional] -->|online (utama)| Server[(Server pusat / SaaS)]
+  Tx[Aksi operasional] -->|"online (utama)"| Server[(Server pusat / SaaS)]
   Tx -.->|saat offline/LAN| Local[(DB lokal / LAN)]
   Local --> Outbox[Outbox event + object queue]
   Outbox -->|saat online kembali| Sync[Sync push/pull<br/>HMAC signed]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 🇬🇧 English (default) · 🇮🇩 [Bahasa Indonesia (sumber)](README.id.md)
 
-<!-- i18n-source-hash: sha256:19dadca4e60924c2e784150d7d61d87c98b09ca41a3437e9eb5f8612ce1d7cd9 -->
+<!-- i18n-source-hash: sha256:e43f369a9cbec3d517c478ff66e686386b832c80c4778934b96aea50c02588e6 -->
 
 [![CI](https://img.shields.io/github/actions/workflow/status/ahliweb/awcms/ci.yml?branch=main&label=CI&logo=github)](https://github.com/ahliweb/awcms/actions/workflows/ci.yml) [![CodeQL](https://img.shields.io/github/actions/workflow/status/ahliweb/awcms/codeql.yml?branch=main&label=CodeQL&logo=github)](https://github.com/ahliweb/awcms/actions/workflows/codeql.yml) [![License](https://img.shields.io/badge/License-MIT-blue)](LICENSE) [![runtime](https://img.shields.io/badge/runtime-Bun-blue?logo=bun&logoColor=white)](https://bun.sh)
 
@@ -105,7 +105,7 @@ These foundation modules do not implement ERP logic — they only provide neutra
 
 ```mermaid
 flowchart LR
-  Tx[Operational action] -->|online (primary)| Server[(Central server / SaaS)]
+  Tx[Operational action] -->|"online (primary)"| Server[(Central server / SaaS)]
   Tx -.->|when offline/LAN| Local[(Local / LAN DB)]
   Local --> Outbox[Outbox event + object queue]
   Outbox -->|when back online| Sync[Sync push/pull<br/>HMAC signed]

--- a/docs/awcms/21_module_admission_governance.md
+++ b/docs/awcms/21_module_admission_governance.md
@@ -60,13 +60,13 @@ flowchart TD
   Q5 -- Ya --> Reject[DITOLAK secara eksplisit.\nLihat §7 — tidak ada pengecualian\ntanpa ADR baru yang mensupersede\nADR-0001/ADR terkait Bun-only runtime]
   Q5 -- Tidak --> Q1{Apakah platform base\ntidak bisa boot/berfungsi\nuntuk deployment mana pun\ntanpanya?}
   Q1 -- Ya --> Core[Kategori: Core\nButuh ADR + 2 maintainer approval]
-  Q1 -- Tidak --> Q2{Apakah ini kapabilitas\ninfrastruktur/reusable lintas-modul\n(bukan fitur produk berdiri sendiri)?}
+  Q1 -- Tidak --> Q2{"Apakah ini kapabilitas\ninfrastruktur/reusable lintas-modul\n(bukan fitur produk berdiri sendiri)?"}
   Q2 -- Ya --> Sys[Kategori: System\nOff-by-default via *_ENABLED bila\nmelibatkan provider eksternal]
-  Q2 -- Tidak --> Q3{Apakah ini modul domain bisnis ERP\ngenerik lintas tenant ERP\n(finance/inventory/procurement/\nmanufacturing/hr-payroll/tax)?}
+  Q2 -- Tidak --> Q3{"Apakah ini modul domain bisnis ERP\ngenerik lintas tenant ERP\n(finance/inventory/procurement/\nmanufacturing/hr-payroll/tax)?"}
   Q3 -- Tidak --> Derived[BUKAN untuk repo base ini.\nSpesifik satu vertikal non-generik —\nbuat di repo aplikasi turunan]
-  Q3 -- Ya --> Q4{Apakah ini adapter untuk\nsatu provider eksternal spesifik\n(bukan modul mandiri)?}
+  Q3 -- Ya --> Q4{"Apakah ini adapter untuk\nsatu provider eksternal spesifik\n(bukan modul mandiri)?"}
   Q4 -- Ya --> Ext[Kategori: External Integration\nHidup DI DALAM modul pemilik\nkapabilitas — lihat §6]
-  Q4 -- Tidak --> Q6{Sudah lolos proposal template\n+ ADR checklist (§9),\ndisetujui maintainer?}
+  Q4 -- Tidak --> Q6{"Sudah lolos proposal template\n+ ADR checklist (§9),\ndisetujui maintainer?"}
   Q6 -- Belum --> Propose[Isi docs/awcms/templates/\nmodule-proposal-template.md,\nbuka issue, tunggu keputusan]
   Q6 -- Ya --> Opt[Kategori: ERP Domain Module\nScaffold via skill awcms-new-module]
 ```

--- a/scripts/lib/docs-checks.mjs
+++ b/scripts/lib/docs-checks.mjs
@@ -33,8 +33,65 @@ export const MERMAID_TYPES = [
  * @typedef {{ file: string, line: number, message: string }} Problem
  */
 
+/** Tipe diagram yang memakai grammar flowchart (satu-satunya yang aturan kurung di bawah berlaku untuknya). */
+const MERMAID_FLOWCHART_TYPES = new Set(["flowchart", "graph"]);
+
 /**
- * Validasi blok kode berpagar mermaid: setiap blok tertutup dan diawali tipe diagram dikenal.
+ * Pasangan pembatas BENTUK node yang memang mengandung kurung — di sini kurung
+ * adalah sintaks, bukan teks: silinder `[( )]`, stadium `([ ])`, lingkaran
+ * `(( ))`, lingkaran-ganda `((( )))`, subrutin `[[ ]]`, heksagon `{{ }}`.
+ * Dihapus lebih dulu supaya `Server[(Central server / SaaS)]` — yang di-parse
+ * mermaid dengan baik — tidak ikut ditandai.
+ */
+const MERMAID_SHAPE_DELIMITERS =
+  /\(\(\(|\)\)\)|\[\(|\)\]|\(\[|\]\)|\(\(|\)\)|\[\[|\]\]|\{\{|\}\}/g;
+
+/** Teks yang sudah dikutip aman apa pun isinya — mermaid tak mem-parse isinya. */
+const MERMAID_QUOTED_TEXT = /"[^"]*"/g;
+
+/**
+ * Sisa `(` atau `)` pada sebuah baris flowchart setelah teks ber-kutip dan
+ * pembatas bentuk dibuang — yaitu kurung yang berdiri di posisi TEKS.
+ *
+ * Ini bukan aturan gaya. Grammar flowchart mermaid memperlakukan `(` sebagai
+ * token pembuka bentuk node, jadi kurung di dalam teks label GAGAL di-parse dan
+ * GitHub mengganti SELURUH diagram dengan kotak "Unable to render rich
+ * display". Dua diagram di repo ini rusak persis begitu sementara
+ * `bun run check` tetap hijau — pemeriksa ini dulu hanya memvalidasi pagar blok
+ * dan tipe diagram, tak pernah isinya:
+ *
+ * - `README.md`/`README.id.md` — label SISI `-->|online (primary)|`;
+ * - `docs/awcms/21_module_admission_governance.md` — label NODE rhombus
+ *   `Q2{... (bukan fitur produk berdiri sendiri)?}`.
+ *
+ * Perbaikannya sama untuk keduanya: kutip labelnya (`|"online (primary)"|`,
+ * `{"... (bukan ...)?"}`). Semua klaim di atas diverifikasi terhadap parser
+ * mermaid 11 — engine yang sama dengan yang dipakai GitHub — bukan disimpulkan
+ * dari membaca dokumentasi: tanpa kutip GAGAL, dengan kutip LOLOS, dan bentuk
+ * silinder `[( )]` LOLOS apa adanya.
+ *
+ * CAKUPAN — sempit dan dinyatakan terbuka: ini pemeriksa SINTAKSIS satu kelas
+ * cacat, bukan parser mermaid, dan hanya berlaku untuk `flowchart`/`graph`
+ * (di `sequenceDiagram` dkk. kurung dalam teks sah). Cacat mermaid kelas lain
+ * tetap lolos. Menutupnya sepenuhnya berarti menarik `mermaid` + DOM ke dalam
+ * pemeriksa dokumentasi yang justru bernilai karena nol-dependensi — pilihan
+ * yang berdiri sendiri, bukan efek samping perbaikan ini.
+ *
+ * @param {string} line
+ * @returns {boolean}
+ */
+export function hasUnquotedMermaidParenthesis(line) {
+  const stripped = line
+    .replace(MERMAID_QUOTED_TEXT, "")
+    .replace(MERMAID_SHAPE_DELIMITERS, " ");
+
+  return /[()]/.test(stripped);
+}
+
+/**
+ * Validasi blok kode berpagar mermaid: setiap blok tertutup, diawali tipe
+ * diagram dikenal, dan — untuk `flowchart`/`graph` — tak ada kurung
+ * tak-terkutip di posisi teks (lihat `hasUnquotedMermaidParenthesis`).
  * @param {string} file
  * @param {string[]} lines
  * @returns {Problem[]}
@@ -45,12 +102,14 @@ export function checkMermaid(file, lines) {
   let inBlock = false;
   let blockStart = 0;
   let sawType = false;
+  let isFlowchart = false;
   for (let i = 0; i < lines.length; i++) {
     const trimmed = (lines[i] ?? "").trim();
     if (!inBlock && trimmed === "```mermaid") {
       inBlock = true;
       blockStart = i + 1;
       sawType = false;
+      isFlowchart = false;
       continue;
     }
     if (inBlock) {
@@ -74,7 +133,21 @@ export function checkMermaid(file, lines) {
             message: `tipe diagram mermaid tak dikenal: "${first}"`
           });
         }
+        isFlowchart = MERMAID_FLOWCHART_TYPES.has(first);
         sawType = true; // hanya periksa baris konten pertama
+        continue; // baris tipe diagram sendiri tak punya label
+      }
+
+      if (
+        isFlowchart &&
+        !trimmed.startsWith("%%") &&
+        hasUnquotedMermaidParenthesis(trimmed)
+      ) {
+        problems.push({
+          file,
+          line: i + 1,
+          message: `label mermaid memuat kurung tanpa tanda kutip — GitHub gagal me-render SELURUH diagram; kutip labelnya (mis. |"a (b)"| atau {"a (b)"}): ${trimmed}`
+        });
       }
     }
   }

--- a/tests/docs-checks.test.mjs
+++ b/tests/docs-checks.test.mjs
@@ -60,6 +60,79 @@ describe("checkMermaid", () => {
     );
   });
 
+  // Kedua kasus di bawah adalah cacat NYATA yang lolos gerbang ini selama
+  // berbulan-bulan: GitHub mengganti SELURUH diagram dengan "Unable to render
+  // rich display" sementara `bun run check` hijau, karena pemeriksa ini hanya
+  // melihat pagar blok dan tipe diagram. Semua ekspektasi di sini dicocokkan
+  // dengan perilaku parser mermaid 11 NYATA (engine yang sama dengan GitHub),
+  // bukan dengan dugaan: bentuk tanpa kutip GAGAL, bentuk berkutip LOLOS.
+  test("label SISI ber-kurung tanpa kutip dilaporkan (cacat README)", () => {
+    const md = [
+      "```mermaid",
+      "flowchart LR",
+      "  Tx[Operational action] -->|online (primary)| Server[(Central server)]",
+      "```"
+    ].join("\n");
+    const problems = checkMermaid("README.md", lines(md));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]?.line).toBe(3);
+    expect(problems[0]?.message).toContain("online (primary)");
+  });
+
+  test("label NODE rhombus ber-kurung tanpa kutip dilaporkan (cacat doc 21)", () => {
+    const md = [
+      "```mermaid",
+      "flowchart TD",
+      "  Q1 -- Tidak --> Q2{Apakah ini kapabilitas reusable (bukan fitur)?}",
+      "```"
+    ].join("\n");
+    const problems = checkMermaid("f.md", lines(md));
+    expect(problems).toHaveLength(1);
+    expect(problems[0]?.line).toBe(3);
+  });
+
+  test("versi berkutip dari kedua cacat itu diterima", () => {
+    const md = [
+      "```mermaid",
+      "flowchart LR",
+      '  Tx[Operational action] -->|"online (primary)"| Server[(Central server / SaaS)]',
+      '  Q1 -- Tidak --> Q2{"Apakah ini kapabilitas reusable (bukan fitur)?"}',
+      "```"
+    ].join("\n");
+    expect(checkMermaid("README.md", lines(md))).toEqual([]);
+  });
+
+  // Pembatas BENTUK yang mengandung kurung (silinder `[( )]`, stadium `([ ])`,
+  // lingkaran `(( ))`, subrutin, heksagon) adalah SINTAKS, bukan teks — mermaid
+  // mem-parsenya dengan baik, jadi aturan ini tidak boleh menandainya. Tanpa
+  // pengecualian ini, `Server[(Central server / SaaS)]` di README sendiri jadi
+  // temuan palsu dan gerbangnya tak bisa dipakai.
+  test("bentuk node yang memang memakai kurung sebagai sintaks tidak ditandai", () => {
+    const md = [
+      "```mermaid",
+      "flowchart LR",
+      "  Local[(Local / LAN DB)] --> Round((Titik))",
+      "  Stadium([Mulai]) --> Sub[[Subrutin]]",
+      "  Hex{{Keputusan}} --> Plain[Teks biasa]",
+      "```"
+    ].join("\n");
+    expect(checkMermaid("f.md", lines(md))).toEqual([]);
+  });
+
+  // Aturannya khusus grammar flowchart. Di sequenceDiagram kurung dalam teks
+  // pesan SAH (diverifikasi dengan parser nyata), jadi menerapkannya di sana
+  // akan menghasilkan temuan palsu yang memaksa orang mengedit diagram sehat.
+  test("kurung dalam teks sequenceDiagram tidak ditandai", () => {
+    const md = [
+      "```mermaid",
+      "sequenceDiagram",
+      "  participant A as Klien (browser)",
+      "  A->>B: minta token (sekali pakai)",
+      "```"
+    ].join("\n");
+    expect(checkMermaid("f.md", lines(md))).toEqual([]);
+  });
+
   test("dua blok, satu rusak satu valid", () => {
     const md = [
       "```mermaid",


### PR DESCRIPTION
## Masalah

Saat parse gagal, GitHub tidak merender sebagian — ia mengganti **seluruh** diagram dengan kotak `Unable to render rich display`. Dua diagram di repo ini gagal parse, sementara `bun run check` tetap hijau: `checkMermaid` hanya memvalidasi pagar blok dan tipe diagram, **tak pernah isinya**.

Grammar flowchart mermaid memperlakukan `(` sebagai token pembuka bentuk node, jadi kurung di posisi TEKS mematikan diagram:

| Berkas | Bentuk | Dampak |
| --- | --- | --- |
| `README.md` / `README.id.md` | label **sisi** `-->\|online (primary)\|` | diagram hybrid online-first di halaman depan GitHub tidak tampil |
| `docs/awcms/21_module_admission_governance.md` | 4 label **node** rhombus, mis. `Q2{... (bukan fitur produk berdiri sendiri)?}` | flowchart admisi modul rusak diam-diam, tak pernah dilaporkan |

## Perubahan

- **Kutip label** di kelima baris tersebut (`\|"online (primary)"\|`, `{"... (bukan ...)?"}`). Bentuk silinder `[( )]` di README **tidak** diubah — di sana kurung adalah sintaks bentuk dan mermaid mem-parsenya dengan baik.
- **Perluas gerbang `check:docs`**: untuk blok `flowchart`/`graph`, setiap `(`/`)` yang tersisa setelah teks ber-kutip dan pembatas bentuk (`[( )]`, `([ ])`, `(( ))`, `[[ ]]`, `{{ }}`) dibuang = temuan, dengan pesan yang menyebut perbaikannya. Aturan ini sengaja **tidak** berlaku untuk `sequenceDiagram` dkk., tempat kurung dalam teks memang sah.
- Perbarui penanda `i18n-source-hash` `README.md` karena `README.id.md` ikut berubah.

## Bukti

Semua klaim diverifikasi terhadap **parser mermaid 11 nyata** — engine yang sama dengan yang dipakai GitHub — bukan disimpulkan dari dokumentasi:

- tanpa kutip **GAGAL**, dengan kutip **LOLOS** (label sisi maupun node rhombus);
- silinder/stadium/lingkaran/subrutin/heksagon **LOLOS** apa adanya → itulah kenapa pembatas bentuk harus dikecualikan, kalau tidak `Server[(Central server / SaaS)]` jadi temuan palsu;
- kurung dalam teks `sequenceDiagram` **LOLOS** → itulah kenapa aturannya dibatasi ke flowchart.

Sesudah perbaikan: **85 blok mermaid di seluruh markdown ter-track di-parse, nol rusak**. Gerbangnya menandai tepat lima baris cacat itu (dibuktikan dengan mengembalikan baris aslinya) dan **nol temuan palsu** di 85 blok tersebut.

Cakupan gerbang dinyatakan terbuka di kode: ini pemeriksa sintaksis satu kelas cacat, bukan parser mermaid. Menutup semua kelas berarti menarik `mermaid` + DOM ke dalam pemeriksa dokumentasi yang justru bernilai karena nol-dependensi — keputusan tersendiri, bukan efek samping perbaikan ini.

Changeset: `patch` — gerbang `changesets:policy:check` menuntutnya karena perubahan menyentuh `scripts/lib/docs-checks.mjs` dan `tests/`, di luar kelas docs/agent-tooling. Nol perubahan perilaku runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)