### PR TITLE
fix(blog-content): daftar post mengembalikan apa yang kontraknya janjikan + ?view=full

### DIFF
--- a/.changeset/blog-posts-build-feed-view-full.md
+++ b/.changeset/blog-posts-build-feed-view-full.md
@@ -1,0 +1,40 @@
+---
+"awcms": patch
+---
+
+`GET /api/v1/blog/posts` mengembalikan apa yang kontraknya janjikan, dan
+mendapat mode `?view=full` untuk build feed.
+
+Kontrak OpenAPI menyatakan endpoint ini mengembalikan `BlogPost` — lengkap
+dengan `contentJson`, `excerpt`, `metaDescription`, `canonicalUrl`, dan
+`translationGroupId`. Implementasinya mengembalikan ringkasan yang tidak memuat
+satu pun dari itu. Selisih itu tidak pernah gagal di mana pun: klien yang
+mempercayai dokumen membaca field-field tersebut sebagai `undefined`.
+
+Akibatnya nyata dan sudah terjadi. Sebuah situs `awcms-astro` membangun hijau
+dengan **badan setiap artikel kosong** — dan karena seksi tempat artikel berada
+juga tinggal di dalam `contentJson`, **seluruh seksinya kosong juga**. Tidak ada
+error di build mana pun, tidak ada 4xx, tidak ada baris log.
+
+Tiga perubahan:
+
+- **`?view=full`** mengembalikan baris penuh (`BlogPost`) dengan cursor keyset
+  yang sama, batas halaman 50 karena barisnya membawa `contentJson`. Ia
+  **mensyaratkan** `order=created_at`: traversal penuh hanya sehat di atas
+  urutan yang tidak berubah, dan syaratnya dinyatakan alih-alih diam-diam
+  disubstitusi — sikap yang sama seperti penolakan `cursor` atas urutan mutable.
+  Tanpa mode ini, satu-satunya cara membangun situs adalah menyusuri daftar lalu
+  mengambil ulang setiap post satu per satu (N+1 permintaan per build, ke
+  endpoint admin, pada setiap publish).
+- **`translationGroupId` kini benar-benar dikembalikan** — oleh `view=full`
+  maupun `GET /api/v1/blog/posts/{id}`. Kolomnya sudah ada dan bisa ditulis
+  sejak awal, tetapi tidak satu pun endpoint baca mengembalikannya, sehingga
+  klien bisa menyetel pasangan terjemahan dan tidak pernah bisa membacanya lagi.
+- **Bentuk ringkasannya dinyatakan sebagai skema tersendiri**
+  (`BlogPostSummary`) alih-alih dibiarkan disimpulkan pembaca. Dokumen yang
+  menjanjikan lebih dari yang dikirim kode adalah dokumen yang membuat klien
+  salah dengan yakin.
+
+Validasi query dipindahkan ke `parseBlogPostListQuery` (domain, murni) supaya
+setiap penolakan punya tes tanpa basis data — sebelumnya ia inline di route dan
+tidak bisa dijangkau tes mana pun tanpa sesi dan Postgres.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -4697,19 +4697,25 @@ Read-only preview for the admin editor. Gated by blog_content.pages.read.
 - **operationId**: `blogListPosts`
 - **Security**: bearerAuth + tenantHeader
 
-Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100 — max 50 with `view=full`, whose rows carry `contentJson`).
 
 Ordering defaults to `updated_at DESC` — right for an admin table, and unsound as a keyset key because editing a post moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY post (a build feed) passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
 
+**The default response is `BlogPostSummary`, not `BlogPost`.** It carries no `contentJson`, `excerpt`, `metaDescription`, `canonicalUrl`, or `translationGroupId`. This document used to say otherwise, and a client that believed it built an entire static site with every article body empty — nothing failed, because a missing field reads as `undefined`. A caller that needs the body asks for `?view=full` (which requires `order=created_at`) and receives `BlogPost`.
+
 **Parameters**
 
-| Name               | In     | Required | Type                                                          | Description                                                                                                                                          |
-| ------------------ | ------ | -------- | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `status`           | query  | no       | enum(`draft`, `review`, `scheduled`, `published`, `archived`) |                                                                                                                                                      |
-| `limit`            | query  | no       | integer                                                       |                                                                                                                                                      |
-| `order`            | query  | no       | enum(`created_at`, `updated_at`)                              | Sort key. `created_at` selects the STABLE, cursor-capable traversal; `updated_at` (default) is the admin ordering and rejects `cursor`.              |
-| `cursor`           | query  | no       | string                                                        | Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor". |
-| `X-Correlation-ID` | header | no       | string                                                        |                                                                                                                                                      |
+| Name     | In    | Required | Type                                                          | Description                                                                                                                                                                                           |
+| -------- | ----- | -------- | ------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `status` | query | no       | enum(`draft`, `review`, `scheduled`, `published`, `archived`) |                                                                                                                                                                                                       |
+| `limit`  | query | no       | integer                                                       |                                                                                                                                                                                                       |
+| `order`  | query | no       | enum(`created_at`, `updated_at`)                              | Sort key. `created_at` selects the STABLE, cursor-capable traversal; `updated_at` (default) is the admin ordering and rejects `cursor`.                                                               |
+| `cursor` | query | no       | string                                                        | Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor".                                                  |
+| `view`   | query | no       | enum(`summary`, `full`)                                       | Response projection. `summary` (default) returns `BlogPostSummary`; `full` returns `BlogPost` — every column the detail endpoint returns except `termIds`, which would cost one extra query per post. |
+
+`full` requires `order=created_at`: a full traversal is only sound over the immutable ordering, and the ordering is demanded rather than silently substituted. An unrecognised value is a 400, never a silent fallback to `summary`.
+|
+| `X-Correlation-ID` | header | no | string | |
 
 **Responses**
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -3205,9 +3205,11 @@ paths:
       operationId: blogListPosts
       summary: List this tenant's non-deleted blog posts
       description: |
-        Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+        Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100 — max 50 with `view=full`, whose rows carry `contentJson`).
 
         Ordering defaults to `updated_at DESC` — right for an admin table, and unsound as a keyset key because editing a post moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY post (a build feed) passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
+
+        **The default response is `BlogPostSummary`, not `BlogPost`.** It carries no `contentJson`, `excerpt`, `metaDescription`, `canonicalUrl`, or `translationGroupId`. This document used to say otherwise, and a client that believed it built an entire static site with every article body empty — nothing failed, because a missing field reads as `undefined`. A caller that needs the body asks for `?view=full` (which requires `order=created_at`) and receives `BlogPost`.
       parameters:
         - name: status
           in: query
@@ -3238,6 +3240,17 @@ paths:
           description: Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor".
           schema:
             type: string
+        - name: view
+          in: query
+          description: |
+            Response projection. `summary` (default) returns `BlogPostSummary`; `full` returns `BlogPost` — every column the detail endpoint returns except `termIds`, which would cost one extra query per post.
+
+            `full` requires `order=created_at`: a full traversal is only sound over the immutable ordering, and the ordering is demanded rather than silently substituted. An unrecognised value is a 400, never a silent fallback to `summary`.
+          schema:
+            type: string
+            enum:
+              - summary
+              - full
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -3256,8 +3269,11 @@ paths:
                     properties:
                       posts:
                         type: array
+                        description: "`BlogPostSummary` by default; `BlogPost` when `view=full`."
                         items:
-                          $ref: "#/components/schemas/BlogPost"
+                          oneOf:
+                            - $ref: "#/components/schemas/BlogPostSummary"
+                            - $ref: "#/components/schemas/BlogPost"
                       nextCursor:
                         type: string
                         nullable: true
@@ -15658,6 +15674,60 @@ components:
           items:
             type: string
             format: uuid
+    BlogPostSummary:
+      type: object
+      description: |
+        What the LIST endpoint returns by default — deliberately not a `BlogPost`.
+
+        It exists as its own schema because the list used to be documented as returning `BlogPost`, and it never did: no `contentJson`, `excerpt`, `metaDescription`, `canonicalUrl`, or `translationGroupId`. A client that trusted the document read those as `undefined` and published a site with empty articles, with nothing failing. Ask for `?view=full` to get `BlogPost`.
+      required:
+        - id
+        - tenantId
+        - title
+        - slug
+        - status
+        - visibility
+        - locale
+        - createdAt
+        - updatedAt
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        status:
+          type: string
+          enum:
+            - draft
+            - review
+            - scheduled
+            - published
+            - archived
+        visibility:
+          type: string
+          enum:
+            - public
+            - private
+            - unlisted
+        locale:
+          type: string
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Immutable — the only sort key this list can paginate over soundly.
+        updatedAt:
+          type: string
+          format: date-time
     BlogPostWriteInput:
       type: object
       description: Shared shape for POST /api/v1/blog/posts (all fields required) and PATCH /api/v1/blog/posts/{id} (all fields optional, only present fields change).

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -34,9 +34,11 @@ paths:
       operationId: blogListPosts
       summary: List this tenant's non-deleted blog posts
       description: |
-        Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100).
+        Gated by blog_content.posts.read. Optional ?status= filter, ?limit= bounded (default 20, max 100 — max 50 with `view=full`, whose rows carry `contentJson`).
 
         Ordering defaults to `updated_at DESC` — right for an admin table, and unsound as a keyset key because editing a post moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY post (a build feed) passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
+
+        **The default response is `BlogPostSummary`, not `BlogPost`.** It carries no `contentJson`, `excerpt`, `metaDescription`, `canonicalUrl`, or `translationGroupId`. This document used to say otherwise, and a client that believed it built an entire static site with every article body empty — nothing failed, because a missing field reads as `undefined`. A caller that needs the body asks for `?view=full` (which requires `order=created_at`) and receives `BlogPost`.
       parameters:
         - name: status
           in: query
@@ -60,6 +62,15 @@ paths:
           description: Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor".
           schema:
             type: string
+        - name: view
+          in: query
+          description: |
+            Response projection. `summary` (default) returns `BlogPostSummary`; `full` returns `BlogPost` — every column the detail endpoint returns except `termIds`, which would cost one extra query per post.
+
+            `full` requires `order=created_at`: a full traversal is only sound over the immutable ordering, and the ordering is demanded rather than silently substituted. An unrecognised value is a 400, never a silent fallback to `summary`.
+          schema:
+            type: string
+            enum: [summary, full]
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -77,8 +88,11 @@ paths:
                     properties:
                       posts:
                         type: array
+                        description: "`BlogPostSummary` by default; `BlogPost` when `view=full`."
                         items:
-                          $ref: "#/components/schemas/BlogPost"
+                          oneOf:
+                            - $ref: "#/components/schemas/BlogPostSummary"
+                            - $ref: "#/components/schemas/BlogPost"
                       nextCursor:
                         type: string
                         nullable: true
@@ -2442,6 +2456,54 @@ components:
         autoInternalTagLinksDisabled:
           type: boolean
           description: Per-post opt-out of automatic internal tag linking.
+    BlogPostSummary:
+      type: object
+      description: |
+        What the LIST endpoint returns by default — deliberately not a `BlogPost`.
+
+        It exists as its own schema because the list used to be documented as returning `BlogPost`, and it never did: no `contentJson`, `excerpt`, `metaDescription`, `canonicalUrl`, or `translationGroupId`. A client that trusted the document read those as `undefined` and published a site with empty articles, with nothing failing. Ask for `?view=full` to get `BlogPost`.
+      required:
+        [
+          id,
+          tenantId,
+          title,
+          slug,
+          status,
+          visibility,
+          locale,
+          createdAt,
+          updatedAt
+        ]
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        status:
+          type: string
+          enum: [draft, review, scheduled, published, archived]
+        visibility:
+          type: string
+          enum: [public, private, unlisted]
+        locale:
+          type: string
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          description: Immutable — the only sort key this list can paginate over soundly.
+        updatedAt:
+          type: string
+          format: date-time
     BlogPost:
       type: object
       required:

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -93,6 +93,16 @@ export type BlogPostView = {
   version: number;
   /** Issue #641 — manual per-post opt-out of automatic internal tag linking. */
   autoInternalTagLinksDisabled: boolean;
+  /**
+   * Groups the locale variants of one logical post.
+   *
+   * Writable since the column existed and returned by nothing until now, even
+   * though the OpenAPI `BlogPost` schema declared it the whole time. A client
+   * pairing locales (an `awcms-astro` build is the one that hit this) could set
+   * the field and never read it back, so every translation looked like an
+   * unrelated post.
+   */
+  translationGroupId: string | null;
 };
 
 type BlogPostRow = {
@@ -123,6 +133,7 @@ type BlogPostRow = {
   restored_by: string | null;
   version: number;
   auto_internal_tag_links_disabled: boolean;
+  translation_group_id: string | null;
 };
 
 function toView(row: BlogPostRow): BlogPostView {
@@ -153,7 +164,8 @@ function toView(row: BlogPostRow): BlogPostView {
     restoredAt: row.restored_at,
     restoredBy: row.restored_by,
     version: row.version,
-    autoInternalTagLinksDisabled: row.auto_internal_tag_links_disabled
+    autoInternalTagLinksDisabled: row.auto_internal_tag_links_disabled,
+    translationGroupId: row.translation_group_id
   };
 }
 
@@ -180,7 +192,8 @@ export async function createBlogPost(
       content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       created_at, updated_at, deleted_at, deleted_by, delete_reason,
-      restored_at, restored_by, version, auto_internal_tag_links_disabled
+      restored_at, restored_by, version, auto_internal_tag_links_disabled,
+      translation_group_id
   `) as BlogPostRow[];
 
   return toView(rows[0]!);
@@ -204,7 +217,8 @@ export async function fetchBlogPostById(
       content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       created_at, updated_at, deleted_at, deleted_by, delete_reason,
-      restored_at, restored_by, version, auto_internal_tag_links_disabled
+      restored_at, restored_by, version, auto_internal_tag_links_disabled,
+      translation_group_id
         FROM awcms_blog_posts
         WHERE tenant_id = ${tenantId} AND id = ${postId}
       `
@@ -213,7 +227,8 @@ export async function fetchBlogPostById(
       content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       created_at, updated_at, deleted_at, deleted_by, delete_reason,
-      restored_at, restored_by, version, auto_internal_tag_links_disabled
+      restored_at, restored_by, version, auto_internal_tag_links_disabled,
+      translation_group_id
         FROM awcms_blog_posts
         WHERE tenant_id = ${tenantId} AND id = ${postId} AND deleted_at IS NULL
       `
@@ -230,6 +245,15 @@ export type ListBlogPostsFilter = {
 
 const DEFAULT_LIST_LIMIT = 20;
 const MAX_LIST_LIMIT = 100;
+
+/**
+ * Full rows carry `content_json` — a page of 100 of them is a different order
+ * of magnitude from a page of summaries. The caller that wants them (a static
+ * build) walks the whole set anyway, so a smaller page costs it nothing while
+ * bounding any single response.
+ */
+const DEFAULT_FULL_LIST_LIMIT = 20;
+const MAX_FULL_LIST_LIMIT = 50;
 
 /**
  * STABLE, cursor-paginated traversal — ordered `(created_at DESC, id DESC)`.
@@ -298,6 +322,78 @@ export async function listBlogPostsPage(
 }
 
 /** `LIMIT` bounded (default 20, max 100), newest-updated first — same bounded-list convention as `email/templates` and `workflows/tasks`. For a STABLE traversal past page one, use {@link listBlogPostsPage}. */
+/**
+ * The same stable traversal as {@link listBlogPostsPage}, but returning FULL
+ * posts instead of summaries — the shape the OpenAPI contract calls `BlogPost`.
+ *
+ * ## Why this exists
+ *
+ * A static-site build needs every published post WITH its body: `contentJson`,
+ * `excerpt`, `metaDescription`, `canonicalUrl`, and `translationGroupId`. The
+ * summary traversal carries none of those, so the only way to build a site was
+ * to walk the list and then fetch every post again by id — N+1 requests per
+ * build, against an admin endpoint, on every publish.
+ *
+ * Worse, nothing said so. The contract documented this endpoint as returning
+ * `BlogPost`, the implementation returned a summary, and a client that trusted
+ * the contract read `contentJson` as `undefined` — producing a site that built
+ * green with every article body empty, and (because the section an article
+ * belongs to also lives inside `contentJson`) every section empty too. That is
+ * the defect this closes, and the reason the summary shape is now spelled out
+ * in the contract as its own schema instead of being left to be inferred.
+ *
+ * The projection is deliberately identical to `fetchBlogPostById`'s, minus the
+ * per-post `termIds` — those are a second query each, which would put the N+1
+ * straight back.
+ */
+export async function listBlogPostsFullPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  options: {
+    status?: BlogContentStatus;
+    limit?: number;
+    cursor?: KeysetCursor | null;
+  } = {}
+): Promise<{ items: BlogPostView[]; nextCursor: string | null }> {
+  const limit = boundedPageSize(
+    options.limit,
+    DEFAULT_FULL_LIST_LIMIT,
+    MAX_FULL_LIST_LIMIT
+  );
+
+  const cursorCreatedAt = options.cursor?.createdAt ?? null;
+  const cursorId = options.cursor?.id ?? null;
+  const status = options.status ?? null;
+
+  const rows = (await tx`
+    SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      meta_description, canonical_url, locale, published_at, scheduled_at,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      restored_at, restored_by, version, auto_internal_tag_links_disabled,
+      translation_group_id,
+      to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
+    FROM awcms_blog_posts
+    WHERE tenant_id = ${tenantId}
+      AND deleted_at IS NULL
+      AND (${status}::text IS NULL OR status = ${status})
+      AND (
+        ${cursorCreatedAt}::timestamptz IS NULL
+        OR (created_at, id) < (${cursorCreatedAt}::timestamptz, ${cursorId}::uuid)
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${limit}
+  `) as (BlogPostRow & { created_at_cursor: string })[];
+
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === limit && last
+      ? encodeKeysetCursor(last.created_at_cursor, last.id)
+      : null;
+
+  return { items: rows.map(toView), nextCursor };
+}
+
 export async function listBlogPosts(
   tx: Bun.SQL,
   tenantId: string,
@@ -384,7 +480,8 @@ export async function updateBlogPost(
       content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       created_at, updated_at, deleted_at, deleted_by, delete_reason,
-      restored_at, restored_by, version, auto_internal_tag_links_disabled
+      restored_at, restored_by, version, auto_internal_tag_links_disabled,
+      translation_group_id
   `) as BlogPostRow[];
 
   return rows[0] ? toView(rows[0]) : null;
@@ -441,7 +538,8 @@ export async function transitionBlogPostStatus(
       content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       created_at, updated_at, deleted_at, deleted_by, delete_reason,
-      restored_at, restored_by, version, auto_internal_tag_links_disabled
+      restored_at, restored_by, version, auto_internal_tag_links_disabled,
+      translation_group_id
   `) as BlogPostRow[];
 
   return rows[0] ? toView(rows[0]) : null;
@@ -462,7 +560,8 @@ export async function restoreBlogPost(
       content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       created_at, updated_at, deleted_at, deleted_by, delete_reason,
-      restored_at, restored_by, version, auto_internal_tag_links_disabled
+      restored_at, restored_by, version, auto_internal_tag_links_disabled,
+      translation_group_id
   `) as BlogPostRow[];
 
   return rows[0] ? toView(rows[0]) : null;

--- a/src/modules/blog-content/domain/blog-post-list-query.ts
+++ b/src/modules/blog-content/domain/blog-post-list-query.ts
@@ -1,0 +1,134 @@
+/**
+ * Parses and validates the query string of `GET /api/v1/blog/posts`.
+ *
+ * ## Why this is a domain function and not inline in the route
+ *
+ * Every rule here is a rule about what a caller may ASK for, and each one
+ * exists because the wrong answer is silent:
+ *
+ *   - a cursor over the mutable ordering skips or repeats rows, and the caller
+ *     cannot tell (see `blog-post-directory.ts`);
+ *   - a malformed cursor treated as "no cursor" restarts the traversal from
+ *     page one, so a build quietly re-reads what it already had and never
+ *     reaches the end;
+ *   - an unknown `view` silently falling back to summaries hands back rows
+ *     without `contentJson` to a caller that asked for full posts — the exact
+ *     failure this parameter was added to end.
+ *
+ * None of those can be reached through the route without a database and a
+ * session, so inline validation is validation nothing tests. Here it is a pure
+ * function over `URLSearchParams`, and `tests/blog-content-posts-list-query.test.ts`
+ * covers each refusal.
+ */
+import { isBlogContentStatus, type BlogContentStatus } from "./post-status";
+
+import {
+  decodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
+
+/** `summary` is the admin table's shape; `full` is the build feed's. */
+export type BlogPostListView = "summary" | "full";
+
+export type BlogPostListQuery = {
+  status?: BlogContentStatus;
+  limit?: number;
+  /** True only for `order=created_at` — the sole ordering a cursor is sound over. */
+  stableOrder: boolean;
+  cursor: KeysetCursor | null;
+  view: BlogPostListView;
+};
+
+export type BlogPostListQueryResult =
+  { valid: true; value: BlogPostListQuery } | { valid: false; message: string };
+
+const VIEWS: readonly BlogPostListView[] = ["summary", "full"];
+
+export function parseBlogPostListQuery(
+  params: URLSearchParams
+): BlogPostListQueryResult {
+  const statusParam = params.get("status");
+  let status: BlogContentStatus | undefined;
+
+  if (statusParam !== null) {
+    if (!isBlogContentStatus(statusParam)) {
+      return {
+        valid: false,
+        message:
+          "status must be one of draft, review, scheduled, published, archived."
+      };
+    }
+
+    status = statusParam;
+  }
+
+  const limitParam = params.get("limit");
+  const limit = limitParam ? Number(limitParam) : undefined;
+
+  if (
+    limitParam !== null &&
+    (!Number.isFinite(limit) || (limit as number) < 1)
+  ) {
+    return { valid: false, message: "limit must be a positive number." };
+  }
+
+  const orderParam = params.get("order");
+
+  if (
+    orderParam !== null &&
+    orderParam !== "created_at" &&
+    orderParam !== "updated_at"
+  ) {
+    return {
+      valid: false,
+      message: "order must be one of created_at, updated_at."
+    };
+  }
+
+  const stableOrder = orderParam === "created_at";
+  const cursorParam = params.get("cursor");
+
+  if (cursorParam !== null && !stableOrder) {
+    return {
+      valid: false,
+      message:
+        "cursor requires order=created_at — updated_at changes on every edit, so a cursor over it can skip or repeat posts."
+    };
+  }
+
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam !== null && cursor === null) {
+    return { valid: false, message: "cursor is malformed." };
+  }
+
+  const viewParam = params.get("view");
+
+  if (viewParam !== null && !VIEWS.includes(viewParam as BlogPostListView)) {
+    return { valid: false, message: "view must be one of summary, full." };
+  }
+
+  // `view=full` is the build feed, and a build feed is a TRAVERSAL: it only
+  // means anything if the caller can walk it to the end. Serving it over the
+  // mutable ordering would hand back a first page that cannot be continued —
+  // `cursor` is refused there — so the ordering is demanded up front instead of
+  // being silently substituted, which is the same stance `cursor` takes.
+  if (viewParam === "full" && !stableOrder) {
+    return {
+      valid: false,
+      message:
+        "view=full requires order=created_at — a full traversal is only sound over the immutable ordering."
+    };
+  }
+
+  return {
+    valid: true,
+    value: {
+      status,
+      limit,
+      stableOrder,
+      cursor,
+      view: (viewParam as BlogPostListView | null) ?? "summary"
+    }
+  };
+}

--- a/src/pages/api/v1/blog/posts/index.ts
+++ b/src/pages/api/v1/blog/posts/index.ts
@@ -18,9 +18,10 @@ import { recordAuditEvent } from "../../../../../modules/logging/application/aud
 import {
   createBlogPost,
   listBlogPosts,
+  listBlogPostsFullPage,
   listBlogPostsPage
 } from "../../../../../modules/blog-content/application/blog-post-directory";
-import { decodeKeysetCursor } from "../../../../../modules/_shared/keyset-pagination";
+import { parseBlogPostListQuery } from "../../../../../modules/blog-content/domain/blog-post-list-query";
 import {
   countExistingTerms,
   syncPostTermAssignments
@@ -31,10 +32,6 @@ import { validateVideoNewsThumbnailReferencesForFullOnlineR2Mode } from "../../.
 import { mediaLibraryPortAdapter } from "../../../../../modules/media-library/application/media-library-port-adapter";
 import { validateCreateBlogPostInput } from "../../../../../modules/blog-content/domain/blog-post-validation";
 import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
-import {
-  isBlogContentStatus,
-  type BlogContentStatus
-} from "../../../../../modules/blog-content/domain/post-status";
 
 const READ_GUARD = {
   moduleKey: "blog_content",
@@ -77,61 +74,13 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const statusParam = url.searchParams.get("status");
-  let status: BlogContentStatus | undefined;
+  const query = parseBlogPostListQuery(url.searchParams);
 
-  if (statusParam !== null) {
-    if (!isBlogContentStatus(statusParam)) {
-      return fail(
-        400,
-        "VALIDATION_ERROR",
-        "status must be one of draft, review, scheduled, published, archived."
-      );
-    }
-
-    status = statusParam;
+  if (!query.valid) {
+    return fail(400, "VALIDATION_ERROR", query.message);
   }
 
-  const limitParam = url.searchParams.get("limit");
-  const limit = limitParam ? Number(limitParam) : undefined;
-
-  if (
-    limitParam !== null &&
-    (!Number.isFinite(limit) || (limit as number) < 1)
-  ) {
-    return fail(400, "VALIDATION_ERROR", "limit must be a positive number.");
-  }
-
-  const orderParam = url.searchParams.get("order");
-
-  if (
-    orderParam !== null &&
-    orderParam !== "created_at" &&
-    orderParam !== "updated_at"
-  ) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "order must be one of created_at, updated_at."
-    );
-  }
-
-  const stableOrder = orderParam === "created_at";
-  const cursorParam = url.searchParams.get("cursor");
-
-  if (cursorParam !== null && !stableOrder) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "cursor requires order=created_at — updated_at changes on every edit, so a cursor over it can skip or repeat posts."
-    );
-  }
-
-  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
-
-  if (cursorParam !== null && cursor === null) {
-    return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
-  }
+  const { status, limit, stableOrder, cursor, view } = query.value;
 
   const sql = getDatabaseClient();
   const tokenHash = hashSessionToken(token);
@@ -148,6 +97,16 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
 
     if (!auth.allowed) {
       return auth.denied;
+    }
+
+    if (view === "full") {
+      const page = await listBlogPostsFullPage(tx, tenantId, {
+        status,
+        limit,
+        cursor
+      });
+
+      return ok({ posts: page.items, nextCursor: page.nextCursor });
     }
 
     if (stableOrder) {

--- a/tests/blog-content-posts-list-query.test.ts
+++ b/tests/blog-content-posts-list-query.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `GET /api/v1/blog/posts` query contract.
+ *
+ * Every refusal below exists because the ACCEPTING version of it fails
+ * silently — the caller gets 200 and wrong data, and neither side can tell:
+ *
+ *   - a cursor over `updated_at` skips or repeats rows as posts are edited;
+ *   - a malformed cursor read as "no cursor" restarts the traversal at page
+ *     one, so a build re-reads what it already has and never terminates;
+ *   - `view=full` over the mutable ordering hands back a first page that
+ *     cannot be continued, because `cursor` is refused there;
+ *   - an unknown `view` falling back to summaries returns rows without
+ *     `contentJson` to a caller that asked for full posts. That exact defect
+ *     — the contract promising `BlogPost` while the endpoint returned a
+ *     summary — built an entire static site with every article body empty and
+ *     nothing failing anywhere.
+ *
+ * These are pure over `URLSearchParams`: no database, no session, so they run
+ * in the `quality` job rather than only where a Postgres is available.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { encodeKeysetCursor } from "../src/modules/_shared/keyset-pagination";
+import { parseBlogPostListQuery } from "../src/modules/blog-content/domain/blog-post-list-query";
+
+function parse(qs: string) {
+  return parseBlogPostListQuery(new URLSearchParams(qs));
+}
+
+const CURSOR = encodeKeysetCursor(
+  "2026-07-17T10:00:00.029058+00:00",
+  "11111111-2222-4333-8444-555555555555"
+);
+
+describe("defaults", () => {
+  test("an empty query is the admin table's traversal", () => {
+    const result = parse("");
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+
+    expect(result.value.view).toBe("summary");
+    expect(result.value.stableOrder).toBe(false);
+    expect(result.value.cursor).toBeNull();
+    expect(result.value.status).toBeUndefined();
+    expect(result.value.limit).toBeUndefined();
+  });
+
+  test("order=created_at selects the cursor-capable traversal", () => {
+    const result = parse("order=created_at");
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.stableOrder).toBe(true);
+  });
+});
+
+describe("refusals", () => {
+  test.each([
+    ["status=published", true],
+    ["status=nonsense", false],
+    ["limit=50", true],
+    ["limit=0", false],
+    ["limit=-1", false],
+    ["limit=abc", false],
+    ["order=created_at", true],
+    ["order=title", false],
+    ["view=summary", true],
+    ["view=full&order=created_at", true],
+    ["view=FULL&order=created_at", false],
+    ["view=full", false]
+  ])("%s -> valid=%p", (qs, valid) => {
+    expect(parse(qs).valid).toBe(valid);
+  });
+
+  test("cursor over the mutable ordering is refused, not honoured", () => {
+    const result = parse(`cursor=${CURSOR}`);
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.message).toContain("order=created_at");
+  });
+
+  test("a malformed cursor is a 400, never treated as no cursor", () => {
+    const result = parse("order=created_at&cursor=not-a-cursor");
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.message).toContain("malformed");
+  });
+
+  test("view=full names the ordering it needs instead of substituting one", () => {
+    const result = parse("view=full");
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.message).toContain("order=created_at");
+  });
+});
+
+describe("the build feed's own request", () => {
+  test("parses whole, cursor included", () => {
+    const result = parse(
+      `status=published&order=created_at&view=full&limit=50&cursor=${CURSOR}`
+    );
+
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+
+    expect(result.value).toMatchObject({
+      status: "published",
+      limit: 50,
+      stableOrder: true,
+      view: "full"
+    });
+    expect(result.value.cursor).toEqual({
+      createdAt: "2026-07-17T10:00:00.029058+00:00",
+      id: "11111111-2222-4333-8444-555555555555"
+    });
+  });
+});


### PR DESCRIPTION
## Cacatnya

Kontrak OpenAPI menyatakan `GET /api/v1/blog/posts` mengembalikan `BlogPost` — lengkap dengan `contentJson`, `excerpt`, `metaDescription`, `canonicalUrl`, dan `translationGroupId`. Implementasinya mengembalikan `BlogPostSummary`, yang tidak memuat satu pun dari itu.

Selisih itu tidak pernah gagal di mana pun. Klien yang mempercayai dokumen membaca field-field tersebut sebagai `undefined` — bukan error, bukan 4xx, bukan satu baris log.

**Akibatnya sudah terjadi, bukan hipotetis.** Adapter konten `awcms-astro` ditulis dari dokumen ini (komentar tipenya menyebut `openapi/awcms-public-api.openapi.yaml`). Hasilnya: situs statis yang build **hijau** dengan badan setiap artikel kosong — dan karena seksi tempat sebuah artikel berada juga tersimpan di dalam `contentJson`, **seluruh seksinya kosong juga**.

`translationGroupId` versi keduanya: kolomnya bisa ditulis sejak awal, dideklarasikan di skema OpenAPI, dan **tidak dikembalikan satu pun endpoint baca** (`fetchPostTranslations` tidak terpasang di rute mana pun). Klien bisa menyetel pasangan terjemahan dan tidak pernah bisa membacanya lagi.

## Perubahannya

- **`?view=full`** mengembalikan baris penuh dengan cursor keyset yang sama, `MAX_FULL_LIST_LIMIT = 50` karena barisnya membawa `contentJson`. Proyeksinya identik dengan `fetchBlogPostById` minus `termIds` — yang satu query per post, yaitu N+1 yang justru sedang dihapus.

  Ia **mensyaratkan** `order=created_at`. Traversal penuh hanya sehat di atas urutan yang tidak berubah, dan syaratnya dinyatakan alih-alih diam-diam disubstitusi — sikap yang sama seperti penolakan `cursor` atas urutan mutable. Nilai `view` yang tidak dikenal adalah 400, bukan fallback diam ke `summary`.

- **`translationGroupId` kini benar-benar dikembalikan**, oleh `view=full` maupun `GET /api/v1/blog/posts/{id}`. Kolomnya ditambahkan ke SELURUH enam proyeksi baris penuh di `blog-post-directory.ts`, bukan hanya yang dibutuhkan hari ini: satu proyeksi yang terlewat akan mengembalikan `undefined` untuk field yang tipenya menjanjikan nilai.

- **`BlogPostSummary` menjadi skema tersendiri** di kontrak. Dokumen yang menjanjikan lebih daripada yang dikirim kode adalah dokumen yang membuat klien salah dengan yakin.

- **Validasi query pindah ke `parseBlogPostListQuery`** (domain, murni atas `URLSearchParams`). Sebelumnya inline di route dan tidak terjangkau tes mana pun tanpa sesi dan Postgres; sekarang 18 tes menutup setiap penolakan dan berjalan di job `quality`.

## Keamanan

Tidak ada permukaan baru: `view=full` melewati `READ_GUARD` yang sama (`blog_content.posts.read`), `withTenant` yang sama, dan mengembalikan field yang sama dengan endpoint detail yang sudah ada. Sebuah kredensial yang bisa memanggil `view=full` sudah bisa mengambil isi yang sama satu per satu lewat `/posts/{id}`.

## Verifikasi

`bun run typecheck`, `bun run lint`, `api:spec:check`, `api:docs:check` bersih. `bun run test` **tidak bisa dituntaskan di mesin ini**: Postgres di container tidak terjangkau dari host (113 kegagalan, seluruhnya `ERR_POSTGRES_CONNECTION_TIMEOUT`), jadi lapisan integrasi diserahkan ke CI.

Sisi konsumen: [`ahliweb/awcms-astro#17`](https://github.com/ahliweb/awcms-astro/pull/17) — menunggu PR ini mendarat lebih dulu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)