### PR TITLE
feat(blog-content): /admin/blog-pages — the page console (ADR-0057 step 3)

### DIFF
--- a/.changeset/admin-blog-pages-console.md
+++ b/.changeset/admin-blog-pages-console.md
@@ -1,0 +1,27 @@
+---
+"awcms": minor
+---
+
+feat(blog-content): `/admin/blog-pages` — the page console (ADR-0057 step 3)
+
+Completes ADR-0057. The screen drives **all eight** `pages.*` permissions —
+`read`/`create`/`update`/`publish`/`archive`/`delete`/`restore`/`purge` — four
+of which had no surface at all until the previous change, and so no screen
+could have driven them.
+
+Two views, because delete and archive are different axes: the default lists
+live pages, `?view=deleted` lists the bin. Control placement follows what each
+endpoint accepts — Restore on bin rows, Publish/Archive/Delete on live rows,
+Purge on both. `listBlogPagesForAdmin` gains the `deletedOnly` filter that makes
+the bin reachable.
+
+`pages.update` is driven through the structure fields this screen owns (title,
+slug, page type, menu order), not a body editor. Re-parenting is deliberately
+absent: the API performs no cycle detection, and a control that can make a page
+its own ancestor is worse than none.
+
+The status filter offers the three states a page can reach, not all five —
+there is no `pages.schedule` and no review queue.
+
+Sidebar gains a second `blog_content` entry, gated on `pages.read` rather than
+`posts.read`.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -87,7 +87,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base  | **21** (lihat daftar di ARCHITECTURE.md)                                                                                 | `src/modules/index.ts`                                                                  |
 | Migrasi     | **88** (`sql/001`–`088`)                                                                                                 | `ls sql/`                                                                               |
 | ADR         | **0000**–**0057** (`0000` = template)                                                                                    | `ls docs/adr/`                                                                          |
-| Layar admin | **28** berkas `.astro` di `src/pages/admin/`; **0 dari 21 modul** tanpa layar — nol pengecualian, tak ada yang disengaja | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Layar admin | **29** berkas `.astro` di `src/pages/admin/`; **0 dari 21 modul** tanpa layar — nol pengecualian, tak ada yang disengaja | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Kontrak     | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.4.0**                                                | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
 > **Angka tabel ini pernah basi tanpa ada yang merah.** Sebelum PR #339 barisnya
@@ -428,12 +428,37 @@ NULL`, jadi pencarian publik untuk page **selalu** nol baris — di atas index
     becomes one", dan soft delete hari ini punya efek render yang sama persis.
     **Nol migrasi** — kolom, CHECK,
     index dan baris katalog sudah ada; yang hilang murni lapisan aplikasi + route.
-    Urutan mengikat: permukaan dulu, `/admin/blog/pages` menyusul.
+    Urutan mengikat: permukaan dulu, `/admin/blog-pages` menyusul.
 
-    **Permukaan SELESAI** — `sql/`-nol, empat rute ter-guard/ter-audit/
-    ber-`Idempotency-Key` (`publish`/`archive`/`restore`/`purge`) lewat
+    **ADR-0057 SELESAI SELURUHNYA — tiga PR, nol migrasi.** Permukaan (#350):
+    empat rute ter-guard/ter-audit/ber-`Idempotency-Key` lewat
     `defineTenantRoute`, plus `domain/page-status.ts` dan tiga fungsi directory.
-    Layar `/admin/blog/pages` menyusul.
+    Layar (#352): **`/admin/blog-pages`** menggerakkan **kedelapan** permission,
+    dua tampilan (hidup + bin), edit STRUKTUR (judul/slug/tipe/urutan menu)
+    bukan editor badan, tanpa re-parenting (API tak punya deteksi siklus).
+    Contract test-nya memuat satu asersi maju: permission `pages.*` KESEMBILAN
+    yang di-seed akan memerahkan CI, karena begitulah empat yang ini lolos
+    berbulan-bulan.
+
+- **Bug yang ditemukan dalam perjalanan, sudah diperbaiki (#351).** Tombol
+  **Restore** di `/admin/blog` (#340, enam hari sebelumnya) **tidak pernah bisa
+  bekerja**. `listBlogPostsForAdmin` menyaring keras `deleted_at IS NULL` dan
+  layar itu tak punya filter "deleted", jadi Restore digantungkan pada
+  `status === "archived"` — sumbu yang BERBEDA. Endpoint-nya menuntut
+  `canRestorePost` (`deleted_at IS NOT NULL`), sehingga tombolnya dirender
+  persis pada baris yang pasti 404 dan tak pernah pada baris yang akan
+  berhasil. Teks konfirmasi hapusnya bahkan menjanjikan sebaliknya
+  ("recoverable until it is purged"). Diperbaiki dengan filter `deletedOnly`
+  di kedua fungsi daftar admin + tampilan `?view=deleted` di kedua layar.
+
+  > **Gate §F TIDAK menangkap ini, dan itu batas yang perlu diketahui.** Ia
+  > bertanya "apakah permission ini punya penegak" — dan `posts.restore` punya;
+  > endpoint-nya ada dan benar. Yang salah adalah LAYAR memanggilnya pada baris
+  > yang salah. Itu lapisan contract-test per-layar, dan contract test yang ada
+  > tidak menanyakannya. Sekarang menanyakan, di kedua layar, mutation-proven.
+  > Pelajaran umumnya: gate cakupan permission dan contract test layar menjawab
+  > **dua pertanyaan berbeda**, dan sebuah kontrol bisa lulus yang pertama
+  > sambil mustahil dipakai.
 
 - **Gate cakupan permission — BARU, dan ia menemukan lima gap lagi.**
   `bun run access:permissions:enforcement:check` (ADR-0057 §F) menuntut tiap

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -29,7 +29,7 @@
         }
       ],
       "permissionCount": 43,
-      "navigationCount": 1,
+      "navigationCount": 2,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/blog-content/application/blog-page-directory.ts
+++ b/src/modules/blog-content/application/blog-page-directory.ts
@@ -275,6 +275,17 @@ export type ListBlogPagesForAdminFilter = {
   search?: string;
   status?: BlogContentStatus;
   pageType?: PageType;
+  /**
+   * `true` lists ONLY soft-deleted pages — the bin — instead of only live ones.
+   *
+   * Present from this list's first admin consumer rather than added after,
+   * because the post list shipped without it and that single omission made
+   * `posts.restore` undrivable: with `deleted_at IS NULL` hard-filtered, the
+   * console hung Restore off `status = 'archived'`, which is a different axis
+   * and a guaranteed 404. See the same field on
+   * `ListBlogPostsForAdminFilter` for the full account.
+   */
+  deletedOnly?: boolean;
   page?: number;
   pageSize?: number;
 };
@@ -310,11 +321,13 @@ export async function listBlogPagesForAdmin(
   const search = filter.search?.trim() || null;
   const status = filter.status ?? null;
   const pageType = filter.pageType ?? null;
+  const deletedOnly = filter.deletedOnly === true;
 
   const rows = (await tx`
     SELECT id, tenant_id, title, slug, status, visibility, page_type, parent_page_id, menu_order, locale, updated_at
     FROM awcms_blog_pages
-    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    WHERE tenant_id = ${tenantId}
+      AND (CASE WHEN ${deletedOnly} THEN deleted_at IS NOT NULL ELSE deleted_at IS NULL END)
       AND (${status}::text IS NULL OR status = ${status})
       AND (${pageType}::text IS NULL OR page_type = ${pageType})
       AND (${search}::text IS NULL OR title ILIKE '%' || ${search} || '%')
@@ -325,7 +338,8 @@ export async function listBlogPagesForAdmin(
   const countRows = (await tx`
     SELECT count(*)::int AS count
     FROM awcms_blog_pages
-    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+    WHERE tenant_id = ${tenantId}
+      AND (CASE WHEN ${deletedOnly} THEN deleted_at IS NOT NULL ELSE deleted_at IS NULL END)
       AND (${status}::text IS NULL OR status = ${status})
       AND (${pageType}::text IS NULL OR page_type = ${pageType})
       AND (${search}::text IS NULL OR title ILIKE '%' || ${search} || '%')

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -84,10 +84,14 @@ export const blogContentModule = defineModule({
    * `tests/admin-navigation-registry.test.ts` now fails on any entry whose
    * path has no page, in both directions.
    *
-   * ONE entry for fifteen activity codes, on purpose: this is the post
-   * lifecycle screen. Pages, taxonomy, presentation, settings and homepage
-   * composition are sibling screens, and each brings its own entry when its
-   * page lands — not before.
+   * Two entries for fifteen activity codes: the post lifecycle and the page
+   * lifecycle. Taxonomy, presentation, settings and homepage composition are
+   * still sibling screens, and each brings its own entry when its page lands —
+   * not before.
+   *
+   * The pages entry is gated on `pages.read` rather than `posts.read`: they
+   * are separate permissions, and an operator granted one and not the other
+   * must see exactly the screen they can use.
    */
   navigation: [
     {
@@ -95,6 +99,12 @@ export const blogContentModule = defineModule({
       path: "/admin/blog",
       order: 36,
       requiredPermission: "blog_content.posts.read"
+    },
+    {
+      labelKey: "admin.layout.nav_blog_pages",
+      path: "/admin/blog-pages",
+      order: 37,
+      requiredPermission: "blog_content.pages.read"
     }
   ],
   permissions: [

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -180,6 +180,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_data_lifecycle": "Data lifecycle",
   "admin.layout.nav_idn_regions": "Region datasets",
   "admin.layout.nav_blog": "Blog posts",
+  "admin.layout.nav_blog_pages": "Blog pages",
   "admin.layout.nav_media": "Media library",
   "admin.layout.nav_reporting": "Reporting operations",
   "admin.layout.nav_approvals": "Approvals",

--- a/src/pages/admin/blog-pages.astro
+++ b/src/pages/admin/blog-pages.astro
@@ -1,0 +1,930 @@
+---
+/**
+ * Blog pages console — the structural half of `blog_content`.
+ *
+ * Sibling of `/admin/blog` (posts). Pages are the site's standing content —
+ * about, contact, privacy policy — so this screen is a hierarchy and a
+ * lifecycle, not an editorial queue.
+ *
+ * ## Scope
+ *
+ * Drives all EIGHT `pages.*` permissions: `read`/`create`/`update`/`publish`/
+ * `archive`/`delete`/`restore`/`purge`. Four of them had no surface at all
+ * until [ADR-0057](../../../docs/adr/0057-blog-page-lifecycle.md) — until then
+ * `createBlogPage` wrote a literal `'draft'` and nothing could ever move it, so
+ * every page in every tenant was permanently unpublished and the public page
+ * search returned nothing by construction.
+ *
+ * The lifecycle here is NARROWER than posts': no "submit for review", no
+ * "schedule". `sql/036` seeded no `pages.schedule`, and ADR-0057 §B records
+ * that as a decision rather than a gap — `domain/page-status.ts` holds the
+ * three-state table this screen renders against.
+ *
+ * ## Two views, because delete and archive are different axes
+ *
+ * `?view=deleted` lists the bin. This is not a nicety: the post console
+ * shipped without it and `posts.restore` became a permission the screen
+ * appeared to drive and could not, because a soft-deleted row was never on
+ * screen and Restore was therefore hung off `status === "archived"` — a
+ * guaranteed 404 (#351). Control placement here follows what each endpoint
+ * accepts, not what looks tidy:
+ *
+ * - **Restore** — bin rows only (`canRestorePage`: `deleted_at IS NOT NULL`);
+ * - **Delete** — live rows only; it is already deleted in the bin;
+ * - **Publish / Archive** — live rows only. `transitionBlogPageStatus` matches
+ *   `deleted_at IS NULL`, so both 404 on a binned page;
+ * - **Purge** — BOTH, because `canPurgePage` accepts archived OR soft-deleted.
+ *
+ * ## No body editor, and one absence worth naming
+ *
+ * Same boundary `/admin/blog` drew: authoring a page body is a rich-text
+ * surface plus SEO fields and media, not a corner of a list. `pages.update` is
+ * driven through the STRUCTURE fields this screen genuinely owns — title,
+ * slug, page type, menu order — which is what an operator reorganising a site
+ * menu actually needs, and what no other screen offers.
+ *
+ * `parent_page_id` is displayed but not editable here. Re-parenting is a tree
+ * operation: it needs cycle detection the API does not currently perform, and
+ * a `<select>` of every page in the tenant is not a tree editor. Showing a
+ * control that can produce a cycle would be worse than showing none.
+ *
+ * ## Reads / writes / gates
+ *
+ * Reads go through this module's own application functions inside ONE
+ * `withTenantOrThrow`, awaited sequentially — concurrent queries on a single
+ * transaction connection leak it. Nothing here writes SQL; every mutation is a
+ * request to a guarded endpoint, so audit rows and idempotency records cannot
+ * be bypassed.
+ *
+ * Idempotency splits per-endpoint, and this screen mirrors that split exactly:
+ * the four lifecycle mutations require an `Idempotency-Key`; create, update and
+ * soft delete require none, and sending one would imply a replay contract those
+ * endpoints declined.
+ *
+ * Permission gates below are UX-only — `authorizeInTransaction` in the routes
+ * is the authority.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listBlogPagesForAdmin,
+  type ListBlogPagesForAdminResult
+} from "../../modules/blog-content/application/blog-page-directory";
+import {
+  BLOG_CONTENT_VISIBILITIES,
+  isBlogContentStatus,
+  type BlogContentStatus
+} from "../../modules/blog-content/domain/post-status";
+import { BLOG_PAGE_STATUSES } from "../../modules/blog-content/domain/page-status";
+import {
+  PAGE_TYPES,
+  isPageType
+} from "../../modules/blog-content/domain/page-type";
+import {
+  MAX_EXCERPT_LENGTH,
+  MAX_TITLE_LENGTH
+} from "../../modules/blog-content/domain/content-validation";
+
+const ssr = Astro.locals.ssrContext!;
+
+const canRead = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "read")
+);
+const canCreate = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "create")
+);
+const canUpdate = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "update")
+);
+const canPublish = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "publish")
+);
+const canArchive = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "archive")
+);
+const canDelete = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "delete")
+);
+const canRestore = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "restore")
+);
+const canPurge = ssr.permissions.has(
+  permissionKey("blog_content", "pages", "purge")
+);
+
+function readParam(name: string): string {
+  return (Astro.url.searchParams.get(name) ?? "").trim();
+}
+
+const searchFilter = readParam("search");
+
+const statusRaw = readParam("status");
+// An unknown value is dropped rather than forwarded: a hand-edited query
+// string must not turn this screen into an error page.
+const statusFilter: BlogContentStatus | undefined = isBlogContentStatus(
+  statusRaw
+)
+  ? statusRaw
+  : undefined;
+
+const pageTypeRaw = readParam("pageType");
+const pageTypeFilter = isPageType(pageTypeRaw) ? pageTypeRaw : undefined;
+
+const pageRaw = Number(readParam("page"));
+const pageNumber = Number.isInteger(pageRaw) && pageRaw > 0 ? pageRaw : 1;
+
+const showsBin = readParam("view") === "deleted";
+
+/** `?edit=<id>` opens the structure form for one page, below the table. */
+const editingPageId = readParam("edit");
+
+let listing: ListBlogPagesForAdminResult | null = null;
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
+      listing = await listBlogPagesForAdmin(tx, ssr.tenantId, {
+        search: searchFilter || undefined,
+        status: statusFilter,
+        pageType: pageTypeFilter,
+        deletedOnly: showsBin || undefined,
+        page: pageNumber
+      });
+    });
+  } catch (error) {
+    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
+    // must never render as "this tenant has no pages".
+    loadError = true;
+    logAdminPageError("admin/blog-pages.astro: failed to load pages", error, {
+      correlationId: Astro.locals.correlationId
+    });
+  }
+}
+
+const STATUS_VARIANT: Record<string, string> = {
+  draft: "neutral",
+  review: "info",
+  scheduled: "info",
+  published: "success",
+  archived: "warning"
+};
+
+function formatTimestamp(value: Date | null): string {
+  return value ? value.toISOString() : "—";
+}
+
+/** Rebuilds the current query string with keys replaced — keeps filters across paging. */
+function linkWith(overrides: Record<string, string | null>): string {
+  const params = new URLSearchParams(Astro.url.search);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) params.delete(key);
+    else params.set(key, value);
+  }
+  // Paging is per-view: carrying `page=3` from a long list into a two-row bin
+  // lands the operator on an empty page that looks like an empty bin.
+  if ("view" in overrides) params.delete("page");
+  const query = params.toString();
+  return query ? `/admin/blog-pages?${query}` : "/admin/blog-pages";
+}
+
+const pages = listing?.items ?? [];
+const total = listing?.total ?? 0;
+const pageSize = listing?.pageSize ?? 20;
+const lastPage = Math.max(1, Math.ceil(total / pageSize));
+const hasFilters =
+  searchFilter !== "" ||
+  statusFilter !== undefined ||
+  pageTypeFilter !== undefined;
+
+const showsRowActions =
+  canUpdate || canPublish || canArchive || canDelete || canRestore || canPurge;
+const pageColumns = 5 + (showsRowActions ? 1 : 0);
+
+const editingPage = editingPageId
+  ? (pages.find((entry) => entry.id === editingPageId) ?? null)
+  : null;
+---
+
+<AdminLayout title="Blog pages">
+  <header class="page-header fade-in-up">
+    <h1 id="pages-heading">Blog pages</h1>
+    <p class="page-description">
+      Standing site content — about, contact, policies. Pages have a narrower
+      lifecycle than posts: <strong>draft, published, archived</strong>, with no
+      review queue and no scheduling. Posts live on <a href="/admin/blog"
+        >the blog console</a
+      >.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="pages-denied">
+        You do not have permission to view blog pages.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="pages-error">
+        Pages could not be loaded right now. This is a problem reading the list,
+        not an empty list — please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <p
+        id="pages-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <form method="get" class="admin-toolbar fade-in-up" id="page-filter-form">
+        <label for="filter-search">Search titles</label>
+        <input
+          id="filter-search"
+          name="search"
+          type="search"
+          value={searchFilter}
+          autocomplete="off"
+        />
+
+        <label for="filter-status">Status</label>
+        <select id="filter-status" name="status">
+          <option value="" selected={statusFilter === undefined}>
+            Any status
+          </option>
+          {/* The page lifecycle's three, not all five: offering `review` or
+              `scheduled` would filter for states no page can reach. */}
+          {BLOG_PAGE_STATUSES.map((value) => (
+            <option value={value} selected={statusFilter === value}>
+              {value}
+            </option>
+          ))}
+        </select>
+
+        <label for="filter-page-type">Type</label>
+        <select id="filter-page-type" name="pageType">
+          <option value="" selected={pageTypeFilter === undefined}>
+            Any type
+          </option>
+          {PAGE_TYPES.map((value) => (
+            <option value={value} selected={pageTypeFilter === value}>
+              {value}
+            </option>
+          ))}
+        </select>
+
+        <button type="submit">Apply filters</button>
+
+        {/* Carried across submit, so applying a filter does not silently
+            bounce the operator out of the bin. */}
+        {showsBin && <input type="hidden" name="view" value="deleted" />}
+
+        <a
+          class="quick-link"
+          href={linkWith({ view: showsBin ? null : "deleted", edit: null })}
+        >
+          {showsBin ? "← Back to live pages" : "View deleted pages"}
+        </a>
+      </form>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="page-list-title"
+      >
+        <h2 class="admin-section-title" id="page-list-title">
+          {showsBin ? "Deleted pages" : "Pages"}
+          <span class="count-pill">{total}</span>
+        </h2>
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack" id="blog-pages-table">
+            <caption class="sr-only">
+              Blog pages, most recently updated first.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Title</th>
+                <th scope="col">Status</th>
+                <th scope="col">Type</th>
+                <th scope="col">Menu order</th>
+                <th scope="col">Updated</th>
+                {showsRowActions && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {pages.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={pageColumns}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ▤
+                      </span>
+                      <span class="empty-state-title">
+                        {showsBin
+                          ? "Nothing in the bin"
+                          : hasFilters
+                            ? "No pages match these filters"
+                            : "No pages yet"}
+                      </span>
+                      <span class="empty-state-text">
+                        {showsBin
+                          ? "Deleted pages appear here until they are purged."
+                          : hasFilters
+                            ? "Clear or widen the filters above to see more pages."
+                            : "Create a draft below to get started."}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                pages.map((entry) => (
+                  <tr data-page-row={entry.id}>
+                    <td data-label="Title">
+                      <span set:text={entry.title} />
+                      <span class="cell-muted">
+                        {" "}
+                        · <span class="cell-code">{entry.slug}</span> ·{" "}
+                        {entry.locale}
+                      </span>
+                      {entry.parentPageId && (
+                        <span class="cell-muted">
+                          {" "}
+                          · child of{" "}
+                          <span class="cell-code">{entry.parentPageId}</span>
+                        </span>
+                      )}
+                    </td>
+                    <td data-label="Status">
+                      <span
+                        class="status-badge"
+                        data-variant={STATUS_VARIANT[entry.status] ?? "neutral"}
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {entry.status}
+                      </span>
+                    </td>
+                    <td data-label="Type">
+                      <span class="cell-code">{entry.pageType}</span>
+                    </td>
+                    <td data-label="Menu order">
+                      <span class="cell-muted">{entry.menuOrder}</span>
+                    </td>
+                    <td data-label="Updated">
+                      <span class="cell-muted">
+                        {formatTimestamp(entry.updatedAt)}
+                      </span>
+                    </td>
+                    {showsRowActions && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          {canUpdate && !showsBin && (
+                            <a
+                              class="quick-link"
+                              href={linkWith({ edit: entry.id })}
+                            >
+                              Edit structure
+                              <span class="quick-link-arrow" aria-hidden="true">
+                                →
+                              </span>
+                            </a>
+                          )}
+                          {/* `transitionBlogPageStatus` matches
+                              `deleted_at IS NULL`, so a binned page has no
+                              transition to offer. */}
+                          {canPublish &&
+                            !showsBin &&
+                            entry.status !== "published" && (
+                              <button
+                                type="button"
+                                class="btn-inline page-publish-btn"
+                                data-page-id={entry.id}
+                              >
+                                Publish
+                              </button>
+                            )}
+                          {canArchive &&
+                            !showsBin &&
+                            entry.status === "published" && (
+                              <button
+                                type="button"
+                                class="btn-inline page-archive-btn"
+                                data-page-id={entry.id}
+                              >
+                                Archive
+                              </button>
+                            )}
+                          {/* Restore undoes the BIN. Hanging it off
+                              `status === "archived"` is the defect #351 fixed
+                              on the post console: archived is a different axis
+                              and the endpoint answers 404. */}
+                          {canRestore && showsBin && (
+                            <button
+                              type="button"
+                              class="btn-inline page-restore-btn"
+                              data-page-id={entry.id}
+                            >
+                              Restore
+                            </button>
+                          )}
+                          {canDelete && !showsBin && (
+                            <button
+                              type="button"
+                              class="btn-inline btn-inline--danger page-delete-btn"
+                              data-page-id={entry.id}
+                              data-page-title={entry.title}
+                            >
+                              Delete
+                            </button>
+                          )}
+                          {/* `canPurgePage` accepts archived OR soft-deleted,
+                              so both views can offer it. */}
+                          {canPurge &&
+                            (showsBin || entry.status === "archived") && (
+                              <button
+                                type="button"
+                                class="btn-inline btn-inline--danger page-purge-btn"
+                                data-page-id={entry.id}
+                                data-page-title={entry.title}
+                              >
+                                Purge
+                              </button>
+                            )}
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {total > pageSize && (
+          <div class="admin-toolbar">
+            {pageNumber > 1 && (
+              <a
+                class="quick-link"
+                href={linkWith({ page: String(pageNumber - 1) })}
+              >
+                ← Previous
+              </a>
+            )}
+            <span class="cell-muted">
+              Page {pageNumber} of {lastPage}
+            </span>
+            {pageNumber < lastPage && (
+              <a
+                class="quick-link"
+                href={linkWith({ page: String(pageNumber + 1) })}
+              >
+                Next →
+              </a>
+            )}
+          </div>
+        )}
+      </section>
+    )
+  }
+
+  {
+    canUpdate && !loadError && editingPage && (
+      <section class="admin-section fade-in-up" aria-labelledby="edit-title">
+        <h2 class="admin-section-title" id="edit-title">
+          Edit structure
+        </h2>
+        <form id="page-edit-form" class="admin-create-form">
+          <p class="form-legend">
+            <span class="cell-code">{editingPage.id}</span>
+            {" · "}
+            <a href={linkWith({ edit: null })}>Close</a>
+          </p>
+          <p class="form-legend">
+            Structure only — title, address and menu placement. The page body is
+            written in the editor, which is not part of this screen.
+            Re-parenting is not offered here: it needs cycle detection the API
+            does not perform, and a control that can build a loop is worse than
+            none.
+          </p>
+          <p
+            id="page-edit-error"
+            class="admin-create-error"
+            role="alert"
+            hidden
+          />
+
+          <input type="hidden" id="edit-page-id" value={editingPage.id} />
+
+          <label for="edit-title-field">
+            Title
+            {/* `maxlength` comes from the SAME constant the validator
+                enforces, so the browser cannot accept what the server
+                rejects. */}
+            <input
+              type="text"
+              id="edit-title-field"
+              name="title"
+              required
+              maxlength={MAX_TITLE_LENGTH}
+              value={editingPage.title}
+              autocomplete="off"
+            />
+          </label>
+
+          <label for="edit-slug">
+            Slug
+            <input
+              type="text"
+              id="edit-slug"
+              name="slug"
+              required
+              value={editingPage.slug}
+              autocomplete="off"
+            />
+          </label>
+
+          <label for="edit-page-type">
+            Page type
+            <select id="edit-page-type" name="pageType">
+              {PAGE_TYPES.map((value) => (
+                <option value={value} selected={editingPage.pageType === value}>
+                  {value}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label for="edit-menu-order">
+            Menu order
+            <input
+              type="number"
+              id="edit-menu-order"
+              name="menuOrder"
+              step="1"
+              value={String(editingPage.menuOrder)}
+            />
+          </label>
+
+          <button type="submit" id="page-edit-submit">
+            Save structure
+          </button>
+        </form>
+      </section>
+    )
+  }
+
+  {
+    canCreate && !loadError && !showsBin && (
+      <section class="admin-section fade-in-up" aria-labelledby="create-title">
+        <h2 class="admin-section-title" id="create-title">
+          New page
+        </h2>
+        <form id="page-create-form" class="admin-create-form">
+          <p class="form-legend">
+            Creates a draft. The body is written in the page editor, which is
+            not part of this screen yet.
+          </p>
+          <p
+            id="page-create-error"
+            class="admin-create-error"
+            role="alert"
+            hidden
+          />
+
+          <label for="create-title-field">
+            Title
+            <input
+              type="text"
+              id="create-title-field"
+              name="title"
+              required
+              maxlength={MAX_TITLE_LENGTH}
+              autocomplete="off"
+            />
+          </label>
+
+          <label for="create-slug">
+            Slug
+            <input
+              type="text"
+              id="create-slug"
+              name="slug"
+              required
+              autocomplete="off"
+              placeholder="url-safe-identifier"
+            />
+          </label>
+
+          <label for="create-locale">
+            Locale
+            <input
+              type="text"
+              id="create-locale"
+              name="locale"
+              value="id"
+              autocomplete="off"
+            />
+          </label>
+
+          <label for="create-page-type">
+            Page type
+            <select id="create-page-type" name="pageType">
+              {PAGE_TYPES.map((value) => (
+                <option value={value}>{value}</option>
+              ))}
+            </select>
+          </label>
+
+          <label for="create-visibility">
+            Visibility
+            <select id="create-visibility" name="visibility">
+              {BLOG_CONTENT_VISIBILITIES.map((value) => (
+                <option value={value}>{value}</option>
+              ))}
+            </select>
+          </label>
+
+          <label for="create-menu-order">
+            Menu order
+            <input
+              type="number"
+              id="create-menu-order"
+              name="menuOrder"
+              step="1"
+              value="0"
+            />
+          </label>
+
+          <label for="create-excerpt">
+            Excerpt (optional)
+            <textarea
+              id="create-excerpt"
+              name="excerpt"
+              rows="2"
+              maxlength={MAX_EXCERPT_LENGTH}
+            />
+          </label>
+
+          <button type="submit" id="page-create-submit">
+            Create draft
+          </button>
+        </form>
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'`
+  // with no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("pages-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  /** All four lifecycle endpoints require the header; create/update/delete require none. */
+  function idempotency(): Record<string, string> {
+    return { "Idempotency-Key": crypto.randomUUID() };
+  }
+
+  function wireLifecycle(
+    selector: string,
+    busyLabel: string,
+    url: (pageId: string) => string,
+    options: {
+      confirm?: (button: HTMLButtonElement) => string | null;
+      failure: string;
+    }
+  ): void {
+    document.querySelectorAll<HTMLButtonElement>(selector).forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const pageId = button.dataset.pageId;
+        if (!pageId) return;
+
+        const confirmText = options.confirm?.(button) ?? null;
+        if (confirmText !== null && !window.confirm(confirmText)) return;
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, busyLabel);
+
+        const result = await sendJson(
+          "POST",
+          url(pageId),
+          undefined,
+          idempotency()
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // Generic copy only — never surface internal detail.
+        showActionError(options.failure);
+        unlock();
+      });
+    });
+  }
+
+  wireLifecycle(
+    ".page-publish-btn",
+    "Publishing…",
+    (id) => `/api/v1/blog/pages/${id}/publish`,
+    {
+      confirm: () =>
+        "Publish this page? It becomes visible on the public site immediately.",
+      failure:
+        "Could not publish the page. It may be blocked by the content quality checklist."
+    }
+  );
+
+  wireLifecycle(
+    ".page-archive-btn",
+    "Archiving…",
+    (id) => `/api/v1/blog/pages/${id}/archive`,
+    {
+      confirm: () =>
+        "Archive this page? It is removed from the public site but kept.",
+      failure: "Could not archive the page. Please try again."
+    }
+  );
+
+  wireLifecycle(
+    ".page-restore-btn",
+    "Restoring…",
+    (id) => `/api/v1/blog/pages/${id}/restore`,
+    { failure: "Could not restore the page. Please try again." }
+  );
+
+  wireLifecycle(
+    ".page-purge-btn",
+    "Purging…",
+    (id) => `/api/v1/blog/pages/${id}/purge`,
+    {
+      confirm: (button) =>
+        `Permanently delete "${button.dataset.pageTitle ?? "this page"}"? This cannot be undone — the page row is removed, not soft-deleted. Any advertisement placement targeting it stops matching.`,
+      failure:
+        "Could not purge the page. A page must be archived or deleted first."
+    }
+  );
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".page-delete-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const pageId = button.dataset.pageId;
+        if (!pageId) return;
+        const title = button.dataset.pageTitle ?? "this page";
+
+        if (
+          !window.confirm(
+            `Delete "${title}"? It is soft-deleted — recoverable from "View deleted pages" until it is purged.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Deleting…");
+
+        // Soft delete needs no key: the endpoint's `deleted_at IS NULL` guard
+        // makes a repeat a no-op rather than a second deletion.
+        const result = await sendJson("DELETE", `/api/v1/blog/pages/${pageId}`);
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        showActionError("Could not delete the page. Please try again.");
+        unlock();
+      });
+    });
+
+  const editForm = document.getElementById(
+    "page-edit-form"
+  ) as HTMLFormElement | null;
+
+  editForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "page-edit-submit"
+    ) as HTMLButtonElement | null;
+    const idField = document.getElementById(
+      "edit-page-id"
+    ) as HTMLInputElement | null;
+    if (!submit || submit.disabled || !idField) return;
+
+    const data = new FormData(editForm);
+    const errorElement = document.getElementById("page-edit-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Saving…");
+
+    // PATCH is a partial update; only the structure fields this screen owns
+    // are sent, so a concurrent body edit is not clobbered by a stale copy.
+    const result = await sendJson(
+      "PATCH",
+      `/api/v1/blog/pages/${idField.value}`,
+      {
+        title: String(data.get("title") ?? "").trim(),
+        slug: String(data.get("slug") ?? "").trim(),
+        pageType: String(data.get("pageType") ?? "standard"),
+        menuOrder: Number(data.get("menuOrder") ?? 0)
+      }
+    );
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    if (errorElement) {
+      errorElement.textContent =
+        result.errorCode === "CONFLICT"
+          ? "A page with that slug and locale already exists."
+          : "Could not save the page. Check the title and slug, then try again.";
+      errorElement.hidden = false;
+    }
+    unlock();
+  });
+
+  const createForm = document.getElementById(
+    "page-create-form"
+  ) as HTMLFormElement | null;
+
+  createForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "page-create-submit"
+    ) as HTMLButtonElement | null;
+    if (!submit || submit.disabled) return;
+
+    const data = new FormData(createForm);
+    const errorElement = document.getElementById("page-create-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Creating…");
+
+    const excerpt = String(data.get("excerpt") ?? "").trim();
+    const body: Record<string, unknown> = {
+      title: String(data.get("title") ?? "").trim(),
+      slug: String(data.get("slug") ?? "").trim(),
+      locale: String(data.get("locale") ?? "").trim() || "id",
+      visibility: String(data.get("visibility") ?? "public"),
+      pageType: String(data.get("pageType") ?? "standard"),
+      menuOrder: Number(data.get("menuOrder") ?? 0),
+      // The validator requires both content fields; a new draft starts empty
+      // and the body is written in the editor, which is not this screen.
+      contentJson: {},
+      contentText: ""
+    };
+    // Omitted rather than sent as "": an empty string is a value, and the
+    // validator treats absent as "no excerpt".
+    if (excerpt !== "") body.excerpt = excerpt;
+
+    // No `Idempotency-Key`: `POST /api/v1/blog/pages` requires none — a retry
+    // that duplicates a create is caught by the slug/locale unique index.
+    const result = await sendJson("POST", "/api/v1/blog/pages", body);
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    if (errorElement) {
+      errorElement.textContent =
+        result.errorCode === "CONFLICT"
+          ? "A page with that slug and locale already exists."
+          : "Could not create the draft. Check the title and slug, then try again.";
+      errorElement.hidden = false;
+    }
+    unlock();
+  });
+</script>

--- a/tests/admin-blog-page-contract.test.ts
+++ b/tests/admin-blog-page-contract.test.ts
@@ -349,12 +349,26 @@ describe("/admin/blog permission gates", () => {
     expect(nav!.requiredPermission).toBe("blog_content.posts.read");
     expect(declaredTriples().has(nav!.requiredPermission as Triple)).toBe(true);
 
-    // ONE entry for fifteen activity codes: this is the lifecycle screen, and
-    // its siblings bring their own entries when their pages land. A second
+    // TWO entries for fifteen activity codes: the post lifecycle and the page
+    // lifecycle (ADR-0057). Taxonomy, presentation, settings and homepage
+    // composition still bring their own entries when their pages land. An
     // entry appearing here without a page is what
     // `admin-navigation-registry.test.ts` catches.
-    expect(
-      listModules().find((module) => module.key === "blog_content")?.navigation
-    ).toHaveLength(1);
+    const navigation = listModules().find(
+      (module) => module.key === "blog_content"
+    )?.navigation;
+
+    expect(navigation).toHaveLength(2);
+    expect(navigation?.map((entry) => entry.path).sort()).toEqual([
+      "/admin/blog",
+      "/admin/blog-pages"
+    ]);
+
+    // Gated on their OWN permissions: an operator granted one and not the
+    // other must see exactly the screen they can use.
+    const pagesEntry = navigation?.find(
+      (entry) => entry.path === "/admin/blog-pages"
+    );
+    expect(pagesEntry?.requiredPermission).toBe("blog_content.pages.read");
   });
 });

--- a/tests/admin-blog-pages-page-contract.test.ts
+++ b/tests/admin-blog-pages-page-contract.test.ts
@@ -1,0 +1,280 @@
+/**
+ * `/admin/blog-pages` gates against the endpoints it drives, and is explicit
+ * about what it deliberately does not offer.
+ *
+ * Sibling of `tests/admin-blog-page-contract.test.ts`. What is specific here:
+ *
+ * - **it drives ALL eight `pages.*` permissions**, unlike the post console
+ *   which claims eleven of forty-three. Four of those eight had no surface at
+ *   all until ADR-0057, so "the screen drives every one" is the assertion that
+ *   proves the ADR landed whole;
+ * - **Restore is gated on the bin view, not on archived status.** That is the
+ *   defect #351 fixed one screen over, and the reason this file asserts the
+ *   correct shape from the first commit rather than after someone hits a 404;
+ * - **the lifecycle is narrower than posts'** — no `schedule`, no
+ *   `submit-review`. The screen must not offer either, because no permission
+ *   and no route exists for them on pages.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/blog-pages.astro";
+const PAGES_ROUTE = "src/pages/api/v1/blog/pages/index.ts";
+const PAGE_ITEM_ROUTE = "src/pages/api/v1/blog/pages/[id].ts";
+
+const LIFECYCLE_ROUTES = [
+  "src/pages/api/v1/blog/pages/[id]/publish.ts",
+  "src/pages/api/v1/blog/pages/[id]/archive.ts",
+  "src/pages/api/v1/blog/pages/[id]/restore.ts",
+  "src/pages/api/v1/blog/pages/[id]/purge.ts"
+];
+
+const ROUTES = [PAGES_ROUTE, PAGE_ITEM_ROUTE, ...LIFECYCLE_ROUTES];
+
+/** All eight — this screen leaves none of its activity's permissions undriven. */
+const PAGE_KEYS = [
+  "blog_content.pages.archive",
+  "blog_content.pages.create",
+  "blog_content.pages.delete",
+  "blog_content.pages.publish",
+  "blog_content.pages.purge",
+  "blog_content.pages.read",
+  "blog_content.pages.restore",
+  "blog_content.pages.update"
+] as const;
+
+type Triple = `${string}.${string}.${string}`;
+
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function pageTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+function declaredTriples(): Set<Triple> {
+  return new Set<Triple>(
+    (listModules()
+      .find((module) => module.key === "blog_content")
+      ?.permissions?.map(
+        (permission) =>
+          `blog_content.${permission.activityCode}.${permission.action}`
+      ) ?? []) as Triple[]
+  );
+}
+
+describe("/admin/blog-pages permission gates", () => {
+  test("the page claims exactly the eight pages.* permissions", async () => {
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+
+    // Enumerated, so a permission from a sibling activity quietly appearing
+    // here — instead of on the screen that should own it — fails loudly.
+    expect([...pageKeys].sort()).toEqual([...PAGE_KEYS]);
+  });
+
+  test("every key it gates on is one its endpoints actually enforce", async () => {
+    const enforced = new Set<Triple>();
+    for (const route of ROUTES) {
+      for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+
+    // Guards really were parsed — an empty set would make the subset check
+    // pass vacuously, the shape of gate this repo has been burned by.
+    expect(enforced.size).toBeGreaterThan(0);
+
+    // `pages.update` is enforced through an activity const plus a literal
+    // action, which the triple regex cannot see. Assert it directly rather
+    // than letting it fall through as unenforced.
+    const item = await readFile(PAGE_ITEM_ROUTE, "utf8");
+    expect(item).toContain('moduleKey: "blog_content"');
+    expect(item).toContain('activityCode: "pages"');
+    expect(item).toContain('action: "update"');
+    enforced.add("blog_content.pages.update");
+
+    const pageKeys = pageTriplesFrom(await readFile(PAGE, "utf8"));
+    expect([...pageKeys].filter((key) => !enforced.has(key))).toEqual([]);
+  });
+
+  test("and every one is declared by the descriptor, so a migration seeds it", async () => {
+    const declared = declaredTriples();
+    const missing = [...pageTriplesFrom(await readFile(PAGE, "utf8"))].filter(
+      (key) => !declared.has(key)
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  test("no pages.* permission is left undriven — ADR-0057 landed whole", () => {
+    const declaredPages = [...declaredTriples()].filter((key) =>
+      key.startsWith("blog_content.pages.")
+    );
+
+    // Eight declared, eight on the screen. If a ninth is ever seeded, this
+    // fails and forces the screen question to be answered rather than missed —
+    // which is exactly how the four this ADR closed went unnoticed for months.
+    expect(declaredPages.sort()).toEqual([...PAGE_KEYS]);
+  });
+
+  test("Restore is gated on the bin view, not on archived status", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // The defect #351 fixed on the post console: archived is a different axis
+    // from soft-deleted, and `POST .../restore` requires `canRestorePage`
+    // (`deleted_at IS NOT NULL`), so that shape renders the control exactly
+    // where it must 404.
+    expect(page).not.toMatch(
+      /canRestore\s*&&\s*entry\.status\s*===\s*"archived"/
+    );
+    expect(page).toMatch(/canRestore\s*&&\s*showsBin/);
+
+    const restore = await readFile(
+      "src/pages/api/v1/blog/pages/[id]/restore.ts",
+      "utf8"
+    );
+    expect(restore).toContain("canRestorePage");
+    expect(restore).toContain("includeDeleted: true");
+  });
+
+  test("the bin is reachable, so a restorable page can actually be on screen", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const directory = await readFile(
+      "src/modules/blog-content/application/blog-page-directory.ts",
+      "utf8"
+    );
+
+    expect(directory).toContain("deletedOnly?: boolean");
+    expect(directory).toMatch(/CASE WHEN \$\{deletedOnly\}/);
+    expect(page).toContain("deletedOnly: showsBin || undefined");
+    expect(page).toContain('readParam("view") === "deleted"');
+  });
+
+  test("a soft-deleted page is offered no lifecycle transition", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // `transitionBlogPageStatus` matches `deleted_at IS NULL`, so publish and
+    // archive both 404 on a binned page. Delete too — it is already deleted.
+    // Matched with `\s*` because prettier wraps these JSX conditions.
+    for (const control of ["canPublish", "canArchive", "canDelete"]) {
+      expect(page).toMatch(
+        new RegExp(String.raw`\{${control}\s*&&\s*!showsBin\s*&&`)
+      );
+    }
+
+    // Purge is the deliberate exception: `canPurgePage` accepts either state.
+    expect(page).toMatch(
+      /canPurge\s*&&\s*\(showsBin\s*\|\|\s*entry\.status\s*===\s*"archived"\)/
+    );
+  });
+
+  test("the page lifecycle is narrower than posts' — no schedule, no review", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const declared = declaredTriples();
+
+    // Neither permission is seeded, so a control for either would be gated on
+    // something no role can hold — the latent-authz trap this repo has shipped
+    // more than once.
+    expect(declared.has("blog_content.pages.schedule" as Triple)).toBe(false);
+    expect(declared.has("blog_content.pages.review" as Triple)).toBe(false);
+
+    expect(page).not.toContain("/schedule");
+    expect(page).not.toContain("submit-review");
+
+    // The status filter offers the three reachable states, not all five.
+    expect(page).toContain("BLOG_PAGE_STATUSES");
+    expect(page).not.toContain("BLOG_CONTENT_STATUSES.map");
+  });
+
+  test("the page never mutates directly — it posts to the guarded endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // No SQL write anywhere in the screen: every change goes out over fetch, so
+    // the endpoints' audit rows and idempotency records cannot be bypassed.
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+
+    expect(page).toContain('"/api/v1/blog/pages"');
+    expect(page).toContain("/api/v1/blog/pages/${id}/publish`");
+    expect(page).toContain("/api/v1/blog/pages/${id}/archive`");
+    expect(page).toContain("/api/v1/blog/pages/${id}/restore`");
+    expect(page).toContain("/api/v1/blog/pages/${id}/purge`");
+    expect(page).toContain("/api/v1/blog/pages/${pageId}`");
+  });
+
+  test("the four lifecycle mutations send a key; create, update and delete do not", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    for (const route of LIFECYCLE_ROUTES) {
+      expect(await readFile(route, "utf8")).toContain("IDEMPOTENCY_REQUIRED");
+    }
+
+    // And the three that take none really do decline one — the screen's choice
+    // is only correct while that stays true.
+    expect(await readFile(PAGES_ROUTE, "utf8")).not.toContain(
+      "IDEMPOTENCY_REQUIRED"
+    );
+    expect(await readFile(PAGE_ITEM_ROUTE, "utf8")).not.toContain(
+      "IDEMPOTENCY_REQUIRED"
+    );
+
+    // One helper spells the header once for the four; the create and edit
+    // submits are separate handlers that never call it. Sliced per request so
+    // adding a header to either turns this red while the four stay untouched.
+    expect(page).toContain('"Idempotency-Key": crypto.randomUUID()');
+
+    const createCall = page.slice(page.indexOf('"/api/v1/blog/pages"'));
+    expect(createCall.slice(0, createCall.indexOf(");"))).not.toContain(
+      "Idempotency-Key"
+    );
+
+    const patchCall = page.slice(page.indexOf('sendJson("PATCH"'));
+    expect(patchCall.slice(0, patchCall.indexOf("});"))).not.toContain(
+      "Idempotency-Key"
+    );
+  });
+
+  test("form bounds come from the constants the validator enforces", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain("MAX_TITLE_LENGTH");
+    expect(page).toContain("MAX_EXCERPT_LENGTH");
+    // A hand-typed `maxlength` drifts into a browser accepting what the server
+    // rejects with a 400 the author cannot act on.
+    expect(page).not.toMatch(/maxlength=\{?"?\d/);
+  });
+
+  test("re-parenting is deliberately absent — no control can build a cycle", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // `parentPageId` is DISPLAYED (the tree is worth seeing) but never sent:
+    // the API performs no cycle detection, so a `<select>` of every page would
+    // let an operator make a page its own ancestor.
+    expect(page).toContain("entry.parentPageId");
+    expect(page).not.toMatch(/name="parentPageId"/);
+    expect(page).not.toMatch(/parentPageId:\s*[A-Za-z]/);
+  });
+});


### PR DESCRIPTION
Completes [ADR-0057](https://github.com/ahliweb/awcms/blob/main/docs/adr/0057-blog-page-lifecycle.md). Step 3 of 3, after #349 (the ADR) and #350 (the surface).

The screen drives **all eight** `pages.*` permissions — `read`/`create`/`update`/`publish`/`archive`/`delete`/`restore`/`purge`. Four of them had no surface at all until #350, so no screen could have driven them; asserting that all eight now sit on one page is what proves the ADR landed whole rather than half.

## Two views, because delete and archive are different axes

Default lists live pages; `?view=deleted` lists the bin. This is not polish — it is the defect #351 fixed one screen over, applied here from the first commit rather than after someone hits a 404. Control placement follows what each endpoint actually accepts:

| Control | Where | Why |
| --- | --- | --- |
| Restore | bin rows only | `canRestorePage` requires `deleted_at IS NOT NULL` |
| Delete | live rows only | it is already deleted in the bin |
| Publish / Archive | live rows only | `transitionBlogPageStatus` matches `deleted_at IS NULL`, so both 404 on a binned page |
| Purge | **both** | `canPurgePage` accepts archived **or** soft-deleted |

`listBlogPagesForAdmin` gains the `deletedOnly` filter that makes the bin reachable, carrying the same reasoning as the post list's: a separate *view* rather than an `includeDeleted` union, because mixing binned rows into the working list gives every status badge two possible meanings.

## What it deliberately does not offer

- **No body editor.** `pages.update` is driven through the *structure* fields this screen genuinely owns — title, slug, page type, menu order — which is what an operator reorganising a site menu needs, and what no other screen offers. A page body is a rich-text surface plus SEO fields and media; same boundary `/admin/blog` drew.
- **No re-parenting**, although `parent_page_id` is displayed. The API performs no cycle detection, and a `<select>` of every page in the tenant is not a tree editor — a control that can make a page its own ancestor is worse than none.
- **Three statuses in the filter, not five.** Offering `review` or `scheduled` would filter for states no page can reach, and a control for either would be gated on a permission nothing seeds — the latent-authz trap this repo has shipped more than once.

## Gates

Twelve contract tests, two **mutation-proven** before commit:

| Mutation | Test that went red |
| --- | --- |
| `canRestore && entry.status === "archived"` | *Restore is gated on the bin view* |
| `const canPurge = true` | *the page claims exactly the eight `pages.*` permissions* |

Both green again on revert.

One test is deliberately forward-looking: *"no `pages.*` permission is left undriven"* compares the descriptor's `pages.*` set against the screen's, so a **ninth** seeded permission fails CI and forces the screen question to be answered — precisely how the four this ADR closed went unnoticed for months.

The sidebar gains a second `blog_content` entry, gated on `pages.read` rather than `posts.read`: they are separate permissions, and an operator granted one and not the other must see exactly the screen they can use. The blog contract test now asserts two entries and their paths rather than one.

## Verification

Full `bun run check` green locally against a real Postgres: **3387 pass, 0 fail**. 29 admin screens; still zero modules without navigation. No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)