### PR TITLE
feat(logging): audit trail viewer at /admin/audit-trail

### DIFF
--- a/.changeset/audit-trail-admin-screen.md
+++ b/.changeset/audit-trail-admin-screen.md
@@ -1,0 +1,11 @@
+---
+"awcms": minor
+---
+
+Add the `/admin/audit-trail` viewer and put `logging` in the admin sidebar.
+
+`logging` has exactly one HTTP surface (`GET /api/v1/logs/audit`) and had no screen, so the tenant's audit history — the record of every high-risk action the system takes — was readable only by `curl`. For the module whose whole purpose is accountability, that is a poor place to have no UI.
+
+The screen lists events newest-first with a resource-type filter and a per-event detail disclosure (correlation id + the already-redacted `attributes`, rendered as escaped text, never as HTML). It is read-only and ships **no client script at all**: the audit trail is append-only by design, so the filter is a plain `method="get"` form that works with JavaScript disabled.
+
+`listAuditEvents` clamps to 100 rows and has no cursor, so the page states that bound whenever the view is full rather than letting a truncated audit log read as "this is everything that happened". Adding keyset pagination to that endpoint is a follow-up with its own OpenAPI change, deliberately not smuggled in here.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -174,7 +174,7 @@
       "capabilitiesProvided": [],
       "capabilitiesConsumed": [],
       "permissionCount": 1,
-      "navigationCount": 0,
+      "navigationCount": 1,
       "jobCount": 1,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/logging/module.ts
+++ b/src/modules/logging/module.ts
@@ -21,6 +21,17 @@ export const loggingModule = defineModule({
     openApiPath: "openapi/modules/logging.openapi.yaml",
     basePath: "/api/v1/logs"
   },
+  // `/admin/audit-trail` — the read-only viewer over `GET /api/v1/logs/audit`.
+  // Gated on the module's single permission, which is also the one that
+  // endpoint enforces, so a viewer who can see the link can use the page.
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_audit_trail",
+      path: "/admin/audit-trail",
+      order: 60,
+      requiredPermission: "logging.audit_trail.read"
+    }
+  ],
   permissions: [
     {
       activityCode: "audit_trail",

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -170,6 +170,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_modules": "Modules",
   "admin.layout.nav_sidebar_menu": "Sidebar menu",
   "admin.layout.nav_email_templates": "Email templates",
+  "admin.layout.nav_audit_trail": "Audit trail",
   "admin.layout.nav_comments": "Moderation queue",
   "admin.layout.nav_visitor_analytics": "Visitor analytics",
   "admin.layout.nav_profiles": "Profiles",

--- a/src/pages/admin/audit-trail.astro
+++ b/src/pages/admin/audit-trail.astro
@@ -1,0 +1,348 @@
+---
+/**
+ * Audit trail viewer — the admin screen for `logging`.
+ *
+ * `logging` has exactly ONE HTTP surface (`GET /api/v1/logs/audit`) and no
+ * screen, so the tenant's audit history — the record of every high-risk action
+ * this system takes — was readable only by `curl`. That is the module whose
+ * whole purpose is accountability, so it is a poor one to leave unreadable.
+ *
+ * ## Read-only, therefore NO client script
+ *
+ * Every other admin screen here ships a `<script>` importing
+ * `admin-form-client` because it mutates. This one never writes: the audit
+ * trail is append-only by design (`recordAuditEvent` is the only writer, and it
+ * is called by other modules inside their own transactions). So the filter is a
+ * plain `method="get"` form that navigates with query params and works with
+ * JavaScript disabled — no bundle, nothing for CSP to admit, and no
+ * double-submit to guard.
+ *
+ * ## The 100-row bound is real, and said out loud
+ *
+ * `listAuditEvents` clamps `limit` to a hard maximum of 100 and has NO cursor
+ * (unlike `_shared/keyset-pagination.ts`, which the newer list endpoints use).
+ * A viewer therefore sees the newest N up to 100 for the chosen filter, and
+ * NOTHING tells them older rows exist unless the page says so — a silently
+ * truncated audit log is worse than an obviously truncated one, because it
+ * reads as "this is everything that happened". The footer states the bound
+ * whenever the page is full. Adding keyset pagination to this endpoint is a
+ * follow-up with its own OpenAPI change; it is deliberately not smuggled in
+ * here.
+ *
+ * `attributes` is already redacted at WRITE time by `redactSensitiveAttributes`
+ * (password/token/NPWP/NIK/phone/email never reach the row), so rendering it is
+ * safe — and it is rendered as escaped TEXT inside `<details>`, never as HTML.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listAuditEvents,
+  type AuditEventRecord
+} from "../../modules/logging/application/audit-log";
+
+const ssr = Astro.locals.ssrContext;
+
+if (!ssr) {
+  throw new Error(
+    "audit-trail.astro rendered without Astro.locals.ssrContext — the /admin guard in src/middleware.ts must run first."
+  );
+}
+
+const canRead = ssr.permissions.has(
+  permissionKey("logging", "audit_trail", "read")
+);
+
+/** Mirrors `MAX_LIST_LIMIT` in `logging/application/audit-log.ts`. */
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Filters ride the query string so the view is linkable and needs no script.
+ * Both are re-validated here rather than trusted: `resourceType` is passed as a
+ * bound parameter by `listAuditEvents` (never interpolated), and `limit` is
+ * clamped by the same function, but a NaN from `?limit=abc` would otherwise
+ * render as a blank input.
+ */
+const resourceTypeFilter =
+  Astro.url.searchParams.get("resourceType")?.trim() || "";
+
+const requestedLimit = Number(Astro.url.searchParams.get("limit"));
+const limit =
+  Number.isFinite(requestedLimit) && requestedLimit >= 1
+    ? Math.min(Math.trunc(requestedLimit), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+let events: AuditEventRecord[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    events = await withTenantOrThrow(sql, ssr.tenantId, async (tx) =>
+      listAuditEvents(tx, ssr.tenantId, {
+        resourceType: resourceTypeFilter || undefined,
+        limit
+      })
+    );
+  } catch (error) {
+    logAdminPageError(
+      "admin/audit-trail.astro: failed to load audit events",
+      error,
+      {
+        correlationId: Astro.locals.correlationId
+      }
+    );
+    loadError = true;
+  }
+}
+
+/**
+ * Resource types present in THIS result set, offered as a `<datalist>`.
+ *
+ * Deliberately not a `<select>`: there is no endpoint that enumerates every
+ * resource type a tenant has ever audited, so a dropdown built from one page
+ * would silently present itself as the complete set and make the other values
+ * unreachable. A text input with suggestions stays honest — anything can be
+ * typed, these are just the ones on screen.
+ */
+const suggestedResourceTypes = [
+  ...new Set(events.map((event) => event.resourceType))
+].sort();
+
+/** The page is full, so older rows almost certainly exist beyond this bound. */
+const possiblyTruncated = events.length >= limit;
+
+/** `2026-08-01T03:18:38.929Z` -> `2026-08-01 03:18:38` (UTC, locale-independent). */
+function formatTimestamp(value: Date): string {
+  return value.toISOString().replace("T", " ").slice(0, 19);
+}
+
+/** Audit severity -> the shared `.status-badge` variant vocabulary. */
+function severityVariant(severity: string): string {
+  if (severity === "critical") return "danger";
+  if (severity === "warning") return "warning";
+  return "neutral";
+}
+---
+
+<AdminLayout title="Audit trail">
+  <header class="page-header fade-in-up">
+    <h1 id="audit-trail-heading">Audit trail</h1>
+    <p class="page-description">
+      Append-only record of high-risk actions taken in this tenant — who did
+      what, to which resource, and when. Sensitive values are redacted before an
+      event is ever stored, so nothing here can be un-redacted.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="audit-trail-denied">
+        You do not have permission to view the audit trail.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="audit-trail-error">
+        The audit trail could not be loaded right now. Please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <>
+        {/* A GET form: it navigates with query params, so the filter works
+            with JavaScript disabled and ships no bundle. */}
+        <form class="admin-create-form fade-in-up" method="get" role="search">
+          <p class="form-legend">Filter</p>
+
+          <label for="filter-resource-type">
+            Resource type
+            <input
+              type="text"
+              id="filter-resource-type"
+              name="resourceType"
+              value={resourceTypeFilter}
+              list="audit-resource-types"
+              placeholder="Any resource type"
+            />
+          </label>
+          <datalist id="audit-resource-types">
+            {suggestedResourceTypes.map((resourceType) => (
+              <option value={resourceType} />
+            ))}
+          </datalist>
+
+          <label for="filter-limit">
+            Rows (max {MAX_LIMIT})
+            <input
+              type="number"
+              id="filter-limit"
+              name="limit"
+              value={limit}
+              min="1"
+              max={MAX_LIMIT}
+            />
+          </label>
+
+          <button type="submit" class="module-toggle">
+            Apply filter
+          </button>
+          {(resourceTypeFilter !== "" || limit !== DEFAULT_LIMIT) && (
+            <a class="btn-inline" href="/admin/audit-trail">
+              Clear filter
+            </a>
+          )}
+        </form>
+
+        <section class="admin-section fade-in-up" id="audit-trail-events">
+          <h2 class="admin-section-title">
+            Events
+            <span class="count-pill">{events.length}</span>
+          </h2>
+
+          <div class="data-table-scroll">
+            <table class="data-table data-table--stack">
+              <caption class="sr-only">
+                Audit events, newest first
+                {resourceTypeFilter !== "" &&
+                  `, filtered to resource type ${resourceTypeFilter}`}
+              </caption>
+              <thead>
+                <tr>
+                  <th scope="col">When (UTC)</th>
+                  <th scope="col">Severity</th>
+                  <th scope="col">Module</th>
+                  <th scope="col">Action</th>
+                  <th scope="col">Resource</th>
+                  <th scope="col">Message</th>
+                  <th scope="col">Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {events.length === 0 && (
+                  <tr>
+                    <td class="data-table-empty" colspan={7}>
+                      <div class="empty-state">
+                        <span class="empty-state-icon" aria-hidden="true">
+                          🗒
+                        </span>
+                        <span class="empty-state-title">
+                          {resourceTypeFilter === ""
+                            ? "No audit events yet"
+                            : "No audit events match this filter"}
+                        </span>
+                        <span class="empty-state-text">
+                          {resourceTypeFilter === ""
+                            ? "High-risk actions are recorded here as they happen."
+                            : "Try a different resource type, or clear the filter."}
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+                {events.map((event) => (
+                  <tr>
+                    <td data-label="When (UTC)">
+                      <span class="cell-code">
+                        {formatTimestamp(event.createdAt)}
+                      </span>
+                    </td>
+                    <td data-label="Severity">
+                      <span
+                        class="status-badge"
+                        data-variant={severityVariant(event.severity)}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {event.severity}
+                      </span>
+                    </td>
+                    <td data-label="Module">
+                      <span class="cell-code">{event.moduleKey}</span>
+                    </td>
+                    <td data-label="Action">
+                      <span class="cell-code">{event.action}</span>
+                    </td>
+                    <td data-label="Resource">
+                      <span class="cell-code">{event.resourceType}</span>
+                      {event.resourceId !== null && (
+                        <>
+                          {" "}
+                          <span class="cell-muted">{event.resourceId}</span>
+                        </>
+                      )}
+                    </td>
+                    <td data-label="Message">{event.message}</td>
+                    <td data-label="Detail" class="stacked-block">
+                      {event.attributes === null &&
+                      event.correlationId === null ? (
+                        <span class="cell-muted">—</span>
+                      ) : (
+                        <details>
+                          <summary>View</summary>
+                          {event.correlationId !== null && (
+                            <p class="cell-muted">
+                              Correlation:{" "}
+                              <span class="cell-code">
+                                {event.correlationId}
+                              </span>
+                            </p>
+                          )}
+                          {event.attributes !== null && (
+                            /* Escaped text, never `set:html` — the value is
+                               redacted but still caller-supplied JSON. */
+                            <pre class="audit-attributes">
+                              {JSON.stringify(event.attributes, null, 2)}
+                            </pre>
+                          )}
+                        </details>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {possiblyTruncated && (
+            <p class="page-description" id="audit-trail-truncated">
+              Showing the {events.length} most recent matching events. This view
+              is capped at {MAX_LIMIT} rows and cannot page further back — older
+              events exist and are retained according to the audit retention
+              policy.
+            </p>
+          )}
+        </section>
+      </>
+    )
+  }
+</AdminLayout>
+
+<style>
+  /* Long redacted JSON must not force the whole table to scroll sideways. */
+  .audit-attributes {
+    margin: var(--sp-2) 0 0;
+    padding: var(--sp-2);
+    border-radius: var(--radius-md);
+    background: var(--color-surface-2);
+    border: 1px solid var(--color-border);
+    font-family: var(--font-mono);
+    font-size: var(--fs-xs);
+    line-height: 1.5;
+    max-height: 18rem;
+    overflow: auto;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+
+  details > summary {
+    cursor: pointer;
+  }
+</style>

--- a/tests/admin-audit-trail-page-contract.test.ts
+++ b/tests/admin-audit-trail-page-contract.test.ts
@@ -1,0 +1,140 @@
+/**
+ * `/admin/audit-trail` gates against the endpoint it reads.
+ *
+ * Sibling of `admin-security-page-contract.test.ts` and
+ * `admin-site-search-page-contract.test.ts`, for the same silent failure: a
+ * page that gates on a permission key NO migration seeds hides the screen from
+ * everyone — including the owner — while looking perfectly correct. This repo
+ * has shipped that bug twice.
+ *
+ * `logging` declares exactly ONE permission, which makes a wrong guess here
+ * total rather than partial: `logging.audit.read` or `logging.audit_trail.view`
+ * both read naturally and would deny every caller with no visible clue.
+ *
+ * Also pinned: this screen must stay READ-ONLY. The audit trail is append-only
+ * by design — `recordAuditEvent` is the only writer, called by other modules
+ * inside their own transactions. A mutation control appearing on this page
+ * would mean someone had invented a way to edit an audit log.
+ *
+ * Pure — no database, no network.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/audit-trail.astro";
+const ROUTE = "src/pages/api/v1/logs/audit.ts";
+
+type Triple = `${string}.${string}.${string}`;
+
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    const [, moduleKey, activityCode, action] = match;
+    if (moduleKey && activityCode && action) {
+      found.add(`${moduleKey}.${activityCode}.${action}` as Triple);
+    }
+  }
+
+  return found;
+}
+
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    const [, moduleKey, activityCode, action] = match;
+    if (moduleKey && activityCode && action) {
+      found.add(`${moduleKey}.${activityCode}.${action}` as Triple);
+    }
+  }
+
+  return found;
+}
+
+describe("/admin/audit-trail permission gate", () => {
+  test("the key the page gates on is the one the endpoint enforces", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    const enforced = guardTriplesFrom(await readFile(ROUTE, "utf8"));
+
+    // Neither side may be empty, or the subset check below passes vacuously —
+    // the shape of gate this repo has already been burned by.
+    expect(pageKeys.size).toBe(1);
+    expect(enforced.size).toBeGreaterThan(0);
+    expect([...pageKeys].filter((key) => !enforced.has(key))).toEqual([]);
+  });
+
+  test("and is declared by the module descriptor, so a migration seeds it", async () => {
+    const declared = new Set<Triple>(
+      (listModules()
+        .find((module) => module.key === "logging")
+        ?.permissions?.map(
+          (permission) =>
+            `logging.${permission.activityCode}.${permission.action}`
+        ) ?? []) as Triple[]
+    );
+
+    expect(declared.size).toBeGreaterThan(0);
+
+    const missing = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].filter(
+      (key) => !declared.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  test("the screen is read-only — no SQL write, no mutating fetch", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+    // No mutation helper is IMPORTED. Matched as an import statement, not as a
+    // substring: the page's own header comment names `admin-form-client` while
+    // explaining why this screen does not need it, and a bare `toContain` would
+    // fail on the explanation rather than on the behaviour.
+    expect(page).not.toMatch(
+      /import\s*\{[^}]*\}\s*from\s*["'][^"']*admin-form-client/
+    );
+    expect(page).not.toMatch(/sendJson\(\s*"(POST|PATCH|PUT|DELETE)"/);
+    // The filter is a GET form, which is why the page needs no script at all.
+    expect(page).toContain('method="get"');
+  });
+
+  test("the bounded 100-row window is disclosed, not silently truncated", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // `listAuditEvents` clamps to MAX_LIST_LIMIT = 100 with no cursor. A page
+    // that renders the cap without saying so reads as "this is everything that
+    // happened", which for an AUDIT log is the worst possible wrong impression.
+    expect(page).toContain("possiblyTruncated");
+    expect(page).toContain("audit-trail-truncated");
+  });
+
+  test("the endpoint's clamp is still 100, so the page's constant is not stale", async () => {
+    const source = await readFile(
+      "src/modules/logging/application/audit-log.ts",
+      "utf8"
+    );
+    const match = source.match(/MAX_LIST_LIMIT\s*=\s*(\d+)/);
+
+    expect(match?.[1]).toBe("100");
+    expect(await readFile(PAGE, "utf8")).toContain("const MAX_LIMIT = 100");
+  });
+
+  test("the sidebar entry points at this page and is gated on that same key", () => {
+    const nav = listModules()
+      .find((module) => module.key === "logging")
+      ?.navigation?.find((entry) => entry.path === "/admin/audit-trail");
+
+    expect(nav).toBeDefined();
+    expect(nav!.requiredPermission).toBe("logging.audit_trail.read");
+  });
+});


### PR DESCRIPTION
## Ringkasan

`logging` punya **tepat satu** permukaan HTTP (`GET /api/v1/logs/audit`) dan tidak punya layar, jadi riwayat audit tenant — catatan setiap aksi high-risk yang dilakukan sistem ini — hanya bisa dibaca lewat `curl`. Untuk modul yang seluruh tujuannya adalah akuntabilitas, itu tempat yang buruk untuk tidak punya UI.

Tidak ada endpoint, migrasi, atau permission baru.

## Yang dirender

Daftar event terbaru-dulu + filter resource type + detail per-event (`correlationId` dan `attributes`). `attributes` sudah diredaksi **saat tulis** oleh `redactSensitiveAttributes` (password/token/NPWP/NIK/telepon/email tidak pernah sampai ke baris), dan di-render sebagai **teks ter-escape** di dalam `<details>` — tidak pernah lewat `set:html`.

## Keputusan yang perlu dilihat reviewer

**1. Read-only, jadi TIDAK ada client script sama sekali.**
Audit trail bersifat append-only by design — `recordAuditEvent` satu-satunya penulis, dipanggil modul lain di dalam transaksi mereka sendiri. Jadi tidak ada yang perlu di-POST: filternya `<form method="get">` biasa yang bernavigasi lewat query param. Jalan tanpa JavaScript, tidak menambah bundle, dan tidak memberi CSP apa pun untuk diizinkan. Ini satu-satunya layar admin di repo ini yang tidak mengimpor `admin-form-client`, dan itu disengaja.

**2. Batas 100 baris dinyatakan, bukan disembunyikan.**
`listAuditEvents` meng-clamp ke `MAX_LIST_LIMIT = 100` dan **tidak punya cursor** (berbeda dari `_shared/keyset-pagination.ts` yang dipakai endpoint list yang lebih baru). Halaman yang merender batas itu tanpa mengatakannya akan terbaca sebagai _"ini semua yang pernah terjadi"_ — untuk sebuah **audit log**, itu kesan keliru yang paling mahal. Jadi halaman menyatakan batasnya setiap kali tampilan penuh.

Menambahkan keyset pagination ke endpoint itu adalah follow-up dengan perubahan OpenAPI-nya sendiri, **sengaja tidak diselundupkan** ke PR ini.

**3. Filter resource type = text input + `<datalist>`, bukan `<select>`.**
Tidak ada endpoint yang menyebutkan seluruh resource type yang pernah diaudit sebuah tenant. Dropdown yang dibangun dari satu halaman hasil akan menampilkan dirinya sebagai himpunan lengkap dan membuat nilai lain **tidak terjangkau**. Text input dengan saran tetap jujur.

## Test

`tests/admin-audit-trail-page-contract.test.ts` (6 test, pure — tanpa DB):

- Mengikat satu-satunya permission key halaman ke apa yang **ditegakkan route** dan **dideklarasikan descriptor** (jadi ada migrasi yang men-seed-nya). Karena modul ini hanya punya SATU permission, tebakan yang salah bersifat **total, bukan parsial** — `logging.audit.read` terbaca wajar dan akan men-deny setiap pemanggil tanpa petunjuk apa pun di layar.
- Mengikat layar tetap **read-only**: tidak ada SQL write, tidak ada `admin-form-client` yang diimpor, tidak ada request non-GET.
- Mengikat `MAX_LIMIT` halaman ke clamp endpoint-nya sendiri, supaya konstantanya tidak bisa menjadi basi diam-diam.

**Mutation-proven:**

```
permissionKey("logging", "audit_trail", "read") -> ("logging", "audit", "read")
=> 2 fail, lalu 6 pass setelah dikembalikan
```

Catatan: assertion "tidak mengimpor `admin-form-client`" sengaja mencocokkan **pernyataan import**, bukan substring — komentar header halaman menyebut nama itu saat menjelaskan kenapa layar ini tidak membutuhkannya, dan `toContain` polos akan gagal pada penjelasannya, bukan pada perilakunya.

## Verifikasi

`lint`, `typecheck`, `build`, `modules:compose:check`, `modules:composition:inventory:check` (inventory di-regenerate), `logging:lint:check`, `db:tenant-context:check` — semua hijau. Test integrasi DB-gated tidak bisa dijalankan dari sandbox ini (Postgres tak terjangkau dari host); CI yang menjalankannya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)