### PR TITLE
feat(blog-content): traversal stabil ber-cursor untuk GET /api/v1/blog/posts

### DIFF
--- a/.changeset/blog-post-cursor-pagination.md
+++ b/.changeset/blog-post-cursor-pagination.md
@@ -1,0 +1,38 @@
+---
+"awcms": minor
+---
+
+`GET /api/v1/blog/posts` dapat traversal stabil ber-cursor — build feed tidak
+lagi berhenti di 100 post.
+
+Endpoint ini hanya punya `?limit=` (maks 100) dan tanpa cursor, jadi tidak ada
+cara membaca lebih dari 100 post. Adapter `awcms-astro` **melempar** saat
+menyentuh batas itu alih-alih memotong diam-diam, sehingga situs dengan lebih
+dari 100 artikel tidak bisa di-build sama sekali.
+
+Yang TIDAK dilakukan: menambahkan `?cursor=` ke urutan yang sudah ada.
+Default-nya `updated_at DESC` — benar untuk tabel admin dan tidak sah sebagai
+kunci keyset, karena menyunting sebuah post memindahkannya: satu baris bisa
+melintasi batas halaman di antara dua permintaan lalu terlewat atau muncul dua
+kali, dan tak ada apa pun yang bisa mendeteksinya. Sebuah cursor hanya sah di
+atas urutan yang tidak berubah oleh tulisan yang dibalapinya.
+
+Jadi `?order=created_at` memilih traversal stabil (kolom immutable) dan
+`?cursor=` hanya berlaku bersamanya; `?cursor=` di atas urutan default **ditolak
+400** dengan alasannya, bukan diam-diam dilayani. Default endpoint tidak berubah
+sama sekali — tabel admin tetap urut `updated_at`.
+
+`nextCursor` dicetak di lapisan yang masih memegang teks presisi mikrodetik,
+tidak pernah diturunkan ulang dari `Date` JS di rute. Itu bukan kehati-hatian
+teoretis: `timestamptz` menyimpan mikrodetik, `Date` hanya milidetik, dan driver
+MEMBULATKAN KE BAWAH — cursor dari `Date` menunjuk instant yang lebih awal dari
+barisnya sendiri dan melewatkan setiap baris yang berbagi milidetik itu (Issue
+#158; terukur: 105 baris → halaman 2 berisi 4, batch-insert → halaman 2 berisi
+0).
+
+Diverifikasi terhadap PostgreSQL nyata dengan kasus terburuknya: 25 post
+di-insert dalam SATU statement sehingga berbagi `created_at` sampai mikrodetik.
+Mutation-proven — mengganti sumber cursor jadi `new Date(row.created_at)`
+memerahkan 3 dari 5 test.
+
+`BlogPostSummary` mendapat field `createdAt` (aditif).

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -4672,13 +4672,17 @@ Read-only preview for the admin editor. Gated by blog_content.pages.read.
 
 Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
 
+Ordering defaults to `updated_at DESC` — right for an admin table, and unsound as a keyset key because editing a post moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY post (a build feed) passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
+
 **Parameters**
 
-| Name               | In     | Required | Type                                                          | Description |
-| ------------------ | ------ | -------- | ------------------------------------------------------------- | ----------- |
-| `status`           | query  | no       | enum(`draft`, `review`, `scheduled`, `published`, `archived`) |             |
-| `limit`            | query  | no       | integer                                                       |             |
-| `X-Correlation-ID` | header | no       | string                                                        |             |
+| Name               | In     | Required | Type                                                          | Description                                                                                                                                          |
+| ------------------ | ------ | -------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `status`           | query  | no       | enum(`draft`, `review`, `scheduled`, `published`, `archived`) |                                                                                                                                                      |
+| `limit`            | query  | no       | integer                                                       |                                                                                                                                                      |
+| `order`            | query  | no       | enum(`created_at`, `updated_at`)                              | Sort key. `created_at` selects the STABLE, cursor-capable traversal; `updated_at` (default) is the admin ordering and rejects `cursor`.              |
+| `cursor`           | query  | no       | string                                                        | Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor". |
+| `X-Correlation-ID` | header | no       | string                                                        |                                                                                                                                                      |
 
 **Responses**
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -3204,7 +3204,10 @@ paths:
         - Blog Content
       operationId: blogListPosts
       summary: List this tenant's non-deleted blog posts
-      description: Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+      description: |
+        Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+
+        Ordering defaults to `updated_at DESC` — right for an admin table, and unsound as a keyset key because editing a post moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY post (a build feed) passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
       parameters:
         - name: status
           in: query
@@ -3222,6 +3225,19 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
+        - name: order
+          in: query
+          description: Sort key. `created_at` selects the STABLE, cursor-capable traversal; `updated_at` (default) is the admin ordering and rejects `cursor`.
+          schema:
+            type: string
+            enum:
+              - created_at
+              - updated_at
+        - name: cursor
+          in: query
+          description: Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor".
+          schema:
+            type: string
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -3242,6 +3258,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/BlogPost"
+                      nextCursor:
+                        type: string
+                        nullable: true
+                        description: Present only with `order=created_at`. Null means the traversal is complete.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -33,7 +33,10 @@ paths:
         - Blog Content
       operationId: blogListPosts
       summary: List this tenant's non-deleted blog posts
-      description: Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+      description: |
+        Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+
+        Ordering defaults to `updated_at DESC` — right for an admin table, and unsound as a keyset key because editing a post moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY post (a build feed) passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
       parameters:
         - name: status
           in: query
@@ -46,6 +49,17 @@ paths:
             type: integer
             minimum: 1
             maximum: 100
+        - name: order
+          in: query
+          description: Sort key. `created_at` selects the STABLE, cursor-capable traversal; `updated_at` (default) is the admin ordering and rejects `cursor`.
+          schema:
+            type: string
+            enum: [created_at, updated_at]
+        - name: cursor
+          in: query
+          description: Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor".
+          schema:
+            type: string
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -65,6 +79,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/BlogPost"
+                      nextCursor:
+                        type: string
+                        nullable: true
+                        description: Present only with `order=created_at`. Null means the traversal is complete.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -817,6 +817,32 @@ Seluruh string UI (~300 key baru, namespace `admin.blog.*`) ditambahkan ke `i18n
 - Rendering publik tetap aman dari XSS — tidak diubah oleh issue ini; `content_json`/`content_text`/widget `bodyText`/ad `imageUrl`/`linkUrl` tetap lewat whitelist renderer yang sama (`content-block-rendering.ts`, `ads-directory.ts`'s `renderAdHtml`). Editor admin (`contentJson` textarea) mengizinkan penulis mengetik apa pun, tapi validasi server (`validateContentJsonField`'s `containsUnsafeHtml`) tetap menolak `<script>`/`<iframe>`/`<embed>`/`<object>`/inline handler/`javascript:` sebelum tersimpan — editor tidak melonggarkan aturan itu.
 - Pesan error tidak membocorkan stack trace — action banner admin selalu menampilkan `error.message` dari respons API (yang sendiri sudah aman, doc 10) atau string generik `common.network_error`, tidak pernah `error.stack`/exception mentah dari `console.error` (yang hanya dicatat server-side).
 
+### Build feed: traversal stabil ber-cursor
+
+`GET /api/v1/blog/posts` default-nya urut `updated_at DESC` — benar untuk tabel
+admin, dan **tidak sah** sebagai kunci keyset: menyunting sebuah post
+memindahkannya, sehingga satu baris bisa melintasi batas halaman di antara dua
+permintaan lalu terlewat atau muncul dua kali, tanpa apa pun yang bisa
+mendeteksinya.
+
+Pemanggil yang butuh SELURUH post (build feed `awcms-astro`) memakai:
+
+```
+GET /api/v1/blog/posts?order=created_at&limit=100
+GET /api/v1/blog/posts?order=created_at&limit=100&cursor=<nextCursor>
+```
+
+`created_at` immutable, jadi traversal-nya stabil. `?cursor=` tanpa
+`?order=created_at` **ditolak 400**, bukan diam-diam dilayani — paginasi senyap
+di atas urutan yang bisa berubah persis muncul sebagai "beberapa artikel hilang
+dari situs" berbulan-bulan kemudian.
+
+`nextCursor` dicetak di lapisan yang masih memegang teks presisi mikrodetik
+(`to_char(... 'US')`), tidak pernah diturunkan ulang dari `Date` JS di rute —
+`Date` sudah membulatkan ke bawah mikrodetiknya dan menghidupkan kembali bug
+row-skipping Issue #158. Dibuktikan di `tests/integration/blog-post-cursor.integration.test.ts`
+dengan batch-insert yang seluruh barisnya berbagi satu instant.
+
 ### Testing commands
 
 ```bash

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -10,6 +10,10 @@ import {
   boundedPageNumber,
   boundedPageSize
 } from "../../_shared/offset-pagination";
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
 
 /**
  * Read/write query module for `awcms_blog_posts` (Issue #537 scaffolded
@@ -27,6 +31,8 @@ export type BlogPostSummary = {
   locale: string;
   publishedAt: Date | null;
   updatedAt: Date;
+  /** Immutable — the only sort key a keyset cursor over this table can be sound on. */
+  createdAt: Date;
 };
 
 type BlogPostSummaryRow = {
@@ -39,6 +45,7 @@ type BlogPostSummaryRow = {
   locale: string;
   published_at: Date | null;
   updated_at: Date;
+  created_at: Date;
 };
 
 function toBlogPostSummary(row: BlogPostSummaryRow): BlogPostSummary {
@@ -51,7 +58,8 @@ function toBlogPostSummary(row: BlogPostSummaryRow): BlogPostSummary {
     visibility: row.visibility,
     locale: row.locale,
     publishedAt: row.published_at,
-    updatedAt: row.updated_at
+    updatedAt: row.updated_at,
+    createdAt: row.created_at
   };
 }
 
@@ -223,7 +231,73 @@ export type ListBlogPostsFilter = {
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
 
-/** `LIMIT` bounded (default 20, max 100), newest-updated first — same bounded-list convention as `email/templates` and `workflows/tasks` (no cursor pagination yet). */
+/**
+ * STABLE, cursor-paginated traversal — ordered `(created_at DESC, id DESC)`.
+ *
+ * ## Why this is a second function and not a `cursor` option on the one above
+ *
+ * `listBlogPosts` orders by `updated_at`, which is the right answer for a human
+ * looking at an admin table and the WRONG key for a keyset cursor: editing any
+ * post moves it in the ordering, so a row can cross the page boundary between
+ * two requests and be skipped — or returned twice — with nothing to detect it.
+ * A cursor is only sound over an ordering that does not change under the writes
+ * the traversal races with, so this one uses `created_at`, which is immutable.
+ *
+ * The caller therefore CHOOSES a traversal rather than accidentally mixing
+ * them; the route refuses a cursor against the mutable ordering outright.
+ *
+ * `nextCursor` is minted here, where the full-microsecond text is still in
+ * hand — never re-derived from a JS `Date` in a route, which would floor the
+ * microseconds and resurrect the row-skipping bug of Issue #158.
+ */
+export async function listBlogPostsPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  options: {
+    status?: BlogContentStatus;
+    limit?: number;
+    cursor?: KeysetCursor | null;
+  } = {}
+): Promise<{ items: BlogPostSummary[]; nextCursor: string | null }> {
+  const limit = boundedPageSize(
+    options.limit,
+    DEFAULT_LIST_LIMIT,
+    MAX_LIST_LIMIT
+  );
+
+  const cursorCreatedAt = options.cursor?.createdAt ?? null;
+  const cursorId = options.cursor?.id ?? null;
+  const status = options.status ?? null;
+
+  // One statement for both filtered and unfiltered: `${status}::text IS NULL`
+  // keeps the plan shape identical and stops this from growing a fourth
+  // near-identical copy of the same SELECT as filters accumulate.
+  const rows = (await tx`
+    SELECT id, tenant_id, title, slug, status, visibility, locale, published_at,
+           updated_at, created_at,
+           to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
+    FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId}
+      AND deleted_at IS NULL
+      AND (${status}::text IS NULL OR status = ${status})
+      AND (
+        ${cursorCreatedAt}::timestamptz IS NULL
+        OR (created_at, id) < (${cursorCreatedAt}::timestamptz, ${cursorId}::uuid)
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${limit}
+  `) as (BlogPostSummaryRow & { created_at_cursor: string })[];
+
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === limit && last
+      ? encodeKeysetCursor(last.created_at_cursor, last.id)
+      : null;
+
+  return { items: rows.map(toBlogPostSummary), nextCursor };
+}
+
+/** `LIMIT` bounded (default 20, max 100), newest-updated first — same bounded-list convention as `email/templates` and `workflows/tasks`. For a STABLE traversal past page one, use {@link listBlogPostsPage}. */
 export async function listBlogPosts(
   tx: Bun.SQL,
   tenantId: string,
@@ -238,14 +312,14 @@ export async function listBlogPosts(
   const rows = (
     filter.status
       ? await tx`
-        SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at
+        SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at, created_at
         FROM awcms_blog_posts
         WHERE tenant_id = ${tenantId} AND status = ${filter.status} AND deleted_at IS NULL
         ORDER BY updated_at DESC
         LIMIT ${limit}
       `
       : await tx`
-        SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at
+        SELECT id, tenant_id, title, slug, status, visibility, locale, published_at, updated_at, created_at
         FROM awcms_blog_posts
         WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
         ORDER BY updated_at DESC

--- a/src/pages/api/v1/blog/posts/index.ts
+++ b/src/pages/api/v1/blog/posts/index.ts
@@ -17,8 +17,10 @@ import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   createBlogPost,
-  listBlogPosts
+  listBlogPosts,
+  listBlogPostsPage
 } from "../../../../../modules/blog-content/application/blog-post-directory";
+import { decodeKeysetCursor } from "../../../../../modules/_shared/keyset-pagination";
 import {
   countExistingTerms,
   syncPostTermAssignments
@@ -46,7 +48,24 @@ const CREATE_GUARD = {
   action: "create" as const
 };
 
-/** `GET /api/v1/blog/posts` (Issue #538) — list this tenant's non-deleted posts, `?status=` optional filter, `?limit=` bounded (default 20, max 100). */
+/**
+ * `GET /api/v1/blog/posts` (Issue #538) — list this tenant's non-deleted posts.
+ * `?status=` optional filter, `?limit=` bounded (default 20, max 100).
+ *
+ * ## `?order=` and `?cursor=` — a stable traversal for builds and exports
+ *
+ * The default ordering is `updated_at DESC`: right for a human scanning an
+ * admin table, and unsound as a keyset key, because editing any post moves it
+ * and a row can cross the page boundary between two requests — skipped, or
+ * returned twice, with nothing able to detect it.
+ *
+ * So a caller that needs EVERY post (an `awcms-astro` build feed is the reason
+ * this exists) asks for `?order=created_at`, which is immutable, and follows
+ * `nextCursor`. Passing `?cursor=` without it is refused outright rather than
+ * quietly honoured: silently paginating over a mutable ordering is exactly the
+ * bug that would surface as "a few articles are missing from the site" months
+ * later.
+ */
 export const GET: APIRoute = async ({ request, cookies, url }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
 
@@ -83,6 +102,37 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
     return fail(400, "VALIDATION_ERROR", "limit must be a positive number.");
   }
 
+  const orderParam = url.searchParams.get("order");
+
+  if (
+    orderParam !== null &&
+    orderParam !== "created_at" &&
+    orderParam !== "updated_at"
+  ) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "order must be one of created_at, updated_at."
+    );
+  }
+
+  const stableOrder = orderParam === "created_at";
+  const cursorParam = url.searchParams.get("cursor");
+
+  if (cursorParam !== null && !stableOrder) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "cursor requires order=created_at — updated_at changes on every edit, so a cursor over it can skip or repeat posts."
+    );
+  }
+
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam !== null && cursor === null) {
+    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+  }
+
   const sql = getDatabaseClient();
   const tokenHash = hashSessionToken(token);
   const now = new Date();
@@ -98,6 +148,16 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
 
     if (!auth.allowed) {
       return auth.denied;
+    }
+
+    if (stableOrder) {
+      const page = await listBlogPostsPage(tx, tenantId, {
+        status,
+        limit,
+        cursor
+      });
+
+      return ok({ posts: page.items, nextCursor: page.nextCursor });
     }
 
     const posts = await listBlogPosts(tx, tenantId, {

--- a/tests/integration/blog-post-cursor.integration.test.ts
+++ b/tests/integration/blog-post-cursor.integration.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Cursor traversal over `awcms_blog_posts` against a real PostgreSQL.
+ *
+ * The bug this guards against does not reproduce in a unit test, because it
+ * lives in the gap between what `timestamptz` stores (microseconds) and what a
+ * JS `Date` can hold (milliseconds). Issue #158 measured it on offices: 105 rows
+ * paged to 4, and a batch insert sharing one millisecond paged to 0. So the
+ * decisive case here is a batch insert whose rows share a millisecond — if the
+ * cursor ever loses precision again, this suite loses rows and says so.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { decodeKeysetCursor } from "../../src/modules/_shared/keyset-pagination";
+import { listBlogPostsPage } from "../../src/modules/blog-content/application/blog-post-directory";
+
+const TENANT = "f1111111-1111-4111-8111-111111111111";
+const AUTHOR = "f0000000-0000-4000-8000-000000000001";
+
+const TOTAL_POSTS = 25;
+const PAGE_SIZE = 10;
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'cursor-tenant', 'Cursor Tenant')
+  `;
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Author')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'author@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${AUTHOR}, ${TENANT}, ${identity[0]!.id})
+  `;
+}
+
+/**
+ * One statement inserts every row, so they share a `created_at` down to the
+ * microsecond — the shape that reduced page 2 to ZERO rows before Issue #158
+ * was fixed, and the reason this suite exists at all.
+ */
+async function seedPosts(count: number): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text, status, visibility, locale)
+    SELECT ${TENANT}, ${AUTHOR}, 'Post ' || n, 'post-' || n, '{}'::jsonb, '', 'published', 'public', 'id'
+    FROM generate_series(1, ${count}) AS n
+  `;
+}
+
+async function collectAllPages(): Promise<string[]> {
+  const runtime = getRuntimeSql();
+  const seen: string[] = [];
+  let cursor: string | null = null;
+
+  for (let guard = 0; guard < 100; guard += 1) {
+    const page: { items: { id: string }[]; nextCursor: string | null } =
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        listBlogPostsPage(tx, TENANT, {
+          limit: PAGE_SIZE,
+          cursor: cursor ? decodeKeysetCursor(cursor) : null
+        })
+      );
+
+    seen.push(...page.items.map((item) => item.id));
+
+    if (!page.nextCursor) return seen;
+    cursor = page.nextCursor;
+  }
+
+  throw new Error("cursor traversal did not terminate");
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("blog post cursor traversal", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("a batch sharing one instant is traversed WITHOUT losing rows", async () => {
+    await seedPosts(TOTAL_POSTS);
+
+    const seen = await collectAllPages();
+
+    expect(seen).toHaveLength(TOTAL_POSTS);
+    expect(new Set(seen).size).toBe(TOTAL_POSTS);
+  });
+
+  test("page two is not empty (the exact Issue #158 symptom)", async () => {
+    await seedPosts(TOTAL_POSTS);
+    const runtime = getRuntimeSql();
+
+    const first = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogPostsPage(tx, TENANT, { limit: PAGE_SIZE })
+    );
+    expect(first.items).toHaveLength(PAGE_SIZE);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogPostsPage(tx, TENANT, {
+        limit: PAGE_SIZE,
+        cursor: decodeKeysetCursor(first.nextCursor!)
+      })
+    );
+
+    expect(second.items).toHaveLength(PAGE_SIZE);
+    // No overlap: the boundary row must not repeat.
+    const firstIds = new Set(first.items.map((i) => i.id));
+    expect(second.items.some((i) => firstIds.has(i.id))).toBe(false);
+  });
+
+  test("the last page reports no next cursor", async () => {
+    await seedPosts(PAGE_SIZE * 2);
+
+    const runtime = getRuntimeSql();
+    const first = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogPostsPage(tx, TENANT, { limit: PAGE_SIZE })
+    );
+    const second = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogPostsPage(tx, TENANT, {
+        limit: PAGE_SIZE,
+        cursor: decodeKeysetCursor(first.nextCursor!)
+      })
+    );
+
+    // Exactly two full pages: the second is full, so a third request is needed
+    // to learn the traversal is over. That is the honest cost of "limit rows
+    // returned" as the has-more signal, and the loop above handles it.
+    const third = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogPostsPage(tx, TENANT, {
+        limit: PAGE_SIZE,
+        cursor: decodeKeysetCursor(second.nextCursor!)
+      })
+    );
+
+    expect(third.items).toHaveLength(0);
+    expect(third.nextCursor).toBeNull();
+  });
+
+  test("the status filter survives the cursor", async () => {
+    await seedPosts(PAGE_SIZE);
+    await getAdminSql()`
+      UPDATE awcms_blog_posts SET status = 'draft'
+      WHERE tenant_id = ${TENANT} AND slug IN ('post-1', 'post-2')
+    `;
+
+    const runtime = getRuntimeSql();
+    const page = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogPostsPage(tx, TENANT, { status: "published", limit: PAGE_SIZE })
+    );
+
+    expect(page.items).toHaveLength(PAGE_SIZE - 2);
+    expect(page.items.every((item) => item.status === "published")).toBe(true);
+  });
+
+  test("soft-deleted posts never appear", async () => {
+    await seedPosts(PAGE_SIZE);
+    await getAdminSql()`
+      UPDATE awcms_blog_posts SET deleted_at = now()
+      WHERE tenant_id = ${TENANT} AND slug = 'post-1'
+    `;
+
+    const seen = await collectAllPages();
+
+    expect(seen).toHaveLength(PAGE_SIZE - 1);
+  });
+});


### PR DESCRIPTION
## Yang diblokir

`GET /api/v1/blog/posts` hanya punya `?limit=` (maks 100) dan **tidak punya cursor** — komentarnya sendiri menulis "no cursor pagination yet". Adapter `awcms-astro` **melempar** saat menyentuh batas itu alih-alih memotong diam-diam (perilaku yang benar), jadi situs dengan lebih dari 100 artikel **tidak bisa di-build sama sekali**.

## Yang sengaja TIDAK dilakukan

Menambahkan `?cursor=` ke urutan yang sudah ada.

Default-nya `updated_at DESC`: benar untuk tabel admin, dan **tidak sah** sebagai kunci keyset. Menyunting sebuah post memindahkannya di dalam urutan, sehingga satu baris bisa melintasi batas halaman di antara dua permintaan — terlewat, atau muncul dua kali — tanpa apa pun yang bisa mendeteksinya. Sebuah cursor hanya sah di atas urutan yang **tidak berubah oleh tulisan yang dibalapinya**.

Jadi:

| | |
| --- | --- |
| `?order=created_at` | traversal STABIL (kolom immutable), mengembalikan `nextCursor` |
| `?order=updated_at` (default) | urutan admin, perilaku **tidak berubah sama sekali** |
| `?cursor=` tanpa `order=created_at` | **400**, dengan alasannya — bukan diam-diam dilayani |

Penolakan itu bukan formalitas. Paginasi senyap di atas urutan yang bisa berubah muncul sebagai "beberapa artikel hilang dari situs" berbulan-bulan kemudian, di tempat yang tak seorang pun hubungkan dengan paginasi.

## Presisi

`nextCursor` dicetak di lapisan yang masih memegang teks presisi mikrodetik (`to_char(… 'US')`), **tidak pernah** diturunkan ulang dari `Date` JS di rute. `timestamptz` menyimpan mikrodetik, `Date` hanya milidetik, dan driver **membulatkan ke bawah** — cursor dari `Date` menunjuk instant yang lebih awal dari barisnya sendiri lalu melewatkan setiap baris yang berbagi milidetik itu (Issue #158; terukur dulu: 105 baris → halaman 2 berisi 4; batch-insert → halaman 2 berisi **0**).

## Verifikasi

5 test integrasi terhadap PostgreSQL nyata, dengan kasus terburuknya sebagai kasus utama: **25 post di-insert dalam SATU statement** sehingga seluruhnya berbagi `created_at` sampai mikrodetik — bentuk yang dulu mereduksi halaman 2 menjadi nol baris.

Mutation-proven: mengganti sumber cursor menjadi `new Date(row.created_at)` memerahkan **3 dari 5** test, lalu hijau lagi setelah dipulihkan.

## Koreksi catatan lama

Perubahan ini berangkat dari asumsi bahwa `_shared/keyset-pagination.ts` "masih kehilangan baris di 3 endpoint". **Itu tidak berlaku lagi**: helper sudah membawa presisi penuh sebagai teks, dan seluruh 11 call site diaudit dalam PR ini — dua yang tidak memakai `KEYSET_CURSOR_CREATED_AT_SQL` (`visitor-analytics/session-directory`, `business-scope/conflicts`) ternyata memakai kolom presisi-penuh mereka sendiri (`last_seen_at_cursor`, `occurredAtCursor`) dan sudah benar.

`BlogPostSummary` mendapat field `createdAt` (aditif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)