### PR TITLE
fix(access): the enforcement gate called two enforced permissions unenforced

### DIFF
--- a/.changeset/permission-enforcement-constant-scoping.md
+++ b/.changeset/permission-enforcement-constant-scoping.md
@@ -1,0 +1,19 @@
+---
+"awcms": patch
+---
+
+Fix `access:permissions:enforcement:check` reporting enforced permissions as unenforced.
+
+The gate resolved `const NAME = "value"` bindings across the whole repo as one
+flat namespace. `MODULE_KEY` is bound in five files to four different values, so
+the "a name bound to two values is unresolvable" rule silenced it everywhere —
+including in the file that binds it one line above its own guard. The guards in
+`src/pages/api/v1/analytics/settings.ts` were therefore invisible, and
+`visitor_analytics.settings.read`/`.update` were recorded in the exception list
+as permissions nothing enforces, with a stated reason the route disproves.
+
+Constants now resolve file-first (`resolveConstantsForSource`); the cross-file
+table is consulted only for names a file does not bind itself, which is exactly
+the set that can only have arrived by import. A name a file binds twice to
+different values stays unresolvable. Both exception entries are removed; the
+score moves from 199/205 with 6 exceptions to 201/205 with 4.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -460,28 +460,54 @@ NULL`, jadi pencarian publik untuk page **selalu** nol baris — di atas index
   > **dua pertanyaan berbeda**, dan sebuah kontrol bisa lulus yang pertama
   > sambil mustahil dipakai.
 
-- **Gate cakupan permission — BARU, dan ia menemukan lima gap lagi.**
+- **Gate cakupan permission — BARU, dan ia menemukan TIGA gap lagi.**
   `bun run access:permissions:enforcement:check` (ADR-0057 §F) menuntut tiap
   permission terdeklarasi punya call site `authorizeInTransaction` atau
   terdaftar sebagai pengecualian ber-alasan. Murni (registry + teks sumber),
-  masuk rantai `check`. Skor pertama: **199/205 tergerbangi, 6 pengecualian**.
+  masuk rantai `check`. Skor: **201/205 tergerbangi, 4 pengecualian**.
 
-  Lima di antaranya **temuan baru**, semuanya diverifikasi ke kode, dan
-  masing-masing butuh keputusan yang sama dengan ADR-0057 §A — beri permukaan,
-  atau cabut:
+  Ketiganya **temuan baru**, semuanya diverifikasi ke kode, dan masing-masing
+  butuh keputusan yang sama dengan ADR-0057 §A — beri permukaan, atau cabut:
   - `profile_identity.profile_management.restore` — **lubang nyata**: tak ada
     rute restore sama sekali, jadi profil yang di-soft-delete tidak bisa
-    dipulihkan lewat API. Bentuk yang sama dengan yang ADR-0056 §B tutup untuk
-    objek media.
-  - `visitor_analytics.settings.read` + `.update` — setting analitik per-tenant
-    tak punya permukaan apa pun.
+    dipulihkan lewat API. `awcms_profiles` membawa
+    `deleted_at`/`restored_at`/`restored_by` sejak `sql/003` dan
+    `party-directory.ts` mengekspor `softDeleteParty` **tanpa pasangan** —
+    bentuk yang sama dengan yang ADR-0056 §B tutup untuk objek media.
   - `blog_content.seo.configure` — satu-satunya kemunculan `"seo"` di repo
     adalah deklarasi descriptor itu sendiri; kemungkinan besar **pencabutan**,
     karena default SEO blog nyatanya dikonfigurasi lewat blog settings.
   - `comments.moderation.delete` — model moderasi ADR-0041 adalah
     arsip-bukan-hapus, jadi ini pun kandidat pencabutan.
 
-  Yang keenam sudah diketahui: `blog_content.posts.export` (ADR-0057 §F).
+  Yang keempat sudah diketahui: `blog_content.posts.export` (ADR-0057 §F).
+
+  > **Skor pertamanya 199/205 dengan 6 pengecualian, dan DUA di antaranya
+  > adalah bug gate-nya sendiri.** `visitor_analytics.settings.read`/`.update`
+  > **tergerbangi** — `src/pages/api/v1/analytics/settings.ts` membangun
+  > `READ_GUARD`/`UPDATE_GUARD` tepat pada activity itu. Yang salah: scanner
+  > membaca konstanta seluruh repo sebagai **satu namespace datar**, sementara
+  > `MODULE_KEY` terikat ke **empat nilai berbeda di lima berkas**, sehingga
+  > aturan "nama berkonflik = tak-terpecahkan" mematikannya di **semua** berkas
+  > — termasuk berkas yang mengikatnya sendiri satu baris di atas guard-nya.
+  > Alasan tertulis kedua pengecualian itu bahkan menyatakan, tentang rute yang
+  > ada, bahwa "no route names a settings activity".
+  >
+  > Ini persis peringatan yang tertulis di header berkas scanner itu sendiri,
+  > dan ia tetap dipercaya. Draf 4 kini beku sebagai test bersama tiga draf
+  > sebelumnya: konstanta diselesaikan **file-first**
+  > (`resolveConstantsForSource`), tabel lintas-berkas hanya untuk nama yang
+  > tak diikat berkas itu — yakni persis himpunan yang cuma bisa datang lewat
+  > `import`. Nama yang diikat DUA KALI di dalam satu berkas tetap
+  > tak-terpecahkan; menebak di situ hanya menukar satu jawaban salah dengan
+  > lawannya. Mutation-proven di dua lapis: helper DAN
+  > `evaluateEnforcementCoverage`, karena helper yang benar dengan satu-satunya
+  > pemanggilnya masih meneruskan tabel datar akan **tampak** diperbaiki.
+  >
+  > Pelajaran yang lebih umum, dan ini yang ketiga kalinya di repo ini: sebuah
+  > gate yang menjawab "tak tergerbangi" untuk yang tergerbangi tidak berhenti
+  > pada satu laporan salah — ia **melahirkan dokumen**. Kedua entri itu ditulis
+  > sebagai KEPUTUSAN ber-alasan, bukan sebagai temuan yang menunggu verifikasi.
 
   > **Gate-nya sendiri butuh tiga kali tulis ulang, dan itu pelajarannya.**
   > Draf 1 hanya membaca literal string → **39 false positive**, termasuk tiga

--- a/scripts/permission-enforcement-check.ts
+++ b/scripts/permission-enforcement-check.ts
@@ -35,17 +35,25 @@ const EXCEPTIONS: readonly EnforcementException[] = [
       "Declared by the descriptor and seeded by sql/036, with no endpoint anywhere that enforces it — recorded in /admin/blog's header and in ADR-0057 §F as a revocation candidate awaiting its own ADR. Building a surface to justify the catalogue row would be the tail wagging the dog."
   },
 
-  // The five below were found by this gate on its first run, and every one was
-  // verified against the code before being written down. They are NOT excused
-  // because they are acceptable — they are the same defect ADR-0057 documents
-  // for `pages`, in five more places, and each needs the decision ADR-0057 §A
-  // made: give it a surface, or revoke it.
+  // The three below were found by this gate on its first run. They are NOT
+  // excused because they are acceptable — they are the same defect ADR-0057
+  // documents for `pages`, in three more places, and each needs the decision
+  // ADR-0057 §A made: give it a surface, or revoke it.
   //
-  // They are recorded rather than fixed here because closing five unrelated
-  // holes inside a change about blog pages produces something nobody can
-  // review as either. `docs/PROJECT_STATE.md` §4 carries them as backlog. What
-  // this list buys today is that they are visible, counted, and that a SIXTH
-  // one turns CI red instead of waiting for the next manual audit.
+  // They are recorded rather than fixed here because closing unrelated holes
+  // inside a change about blog pages produces something nobody can review as
+  // either. `docs/PROJECT_STATE.md` §4 carries them as backlog. What this list
+  // buys today is that they are visible, counted, and that a FOURTH one turns
+  // CI red instead of waiting for the next manual audit.
+  //
+  // The first run listed FIVE, and two of them — `visitor_analytics.settings`
+  // read and update — were the gate's own bug, not a gap: it read the repo's
+  // constants as one flat namespace, `MODULE_KEY` is bound to four different
+  // values across five files, and the guard in `analytics/settings.ts` became
+  // invisible. Their written reasons asserted, of a route that exists, that no
+  // route names a settings activity. Constants now resolve file-first
+  // (`resolveConstantsForSource`), and the two entries are gone — the gate's
+  // stale-exception rule would now reject them anyway.
   {
     key: "blog_content.seo.configure",
     reason:
@@ -59,17 +67,7 @@ const EXCEPTIONS: readonly EnforcementException[] = [
   {
     key: "profile_identity.profile_management.restore",
     reason:
-      "profile_identity has no restore route at all; the five profile routes gate read/create/update/merge. Soft-deleted profiles therefore cannot be recovered through the API, which is a real hole rather than a spare permission — the same shape ADR-0056 §B closed for media objects. Needs its own ADR."
-  },
-  {
-    key: "visitor_analytics.settings.read",
-    reason:
-      "Every analytics route gates on the dashboard/sessions/retention activities; no route names a settings activity. Per-tenant analytics settings have no surface at all. Needs its own ADR, together with the update below."
-  },
-  {
-    key: "visitor_analytics.settings.update",
-    reason:
-      "Pair of the read above — declared and seeded, with no endpoint that enforces it."
+      "profile_identity has no restore route at all; the five profile routes gate read/create/update/delete. `awcms_profiles` carries deleted_at/restored_at/restored_by since sql/003 and party-directory.ts exports softDeleteParty with no counterpart, so a soft-deleted profile cannot be recovered through the API — a real hole rather than a spare permission, the same shape ADR-0056 §B closed for media objects. Needs its own ADR."
   }
 ];
 

--- a/src/modules/_shared/permission-enforcement-coverage.ts
+++ b/src/modules/_shared/permission-enforcement-coverage.ts
@@ -108,6 +108,11 @@ function stripComments(source: string): string {
  * UNRESOLVED rather than guessed: the resulting report of "unenforced" is
  * visible and fixable, whereas guessing one of the two values could mark a
  * permission enforced on the strength of an unrelated file's constant.
+ *
+ * That conflict rule is right for names that arrive by IMPORT and wrong for
+ * names a file binds itself, which is why callers resolve through
+ * `resolveConstantsForSource` rather than passing the cross-file table
+ * directly. See its comment for the two permissions the flat table lost.
  */
 function readStringField(
   literal: string,
@@ -193,6 +198,40 @@ export function collectStringConstants(
   }
 
   return constants;
+}
+
+/**
+ * The bindings visible to ONE source file: its own `const NAME = "value"`
+ * first, and the cross-file table only for names it does not bind itself.
+ *
+ * Reading the repo as one flat namespace instead is not a rounding error — it
+ * is the very false-positive class this file's header warns about, produced by
+ * the gate's own first release, and it was believed. `MODULE_KEY` is bound in
+ * five files to four different values (`visitor_analytics`, `email` twice,
+ * `sync_storage`, `domain_event_runtime`), so the conflict rule above left it
+ * unresolvable EVERYWHERE. The guard in `src/pages/api/v1/analytics/settings.ts`
+ * — `moduleKey: MODULE_KEY`, with `const MODULE_KEY = "visitor_analytics"` two
+ * dozen lines above it — was therefore invisible, and
+ * `visitor_analytics.settings.read`/`.update` were written into the exception
+ * list as decisions, with a stated reason ("no route names a settings
+ * activity") that the route disproves line by line.
+ *
+ * A name the file binds itself wins outright; the cross-file table is consulted
+ * only for the names that can only have arrived by import. A file that binds
+ * one name to two values still resolves to `null` — locally unresolvable is
+ * still unresolvable, and guessing there would reintroduce the opposite defect.
+ */
+export function resolveConstantsForSource(
+  source: string,
+  crossFileConstants: ReadonlyMap<string, string | null>
+): Map<string, string | null> {
+  const resolved = new Map(crossFileConstants);
+
+  for (const [name, value] of collectStringConstants([source])) {
+    resolved.set(name, value);
+  }
+
+  return resolved;
 }
 
 /**
@@ -339,10 +378,12 @@ export function evaluateEnforcementCoverage(
   sources: readonly string[],
   exceptions: readonly EnforcementException[]
 ): EnforcementCoverageResult {
-  const constants = collectStringConstants(sources);
+  const crossFileConstants = collectStringConstants(sources);
   const enforced = new Set<string>();
 
   for (const source of sources) {
+    const constants = resolveConstantsForSource(source, crossFileConstants);
+
     for (const triple of collectGuardTriples(source, constants)) {
       enforced.add(permissionTripleKey(triple));
     }

--- a/tests/permission-enforcement-coverage.test.ts
+++ b/tests/permission-enforcement-coverage.test.ts
@@ -4,7 +4,8 @@ import {
   collectGuardTriples,
   collectStringConstants,
   evaluateEnforcementCoverage,
-  permissionTripleKey
+  permissionTripleKey,
+  resolveConstantsForSource
 } from "../src/modules/_shared/permission-enforcement-coverage";
 import type { ModuleDescriptor } from "../src/modules/_shared/module-contract";
 
@@ -16,10 +17,15 @@ import type { ModuleDescriptor } from "../src/modules/_shared/module-contract";
  * Draft 1 read string literals only and produced 39 false positives.
  * Draft 2 matched innermost braces and missed every guard with a nested field.
  * Draft 3 required a literal action and missed both conditional guards.
+ * Draft 4 — the one that SHIPPED — read every file's constants as one flat
+ * namespace, so a name bound to different values in different files became
+ * unresolvable in all of them.
  *
  * A scanner that answers "unenforced" for enforced permissions is worse than
  * no scanner: it trains its readers to add exceptions until the gate asks
- * nothing at all. Each case below is one of those drafts, frozen.
+ * nothing at all. Each case below is one of those drafts, frozen. Draft 4 is
+ * the proof that the warning was not hypothetical: it was written in this
+ * file's own header, and two exceptions were recorded on its strength anyway.
  */
 
 function guard(
@@ -94,6 +100,81 @@ describe("collectGuardTriples", () => {
         constants
       )
     ).toEqual([]);
+  });
+
+  test("a file's own constant beats a cross-file collision on the same name (draft 4)", () => {
+    // The shipped defect, reduced. `MODULE_KEY` is bound in five files to four
+    // different values, so the cross-file table resolves it to null — and the
+    // guard in `analytics/settings.ts`, whose own file binds it one line up,
+    // became invisible. `visitor_analytics.settings.read` and `.update` were
+    // then recorded as permissions nothing enforces.
+    const analyticsSettingsRoute = `
+      const MODULE_KEY = "visitor_analytics";
+      const READ_GUARD = {
+        moduleKey: MODULE_KEY,
+        activityCode: "settings",
+        action: "read" as const
+      };
+    `;
+    const emailDispatch = `const MODULE_KEY = "email";`;
+    const syncDispatch = `const MODULE_KEY = "sync_storage";`;
+
+    const crossFile = collectStringConstants([
+      analyticsSettingsRoute,
+      emailDispatch,
+      syncDispatch
+    ]);
+
+    // Unresolvable across the repo, and that much is correct.
+    expect(crossFile.get("MODULE_KEY")).toBeNull();
+
+    // Resolvable inside the file that binds it, which is the only scope that
+    // decides what this guard means.
+    const scoped = resolveConstantsForSource(analyticsSettingsRoute, crossFile);
+    expect(scoped.get("MODULE_KEY")).toBe("visitor_analytics");
+
+    expect(
+      collectGuardTriples(analyticsSettingsRoute, scoped).map(
+        permissionTripleKey
+      )
+    ).toEqual([guard("visitor_analytics", "settings", "read")]);
+  });
+
+  test("a name a file binds twice to different values stays unresolvable in that file", () => {
+    // Local scope wins, but locally ambiguous is still ambiguous — resolving
+    // to either value here would swap one false answer for the other.
+    const source = `
+      const ACTIVITY = "settings";
+      const ACTIVITY = "dashboard";
+      const G = { moduleKey: "visitor_analytics", activityCode: ACTIVITY, action: "read" };
+    `;
+
+    const scoped = resolveConstantsForSource(source, new Map());
+
+    expect(scoped.get("ACTIVITY")).toBeNull();
+    expect(collectGuardTriples(source, scoped)).toEqual([]);
+  });
+
+  test("an imported constant still resolves through the cross-file table", () => {
+    // File-first must not mean file-only: most guards name their module key
+    // through a constant that lives in another module entirely.
+    const constantsSource = `export const THEMING_MODULE_KEY = "theming";`;
+    const routeSource = `
+      const G = {
+        moduleKey: THEMING_MODULE_KEY,
+        activityCode: "version",
+        action: "publish"
+      };
+    `;
+
+    const scoped = resolveConstantsForSource(
+      routeSource,
+      collectStringConstants([constantsSource, routeSource])
+    );
+
+    expect(
+      collectGuardTriples(routeSource, scoped).map(permissionTripleKey)
+    ).toEqual([guard("theming", "version", "publish")]);
   });
 
   test("reads a guard that carries a nested object (draft 2)", () => {
@@ -222,6 +303,31 @@ describe("evaluateEnforcementCoverage", () => {
     expect(result.unenforced.map((entry) => entry.key)).toEqual([
       "blog_content.pages.publish"
     ]);
+  });
+
+  test("scopes constants per file end-to-end, not just in the helper (draft 4)", () => {
+    // The gate calls `evaluateEnforcementCoverage`, so scoping has to hold
+    // HERE. Passing the flat table through was the shipped bug, and it is one
+    // line — a helper that scopes correctly while its only caller does not
+    // would look fixed and behave exactly as before.
+    const result = evaluateEnforcementCoverage(
+      [
+        moduleWith("visitor_analytics", [
+          { activityCode: "settings", action: "read" }
+        ])
+      ],
+      [
+        `
+          const MODULE_KEY = "visitor_analytics";
+          const READ_GUARD = { moduleKey: MODULE_KEY, activityCode: "settings", action: "read" };
+        `,
+        `const MODULE_KEY = "email";`
+      ],
+      []
+    );
+
+    expect(result.unenforced).toEqual([]);
+    expect(result.valid).toBe(true);
   });
 
   test("reports an exception that has since gained an enforcer as stale", () => {


### PR DESCRIPTION
## Apa yang salah

`bun run access:permissions:enforcement:check` (ADR-0057 §F) melaporkan `visitor_analytics.settings.read` dan `.update` sebagai permission yang **tak digerbangi apa pun**. Keduanya digerbangi — `src/pages/api/v1/analytics/settings.ts` membangun `READ_GUARD`/`UPDATE_GUARD` persis pada activity itu, lengkap dengan audit dan `Idempotency-Key`.

Penyebabnya bukan pada rute, melainkan pada scanner: ia menyelesaikan setiap `const NAME = "value"` di seluruh repo lewat **satu tabel datar**. `MODULE_KEY` terikat di lima berkas ke empat nilai berbeda:

| berkas | nilai |
| --- | --- |
| `pages/api/v1/analytics/settings.ts` | `visitor_analytics` |
| `modules/email/application/email-dispatch.ts` | `email` |
| `modules/email/application/announcement-directory.ts` | `email` |
| `modules/sync-storage/application/object-dispatch.ts` | `sync_storage` |
| `modules/domain-event-runtime/application/consumer-state-directory.ts` | `domain_event_runtime` |

Aturan "nama berkonflik = tak-terpecahkan" benar untuk nama yang datang lewat `import`, dan salah untuk nama yang **diikat berkas itu sendiri** — di sini satu baris di atas guard-nya.

## Kenapa ini lebih dari satu laporan salah

Kedua permission itu tidak sekadar dilaporkan keliru; keduanya **ditulis ke daftar `EXCEPTIONS` sebagai KEPUTUSAN ber-alasan**, dan alasannya menyatakan tentang rute yang ada bahwa *"no route names a settings activity"*.

Header berkas scanner itu sendiri sudah memuat peringatannya: scanner yang menjawab "tak tergerbangi" untuk yang tergerbangi lebih buruk daripada tak ada scanner, karena ia melatih pembacanya menambah pengecualian sampai gate-nya tak menanyakan apa pun. Peringatan itu tetap dipercaya pada run pertamanya.

## Perbaikan

`resolveConstantsForSource(source, crossFileConstants)` — ikatan milik berkas menang mutlak; tabel lintas-berkas hanya dikonsultasi untuk nama yang **tidak** diikat berkas itu, yakni persis himpunan yang cuma bisa datang lewat `import`. Nama yang diikat dua kali **di dalam satu berkas** tetap tak-terpecahkan: menebak di situ hanya menukar satu jawaban salah dengan lawannya.

## Mutation proof

Dua lapis, karena helper yang benar sementara satu-satunya pemanggilnya masih meneruskan tabel datar akan **tampak** diperbaiki:

- kembalikan `evaluateEnforcementCoverage` ke tabel datar → gate MERAH, persis pada dua permission itu dan tak ada yang lain;
- test end-to-end `evaluateEnforcementCoverage` MERAH pada mutasi yang sama.

Draf 4 kini beku sebagai test bersama tiga draf sebelumnya (39 false positive / kurung terdalam / action literal).

## Skor & sisa

**199/205 dengan 6 pengecualian → 201/205 dengan 4.** Tak ada satu pun permission yang berbalik ke arah sebaliknya (199 + 2 = 201).

Tiga pengecualian tersisa diverifikasi ulang ke kode dan tetap butuh keputusan ADR-0057 §A (beri permukaan, atau cabut):

- `profile_identity.profile_management.restore` — **lubang nyata**. Alasannya dipertajam dengan bukti: `awcms_profiles` membawa `deleted_at`/`restored_at`/`restored_by` sejak `sql/003`, dan `party-directory.ts` mengekspor `softDeleteParty` **tanpa pasangan**;
- `blog_content.seo.configure` — kandidat pencabutan;
- `comments.moderation.delete` — kandidat pencabutan (model ADR-0041 arsip-bukan-hapus).

Yang keempat sudah diketahui sejak ADR-0057 §F: `blog_content.posts.export`.

## Verifikasi

26 gate rantai `check` + `build` hijau di host. Suite penuh: 108 gagal — **identik dengan baseline pohon bersih** (provisioning `awcms_app` di Postgres lokal, `28P01`), dan perubahan ini menambah 4 test/4 pass tanpa menyentuh permukaan DB mana pun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)