### PR TITLE
feat(media-library): /admin/media console, the last module screen

### DIFF
--- a/.changeset/admin-media-console.md
+++ b/.changeset/admin-media-console.md
@@ -1,0 +1,21 @@
+---
+"awcms": minor
+---
+
+Add `/admin/media` and put `media_library` in the admin sidebar — the last module in this base without a screen.
+
+It was listed for two waves beside modules that were genuinely only missing a page, and that was wrong for this one. [ADR-0056](../docs/adr/0056-media-library-admin-surface.md) found that five of eleven permissions were enforced by nothing, five application functions had zero callers, and there was **no list function at all** — so this screen could not have been built on the surface that existed, whatever the permission catalog said. `attach`/`detach` were revoked (§A), `delete`/`restore`/`purge` got endpoints (§B), and the browse listing got its own function and route (§C). This is what those three were for.
+
+The console browses with §C's filters — status, mime type, and the three-way `live`/`deleted`/`all` — then deletes, restores, and purges. Reads go through `listMediaObjects` inside one `withTenantOrThrow`; writes post to the guarded endpoints, each with a fresh `Idempotency-Key`. Unlike `/admin/blog` there is no opt-out, and unlike `/admin/sync` there is no endpoint that declines the header: all three here require it.
+
+**Three deliberate absences**, each pinned by `tests/admin-media-page-contract.test.ts` so they stay decisions rather than becoming gaps:
+
+- **Upload** (`media.create`/`.verify`/`.cancel`) — a three-step browser flow (create session → PUT the bytes straight to R2 → finalize) with real file input, progress, and client-side failure modes. A button that starts a session this page cannot finish leaves a `pending_upload` row behind on every misclick, which is precisely the litter the reconciliation job exists to clean up.
+- **`enforcement.read`/`.enable`** — a tenant-wide, ONE-WAY content policy switch, not an object action. It belongs on `/admin/security` with the other policy controls; offering it beside a row of files would misrepresent its blast radius.
+- **No `<img>` preview.** A registry row can be `pending_upload` or `failed` — the bytes may be absent, unverified, or the very thing an operator is here to delete. Rendering them is how a policy-violating image gets shown one more time, to the person removing it.
+
+The delete prompt asks for a real reason rather than sending a placeholder, because it lands on an audit row that outlives the object, and its `maxlength` comes from the constant the validator enforces. Purge is the only irreversible action and is the only one behind a `confirm`. It is also the only failure this screen names specifically: `MEDIA_OBJECT_REFERENCED` gets "remove that reference first" rather than "please try again", because retrying will never succeed while the foreign key is live.
+
+**This closes ADR-0021's first criterion.** `idn-admin-regions` is now the only module without a screen, and that is a documented decision (ADR-0052 moved its lifecycle to operator jobs). The contract test asserts it repo-wide, so the next module to land without `navigation` turns CI red instead of quietly becoming a second exception.
+
+Mutation-proven four ways: gating a control on the revoked `media.detach`, dropping one mutation's `Idempotency-Key`, rendering a preview `<img>`, and removing the navigation entry each turn it red.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -81,14 +81,14 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 
 ## 2. Inventori ringkas
 
-| Aspek       | Nilai (per commit ini)                                                              | Sumber kebenaran                                                                        |
-| ----------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Versi       | **6.4.0** (2026-07-26); **53 changeset menunggu** rilis berikutnya                  | `package.json`, `CHANGELOG.md`, tag `v*`                                                |
-| Modul base  | **21** (lihat daftar di ARCHITECTURE.md)                                            | `src/modules/index.ts`                                                                  |
-| Migrasi     | **87** (`sql/001`–`087`)                                                            | `ls sql/`                                                                               |
-| ADR         | **0000**–**0056** (`0000` = template)                                               | `ls docs/adr/`                                                                          |
-| Layar admin | **27** berkas `.astro` di `src/pages/admin/`; **1 dari 21 modul** masih tanpa layar | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Kontrak     | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.4.0**           | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
+| Aspek       | Nilai (per commit ini)                                                                                                              | Sumber kebenaran                                                                        |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Versi       | **6.4.0** (2026-07-26); **53 changeset menunggu** rilis berikutnya                                                                  | `package.json`, `CHANGELOG.md`, tag `v*`                                                |
+| Modul base  | **21** (lihat daftar di ARCHITECTURE.md)                                                                                            | `src/modules/index.ts`                                                                  |
+| Migrasi     | **87** (`sql/001`–`087`)                                                                                                            | `ls sql/`                                                                               |
+| ADR         | **0000**–**0056** (`0000` = template)                                                                                               | `ls docs/adr/`                                                                          |
+| Layar admin | **28** berkas `.astro` di `src/pages/admin/`; **0 dari 21 modul** tanpa layar tak-disengaja (`idn-admin-regions` sengaja, ADR-0052) | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Kontrak     | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.4.0**                                                           | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
 > **Angka tabel ini pernah basi tanpa ada yang merah.** Sebelum PR #339 barisnya
 > berbunyi "20 berkas / 7 dari 21 modul" sementara `main` sudah memuat 22 berkas dan
@@ -313,8 +313,8 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
     test karena BEDA KELAS: `posts.export` dideklarasikan + di-seed `sql/036` dan
     **tak ada endpoint mana pun yang menegakkannya**; `search.read` punya rute tapi
     daftar admin sudah punya pencarian sendiri yang mentoleransi query kosong.
-  - `media-library` — **BELUM, dan bukan sekadar layar
-    ([ADR-0056](adr/0056-media-library-admin-surface.md)).** Lima dari sebelas
+  - ~~`media-library`~~ **SELESAI (#345)** — `/admin/media`. Dan ini bukan sekadar
+    layar ([ADR-0056](adr/0056-media-library-admin-surface.md)): lima dari sebelas
     permission-nya tidak digerbangi apa pun (`attach`/`detach`/`delete`/`restore`/
     `purge`), lima fungsi aplikasi yang memanggilnya nol, dan tidak ada fungsi
     `list*` sama sekali — `GET /api/v1/media/objects` menuntut `?ids=`, ia resolver
@@ -345,8 +345,23 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
     tiap halaman; mengembalikan kursor ke `Date` kehilangan 57 baris (jebakan
     #158, dan registry media adalah tempat paling mungkin ia kambuh).
 
-    **ADR-0056 selesai seluruhnya. Yang tersisa hanyalah layar `/admin/media`
-    itu sendiri** — dan sesudahnya kriteria 1 ADR-0021 tinggal nol pengecualian.
+    **Layar (#345).** Konsol siklus hidup objek: browse ber-filter, lalu
+    delete/restore/purge — empat permission, tiap mutasi ber-`Idempotency-Key`
+    baru (tak ada opt-out seperti `/admin/blog`, dan tak ada endpoint yang
+    menolak header seperti `/admin/sync`). TIGA absen sengaja, digerbangi
+    contract test agar tetap keputusan: **unggah** (`create`/`verify`/`cancel`)
+    — alur tiga langkah di browser, tombol yang memulai sesi tapi tak bisa
+    menuntaskannya meninggalkan baris `pending_upload` tiap salah klik;
+    **`enforcement.*`** — saklar kebijakan tenant SATU ARAH, bukan aksi objek,
+    tempatnya di `/admin/security`; dan **tanpa pratinjau `<img>`** — baris bisa
+    `pending_upload`/`failed`, bytes-nya mungkin tak ada, belum terverifikasi,
+    atau justru hal yang sedang dihapus operator.
+
+    **ADR-0056 SELESAI SELURUHNYA, dan dengan itu kriteria 1 ADR-0021 nol
+    pengecualian tak-disengaja** — `idn-admin-regions` satu-satunya modul tanpa
+    layar, dan itu memang keputusan (ADR-0052). Contract test layar ini ikut
+    menegakkannya lintas-modul, jadi modul berikutnya yang mendarat tanpa
+    `navigation` memerahkan CI alih-alih diam-diam menambah pengecualian.
 
     > **Temuan sampingan, sudah diperbaiki di PR yang sama.** SQLSTATE Postgres
     > ada di `error.errno`, BUKAN `error.code` — Bun mengisi `code` dengan

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -190,7 +190,7 @@
       "capabilitiesProvided": ["media_library"],
       "capabilitiesConsumed": [],
       "permissionCount": 9,
-      "navigationCount": 0,
+      "navigationCount": 1,
       "jobCount": 1,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/media-library/README.md
+++ b/src/modules/media-library/README.md
@@ -157,12 +157,34 @@ Issue #158; `tests/integration/media-object-list.integration.test.ts` inserts
 107 rows in ONE statement and walks every page, and reverting the cursor to a
 `Date` loses 57 of them.
 
+## `/admin/media` ([ADR-0056](../../../docs/adr/0056-media-library-admin-surface.md), ADR-0051)
+
+The object lifecycle console: browse with the §C filters, then delete, restore,
+or purge. Four permissions — `media.read`, `.delete`, `.restore`, `.purge`.
+Every mutation posts to the guarded endpoint with a fresh `Idempotency-Key`
+(unlike `/admin/sync`, where no endpoint wants one, all three here require it).
+
+Three deliberate absences, each pinned by
+`tests/admin-media-page-contract.test.ts` so they stay decisions rather than
+becoming gaps:
+
+- **Upload** (`media.create`/`.verify`/`.cancel`) — a three-step browser flow
+  (create session → PUT to R2 → finalize) with file input, progress, and
+  client-side failure modes. A button that starts a session this page cannot
+  finish leaves a `pending_upload` row on every misclick, which is exactly the
+  litter the reconciliation job cleans up.
+- **`enforcement.*`** — a tenant-wide ONE-WAY policy switch, not an object
+  action. It lives on `/admin/security` with the other policy controls.
+- **No `<img>` preview.** A row can be `pending_upload` or `failed`: the bytes
+  may be absent, unverified, or the very thing the operator came to remove.
+  Rendering them shows a policy-violating image one more time, to the person
+  removing it.
+
 ## Not ported to this base (deferred, additive)
 
-The `/admin/media` screen (micro step 5d — the whole API half is now ported, so
-this is all that remains of it; the module still declares no `navigation`),
-responsive `srcset` render (step 5b), and the PDF media type (step 5c). The
-allowed MIME set stays the four raster types.
+Responsive `srcset` render (micro step 5b) and the PDF media type (step 5c).
+The allowed MIME set stays the four raster types. Step 5d — the lifecycle API
+and `/admin/media` — is now ported in full.
 
 ## Resolusi referensi media (`GET /api/v1/media/objects`)
 

--- a/src/modules/media-library/module.ts
+++ b/src/modules/media-library/module.ts
@@ -76,6 +76,20 @@ export const mediaLibraryModule = defineModule({
     // `/api/v1/media/enforcement` was falling to `tenant_admin`'s catch-all.
     routes: ["/api/v1/media"]
   },
+  // ADR-0056 — ONE entry for eleven activity codes' worth of surface, because
+  // this module's screen is the object lifecycle and nothing else. Upload lives
+  // wherever a composer needs it (a three-step browser flow, not a button), and
+  // the enforcement switch is a tenant-wide one-way policy that belongs on
+  // `/admin/security`. A second entry appearing here without a page is what
+  // `admin-navigation-registry.test.ts` catches.
+  navigation: [
+    {
+      labelKey: "admin.layout.nav_media",
+      path: "/admin/media",
+      order: 34,
+      requiredPermission: "media_library.media.read"
+    }
+  ],
   permissions: [
     {
       activityCode: MEDIA_PERMISSION_ACTIVITY_CODE,

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -180,6 +180,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_data_lifecycle": "Data lifecycle",
   "admin.layout.nav_idn_regions": "Region datasets",
   "admin.layout.nav_blog": "Blog posts",
+  "admin.layout.nav_media": "Media library",
   "admin.layout.nav_reporting": "Reporting operations",
   "admin.layout.nav_approvals": "Approvals",
   "admin.layout.nav_domain_events": "Domain events",

--- a/src/pages/admin/media.astro
+++ b/src/pages/admin/media.astro
@@ -1,0 +1,638 @@
+---
+/**
+ * Media library console — the last module in this base without a screen.
+ *
+ * ## Why this took an ADR and four PRs
+ *
+ * It was listed for two waves beside modules that were genuinely only missing a
+ * page. That was wrong for this one ([ADR-0056](../../../docs/adr/0056-media-library-admin-surface.md)):
+ * five of eleven permissions were enforced by nothing, five application
+ * functions had zero callers, and there was **no list function at all** — so
+ * this screen could not have been built on the surface that existed, whatever
+ * the catalog said. `attach`/`detach` were revoked (§A, `sql/087`),
+ * `delete`/`restore`/`purge` got endpoints (§B), and the browse listing got its
+ * own function and route (§C). This page is what those three were for.
+ *
+ * All four remaining reachable permissions are driven here:
+ * `media.read`, `media.delete`, `media.restore`, `media.purge`.
+ *
+ * ## Three deliberate absences
+ *
+ * - **`media.create`/`media.verify`/`media.cancel`** — the presigned upload
+ *   flow. Uploading is a three-step browser dance (create session → PUT the
+ *   bytes straight to R2 → finalize) with real file input, progress, and
+ *   client-side failure modes. A button that starts a session this page cannot
+ *   finish would leave `pending_upload` rows behind on every misclick, which is
+ *   precisely the litter the reconciliation job exists to clean up. Upload
+ *   belongs to whatever composer surface needs it.
+ * - **`enforcement.read`/`enforcement.enable`** — a tenant-wide, ONE-WAY
+ *   content policy switch, not an object action. It is on `/admin/security`
+ *   with the other policy controls; offering it beside a row of thumbnails
+ *   would misrepresent its blast radius.
+ * - **No preview `<img>`.** A registry row can be in `pending_upload` or
+ *   `failed` — the bytes may be absent, unverified, or the very thing an
+ *   operator is here to delete. Rendering them is how a policy-violating image
+ *   gets shown one more time, to the person removing it.
+ *
+ * ## Reads
+ *
+ * `listMediaObjects` inside ONE `withTenantOrThrow`, awaited sequentially —
+ * concurrent queries on a single transaction connection leak it. Keyset
+ * paginated: the cursor carries full-precision `created_at` text, so a page
+ * boundary cannot skip rows sharing a millisecond, which a batch upload
+ * produces by the dozen.
+ *
+ * ## Writes
+ *
+ * Nothing here writes SQL. All three mutations post to the guarded endpoints,
+ * each with a fresh `Idempotency-Key` — unlike `/admin/sync`, where none of the
+ * endpoints wants one, every endpoint here requires it.
+ *
+ * ## Gates
+ *
+ * UX-only; `authorizeInTransaction` in the routes is the authority. Pinned by
+ * `tests/admin-media-page-contract.test.ts`, which also asserts that the three
+ * absences above stay absences rather than quietly becoming gaps.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { decodeKeysetCursor } from "../../modules/_shared/keyset-pagination";
+import { MAX_DELETE_REASON_LENGTH } from "../../modules/media-library/domain/media-lifecycle-validation";
+import {
+  listMediaObjects,
+  MEDIA_OBJECT_LIST_LIMIT,
+  type MediaObjectDeletionFilter,
+  type NewsMediaObjectStatus,
+  type NewsMediaObjectView
+} from "../../modules/media-library/application/media-object-directory";
+
+const ssr = Astro.locals.ssrContext!;
+
+const canRead = ssr.permissions.has(
+  permissionKey("media_library", "media", "read")
+);
+const canDelete = ssr.permissions.has(
+  permissionKey("media_library", "media", "delete")
+);
+const canRestore = ssr.permissions.has(
+  permissionKey("media_library", "media", "restore")
+);
+const canPurge = ssr.permissions.has(
+  permissionKey("media_library", "media", "purge")
+);
+
+function readParam(name: string): string {
+  return (Astro.url.searchParams.get(name) ?? "").trim();
+}
+
+const STATUS_OPTIONS: readonly NewsMediaObjectStatus[] = [
+  "pending_upload",
+  "uploaded",
+  "verified",
+  "attached",
+  "orphaned",
+  "deleted",
+  "failed"
+];
+
+const DELETION_OPTIONS: readonly MediaObjectDeletionFilter[] = [
+  "live",
+  "deleted",
+  "all"
+];
+
+const statusRaw = readParam("status");
+const statusFilter = (STATUS_OPTIONS as readonly string[]).includes(statusRaw)
+  ? (statusRaw as NewsMediaObjectStatus)
+  : undefined;
+
+const deletionRaw = readParam("deletion");
+const deletionFilter = (DELETION_OPTIONS as readonly string[]).includes(
+  deletionRaw
+)
+  ? (deletionRaw as MediaObjectDeletionFilter)
+  : "live";
+
+const mimeTypeFilter = readParam("mimeType").toLowerCase() || undefined;
+
+const cursorParam = readParam("cursor");
+// A malformed cursor is dropped rather than forwarded — a hand-edited query
+// string must not turn this screen into an error page. The API answers 400 for
+// the same input, which is correct there: a machine caller should be told.
+const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+let objects: NewsMediaObjectView[] = [];
+let nextCursor: string | null = null;
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
+      const page = await listMediaObjects(
+        tx,
+        ssr.tenantId,
+        {
+          status: statusFilter,
+          mimeType: mimeTypeFilter,
+          deletion: deletionFilter
+        },
+        cursor ?? undefined
+      );
+      objects = page.items;
+      nextCursor = page.nextCursor;
+    });
+  } catch (error) {
+    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
+    // must never render as "this tenant has no media".
+    loadError = true;
+    logAdminPageError(
+      "admin/media.astro: failed to load the media library",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+}
+
+/**
+ * `verified`/`attached` are the two statuses safe to reference publicly
+ * (`isNewsMediaObjectSafeForPublicReference`). The rest are shown, and shown as
+ * what they are — this list exists for the unhealthy ones.
+ */
+const STATUS_VARIANT: Record<string, string> = {
+  pending_upload: "info",
+  uploaded: "info",
+  verified: "success",
+  attached: "success",
+  orphaned: "warning",
+  deleted: "warning",
+  failed: "danger"
+};
+
+function formatBytes(bytes: number | null): string {
+  if (bytes === null) return "—";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDimensions(view: NewsMediaObjectView): string {
+  if (view.width === null || view.height === null) return "—";
+  return `${view.width}×${view.height}`;
+}
+
+function formatTimestamp(value: Date | null): string {
+  return value ? value.toISOString().replace("T", " ").slice(0, 19) : "—";
+}
+
+/** Rebuilds the current query string with one key replaced — keeps filters across paging. */
+function linkWith(overrides: Record<string, string | null>): string {
+  const params = new URLSearchParams(Astro.url.search);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null || value === "") params.delete(key);
+    else params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `/admin/media?${query}` : "/admin/media";
+}
+
+const unsafeCount = objects.filter(
+  (item) => item.status !== "verified" && item.status !== "attached"
+).length;
+const deletedCount = objects.filter((item) => item.deletedAt !== null).length;
+const canActOnAny = canDelete || canRestore || canPurge;
+const columnCount = canActOnAny ? 8 : 7;
+---
+
+<AdminLayout title="Media library">
+  <header class="page-header fade-in-up">
+    <h1 id="media-heading">Media library</h1>
+    <p class="page-description">
+      Every media object this tenant has registered, in any state — including
+      the ones that never finished uploading or failed verification. Deleting is
+      reversible; purging is not, and clears the registry row rather than the
+      stored file.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="media-denied">
+        You do not have permission to view the media library.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="media-error">
+        The media library could not be loaded right now. This is a problem
+        reading it, not an empty library — please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <p
+        id="media-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section class="admin-section fade-in-up" aria-label="Media summary">
+        <div class="stat-grid stagger-children">
+          <div class="stat-card">
+            <span class="stat-label">On this page</span>
+            <span class="stat-value">{objects.length}</span>
+            <span class="stat-hint">{MEDIA_OBJECT_LIST_LIMIT} per page</span>
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Not publicly referenceable</span>
+            <span class="stat-value">{unsafeCount}</span>
+            {unsafeCount > 0 && (
+              <span class="stat-hint">
+                Only verified and attached objects resolve
+              </span>
+            )}
+          </div>
+          <div class="stat-card">
+            <span class="stat-label">Soft-deleted (this page)</span>
+            <span class="stat-value">{deletedCount}</span>
+          </div>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="media-filter-title"
+      >
+        <h2 class="admin-section-title" id="media-filter-title">
+          Filters
+        </h2>
+        {/* A GET form, so every filtered view is a shareable URL and the back
+            button works. Paging drops `cursor` by omitting it. */}
+        <form method="get" action="/admin/media" class="admin-filter-form">
+          <label class="field">
+            <span class="field-label">Status</span>
+            <select name="status" class="field-input">
+              <option value="">Any</option>
+              {STATUS_OPTIONS.map((option) => (
+                <option value={option} selected={statusRaw === option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Deletion</span>
+            <select name="deletion" class="field-input">
+              {DELETION_OPTIONS.map((option) => (
+                <option value={option} selected={deletionFilter === option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label class="field">
+            <span class="field-label">Mime type</span>
+            <input
+              type="text"
+              name="mimeType"
+              class="field-input"
+              value={readParam("mimeType")}
+              placeholder="image/png"
+            />
+          </label>
+
+          <div class="admin-toolbar">
+            <button type="submit" class="btn-primary">
+              Apply
+            </button>
+            <a class="quick-link" href="/admin/media">
+              Reset
+            </a>
+          </div>
+        </form>
+      </section>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="media-objects-title"
+        id="media-objects"
+      >
+        <h2 class="admin-section-title" id="media-objects-title">
+          Objects
+          <span class="count-pill">{objects.length}</span>
+        </h2>
+        <p class="page-description">
+          Deleting an object stops every reference to it resolving immediately —
+          a published page pointing at it loses its image. That is the point
+          when the object should not be served, and restore is how it comes
+          back. Purging removes the registry row only; the stored file is
+          removed later by the reconciliation job, which owns the bucket.
+        </p>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack" id="media-objects-table">
+            <caption class="sr-only">Registered media objects.</caption>
+            <thead>
+              <tr>
+                <th scope="col">Object</th>
+                <th scope="col">Type</th>
+                <th scope="col">Size</th>
+                <th scope="col">Dimensions</th>
+                <th scope="col">Status</th>
+                <th scope="col">Created</th>
+                <th scope="col">Deleted</th>
+                {canActOnAny && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {objects.length === 0 ? (
+                <tr>
+                  <td colspan={columnCount} class="cell-muted">
+                    No media objects match these filters.
+                  </td>
+                </tr>
+              ) : (
+                objects.map((item) => (
+                  <tr>
+                    <td data-label="Object">
+                      {/* `set:text`, never parsed: a filename is caller-supplied
+                          and reaches this table verbatim. No image tag either — see
+                          this file's header. */}
+                      <span
+                        class="cell-strong"
+                        set:text={item.originalFilename ?? item.objectKey}
+                      />
+                      <span class="cell-muted" set:text={item.objectKey} />
+                    </td>
+                    <td data-label="Type" set:text={item.mimeType} />
+                    <td data-label="Size">{formatBytes(item.sizeBytes)}</td>
+                    <td data-label="Dimensions">{formatDimensions(item)}</td>
+                    <td data-label="Status">
+                      <span
+                        class={`status-badge status-badge--${STATUS_VARIANT[item.status] ?? "info"}`}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {item.status}
+                      </span>
+                    </td>
+                    <td data-label="Created">
+                      <span class="cell-muted">
+                        {formatTimestamp(item.createdAt)}
+                      </span>
+                    </td>
+                    <td data-label="Deleted">
+                      {item.deletedAt === null ? (
+                        <span class="cell-muted">—</span>
+                      ) : (
+                        <>
+                          <span class="cell-muted">
+                            {formatTimestamp(item.deletedAt)}
+                          </span>
+                          <span
+                            class="cell-muted"
+                            set:text={item.deleteReason ?? ""}
+                          />
+                        </>
+                      )}
+                    </td>
+                    {canActOnAny && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          {item.deletedAt === null
+                            ? canDelete && (
+                                <button
+                                  type="button"
+                                  class="btn-inline media-delete-btn"
+                                  data-media-id={item.id}
+                                  data-media-label={
+                                    item.originalFilename ?? item.objectKey
+                                  }
+                                >
+                                  Delete
+                                </button>
+                              )
+                            : [
+                                canRestore && (
+                                  <button
+                                    type="button"
+                                    class="btn-inline media-restore-btn"
+                                    data-media-id={item.id}
+                                  >
+                                    Restore
+                                  </button>
+                                ),
+                                canPurge && (
+                                  <button
+                                    type="button"
+                                    class="btn-inline btn-inline--danger media-purge-btn"
+                                    data-media-id={item.id}
+                                    data-media-label={
+                                      item.originalFilename ?? item.objectKey
+                                    }
+                                  >
+                                    Purge
+                                  </button>
+                                )
+                              ]}
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {nextCursor && (
+          <div class="admin-toolbar">
+            {/* Keyset, not offset: the cursor carries full-precision
+                `created_at` TEXT, so a page boundary cannot skip rows sharing a
+                millisecond — which a batch upload produces by the dozen. */}
+            <a class="quick-link" href={linkWith({ cursor: nextCursor })}>
+              Next page
+              <span class="quick-link-arrow" aria-hidden="true">
+                →
+              </span>
+            </a>
+          </div>
+        )}
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'`
+  // with no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+  import { MAX_DELETE_REASON_LENGTH } from "../../modules/media-library/domain/media-lifecycle-validation";
+
+  const actionError = document.getElementById("media-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  /**
+   * Every endpoint on this screen requires `Idempotency-Key` — unlike
+   * `/admin/sync`, where none does. A fresh uuid per click, so a double-click
+   * replays the first result instead of doing the work twice.
+   */
+  function idempotency(): Record<string, string> {
+    return { "Idempotency-Key": crypto.randomUUID() };
+  }
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".media-delete-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.mediaId;
+        if (!id) return;
+        const label = button.dataset.mediaLabel ?? "this object";
+
+        // A reason is required by the endpoint and recorded on the audit row,
+        // which outlives the object. Prompt rather than send a placeholder:
+        // "deleted via admin" tells the next reader nothing.
+        const reason = window.prompt(
+          `Why are you deleting ${label}? Every reference to it stops resolving immediately — a published page pointing at it loses its image. Restore undoes this.`
+        );
+        if (reason === null) return;
+
+        if (reason.trim() === "") {
+          showActionError("A reason is required to delete a media object.");
+          return;
+        }
+
+        if (reason.trim().length > MAX_DELETE_REASON_LENGTH) {
+          showActionError(
+            `The reason must be at most ${MAX_DELETE_REASON_LENGTH} characters.`
+          );
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Deleting…");
+
+        const result = await sendJson(
+          "DELETE",
+          `/api/v1/media/objects/${id}`,
+          { reason: reason.trim() },
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // Generic copy only — never surface internal detail.
+        showActionError("Could not delete the media object. Please try again.");
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".media-restore-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.mediaId;
+        if (!id) return;
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Restoring…");
+
+        // No body: this endpoint takes none, and its request hash covers the id
+        // alone.
+        const result = await sendJson(
+          "POST",
+          `/api/v1/media/objects/${id}/restore`,
+          undefined,
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError(
+          "Could not restore the media object. Please try again."
+        );
+        unlock();
+      });
+    });
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".media-purge-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const id = button.dataset.mediaId;
+        if (!id) return;
+        const label = button.dataset.mediaLabel ?? "this object";
+
+        // The one action on this screen that cannot be undone.
+        if (
+          !window.confirm(
+            `Purge ${label}? This removes its registry row permanently and cannot be undone. The stored file is removed later by the reconciliation job.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Purging…");
+
+        const result = await sendJson(
+          "POST",
+          `/api/v1/media/objects/${id}/purge`,
+          undefined,
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // The one failure worth naming: a live foreign key is caller-actionable
+        // in a way "try again" is not — retrying will never succeed.
+        showActionError(
+          result.errorCode === "MEDIA_OBJECT_REFERENCED"
+            ? "This object is still referenced by another resource. Remove that reference first."
+            : "Could not purge the media object. Please try again."
+        );
+        unlock();
+      });
+    });
+</script>

--- a/tests/admin-media-page-contract.test.ts
+++ b/tests/admin-media-page-contract.test.ts
@@ -1,0 +1,320 @@
+/**
+ * `/admin/media` gates against the endpoints it drives, and is explicit about
+ * the permissions it deliberately does NOT drive.
+ *
+ * Sixth of the admin page contracts, and the one that closes ADR-0021's first
+ * criterion: after this, no module in this base is without a screen.
+ *
+ * What is specific here is that this page could not have existed before its
+ * three ADR-0056 steps landed. So the assertions run in both directions: the
+ * page drives exactly the four permissions that are now enforced, and the three
+ * it skips are skipped for a stated reason rather than missed.
+ *
+ * Three traps specific to this module:
+ *
+ * - **`media.attach`/`media.detach` are REVOKED** (`sql/087`). A control gated
+ *   on either would deny every caller including the owner, because no migration
+ *   seeds them any more — the latent-authz shape, arrived at from the other
+ *   direction than usual.
+ * - **`enforcement.enable` is one-way and tenant-wide.** It is not an object
+ *   action, and a button for it beside a row of thumbnails would misrepresent
+ *   what it does. There is deliberately no `enforcement.disable` anywhere.
+ * - **No `<img>` preview.** A registry row can be `pending_upload` or `failed`
+ *   — the bytes may be absent, unverified, or the very thing the operator came
+ *   to remove. Rendering them shows a policy-violating image one more time, to
+ *   the person removing it.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import { SIDEBAR_LABELS } from "../src/modules/module-management/domain/sidebar-menu";
+
+const PAGE = "src/pages/admin/media.astro";
+const LIST_ROUTE = "src/pages/api/v1/media/objects/list.ts";
+const DELETE_ROUTE = "src/pages/api/v1/media/objects/[id].ts";
+const RESTORE_ROUTE = "src/pages/api/v1/media/objects/[id]/restore.ts";
+const PURGE_ROUTE = "src/pages/api/v1/media/objects/[id]/purge.ts";
+
+const ROUTES = [LIST_ROUTE, DELETE_ROUTE, RESTORE_ROUTE, PURGE_ROUTE];
+
+/** Exactly what the page gates on, enumerated so an addition is loud. */
+const PAGE_KEYS = [
+  "media_library.media.delete",
+  "media_library.media.purge",
+  "media_library.media.read",
+  "media_library.media.restore"
+] as const;
+
+/** Declared and enforced, deliberately not on this page — see the header. */
+const DELIBERATE_ABSENCES = [
+  "media_library.media.create",
+  "media_library.media.verify",
+  "media_library.media.cancel",
+  "media_library.enforcement.read",
+  "media_library.enforcement.enable"
+] as const;
+
+type Triple = `${string}.${string}.${string}`;
+
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  // Both spellings: these routes use the shared activity-code constant, and a
+  // literal-only regex would see zero guards and pass vacuously.
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*(?:MEDIA_PERMISSION_ACTIVITY_CODE|"([a-z_]+)"),\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2] ?? "media"}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function declaredTriples(): Set<Triple> {
+  return new Set<Triple>(
+    (listModules()
+      .find((module) => module.key === "media_library")
+      ?.permissions?.map(
+        (permission) =>
+          `media_library.${permission.activityCode}.${permission.action}`
+      ) ?? []) as Triple[]
+  );
+}
+
+describe("/admin/media permission gates", () => {
+  test("every key the page gates on is one its endpoints actually enforce", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    expect(pageKeys.size).toBe(PAGE_KEYS.length);
+
+    const enforced = new Set<Triple>();
+    for (const route of ROUTES) {
+      for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+
+    // Non-vacuous: an empty `enforced` would make the subset check pass while
+    // proving nothing, the shape of gate this repo has been burned by.
+    expect(enforced.size).toBe(4);
+
+    expect([...pageKeys].filter((key) => !enforced.has(key))).toEqual([]);
+  });
+
+  test("and is declared by the module descriptor, so a migration seeds it", async () => {
+    const declared = declaredTriples();
+    expect(declared.size).toBe(9);
+
+    const missing = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].filter(
+      (key) => !declared.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  test("the page claims exactly the lifecycle four", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+
+    expect([...pageKeys].sort()).toEqual([...PAGE_KEYS]);
+  });
+
+  test("the revoked attach/detach appear nowhere on the page", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const declared = declaredTriples();
+
+    // Revoked by sql/087 — a control gated on either would deny every caller
+    // including the owner, because nothing seeds them any more.
+    for (const action of ["attach", "detach"]) {
+      expect(declared.has(`media_library.media.${action}` as Triple)).toBe(
+        false
+      );
+      expect(page).not.toContain(`"media", "${action}"`);
+    }
+  });
+
+  test("the deliberate absences stay absent, and stay enforced elsewhere", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const pageKeys = pageTriplesFrom(page);
+    const declared = declaredTriples();
+
+    for (const key of DELIBERATE_ABSENCES) {
+      // Still real: each is declared, seeded, and enforced by its own route.
+      // These are decisions about scope, not permissions left dangling.
+      expect(declared.has(key as Triple)).toBe(true);
+      expect(pageKeys.has(key as Triple)).toBe(false);
+    }
+
+    // And the page says why, so the split survives the next reader.
+    expect(page).toContain("presigned upload");
+    expect(page).toContain("ONE-WAY");
+  });
+
+  test("there is no enforcement.disable to gate on, and never may be", () => {
+    const declared = declaredTriples();
+
+    expect(declared.has("media_library.enforcement.disable" as Triple)).toBe(
+      false
+    );
+  });
+});
+
+describe("/admin/media behaviour", () => {
+  test("the page never mutates directly — it posts to the guarded endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // No SQL write anywhere in the screen: every change goes out over fetch, so
+    // the endpoints' audit rows and idempotency records cannot be bypassed.
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+
+    expect(page).toContain("/api/v1/media/objects/${id}`");
+    expect(page).toContain("/api/v1/media/objects/${id}/restore`");
+    expect(page).toContain("/api/v1/media/objects/${id}/purge`");
+  });
+
+  test("all three mutations carry an Idempotency-Key, because all three require one", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    for (const route of [DELETE_ROUTE, RESTORE_ROUTE, PURGE_ROUTE]) {
+      expect(await readFile(route, "utf8")).toContain("IDEMPOTENCY_REQUIRED");
+    }
+
+    // Spelled once, applied by every call. Unlike `/admin/blog` there is no
+    // opt-out here, and unlike `/admin/sync` there is no endpoint that declines
+    // the header.
+    expect(page).toContain('"Idempotency-Key": crypto.randomUUID()');
+    expect(page).not.toContain("idempotent: false");
+
+    // Three call sites plus the helper declaration.
+    expect([...page.matchAll(/(?<!function )idempotency\(\)/g)].length).toBe(3);
+  });
+
+  test("no <img> renders registry bytes", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Scoped to the TEMPLATE, not the whole file: the frontmatter comment
+    // explains this rule and names the tag while doing so, which would fail
+    // the assertion for the opposite of the reason it exists.
+    const template = page.slice(page.indexOf("\n---\n", 4) + 5);
+    expect(template).toContain("<AdminLayout");
+
+    // A row can be `pending_upload` or `failed`: the bytes may be absent,
+    // unverified, or the very thing the operator is here to delete.
+    expect(template).not.toMatch(/<img\b/i);
+    expect(template).not.toContain("item.publicUrl");
+  });
+
+  test("caller-supplied text is escaped, never interpolated as markup", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // A filename reaches this table verbatim from whoever uploaded it.
+    expect(page).toContain("set:text={item.originalFilename");
+    expect(page).toContain("set:text={item.objectKey}");
+    expect(page).not.toContain("set:html");
+  });
+
+  test("reads run in one transaction and page by keyset, not offset", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain("withTenantOrThrow");
+    expect(page).toContain("decodeKeysetCursor");
+
+    // Case-sensitive on the SQL keyword, plus the query parameter a page-number
+    // pager would need. A case-insensitive `\boffset\b` would match this
+    // screen's own comment explaining why it does NOT use one.
+    expect(page).not.toMatch(/\bOFFSET\b/);
+    expect(page).not.toContain('"offset"');
+    expect(page).not.toContain("offset=");
+    // Concurrent queries on one transaction connection leak it.
+    expect(page).not.toContain("Promise.all");
+  });
+
+  test("a load failure renders as a failure, never as an empty library", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain("loadError");
+    expect(page).toContain("logAdminPageError");
+    expect(page).toContain("not an empty library");
+  });
+
+  test("the delete bound comes from the constant the validator enforces", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain("MAX_DELETE_REASON_LENGTH");
+    // A hand-typed number drifts into the browser accepting what the server
+    // rejects with a 400 the author cannot act on.
+    expect(page).not.toMatch(/at most 500 characters/);
+
+    const validation = await readFile(
+      "src/modules/media-library/domain/media-lifecycle-validation.ts",
+      "utf8"
+    );
+    expect(validation).toContain("export const MAX_DELETE_REASON_LENGTH");
+  });
+
+  test("the purge failure that retrying cannot fix is named", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // "Please try again" is wrong for a live foreign key — retrying will never
+    // succeed, and the caller has an action available.
+    expect(page).toContain("MEDIA_OBJECT_REFERENCED");
+    expect(page).toContain("Remove that reference first");
+  });
+});
+
+describe("/admin/media sidebar entry", () => {
+  test("points at this page and is gated on a real permission", () => {
+    const nav = listModules()
+      .find((module) => module.key === "media_library")
+      ?.navigation?.find((entry) => entry.path === "/admin/media");
+
+    expect(nav).toBeDefined();
+    expect(nav!.requiredPermission).toBe("media_library.media.read");
+    expect(declaredTriples().has(nav!.requiredPermission as Triple)).toBe(true);
+
+    // ONE entry: this module's screen is the object lifecycle and nothing else.
+    expect(
+      listModules().find((module) => module.key === "media_library")?.navigation
+    ).toHaveLength(1);
+  });
+
+  test("its label resolves rather than rendering the raw key", () => {
+    const nav = listModules().find((module) => module.key === "media_library")
+      ?.navigation?.[0];
+
+    expect(nav).toBeDefined();
+    expect(SIDEBAR_LABELS[nav!.labelKey]).toBe("Media library");
+  });
+});
+
+describe("ADR-0021 criterion 1", () => {
+  test("no active module is left without an admin screen", () => {
+    const withoutScreen = listModules()
+      .filter((module) => module.status === "active")
+      .filter((module) => (module.navigation ?? []).length === 0)
+      .map((module) => module.key);
+
+    // `media_library` was the last one. `idn_admin_regions` is deliberate and
+    // documented (ADR-0052 moved its lifecycle to operator jobs), so if it is
+    // the only survivor this criterion is met as written.
+    expect(withoutScreen.filter((key) => key !== "idn_admin_regions")).toEqual(
+      []
+    );
+  });
+});


### PR DESCRIPTION
The end of ADR-0056, and of ADR-0051's screen backlog. Follows #342 (§A), #343 (§B), #344 (§C).

## Why this one needed four PRs

`media_library` sat on the "modules without a screen" list for two waves, beside modules that were genuinely only missing a page. ADR-0056 found that framing was wrong here: **five of eleven permissions were enforced by nothing**, five application functions had **zero callers**, and there was **no list function at all**. This screen could not have been built on the surface that existed, whatever the permission catalog said.

So: §A revoked `attach`/`detach`, §B gave `delete`/`restore`/`purge` endpoints, §C added the browse listing and its route. This PR is what those three were for.

## The console

Browse with §C's filters — status, mime type, and the three-way `live`/`deleted`/`all` — then delete, restore, purge. Four permissions: `media.read`, `.delete`, `.restore`, `.purge`.

Reads go through `listMediaObjects` inside one `withTenantOrThrow`. Writes post to the guarded endpoints with a fresh `Idempotency-Key` each — unlike `/admin/blog` there is no opt-out, and unlike `/admin/sync` there is no endpoint that declines the header.

## Three deliberate absences

Each pinned by `tests/admin-media-page-contract.test.ts`, so they stay decisions rather than becoming gaps:

- **Upload** (`media.create`/`.verify`/`.cancel`) — a three-step browser flow (create session → PUT the bytes straight to R2 → finalize) with real file input, progress, and client-side failure modes. A button that starts a session this page cannot finish leaves a `pending_upload` row behind on **every misclick** — precisely the litter the reconciliation job exists to clean up.
- **`enforcement.read`/`.enable`** — a tenant-wide, ONE-WAY content policy switch, not an object action. It belongs on `/admin/security`; offering it beside a row of files would misrepresent its blast radius.
- **No `<img>` preview.** A registry row can be `pending_upload` or `failed` — the bytes may be absent, unverified, or *the very thing an operator is here to delete*. Rendering them is how a policy-violating image gets shown one more time, to the person removing it.

## Small things that matter

The delete prompt asks for a real reason rather than sending a placeholder, because it lands on an audit row that outlives the object; its bound comes from the constant the validator enforces, not a hand-typed 500.

Purge is the only irreversible action, the only one behind a `confirm`, and the only failure this screen names specifically: `MEDIA_OBJECT_REFERENCED` gets *"remove that reference first"* rather than *"please try again"* — retrying will never succeed while the foreign key is live.

## This closes ADR-0021's criterion 1

`idn-admin-regions` is now the only module without a screen, and that is a documented decision (ADR-0052 moved its lifecycle to operator jobs). ADR-0021 claimed `admin-navigation-registry.test.ts` enforced "every module has a screen"; it did not. The new contract test asserts it **repo-wide**, so the next module to land without `navigation` turns CI red instead of quietly becoming a second exception.

## Verification

17 contract tests. Mutation-proven, each red on its own:

| Mutation | Result |
|---|---|
| Gate a control on the revoked `media.detach` | 4 red |
| Drop one mutation's `Idempotency-Key` | 1 red |
| Render a preview `<img>` of the bytes | 1 red |
| Remove the navigation entry | 3 red (incl. criterion 1) |

Full `bun run check` green locally — 3319 pass, 0 fail, build complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)