### PR TITLE
feat(media-library): object lifecycle endpoints (ADR-0056 §B)

### DIFF
--- a/.changeset/media-object-lifecycle-endpoints.md
+++ b/.changeset/media-object-lifecycle-endpoints.md
@@ -1,0 +1,23 @@
+---
+"awcms": minor
+---
+
+Give `media_library`'s delete/restore/purge permissions the endpoints they never had (ADR-0056 §B), and fix a Postgres error-code check that could never be true.
+
+All three permissions have been in the global catalog since `sql/052`, granted whole to every tenant owner, and enforced by nothing — no route, no application function, no job. The functions behind them were written and had zero callers. So an object uploaded by mistake, orphaned, or violating policy disappeared only if the reconciliation job happened to categorise it that way, on the job's own schedule; there was no way for an administrator to remove one, and no way to undo it if they were wrong.
+
+- `DELETE /api/v1/media/objects/{id}` — soft delete, body `{ reason }` required and bounded at 500 characters. The reason is part of the request hash, so replaying one key with a different reason is a different request rather than a stored response describing a reason nobody sent.
+- `POST /api/v1/media/objects/{id}/restore` — the undo. A live object answers 404: "there was nothing to undo" and "it worked" must not share a response.
+- `POST /api/v1/media/objects/{id}/purge` — hard-deletes the registry row of an already soft-deleted object.
+
+All three are `HIGH_RISK_ACTIONS` and require `Idempotency-Key`, each under its own scope so a delete's key cannot collide with a purge's.
+
+**Soft delete breaks live references, deliberately.** `resolveMediaReferences` filters `deleted_at IS NULL`, so a post whose `featured_media_id` points at a deleted object resolves to nothing immediately. That is the intended outcome for the case this serves, and `restore` is what makes it recoverable. Nothing here scans for referencing rows first: that would make a System Foundation module know its own consumers.
+
+**`purge` clears the registry, not the R2 bytes.** The `news-media:reconcile` job owns the bucket; a second writer would mean two processes with different ideas of what is safe to remove. Accepted, stated cost: a window where the R2 object outlives its registry row, closed by the next reconciliation tick.
+
+`awcms_news_portal_ad_placements.media_object_id` is a hard NOT NULL FK, so purging a still-referenced object answers `409 MEDIA_OBJECT_REFERENCED`. That path runs inside a **savepoint** — in PostgreSQL a `23503` aborts the whole transaction, so catching it without one turns a caller-actionable 409 into a 500 at the COMMIT `withTenant` performs. Verified against a real database rather than reasoned about.
+
+That verification turned up a second thing. **The SQLSTATE is on `error.errno`, not `error.code`** — Bun sets `code` to its own `"ERR_POSTGRES_SERVER_ERROR"` for every server error alike, so `error.code === "23505"` is not a subtly wrong check but one that can never be true, leaving everything downstream of it dead. Ten sites in this repo already used `String(error.errno)`. One did not: `tenant-provisioning.ts`, where `POST /api/v1/tenants` promises `409 duplicate_tenant_code` and served a 500 on the concurrent-duplicate race the savepoint exists for (its pre-check SELECT hid the ordinary case). Fixed here rather than filed, and `tests/postgres-sqlstate-detection.test.ts` now gates it repo-wide — mutation-proven by restoring the original defect.
+
+`media_library` now has zero ungated permissions. ADR-0056 §C (a list function and its own route) is what remains before the screen.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -323,7 +323,28 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
     `delete`/`restore`/`purge` (lubang nyata), tambah rute daftar sendiri. Layar
     menyusul SETELAH ketiganya.
 
-    **Kemajuan: §A SELESAI.** `sql/087` mencabut `attach`/`detach` dari katalog
+    **Kemajuan: §A + §B SELESAI.** §B memberi `delete`/`restore`/`purge`
+    endpoint ter-guard, ter-audit, ber-`Idempotency-Key`
+    (`DELETE /api/v1/media/objects/{id}`, `.../{id}/restore`, `.../{id}/purge`).
+    Nol permission `media_library` kini tak-tergerbangi. `purge` memurnikan
+    REGISTRY saja — job rekonsiliasi tetap satu-satunya penulis bucket — dan
+    berjalan dalam SAVEPOINT karena FK keras dari
+    `awcms_news_portal_ad_placements` membuat `23503` MEMBATALKAN transaksi
+    (tanpa savepoint, 409 yang bisa ditindaklanjuti berubah jadi 500 saat
+    COMMIT). Tersisa §C: `listMediaObjects` + rute daftar sendiri, lalu layar.
+
+    > **Temuan sampingan, sudah diperbaiki di PR yang sama.** SQLSTATE Postgres
+    > ada di `error.errno`, BUKAN `error.code` — Bun mengisi `code` dengan
+    > konstanta miliknya sendiri (`ERR_POSTGRES_SERVER_ERROR`) untuk SEMUA error
+    > server. Jadi `error.code === "23505"` bukan cek yang agak salah, melainkan
+    > cek yang TAK PERNAH bisa benar. Sepuluh situs di repo ini sudah benar
+    > (`String(error.errno)`); satu tidak: `tenant-provisioning.ts` —
+    > `POST /api/v1/tenants` menjanjikan 409 untuk `tenant_code` duplikat tapi
+    > menyajikan 500 pada kasus balapan (pre-check SELECT menutupi kasus biasa).
+    > Ditemukan dengan MEMPROBE database nyata, bukan dengan membaca; digerbangi
+    > `tests/postgres-sqlstate-detection.test.ts`.
+
+    **§A SELESAI.** `sql/087` mencabut `attach`/`detach` dari katalog
     dan dari tiap grant role; dua fungsi nol-pemanggil dihapus. Modul kini
     mendeklarasikan **9 permission (7 `media.*` + 2 `enforcement.*`)**, dan yang
     belum tergerbangi tinggal **tiga**: `delete`/`restore`/`purge` — semuanya

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -4366,6 +4366,100 @@ Batch rather than one-per-id because a build feed resolves every image on a page
 | 401    | Missing or invalid session.                             | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.                             | [`ApiError`](#standard-error-envelope) |
 
+### `DELETE /api/v1/media/objects/{id}` — Soft delete one media object.
+
+- **operationId**: `mediaObjectSoftDelete`
+- **Security**: bearerAuth + tenantHeader
+
+Gated on `media_library.media.delete`. High-risk, requires `Idempotency-Key`. Body: `{ "reason": string }` — required, trimmed, at most 500 characters, and recorded on the audit row.
+
+Soft delete only: `deleted_at`/`deleted_by`/`delete_reason` are set and `status` is left alone. The R2 object is untouched.
+
+This BREAKS live references on purpose — `GET /api/v1/media/objects` resolves only non-deleted objects, so a post whose `featured_media_id` points here begins resolving to nothing immediately. That is the intended outcome for the case this endpoint serves (a policy-violating image must stop being served), and it is recoverable through `POST /api/v1/media/objects/{id}/restore`. The endpoint deliberately does not scan for referencing rows first: that would require this module to know its own consumers.
+
+An already-deleted object and an unknown id both answer 404 — a distinct "already deleted" would let a caller without `media.read` probe which ids exist.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `Idempotency-Key`  | header | yes      | string        |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Request body** (required): [`SoftDeleteMediaObjectRequest`](#schema-softdeletemediaobjectrequest)
+
+**Responses**
+
+| Status | Description                                                                       | Schema                                 |
+| ------ | --------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | The media object is soft-deleted.                                                 | object                                 |
+| 400    | Validation error.                                                                 | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                       | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                       | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                               | [`ApiError`](#standard-error-envelope) |
+| 409    | The Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`). | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/media/objects/{id}/purge` — Hard-delete the registry row of an already soft-deleted media object.
+
+- **operationId**: `mediaObjectPurge`
+- **Security**: bearerAuth + tenantHeader
+
+Gated on `media_library.media.purge`. High-risk, requires `Idempotency-Key`, and cannot be undone. No body.
+
+**Clears the registry row, NOT the R2 bytes.** The `news-media:reconcile` job owns the bucket and has the ordering discipline for deleting from it; a second writer here would mean two processes with different ideas of what is safe to remove. Accepted, stated cost: a window where the R2 object outlives its registry row, closed by the next reconciliation tick, which sees a key with no row and treats it as an orphan-in-R2.
+
+The object must ALREADY be soft-deleted — purging a live object answers 404 rather than destroying it.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `Idempotency-Key`  | header | yes      | string        |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Responses**
+
+| Status | Description                                                                                                                                                                                              | Schema                                 |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | The registry row is gone. The R2 object is removed later by the reconciliation job.                                                                                                                      | object                                 |
+| 400    | Validation error.                                                                                                                                                                                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                                                                                                              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                                                                                                              | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                                                                                                                                      | [`ApiError`](#standard-error-envelope) |
+| 409    | Another resource still holds a foreign key to this object (`MEDIA_OBJECT_REFERENCED` — remove the reference first), or the Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`). | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/media/objects/{id}/restore` — Undo a soft delete.
+
+- **operationId**: `mediaObjectRestore`
+- **Security**: bearerAuth + tenantHeader
+
+Gated on `media_library.media.restore`. High-risk, requires `Idempotency-Key`. No body.
+
+Clears `deleted_at`/`deleted_by`/`delete_reason` and stamps `restored_at`/`restored_by`. `status` is untouched — soft delete is orthogonal to it — so the object returns to whatever lifecycle state it was in.
+
+Restoring an object that is NOT soft-deleted answers 404 rather than succeeding as a no-op: "there was nothing to undo" and "it worked" must not share a response.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `Idempotency-Key`  | header | yes      | string        |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Responses**
+
+| Status | Description                                                                       | Schema                                 |
+| ------ | --------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | The media object is restored.                                                     | object                                 |
+| 400    | Validation error.                                                                 | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                       | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                       | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                               | [`ApiError`](#standard-error-envelope) |
+| 409    | The Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`). | [`ApiError`](#standard-error-envelope) |
+
 ## Blog Content
 
 Tenant-scoped blog/content administration (blog_content module, ported from awcms-mini) — posts and pages with their full lifecycle (draft → review → scheduled/published → archived, soft delete/restore/purge), hierarchical categories/tags, append-only revision history (restore APPENDS a revision, never overwrites), PostgreSQL full-text search, presentation/monetization extensions (templates, hierarchical menus, position-based widgets, advertisements), per-tenant blog settings, internal tag-link policy, and the editorial content-quality checklist. The public, anonymous reader surface (`/blog/{tenantCode}/...` index/detail/archive/search/feed/sitemap, ADR-0009) is served by Astro text/html/xml routes and is deliberately NOT part of this REST contract. Publish/unpublish/purge and settings writes are ABAC-gated, idempotency-keyed, and audited.
@@ -8205,6 +8299,20 @@ Every field is optional — an omitted field keeps its current value.
   "suggestionsEnabled": false,
   "suggestionLimit": 1,
   "analyticsEnabled": false
+}
+```
+
+### Schema: SoftDeleteMediaObjectRequest
+
+| Field    | Type   | Required | Nullable | Description                                                                                                                                                                                          |
+| -------- | ------ | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `reason` | string | yes      | no       | Why the object is being removed. Trimmed before length-checking, so a whitespace-only value fails as "required". Written to the audit row, which outlives the object it describes — hence the bound. |
+
+**Example**
+
+```json
+{
+  "reason": "string"
 }
 ```
 

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -597,6 +597,21 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/media/objects/[id].ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
+      "path": "src/pages/api/v1/media/objects/[id]/purge.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
+      "path": "src/pages/api/v1/media/objects/[id]/restore.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/media/objects/index.ts",
       "workClass": "interactive",
       "source": "factory"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -8112,6 +8112,173 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/media/objects/{id}:
+    delete:
+      operationId: mediaObjectSoftDelete
+      tags:
+        - News Media
+      summary: Soft delete one media object.
+      description: |
+        Gated on `media_library.media.delete`. High-risk, requires `Idempotency-Key`. Body: `{ "reason": string }` — required, trimmed, at most 500 characters, and recorded on the audit row.
+
+        Soft delete only: `deleted_at`/`deleted_by`/`delete_reason` are set and `status` is left alone. The R2 object is untouched.
+
+        This BREAKS live references on purpose — `GET /api/v1/media/objects` resolves only non-deleted objects, so a post whose `featured_media_id` points here begins resolving to nothing immediately. That is the intended outcome for the case this endpoint serves (a policy-violating image must stop being served), and it is recoverable through `POST /api/v1/media/objects/{id}/restore`. The endpoint deliberately does not scan for referencing rows first: that would require this module to know its own consumers.
+
+        An already-deleted object and an unknown id both answer 404 — a distinct "already deleted" would let a caller without `media.read` probe which ids exist.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SoftDeleteMediaObjectRequest"
+      responses:
+        "200":
+          description: The media object is soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/MediaObjectLifecycleResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/objects/{id}/purge:
+    post:
+      operationId: mediaObjectPurge
+      tags:
+        - News Media
+      summary: Hard-delete the registry row of an already soft-deleted media object.
+      description: |
+        Gated on `media_library.media.purge`. High-risk, requires `Idempotency-Key`, and cannot be undone. No body.
+
+        **Clears the registry row, NOT the R2 bytes.** The `news-media:reconcile` job owns the bucket and has the ordering discipline for deleting from it; a second writer here would mean two processes with different ideas of what is safe to remove. Accepted, stated cost: a window where the R2 object outlives its registry row, closed by the next reconciliation tick, which sees a key with no row and treats it as an orphan-in-R2.
+
+        The object must ALREADY be soft-deleted — purging a live object answers 404 rather than destroying it.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The registry row is gone. The R2 object is removed later by the reconciliation job.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/MediaObjectLifecycleResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Another resource still holds a foreign key to this object (`MEDIA_OBJECT_REFERENCED` — remove the reference first), or the Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/objects/{id}/restore:
+    post:
+      operationId: mediaObjectRestore
+      tags:
+        - News Media
+      summary: Undo a soft delete.
+      description: |
+        Gated on `media_library.media.restore`. High-risk, requires `Idempotency-Key`. No body.
+
+        Clears `deleted_at`/`deleted_by`/`delete_reason` and stamps `restored_at`/`restored_by`. `status` is untouched — soft delete is orthogonal to it — so the object returns to whatever lifecycle state it was in.
+
+        Restoring an object that is NOT soft-deleted answers 404 rather than succeeding as a no-op: "there was nothing to undo" and "it worked" must not share a response.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The media object is restored.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/MediaObjectRestored"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/modules:
     get:
       operationId: listModuleCatalog
@@ -17022,6 +17189,39 @@ components:
           description: Human-readable evidence, one entry per failing check. Names environment variables, never their values.
           items:
             type: string
+    MediaObjectLifecycleResult:
+      type: object
+      description: Result of a terminal lifecycle action. `status` here is the ACTION's outcome, not the object's `status` column.
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum:
+            - deleted
+            - purged
+    MediaObjectRestored:
+      type: object
+      description: Result of a restore. `status` here IS the object's own lifecycle status column, untouched by soft delete and therefore whatever it was before.
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum:
+            - pending_upload
+            - uploaded
+            - verified
+            - attached
+            - orphaned
+            - deleted
+            - failed
+        restoredAt:
+          type: string
+          format: date-time
+          nullable: true
     ModerationQueueItem:
       type: object
       properties:
@@ -18456,6 +18656,16 @@ components:
         updatedAt:
           type: string
           format: date-time
+    SoftDeleteMediaObjectRequest:
+      type: object
+      required:
+        - reason
+      properties:
+        reason:
+          type: string
+          minLength: 1
+          maxLength: 500
+          description: Why the object is being removed. Trimmed before length-checking, so a whitespace-only value fails as "required". Written to the audit row, which outlives the object it describes — hence the bound.
     SsoProvider:
       type: object
       description: A tenant OIDC SSO provider. The client secret is never included — only whether one is configured and, for the env-referenced case, the variable name.

--- a/openapi/modules/media-library.openapi.yaml
+++ b/openapi/modules/media-library.openapi.yaml
@@ -217,6 +217,170 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/media/objects/{id}:
+    delete:
+      operationId: mediaObjectSoftDelete
+      tags:
+        - News Media
+      summary: Soft delete one media object.
+      description: |
+        Gated on `media_library.media.delete`. High-risk, requires `Idempotency-Key`. Body: `{ "reason": string }` — required, trimmed, at most 500 characters, and recorded on the audit row.
+
+        Soft delete only: `deleted_at`/`deleted_by`/`delete_reason` are set and `status` is left alone. The R2 object is untouched.
+
+        This BREAKS live references on purpose — `GET /api/v1/media/objects` resolves only non-deleted objects, so a post whose `featured_media_id` points here begins resolving to nothing immediately. That is the intended outcome for the case this endpoint serves (a policy-violating image must stop being served), and it is recoverable through `POST /api/v1/media/objects/{id}/restore`. The endpoint deliberately does not scan for referencing rows first: that would require this module to know its own consumers.
+
+        An already-deleted object and an unknown id both answer 404 — a distinct "already deleted" would let a caller without `media.read` probe which ids exist.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SoftDeleteMediaObjectRequest"
+      responses:
+        "200":
+          description: The media object is soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/MediaObjectLifecycleResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/objects/{id}/restore:
+    post:
+      operationId: mediaObjectRestore
+      tags:
+        - News Media
+      summary: Undo a soft delete.
+      description: |
+        Gated on `media_library.media.restore`. High-risk, requires `Idempotency-Key`. No body.
+
+        Clears `deleted_at`/`deleted_by`/`delete_reason` and stamps `restored_at`/`restored_by`. `status` is untouched — soft delete is orthogonal to it — so the object returns to whatever lifecycle state it was in.
+
+        Restoring an object that is NOT soft-deleted answers 404 rather than succeeding as a no-op: "there was nothing to undo" and "it worked" must not share a response.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The media object is restored.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/MediaObjectRestored"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/media/objects/{id}/purge:
+    post:
+      operationId: mediaObjectPurge
+      tags:
+        - News Media
+      summary: Hard-delete the registry row of an already soft-deleted media object.
+      description: |
+        Gated on `media_library.media.purge`. High-risk, requires `Idempotency-Key`, and cannot be undone. No body.
+
+        **Clears the registry row, NOT the R2 bytes.** The `news-media:reconcile` job owns the bucket and has the ordering discipline for deleting from it; a second writer here would mean two processes with different ideas of what is safe to remove. Accepted, stated cost: a window where the R2 object outlives its registry row, closed by the next reconciliation tick, which sees a key with no row and treats it as an orphan-in-R2.
+
+        The object must ALREADY be soft-deleted — purging a live object answers 404 rather than destroying it.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The registry row is gone. The R2 object is removed later by the reconciliation job.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/MediaObjectLifecycleResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Another resource still holds a foreign key to this object (`MEDIA_OBJECT_REFERENCED` — remove the reference first), or the Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/media/enforcement:
     get:
       tags:
@@ -285,6 +449,47 @@ paths:
                 $ref: "#/components/schemas/ApiError"
 components:
   schemas:
+    SoftDeleteMediaObjectRequest:
+      type: object
+      required:
+        - reason
+      properties:
+        reason:
+          type: string
+          minLength: 1
+          maxLength: 500
+          description: Why the object is being removed. Trimmed before length-checking, so a whitespace-only value fails as "required". Written to the audit row, which outlives the object it describes — hence the bound.
+    MediaObjectLifecycleResult:
+      type: object
+      description: Result of a terminal lifecycle action. `status` here is the ACTION's outcome, not the object's `status` column.
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum: [deleted, purged]
+    MediaObjectRestored:
+      type: object
+      description: Result of a restore. `status` here IS the object's own lifecycle status column, untouched by soft delete and therefore whatever it was before.
+      properties:
+        id:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum:
+            - pending_upload
+            - uploaded
+            - verified
+            - attached
+            - orphaned
+            - deleted
+            - failed
+        restoredAt:
+          type: string
+          format: date-time
+          nullable: true
     ResolvedMediaReference:
       type: object
       description: A media object safe to reference publicly (verified/attached, same tenant, not deleted).

--- a/src/modules/media-library/README.md
+++ b/src/modules/media-library/README.md
@@ -81,16 +81,56 @@ media-library/
 | `052`     | Repoint permission ownership `news_portal.media.*` → `media_library.media.*` (INSERT → repoint role grants → DELETE; order load-bearing) |
 | `053`     | `awcms_media_library_tenant_state` (RLS ENABLE+FORCE + tenant_isolation) + backfill from `awcms_news_portal_tenant_state`                |
 | `054`     | `media_library.enforcement.{read,enable}` permission catalog rows                                                                        |
+| `087`     | REVOKE `media_library.media.{attach,detach}` — grants first, then catalog rows (ADR-0056 §A)                                             |
 
 Registry/upload/homepage/ad-placement tables (`041`–`045`) were created before
 the inversion and are unchanged.
 
+## Object lifecycle ([ADR-0056](../../../docs/adr/0056-media-library-admin-surface.md) §B)
+
+Three of this module's permissions sat in the catalog since `sql/052`, granted
+to every tenant owner, and enforced by **nothing** — no route, no function, no
+job. The functions behind them were written and had zero callers. So an object
+uploaded by mistake, orphaned, or violating policy disappeared only if the
+reconciliation job happened to categorise it that way, on the job's schedule.
+There was no way for an administrator to remove one, and no way to undo it.
+
+| Endpoint                                  | Permission                    | Notes                                                               |
+| ----------------------------------------- | ----------------------------- | ------------------------------------------------------------------- |
+| `DELETE /api/v1/media/objects/{id}`       | `media_library.media.delete`  | Body `{ reason }`, required and bounded. Soft delete; R2 untouched. |
+| `POST /api/v1/media/objects/{id}/restore` | `media_library.media.restore` | Undo. A live object answers 404, not a silent success.              |
+| `POST /api/v1/media/objects/{id}/purge`   | `media_library.media.purge`   | Hard-deletes the REGISTRY ROW only. Cannot be undone.               |
+
+All three are high-risk actions and require `Idempotency-Key`.
+
+**Soft delete breaks live references, deliberately.** `resolveMediaReferences`
+filters `deleted_at IS NULL`, so a post whose `featured_media_id` points at a
+deleted object resolves to nothing immediately. That is the intended outcome for
+the case this exists to serve — a policy-violating image must stop being served
+— and `restore` is why it is recoverable. None of these endpoints scans for
+referencing rows first: that would make this module know its own consumers.
+
+**`purge` clears the registry, not the bucket.** The `news-media:reconcile` job
+owns R2 and has the ordering discipline for deleting from it; a second writer
+here would mean two processes with different ideas of what is safe to remove.
+Accepted, stated cost: a window where the R2 object outlives its registry row,
+closed by the next reconciliation tick, which sees a key with no row and treats
+it as an orphan-in-R2.
+
+`awcms_news_portal_ad_placements.media_object_id` is a hard NOT NULL FK here, so
+purging a still-referenced object answers `409 MEDIA_OBJECT_REFERENCED`. That
+path runs inside a **savepoint**: in PostgreSQL a `23503` aborts the whole
+transaction, so catching it without one turns a caller-actionable 409 into a 500
+at COMMIT. The SQLSTATE is read from `error.errno` — Bun puts its own constant
+on `error.code`, so comparing `code` to `"23503"` can never be true
+(`tests/postgres-sqlstate-detection.test.ts` now gates this repo-wide).
+
 ## Not ported to this base (deferred, additive)
 
-Media lifecycle/browser surface (`/api/v1/media/objects/*`, `/admin/media` —
-micro step 5d), responsive `srcset` render (step 5b), and the PDF media type
-(step 5c). The allowed MIME set stays the four raster types and the module
-declares no `navigation` yet.
+The `/admin/media` screen (micro step 5d — the lifecycle API half above is now
+ported, so this module still declares no `navigation`), responsive `srcset`
+render (step 5b), and the PDF media type (step 5c). The allowed MIME set stays
+the four raster types.
 
 ## Resolusi referensi media (`GET /api/v1/media/objects`)
 

--- a/src/modules/media-library/application/media-object-directory.ts
+++ b/src/modules/media-library/application/media-object-directory.ts
@@ -873,11 +873,68 @@ export async function restoreNewsMediaObject(
   return restored;
 }
 
+export type PurgeNewsMediaObjectResult =
+  | { ok: true; objectKey: string }
+  /** No row matched `id` in this tenant with `deleted_at IS NOT NULL`. */
+  | { ok: false; reason: "not_purgeable" }
+  /** A live FK still points at the row — see the savepoint note below. */
+  | { ok: false; reason: "still_referenced" };
+
+/** Postgres foreign-key violation. */
+const FOREIGN_KEY_VIOLATION = "23503";
+
 /**
- * Hard delete. Caller must have already verified the row is soft-deleted
- * (this only guards it at the SQL level via `deleted_at IS NOT NULL` in the
- * WHERE clause) — same "caller verifies eligibility first" convention as
- * `blog-content/application/blog-post-directory.ts`'s `purgeBlogPost`.
+ * The SQLSTATE is on `errno`, NOT on `code`. Bun sets `code` to its own
+ * `"ERR_POSTGRES_SERVER_ERROR"` for every server error alike, so comparing
+ * `code` against a SQLSTATE is always false — the error would be rethrown and
+ * the caller-actionable 409 would surface as a 500. Verified against
+ * PostgreSQL 18 + Bun 1.3.14; `String()` because `errno` is typed loosely
+ * enough to be a number in other Bun error shapes. Same idiom as the ten other
+ * violation checks in this repo (`role-admin.ts`, `office-directory.ts`, ...).
+ */
+function isForeignKeyViolation(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "errno" in error &&
+    String((error as { errno?: unknown }).errno) === FOREIGN_KEY_VIOLATION
+  );
+}
+
+/** Fixed identifier — never built from input. */
+const PURGE_SAVEPOINT = "awcms_purge_media_object";
+
+/**
+ * Hard delete of the REGISTRY ROW. Eligibility is enforced in the `WHERE`
+ * (`deleted_at IS NOT NULL`), so an object that was never soft-deleted comes
+ * back `not_purgeable` rather than silently vanishing.
+ *
+ * ## This does NOT delete the R2 object (ADR-0056 §B)
+ *
+ * The reconciliation job owns the bucket. Deleting bytes here would put two
+ * writers on one bucket with two different ideas of what is safe to remove, and
+ * the job already has the ordering discipline for it (see
+ * `scripts/news-media-r2-reconcile.ts`). The accepted, stated cost is a window
+ * where the R2 object outlives its registry row — closed by the next
+ * reconciliation tick, which sees a key with no row and treats it as an
+ * orphan-in-R2.
+ *
+ * ## Why a savepoint, and why no pre-check
+ *
+ * `awcms_news_portal_ad_placements.media_object_id` is a hard, NOT NULL FK to
+ * this table with no `ON DELETE` clause — so purging a still-referenced object
+ * raises `23503`. In PostgreSQL that ABORTS the transaction: every later
+ * statement fails with "current transaction is aborted", and the COMMIT
+ * `withTenant` performs on a returned 4xx fails too. Catching the error without
+ * a savepoint turns a caller-actionable 409 into a 500.
+ *
+ * There is deliberately no pre-check SELECT to go with it — unlike
+ * `provisionTenant`, which pre-checks then uses the savepoint only for the race.
+ * A pre-check here would have to name the referencing tables, i.e. this module
+ * would have to know its own CONSUMERS (`module.ts`: "media must never depend on
+ * its own consumers"). Letting the FK answer keeps that knowledge in the
+ * database, where it already lives, and stays correct the day a second module
+ * adds a reference.
  */
 export async function purgeNewsMediaObject(
   tx: Bun.SQL,
@@ -885,14 +942,31 @@ export async function purgeNewsMediaObject(
   actorTenantUserId: string,
   id: string,
   correlationId?: string
-): Promise<boolean> {
-  const rows = (await tx`
-    DELETE FROM awcms_news_media_objects
-    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
-    RETURNING object_key
-  `) as { object_key: string }[];
+): Promise<PurgeNewsMediaObjectResult> {
+  await tx.unsafe(`SAVEPOINT ${PURGE_SAVEPOINT}`);
 
-  if (rows.length === 0) return false;
+  let rows: { object_key: string }[];
+
+  try {
+    rows = (await tx`
+      DELETE FROM awcms_news_media_objects
+      WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
+      RETURNING object_key
+    `) as { object_key: string }[];
+
+    await tx.unsafe(`RELEASE SAVEPOINT ${PURGE_SAVEPOINT}`);
+  } catch (error) {
+    await tx.unsafe(`ROLLBACK TO SAVEPOINT ${PURGE_SAVEPOINT}`);
+
+    if (isForeignKeyViolation(error)) {
+      return { ok: false, reason: "still_referenced" };
+    }
+    throw error;
+  }
+
+  if (rows.length === 0) return { ok: false, reason: "not_purgeable" };
+
+  const objectKey = rows[0]!.object_key;
 
   await recordAuditEvent(tx, {
     tenantId,
@@ -902,10 +976,10 @@ export async function purgeNewsMediaObject(
     resourceType: AUDIT_RESOURCE_TYPE,
     resourceId: id,
     severity: "warning",
-    message: `News media object purged: ${rows[0]!.object_key}.`,
-    attributes: { objectKey: rows[0]!.object_key },
+    message: `News media object purged: ${objectKey}.`,
+    attributes: { objectKey },
     correlationId
   });
 
-  return true;
+  return { ok: true, objectKey };
 }

--- a/src/modules/media-library/domain/media-lifecycle-validation.ts
+++ b/src/modules/media-library/domain/media-lifecycle-validation.ts
@@ -1,0 +1,82 @@
+/**
+ * Request-shape validation for the media object LIFECYCLE endpoints
+ * (ADR-0056 §B: soft delete, restore, purge). Pure — no DB/network access,
+ * same `{ valid: true; value } | { valid: false; errors }` convention as
+ * `media-upload-session-validation.ts` beside it.
+ *
+ * ## Why this file exists rather than reusing `validateDeleteReasonInput`
+ *
+ * `blog_content/domain/content-validation.ts` already exports a shared
+ * `{ reason: string }` validator, and three blog resources use it. Importing it
+ * here would make `media_library` — a System Foundation module — depend on one
+ * of its own CONSUMERS, which `module.ts` forbids in as many words: "media must
+ * never depend on its own consumers". `modules:dag:check` would refuse the
+ * edge, and it would be right to.
+ *
+ * So the shape is duplicated on purpose, and it is deliberately not identical:
+ * the blog validator accepts any non-empty reason, while this one bounds the
+ * length. A reason is written into an audit row that outlives the object it
+ * describes; an unbounded one is a write-amplification path through an endpoint
+ * whose whole point is destructive actions.
+ */
+
+export type ValidationError = {
+  field: string;
+  message: string;
+};
+
+/**
+ * Bounds for the soft-delete reason. Exported because the `/admin/media` screen
+ * renders `maxlength` from them — a hand-typed number there drifts into a
+ * browser accepting what this validator rejects with a 400 the author cannot
+ * act on (the same trap `/admin/blog` and `/admin/approvals` each hit).
+ */
+export const MIN_DELETE_REASON_LENGTH = 1;
+export const MAX_DELETE_REASON_LENGTH = 500;
+
+export type SoftDeleteMediaObjectInput = {
+  reason: string;
+};
+
+export type SoftDeleteMediaObjectValidationResult =
+  | { valid: true; value: SoftDeleteMediaObjectInput }
+  | { valid: false; errors: ValidationError[] };
+
+/**
+ * `DELETE /api/v1/media/objects/{id}` body: `{ reason: string }`.
+ *
+ * The reason is REQUIRED, matching every other soft-delete surface in this repo
+ * (`DELETE /api/v1/blog/posts/{id}`, `/api/v1/profiles/{id}`,
+ * `/api/v1/email/templates/{id}`). It is trimmed before length-checking, so a
+ * body of only whitespace fails as "required" rather than passing as a
+ * 20-character reason that says nothing.
+ */
+export function validateSoftDeleteMediaObjectInput(
+  body: unknown
+): SoftDeleteMediaObjectValidationResult {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const raw = record.reason;
+
+  if (typeof raw !== "string" || raw.trim().length < MIN_DELETE_REASON_LENGTH) {
+    return {
+      valid: false,
+      errors: [{ field: "reason", message: "reason is required." }]
+    };
+  }
+
+  const reason = raw.trim();
+
+  if (reason.length > MAX_DELETE_REASON_LENGTH) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "reason",
+          message: `reason must be at most ${MAX_DELETE_REASON_LENGTH} characters.`
+        }
+      ]
+    };
+  }
+
+  return { valid: true, value: { reason } };
+}

--- a/src/modules/tenant-admin/application/tenant-provisioning.ts
+++ b/src/modules/tenant-admin/application/tenant-provisioning.ts
@@ -35,12 +35,27 @@ export type ProvisionTenantResult =
 /** Postgres unique-violation. */
 const UNIQUE_VIOLATION = "23505";
 
+/**
+ * The SQLSTATE is on `errno`, NOT on `code`. This read `code` until ADR-0056
+ * §B's work turned up the same mistake in new code and probed the real error
+ * shape: Bun sets `code` to its own `"ERR_POSTGRES_SERVER_ERROR"` for every
+ * server error alike, so the comparison was always false. The pre-check SELECT
+ * above hid it for the ordinary case; the RACE this savepoint exists for — two
+ * callers submitting the same `tenant_code` concurrently — rethrew instead of
+ * answering `duplicate_tenant_code`, and `POST /api/v1/tenants` served a 500
+ * where it had promised a 409.
+ *
+ * `String()` because `errno` is typed loosely enough to be a number in other
+ * Bun error shapes. This is now the same idiom as the ten other violation
+ * checks in this repo (`role-admin.ts`, `office-directory.ts`, ...), which had
+ * it right all along.
+ */
 function isUniqueViolation(error: unknown): boolean {
   return (
     typeof error === "object" &&
     error !== null &&
-    "code" in error &&
-    (error as { code?: unknown }).code === UNIQUE_VIOLATION
+    "errno" in error &&
+    String((error as { errno?: unknown }).errno) === UNIQUE_VIOLATION
   );
 }
 

--- a/src/pages/api/v1/media/objects/[id].ts
+++ b/src/pages/api/v1/media/objects/[id].ts
@@ -1,0 +1,167 @@
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../modules/_shared/idempotency";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../modules/media-library/domain/media-permissions";
+import { validateSoftDeleteMediaObjectInput } from "../../../../../modules/media-library/domain/media-lifecycle-validation";
+import { softDeleteNewsMediaObject } from "../../../../../modules/media-library/application/media-object-directory";
+import { log } from "../../../../../lib/logging/logger";
+
+/**
+ * `DELETE /api/v1/media/objects/{id}` (ADR-0056 §B) — soft delete one media
+ * object.
+ *
+ * ## Why this endpoint had to exist
+ *
+ * `media_library.media.delete` has been in the permission catalog since
+ * `sql/052`, granted to every tenant owner, and enforced by NOTHING. The
+ * function behind it (`softDeleteNewsMediaObject`) was written and had zero
+ * callers. So an object uploaded by mistake, orphaned, or violating policy
+ * could only disappear if the reconciliation job happened to categorise it that
+ * way, on the job's own schedule — there was no way for an administrator to
+ * remove one, and no way to undo it if they were wrong. `restore.ts` beside
+ * this file is the other half, and is why a required reason is affordable here.
+ *
+ * ## Soft delete BREAKS live references, on purpose
+ *
+ * `resolveMediaReferences` filters `deleted_at IS NULL`, so a post whose
+ * `featured_media_id` points here starts resolving to nothing the moment this
+ * succeeds. That is the point for the case this endpoint exists to serve — a
+ * policy-violating image must stop being served — and it is recoverable, which
+ * is exactly why `restore` is a sibling and not a later idea. This endpoint
+ * deliberately does not scan for referencing rows first: doing so would make
+ * `media_library` know its own consumers, which `module.ts` forbids.
+ *
+ * `delete` is in `HIGH_RISK_ACTIONS`, so `Idempotency-Key` is required. The row
+ * is a soft delete, so the R2 object is untouched either way.
+ */
+const IDEMPOTENCY_SCOPE = "media_object_delete";
+
+type Prepared = { idempotencyKey: string; reason: string };
+
+export const DELETE = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: async ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    const bodyRead = await readJsonBody(request);
+
+    if (bodyRead.tooLarge) {
+      return bodyTooLargeResponse(bodyRead.limitBytes);
+    }
+
+    const validation = validateSoftDeleteMediaObjectInput(bodyRead.value);
+
+    if (!validation.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "reason is required.",
+        {},
+        validation.errors
+      );
+    }
+
+    return { idempotencyKey, reason: validation.value.reason };
+  },
+  authorize: {
+    moduleKey: "media_library",
+    activityCode: MEDIA_PERMISSION_ACTIVITY_CODE,
+    action: "delete"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const objectId = params.id;
+
+    if (!objectId) {
+      return fail(400, "VALIDATION_ERROR", "Media object id is required.");
+    }
+
+    // The reason is part of the request hash: replaying the same key with a
+    // different reason is a different request, and the audit row records which
+    // reason was actually written.
+    const requestHash = computeRequestHash({
+      objectId,
+      reason: prepared.reason,
+      action: "delete"
+    });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    // `softDeleteNewsMediaObject` writes its own audit event and matches on
+    // `deleted_at IS NULL`, so an already-deleted object is indistinguishable
+    // from an unknown one here — both 404. That is deliberate: a distinct
+    // "already deleted" answer would let a caller without `media.read` probe
+    // which ids exist.
+    const deleted = await softDeleteNewsMediaObject(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      objectId,
+      prepared.reason,
+      locals.correlationId
+    );
+
+    if (!deleted) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Media object not found.");
+    }
+
+    log("info", "media-library.object.deleted", {
+      correlationId: locals.correlationId,
+      tenantId,
+      moduleKey: "media_library",
+      objectId
+    });
+
+    const response = ok({ id: objectId, status: "deleted" });
+    const body = await response.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+
+    return response;
+  }
+});

--- a/src/pages/api/v1/media/objects/[id]/purge.ts
+++ b/src/pages/api/v1/media/objects/[id]/purge.ts
@@ -1,0 +1,146 @@
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../../modules/media-library/domain/media-permissions";
+import { purgeNewsMediaObject } from "../../../../../../modules/media-library/application/media-object-directory";
+import { log } from "../../../../../../lib/logging/logger";
+
+/**
+ * `POST /api/v1/media/objects/{id}/purge` (ADR-0056 §B) — hard-delete the
+ * registry row of an already soft-deleted media object.
+ *
+ * ## `purge` clears the REGISTRY, not the R2 bytes
+ *
+ * This is the decision ADR-0056 §B states explicitly, and it is not an
+ * oversight to be fixed later. The reconciliation job
+ * (`scripts/news-media-r2-reconcile.ts`) owns the bucket and has the ordering
+ * discipline for deleting from it. A second writer here would mean two
+ * processes with two different ideas of what is safe to remove from one bucket.
+ *
+ * Accepted and stated cost: a window where the R2 object outlives its registry
+ * row. The next reconciliation tick sees a key with no row, categorises it as
+ * orphan-in-R2, and removes it — the job's existing self-healing path, not a
+ * new one.
+ *
+ * ## Eligibility, and the 409 a foreign key produces
+ *
+ * The row must already be soft-deleted; `purgeNewsMediaObject` enforces that in
+ * its `WHERE`, so purging a live object answers 404 rather than destroying it.
+ * `awcms_news_portal_ad_placements.media_object_id` is a hard NOT NULL FK with
+ * no `ON DELETE`, so purging a still-referenced object answers `409
+ * MEDIA_OBJECT_REFERENCED`. That path runs inside a savepoint — see the
+ * application function — because in PostgreSQL a `23503` aborts the whole
+ * transaction, and the COMMIT `withTenant` performs on a returned 4xx would
+ * fail with it.
+ *
+ * `purge` is in `HIGH_RISK_ACTIONS` and is the one action here that cannot be
+ * undone, so `Idempotency-Key` is required.
+ */
+const IDEMPOTENCY_SCOPE = "media_object_purge";
+
+type Prepared = { idempotencyKey: string };
+
+export const POST = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    return { idempotencyKey };
+  },
+  authorize: {
+    moduleKey: "media_library",
+    activityCode: MEDIA_PERMISSION_ACTIVITY_CODE,
+    action: "purge"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const objectId = params.id;
+
+    if (!objectId) {
+      return fail(400, "VALIDATION_ERROR", "Media object id is required.");
+    }
+
+    const requestHash = computeRequestHash({ objectId, action: "purge" });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const result = await purgeNewsMediaObject(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      objectId,
+      locals.correlationId
+    );
+
+    if (!result.ok) {
+      if (result.reason === "still_referenced") {
+        return fail(
+          409,
+          "MEDIA_OBJECT_REFERENCED",
+          "Media object is still referenced by another resource and cannot be purged. Remove the reference first."
+        );
+      }
+
+      return fail(
+        404,
+        "RESOURCE_NOT_FOUND",
+        "Media object not found, or is not soft-deleted."
+      );
+    }
+
+    log("warning", "media-library.object.purged", {
+      correlationId: locals.correlationId,
+      tenantId,
+      moduleKey: "media_library",
+      objectId
+    });
+
+    const response = ok({ id: objectId, status: "purged" });
+    const body = await response.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+
+    return response;
+  }
+});

--- a/src/pages/api/v1/media/objects/[id]/restore.ts
+++ b/src/pages/api/v1/media/objects/[id]/restore.ts
@@ -1,0 +1,130 @@
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../../modules/media-library/domain/media-permissions";
+import { restoreNewsMediaObject } from "../../../../../../modules/media-library/application/media-object-directory";
+import { log } from "../../../../../../lib/logging/logger";
+
+/**
+ * `POST /api/v1/media/objects/{id}/restore` (ADR-0056 §B) — undo a soft delete.
+ *
+ * This is the half that makes `DELETE /api/v1/media/objects/{id}` an affordable
+ * action rather than a one-way door. Soft-deleting a media object stops every
+ * reference to it resolving (`resolveMediaReferences` filters
+ * `deleted_at IS NULL`), so without a restore path a mistaken deletion would
+ * break a published page with no in-band recovery — the shape of hole ADR-0056
+ * §B was written to close, not to reproduce one level down.
+ *
+ * `restoreNewsMediaObject` matches on `deleted_at IS NOT NULL`, so restoring a
+ * live object is a 404, not a no-op success: "there was nothing to undo" and
+ * "it worked" must not share a response.
+ *
+ * `restore` is in `HIGH_RISK_ACTIONS` — it returns content to being publicly
+ * referenceable — so `Idempotency-Key` is required. Note the asymmetry with
+ * `delete`: this endpoint takes no body, so its request hash covers the id
+ * alone.
+ */
+const IDEMPOTENCY_SCOPE = "media_object_restore";
+
+type Prepared = { idempotencyKey: string };
+
+export const POST = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    return { idempotencyKey };
+  },
+  authorize: {
+    moduleKey: "media_library",
+    activityCode: MEDIA_PERMISSION_ACTIVITY_CODE,
+    action: "restore"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const objectId = params.id;
+
+    if (!objectId) {
+      return fail(400, "VALIDATION_ERROR", "Media object id is required.");
+    }
+
+    const requestHash = computeRequestHash({ objectId, action: "restore" });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const restored = await restoreNewsMediaObject(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      objectId,
+      locals.correlationId
+    );
+
+    if (!restored) {
+      return fail(
+        404,
+        "RESOURCE_NOT_FOUND",
+        "Media object not found, or is not soft-deleted."
+      );
+    }
+
+    log("info", "media-library.object.restored", {
+      correlationId: locals.correlationId,
+      tenantId,
+      moduleKey: "media_library",
+      objectId
+    });
+
+    const response = ok({
+      id: restored.id,
+      status: restored.status,
+      restoredAt: restored.restoredAt
+    });
+    const body = await response.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+
+    return response;
+  }
+});

--- a/tests/media-object-lifecycle-routes.test.ts
+++ b/tests/media-object-lifecycle-routes.test.ts
@@ -1,0 +1,244 @@
+/**
+ * ADR-0056 §B — the three media object lifecycle endpoints gate on the three
+ * permissions that were seeded with no surface at all.
+ *
+ * This is the inverse of the usual page contract: there is no screen yet, so
+ * what has to be proven is that the permissions the catalog has been handing
+ * out since `sql/052` are now enforced by real guards, and enforced on the
+ * SAME keys the descriptor declares. A guard naming an action nothing seeds
+ * denies everyone including the owner, and the endpoint would look perfectly
+ * correct in review — this repo has shipped that defect twice.
+ *
+ * Four things specific to this trio:
+ *
+ * - **`purge` deletes the registry row, never R2 bytes** (§B). A future edit
+ *   that reaches for the R2 client from the route would silently make the
+ *   endpoint a second writer on a bucket the reconciliation job owns.
+ * - **`purge` runs inside a SAVEPOINT.** `awcms_news_portal_ad_placements`
+ *   holds a hard NOT NULL FK here, and a `23503` aborts the transaction — so
+ *   catching it without the savepoint turns a caller-actionable 409 into a
+ *   500 at COMMIT time.
+ * - **All three require `Idempotency-Key`**, unlike `cancel` beside them.
+ * - **`media_library` must not import `blog_content`** to validate a delete
+ *   reason, which is why the shared blog validator is duplicated rather than
+ *   reused.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { mediaLibraryModule } from "../src/modules/media-library/module";
+import {
+  MAX_DELETE_REASON_LENGTH,
+  validateSoftDeleteMediaObjectInput
+} from "../src/modules/media-library/domain/media-lifecycle-validation";
+
+const DELETE_ROUTE = "src/pages/api/v1/media/objects/[id].ts";
+const RESTORE_ROUTE = "src/pages/api/v1/media/objects/[id]/restore.ts";
+const PURGE_ROUTE = "src/pages/api/v1/media/objects/[id]/purge.ts";
+const DIRECTORY =
+  "src/modules/media-library/application/media-object-directory.ts";
+
+const ROUTES = [
+  { file: DELETE_ROUTE, action: "delete" },
+  { file: RESTORE_ROUTE, action: "restore" },
+  { file: PURGE_ROUTE, action: "purge" }
+] as const;
+
+function guardActionsFrom(source: string): Set<string> {
+  const found = new Set<string>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*MEDIA_PERMISSION_ACTIVITY_CODE,\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    if (match[1] === "media_library") found.add(match[2]!);
+  }
+
+  return found;
+}
+
+function declaredMediaActions(): Set<string> {
+  return new Set(
+    (mediaLibraryModule.permissions ?? [])
+      .filter((permission) => permission.activityCode === "media")
+      .map((permission) => permission.action)
+  );
+}
+
+describe("ADR-0056 §B — the three ungated permissions now have guards", () => {
+  test("each route gates on its own action, and on a key the descriptor declares", async () => {
+    const declared = declaredMediaActions();
+
+    // Non-vacuous: if the descriptor stopped declaring `media.*` entirely, the
+    // subset assertions below would all pass while proving nothing.
+    expect(declared.size).toBe(7);
+
+    for (const { file, action } of ROUTES) {
+      const actions = guardActionsFrom(await readFile(file, "utf8"));
+
+      expect(actions).toEqual(new Set([action]));
+      expect(declared.has(action)).toBe(true);
+    }
+  });
+
+  test("the guards use the shared activity-code constant, not a re-typed string", async () => {
+    for (const { file } of ROUTES) {
+      const source = await readFile(file, "utf8");
+
+      expect(source).toContain("MEDIA_PERMISSION_ACTIVITY_CODE");
+      // A literal `activityCode: "media"` would still work today and would
+      // silently survive a rename of the activity code.
+      expect(source).not.toContain('activityCode: "media"');
+    }
+  });
+
+  test("all three require Idempotency-Key — every one is a HIGH_RISK_ACTION", async () => {
+    for (const { file } of ROUTES) {
+      const source = await readFile(file, "utf8");
+
+      expect(source).toContain("IDEMPOTENCY_REQUIRED");
+      expect(source).toContain("findIdempotencyRecord");
+      expect(source).toContain("saveIdempotencyRecord");
+      expect(source).toContain("IDEMPOTENCY_CONFLICT");
+    }
+  });
+
+  test("each route has its OWN idempotency scope", async () => {
+    const scopes = new Set<string>();
+
+    for (const { file } of ROUTES) {
+      const source = await readFile(file, "utf8");
+      const match = source.match(/IDEMPOTENCY_SCOPE = "([a-z_]+)"/);
+
+      expect(match).not.toBeNull();
+      scopes.add(match![1]!);
+    }
+
+    // Sharing one scope would let a delete's key collide with a purge's, so a
+    // replayed key could return the wrong action's stored response.
+    expect(scopes.size).toBe(ROUTES.length);
+  });
+
+  test("delete's request hash covers the reason, restore's and purge's cannot", async () => {
+    const deleteSource = await readFile(DELETE_ROUTE, "utf8");
+
+    // Otherwise replaying one key with a different reason returns the first
+    // response while the audit row records a reason the caller never sent.
+    expect(deleteSource).toMatch(
+      /computeRequestHash\(\{[\s\S]*?reason: prepared\.reason[\s\S]*?\}\)/
+    );
+
+    // Scoped to the hash call, not the whole file — both siblings discuss
+    // reasons in prose, and asserting over that would fail for the wrong cause.
+    for (const file of [RESTORE_ROUTE, PURGE_ROUTE]) {
+      const source = await readFile(file, "utf8");
+      const call = source.slice(source.indexOf("computeRequestHash("));
+
+      expect(call.slice(0, call.indexOf(");"))).not.toContain("reason");
+    }
+  });
+});
+
+describe("purge clears the registry, not the bucket", () => {
+  test("the route never reaches for R2", async () => {
+    const source = await readFile(PURGE_ROUTE, "utf8");
+
+    // The reconciliation job owns the bucket. A second writer here is the
+    // failure mode §B names explicitly.
+    expect(source).not.toContain("media-r2-client");
+    expect(source).not.toContain("deleteObject");
+    expect(source).not.toMatch(/\bR2Client\b/);
+  });
+
+  test("the hard delete runs inside a savepoint and maps 23503 to a reason", async () => {
+    const directory = await readFile(DIRECTORY, "utf8");
+    const purgeFn = directory.slice(
+      directory.indexOf("export async function purgeNewsMediaObject")
+    );
+
+    expect(purgeFn).toContain("SAVEPOINT ${PURGE_SAVEPOINT}");
+    expect(purgeFn).toContain("ROLLBACK TO SAVEPOINT ${PURGE_SAVEPOINT}");
+    expect(purgeFn).toContain("RELEASE SAVEPOINT ${PURGE_SAVEPOINT}");
+    expect(directory).toContain('const FOREIGN_KEY_VIOLATION = "23503"');
+    expect(purgeFn).toContain('reason: "still_referenced"');
+
+    // Eligibility stays in the WHERE clause: a live object must answer 404,
+    // never be destroyed by a purge call that skipped the soft-delete step.
+    expect(purgeFn).toContain("deleted_at IS NOT NULL");
+  });
+
+  test("the route surfaces the FK case as 409, distinct from 404", async () => {
+    const source = await readFile(PURGE_ROUTE, "utf8");
+
+    expect(source).toContain("MEDIA_OBJECT_REFERENCED");
+    expect(source).toContain('result.reason === "still_referenced"');
+    expect(source).toContain("RESOURCE_NOT_FOUND");
+  });
+});
+
+describe("the delete-reason validator", () => {
+  test("does not import blog_content — media must not depend on its consumers", async () => {
+    const source = await readFile(
+      "src/modules/media-library/domain/media-lifecycle-validation.ts",
+      "utf8"
+    );
+
+    // `blog-content/domain/content-validation.ts` exports an equivalent
+    // validator, and reusing it would be a System Foundation module importing
+    // one of its own consumers. Asserted over IMPORTS only: the file's header
+    // names `blog_content` while explaining why it does not import it.
+    const imports = source
+      .split("\n")
+      .filter((line) => line.startsWith("import "));
+
+    expect(imports.join("\n")).not.toContain("blog-content");
+    expect(source).not.toMatch(/from\s+"[^"]*blog[^"]*"/);
+
+    // Same rule at the route: the reason validator must come from this module.
+    expect(await readFile(DELETE_ROUTE, "utf8")).not.toMatch(
+      /from\s+"[^"]*blog[^"]*"/
+    );
+  });
+
+  test("requires a reason, trims it, and bounds its length", () => {
+    expect(validateSoftDeleteMediaObjectInput({}).valid).toBe(false);
+    expect(validateSoftDeleteMediaObjectInput({ reason: "" }).valid).toBe(
+      false
+    );
+    // Whitespace-only must fail as "required", not pass as a long reason.
+    expect(validateSoftDeleteMediaObjectInput({ reason: "   " }).valid).toBe(
+      false
+    );
+    expect(validateSoftDeleteMediaObjectInput({ reason: 42 }).valid).toBe(
+      false
+    );
+
+    const tooLong = validateSoftDeleteMediaObjectInput({
+      reason: "x".repeat(MAX_DELETE_REASON_LENGTH + 1)
+    });
+    expect(tooLong.valid).toBe(false);
+
+    const atLimit = validateSoftDeleteMediaObjectInput({
+      reason: "x".repeat(MAX_DELETE_REASON_LENGTH)
+    });
+    expect(atLimit.valid).toBe(true);
+
+    const trimmed = validateSoftDeleteMediaObjectInput({
+      reason: "  policy violation  "
+    });
+    expect(trimmed.valid).toBe(true);
+    expect(trimmed.valid && trimmed.value.reason).toBe("policy violation");
+  });
+
+  test("the route uses it rather than reading request.reason directly", async () => {
+    const source = await readFile(DELETE_ROUTE, "utf8");
+
+    expect(source).toContain("validateSoftDeleteMediaObjectInput");
+    expect(source).toContain("readJsonBody");
+    // Without the size guard an unbounded body reaches JSON.parse before any
+    // validation runs.
+    expect(source).toContain("bodyTooLargeResponse");
+  });
+});

--- a/tests/postgres-sqlstate-detection.test.ts
+++ b/tests/postgres-sqlstate-detection.test.ts
@@ -1,0 +1,92 @@
+/**
+ * A Postgres SQLSTATE is read from `error.errno`, never from `error.code`.
+ *
+ * Bun's `PostgresError` sets `code` to its own constant
+ * `"ERR_POSTGRES_SERVER_ERROR"` for EVERY server error alike, and puts the
+ * five-character SQLSTATE on `errno` (verified against PostgreSQL 18 + Bun
+ * 1.3.14: a `23503` arrives as `{code: "ERR_POSTGRES_SERVER_ERROR", errno:
+ * "23503", constraint: "...", detail: "..."}`).
+ *
+ * So `error.code === "23505"` is not a subtly wrong check — it is a check that
+ * can never be true. Everything downstream of it is dead code: the error is
+ * rethrown, and an endpoint that promised a caller-actionable 409 serves a 500
+ * instead.
+ *
+ * ## Why a gate rather than a code review note
+ *
+ * It reads correctly. `error.code` is exactly where a SQLSTATE lives in
+ * `node-postgres`, `pg`, and most Node ecosystem drivers, so the wrong version
+ * is what an experienced reviewer expects to see. Ten sites in this repo got it
+ * right; two got it wrong, and both were found by probing a live database, not
+ * by reading. `tenant-provisioning.ts` had shipped with it — its pre-check
+ * SELECT hid the ordinary case, leaving only the concurrent-duplicate race
+ * answering 500 where the contract says 409.
+ *
+ * Pure — no database. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+/** A five-digit SQLSTATE literal, or a constant named after one. */
+const SQLSTATE_OPERAND =
+  /(["'`]\d{5}["'`]|[A-Z][A-Z0-9_]*(?:VIOLATION|SQLSTATE|ERROR_CODE))/;
+
+async function sourceFiles(): Promise<string[]> {
+  const files: string[] = [];
+
+  for await (const file of new Bun.Glob("src/**/*.ts").scan({
+    cwd: process.cwd()
+  })) {
+    files.push(file);
+  }
+
+  return files;
+}
+
+describe("Postgres SQLSTATE detection", () => {
+  test("no source compares `.code` against a SQLSTATE", async () => {
+    const files = await sourceFiles();
+
+    // Non-vacuous: an empty scan would make the assertion below pass while
+    // checking nothing — the shape of gate this repo has been burned by.
+    expect(files.length).toBeGreaterThan(100);
+
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const lines = (await readFile(file, "utf8")).split("\n");
+
+      lines.forEach((line, index) => {
+        const match = line.match(/\.code\s*===?=?\s*(.+)$/);
+
+        if (match && SQLSTATE_OPERAND.test(match[1]!)) {
+          offenders.push(`${file}:${index + 1}: ${line.trim()}`);
+        }
+      });
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test("every violation constant in the repo is compared against `errno`", async () => {
+    const files = await sourceFiles();
+    let comparisons = 0;
+
+    for (const file of files) {
+      const source = await readFile(file, "utf8");
+
+      for (const match of source.matchAll(
+        /String\(\s*\(?\s*error(?: as \{[^}]*\})?\s*\)?\.errno\s*\)\s*===\s*([A-Z][A-Z0-9_]*)/g
+      )) {
+        expect(match[1]).toMatch(/VIOLATION/);
+        comparisons += 1;
+      }
+    }
+
+    // Guards the guard: if the idiom is ever refactored into a helper this
+    // count collapses, and the assertion above would silently stop covering
+    // anything.
+    expect(comparisons).toBeGreaterThanOrEqual(10);
+  });
+});


### PR DESCRIPTION
ADR-0056 §B, following #342. After this, `media_library` has **zero ungated permissions** — only §C (a list function and its own route) stands between here and the `/admin/media` screen.

## The hole

`media.delete`, `media.restore`, `media.purge` have been in the global catalog since `sql/052`, granted whole to every tenant owner, and enforced by **nothing** — no route, no application function, no job. The functions behind them were written and had zero callers.

So an object uploaded by mistake, orphaned, or violating policy disappeared only if the reconciliation job happened to categorise it that way, on the job's own schedule. There was no way for an administrator to remove one, and no way to undo it if they were wrong.

| Endpoint | Permission | Notes |
|---|---|---|
| `DELETE /api/v1/media/objects/{id}` | `media.delete` | Body `{ reason }`, required, bounded at 500. |
| `POST /api/v1/media/objects/{id}/restore` | `media.restore` | A live object answers 404. |
| `POST /api/v1/media/objects/{id}/purge` | `media.purge` | Registry row only. Cannot be undone. |

All three are `HIGH_RISK_ACTIONS` and require `Idempotency-Key`, **each under its own scope** so a delete's key cannot collide with a purge's. Delete's request hash covers the reason — otherwise a replayed key returns the first response while the audit row records a reason nobody sent.

## Three decisions worth reviewing

**Soft delete breaks live references, deliberately.** `resolveMediaReferences` filters `deleted_at IS NULL`, so a post whose `featured_media_id` points here resolves to nothing immediately. That is the intended outcome for the case this serves — a policy-violating image must stop being served — and `restore` is what makes it recoverable. Nothing scans for referencing rows first: that would make a System Foundation module know its own consumers, which `module.ts` forbids in as many words.

**`purge` clears the registry, not the R2 bytes** (§B states this). The `news-media:reconcile` job owns the bucket; a second writer would mean two processes with different ideas of what is safe to remove. Accepted, stated cost: a window where the R2 object outlives its registry row, closed by the next tick, which sees a key with no row and treats it as orphan-in-R2.

**`purge` runs inside a SAVEPOINT.** `awcms_news_portal_ad_placements.media_object_id` is a hard NOT NULL FK, so purging a referenced object raises `23503` — and in PostgreSQL that **aborts the whole transaction**. Catching it without a savepoint turns a caller-actionable 409 into a 500 at the COMMIT `withTenant` performs. There is deliberately no pre-check SELECT to go with it (unlike `provisionTenant`): a pre-check would have to name the referencing tables. Letting the FK answer keeps that knowledge in the database and stays correct the day a second module adds a reference.

## A defect the verification turned up

I probed the savepoint behaviour against a real database rather than reasoning about it, and the probe printed something I did not expect:

```
code:  ERR_POSTGRES_SERVER_ERROR
errno: 23503
```

**The SQLSTATE is on `error.errno`, not `error.code`.** Bun sets `code` to its own constant for every server error alike, so `error.code === "23505"` is not a subtly wrong check — it is one that can never be true, leaving everything downstream of it dead code.

My new `isForeignKeyViolation` had it wrong. So does one pre-existing site: **`tenant-provisioning.ts`**, where `POST /api/v1/tenants` promises `409 duplicate_tenant_code` and served a **500** on the concurrent-duplicate race its savepoint exists for. Its pre-check SELECT hid the ordinary case, which is why it shipped.

It reads correctly — `error.code` is exactly where a SQLSTATE lives in `pg` and most Node drivers, so the wrong version is what a reviewer expects to see. Ten sites here already used `String(error.errno)`; two did not, and both were found by probing, not reading. Fixed rather than filed, and `tests/postgres-sqlstate-detection.test.ts` now gates it repo-wide.

## Verification

`tests/media-object-lifecycle-routes.test.ts` (11 tests) plus the new SQLSTATE gate. Mutation-proven, each red on its own:

| Mutation | Result |
|---|---|
| Guard `purge` on an action nothing seeds | red |
| Give `restore` the same idempotency scope as `purge` | red |
| Drop `ROLLBACK TO SAVEPOINT` from purge | red |
| Drop the reason from delete's request hash | red |
| **Restore the original `.code === UNIQUE_VIOLATION` defect** | red |

Savepoint mechanics verified against PostgreSQL 18: without one, the next statement fails `current transaction is aborted`; with one, the transaction stays usable and the COMMIT succeeds.

Full `bun run check` green locally — 3285 pass, 0 fail, build complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)