### PR TITLE
feat(blog-content): give blog pages a lifecycle (ADR-0057)

### DIFF
--- a/.changeset/blog-page-lifecycle-surface.md
+++ b/.changeset/blog-page-lifecycle-surface.md
@@ -1,0 +1,27 @@
+---
+"awcms": minor
+---
+
+feat(blog-content): blog pages can be published (ADR-0057)
+
+`pages.publish`, `pages.archive`, `pages.restore` and `pages.purge` have been
+seeded since `sql/036` and enforced by nothing. That was not a spare catalogue
+row: `createBlogPage` wrote a literal `'draft'`, `updateBlogPage` never touched
+`status`, and the scheduled-publish job reads only posts — so **no code path
+could publish a page**, while public page search filtered on
+`status = 'published'` and always returned nothing.
+
+Four guarded, audited, `Idempotency-Key`-bearing routes close it:
+`POST /api/v1/blog/pages/{id}/publish`, `/archive`, `/restore`, `/purge`.
+Publish runs the same content-quality checklist posts do, which the page
+preview endpoint has been reporting with nothing to gate.
+
+The page lifecycle is deliberately narrower than posts' — no `review`, no
+`scheduled`, since no `pages.schedule` permission was ever seeded. `purge`
+reports the ad placements it leaves inert rather than refusing or cascading.
+
+Also adds `bun run access:permissions:enforcement:check`: every declared
+permission must have an `authorizeInTransaction` guard or a recorded reason.
+It found five further gaps beyond pages, all now recorded and tracked.
+
+No migrations — the columns, CHECK, index and catalogue rows already existed.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -430,13 +430,49 @@ NULL`, jadi pencarian publik untuk page **selalu** nol baris — di atas index
     index dan baris katalog sudah ada; yang hilang murni lapisan aplikasi + route.
     Urutan mengikat: permukaan dulu, `/admin/blog/pages` menyusul.
 
-    Tiga saudara sisanya (taxonomy, presentation, settings/homepage) sejauh
-    audit ini permukaannya lengkap — seluruhnya pasangan `read`/`configure`
-    ber-route. ADR-0057 §F menjadikan "sejauh audit ini" klaim yang dijaga:
-    gate baru menuntut tiap permission terdeklarasi punya call site
-    `authorizeInTransaction` atau terdaftar sebagai pengecualian ber-alasan.
-    Tanpa itu, kelas cacat yang sama sudah lolos DUA kali dan keduanya hanya
-    ketahuan karena seseorang hendak membangun layarnya.
+    **Permukaan SELESAI** — `sql/`-nol, empat rute ter-guard/ter-audit/
+    ber-`Idempotency-Key` (`publish`/`archive`/`restore`/`purge`) lewat
+    `defineTenantRoute`, plus `domain/page-status.ts` dan tiga fungsi directory.
+    Layar `/admin/blog/pages` menyusul.
+
+- **Gate cakupan permission — BARU, dan ia menemukan lima gap lagi.**
+  `bun run access:permissions:enforcement:check` (ADR-0057 §F) menuntut tiap
+  permission terdeklarasi punya call site `authorizeInTransaction` atau
+  terdaftar sebagai pengecualian ber-alasan. Murni (registry + teks sumber),
+  masuk rantai `check`. Skor pertama: **199/205 tergerbangi, 6 pengecualian**.
+
+  Lima di antaranya **temuan baru**, semuanya diverifikasi ke kode, dan
+  masing-masing butuh keputusan yang sama dengan ADR-0057 §A — beri permukaan,
+  atau cabut:
+  - `profile_identity.profile_management.restore` — **lubang nyata**: tak ada
+    rute restore sama sekali, jadi profil yang di-soft-delete tidak bisa
+    dipulihkan lewat API. Bentuk yang sama dengan yang ADR-0056 §B tutup untuk
+    objek media.
+  - `visitor_analytics.settings.read` + `.update` — setting analitik per-tenant
+    tak punya permukaan apa pun.
+  - `blog_content.seo.configure` — satu-satunya kemunculan `"seo"` di repo
+    adalah deklarasi descriptor itu sendiri; kemungkinan besar **pencabutan**,
+    karena default SEO blog nyatanya dikonfigurasi lewat blog settings.
+  - `comments.moderation.delete` — model moderasi ADR-0041 adalah
+    arsip-bukan-hapus, jadi ini pun kandidat pencabutan.
+
+  Yang keenam sudah diketahui: `blog_content.posts.export` (ADR-0057 §F).
+
+  > **Gate-nya sendiri butuh tiga kali tulis ulang, dan itu pelajarannya.**
+  > Draf 1 hanya membaca literal string → **39 false positive**, termasuk tiga
+  > permission yang endpoint-nya mendarat minggu itu juga (banyak modul menulis
+  > `moduleKey: THEMING_MODULE_KEY`). Draf 2 mencocokkan kurung terdalam →
+  > setiap guard ber-field bersarang tak terlihat (`workflow.approval.approve`).
+  > Draf 3 menuntut action literal → dua guard kondisional
+  > (`comments.moderation.approve`/`.reject`) terlewat. Scanner yang menjawab
+  > "tak tergerbangi" untuk yang tergerbangi LEBIH buruk daripada tak ada
+  > scanner: ia melatih pembacanya menambah pengecualian sampai gate-nya tak
+  > menanyakan apa pun. Ketiga draf itu dibekukan sebagai test di
+  > `tests/permission-enforcement-coverage.test.ts`.
+
+  Tiga saudara `blog_content` sisanya (taxonomy, presentation, settings/homepage)
+  permukaannya lengkap — dan itu kini klaim yang **dijaga**, bukan hasil audit
+  manual sekali jalan.
 
   - ~~`idn-admin-regions`~~ **SUDAH PUNYA LAYAR** — `/admin/idn-regions`, mendarat
     di #332. Entri ini sebelumnya berbunyi "sengaja tanpa layar"; itu **usang**,

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -4909,6 +4909,82 @@ Gated by blog_content.pages.delete.
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
 
+### `POST /api/v1/blog/pages/{id}/archive` — Archive a blog page
+
+- **operationId**: `blogArchivePage`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.pages.archive (ADR-0057). High-risk, requires Idempotency-Key. Removes the page from the public site without destroying it; published_at is retained so a later re-publish keeps the original go-live date.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                                                                                  | Schema                                 |
+| ------ | -------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Page archived (or an idempotent replay).                                                     | object                                 |
+| 400    | Validation error.                                                                            | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                  | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                  | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                          | [`ApiError`](#standard-error-envelope) |
+| 409    | Invalid status transition, or the Idempotency-Key was already used with a different request. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/blog/pages/{id}/publish` — Publish a blog page
+
+- **operationId**: `blogPublishPage`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.pages.publish (ADR-0057). High-risk, requires Idempotency-Key. Blocked (422) if the content quality checklist fails when full-online R2-only mode is active for the tenant. Pages have a narrower lifecycle than posts - no review, no scheduled - so the only sources for this transition are draft and archived. No social-publishing hook is invoked - that port's trigger is post_published and a page is not an article.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                                                                                  | Schema                                 |
+| ------ | -------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Page published (or an idempotent replay).                                                    | object                                 |
+| 400    | Validation error.                                                                            | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                  | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                  | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                          | [`ApiError`](#standard-error-envelope) |
+| 409    | Invalid status transition, or the Idempotency-Key was already used with a different request. | [`ApiError`](#standard-error-envelope) |
+| 422    | Publish is blocked by the content quality checklist.                                         | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/blog/pages/{id}/purge` — Permanently purge an archived or soft-deleted blog page
+
+- **operationId**: `blogPurgePage`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.pages.purge (ADR-0057). High-risk, irreversible, requires Idempotency-Key. Only an archived or previously soft-deleted page may be purged. Advertisement placements targeting this page neither block the purge nor are deleted with it - they simply go inert, exactly as they already do for a soft-deleted page, because the render query matches target_id against the page being rendered. Their count is returned as adPlacementsNowInert so the change is visible rather than silent.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                                                                                                      | Schema                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Page purged (or an idempotent replay).                                                                           | object                                 |
+| 400    | Validation error.                                                                                                | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                      | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                      | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                                              | [`ApiError`](#standard-error-envelope) |
+| 409    | The page is neither archived nor soft-deleted, or the Idempotency-Key was already used with a different request. | [`ApiError`](#standard-error-envelope) |
+
 ### `GET /api/v1/blog/pages/{id}/quality-checklist` — Preview the content quality checklist for a page
 
 - **operationId**: `blogGetPageQualityChecklist`
@@ -4931,6 +5007,31 @@ Read-only preview for the admin editor. Gated by blog_content.pages.read.
 | 401    | Missing or invalid session. | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/blog/pages/{id}/restore` — Restore a soft-deleted blog page
+
+- **operationId**: `blogRestorePage`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.pages.restore (ADR-0057). High-risk, requires Idempotency-Key. Undoes a soft delete, not an archive - lifecycle status is left untouched, so a page soft-deleted while published comes back published. A page that is not soft-deleted answers 404, the same shape as an unknown id, so restore cannot be used to probe which ids exist.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `Idempotency-Key`  | header | yes      | string |             |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                                                    | Schema                                 |
+| ------ | -------------------------------------------------------------- | -------------------------------------- |
+| 200    | Page restored (or an idempotent replay).                       | object                                 |
+| 400    | Validation error.                                              | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                    | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                    | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                            | [`ApiError`](#standard-error-envelope) |
+| 409    | The Idempotency-Key was already used with a different request. | [`ApiError`](#standard-error-envelope) |
 
 ### `GET /api/v1/blog/posts` — List this tenant's non-deleted blog posts
 

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -237,9 +237,29 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/blog/pages/[id]/archive.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
+      "path": "src/pages/api/v1/blog/pages/[id]/publish.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
+      "path": "src/pages/api/v1/blog/pages/[id]/purge.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/blog/pages/[id]/quality-checklist.ts",
       "workClass": "interactive",
       "source": "default"
+    },
+    {
+      "path": "src/pages/api/v1/blog/pages/[id]/restore.ts",
+      "workClass": "interactive",
+      "source": "factory"
     },
     {
       "path": "src/pages/api/v1/blog/pages/index.ts",

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -3246,6 +3246,171 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/blog/pages/{id}/archive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogArchivePage
+      summary: Archive a blog page
+      description: Gated by blog_content.pages.archive (ADR-0057). High-risk, requires Idempotency-Key. Removes the page from the public site without destroying it; published_at is retained so a later re-publish keeps the original go-live date.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page archived (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/{id}/publish:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPublishPage
+      summary: Publish a blog page
+      description: Gated by blog_content.pages.publish (ADR-0057). High-risk, requires Idempotency-Key. Blocked (422) if the content quality checklist fails when full-online R2-only mode is active for the tenant. Pages have a narrower lifecycle than posts - no review, no scheduled - so the only sources for this transition are draft and archived. No social-publishing hook is invoked - that port's trigger is post_published and a page is not an article.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page published (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Publish is blocked by the content quality checklist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/{id}/purge:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPurgePage
+      summary: Permanently purge an archived or soft-deleted blog page
+      description: Gated by blog_content.pages.purge (ADR-0057). High-risk, irreversible, requires Idempotency-Key. Only an archived or previously soft-deleted page may be purged. Advertisement placements targeting this page neither block the purge nor are deleted with it - they simply go inert, exactly as they already do for a soft-deleted page, because the render query matches target_id against the page being rendered. Their count is returned as adPlacementsNowInert so the change is visible rather than silent.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page purged (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      status:
+                        type: string
+                        enum:
+                          - purged
+                      adPlacementsNowInert:
+                        type: integer
+                        minimum: 0
+                        description: Advertisement placements that targeted this page and are now inert.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The page is neither archived nor soft-deleted, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/blog/pages/{id}/quality-checklist:
     parameters:
       - name: id
@@ -3290,6 +3455,55 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/blog/pages/{id}/restore:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogRestorePage
+      summary: Restore a soft-deleted blog page
+      description: Gated by blog_content.pages.restore (ADR-0057). High-risk, requires Idempotency-Key. Undoes a soft delete, not an archive - lifecycle status is left untouched, so a page soft-deleted while published comes back published. A page that is not soft-deleted answers 404, the same shape as an unknown id, so restore cannot be used to probe which ids exist.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page restored (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/blog/posts:
     get:
       tags:

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -1058,6 +1058,215 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/blog/pages/{id}/publish:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPublishPage
+      summary: Publish a blog page
+      description: Gated by blog_content.pages.publish (ADR-0057). High-risk, requires Idempotency-Key. Blocked (422) if the content quality checklist fails when full-online R2-only mode is active for the tenant. Pages have a narrower lifecycle than posts - no review, no scheduled - so the only sources for this transition are draft and archived. No social-publishing hook is invoked - that port's trigger is post_published and a page is not an article.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page published (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: Publish is blocked by the content quality checklist.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/{id}/archive:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogArchivePage
+      summary: Archive a blog page
+      description: Gated by blog_content.pages.archive (ADR-0057). High-risk, requires Idempotency-Key. Removes the page from the public site without destroying it; published_at is retained so a later re-publish keeps the original go-live date.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page archived (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Invalid status transition, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/{id}/restore:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogRestorePage
+      summary: Restore a soft-deleted blog page
+      description: Gated by blog_content.pages.restore (ADR-0057). High-risk, requires Idempotency-Key. Undoes a soft delete, not an archive - lifecycle status is left untouched, so a page soft-deleted while published comes back published. A page that is not soft-deleted answers 404, the same shape as an unknown id, so restore cannot be used to probe which ids exist.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page restored (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/{id}/purge:
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+    post:
+      tags:
+        - Blog Content
+      operationId: blogPurgePage
+      summary: Permanently purge an archived or soft-deleted blog page
+      description: Gated by blog_content.pages.purge (ADR-0057). High-risk, irreversible, requires Idempotency-Key. Only an archived or previously soft-deleted page may be purged. Advertisement placements targeting this page neither block the purge nor are deleted with it - they simply go inert, exactly as they already do for a soft-deleted page, because the render query matches target_id against the page being rendered. Their count is returned as adPlacementsNowInert so the change is visible rather than silent.
+      parameters:
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Page purged (or an idempotent replay).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                        format: uuid
+                      status:
+                        type: string
+                        enum: [purged]
+                      adPlacementsNowInert:
+                        type: integer
+                        minimum: 0
+                        description: Advertisement placements that targeted this page and are now inert.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: The page is neither archived nor soft-deleted, or the Idempotency-Key was already used with a different request.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/blog/terms:
     get:
       tags:

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "email:templates:seed-defaults": "bun scripts/email-templates-seed-defaults.ts",
     "reporting:projections:refresh": "bun scripts/reporting-projections-refresh.ts",
     "reporting:projections:registry:check": "bun scripts/reporting-projection-registry-check.ts",
+    "access:permissions:enforcement:check": "bun scripts/permission-enforcement-check.ts",
     "identity-access:sod-registry:check": "bun scripts/identity-access-sod-registry-check.ts",
     "family:conformance:check": "bun scripts/family-conformance-check.ts",
     "reporting:exports:dispatch": "bun scripts/reporting-exports-dispatch.ts",
@@ -107,7 +108,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run access:permissions:enforcement:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,12 +23,13 @@ lalu membangun duplikatnya.
 
 <!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-64 target menjalankan berkas di `scripts/`; 23 di antaranya
+65 target menjalankan berkas di `scripts/`; 24 di antaranya
 ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
 terjadwal, atau oleh workflow CI tertentu.
 
 | Target                                   | Skrip                                          | Gate |
 | ---------------------------------------- | ---------------------------------------------- | ---- |
+| `access:permissions:enforcement:check`   | `permission-enforcement-check.ts`              | ✅   |
 | `analytics:purge`                        | `visitor-analytics-purge.ts`                   | —    |
 | `analytics:rollup`                       | `visitor-analytics-rollup.ts`                  | —    |
 | `api:docs:check`                         | `api-docs-check.ts`                            | ✅   |

--- a/scripts/permission-enforcement-check.ts
+++ b/scripts/permission-enforcement-check.ts
@@ -1,0 +1,131 @@
+/**
+ * permission-enforcement-check.ts — `bun run access:permissions:enforcement:check`.
+ *
+ * ADR-0057 §F. Every permission a module descriptor declares must have an
+ * `authorizeInTransaction` guard somewhere in `src/`, or a recorded reason why
+ * it does not. Pure: registry + source text, no database, no network.
+ *
+ * The gate exists because two modules shipped seeded-but-unchecked permissions
+ * and both were caught by hand, months later, only when someone tried to build
+ * their admin screen. For `blog_content` the consequence was that a page could
+ * never be published at all. See `permission-enforcement-coverage.ts` for what
+ * this can and cannot prove.
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import { listModules } from "../src/modules";
+import {
+  evaluateEnforcementCoverage,
+  type EnforcementException
+} from "../src/modules/_shared/permission-enforcement-coverage";
+
+/**
+ * Permissions with no enforcer, each with the reason it stays that way.
+ *
+ * This list is a set of DECISIONS, not a backlog. A permission that ought to
+ * be enforced belongs in code, not here — and the gate reports an entry whose
+ * permission has since gained an enforcer as stale, so an exception cannot
+ * outlive its reason unnoticed.
+ */
+const EXCEPTIONS: readonly EnforcementException[] = [
+  {
+    key: "blog_content.posts.export",
+    reason:
+      "Declared by the descriptor and seeded by sql/036, with no endpoint anywhere that enforces it — recorded in /admin/blog's header and in ADR-0057 §F as a revocation candidate awaiting its own ADR. Building a surface to justify the catalogue row would be the tail wagging the dog."
+  },
+
+  // The five below were found by this gate on its first run, and every one was
+  // verified against the code before being written down. They are NOT excused
+  // because they are acceptable — they are the same defect ADR-0057 documents
+  // for `pages`, in five more places, and each needs the decision ADR-0057 §A
+  // made: give it a surface, or revoke it.
+  //
+  // They are recorded rather than fixed here because closing five unrelated
+  // holes inside a change about blog pages produces something nobody can
+  // review as either. `docs/PROJECT_STATE.md` §4 carries them as backlog. What
+  // this list buys today is that they are visible, counted, and that a SIXTH
+  // one turns CI red instead of waiting for the next manual audit.
+  {
+    key: "blog_content.seo.configure",
+    reason:
+      'No route and no application function names activityCode "seo" anywhere — the only occurrence in the repo is the descriptor declaration itself. Blog SEO defaults are in fact configured through blog settings (blog_content.settings.configure), so this is most likely a revocation, not a missing endpoint. Needs its own ADR.'
+  },
+  {
+    key: "comments.moderation.delete",
+    reason:
+      "The moderation surface enforces approve/reject (one conditional guard), archive and restore, plus a public delete-request flow — but nothing gates a moderator delete. ADR-0041's moderation model is archive-not-delete, so this is a revocation candidate rather than a missing route. Needs its own ADR."
+  },
+  {
+    key: "profile_identity.profile_management.restore",
+    reason:
+      "profile_identity has no restore route at all; the five profile routes gate read/create/update/merge. Soft-deleted profiles therefore cannot be recovered through the API, which is a real hole rather than a spare permission — the same shape ADR-0056 §B closed for media objects. Needs its own ADR."
+  },
+  {
+    key: "visitor_analytics.settings.read",
+    reason:
+      "Every analytics route gates on the dashboard/sessions/retention activities; no route names a settings activity. Per-tenant analytics settings have no surface at all. Needs its own ADR, together with the update below."
+  },
+  {
+    key: "visitor_analytics.settings.update",
+    reason:
+      "Pair of the read above — declared and seeded, with no endpoint that enforces it."
+  }
+];
+
+const SOURCE_ROOT = "src";
+const SOURCE_EXTENSIONS = [".ts", ".astro"];
+
+function collectSourceFiles(directory: string, into: string[]): void {
+  for (const entry of readdirSync(directory)) {
+    const path = join(directory, entry);
+
+    if (statSync(path).isDirectory()) {
+      collectSourceFiles(path, into);
+      continue;
+    }
+
+    if (SOURCE_EXTENSIONS.some((extension) => path.endsWith(extension))) {
+      into.push(path);
+    }
+  }
+}
+
+function main(): void {
+  const files: string[] = [];
+  collectSourceFiles(SOURCE_ROOT, files);
+
+  const sources = files.map((file) => readFileSync(file, "utf8"));
+  const result = evaluateEnforcementCoverage(
+    listModules(),
+    sources,
+    EXCEPTIONS
+  );
+
+  if (result.valid) {
+    console.log(
+      `access:permissions:enforcement:check OK — ${result.enforcedCount}/${result.declaredCount} declared permission(s) have an authorizeInTransaction guard; ${EXCEPTIONS.length} recorded exception(s).`
+    );
+    return;
+  }
+
+  console.error("access:permissions:enforcement:check FAILED —");
+
+  for (const permission of result.unenforced) {
+    console.error(
+      `  ${permission.key} — declared by module "${permission.moduleKey}" and enforced by nothing. Add an authorizeInTransaction guard, or record the reason in EXCEPTIONS in this script (with the ADR that decided it).`
+    );
+  }
+
+  for (const key of result.staleExceptions) {
+    console.error(
+      `  ${key} — stale exception: the permission is no longer declared, or it now HAS an enforcer. Remove the entry from EXCEPTIONS.`
+    );
+  }
+
+  process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  main();
+}

--- a/src/modules/_shared/permission-enforcement-coverage.ts
+++ b/src/modules/_shared/permission-enforcement-coverage.ts
@@ -1,0 +1,391 @@
+import type { ModuleDescriptor } from "./module-contract";
+
+/**
+ * Permission-enforcement coverage (ADR-0057 §F).
+ *
+ * Two modules have now shipped seeded permissions that NOTHING checks, and
+ * both were found only because someone set out to build the screen for them:
+ * `media_library` had five (ADR-0056), `blog_content` had four (ADR-0057), and
+ * in the second case the gap was not a spare catalogue row — it meant a page
+ * could never be published by any code path in the repo, while public page
+ * search filtered on `status = 'published'` and therefore always returned
+ * nothing.
+ *
+ * Every existing gate answers a different question. `admin-navigation-registry`
+ * catches a navigation entry whose path has no page. The per-screen contract
+ * tests bind a screen's permission keys to what its routes enforce. None of
+ * them asks whether a DECLARED permission has an enforcer at all, which is why
+ * both gaps sat in `main` with `bun run check` green.
+ *
+ * This module answers exactly that, and nothing more: for every permission a
+ * module descriptor declares, does some source file build an
+ * `authorizeInTransaction` guard for it — or is its absence recorded as a
+ * decision?
+ *
+ * ## What counts as an enforcer, and why the shape is the whole test
+ *
+ * `authorizeInTransaction(tx, tenantId, tokenHash, now, guard)` takes an
+ * `AccessRequest`: an object literal carrying `moduleKey`, `activityCode` and
+ * `action` together. Requiring all THREE keys in one literal is what separates
+ * a guard from the two things that would otherwise be mistaken for one:
+ *
+ * - **audit events** carry `moduleKey` and `action` but never `activityCode`,
+ *   and their `action` is a dotted event name (`blog.page.purged`) rather than
+ *   a permission action. `media-object-directory.ts` is full of them, and
+ *   ADR-0056 records that reading them as gates gives the wrong answer;
+ * - **row mappings** (`action: record.action`) carry no string literal at all.
+ *
+ * ## Why it scans all of `src/`, not `src/pages/api/`
+ *
+ * `media_library.media.verify` is enforced inside an application function
+ * (`media-finalize-upload-session.ts`), not in a route file. ADR-0056 §1 notes
+ * that scanning route files alone gets the answer wrong in BOTH directions —
+ * it misses that gate and mistakes audit-action strings for gates.
+ *
+ * This is a purely syntactic check and it is honest about that: it proves a
+ * guard for the permission is CONSTRUCTED somewhere, not that it sits on the
+ * right endpoint or that the endpoint is reachable. That is the class of defect
+ * it is for. A permission enforced only in dead code would still pass, and the
+ * per-screen contract tests are what cover the next layer down.
+ */
+
+/** `moduleKey.activityCode.action` — the same spelling `permissionKey()` produces. */
+export type PermissionTriple = {
+  moduleKey: string;
+  activityCode: string;
+  action: string;
+};
+
+export type EnforcementException = {
+  key: string;
+  reason: string;
+};
+
+export type UnenforcedPermission = {
+  key: string;
+  moduleKey: string;
+};
+
+export type EnforcementCoverageResult = {
+  valid: boolean;
+  declaredCount: number;
+  enforcedCount: number;
+  unenforced: UnenforcedPermission[];
+  /** Exceptions whose permission is no longer declared, or has since gained an enforcer — a stale allow-list entry is how a gate quietly stops asking. */
+  staleExceptions: string[];
+};
+
+export function permissionTripleKey(triple: PermissionTriple): string {
+  return `${triple.moduleKey}.${triple.activityCode}.${triple.action}`;
+}
+
+/**
+ * Strips `//` and block comments so that prose mentioning a guard shape cannot
+ * be mistaken for one. This file's own header would otherwise register as an
+ * enforcer for several permissions.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+}
+
+/**
+ * A guard field is written one of two ways, and a scanner that only reads the
+ * first is not merely incomplete — it reports the majority of this repo's
+ * permissions as unenforced:
+ *
+ *     moduleKey: "media_library"          // string literal
+ *     moduleKey: THEMING_MODULE_KEY       // imported string constant
+ *
+ * `theming`, `site_search`, `seo_distribution`, `comments`, `media_library`
+ * and others name their module key and activity codes through constants. The
+ * first draft of this gate read literals only and produced 39 false positives,
+ * including three permissions that had gained endpoints the same week.
+ *
+ * `constants` maps every `const NAME = "value"` found across the scanned
+ * sources. A name bound to two different values anywhere is deliberately left
+ * UNRESOLVED rather than guessed: the resulting report of "unenforced" is
+ * visible and fixable, whereas guessing one of the two values could mark a
+ * permission enforced on the strength of an unrelated file's constant.
+ */
+function readStringField(
+  literal: string,
+  field: string,
+  constants: ReadonlyMap<string, string | null>
+): string | null {
+  const match = new RegExp(
+    `\\b${field}\\s*:\\s*(?:"([^"]+)"|([A-Za-z_$][A-Za-z0-9_$]*))`
+  ).exec(literal);
+
+  if (!match) return null;
+  if (match[1] !== undefined) return match[1];
+
+  return constants.get(match[2]!) ?? null;
+}
+
+/**
+ * `action` is the one guard field that is not always a single value. Two
+ * comments routes decide it per request:
+ *
+ *     action: (decision === "approve" ? "approve" : "reject") as ...
+ *
+ * A reader that only accepts `action: "literal"` reports both
+ * `comments.moderation.approve` and `.reject` as unenforced while the route
+ * gates every request on one of them. So every string literal in the
+ * expression counts — the guard really can require any of them.
+ *
+ * The expression ends at the field separator, and the scan is over a literal
+ * with nested objects already blanked, so a comma inside a nested value cannot
+ * cut it short.
+ */
+function readActionValues(
+  fields: string,
+  constants: ReadonlyMap<string, string | null>
+): string[] {
+  const match = /\baction\s*:\s*([^,\n]*(?:\n(?![^\n]*:)[^,\n]*)*)/.exec(
+    fields
+  );
+  if (!match) return [];
+
+  const expression = match[1]!;
+  const literals = [...expression.matchAll(/"([^"]+)"/g)].map(
+    (found) => found[1]!
+  );
+
+  if (literals.length > 0) return literals;
+
+  const identifier = /^\s*([A-Za-z_$][A-Za-z0-9_$]*)\s*$/.exec(expression);
+  if (!identifier) return [];
+
+  const resolved = constants.get(identifier[1]!);
+  return resolved ? [resolved] : [];
+}
+
+const STRING_CONSTANT =
+  /(?:^|\n)\s*(?:export\s+)?const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*(?::\s*[^=]+)?=\s*"([^"]+)"/g;
+
+/**
+ * Collects `const NAME = "value"` bindings across all sources. Conflicting
+ * bindings for one name resolve to `null` (unresolvable) rather than to either
+ * value — see `readStringField`.
+ */
+export function collectStringConstants(
+  sources: readonly string[]
+): Map<string, string | null> {
+  const constants = new Map<string, string | null>();
+
+  for (const source of sources) {
+    const clean = stripComments(source);
+    for (const match of clean.matchAll(STRING_CONSTANT)) {
+      const name = match[1]!;
+      const value = match[2]!;
+
+      if (!constants.has(name)) {
+        constants.set(name, value);
+        continue;
+      }
+
+      if (constants.get(name) !== value) {
+        constants.set(name, null);
+      }
+    }
+  }
+
+  return constants;
+}
+
+/**
+ * Every balanced `{...}` region, outermost included.
+ *
+ * An innermost-braces-only match is not enough, and the way it fails is
+ * instructive: `workflows/tasks/{id}/decisions.ts` builds its guard as
+ * `{ ...GUARD_ACTIVITY, action: "approve", resourceAttributes: { ... } }`.
+ * Matching innermost braces finds only `resourceAttributes`' object and never
+ * the guard around it, so a fully enforced permission reads as unenforced.
+ */
+function findObjectLiterals(text: string): string[] {
+  const regions: string[] = [];
+  const opens: number[] = [];
+
+  for (let index = 0; index < text.length; index += 1) {
+    const character = text[index];
+
+    if (character === "{") {
+      opens.push(index);
+      continue;
+    }
+
+    if (character === "}" && opens.length > 0) {
+      regions.push(text.slice(opens.pop()!, index + 1));
+    }
+  }
+
+  return regions;
+}
+
+/**
+ * Blanks out nested `{...}` so a field is read only when it belongs to THIS
+ * literal. Without it, an audit-event object carrying
+ * `attributes: { action: "..." }` inside a literal that also names a module
+ * and activity would register as a guard for a permission nobody checks.
+ */
+function withoutNestedLiterals(region: string): string {
+  const inner = region.slice(1, -1);
+  let depth = 0;
+  let masked = "";
+
+  for (const character of inner) {
+    if (character === "{") {
+      depth += 1;
+      masked += " ";
+      continue;
+    }
+
+    if (character === "}") {
+      depth = Math.max(0, depth - 1);
+      masked += " ";
+      continue;
+    }
+
+    masked += depth > 0 ? " " : character;
+  }
+
+  return masked;
+}
+
+/**
+ * Collects every guard triple a single source file constructs.
+ *
+ * Handles the two shapes the repo actually uses:
+ *
+ * 1. all three keys in one literal —
+ *    `{ moduleKey: "blog_content", activityCode: "pages", action: "publish" as const }`;
+ * 2. an activity constant spread beside a per-call action —
+ *    `const UPDATE_ACTIVITY = { moduleKey: "blog_content", activityCode: "pages" };`
+ *    then `{ ...UPDATE_ACTIVITY, action: "update" }`. Four routes do this
+ *    because they gate two actions through one activity, and a scanner that
+ *    missed it would report `blog_content.pages.update` unenforced while the
+ *    route enforces it on every request.
+ */
+export function collectGuardTriples(
+  source: string,
+  constants: ReadonlyMap<string, string | null> = new Map()
+): PermissionTriple[] {
+  const clean = stripComments(source);
+  const regions = findObjectLiterals(clean);
+  const literals = regions.map((region) => ({
+    region,
+    fields: withoutNestedLiterals(region)
+  }));
+
+  const activityConstants = new Map<
+    string,
+    { moduleKey: string; activityCode: string }
+  >();
+
+  for (const { region, fields } of literals) {
+    const moduleKey = readStringField(fields, "moduleKey", constants);
+    const activityCode = readStringField(fields, "activityCode", constants);
+
+    if (!moduleKey || !activityCode) continue;
+
+    // `const NAME = { moduleKey: ..., activityCode: ... }` — the assignment
+    // ends where this literal begins, so look back from it.
+    const at = clean.indexOf(region);
+    const preceding = clean.slice(Math.max(0, at - 120), at);
+    const nameMatch =
+      /(?:const|let|var)\s+([A-Za-z0-9_$]+)\s*(?::[^=]*)?=\s*$/.exec(preceding);
+
+    if (nameMatch) {
+      activityConstants.set(nameMatch[1]!, { moduleKey, activityCode });
+    }
+  }
+
+  const triples: PermissionTriple[] = [];
+
+  for (const { fields } of literals) {
+    const actions = readActionValues(fields, constants);
+    if (actions.length === 0) continue;
+
+    const moduleKey = readStringField(fields, "moduleKey", constants);
+    const activityCode = readStringField(fields, "activityCode", constants);
+
+    if (moduleKey && activityCode) {
+      for (const action of actions) {
+        triples.push({ moduleKey, activityCode, action });
+      }
+      continue;
+    }
+
+    // No `activityCode` of its own — an audit event, unless it spreads an
+    // activity constant.
+    const spread = /\.\.\.([A-Za-z0-9_$]+)/.exec(fields);
+    if (!spread) continue;
+
+    const activity = activityConstants.get(spread[1]!);
+    if (!activity) continue;
+
+    for (const action of actions) {
+      triples.push({ ...activity, action });
+    }
+  }
+
+  return triples;
+}
+
+export function evaluateEnforcementCoverage(
+  modules: readonly ModuleDescriptor[],
+  sources: readonly string[],
+  exceptions: readonly EnforcementException[]
+): EnforcementCoverageResult {
+  const constants = collectStringConstants(sources);
+  const enforced = new Set<string>();
+
+  for (const source of sources) {
+    for (const triple of collectGuardTriples(source, constants)) {
+      enforced.add(permissionTripleKey(triple));
+    }
+  }
+
+  const declared = new Map<string, string>();
+
+  for (const module of modules) {
+    for (const permission of module.permissions ?? []) {
+      const key = permissionTripleKey({
+        moduleKey: module.key,
+        activityCode: permission.activityCode,
+        action: permission.action
+      });
+      declared.set(key, module.key);
+    }
+  }
+
+  const excused = new Set(exceptions.map((exception) => exception.key));
+
+  const unenforced: UnenforcedPermission[] = [];
+
+  for (const [key, moduleKey] of declared) {
+    if (enforced.has(key) || excused.has(key)) continue;
+    unenforced.push({ key, moduleKey });
+  }
+
+  // An exception for a permission that is gone, or that now HAS an enforcer,
+  // is worse than no exception: it is a documented reason that no longer
+  // applies to anything, and it keeps the gate from asking again.
+  const staleExceptions = [...excused].filter(
+    (key) => !declared.has(key) || enforced.has(key)
+  );
+
+  unenforced.sort((left, right) => left.key.localeCompare(right.key));
+  staleExceptions.sort();
+
+  return {
+    valid: unenforced.length === 0 && staleExceptions.length === 0,
+    declaredCount: declared.size,
+    enforcedCount: [...declared.keys()].filter((key) => enforced.has(key))
+      .length,
+    unenforced,
+    staleExceptions
+  };
+}

--- a/src/modules/blog-content/application/blog-page-directory.ts
+++ b/src/modules/blog-content/application/blog-page-directory.ts
@@ -7,6 +7,7 @@ import type {
   UpdateBlogPageInput
 } from "../domain/blog-page-validation";
 import type { PageType } from "../domain/page-type";
+import type { BlogPageStatus } from "../domain/page-status";
 import {
   boundedPageNumber,
   boundedPageSize
@@ -15,11 +16,23 @@ import {
 /**
  * Read/write query module for `awcms_blog_pages` (Issue #539) — same
  * "directory holds both reads and writes for one resource" convention
- * `blog-post-directory.ts` (Issue #538) established. Pages get plain CRUD
- * only (no publish/schedule/archive/restore/purge lifecycle actions —
- * doc issue #539's Routes section lists only GET/POST/GET/PATCH/DELETE for
- * pages, unlike posts; those permissions are already seeded (#537) for a
- * future issue to wire up, not this one).
+ * `blog-post-directory.ts` (Issue #538) established.
+ *
+ * This file used to say pages get plain CRUD only, and that the seeded
+ * lifecycle permissions were left "for a future issue to wire up, not this
+ * one". That future issue never arrived, and the cost was not a spare
+ * catalogue row: `createBlogPage` writes a literal `'draft'`, `updateBlogPage`
+ * never touches `status`, and `blog-scheduled-publish.ts` reads only
+ * `awcms_blog_posts` — so no code path in the repo could publish a page, while
+ * `blog-search.ts` filtered public pages on `status = 'published'` and
+ * therefore always returned nothing.
+ *
+ * [ADR-0057](../../../../docs/adr/0057-blog-page-lifecycle.md) closes that.
+ * Pages now have publish/archive/restore/purge, deliberately WITHOUT the
+ * `review` and `scheduled` states posts have — `sql/036` seeded no
+ * `pages.schedule`, which is a decision the catalogue already made. The
+ * transition rules live in `domain/page-status.ts`, separate from the post
+ * table for the same reason.
  */
 export type BlogPageSummary = {
   id: string;
@@ -390,4 +403,125 @@ export async function softDeleteBlogPage(
   `;
 
   return rows.length > 0;
+}
+
+/**
+ * Shared mutation for publish/archive/restore-to-draft (ADR-0057 §A) — the
+ * page counterpart of `transitionBlogPostStatus`. Transition VALIDITY is
+ * checked by the caller through `isValidPageStatusTransition` before this
+ * runs, so this stays a plain conditional write rather than a second source of
+ * truth about which transitions are legal.
+ *
+ * `scheduled_at` is cleared unconditionally rather than branched on, unlike
+ * the post version: no page transition can target `scheduled`, so the only
+ * reachable branch there would be the clearing one. It is written rather than
+ * ignored because a row that reached `scheduled` outside this repo's code
+ * paths must not keep a stale timestamp after moving on.
+ *
+ * `published_at` is set on the way IN to `published` and never cleared. That
+ * is deliberate and matches posts: it records when the page first went live,
+ * which is what `blog-search.ts`'s public filter and the SEO facts adapter
+ * read. Clearing it on archive would make an un-archived page look like it had
+ * never been published.
+ */
+export async function transitionBlogPageStatus(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string,
+  toStatus: BlogPageStatus
+): Promise<BlogPageView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_pages
+    SET status = ${toStatus},
+        published_at = CASE WHEN ${toStatus === "published"} THEN now() ELSE published_at END,
+        scheduled_at = NULL,
+        version = version + 1,
+        updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_title,
+      meta_description, canonical_url, locale, page_type, parent_page_id,
+      menu_order, published_at, scheduled_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
+  `) as BlogPageRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+/** Undoes `softDeleteBlogPage`; the `deleted_at IS NOT NULL` predicate makes a repeat a no-op rather than a second restore. */
+export async function restoreBlogPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  id: string
+): Promise<BlogPageView | null> {
+  const rows = (await tx`
+    UPDATE awcms_blog_pages
+    SET deleted_at = NULL, deleted_by = NULL, delete_reason = NULL,
+        restored_at = now(), restored_by = ${actorTenantUserId}, updated_at = now()
+    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
+    RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
+      content_text, status, visibility, featured_media_id, seo_title,
+      meta_description, canonical_url, locale, page_type, parent_page_id,
+      menu_order, published_at, scheduled_at, created_at, updated_at,
+      deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
+  `) as BlogPageRow[];
+
+  return rows[0] ? toView(rows[0]) : null;
+}
+
+export type PurgeBlogPageResult = {
+  purged: boolean;
+  /**
+   * Ad placements that targeted this page and are now inert (ADR-0057 §C).
+   * Counted BEFORE the delete, because afterwards nothing distinguishes them
+   * from placements that were already pointing at nothing.
+   */
+  adPlacementsNowInert: number;
+};
+
+/**
+ * Hard delete (ADR-0057 §C). The caller checks `canPurgePage` first.
+ *
+ * Nothing is cascaded, and there is no page equivalent of the
+ * `awcms_blog_post_terms` cleanup `purgeBlogPost` does: pages have no taxonomy
+ * assignment table. `awcms_blog_revisions` rows under
+ * `resource_type = 'page'` are deliberately LEFT, which is the same call
+ * `purgeBlogPost` makes for its own revisions — no FK points at the content
+ * row, and the history stays a record for the same reason audit events keep
+ * referencing purged resources by id.
+ *
+ * Ad placements targeting this page are deliberately NOT touched. ADR-0057 §C:
+ * `ad-placement-reference-validation.ts` already decided a target deleted
+ * later "is not an error and never becomes one", and
+ * `listActiveAdPlacementsForRendering` matches `target_id` against the page
+ * BEING RENDERED — a purged page is never rendered, so its placements are
+ * never matched. They go inert, exactly as they already do for a soft-deleted
+ * page. Deleting rows owned by another surface as a side effect is the
+ * ownership ADR-0044 tidied; the count is returned instead so the change is
+ * visible rather than silent.
+ */
+export async function purgeBlogPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  id: string
+): Promise<PurgeBlogPageResult> {
+  const inertRows = (await tx`
+    SELECT count(*)::int AS count
+    FROM awcms_news_portal_ad_placements
+    WHERE tenant_id = ${tenantId}
+      AND target_type = 'page' AND target_id = ${id}
+      AND deleted_at IS NULL
+  `) as { count: number }[];
+
+  const rows = await tx`
+    DELETE FROM awcms_blog_pages
+    WHERE tenant_id = ${tenantId} AND id = ${id}
+    RETURNING id
+  `;
+
+  return {
+    purged: rows.length > 0,
+    adPlacementsNowInert: inertRows[0]?.count ?? 0
+  };
 }

--- a/src/modules/blog-content/domain/page-status.ts
+++ b/src/modules/blog-content/domain/page-status.ts
@@ -1,0 +1,105 @@
+import type { BlogContentStatus } from "./post-status";
+
+/**
+ * Page lifecycle rules (ADR-0057) — deliberately SEPARATE from
+ * `post-status.ts`'s `ALLOWED_STATUS_TRANSITIONS`, not a re-export of it.
+ *
+ * Pages and posts share a status column (`sql/035` created
+ * `awcms_blog_pages.status` identically to the post one, CHECK included) but
+ * they do NOT share a lifecycle. `sql/036` seeds eight `pages.*` permissions
+ * and there is no `pages.schedule` among them, while posts have one — so the
+ * narrower page lifecycle is a decision the catalogue already made, not an
+ * omission to patch here.
+ *
+ * ADR-0057 §B records the substance: a page is structural site content (about,
+ * contact, privacy policy). Editorial review queues and timed publishing are
+ * newsroom needs, and `blog_content` already has both where they belong, on
+ * posts. Copying them onto pages would mean two more permissions to seed, gate
+ * and screen for a workflow nobody has asked for.
+ *
+ * Sharing one table between the two callers would leave it correct for one and
+ * too permissive for the other, which is the failure this file exists to avoid:
+ * without it, `isValidStatusTransition` would happily let a page reach
+ * `scheduled` — a status no page permission can ever be granted for, and one
+ * `blog-scheduled-publish.ts` (posts only) would never move on again.
+ */
+
+/** The three states a page can be in. A strict subset of `BlogContentStatus`. */
+export type BlogPageStatus = Extract<
+  BlogContentStatus,
+  "draft" | "published" | "archived"
+>;
+
+export const BLOG_PAGE_STATUSES: readonly BlogPageStatus[] = [
+  "draft",
+  "published",
+  "archived"
+];
+
+export function isBlogPageStatus(value: unknown): value is BlogPageStatus {
+  return (
+    typeof value === "string" &&
+    (BLOG_PAGE_STATUSES as string[]).includes(value)
+  );
+}
+
+/**
+ * ```
+ * draft ──────► published ──────► archived
+ *   ▲               │                 │
+ *   └───────────────┴─────────────────┘
+ * ```
+ *
+ * Every edge is reversible back to `draft`, which is what makes `archived` a
+ * recoverable state rather than a one-way door — the same shape posts have,
+ * minus the two statuses pages cannot reach.
+ */
+const ALLOWED_PAGE_STATUS_TRANSITIONS: Record<
+  BlogPageStatus,
+  readonly BlogPageStatus[]
+> = {
+  draft: ["published", "archived"],
+  published: ["archived", "draft"],
+  archived: ["draft"]
+};
+
+/**
+ * A page row read from the database carries `BlogContentStatus`, because the
+ * column's CHECK still accepts all five. A row already sitting in `review` or
+ * `scheduled` therefore cannot be reached by any code path in this repo — but
+ * it is not impossible in a database someone has edited by hand, and answering
+ * "no valid transition" is the fail-closed reading.
+ */
+export function isValidPageStatusTransition(
+  from: BlogContentStatus,
+  to: BlogPageStatus
+): boolean {
+  if (!isBlogPageStatus(from)) {
+    return false;
+  }
+
+  if (from === to) {
+    return true;
+  }
+
+  return ALLOWED_PAGE_STATUS_TRANSITIONS[from].includes(to);
+}
+
+/** Restore only makes sense for a currently soft-deleted page — same precondition `canRestorePost` states for posts. */
+export function canRestorePage(deletedAt: Date | null): boolean {
+  return deletedAt !== null;
+}
+
+/**
+ * ADR-0057 §C reuses the post precondition verbatim: purge is forbidden for
+ * live content unless it has been archived or soft-deleted first. Kept as its
+ * own function rather than importing `canPurgePost` so the page lifecycle owns
+ * its own rules end to end — the two agreeing today is a fact about the
+ * decision, not a dependency between them.
+ */
+export function canPurgePage(
+  status: BlogContentStatus,
+  deletedAt: Date | null
+): boolean {
+  return deletedAt !== null || status === "archived";
+}

--- a/src/pages/api/v1/blog/pages/[id]/archive.ts
+++ b/src/pages/api/v1/blog/pages/[id]/archive.ts
@@ -1,0 +1,152 @@
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogPageById,
+  transitionBlogPageStatus
+} from "../../../../../../modules/blog-content/application/blog-page-directory";
+import { isValidPageStatusTransition } from "../../../../../../modules/blog-content/domain/page-status";
+
+/**
+ * `POST /api/v1/blog/pages/{id}/archive` (ADR-0057 §A).
+ *
+ * Archiving removes the page from the public site without destroying it, and
+ * is reversible in both directions the page lifecycle allows: back to `draft`,
+ * or on to purge — archive is in fact the only route to purge for a page that
+ * was never soft-deleted (`canPurgePage` accepts archived OR soft-deleted).
+ *
+ * `published_at` is NOT cleared by the transition. An archived page later
+ * returned to draft and re-published keeps the date it first went live, which
+ * is what the public search filter and the SEO facts adapter read.
+ *
+ * No content quality checklist here, unlike publish: the checklist guards what
+ * becomes PUBLIC, and this is the transition away from public. Gating it would
+ * mean a page that fails the checklist cannot be taken down.
+ *
+ * High-risk mutation: `Idempotency-Key` required.
+ */
+const IDEMPOTENCY_SCOPE = "blog_page_archive";
+
+type Prepared = { idempotencyKey: string };
+
+export const POST = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    return { idempotencyKey };
+  },
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "pages",
+    action: "archive"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const pageId = params.id;
+
+    if (!pageId) {
+      return fail(400, "VALIDATION_ERROR", "Page id is required.");
+    }
+
+    const correlationId = locals.correlationId;
+    const requestHash = computeRequestHash({ pageId, action: "archive" });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const page = await fetchBlogPageById(tx, tenantId, pageId);
+
+    if (!page) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    if (!isValidPageStatusTransition(page.status, "archived")) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot archive a page in status "${page.status}".`
+      );
+    }
+
+    const updated = await transitionBlogPageStatus(
+      tx,
+      tenantId,
+      pageId,
+      "archived"
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.page.archived",
+      resourceType: "blog_page",
+      resourceId: pageId,
+      severity: "info",
+      message: `Blog page archived: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.page.archived", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      pageId,
+      slug: updated.slug
+    });
+
+    const response = ok(updated);
+    const body = await response.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+
+    return response;
+  }
+});

--- a/src/pages/api/v1/blog/pages/[id]/publish.ts
+++ b/src/pages/api/v1/blog/pages/[id]/publish.ts
@@ -1,0 +1,213 @@
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogPageById,
+  transitionBlogPageStatus
+} from "../../../../../../modules/blog-content/application/blog-page-directory";
+import { isValidPageStatusTransition } from "../../../../../../modules/blog-content/domain/page-status";
+import { fetchBlogSettings } from "../../../../../../modules/blog-content/application/blog-settings-directory";
+import {
+  checklistBlockersToErrorDetails,
+  evaluateContentQualityChecklistForContent
+} from "../../../../../../modules/blog-content/application/content-quality-checklist-gate";
+import { mediaLibraryPortAdapter } from "../../../../../../modules/media-library/application/media-library-port-adapter";
+
+/**
+ * `POST /api/v1/blog/pages/{id}/publish` (ADR-0057 §A).
+ *
+ * `pages.publish` has been seeded since `sql/036` and gated by nothing, and the
+ * consequence was not a spare permission: `createBlogPage` writes a literal
+ * `'draft'` and `updateBlogPage` never touches `status`, so until this route
+ * existed **no code path could publish a page at all**. This is the one that
+ * makes `awcms_blog_pages.status` reachable.
+ *
+ * Deliberately NOT a copy of `posts/{id}/publish.ts`, in three ways:
+ *
+ * - the transition table is the page one (`isValidPageStatusTransition`) — a
+ *   page has no `review` or `scheduled` state to come from;
+ * - `termIds` is the constant `0`, not a lookup. Pages have no taxonomy
+ *   assignment table, which is why `taxonomy_exists` is always reported
+ *   non-applicable for them — the same constant
+ *   `pages/{id}/quality-checklist.ts` already passes;
+ * - no social-publishing port call. That port's trigger is `post_published`,
+ *   and a page is not an article; inventing a page trigger would write a
+ *   contract into a no-op adapter that the real module has never agreed to.
+ *
+ * The content quality checklist runs BEFORE the transition, server-side, the
+ * same gate posts use. `pages/{id}/quality-checklist.ts` has been reporting
+ * that checklist as preview-only, its header explaining that "nothing currently
+ * blocks a page transition server-side because no such transition exists to
+ * gate". That sentence stops being true here.
+ *
+ * High-risk mutation: `Idempotency-Key` required.
+ */
+const IDEMPOTENCY_SCOPE = "blog_page_publish";
+
+type Prepared = { idempotencyKey: string };
+
+export const POST = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    return { idempotencyKey };
+  },
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "pages",
+    action: "publish"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const pageId = params.id;
+
+    if (!pageId) {
+      return fail(400, "VALIDATION_ERROR", "Page id is required.");
+    }
+
+    const correlationId = locals.correlationId;
+    const requestHash = computeRequestHash({ pageId, action: "publish" });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const page = await fetchBlogPageById(tx, tenantId, pageId);
+
+    if (!page) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    if (!isValidPageStatusTransition(page.status, "published")) {
+      return fail(
+        409,
+        "INVALID_STATUS_TRANSITION",
+        `Cannot publish a page in status "${page.status}".`
+      );
+    }
+
+    const blogSettings = await fetchBlogSettings(tx, tenantId);
+    const checklist = await evaluateContentQualityChecklistForContent(
+      tx,
+      tenantId,
+      "page",
+      page,
+      0,
+      mediaLibraryPortAdapter,
+      blogSettings.contentQualityChecklistPolicy,
+      {
+        socialPreviewFallback: {
+          tenantFallbackImageMediaId:
+            blogSettings.socialPreviewFallbackImageMediaId,
+          contentImageFallbackEnabled:
+            blogSettings.socialPreviewContentImageFallbackEnabled
+        }
+      }
+    );
+
+    if (!checklist.passed) {
+      await recordAuditEvent(tx, {
+        tenantId,
+        actorTenantUserId: auth.context.tenantUserId,
+        moduleKey: "blog_content",
+        action: "blog.page.publish_blocked_by_checklist",
+        resourceType: "blog_page",
+        resourceId: pageId,
+        severity: "warning",
+        message: `Blog page publish blocked by content quality checklist: ${page.slug}.`,
+        attributes: {
+          blockedRuleIds: checklist.blockers.map((blocker) => blocker.ruleId)
+        },
+        correlationId
+      });
+
+      return fail(
+        422,
+        "CONTENT_QUALITY_CHECKLIST_BLOCKED",
+        "Publish is blocked by the content quality checklist.",
+        {},
+        checklistBlockersToErrorDetails(checklist)
+      );
+    }
+
+    const updated = await transitionBlogPageStatus(
+      tx,
+      tenantId,
+      pageId,
+      "published"
+    );
+
+    if (!updated) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.page.published",
+      resourceType: "blog_page",
+      resourceId: pageId,
+      severity: "info",
+      message: `Blog page published: ${updated.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.page.published", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      pageId,
+      slug: updated.slug
+    });
+
+    const response = ok({ ...updated, qualityChecklist: checklist });
+    const body = await response.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+
+    return response;
+  }
+});

--- a/src/pages/api/v1/blog/pages/[id]/purge.ts
+++ b/src/pages/api/v1/blog/pages/[id]/purge.ts
@@ -1,0 +1,154 @@
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogPageById,
+  purgeBlogPage
+} from "../../../../../../modules/blog-content/application/blog-page-directory";
+import { canPurgePage } from "../../../../../../modules/blog-content/domain/page-status";
+
+/**
+ * `POST /api/v1/blog/pages/{id}/purge` (ADR-0057 §A/§C). Irreversible hard
+ * delete, `409 PURGE_NOT_ALLOWED` unless the page is archived or already
+ * soft-deleted (`canPurgePage`, the same precondition posts use).
+ *
+ * ADR-0057 §C — ad placements that target this page neither block the purge
+ * nor are deleted with it. The first draft of that ADR made this a 409, and
+ * reading `ad-placement-reference-validation.ts` refuted it: that module has
+ * already decided a target deleted later "is not an error and never becomes
+ * one", and `listActiveAdPlacementsForRendering` matches `target_id` against
+ * the page BEING RENDERED — a purged page is never rendered, so its placements
+ * are never matched. They go inert, precisely as they already do for a
+ * soft-deleted page, so purge introduces no failure mode that soft delete has
+ * not carried unremarked all along.
+ *
+ * What it does instead is REPORT: `adPlacementsNowInert`, in the response body
+ * and on the audit event. A slot that quietly stops filling three weeks later,
+ * with nothing connecting it to a page someone purged, is the "vanishes with no
+ * record" ADR-0044 §4 refuses.
+ *
+ * High-risk mutation: `Idempotency-Key` required. Audited at `critical`.
+ */
+const IDEMPOTENCY_SCOPE = "blog_page_purge";
+
+type Prepared = { idempotencyKey: string };
+
+export const POST = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    return { idempotencyKey };
+  },
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "pages",
+    action: "purge"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const pageId = params.id;
+
+    if (!pageId) {
+      return fail(400, "VALIDATION_ERROR", "Page id is required.");
+    }
+
+    const correlationId = locals.correlationId;
+    const requestHash = computeRequestHash({ pageId, action: "purge" });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const page = await fetchBlogPageById(tx, tenantId, pageId, {
+      includeDeleted: true
+    });
+
+    if (!page) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    if (!canPurgePage(page.status, page.deletedAt)) {
+      return fail(
+        409,
+        "PURGE_NOT_ALLOWED",
+        "Page must be archived or soft-deleted before it can be purged."
+      );
+    }
+
+    const result = await purgeBlogPage(tx, tenantId, pageId);
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.page.purged",
+      resourceType: "blog_page",
+      resourceId: pageId,
+      severity: "critical",
+      message: "Blog page purged.",
+      attributes: { adPlacementsNowInert: result.adPlacementsNowInert },
+      correlationId
+    });
+
+    log("info", "blog-content.page.purged", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      pageId,
+      adPlacementsNowInert: result.adPlacementsNowInert
+    });
+
+    const response = ok({
+      id: pageId,
+      status: "purged",
+      adPlacementsNowInert: result.adPlacementsNowInert
+    });
+    const body = await response.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+
+    return response;
+  }
+});

--- a/src/pages/api/v1/blog/pages/[id]/quality-checklist.ts
+++ b/src/pages/api/v1/blog/pages/[id]/quality-checklist.ts
@@ -25,14 +25,18 @@ const READ_GUARD = {
  * checklist.ts` exactly — see that file's header for the full rationale.
  * `taxonomy_exists` is always reported non-applicable for pages
  * (`awcms_blog_pages` has no category/tag assignment table, unlike
- * posts' `awcms_blog_post_terms`). There is currently no
- * `POST /api/v1/blog/pages/{id}/publish` or `.../schedule` endpoint in this
- * codebase at all — pages are created directly in `status = 'draft'` with
- * no lifecycle-transition route (a pre-existing gap, out of this issue's
- * atomic scope to add). This endpoint is therefore preview-only for pages:
- * it reports the same checklist a page WOULD need to pass, but nothing
- * currently blocks a page transition server-side because no such
- * transition exists to gate.
+ * posts' `awcms_blog_post_terms`).
+ *
+ * This header used to end by noting that no `POST .../publish` endpoint
+ * existed, so nothing blocked a page transition server-side "because no such
+ * transition exists to gate". [ADR-0057](../../../../../../../docs/adr/0057-blog-page-lifecycle.md)
+ * added the transition, and `pages/{id}/publish.ts` now runs this same
+ * checklist as a real gate before it. This route stays what it always was —
+ * a read-only preview of the result the editor can see before trying — but it
+ * is now a preview OF something rather than a preview of nothing.
+ *
+ * There is still no `.../schedule`, and there will not be: pages have no
+ * `scheduled` state (ADR-0057 §B).
  */
 export const GET: APIRoute = async ({ request, params, cookies }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);

--- a/src/pages/api/v1/blog/pages/[id]/restore.ts
+++ b/src/pages/api/v1/blog/pages/[id]/restore.ts
@@ -1,0 +1,154 @@
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { log } from "../../../../../../lib/logging/logger";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import {
+  fetchBlogPageById,
+  restoreBlogPage
+} from "../../../../../../modules/blog-content/application/blog-page-directory";
+import { canRestorePage } from "../../../../../../modules/blog-content/domain/page-status";
+
+/**
+ * `POST /api/v1/blog/pages/{id}/restore` (ADR-0057 §A).
+ *
+ * This undoes SOFT DELETE, not archiving — the two are different axes on a
+ * page, exactly as on a post. `deleted_at` says the row is in the bin;
+ * `status` says where in the lifecycle it sits. Restoring returns the row from
+ * the bin and leaves its status untouched, so a page soft-deleted while
+ * published comes back published. To bring an ARCHIVED page back, publish it.
+ *
+ * The lookup passes `includeDeleted: true` for a reason the default hides: the
+ * default read filters `deleted_at IS NULL`, so without it every restore
+ * target would answer 404 — the row it is looking for is by definition deleted.
+ *
+ * High-risk mutation: `Idempotency-Key` required.
+ */
+const IDEMPOTENCY_SCOPE = "blog_page_restore";
+
+type Prepared = { idempotencyKey: string };
+
+export const POST = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    return { idempotencyKey };
+  },
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "pages",
+    action: "restore"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const pageId = params.id;
+
+    if (!pageId) {
+      return fail(400, "VALIDATION_ERROR", "Page id is required.");
+    }
+
+    const correlationId = locals.correlationId;
+    const requestHash = computeRequestHash({ pageId, action: "restore" });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const page = await fetchBlogPageById(tx, tenantId, pageId, {
+      includeDeleted: true
+    });
+
+    // One shape for "no such page" and "that page is not deleted". A
+    // distinguishable answer would let a caller probe which ids exist by
+    // watching restore fail differently.
+    if (!page || !canRestorePage(page.deletedAt)) {
+      return fail(
+        404,
+        "RESOURCE_NOT_FOUND",
+        "Blog page not found, or is not soft-deleted."
+      );
+    }
+
+    const restored = await restoreBlogPage(
+      tx,
+      tenantId,
+      auth.context.tenantUserId,
+      pageId
+    );
+
+    if (!restored) {
+      return fail(
+        404,
+        "RESOURCE_NOT_FOUND",
+        "Blog page not found, or is not soft-deleted."
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "blog_content",
+      action: "blog.page.restored",
+      resourceType: "blog_page",
+      resourceId: pageId,
+      severity: "info",
+      message: `Blog page restored: ${restored.slug}.`,
+      correlationId
+    });
+
+    log("info", "blog-content.page.restored", {
+      correlationId,
+      tenantId,
+      moduleKey: "blog_content",
+      pageId,
+      slug: restored.slug
+    });
+
+    const response = ok(restored);
+    const body = await response.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      body
+    );
+
+    return response;
+  }
+});

--- a/tests/permission-enforcement-coverage.test.ts
+++ b/tests/permission-enforcement-coverage.test.ts
@@ -1,0 +1,265 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectGuardTriples,
+  collectStringConstants,
+  evaluateEnforcementCoverage,
+  permissionTripleKey
+} from "../src/modules/_shared/permission-enforcement-coverage";
+import type { ModuleDescriptor } from "../src/modules/_shared/module-contract";
+
+/**
+ * ADR-0057 §F. These tests are not about the happy path — they are the record
+ * of what the first three drafts of this scanner got WRONG, each of which
+ * reported permissions as unenforced while the routes gated every request.
+ *
+ * Draft 1 read string literals only and produced 39 false positives.
+ * Draft 2 matched innermost braces and missed every guard with a nested field.
+ * Draft 3 required a literal action and missed both conditional guards.
+ *
+ * A scanner that answers "unenforced" for enforced permissions is worse than
+ * no scanner: it trains its readers to add exceptions until the gate asks
+ * nothing at all. Each case below is one of those drafts, frozen.
+ */
+
+function guard(
+  moduleKey: string,
+  activityCode: string,
+  action: string
+): string {
+  return permissionTripleKey({ moduleKey, activityCode, action });
+}
+
+function moduleWith(
+  key: string,
+  permissions: { activityCode: string; action: string }[]
+): ModuleDescriptor {
+  return {
+    key,
+    permissions: permissions.map((permission) => ({
+      ...permission,
+      description: `${permission.activityCode} ${permission.action}`
+    }))
+  } as unknown as ModuleDescriptor;
+}
+
+describe("collectGuardTriples", () => {
+  test("reads a plain three-literal guard", () => {
+    const source = `
+      const PUBLISH_GUARD = {
+        moduleKey: "blog_content",
+        activityCode: "pages",
+        action: "publish" as const
+      };
+    `;
+
+    expect(collectGuardTriples(source).map(permissionTripleKey)).toEqual([
+      guard("blog_content", "pages", "publish")
+    ]);
+  });
+
+  test("resolves guard fields written as imported constants (draft 1)", () => {
+    // `theming`, `site_search`, `seo_distribution`, `comments` and
+    // `media_library` all name their module key or activity through a
+    // constant. Reading literals only reported all of them unenforced.
+    const constantsSource = `
+      export const THEMING_MODULE_KEY = "theming";
+      export const THEMING_VERSION_ACTIVITY_CODE = "version";
+    `;
+    const routeSource = `
+      const PUBLISH_GUARD = {
+        moduleKey: THEMING_MODULE_KEY,
+        activityCode: THEMING_VERSION_ACTIVITY_CODE,
+        action: "publish" as const
+      };
+    `;
+
+    const constants = collectStringConstants([constantsSource, routeSource]);
+
+    expect(
+      collectGuardTriples(routeSource, constants).map(permissionTripleKey)
+    ).toEqual([guard("theming", "version", "publish")]);
+  });
+
+  test("leaves a constant bound to two different values unresolved rather than guessing", () => {
+    const constants = collectStringConstants([
+      `const ACTIVITY = "version";`,
+      `const ACTIVITY = "config";`
+    ]);
+
+    expect(constants.get("ACTIVITY")).toBeNull();
+    expect(
+      collectGuardTriples(
+        `const G = { moduleKey: "theming", activityCode: ACTIVITY, action: "publish" };`,
+        constants
+      )
+    ).toEqual([]);
+  });
+
+  test("reads a guard that carries a nested object (draft 2)", () => {
+    // `workflows/tasks/{id}/decisions.ts`. Matching innermost braces finds
+    // only `resourceAttributes` and never the guard wrapped around it.
+    const source = `
+      const GUARD_ACTIVITY = { moduleKey: "workflow", activityCode: "approval" };
+      const guardRequest = {
+        ...GUARD_ACTIVITY,
+        action: "approve" as const,
+        resourceType: "workflow_task",
+        resourceAttributes: {
+          tenantId,
+          requestedByTenantUserId: task?.requested_by_tenant_user_id
+        }
+      };
+    `;
+
+    expect(collectGuardTriples(source).map(permissionTripleKey)).toContain(
+      guard("workflow", "approval", "approve")
+    );
+  });
+
+  test("reads both branches of a conditional action (draft 3)", () => {
+    // `comments/admin/{id}/moderate.ts` decides the action per request; the
+    // route really does gate on one of the two.
+    const source = `
+      const MODERATE_GUARD = {
+        moduleKey: "comments",
+        activityCode: "moderation",
+        action: (decision === "approve" ? "approve" : "reject") as
+          | "approve"
+          | "reject"
+      };
+    `;
+
+    const keys = collectGuardTriples(source).map(permissionTripleKey);
+
+    expect(keys).toContain(guard("comments", "moderation", "approve"));
+    expect(keys).toContain(guard("comments", "moderation", "reject"));
+  });
+
+  test("does not mistake an audit event for a guard", () => {
+    // Audit events carry `moduleKey` and `action` but never `activityCode`,
+    // and their action is an event name. ADR-0056 §1 records that reading
+    // these as gates gives the wrong answer.
+    const source = `
+      await recordAuditEvent(tx, {
+        tenantId,
+        moduleKey: "blog_content",
+        action: "blog.page.purged",
+        resourceType: "blog_page"
+      });
+    `;
+
+    expect(collectGuardTriples(source)).toEqual([]);
+  });
+
+  test("does not read an action out of a nested attributes object", () => {
+    const source = `
+      await recordAuditEvent(tx, {
+        moduleKey: "theming",
+        activityCode: "version",
+        attributes: { action: "publish" }
+      });
+    `;
+
+    expect(collectGuardTriples(source)).toEqual([]);
+  });
+
+  test("ignores guard shapes that appear in comments", () => {
+    const source = `
+      // const GUARD = { moduleKey: "blog_content", activityCode: "pages", action: "publish" };
+      /* { moduleKey: "comments", activityCode: "moderation", action: "delete" } */
+      const unrelated = 1;
+    `;
+
+    expect(collectGuardTriples(source)).toEqual([]);
+  });
+});
+
+describe("evaluateEnforcementCoverage", () => {
+  const modules = [
+    moduleWith("blog_content", [
+      { activityCode: "pages", action: "publish" },
+      { activityCode: "posts", action: "export" }
+    ])
+  ];
+
+  test("passes when every declared permission has a guard or a reason", () => {
+    const result = evaluateEnforcementCoverage(
+      modules,
+      [
+        `const G = { moduleKey: "blog_content", activityCode: "pages", action: "publish" };`
+      ],
+      [
+        {
+          key: "blog_content.posts.export",
+          reason: "No endpoint; ADR pending."
+        }
+      ]
+    );
+
+    expect(result.valid).toBe(true);
+    expect(result.enforcedCount).toBe(1);
+    expect(result.declaredCount).toBe(2);
+  });
+
+  test("reports the original ADR-0057 defect: a declared permission nothing enforces", () => {
+    const result = evaluateEnforcementCoverage(
+      modules,
+      // The state of `main` before this change — pages could be created and
+      // updated, and no code path could publish one.
+      [
+        `const G = { moduleKey: "blog_content", activityCode: "pages", action: "update" };`
+      ],
+      [
+        {
+          key: "blog_content.posts.export",
+          reason: "No endpoint; ADR pending."
+        }
+      ]
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.unenforced.map((entry) => entry.key)).toEqual([
+      "blog_content.pages.publish"
+    ]);
+  });
+
+  test("reports an exception that has since gained an enforcer as stale", () => {
+    // An exception outliving its reason is how a gate quietly stops asking.
+    const result = evaluateEnforcementCoverage(
+      modules,
+      [
+        `const A = { moduleKey: "blog_content", activityCode: "pages", action: "publish" };`,
+        `const B = { moduleKey: "blog_content", activityCode: "posts", action: "export" };`
+      ],
+      [
+        {
+          key: "blog_content.posts.export",
+          reason: "No endpoint; ADR pending."
+        }
+      ]
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.staleExceptions).toEqual(["blog_content.posts.export"]);
+  });
+
+  test("reports an exception for a permission that is no longer declared as stale", () => {
+    const result = evaluateEnforcementCoverage(
+      modules,
+      [
+        `const A = { moduleKey: "blog_content", activityCode: "pages", action: "publish" };`
+      ],
+      [
+        {
+          key: "blog_content.posts.export",
+          reason: "No endpoint; ADR pending."
+        },
+        { key: "media_library.media.attach", reason: "Revoked by ADR-0056 §A." }
+      ]
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.staleExceptions).toEqual(["media_library.media.attach"]);
+  });
+});


### PR DESCRIPTION
Implements [ADR-0057](https://github.com/ahliweb/awcms/blob/main/docs/adr/0057-blog-page-lifecycle.md) §A–§F. Step 2 of 3; `/admin/blog/pages` follows.

## What was broken

`pages.publish`, `pages.archive`, `pages.restore` and `pages.purge` have been seeded since `sql/036` and enforced by nothing. That was not a spare catalogue row:

- `createBlogPage` writes a literal `'draft'`
- `updateBlogPage` never touches `status` — `UpdateBlogPageInput` has no such field
- `blog-scheduled-publish.ts` reads only `awcms_blog_posts`

There is no other writer of `awcms_blog_pages.status` in the repo, so **no code path could publish a page.** Meanwhile `blog-search.ts` filters its public page branch on `status = 'published' AND published_at IS NOT NULL`, against `awcms_blog_pages_tenant_status_published_idx` — an index `sql/035` built for exactly that query — and has therefore always returned zero rows.

## What lands

Four routes, all through `defineTenantRoute` (Issue #255), guarded, audited, `Idempotency-Key`-bearing:

```
POST /api/v1/blog/pages/{id}/publish | archive | restore | purge
```

plus `domain/page-status.ts` and three directory functions (`transitionBlogPageStatus`, `restoreBlogPage`, `purgeBlogPage`).

**The lifecycle is deliberately narrower than posts'** — no `review`, no `scheduled`. `sql/036` seeded no `pages.schedule`, which is a decision the catalogue already made. The transition table is its own rather than shared with posts: sharing one would leave it correct for one caller and too permissive for the other, letting a page reach `scheduled` — a status no page permission can be granted for, and one the posts-only publish job would never move on again.

Publish runs the same content quality checklist posts do, which makes `pages/{id}/quality-checklist.ts` a preview *of* something. Its header has been explaining that "nothing currently blocks a page transition server-side because no such transition exists to gate"; that is no longer true, and the header is updated.

`purge` **reports rather than refuses** (ADR-0057 §C): ad placements targeting the page go inert exactly as they already do for a soft-deleted page, because the render query matches `target_id` against the page *being rendered*. The response carries `adPlacementsNowInert` so the change is visible instead of silent.

**Zero migrations.** The columns, CHECK, index and catalogue rows all already existed.

## The gate (§F), and the three drafts it took

`bun run access:permissions:enforcement:check` — every declared permission needs an `authorizeInTransaction` guard or a recorded reason. Pure (registry + source text), in the `check` chain, **mutation-proven against the original defect**: delete a lifecycle route and it names that permission.

First score: **199/205 enforced, 6 exceptions** — five newly found, each verified against code before being written down:

| Permission | Verdict |
| --- | --- |
| `profile_identity.profile_management.restore` | **Real hole** — no restore route exists, so soft-deleted profiles cannot be recovered through the API |
| `visitor_analytics.settings.read` / `.update` | No surface at all |
| `blog_content.seo.configure` | Likely a revocation — the only occurrence of that activity in the repo is the descriptor line itself |
| `comments.moderation.delete` | Likely a revocation — ADR-0041's model is archive-not-delete |

They are recorded rather than fixed here: closing five unrelated holes inside a change about blog pages produces something nobody can review as either. `PROJECT_STATE.md` §4 carries them as backlog.

**The scanner needed three rewrites, and each failure is frozen as a test:**

1. **Draft 1** read string literals only → **39 false positives**, including three permissions whose endpoints had landed that same week. Many modules write `moduleKey: THEMING_MODULE_KEY`, not a literal.
2. **Draft 2** matched innermost braces → never saw a guard carrying a nested field (`workflow.approval.approve`, whose guard wraps `resourceAttributes`).
3. **Draft 3** required a literal action → missed both conditional guards (`comments.moderation.approve`/`.reject`, decided per request by a ternary).

A scanner that reports enforced permissions as unenforced is worse than none — it trains its readers to add exceptions until the gate asks nothing at all.

## Verification

Full `bun run check` green locally against a real Postgres: **3372 pass, 0 fail**, plus lint, docs, translation-hash, OpenAPI bundle + spec check, api-reference regeneration, tenant-route factory, work-class registry, typecheck and build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)