### PR TITLE
feat(media-library): endpoint resolusi referensi media batch

### DIFF
--- a/.changeset/media-object-resolve-endpoint.md
+++ b/.changeset/media-object-resolve-endpoint.md
@@ -1,0 +1,41 @@
+---
+"awcms": minor
+---
+
+`GET /api/v1/media/objects` — resolusi referensi media batch, sehingga artikel
+terbit tidak lagi kehilangan gambarnya di konsumen luar.
+
+`awcms_blog_posts` membawa `featured_media_id` dan `seo_image_media_id`, tetapi
+`media_library` **tidak mengekspos satu pun endpoint baca** — hanya upload
+session dan flag enforcement. Konsumen di luar proses karena itu bisa melihat
+bahwa sebuah post PUNYA gambar tanpa cara apa pun mengetahui URL-nya. Itulah
+sebab `article-images.ts` di `awcms-astro` mengembalikan `src: undefined` dan
+setiap artikel terbit tanpa gambarnya, sementara tidak ada satu pun yang gagal.
+
+Logika resolusinya bukan hal baru: `MediaLibraryPort.resolveMediaReferences`
+sudah melakukannya untuk konsumen in-process sejak ADR-0036. Ini panggilan yang
+sama lewat HTTP, dengan aturan keamanan yang sama — hanya objek `verified` /
+`attached`, satu tenant, tidak soft-deleted, yang resolve. Tanpa migrasi:
+permission `media_library.media.read` sudah diseed sejak `sql/052` sambil
+menunggu permukaannya (ADR-0026 langkah 5d).
+
+Dua keputusan bentuk yang tidak sepele:
+
+- **Batch, bukan satu-per-id.** Build feed me-resolve seluruh gambar satu halaman
+  sekaligus; satu request per id membuat situs 200 post jadi ribuan round-trip,
+  sementara query di bawahnya memang sudah satu `id = ANY(...)`.
+- **Id yang gagal DILAPORKAN, bukan dibuang.** Mengembalikan hanya yang berhasil
+  membuat "resource ini tidak punya gambar" dan "referensi gambarnya rusak"
+  menjadi respons yang sama — ambiguitas yang membuat celah ini bertahan tanpa
+  disadari. Semua sebab kegagalan dilebur ke satu ember (`unresolved`) supaya
+  endpoint-nya tidak jadi oracle atas sebab mana; id yang bukan uuid ditolak 400
+  karena "Anda mengirim sampah" adalah fakta yang berbeda.
+
+Read-only, jadi kredensial mesin (ADR-0049) boleh memegangnya — inilah yang
+melengkapi build feed.
+
+Diverifikasi terhadap PostgreSQL nyata (7 test): objek belum-terverifikasi,
+soft-deleted, dan milik tenant lain masing-masing TIDAK PERNAH resolve; batch
+campuran resolve sebagian alih-alih gagal utuh; dan objek yang sama tetap
+resolve dari tenant pemiliknya (memastikan kegagalan lintas-tenant itu memang
+tenant scoping, bukan baris rusak).

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -4292,6 +4292,33 @@ Gated by media_library.media.verify. High-risk, requires Idempotency-Key. Verifi
 | 422    | Uploaded object failed content verification (`UPLOAD_VERIFICATION_FAILED`). `error.details.reason` is one of `object_not_found`, `size_exceeded`, `mime_not_recognized`, `mime_not_allowed`, `mime_mismatch`, `checksum_mismatch`. | [`ApiError`](#standard-error-envelope) |
 | 502    | Unable to verify the uploaded object right now (R2 provider error/circuit breaker open) — retry shortly.                                                                                                                           | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/media/objects` — Batch-resolve media object ids to their public reference.
+
+- **operationId**: `mediaResolveObjects`
+- **Security**: bearerAuth + tenantHeader
+
+Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+
+An object resolves ONLY when it is `verified` or `attached`, belongs to the calling tenant, and is not soft-deleted. Everything else — unknown, cross-tenant, unverified, deleted — is returned in `unresolved` rather than dropped, so a caller can tell "this resource has no image" from "this resource's image reference is broken". A malformed (non-uuid) id is a 400 instead: "you sent junk" and "that object is not referenceable" are different facts.
+
+Batch rather than one-per-id because a build feed resolves every image on a page at once, and the underlying query is already a single `id = ANY(...)`.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description                                      |
+| ------------------ | ------ | -------- | ------ | ------------------------------------------------ |
+| `ids`              | query  | yes      | string | Comma-separated media object uuids, at most 100. |
+| `X-Correlation-ID` | header | no       | string |                                                  |
+
+**Responses**
+
+| Status | Description                                             | Schema                                 |
+| ------ | ------------------------------------------------------- | -------------------------------------- |
+| 200    | Resolved references, plus the ids that did not resolve. | object                                 |
+| 400    | Validation error.                                       | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                             | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                             | [`ApiError`](#standard-error-envelope) |
+
 ## Blog Content
 
 Tenant-scoped blog/content administration (blog_content module, ported from awcms-mini) — posts and pages with their full lifecycle (draft → review → scheduled/published → archived, soft delete/restore/purge), hierarchical categories/tags, append-only revision history (restore APPENDS a revision, never overwrites), PostgreSQL full-text search, presentation/monetization extensions (templates, hierarchical menus, position-based widgets, advertisements), per-tenant blog settings, internal tag-link policy, and the editorial content-quality checklist. The public, anonymous reader surface (`/blog/{tenantCode}/...` index/detail/archive/search/feed/sitemap, ADR-0009) is served by Astro text/html/xml routes and is deliberately NOT part of this REST contract. Publish/unpublish/purge and settings writes are ABAC-gated, idempotency-keyed, and audited.

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -597,6 +597,11 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/media/objects/index.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/modules/[moduleKey].ts",
       "workClass": "interactive",
       "source": "default"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -8045,6 +8045,57 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/media/objects:
+    get:
+      operationId: mediaResolveObjects
+      tags:
+        - News Media
+      summary: Batch-resolve media object ids to their public reference.
+      description: |
+        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+
+        An object resolves ONLY when it is `verified` or `attached`, belongs to the calling tenant, and is not soft-deleted. Everything else — unknown, cross-tenant, unverified, deleted — is returned in `unresolved` rather than dropped, so a caller can tell "this resource has no image" from "this resource's image reference is broken". A malformed (non-uuid) id is a 400 instead: "you sent junk" and "that object is not referenceable" are different facts.
+
+        Batch rather than one-per-id because a build feed resolves every image on a page at once, and the underlying query is already a single `id = ANY(...)`.
+      parameters:
+        - name: ids
+          in: query
+          required: true
+          description: Comma-separated media object uuids, at most 100.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Resolved references, plus the ids that did not resolve.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ResolvedMediaReference"
+                      unresolved:
+                        type: array
+                        description: Ids that are unknown, cross-tenant, unverified, or soft-deleted — one bucket on purpose, so the response is not an oracle over which.
+                        items:
+                          type: string
+                          format: uuid
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/modules:
     get:
       operationId: listModuleCatalog
@@ -17288,6 +17339,29 @@ components:
         requestedAt:
           type: string
           format: date-time
+    ResolvedMediaReference:
+      type: object
+      description: A media object safe to reference publicly (verified/attached, same tenant, not deleted).
+      properties:
+        id:
+          type: string
+          format: uuid
+        publicUrl:
+          type: string
+        altText:
+          type: string
+          nullable: true
+        mimeType:
+          type: string
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+        sizeBytes:
+          type: integer
+          nullable: true
     RetentionPurgeResult:
       type: object
       properties:

--- a/openapi/modules/media-library.openapi.yaml
+++ b/openapi/modules/media-library.openapi.yaml
@@ -167,6 +167,56 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/media/objects:
+    get:
+      operationId: mediaResolveObjects
+      tags:
+        - News Media
+      summary: Batch-resolve media object ids to their public reference.
+      description: |
+        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+
+        An object resolves ONLY when it is `verified` or `attached`, belongs to the calling tenant, and is not soft-deleted. Everything else — unknown, cross-tenant, unverified, deleted — is returned in `unresolved` rather than dropped, so a caller can tell "this resource has no image" from "this resource's image reference is broken". A malformed (non-uuid) id is a 400 instead: "you sent junk" and "that object is not referenceable" are different facts.
+
+        Batch rather than one-per-id because a build feed resolves every image on a page at once, and the underlying query is already a single `id = ANY(...)`.
+      parameters:
+        - name: ids
+          in: query
+          required: true
+          description: Comma-separated media object uuids, at most 100.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Resolved references, plus the ids that did not resolve.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ResolvedMediaReference"
+                      unresolved:
+                        type: array
+                        description: Ids that are unknown, cross-tenant, unverified, or soft-deleted — one bucket on purpose, so the response is not an oracle over which.
+                        items:
+                          type: string
+                          format: uuid
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/media/enforcement:
     get:
       tags:
@@ -235,6 +285,29 @@ paths:
                 $ref: "#/components/schemas/ApiError"
 components:
   schemas:
+    ResolvedMediaReference:
+      type: object
+      description: A media object safe to reference publicly (verified/attached, same tenant, not deleted).
+      properties:
+        id:
+          type: string
+          format: uuid
+        publicUrl:
+          type: string
+        altText:
+          type: string
+          nullable: true
+        mimeType:
+          type: string
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+        sizeBytes:
+          type: integer
+          nullable: true
     CreateNewsMediaUploadSessionRequest:
       type: object
       required:

--- a/src/modules/media-library/README.md
+++ b/src/modules/media-library/README.md
@@ -91,3 +91,30 @@ Media lifecycle/browser surface (`/api/v1/media/objects/*`, `/admin/media` —
 micro step 5d), responsive `srcset` render (step 5b), and the PDF media type
 (step 5c). The allowed MIME set stays the four raster types and the module
 declares no `navigation` yet.
+
+## Resolusi referensi media (`GET /api/v1/media/objects`)
+
+Registry ini sebelumnya **tidak punya permukaan baca sama sekali** — hanya
+upload session dan flag enforcement. Akibatnya konsumen di luar proses bisa
+melihat bahwa sebuah post PUNYA gambar (`featured_media_id`,
+`seo_image_media_id`) tanpa cara apa pun mengetahui URL-nya; `article-images.ts`
+di `awcms-astro` mengembalikan `src: undefined` justru karena itu, dan setiap
+artikel terbit tanpa gambarnya sementara tak ada yang gagal.
+
+`GET /api/v1/media/objects?ids=<uuid>,<uuid>` me-resolve maksimal 100 id sekali
+jalan (gerbang `media_library.media.read` — permission yang sudah diseed sejak
+`sql/052` sambil menunggu permukaannya, ADR-0026 langkah 5d). Logikanya BUKAN
+baru: `MediaLibraryPort.resolveMediaReferences` sudah melakukan hal yang sama
+untuk konsumen in-process. Ini panggilan yang sama, lewat HTTP, dengan aturan
+keamanan yang sama — hanya objek `verified`/`attached`, satu tenant, tidak
+soft-deleted, yang resolve.
+
+Id yang tidak resolve **dilaporkan** di `unresolved`, tidak dibuang: mengembalikan
+hanya yang berhasil membuat "resource ini tidak punya gambar" dan "referensi
+gambarnya rusak" jadi respons yang sama — ambiguitas yang membuat celah gambar
+hilang ini bertahan tanpa disadari. Id yang bukan uuid ditolak 400, karena
+"Anda mengirim sampah" dan "objek itu tak boleh dirujuk" adalah dua fakta
+berbeda.
+
+Read-only, jadi kredensial mesin ([ADR-0049](../../../docs/adr/0049-machine-credentials-and-session-introspection.md))
+boleh memegangnya.

--- a/src/pages/api/v1/media/objects/index.ts
+++ b/src/pages/api/v1/media/objects/index.ts
@@ -1,0 +1,115 @@
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import {
+  MEDIA_PERMISSION_ACTIVITY_CODE,
+  MEDIA_PERMISSIONS
+} from "../../../../../modules/media-library/domain/media-permissions";
+import { mediaLibraryPortAdapter } from "../../../../../modules/media-library/application/media-library-port-adapter";
+
+/**
+ * `GET /api/v1/media/objects?ids=<uuid>,<uuid>` — batch-resolve media object ids
+ * to their public reference (URL + alt text + intrinsic metadata).
+ *
+ * ## Why this endpoint had to exist
+ *
+ * `awcms_blog_posts` carries `featured_media_id` and `seo_image_media_id`, but
+ * `media_library` exposed no read surface at all — only upload sessions and the
+ * enforcement flag. So an external consumer could see that a post HAS an image
+ * and had no way to learn its URL. `awcms-astro`'s `article-images.ts` returns
+ * `src: undefined` for exactly this reason, and every article it publishes goes
+ * out without its image while nothing anywhere fails.
+ *
+ * The resolution logic itself is NOT new: `MediaLibraryPort.resolveMediaReferences`
+ * has always done this for in-process consumers. This is the same call, reached
+ * over HTTP, with the same safety rule — only `verified`/`attached`, same-tenant,
+ * non-deleted objects resolve.
+ *
+ * ## Batch, not one-per-id
+ *
+ * A build feed resolves every image on a page at once. One request per id would
+ * turn a 200-post site into a thousand round trips, and the port is already
+ * batch-shaped (`id = ANY(...)`, one query).
+ *
+ * ## Unresolved ids are REPORTED, not dropped
+ *
+ * An id that is unknown, cross-tenant, soft-deleted, or not yet verified comes
+ * back in `unresolved`. Returning only what resolved would make "this post has
+ * no image" and "this post's image is broken" the same response — the exact
+ * ambiguity that let the missing-images gap sit unnoticed. It leaks nothing: the
+ * caller supplied the ids, and every failure reason collapses into one bucket.
+ *
+ * Gated on `media_library.media.read`, a permission declared and seeded since
+ * `sql/052` while waiting for its surface (ADR-0026 step 5d). Read-only, so a
+ * machine credential (ADR-0049) may hold it.
+ */
+const MAX_IDS = 100;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "media_library",
+    activityCode: MEDIA_PERMISSION_ACTIVITY_CODE,
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, url }) => {
+    const idsParam = url.searchParams.get("ids");
+
+    if (!idsParam) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "ids is required — a comma-separated list of media object uuids."
+      );
+    }
+
+    const ids = idsParam
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+
+    if (ids.length === 0) {
+      return fail(400, "VALIDATION_ERROR", "ids must contain at least one id.");
+    }
+
+    if (ids.length > MAX_IDS) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        `ids accepts at most ${MAX_IDS} values per request.`
+      );
+    }
+
+    // A malformed id is refused rather than reported as merely "unresolved":
+    // "you sent junk" and "that object is not referenceable" are different
+    // facts, and collapsing them hides a caller-side bug behind a normal-looking
+    // response.
+    const malformed = ids.filter((id) => !UUID_PATTERN.test(id));
+
+    if (malformed.length > 0) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "ids must all be uuids.",
+        {},
+        { malformed }
+      );
+    }
+
+    const unique = [...new Set(ids)];
+    const resolved = await mediaLibraryPortAdapter.resolveMediaReferences(
+      tx,
+      tenantId,
+      unique
+    );
+
+    return ok({
+      items: unique
+        .filter((id) => resolved.has(id))
+        .map((id) => ({ id, ...resolved.get(id)! })),
+      unresolved: unique.filter((id) => !resolved.has(id))
+    });
+  }
+});

--- a/tests/integration/media-object-resolve.integration.test.ts
+++ b/tests/integration/media-object-resolve.integration.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Batch media resolution (`GET /api/v1/media/objects`) against a real
+ * PostgreSQL — driven through the port adapter the route calls, so the safety
+ * rule under test is the same one the endpoint enforces.
+ *
+ * The rule that matters: an object resolves ONLY when it is verified/attached,
+ * same-tenant, and not soft-deleted. Everything else lands in `unresolved`,
+ * never in `items` — a media URL is a public reference, and handing one out for
+ * an unverified upload publishes whatever a caller managed to put in the bucket.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { mediaLibraryPortAdapter } from "../../src/modules/media-library/application/media-library-port-adapter";
+
+const TENANT_A = "a2222222-2222-4222-8222-222222222222";
+const TENANT_B = "b2222222-2222-4222-8222-222222222222";
+const AUTHOR_A = "a2000000-0000-4000-8000-000000000001";
+const AUTHOR_B = "b2000000-0000-4000-8000-000000000001";
+
+type Seeded = Record<string, string>;
+let ids: Seeded = {};
+
+async function seedTenant(
+  tenantId: string,
+  code: string,
+  userId: string
+): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${tenantId}, ${code}, ${code})
+  `;
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${tenantId}, 'person', 'Uploader')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${tenantId}, ${profile[0]!.id}, ${`${code}@example.test`}, 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${userId}, ${tenantId}, ${identity[0]!.id})
+  `;
+}
+
+/**
+ * `module_key = 'news_portal'` and `storage_driver = 'cloudflare_r2'` are CHECK
+ * constraints on the table (`sql/041`), never relaxed since. ADR-0036 moved the
+ * registry's OWNERSHIP to `media_library` and ADR-0044 folded `news_portal`
+ * into `blog_content`, but both deliberately kept the physical names — so these
+ * literals are what a real row still carries, not leftovers in the fixture.
+ */
+async function seedMedia(
+  tenantId: string,
+  userId: string,
+  label: string,
+  status: string,
+  options: { deleted?: boolean } = {}
+): Promise<string> {
+  // `object_key` is CHECK-constrained to `news-media/<tenant_id>/YYYY/MM/<uuid>.<ext>`,
+  // verified per-row against the row's OWN tenant_id — so a fixture cannot use a
+  // convenient short key, and a cross-tenant key is rejected by the database
+  // rather than by application code.
+  const objectKey = `news-media/${tenantId}/2026/08/${crypto.randomUUID()}.png`;
+
+  // `status='attached'` REQUIRES both owner columns and anything else requires
+  // them null (`owner_consistency_check`), so the fixture cannot flip status
+  // alone — the database will not hold a half-attached row.
+  const attached = status === "attached";
+
+  const rows = (await getAdminSql()`
+    INSERT INTO awcms_news_media_objects
+      (tenant_id, module_key, storage_driver, bucket_name, object_key,
+       public_url, mime_type, alt_text, status, owner_resource_type,
+       owner_resource_id, created_by_tenant_user_id, deleted_at)
+    VALUES (
+      ${tenantId}, 'news_portal', 'cloudflare_r2', 'bucket', ${objectKey},
+      ${`https://cdn.example.test/${label}.png`}, 'image/png', ${`alt ${label}`},
+      ${status}, ${attached ? "blog_post" : null},
+      ${attached ? crypto.randomUUID() : null},
+      ${userId}, ${options.deleted ? new Date() : null}
+    )
+    RETURNING id
+  `) as { id: string }[];
+
+  return rows[0]!.id;
+}
+
+async function resolve(
+  tenantId: string,
+  requested: string[]
+): Promise<{ items: string[]; unresolved: string[] }> {
+  const resolved = await withTenantOrThrow(getRuntimeSql(), tenantId, (tx) =>
+    mediaLibraryPortAdapter.resolveMediaReferences(tx, tenantId, requested)
+  );
+
+  return {
+    items: requested.filter((id) => resolved.has(id)),
+    unresolved: requested.filter((id) => !resolved.has(id))
+  };
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("media object batch resolution", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant(TENANT_A, "media-a", AUTHOR_A);
+    await seedTenant(TENANT_B, "media-b", AUTHOR_B);
+
+    ids = {
+      verified: await seedMedia(TENANT_A, AUTHOR_A, "verified", "verified"),
+      attached: await seedMedia(TENANT_A, AUTHOR_A, "attached", "attached"),
+      pending: await seedMedia(TENANT_A, AUTHOR_A, "pending", "pending_upload"),
+      deletedRow: await seedMedia(TENANT_A, AUTHOR_A, "deleted", "verified", {
+        deleted: true
+      }),
+      otherTenant: await seedMedia(TENANT_B, AUTHOR_B, "other", "verified")
+    };
+  });
+
+  test("verified and attached objects resolve with their public reference", async () => {
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+      mediaLibraryPortAdapter.resolveMediaReferences(tx, TENANT_A, [
+        ids.verified!,
+        ids.attached!
+      ])
+    );
+
+    expect(result.size).toBe(2);
+    expect(result.get(ids.verified!)?.publicUrl).toBe(
+      "https://cdn.example.test/verified.png"
+    );
+    expect(result.get(ids.verified!)?.altText).toBe("alt verified");
+    expect(result.get(ids.attached!)?.mimeType).toBe("image/png");
+  });
+
+  // Each of these would publish a URL that must not be public. They are the
+  // reason the endpoint cannot simply be "SELECT public_url WHERE id = ANY".
+  test.each([
+    ["an unverified upload", "pending"],
+    ["a soft-deleted object", "deletedRow"],
+    ["another tenant's object", "otherTenant"]
+  ])("%s never resolves", async (_label, key) => {
+    const result = await resolve(TENANT_A, [ids[key]!]);
+
+    expect(result.items).toEqual([]);
+    expect(result.unresolved).toEqual([ids[key]!]);
+  });
+
+  test("an unknown id is unresolved, not an error", async () => {
+    const unknown = "00000000-0000-4000-8000-000000000000";
+    const result = await resolve(TENANT_A, [ids.verified!, unknown]);
+
+    expect(result.items).toEqual([ids.verified!]);
+    expect(result.unresolved).toEqual([unknown]);
+  });
+
+  test("a mixed batch resolves partially rather than failing whole", async () => {
+    const result = await resolve(TENANT_A, [
+      ids.verified!,
+      ids.pending!,
+      ids.otherTenant!,
+      ids.attached!
+    ]);
+
+    expect(result.items).toEqual([ids.verified!, ids.attached!]);
+    expect(result.unresolved).toEqual([ids.pending!, ids.otherTenant!]);
+  });
+
+  test("the same object is resolvable from its OWN tenant", async () => {
+    // Pins that the cross-tenant miss above is tenant scoping, not a broken row.
+    const result = await resolve(TENANT_B, [ids.otherTenant!]);
+
+    expect(result.items).toEqual([ids.otherTenant!]);
+  });
+});


### PR DESCRIPTION
## Celah yang ditutup

`awcms_blog_posts` membawa `featured_media_id` dan `seo_image_media_id`, tetapi `media_library` **tidak mengekspos satu pun endpoint baca** — OpenAPI-nya hanya upload session dan flag enforcement.

Konsumen di luar proses karena itu bisa melihat bahwa sebuah post PUNYA gambar dan tidak punya cara apa pun mengetahui URL-nya. Itulah sebab `src/lib/article-images.ts` di `awcms-astro` mengembalikan `src: undefined` dan setiap pemanggilnya merender blok bertoken: **setiap artikel terbit tanpa gambarnya, dan tidak ada satu pun yang gagal.**

## Ini bukan logika baru

`MediaLibraryPort.resolveMediaReferences` sudah melakukan persis ini untuk konsumen in-process sejak ADR-0036 — satu query `id = ANY(...)`, memfilter ke objek yang aman dirujuk publik. PR ini mengekspos panggilan yang **sama** lewat HTTP dengan aturan keamanan yang **sama**: hanya `verified`/`attached`, satu tenant, tidak soft-deleted.

**Tanpa migrasi.** `media_library.media.read` sudah diseed sejak `sql/052`, dideklarasikan lebih dulu sambil menunggu permukaannya (ADR-0026 langkah 5d) — jadi ini mengisi permission yang sudah ada, bukan menambah yang baru.

## Dua keputusan bentuk

**Batch, bukan satu-per-id.** Build feed me-resolve seluruh gambar satu halaman sekaligus; satu request per id membuat situs 200 post menjadi ribuan round-trip, sementara query di bawahnya memang sudah batch.

**Id yang gagal DILAPORKAN, tidak dibuang.** Mengembalikan hanya yang berhasil membuat *"resource ini tidak punya gambar"* dan *"referensi gambarnya rusak"* menjadi respons yang identik — ambiguitas itulah yang membuat celah gambar-hilang ini bertahan tanpa disadari. Semua sebab kegagalan (tak dikenal / lintas-tenant / belum terverifikasi / terhapus) dilebur ke satu ember `unresolved` supaya endpoint-nya tidak menjadi oracle atas sebab mana; id yang bukan uuid ditolak **400**, karena "Anda mengirim sampah" adalah fakta yang berbeda dari "objek itu tak boleh dirujuk".

Read-only, jadi kredensial mesin (ADR-0049) boleh memegangnya — ini potongan terakhir yang membuat build feed lengkap.

## Verifikasi

7 test integrasi terhadap PostgreSQL nyata. Yang diuji adalah aturan keamanannya, bukan happy path: objek **belum terverifikasi**, **soft-deleted**, dan **milik tenant lain** masing-masing tidak pernah resolve; batch campuran resolve sebagian alih-alih gagal utuh; dan objek yang sama **tetap** resolve dari tenant pemiliknya — memastikan kegagalan lintas-tenant itu benar tenant scoping, bukan baris rusak.

Fixture-nya sendiri mengajarkan sesuatu: tabel ini menolak tiga bentuk baris yang "masuk akal" — `module_key` harus tetap `news_portal` dan `storage_driver` `cloudflare_r2` (ADR-0036/0044 memindahkan kepemilikan, bukan nama fisik), `object_key` diverifikasi per-baris terhadap `tenant_id` baris itu sendiri, dan `status='attached'` mewajibkan kedua kolom owner. Ketiganya ditegakkan database, bukan kode aplikasi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)