### PR TITLE
fix(identity-access): deaktivasi tenant user mencabut sesinya seketika

### DIFF
--- a/.changeset/revoke-sessions-on-deactivate.md
+++ b/.changeset/revoke-sessions-on-deactivate.md
@@ -1,0 +1,28 @@
+---
+"awcms": patch
+---
+
+Menonaktifkan tenant user kini benar-benar mengakhiri aksesnya — seketika,
+bukan "paling lama satu masa berlaku sesi".
+
+`setTenantUserStatus` menulis `status = 'inactive'` dan komentar dokumennya
+sendiri menyatakan itu "revokes all of a user's access". Rantai guard tidak
+pernah membaca kolom itu: `resolveTenantContext` mencari sesi dan BARIS tenant
+user, bukan statusnya. Jadi pengguna yang baru dinonaktifkan tetap bekerja
+normal sampai sesinya kebetulan kedaluwarsa — dan satu-satunya cara
+menyadarinya adalah mencoba.
+
+Deaktivasi kini mencabut setiap sesi hidup identitas itu, **di dalam transaksi
+yang sama** dengan penulisan status: deaktivasi yang ter-commit sementara
+pencabutannya gagal akan meninggalkan sesi hidup persis untuk akun yang baru
+saja diputuskan untuk ditutup.
+
+Kredensial mesin tidak butuh sapuan terpisah — jalur prinsipal mesin (ADR-0049)
+mensyaratkan tenant user AKTIF, jadi keduanya berhenti pada instan yang sama.
+Test membuktikan keduanya bekerja terpisah: menghapus pencabutan sesi
+memerahkan 3 test, sementara test kredensial mesin tetap hijau.
+
+Diverifikasi terhadap PostgreSQL nyata (6 test), termasuk dua yang menjaga arah
+sebaliknya: sesi pengguna lain tidak tersentuh, dan reaktivasi **tidak**
+menghidupkan kembali sesi yang sudah dicabut — urutan deactivate/reactivate
+justru yang dipakai operator saat mencurigai sebuah sesi.

--- a/src/modules/identity-access/application/user-admin.ts
+++ b/src/modules/identity-access/application/user-admin.ts
@@ -19,6 +19,7 @@
  * row references the stable `tenant_user_id`, not the identifier.
  */
 import { recordAuditEvent } from "../../logging/application/audit-log";
+import { revokeAllSessionsForIdentity } from "./session-revocation";
 
 const AUDIT_MODULE_KEY = "identity_access";
 const POSTGRES_UNIQUE_VIOLATION = "23505";
@@ -135,6 +136,7 @@ export type TenantUserStatusRecord = {
 
 type TenantUserStatusRow = {
   id: string;
+  identity_id: string;
   status: string;
   updated_at: Date;
 };
@@ -152,8 +154,18 @@ export type SetStatusResult =
 /**
  * Sets a tenant user's status.
  *
- * Deactivation (`status = 'inactive'`) revokes all of a user's access (login
- * reads this status), so two lockout foot-guns are blocked BEFORE the write —
+ * Deactivation (`status = 'inactive'`) blocks LOGIN, and — since this change —
+ * also revokes every session the user already holds. Those are two different
+ * things, and the gap between them was real: `resolveTenantContext` never reads
+ * `status`, so before this a deactivated user kept working normally until their
+ * session happened to expire. "Revoke this person's access" has to mean now,
+ * not "in up to a session lifetime".
+ *
+ * Machine credentials bound to the user need no separate sweep: the machine
+ * principal path (`resolveTenantContextForTenantUser`, ADR-0049) requires an
+ * ACTIVE tenant user, so they stop resolving at the same instant.
+ *
+ * Two lockout foot-guns are blocked BEFORE the write —
  * mirroring `softDeleteRole`'s `is_system` guard:
  *  - `self_blocked` — an actor cannot deactivate themselves.
  *  - `last_admin_blocked` — the last active member of an `is_system` (owner)
@@ -214,10 +226,22 @@ export async function setTenantUserStatus(
     UPDATE awcms_tenant_users
     SET status = ${status}, updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${tenantUserId}
-    RETURNING id, status, updated_at
+    RETURNING id, identity_id, status, updated_at
   `) as TenantUserStatusRow[];
 
   if (rows.length === 0) return { outcome: "not_found" };
+
+  if (status === "inactive") {
+    // Inside the same transaction as the status write: a deactivation that
+    // committed while the revocation failed would leave a live session behind
+    // for exactly the account someone just decided to shut out.
+    await revokeAllSessionsForIdentity(
+      tx,
+      tenantId,
+      rows[0]!.identity_id,
+      new Date()
+    );
+  }
 
   const record: TenantUserStatusRecord = {
     id: rows[0]!.id,

--- a/tests/integration/deactivation-revokes-sessions.integration.test.ts
+++ b/tests/integration/deactivation-revokes-sessions.integration.test.ts
@@ -1,0 +1,274 @@
+/**
+ * Deactivating a tenant user must end their access NOW, not "in up to a session
+ * lifetime" (against a real PostgreSQL).
+ *
+ * The gap this pins was real and invisible: `setTenantUserStatus` wrote
+ * `status = 'inactive'` and its own doc comment claimed that "revokes all of a
+ * user's access", but the guard chain never reads that column —
+ * `resolveTenantContext` looks up a session and a tenant-user ROW, not its
+ * status. So a deactivated user kept working normally until their session
+ * happened to expire, and the only way to notice was to try.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { hashSessionToken } from "../../src/lib/auth/session-token";
+import { authorizeInTransaction } from "../../src/modules/identity-access/application/access-guard";
+import { setTenantUserStatus } from "../../src/modules/identity-access/application/user-admin";
+import { issueMachineCredential } from "../../src/modules/identity-access/application/machine-credential-directory";
+import { resetPolicyCache } from "../../src/modules/identity-access/application/policy-cache";
+
+const TENANT = "c3333333-3333-4333-8333-333333333333";
+const ADMIN_USER = "c3000000-0000-4000-8000-000000000001";
+const TARGET_USER = "c3000000-0000-4000-8000-000000000002";
+const ADMIN_ROLE = "c3000000-0000-4000-8000-0000000000a1";
+const TARGET_ROLE = "c3000000-0000-4000-8000-0000000000a2";
+
+const TARGET_SESSION = "target-session-token";
+
+const GUARD = {
+  moduleKey: "blog_content",
+  activityCode: "posts",
+  action: "read"
+} as const;
+
+let targetIdentity = "";
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'deact-tenant', 'Deactivation Tenant')
+  `;
+
+  for (const user of [
+    { id: ADMIN_USER, label: "admin" },
+    { id: TARGET_USER, label: "target" }
+  ]) {
+    const profile = (await admin`
+      INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+      VALUES (${TENANT}, 'person', ${`Display ${user.label}`})
+      RETURNING id
+    `) as { id: string }[];
+    const identity = (await admin`
+      INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${TENANT}, ${profile[0]!.id}, ${`${user.label}@example.test`}, 'x')
+      RETURNING id
+    `) as { id: string }[];
+    await admin`
+      INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+      VALUES (${user.id}, ${TENANT}, ${identity[0]!.id})
+    `;
+
+    if (user.id === TARGET_USER) targetIdentity = identity[0]!.id;
+  }
+
+  // The admin holds the system role so the last-admin guard never fires on the
+  // target; the target holds an ordinary role carrying the read permission.
+  await admin`
+    INSERT INTO awcms_roles (id, tenant_id, role_code, role_name, is_system)
+    VALUES (${ADMIN_ROLE}, ${TENANT}, 'owner', 'Owner', true),
+           (${TARGET_ROLE}, ${TENANT}, 'editor', 'Editor', false)
+  `;
+
+  const permission = (await admin`
+    SELECT id FROM awcms_permissions
+    WHERE module_key = 'blog_content' AND activity_code = 'posts' AND action = 'read'
+  `) as { id: string }[];
+
+  await admin`
+    INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+    VALUES (${TENANT}, ${TARGET_ROLE}, ${permission[0]!.id})
+  `;
+
+  await admin`
+    INSERT INTO awcms_access_assignments (tenant_id, tenant_user_id, role_id, assigned_by)
+    VALUES (${TENANT}, ${ADMIN_USER}, ${ADMIN_ROLE}, ${ADMIN_USER}),
+           (${TENANT}, ${TARGET_USER}, ${TARGET_ROLE}, ${ADMIN_USER})
+  `;
+
+  await admin`
+    INSERT INTO awcms_sessions (tenant_id, identity_id, token_hash, expires_at)
+    VALUES (${TENANT}, ${targetIdentity}, ${hashSessionToken(TARGET_SESSION)}, now() + interval '8 hours')
+  `;
+}
+
+async function authorizeAs(token: string): Promise<boolean> {
+  const result = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+    authorizeInTransaction(
+      tx,
+      TENANT,
+      hashSessionToken(token),
+      new Date(),
+      GUARD
+    )
+  );
+
+  return result.allowed;
+}
+
+async function deactivateTarget(): Promise<string> {
+  const result = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+    setTenantUserStatus(tx, TENANT, ADMIN_USER, TARGET_USER, "inactive")
+  );
+
+  return result.outcome;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("deactivation revokes live access", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    resetPolicyCache();
+    await seedFixtures();
+  });
+
+  test("a live session stops working the moment the user is deactivated", async () => {
+    expect(await authorizeAs(TARGET_SESSION)).toBe(true);
+
+    expect(await deactivateTarget()).toBe("updated");
+
+    expect(await authorizeAs(TARGET_SESSION)).toBe(false);
+  });
+
+  test("the session row is actually revoked, not merely refused", async () => {
+    await deactivateTarget();
+
+    const rows = (await getAdminSql()`
+      SELECT revoked_at FROM awcms_sessions
+      WHERE tenant_id = ${TENANT} AND identity_id = ${targetIdentity}
+    `) as { revoked_at: Date | null }[];
+
+    // Refusing at the guard would be enough for THIS test to pass while leaving
+    // a live row behind for any other reader of the table; the revocation has
+    // to be a fact in the data.
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.revoked_at).not.toBeNull();
+  });
+
+  test("machine credentials of the deactivated user stop resolving too", async () => {
+    const issued = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      issueMachineCredential(
+        tx,
+        TENANT,
+        ADMIN_USER,
+        {
+          name: "target feed",
+          tenantUserId: TARGET_USER,
+          allowedPermissionKeys: ["blog_content.posts.read"],
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000)
+        },
+        new Date()
+      )
+    );
+
+    if (issued.outcome !== "issued") throw new Error("issuance failed");
+
+    expect(await authorizeAs(issued.token)).toBe(true);
+
+    await deactivateTarget();
+
+    expect(await authorizeAs(issued.token)).toBe(false);
+  });
+
+  test("reactivating does NOT resurrect the revoked session", async () => {
+    await deactivateTarget();
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      setTenantUserStatus(tx, TENANT, ADMIN_USER, TARGET_USER, "active")
+    );
+
+    // The user may sign in again; the token that was live at deactivation must
+    // stay dead. Anything else would mean a compromised session survives a
+    // deactivate/reactivate cycle, which is exactly the sequence an operator
+    // reaches for when they suspect one.
+    expect(await authorizeAs(TARGET_SESSION)).toBe(false);
+  });
+
+  test("an unrelated user's session is untouched", async () => {
+    const adminSession = "admin-session-token";
+    await getAdminSql()`
+      INSERT INTO awcms_sessions (tenant_id, identity_id, token_hash, expires_at)
+      SELECT ${TENANT}, identity_id, ${hashSessionToken(adminSession)}, now() + interval '8 hours'
+      FROM awcms_tenant_users WHERE id = ${ADMIN_USER}
+    `;
+
+    await deactivateTarget();
+
+    const rows = (await getAdminSql()`
+      SELECT revoked_at FROM awcms_sessions
+      WHERE tenant_id = ${TENANT} AND token_hash = ${hashSessionToken(adminSession)}
+    `) as { revoked_at: Date | null }[];
+
+    expect(rows[0]?.revoked_at).toBeNull();
+  });
+
+  test("a machine credential for a DIFFERENT user keeps working", async () => {
+    const issued = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      issueMachineCredential(
+        tx,
+        TENANT,
+        ADMIN_USER,
+        {
+          name: "admin feed",
+          tenantUserId: ADMIN_USER,
+          allowedPermissionKeys: ["blog_content.posts.read"],
+          expiresAt: new Date(Date.now() + 60 * 60 * 1000)
+        },
+        new Date()
+      )
+    );
+
+    if (issued.outcome !== "issued") throw new Error("issuance failed");
+
+    await deactivateTarget();
+
+    // Sanity that the sweep is scoped to the deactivated identity — a
+    // revocation that took out everything would also pass every test above.
+    const stillWorks = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      authorizeInTransaction(
+        tx,
+        TENANT,
+        hashSessionToken(issued.token),
+        new Date(),
+        {
+          moduleKey: "identity_access",
+          activityCode: "access_control",
+          action: "read"
+        }
+      )
+    );
+
+    // The admin's credential is narrowed to blog read, so access_control is
+    // denied — but with 403 (authenticated, not permitted), never 401.
+    expect(stillWorks.allowed).toBe(false);
+    if (!stillWorks.allowed) expect(stillWorks.denied.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Celahnya, dan kenapa tak terlihat

`setTenantUserStatus` menulis `status = 'inactive'`, dan komentar dokumennya sendiri menyatakan bahwa itu **"revokes all of a user's access (login reads this status)"**.

Bagian dalam kurung itu benar, kalimat utamanya tidak. Rantai guard tidak pernah membaca kolom itu: `resolveTenantContext` mencari sebuah sesi dan **baris** tenant user, bukan statusnya. Jadi pengguna yang baru dinonaktifkan tetap membaca, menulis, dan bertindak seperti biasa sampai sesinya kebetulan kedaluwarsa — hingga delapan jam kemudian.

Tidak ada yang gagal, tidak ada yang tercatat, dan satu-satunya cara menyadarinya adalah mencoba. Ditemukan saat security review ADR-0049, ketika jalur kredensial mesin harus memutuskan apakah mewarisi kelonggaran yang sama (jawabannya: tidak).

## Perbaikannya

Deaktivasi mencabut setiap sesi hidup identitas itu, **di dalam transaksi yang sama** dengan penulisan status. Bukan detail: deaktivasi yang ter-commit sementara pencabutannya gagal akan meninggalkan sesi hidup persis untuk akun yang baru saja diputuskan untuk ditutup.

Reuse `revokeAllSessionsForIdentity`, helper yang sudah dipakai jalur password reset dengan alasan yang sama — dan yang juga menangani state step-up MFA tanpa menyebutnya (`mfa-session-assurance.ts` memperlakukan baris ber-`revoked_at` sebagai hilang, jadi sesi `aal2` berhenti menjadi `aal2` pada instan yang sama).

**Kredensial mesin tidak butuh sapuan terpisah.** Jalur prinsipal mesin (ADR-0049) mensyaratkan tenant user AKTIF, jadi keduanya berhenti pada instan yang sama lewat mekanisme yang berbeda. Test membuktikan keduanya independen: menghapus pencabutan sesi memerahkan 3 test sementara test kredensial mesin **tetap hijau**.

## Verifikasi

6 test integrasi terhadap PostgreSQL nyata. Dua di antaranya menjaga arah sebaliknya, karena pencabutan yang terlalu luas akan lulus semua test lainnya:

- sesi pengguna **lain** tidak tersentuh;
- kredensial mesin milik pengguna lain tetap terautentikasi (403 karena cakupannya, bukan 401).

Satu lagi menjaga urutan yang justru dipakai operator saat mencurigai sebuah sesi: **reaktivasi tidak menghidupkan kembali** sesi yang sudah dicabut.

Satu test sengaja memeriksa barisnya di database, bukan hanya keputusan guard — menolak di guard saja akan meluluskan test perilaku sambil meninggalkan baris hidup untuk pembaca tabel lain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)