### PR TITLE
chore(docs): gerbangi rujukan `bun run` di README modul & komentar kode, lalu perbaiki tujuh rujukan hantu

### DIFF
--- a/.changeset/script-reference-gate-covers-source.md
+++ b/.changeset/script-reference-gate-covers-source.md
@@ -1,0 +1,45 @@
+---
+"awcms": patch
+---
+
+Perluas gerbang rujukan `bun run` ke README modul dan **komentar kode**, lalu
+perbaiki tujuh rujukan hantu yang selama ini hidup di balik `check` hijau.
+
+`checkKnownScripts` hanya membaca lima berkas markdown akar (`README*.md`,
+`AGENTS.md`, `CONTRIBUTING.md`, `docs/ARCHITECTURE.md`). Di luar lima itu, sebuah
+perintah yang tidak pernah ada tetap bisa berdiri sebagai instruksi. Tujuh
+ditemukan:
+
+- Enam komentar di `src/lib/jobs/` + `src/modules/module-management/` menyuruh
+  pembacanya menjalankan target `modules:sync`. Target itu **tidak pernah ada di
+  repo ini** — mekanismenya `POST /api/v1/modules/sync`, dan `enableTenantModule`
+  bahkan sudah memanggil `syncModuleDescriptors` sendiri supaya operator tak
+  perlu mengingat apa pun.
+- `src/modules/blog-content/README.md` mendaftarkan `bun run production:preflight`
+  di antara perintah verifikasi nyata. Orkestrator itu belum diport; tiga
+  tahapnya yang sudah nyata (`config:validate`, `security:readiness`,
+  `db:pool:health`) menggantikannya.
+
+Komentar kode adalah dokumentasi current-state yang paling dipercaya sekaligus
+yang paling tidak pernah diaudit — ia dibaca persis saat seseorang sedang
+memutuskan tindakan. Karena itu cakupan gerbang kini: lima berkas akar +
+`docs/PROJECT_STATE.md` + `scripts/README.md` + README modul `src/**` + seluruh
+sumber `src/`/`scripts/`. `docs/awcms/` dan `.claude/skills/` tetap di luar —
+isinya target adaptasi awcms-mini yang memang boleh menyebut tooling belum-ada —
+begitu pula `tests/`, yang fixture-nya sengaja memakai nama fiktif untuk menguji
+gerbang ini.
+
+Kelas cacatnya dibuktikan dua arah sebelum ditutup: mengembalikan komentar
+`modules:sync` yang asli DAN menambahkan satu rujukan hantu ke
+`docs/PROJECT_STATE.md` masing-masing memerahkan gerbang. Gerbangnya juga
+langsung menangkap komentar penjelasnya sendiri pada run pertama — kali kelima
+bentuk itu muncul di repo ini, dan alasan komentar itu kini sengaja tidak menulis
+nama target dalam bentuk `bun run …`.
+
+Dokumen current-state ikut disegarkan agar tidak berbohong ke arah sebaliknya:
+`docs/ARCHITECTURE.md` masih menulis "20 modul terdaftar" (21) dan **dua kali**
+menyebut `idn-admin-regions` sebagai "belum di-port" padahal modul itu sudah
+mendarat (#312) — klaim negatif yang makin salah seiring waktu tanpa pernah gagal
+sendiri. `docs/PROJECT_STATE.md` disetel ulang ke 21 modul / ADR 0000–0048, dan
+kontrak alur kerjanya tidak lagi mewajibkan mini-first yang sudah **ditangguhkan**
+ADR-0047.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,7 +30,7 @@ src/modules/<module>/
   api/                  # (opsional) skema/handler bersama; route file tetap di src/pages
 ```
 
-20 modul terdaftar di `src/modules/index.ts` (urutan = urutan registrasi):
+21 modul terdaftar di `src/modules/index.ts` (urutan = urutan registrasi):
 
 - **`logging`** — audit trail lintas modul (`awcms_audit_events`) + purge terjadwal.
 - **`tenant_admin`** — tenant root, hierarki office, tenant settings, setup wizard sekali jalan.
@@ -57,9 +57,11 @@ src/modules/<module>/
 
 - **`comments`** (`type: "domain"`) — di-port dari micro ([ADR-0041](adr/0041-comments-module-admission.md), `sql/066`-`sql/067`): komentar **moderation-first** di atas resource yang **sudah terbit & publik**. Memiliki thread, komentar ber-kedalaman-terbatas (hard cap 4), riwayat moderasi append-only, laporan penyalahgunaan, setting per-tenant, telemetri anti-abuse terminimalisasi, dan langganan notifikasi-balasan terenkripsi. **Konsumen/agregator** descriptor `commentableResources` (`MODULE_CONTRACT_VERSION` 2.3.0) — modul konten MENDEKLARASIKAN resource mana yang boleh dikomentari; `comments` menemukannya lewat `listModules()`. Tulang punggung keamanannya: batas publikasi ditegakkan di perbatasan resource→thread (draft/privat/terhapus tak pernah menerima maupun mengekspos komentar); body disimpan **teks polos** dan di-escape saat render (tak ada HTML tersimpan → tak ada XSS tersimpan), hanya autolink http(s) `rel="nofollow ugc noopener noreferrer"`; respons submit publik **seragam** sehingga endpoint tak bisa dipakai sebagai oracle blocked-term atau konten belum-terbit; PII penulis diminimalkan (sha256 + mask, tak pernah mentah). Notifikasi balasan lewat outbox event (payload tanpa alamat), retensi meng-**anonimkan** di tempat (bukan menghapus) dan menghormati legal hold. Admin `/admin/comments` + API `/api/v1/comments/*`.
 
+- **`idn-admin-regions`** (`type: "system"`) — dirintis langsung di sini ([ADR-0046](adr/0046-idn-admin-regions-module-admission.md), #312, `sql/080` skema + `sql/081` permission): master data wilayah administratif Indonesia (provinsi/kabupaten-kota/kecamatan/desa-kelurahan) **ber-versi & ter-provenance**, disumber dari dataset komunitas `cahyadsn/wilayah` (MIT) yang di-**vendor** di `data/idn-admin-regions/`. Dua tabelnya (`awcms_idn_region_datasets`, `awcms_idn_admin_regions`) **GLOBAL** — tanpa `tenant_id`, tanpa RLS, seperti `awcms_permissions`/`awcms_modules` — karena provinsi "Aceh" adalah baris yang sama untuk setiap tenant; keduanya terdaftar di `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES` (`scripts/security-readiness.ts`) sehingga privilese per-role wajib dideklarasikan eksplisit, bukan diwarisi DML massal. Yang global adalah **barisnya**, bukan izinnya: setiap endpoint tetap melewati sesi + konteks tenant + ABAC default-deny. Impor 91.599 baris adalah **job deployment** (`bun run idn-regions:import`, dry-run secara default, berjalan sebagai `awcms_worker`) — bukan panggilan HTTP; sedangkan **aktivasi/rollback** versi dataset adalah keputusan jalur-request sehingga ABAC-gated, ber-idempotency-key, dan ter-audit. Lookup baca-saja di `/api/v1/idn-regions/*`. Belum punya `navigation`: layar operator platformnya milik `awcms-astro` ([ADR-0048](adr/0048-frontend-role-split-awcms-astro-internal-admin.md)).
+
 Modul lain di ekosistem keluarga (mis. `newsletter`,
-`social-publishing`, `document-infrastructure`, `integration-hub`,
-`idn-admin-regions`) **belum di-port** ke repo ini — lihat
+`social-publishing`, `document-infrastructure`, `integration-hub`)
+**belum di-port** ke repo ini — lihat
 skill masing-masing (ditandai "BACAAN SAJA") + [`awcms/absorb-awcms-micro-roadmap.md`](awcms/absorb-awcms-micro-roadmap.md)
 untuk spesifikasi target & urutan porting.
 
@@ -376,7 +378,7 @@ Sudah live dan diverifikasi terhadap kode (bukan rencana):
 Gap yang genuinely masih ada (jangan diklaim selesai):
 
 - Modul keluarga yang belum di-port (`newsletter`, `social-publishing`,
-  `document-infrastructure`, `integration-hub`, `idn-admin-regions`) — lihat skill masing-masing
+  `document-infrastructure`, `integration-hub`) — lihat skill masing-masing
   (BACAAN SAJA) untuk spesifikasi target, dan
   [`awcms/absorb-awcms-micro-roadmap.md`](awcms/absorb-awcms-micro-roadmap.md)
   untuk urutannya. Pasca-[ADR-0034](adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md)

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -36,14 +36,33 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 - Dokumen/skill yang masih menyebut "repo turunan / derived" sebagai jalur aktif adalah
   **usang** — perlakukan sebagai catatan historis (banyak sudah bertanda DEPRECATED).
 
+**Perubahan 31 Juli 2026 — dua ADR yang mengubah cara kerja, bukan cuma isi kode:**
+
+- [ADR-0047](adr/0047-mini-micro-frozen-foundation-built-here.md): `awcms-mini` dan
+  `awcms-micro` **dibekukan sebagai referensi** (boleh dibaca & di-port _keluar_, tidak
+  menerima perubahan). Konsekuensinya aturan **mini-first ditangguhkan** — selama
+  pembekuan, fitur fondasi **dirintis langsung di repo ini**. Ini **bukan** pelonggaran:
+  ADR §3 mendaftarkan ulang setiap penjagaan yang dulu dibawa jalur mini-first secara
+  eksplisit (ADR wajib untuk perubahan standar, security review tambahan untuk
+  `auth`/`access`/`sync`, `bun run check` penuh, OpenAPI/AsyncAPI sinkron, RLS `FORCE`,
+  ABAC default-deny). ADR §4: **setiap fitur fondasi yang mendarat selama pembekuan
+  WAJIB dicatat sebagai divergence** di `awcms-family-compatibility.yaml` **saat ia
+  mendarat**, bukan belakangan.
+- [ADR-0048](adr/0048-frontend-role-split-awcms-astro-internal-admin.md): pembagian peran
+  frontend. Layar **platform/operator internal** (master data global, rilis/rollback data,
+  kesehatan lintas tenant) dibangun di **`awcms-astro`**; layar **tenant atas datanya
+  sendiri** + seluruh permukaan publik tetap di **`awcms`**. Permukaan otorisasi tetap
+  SATU — memindahkan layar tidak memindahkan izinnya. Aturan ini mengikat layar **baru**;
+  pemilahan `/admin/*` yang sudah ada adalah pekerjaan tersendiri dengan ADR sendiri.
+
 ## 2. Inventori ringkas
 
 | Aspek      | Nilai (per commit ini)                                                    | Sumber kebenaran                                      |
 | ---------- | ------------------------------------------------------------------------- | ----------------------------------------------------- |
 | Versi      | **6.4.0** (2026-07-26); 0 changeset menunggu                              | `package.json`, `CHANGELOG.md`, tag `v*`              |
-| Modul base | **20** (lihat daftar di ARCHITECTURE.md)                                  | `src/modules/index.ts`                                |
+| Modul base | **21** (lihat daftar di ARCHITECTURE.md)                                  | `src/modules/index.ts`                                |
 | Migrasi    | **81** (`sql/001`–`081`)                                                  | `ls sql/`                                             |
-| ADR        | **0000**–**0045** (`0000` = template)                                     | `docs/adr/README.id.md` (indeks ter-gate)             |
+| ADR        | **0000**–**0048** (`0000` = template)                                     | `docs/adr/README.id.md` (indeks ter-gate)             |
 | Kontrak    | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.4.0** | `openapi/`, `asyncapi/`, `_shared/module-contract.ts` |
 
 > **Rilis:** `v6.0.0` (2026-07-21) adalah **rilis nyata pertama** yang menjalankan
@@ -57,15 +76,17 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 > job pause di "Waiting for review" sebelum sign/attest/publish (lihat
 > [`release-process.md`](awcms/release-process.md) §Environment approval).
 
-Modul (20, urutan `src/modules/index.ts`): `logging`, `tenant-admin`,
+Modul (21, urutan `src/modules/index.ts`): `logging`, `tenant-admin`,
 `profile-identity`, `identity-access`, `module-management`, `domain-event-runtime`,
 `sync-storage`, `workflow-approval`, `email`, `reporting`, `theming`,
 **`media-library`**, `blog-content`, **`tenant-domain`**, **`visitor-analytics`**,
 **`data-lifecycle`**, **`seo-distribution`**, **`form-drafts`**, **`site-search`**,
-**`comments`**.
+**`comments`**, `idn-admin-regions`.
 (Delapan yang di-bold = gelombang penyerapan awcms-micro, 2026-07-24/25 — lihat §3/§4.
 `news-portal` **tidak lagi ada**: dilebur ke `blog-content` oleh
-[ADR-0044](adr/0044-merge-news-portal-into-blog-content.md), #300.)
+[ADR-0044](adr/0044-merge-news-portal-into-blog-content.md), #300.
+`idn-admin-regions` (#312, ADR-0046) **bukan** hasil port — ia modul pertama yang
+dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 > Catatan: generator `repo:inventory` **belum diport** dari `awcms-mini`, jadi
 > [`awcms/repo-inventory.md`](awcms/repo-inventory.md) adalah placeholder — jangan
@@ -170,6 +191,15 @@ Modul (20, urutan `src/modules/index.ts`): `logging`, `tenant-admin`,
   `bun run tenant-domain:dns:sync` sebagai `awcms_worker` SELECT-only. Tanpa
   `TENANT_DOMAIN_SERVING_TARGET` job no-op — tidak ada default, karena menebak berarti
   outage seluruh platform.
+- **`idn-admin-regions`** ([ADR-0046](adr/0046-idn-admin-regions-module-admission.md), #312,
+  `sql/080` skema + `sql/081` permission) — master data wilayah administratif Indonesia
+  ber-versi, ter-provenance, bisa di-rollback; dataset `cahyadsn/wilayah` (MIT) di-vendor
+  di `data/idn-admin-regions/`. **Dua tabelnya GLOBAL** (tanpa `tenant_id`, tanpa RLS —
+  terdaftar di `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES`), otorisasi tetap per-tenant
+  default-deny. Impor = job deployment dry-run-by-default (`bun run idn-regions:import`,
+  `awcms_worker`); aktivasi/rollback = aksi admin ter-audit ber-idempotency-key. Modul
+  pertama yang **dirintis langsung di sini** (bukan port) di bawah ADR-0047, dan sengaja
+  **tanpa `navigation`** — layar operatornya milik `awcms-astro` (ADR-0048).
 - **Dua environment ter-deploy nyata** — produksi `awcms.ahlikoding.com`, staging
   `awcms-staging.ahlikoding.com` (Coolify, host yang sama, DB & secret terpisah). Staging
   ter-migrasi penuh (69) dan berjalan sebagai role least-privilege terpisah. Rincian,
@@ -178,6 +208,19 @@ Modul (20, urutan `src/modules/index.ts`): `logging`, `tenant-admin`,
 
 ## 4. Backlog / langkah berikutnya
 
+- **Kontrak yang menahan `awcms-astro` — LANGKAH BERIKUTNYA yang dinamai ADR-0047.**
+  Dua cacat kontrak, keduanya diverifikasi terhadap staging (bukan disimpulkan dari
+  dokumen): (1) `resolveAuthInputs` membaca `x-awcms-tenant-id` sementara `awcms-astro`
+  mengirim `X-Tenant-Code`/`X-Tenant-Id` — setiap nilai `X-Tenant-Code` balas
+  `400 TENANT_REQUIRED`; (2) **tidak ada kredensial yang bisa dipegang sebuah build** —
+  bearer yang diterima `/api/v1/blog/posts` adalah token **sesi** ber-hash, dan skema di
+  sini tak punya tabel token mesin sama sekali. Menutup (2) berarti konsep
+  **machine credential** di `identity_access` — dan endpoint introspeksi sesi
+  `GET /api/v1/auth/session` yang [ADR-0045](adr/0045-jualanku-porting-awcms-system-of-record-astro-bff.md)
+  sudah putuskan (desain di [`awcms/jualanku/05-kontrak-sesi-dan-bff.md`](awcms/jualanku/05-kontrak-sesi-dan-bff.md) §3)
+  juga membutuhkannya, sehingga keduanya **satu percakapan desain**, bukan dua.
+  ADR-0048 menegaskan keduanya harus selesai sebelum layar internal pertama di
+  `awcms-astro` bisa memanggil repo ini.
 - **Katalog tag OpenAPI & kepemilikan fragment — SELESAI (2026-07-30).** Temuan graphify
   2026-07-29 ternyata **lebih luas dari yang dilaporkan**: bukan hanya `blog_content` yang
   hilang dari `docs/awcms/api-reference.md`, melainkan **55 operasi dari empat modul** —
@@ -285,9 +328,16 @@ Modul (20, urutan `src/modules/index.ts`): `logging`, `tenant-admin`,
 
 ## 5. Kontrak alur kerja (ringkas)
 
-1. **Mini-first**: fitur fondasi diuji di `awcms-mini` dulu, lalu **diport** ke sini
-   (rename prefix `awcms_mini_` → `awcms_`, penomoran migrasi lanjut). Lihat
-   [`awcms/alur-pengembangan-mini-first.md`](awcms/alur-pengembangan-mini-first.md).
+1. **Mini-first DITANGGUHKAN** ([ADR-0047](adr/0047-mini-micro-frozen-foundation-built-here.md),
+   31 Juli 2026): `awcms-mini`/`awcms-micro` beku, jadi fitur fondasi **dirintis langsung
+   di sini**. Port _keluar_ dari kedua repo itu tetap boleh dan tetap memakai langkah
+   rename `awcms_mini_`/`awcms_micro_` → `awcms_` di
+   [`awcms/alur-pengembangan-mini-first.md`](awcms/alur-pengembangan-mini-first.md)
+   (dokumen itu kembali berlaku utuh begitu pembekuan dicabut). Fitur fondasi yang
+   mendarat selama pembekuan: **ADR wajib**, security review tambahan untuk
+   `auth`/`access`/`sync`, dan **entri divergence di
+   [`awcms-family-compatibility.yaml`](../awcms-family-compatibility.yaml) saat ia
+   mendarat** — bukan retroaktif.
 2. **Branch dulu** (jangan commit ke `main`); satu PR = satu perubahan atomic.
 3. **`bun run check` PENUH** sebelum PR (lint + docs + kontrak + typecheck + test + build;
    `bun run format` dulu bila perlu). Changeset wajib untuk perubahan perilaku.
@@ -310,6 +360,16 @@ Modul (20, urutan `src/modules/index.ts`): `logging`, `tenant-admin`,
   `api-reference.md` tanpa satu pun gate merah (pernah menimpa 55 operasi/4 modul).
   Digerbangi dua arah sejak PR #308, berbarengan dengan gate kepemilikan fragment
   (`api.openApiPath` wajib menunjuk fragment sendiri, bukan bundel).
+- **Rujukan `bun run <target>` di KOMENTAR KODE ikut digerbangi** sejak sinkronisasi
+  scripts↔docs: `check:docs` memeriksa berkas current-state — lima berkas markdown akar,
+  dokumen ini, `scripts/README.md`, README modul `src/**`, **dan seluruh sumber
+  `src/`/`scripts/`**. Sebelumnya hanya lima markdown akar, sehingga enam komentar di
+  `src/modules/module-management/` bisa menyuruh pembacanya menjalankan target
+  `modules:sync` yang tak pernah ada (mekanisme sesungguhnya `POST /api/v1/modules/sync`)
+  dengan `bun run check` tetap hijau. `docs/awcms/` + `.claude/skills/` tetap DI LUAR
+  gerbang: isinya target adaptasi awcms-mini yang memang boleh menyebut tooling belum-ada
+  (`production:preflight`, `repo:inventory:*`, `performance:*`, dst. — daftar lengkapnya
+  di [`../scripts/README.md`](../scripts/README.md) §Ditunda).
 - **Kurung tak-terkutip mematikan SELURUH diagram mermaid** di GitHub (bukan sebagian):
   di `flowchart`/`graph`, `(` adalah token pembuka bentuk node, jadi
   `-->|online (primary)|` atau `{... (x)?}` gagal parse dan diganti kotak "Unable to

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -128,6 +128,17 @@ dibangun. `scripts:inventory:check` **menolak** kalau salah satu dari nama di
 bawah ternyata sudah terdaftar di `package.json` — itu tepat cara tabel
 sebelumnya membusuk.
 
+Nama-nama ini boleh disebut sebagai **target** di `docs/awcms/` dan
+`.claude/skills/` (dokumen yang diadaptasi dari repo acuan), tetapi tidak boleh
+muncul sebagai `bun run <target>` di berkas **current-state**: `README*.md`,
+`AGENTS.md`, `CONTRIBUTING.md`, `docs/ARCHITECTURE.md`, `docs/PROJECT_STATE.md`,
+berkas ini, README modul `src/**`, dan **komentar kode** di `src/`/`scripts/`.
+`check:docs` menggerbanginya. Cakupan sumber itu ditambahkan setelah ditemukan
+enam komentar di `src/modules/module-management/` yang menyuruh pembacanya
+menjalankan target `modules:sync` — perintah yang tak pernah ada di repo ini
+(mekanisme sesungguhnya `POST /api/v1/modules/sync`) — sementara `bun run check`
+tetap hijau karena gate lamanya hanya membaca lima berkas markdown akar.
+
 | Target acuan                                    | Prasyarat yang belum ada                                                    |
 | ----------------------------------------------- | --------------------------------------------------------------------------- |
 | `repo:inventory:generate` / `:check`            | Generator inventaris repo lintas-artefak (OpenAPI + komposisi modul + docs) |

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -8,6 +8,10 @@
  *  2. Tautan relatif Markdown menunjuk ke berkas/anchor yang ada.
  *  3. Regresi penamaan: sisa identifier repo acuan (`awcms_mini_`/`AWCMS_MINI_`)
  *     yang belum diadaptasi ke prefix repo ini (`awcms_`/`AWCMS_`).
+ *  3b. Rujukan `bun run <target>` di berkas current-state (lihat
+ *     `isAuthoritativeScriptFile`) menunjuk script yang benar-benar ada di
+ *     `package.json` — termasuk README modul `src/**` dan komentar kode
+ *     `src/`/`scripts/`, bukan hanya lima berkas markdown akar.
  *  4. Rujukan migration hantu: setiap `sql/NNN` yang disebut dokumentasi
  *     (termasuk `.claude/skills/`, yang DIIKUTI agen) benar-benar ada di
  *     `sql/` — penomoran awcms-mini yang terbawa saat adaptasi dokumen
@@ -30,7 +34,9 @@ import {
   checkNaming,
   checkKnownScripts,
   checkSqlMigrationReferences,
-  AUTHORITATIVE_SCRIPT_DOC_FILES,
+  isAuthoritativeScriptFile,
+  AUTHORITATIVE_SCRIPT_SOURCE_DIRS,
+  AUTHORITATIVE_SCRIPT_SOURCE_EXTENSIONS,
   extractLinks,
   classifyLink,
   splitTarget,
@@ -86,6 +92,27 @@ function anyComposeFileExists() {
  * @type {Set<string>}
  */
 const GENERATED_EXEMPT = new Set(["docs/awcms/agent-memory.md"]);
+
+/**
+ * Berkas SUMBER yang ikut diperiksa rujukan `bun run`-nya (lihat
+ * `AUTHORITATIVE_SCRIPT_SOURCE_DIRS`). Hanya pemeriksaan script yang berlaku di
+ * sini — mermaid/tautan/naming adalah pemeriksaan markdown.
+ * @returns {string[]}
+ */
+function listAuthoritativeSources() {
+  const out = execFileSync(
+    "git",
+    ["ls-files", ...AUTHORITATIVE_SCRIPT_SOURCE_DIRS],
+    { cwd: ROOT, encoding: "utf8" }
+  );
+  return out
+    .split("\n")
+    .filter(Boolean)
+    .filter((file) =>
+      AUTHORITATIVE_SCRIPT_SOURCE_EXTENSIONS.some((ext) => file.endsWith(ext))
+    )
+    .filter((file) => existsSync(join(ROOT, file)));
+}
 
 /** @returns {string[]} */
 function listMarkdown() {
@@ -204,7 +231,7 @@ export function runChecks() {
     problems.push(...checkLinks(file, content));
     problems.push(...checkNaming(file, lines));
     problems.push(...checkSqlMigrationReferences(file, lines, sqlFileNames));
-    if (AUTHORITATIVE_SCRIPT_DOC_FILES.has(file)) {
+    if (isAuthoritativeScriptFile(file)) {
       problems.push(...checkKnownScripts(file, lines, knownScripts));
     }
     if (composeServiceNames) {
@@ -212,6 +239,11 @@ export function runChecks() {
         ...checkComposeServiceNames(file, content, composeServiceNames)
       );
     }
+  }
+
+  for (const file of listAuthoritativeSources()) {
+    const lines = readFileSync(join(ROOT, file), "utf8").split("\n");
+    problems.push(...checkKnownScripts(file, lines, knownScripts));
   }
   return problems;
 }
@@ -225,6 +257,6 @@ if (import.meta.main) {
     process.exit(1);
   }
   console.log(
-    "check:docs OK — mermaid, tautan internal, penamaan, rujukan migration `sql/NNN`, dan rujukan `bun run` di dokumen current-state valid (cek nama service docker compose menyusul begitu docker-compose*.yml ada)."
+    "check:docs OK — mermaid, tautan internal, penamaan, rujukan migration `sql/NNN`, dan rujukan `bun run` di berkas current-state (dokumen + README modul + sumber `src/`/`scripts/`) valid (cek nama service docker compose menyusul begitu docker-compose*.yml ada)."
   );
 }

--- a/scripts/lib/docs-checks.mjs
+++ b/scripts/lib/docs-checks.mjs
@@ -260,6 +260,11 @@ export function checkNaming(file, lines) {
  * `.claude/skills/` sengaja TIDAK termasuk — isinya diadaptasi dari awcms-mini
  * sebagai target (lihat `docs/awcms/README.md` §Status) dan boleh menyebut
  * script yang belum diimplementasikan.
+ *
+ * `docs/PROJECT_STATE.md` dan `scripts/README.md` ada di sini karena keduanya
+ * mendeklarasikan dirinya sebagai cermin keadaan repo (titik-lanjut ter-versioning
+ * dan inventaris scripts) — persis kelas berkas yang pembacanya perlakukan
+ * sebagai fakta.
  * @type {Set<string>}
  */
 export const AUTHORITATIVE_SCRIPT_DOC_FILES = new Set([
@@ -267,13 +272,52 @@ export const AUTHORITATIVE_SCRIPT_DOC_FILES = new Set([
   "README.id.md",
   "AGENTS.md",
   "CONTRIBUTING.md",
-  "docs/ARCHITECTURE.md"
+  "docs/ARCHITECTURE.md",
+  "docs/PROJECT_STATE.md",
+  "scripts/README.md"
 ]);
+
+/**
+ * Ekstensi berkas SUMBER yang ikut dijaga. Komentar kode adalah dokumentasi
+ * current-state yang paling dipercaya — dan yang paling tidak pernah diaudit:
+ * enam komentar di `src/modules/module-management/` sempat menyuruh pembacanya
+ * menjalankan target `modules:sync` yang tak pernah ada di repo ini (mekanisme
+ * sesungguhnya `POST /api/v1/modules/sync`), sementara `bun run check` hijau
+ * karena gate hanya membaca lima berkas markdown. Komentar ini pun sengaja
+ * TIDAK menulis nama target itu dalam bentuk `bun run …`: gate ini membaca
+ * dirinya sendiri.
+ *
+ * `tests/` sengaja DI LUAR: fixture-nya memang menyebut target fiktif
+ * (`ghost:one`, `example-crm:reconcile`) untuk menguji gate ini sendiri.
+ * @type {string[]}
+ */
+export const AUTHORITATIVE_SCRIPT_SOURCE_EXTENSIONS = [".ts", ".mjs", ".astro"];
+
+/** @type {string[]} */
+export const AUTHORITATIVE_SCRIPT_SOURCE_DIRS = ["src/", "scripts/"];
+
+/**
+ * Apakah `file` wajib menunjuk script `package.json` yang nyata?
+ *
+ * Tiga kelas: berkas current-state bernama eksplisit di atas, README modul di
+ * `src/**` (deskripsi modul sebagaimana ADANYA — bukan target port), dan
+ * berkas sumber di `src/`/`scripts/`.
+ * @param {string} file path relatif terhadap root repo
+ * @returns {boolean}
+ */
+export function isAuthoritativeScriptFile(file) {
+  if (AUTHORITATIVE_SCRIPT_DOC_FILES.has(file)) return true;
+  if (file.startsWith("src/") && file.endsWith("README.md")) return true;
+  return (
+    AUTHORITATIVE_SCRIPT_SOURCE_DIRS.some((dir) => file.startsWith(dir)) &&
+    AUTHORITATIVE_SCRIPT_SOURCE_EXTENSIONS.some((ext) => file.endsWith(ext))
+  );
+}
 
 /**
  * Deteksi rujukan `bun run <script>` yang tidak terdaftar di `package.json`.
  * Hanya dipanggil untuk berkas current-state (lihat
- * `AUTHORITATIVE_SCRIPT_DOC_FILES`) agar tidak salah menandai command "target"
+ * `isAuthoritativeScriptFile`) agar tidak salah menandai command "target"
  * di docs/skills yang memang belum diimplementasikan.
  * @param {string} file
  * @param {string[]} lines
@@ -291,7 +335,7 @@ export function checkKnownScripts(file, lines, knownScripts) {
       problems.push({
         file,
         line: i + 1,
-        message: `rujukan \`bun run ${script}\` tidak ada di package.json (dokumen current-state wajib menunjuk script nyata)`
+        message: `rujukan \`bun run ${script}\` tidak ada di package.json (berkas current-state wajib menunjuk script nyata)`
       });
     }
   });

--- a/src/lib/jobs/job-runner.ts
+++ b/src/lib/jobs/job-runner.ts
@@ -2,7 +2,7 @@
  * Shared worker runner (Issue #697, epic #679, platform-hardening).
  *
  * Every `scripts/*.ts` cron/systemd worker (`bun run logs:audit:purge`,
- * `bun run modules:sync`, ...) re-implements the same handful of concerns
+ * `bun run domain-events:dispatch`, ...) re-implements the same handful of concerns
  * slightly differently: iterate tenants, generate a correlation/run id,
  * decide the process exit code, print a completion summary, and log
  * failures safely. `runJob` is the single place that logic now lives —

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -827,7 +827,11 @@ bun test                               # unit + integration; DATABASE_URL wajib 
 bun test tests/integration/blog-content-admin-ui.integration.test.ts  # test baru khusus Issue #543
 bun run build                          # Astro build, termasuk seluruh layar admin/blog/*
 bun run check                          # lint + check:docs + api:spec:check + typecheck + test + build
-bun run production:preflight           # gate go-live penuh (lihat §Known limitations soal env sandbox)
+bun run config:validate                # kontrak env (satu dari tiga tahap go-live yang sudah nyata)
+bun run security:readiness             # postur keamanan (RLS FORCE, default-deny, audit trail)
+bun run db:pool:health                 # kesehatan pool/backpressure
+# Orkestrator `production:preflight` yang menjalankan ketiganya sebagai satu
+# gated go/no-go BELUM ada di repo ini — lihat docs/awcms/production-preflight-runbook.md §Status dokumen.
 ```
 
 ### Operational checklist (Issue #543)

--- a/src/modules/module-management/application/job-registry.ts
+++ b/src/modules/module-management/application/job-registry.ts
@@ -1,8 +1,8 @@
 /**
  * Module job/command registry service. Reads directly from `listModules()` —
  * never `awcms_module_jobs` — same reasoning as the navigation registry and
- * tenant module lifecycle: that table only reflects whatever
- * `bun run modules:sync` last wrote, and this is documentation the operator
+ * tenant module lifecycle: that table only reflects whatever the last
+ * `POST /api/v1/modules/sync` wrote, and this is documentation the operator
  * reads, not something that should silently go stale until someone remembers
  * to sync. No I/O at all: every job descriptor is trusted,
  * statically-imported code metadata already in this process.

--- a/src/modules/module-management/application/module-catalog.ts
+++ b/src/modules/module-management/application/module-catalog.ts
@@ -3,7 +3,7 @@
  * is the source of truth for a module's static metadata
  * (name/version/description/dependencies/api/events/type) — it is always
  * current, never stale, unlike the DB registry which only reflects whatever
- * `bun run modules:sync` last wrote. This merges the two: static fields come
+ * the last `POST /api/v1/modules/sync` wrote. This merges the two: static fields come
  * from the descriptor, `lifecycleStatus`/`isCore`/`lastSyncedAt` come from
  * `awcms_modules` when a row exists (falling back to the descriptor's own
  * `status`/`isCore` if sync hasn't run yet).

--- a/src/modules/module-management/application/navigation-registry.ts
+++ b/src/modules/module-management/application/navigation-registry.ts
@@ -3,7 +3,7 @@
  * directly from the live code registry (`listModules()`) — never
  * `awcms_module_navigation` — same reasoning as
  * `tenant-module-lifecycle.ts`'s dependency graph: that table only reflects
- * whatever `bun run modules:sync` last wrote, and a sidebar rendered on every
+ * whatever the last `POST /api/v1/modules/sync` wrote, and a sidebar rendered on every
  * admin request must never depend on someone having remembered to run a sync
  * first. This also keeps the per-request cost to exactly one lightweight
  * query (the tenant's disabled-module keys).

--- a/src/modules/module-management/application/tenant-module-lifecycle.ts
+++ b/src/modules/module-management/application/tenant-module-lifecycle.ts
@@ -141,8 +141,8 @@ export async function enableTenantModule(
 ): Promise<TenantModuleMutationResult> {
   // `awcms_tenant_modules.module_key` has an FK to `awcms_modules` — ensure
   // the registry is current before writing tenant state that references it,
-  // rather than requiring an operator to have already run
-  // `bun run modules:sync`/`POST /api/v1/modules/sync` at least once.
+  // rather than requiring an operator to have already called
+  // `POST /api/v1/modules/sync` at least once.
   // Idempotent and cheap (a handful of upserts, no network calls).
   await syncModuleDescriptors(tx);
 

--- a/src/modules/module-management/domain/tenant-module-lifecycle.ts
+++ b/src/modules/module-management/domain/tenant-module-lifecycle.ts
@@ -8,7 +8,7 @@
  * The dependency graph itself always comes from the live code registry
  * (`listModules()`'s own `dependencies` arrays), never the DB's
  * `awcms_module_dependencies` table — that table only reflects whatever
- * `bun run modules:sync` last wrote, and enable/disable must never depend on
+ * the last `POST /api/v1/modules/sync` wrote, and enable/disable must never depend on
  * someone having remembered to run a sync first.
  */
 import type { ModuleDescriptor } from "../../_shared/module-contract";

--- a/tests/docs-checks.test.mjs
+++ b/tests/docs-checks.test.mjs
@@ -14,6 +14,7 @@ import {
   checkSqlMigrationReferences,
   SQL_REF_UNCHECKED_FILES,
   AUTHORITATIVE_SCRIPT_DOC_FILES,
+  isAuthoritativeScriptFile,
   extractLinks,
   classifyLink,
   splitTarget,
@@ -266,6 +267,51 @@ describe("checkKnownScripts", () => {
     expect(AUTHORITATIVE_SCRIPT_DOC_FILES.has("docs/awcms/README.md")).toBe(
       false
     );
+  });
+});
+
+describe("isAuthoritativeScriptFile", () => {
+  test("dokumen state & inventaris scripts ikut dijaga", () => {
+    expect(isAuthoritativeScriptFile("docs/PROJECT_STATE.md")).toBe(true);
+    expect(isAuthoritativeScriptFile("scripts/README.md")).toBe(true);
+  });
+
+  test("README modul di src/ ikut dijaga", () => {
+    expect(
+      isAuthoritativeScriptFile("src/modules/blog-content/README.md")
+    ).toBe(true);
+  });
+
+  test("komentar kode src/ dan scripts/ ikut dijaga", () => {
+    expect(
+      isAuthoritativeScriptFile(
+        "src/modules/module-management/application/job-registry.ts"
+      )
+    ).toBe(true);
+    expect(isAuthoritativeScriptFile("scripts/db-migrate.ts")).toBe(true);
+    expect(isAuthoritativeScriptFile("src/pages/admin/index.astro")).toBe(true);
+  });
+
+  // Kelas berkas yang justru HARUS bebas menyebut target yang belum ada:
+  // docs/skills diadaptasi dari awcms-mini sebagai target, dan fixture test
+  // memang memakai nama fiktif untuk menguji gate ini.
+  test("docs target, skill, dan test TIDAK dijaga", () => {
+    expect(isAuthoritativeScriptFile("docs/awcms/performance-suite.md")).toBe(
+      false
+    );
+    expect(
+      isAuthoritativeScriptFile(".claude/skills/awcms-i18n/SKILL.md")
+    ).toBe(false);
+    expect(isAuthoritativeScriptFile("tests/docs-checks.test.mjs")).toBe(false);
+    expect(
+      isAuthoritativeScriptFile(
+        "tests/fixtures/example-domain-modules/modules/example-crm/module.ts"
+      )
+    ).toBe(false);
+  });
+
+  test("berkas non-sumber di src/ (mis. .css) tidak ikut dipindai", () => {
+    expect(isAuthoritativeScriptFile("src/styles/tokens.css")).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Kenapa

`checkKnownScripts` hanya membaca **lima berkas markdown akar** (`README*.md`, `AGENTS.md`, `CONTRIBUTING.md`, `docs/ARCHITECTURE.md`). Di luar lima itu, sebuah perintah yang tidak pernah ada tetap bisa berdiri sebagai instruksi — dan tujuh memang begitu, semuanya hidup berdampingan dengan `bun run check` hijau:

- **Enam komentar** di `src/lib/jobs/job-runner.ts` + `src/modules/module-management/` menyuruh pembacanya menjalankan target `modules:sync`. Target itu **tidak pernah ada di repo ini** — mekanismenya `POST /api/v1/modules/sync`, dan `enableTenantModule` bahkan sudah memanggil `syncModuleDescriptors` sendiri supaya operator tak perlu mengingat apa pun.
- `src/modules/blog-content/README.md` mendaftarkan `bun run production:preflight` di antara perintah verifikasi nyata. Orkestrator itu belum diport; tiga tahapnya yang sudah nyata (`config:validate`, `security:readiness`, `db:pool:health`) menggantikannya.

Komentar kode adalah dokumentasi current-state yang paling dipercaya sekaligus yang paling tidak pernah diaudit — ia dibaca persis saat seseorang sedang memutuskan tindakan.

## Apa yang berubah

Cakupan gerbang kini: lima berkas akar + `docs/PROJECT_STATE.md` + `scripts/README.md` + README modul `src/**` + **seluruh sumber `src/`/`scripts/`**.

Yang sengaja TETAP di luar: `docs/awcms/` dan `.claude/skills/` (target adaptasi awcms-mini yang memang boleh menyebut tooling belum-ada — daftarnya di `scripts/README.md` §Ditunda), dan `tests/` (fixture-nya sengaja memakai nama fiktif untuk menguji gerbang ini).

## Bagaimana dibuktikan

Kelas cacatnya dibuktikan **dua arah** sebelum ditutup: mengembalikan komentar `modules:sync` yang asli **dan** menambahkan satu rujukan hantu ke `docs/PROJECT_STATE.md` masing-masing memerahkan gerbang. Gerbangnya juga langsung menangkap komentar penjelasnya sendiri pada run pertama — kali kelima bentuk itu muncul di repo ini, dan alasan komentar itu kini sengaja tidak menulis nama target dalam bentuk `bun run …`.

## Dokumen current-state ikut disegarkan

Supaya tidak berbohong ke arah sebaliknya:

- `docs/ARCHITECTURE.md` masih menulis "20 modul terdaftar" (21) dan **dua kali** menyebut `idn-admin-regions` sebagai "belum di-port" padahal modul itu sudah mendarat (#312) — klaim negatif yang makin salah seiring waktu tanpa pernah gagal sendiri.
- `docs/PROJECT_STATE.md` disetel ulang ke 21 modul / ADR 0000–0048, mencatat ADR-0047 (mini-first **ditangguhkan**, fondasi dirintis langsung di sini) + ADR-0048 (pembagian peran frontend), dan kontrak alur kerjanya tidak lagi mewajibkan mini-first.

## Verifikasi

`bun run check` penuh. Suite DB-gated gagal di lingkungan tanpa Postgres — di-diff terhadap `main`: **nol kegagalan baru**, +5 test lulus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)