### PR TITLE
feat(reporting): admin console at /admin/reporting

### DIFF
--- a/.changeset/admin-reporting-console.md
+++ b/.changeset/admin-reporting-console.md
@@ -1,0 +1,17 @@
+---
+"awcms": minor
+---
+
+Add the `/admin/reporting` console and put `reporting` in the admin sidebar.
+
+`reporting` had seven permissions and, between them, one page: `/admin` renders four of its five dashboard views. Everything Issue #753 built — the projection registry, live freshness, rebuild, reconciliation, scheduled exports and artifact download — had no screen at all, and neither did `email-health`, the fifth dashboard view. All of it was reachable only by `curl`. Under ADR-0051 the screen belongs here.
+
+The console renders each registered projection with its live freshness status, metric values and most recent reconciliation, plus rebuild history, scheduled-export management, on-demand export, and the export-run history with checksum-verified download links. It deliberately does not repeat the four aggregations `/admin` already shows; a projection links to its own `drillDownPath` instead.
+
+Reads reuse this module's own application functions inside one `withTenantOrThrow` transaction, awaited sequentially. `listProjectionSummariesForTenant` is handed the caller's real granted-permission set, so the per-descriptor `requiredPermission` filter stays honest on this path too. Writes go to the guarded `/api/v1/reports/*` endpoints — five with a fresh `Idempotency-Key` per click, `reconcile` with none, because that endpoint mutates no business state and requires none.
+
+`tests/admin-reporting-page-contract.test.ts` pins all seven permission keys against what the routes enforce and the descriptor declares. Three plausible-but-wrong guesses would each have rendered a control that denies every caller including the owner: `projections.cancel` for cancelling a rebuild (it is `projections.rebuild`), `projections.read` for reconciling (it is `projections.analyze`), and `exports.configure` for triggering an export (it is `exports.export`).
+
+`MIN_EXPORT_INTERVAL_MINUTES` / `MAX_EXPORT_INTERVAL_MINUTES` / `MIN_REASON_LENGTH` / `MAX_REASON_LENGTH` move to `reporting/domain/operator-input-bounds.ts` and are now imported by both the three routes that validate them and the form that renders them as `min` / `max` / `maxlength`, so the browser cannot accept what the server rejects.
+
+Also corrects `reporting/README.md`, which described an `/admin/reporting/projections` page and a `submitJson` helper that never existed in this repo.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -244,7 +244,7 @@
       "capabilitiesProvided": [],
       "capabilitiesConsumed": [],
       "permissionCount": 7,
-      "navigationCount": 0,
+      "navigationCount": 1,
       "jobCount": 2,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -179,6 +179,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_visitor_analytics": "Visitor analytics",
   "admin.layout.nav_data_lifecycle": "Data lifecycle",
   "admin.layout.nav_idn_regions": "Region datasets",
+  "admin.layout.nav_reporting": "Reporting operations",
   "admin.layout.nav_profiles": "Profiles",
   "admin.layout.nav_users": "Users",
   "admin.layout.nav_roles": "Roles",

--- a/src/modules/reporting/README.md
+++ b/src/modules/reporting/README.md
@@ -228,15 +228,29 @@ finding, PR #781).
 
 ### Admin UI
 
-`/admin/reporting/projections` (`src/pages/admin/reporting/
-projections.astro`) — freshness-status table with rebuild/cancel/
-reconcile/export actions, scheduled-export management, export-run
-history with download links. Every mutation goes through the real
-`/api/v1/reports/*` endpoints via `submitJson`, no privileged shortcut.
+`/admin/reporting` (`src/pages/admin/reporting.astro`, ADR-0051) — the
+projection cards with live freshness status, metric values and the most
+recent reconciliation; rebuild / cancel-rebuild / reconcile actions;
+rebuild history; scheduled-export management (create, disable) and
+on-demand trigger; export-run history with checksum-verified download
+links. It also renders `email-health`, the one dashboard view `/admin`
+never picked up.
+
+Every mutation goes through the real `/api/v1/reports/*` endpoints — no
+privileged shortcut, no SQL in the page. Five of them send a fresh
+per-click `Idempotency-Key`; `reconcile` sends none, because that
+endpoint mutates no business state and requires none.
+
+> This section previously described `/admin/reporting/projections` and a
+> `submitJson` helper. Neither existed in this repo — the text came over
+> with the port and was never true here. Nothing rendered any of this
+> until the page above landed; the module simply had no `navigation`
+> entry, so the registry gate that would have caught a dangling path had
+> nothing to check. Docs are not gated the way descriptors are.
 
 ## Belum tersedia
 
 - **Tidak ada worker, materialized view, atau caching layer** untuk KELIMA endpoint live di atas — endpoint-endpoint ini sengaja tetap live aggregation setiap request, tidak berubah oleh §Projections di bawah. Untuk tenant dengan volume data besar (banyak sync node/decision log), latensi dashboard akan mengikuti biaya query langsung; optimasi (materialized view terjadwal, cache, dsb.) sengaja **di luar scope** issue 9.1 ini. Issue #753 (§Projections di bawah) menambahkan jalur BARU dan TERPISAH (proyeksi read-model + worker + freshness) yang membungkus SEBAGIAN dari dua endpoint ini (access-audit, module-usage) tanpa mengubah endpoint live itu sendiri — keduanya tetap tersedia berdampingan, bukan salah satu digantikan.
 - Tidak ada pagination/filter tanggal kustom pada `access-audit` — window 30 hari saat ini hardcoded (`ACCESS_AUDIT_DECISION_WINDOW_DAYS`).
 - Modul domain turunan (mis. AWPOS) menambah view reporting domainnya sendiri (penjualan, stok, pajak) di modul terpisah, bukan di modul generik ini.
-- `GET /api/v1/reports/email-health` (#5 di atas) belum ditambahkan ke SSR dashboard (`src/pages/admin/index.astro`) — dashboard admin baru menampilkan empat view pertama (tenant activity, access/audit, sync health, module usage); email queue health baru tersedia lewat endpoint API, belum lewat kartu di `/admin`.
+- `GET /api/v1/reports/email-health` (#5 di atas) tetap **belum** ada di SSR dashboard (`src/pages/admin/index.astro`) — dashboard admin masih menampilkan empat view pertama (tenant activity, access/audit, sync health, module usage). Sejak ADR-0051 view kelima ini dirender di `/admin/reporting` (§Admin UI di atas), jadi ia tidak lagi API-only; memindahkannya/menduplikasinya ke kartu `/admin` sengaja tidak dilakukan — satu view satu tempat.

--- a/src/modules/reporting/domain/operator-input-bounds.ts
+++ b/src/modules/reporting/domain/operator-input-bounds.ts
@@ -1,0 +1,32 @@
+/**
+ * Bounds this module's operator-facing endpoints validate, in one place so a
+ * form and its validator cannot drift apart.
+ *
+ * These were four inline literals across three route files. That is fine while
+ * `curl` is the only client — it stops being fine the moment a screen renders
+ * `minlength`/`min`/`max` attributes for them, because a hand-typed bound in
+ * the markup produces a browser that happily submits what the server then
+ * rejects with a 400 the user cannot act on. Same reasoning
+ * `data_lifecycle/domain/legal-hold.ts` records for its own exported bounds.
+ *
+ * Pure constants — no I/O, no imports.
+ */
+
+/**
+ * A scheduled export may run at most four times an hour. Below this the
+ * dispatcher's own 15-minute recommended schedule could not honour the
+ * interval anyway (`reporting`'s `bun run reporting:exports:dispatch` job).
+ */
+export const MIN_EXPORT_INTERVAL_MINUTES = 15;
+
+/** 30 days. */
+export const MAX_EXPORT_INTERVAL_MINUTES = 60 * 24 * 30;
+
+/**
+ * Reason text accompanying a rebuild trigger or a schedule disable. Required
+ * (a zero-length reason is rejected) — both actions are audited, and an audit
+ * row whose reason is empty records that something happened without recording
+ * why.
+ */
+export const MIN_REASON_LENGTH = 1;
+export const MAX_REASON_LENGTH = 500;

--- a/src/modules/reporting/module.ts
+++ b/src/modules/reporting/module.ts
@@ -60,6 +60,20 @@ export const reportingModule = defineModule({
     openApiPath: "openapi/modules/reporting.openapi.yaml",
     basePath: "/api/v1/reports"
   },
+  // `/admin` (a CORE_NAV_ENTRIES item, owned by no module) renders four of
+  // this module's five dashboard views. This entry is for the surface that
+  // had no page at all: projection freshness/rebuild/reconciliation,
+  // scheduled exports, and the fifth view, email queue health. Gated on
+  // `projections.read` rather than `dashboard.read` — that is the permission
+  // the largest part of the screen actually needs.
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_reporting",
+      path: "/admin/reporting",
+      order: 76,
+      requiredPermission: "reporting.projections.read"
+    }
+  ],
   permissions: [
     {
       activityCode: "dashboard",

--- a/src/pages/admin/reporting.astro
+++ b/src/pages/admin/reporting.astro
@@ -1,0 +1,1183 @@
+---
+/**
+ * Reporting operations console — the read-model side of `reporting`.
+ *
+ * `reporting` owns two very different surfaces, and only one of them had a
+ * screen. The five live dashboard views are rendered by `/admin/index.astro`
+ * — except `email-health`, which was never wired into it — while the entire
+ * projection/export machinery (Issue #753: registry, freshness, rebuild,
+ * reconciliation, scheduled exports, artifact download) had no page at all.
+ * Its seven permissions were reachable only by `curl`. Under ADR-0051 the
+ * screen belongs here; this is it.
+ *
+ * Deliberately NOT a second dashboard. The four aggregations `/admin` already
+ * renders are not repeated here — a projection's own card links to its
+ * `drillDownPath` instead. What this page adds on the dashboard side is the
+ * fifth view, `email-health`, which is the only one of the five with no
+ * rendering anywhere.
+ *
+ * ## Reads
+ *
+ * All reads go through this module's own application functions inside ONE
+ * `withTenantOrThrow`, awaited SEQUENTIALLY — concurrent queries on a single
+ * transaction connection leak it (`projection-directory.ts` records the
+ * confirmed empirical hang).
+ *
+ * `listProjectionSummariesForTenant` is handed `ssr.permissions` because it
+ * applies a SECOND filter beyond this page's coarse gate: each descriptor's
+ * own `requiredPermission`. Passing the real granted set — not a synthetic
+ * "everything" set — is what keeps that layer honest here too.
+ *
+ * The per-projection reconciliation history is one extra query per rendered
+ * projection. That is a fan-out, and it is bounded on purpose: the projection
+ * registry is CODE-declared (`listModules()`), so its size is a deployment
+ * constant a tenant cannot grow, and each call is itself `LIMIT 50`.
+ *
+ * ## Writes
+ *
+ * Nothing here writes SQL. Every mutation posts to the guarded endpoint, so
+ * its audit row, its idempotency record and its ABAC decision log cannot be
+ * bypassed by a screen that writes for itself.
+ *
+ * Five of the six mutations carry a fresh per-click `Idempotency-Key`
+ * (`IDEMPOTENCY_REQUIRED` otherwise). Reconcile carries NONE: that endpoint
+ * documents itself as mutating no business state — it only appends a
+ * comparison snapshot — and sending a key would imply a replay contract it
+ * does not have. This is the same split `/admin/data-lifecycle` makes for its
+ * dry-run.
+ *
+ * ## Gates
+ *
+ * Every gate here is UX-only; `authorizeInTransaction` in the routes is the
+ * authority. The triples are exactly the ones those routes enforce, pinned by
+ * `tests/admin-reporting-page-contract.test.ts`. Two of them are easy to guess
+ * wrong in a way that would deny everyone while looking correct:
+ *
+ * - cancelling a rebuild is `projections.rebuild`, not a `projections.cancel`
+ *   that no migration seeds;
+ * - reconciling is `projections.analyze`, not `projections.read`;
+ * - triggering an export is `exports.export`, not `exports.configure`.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  fetchEmailHealthReport,
+  type EmailHealthReport
+} from "../../modules/reporting/application/email-health-report";
+import {
+  listProjectionSummariesForTenant,
+  type ProjectionSummaryView
+} from "../../modules/reporting/application/projection-directory";
+import {
+  listRebuildRuns,
+  type RebuildRunRow
+} from "../../modules/reporting/application/rebuild-run-store";
+import {
+  listReconciliationRuns,
+  type ReconciliationRunRow
+} from "../../modules/reporting/application/reconciliation-run-store";
+import {
+  listScheduledExports,
+  type ScheduledExportRow
+} from "../../modules/reporting/application/scheduled-export-store";
+import {
+  listExportRuns,
+  type ExportRunRow
+} from "../../modules/reporting/application/export-run-store";
+import {
+  MAX_EXPORT_INTERVAL_MINUTES,
+  MAX_REASON_LENGTH,
+  MIN_EXPORT_INTERVAL_MINUTES,
+  MIN_REASON_LENGTH
+} from "../../modules/reporting/domain/operator-input-bounds";
+
+const ssr = Astro.locals.ssrContext!;
+
+const canReadDashboard = ssr.permissions.has(
+  permissionKey("reporting", "dashboard", "read")
+);
+const canReadProjections = ssr.permissions.has(
+  permissionKey("reporting", "projections", "read")
+);
+const canRebuild = ssr.permissions.has(
+  permissionKey("reporting", "projections", "rebuild")
+);
+const canReconcile = ssr.permissions.has(
+  permissionKey("reporting", "projections", "analyze")
+);
+const canReadExports = ssr.permissions.has(
+  permissionKey("reporting", "exports", "read")
+);
+const canConfigureExports = ssr.permissions.has(
+  permissionKey("reporting", "exports", "configure")
+);
+const canTriggerExport = ssr.permissions.has(
+  permissionKey("reporting", "exports", "export")
+);
+
+const canSeeAnything = canReadDashboard || canReadProjections || canReadExports;
+
+let emailHealth: EmailHealthReport | null = null;
+let projections: ProjectionSummaryView[] = [];
+let reconciliationsByKey = new Map<string, ReconciliationRunRow[]>();
+let rebuildRuns: RebuildRunRow[] = [];
+let exportConfigs: ScheduledExportRow[] = [];
+let exportRuns: ExportRunRow[] = [];
+let loadError = false;
+
+if (canSeeAnything) {
+  try {
+    const sql = getDatabaseClient();
+    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
+      if (canReadDashboard) {
+        emailHealth = await fetchEmailHealthReport(tx, ssr.tenantId);
+      }
+
+      if (canReadProjections) {
+        projections = await listProjectionSummariesForTenant(
+          tx,
+          ssr.tenantId,
+          ssr.permissions
+        );
+
+        const byKey = new Map<string, ReconciliationRunRow[]>();
+        for (const projection of projections) {
+          byKey.set(
+            projection.key,
+            await listReconciliationRuns(tx, ssr.tenantId, projection.key)
+          );
+        }
+        reconciliationsByKey = byKey;
+
+        rebuildRuns = await listRebuildRuns(tx, ssr.tenantId);
+      }
+
+      if (canReadExports) {
+        exportConfigs = await listScheduledExports(tx, ssr.tenantId);
+        exportRuns = await listExportRuns(tx, ssr.tenantId);
+      }
+    });
+  } catch (error) {
+    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
+    // must never render as "there are no projections".
+    loadError = true;
+    logAdminPageError(
+      "admin/reporting.astro: failed to load the reporting console",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+}
+
+/** Freshness status -> `status-badge` variant. `rebuilding` is progress, not a fault. */
+const FRESHNESS_VARIANT: Record<string, string> = {
+  current: "success",
+  delayed: "warning",
+  stale: "warning",
+  rebuilding: "info",
+  failed: "danger"
+};
+
+const REBUILD_VARIANT: Record<RebuildRunRow["status"], string> = {
+  running: "info",
+  completed: "success",
+  failed: "danger",
+  cancelled: "neutral"
+};
+
+const EXPORT_RUN_VARIANT: Record<ExportRunRow["status"], string> = {
+  completed: "success",
+  failed: "danger"
+};
+
+function formatTimestamp(value: Date | string | null): string {
+  if (value === null) return "—";
+  return typeof value === "string" ? value : value.toISOString();
+}
+
+/** Seconds since the last successful update, rendered for a human. */
+function formatAge(ageSeconds: number | null): string {
+  if (ageSeconds === null) return "never updated";
+  if (ageSeconds < 90) return `${Math.round(ageSeconds)}s ago`;
+  if (ageSeconds < 5400) return `${Math.round(ageSeconds / 60)}m ago`;
+  if (ageSeconds < 172800) return `${Math.round(ageSeconds / 3600)}h ago`;
+  return `${Math.round(ageSeconds / 86400)}d ago`;
+}
+
+function formatInterval(minutes: number): string {
+  if (minutes % 1440 === 0) return `every ${minutes / 1440}d`;
+  if (minutes % 60 === 0) return `every ${minutes / 60}h`;
+  return `every ${minutes}m`;
+}
+
+/** `expiresAt` in the past means the download endpoint answers 410, not the bytes. */
+function isExpired(run: ExportRunRow): boolean {
+  return run.expiresAt !== null && run.expiresAt.getTime() <= Date.now();
+}
+
+const projectionKeys = projections.map((projection) => projection.key);
+const showExportActions = canTriggerExport && projectionKeys.length > 0;
+const exportConfigColumns = canConfigureExports ? 6 : 5;
+---
+
+<AdminLayout title="Reporting operations">
+  <header class="page-header fade-in-up">
+    <h1 id="reporting-heading">Reporting operations</h1>
+    <p class="page-description">
+      Read-model health and delivery: the freshness of every registered
+      projection, the rebuilds and reconciliations run against them, the email
+      queue, and the scheduled exports built from them. The tenant activity,
+      access &amp; audit, sync health and module usage views live on the
+      <a href="/admin">dashboard</a>.
+    </p>
+  </header>
+
+  {
+    !canSeeAnything && (
+      <p class="state-notice fade-in-up" id="reporting-denied">
+        You do not have permission to view reporting operations.
+      </p>
+    )
+  }
+
+  {
+    canSeeAnything && loadError && (
+      <p class="state-notice fade-in-up" id="reporting-error">
+        The reporting console could not be loaded right now. This is a problem
+        reading it, not an empty console — please try again later.
+      </p>
+    )
+  }
+
+  {
+    canSeeAnything && !loadError && (
+      <p
+        id="reporting-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canReadDashboard && !loadError && emailHealth && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="email-health-title"
+        id="reporting-email-health"
+      >
+        <h2 class="admin-section-title" id="email-health-title">
+          Email queue health
+          <span
+            class="status-badge"
+            data-variant={emailHealth.isHealthy ? "success" : "warning"}
+          >
+            <span class="status-dot" aria-hidden="true" />
+            {emailHealth.isHealthy ? "healthy" : "needs attention"}
+          </span>
+        </h2>
+        <p class="page-description">
+          The fifth management reporting view. An idle queue is healthy — only
+          failures and a retry backlog are not.
+        </p>
+
+        <div class="stat-grid stagger-children">
+          <div class="stat-card">
+            <span class="stat-label">Queued</span>
+            <span class="stat-value">{emailHealth.queuedCount}</span>
+            <span class="stat-hint">
+              Oldest: {formatTimestamp(emailHealth.oldestQueuedAt)}
+            </span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Awaiting retry</span>
+            <span class="stat-value">{emailHealth.retryWaitCount}</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Failed</span>
+            <span class="stat-value">{emailHealth.failedCount}</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Suppressed</span>
+            <span class="stat-value">{emailHealth.suppressedCount}</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Sent (24h)</span>
+            <span class="stat-value">{emailHealth.sentLast24hCount}</span>
+            <span class="stat-hint">
+              Last: {formatTimestamp(emailHealth.mostRecentSentAt)}
+            </span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Dispatch</span>
+            <span class="stat-value stat-value--mono">
+              {emailHealth.emailEnabled
+                ? (emailHealth.provider ?? "enabled")
+                : "disabled"}
+            </span>
+            {/* Process env, not a per-tenant setting — see `fetchEmailHealthReport`. */}
+            <span class="stat-hint">Deployment-wide setting</span>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canReadProjections && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="projections-title"
+        id="reporting-projections"
+      >
+        <h2 class="admin-section-title" id="projections-title">
+          Projections
+          <span class="count-pill">{projections.length}</span>
+        </h2>
+        <p class="page-description">
+          Freshness is computed live from the last successful update, never read
+          back from a stored column — a projection whose updater stopped running
+          ages into <code>stale</code> on its own rather than staying frozen at{" "}
+          <code>current</code>.
+        </p>
+
+        {projections.length === 0 ? (
+          <div class="empty-state">
+            <span class="empty-state-icon" aria-hidden="true">
+              ◔
+            </span>
+            <span class="empty-state-title">No projections visible</span>
+            <span class="empty-state-text">
+              Projections are declared in code by the modules that own them. Any
+              that exist require their own permission on top of this screen's,
+              so this can also mean none of them is granted to you.
+            </span>
+          </div>
+        ) : (
+          <div class="stagger-children">
+            {projections.map((projection) => {
+              const reconciliations =
+                reconciliationsByKey.get(projection.key) ?? [];
+              const latest = reconciliations[0] ?? null;
+              const isRebuilding = projection.freshness.status === "rebuilding";
+
+              return (
+                <article
+                  class="admin-panel hover-lift"
+                  data-projection-key={projection.key}
+                >
+                  <h3>
+                    <span class="cell-code">{projection.key}</span>
+                    <span
+                      class="status-badge"
+                      data-variant={
+                        FRESHNESS_VARIANT[projection.freshness.status] ??
+                        "neutral"
+                      }
+                    >
+                      <span class="status-dot" aria-hidden="true" />
+                      {projection.freshness.status}
+                    </span>
+                  </h3>
+                  <p class="page-description">{projection.description}</p>
+
+                  <dl class="stat-grid">
+                    <div class="stat-card">
+                      <dt class="stat-label">Owner</dt>
+                      <dd class="stat-value stat-value--mono">
+                        {projection.ownerModuleKey} v{projection.version}
+                      </dd>
+                    </div>
+                    <div class="stat-card">
+                      <dt class="stat-label">Last success</dt>
+                      <dd class="stat-value stat-value--mono">
+                        {formatAge(projection.freshness.ageSeconds)}
+                      </dd>
+                      <span class="stat-hint">
+                        {formatTimestamp(projection.freshness.lastSuccessAt)}
+                      </span>
+                    </div>
+                    <div class="stat-card">
+                      <dt class="stat-label">Consecutive failures</dt>
+                      <dd class="stat-value">
+                        {projection.freshness.consecutiveFailures}
+                      </dd>
+                    </div>
+                    {Object.entries(projection.metrics).map(
+                      ([metricKey, value]) => (
+                        <div class="stat-card">
+                          <dt class="stat-label">
+                            {projection.metricLabels[metricKey] ?? metricKey}
+                          </dt>
+                          <dd class="stat-value">{value}</dd>
+                        </div>
+                      )
+                    )}
+                  </dl>
+
+                  {projection.freshness.lastErrorMessage && (
+                    <p class="state-notice">
+                      Last error:
+                      <span
+                        class="cell-code"
+                        set:text={projection.freshness.lastErrorMessage}
+                      />
+                    </p>
+                  )}
+
+                  {latest && (
+                    <details>
+                      <summary>
+                        Reconciliation ·{" "}
+                        {latest.mismatch
+                          ? "mismatch against source"
+                          : "matched source"}{" "}
+                        · {formatTimestamp(latest.executedAt)}
+                      </summary>
+                      <table class="data-table data-table--stack">
+                        <caption class="sr-only">
+                          Most recent reconciliation of {projection.key}.
+                        </caption>
+                        <thead>
+                          <tr>
+                            <th scope="col">Metric</th>
+                            <th scope="col">Projection</th>
+                            <th scope="col">Source</th>
+                            <th scope="col">Match</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {latest.details.map((detail) => (
+                            <tr>
+                              <td data-label="Metric">
+                                <span class="cell-code">
+                                  {detail.metricKey}
+                                </span>
+                              </td>
+                              <td data-label="Projection">
+                                {detail.projectionTotal}
+                              </td>
+                              <td data-label="Source">{detail.sourceTotal}</td>
+                              <td data-label="Match">
+                                {detail.mismatch ? "differs" : "equal"}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </details>
+                  )}
+
+                  <div class="row-actions">
+                    {projection.drillDownPath && (
+                      <a class="quick-link" href={projection.drillDownPath}>
+                        Drill down
+                        <span class="quick-link-arrow" aria-hidden="true">
+                          →
+                        </span>
+                      </a>
+                    )}
+
+                    {canReconcile && (
+                      <button
+                        type="button"
+                        class="module-toggle projection-reconcile-btn"
+                        data-projection-key={projection.key}
+                      >
+                        Reconcile
+                      </button>
+                    )}
+
+                    {canRebuild && isRebuilding && (
+                      <button
+                        type="button"
+                        class="btn-inline btn-inline--danger projection-rebuild-cancel-btn"
+                        data-projection-key={projection.key}
+                      >
+                        Cancel rebuild
+                      </button>
+                    )}
+                  </div>
+
+                  {canRebuild && !isRebuilding && (
+                    <div class="admin-toolbar">
+                      <label for={`rebuild-reason-${projection.key}`}>
+                        Rebuild reason
+                      </label>
+                      <input
+                        type="text"
+                        id={`rebuild-reason-${projection.key}`}
+                        class="projection-rebuild-reason"
+                        data-projection-key={projection.key}
+                        minlength={MIN_REASON_LENGTH}
+                        maxlength={MAX_REASON_LENGTH}
+                        autocomplete="off"
+                        placeholder="Why this rebuild is needed"
+                      />
+                      <button
+                        type="button"
+                        class="btn-inline projection-rebuild-btn"
+                        data-projection-key={projection.key}
+                      >
+                        Rebuild
+                      </button>
+                    </div>
+                  )}
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  {
+    canReadProjections && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="rebuild-history-title"
+        id="reporting-rebuild-history"
+      >
+        <h2 class="admin-section-title" id="rebuild-history-title">
+          Rebuild history
+          <span class="count-pill">{rebuildRuns.length}</span>
+        </h2>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">
+              Projection rebuild runs, newest first, capped at 100 rows.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Projection</th>
+                <th scope="col">Status</th>
+                <th scope="col">Rows</th>
+                <th scope="col">Started</th>
+                <th scope="col">Finished</th>
+                <th scope="col">Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rebuildRuns.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={6}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ↻
+                      </span>
+                      <span class="empty-state-title">No rebuilds yet</span>
+                      <span class="empty-state-text">
+                        Incremental updates keep a projection current without
+                        one; a rebuild is for recovering after a source or
+                        definition change.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                rebuildRuns.map((run) => (
+                  <tr>
+                    <td data-label="Projection">
+                      <span class="cell-code">{run.projectionKey}</span>
+                    </td>
+                    <td data-label="Status">
+                      <span
+                        class="status-badge"
+                        data-variant={REBUILD_VARIANT[run.status]}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {run.status}
+                      </span>
+                      {run.cancelRequested && run.status === "running" && (
+                        <span class="cell-muted"> · cancelling</span>
+                      )}
+                    </td>
+                    <td data-label="Rows">{run.rowsProcessed}</td>
+                    <td data-label="Started">
+                      <span class="cell-muted">
+                        {formatTimestamp(run.startedAt)}
+                      </span>
+                    </td>
+                    <td data-label="Finished">
+                      <span class="cell-muted">
+                        {formatTimestamp(run.completedAt)}
+                      </span>
+                    </td>
+                    <td data-label="Reason">
+                      <span set:text={run.reason ?? "—"} />
+                      {run.errorMessage && (
+                        <span class="cell-code" set:text={run.errorMessage} />
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canReadExports && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="export-configs-title"
+        id="reporting-export-configs"
+      >
+        <h2 class="admin-section-title" id="export-configs-title">
+          Scheduled exports
+          <span class="count-pill">{exportConfigs.length}</span>
+        </h2>
+        <p class="page-description">
+          Generated by <code>reporting:exports:dispatch</code>. Disabling a
+          schedule retires it — there is no re-enable, so an interval change
+          means creating a new schedule.
+        </p>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">
+              Scheduled export configurations for this tenant.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Projection</th>
+                <th scope="col">Format</th>
+                <th scope="col">Interval</th>
+                <th scope="col">State</th>
+                <th scope="col">Created</th>
+                {canConfigureExports && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {exportConfigs.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={exportConfigColumns}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ⇩
+                      </span>
+                      <span class="empty-state-title">
+                        No scheduled exports
+                      </span>
+                      <span class="empty-state-text">
+                        A projection can still be exported on demand below.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                exportConfigs.map((config) => (
+                  <tr>
+                    <td data-label="Projection">
+                      <span class="cell-code">{config.projectionKey}</span>
+                    </td>
+                    <td data-label="Format">
+                      <span class="cell-code">{config.format}</span>
+                    </td>
+                    <td data-label="Interval">
+                      {formatInterval(config.scheduleIntervalMinutes)}
+                    </td>
+                    <td data-label="State">
+                      <span
+                        class="status-badge"
+                        data-variant={config.enabled ? "success" : "neutral"}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {config.enabled ? "enabled" : "retired"}
+                      </span>
+                    </td>
+                    <td data-label="Created">
+                      <span class="cell-muted">
+                        {formatTimestamp(config.createdAt)}
+                      </span>
+                    </td>
+                    {canConfigureExports && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          {config.enabled && (
+                            <button
+                              type="button"
+                              class="btn-inline btn-inline--danger export-disable-btn"
+                              data-export-id={config.id}
+                              data-export-label={config.projectionKey}
+                            >
+                              Disable
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {canConfigureExports && projectionKeys.length > 0 && (
+          <form id="export-create-form" class="admin-create-form">
+            <p class="form-legend">Schedule a new export</p>
+            <p
+              id="export-create-error"
+              class="admin-create-error"
+              role="alert"
+              hidden
+            />
+
+            <label for="export-projection-key">
+              Projection
+              <select id="export-projection-key" name="projectionKey" required>
+                {projectionKeys.map((key) => (
+                  <option value={key}>{key}</option>
+                ))}
+              </select>
+            </label>
+
+            <label for="export-format">
+              Format
+              <select id="export-format" name="format" required>
+                <option value="csv">csv</option>
+                <option value="json">json</option>
+              </select>
+            </label>
+
+            <label for="export-interval">
+              Interval (minutes)
+              {/* Bounds come from the same constants the endpoint validates
+                  against, so the browser can never accept what the server
+                  rejects. */}
+              <input
+                type="number"
+                id="export-interval"
+                name="scheduleIntervalMinutes"
+                required
+                step="1"
+                min={MIN_EXPORT_INTERVAL_MINUTES}
+                max={MAX_EXPORT_INTERVAL_MINUTES}
+                value={String(MIN_EXPORT_INTERVAL_MINUTES * 4)}
+              />
+            </label>
+
+            <button type="submit" id="export-create-submit">
+              Create schedule
+            </button>
+          </form>
+        )}
+
+        {showExportActions && (
+          <form id="export-trigger-form" class="admin-create-form">
+            <p class="form-legend">Export once, now</p>
+            <p
+              id="export-trigger-error"
+              class="admin-create-error"
+              role="alert"
+              hidden
+            />
+
+            <label for="trigger-projection-key">
+              Projection
+              <select id="trigger-projection-key" name="projectionKey" required>
+                {projectionKeys.map((key) => (
+                  <option value={key}>{key}</option>
+                ))}
+              </select>
+            </label>
+
+            <label for="trigger-format">
+              Format
+              <select id="trigger-format" name="format" required>
+                <option value="csv">csv</option>
+                <option value="json">json</option>
+              </select>
+            </label>
+
+            <button type="submit" id="export-trigger-submit">
+              Generate export
+            </button>
+          </form>
+        )}
+      </section>
+    )
+  }
+
+  {
+    canReadExports && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="export-runs-title"
+        id="reporting-export-runs"
+      >
+        <h2 class="admin-section-title" id="export-runs-title">
+          Export runs
+          <span class="count-pill">{exportRuns.length}</span>
+        </h2>
+        <p class="page-description">
+          Each artifact is checksum-verified when downloaded, and an expired one
+          is refused rather than served stale.
+        </p>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">
+              Export runs, newest first, capped at 100 rows.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Projection</th>
+                <th scope="col">Status</th>
+                <th scope="col">Rows</th>
+                <th scope="col">Created</th>
+                <th scope="col">Expires</th>
+                <th scope="col">Artifact</th>
+              </tr>
+            </thead>
+            <tbody>
+              {exportRuns.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={6}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ⌸
+                      </span>
+                      <span class="empty-state-title">No export runs</span>
+                      <span class="empty-state-text">
+                        Runs appear here once a schedule fires or an on-demand
+                        export is generated.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                exportRuns.map((run) => (
+                  <tr>
+                    <td data-label="Projection">
+                      <span class="cell-code">{run.projectionKey}</span>
+                      <span class="cell-muted"> · {run.format}</span>
+                    </td>
+                    <td data-label="Status">
+                      <span
+                        class="status-badge"
+                        data-variant={EXPORT_RUN_VARIANT[run.status]}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {run.status}
+                      </span>
+                      {run.errorMessage && (
+                        <span class="cell-code" set:text={run.errorMessage} />
+                      )}
+                    </td>
+                    <td data-label="Rows">{run.rowCount}</td>
+                    <td data-label="Created">
+                      <span class="cell-muted">
+                        {formatTimestamp(run.createdAt)}
+                      </span>
+                    </td>
+                    <td data-label="Expires">
+                      <span class="cell-muted">
+                        {formatTimestamp(run.expiresAt)}
+                      </span>
+                    </td>
+                    <td data-label="Artifact">
+                      {run.status === "completed" && !isExpired(run) ? (
+                        // Cookie auth rides along on a plain navigation, and
+                        // the endpoint re-checks RBAC/ABAC at download time —
+                        // a link here grants nothing a fetch would not.
+                        <a
+                          class="quick-link"
+                          href={`/api/v1/reports/exports/runs/${run.id}/download`}
+                        >
+                          Download
+                          <span class="quick-link-arrow" aria-hidden="true">
+                            →
+                          </span>
+                        </a>
+                      ) : (
+                        <span class="cell-muted">
+                          {isExpired(run) ? "expired" : "unavailable"}
+                        </span>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'`
+  // with no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  // Bundled unconditionally (Astro hoists at build time): a viewer without a
+  // given permission renders no control, so its listener never binds.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("reporting-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  function showFormError(id: string, message: string): void {
+    const element = document.getElementById(id);
+    if (!element) return;
+    element.textContent = message;
+    element.hidden = false;
+  }
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".projection-rebuild-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const key = button.dataset.projectionKey;
+        if (!key) return;
+
+        const reasonInput = document.querySelector<HTMLInputElement>(
+          `.projection-rebuild-reason[data-projection-key="${key}"]`
+        );
+        const reason = reasonInput?.value.trim() ?? "";
+        if (reason === "") {
+          showActionError(
+            "A rebuild needs a reason — it is recorded in the audit trail."
+          );
+          reasonInput?.focus();
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Starting…");
+
+        // A fresh key per click: without one the endpoint answers
+        // `IDEMPOTENCY_REQUIRED`, and reusing one would replay the first
+        // response instead of starting the rebuild the operator just asked
+        // for.
+        const result = await sendJson(
+          "POST",
+          `/api/v1/reports/projections/${key}/rebuild`,
+          { reason },
+          { "Idempotency-Key": crypto.randomUUID() }
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // Generic copy only — never surface internal detail.
+        showActionError("Could not start the rebuild. Please try again.");
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".projection-rebuild-cancel-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const key = button.dataset.projectionKey;
+        if (!key) return;
+
+        if (
+          !window.confirm(
+            `Cancel the running rebuild of ${key}? Its progress so far is kept, but the read model stays partial until a rebuild completes.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Cancelling…");
+
+        // Bodyless — the endpoint derives everything from the path.
+        const result = await sendJson(
+          "POST",
+          `/api/v1/reports/projections/${key}/rebuild/cancel`,
+          undefined,
+          { "Idempotency-Key": crypto.randomUUID() }
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not cancel the rebuild. Please try again.");
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".projection-reconcile-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const key = button.dataset.projectionKey;
+        if (!key) return;
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Reconciling…");
+
+        // No `Idempotency-Key`: this endpoint mutates no business state — it
+        // appends a comparison snapshot — so it requires none, and sending
+        // one would imply a replay contract it does not have.
+        const result = await sendJson(
+          "POST",
+          `/api/v1/reports/projections/${key}/reconcile`
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError(
+          "Could not reconcile the projection. Please try again."
+        );
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".export-disable-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.exportId;
+        if (!id) return;
+        const label = button.dataset.exportLabel ?? "this schedule";
+
+        // Retiring is not undoable from this screen — there is no re-enable.
+        if (
+          !window.confirm(
+            `Disable the ${label} export schedule? It is retired, not paused — re-enabling means creating a new schedule.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Disabling…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/reports/exports/${id}/disable`,
+          { reason: "Disabled from the admin reporting operations screen." },
+          { "Idempotency-Key": crypto.randomUUID() }
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not disable the schedule. Please try again.");
+        unlock();
+      });
+    });
+
+  const createForm = document.getElementById(
+    "export-create-form"
+  ) as HTMLFormElement | null;
+
+  createForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "export-create-submit"
+    ) as HTMLButtonElement | null;
+    if (!submit || submit.disabled) return;
+
+    const data = new FormData(createForm);
+    const interval = Number(data.get("scheduleIntervalMinutes"));
+    if (!Number.isInteger(interval)) {
+      showFormError(
+        "export-create-error",
+        "Interval must be a whole number of minutes."
+      );
+      return;
+    }
+
+    const errorElement = document.getElementById("export-create-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Creating…");
+
+    // `filter` is deliberately omitted: the endpoint rejects a non-empty one
+    // because generated exports do not consult it yet.
+    const result = await sendJson(
+      "POST",
+      "/api/v1/reports/exports",
+      {
+        projectionKey: String(data.get("projectionKey") ?? ""),
+        format: String(data.get("format") ?? ""),
+        scheduleIntervalMinutes: interval
+      },
+      { "Idempotency-Key": crypto.randomUUID() }
+    );
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    showFormError(
+      "export-create-error",
+      "Could not create the schedule. Please try again."
+    );
+    unlock();
+  });
+
+  const triggerForm = document.getElementById(
+    "export-trigger-form"
+  ) as HTMLFormElement | null;
+
+  triggerForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "export-trigger-submit"
+    ) as HTMLButtonElement | null;
+    if (!submit || submit.disabled) return;
+
+    const data = new FormData(triggerForm);
+    const errorElement = document.getElementById("export-trigger-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Generating…");
+
+    const result = await sendJson(
+      "POST",
+      "/api/v1/reports/exports/trigger",
+      {
+        projectionKey: String(data.get("projectionKey") ?? ""),
+        format: String(data.get("format") ?? "")
+      },
+      { "Idempotency-Key": crypto.randomUUID() }
+    );
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    showFormError(
+      "export-trigger-error",
+      "Could not generate the export. Please try again."
+    );
+    unlock();
+  });
+</script>

--- a/src/pages/api/v1/reports/exports/[id]/disable.ts
+++ b/src/pages/api/v1/reports/exports/[id]/disable.ts
@@ -18,6 +18,10 @@ import {
 } from "../../../../../../modules/_shared/idempotency";
 import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
 import { disableScheduledExport } from "../../../../../../modules/reporting/application/scheduled-export-store";
+import {
+  MAX_REASON_LENGTH,
+  MIN_REASON_LENGTH
+} from "../../../../../../modules/reporting/domain/operator-input-bounds";
 
 const IDEMPOTENCY_SCOPE = "reporting_scheduled_export_disable";
 
@@ -55,8 +59,12 @@ export const POST: APIRoute = async ({ request, cookies, locals, params }) => {
   }
 
   const reason = typeof body.reason === "string" ? body.reason.trim() : "";
-  if (reason.length < 1 || reason.length > 500) {
-    return fail(400, "VALIDATION_ERROR", "reason must be 1-500 characters.");
+  if (reason.length < MIN_REASON_LENGTH || reason.length > MAX_REASON_LENGTH) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      `reason must be ${MIN_REASON_LENGTH}-${MAX_REASON_LENGTH} characters.`
+    );
   }
 
   const requestHash = computeRequestHash({ ...body, id, action: "disable" });

--- a/src/pages/api/v1/reports/exports/index.ts
+++ b/src/pages/api/v1/reports/exports/index.ts
@@ -19,13 +19,15 @@ import {
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import { findProjectionDescriptor } from "../../../../../modules/reporting/application/projection-directory";
 import {
+  MAX_EXPORT_INTERVAL_MINUTES,
+  MIN_EXPORT_INTERVAL_MINUTES
+} from "../../../../../modules/reporting/domain/operator-input-bounds";
+import {
   createScheduledExport,
   listScheduledExports
 } from "../../../../../modules/reporting/application/scheduled-export-store";
 
 const IDEMPOTENCY_SCOPE = "reporting_scheduled_export_create";
-const MIN_INTERVAL_MINUTES = 15;
-const MAX_INTERVAL_MINUTES = 60 * 24 * 30; // 30 days
 
 /** `GET /api/v1/reports/exports` (Issue #753) — list scheduled export configs for the caller's tenant. */
 export const GET: APIRoute = async ({ request, cookies, url }) => {
@@ -135,13 +137,13 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
   }
   if (
     !Number.isInteger(scheduleIntervalMinutes) ||
-    scheduleIntervalMinutes < MIN_INTERVAL_MINUTES ||
-    scheduleIntervalMinutes > MAX_INTERVAL_MINUTES
+    scheduleIntervalMinutes < MIN_EXPORT_INTERVAL_MINUTES ||
+    scheduleIntervalMinutes > MAX_EXPORT_INTERVAL_MINUTES
   ) {
     return fail(
       400,
       "VALIDATION_ERROR",
-      `scheduleIntervalMinutes must be an integer between ${MIN_INTERVAL_MINUTES} and ${MAX_INTERVAL_MINUTES}.`
+      `scheduleIntervalMinutes must be an integer between ${MIN_EXPORT_INTERVAL_MINUTES} and ${MAX_EXPORT_INTERVAL_MINUTES}.`
     );
   }
 

--- a/src/pages/api/v1/reports/projections/[key]/rebuild/index.ts
+++ b/src/pages/api/v1/reports/projections/[key]/rebuild/index.ts
@@ -19,6 +19,10 @@ import {
 import { recordAuditEvent } from "../../../../../../../modules/logging/application/audit-log";
 import { findProjectionDescriptor } from "../../../../../../../modules/reporting/application/projection-directory";
 import { triggerOrResumeRebuild } from "../../../../../../../modules/reporting/application/projection-rebuild";
+import {
+  MAX_REASON_LENGTH,
+  MIN_REASON_LENGTH
+} from "../../../../../../../modules/reporting/domain/operator-input-bounds";
 
 const IDEMPOTENCY_SCOPE = "reporting_projection_rebuild";
 
@@ -65,8 +69,12 @@ export const POST: APIRoute = async ({ request, cookies, locals, params }) => {
   }
 
   const reason = typeof body.reason === "string" ? body.reason.trim() : "";
-  if (reason.length < 1 || reason.length > 500) {
-    return fail(400, "VALIDATION_ERROR", "reason must be 1-500 characters.");
+  if (reason.length < MIN_REASON_LENGTH || reason.length > MAX_REASON_LENGTH) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      `reason must be ${MIN_REASON_LENGTH}-${MAX_REASON_LENGTH} characters.`
+    );
   }
 
   const descriptor = findProjectionDescriptor(key);

--- a/tests/admin-reporting-page-contract.test.ts
+++ b/tests/admin-reporting-page-contract.test.ts
@@ -1,0 +1,252 @@
+/**
+ * `/admin/reporting` gates against the endpoints it drives.
+ *
+ * Sibling of `admin-data-lifecycle-page-contract.test.ts`, for the same silent
+ * failure: a page gating on a permission key no migration seeds hides the
+ * section from everyone — including the owner — while still looking like a
+ * working screen with an empty area. This repo has shipped that bug twice, both
+ * times by inventing a plausible action name.
+ *
+ * `reporting` is an unusually good place to repeat it. Its seven permissions
+ * span three activity codes and four non-CRUD actions (`rebuild`, `analyze`,
+ * `configure`, `export`), and the natural guesses are all wrong in the same
+ * direction:
+ *
+ * - cancelling a rebuild reads like `projections.cancel` — the endpoint
+ *   enforces `projections.rebuild`;
+ * - reconciling reads like `projections.read` (it only compares numbers) — the
+ *   endpoint enforces `projections.analyze`;
+ * - triggering an export reads like `exports.configure` (it is an operator
+ *   action on a schedule's projection) — the endpoint enforces
+ *   `exports.export`.
+ *
+ * Each of those would render a control that denies every caller.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/reporting.astro";
+const ROUTES = [
+  "src/pages/api/v1/reports/email-health.ts",
+  "src/pages/api/v1/reports/projections/index.ts",
+  "src/pages/api/v1/reports/projections/[key]/index.ts",
+  "src/pages/api/v1/reports/projections/[key]/rebuild/index.ts",
+  "src/pages/api/v1/reports/projections/[key]/rebuild/cancel.ts",
+  "src/pages/api/v1/reports/projections/[key]/reconcile.ts",
+  "src/pages/api/v1/reports/exports/index.ts",
+  "src/pages/api/v1/reports/exports/runs.ts",
+  "src/pages/api/v1/reports/exports/trigger.ts",
+  "src/pages/api/v1/reports/exports/[id]/disable.ts",
+  "src/pages/api/v1/reports/exports/runs/[id]/download.ts"
+];
+
+type Triple = `${string}.${string}.${string}`;
+
+/** `{ moduleKey: "reporting", activityCode: …, action: … }` → `module.activity.action`. */
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+/** `permissionKey("reporting", "projections", "analyze")` → the same shape. */
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function declaredTriples(): Set<Triple> {
+  return new Set<Triple>(
+    (listModules()
+      .find((module) => module.key === "reporting")
+      ?.permissions?.map(
+        (permission) =>
+          `reporting.${permission.activityCode}.${permission.action}`
+      ) ?? []) as Triple[]
+  );
+}
+
+describe("/admin/reporting permission gates", () => {
+  test("every key the page gates on is one its endpoints actually enforce", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    expect(pageKeys.size).toBe(7);
+
+    const enforced = new Set<Triple>();
+    for (const route of ROUTES) {
+      for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+
+    // Guards really were parsed — an empty `enforced` would make the subset
+    // check below pass vacuously, the shape of gate this repo has been burned
+    // by before.
+    expect(enforced.size).toBeGreaterThan(0);
+    expect([...pageKeys].filter((key) => !enforced.has(key))).toEqual([]);
+  });
+
+  test("and is declared by the module descriptor, so a migration seeds it", async () => {
+    const declared = declaredTriples();
+    expect(declared.size).toBe(7);
+
+    const missing = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].filter(
+      (key) => !declared.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  test("the page covers all seven — a screen for six leaves a surface curl-only", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+
+    // The whole reason this screen exists: `reporting` had seven permissions
+    // and one page rendering four dashboard views. Enumerated rather than
+    // compared as sets so a NEW permission added later fails here loudly and
+    // its author has to decide whether the screen should drive it.
+    expect([...pageKeys].sort()).toEqual([
+      "reporting.dashboard.read",
+      "reporting.exports.configure",
+      "reporting.exports.export",
+      "reporting.exports.read",
+      "reporting.projections.analyze",
+      "reporting.projections.read",
+      "reporting.projections.rebuild"
+    ]);
+  });
+
+  test("cancel is gated on rebuild, and the endpoint agrees", async () => {
+    const cancel = await readFile(
+      "src/pages/api/v1/reports/projections/[key]/rebuild/cancel.ts",
+      "utf8"
+    );
+
+    // A `projections.cancel` key exists nowhere — not in the descriptor, not
+    // in any migration — so a page inventing it would hide the button from
+    // every operator including the owner.
+    expect(guardTriplesFrom(cancel).has("reporting.projections.rebuild")).toBe(
+      true
+    );
+    expect(
+      declaredTriples().has("reporting.projections.cancel" as Triple)
+    ).toBe(false);
+  });
+
+  test("reconcile is gated on analyze, not read", async () => {
+    const reconcile = await readFile(
+      "src/pages/api/v1/reports/projections/[key]/reconcile.ts",
+      "utf8"
+    );
+    const enforced = guardTriplesFrom(reconcile);
+
+    expect(enforced.has("reporting.projections.analyze")).toBe(true);
+    expect(enforced.has("reporting.projections.read")).toBe(false);
+  });
+
+  test("triggering an export is gated on export, not configure", async () => {
+    const trigger = await readFile(
+      "src/pages/api/v1/reports/exports/trigger.ts",
+      "utf8"
+    );
+    const enforced = guardTriplesFrom(trigger);
+
+    expect(enforced.has("reporting.exports.export")).toBe(true);
+    expect(enforced.has("reporting.exports.configure")).toBe(false);
+  });
+
+  test("the page never mutates directly — it posts to the guarded endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // No SQL write anywhere in the screen: every change goes out over fetch,
+    // so the endpoints' audit rows, idempotency records and decision logs
+    // cannot be bypassed by rendering a form that writes for itself.
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+
+    expect(page).toContain("/api/v1/reports/projections/${key}/rebuild`");
+    expect(page).toContain(
+      "/api/v1/reports/projections/${key}/rebuild/cancel`"
+    );
+    expect(page).toContain("/api/v1/reports/projections/${key}/reconcile`");
+    expect(page).toContain('"/api/v1/reports/exports"');
+    expect(page).toContain('"/api/v1/reports/exports/trigger"');
+    expect(page).toContain("/api/v1/reports/exports/${id}/disable`");
+  });
+
+  test("the five mutating calls carry a fresh Idempotency-Key — reconcile carries none", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Rebuild, cancel, disable, create and trigger all answer
+    // `IDEMPOTENCY_REQUIRED` without the header, so a screen that omitted it
+    // would render controls that always fail. A per-click `crypto.randomUUID()`
+    // is also what makes a deliberate second action actually run, instead of
+    // replaying the first one's stored response.
+    expect(
+      page.match(/"Idempotency-Key": crypto\.randomUUID\(\)/g)
+    ).toHaveLength(5);
+
+    // Reconcile requires no key BECAUSE it mutates no business state — it only
+    // appends a comparison snapshot. Scoped to the request that names that URL
+    // so adding the header there turns this red while the five legitimate ones
+    // stay untouched.
+    const reconcileCall = page.slice(
+      page.indexOf("/api/v1/reports/projections/${key}/reconcile`")
+    );
+    const reconcileOptions = reconcileCall.slice(
+      0,
+      reconcileCall.indexOf(");")
+    );
+    expect(reconcileOptions).not.toContain("Idempotency-Key");
+  });
+
+  test("form bounds come from the constants the endpoints validate against", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // A hand-typed `min`/`max`/`maxlength` drifts into a browser that accepts
+    // what the server rejects with a 400 the operator cannot act on.
+    expect(page).toContain("MIN_EXPORT_INTERVAL_MINUTES");
+    expect(page).toContain("MAX_EXPORT_INTERVAL_MINUTES");
+    expect(page).toContain("MAX_REASON_LENGTH");
+    expect(page).not.toMatch(/max=\{?"?\d/);
+
+    for (const route of [
+      "src/pages/api/v1/reports/exports/index.ts",
+      "src/pages/api/v1/reports/exports/[id]/disable.ts",
+      "src/pages/api/v1/reports/projections/[key]/rebuild/index.ts"
+    ]) {
+      expect(await readFile(route, "utf8")).toContain(
+        "reporting/domain/operator-input-bounds"
+      );
+    }
+  });
+
+  test("the sidebar entry points at this page and is gated on a real permission", () => {
+    const nav = listModules()
+      .find((module) => module.key === "reporting")
+      ?.navigation?.find((entry) => entry.path === "/admin/reporting");
+
+    expect(nav).toBeDefined();
+    expect(nav!.requiredPermission).toBe("reporting.projections.read");
+    expect(declaredTriples().has(nav!.requiredPermission as Triple)).toBe(true);
+    // `admin-navigation-registry.test.ts` already binds path→file and
+    // labelKey→SIDEBAR_LABELS; this pins the gate specifically.
+  });
+});


### PR DESCRIPTION
`reporting` had seven permissions and, between them, one page: `/admin` renders four of its five dashboard views. Everything Issue #753 built — the projection registry, live freshness, rebuild, reconciliation, scheduled exports and artifact download — had no screen at all, and neither did `email-health`, the fifth dashboard view. All of it was reachable only by `curl`. Under [ADR-0051](docs/adr/0051-admin-screens-consolidated-in-awcms.md) the screen belongs here.

## What it renders

- **Email queue health** — the fifth management reporting view, which `/admin` never picked up.
- **Projections** — one card each: live freshness status, metric values against their declared labels, last error, most recent reconciliation with its per-metric comparison, and a `drillDownPath` link. Actions: rebuild (reason required), cancel a running rebuild, reconcile.
- **Rebuild history** and **export-run history** with checksum-verified download links.
- **Scheduled exports** — list, create, disable (retire), and a one-off "export now".

It deliberately does not repeat the four aggregations `/admin` already shows, so no view is rendered in two places.

## Reads

All through this module's own application functions inside ONE `withTenantOrThrow`, awaited sequentially — concurrent queries on a single transaction connection leak it.

`listProjectionSummariesForTenant` is handed the caller's **real** granted-permission set rather than a synthetic everything-set: it applies a second filter by each descriptor's own `requiredPermission`, and that layer is only honest if the page feeds it the truth.

The per-projection reconciliation lookup is a fan-out, bounded on purpose — the projection registry is code-declared, so a tenant cannot grow it, and each call is itself `LIMIT 50`.

## Writes

No SQL in the page. Every mutation posts to the guarded endpoint, so its audit row, idempotency record and decision log cannot be bypassed.

Five carry a fresh per-click `Idempotency-Key`. **Reconcile carries none** — that endpoint mutates no business state (it only appends a comparison snapshot) and sending a key would imply a replay contract it does not have. Same split `/admin/data-lifecycle` makes for its dry-run.

## The latent-authz trap

Three plausible guesses would each have rendered a control that denies every caller **including the owner**:

| Control | Reads like | Actually enforced |
|---|---|---|
| Cancel a rebuild | `projections.cancel` | `projections.rebuild` |
| Reconcile | `projections.read` | `projections.analyze` |
| Export now | `exports.configure` | `exports.export` |

`tests/admin-reporting-page-contract.test.ts` pins all seven keys against what the routes enforce **and** what the descriptor declares. **Mutation-proven four ways**, each RED then reverted GREEN: the reconcile-on-read gate, an `Idempotency-Key` added to reconcile, a nav entry gated on an unseeded `projections.view`, and a hand-typed interval bound.

## Bounds

`MIN_EXPORT_INTERVAL_MINUTES` / `MAX_EXPORT_INTERVAL_MINUTES` / `MIN_REASON_LENGTH` / `MAX_REASON_LENGTH` move to `reporting/domain/operator-input-bounds.ts`, imported by both the three routes that validate them and the form that renders them as `min`/`max`/`maxlength`. A hand-typed bound drifts into a browser accepting what the server rejects with a 400 the operator cannot act on.

## Docs correction

`reporting/README.md` described an `/admin/reporting/projections` page and a `submitJson` helper that **never existed in this repo** — text that came over with the port. Nothing rendered any of it, and because the module declared no `navigation`, the registry gate that catches a dangling path had nothing to check. Docs are not gated the way descriptors are.

## Verification

- Full static gates green on the host (lint, `check:docs`, `api:spec:check`, all `modules:*` gates, `family:conformance`, `logging:lint`, …), plus `typecheck` and `build`.
- Full test suite against a real migrated PostgreSQL (86 migrations): **3227 pass**. The only 2 failures are `check-docs-integration`'s "repo nyata" tests, which need `git` and so fail inside the `oven/bun` container; both pass on the host.
- **Zero migrations** — the authorization surface already existed; only the screen was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)