### PR TITLE
fix(reporting): dashboard no longer alarms when a tenant has zero sync nodes

### DIFF
--- a/.changeset/dashboard-sync-not-configured.md
+++ b/.changeset/dashboard-sync-not-configured.md
@@ -1,0 +1,11 @@
+---
+"awcms": patch
+---
+
+Stop the admin dashboard reporting a permanent false alarm when a tenant has no sync nodes.
+
+`shapeSyncHealth`'s `isHealthy` is deliberately `false` for a tenant with zero registered sync nodes — "there is nothing actively syncing" is the right answer for the report. The dashboard rendered that same boolean directly as an amber "Needs attention" badge, so an online-first deployment that never enrols an offline node (ADR-0035 makes sync the resilience mode, not the main path) sat at `0/0` showing a warning with no action behind it. A badge that is always lit is one operators learn to ignore, including on the day it means something.
+
+The dashboard now distinguishes the two states that boolean conflates: **no nodes registered** renders a muted "Not configured", while **nodes enrolled but none active**, open conflicts, or failed objects still render "Needs attention". The `GET /api/v1/reports/sync-health` contract is unchanged — `isHealthy` still answers exactly as before.
+
+The decision is a pure `classifySyncHealthDisplay` in `reporting/domain/sync-health.ts` rather than inline `.astro` frontmatter, so it is reachable by unit tests at all (`tsc --noEmit` does not read `.astro`).

--- a/src/modules/reporting/domain/sync-health.ts
+++ b/src/modules/reporting/domain/sync-health.ts
@@ -36,3 +36,36 @@ export function shapeSyncHealth(counts: SyncHealthCounts): SyncHealthView {
     isHealthy
   };
 }
+
+/**
+ * How a DASHBOARD should render sync health — deliberately three states, where
+ * `isHealthy` above is two.
+ *
+ * `isHealthy` is false for a tenant with zero registered nodes, and that is
+ * correct for the report: nothing is syncing. But the admin dashboard was
+ * rendering that same boolean as an amber "Needs attention" badge, so an
+ * online-first deployment that never enrols an offline node (ADR-0035: sync is
+ * the resilience mode, not the main path) sat at `0/0` showing a permanent
+ * warning with no action behind it. A badge that is always lit is one operators
+ * learn to ignore — including on the day it means something.
+ *
+ * `"not_configured"` is therefore NOT a degraded state; it is the steady state
+ * of a tenant that does not use sync. A tenant that HAS enrolled nodes but has
+ * none active is still `"needs_attention"` — that one is a real regression.
+ *
+ * Pure and separate from the view above so the distinction is unit-testable:
+ * the same logic inline in `index.astro` frontmatter is unreachable by any test
+ * (`tsc --noEmit` does not even read `.astro`).
+ */
+export type SyncHealthDisplayState =
+  "healthy" | "not_configured" | "needs_attention";
+
+export function classifySyncHealthDisplay(
+  view: Pick<SyncHealthView, "totalNodeCount" | "isHealthy">
+): SyncHealthDisplayState {
+  if (view.isHealthy) return "healthy";
+  // Checked AFTER `isHealthy` so a tenant with zero nodes but (impossibly)
+  // healthy counts is never labelled unconfigured on a contradiction.
+  if (view.totalNodeCount === 0) return "not_configured";
+  return "needs_attention";
+}

--- a/src/pages/admin/index.astro
+++ b/src/pages/admin/index.astro
@@ -42,6 +42,7 @@ import { permissionKey } from "../../modules/identity-access/domain/access-contr
 import { fetchTenantActivityReport } from "../../modules/reporting/application/tenant-activity-report";
 import { fetchAccessAuditReport } from "../../modules/reporting/application/access-audit-report";
 import { fetchSyncHealthReport } from "../../modules/reporting/application/sync-health-report";
+import { classifySyncHealthDisplay } from "../../modules/reporting/domain/sync-health";
 import { fetchModuleUsageReport } from "../../modules/reporting/application/module-usage-report";
 import { logAdminPageError } from "../../lib/logging/error-log";
 
@@ -91,8 +92,16 @@ if (hasDashboardAccess) {
   }
 }
 
-const syncNeedsAttention =
-  dashboard !== null && !dashboard.syncHealth.isHealthy;
+/**
+ * Three states, not two — see `classifySyncHealthDisplay` for why `0/0` must
+ * not render as an alarm. The classifier is pure and lives in the domain so it
+ * is unit-testable; this file only maps its result onto badges.
+ */
+const syncDisplayState =
+  dashboard === null ? null : classifySyncHealthDisplay(dashboard.syncHealth);
+
+const syncNotConfigured = syncDisplayState === "not_configured";
+const syncNeedsAttention = syncDisplayState === "needs_attention";
 
 /* Decorative line icons (aria-hidden), injected with `set:html`. Static SVG
    only — no inline style or script — so they carry no CSP cost, and
@@ -159,7 +168,13 @@ const ICON_MODULES =
             </span>
           </article>
 
-          <article class="kpi kpi--warning fade-in-up">
+          <article
+            class:list={[
+              "kpi",
+              "fade-in-up",
+              syncNeedsAttention ? "kpi--warning" : "kpi--muted"
+            ]}
+          >
             <span class="kpi-icon" set:html={ICON_SYNC} />
             <span class="kpi-value">
               {dashboard.syncHealth.activeNodeCount}/
@@ -169,6 +184,11 @@ const ICON_MODULES =
             {syncNeedsAttention && (
               <span class="kpi-status">
                 <span class="badge badge--warning">Needs attention</span>
+              </span>
+            )}
+            {syncNotConfigured && (
+              <span class="kpi-status">
+                <span class="badge badge--muted">Not configured</span>
               </span>
             )}
           </article>
@@ -243,6 +263,11 @@ const ICON_MODULES =
               {syncNeedsAttention && (
                 <span class="card-header-badge">
                   <span class="badge badge--warning">Needs attention</span>
+                </span>
+              )}
+              {syncNotConfigured && (
+                <span class="card-header-badge">
+                  <span class="badge badge--muted">Not configured</span>
                 </span>
               )}
             </header>
@@ -392,6 +417,12 @@ const ICON_MODULES =
   }
   .kpi--warning {
     --kpi-accent: var(--color-warning);
+  }
+  /* Sync with no nodes enrolled: a category marker, not a state. The tile used
+     to be hard-coded `kpi--warning`, which painted an amber bar on a tenant
+     that simply does not use offline sync. */
+  .kpi--muted {
+    --kpi-accent: var(--color-border);
   }
 
   .kpi-icon {

--- a/tests/reporting.test.ts
+++ b/tests/reporting.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { permissionKey } from "../src/modules/identity-access/domain/access-control";
-import { shapeSyncHealth } from "../src/modules/reporting/domain/sync-health";
+import {
+  classifySyncHealthDisplay,
+  shapeSyncHealth
+} from "../src/modules/reporting/domain/sync-health";
 import { shapeEmailHealth } from "../src/modules/reporting/domain/email-health";
 
 describe("permissionKey — reporting dashboard guard", () => {
@@ -85,6 +88,84 @@ describe("shapeSyncHealth", () => {
     expect(view.openConflictCount).toBe(2);
     expect(view.pendingObjectCount).toBe(7);
     expect(view.failedObjectCount).toBe(4);
+  });
+});
+
+describe("classifySyncHealthDisplay — the dashboard's three states", () => {
+  test("a tenant with NO nodes is 'not_configured', not an alarm", () => {
+    // The bug this pins: the dashboard rendered `!isHealthy` as an amber
+    // "Needs attention" badge, so an online-first deployment that never enrols
+    // an offline node showed a permanent warning with no action behind it.
+    // `isHealthy` stays false here — the REPORT contract is unchanged — but the
+    // display state must not be the alarm.
+    const view = shapeSyncHealth({
+      totalNodeCount: 0,
+      activeNodeCount: 0,
+      openConflictCount: 0,
+      pendingObjectCount: 0,
+      failedObjectCount: 0
+    });
+
+    expect(view.isHealthy).toBe(false);
+    expect(classifySyncHealthDisplay(view)).toBe("not_configured");
+  });
+
+  test("nodes enrolled but none active IS 'needs_attention'", () => {
+    // The case that must NOT be swallowed by the fix above: sync was set up and
+    // has since stopped, which is a real regression a tenant should act on.
+    const view = shapeSyncHealth({
+      totalNodeCount: 3,
+      activeNodeCount: 0,
+      openConflictCount: 0,
+      pendingObjectCount: 0,
+      failedObjectCount: 0
+    });
+
+    expect(classifySyncHealthDisplay(view)).toBe("needs_attention");
+  });
+
+  test("open conflicts are 'needs_attention' even with every node active", () => {
+    const view = shapeSyncHealth({
+      totalNodeCount: 2,
+      activeNodeCount: 2,
+      openConflictCount: 1,
+      pendingObjectCount: 0,
+      failedObjectCount: 0
+    });
+
+    expect(classifySyncHealthDisplay(view)).toBe("needs_attention");
+  });
+
+  test("failed objects are 'needs_attention' even with every node active", () => {
+    const view = shapeSyncHealth({
+      totalNodeCount: 2,
+      activeNodeCount: 2,
+      openConflictCount: 0,
+      pendingObjectCount: 0,
+      failedObjectCount: 1
+    });
+
+    expect(classifySyncHealthDisplay(view)).toBe("needs_attention");
+  });
+
+  test("a working sync setup is 'healthy'", () => {
+    const view = shapeSyncHealth({
+      totalNodeCount: 2,
+      activeNodeCount: 2,
+      openConflictCount: 0,
+      pendingObjectCount: 5,
+      failedObjectCount: 0
+    });
+
+    expect(classifySyncHealthDisplay(view)).toBe("healthy");
+  });
+
+  test("'healthy' wins over a zero-node contradiction", () => {
+    // Defensive ordering, not a reachable state: if the two inputs ever
+    // disagree, never label a healthy tenant unconfigured.
+    expect(
+      classifySyncHealthDisplay({ totalNodeCount: 0, isHealthy: true })
+    ).toBe("healthy");
   });
 });
 


### PR DESCRIPTION
## Masalah (terlihat di staging)

Dashboard `awcms-staging` menampilkan **"Needs attention"** permanen pada kartu Sync Health dengan `0/0 Active nodes`.

Itu bukan kondisi nyata. `reporting/domain/sync-health.ts`:

```ts
const isHealthy =
  counts.activeNodeCount > 0 && !hasOpenConflicts && !hasFailedObjects;
```

`isHealthy` sengaja `false` untuk tenant tanpa node — komentarnya menyatakannya terang-terangan: _"A tenant with zero registered nodes is not considered healthy — there is nothing actively syncing."_ Itu **jawaban yang benar untuk REPORT**.

Yang keliru adalah dashboard meneruskan boolean itu langsung menjadi badge alarm:

```ts
const syncNeedsAttention = dashboard !== null && !dashboard.syncHealth.isHealthy;
```

`awcms` adalah **online-first** (ADR-0035) — sync itu mode ketahanan, bukan jalur utama. Deployment yang memang tidak pernah mendaftarkan node offline duduk di `0/0` **selamanya** sambil menyalakan peringatan yang tidak punya aksi. Badge yang selalu menyala adalah badge yang operator belajar abaikan — termasuk di hari ia benar-benar berarti sesuatu.

## Perubahan

Memisahkan dua keadaan yang selama ini ditumpuk pada satu boolean:

| Keadaan | Sebelum | Sesudah |
| --- | --- | --- |
| 0 node terdaftar | Needs attention | **Not configured** (muted, bukan alarm) |
| Ada node, tak satu pun aktif | Needs attention | Needs attention |
| Ada conflict terbuka | Needs attention | Needs attention |
| Ada objek gagal | Needs attention | Needs attention |

**Kontrak API tidak bergerak.** `GET /api/v1/reports/sync-health` tetap menjawab `isHealthy` persis seperti sebelumnya — ini murni keputusan presentasi. Tidak ada migrasi, tidak ada perubahan OpenAPI, tidak ada permission baru. Badge `badge--muted` sudah dipakai di halaman yang sama, jadi tidak ada token desain baru; satu varian aksen `kpi--muted` ditambahkan memakai `--color-border` yang sudah ada.

## Kenapa logikanya diangkat ke `domain/`

Logika di frontmatter `.astro` **tidak terjangkau test apa pun** — `tsc --noEmit` bahkan tidak membaca `.astro` (blind spot yang sudah dikenal di repo ini). Jadi keputusannya menjadi `classifySyncHealthDisplay` yang murni, di sebelah `shapeSyncHealth`, dan halaman hanya memetakan hasilnya ke badge.

## Test

6 unit test baru di `tests/reporting.test.ts` — termasuk yang menjaga agar perbaikan ini **tidak menelan alarm yang nyata**: tenant dengan node terdaftar tapi nol aktif tetap `needs_attention` (sync pernah jalan lalu berhenti — itu regresi sungguhan), dan urutan cek `isHealthy` dulu supaya kontradiksi tidak pernah melabeli tenant sehat sebagai unconfigured.

**Mutation-proven** — mengembalikan perilaku dua-keadaan yang lama memerahkan test:

```
- if (view.totalNodeCount === 0) return "not_configured";
=> (fail) a tenant with NO nodes is 'not_configured', not an alarm
```

`lint`, `typecheck`, `build`, `logging:lint:check`, `db:tenant-context:check` hijau; 28/28 test hijau di berkas yang tersentuh. Test integrasi DB-gated tidak bisa dijalankan dari sandbox ini (Postgres tak terjangkau dari host); CI yang menjalankannya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)