### PR TITLE
fix(docs): idn-admin-regions has a screen — ADR-0021 criterion 1 has ZERO exceptions

### DIFF
--- a/.changeset/adr-0021-criterion-zero-exceptions.md
+++ b/.changeset/adr-0021-criterion-zero-exceptions.md
@@ -1,0 +1,11 @@
+---
+"awcms": patch
+---
+
+Correct a stale claim: `idn-admin-regions` is not screenless, so ADR-0021's criterion 1 has **zero** exceptions rather than one.
+
+`docs/PROJECT_STATE.md` §4 listed `idn-admin-regions` as "deliberately without a screen, see ADR-0052", the contract test added with `/admin/media` carried a matching carve-out, and PR #345's own body repeated it as fact. All three were wrong: `/admin/idn-regions` landed in #332.
+
+ADR-0052 moved that module's dataset **lifecycle** to operator jobs — not the whole module — and the two read permissions it kept are exactly what that screen drives. Verified against the code rather than the documents: `grep -L 'navigation:' src/modules/*/module.ts` now returns nothing at all.
+
+The carve-out also failed in the other direction. With `idn_admin_regions` excused, that module could have **lost** its screen and the test would still have passed — an exception written for a module that did not need one, protecting it from the check it was supposed to be under. The assertion is now a plain `toEqual([])`, mutation-proven by removing `idn-admin-regions`' navigation entry.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -81,14 +81,14 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 
 ## 2. Inventori ringkas
 
-| Aspek       | Nilai (per commit ini)                                                                                                              | Sumber kebenaran                                                                        |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Versi       | **6.4.0** (2026-07-26); **53 changeset menunggu** rilis berikutnya                                                                  | `package.json`, `CHANGELOG.md`, tag `v*`                                                |
-| Modul base  | **21** (lihat daftar di ARCHITECTURE.md)                                                                                            | `src/modules/index.ts`                                                                  |
-| Migrasi     | **88** (`sql/001`–`088`)                                                                                                            | `ls sql/`                                                                               |
-| ADR         | **0000**–**0056** (`0000` = template)                                                                                               | `ls docs/adr/`                                                                          |
-| Layar admin | **28** berkas `.astro` di `src/pages/admin/`; **0 dari 21 modul** tanpa layar tak-disengaja (`idn-admin-regions` sengaja, ADR-0052) | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Kontrak     | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.4.0**                                                           | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
+| Aspek       | Nilai (per commit ini)                                                                                                   | Sumber kebenaran                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| Versi       | **6.4.0** (2026-07-26); **53 changeset menunggu** rilis berikutnya                                                       | `package.json`, `CHANGELOG.md`, tag `v*`                                                |
+| Modul base  | **21** (lihat daftar di ARCHITECTURE.md)                                                                                 | `src/modules/index.ts`                                                                  |
+| Migrasi     | **88** (`sql/001`–`088`)                                                                                                 | `ls sql/`                                                                               |
+| ADR         | **0000**–**0056** (`0000` = template)                                                                                    | `ls docs/adr/`                                                                          |
+| Layar admin | **28** berkas `.astro` di `src/pages/admin/`; **0 dari 21 modul** tanpa layar — nol pengecualian, tak ada yang disengaja | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Kontrak     | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.4.0**                                                | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
 > **Angka tabel ini pernah basi tanpa ada yang merah.** Sebelum PR #339 barisnya
 > berbunyi "20 berkas / 7 dari 21 modul" sementara `main` sudah memuat 22 berkas dan
@@ -391,8 +391,13 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
     > `media-object-directory.ts` juga penuh string `action: "..."` yang merupakan
     > nama aksi AUDIT, bukan gerbang permission.
 
-  - `idn-admin-regions` — sengaja tanpa layar, lihat §3 (ADR-0052 memindahkan
-    lifecycle-nya ke job operator; sisanya dua permission baca).
+  - ~~`idn-admin-regions`~~ **SUDAH PUNYA LAYAR** — `/admin/idn-regions`, mendarat
+    di #332. Entri ini sebelumnya berbunyi "sengaja tanpa layar"; itu **usang**,
+    dan sempat diulang dalam badan PR #345 ("satu-satunya modul tanpa layar").
+    Diverifikasi ke kode: `grep -L 'navigation:' src/modules/*/module.ts` kini
+    mengembalikan **nol** baris. ADR-0052 memindahkan LIFECYCLE dataset-nya ke
+    job operator — bukan seluruh modulnya — dan dua permission baca yang tersisa
+    justru digerakkan layar itu.
 
   Ikuti pola gelombang #321–#330 di §3 — termasuk contract test per layar, yang
   **mutation-proven** (kembalikan cacat aslinya dan pastikan MERAH) sebelum di-commit.

--- a/tests/admin-media-page-contract.test.ts
+++ b/tests/admin-media-page-contract.test.ts
@@ -304,17 +304,22 @@ describe("/admin/media sidebar entry", () => {
 });
 
 describe("ADR-0021 criterion 1", () => {
-  test("no active module is left without an admin screen", () => {
+  test("no active module is left without an admin screen — ZERO exceptions", () => {
     const withoutScreen = listModules()
       .filter((module) => module.status === "active")
       .filter((module) => (module.navigation ?? []).length === 0)
       .map((module) => module.key);
 
-    // `media_library` was the last one. `idn_admin_regions` is deliberate and
-    // documented (ADR-0052 moved its lifecycle to operator jobs), so if it is
-    // the only survivor this criterion is met as written.
-    expect(withoutScreen.filter((key) => key !== "idn_admin_regions")).toEqual(
-      []
-    );
+    // `media_library` was the last one, and there is no carve-out. An earlier
+    // draft of this test excused `idn_admin_regions` as "deliberately
+    // screenless" — a claim `docs/PROJECT_STATE.md` also carried and PR #345's
+    // body repeated. It was stale: `/admin/idn-regions` landed in #332.
+    // ADR-0052 moved that module's dataset LIFECYCLE to operator jobs, not the
+    // whole module, and the two read permissions it kept are exactly what that
+    // screen drives.
+    //
+    // The excuse mattered in the wrong direction too: with it, `idn_admin_regions`
+    // could have LOST its screen and this test would still have passed.
+    expect(withoutScreen).toEqual([]);
   });
 });


### PR DESCRIPTION
Found while verifying the final numbers after #345, and it corrects something I got wrong in that PR's own body.

## The stale claim, in three places

`docs/PROJECT_STATE.md` §4 listed `idn-admin-regions` as *"sengaja tanpa layar, lihat §3 (ADR-0052)"*. The contract test shipped with `/admin/media` carried a matching carve-out. And **PR #345's body repeated it as fact** — "`idn-admin-regions` is now the only module without a screen".

All three were wrong. **`/admin/idn-regions` landed in #332.**

ADR-0052 moved that module's dataset **lifecycle** to operator jobs — not the whole module — and the two read permissions it kept are exactly what that screen drives. Verified against the code rather than the documents:

```
$ grep -L 'navigation:' src/modules/*/module.ts
$          # nothing
```

## The carve-out failed in the other direction too

```js
expect(withoutScreen.filter((key) => key !== "idn_admin_regions")).toEqual([]);
```

With `idn_admin_regions` excused, that module could have **lost** its screen and the test would still have passed. An exception written for a module that did not need one, quietly exempting it from the check it was supposed to be under.

Now a plain `toEqual([])`. Mutation-proven by removing `idn-admin-regions`' `navigation` entry — red.

## Net effect

ADR-0021's criterion 1 is at **zero exceptions**, not "one deliberate exception". The table row in §4 now says so, and the command that produces the number is beside it.

Full `bun run check` green — 3360 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)