### PR TITLE
feat(workflow-approval): approval inbox at /admin/approvals

### DIFF
--- a/.changeset/admin-approvals-screen.md
+++ b/.changeset/admin-approvals-screen.md
@@ -1,0 +1,21 @@
+---
+"awcms": minor
+---
+
+Add the `/admin/approvals` inbox and put `workflow_approval` in the admin sidebar.
+
+The module shipped a complete engine — graph definitions, quorum, delegation, escalation, administrative recovery — and no screen, so every approval in this base could only be decided with `curl`. Under ADR-0051 the screen belongs here.
+
+The inbox lists tasks with the same filters the JSON route accepts (status, workflow key, resource type, overdue, safe search) over keyset pagination, and offers approve/reject, reassign and force-decision per row, a per-instance history panel carrying the cancel action, and the delegation ledger with create and revoke. Reads go through this module's own application functions inside one `withTenantOrThrow`, awaited sequentially; instance history is fetched only when `?instance=` names one, because doing it per row would be up to 100 queries for a list nobody expanded.
+
+Writes go to the guarded endpoints, all six with a fresh `Idempotency-Key` per click — unlike `/admin/reporting` there is no exception here, because every one of them requires the header.
+
+Cancel sits on the instance panel rather than the task row: cancelling ends the whole instance and every pending task under it, so offering it beside a single task would misrepresent its blast radius.
+
+`tests/admin-approvals-page-contract.test.ts` pins the page's eight permission keys against what the routes enforce and the descriptor declares. Two traps are specific to this module and both would deny every caller while reading perfectly: the permission namespace is `workflow`, not `workflow_approval` (the directory, README and descriptor name all say the latter), and approve/reject share one permission — `approval.approve` is the ability to decide, not its direction, and `approval.reject` is seeded nowhere.
+
+The six `definition.*` permissions are deliberately left to their own screen: authoring a node graph needs a real editor, and a raw-JSON textarea that accepts a malformed graph until publish rejects it is a worse affordance than none. The contract test asserts they stay off this page, so the split remains a decision rather than a gap.
+
+`MAX_REASON_LENGTH` — written out as a bare `500` in five separate files — moves to `workflow-approval/domain/reason-bounds.ts`, imported by all of them and by the form that renders it as `maxlength`.
+
+Also corrects `workflow-approval/README.md`, which described an `/admin/workflows` page that never existed in this repo.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -399,7 +399,7 @@
       "capabilitiesProvided": [],
       "capabilitiesConsumed": [],
       "permissionCount": 14,
-      "navigationCount": 0,
+      "navigationCount": 1,
       "jobCount": 1,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -179,6 +179,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_visitor_analytics": "Visitor analytics",
   "admin.layout.nav_data_lifecycle": "Data lifecycle",
   "admin.layout.nav_idn_regions": "Region datasets",
+  "admin.layout.nav_approvals": "Approvals",
   "admin.layout.nav_profiles": "Profiles",
   "admin.layout.nav_users": "Users",
   "admin.layout.nav_roles": "Roles",

--- a/src/modules/workflow-approval/README.md
+++ b/src/modules/workflow-approval/README.md
@@ -82,9 +82,15 @@ Reassign (`POST /workflows/tasks/{id}/reassign`), cancel (`POST /workflows/insta
 
 `workflow_instances_active_total`/`workflow_tasks_overdue_total` (gauges, sampled per escalation-job pass), `workflow_task_decision_duration_ms` (histogram), `workflow_escalation_total`/`workflow_recovery_action_total` (counters) — all unlabeled or labeled with a fixed, code-defined enum only (never a tenant/resource id).
 
-## Admin UI (`/admin/workflows`)
+## Admin UI (`/admin/approvals`)
 
-`src/pages/admin/workflows/index.astro` — the consolidated approval inbox screen: filters (status/workflow key/resource type/overdue), safe search, keyset "load more" pagination, per-row approve/reject/reassign/force-decide/cancel actions (each gated by its own permission, each a real client-side `fetch` against the existing endpoints above, same convention `admin/analytics.astro` established — the UI is never the enforcement point, only a second, strictly-more-restrictive convenience layer over already-guarded server-side ABAC), and an expandable immutable action-history panel per row. Deliberately NOT built in this issue: a visual definition/graph editor — `POST/PUT /workflows/definitions/**` are exercised by tests and usable directly, but authoring a node/transition graph today is done via the API, same precedent Issue 11.1 set for the original linear engine (backlog for a follow-up issue, not silently dropped).
+`src/pages/admin/approvals.astro` (ADR-0051) — the consolidated approval inbox: filters (status/workflow key/resource type/overdue), safe search, keyset pagination, per-row approve/reject/reassign/force-decide, a per-instance history panel (`?instance=<id>`) carrying the cancel action, and the delegation ledger with create/revoke. Each control is gated by its own permission and is a real client-side `fetch` against the endpoints above — the UI is never the enforcement point, only a second, strictly-more-restrictive convenience layer over already-guarded server-side ABAC. Pinned by `tests/admin-approvals-page-contract.test.ts`.
+
+Cancel lives on the instance panel rather than the task row on purpose: cancelling ends the whole instance and every pending task under it, so offering it beside a single task would misrepresent its blast radius.
+
+Deliberately NOT built here: a definition/graph editor. `POST/PUT /workflows/definitions/**` are exercised by tests and usable directly, but authoring a node/transition graph needs a real editor — a raw-JSON textarea that accepts a malformed graph until the publish call rejects it is a worse affordance than none. The six `definition.*` permissions are therefore claimed by no screen yet, and the contract test asserts they stay off this one so the split remains a decision rather than a gap.
+
+> This section previously described `/admin/workflows` and `src/pages/admin/workflows/index.astro`. Neither existed in this repo — the text came over with the port. Because the module declared no `navigation`, the registry gate that catches a dangling path had nothing to check; docs are not gated the way descriptors are.
 
 ## Deferred (explicitly out of scope for Issue #747, not silently dropped)
 

--- a/src/modules/workflow-approval/domain/reason-bounds.ts
+++ b/src/modules/workflow-approval/domain/reason-bounds.ts
@@ -1,0 +1,19 @@
+/**
+ * The reason-text bound every operator action in this module validates
+ * against, in one place.
+ *
+ * `const MAX_REASON_LENGTH = 500` was written out five separate times — once
+ * privately in `workflow-delegation.ts` and once in each of four route files.
+ * Five copies of a number agree until one of them is edited. That was survivable
+ * while `curl` was the only client; it stops being survivable the moment a
+ * screen renders `maxlength` from it, because a form built against a stale copy
+ * accepts text the server then rejects with a 400 the operator cannot act on.
+ *
+ * Every one of these actions is audited, and a decision recorded without a
+ * reason records that something happened without recording why — which is why
+ * the minimum is 1 and not 0 for the mandatory-reason paths.
+ *
+ * Pure constants — no I/O, no imports.
+ */
+export const MIN_REASON_LENGTH = 1;
+export const MAX_REASON_LENGTH = 500;

--- a/src/modules/workflow-approval/domain/workflow-delegation.ts
+++ b/src/modules/workflow-approval/domain/workflow-delegation.ts
@@ -1,3 +1,4 @@
+import { MAX_REASON_LENGTH } from "./reason-bounds";
 /**
  * Delegation/substitute-assignment domain logic (Issue #747). Pure
  * functions — `application/workflow-delegation-directory.ts` owns all
@@ -119,7 +120,6 @@ export type CreateDelegationValidationResult =
 
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const MAX_REASON_LENGTH = 500;
 
 export function validateCreateDelegationRequestBody(
   body: unknown,

--- a/src/modules/workflow-approval/module.ts
+++ b/src/modules/workflow-approval/module.ts
@@ -114,5 +114,18 @@ export const workflowApprovalModule = defineModule({
   api: {
     openApiPath: "openapi/modules/workflow-approval.openapi.yaml",
     basePath: "/api/v1/workflows"
-  }
+  },
+  // The inbox half of this module's admin surface (ADR-0051). Definition
+  // authoring is deliberately NOT here — it needs a graph editor, not a corner
+  // of the inbox — so it will arrive as its own entry alongside this one.
+  // Gated on `approval.read`: an approver who can see nothing else on the page
+  // should still reach it.
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_approvals",
+      path: "/admin/approvals",
+      order: 62,
+      requiredPermission: "workflow.approval.read"
+    }
+  ]
 });

--- a/src/modules/workflow-approval/module.ts
+++ b/src/modules/workflow-approval/module.ts
@@ -9,11 +9,6 @@ export const workflowApprovalModule = defineModule({
     "Managed, versioned workflow-definition engine ported from awcms-mini's proven workflow-approval module: draft/publish/retire lifecycle with immutable published/retired versions and version pinning per instance, generic nodes/transitions (sequential approval, bounded conditional routing, parallel/join fan-out/fan-in, notify), quorum/any/all approval rules, effective-dated delegation/substitution, escalation/timeout policies processed by a scheduled worker job, and administrative recovery (reassign/cancel/force-decision) with explicit permissions, reason, Idempotency-Key, and full audit. Self-approval guard reused unchanged from identity_access's ABAC evaluator. Module-contributed condition resolvers/actions are a static, reviewed-source-code registry (`infrastructure/condition-action-registry.ts`) — never runtime-registered or arbitrary tenant-supplied code (doc 21 §3 decision tree, node Q5). See README.",
   dependencies: ["tenant_admin", "identity_access", "domain_event_runtime"],
   type: "system",
-  // No `navigation` entries yet — an admin UI for the approval inbox
-  // (src/pages/admin/workflows/*.astro) does not exist in this base;
-  // declaring a nav entry with no matching page would be a real 404. Add
-  // navigation once that UI ships, matching every other ported module's
-  // convention (a real page always exists first).
   permissions: [
     {
       activityCode: "approval",

--- a/src/pages/admin/approvals.astro
+++ b/src/pages/admin/approvals.astro
@@ -1,0 +1,1091 @@
+---
+/**
+ * Approval inbox — the decision surface of `workflow_approval`.
+ *
+ * The module shipped a complete engine (graph definitions, quorum, delegation,
+ * escalation, administrative recovery) and no screen, so every approval in this
+ * base could only be decided with `curl`. Under ADR-0051 the screen belongs
+ * here; this is the inbox half of it.
+ *
+ * ## Scope, and what is deliberately absent
+ *
+ * This page covers the eight permissions an approver or an operator recovering
+ * a stuck instance needs: `approval.read`, `approval.approve`, the three
+ * `recovery.*`, and the three `delegation.*`.
+ *
+ * The six `definition.*` permissions are NOT gated here. Authoring a workflow
+ * definition means editing a validated node graph, and the honest options are a
+ * real graph editor or a raw-JSON textarea. A textarea that silently accepts a
+ * malformed graph until the publish call rejects it is a worse affordance than
+ * no affordance, so definitions get their own screen rather than a corner of
+ * this one. `tests/admin-approvals-page-contract.test.ts` asserts that this
+ * page claims none of them, so the split stays deliberate rather than becoming
+ * a gap nobody notices.
+ *
+ * There is also no user PICKER for reassignment or delegation, only a tenant
+ * user id field. Rendering a directory of tenant users here would hand the
+ * whole list to anyone holding `recovery.reassign` — a disclosure
+ * `identity_access` gates separately on its own permissions. The field links to
+ * `/admin/users`, where that data is already properly gated.
+ *
+ * ## Reads
+ *
+ * Through this module's own application functions inside ONE
+ * `withTenantOrThrow`, awaited sequentially — concurrent queries on a single
+ * transaction connection leak it.
+ *
+ * The instance history is fetched only when `?instance=<id>` names one. Doing
+ * it per row would be up to 100 extra queries for a list nobody has expanded.
+ *
+ * ## Writes
+ *
+ * Nothing here writes SQL. All six mutations post to the guarded endpoints with
+ * a fresh per-click `Idempotency-Key`; every one of them requires the header
+ * and every one is audited.
+ *
+ * ## Gates
+ *
+ * UX-only; `authorizeInTransaction` in the routes is the authority. Two are
+ * easy to get wrong in a way that denies everyone while reading perfectly:
+ *
+ * - approve and reject share ONE permission, `approval.approve` — the
+ *   permission is the ability to decide, and a separate `approval.reject` is
+ *   seeded nowhere;
+ * - the module key is `workflow`, not `workflow_approval` (the directory name).
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { decodeKeysetCursor } from "../../modules/_shared/keyset-pagination";
+import {
+  listWorkflowInboxTasks,
+  listWorkflowInstanceHistory,
+  type WorkflowInstanceHistoryEntry,
+  type WorkflowTaskListItem
+} from "../../modules/workflow-approval/application/workflow-inbox-directory";
+import {
+  listWorkflowDelegations,
+  type WorkflowDelegationRow
+} from "../../modules/workflow-approval/application/workflow-delegation-directory";
+import {
+  MAX_REASON_LENGTH,
+  MIN_REASON_LENGTH
+} from "../../modules/workflow-approval/domain/reason-bounds";
+
+const ssr = Astro.locals.ssrContext!;
+
+const canRead = ssr.permissions.has(
+  permissionKey("workflow", "approval", "read")
+);
+const canDecide = ssr.permissions.has(
+  permissionKey("workflow", "approval", "approve")
+);
+const canReassign = ssr.permissions.has(
+  permissionKey("workflow", "recovery", "reassign")
+);
+const canCancel = ssr.permissions.has(
+  permissionKey("workflow", "recovery", "cancel")
+);
+const canForceDecide = ssr.permissions.has(
+  permissionKey("workflow", "recovery", "force_decide")
+);
+const canReadDelegations = ssr.permissions.has(
+  permissionKey("workflow", "delegation", "read")
+);
+const canCreateDelegation = ssr.permissions.has(
+  permissionKey("workflow", "delegation", "create")
+);
+const canRevokeDelegation = ssr.permissions.has(
+  permissionKey("workflow", "delegation", "revoke")
+);
+
+/** Mirrors `VALID_STATUSES` in `src/pages/api/v1/workflows/tasks/index.ts`. */
+const STATUS_OPTIONS = [
+  "pending",
+  "completed",
+  "skipped",
+  "cancelled"
+] as const;
+type TaskStatus = (typeof STATUS_OPTIONS)[number];
+
+const STATUS_VARIANT: Record<TaskStatus, string> = {
+  pending: "info",
+  completed: "success",
+  skipped: "neutral",
+  cancelled: "neutral"
+};
+
+function readParam(name: string): string {
+  return (Astro.url.searchParams.get(name) ?? "").trim();
+}
+
+const statusRaw = readParam("status");
+// An unknown `status` falls back to the endpoint's own default rather than
+// being forwarded: the route answers a bad value with a 400, and a hand-edited
+// query string must not turn this screen into an error page.
+const statusFilter: TaskStatus = (STATUS_OPTIONS as readonly string[]).includes(
+  statusRaw
+)
+  ? (statusRaw as TaskStatus)
+  : "pending";
+const workflowKeyFilter = readParam("workflowKey");
+const resourceTypeFilter = readParam("resourceType");
+const searchFilter = readParam("search");
+const overdueOnly = readParam("overdue") === "true";
+const selectedInstanceId = readParam("instance");
+
+const cursorParam = readParam("cursor");
+// A malformed cursor is dropped rather than forwarded, for the same reason.
+const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+let tasks: WorkflowTaskListItem[] = [];
+let nextCursor: string | null = null;
+let history: WorkflowInstanceHistoryEntry[] = [];
+let delegations: WorkflowDelegationRow[] = [];
+let loadError = false;
+
+const canSeeAnything = canRead || canReadDelegations;
+
+if (canSeeAnything) {
+  try {
+    const sql = getDatabaseClient();
+    const now = new Date();
+    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
+      if (canRead) {
+        const result = await listWorkflowInboxTasks(
+          tx,
+          ssr.tenantId,
+          {
+            status: statusFilter,
+            workflowKey: workflowKeyFilter || undefined,
+            resourceType: resourceTypeFilter || undefined,
+            search: searchFilter || undefined,
+            overdueOnly
+          },
+          now,
+          cursor
+        );
+        tasks = result.tasks;
+        nextCursor = result.nextCursor;
+
+        if (selectedInstanceId) {
+          // `listWorkflowInstanceHistory` asserts the id is a UUID and throws
+          // otherwise, which the surrounding catch turns into the load-error
+          // notice — a hand-edited `?instance=` must not 500 the page.
+          history = await listWorkflowInstanceHistory(
+            tx,
+            ssr.tenantId,
+            selectedInstanceId
+          );
+        }
+      }
+
+      if (canReadDelegations) {
+        delegations = await listWorkflowDelegations(tx, ssr.tenantId);
+      }
+    });
+  } catch (error) {
+    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
+    // must never render as "there is nothing to approve".
+    loadError = true;
+    logAdminPageError(
+      "admin/approvals.astro: failed to load the approval inbox",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+}
+
+function formatTimestamp(value: Date | string | null): string {
+  if (value === null) return "—";
+  return typeof value === "string" ? value : value.toISOString();
+}
+
+/** Rebuilds the current query string with one key replaced — keeps filters across paging. */
+function linkWith(overrides: Record<string, string | null>): string {
+  const params = new URLSearchParams(Astro.url.search);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) params.delete(key);
+    else params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `/admin/approvals?${query}` : "/admin/approvals";
+}
+
+const hasFilters =
+  workflowKeyFilter !== "" ||
+  resourceTypeFilter !== "" ||
+  searchFilter !== "" ||
+  overdueOnly ||
+  statusFilter !== "pending";
+
+const showRecovery = canReassign || canForceDecide;
+const taskColumns = 6 + (canDecide || showRecovery ? 1 : 0);
+const delegationColumns = canRevokeDelegation ? 7 : 6;
+const selectedTask = selectedInstanceId
+  ? (tasks.find((task) => task.instanceId === selectedInstanceId) ?? null)
+  : null;
+---
+
+<AdminLayout title="Approvals">
+  <header class="page-header fade-in-up">
+    <h1 id="approvals-heading">Approvals</h1>
+    <p class="page-description">
+      Tasks awaiting a decision, the history behind them, and the delegations
+      that let someone else decide on your behalf. Overdue tasks are escalated
+      by <code>workflow:escalations:dispatch</code>; escalation notifies, it
+      never decides.
+    </p>
+  </header>
+
+  {
+    !canSeeAnything && (
+      <p class="state-notice fade-in-up" id="approvals-denied">
+        You do not have permission to view approvals.
+      </p>
+    )
+  }
+
+  {
+    canSeeAnything && loadError && (
+      <p class="state-notice fade-in-up" id="approvals-error">
+        The approval inbox could not be loaded right now. This is a problem
+        reading it, not an empty inbox — please try again later.
+      </p>
+    )
+  }
+
+  {
+    canSeeAnything && !loadError && (
+      <p
+        id="approvals-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <form method="get" class="admin-toolbar fade-in-up" id="task-filter-form">
+        <label for="filter-status">Status</label>
+        <select id="filter-status" name="status">
+          {STATUS_OPTIONS.map((value) => (
+            <option value={value} selected={statusFilter === value}>
+              {value}
+            </option>
+          ))}
+        </select>
+
+        <label for="filter-workflow-key">Workflow key</label>
+        <input
+          id="filter-workflow-key"
+          name="workflowKey"
+          type="text"
+          value={workflowKeyFilter}
+          autocomplete="off"
+          placeholder="e.g. purchase_requisition"
+        />
+
+        <label for="filter-resource-type">Resource type</label>
+        <input
+          id="filter-resource-type"
+          name="resourceType"
+          type="text"
+          value={resourceTypeFilter}
+          autocomplete="off"
+        />
+
+        <label for="filter-search">Search</label>
+        <input
+          id="filter-search"
+          name="search"
+          type="search"
+          value={searchFilter}
+          autocomplete="off"
+          placeholder="resource id, key or name"
+        />
+
+        <label for="filter-overdue">
+          <input
+            id="filter-overdue"
+            name="overdue"
+            type="checkbox"
+            value="true"
+            checked={overdueOnly}
+          />
+          Overdue only
+        </label>
+
+        <button type="submit">Apply filters</button>
+      </form>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="task-list-title"
+      >
+        <h2 class="admin-section-title" id="task-list-title">
+          Tasks
+          <span class="count-pill">{tasks.length}</span>
+        </h2>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack" id="approval-tasks-table">
+            <caption class="sr-only">
+              Workflow tasks, newest first, 100 per page.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Workflow</th>
+                <th scope="col">Resource</th>
+                <th scope="col">Node</th>
+                <th scope="col">Quorum</th>
+                <th scope="col">Due</th>
+                <th scope="col">Status</th>
+                {(canDecide || showRecovery) && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {tasks.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={taskColumns}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ✓
+                      </span>
+                      <span class="empty-state-title">
+                        {hasFilters
+                          ? "No tasks match these filters"
+                          : "Nothing awaiting a decision"}
+                      </span>
+                      <span class="empty-state-text">
+                        {hasFilters
+                          ? "Clear or widen the filters above to see more tasks."
+                          : "Tasks appear here when a module starts a workflow instance."}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                tasks.map((task) => (
+                  <tr data-task-row={task.id}>
+                    <td data-label="Workflow">
+                      <span class="cell-code">{task.workflowKey}</span>
+                      <span class="cell-muted"> · {task.workflowName}</span>
+                    </td>
+                    <td data-label="Resource">
+                      <span class="cell-code">{task.resourceType}</span>
+                      <span class="cell-muted"> · {task.resourceId}</span>
+                      <a
+                        class="quick-link"
+                        href={linkWith({
+                          instance: task.instanceId,
+                          cursor: null
+                        })}
+                      >
+                        History
+                        <span class="quick-link-arrow" aria-hidden="true">
+                          →
+                        </span>
+                      </a>
+                    </td>
+                    <td data-label="Node">
+                      <span class="cell-code">{task.nodeId}</span>
+                    </td>
+                    <td data-label="Quorum">
+                      <span class="cell-code">{task.quorumRule}</span>
+                    </td>
+                    <td data-label="Due">
+                      <span class="cell-muted">
+                        {formatTimestamp(task.dueAt)}
+                      </span>
+                      {task.overdue && (
+                        <span class="status-badge" data-variant="warning">
+                          <span class="status-dot" aria-hidden="true" />
+                          overdue
+                        </span>
+                      )}
+                    </td>
+                    <td data-label="Status">
+                      <span
+                        class="status-badge"
+                        data-variant={
+                          STATUS_VARIANT[task.status as TaskStatus] ?? "neutral"
+                        }
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {task.status}
+                      </span>
+                    </td>
+                    {(canDecide || showRecovery) && (
+                      <td data-label="Actions">
+                        {task.status === "pending" ? (
+                          <div class="row-actions">
+                            {canDecide && (
+                              <>
+                                {/* One permission covers both: the ability to
+                                    decide, not the direction of the decision.
+                                    A separate `approval.reject` is seeded
+                                    nowhere. */}
+                                <button
+                                  type="button"
+                                  class="btn-inline task-decide-btn"
+                                  data-task-id={task.id}
+                                  data-decision="approve"
+                                >
+                                  Approve
+                                </button>
+                                <button
+                                  type="button"
+                                  class="btn-inline btn-inline--danger task-decide-btn"
+                                  data-task-id={task.id}
+                                  data-decision="reject"
+                                >
+                                  Reject
+                                </button>
+                              </>
+                            )}
+                            {canReassign && (
+                              <button
+                                type="button"
+                                class="btn-inline task-reassign-btn"
+                                data-task-id={task.id}
+                              >
+                                Reassign
+                              </button>
+                            )}
+                            {canForceDecide && (
+                              <button
+                                type="button"
+                                class="btn-inline btn-inline--danger task-force-btn"
+                                data-task-id={task.id}
+                              >
+                                Force decision
+                              </button>
+                            )}
+                          </div>
+                        ) : (
+                          <span class="cell-muted">decided</span>
+                        )}
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {nextCursor && (
+          <div class="admin-toolbar">
+            {/* Keyset, not offset: the cursor carries full-precision
+                `created_at` text, so a page boundary cannot skip or repeat a
+                row the way a millisecond-truncated timestamp would. */}
+            <a class="quick-link" href={linkWith({ cursor: nextCursor })}>
+              Next 100
+              <span class="quick-link-arrow" aria-hidden="true">
+                →
+              </span>
+            </a>
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  {
+    canRead && !loadError && selectedInstanceId && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="instance-history-title"
+        id="instance-history"
+      >
+        <h2 class="admin-section-title" id="instance-history-title">
+          Instance history
+          <span class="count-pill">{history.length}</span>
+        </h2>
+        <p class="page-description">
+          <span class="cell-code">{selectedInstanceId}</span>
+          {selectedTask && (
+            <span class="cell-muted">
+              {" "}
+              · {selectedTask.workflowKey} · {selectedTask.resourceType}/
+              {selectedTask.resourceId}
+            </span>
+          )}
+        </p>
+
+        <div class="row-actions">
+          <a class="quick-link" href={linkWith({ instance: null })}>
+            Close history
+          </a>
+          {canCancel && (
+            <button
+              type="button"
+              class="btn-inline btn-inline--danger instance-cancel-btn"
+              data-instance-id={selectedInstanceId}
+            >
+              Cancel instance
+            </button>
+          )}
+        </div>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">
+              Decisions and audit events for this workflow instance.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">When</th>
+                <th scope="col">Kind</th>
+                <th scope="col">Action</th>
+                <th scope="col">Actor</th>
+                <th scope="col">Detail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={5}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ⌸
+                      </span>
+                      <span class="empty-state-title">No history</span>
+                      <span class="empty-state-text">
+                        Nothing has been decided or recorded against this
+                        instance yet — or the id does not name one.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                history.map((entry) => (
+                  <tr>
+                    <td data-label="When">
+                      <span class="cell-muted">
+                        {formatTimestamp(entry.createdAt)}
+                      </span>
+                    </td>
+                    <td data-label="Kind">
+                      <span class="cell-code">{entry.kind}</span>
+                    </td>
+                    <td data-label="Action">
+                      <span class="cell-code">{entry.action}</span>
+                    </td>
+                    <td data-label="Actor">
+                      <span class="cell-muted">
+                        {entry.actorTenantUserId ?? "—"}
+                      </span>
+                    </td>
+                    <td data-label="Detail">
+                      {/* `set:text` rather than a child expression: <pre>
+                          preserves whitespace and prettier reindents .astro
+                          children, so an expression written between the tags
+                          comes back wrapped in template indentation that <pre>
+                          then renders. `set:text` escapes and sets the content
+                          directly. */}
+                      <details>
+                        <summary>Detail</summary>
+                        <pre
+                          class="cell-code"
+                          set:text={JSON.stringify(entry.detail, null, 2)}
+                        />
+                      </details>
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canReadDelegations && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="delegations-title"
+        id="delegations"
+      >
+        <h2 class="admin-section-title" id="delegations-title">
+          Delegations
+          <span class="count-pill">{delegations.length}</span>
+        </h2>
+        <p class="page-description">
+          A delegation lets the delegate decide on the delegator's behalf while
+          it is in effect. It never widens what the delegate may decide beyond
+          the delegator's own eligibility.
+        </p>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">
+              Workflow delegations for this tenant.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Delegator</th>
+                <th scope="col">Delegate</th>
+                <th scope="col">Scope</th>
+                <th scope="col">From</th>
+                <th scope="col">To</th>
+                <th scope="col">Status</th>
+                {canRevokeDelegation && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {delegations.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={delegationColumns}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ⇄
+                      </span>
+                      <span class="empty-state-title">No delegations</span>
+                      <span class="empty-state-text">
+                        Nobody is currently deciding on anyone else's behalf.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                delegations.map((row) => (
+                  <tr>
+                    <td data-label="Delegator">
+                      <span class="cell-code">
+                        {row.delegator_tenant_user_id}
+                      </span>
+                    </td>
+                    <td data-label="Delegate">
+                      <span class="cell-code">
+                        {row.delegate_tenant_user_id}
+                      </span>
+                    </td>
+                    <td data-label="Scope">
+                      <span class="cell-muted">
+                        {row.workflow_key ?? "any workflow"} ·{" "}
+                        {row.resource_type ?? "any resource"}
+                      </span>
+                    </td>
+                    <td data-label="From">
+                      <span class="cell-muted">
+                        {formatTimestamp(row.effective_from)}
+                      </span>
+                    </td>
+                    <td data-label="To">
+                      <span class="cell-muted">
+                        {formatTimestamp(row.effective_to)}
+                      </span>
+                    </td>
+                    <td data-label="Status">
+                      <span
+                        class="status-badge"
+                        data-variant={
+                          row.status === "active" ? "success" : "neutral"
+                        }
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {row.status}
+                      </span>
+                    </td>
+                    {canRevokeDelegation && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          {row.status === "active" && (
+                            <button
+                              type="button"
+                              class="btn-inline btn-inline--danger delegation-revoke-btn"
+                              data-delegation-id={row.id}
+                            >
+                              Revoke
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {canCreateDelegation && (
+          <form id="delegation-create-form" class="admin-create-form">
+            <p class="form-legend">Delegate your decisions</p>
+            <p
+              id="delegation-create-error"
+              class="admin-create-error"
+              role="alert"
+              hidden
+            />
+
+            <label for="delegate-user-id">
+              Delegate tenant user id
+              {/* A free-text id, not a picker: a directory of tenant users is
+                  `identity_access` data, gated on its own permissions. Find
+                  the id on <a href="/admin/users">Users</a>. */}
+              <input
+                type="text"
+                id="delegate-user-id"
+                name="delegateTenantUserId"
+                required
+                autocomplete="off"
+                placeholder="UUID from /admin/users"
+              />
+            </label>
+
+            <label for="delegation-workflow-key">
+              Workflow key (optional — blank means every workflow)
+              <input
+                type="text"
+                id="delegation-workflow-key"
+                name="workflowKey"
+                autocomplete="off"
+              />
+            </label>
+
+            <label for="delegation-resource-type">
+              Resource type (optional — blank means every resource)
+              <input
+                type="text"
+                id="delegation-resource-type"
+                name="resourceType"
+                autocomplete="off"
+              />
+            </label>
+
+            <label for="delegation-effective-to">
+              Effective until (optional)
+              <input
+                type="datetime-local"
+                id="delegation-effective-to"
+                name="effectiveTo"
+              />
+            </label>
+
+            <label for="delegation-reason">
+              Reason
+              {/* Bounds come from the same constant the validator enforces. */}
+              <input
+                type="text"
+                id="delegation-reason"
+                name="reason"
+                required
+                minlength={MIN_REASON_LENGTH}
+                maxlength={MAX_REASON_LENGTH}
+                autocomplete="off"
+              />
+            </label>
+
+            <button type="submit" id="delegation-create-submit">
+              Create delegation
+            </button>
+          </form>
+        )}
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'`
+  // with no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("approvals-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  /** Every mutation below requires the header; a fresh value per click is also what makes a deliberate second action run instead of replaying the first. */
+  function idempotency(): Record<string, string> {
+    return { "Idempotency-Key": crypto.randomUUID() };
+  }
+
+  function askReason(prompt: string): string | null {
+    const reason = window.prompt(prompt);
+    if (reason === null) return null;
+    const trimmed = reason.trim();
+    if (trimmed === "") {
+      showActionError(
+        "A reason is required — it is recorded in the audit trail."
+      );
+      return null;
+    }
+    return trimmed;
+  }
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".task-decide-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const taskId = button.dataset.taskId;
+        const decision = button.dataset.decision;
+        if (!taskId || !decision) return;
+
+        const reason = askReason(
+          `Reason for this ${decision} (recorded against the task):`
+        );
+        if (reason === null) return;
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Submitting…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/workflows/tasks/${taskId}/decisions`,
+          { decision, reason },
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // Generic copy only — never surface internal detail. `ACCESS_DENIED`
+        // here most often means the caller is not an eligible decider for THIS
+        // task (assignment/delegation), which is a narrower rule than the
+        // permission, so it is worth distinguishing.
+        showActionError(
+          result.errorCode === "ACCESS_DENIED"
+            ? "You are not an eligible decider for this task."
+            : "Could not record the decision. Please try again."
+        );
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".task-reassign-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const taskId = button.dataset.taskId;
+        if (!taskId) return;
+
+        const toTenantUserId = window.prompt(
+          "Reassign to which tenant user id? (find it on /admin/users)"
+        );
+        if (toTenantUserId === null || toTenantUserId.trim() === "") return;
+
+        const reason = askReason("Reason for the reassignment:");
+        if (reason === null) return;
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Reassigning…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/workflows/tasks/${taskId}/reassign`,
+          { toTenantUserId: toTenantUserId.trim(), reason },
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not reassign the task. Please try again.");
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".task-force-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const taskId = button.dataset.taskId;
+        if (!taskId) return;
+
+        const decision = window.prompt(
+          'Force which decision — type "approve" or "reject"?'
+        );
+        if (decision !== "approve" && decision !== "reject") return;
+
+        // An administrative override decides on someone else's behalf and is
+        // recorded as such. Confirm before asking for the reason.
+        if (
+          !window.confirm(
+            `Force-${decision} this task? This overrides the assigned deciders and is recorded as an administrative override.`
+          )
+        ) {
+          return;
+        }
+
+        const reason = askReason("Reason for the override:");
+        if (reason === null) return;
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Overriding…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/workflows/tasks/${taskId}/force-decision`,
+          { decision, reason },
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not force the decision. Please try again.");
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".instance-cancel-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const instanceId = button.dataset.instanceId;
+        if (!instanceId) return;
+
+        if (
+          !window.confirm(
+            "Cancel this workflow instance? Its pending tasks are cancelled with it and it cannot be resumed."
+          )
+        ) {
+          return;
+        }
+
+        const reason = askReason("Reason for cancelling the instance:");
+        if (reason === null) return;
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Cancelling…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/workflows/instances/${instanceId}/cancel`,
+          { reason },
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not cancel the instance. Please try again.");
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".delegation-revoke-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.delegationId;
+        if (!id) return;
+
+        if (
+          !window.confirm(
+            "Revoke this delegation? The delegate stops being eligible immediately."
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Revoking…");
+
+        // `reason` is optional on this endpoint, unlike the others.
+        const result = await sendJson(
+          "POST",
+          `/api/v1/workflows/delegations/${id}/revoke`,
+          { reason: "Revoked from the admin approvals screen." },
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not revoke the delegation. Please try again.");
+        unlock();
+      });
+    });
+
+  const delegationForm = document.getElementById(
+    "delegation-create-form"
+  ) as HTMLFormElement | null;
+
+  delegationForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "delegation-create-submit"
+    ) as HTMLButtonElement | null;
+    if (!submit || submit.disabled) return;
+
+    const data = new FormData(delegationForm);
+    const errorElement = document.getElementById("delegation-create-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Creating…");
+
+    const workflowKey = String(data.get("workflowKey") ?? "").trim();
+    const resourceType = String(data.get("resourceType") ?? "").trim();
+    const effectiveTo = String(data.get("effectiveTo") ?? "").trim();
+
+    // Blank optional fields are OMITTED rather than sent as "": the validator
+    // rejects a non-string/non-ISO value, and an empty string is not "no
+    // scope", it is an invalid scope.
+    const body: Record<string, unknown> = {
+      delegateTenantUserId: String(
+        data.get("delegateTenantUserId") ?? ""
+      ).trim(),
+      reason: String(data.get("reason") ?? "").trim()
+    };
+    if (workflowKey !== "") body.workflowKey = workflowKey;
+    if (resourceType !== "") body.resourceType = resourceType;
+    // `datetime-local` yields local wall-clock with no zone; converting through
+    // `Date` gives the validator the ISO 8601 string it requires.
+    if (effectiveTo !== "")
+      body.effectiveTo = new Date(effectiveTo).toISOString();
+
+    const result = await sendJson(
+      "POST",
+      "/api/v1/workflows/delegations",
+      body,
+      idempotency()
+    );
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    if (errorElement) {
+      errorElement.textContent =
+        "Could not create the delegation. Please check the tenant user id and try again.";
+      errorElement.hidden = false;
+    }
+    unlock();
+  });
+</script>

--- a/src/pages/api/v1/workflows/delegations/[id]/revoke.ts
+++ b/src/pages/api/v1/workflows/delegations/[id]/revoke.ts
@@ -26,6 +26,7 @@ import {
   WorkflowDelegationForbiddenError,
   WorkflowDelegationNotFoundError
 } from "../../../../../../modules/workflow-approval/application/workflow-delegation-directory";
+import { MAX_REASON_LENGTH } from "../../../../../../modules/workflow-approval/domain/reason-bounds";
 
 /**
  * Security-auditor finding (PR #778): this route previously gated on
@@ -47,7 +48,6 @@ const REVOKE_GUARD = {
   action: "revoke" as const
 };
 const REVOKE_IDEMPOTENCY_SCOPE = "workflow_delegation_revoke";
-const MAX_REASON_LENGTH = 500;
 
 type RevokeRequestBody = { reason?: unknown };
 

--- a/src/pages/api/v1/workflows/instances/[id]/cancel.ts
+++ b/src/pages/api/v1/workflows/instances/[id]/cancel.ts
@@ -26,6 +26,7 @@ import {
   cancelWorkflowInstance,
   WorkflowRecoveryError
 } from "../../../../../../modules/workflow-approval/application/workflow-recovery";
+import { MAX_REASON_LENGTH } from "../../../../../../modules/workflow-approval/domain/reason-bounds";
 
 const CANCEL_GUARD = {
   moduleKey: "workflow",
@@ -33,7 +34,6 @@ const CANCEL_GUARD = {
   action: "cancel" as const
 };
 const IDEMPOTENCY_SCOPE = "workflow_instance_cancel";
-const MAX_REASON_LENGTH = 500;
 
 type CancelRequestBody = { reason?: unknown };
 

--- a/src/pages/api/v1/workflows/tasks/[id]/force-decision.ts
+++ b/src/pages/api/v1/workflows/tasks/[id]/force-decision.ts
@@ -27,6 +27,7 @@ import {
   WorkflowRecoveryError
 } from "../../../../../../modules/workflow-approval/application/workflow-recovery";
 import { fetchTaskWithInstanceForDecision } from "../../../../../../modules/workflow-approval/application/workflow-instance-decision";
+import { MAX_REASON_LENGTH } from "../../../../../../modules/workflow-approval/domain/reason-bounds";
 
 const FORCE_DECIDE_GUARD = {
   moduleKey: "workflow",
@@ -34,7 +35,6 @@ const FORCE_DECIDE_GUARD = {
   action: "force_decide" as const
 };
 const IDEMPOTENCY_SCOPE = "workflow_task_force_decision";
-const MAX_REASON_LENGTH = 500;
 // No notification port is wired in this base — see decisions.ts for why the
 // `email`-owned WorkflowNotificationPort adapter is not injected yet.
 

--- a/src/pages/api/v1/workflows/tasks/[id]/reassign.ts
+++ b/src/pages/api/v1/workflows/tasks/[id]/reassign.ts
@@ -26,6 +26,7 @@ import {
   reassignWorkflowTask,
   WorkflowRecoveryError
 } from "../../../../../../modules/workflow-approval/application/workflow-recovery";
+import { MAX_REASON_LENGTH } from "../../../../../../modules/workflow-approval/domain/reason-bounds";
 
 const REASSIGN_GUARD = {
   moduleKey: "workflow",
@@ -35,7 +36,6 @@ const REASSIGN_GUARD = {
 const IDEMPOTENCY_SCOPE = "workflow_task_reassign";
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-const MAX_REASON_LENGTH = 500;
 
 type ReassignRequestBody = { toTenantUserId?: unknown; reason?: unknown };
 

--- a/tests/admin-approvals-page-contract.test.ts
+++ b/tests/admin-approvals-page-contract.test.ts
@@ -1,0 +1,262 @@
+/**
+ * `/admin/approvals` gates against the endpoints it drives.
+ *
+ * Sibling of `admin-data-lifecycle-page-contract.test.ts` and
+ * `admin-reporting-page-contract.test.ts`, for the same silent failure: a page
+ * gating on a permission key no migration seeds hides the control from everyone
+ * — including the owner — while still looking like a working screen. This repo
+ * has shipped that bug twice by inventing a plausible action name.
+ *
+ * `workflow_approval` sets two fresh traps for it:
+ *
+ * - **The module key is `workflow`, not `workflow_approval`.** The directory,
+ *   the README and the descriptor's own name all say "workflow approval"; the
+ *   permission namespace does not. `workflow_approval.approval.read` reads
+ *   perfectly and matches nothing.
+ * - **Approve and reject share ONE permission**, `approval.approve` — the
+ *   permission is the ability to decide, not the direction. A page that gated
+ *   its Reject button on `approval.reject` would hide it from every approver.
+ *
+ * It also pins the deliberate SCOPE of this screen: the six `definition.*`
+ * permissions belong to a future definitions screen, and this test fails if
+ * they quietly leak into this one — the difference between a decision that was
+ * made and a gap nobody noticed.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/approvals.astro";
+const ROUTES = [
+  "src/pages/api/v1/workflows/tasks/index.ts",
+  "src/pages/api/v1/workflows/tasks/[id]/decisions.ts",
+  "src/pages/api/v1/workflows/tasks/[id]/reassign.ts",
+  "src/pages/api/v1/workflows/tasks/[id]/force-decision.ts",
+  "src/pages/api/v1/workflows/instances/[id].ts",
+  "src/pages/api/v1/workflows/instances/[id]/cancel.ts",
+  "src/pages/api/v1/workflows/delegations/index.ts",
+  "src/pages/api/v1/workflows/delegations/[id]/revoke.ts"
+];
+
+type Triple = `${string}.${string}.${string}`;
+
+/**
+ * These routes declare their guard as a module-level const spanning several
+ * lines — `{ moduleKey: "workflow", activityCode: "recovery", action: "cancel"
+ * as const }` — so the pattern tolerates newlines and the `as const` suffix.
+ */
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+/** `permissionKey("workflow", "recovery", "force_decide")` → the same shape. */
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function declaredTriples(): Set<Triple> {
+  return new Set<Triple>(
+    (listModules()
+      .find((module) => module.key === "workflow")
+      ?.permissions?.map(
+        (permission) =>
+          `workflow.${permission.activityCode}.${permission.action}`
+      ) ?? []) as Triple[]
+  );
+}
+
+const PAGE_KEYS = [
+  "workflow.approval.approve",
+  "workflow.approval.read",
+  "workflow.delegation.create",
+  "workflow.delegation.read",
+  "workflow.delegation.revoke",
+  "workflow.recovery.cancel",
+  "workflow.recovery.force_decide",
+  "workflow.recovery.reassign"
+] as const;
+
+const DEFINITION_KEYS = [
+  "workflow.definition.create",
+  "workflow.definition.delete",
+  "workflow.definition.publish",
+  "workflow.definition.read",
+  "workflow.definition.retire",
+  "workflow.definition.update"
+] as const;
+
+describe("/admin/approvals permission gates", () => {
+  test("the module key is `workflow`, which is what the descriptor declares", () => {
+    // The one assertion that would have caught the whole class at once: every
+    // other test here builds on this namespace being right.
+    const declared = declaredTriples();
+
+    expect(declared.size).toBe(14);
+    expect(declared.has("workflow.approval.read")).toBe(true);
+    expect(
+      listModules().some((module) => module.key === "workflow_approval")
+    ).toBe(false);
+  });
+
+  test("every key the page gates on is one its endpoints actually enforce", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    expect(pageKeys.size).toBe(PAGE_KEYS.length);
+
+    const enforced = new Set<Triple>();
+    for (const route of ROUTES) {
+      for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+
+    // Guards really were parsed — an empty `enforced` would make the subset
+    // check pass vacuously, the shape of gate this repo has been burned by.
+    expect(enforced.size).toBeGreaterThan(0);
+
+    // `decisions.ts` is the one route whose guard is assembled in two pieces
+    // (`GUARD_ACTIVITY` plus a literal `action`), so the regex above cannot see
+    // it. Assert it directly rather than letting it fall through the subset
+    // check as an unenforced key.
+    const decisions = await readFile(ROUTES[1]!, "utf8");
+    expect(decisions).toContain('moduleKey: "workflow"');
+    expect(decisions).toContain('activityCode: "approval"');
+    expect(decisions).toContain('action: "approve" as const');
+    enforced.add("workflow.approval.approve");
+
+    expect([...pageKeys].filter((key) => !enforced.has(key))).toEqual([]);
+  });
+
+  test("and is declared by the module descriptor, so a migration seeds it", async () => {
+    const declared = declaredTriples();
+    const missing = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].filter(
+      (key) => !declared.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  test("the page claims exactly the inbox/recovery/delegation eight", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+
+    expect([...pageKeys].sort()).toEqual([...PAGE_KEYS]);
+  });
+
+  test("the six definition.* permissions stay out — a screen, not a gap", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+
+    // Every one of them is a real, seeded permission this page could have
+    // gated on. Leaving them out is a decision (definitions need a graph
+    // editor); this assertion is what keeps it a decision rather than an
+    // oversight, and it turns red the moment a definitions surface is added
+    // here instead of on its own screen.
+    const declared = declaredTriples();
+    for (const key of DEFINITION_KEYS) {
+      expect(declared.has(key)).toBe(true);
+      expect(pageKeys.has(key)).toBe(false);
+    }
+  });
+
+  test("reject shares approve's permission — there is no approval.reject", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(declaredTriples().has("workflow.approval.reject" as Triple)).toBe(
+      false
+    );
+    // Both buttons render under the same gate, so the page must not mention a
+    // second decision permission at all.
+    expect(page).toContain('data-decision="approve"');
+    expect(page).toContain('data-decision="reject"');
+    expect(page).not.toContain('"approval", "reject"');
+  });
+
+  test("the page never mutates directly — it posts to the guarded endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // No SQL write anywhere in the screen: every change goes out over fetch, so
+    // the endpoints' audit rows, idempotency records and decision logs cannot
+    // be bypassed by a screen that writes for itself.
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+
+    expect(page).toContain("/api/v1/workflows/tasks/${taskId}/decisions`");
+    expect(page).toContain("/api/v1/workflows/tasks/${taskId}/reassign`");
+    expect(page).toContain("/api/v1/workflows/tasks/${taskId}/force-decision`");
+    expect(page).toContain("/api/v1/workflows/instances/${instanceId}/cancel`");
+    expect(page).toContain("/api/v1/workflows/delegations/${id}/revoke`");
+    expect(page).toContain('"/api/v1/workflows/delegations"');
+  });
+
+  test("all six mutations carry an Idempotency-Key, because all six require one", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Unlike `/admin/reporting`, there is no exception here: every mutating
+    // endpoint this page calls answers `IDEMPOTENCY_REQUIRED` without the
+    // header, so a call that omitted it would render a control that always
+    // fails.
+    // Lookbehind excludes the helper's own declaration, so this counts CALL
+    // SITES — six mutations, six headers.
+    expect(page.match(/(?<!function )idempotency\(\)/g)).toHaveLength(6);
+    expect(page).toContain('"Idempotency-Key": crypto.randomUUID()');
+
+    for (const route of ROUTES.slice(1)) {
+      const source = await readFile(route, "utf8");
+      if (!source.includes("export const POST")) continue;
+      expect(source).toContain("IDEMPOTENCY_REQUIRED");
+    }
+  });
+
+  test("form bounds come from the constant the validators enforce", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain("MAX_REASON_LENGTH");
+    expect(page).toContain("MIN_REASON_LENGTH");
+    // The bound was duplicated as a bare `500` in five files; a sixth copy in
+    // the markup would drift into a browser accepting what the server rejects.
+    expect(page).not.toMatch(/maxlength=\{?"?\d/);
+
+    for (const route of [
+      "src/pages/api/v1/workflows/tasks/[id]/reassign.ts",
+      "src/pages/api/v1/workflows/tasks/[id]/force-decision.ts",
+      "src/pages/api/v1/workflows/instances/[id]/cancel.ts",
+      "src/pages/api/v1/workflows/delegations/[id]/revoke.ts",
+      "src/modules/workflow-approval/domain/workflow-delegation.ts"
+    ]) {
+      const source = await readFile(route, "utf8");
+      expect(source).toContain("reason-bounds");
+      expect(source).not.toContain("MAX_REASON_LENGTH = 500");
+    }
+  });
+
+  test("the sidebar entry points at this page and is gated on a real permission", () => {
+    const nav = listModules()
+      .find((module) => module.key === "workflow")
+      ?.navigation?.find((entry) => entry.path === "/admin/approvals");
+
+    expect(nav).toBeDefined();
+    expect(nav!.requiredPermission).toBe("workflow.approval.read");
+    expect(declaredTriples().has(nav!.requiredPermission as Triple)).toBe(true);
+    // `admin-navigation-registry.test.ts` already binds path→file and
+    // labelKey→SIDEBAR_LABELS; this pins the gate specifically.
+  });
+});


### PR DESCRIPTION
The module shipped a complete engine — graph definitions, quorum, delegation, escalation, administrative recovery — and **no screen**, so every approval in this base could only be decided with `curl`. Under [ADR-0051](docs/adr/0051-admin-screens-consolidated-in-awcms.md) the screen belongs here. This is the inbox half of it.

## What it renders

- **Task inbox** — the same filters the JSON route accepts (status, workflow key, resource type, overdue, safe search) over keyset pagination. Per row: approve / reject, reassign, force-decision.
- **Instance history** (`?instance=<id>`) — decisions unioned with audit events, and the **cancel** action.
- **Delegations** — the ledger, plus create and revoke.

Cancel sits on the instance panel rather than the task row on purpose: cancelling ends the whole instance and every pending task under it, so offering it beside a single task would misrepresent its blast radius.

## Reads

Through this module's own application functions inside ONE `withTenantOrThrow`, awaited sequentially. Instance history is fetched only when `?instance=` names one — per row it would be up to 100 extra queries for a list nobody expanded. A malformed `?cursor=` or `?status=` is dropped rather than forwarded, so a hand-edited query string cannot turn the screen into the endpoint's 400.

## Writes

No SQL in the page. All six mutations post to the guarded endpoints with a fresh `Idempotency-Key` per click — unlike `/admin/reporting` there is no exception here, because every one of these endpoints requires the header.

There is **no user picker** for reassignment or delegation, only a tenant user id field linking to `/admin/users`. Rendering a directory of tenant users here would hand the whole list to anyone holding `recovery.reassign` — a disclosure `identity_access` gates separately on its own permissions.

## The latent-authz traps

Two are specific to this module, and each would deny **every** caller while reading perfectly:

| Trap | Looks right | Actually |
|---|---|---|
| Namespace | `workflow_approval.*` (the directory, README and descriptor name all say it) | `workflow.*` |
| Reject | `approval.reject` | `approval.approve` — the permission is the ability to decide, not its direction |

`tests/admin-approvals-page-contract.test.ts` pins the page's eight keys against what the routes enforce **and** what the descriptor declares. **Mutation-proven four ways**, each RED then reverted GREEN: the wrong module key, a Reject button gated on `approval.reject`, a `definition.read` gate leaking onto this page, and a mutation losing its `Idempotency-Key`.

## Scope: `definition.*` is deliberately elsewhere

The six `definition.*` permissions are left to their own screen. Authoring a node graph needs a real editor; a raw-JSON textarea that accepts a malformed graph until the publish call rejects it is a worse affordance than none. The contract test asserts they stay **off** this page, so the split remains a decision rather than becoming a gap nobody notices.

## Bounds

`MAX_REASON_LENGTH` — written out as a bare `500` in five separate files — moves to `workflow-approval/domain/reason-bounds.ts`, imported by all of them and by the form that renders it as `maxlength`. Five copies of a number agree until one is edited.

## Docs correction

`workflow-approval/README.md` described an `/admin/workflows` page and `src/pages/admin/workflows/index.astro` that **never existed in this repo** — text that came over with the port. Because the module declared no `navigation`, the registry gate that catches a dangling path had nothing to check.

## Verification

Full `bun run check` green against a real migrated PostgreSQL (86 migrations): **3229 pass, 0 fail**, build complete. **Zero migrations** — the authorization surface already existed; only the screen was missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)