### PR TITLE
feat(media-library): browse listing route (ADR-0056 §C)

### DIFF
--- a/.changeset/media-object-list-route.md
+++ b/.changeset/media-object-list-route.md
@@ -1,0 +1,23 @@
+---
+"awcms": minor
+---
+
+Add `listMediaObjects` and `GET /api/v1/media/objects/list` (ADR-0056 §C) — the last piece before `/admin/media`.
+
+Until now the application layer had only point lookups: `fetchNewsMediaObjectById`, `fetchNewsMediaObjectsByIds`, `fetchNewsMediaObjectByObjectKey`. There was no way to ask "what media does this tenant have", so a browse screen could not be built on the existing surface at all, whatever the permission catalog said.
+
+**It gets its own route rather than a mode on the resolver.** `GET /api/v1/media/objects` demands `?ids=` — it is a batch resolver built for the `awcms-astro` build to swap ids for public URLs. Teaching it a "no `ids` means list everything" branch would turn a request that is a 400 today into a dump of the entire registry: a contract change wearing the clothes of an addition, and one no existing caller could opt out of.
+
+`list` cannot be read as an object id, because `[id].ts` and its children now require a uuid and answer 400 otherwise. That closes the path ambiguity from the other side, so Astro's static-before-dynamic precedence is not the only thing keeping `/list` and `/{id}` apart.
+
+**The listing deliberately outgrows the resolver's safety rule.** It returns rows in any status — `pending_upload`, `failed`, `orphaned` — and, with `deletion=deleted|all`, soft-deleted ones. `isNewsMediaObjectSafeForPublicReference` admits only `verified`/`attached`; an administrator opens this list precisely because of the objects that are *not* healthy, and §B's lifecycle endpoints would otherwise have no way to find their targets. `media.read` keeps it inside the tenant, and nothing returned here may be used as a public reference.
+
+`deletion` is three states rather than a boolean `includeDeleted`: "show me what I deleted" is the question restore and purge exist to answer, and a boolean cannot ask it. It defaults to `live`, so deleted objects are opt-in.
+
+Filters and cursors are **refused when malformed, never ignored** — a silently dropped filter answers 200 with a page nobody asked for, and a corrupt cursor treated as "no cursor" serves page 1 to a caller paging through page 4, forever.
+
+The cursor carries full-precision `created_at` text, never a JS `Date`. A media registry is one of the likeliest places to resurrect Issue #158, because a batch upload writes many rows inside a single millisecond. `tests/integration/media-object-list.integration.test.ts` inserts 107 rows in ONE statement — so they share a transaction timestamp exactly — and walks every page; reverting the cursor to `Date` loses 57 of them and turns four tests red.
+
+The projection omits `bucket_name`/`storage_driver` (deployment facts a browse screen has no use for) and `owner_resource_type`/`owner_resource_id` (vestigial since ADR-0036 moved attachment to the consumer's FK — shipping them would invite a screen to present them as current).
+
+ADR-0056 is now complete. What remains is the `/admin/media` screen itself.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -331,7 +331,22 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
     berjalan dalam SAVEPOINT karena FK keras dari
     `awcms_news_portal_ad_placements` membuat `23503` MEMBATALKAN transaksi
     (tanpa savepoint, 409 yang bisa ditindaklanjuti berubah jadi 500 saat
-    COMMIT). Tersisa §C: `listMediaObjects` + rute daftar sendiri, lalu layar.
+    COMMIT).
+
+    **§C SELESAI juga.** `listMediaObjects` (keyset, 50/halaman) +
+    `GET /api/v1/media/objects/list` — rute SENDIRI, bukan mode-ganda pada
+    `?ids=`. Sebelumnya lapisan aplikasi hanya punya point lookup, jadi layar
+    browse memang TIDAK BISA dibangun di atas permukaan lama, apa pun kata
+    permission-nya. Daftar ini sengaja MELAMPAUI aturan aman resolver (status
+    apa pun, plus soft-deleted bila diminta): justru objek tak-sehat itulah
+    alasan administrator membukanya. `/list` tak bisa bentrok dengan id karena
+    rute `/{id}` kini menuntut uuid. Kursor membawa teks presisi mikrodetik —
+    integration test menyisipkan 107 baris dalam SATU statement lalu menyusuri
+    tiap halaman; mengembalikan kursor ke `Date` kehilangan 57 baris (jebakan
+    #158, dan registry media adalah tempat paling mungkin ia kambuh).
+
+    **ADR-0056 selesai seluruhnya. Yang tersisa hanyalah layar `/admin/media`
+    itu sendiri** — dan sesudahnya kriteria 1 ADR-0021 tinggal nol pengecualian.
 
     > **Temuan sampingan, sudah diperbaiki di PR yang sama.** SQLSTATE Postgres
     > ada di `error.errno`, BUKAN `error.code` — Bun mengisi `code` dengan

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -4460,6 +4460,42 @@ Restoring an object that is NOT soft-deleted answers 404 rather than succeeding 
 | 404    | Resource not found.                                                               | [`ApiError`](#standard-error-envelope) |
 | 409    | The Idempotency-Key was reused with a different request (`IDEMPOTENCY_CONFLICT`). | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/media/objects/list` — Browse this tenant's media registry.
+
+- **operationId**: `mediaObjectList`
+- **Security**: bearerAuth + tenantHeader
+
+Gated on `media_library.media.read`. Keyset-paginated, newest first, 50 per page. Read-only, so a machine credential (ADR-0049) may hold it.
+
+**A separate path from `GET /api/v1/media/objects`, deliberately.** That endpoint demands `?ids=` — it is a batch RESOLVER built for the `awcms-astro` build to swap ids for public URLs. Teaching it a "no `ids` means list everything" branch would turn a request that is a 400 today into a dump of the whole registry: a contract change wearing the clothes of an addition, and one no existing caller could opt out of.
+
+`list` can never be mistaken for an object id — the object routes require a uuid and answer 400 otherwise — so this static path and `/{id}` do not contend.
+
+**Unlike the resolver, this returns rows in ANY status** (`pending_upload`, `failed`, `orphaned`) and, with `deletion`, soft-deleted ones. That inverts the resolver's public-safety rule on purpose: an administrator opens this list precisely because of the objects that are not healthy, and the lifecycle endpoints need a way to find their targets. Nothing returned here may be used as a public reference — that is what the resolver is for.
+
+The projection omits `bucket_name`/`storage_driver` (deployment facts) and `owner_resource_type`/`owner_resource_id` (vestigial since ADR-0036 moved attachment to the consumer's FK).
+
+`cursor` is opaque: pass back `nextCursor` verbatim. A malformed one is a 400, never silently treated as "no cursor" — that would serve page 1 to a caller who asked for page 4.
+
+**Parameters**
+
+| Name               | In     | Required | Type                                                                                        | Description                                                                                                                                |
+| ------------------ | ------ | -------- | ------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `status`           | query  | no       | enum(`pending_upload`, `uploaded`, `verified`, `attached`, `orphaned`, `deleted`, `failed`) | Exact media object status. An unrecognised value is a 400, never ignored.                                                                  |
+| `mimeType`         | query  | no       | string                                                                                      | Exact mime type. Lowercased before matching, since that is how the registry stores it.                                                     |
+| `deletion`         | query  | no       | enum(`live`, `deleted`, `all`)                                                              | Which soft-delete state to list. Defaults to `live`; `deleted` is what a restore/purge workflow needs, and a boolean could not ask for it. |
+| `cursor`           | query  | no       | string                                                                                      | Opaque keyset cursor from a previous response's `nextCursor`.                                                                              |
+| `X-Correlation-ID` | header | no       | string                                                                                      |                                                                                                                                            |
+
+**Responses**
+
+| Status | Description                              | Schema                                 |
+| ------ | ---------------------------------------- | -------------------------------------- |
+| 200    | One page of media objects, newest first. | object                                 |
+| 400    | Validation error.                        | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.              | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.              | [`ApiError`](#standard-error-envelope) |
+
 ## Blog Content
 
 Tenant-scoped blog/content administration (blog_content module, ported from awcms-mini) — posts and pages with their full lifecycle (draft → review → scheduled/published → archived, soft delete/restore/purge), hierarchical categories/tags, append-only revision history (restore APPENDS a revision, never overwrites), PostgreSQL full-text search, presentation/monetization extensions (templates, hierarchical menus, position-based widgets, advertisements), per-tenant blog settings, internal tag-link policy, and the editorial content-quality checklist. The public, anonymous reader surface (`/blog/{tenantCode}/...` index/detail/archive/search/feed/sitemap, ADR-0009) is served by Astro text/html/xml routes and is deliberately NOT part of this REST contract. Publish/unpublish/purge and settings writes are ABAC-gated, idempotency-keyed, and audited.

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -617,6 +617,11 @@
       "source": "factory"
     },
     {
+      "path": "src/pages/api/v1/media/objects/list.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/modules/[moduleKey].ts",
       "workClass": "interactive",
       "source": "default"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -8279,6 +8279,94 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/media/objects/list:
+    get:
+      operationId: mediaObjectList
+      tags:
+        - News Media
+      summary: Browse this tenant's media registry.
+      description: |
+        Gated on `media_library.media.read`. Keyset-paginated, newest first, 50 per page. Read-only, so a machine credential (ADR-0049) may hold it.
+
+        **A separate path from `GET /api/v1/media/objects`, deliberately.** That endpoint demands `?ids=` — it is a batch RESOLVER built for the `awcms-astro` build to swap ids for public URLs. Teaching it a "no `ids` means list everything" branch would turn a request that is a 400 today into a dump of the whole registry: a contract change wearing the clothes of an addition, and one no existing caller could opt out of.
+
+        `list` can never be mistaken for an object id — the object routes require a uuid and answer 400 otherwise — so this static path and `/{id}` do not contend.
+
+        **Unlike the resolver, this returns rows in ANY status** (`pending_upload`, `failed`, `orphaned`) and, with `deletion`, soft-deleted ones. That inverts the resolver's public-safety rule on purpose: an administrator opens this list precisely because of the objects that are not healthy, and the lifecycle endpoints need a way to find their targets. Nothing returned here may be used as a public reference — that is what the resolver is for.
+
+        The projection omits `bucket_name`/`storage_driver` (deployment facts) and `owner_resource_type`/`owner_resource_id` (vestigial since ADR-0036 moved attachment to the consumer's FK).
+
+        `cursor` is opaque: pass back `nextCursor` verbatim. A malformed one is a 400, never silently treated as "no cursor" — that would serve page 1 to a caller who asked for page 4.
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: Exact media object status. An unrecognised value is a 400, never ignored.
+          schema:
+            type: string
+            enum:
+              - pending_upload
+              - uploaded
+              - verified
+              - attached
+              - orphaned
+              - deleted
+              - failed
+        - name: mimeType
+          in: query
+          required: false
+          description: Exact mime type. Lowercased before matching, since that is how the registry stores it.
+          schema:
+            type: string
+        - name: deletion
+          in: query
+          required: false
+          description: Which soft-delete state to list. Defaults to `live`; `deleted` is what a restore/purge workflow needs, and a boolean could not ask for it.
+          schema:
+            type: string
+            enum:
+              - live
+              - deleted
+              - all
+            default: live
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous response's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: One page of media objects, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/MediaObjectListItem"
+                      nextCursor:
+                        type: string
+                        nullable: true
+                        description: Null on the last page.
+                      pageSize:
+                        type: integer
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/modules:
     get:
       operationId: listModuleCatalog
@@ -17201,6 +17289,67 @@ components:
           enum:
             - deleted
             - purged
+    MediaObjectListItem:
+      type: object
+      description: One registry row as the browse listing presents it. NOT a public reference — unlike `ResolvedMediaReference`, an item here may be in any status, including one that is unsafe to publish.
+      properties:
+        id:
+          type: string
+          format: uuid
+        objectKey:
+          type: string
+        publicUrl:
+          type: string
+        originalFilename:
+          type: string
+          nullable: true
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          nullable: true
+        checksumSha256:
+          type: string
+          nullable: true
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            - pending_upload
+            - uploaded
+            - verified
+            - attached
+            - orphaned
+            - deleted
+            - failed
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+        deleteReason:
+          type: string
+          nullable: true
+        restoredAt:
+          type: string
+          format: date-time
+          nullable: true
     MediaObjectRestored:
       type: object
       description: Result of a restore. `status` here IS the object's own lifecycle status column, untouched by soft delete and therefore whatever it was before.

--- a/openapi/modules/media-library.openapi.yaml
+++ b/openapi/modules/media-library.openapi.yaml
@@ -217,6 +217,90 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/media/objects/list:
+    get:
+      operationId: mediaObjectList
+      tags:
+        - News Media
+      summary: Browse this tenant's media registry.
+      description: |
+        Gated on `media_library.media.read`. Keyset-paginated, newest first, 50 per page. Read-only, so a machine credential (ADR-0049) may hold it.
+
+        **A separate path from `GET /api/v1/media/objects`, deliberately.** That endpoint demands `?ids=` — it is a batch RESOLVER built for the `awcms-astro` build to swap ids for public URLs. Teaching it a "no `ids` means list everything" branch would turn a request that is a 400 today into a dump of the whole registry: a contract change wearing the clothes of an addition, and one no existing caller could opt out of.
+
+        `list` can never be mistaken for an object id — the object routes require a uuid and answer 400 otherwise — so this static path and `/{id}` do not contend.
+
+        **Unlike the resolver, this returns rows in ANY status** (`pending_upload`, `failed`, `orphaned`) and, with `deletion`, soft-deleted ones. That inverts the resolver's public-safety rule on purpose: an administrator opens this list precisely because of the objects that are not healthy, and the lifecycle endpoints need a way to find their targets. Nothing returned here may be used as a public reference — that is what the resolver is for.
+
+        The projection omits `bucket_name`/`storage_driver` (deployment facts) and `owner_resource_type`/`owner_resource_id` (vestigial since ADR-0036 moved attachment to the consumer's FK).
+
+        `cursor` is opaque: pass back `nextCursor` verbatim. A malformed one is a 400, never silently treated as "no cursor" — that would serve page 1 to a caller who asked for page 4.
+      parameters:
+        - name: status
+          in: query
+          required: false
+          description: Exact media object status. An unrecognised value is a 400, never ignored.
+          schema:
+            type: string
+            enum:
+              - pending_upload
+              - uploaded
+              - verified
+              - attached
+              - orphaned
+              - deleted
+              - failed
+        - name: mimeType
+          in: query
+          required: false
+          description: Exact mime type. Lowercased before matching, since that is how the registry stores it.
+          schema:
+            type: string
+        - name: deletion
+          in: query
+          required: false
+          description: "Which soft-delete state to list. Defaults to `live`; `deleted` is what a restore/purge workflow needs, and a boolean could not ask for it."
+          schema:
+            type: string
+            enum: [live, deleted, all]
+            default: live
+        - name: cursor
+          in: query
+          required: false
+          description: Opaque keyset cursor from a previous response's `nextCursor`.
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: One page of media objects, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/MediaObjectListItem"
+                      nextCursor:
+                        type: string
+                        nullable: true
+                        description: Null on the last page.
+                      pageSize:
+                        type: integer
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/media/objects/{id}:
     delete:
       operationId: mediaObjectSoftDelete
@@ -449,6 +533,67 @@ paths:
                 $ref: "#/components/schemas/ApiError"
 components:
   schemas:
+    MediaObjectListItem:
+      type: object
+      description: One registry row as the browse listing presents it. NOT a public reference — unlike `ResolvedMediaReference`, an item here may be in any status, including one that is unsafe to publish.
+      properties:
+        id:
+          type: string
+          format: uuid
+        objectKey:
+          type: string
+        publicUrl:
+          type: string
+        originalFilename:
+          type: string
+          nullable: true
+        mimeType:
+          type: string
+        sizeBytes:
+          type: integer
+          nullable: true
+        checksumSha256:
+          type: string
+          nullable: true
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+        altText:
+          type: string
+          nullable: true
+        caption:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum:
+            - pending_upload
+            - uploaded
+            - verified
+            - attached
+            - orphaned
+            - deleted
+            - failed
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+        deleteReason:
+          type: string
+          nullable: true
+        restoredAt:
+          type: string
+          format: date-time
+          nullable: true
     SoftDeleteMediaObjectRequest:
       type: object
       required:

--- a/src/modules/media-library/README.md
+++ b/src/modules/media-library/README.md
@@ -125,12 +125,44 @@ at COMMIT. The SQLSTATE is read from `error.errno` — Bun puts its own constant
 on `error.code`, so comparing `code` to `"23503"` can never be true
 (`tests/postgres-sqlstate-detection.test.ts` now gates this repo-wide).
 
+## Browse listing ([ADR-0056](../../../docs/adr/0056-media-library-admin-surface.md) §C)
+
+`GET /api/v1/media/objects/list` — gated on `media_library.media.read`, keyset
+paginated (50/page), newest first. Filters: `status`, `mimeType`, `deletion`
+(`live` | `deleted` | `all`, default `live`), `cursor`.
+
+Before this, the application layer had only point lookups
+(`fetchNewsMediaObjectById`, `...ByIds`, `...ByObjectKey`). There was no way to
+ask "what media does this tenant have", so a browse screen could not be built on
+the existing surface at all, whatever the permissions said.
+
+**A separate path from `GET /api/v1/media/objects`, deliberately.** That
+endpoint demands `?ids=` — it is a batch RESOLVER for the `awcms-astro` build.
+Teaching it a no-`ids` mode would turn a request that is a **400 today** into a
+dump of the whole registry: a contract change wearing the clothes of an
+addition. `list` can never be read as an object id, because the `/{id}` routes
+require a uuid and answer 400 otherwise — so the static/dynamic precedence rule
+is not the only thing keeping the two paths apart.
+
+**It deliberately outgrows the resolver's safety rule**, returning rows in ANY
+status and, on request, soft-deleted ones. `isNewsMediaObjectSafeForPublicReference`
+admits only `verified`/`attached`; an administrator opens this list precisely
+because of the objects that are NOT healthy, and §B's lifecycle endpoints would
+otherwise have no way to find their targets. Nothing returned here may be used
+as a public reference — that is what the resolver is for.
+
+The cursor carries full-precision `created_at` text, never a JS `Date`. A batch
+upload writes many rows inside one millisecond, which is the exact shape of
+Issue #158; `tests/integration/media-object-list.integration.test.ts` inserts
+107 rows in ONE statement and walks every page, and reverting the cursor to a
+`Date` loses 57 of them.
+
 ## Not ported to this base (deferred, additive)
 
-The `/admin/media` screen (micro step 5d — the lifecycle API half above is now
-ported, so this module still declares no `navigation`), responsive `srcset`
-render (step 5b), and the PDF media type (step 5c). The allowed MIME set stays
-the four raster types.
+The `/admin/media` screen (micro step 5d — the whole API half is now ported, so
+this is all that remains of it; the module still declares no `navigation`),
+responsive `srcset` render (step 5b), and the PDF media type (step 5c). The
+allowed MIME set stays the four raster types.
 
 ## Resolusi referensi media (`GET /api/v1/media/objects`)
 

--- a/src/modules/media-library/application/media-object-directory.ts
+++ b/src/modules/media-library/application/media-object-directory.ts
@@ -1,4 +1,9 @@
 import { recordAuditEvent } from "../../logging/application/audit-log";
+import {
+  encodeKeysetCursor,
+  KEYSET_CURSOR_CREATED_AT_SQL,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
 import type { NewsMediaR2Config } from "../domain/media-r2-config";
 import {
   buildNewsMediaObjectKey,
@@ -243,6 +248,119 @@ export async function createPendingNewsMediaObject(
 export type FetchNewsMediaObjectOptions = {
   includeDeleted?: boolean;
 };
+
+/**
+ * Column list shared by the keyset list query below. The point lookups keep
+ * their inline lists — rewriting six working queries to share a constant would
+ * be churn dressed as tidiness — but a list query must select these columns
+ * PLUS the cursor expression, and repeating them a seventh time beside an
+ * `AS created_at_cursor` alias is exactly where a column silently goes missing.
+ */
+const SELECT_COLUMNS =
+  "id, tenant_id, module_key, owner_resource_type, owner_resource_id, " +
+  "storage_driver, bucket_name, object_key, original_filename, public_url, " +
+  "mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption, " +
+  "status, created_by_tenant_user_id, created_at, updated_at, " +
+  "deleted_at, deleted_by, delete_reason, restored_at, restored_by";
+
+/** Page size for {@link listMediaObjects} — bounded, keyset-paginated. */
+export const MEDIA_OBJECT_LIST_LIMIT = 50;
+
+/**
+ * Which soft-delete state a listing wants.
+ *
+ * A boolean `includeDeleted` (the point lookups' convention) is wrong for a
+ * BROWSE surface: the admin screen's whole reason to look at deleted objects is
+ * to restore or purge them, and folding them in with live ones makes "show me
+ * what I deleted" impossible to ask. Three explicit states, `"live"` by default
+ * — a listing that silently included soft-deleted objects would put rows in
+ * front of an operator that no consumer can resolve.
+ */
+export type MediaObjectDeletionFilter = "live" | "deleted" | "all";
+
+export type ListMediaObjectsFilter = {
+  status?: NewsMediaObjectStatus;
+  /** Exact match on the stored (already lowercased) mime type. */
+  mimeType?: string;
+  deletion?: MediaObjectDeletionFilter;
+};
+
+/**
+ * Browse the tenant's media registry — keyset paginated, newest first
+ * (ADR-0056 §C).
+ *
+ * ## Why this is a new function and not a widened `?ids=`
+ *
+ * `GET /api/v1/media/objects` demands `?ids=`: it is a batch RESOLVER, built
+ * for `awcms-astro` to swap ids for URLs at build time, and it answers only for
+ * objects safe to reference publicly. Before this function the application
+ * layer had `fetchNewsMediaObjectById`, `fetchNewsMediaObjectsByIds`, and
+ * `fetchNewsMediaObjectByObjectKey` — every one a point lookup. There was no
+ * way to ask "what media does this tenant have", so a browse screen could not
+ * be built on the existing surface at all, whatever the permissions said.
+ *
+ * Teaching the resolver a no-`ids` mode would turn a request that is a 400
+ * today into a dump of the whole registry — a contract change wearing the
+ * clothes of an addition. Hence a separate function and a separate route.
+ *
+ * ## Deliberately unlike the resolver
+ *
+ * This returns rows in ANY status, including `pending_upload` and `failed`,
+ * and (when asked) soft-deleted ones. That is the opposite of
+ * `isNewsMediaObjectSafeForPublicReference`, and it is correct here: an
+ * administrator's reason to open this list is usually the objects that are NOT
+ * healthy. The `media.read` guard is what keeps that inside the tenant, and no
+ * caller of this function may use its rows as a public reference — use the port
+ * for that.
+ *
+ * The cursor carries FULL-PRECISION `created_at` text
+ * (`KEYSET_CURSOR_CREATED_AT_SQL`), never a JS `Date`, so a page boundary
+ * cannot skip rows sharing a millisecond — the trap this repo already paid for
+ * (Issue #158), and one a media registry walks straight into, since a batch
+ * upload writes many rows inside the same millisecond.
+ */
+export async function listMediaObjects(
+  tx: Bun.SQL,
+  tenantId: string,
+  filter: ListMediaObjectsFilter = {},
+  cursor?: KeysetCursor
+): Promise<{ items: NewsMediaObjectView[]; nextCursor: string | null }> {
+  const statusParam = filter.status ?? null;
+  const mimeTypeParam = filter.mimeType ?? null;
+  const deletion: MediaObjectDeletionFilter = filter.deletion ?? "live";
+  const cursorCreatedAt = cursor ? cursor.createdAt : null;
+  const cursorId = cursor ? cursor.id : null;
+
+  const rows = (await tx`
+    SELECT ${tx.unsafe(SELECT_COLUMNS)},
+           ${tx.unsafe(KEYSET_CURSOR_CREATED_AT_SQL)} AS created_at_cursor
+    FROM awcms_news_media_objects
+    WHERE tenant_id = ${tenantId}
+      AND (${statusParam}::text IS NULL OR status = ${statusParam})
+      AND (${mimeTypeParam}::text IS NULL OR mime_type = ${mimeTypeParam})
+      AND (
+        ${deletion} = 'all'
+        OR (${deletion} = 'live' AND deleted_at IS NULL)
+        OR (${deletion} = 'deleted' AND deleted_at IS NOT NULL)
+      )
+      AND (
+        ${cursorCreatedAt}::timestamptz IS NULL
+        OR (created_at, id) < (${cursorCreatedAt}::timestamptz, ${cursorId}::uuid)
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${MEDIA_OBJECT_LIST_LIMIT}
+  `) as (NewsMediaObjectRow & { created_at_cursor: string })[];
+
+  const last = rows[rows.length - 1];
+
+  return {
+    items: rows.map(toView),
+    nextCursor:
+      rows.length === MEDIA_OBJECT_LIST_LIMIT && last
+        ? encodeKeysetCursor(last.created_at_cursor, last.id)
+        : null
+  };
+}
 
 export async function fetchNewsMediaObjectById(
   tx: Bun.SQL,

--- a/src/modules/media-library/domain/media-object-id.ts
+++ b/src/modules/media-library/domain/media-object-id.ts
@@ -1,0 +1,25 @@
+/**
+ * Path-parameter validation for the media object routes.
+ *
+ * ## Why the id shape is load-bearing here, and not merely tidy
+ *
+ * `GET /api/v1/media/objects/list` (ADR-0056 §C) is a STATIC sibling of
+ * `[id].ts`. Astro resolves static routes first, so `/objects/list` reaches the
+ * list route — but that is a framework precedence rule, and on its own it makes
+ * "the list" and "the object whose id is `list`" two readings of one path, with
+ * only the framework deciding between them.
+ *
+ * Requiring a uuid closes it from the other side: there is no object `list`
+ * could have addressed, so the precedence rule is not what keeps the two apart.
+ * `tests/media-object-list-route.test.ts` asserts both halves.
+ *
+ * The secondary benefit is the ordinary one — a malformed id answers `400`
+ * before the transaction opens, instead of `22P02 invalid input syntax for type
+ * uuid` surfacing as a 500 the caller cannot act on.
+ */
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isMediaObjectId(value: string | undefined): value is string {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}

--- a/src/pages/api/v1/media/objects/[id].ts
+++ b/src/pages/api/v1/media/objects/[id].ts
@@ -16,6 +16,7 @@ import {
 import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../modules/media-library/domain/media-permissions";
 import { validateSoftDeleteMediaObjectInput } from "../../../../../modules/media-library/domain/media-lifecycle-validation";
 import { softDeleteNewsMediaObject } from "../../../../../modules/media-library/application/media-object-directory";
+import { isMediaObjectId } from "../../../../../modules/media-library/domain/media-object-id";
 import { log } from "../../../../../lib/logging/logger";
 
 /**
@@ -91,8 +92,8 @@ export const DELETE = defineTenantRoute<Prepared>({
   handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
     const objectId = params.id;
 
-    if (!objectId) {
-      return fail(400, "VALIDATION_ERROR", "Media object id is required.");
+    if (!isMediaObjectId(objectId)) {
+      return fail(400, "VALIDATION_ERROR", "Media object id must be a uuid.");
     }
 
     // The reason is part of the request hash: replaying the same key with a

--- a/src/pages/api/v1/media/objects/[id]/purge.ts
+++ b/src/pages/api/v1/media/objects/[id]/purge.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../../../modules/_shared/idempotency";
 import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../../modules/media-library/domain/media-permissions";
 import { purgeNewsMediaObject } from "../../../../../../modules/media-library/application/media-object-directory";
+import { isMediaObjectId } from "../../../../../../modules/media-library/domain/media-object-id";
 import { log } from "../../../../../../lib/logging/logger";
 
 /**
@@ -71,8 +72,8 @@ export const POST = defineTenantRoute<Prepared>({
   handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
     const objectId = params.id;
 
-    if (!objectId) {
-      return fail(400, "VALIDATION_ERROR", "Media object id is required.");
+    if (!isMediaObjectId(objectId)) {
+      return fail(400, "VALIDATION_ERROR", "Media object id must be a uuid.");
     }
 
     const requestHash = computeRequestHash({ objectId, action: "purge" });

--- a/src/pages/api/v1/media/objects/[id]/restore.ts
+++ b/src/pages/api/v1/media/objects/[id]/restore.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../../../modules/_shared/idempotency";
 import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../../modules/media-library/domain/media-permissions";
 import { restoreNewsMediaObject } from "../../../../../../modules/media-library/application/media-object-directory";
+import { isMediaObjectId } from "../../../../../../modules/media-library/domain/media-object-id";
 import { log } from "../../../../../../lib/logging/logger";
 
 /**
@@ -59,8 +60,8 @@ export const POST = defineTenantRoute<Prepared>({
   handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
     const objectId = params.id;
 
-    if (!objectId) {
-      return fail(400, "VALIDATION_ERROR", "Media object id is required.");
+    if (!isMediaObjectId(objectId)) {
+      return fail(400, "VALIDATION_ERROR", "Media object id must be a uuid.");
     }
 
     const requestHash = computeRequestHash({ objectId, action: "restore" });

--- a/src/pages/api/v1/media/objects/list.ts
+++ b/src/pages/api/v1/media/objects/list.ts
@@ -1,0 +1,165 @@
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import { decodeKeysetCursor } from "../../../../../modules/_shared/keyset-pagination";
+import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../modules/media-library/domain/media-permissions";
+import {
+  listMediaObjects,
+  MEDIA_OBJECT_LIST_LIMIT,
+  type ListMediaObjectsFilter,
+  type MediaObjectDeletionFilter,
+  type NewsMediaObjectStatus
+} from "../../../../../modules/media-library/application/media-object-directory";
+
+/**
+ * `GET /api/v1/media/objects/list` (ADR-0056 §C) — browse this tenant's media
+ * registry, keyset-paginated, newest first.
+ *
+ * ## Why a separate route from `GET /api/v1/media/objects`
+ *
+ * That endpoint demands `?ids=`. It is a batch RESOLVER built for the
+ * `awcms-astro` build to swap ids for public URLs, and it answers only for
+ * objects safe to reference publicly. Adding a "no `ids` means list everything"
+ * branch to it would change what a request that is a **400 today** means, into
+ * a dump of the entire registry — a contract change wearing the clothes of an
+ * addition, and one no existing caller could opt out of.
+ *
+ * ## `/list` is unambiguous because ids are uuids
+ *
+ * This file is a STATIC sibling of `[id].ts`, and Astro resolves static routes
+ * before dynamic ones. The two can never contend: `list` is not a uuid, and
+ * `[id].ts` and its children reject a non-uuid id with `400` before touching
+ * the database, so there is no object this path could otherwise have addressed.
+ * `tests/media-object-list-route.test.ts` pins both halves.
+ *
+ * ## What this returns that the resolver will not
+ *
+ * Rows in ANY status — `pending_upload`, `failed`, `orphaned` — and, on
+ * request, soft-deleted ones. That inverts
+ * `isNewsMediaObjectSafeForPublicReference` on purpose: an administrator opens
+ * this list precisely because of the objects that are NOT healthy, and the
+ * lifecycle endpoints (§B) need a way to find their targets. `media.read`
+ * keeps it inside the tenant; nothing here may be used as a public reference.
+ *
+ * The projection is deliberately narrower than the row: `bucket_name` and
+ * `storage_driver` are deployment facts a browse screen has no use for, and
+ * `owner_resource_type`/`owner_resource_id` are vestigial since ADR-0036 moved
+ * attachment to the consumer's FK — shipping them would invite a screen to
+ * present them as current.
+ *
+ * Read-only, so a machine credential (ADR-0049) may hold the permission.
+ */
+const VALID_STATUSES: readonly NewsMediaObjectStatus[] = [
+  "pending_upload",
+  "uploaded",
+  "verified",
+  "attached",
+  "orphaned",
+  "deleted",
+  "failed"
+];
+
+const VALID_DELETION_FILTERS: readonly MediaObjectDeletionFilter[] = [
+  "live",
+  "deleted",
+  "all"
+];
+
+type Prepared = {
+  filter: ListMediaObjectsFilter;
+  cursor: ReturnType<typeof decodeKeysetCursor>;
+};
+
+export const GET = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: ({ url }) => {
+    const status = url.searchParams.get("status");
+    const mimeType = url.searchParams.get("mimeType");
+    const deletion = url.searchParams.get("deletion");
+    const cursorParam = url.searchParams.get("cursor");
+
+    // An unknown filter value is REFUSED, never ignored. Silently dropping it
+    // answers 200 with a page the caller did not ask for, and a screen filtered
+    // on a typo would look like an empty registry.
+    if (status !== null && !VALID_STATUSES.includes(status as never)) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        `status must be one of: ${VALID_STATUSES.join(", ")}.`
+      );
+    }
+
+    if (
+      deletion !== null &&
+      !VALID_DELETION_FILTERS.includes(deletion as never)
+    ) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        `deletion must be one of: ${VALID_DELETION_FILTERS.join(", ")}.`
+      );
+    }
+
+    let cursor: ReturnType<typeof decodeKeysetCursor>;
+
+    if (cursorParam === null) {
+      cursor = null;
+    } else {
+      cursor = decodeKeysetCursor(cursorParam);
+
+      // A corrupt cursor must not be treated as "no cursor": that quietly
+      // serves page 1 to a caller who asked for page 4, and the loop never
+      // terminates.
+      if (!cursor) {
+        return fail(400, "VALIDATION_ERROR", "cursor is malformed.");
+      }
+    }
+
+    return {
+      filter: {
+        status: (status as NewsMediaObjectStatus | null) ?? undefined,
+        // Stored lowercased by `createPendingNewsMediaObject`, so the filter
+        // matches it rather than requiring the caller to know that.
+        mimeType: mimeType?.trim().toLowerCase() || undefined,
+        deletion: (deletion as MediaObjectDeletionFilter | null) ?? undefined
+      },
+      cursor
+    };
+  },
+  authorize: {
+    moduleKey: "media_library",
+    activityCode: MEDIA_PERMISSION_ACTIVITY_CODE,
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, prepared }) => {
+    const { items, nextCursor } = await listMediaObjects(
+      tx,
+      tenantId,
+      prepared.filter,
+      prepared.cursor ?? undefined
+    );
+
+    return ok({
+      items: items.map((item) => ({
+        id: item.id,
+        objectKey: item.objectKey,
+        publicUrl: item.publicUrl,
+        originalFilename: item.originalFilename,
+        mimeType: item.mimeType,
+        sizeBytes: item.sizeBytes,
+        checksumSha256: item.checksumSha256,
+        width: item.width,
+        height: item.height,
+        altText: item.altText,
+        caption: item.caption,
+        status: item.status,
+        createdAt: item.createdAt,
+        updatedAt: item.updatedAt,
+        deletedAt: item.deletedAt,
+        deleteReason: item.deleteReason,
+        restoredAt: item.restoredAt
+      })),
+      nextCursor,
+      pageSize: MEDIA_OBJECT_LIST_LIMIT
+    });
+  }
+});

--- a/tests/integration/media-object-list.integration.test.ts
+++ b/tests/integration/media-object-list.integration.test.ts
@@ -1,0 +1,269 @@
+/**
+ * `listMediaObjects` (ADR-0056 §C) against a real PostgreSQL.
+ *
+ * This is the function `GET /api/v1/media/objects/list` is built on, and it is
+ * the first LIST over `awcms_news_media_objects` — every other read in this
+ * module is a point lookup. Three properties need a real database to prove:
+ *
+ * 1. **The keyset cursor does not skip rows sharing a millisecond.** A media
+ *    registry walks straight into Issue #158's trap: a batch upload writes many
+ *    rows inside one millisecond, and a cursor built from a JS `Date` (which
+ *    drops the microseconds PostgreSQL stores) denotes an instant strictly
+ *    EARLIER than the row it came from, silently skipping every sibling. Only a
+ *    real `timestamptz` shows this — a mock cannot.
+ * 2. **The three-way deletion filter really partitions.** `live` and `deleted`
+ *    must be disjoint and must sum to `all`.
+ * 3. **RLS still holds.** The listing runs under the runtime role, so a tenant
+ *    must not see another's objects even though the function is designed to
+ *    return rows in ANY status — the widest read this module has.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { decodeKeysetCursor } from "../../src/modules/_shared/keyset-pagination";
+import {
+  listMediaObjects,
+  MEDIA_OBJECT_LIST_LIMIT,
+  type NewsMediaObjectView
+} from "../../src/modules/media-library/application/media-object-directory";
+
+const TENANT_A = "a3333333-3333-4333-8333-333333333333";
+const TENANT_B = "b3333333-3333-4333-8333-333333333333";
+const AUTHOR_A = "a3000000-0000-4000-8000-000000000001";
+const AUTHOR_B = "b3000000-0000-4000-8000-000000000001";
+
+/** Two full pages plus a partial one, so `nextCursor` is exercised both ways. */
+const BATCH = MEDIA_OBJECT_LIST_LIMIT * 2 + 7;
+
+async function seedTenant(
+  tenantId: string,
+  code: string,
+  userId: string
+): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${tenantId}, ${code}, ${code})
+  `;
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${tenantId}, 'person', 'Uploader')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${tenantId}, ${profile[0]!.id}, ${`${code}@example.test`}, 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${userId}, ${tenantId}, ${identity[0]!.id})
+  `;
+}
+
+/**
+ * ONE statement inserting every row, so they genuinely share a transaction
+ * timestamp — `now()` is fixed for the whole transaction, which is the harshest
+ * possible version of the millisecond-collision case and exactly what a batch
+ * upload produces.
+ *
+ * `module_key`/`storage_driver`/`object_key` shapes are CHECK constraints on
+ * `sql/041` and are verified per-row against the row's OWN `tenant_id`, so a
+ * fixture cannot use a convenient short key.
+ */
+async function seedBatch(
+  tenantId: string,
+  userId: string,
+  count: number
+): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_news_media_objects
+      (tenant_id, module_key, storage_driver, bucket_name, object_key,
+       public_url, mime_type, status, created_by_tenant_user_id)
+    SELECT ${tenantId}, 'news_portal', 'cloudflare_r2', 'bucket',
+           'news-media/' || ${tenantId} || '/2026/08/' || gen_random_uuid() || '.png',
+           'https://cdn.example.test/' || g || '.png',
+           CASE WHEN g % 4 = 0 THEN 'image/webp' ELSE 'image/png' END,
+           CASE WHEN g % 3 = 0 THEN 'verified' ELSE 'uploaded' END,
+           ${userId}
+    FROM generate_series(1, ${count}) AS g
+  `;
+}
+
+async function walkEveryPage(tenantId: string): Promise<{
+  ids: string[];
+  pages: number;
+}> {
+  return withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
+    const ids: string[] = [];
+    let cursor = undefined;
+    let pages = 0;
+
+    for (;;) {
+      const page = await listMediaObjects(tx, tenantId, {}, cursor);
+      pages += 1;
+      ids.push(...page.items.map((item) => item.id));
+
+      if (!page.nextCursor) break;
+
+      cursor = decodeKeysetCursor(page.nextCursor) ?? undefined;
+      expect(cursor).toBeDefined();
+
+      // A cursor that never terminates is the other failure mode, and an
+      // unbounded loop here would hang the suite rather than fail it.
+      if (pages > 20) throw new Error("cursor did not terminate");
+    }
+
+    return { ids, pages };
+  });
+}
+
+async function listOnce(
+  tenantId: string,
+  filter: Parameters<typeof listMediaObjects>[2]
+): Promise<NewsMediaObjectView[]> {
+  return withTenantOrThrow(getRuntimeSql(), tenantId, async (tx) => {
+    const page = await listMediaObjects(tx, tenantId, filter);
+    return page.items;
+  });
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("media object listing", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant(TENANT_A, "media-list-a", AUTHOR_A);
+    await seedTenant(TENANT_B, "media-list-b", AUTHOR_B);
+    await seedBatch(TENANT_A, AUTHOR_A, BATCH);
+    await seedBatch(TENANT_B, AUTHOR_B, 5);
+  });
+
+  test("paging visits every row exactly once, even when they share a timestamp", async () => {
+    const { ids, pages } = await walkEveryPage(TENANT_A);
+
+    // The property that matters: nothing skipped and nothing repeated. With a
+    // millisecond-precision cursor this comes back short — measured at 4 of 105
+    // when the bug was live (Issue #158).
+    expect(ids.length).toBe(BATCH);
+    expect(new Set(ids).size).toBe(BATCH);
+    expect(pages).toBe(3);
+  });
+
+  test("a full page yields a cursor and a partial page does not", async () => {
+    await withTenantOrThrow(getRuntimeSql(), TENANT_A, async (tx) => {
+      const first = await listMediaObjects(tx, TENANT_A, {});
+
+      expect(first.items.length).toBe(MEDIA_OBJECT_LIST_LIMIT);
+      expect(first.nextCursor).not.toBeNull();
+
+      const last = await listMediaObjects(
+        tx,
+        TENANT_A,
+        {},
+        decodeKeysetCursor(
+          (await listMediaObjects(
+            tx,
+            TENANT_A,
+            {},
+            decodeKeysetCursor(first.nextCursor!)!
+          ))!.nextCursor!
+        )!
+      );
+
+      expect(last.items.length).toBe(BATCH - MEDIA_OBJECT_LIST_LIMIT * 2);
+      expect(last.nextCursor).toBeNull();
+    });
+  });
+
+  test("rows come back newest first", async () => {
+    const items = await listOnce(TENANT_A, {});
+    const timestamps = items.map((item) => item.createdAt.getTime());
+
+    expect([...timestamps].sort((a, b) => b - a)).toEqual(timestamps);
+  });
+
+  test("status and mimeType filters narrow the result", async () => {
+    const verified = await listOnce(TENANT_A, { status: "verified" });
+    const webp = await listOnce(TENANT_A, { mimeType: "image/webp" });
+
+    expect(verified.length).toBeGreaterThan(0);
+    expect(verified.every((item) => item.status === "verified")).toBe(true);
+
+    expect(webp.length).toBeGreaterThan(0);
+    expect(webp.every((item) => item.mimeType === "image/webp")).toBe(true);
+
+    // A filter matching nothing is an empty page, not an unfiltered one — the
+    // failure mode where an ignored filter looks like a working one.
+    expect(await listOnce(TENANT_A, { mimeType: "image/avif" })).toEqual([]);
+  });
+
+  test("unlike the resolver, unhealthy statuses are INCLUDED", async () => {
+    // `isNewsMediaObjectSafeForPublicReference` admits only verified/attached.
+    // This listing must not: an administrator opens it precisely because of the
+    // objects that are not healthy.
+    const statuses = new Set(
+      (await listOnce(TENANT_A, {})).map((i) => i.status)
+    );
+
+    expect(statuses.has("uploaded")).toBe(true);
+  });
+
+  test("the deletion filter partitions live and deleted, and `all` is their union", async () => {
+    const [target] = await listOnce(TENANT_A, {});
+    expect(target).toBeDefined();
+
+    await getAdminSql()`
+      UPDATE awcms_news_media_objects
+      SET deleted_at = now(), delete_reason = 'integration'
+      WHERE id = ${target!.id}
+    `;
+
+    const live = await walkEveryPage(TENANT_A);
+    expect(live.ids).not.toContain(target!.id);
+    expect(live.ids.length).toBe(BATCH - 1);
+
+    const deleted = await listOnce(TENANT_A, { deletion: "deleted" });
+    expect(deleted.map((item) => item.id)).toEqual([target!.id]);
+    expect(deleted[0]!.deleteReason).toBe("integration");
+
+    const all = await listOnce(TENANT_A, { deletion: "all" });
+    expect(all.length).toBe(MEDIA_OBJECT_LIST_LIMIT);
+    expect(all.some((item) => item.id === target!.id)).toBe(true);
+  });
+
+  test("a tenant never sees another tenant's objects", async () => {
+    const a = await walkEveryPage(TENANT_A);
+    const b = await walkEveryPage(TENANT_B);
+
+    expect(a.ids.length).toBe(BATCH);
+    expect(b.ids.length).toBe(5);
+    expect(a.ids.some((id) => b.ids.includes(id))).toBe(false);
+  });
+});

--- a/tests/media-object-list-route.test.ts
+++ b/tests/media-object-list-route.test.ts
@@ -1,0 +1,153 @@
+/**
+ * `GET /api/v1/media/objects/list` (ADR-0056 §C) is a SEPARATE route, and the
+ * batch resolver beside it stays exactly as strict as it was.
+ *
+ * The decision under test is the one §C rejects an alternative for: teaching
+ * `GET /api/v1/media/objects` a "no `ids` means list everything" branch would
+ * turn a request that is a **400 today** into a dump of the whole registry —
+ * a contract change wearing the clothes of an addition, which no existing
+ * caller could opt out of. So the resolver must keep failing without `ids`, and
+ * the list must not live inside it.
+ *
+ * The second thing pinned here is the path ambiguity `/list` creates. It is a
+ * static sibling of `[id].ts`; Astro resolves static before dynamic, but that
+ * is a framework rule, and on its own it leaves "the list" and "the object
+ * whose id is `list`" as two readings of one path. Requiring a uuid on the
+ * dynamic routes closes it from the other side — there is no object `/list`
+ * could otherwise address.
+ *
+ * Pure — no database, no network. The query itself is exercised against a real
+ * PostgreSQL in `tests/integration/media-object-list.integration.test.ts`,
+ * which is where the cursor-precision property actually lives.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { isMediaObjectId } from "../src/modules/media-library/domain/media-object-id";
+import { MEDIA_OBJECT_LIST_LIMIT } from "../src/modules/media-library/application/media-object-directory";
+
+const LIST_ROUTE = "src/pages/api/v1/media/objects/list.ts";
+const RESOLVER_ROUTE = "src/pages/api/v1/media/objects/index.ts";
+const DIRECTORY =
+  "src/modules/media-library/application/media-object-directory.ts";
+
+const ID_ROUTES = [
+  "src/pages/api/v1/media/objects/[id].ts",
+  "src/pages/api/v1/media/objects/[id]/restore.ts",
+  "src/pages/api/v1/media/objects/[id]/purge.ts"
+];
+
+describe("the list is a separate route, not a mode on the resolver", () => {
+  test("the resolver still refuses a request without ids", async () => {
+    const source = await readFile(RESOLVER_ROUTE, "utf8");
+
+    expect(source).toContain('url.searchParams.get("ids")');
+    expect(source).toContain("ids is required");
+    // The branch §C rejects. Its absence is the whole decision.
+    expect(source).not.toContain("listMediaObjects");
+  });
+
+  test("the resolver keeps its 100-id ceiling and uuid check", async () => {
+    const source = await readFile(RESOLVER_ROUTE, "utf8");
+
+    expect(source).toContain("const MAX_IDS = 100");
+    expect(source).toContain("ids must all be uuids");
+  });
+
+  test("the list route gates on media.read, the same permission as the resolver", async () => {
+    const list = await readFile(LIST_ROUTE, "utf8");
+
+    expect(list).toContain("MEDIA_PERMISSION_ACTIVITY_CODE");
+    expect(list).toContain('action: "read"');
+    // Read-only: a listing must never carry a write guard, and a GET that
+    // required `media.delete` would hide the screen from everyone who can only
+    // look.
+    expect(list).not.toContain('action: "delete"');
+    expect(list).not.toContain('action: "purge"');
+  });
+
+  test("the list route is bounded and keyset-paged, never OFFSET", async () => {
+    const list = await readFile(LIST_ROUTE, "utf8");
+    const directory = await readFile(DIRECTORY, "utf8");
+    const listFn = directory.slice(
+      directory.indexOf("export async function listMediaObjects")
+    );
+
+    expect(list).toContain("decodeKeysetCursor");
+    expect(list).toContain("MEDIA_OBJECT_LIST_LIMIT");
+    expect(MEDIA_OBJECT_LIST_LIMIT).toBeLessThanOrEqual(100);
+
+    // Full-precision cursor text, never a JS `Date` — Issue #158. A batch
+    // upload writes many rows inside one millisecond, so this module is one of
+    // the likeliest places to resurrect it.
+    expect(listFn).toContain("KEYSET_CURSOR_CREATED_AT_SQL");
+    expect(listFn).toContain("created_at_cursor");
+    expect(listFn).not.toContain("toISOString");
+    expect(listFn).not.toMatch(/\bOFFSET\b/);
+    expect(listFn).toContain("ORDER BY created_at DESC, id DESC");
+  });
+
+  test("a malformed cursor is refused, not silently treated as page 1", async () => {
+    const list = await readFile(LIST_ROUTE, "utf8");
+
+    // Treating a corrupt cursor as absent serves page 1 to a caller who asked
+    // for page 4, and the paging loop never terminates.
+    expect(list).toContain("cursor is malformed");
+  });
+
+  test("unknown filter values are refused, not ignored", async () => {
+    const list = await readFile(LIST_ROUTE, "utf8");
+
+    expect(list).toContain("status must be one of");
+    expect(list).toContain("deletion must be one of");
+  });
+});
+
+describe("`/list` cannot collide with an object id", () => {
+  test("`list` is not a valid media object id", () => {
+    expect(isMediaObjectId("list")).toBe(false);
+    expect(isMediaObjectId(undefined)).toBe(false);
+    expect(isMediaObjectId("not-a-uuid")).toBe(false);
+    expect(isMediaObjectId(crypto.randomUUID())).toBe(true);
+  });
+
+  test("every dynamic media object route validates the id as a uuid", async () => {
+    for (const file of ID_ROUTES) {
+      const source = await readFile(file, "utf8");
+
+      expect(source).toContain("isMediaObjectId");
+      // Without this the framework's static-before-dynamic rule is the ONLY
+      // thing keeping the two paths apart.
+      expect(source).toContain("Media object id must be a uuid");
+    }
+  });
+});
+
+describe("the listing deliberately outgrows the resolver's safety rule", () => {
+  test("it does not filter on isNewsMediaObjectSafeForPublicReference", async () => {
+    const directory = await readFile(DIRECTORY, "utf8");
+    const listFn = directory.slice(
+      directory.indexOf("export async function listMediaObjects"),
+      directory.indexOf("export type MarkNewsMediaObjectUploadedInput")
+    );
+
+    // An administrator opens this list precisely because of the objects that
+    // are NOT healthy — pending, failed, orphaned. Narrowing it to publicly
+    // referenceable rows would make the lifecycle endpoints unreachable from a
+    // screen, since their targets are exactly the excluded ones.
+    expect(listFn).not.toContain("isNewsMediaObjectSafeForPublicReference");
+    expect(listFn).not.toContain("'verified'");
+  });
+
+  test("but defaults to live rows, so deleted objects are opt-in", async () => {
+    const directory = await readFile(DIRECTORY, "utf8");
+
+    expect(directory).toContain('filter.deletion ?? "live"');
+    // Three states, not a boolean: "show me what I deleted" is the question the
+    // restore/purge endpoints exist to answer, and a boolean cannot ask it.
+    expect(directory).toContain(
+      'export type MediaObjectDeletionFilter = "live" | "deleted" | "all"'
+    );
+  });
+});


### PR DESCRIPTION
ADR-0056 §C, following #342 (§A) and #343 (§B). **This completes the ADR** — what remains is the `/admin/media` screen itself.

## Why the screen was never one PR away

Until now the application layer had only point lookups — `fetchNewsMediaObjectById`, `fetchNewsMediaObjectsByIds`, `fetchNewsMediaObjectByObjectKey`. There was **no list function at all**, so "what media does this tenant have" was a question the surface could not answer, whatever the permission catalog said. That is the finding that turned "the screen is missing" into a three-part ADR.

`GET /api/v1/media/objects/list` — `media_library.media.read`, keyset-paginated 50/page, newest first, filters `status` / `mimeType` / `deletion` / `cursor`.

## Three decisions worth reviewing

**Its own route, not a mode on the resolver.** `GET /api/v1/media/objects` demands `?ids=`; it is a batch resolver built for the `awcms-astro` build. A "no `ids` means list everything" branch would turn a request that is a **400 today** into a dump of the entire registry — a contract change wearing the clothes of an addition, which no existing caller could opt out of.

`list` cannot be read as an object id, because `[id].ts` and its children now **require a uuid** and answer 400 otherwise. That closes the ambiguity from the other side, so Astro's static-before-dynamic precedence is not the only thing keeping `/list` and `/{id}` apart.

**It deliberately outgrows the resolver's safety rule.** Rows in any status — `pending_upload`, `failed`, `orphaned` — plus soft-deleted ones on request. `isNewsMediaObjectSafeForPublicReference` admits only `verified`/`attached`, and an administrator opens this list *precisely because of* the objects that are not healthy; §B's lifecycle endpoints would otherwise have no way to find their targets. Nothing here may be used as a public reference — that is what the resolver is for.

**`deletion` is three states, not a boolean.** "Show me what I deleted" is the question restore and purge exist to answer, and `includeDeleted: true` cannot ask it. Defaults to `live`, so deleted rows are opt-in.

Filters and cursors are **refused when malformed, never ignored**: a silently dropped filter answers 200 with a page nobody asked for, and a corrupt cursor treated as absent serves page 1 to a caller paging through page 4, forever.

## The cursor, and why this needed a real database

A media registry is one of the likeliest places to resurrect **Issue #158** — a batch upload writes many rows inside a single millisecond, and a cursor built from a JS `Date` (which drops the microseconds PostgreSQL stores) denotes an instant strictly *earlier* than the row it came from, skipping every sibling.

`tests/integration/media-object-list.integration.test.ts` inserts **107 rows in ONE statement**, so they share a transaction timestamp exactly — the harshest version of the case — and walks every page asserting nothing is skipped or repeated.

Mutation-proven by reverting the cursor to `encodeKeysetCursor(last.created_at.toISOString(), ...)`, the original defect:

```
Expected: 107   Received: 50    (paging visits every row exactly once)
Expected: 7     Received: 50    (partial last page)
Expected: 106   Received: 50    (deletion filter partitions)
Expected: 107   Received: 50    (cross-tenant isolation)
```

**57 of 107 rows lost, four tests red.** A pure test could not have shown this.

Seven integration tests total, also covering the three-way deletion partition (`live` ⊎ `deleted` = `all`) and RLS holding across tenants under the runtime role — worth asserting explicitly here, since this is the widest read the module has.

Plus `tests/media-object-list-route.test.ts` (10 pure tests) pinning the resolver's unchanged strictness, the uuid guard on all three `/{id}` routes, and the keyset-not-OFFSET properties.

Full `bun run check` green locally — 3302 pass, 0 fail, build complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)