### PR TITLE
feat(form-drafts): ops screen at /admin/form-drafts

### DIFF
--- a/.changeset/form-drafts-admin-screen.md
+++ b/.changeset/form-drafts-admin-screen.md
@@ -1,0 +1,23 @@
+---
+"awcms": minor
+---
+
+feat(form-drafts): add the `/admin/form-drafts` ops screen and its sidebar entry
+
+`form_drafts` shipped a complete admin API but no screen and no `navigation`
+entry, so the module was invisible in the admin sidebar and the only way to see
+or clear a tenant's accumulated drafts was the JSON API or the daily
+`form-drafts:purge` job.
+
+Adds `/admin/form-drafts`: a filter bar (module key / wizard key / status)
+driving the same filters `GET /api/v1/form-drafts` accepts, the bounded
+newest-first list, a collapsed read-only payload inspector, and a per-row
+delete that calls `DELETE /api/v1/form-drafts/{id}`. Registered in the sidebar
+under System, gated on `form_drafts.draft.read`.
+
+Deliberately not included: a create form, a step editor, and a submit button.
+Drafts are produced by other modules' wizards, and submitting is a domain
+transition that wizard owns — a janitor screen that flipped a draft to
+`submitted` would report work as finished while nothing downstream ran.
+
+No schema, endpoint, or permission change.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -115,7 +115,7 @@
       "capabilitiesProvided": [],
       "capabilitiesConsumed": [],
       "permissionCount": 4,
-      "navigationCount": 0,
+      "navigationCount": 1,
       "jobCount": 1,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/form-drafts/module.ts
+++ b/src/modules/form-drafts/module.ts
@@ -15,9 +15,20 @@ export const FORM_DRAFTS_LIFECYCLE_KEY = "form_drafts.form_drafts";
  * row of `docs/awcms/absorb-awcms-micro-roadmap.md`.
  *
  * Net-new and additive: no existing module changes behaviour, the module DAG
- * stays acyclic (this depends only on `identity_access`), and nothing consumes
- * it yet. It is infrastructure a later multi-step form reaches for, not a
- * tenant-facing feature on its own.
+ * stays acyclic (this depends only on `identity_access`), and no other module's
+ * wizard writes to it yet. It is infrastructure a later multi-step form reaches
+ * for, not a tenant-facing feature on its own.
+ *
+ * It nonetheless declares `navigation` now. The screen it points at,
+ * `/admin/form-drafts`, is an OPS/JANITOR view — filter, inspect the payload
+ * read-only, delete — NOT an authoring UI, so it is useful before any wizard
+ * exists: without it the drafts a tenant accumulates are invisible outside the
+ * JSON API, and the only way to clear a stuck one is the daily purge job. The
+ * entry is gated on `form_drafts.draft.read`, the same triple the routes
+ * enforce and `sql/063` seeds; a non-core entry without a
+ * `requiredPermission` would be visible to everyone (and fails
+ * `tests/admin-navigation-registry.test.ts`). No `group` is set — `form_drafts`
+ * already has a `DEFAULT_MODULE_TYPE` placement (`system`), which wins.
  *
  * `type: "system"` — like `logging`/`data_lifecycle`, this is shared platform
  * mechanism rather than a business capability. A derived or website module owns
@@ -43,6 +54,15 @@ export const formDraftsModule = defineModule({
     openApiPath: "openapi/modules/form-drafts.openapi.yaml",
     basePath: "/api/v1/form-drafts"
   },
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_form_drafts",
+      path: "/admin/form-drafts",
+      // Sits with the other `system` screens, after `/admin/sidebar-menu` (33).
+      order: 34,
+      requiredPermission: "form_drafts.draft.read"
+    }
+  ],
   permissions: FORM_DRAFT_PERMISSIONS.map((permission) => ({
     activityCode: permission.activityCode,
     action: permission.action,

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -169,6 +169,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_tenant_domains": "Tenant domains",
   "admin.layout.nav_modules": "Modules",
   "admin.layout.nav_sidebar_menu": "Sidebar menu",
+  "admin.layout.nav_form_drafts": "Form drafts",
   "admin.layout.nav_email_templates": "Email templates",
   "admin.layout.nav_comments": "Moderation queue",
   "admin.layout.nav_visitor_analytics": "Visitor analytics",

--- a/src/pages/admin/form-drafts.astro
+++ b/src/pages/admin/form-drafts.astro
@@ -1,0 +1,382 @@
+---
+/**
+ * Form drafts screen — an OPS/JANITOR view over `awcms_form_drafts`.
+ *
+ * `form_drafts` is a generic, domain-agnostic scratch store: a draft is created
+ * by some OTHER module's multi-step wizard, and that module owns what the
+ * payload MEANS. So this screen deliberately builds only what a platform
+ * administrator can act on without domain knowledge:
+ *
+ * - a filter bar (module key / wizard key / status) that drives the same
+ *   `moduleKey`/`wizardKey`/`status` filters `GET /api/v1/form-drafts` accepts,
+ * - the bounded newest-first list (the application function caps at 100 rows and
+ *   has no cursor — the same bound the JSON route serves),
+ * - a collapsed, read-only payload inspector, and
+ * - a per-row delete (soft-delete/abandon).
+ *
+ * Deliberately ABSENT — a create form and a step editor. Drafts are produced by
+ * wizards, not typed in by hand here; a hand-built draft would carry a payload
+ * shape no owning module recognises.
+ *
+ * Deliberately ABSENT — the submit button, even though `POST
+ * /api/v1/form-drafts/{id}/submit` exists and is reachable with the `update`
+ * permission this screen could have gated on. Submitting is a DOMAIN
+ * transition: the endpoint only flips `status` to `submitted`, and whatever the
+ * owning wizard does on submission (validate the finished payload, create the
+ * real record, notify) lives in that wizard, not here. A janitor pressing
+ * "Submit" on someone else's half-finished draft would mark it finished while
+ * nothing downstream ever happens — an irreversible, silent lie about state.
+ * Abandoning a draft is the janitorial act; finishing one is not.
+ *
+ * Reads call the SAME application function the JSON route uses (`listFormDrafts`,
+ * see `src/pages/api/v1/form-drafts/index.ts`) inside one
+ * `withTenantOrThrow` — never this app's own HTTP API from frontmatter.
+ *
+ * Every permission gate here is UX-only; `authorizeInTransaction` in the routes
+ * is the authority. The gates use exactly the triples those routes enforce
+ * (`form_drafts.draft.read`, `form_drafts.draft.delete`), pinned by
+ * `tests/admin-form-drafts-page-contract.test.ts`.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listFormDrafts,
+  type FormDraftView
+} from "../../modules/form-drafts/application/form-draft-directory";
+
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(
+  permissionKey("form_drafts", "draft", "read")
+);
+const canDelete = ssr.permissions.has(
+  permissionKey("form_drafts", "draft", "delete")
+);
+
+/** Mirrors `VALID_STATUSES` in `src/pages/api/v1/form-drafts/index.ts`. */
+const STATUS_OPTIONS = ["draft", "submitted", "abandoned", "expired"] as const;
+type DraftStatus = (typeof STATUS_OPTIONS)[number];
+
+function readFilter(name: string): string {
+  return (Astro.url.searchParams.get(name) ?? "").trim();
+}
+
+const moduleKeyFilter = readFilter("moduleKey");
+const wizardKeyFilter = readFilter("wizardKey");
+const statusRaw = readFilter("status");
+// An unknown `status` is dropped rather than sent on: the endpoint answers a
+// bad value with a 400, and a hand-edited query string must not turn this
+// screen into an error page.
+const statusFilter = (STATUS_OPTIONS as readonly string[]).includes(statusRaw)
+  ? (statusRaw as DraftStatus)
+  : "";
+const hasFilters =
+  moduleKeyFilter !== "" || wizardKeyFilter !== "" || statusFilter !== "";
+
+const STATUS_VARIANT: Record<DraftStatus, string> = {
+  draft: "info",
+  submitted: "success",
+  abandoned: "neutral",
+  expired: "warning"
+};
+
+let drafts: FormDraftView[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    // One transaction, one awaited query. Concurrent queries on a single
+    // transaction connection leak it, so nothing here runs in parallel.
+    drafts = await withTenantOrThrow(sql, ssr.tenantId, async (tx) =>
+      listFormDrafts(tx, ssr.tenantId, {
+        moduleKey: moduleKeyFilter || undefined,
+        wizardKey: wizardKeyFilter || undefined,
+        status: statusFilter || undefined
+      })
+    );
+  } catch (error) {
+    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal) — a refusal
+    // must never be rendered as "there are no drafts".
+    loadError = true;
+    logAdminPageError("admin/form-drafts.astro: failed to list drafts", error, {
+      correlationId: Astro.locals.correlationId
+    });
+  }
+}
+
+/** Rendered as a short, single-line preview beside the collapsed payload. */
+function payloadSummary(payload: Record<string, unknown>): string {
+  const keys = Object.keys(payload ?? {});
+  if (keys.length === 0) return "empty payload";
+  return `${keys.length} field(s)`;
+}
+
+const columnCount = canDelete ? 7 : 6;
+---
+
+<AdminLayout title="Form drafts">
+  <header class="page-header fade-in-up">
+    <h1 id="form-drafts-heading">Form drafts</h1>
+    <p class="page-description">
+      Server-side scratch state for multi-step forms. Drafts are created by the
+      wizards of other modules — this screen is for inspecting and clearing
+      them, not for authoring. The newest 100 matching drafts are shown; narrow
+      the list with the filters below. Purged automatically by
+      <code>form-drafts:purge</code>.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="form-drafts-denied">
+        You do not have permission to view form drafts.
+      </p>
+    )
+  }
+
+  {
+    canRead && (
+      <form
+        method="get"
+        class="admin-toolbar fade-in-up"
+        id="draft-filter-form"
+      >
+        <label for="filter-module-key">Module key</label>
+        <input
+          id="filter-module-key"
+          name="moduleKey"
+          type="text"
+          value={moduleKeyFilter}
+          autocomplete="off"
+          placeholder="e.g. blog_content"
+        />
+
+        <label for="filter-wizard-key">Wizard key</label>
+        <input
+          id="filter-wizard-key"
+          name="wizardKey"
+          type="text"
+          value={wizardKeyFilter}
+          autocomplete="off"
+          placeholder="e.g. post_composer"
+        />
+
+        <label for="filter-status">Status</label>
+        <select id="filter-status" name="status">
+          <option value="" selected={statusFilter === ""}>
+            Any status
+          </option>
+          {STATUS_OPTIONS.map((value) => (
+            <option value={value} selected={statusFilter === value}>
+              {value}
+            </option>
+          ))}
+        </select>
+
+        <button type="submit">Apply filters</button>
+      </form>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="form-drafts-error">
+        Form drafts could not be loaded right now. This is a problem reading the
+        list, not an empty list — please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <p
+        id="draft-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="draft-list-title"
+      >
+        <h2 class="admin-section-title" id="draft-list-title">
+          Drafts
+          <span class="count-pill">{drafts.length}</span>
+        </h2>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack" id="form-drafts-table">
+            <caption class="sr-only">
+              Form drafts, newest first, capped at 100 rows.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Module</th>
+                <th scope="col">Wizard</th>
+                <th scope="col">Resource</th>
+                <th scope="col">Step</th>
+                <th scope="col">Status</th>
+                <th scope="col">Updated</th>
+                {canDelete && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {drafts.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={columnCount}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ⌸
+                      </span>
+                      <span class="empty-state-title">
+                        {hasFilters
+                          ? "No drafts match these filters"
+                          : "No form drafts"}
+                      </span>
+                      <span class="empty-state-text">
+                        {hasFilters
+                          ? "Clear or widen the filters above to see more drafts."
+                          : "Drafts appear here as soon as a module's wizard saves one."}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                drafts.map((draft) => (
+                  <tr data-draft-row={draft.id}>
+                    <td data-label="Module">
+                      <span class="cell-code">{draft.moduleKey}</span>
+                    </td>
+                    <td data-label="Wizard">
+                      <span class="cell-code">{draft.wizardKey}</span>
+                    </td>
+                    <td data-label="Resource">
+                      <span class="cell-code">{draft.resourceType}</span>
+                      {draft.resourceId && (
+                        <span class="cell-muted"> · {draft.resourceId}</span>
+                      )}
+                    </td>
+                    <td data-label="Step">
+                      <span class="cell-code">{draft.currentStep}</span>
+                    </td>
+                    <td data-label="Status">
+                      <span
+                        class="status-badge"
+                        data-variant={STATUS_VARIANT[draft.status]}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {draft.status}
+                      </span>
+                    </td>
+                    <td data-label="Updated">
+                      <span class="cell-muted">{draft.updatedAt}</span>
+                      {/* Read-only payload inspection. Collapsed by default so
+                          a wide list stays scannable, and never editable —
+                          editing a payload is the owning wizard's job. */}
+                      <details>
+                        <summary>
+                          Payload ({payloadSummary(draft.payload)})
+                        </summary>
+                        {/* `set:text` rather than a child expression: <pre>
+                            preserves whitespace, and prettier reindents .astro
+                            children — an expression written between the tags
+                            comes back wrapped in the template's own
+                            indentation, which <pre> then renders. `set:text`
+                            escapes and sets the content directly, so the JSON
+                            is the element's only text. */}
+                        <pre
+                          class="cell-code"
+                          set:text={JSON.stringify(draft.payload, null, 2)}
+                        />
+                      </details>
+                    </td>
+                    {canDelete && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          <button
+                            type="button"
+                            class="btn-inline btn-inline--danger draft-delete-btn"
+                            data-draft-id={draft.id}
+                            data-draft-label={`${draft.moduleKey}/${draft.wizardKey}`}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'` with
+  // no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  // Bundled unconditionally (Astro hoists at build time): for a viewer without
+  // `draft.delete` no button renders, so the listener never binds.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("draft-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".draft-delete-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.draftId;
+        if (!id) return;
+        const label = button.dataset.draftLabel ?? "this draft";
+
+        // Destructive and not undoable from this screen — confirm first.
+        if (
+          !window.confirm(
+            `Delete the ${label} draft? Any progress it holds is discarded.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Deleting…");
+
+        // `DELETE /api/v1/form-drafts/{id}` takes an optional `reason` and is
+        // idempotent by construction (`deleted_at IS NULL` guard), so it needs
+        // no `Idempotency-Key`.
+        const result = await sendJson("DELETE", `/api/v1/form-drafts/${id}`, {
+          reason: "Deleted from the admin form drafts screen."
+        });
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // Generic copy only — never surface internal detail (Issue #540).
+        showActionError("Could not delete the draft. Please try again.");
+        unlock();
+      });
+    });
+</script>

--- a/tests/admin-form-drafts-page-contract.test.ts
+++ b/tests/admin-form-drafts-page-contract.test.ts
@@ -1,0 +1,187 @@
+/**
+ * `/admin/form-drafts` gates against the endpoints it drives.
+ *
+ * The failure this pins is silent and looks correct in review: a page that
+ * gates on a permission key NO migration seeds hides its controls from
+ * everyone, INCLUDING the tenant owner, and renders as a working screen with a
+ * missing section. This repo has shipped that bug twice (admin roles write,
+ * admin ABAC policy write), both times by inventing a plausible action name —
+ * `form_drafts` is unusually exposed to it because "submit" and "abandon" are
+ * obvious-sounding actions that its catalog (`sql/063`, seeded from
+ * `FORM_DRAFT_PERMISSIONS`) does not contain: the routes reuse `draft.update`
+ * for submit and `draft.delete` for abandon.
+ *
+ * So: extract the guard triples from the route sources, extract the
+ * `permissionKey(...)` triples from the page, and require the page's set to be
+ * a subset of what the routes actually ENFORCE and of what the module
+ * descriptor DECLARES (which `module-management`'s permission sync compares
+ * against the seed migrations).
+ *
+ * Pure — no database, no network.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/form-drafts.astro";
+const ROUTES = [
+  "src/pages/api/v1/form-drafts/index.ts",
+  "src/pages/api/v1/form-drafts/[id].ts",
+  "src/pages/api/v1/form-drafts/[id]/submit.ts"
+];
+
+type Triple = `${string}.${string}.${string}`;
+
+/**
+ * These routes express their guards as module-level literal objects, e.g.
+ *
+ *   const READ_GUARD = { moduleKey: "form_drafts", activityCode: "draft",
+ *     action: "read" as const };
+ *
+ * so the extractor matches that shape (allowing the `as const` suffix and
+ * arbitrary whitespace/newlines between fields) rather than the shared-constant
+ * form some other modules use. If a route is ever refactored to import its
+ * guard from `form-draft-permissions.ts`, this stops matching — and the
+ * `enforced.size` guard below turns that into a RED test rather than a check
+ * that silently passes on nothing.
+ */
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*(?:\/\/[^\n]*\n\s*)*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+/** `permissionKey("form_drafts", "draft", "read")` → `form_drafts.draft.read`. */
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+async function enforcedTriples(): Promise<Set<Triple>> {
+  const enforced = new Set<Triple>();
+
+  for (const route of ROUTES) {
+    for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+      enforced.add(triple);
+    }
+  }
+
+  return enforced;
+}
+
+describe("/admin/form-drafts permission gates", () => {
+  test("the extractors find something on both sides — no vacuous pass", async () => {
+    // Both subset assertions below are trivially satisfied by an empty left
+    // side or an over-large right side. Pin the fixture explicitly: the page
+    // really does gate, and the routes really were parsed.
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    const enforced = await enforcedTriples();
+
+    expect(pageKeys.size).toBeGreaterThan(0);
+    expect(enforced.size).toBeGreaterThan(0);
+    // The exact triples the three routes enforce today. Stated so a route that
+    // loses or renames a guard is caught here, at the source of truth, instead
+    // of quietly widening what the page is allowed to claim.
+    expect([...enforced].sort()).toEqual([
+      "form_drafts.draft.create",
+      "form_drafts.draft.delete",
+      "form_drafts.draft.read",
+      "form_drafts.draft.update"
+    ]);
+  });
+
+  test("every key the page gates on is one its endpoints actually enforce", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    const enforced = await enforcedTriples();
+
+    expect([...pageKeys].filter((key) => !enforced.has(key)).sort()).toEqual(
+      []
+    );
+  });
+
+  test("and is declared by the module descriptor, so a migration seeds it", async () => {
+    const declared = new Set<Triple>(
+      (listModules()
+        .find((module) => module.key === "form_drafts")
+        ?.permissions?.map(
+          (permission) =>
+            `form_drafts.${permission.activityCode}.${permission.action}`
+        ) ?? []) as Triple[]
+    );
+
+    expect(declared.size).toBeGreaterThan(0);
+
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+
+    expect([...pageKeys].filter((key) => !declared.has(key)).sort()).toEqual(
+      []
+    );
+  });
+
+  test("the janitor screen gates exactly on read and delete", async () => {
+    // Written down because both halves look like mistakes and are not.
+    //
+    // `delete` (not an invented `abandon`/`remove`): the DELETE route is a
+    // soft-delete that flips `status` to `abandoned`, but the ABAC action it
+    // guards on is `delete`.
+    //
+    // No `update`: the screen deliberately ships no submit button and no step
+    // editor — submitting is a domain transition the owning wizard performs,
+    // not a janitorial one (see the page's own header comment). If a future
+    // increment adds one, this assertion is the place that must be updated
+    // consciously.
+    const pageKeys = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].sort();
+
+    expect(pageKeys).toEqual([
+      "form_drafts.draft.delete",
+      "form_drafts.draft.read"
+    ]);
+  });
+
+  test("the page never writes SQL itself — it calls the guarded endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Reads go through the application layer; writes go out over fetch, so the
+    // routes' ABAC guard and audit rows cannot be bypassed by a screen that
+    // mutates for itself.
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+    expect(page).toContain('sendJson("DELETE", `/api/v1/form-drafts/${id}`');
+    // `.astro` is a blind spot for `tsc --noEmit`, so the tenant-context rule
+    // (`db:tenant-context:check`) is asserted here too: the request-path
+    // `withTenant` returns `T | Response`, which on an SSR page silently
+    // renders a `Response` where rows are expected.
+    expect(page).toContain("withTenantOrThrow(");
+    expect(page).not.toMatch(/\bwithTenant\(/);
+  });
+
+  test("the sidebar entry points at a page that exists and is gated on read", async () => {
+    const nav = listModules()
+      .find((module) => module.key === "form_drafts")
+      ?.navigation?.find((entry) => entry.path === "/admin/form-drafts");
+
+    expect(nav).toBeDefined();
+    // A non-core entry without a `requiredPermission` renders for everyone.
+    expect(nav!.requiredPermission).toBe("form_drafts.draft.read");
+    // `admin-navigation-registry.test.ts` already binds path→file and
+    // labelKey→SIDEBAR_LABELS in both directions; this only pins the gate,
+    // which it does not check.
+    await expect(Bun.file(PAGE).exists()).resolves.toBe(true);
+  });
+});


### PR DESCRIPTION
## Ringkasan

`form_drafts` mengapalkan API draft yang lengkap tetapi tidak punya layar dan tidak mendeklarasikan `navigation`, jadi modulnya tidak terlihat di sidebar. PR ini menambahkan layar **ops/janitor** beserta entri sidebar-nya dalam commit yang sama.

Tidak ada endpoint, migrasi, atau permission baru.

## Yang dirender

Daftar draft milik tenant (filter module / wizard / status), inspektur payload read-only yang bisa dilipat, dan aksi hapus. **Bukan** editor wizard — draft dibuat oleh wizard modul lain, bukan diketik di sini.

## Keputusan yang perlu dilihat reviewer

**Submit sengaja TIDAK disertakan.** Endpoint `POST /{id}/submit` hanya membalik `status` menjadi `submitted`; seluruh konsekuensi submit — memvalidasi payload yang sudah selesai, membuat record sebenarnya, mengirim notifikasi — hidup di wizard pemiliknya, yang tidak ikut dalam alur ketika seorang janitor menekan tombol di sini. Menekannya akan menandai draft setengah jadi milik orang lain sebagai selesai sementara tidak ada apa pun di hilir yang pernah berjalan — tanpa bisa dibatalkan dan tanpa jejak. **Mengabaikan draft itu pekerjaan janitor; menyelesaikannya bukan.**

Konsekuensinya halaman ini hanya bergerbang pada `draft.read` dan `draft.delete`, dan tidak butuh `Idempotency-Key` di mana pun (`DELETE /{id}` idempoten lewat guard `deleted_at IS NULL`-nya sendiri). Keputusan ini ditegakkan test, jadi increment berikutnya harus mengubahnya secara sadar.

**`<pre set:text={...}>` untuk payload.** Upaya pertama menaruh ekspresi `JSON.stringify` sebagai anak `<pre>`; prettier meng-indent ulang anak `.astro` bahkan di dalam `<pre>`, dan `<pre>` mempertahankan spasi itu — sehingga JSON ter-render membawa indentasi template. `set:text` menetapkan konten ter-escape tanpa anak yang bisa disentuh prettier. Diverifikasi lewat rebuild sungguhan, bukan diasumsikan.

## Test

`tests/admin-form-drafts-page-contract.test.ts` mengikat permission key halaman ke apa yang ditegakkan route dan dideklarasikan descriptor — kelas bug yang sudah dua kali dikirim repo ini (action karangan yang men-deny bahkan owner sementara kodenya terlihat benar). Anti-vacuity guard-nya mem-pin himpunan yang ditegakkan secara persis (`create`/`delete`/`read`/`update`), bukan sekadar `size > 0`, sehingga regex yang berhenti cocok akan gagal keras alih-alih lolos di atas himpunan kosong.

**Mutation-proven:** mengubah gerbang delete menjadi `form_drafts.draft.remove` → **3 fail** (masing-masing menyebut `form_drafts.draft.remove` secara eksplisit), lalu **6 pass** setelah dikembalikan.

## Verifikasi

**`bun run check` PENUH hijau** — 2785 pass, 428 skip, 0 fail, build selesai. Termasuk `check:docs`, `api:spec:check`, `family:conformance:check`, `modules:routes:check`, `modules:compose:check` (21 modul), `modules:composition:inventory:check`, `logging:lint:check`, `db:tenant-context:check`.

428 test yang di-skip adalah suite DB-gated: Postgres tak terjangkau dari sandbox ini. CI yang menjalankannya.

Bundling script diverifikasi dari keluaran build (external `_astro/*.js`), bukan diasumsikan — script yang ter-inline akan diblokir `default-src 'self'`.

## Batasan yang diketahui

Filter module/wizard adalah input teks bebas, bukan dropdown nilai yang benar-benar ada — opsi yang diturunkan dari hasil yang sudah terfilter akan menyesatkan. `deleteFormDraft` adalah soft delete, tetapi tidak ada API maupun layar yang bisa mendaftar/memulihkan draft ter-soft-delete, jadi penghapusan tak sengaja hanya bisa dipulihkan sampai `form-drafts:purge` berjalan — kandidat follow-up yang wajar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)