### PR TITLE
feat(site-search): admin operations console at /admin/site-search

### DIFF
--- a/.changeset/site-search-admin-console.md
+++ b/.changeset/site-search-admin-console.md
@@ -1,0 +1,11 @@
+---
+"awcms": minor
+---
+
+Add the `/admin/site-search` operations console and put `site_search` in the admin sidebar.
+
+The module shipped its index/settings/diagnostics API (ADR-0040) without a screen, so the whole surface was reachable only by `curl` and `site_search` was invisible in the sidebar. The console renders index status and freshness, documents by resource type, the ten most recent index runs, and the failed-item diagnostics, and drives reconcile, rebuild, and the search-configuration form.
+
+Reads call the same application functions the JSON endpoints use, inside one `withTenantOrThrow` transaction. Writes go to the guarded `/api/v1/site-search/*` endpoints with a fresh `Idempotency-Key` per click, so a deliberate second run really runs instead of replaying the first run's stored response. Every permission gate on the page is UX-only — the endpoints remain the authority.
+
+`tests/admin-site-search-page-contract.test.ts` pins the page's six permission keys to what the routes enforce and the descriptor declares, so a plausible-but-unseeded key (`settings.configure`, `index.update`) cannot silently hide a panel from everyone including the owner.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -287,7 +287,7 @@
       "capabilitiesProvided": [],
       "capabilitiesConsumed": [],
       "permissionCount": 6,
-      "navigationCount": 0,
+      "navigationCount": 1,
       "jobCount": 1,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -170,6 +170,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_modules": "Modules",
   "admin.layout.nav_sidebar_menu": "Sidebar menu",
   "admin.layout.nav_form_drafts": "Form drafts",
+  "admin.layout.nav_site_search": "Site search",
   "admin.layout.nav_email_templates": "Email templates",
   "admin.layout.nav_audit_trail": "Audit trail",
   "admin.layout.nav_comments": "Moderation queue",

--- a/src/modules/site-search/module.ts
+++ b/src/modules/site-search/module.ts
@@ -51,11 +51,19 @@ export const SITE_SEARCH_INDEX_FAILURES_LIFECYCLE_KEY =
  * `renderSafeSnippet` (XSS impossible); anonymous search has per-IP rate limits,
  * query-length bounds, and result caps.
  *
+ * ## Admin surface
+ *
+ * `navigation` points at `/admin/site-search` — the operations console: index
+ * status/freshness, documents by resource type, recent runs, reconcile/rebuild,
+ * the settings form, and failed-item diagnostics. The entry and the page landed
+ * in the SAME change, which is the invariant
+ * `tests/admin-navigation-registry.test.ts` enforces in both directions (a nav
+ * entry with no page is a permanent 404 in the menu; a page no descriptor claims
+ * is unreachable).
+ *
  * ## Deliberately NOT here yet
  *
- * `navigation` is undeclared: the index/settings/diagnostics ADMIN API exists,
- * not an admin screen — the dashboard UI is a documented follow-up (same posture
- * as `seo_distribution`). `capabilities` is undeclared (the search-source seam is
+ * `capabilities` is undeclared (the search-source seam is
  * the descriptor list, not a capability). `events` stays undeclared: index
  * lifecycle events (`awcms.site-search.*`) are documented log lines, not yet
  * published through `domain_event_runtime`. Indexing blog PAGES (no public route
@@ -79,6 +87,19 @@ export const siteSearchModule = defineModule({
     basePath: "/api/v1/site-search",
     routes: ["/api/v1/site-search", "/search"]
   },
+  // Gated on `index.read` — the permission the console's primary panel (status
+  // + recent runs) actually needs. A viewer holding only `settings.read` or
+  // `diagnostics.read` reaches the page directly; the page renders the panels
+  // they are entitled to. Hiding the link is not a security control (the page
+  // and every endpoint it calls guard themselves).
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_site_search",
+      path: "/admin/site-search",
+      order: 40,
+      requiredPermission: "site_search.index.read"
+    }
+  ],
   permissions: [
     {
       activityCode: SITE_SEARCH_INDEX_ACTIVITY_CODE,

--- a/src/pages/admin/site-search.astro
+++ b/src/pages/admin/site-search.astro
@@ -1,0 +1,674 @@
+---
+/**
+ * Site search operations console — the admin screen for `site_search`
+ * (ADR-0040). The module shipped its index/settings/diagnostics API without a
+ * screen, so the whole surface was reachable only by `curl`; its `module.ts`
+ * recorded that as a documented follow-up. This is that follow-up, and it adds
+ * the module's `navigation` entry in the SAME change — an entry without a page
+ * is a permanent 404 in the menu, which `tests/admin-navigation-registry.test.ts`
+ * enforces in both directions.
+ *
+ * Reads call the SAME application functions the JSON endpoints use
+ * (`fetchIndexStatus`/`fetchRecentRuns`/`fetchIndexFailures`/
+ * `fetchSiteSearchSettings`) inside ONE `withTenantOrThrow` transaction, rather
+ * than fetching this app's own API over HTTP — the established pattern for
+ * every other admin page here.
+ *
+ * Writes go the other way: reconcile / rebuild / settings all POST/PUT to the
+ * guarded `/api/v1/site-search/*` endpoints with a fresh `Idempotency-Key` per
+ * click, because all three are idempotency-keyed and audited server-side.
+ *
+ * Every permission gate below is UX-only — the endpoint's ABAC guard is the
+ * authority. The gates exist so a viewer without a permission gets a clean
+ * notice or a hidden control instead of a table that 403s on use.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  fetchIndexFailures,
+  fetchIndexStatus,
+  fetchRecentRuns,
+  type IndexFailureItem,
+  type IndexRunSummary,
+  type IndexStatus
+} from "../../modules/site-search/application/search-diagnostics";
+import { fetchSiteSearchSettings } from "../../modules/site-search/application/search-settings-directory";
+import {
+  MIN_QUERY_LENGTH_MAX,
+  MIN_QUERY_LENGTH_MIN,
+  RESULT_LIMIT_MAX,
+  RESULT_LIMIT_MIN,
+  SUGGESTION_LIMIT_MAX,
+  SUGGESTION_LIMIT_MIN,
+  type SiteSearchSettings
+} from "../../modules/site-search/domain/search-settings";
+
+const ssr = Astro.locals.ssrContext;
+
+if (!ssr) {
+  throw new Error(
+    "site-search.astro rendered without Astro.locals.ssrContext — the /admin guard in src/middleware.ts must run first."
+  );
+}
+
+const canReadIndex = ssr.permissions.has(
+  permissionKey("site_search", "index", "read")
+);
+const canReconcile = ssr.permissions.has(
+  permissionKey("site_search", "index", "reconcile")
+);
+const canRebuild = ssr.permissions.has(
+  permissionKey("site_search", "index", "rebuild")
+);
+const canReadSettings = ssr.permissions.has(
+  permissionKey("site_search", "settings", "read")
+);
+const canUpdateSettings = ssr.permissions.has(
+  permissionKey("site_search", "settings", "update")
+);
+const canReadDiagnostics = ssr.permissions.has(
+  permissionKey("site_search", "diagnostics", "read")
+);
+
+let status: IndexStatus | null = null;
+let recentRuns: IndexRunSummary[] = [];
+let failures: IndexFailureItem[] = [];
+let settings: SiteSearchSettings | null = null;
+let loadError = false;
+
+// One transaction for every panel this viewer is allowed to see. Each fetch is
+// awaited SEQUENTIALLY: concurrent queries on a single transaction connection
+// leak it (idle in transaction) — the same note the API routes carry.
+if (canReadIndex || canReadSettings || canReadDiagnostics) {
+  try {
+    const sql = getDatabaseClient();
+    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
+      const indexStatus = canReadIndex
+        ? await fetchIndexStatus(tx, ssr.tenantId)
+        : null;
+      const runs = canReadIndex
+        ? await fetchRecentRuns(tx, ssr.tenantId, 10)
+        : [];
+      const failed = canReadDiagnostics
+        ? await fetchIndexFailures(tx, ssr.tenantId, 100)
+        : [];
+      const config = canReadSettings
+        ? await fetchSiteSearchSettings(tx, ssr.tenantId)
+        : null;
+      return { indexStatus, runs, failed, config };
+    });
+    status = result.indexStatus;
+    recentRuns = result.runs;
+    failures = result.failed;
+    settings = result.config;
+  } catch (error) {
+    logAdminPageError(
+      "admin/site-search.astro: failed to load console",
+      error,
+      {
+        correlationId: Astro.locals.correlationId
+      }
+    );
+    loadError = true;
+  }
+}
+
+/** `2026-08-01T03:18:38.929Z` -> `2026-08-01 03:18` (UTC, no locale dependency). */
+function formatTimestamp(value: string | null): string {
+  if (!value) return "—";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return "—";
+  return parsed.toISOString().replace("T", " ").slice(0, 16);
+}
+
+/** Run status -> the shared `.status-badge` variant vocabulary. */
+function runStatusVariant(runStatus: string): string {
+  if (runStatus === "succeeded" || runStatus === "completed") return "success";
+  if (runStatus === "failed") return "danger";
+  if (runStatus === "running") return "info";
+  return "neutral";
+}
+
+const resourceTypesValue =
+  settings?.enabledResourceTypes === null ||
+  settings?.enabledResourceTypes === undefined
+    ? ""
+    : settings.enabledResourceTypes.join(", ");
+
+const showIndexActions = canReconcile || canRebuild;
+---
+
+<AdminLayout title="Site search">
+  <header class="page-header fade-in-up">
+    <h1 id="site-search-heading">Site search</h1>
+    <p class="page-description">
+      The tenant's full-text search index over published content: how fresh it
+      is, what it contains, the last runs, and the items that failed to index.
+      The index is a projection of public content only — it is never an
+      authorization source.
+    </p>
+  </header>
+
+  {
+    !canReadIndex && !canReadSettings && !canReadDiagnostics && (
+      <p class="state-notice fade-in-up" id="site-search-denied">
+        You do not have permission to view the search console.
+      </p>
+    )
+  }
+
+  {
+    loadError && (
+      <p class="state-notice fade-in-up" id="site-search-error">
+        The search console could not be loaded right now. Please try again
+        later.
+      </p>
+    )
+  }
+
+  <p
+    id="site-search-action-error"
+    class="admin-create-error"
+    role="alert"
+    hidden
+  >
+  </p>
+
+  {
+    canReadIndex && status && (
+      <section class="admin-section fade-in-up" id="site-search-status">
+        <h2 class="admin-section-title">Index status</h2>
+        <div class="stat-grid stagger-children">
+          <div class="stat-card">
+            <span class="stat-label">Documents indexed</span>
+            <span class="stat-value">{status.documentCount}</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Last indexed</span>
+            <span class="stat-value stat-value--mono">
+              {formatTimestamp(status.latestIndexedAt)}
+            </span>
+            <span class="stat-hint">UTC</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Open failures</span>
+            <span class="stat-value">{status.openFailureCount}</span>
+            {status.openFailureCount > 0 && (
+              <span class="stat-hint">See diagnostics below</span>
+            )}
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Last run</span>
+            <span class="stat-value stat-value--mono">
+              {status.lastRun ? status.lastRun.runType : "—"}
+            </span>
+            {status.lastRun && (
+              <span class="stat-hint">
+                {formatTimestamp(status.lastRun.startedAt)}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {status.byResourceType.length > 0 && (
+          <div class="data-table-scroll">
+            <table class="data-table data-table--stack">
+              <caption>Documents by resource type</caption>
+              <thead>
+                <tr>
+                  <th scope="col">Resource type</th>
+                  <th scope="col">Documents</th>
+                </tr>
+              </thead>
+              <tbody>
+                {status.byResourceType.map((row) => (
+                  <tr>
+                    <td data-label="Resource type">
+                      <span class="cell-code">{row.resourceType}</span>
+                    </td>
+                    <td data-label="Documents">{row.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  {
+    showIndexActions && (
+      <section class="admin-section fade-in-up" id="site-search-actions">
+        <h2 class="admin-section-title">Index operations</h2>
+        <p class="page-description">
+          Reconcile upserts current public documents and removes stale ones.
+          Rebuild deletes every document and re-extracts from scratch — slower,
+          and the public search surface is degraded while it runs.
+        </p>
+        <div class="admin-toolbar">
+          {canReconcile && (
+            <button
+              type="button"
+              id="site-search-reconcile"
+              class="module-toggle"
+            >
+              Reconcile index
+            </button>
+          )}
+          {canRebuild && (
+            <button
+              type="button"
+              id="site-search-rebuild"
+              class="btn-inline btn-inline--danger"
+            >
+              Rebuild index
+            </button>
+          )}
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canReadSettings && settings && (
+      <section class="admin-section fade-in-up" id="site-search-settings">
+        <h2 class="admin-section-title">Search configuration</h2>
+        <form id="site-search-settings-form" class="admin-create-form">
+          <p class="form-legend">
+            {canUpdateSettings
+              ? "These values shape the public search surface."
+              : "Read-only — you do not have permission to change these."}
+          </p>
+          <p
+            id="site-search-settings-error"
+            class="admin-create-error"
+            role="alert"
+            hidden
+          />
+
+          <label for="setting-enabled">
+            <input
+              type="checkbox"
+              id="setting-enabled"
+              name="enabled"
+              checked={settings.enabled}
+              disabled={!canUpdateSettings}
+            />
+            Search enabled
+          </label>
+
+          <label for="setting-suggestions-enabled">
+            <input
+              type="checkbox"
+              id="setting-suggestions-enabled"
+              name="suggestionsEnabled"
+              checked={settings.suggestionsEnabled}
+              disabled={!canUpdateSettings}
+            />
+            Suggestions enabled
+          </label>
+
+          <label for="setting-analytics-enabled">
+            <input
+              type="checkbox"
+              id="setting-analytics-enabled"
+              name="analyticsEnabled"
+              checked={settings.analyticsEnabled}
+              disabled={!canUpdateSettings}
+            />
+            Query analytics (opt-in, stores query hashes and counts only)
+          </label>
+
+          <label for="setting-result-limit">
+            Result limit
+            <input
+              type="number"
+              id="setting-result-limit"
+              name="resultLimit"
+              value={settings.resultLimit}
+              min={RESULT_LIMIT_MIN}
+              max={RESULT_LIMIT_MAX}
+              disabled={!canUpdateSettings}
+            />
+          </label>
+
+          <label for="setting-min-query-length">
+            Minimum query length
+            <input
+              type="number"
+              id="setting-min-query-length"
+              name="minQueryLength"
+              value={settings.minQueryLength}
+              min={MIN_QUERY_LENGTH_MIN}
+              max={MIN_QUERY_LENGTH_MAX}
+              disabled={!canUpdateSettings}
+            />
+          </label>
+
+          <label for="setting-suggestion-limit">
+            Suggestion limit
+            <input
+              type="number"
+              id="setting-suggestion-limit"
+              name="suggestionLimit"
+              value={settings.suggestionLimit}
+              min={SUGGESTION_LIMIT_MIN}
+              max={SUGGESTION_LIMIT_MAX}
+              disabled={!canUpdateSettings}
+            />
+          </label>
+
+          <label for="setting-resource-types">
+            Indexed resource types
+            <input
+              type="text"
+              id="setting-resource-types"
+              name="enabledResourceTypes"
+              value={resourceTypesValue}
+              placeholder="Leave empty for every admitted type"
+              disabled={!canUpdateSettings}
+            />
+          </label>
+
+          {canUpdateSettings && (
+            <button
+              type="submit"
+              id="site-search-settings-submit"
+              class="module-toggle"
+            >
+              Save configuration
+            </button>
+          )}
+        </form>
+      </section>
+    )
+  }
+
+  {
+    canReadIndex && (
+      <section class="admin-section fade-in-up" id="site-search-runs">
+        <h2 class="admin-section-title">
+          Recent index runs
+          <span class="count-pill">{recentRuns.length}</span>
+        </h2>
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">The ten most recent index runs</caption>
+            <thead>
+              <tr>
+                <th scope="col">Started</th>
+                <th scope="col">Type</th>
+                <th scope="col">Status</th>
+                <th scope="col">Indexed</th>
+                <th scope="col">Updated</th>
+                <th scope="col">Removed</th>
+                <th scope="col">Failures</th>
+              </tr>
+            </thead>
+            <tbody>
+              {recentRuns.length === 0 && (
+                <tr>
+                  <td class="data-table-empty" colspan={7}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ⌛
+                      </span>
+                      <span class="empty-state-title">No index runs yet</span>
+                      <span class="empty-state-text">
+                        Run a reconcile to build the index for the first time.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              )}
+              {recentRuns.map((run) => (
+                <tr>
+                  <td data-label="Started">
+                    <span class="cell-code">
+                      {formatTimestamp(run.startedAt)}
+                    </span>
+                  </td>
+                  <td data-label="Type">{run.runType}</td>
+                  <td data-label="Status">
+                    <span
+                      class="status-badge"
+                      data-variant={runStatusVariant(run.status)}
+                    >
+                      <span class="status-dot" aria-hidden="true" />
+                      {run.status}
+                    </span>
+                  </td>
+                  <td data-label="Indexed">{run.documentsIndexed}</td>
+                  <td data-label="Updated">{run.documentsUpdated}</td>
+                  <td data-label="Removed">{run.documentsRemoved}</td>
+                  <td data-label="Failures">
+                    {run.failureCount > 0 ? (
+                      run.failureCount
+                    ) : (
+                      <span class="cell-muted">—</span>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canReadDiagnostics && (
+      <section class="admin-section fade-in-up" id="site-search-failures">
+        <h2 class="admin-section-title">
+          Failed items
+          <span class="count-pill">{failures.length}</span>
+        </h2>
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">
+              Items that could not be indexed, most recent first
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Source</th>
+                <th scope="col">Resource</th>
+                <th scope="col">Locale</th>
+                <th scope="col">Error</th>
+                <th scope="col">Seen</th>
+                <th scope="col">Last seen</th>
+              </tr>
+            </thead>
+            <tbody>
+              {failures.length === 0 && (
+                <tr>
+                  <td class="data-table-empty" colspan={6}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ✓
+                      </span>
+                      <span class="empty-state-title">No failed items</span>
+                      <span class="empty-state-text">
+                        Every source item indexed cleanly.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              )}
+              {failures.map((item) => (
+                <tr>
+                  <td data-label="Source">
+                    <span class="cell-code">{item.sourceKey}</span>
+                  </td>
+                  <td data-label="Resource">
+                    <span class="cell-code">{item.resourceId}</span>
+                  </td>
+                  <td data-label="Locale">{item.locale}</td>
+                  <td data-label="Error">
+                    <span class="status-badge" data-variant="danger">
+                      <span class="status-dot" aria-hidden="true" />
+                      {item.errorClass}
+                    </span>
+                  </td>
+                  <td data-label="Seen">{item.occurrenceCount}</td>
+                  <td data-label="Last seen">
+                    <span class="cell-code">
+                      {formatTimestamp(item.lastSeenAt)}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // Bound unconditionally: the controls only render when the matching
+  // permission gate passed server-side, so `getElementById` returns null for a
+  // viewer who lacks them and the listeners never bind. Astro hoists this
+  // script at build time, so a conditional wrapper would be meaningless.
+  //
+  // The import is deliberate and load-bearing for CSP: an import-free script is
+  // INLINED by Astro, and inline scripts are blocked by this app's
+  // `default-src 'self'` policy. See admin-form-client.ts.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("site-search-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  /**
+   * Reconcile and rebuild are both idempotency-keyed server-side, so each click
+   * mints a FRESH key — reusing one would make a deliberate second run replay
+   * the first run's stored response instead of running again.
+   */
+  async function runIndexOperation(
+    button: HTMLButtonElement,
+    url: string,
+    busyLabel: string,
+    failureMessage: string
+  ): Promise<void> {
+    if (button.disabled) return;
+    const unlock = lockElement(button, busyLabel);
+    if (actionError) actionError.hidden = true;
+
+    const result = await sendJson("POST", url, undefined, {
+      "Idempotency-Key": crypto.randomUUID()
+    });
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    showActionError(failureMessage);
+    unlock();
+  }
+
+  const reconcileButton = document.getElementById(
+    "site-search-reconcile"
+  ) as HTMLButtonElement | null;
+
+  reconcileButton?.addEventListener("click", () => {
+    void runIndexOperation(
+      reconcileButton,
+      "/api/v1/site-search/index/reconcile",
+      "Reconciling…",
+      "Could not reconcile the index. Please try again."
+    );
+  });
+
+  const rebuildButton = document.getElementById(
+    "site-search-rebuild"
+  ) as HTMLButtonElement | null;
+
+  rebuildButton?.addEventListener("click", () => {
+    // Destructive: a rebuild empties the index before refilling it, so the
+    // public search surface is degraded until it finishes.
+    if (
+      !window.confirm(
+        "Rebuild the whole search index? Public search results will be incomplete until it finishes."
+      )
+    ) {
+      return;
+    }
+    void runIndexOperation(
+      rebuildButton,
+      "/api/v1/site-search/index/rebuild",
+      "Rebuilding…",
+      "Could not rebuild the index. Please try again."
+    );
+  });
+
+  const settingsForm = document.getElementById(
+    "site-search-settings-form"
+  ) as HTMLFormElement | null;
+  const settingsError = document.getElementById("site-search-settings-error");
+  const settingsSubmit = document.getElementById(
+    "site-search-settings-submit"
+  ) as HTMLButtonElement | null;
+
+  settingsForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    if (!settingsSubmit || settingsSubmit.disabled) return;
+    const unlock = lockElement(settingsSubmit, "Saving…");
+    if (settingsError) settingsError.hidden = true;
+
+    const formData = new FormData(settingsForm);
+
+    // An empty resource-type list means "every admitted type", which the API
+    // models as null — NOT as an empty array (that would index nothing).
+    const rawTypes = String(formData.get("enabledResourceTypes") ?? "").trim();
+    const enabledResourceTypes =
+      rawTypes === ""
+        ? null
+        : rawTypes
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter((entry) => entry !== "");
+
+    const result = await sendJson(
+      "PUT",
+      "/api/v1/site-search/settings",
+      {
+        enabled: formData.get("enabled") === "on",
+        suggestionsEnabled: formData.get("suggestionsEnabled") === "on",
+        analyticsEnabled: formData.get("analyticsEnabled") === "on",
+        resultLimit: Number(formData.get("resultLimit")),
+        minQueryLength: Number(formData.get("minQueryLength")),
+        suggestionLimit: Number(formData.get("suggestionLimit")),
+        enabledResourceTypes
+      },
+      { "Idempotency-Key": crypto.randomUUID() }
+    );
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    // Generic copy only — never surface internal detail. VALIDATION_ERROR is
+    // the one code worth distinguishing, because it is the user's own input.
+    if (settingsError) {
+      settingsError.textContent =
+        result.errorCode === "VALIDATION_ERROR"
+          ? "Some values are out of range. Check the limits and try again."
+          : "Could not save the configuration. Please try again.";
+      settingsError.hidden = false;
+    }
+    unlock();
+  });
+</script>

--- a/tests/admin-site-search-page-contract.test.ts
+++ b/tests/admin-site-search-page-contract.test.ts
@@ -1,0 +1,171 @@
+/**
+ * `/admin/site-search` gates against the endpoints it drives.
+ *
+ * Sibling of `admin-security-page-contract.test.ts`, for the same silent
+ * failure: a page that gates on a permission key NO migration seeds hides the
+ * section from everyone — including the owner — and still looks like a working
+ * screen with an empty area. This repo has shipped that bug twice, both times by
+ * inventing a plausible action name.
+ *
+ * `site_search` is an easy place to repeat it, because its six permissions use
+ * three DIFFERENT activity codes (`index`, `settings`, `diagnostics`) and two
+ * non-CRUD actions (`reconcile`, `rebuild`). "Tidy" guesses like
+ * `site_search.index.update` or `site_search.settings.configure` would each read
+ * perfectly and deny everyone.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/site-search.astro";
+const ROUTES = [
+  "src/pages/api/v1/site-search/index/status.ts",
+  "src/pages/api/v1/site-search/index/reconcile.ts",
+  "src/pages/api/v1/site-search/index/rebuild.ts",
+  "src/pages/api/v1/site-search/index/failures.ts",
+  "src/pages/api/v1/site-search/settings.ts"
+];
+
+type Triple = `${string}.${string}.${string}`;
+
+/** `{ moduleKey: …, activityCode: …, action: … }` → `module.activity.action`. */
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+
+  // The site-search routes build their guards from the shared constants
+  // (`SITE_SEARCH_MODULE_KEY`, `SITE_SEARCH_INDEX_ACTIVITY_CODE`, …) rather than
+  // string literals, so match the constant names and resolve them — a
+  // literal-only regex would find nothing and pass vacuously.
+  const pattern =
+    /moduleKey:\s*SITE_SEARCH_MODULE_KEY,\s*activityCode:\s*(SITE_SEARCH_[A-Z_]+_ACTIVITY_CODE),\s*action:\s*"([a-z_]+)"/g;
+
+  const activityByConstant: Record<string, string> = {
+    SITE_SEARCH_INDEX_ACTIVITY_CODE: "index",
+    SITE_SEARCH_SETTINGS_ACTIVITY_CODE: "settings",
+    SITE_SEARCH_DIAGNOSTICS_ACTIVITY_CODE: "diagnostics"
+  };
+
+  for (const match of source.matchAll(pattern)) {
+    const constantName = match[1];
+    const action = match[2];
+    if (!constantName || !action) continue;
+    const activity = activityByConstant[constantName];
+    if (activity) found.add(`site_search.${activity}.${action}` as Triple);
+  }
+
+  return found;
+}
+
+/** `permissionKey("site_search", "index", "read")` → the same shape. */
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+describe("/admin/site-search permission gates", () => {
+  test("the activity-code constants still resolve to the values assumed here", () => {
+    // The guard extractor maps constant NAMES to values. If a constant's value
+    // is ever changed, that map silently starts producing wrong triples, so pin
+    // it against the descriptor rather than trusting the mapping.
+    const declared = listModules().find(
+      (module) => module.key === "site_search"
+    );
+
+    expect(declared).toBeDefined();
+    const activityCodes = new Set(
+      declared!.permissions?.map((permission) => permission.activityCode) ?? []
+    );
+    expect(activityCodes).toEqual(
+      new Set(["index", "settings", "diagnostics"])
+    );
+  });
+
+  test("every key the page gates on is one its endpoints actually enforce", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    expect(pageKeys.size).toBe(6);
+
+    const enforced = new Set<Triple>();
+    for (const route of ROUTES) {
+      for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+
+    // Guards really were parsed — an empty `enforced` would make the subset
+    // check below pass vacuously, the shape of gate this repo has been burned by.
+    expect(enforced.size).toBeGreaterThan(0);
+    expect([...pageKeys].filter((key) => !enforced.has(key))).toEqual([]);
+  });
+
+  test("and is declared by the module descriptor, so a migration seeds it", async () => {
+    const declared = new Set<Triple>(
+      (listModules()
+        .find((module) => module.key === "site_search")
+        ?.permissions?.map(
+          (permission) =>
+            `site_search.${permission.activityCode}.${permission.action}`
+        ) ?? []) as Triple[]
+    );
+
+    expect(declared.size).toBeGreaterThan(0);
+
+    const missing = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].filter(
+      (key) => !declared.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  test("the page never mutates directly — it posts to the guarded endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // No SQL write anywhere in the screen: every change goes out over fetch, so
+    // the endpoints' audit rows and idempotency records cannot be bypassed by
+    // rendering a form that writes for itself.
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+    expect(page).toContain('"/api/v1/site-search/index/reconcile"');
+    expect(page).toContain('"/api/v1/site-search/index/rebuild"');
+    expect(page).toContain('"/api/v1/site-search/settings"');
+  });
+
+  test("all three mutations carry a fresh Idempotency-Key", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Reconcile, rebuild, and the settings PUT all reject a request without the
+    // header (`IDEMPOTENCY_REQUIRED`), so a screen that omitted it would render
+    // buttons that always fail. A per-click `crypto.randomUUID()` is also what
+    // makes a deliberate SECOND run actually run, instead of replaying the
+    // first run's stored response.
+    expect(page).toContain('"Idempotency-Key": crypto.randomUUID()');
+    expect(
+      page.match(/"Idempotency-Key": crypto\.randomUUID\(\)/g)
+    ).toHaveLength(2);
+    // One is shared by reconcile+rebuild via `runIndexOperation`, the other is
+    // the settings form — two occurrences covering three mutations.
+    expect(page).toContain("async function runIndexOperation(");
+  });
+
+  test("the sidebar entry points at this page and is gated on a real permission", () => {
+    const nav = listModules()
+      .find((module) => module.key === "site_search")
+      ?.navigation?.find((entry) => entry.path === "/admin/site-search");
+
+    expect(nav).toBeDefined();
+    expect(nav!.requiredPermission).toBe("site_search.index.read");
+    // `admin-navigation-registry.test.ts` already binds path→file and
+    // labelKey→SIDEBAR_LABELS; this pins the gate specifically.
+  });
+});


### PR DESCRIPTION
## Ringkasan

`site_search` mengapalkan API index/settings/diagnostics (ADR-0040) **tanpa layar**, jadi seluruh permukaannya hanya bisa dipakai lewat `curl` dan modulnya tidak terlihat di sidebar. `module.ts`-nya mencatat itu sebagai follow-up terdokumentasi — ini follow-up-nya.

Layar pertama dari batch "modul kecil dulu": API-nya sudah lengkap 100%, jadi PR ini **tidak menambah satu pun endpoint, migrasi, atau permission**.

## Yang dirender

| Panel | Sumber | Gate |
| --- | --- | --- |
| Status index + freshness, dokumen per resource type | `fetchIndexStatus` | `index.read` |
| 10 run terakhir | `fetchRecentRuns` | `index.read` |
| Reconcile / Rebuild | `POST .../index/{reconcile,rebuild}` | `index.reconcile` / `index.rebuild` |
| Form konfigurasi pencarian | `fetchSiteSearchSettings` / `PUT .../settings` | `settings.read` / `settings.update` |
| Item gagal ter-index | `fetchIndexFailures` | `diagnostics.read` |

## Keputusan yang perlu dilihat reviewer

- **Baca lewat application layer, bukan HTTP ke API sendiri** — fungsi yang sama persis dengan yang dipanggil route JSON-nya, dalam **satu** `withTenantOrThrow`. Setiap fetch di-`await` **berurutan**: query konkuren pada satu koneksi transaksi membocorkannya (idle in transaction), catatan yang sudah dibawa route-nya sendiri.
- **Tulis lewat endpoint ber-guard**, dengan `Idempotency-Key` **baru tiap klik**. Reconcile, rebuild, dan settings PUT ketiganya menolak request tanpa header itu; kunci yang dipakai ulang akan membuat run kedua yang disengaja justru **memutar ulang respons run pertama**, bukan menjalankan ulang.
- **`enabledResourceTypes` kosong → `null`, bukan `[]`.** `null` berarti "semua tipe yang diadmisi"; array kosong berarti mengindeks **nol** tipe. Salah satu dari dua ini mematikan pencarian publik tanpa pesan error.
- **Entri `navigation` mendarat di perubahan yang SAMA** dengan halamannya — entri tanpa halaman adalah 404 permanen di menu, dan `tests/admin-navigation-registry.test.ts` menegakkannya dua arah.
- Semua gate permission di halaman bersifat **UX-only**; endpoint tetap otoritasnya.

## Test

`tests/admin-site-search-page-contract.test.ts` (6 test, pure — tanpa DB) mengikat enam permission key halaman ke apa yang **benar-benar ditegakkan route** dan **dideklarasikan descriptor** (jadi ada migrasi yang men-seed-nya).

`site_search` tempat yang mudah untuk mengulang bug latent-authz yang repo ini **sudah kirim dua kali**: permission-nya memakai **tiga** activity code (`index`, `settings`, `diagnostics`) dan **dua** action non-CRUD (`reconcile`, `rebuild`). Tebakan rapi seperti `settings.configure` atau `index.update` terbaca sempurna dan men-deny semua orang, termasuk owner.

**Mutation-proven** — keduanya memerahkan test, lalu hijau lagi setelah dikembalikan:

```
permissionKey("site_search", "settings", "update")  -> "configure"   => 2 fail
permissionKey("site_search", "index", "reconcile")  -> "update"      => 2 fail
```

Extractor guard-nya sengaja mencocokkan **nama konstanta** (route memakai `SITE_SEARCH_*_ACTIVITY_CODE`, bukan literal), dan ada satu test terpisah yang mem-pin nilai konstanta itu ke descriptor supaya pemetaannya tidak diam-diam salah.

## Verifikasi

`lint`, `typecheck`, `build`, dan 14 gate statis (`modules:compose:check`, `modules:composition:inventory:check` — inventory di-regenerate, `logging:lint:check`, `db:tenant-context:check`, `api:tenant-route:check`, `family:conformance:check`, dst.) hijau. **590/590 test hijau** di 45 berkas test yang menyentuh subsistem yang diubah.

Test integrasi DB-gated **tidak bisa** dijalankan dari sandbox ini (Postgres tak terjangkau dari host — timeout di lapisan transport). CI yang menjalankannya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)