### PR TITLE
chore(actions): bump github/codeql-action to 4.37.4 (init + analyze together)

### DIFF
--- a/.changeset/codeql-action-4374.md
+++ b/.changeset/codeql-action-4374.md
@@ -1,0 +1,11 @@
+---
+"awcms": patch
+---
+
+Bump `github/codeql-action` from 4.37.3 to 4.37.4 (`init` and `analyze`
+together).
+
+Dependabot raises these as two PRs because they are two action paths, and
+neither can go green alone: `init` and `analyze` must run from the SAME commit,
+so each half-bump fails both Analyze jobs with a version mismatch. Landing them
+in one commit pinned to one SHA is the only shape that passes.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,13 +47,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Menggantikan #356 dan #358, yang keduanya ditutup.

Dependabot menaikkan `github/codeql-action/init` dan `.../analyze` sebagai **dua PR terpisah** karena keduanya path action yang berbeda. Tapi keduanya **tak bisa hijau sendiri-sendiri**: `init` dan `analyze` wajib berjalan dari commit yang SAMA, jadi tiap setengah-bump memerahkan kedua job Analyze dengan version mismatch — persis yang terlihat di #356 dan #358 (`Analyze (actions)=fail`, `Analyze (javascript-typescript)=fail`).

Satu commit, satu SHA (`f205ea1c3313d32999d8d6a48b4f6530d4437b38`), adalah satu-satunya bentuk yang lolos.

Changeset `patch` disertakan: `.github/workflows/*.yml` **tidak** dikecualikan dari gerbang changeset di repo ini, dan changeset kosong ditolak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)