### PR TITLE
fix(blog-content): /admin/blog's Restore control could never work

### DIFF
--- a/.changeset/fix-admin-blog-restore-unreachable.md
+++ b/.changeset/fix-admin-blog-restore-unreachable.md
@@ -1,0 +1,23 @@
+---
+"awcms": patch
+---
+
+fix(blog-content): `/admin/blog`'s Restore control could never work
+
+`listBlogPostsForAdmin` hard-filtered `deleted_at IS NULL`, so a soft-deleted
+post was never on screen, and the console offered no way to see the bin. The
+Restore control was therefore hung off `status === "archived"` — a different
+axis. An archived post is not soft-deleted, and `POST .../restore` requires
+`canRestorePost` (`deleted_at IS NOT NULL`), so the button was rendered exactly
+where it must answer 404, and never where it would succeed.
+
+The delete confirmation already promised the opposite ("It is soft-deleted —
+recoverable until it is purged"), a promise the UI could not keep.
+
+`listBlogPostsForAdmin` gains a `deletedOnly` filter and the screen gains a
+`?view=deleted` bin. Restore now belongs to bin rows; the lifecycle controls
+belong to live rows, because `transitionBlogPostStatus` also matches
+`deleted_at IS NULL`; Purge appears in both, because `canPurgePost` accepts
+archived or soft-deleted.
+
+No schema change.

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -586,6 +586,22 @@ export type ListBlogPostsForAdminFilter = {
   status?: BlogContentStatus;
   /** Matches posts assigned this category/tag term id (via `awcms_blog_post_terms`). */
   termId?: string;
+  /**
+   * `true` lists ONLY soft-deleted posts — the bin — instead of only live ones.
+   *
+   * Without it `posts.restore` is a permission `/admin/blog` could appear to
+   * drive and never could: this list hard-filtered `deleted_at IS NULL`, so a
+   * soft-deleted post was never on screen to restore, and the Restore control
+   * was therefore rendered against `status = 'archived'` — which is a different
+   * axis, is not soft-deleted, and makes `POST .../restore` answer 404 every
+   * time (it requires `canRestorePost`, i.e. `deleted_at IS NOT NULL`).
+   *
+   * Deliberately a separate VIEW rather than an `includeDeleted` union: mixing
+   * binned rows into the working list gives every row's status badge two
+   * possible meanings, and the operator question is "what is in the bin", not
+   * "show me everything at once".
+   */
+  deletedOnly?: boolean;
   page?: number;
   pageSize?: number;
 };
@@ -632,12 +648,14 @@ export async function listBlogPostsForAdmin(
   const search = filter.search?.trim() || null;
   const status = filter.status ?? null;
   const termId = filter.termId ?? null;
+  const deletedOnly = filter.deletedOnly === true;
 
   const rows = (await tx`
     SELECT p.id, p.tenant_id, p.title, p.slug, p.status, p.visibility, p.locale,
            p.author_tenant_user_id, p.published_at, p.updated_at
     FROM awcms_blog_posts p
-    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL
+    WHERE p.tenant_id = ${tenantId}
+      AND (CASE WHEN ${deletedOnly} THEN p.deleted_at IS NOT NULL ELSE p.deleted_at IS NULL END)
       AND (${status}::text IS NULL OR p.status = ${status})
       AND (${search}::text IS NULL OR p.title ILIKE '%' || ${search} || '%')
       AND (
@@ -654,7 +672,8 @@ export async function listBlogPostsForAdmin(
   const countRows = (await tx`
     SELECT count(*)::int AS count
     FROM awcms_blog_posts p
-    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL
+    WHERE p.tenant_id = ${tenantId}
+      AND (CASE WHEN ${deletedOnly} THEN p.deleted_at IS NOT NULL ELSE p.deleted_at IS NULL END)
       AND (${status}::text IS NULL OR p.status = ${status})
       AND (${search}::text IS NULL OR p.title ILIKE '%' || ${search} || '%')
       AND (

--- a/src/pages/admin/blog.astro
+++ b/src/pages/admin/blog.astro
@@ -49,6 +49,19 @@
  * That is the opposite of `/admin/approvals`, which is keyset — the difference
  * is the UX, not an inconsistency.
  *
+ * ## Two views, because delete and archive are different axes
+ *
+ * `?view=deleted` lists the BIN (`deletedOnly`); the default lists live posts.
+ * The first edition of this screen had only the live list, and that made
+ * `posts.restore` a permission the page appeared to drive and could not: the
+ * list hard-filtered `deleted_at IS NULL`, so the Restore control was hung off
+ * `status === "archived"` instead — a different axis, not soft-deleted, and a
+ * guaranteed 404 from an endpoint that requires `canRestorePost`. Restore now
+ * belongs to bin rows; the lifecycle controls belong to live rows (a
+ * soft-deleted post cannot transition — `transitionBlogPostStatus` matches
+ * `deleted_at IS NULL`); and Purge appears in both, because `canPurgePost`
+ * accepts archived OR soft-deleted.
+ *
  * ## Writes
  *
  * Nothing here writes SQL. The mutations split on idempotency, and the split
@@ -147,6 +160,23 @@ const statusFilter: BlogContentStatus | undefined = isBlogContentStatus(
 const pageRaw = Number(readParam("page"));
 const pageNumber = Number.isInteger(pageRaw) && pageRaw > 0 ? pageRaw : 1;
 
+/**
+ * `?view=deleted` shows the BIN — soft-deleted posts — instead of live ones.
+ *
+ * This screen shipped without it, and the omission made `posts.restore`
+ * undrivable rather than merely absent. `listBlogPostsForAdmin` hard-filtered
+ * `deleted_at IS NULL`, so a soft-deleted post was never on screen; the Restore
+ * control was therefore rendered against `status === "archived"`, which is a
+ * different axis entirely. `POST .../restore` requires `canRestorePost`
+ * (`deleted_at IS NOT NULL`), so the button appeared exactly where it would
+ * 404, and never where it would work.
+ *
+ * Note the two axes stay separate here: `deleted_at` is "in the bin",
+ * `status` is where in the lifecycle a post sits. A post can be soft-deleted
+ * while published, and comes back published.
+ */
+const showsBin = readParam("view") === "deleted";
+
 /** `?post=<id>` opens the revision panel for one post, rather than N queries for a list nobody expanded. */
 const selectedPostId = readParam("post");
 
@@ -161,6 +191,7 @@ if (canRead) {
       listing = await listBlogPostsForAdmin(tx, ssr.tenantId, {
         search: searchFilter || undefined,
         status: statusFilter,
+        deletedOnly: showsBin || undefined,
         page: pageNumber
       });
 
@@ -205,6 +236,9 @@ function linkWith(overrides: Record<string, string | null>): string {
     if (value === null) params.delete(key);
     else params.set(key, value);
   }
+  // Paging is per-view: carrying `page=3` from a 60-post list into a two-row
+  // bin lands the operator on an empty page that looks like an empty bin.
+  if ("view" in overrides) params.delete("page");
   const query = params.toString();
   return query ? `/admin/blog?${query}` : "/admin/blog";
 }
@@ -294,6 +328,17 @@ const selectedPost = selectedPostId
         </select>
 
         <button type="submit">Apply filters</button>
+
+        {/* Carried across submit, so applying a filter does not silently
+            bounce the operator out of the bin. */}
+        {showsBin && <input type="hidden" name="view" value="deleted" />}
+
+        <a
+          class="quick-link"
+          href={linkWith({ view: showsBin ? null : "deleted" })}
+        >
+          {showsBin ? "← Back to live posts" : "View deleted posts"}
+        </a>
       </form>
     )
   }
@@ -305,7 +350,7 @@ const selectedPost = selectedPostId
         aria-labelledby="post-list-title"
       >
         <h2 class="admin-section-title" id="post-list-title">
-          Posts
+          {showsBin ? "Deleted posts" : "Posts"}
           <span class="count-pill">{total}</span>
         </h2>
 
@@ -333,14 +378,18 @@ const selectedPost = selectedPostId
                         ✎
                       </span>
                       <span class="empty-state-title">
-                        {hasFilters
-                          ? "No posts match these filters"
-                          : "No posts yet"}
+                        {showsBin
+                          ? "Nothing in the bin"
+                          : hasFilters
+                            ? "No posts match these filters"
+                            : "No posts yet"}
                       </span>
                       <span class="empty-state-text">
-                        {hasFilters
-                          ? "Clear or widen the filters above to see more posts."
-                          : "Create a draft below to get started."}
+                        {showsBin
+                          ? "Deleted posts appear here until they are purged."
+                          : hasFilters
+                            ? "Clear or widen the filters above to see more posts."
+                            : "Create a draft below to get started."}
                       </span>
                     </div>
                   </td>
@@ -392,43 +441,54 @@ const selectedPost = selectedPostId
                               </span>
                             </a>
                           )}
-                          {canUpdate && post.status === "draft" && (
-                            <button
-                              type="button"
-                              class="btn-inline post-submit-btn"
-                              data-post-id={post.id}
-                            >
-                              Submit for review
-                            </button>
-                          )}
-                          {canPublish && post.status !== "published" && (
-                            <button
-                              type="button"
-                              class="btn-inline post-publish-btn"
-                              data-post-id={post.id}
-                            >
-                              Publish
-                            </button>
-                          )}
-                          {canSchedule && post.status !== "published" && (
-                            <button
-                              type="button"
-                              class="btn-inline post-schedule-btn"
-                              data-post-id={post.id}
-                            >
-                              Schedule
-                            </button>
-                          )}
-                          {canArchive && post.status === "published" && (
-                            <button
-                              type="button"
-                              class="btn-inline post-archive-btn"
-                              data-post-id={post.id}
-                            >
-                              Archive
-                            </button>
-                          )}
-                          {canRestore && post.status === "archived" && (
+                          {canUpdate &&
+                            !showsBin &&
+                            post.status === "draft" && (
+                              <button
+                                type="button"
+                                class="btn-inline post-submit-btn"
+                                data-post-id={post.id}
+                              >
+                                Submit for review
+                              </button>
+                            )}
+                          {canPublish &&
+                            !showsBin &&
+                            post.status !== "published" && (
+                              <button
+                                type="button"
+                                class="btn-inline post-publish-btn"
+                                data-post-id={post.id}
+                              >
+                                Publish
+                              </button>
+                            )}
+                          {canSchedule &&
+                            !showsBin &&
+                            post.status !== "published" && (
+                              <button
+                                type="button"
+                                class="btn-inline post-schedule-btn"
+                                data-post-id={post.id}
+                              >
+                                Schedule
+                              </button>
+                            )}
+                          {canArchive &&
+                            !showsBin &&
+                            post.status === "published" && (
+                              <button
+                                type="button"
+                                class="btn-inline post-archive-btn"
+                                data-post-id={post.id}
+                              >
+                                Archive
+                              </button>
+                            )}
+                          {/* Restore undoes the BIN, so it belongs to rows in
+                              the bin — not to `status === "archived"`, which is
+                              a different axis and makes the endpoint 404. */}
+                          {canRestore && showsBin && (
                             <button
                               type="button"
                               class="btn-inline post-restore-btn"
@@ -437,7 +497,7 @@ const selectedPost = selectedPostId
                               Restore
                             </button>
                           )}
-                          {canDelete && (
+                          {canDelete && !showsBin && (
                             <button
                               type="button"
                               class="btn-inline btn-inline--danger post-delete-btn"
@@ -447,16 +507,19 @@ const selectedPost = selectedPostId
                               Delete
                             </button>
                           )}
-                          {canPurge && post.status === "archived" && (
-                            <button
-                              type="button"
-                              class="btn-inline btn-inline--danger post-purge-btn"
-                              data-post-id={post.id}
-                              data-post-title={post.title}
-                            >
-                              Purge
-                            </button>
-                          )}
+                          {/* `canPurgePost` accepts archived OR soft-deleted,
+                              so both views can offer it. */}
+                          {canPurge &&
+                            (showsBin || post.status === "archived") && (
+                              <button
+                                type="button"
+                                class="btn-inline btn-inline--danger post-purge-btn"
+                                data-post-id={post.id}
+                                data-post-title={post.title}
+                              >
+                                Purge
+                              </button>
+                            )}
                         </div>
                       </td>
                     )}

--- a/tests/admin-blog-page-contract.test.ts
+++ b/tests/admin-blog-page-contract.test.ts
@@ -276,6 +276,70 @@ describe("/admin/blog permission gates", () => {
     expect(validation).toContain("export const MAX_EXCERPT_LENGTH");
   });
 
+  test("Restore is gated on the bin view, not on archived status", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // The original defect: `{canRestore && post.status === "archived" && (`.
+    // Archived is not soft-deleted, and `POST .../restore` requires
+    // `canRestorePost` (`deleted_at IS NOT NULL`), so the control was rendered
+    // exactly where it must 404.
+    expect(page).not.toMatch(
+      /canRestore\s*&&\s*post\.status\s*===\s*"archived"/
+    );
+    expect(page).toMatch(/canRestore\s*&&\s*showsBin/);
+
+    // And the endpoint really does demand a soft-deleted row, which is the
+    // only reason the line above is the correct one.
+    const restore = await readFile(
+      "src/pages/api/v1/blog/posts/[id]/restore.ts",
+      "utf8"
+    );
+    expect(restore).toContain("canRestorePost");
+    expect(restore).toContain("includeDeleted: true");
+  });
+
+  test("the bin is reachable, so a restorable post can actually be on screen", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const directory = await readFile(
+      "src/modules/blog-content/application/blog-post-directory.ts",
+      "utf8"
+    );
+
+    // A `deletedOnly` filter nothing passes would leave the bin unreachable
+    // and Restore undrivable for a second time, one layer down.
+    expect(directory).toContain("deletedOnly?: boolean");
+    expect(directory).toMatch(/CASE WHEN \$\{deletedOnly\}/);
+    expect(page).toContain("deletedOnly: showsBin || undefined");
+    expect(page).toContain('readParam("view") === "deleted"');
+  });
+
+  test("a soft-deleted post is offered no lifecycle transition", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // `transitionBlogPostStatus` matches `deleted_at IS NULL`, so publish,
+    // schedule, archive and submit-for-review all 404 on a binned post.
+    // Matched with `\s*` because prettier wraps these JSX conditions across
+    // lines — an exact-string assertion here reads as a behaviour change the
+    // next time a condition grows a clause.
+    for (const control of [
+      "canUpdate",
+      "canPublish",
+      "canSchedule",
+      "canArchive",
+      // Delete too — it is already deleted.
+      "canDelete"
+    ]) {
+      expect(page).toMatch(
+        new RegExp(String.raw`\{${control}\s*&&\s*!showsBin\s*&&`)
+      );
+    }
+
+    // Purge is the deliberate exception: `canPurgePost` accepts either state.
+    expect(page).toMatch(
+      /canPurge\s*&&\s*\(showsBin\s*\|\|\s*post\.status\s*===\s*"archived"\)/
+    );
+  });
+
   test("the sidebar entry points at this page and is gated on a real permission", () => {
     const nav = listModules()
       .find((module) => module.key === "blog_content")


### PR DESCRIPTION
Found while auditing the `pages` surface for its own screen ([ADR-0057](https://github.com/ahliweb/awcms/blob/main/docs/adr/0057-blog-page-lifecycle.md)) — in the post console that landed six days earlier (#340).

## The defect

`listBlogPostsForAdmin` hard-filters `p.deleted_at IS NULL`, and the screen's only status filter is `BLOG_CONTENT_STATUSES` (draft/review/scheduled/published/archived). **There was no way to see a soft-deleted post.**

So the Restore control was hung off `status === "archived"` instead — a *different axis*:

- `deleted_at` says a row is **in the bin**
- `status` says **where in the lifecycle** it sits

`POST /api/v1/blog/posts/{id}/restore` requires `canRestorePost` (`deleted_at IS NOT NULL`). So the button was rendered exactly on the rows where it must answer **404**, and never on the rows where it would succeed — those were not listed at all.

`posts.restore` was a permission the screen appeared to drive and could not. The delete confirmation already promised the opposite —

> "It is soft-deleted — recoverable until it is purged"

— a promise the UI had no way to keep.

## The fix

`listBlogPostsForAdmin` gains `deletedOnly`; the screen gains `?view=deleted`.

A separate **view** rather than an `includeDeleted` union, deliberately: mixing binned rows into the working list gives every status badge two possible meanings, and the operator question is "what is in the bin", not "show me everything at once".

Control placement now follows what each endpoint actually accepts:

| Control | Where it appears | Why |
| --- | --- | --- |
| Restore | bin rows only | `canRestorePost` requires `deleted_at IS NOT NULL` |
| Delete | live rows only | it is already deleted |
| publish / schedule / archive / submit-review | live rows only | `transitionBlogPostStatus` also matches `deleted_at IS NULL`, so each 404s on a binned post |
| Purge | **both** | `canPurgePost` accepts archived **or** soft-deleted |

Two smaller things that only show up in use: `linkWith` drops `page` when the view changes (carrying `page=3` from a 60-post list into a two-row bin lands the operator on an empty page that reads as an empty bin), and the filter form carries `view` across submit so applying a filter does not silently bounce them out.

## Verification

Four contract tests, **mutation-proven**: restoring the original condition (`canRestore && post.status === "archived"`) turns *"Restore is gated on the bin view"* red, and green again when reverted. They also assert the layer below — that `deletedOnly` exists and is actually passed — so the bin cannot become unreachable again one level down.

Full `bun run check` green locally against a real Postgres: **3375 pass, 0 fail**. No schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)