### PR TITLE
feat(comments): moderators could see deleted comments but never delete one

### DIFF
--- a/.changeset/comments-moderator-delete.md
+++ b/.changeset/comments-moderator-delete.md
@@ -1,0 +1,29 @@
+---
+"awcms": minor
+---
+
+`POST /api/v1/comments/admin/{id}/delete` — the moderator half of a transition
+this module has implemented since ADR-0041 (ADR-0058 §B).
+
+`applyModerationAction` has accepted `"delete"` all along, it is legal from all
+four non-terminal statuses, and the moderation queue can already filter on
+`deleted` — so moderators could see soft-deleted comments without being able to
+delete one. The only actor who could reach that state was the comment's own
+author, inside the edit window.
+
+This is the one irreversible moderator action, and it stays that way: `deleted`
+remains terminal and recovering a deleted comment remains an operator/database
+action. It is accepted because the state was already reachable, the row, body
+and append-only moderation history all survive, and every other moderator
+action is reversible and keeps the body in the queue — leaving no in-band
+answer for content that must be pulled permanently. Bulk moderation
+deliberately does not gain it.
+
+`delete` now also resolves the comment's open reports, alongside
+`approve`/`reject`/`spam`: a deleted comment cannot be acted on again, so
+leaving them open would inflate the queue's report count forever. No existing
+caller is affected — nothing could reach that branch with `delete` before.
+
+Permission-enforcement coverage moves from 202/205 with 3 exceptions to 203/205
+with 2, and the two that remain are exactly the revocations ADR-0058 §C/§D
+decided.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -7541,6 +7541,32 @@ Requires `comments.moderation.archive`. Only an APPROVED comment can be archived
 | 404    | Resource not found.                                                                        | [`ApiError`](#standard-error-envelope) |
 | 409    | Idempotency-Key conflict, or the comment is not approved and therefore cannot be archived. | [`ApiError`](#standard-error-envelope) |
 
+### `POST /api/v1/comments/admin/{id}/delete` — Soft delete a comment as a moderator.
+
+- **operationId**: `deleteCommentAsModerator`
+- **Security**: bearerAuth + tenantHeader
+
+Requires `comments.moderation.delete` (ADR-0058 §B). Legal from every non-terminal status. Non-destructive — the row, its body text and its append-only moderation history are all retained; what is withdrawn is visibility. Open reports on the comment are resolved, since a deleted comment cannot be acted on again.
+
+This is the only moderator transition with no way back through the API: `deleted` is terminal, and recovering a deleted comment is an operator/database action. Use `reject` for a reversible decision, or `archive` to withdraw an approved comment while keeping it restorable. Idempotency-keyed and audited at `warning` severity.
+
+**Parameters**
+
+| Name              | In     | Required | Type          | Description |
+| ----------------- | ------ | -------- | ------------- | ----------- |
+| `id`              | path   | yes      | string (uuid) |             |
+| `Idempotency-Key` | header | yes      | string        |             |
+
+**Responses**
+
+| Status | Description                                                  | Schema                                 |
+| ------ | ------------------------------------------------------------ | -------------------------------------- |
+| 200    | The comment was soft-deleted.                                | object                                 |
+| 401    | Missing or invalid session.                                  | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                  | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                          | [`ApiError`](#standard-error-envelope) |
+| 409    | Idempotency-Key conflict, or the comment is already deleted. | [`ApiError`](#standard-error-envelope) |
+
 ### `POST /api/v1/comments/admin/{id}/moderate` — Approve, reject, or mark a comment as spam.
 
 - **operationId**: `moderateComment`

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -382,6 +382,11 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/comments/admin/[id]/delete.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/comments/admin/[id]/moderate.ts",
       "workClass": "interactive",
       "source": "default"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -5382,6 +5382,54 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/comments/admin/{id}/delete:
+    post:
+      operationId: deleteCommentAsModerator
+      tags:
+        - Comments
+      summary: Soft delete a comment as a moderator.
+      description: |-
+        Requires `comments.moderation.delete` (ADR-0058 §B). Legal from every non-terminal status. Non-destructive — the row, its body text and its append-only moderation history are all retained; what is withdrawn is visibility. Open reports on the comment are resolved, since a deleted comment cannot be acted on again.
+
+        This is the only moderator transition with no way back through the API: `deleted` is terminal, and recovering a deleted comment is an operator/database action. Use `reject` for a reversible decision, or `archive` to withdraw an approved comment while keeping it restorable. Idempotency-keyed and audited at `warning` severity.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The comment was soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ModerationResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: Idempotency-Key conflict, or the comment is already deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/comments/admin/{id}/moderate:
     post:
       operationId: moderateComment

--- a/openapi/modules/comments.openapi.yaml
+++ b/openapi/modules/comments.openapi.yaml
@@ -539,6 +539,64 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/comments/admin/{id}/delete:
+    post:
+      operationId: deleteCommentAsModerator
+      tags:
+        - Comments
+      summary: Soft delete a comment as a moderator.
+      description: >-
+        Requires `comments.moderation.delete` (ADR-0058 §B). Legal from every
+        non-terminal status. Non-destructive — the row, its body text and its
+        append-only moderation history are all retained; what is withdrawn is
+        visibility. Open reports on the comment are resolved, since a deleted
+        comment cannot be acted on again.
+
+
+        This is the only moderator transition with no way back through the API:
+        `deleted` is terminal, and recovering a deleted comment is an
+        operator/database action. Use `reject` for a reversible decision, or
+        `archive` to withdraw an approved comment while keeping it restorable.
+        Idempotency-keyed and audited at `warning` severity.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: Idempotency-Key
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The comment was soft-deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ModerationResult"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: >-
+            Idempotency-Key conflict, or the comment is already deleted.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/comments/admin/{id}/restore:
     post:
       operationId: restoreComment

--- a/scripts/permission-enforcement-check.ts
+++ b/scripts/permission-enforcement-check.ts
@@ -36,11 +36,15 @@ const EXCEPTIONS: readonly EnforcementException[] = [
   },
 
   // ADR-0058 disposes of every entry left in this list, and the list is
-  // therefore shrinking on a schedule rather than sitting still: two get a
-  // surface, two are revoked. `profile_identity.profile_management.restore`
-  // was the first to go — `POST /api/v1/profiles/{id}/restore` (§A). Each
-  // remaining reason now names the section that decided it and the change that
-  // will delete the entry, so an exception cannot quietly become permanent.
+  // therefore shrinking on a schedule rather than sitting still. Two got a
+  // surface and are already gone: `profile_identity.profile_management.restore`
+  // (§A, `POST /api/v1/profiles/{id}/restore`) and `comments.moderation.delete`
+  // (§B, `POST /api/v1/comments/admin/{id}/delete`).
+  //
+  // The two below are the REVOCATIONS, and they are the whole remainder. One
+  // migration removes both rows from the catalogue and from every role grant,
+  // and this list becomes empty — at which point the next exception anyone adds
+  // is the only entry in it, and cannot hide in a long list.
   //
   // The first run listed six, and two of them — `visitor_analytics.settings`
   // read and update — were the gate's own bug, not a gap: it read the repo's
@@ -54,11 +58,6 @@ const EXCEPTIONS: readonly EnforcementException[] = [
     key: "blog_content.seo.configure",
     reason:
       'No route and no application function names activityCode "seo" anywhere — the only occurrence in the repo is the descriptor declaration itself. ADR-0058 §C REVOKES it: blog SEO defaults (seoDefaultTitle/seoDefaultDescription) are already managed through PATCH /api/v1/blog/settings under blog_content.settings.configure, so this row is a second authorisation axis over columns that already have one. Removed when the revocation migration lands.'
-  },
-  {
-    key: "comments.moderation.delete",
-    reason:
-      "The moderation surface enforces approve/reject (one conditional guard), archive and restore, plus a public delete-request flow — but nothing gates a moderator delete. ADR-0058 §B gives it a surface: the transition is already legal from all four non-terminal statuses and the admin queue can already filter `deleted`, while the only actor who can produce that state today is the comment's own author. Removed when that endpoint lands."
   }
 ];
 

--- a/src/modules/comments/application/comment-moderation.ts
+++ b/src/modules/comments/application/comment-moderation.ts
@@ -1,7 +1,16 @@
 /**
- * Admin/moderation flows (ADR-0041, ported from awcms-micro Issue #271): the moderation queue and the
- * approve/reject/spam/archive/restore/delete transitions (single + bulk). The
- * queue is the ONLY surface that exposes moderation metadata (reason codes,
+ * Admin/moderation flows (ADR-0041, ported from awcms-micro Issue #271): the
+ * moderation queue and the approve/reject/spam/archive/restore/delete
+ * transitions.
+ *
+ * This sentence used to end "(single + bulk)", and that was wrong in a way
+ * worth recording: `delete` had no route at all until ADR-0058 §B, and bulk
+ * moderation still only passes approve/reject — deliberately, since a bulk
+ * control for the one irreversible action turns a single mistake into a page
+ * of the queue. A header describing a surface that does not exist is how the
+ * gap survived review: readers saw confirmation instead of a question.
+ *
+ * The queue is the ONLY surface that exposes moderation metadata (reason codes,
  * masked email, report counts). Every transition is validated by the pure
  * `applyModerationAction` state machine, writes an append-only moderation-event
  * row, adjusts thread counters, publishes the `comment.approved` event when
@@ -229,7 +238,24 @@ export async function moderateComment(
   `;
 
   // Resolve open reports when a decision is taken.
-  if (action === "reject" || action === "spam" || action === "approve") {
+  //
+  // `delete` joined this set with ADR-0058 §B, which gave moderators the action
+  // at all. It belongs here for the reason the other three do, only more so: a
+  // deleted comment is the most final decision available and cannot be acted on
+  // again, so leaving its reports `open` would keep it counted in the queue's
+  // `report_count` forever — reported content nobody can do anything about,
+  // inflating every "reports needing attention" reading permanently.
+  //
+  // This touches no existing caller: `archive`/`restore` are unchanged, bulk
+  // moderation only passes approve/reject, and the author self-delete path
+  // (`requestCommentDeletion`) writes its row directly without coming through
+  // here. Before §B no code path could reach this branch with `delete` at all.
+  if (
+    action === "reject" ||
+    action === "spam" ||
+    action === "approve" ||
+    action === "delete"
+  ) {
     await tx`
       UPDATE awcms_comments_reports
       SET status = 'reviewed'

--- a/src/pages/api/v1/comments/admin/[id]/delete.ts
+++ b/src/pages/api/v1/comments/admin/[id]/delete.ts
@@ -1,0 +1,191 @@
+import { recordCounter } from "../../../../../../lib/observability/metrics-port";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../../../modules/_shared/api-response";
+import {
+  computeRequestHash,
+  findIdempotencyRecord,
+  saveIdempotencyRecord
+} from "../../../../../../modules/_shared/idempotency";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import { moderateComment } from "../../../../../../modules/comments/application/comment-moderation";
+import {
+  COMMENTS_MODERATION_ACTIVITY_CODE,
+  COMMENTS_MODULE_KEY
+} from "../../../../../../modules/comments/domain/comments-permissions";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/comments/admin/{id}/delete` — moderator soft delete (ADR-0058 §B).
+ *
+ * The half of this module that never shipped. `applyModerationAction` has
+ * accepted `"delete"` since ADR-0041, `LEGAL_TRANSITIONS` allows it from all
+ * four non-terminal statuses, and the moderation queue can already FILTER on
+ * `deleted` — so moderators could see deleted comments without being able to
+ * delete one. The only actor who could reach that state was the comment's own
+ * author, through `requestCommentDeletion` inside the edit window.
+ *
+ * ## This is the one irreversible moderator action, and that is deliberate
+ *
+ * `LEGAL_TRANSITIONS.deleted` is `[]`. Nothing here changes that: recovering a
+ * deleted comment stays an operator/database action. ADR-0058 §B accepts the
+ * asymmetry because the state was already reachable (so this introduces no new
+ * state and no new terminality), it stays non-destructive (row, body text and
+ * append-only moderation history all survive — ADR-0041's archive-not-delete
+ * model is about the DATA, and the data is kept), and because every other
+ * moderator action is reversible and keeps the body in the queue, which leaves
+ * no in-band answer for content that must be pulled permanently.
+ *
+ * `reject` is the reversible neighbour and stays the default choice; `archive`
+ * is the one for withdrawing an approved comment with its history intact.
+ *
+ * Bulk moderation deliberately does NOT gain this action: bulk turns the cost
+ * of one mistake from a single comment into a page of the queue, and this
+ * mistake cannot be undone in-band.
+ *
+ * Unlike its `archive`/`restore` siblings, this route is built on
+ * `defineTenantRoute` rather than a hand-rolled `withTenant` — those predate
+ * the factory and sit in its allow-list; a new route may not join them.
+ */
+const IDEMPOTENCY_SCOPE = "comments_delete";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type Prepared = { idempotencyKey: string; note: string | null };
+
+export const POST = defineTenantRoute<Prepared>({
+  workClass: "interactive",
+  prepare: async ({ request }) => {
+    const idempotencyKey = request.headers.get("idempotency-key");
+
+    if (!idempotencyKey) {
+      return fail(
+        400,
+        "IDEMPOTENCY_REQUIRED",
+        "Idempotency-Key header is required."
+      );
+    }
+
+    const bodyRead = await readJsonBody(request);
+    if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+
+    const body = bodyRead.value;
+    const note =
+      isRecord(body) && typeof body.note === "string"
+        ? body.note.slice(0, 2000)
+        : null;
+
+    return { idempotencyKey, note };
+  },
+  authorize: {
+    moduleKey: COMMENTS_MODULE_KEY,
+    activityCode: COMMENTS_MODERATION_ACTIVITY_CODE,
+    action: "delete"
+  },
+  handler: async ({ tx, auth, prepared, params, tenantId, locals }) => {
+    const commentId = params.id;
+
+    if (!commentId) {
+      return fail(400, "VALIDATION_ERROR", "Comment id is required.");
+    }
+
+    const correlationId = locals.correlationId;
+    const requestHash = computeRequestHash({ commentId, action: "delete" });
+
+    const existing = await findIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey
+    );
+
+    if (existing) {
+      if (existing.requestHash !== requestHash) {
+        return fail(
+          409,
+          "IDEMPOTENCY_CONFLICT",
+          "Idempotency-Key was already used with a different request."
+        );
+      }
+      return jsonResponse(existing.responseBody, {
+        status: existing.responseStatus
+      });
+    }
+
+    const result = await moderateComment(
+      tx,
+      tenantId,
+      commentId,
+      "delete",
+      {
+        reasonCode: null,
+        actorUserId: auth.context.tenantUserId,
+        note: prepared.note,
+        correlationId
+      },
+      async (auditTx, detail) => {
+        await recordAuditEvent(auditTx, {
+          tenantId,
+          actorTenantUserId: auth.context.tenantUserId,
+          moduleKey: COMMENTS_MODULE_KEY,
+          action: "comments.moderation.delete",
+          resourceType: "comments_comment",
+          resourceId: detail.commentId,
+          // `warning`, not `info` like archive/restore: this is the only
+          // moderator transition with no way back through the API.
+          severity: "warning",
+          message: "Comment soft-deleted by moderator.",
+          attributes: {
+            fromStatus: detail.fromStatus,
+            toStatus: detail.toStatus
+          },
+          correlationId
+        });
+      }
+    );
+
+    recordCounter("comments_moderation_actions_total", {
+      action: "delete",
+      result: result.ok ? "applied" : result.reason
+    });
+
+    if (!result.ok) {
+      if (result.reason === "not_found") {
+        return fail(404, "NOT_FOUND", "Comment not found.");
+      }
+
+      // The only illegal source is `deleted` itself — every other status can
+      // reach it. So this 409 means "already deleted", and saying so is not an
+      // oracle: the caller already holds `moderation.delete`, and the queue
+      // shows deleted comments to exactly that caller.
+      return fail(
+        409,
+        "ILLEGAL_TRANSITION",
+        "That comment is already deleted."
+      );
+    }
+
+    const successResponse = ok({ commentId, status: result.toStatus });
+    const successBody = await successResponse.clone().json();
+
+    await saveIdempotencyRecord(
+      tx,
+      tenantId,
+      IDEMPOTENCY_SCOPE,
+      prepared.idempotencyKey,
+      requestHash,
+      200,
+      successBody
+    );
+
+    return successResponse;
+  }
+});

--- a/tests/comments-moderator-delete-contract.test.ts
+++ b/tests/comments-moderator-delete-contract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `POST /api/v1/comments/admin/{id}/delete` — the moderator half of a
+ * transition this module has implemented since ADR-0041 (ADR-0058 §B).
+ *
+ * The assertions here are the ones that protect a DECISION, not a mechanism.
+ * `moderateComment` already handled `"delete"` end to end, so almost nothing
+ * about this change can break functionally; what can go wrong is that the
+ * deliberate limits quietly stop holding:
+ *
+ * - **`deleted` must stay terminal.** ADR-0058 §B accepts giving moderators one
+ *   irreversible action precisely because the state was already reachable and
+ *   already one-way. Someone adding `deleted: ["pending"]` to make restore
+ *   "work" would be revising ADR-0041's moderation model inside a change that
+ *   is not about it;
+ * - **bulk must NOT gain it.** Bulk turns the cost of one mistake from a single
+ *   comment into a page of the queue, and this mistake has no in-band undo.
+ *   Absences are exactly what nothing catches, which is why the absence is
+ *   asserted rather than trusted;
+ * - **open reports must resolve.** Otherwise a deleted comment keeps inflating
+ *   the queue's `report_count` forever, as reported content nobody can act on.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyModerationAction,
+  isLegalTransition,
+  type CommentStatus
+} from "../src/modules/comments/domain/comment-status";
+import { listModules } from "../src/modules";
+
+const ROUTE = "src/pages/api/v1/comments/admin/[id]/delete.ts";
+const BULK_ROUTE = "src/pages/api/v1/comments/admin/bulk-moderate.ts";
+const MODERATION = "src/modules/comments/application/comment-moderation.ts";
+
+const PERMISSION_KEY = "comments.moderation.delete";
+
+const NON_TERMINAL: readonly CommentStatus[] = [
+  "pending",
+  "approved",
+  "rejected",
+  "spam"
+];
+
+async function read(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+describe("moderator soft delete (ADR-0058 §B)", () => {
+  test("the permission it enforces is one the descriptor actually declares", async () => {
+    const declared = new Set(
+      listModules().flatMap((module) =>
+        (module.permissions ?? []).map(
+          (permission) =>
+            `${module.key}.${permission.activityCode}.${permission.action}`
+        )
+      )
+    );
+
+    expect(declared.has(PERMISSION_KEY)).toBe(true);
+
+    const source = await read(ROUTE);
+
+    expect(source).toContain("COMMENTS_MODULE_KEY");
+    expect(source).toContain("COMMENTS_MODERATION_ACTIVITY_CODE");
+    expect(source).toContain('action: "delete"');
+  });
+
+  test("the route is built on defineTenantRoute, not a hand-rolled withTenant", async () => {
+    // `archive`/`restore` predate the factory and sit in its allow-list. This
+    // route was first written by copying `archive.ts`, and
+    // `api:tenant-route:check` is what caught it — the assertion is here so a
+    // future copy of THIS file inherits the right shape instead.
+    const source = await read(ROUTE);
+
+    expect(source).toContain("defineTenantRoute");
+    expect(source).toContain('workClass: "interactive"');
+    expect(source).not.toContain("withTenant(");
+  });
+
+  test("the route requires an Idempotency-Key", async () => {
+    const source = await read(ROUTE);
+
+    expect(source).toContain('request.headers.get("idempotency-key")');
+    expect(source).toContain("IDEMPOTENCY_REQUIRED");
+    expect(source).toContain("IDEMPOTENCY_CONFLICT");
+  });
+
+  test("delete is reachable from every non-terminal status", () => {
+    for (const from of NON_TERMINAL) {
+      expect(isLegalTransition(from, "deleted")).toBe(true);
+      expect(applyModerationAction(from, "delete").status).toBe("deleted");
+    }
+  });
+
+  test("`deleted` stays terminal — this change adds no way back in-band", () => {
+    // The asymmetry ADR-0058 §B states plainly. If a later change makes
+    // `deleted` recoverable, that is a revision of ADR-0041's moderation model
+    // and needs its own decision, not a passing edit to this table.
+    for (const to of [
+      "pending",
+      "approved",
+      "rejected",
+      "spam"
+    ] as CommentStatus[]) {
+      expect(isLegalTransition("deleted", to)).toBe(false);
+    }
+  });
+
+  test("bulk moderation deliberately does NOT offer delete", async () => {
+    const source = await read(BULK_ROUTE);
+
+    // Bulk decides its action from `decision`, which is approve-or-reject. A
+    // third branch, or the literal passed through, would be the regression.
+    expect(source).not.toContain('"delete"');
+    expect(source).toContain('decision === "approve" ? "approve" : "reject"');
+  });
+
+  test("a moderator delete resolves the comment's open reports", async () => {
+    const source = await read(MODERATION);
+    // Anchored at the comment and read FORWARD. Searching for the table name
+    // from the start of the file finds the queue's `report_count` subquery
+    // instead, which sits hundreds of lines earlier — the slice came back
+    // empty and the assertion passed on nothing until this was fixed.
+    const start = source.indexOf("// Resolve open reports");
+    expect(start).toBeGreaterThan(-1);
+
+    const clause = source.slice(start);
+    const guarded = clause.slice(0, clause.indexOf("awcms_comments_reports"));
+
+    // In the `if`, not merely somewhere between the comment and the UPDATE.
+    expect(guarded).toContain("if (");
+    expect(guarded).toContain('action === "delete"');
+  });
+
+  test("the delete is audited at warning severity, unlike archive/restore", async () => {
+    const source = await read(ROUTE);
+
+    expect(source).toContain('action: "comments.moderation.delete"');
+    expect(source).toContain('severity: "warning"');
+
+    // The neighbours it must NOT be confused with.
+    const archive = await read(
+      "src/pages/api/v1/comments/admin/[id]/archive.ts"
+    );
+    expect(archive).toContain('severity: "info"');
+  });
+});


### PR DESCRIPTION
[ADR-0058](https://github.com/ahliweb/awcms/blob/main/docs/adr/0058-unenforced-permissions-disposition.md) §B — yang kedua dari empat. Nol migrasi, nol perubahan state machine.

## Separuh yang tak pernah mendarat adalah separuh moderator

Seluruh mesinnya sudah ada sejak ADR-0041:

- `applyModerationAction` menerima `"delete"` dan mentransisikannya ke `deleted`;
- `LEGAL_TRANSITIONS` mengizinkannya dari **keempat** status non-terminal;
- `QUEUE_STATUSES` memuat `deleted` — antrean admin bisa **memfilter** state yang tak seorang moderator pun bisa hasilkan;
- descriptor modul menyebutnya "a separate **moderator**/author action".

Satu-satunya aktor yang bisa mencapai state itu adalah **penulis komentar**, lewat `requestCommentDeletion` di dalam edit window.

## Dua keputusan substantif, keduanya mutation-proven

| Mutasi yang dikembalikan | Test yang merah |
| --- | --- |
| `deleted: ["pending"]` (revisi ADR-0041 secara diam-diam) | ``deleted` stays terminal` |
| bulk ikut menerima `delete` | `bulk moderation deliberately does NOT offer delete` |
| `delete` berhenti menutup laporan terbuka | `a moderator delete resolves the comment's open reports` |

**`deleted` tetap terminal.** Ini satu-satunya aksi moderator yang tak terbalikkan, dan rutenya **menyatakannya** alih-alih menyembunyikannya. Diterima karena: state-nya **sudah tercapai** lewat jalur penulis (tak ada state baru, tak ada sifat terminal baru); tetap **non-destruktif** (baris, badan teks, dan riwayat moderasi append-only semua bertahan — model arsip-bukan-hapus ADR-0041 adalah tentang DATA, dan datanya disimpan); dan tanpa itu tak ada jawaban in-band untuk konten yang harus ditarik permanen — `reject`/`spam`/`archive` semuanya reversibel dan semuanya mempertahankan badan komentar di antrean.

**Bulk sengaja TIDAK ikut.** Bulk mengubah biaya satu kesalahan dari satu komentar menjadi satu halaman antrean, dan kesalahan ini tak bisa dibatalkan in-band. Ketiadaan adalah persis yang tak tertangkap apa pun, jadi ketiadaannya **diasersikan**, bukan dipercaya.

**Laporan terbuka ikut ditutup.** `delete` bergabung dengan `approve`/`reject`/`spam` di situ: komentar yang dihapus tak bisa ditindak lagi, jadi membiarkan laporannya `open` akan menggelembungkan `report_count` antrean selamanya — konten terlapor yang tak seorang pun bisa apa-apakan. **Nol caller lama terpengaruh**: sebelum perubahan ini tak ada jalur kode yang bisa mencapai cabang itu dengan `delete` (jalur penulis menulis barisnya sendiri, tidak lewat `moderateComment`).

Audit di severity `warning`, bukan `info` seperti saudara archive/restore.

## Dua koreksi terhadap teks yang ikut membuat cacat ini lolos review

**Header modul mengklaim permukaan yang tak pernah ada** — "approve/reject/spam/archive/restore/**delete** transitions (single + bulk)". `delete` tak punya rute sama sekali, dan bulk sampai sekarang tidak. Ini pelajaran yang sama dengan README `reporting`/`workflow-approval` di PROJECT_STATE §4: yang membacanya melihat konfirmasi, bukan pertanyaan.

**Rutenya semula saya tulis dengan menyalin `archive.ts`** — yang mendahului `defineTenantRoute` dan duduk di allow-list-nya. `api:tenant-route:check` menangkapnya, dan contract test kini mengasersikan factory-nya supaya salinan BERIKUTNYA mewarisi bentuk yang benar, bukan bentuk legacy.

## Verifikasi

26 gate rantai `check` + `build` hijau di host. Suite: **3043 pass**, 108 fail — 108 itu identik baseline pohon bersih (provisioning `awcms_app` Postgres lokal; job Integration CI menjalankannya hijau). Delta pass tepat **+8**, yakni test baru file ini.

Cakupan permission: **202/205 dengan 3 pengecualian → 203/205 dengan 2.** Kedua sisanya persis pencabutan §C/§D — satu PR migrasi lagi dan daftar `EXCEPTIONS` **kosong**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)