### PR TITLE
feat(blog-content): post lifecycle console at /admin/blog

### DIFF
--- a/.changeset/admin-blog-posts-console.md
+++ b/.changeset/admin-blog-posts-console.md
@@ -1,0 +1,24 @@
+---
+"awcms": minor
+---
+
+Add the `/admin/blog` post lifecycle console and put `blog_content` in the admin sidebar.
+
+`blog_content` is the largest module in this repo — 43 permissions across 15 activity codes and ~30 route files — and until now it had no screen at all. Under ADR-0051 the screens belong here; this is the first, and it covers the surface an editor uses every day.
+
+The console lists posts with the module's own admin search/status filters and page-number pagination, and drives eleven permissions: `posts.read`/`create`/`update`/`publish`/`schedule`/`archive`/`delete`/`restore`/`purge` plus `revisions.read`/`restore`. Reads go through `listBlogPostsForAdmin` and `listBlogRevisions` inside one `withTenantOrThrow`, awaited sequentially; revisions are fetched only when `?post=` names one. Every mutation posts to the guarded endpoint.
+
+Pagination is page-number rather than keyset, which is the opposite of `/admin/approvals` — deliberately. `listBlogPostsForAdmin` is LIMIT/OFFSET by design for a human-browsed table with "page 2, 3" controls, and its own header comment records that choice.
+
+The other 32 permissions belong to sibling screens that are not in this change (pages, taxonomy, templates/menus/widgets, settings/seo/theme, internal links, homepage sections, ad placements). Two absences are different in kind, and `tests/admin-blog-page-contract.test.ts` asserts both rather than leaving them to look like gaps:
+
+- **`posts.export` is declared and seeded by `sql/036`, and no endpoint anywhere enforces it.** The test proves this by scanning every route under `src/pages/api/v1/blog/`, so a future export endpoint fails it and forces the screen question to be answered instead of missed.
+- **`search.read` has a route and the page still does not use it.** The admin list already searches by title `ILIKE`, which tolerates the empty query that the `websearch_to_tsquery` surface behind `search.read` rejects.
+
+There is also no body/content editor: authoring a post body needs a rich-text surface plus SEO fields, terms and featured media. `posts.update` is still driven, through "submit for review".
+
+The module-specific trap the contract test pins: `submit-review` is gated on `posts.update`, not a `posts.submit` or `posts.review` — neither is seeded anywhere — and that route builds its guard in two pieces, so a regex over guard triples cannot see it and the test asserts it directly. Idempotency splits too: six lifecycle mutations require an `Idempotency-Key`, while `POST /api/v1/blog/posts` requires none by documented design, because a retry duplicating a create is caught by the `(tenant_id, locale, slug)` partial unique index.
+
+`MAX_TITLE_LENGTH`/`MAX_EXCERPT_LENGTH` are now exported from `content-validation.ts` so the form's `maxlength` comes from the same constants the validator enforces.
+
+Also corrects `blog-content/README.md`, whose §Admin UI described a fifteen-screen `/admin/blog/*` tree that never existed in this repo. It is kept, clearly marked as the awcms-mini specification, because it is a useful target for the sibling screens.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -29,7 +29,7 @@
         }
       ],
       "permissionCount": 43,
-      "navigationCount": 0,
+      "navigationCount": 1,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -748,9 +748,42 @@ Field: `defaultLocale`/`defaultVisibility`/`postsPerPage`/`seoDefaultTitle`/`seo
 
 `GET /blog/{tenantCode}/feed.xml` dan `.../sitemap-blog.xml` (Issue #540) memanggil `fetchBlogSettings` di awal handler dan mengembalikan `404` yang identik dengan tenant-tidak-ditemukan kalau flag terkait `false` — tenant yang mematikan RSS/sitemap tidak membocorkan sinyal "fitur ini ada tapi dimatikan" vs "tenant ini tidak ada", konsisten dengan ADR-0009's "jangan bocorkan keberadaan tenant" yang sudah diterapkan §Public routes.
 
-## Admin UI (Issue #543)
+## Admin UI
 
-Seluruh layar di bawah `/admin/blog` (`src/pages/admin/blog/`), memakai `AdminLayout`/design token yang sudah ada (`docs/awcms/14_ui_ux_design_system.md`), Astro + vanilla JS saja — tidak ada framework UI baru. Pola tiap layar identik `admin/modules/[moduleKey].astro`/`admin/access-users.astro` (referensi yang sudah ada sebelum issue ini): SSR read lewat fungsi application-layer yang sama yang dipakai (atau bisa dipakai) endpoint JSON, seluruh mutasi lewat `fetch()` client-side ke endpoint `/api/v1/blog/...` yang sudah ter-guard/audit/idempotency sejak Issue #538-#542 — halaman admin **tidak pernah** menulis ke database langsung atau melewati guard ABAC endpoint. Permission-gated per-section, mengikuti persis guard endpoint yang mendasarinya (defense-in-depth; enforcement sebenarnya tetap di server).
+**Yang ADA di repo ini: satu layar, `/admin/blog`** (`src/pages/admin/blog.astro`,
+ADR-0051) — konsol siklus hidup post: daftar ber-filter (search judul, status)
+dengan pagination bernomor halaman, aksi baris publish/schedule/archive/soft-delete/
+restore/purge/submit-review, panel revisi (`?post=<id>`) dengan restore, dan form
+draft baru. Sebelas permission digerakkan dari sana; digerbangi
+`tests/admin-blog-page-contract.test.ts`.
+
+Tiga hal yang SENGAJA tidak ada di layar itu, dan bedanya penting:
+
+- **Editor body/konten.** Menulis body post berarti permukaan rich-text/Markdown
+  plus field SEO, term, dan featured media — itu editor, bukan sudut sebuah
+  daftar. `posts.update` tetap digerakkan lewat "submit for review".
+- **`posts.export`.** Dideklarasikan descriptor dan di-seed `sql/036`, dan **tidak
+  ada satu pun endpoint yang menegakkannya**. Layar tidak bisa menggerakkan
+  permission tanpa permukaan; tombolnya akan mengirim request yang 404.
+- **`search.read`.** Endpoint-nya ada, tapi daftar admin sudah punya pencarian
+  sendiri (`ILIKE` judul, yang mentoleransi query kosong — hal yang justru
+  ditolak `websearch_to_tsquery` di balik `search.read`). Dua kotak pencari
+  dengan semantik berbeda di satu layar lebih buruk daripada satu.
+
+**Sisa 32 permission** (pages, taxonomy, templates/menus/widgets, settings/seo/theme,
+internal links, homepage sections, ad placements) menunggu layar saudaranya —
+masing-masing membawa entri `navigation`-nya sendiri saat halamannya mendarat.
+
+> **Segala sesuatu di bawah baris ini adalah SPESIFIKASI awcms-mini (Issue #543),
+> bukan deskripsi kode repo ini.** Pohon layar `/admin/blog/*` di bawah — posts/new,
+> pages, categories, tags, settings, templates, widgets, menus, ads — **tidak ada di
+> sini**; teksnya ikut terbawa saat modul ini di-port, dan karena modul ini dulu
+> tidak mendeklarasikan `navigation`, gerbang `admin-navigation-registry.test.ts`
+> yang menangkap path menggantung tak punya apa pun untuk diperiksa. Dipertahankan
+> karena ia rancangan target yang berguna untuk layar-layar saudara di atas — baca
+> sebagai rencana, bukan sebagai peta kode.
+
+### (spesifikasi mini) Seluruh layar di bawah `/admin/blog` (`src/pages/admin/blog/`), memakai `AdminLayout`/design token yang sudah ada (`docs/awcms/14_ui_ux_design_system.md`), Astro + vanilla JS saja — tidak ada framework UI baru. Pola tiap layar identik `admin/modules/[moduleKey].astro`/`admin/access-users.astro` (referensi yang sudah ada sebelum issue ini): SSR read lewat fungsi application-layer yang sama yang dipakai (atau bisa dipakai) endpoint JSON, seluruh mutasi lewat `fetch()` client-side ke endpoint `/api/v1/blog/...` yang sudah ter-guard/audit/idempotency sejak Issue #538-#542 — halaman admin **tidak pernah** menulis ke database langsung atau melewati guard ABAC endpoint. Permission-gated per-section, mengikuti persis guard endpoint yang mendasarinya (defense-in-depth; enforcement sebenarnya tetap di server).
 
 ```txt
 /admin/blog                    -> dashboard (ringkasan post/draft/scheduled/pages, quick link)

--- a/src/modules/blog-content/domain/content-validation.ts
+++ b/src/modules/blog-content/domain/content-validation.ts
@@ -25,8 +25,16 @@ export type BlogContentCoreValidationResult =
   | { valid: true; value: BlogContentCoreInput }
   | { valid: false; errors: ValidationError[] };
 
-const MAX_TITLE_LENGTH = 200;
-const MAX_EXCERPT_LENGTH = 500;
+/**
+ * Exported so a form can render `maxlength` from the SAME constant this
+ * validator enforces. A hand-typed bound in markup drifts into a browser that
+ * accepts what the server rejects with a 400 the author cannot act on — the
+ * reason `/admin/data-lifecycle` exported its own bounds, and the reason
+ * `reporting`, `workflow-approval` and `domain-event-runtime` each grew a
+ * bounds module rather than a second copy of a number.
+ */
+export const MAX_TITLE_LENGTH = 200;
+export const MAX_EXCERPT_LENGTH = 500;
 
 /** Same list `email-template-validation.ts` uses for admin-authored HTML template shells (doc 20 §XSS) — applied here to `contentJson`/`contentText` (Issue #538 acceptance criterion: "Unsafe HTML/script/embed content is rejected or sanitized"). Rejects rather than sanitizes, same choice email templates made. */
 const UNSAFE_HTML_PATTERNS: readonly RegExp[] = [

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -72,20 +72,31 @@ export const blogContentModule = defineModule({
     ]
   },
   /**
-   * No `navigation` yet — deliberately.
+   * `/admin/blog` is back, in the change that adds the page — which is what
+   * the note that stood here promised.
    *
-   * This module declared `/admin/blog` when it was ported from awcms-mini,
-   * where that page exists. It does not exist here: the port brought the API
-   * and the public routes, not the authoring screens. Nothing rendered
-   * descriptor navigation at the time, so the entry was invisible; once
-   * `AdminLayout.astro` started rendering from the registry it would have been
-   * a 404 in the sidebar, and `descriptor-sync` had already been publishing it
-   * to `awcms_module_navigation` and `GET /api/v1/modules` as a valid item.
+   * The history is worth keeping: this module declared this exact path when it
+   * was ported from awcms-mini, where the page exists. It did not exist here —
+   * the port brought the API and the public routes, not the authoring screens
+   * — and nothing rendered descriptor navigation at the time, so the entry was
+   * invisible while `descriptor-sync` published it to
+   * `awcms_module_navigation` and `GET /api/v1/modules` as a valid item.
+   * `tests/admin-navigation-registry.test.ts` now fails on any entry whose
+   * path has no page, in both directions.
    *
-   * `tests/admin-navigation-registry.test.ts` now fails on any entry whose path
-   * has no page, so this comes back in the same change that adds the screen —
-   * not before.
+   * ONE entry for fifteen activity codes, on purpose: this is the post
+   * lifecycle screen. Pages, taxonomy, presentation, settings and homepage
+   * composition are sibling screens, and each brings its own entry when its
+   * page lands — not before.
    */
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_blog",
+      path: "/admin/blog",
+      order: 36,
+      requiredPermission: "blog_content.posts.read"
+    }
+  ],
   permissions: [
     { activityCode: "posts", action: "read", description: "Read blog posts" },
     {

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -179,6 +179,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_visitor_analytics": "Visitor analytics",
   "admin.layout.nav_data_lifecycle": "Data lifecycle",
   "admin.layout.nav_idn_regions": "Region datasets",
+  "admin.layout.nav_blog": "Blog posts",
   "admin.layout.nav_reporting": "Reporting operations",
   "admin.layout.nav_approvals": "Approvals",
   "admin.layout.nav_domain_events": "Domain events",

--- a/src/pages/admin/blog.astro
+++ b/src/pages/admin/blog.astro
@@ -1,0 +1,946 @@
+---
+/**
+ * Blog posts console — the editorial surface of `blog_content`.
+ *
+ * `blog_content` is the largest module in this repo: 43 permissions across 15
+ * activity codes and ~30 route files, and until now not one screen. Under
+ * ADR-0051 the screens belong here, and this is the FIRST of them — the post
+ * lifecycle, which is the surface an editor uses every day.
+ *
+ * ## Scope, and what is deliberately elsewhere
+ *
+ * This page drives eleven permissions: `posts.read`/`create`/`update`/
+ * `publish`/`schedule`/`archive`/`delete`/`restore`/`purge` and
+ * `revisions.read`/`restore`.
+ *
+ * The other thirty-two belong to sibling screens that are NOT in this change —
+ * pages, taxonomy, templates/menus/widgets, settings/seo/theme, internal
+ * links, homepage sections and ad placements. Cramming fifteen activity codes
+ * into one page would produce something nobody can use and nobody can review.
+ *
+ * Two are absent for reasons worth stating, because "not yet" and "never here"
+ * are different claims and `tests/admin-blog-page-contract.test.ts` asserts
+ * both:
+ *
+ * - **`posts.export` has NO route at all.** It is declared by the descriptor
+ *   and seeded by `sql/036`, and no endpoint anywhere enforces it. A screen
+ *   cannot drive a permission that has no surface, and gating a control on it
+ *   would render a button whose request 404s.
+ * - **`search.read` has a route, and this page still does not use it.** The
+ *   admin list already searches, through `listBlogPostsForAdmin`'s own
+ *   `ILIKE` on title — which tolerates an empty query, the thing the
+ *   `websearch_to_tsquery` surface behind `search.read` rejects. Two search
+ *   boxes with different semantics on one screen is a worse answer than one.
+ *
+ * There is also **no body/content editor** here. Authoring a post body means a
+ * rich-text or Markdown surface plus SEO fields, terms and featured media —
+ * that is an editor, not a corner of a list. `posts.update` is still driven,
+ * through "submit for review", which is the lifecycle half of that permission.
+ *
+ * ## Reads
+ *
+ * Through this module's own application functions inside ONE
+ * `withTenantOrThrow`, awaited sequentially — concurrent queries on a single
+ * transaction connection leak it.
+ *
+ * `listBlogPostsForAdmin` was written for exactly this screen and paginates by
+ * page NUMBER rather than keyset, deliberately: this is a human-browsed table
+ * with "page 2, 3" controls, and its own header comment records that choice.
+ * That is the opposite of `/admin/approvals`, which is keyset — the difference
+ * is the UX, not an inconsistency.
+ *
+ * ## Writes
+ *
+ * Nothing here writes SQL. The mutations split on idempotency, and the split
+ * is per-endpoint rather than per-repo:
+ *
+ * - **six require an `Idempotency-Key`** — publish, schedule, archive,
+ *   restore, purge and revision restore;
+ * - **create requires none, by documented design.** `POST /api/v1/blog/posts`
+ *   records that a retry duplicating a create is caught by the
+ *   `(tenant_id, locale, slug)` partial unique index instead;
+ * - **soft delete and submit-for-review require none** either.
+ *
+ * ## Gates
+ *
+ * UX-only; `authorizeInTransaction` in the routes is the authority. The trap
+ * specific to this module: `submit-review` is gated on `posts.update`, not on
+ * a `posts.submit` or `posts.review` — neither of those is seeded anywhere.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listBlogPostsForAdmin,
+  type ListBlogPostsForAdminResult
+} from "../../modules/blog-content/application/blog-post-directory";
+import {
+  listBlogRevisions,
+  type BlogRevisionSummary
+} from "../../modules/blog-content/application/blog-revision-directory";
+import {
+  BLOG_CONTENT_STATUSES,
+  BLOG_CONTENT_VISIBILITIES,
+  isBlogContentStatus,
+  type BlogContentStatus
+} from "../../modules/blog-content/domain/post-status";
+import {
+  MAX_EXCERPT_LENGTH,
+  MAX_TITLE_LENGTH
+} from "../../modules/blog-content/domain/content-validation";
+
+const ssr = Astro.locals.ssrContext!;
+
+const canRead = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "read")
+);
+const canCreate = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "create")
+);
+// Also the gate on "submit for review" — there is no `posts.submit`.
+const canUpdate = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "update")
+);
+const canPublish = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "publish")
+);
+const canSchedule = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "schedule")
+);
+const canArchive = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "archive")
+);
+const canDelete = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "delete")
+);
+const canRestore = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "restore")
+);
+const canPurge = ssr.permissions.has(
+  permissionKey("blog_content", "posts", "purge")
+);
+const canReadRevisions = ssr.permissions.has(
+  permissionKey("blog_content", "revisions", "read")
+);
+const canRestoreRevisions = ssr.permissions.has(
+  permissionKey("blog_content", "revisions", "restore")
+);
+
+function readParam(name: string): string {
+  return (Astro.url.searchParams.get(name) ?? "").trim();
+}
+
+const searchFilter = readParam("search");
+const statusRaw = readParam("status");
+// An unknown status is dropped rather than forwarded: the list endpoint answers
+// a bad value with a 400, and a hand-edited query string must not turn this
+// screen into an error page.
+const statusFilter: BlogContentStatus | undefined = isBlogContentStatus(
+  statusRaw
+)
+  ? statusRaw
+  : undefined;
+
+const pageRaw = Number(readParam("page"));
+const pageNumber = Number.isInteger(pageRaw) && pageRaw > 0 ? pageRaw : 1;
+
+/** `?post=<id>` opens the revision panel for one post, rather than N queries for a list nobody expanded. */
+const selectedPostId = readParam("post");
+
+let listing: ListBlogPostsForAdminResult | null = null;
+let revisions: BlogRevisionSummary[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
+      listing = await listBlogPostsForAdmin(tx, ssr.tenantId, {
+        search: searchFilter || undefined,
+        status: statusFilter,
+        page: pageNumber
+      });
+
+      if (selectedPostId && canReadRevisions) {
+        // `listBlogRevisions` asserts the id is a UUID and throws otherwise,
+        // which the surrounding catch turns into the load-error notice — a
+        // hand-edited `?post=` must not 500 the page.
+        revisions = await listBlogRevisions(
+          tx,
+          ssr.tenantId,
+          "post",
+          selectedPostId
+        );
+      }
+    });
+  } catch (error) {
+    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
+    // must never render as "this tenant has no posts".
+    loadError = true;
+    logAdminPageError("admin/blog.astro: failed to load posts", error, {
+      correlationId: Astro.locals.correlationId
+    });
+  }
+}
+
+const STATUS_VARIANT: Record<string, string> = {
+  draft: "neutral",
+  review: "info",
+  scheduled: "info",
+  published: "success",
+  archived: "warning"
+};
+
+function formatTimestamp(value: Date | null): string {
+  return value ? value.toISOString() : "—";
+}
+
+/** Rebuilds the current query string with one key replaced — keeps filters across paging. */
+function linkWith(overrides: Record<string, string | null>): string {
+  const params = new URLSearchParams(Astro.url.search);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) params.delete(key);
+    else params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `/admin/blog?${query}` : "/admin/blog";
+}
+
+const posts = listing?.items ?? [];
+const total = listing?.total ?? 0;
+const pageSize = listing?.pageSize ?? 20;
+const lastPage = Math.max(1, Math.ceil(total / pageSize));
+const hasFilters = searchFilter !== "" || statusFilter !== undefined;
+
+const showsRowActions =
+  canPublish ||
+  canSchedule ||
+  canArchive ||
+  canDelete ||
+  canRestore ||
+  canPurge ||
+  canUpdate ||
+  canReadRevisions;
+const postColumns = 5 + (showsRowActions ? 1 : 0);
+const selectedPost = selectedPostId
+  ? (posts.find((post) => post.id === selectedPostId) ?? null)
+  : null;
+---
+
+<AdminLayout title="Blog posts">
+  <header class="page-header fade-in-up">
+    <h1 id="blog-heading">Blog posts</h1>
+    <p class="page-description">
+      The post lifecycle: draft, review, scheduled, published, archived. Pages,
+      taxonomy, presentation and homepage composition are separate screens.
+      Scheduled posts are published by <code>blog:publish:scheduled</code> — scheduling
+      sets the time, it does not publish.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="blog-denied">
+        You do not have permission to view blog posts.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="blog-error">
+        Posts could not be loaded right now. This is a problem reading the list,
+        not an empty list — please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <p
+        id="blog-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <form method="get" class="admin-toolbar fade-in-up" id="post-filter-form">
+        <label for="filter-search">Search titles</label>
+        <input
+          id="filter-search"
+          name="search"
+          type="search"
+          value={searchFilter}
+          autocomplete="off"
+        />
+
+        <label for="filter-status">Status</label>
+        <select id="filter-status" name="status">
+          <option value="" selected={statusFilter === undefined}>
+            Any status
+          </option>
+          {BLOG_CONTENT_STATUSES.map((value) => (
+            <option value={value} selected={statusFilter === value}>
+              {value}
+            </option>
+          ))}
+        </select>
+
+        <button type="submit">Apply filters</button>
+      </form>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="post-list-title"
+      >
+        <h2 class="admin-section-title" id="post-list-title">
+          Posts
+          <span class="count-pill">{total}</span>
+        </h2>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack" id="blog-posts-table">
+            <caption class="sr-only">
+              Blog posts, most recently updated first.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Title</th>
+                <th scope="col">Status</th>
+                <th scope="col">Visibility</th>
+                <th scope="col">Published</th>
+                <th scope="col">Updated</th>
+                {showsRowActions && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {posts.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={postColumns}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ✎
+                      </span>
+                      <span class="empty-state-title">
+                        {hasFilters
+                          ? "No posts match these filters"
+                          : "No posts yet"}
+                      </span>
+                      <span class="empty-state-text">
+                        {hasFilters
+                          ? "Clear or widen the filters above to see more posts."
+                          : "Create a draft below to get started."}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                posts.map((post) => (
+                  <tr data-post-row={post.id}>
+                    <td data-label="Title">
+                      <span set:text={post.title} />
+                      <span class="cell-muted">
+                        {" "}
+                        · <span class="cell-code">{post.slug}</span> ·{" "}
+                        {post.locale}
+                      </span>
+                    </td>
+                    <td data-label="Status">
+                      <span
+                        class="status-badge"
+                        data-variant={STATUS_VARIANT[post.status] ?? "neutral"}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {post.status}
+                      </span>
+                    </td>
+                    <td data-label="Visibility">
+                      <span class="cell-code">{post.visibility}</span>
+                    </td>
+                    <td data-label="Published">
+                      <span class="cell-muted">
+                        {formatTimestamp(post.publishedAt)}
+                      </span>
+                    </td>
+                    <td data-label="Updated">
+                      <span class="cell-muted">
+                        {formatTimestamp(post.updatedAt)}
+                      </span>
+                    </td>
+                    {showsRowActions && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          {canReadRevisions && (
+                            <a
+                              class="quick-link"
+                              href={linkWith({ post: post.id })}
+                            >
+                              Revisions
+                              <span class="quick-link-arrow" aria-hidden="true">
+                                →
+                              </span>
+                            </a>
+                          )}
+                          {canUpdate && post.status === "draft" && (
+                            <button
+                              type="button"
+                              class="btn-inline post-submit-btn"
+                              data-post-id={post.id}
+                            >
+                              Submit for review
+                            </button>
+                          )}
+                          {canPublish && post.status !== "published" && (
+                            <button
+                              type="button"
+                              class="btn-inline post-publish-btn"
+                              data-post-id={post.id}
+                            >
+                              Publish
+                            </button>
+                          )}
+                          {canSchedule && post.status !== "published" && (
+                            <button
+                              type="button"
+                              class="btn-inline post-schedule-btn"
+                              data-post-id={post.id}
+                            >
+                              Schedule
+                            </button>
+                          )}
+                          {canArchive && post.status === "published" && (
+                            <button
+                              type="button"
+                              class="btn-inline post-archive-btn"
+                              data-post-id={post.id}
+                            >
+                              Archive
+                            </button>
+                          )}
+                          {canRestore && post.status === "archived" && (
+                            <button
+                              type="button"
+                              class="btn-inline post-restore-btn"
+                              data-post-id={post.id}
+                            >
+                              Restore
+                            </button>
+                          )}
+                          {canDelete && (
+                            <button
+                              type="button"
+                              class="btn-inline btn-inline--danger post-delete-btn"
+                              data-post-id={post.id}
+                              data-post-title={post.title}
+                            >
+                              Delete
+                            </button>
+                          )}
+                          {canPurge && post.status === "archived" && (
+                            <button
+                              type="button"
+                              class="btn-inline btn-inline--danger post-purge-btn"
+                              data-post-id={post.id}
+                              data-post-title={post.title}
+                            >
+                              Purge
+                            </button>
+                          )}
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {total > pageSize && (
+          <div class="admin-toolbar">
+            {/* Page numbers, not a cursor: `listBlogPostsForAdmin` is
+                LIMIT/OFFSET by design for a human-browsed table, and its own
+                header comment records that choice. */}
+            {pageNumber > 1 && (
+              <a
+                class="quick-link"
+                href={linkWith({ page: String(pageNumber - 1) })}
+              >
+                ← Previous
+              </a>
+            )}
+            <span class="cell-muted">
+              Page {pageNumber} of {lastPage}
+            </span>
+            {pageNumber < lastPage && (
+              <a
+                class="quick-link"
+                href={linkWith({ page: String(pageNumber + 1) })}
+              >
+                Next →
+              </a>
+            )}
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  {
+    canRead && !loadError && canReadRevisions && selectedPostId && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="revisions-title"
+        id="blog-revisions"
+      >
+        <h2 class="admin-section-title" id="revisions-title">
+          Revisions
+          <span class="count-pill">{revisions.length}</span>
+        </h2>
+        <p class="page-description">
+          <span class="cell-code">{selectedPostId}</span>
+          {selectedPost && (
+            <span class="cell-muted"> · {selectedPost.title}</span>
+          )}
+          {" · "}
+          <a href={linkWith({ post: null })}>Close</a>
+        </p>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack">
+            <caption class="sr-only">Revisions for the selected post.</caption>
+            <thead>
+              <tr>
+                <th scope="col">#</th>
+                <th scope="col">Title at revision</th>
+                <th scope="col">Status</th>
+                <th scope="col">Note</th>
+                <th scope="col">Created</th>
+                {canRestoreRevisions && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {revisions.length === 0 ? (
+                <tr>
+                  <td
+                    class="data-table-empty"
+                    colspan={canRestoreRevisions ? 6 : 5}
+                  >
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ⌸
+                      </span>
+                      <span class="empty-state-title">No revisions</span>
+                      <span class="empty-state-text">
+                        A revision is recorded when a post is edited — or the id
+                        does not name a post in this tenant.
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                revisions.map((revision) => (
+                  <tr>
+                    <td data-label="#">{revision.revisionNumber}</td>
+                    <td data-label="Title at revision">
+                      <span set:text={revision.title} />
+                    </td>
+                    <td data-label="Status">
+                      <span class="cell-code">{revision.status}</span>
+                    </td>
+                    <td data-label="Note">
+                      <span
+                        class="cell-muted"
+                        set:text={revision.changeNote ?? "—"}
+                      />
+                    </td>
+                    <td data-label="Created">
+                      <span class="cell-muted">
+                        {formatTimestamp(revision.createdAt)}
+                      </span>
+                    </td>
+                    {canRestoreRevisions && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          <button
+                            type="button"
+                            class="btn-inline revision-restore-btn"
+                            data-post-id={selectedPostId}
+                            data-revision-id={revision.id}
+                            data-revision-number={String(
+                              revision.revisionNumber
+                            )}
+                          >
+                            Restore
+                          </button>
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canCreate && !loadError && (
+      <section class="admin-section fade-in-up" aria-labelledby="create-title">
+        <h2 class="admin-section-title" id="create-title">
+          New draft
+        </h2>
+        <form id="post-create-form" class="admin-create-form">
+          <p class="form-legend">
+            Creates a draft. The body is written in the post editor, which is
+            not part of this screen yet.
+          </p>
+          <p
+            id="post-create-error"
+            class="admin-create-error"
+            role="alert"
+            hidden
+          />
+
+          <label for="create-title-field">
+            Title
+            {/* `maxlength` comes from the SAME constant the validator
+                enforces, so the browser cannot accept what the server
+                rejects. */}
+            <input
+              type="text"
+              id="create-title-field"
+              name="title"
+              required
+              maxlength={MAX_TITLE_LENGTH}
+              autocomplete="off"
+            />
+          </label>
+
+          <label for="create-slug">
+            Slug
+            <input
+              type="text"
+              id="create-slug"
+              name="slug"
+              required
+              autocomplete="off"
+              placeholder="url-safe-identifier"
+            />
+          </label>
+
+          <label for="create-locale">
+            Locale
+            <input
+              type="text"
+              id="create-locale"
+              name="locale"
+              value="id"
+              autocomplete="off"
+            />
+          </label>
+
+          <label for="create-visibility">
+            Visibility
+            <select id="create-visibility" name="visibility">
+              {BLOG_CONTENT_VISIBILITIES.map((value) => (
+                <option value={value}>{value}</option>
+              ))}
+            </select>
+          </label>
+
+          <label for="create-excerpt">
+            Excerpt (optional)
+            <textarea
+              id="create-excerpt"
+              name="excerpt"
+              rows="2"
+              maxlength={MAX_EXCERPT_LENGTH}
+            />
+          </label>
+
+          <button type="submit" id="post-create-submit">
+            Create draft
+          </button>
+        </form>
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'`
+  // with no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("blog-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  /** Publish/schedule/archive/restore/purge/revision-restore all require the header. */
+  function idempotency(): Record<string, string> {
+    return { "Idempotency-Key": crypto.randomUUID() };
+  }
+
+  /** Wires a row button to one endpoint, with an optional confirm and body. */
+  function wireLifecycle(
+    selector: string,
+    busyLabel: string,
+    url: (postId: string) => string,
+    options: {
+      confirm?: (button: HTMLButtonElement) => string | null;
+      body?: (button: HTMLButtonElement) => unknown | null;
+      idempotent?: boolean;
+      failure: string;
+    }
+  ): void {
+    document.querySelectorAll<HTMLButtonElement>(selector).forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const postId = button.dataset.postId;
+        if (!postId) return;
+
+        const confirmText = options.confirm?.(button) ?? null;
+        if (confirmText !== null && !window.confirm(confirmText)) return;
+
+        let body: unknown;
+        if (options.body) {
+          const value = options.body(button);
+          // `null` means the operator cancelled a prompt — not an empty body.
+          if (value === null) return;
+          body = value;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, busyLabel);
+
+        const result = await sendJson(
+          "POST",
+          url(postId),
+          body,
+          options.idempotent === false ? undefined : idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // Generic copy only — never surface internal detail.
+        showActionError(options.failure);
+        unlock();
+      });
+    });
+  }
+
+  wireLifecycle(
+    ".post-publish-btn",
+    "Publishing…",
+    (id) => `/api/v1/blog/posts/${id}/publish`,
+    {
+      confirm: () =>
+        "Publish this post? It becomes visible on the public site immediately.",
+      failure: "Could not publish the post. Please try again."
+    }
+  );
+
+  wireLifecycle(
+    ".post-schedule-btn",
+    "Scheduling…",
+    (id) => `/api/v1/blog/posts/${id}/schedule`,
+    {
+      body: () => {
+        const at = window.prompt(
+          "Publish at (ISO 8601, e.g. 2026-08-05T09:00:00Z):"
+        );
+        if (at === null || at.trim() === "") return null;
+        return { scheduledAt: at.trim() };
+      },
+      failure:
+        "Could not schedule the post. Check the date is in the future and try again."
+    }
+  );
+
+  wireLifecycle(
+    ".post-archive-btn",
+    "Archiving…",
+    (id) => `/api/v1/blog/posts/${id}/archive`,
+    {
+      confirm: () =>
+        "Archive this post? It is removed from the public site but kept.",
+      failure: "Could not archive the post. Please try again."
+    }
+  );
+
+  wireLifecycle(
+    ".post-restore-btn",
+    "Restoring…",
+    (id) => `/api/v1/blog/posts/${id}/restore`,
+    { failure: "Could not restore the post. Please try again." }
+  );
+
+  wireLifecycle(
+    ".post-purge-btn",
+    "Purging…",
+    (id) => `/api/v1/blog/posts/${id}/purge`,
+    {
+      confirm: (button) =>
+        `Permanently delete "${button.dataset.postTitle ?? "this post"}"? This cannot be undone — the post row is removed, not soft-deleted.`,
+      failure: "Could not purge the post. Please try again."
+    }
+  );
+
+  // Submit-for-review is gated on `posts.update` and needs NO key: it is a
+  // status transition to `review`, not work that repeats per call.
+  wireLifecycle(
+    ".post-submit-btn",
+    "Submitting…",
+    (id) => `/api/v1/blog/posts/${id}/submit-review`,
+    {
+      idempotent: false,
+      failure: "Could not submit the post for review. Please try again."
+    }
+  );
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".post-delete-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const postId = button.dataset.postId;
+        if (!postId) return;
+        const title = button.dataset.postTitle ?? "this post";
+
+        if (
+          !window.confirm(
+            `Delete "${title}"? It is soft-deleted — recoverable until it is purged.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Deleting…");
+
+        // Soft delete needs no key: the endpoint's `deleted_at IS NULL` guard
+        // makes a repeat a no-op rather than a second deletion.
+        const result = await sendJson("DELETE", `/api/v1/blog/posts/${postId}`);
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not delete the post. Please try again.");
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".revision-restore-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const postId = button.dataset.postId;
+        const revisionId = button.dataset.revisionId;
+        if (!postId || !revisionId) return;
+        const number = button.dataset.revisionNumber ?? "?";
+
+        if (
+          !window.confirm(
+            `Restore revision ${number}? The post's current content is replaced by this revision's, and the replacement is itself recorded as a new revision.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Restoring…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/blog/posts/${postId}/revisions/${revisionId}/restore`,
+          undefined,
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not restore the revision. Please try again.");
+        unlock();
+      });
+    });
+
+  const createForm = document.getElementById(
+    "post-create-form"
+  ) as HTMLFormElement | null;
+
+  createForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "post-create-submit"
+    ) as HTMLButtonElement | null;
+    if (!submit || submit.disabled) return;
+
+    const data = new FormData(createForm);
+    const errorElement = document.getElementById("post-create-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Creating…");
+
+    const excerpt = String(data.get("excerpt") ?? "").trim();
+    const body: Record<string, unknown> = {
+      title: String(data.get("title") ?? "").trim(),
+      slug: String(data.get("slug") ?? "").trim(),
+      locale: String(data.get("locale") ?? "").trim() || "id",
+      visibility: String(data.get("visibility") ?? "public"),
+      // The validator requires both content fields; a new draft starts empty
+      // and the body is written in the editor, which is not this screen.
+      contentJson: {},
+      contentText: ""
+    };
+    // Omitted rather than sent as "": an empty string is a value, and the
+    // validator treats absent as "no excerpt".
+    if (excerpt !== "") body.excerpt = excerpt;
+
+    // No `Idempotency-Key`: `POST /api/v1/blog/posts` requires none by
+    // documented design — a retry that duplicates a create is caught by the
+    // `(tenant_id, locale, slug)` partial unique index instead.
+    const result = await sendJson("POST", "/api/v1/blog/posts", body);
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    if (errorElement) {
+      errorElement.textContent =
+        result.errorCode === "CONFLICT"
+          ? "A post with that slug and locale already exists."
+          : "Could not create the draft. Check the title and slug, then try again.";
+      errorElement.hidden = false;
+    }
+    unlock();
+  });
+</script>

--- a/tests/admin-blog-page-contract.test.ts
+++ b/tests/admin-blog-page-contract.test.ts
@@ -1,0 +1,296 @@
+/**
+ * `/admin/blog` gates against the endpoints it drives, and is explicit about
+ * the permissions it deliberately does NOT drive.
+ *
+ * Sibling of the four other admin page contracts. What is specific here is
+ * scale: `blog_content` declares 43 permissions across 15 activity codes, so
+ * for the first time "the page drives all of them" is the WRONG assertion. The
+ * useful one is that every gate is real, and that the absences are the ones
+ * intended.
+ *
+ * Three module-specific traps:
+ *
+ * - **`submit-review` is gated on `posts.update`.** It reads like it wants a
+ *   `posts.submit` or `posts.review`; neither is seeded anywhere, so inventing
+ *   one would hide the button from every editor including the owner. The route
+ *   builds its guard in two pieces (an `ACTIVITY` const plus a literal
+ *   `action`), so a regex over guard triples cannot see it — this test asserts
+ *   it directly rather than letting it pass as unenforced.
+ * - **`posts.export` is declared and seeded, and has NO route at all.** A
+ *   screen cannot drive a permission with no surface; a control gated on it
+ *   would issue a request that 404s.
+ * - **`POST /api/v1/blog/posts` requires no `Idempotency-Key` by documented
+ *   design**, while six sibling mutations do. Sending one to create would
+ *   imply a replay contract the endpoint declined on purpose.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/blog.astro";
+const POSTS_ROUTE = "src/pages/api/v1/blog/posts/index.ts";
+const POST_ITEM_ROUTE = "src/pages/api/v1/blog/posts/[id].ts";
+const SUBMIT_ROUTE = "src/pages/api/v1/blog/posts/[id]/submit-review.ts";
+const REVISION_RESTORE_ROUTE =
+  "src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts";
+
+/** Every route this page calls. */
+const ROUTES = [
+  POSTS_ROUTE,
+  POST_ITEM_ROUTE,
+  SUBMIT_ROUTE,
+  "src/pages/api/v1/blog/posts/[id]/publish.ts",
+  "src/pages/api/v1/blog/posts/[id]/schedule.ts",
+  "src/pages/api/v1/blog/posts/[id]/archive.ts",
+  "src/pages/api/v1/blog/posts/[id]/restore.ts",
+  "src/pages/api/v1/blog/posts/[id]/purge.ts",
+  "src/pages/api/v1/blog/posts/[id]/revisions/index.ts",
+  REVISION_RESTORE_ROUTE
+];
+
+/** The six that answer `IDEMPOTENCY_REQUIRED` without the header. */
+const IDEMPOTENT_ROUTES = [
+  "src/pages/api/v1/blog/posts/[id]/publish.ts",
+  "src/pages/api/v1/blog/posts/[id]/schedule.ts",
+  "src/pages/api/v1/blog/posts/[id]/archive.ts",
+  "src/pages/api/v1/blog/posts/[id]/restore.ts",
+  "src/pages/api/v1/blog/posts/[id]/purge.ts",
+  REVISION_RESTORE_ROUTE
+];
+
+const PAGE_KEYS = [
+  "blog_content.posts.archive",
+  "blog_content.posts.create",
+  "blog_content.posts.delete",
+  "blog_content.posts.publish",
+  "blog_content.posts.purge",
+  "blog_content.posts.read",
+  "blog_content.posts.restore",
+  "blog_content.posts.schedule",
+  "blog_content.posts.update",
+  "blog_content.revisions.read",
+  "blog_content.revisions.restore"
+] as const;
+
+type Triple = `${string}.${string}.${string}`;
+
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function declaredTriples(): Set<Triple> {
+  return new Set<Triple>(
+    (listModules()
+      .find((module) => module.key === "blog_content")
+      ?.permissions?.map(
+        (permission) =>
+          `blog_content.${permission.activityCode}.${permission.action}`
+      ) ?? []) as Triple[]
+  );
+}
+
+describe("/admin/blog permission gates", () => {
+  test("every key the page gates on is one its endpoints actually enforce", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    expect(pageKeys.size).toBe(PAGE_KEYS.length);
+
+    const enforced = new Set<Triple>();
+    for (const route of ROUTES) {
+      for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+
+    // Guards really were parsed — an empty `enforced` would make the subset
+    // check pass vacuously, the shape of gate this repo has been burned by.
+    expect(enforced.size).toBeGreaterThan(0);
+
+    // `posts.update` is enforced in two pieces (an `ACTIVITY` const plus a
+    // literal `action`), which the triple regex cannot see. Assert it directly
+    // rather than letting it fall through as unenforced.
+    const submit = await readFile(SUBMIT_ROUTE, "utf8");
+    expect(submit).toContain('moduleKey: "blog_content"');
+    expect(submit).toContain('activityCode: "posts"');
+    expect(submit).toContain('action: "update"');
+    enforced.add("blog_content.posts.update");
+
+    expect([...pageKeys].filter((key) => !enforced.has(key))).toEqual([]);
+  });
+
+  test("and is declared by the module descriptor, so a migration seeds it", async () => {
+    const declared = declaredTriples();
+    expect(declared.size).toBe(43);
+
+    const missing = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].filter(
+      (key) => !declared.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  test("the page claims exactly the post-lifecycle eleven", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+
+    // Enumerated, so a permission quietly appearing on this page — instead of
+    // on the sibling screen that should own it — fails here loudly.
+    expect([...pageKeys].sort()).toEqual([...PAGE_KEYS]);
+  });
+
+  test("submit-review is gated on posts.update — there is no posts.submit", () => {
+    const declared = declaredTriples();
+
+    expect(declared.has("blog_content.posts.update" as Triple)).toBe(true);
+    expect(declared.has("blog_content.posts.submit" as Triple)).toBe(false);
+    expect(declared.has("blog_content.posts.review" as Triple)).toBe(false);
+  });
+
+  test("posts.export is declared, seeded, and has no route — so no control gates on it", async () => {
+    const declared = declaredTriples();
+    const page = await readFile(PAGE, "utf8");
+
+    // Declared and seeded...
+    expect(declared.has("blog_content.posts.export" as Triple)).toBe(true);
+    expect(
+      await readFile("sql/036_awcms_blog_content_permissions.sql", "utf8")
+    ).toContain("'export'");
+
+    // ...and enforced by nothing. Proven by scanning EVERY blog route, not by
+    // trusting the list above, so a future export endpoint makes this test
+    // fail and forces the screen question to be answered rather than missed.
+    const enforced = new Set<Triple>();
+    for await (const file of new Bun.Glob("src/pages/api/v1/blog/**/*.ts").scan(
+      {
+        cwd: process.cwd()
+      }
+    )) {
+      for (const triple of guardTriplesFrom(await readFile(file, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+    expect(enforced.size).toBeGreaterThan(5);
+    expect(enforced.has("blog_content.posts.export" as Triple)).toBe(false);
+
+    // So the page must not gate anything on it.
+    expect(
+      pageTriplesFrom(page).has("blog_content.posts.export" as Triple)
+    ).toBe(false);
+  });
+
+  test("the page never mutates directly — it posts to the guarded endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // No SQL write anywhere in the screen: every change goes out over fetch, so
+    // the endpoints' audit rows and idempotency records cannot be bypassed.
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+
+    expect(page).toContain('"/api/v1/blog/posts"');
+    expect(page).toContain("/api/v1/blog/posts/${id}/publish`");
+    expect(page).toContain("/api/v1/blog/posts/${id}/schedule`");
+    expect(page).toContain("/api/v1/blog/posts/${id}/archive`");
+    expect(page).toContain("/api/v1/blog/posts/${id}/restore`");
+    expect(page).toContain("/api/v1/blog/posts/${id}/purge`");
+    expect(page).toContain("/api/v1/blog/posts/${id}/submit-review`");
+    expect(page).toContain("/api/v1/blog/posts/${postId}`");
+    expect(page).toContain(
+      "/api/v1/blog/posts/${postId}/revisions/${revisionId}/restore`"
+    );
+  });
+
+  test("create sends no Idempotency-Key, because that endpoint requires none", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Scoped to the create request, so adding a header there turns this red
+    // while the six legitimate ones stay untouched.
+    const createCall = page.slice(page.indexOf('"/api/v1/blog/posts"'));
+    expect(createCall.slice(0, createCall.indexOf(");"))).not.toContain(
+      "Idempotency-Key"
+    );
+
+    // And the endpoint really does decline one — the page's choice is only
+    // correct while that stays true.
+    expect(await readFile(POSTS_ROUTE, "utf8")).not.toContain(
+      "IDEMPOTENCY_REQUIRED"
+    );
+    expect(await readFile(POST_ITEM_ROUTE, "utf8")).not.toContain(
+      "IDEMPOTENCY_REQUIRED"
+    );
+    expect(await readFile(SUBMIT_ROUTE, "utf8")).not.toContain(
+      "IDEMPOTENCY_REQUIRED"
+    );
+  });
+
+  test("the six lifecycle mutations that require a key are sent one", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    for (const route of IDEMPOTENT_ROUTES) {
+      expect(await readFile(route, "utf8")).toContain("IDEMPOTENCY_REQUIRED");
+    }
+
+    // The page routes them through one helper plus the revision-restore call,
+    // so the header is spelled once and applied by default — `idempotent:
+    // false` is the explicit opt-out for submit-review.
+    expect(page).toContain('"Idempotency-Key": crypto.randomUUID()');
+    expect(page).toContain("idempotent: false");
+  });
+
+  test("form bounds come from the constants the validator enforces", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain("MAX_TITLE_LENGTH");
+    expect(page).toContain("MAX_EXCERPT_LENGTH");
+    // A hand-typed `maxlength` drifts into a browser accepting what the server
+    // rejects with a 400 the author cannot act on.
+    expect(page).not.toMatch(/maxlength=\{?"?\d/);
+
+    const validation = await readFile(
+      "src/modules/blog-content/domain/content-validation.ts",
+      "utf8"
+    );
+    expect(validation).toContain("export const MAX_TITLE_LENGTH");
+    expect(validation).toContain("export const MAX_EXCERPT_LENGTH");
+  });
+
+  test("the sidebar entry points at this page and is gated on a real permission", () => {
+    const nav = listModules()
+      .find((module) => module.key === "blog_content")
+      ?.navigation?.find((entry) => entry.path === "/admin/blog");
+
+    expect(nav).toBeDefined();
+    expect(nav!.requiredPermission).toBe("blog_content.posts.read");
+    expect(declaredTriples().has(nav!.requiredPermission as Triple)).toBe(true);
+
+    // ONE entry for fifteen activity codes: this is the lifecycle screen, and
+    // its siblings bring their own entries when their pages land. A second
+    // entry appearing here without a page is what
+    // `admin-navigation-registry.test.ts` catches.
+    expect(
+      listModules().find((module) => module.key === "blog_content")?.navigation
+    ).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
`blog_content` is the largest module in this repo — **43 permissions across 15 activity codes** and ~30 route files — and until now not one screen. Under [ADR-0051](docs/adr/0051-admin-screens-consolidated-in-awcms.md) the screens belong here. This is the first, covering the surface an editor uses every day.

This closes the second-to-last entry in `PROJECT_STATE.md` §4's screenless list; only `media-library` remains, and that one needs an ADR rather than a page.

## What it renders

Post list with the module's own admin search/status filters and page-number pagination. Per row: submit-for-review, publish, schedule, archive, soft delete, restore, purge — each shown only when the status allows it. Plus a revisions panel (`?post=<id>`) with restore, and a new-draft form.

Eleven permissions driven: `posts.read`/`create`/`update`/`publish`/`schedule`/`archive`/`delete`/`restore`/`purge`, `revisions.read`/`restore`.

## Page numbers, not keyset — deliberately

The opposite of `/admin/approvals`. `listBlogPostsForAdmin` is LIMIT/OFFSET **by design** for a human-browsed table with "page 2, 3" controls, and its own header comment records that choice. The difference is the UX, not an inconsistency.

## Two absences that differ in kind

The other 32 permissions belong to sibling screens (pages, taxonomy, presentation, settings, homepage composition). Two more are absent for reasons the contract test asserts, so neither reads as an oversight:

| Permission | Why absent |
|---|---|
| `posts.export` | Declared **and seeded** by `sql/036` — and **no endpoint anywhere enforces it**. A control gated on it would issue a request that 404s. The test proves this by scanning *every* route under `src/pages/api/v1/blog/`, so a future export endpoint fails it and forces the screen question to be answered. |
| `search.read` | Has a route; the page still doesn't use it. The admin list already searches by title `ILIKE`, which tolerates the empty query that the `websearch_to_tsquery` surface behind `search.read` rejects. Two search boxes with different semantics is worse than one. |

There is also **no body/content editor**: authoring a post body needs a rich-text surface plus SEO fields, terms and featured media. `posts.update` is still driven, through submit-for-review.

## The traps

- **`submit-review` is gated on `posts.update`** — not `posts.submit` or `posts.review`, neither of which is seeded. That route builds its guard in two pieces (`ACTIVITY` const + literal `action`), so a regex over guard triples **cannot see it**; the test asserts it directly rather than letting it pass as unenforced.
- **Idempotency splits again**: six lifecycle mutations require an `Idempotency-Key`, but `POST /api/v1/blog/posts` requires none *by documented design* — a retry duplicating a create is caught by the `(tenant_id, locale, slug)` partial unique index.

**Mutation-proven four ways**, each RED then reverted GREEN: the invented `posts.submit` gate, a control gated on the surface-less `posts.export`, an `Idempotency-Key` added to create, and a hand-typed `maxlength`.

## Docs correction

`blog-content/README.md` §Admin UI described a **fifteen-screen** `/admin/blog/*` tree that never existed in this repo — the **third** module README found claiming a screen that isn't here. It's kept and clearly marked as the awcms-mini specification, because it's a useful target for the sibling screens.

## Verification

Full `bun run check` green against a real migrated PostgreSQL: **3269 pass, 0 fail**, build complete. **Zero migrations.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)