### PR TITLE
chore(deps-dev): bump @playwright/test to 1.62.1

### DIFF
--- a/.changeset/playwright-1-62-1.md
+++ b/.changeset/playwright-1-62-1.md
@@ -1,0 +1,10 @@
+---
+"awcms": patch
+---
+
+Bump `@playwright/test` from 1.62.0 to 1.62.1 (dev dependency, E2E runner).
+
+Unlike the Astro stack, Playwright is not pinned in
+`awcms-family-compatibility.yaml`, so this bump touches nothing but the
+lockfile — a consumer of this repo binds against its contracts, not its test
+runner.

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.31.1",
-        "@playwright/test": "^1.62.0",
+        "@playwright/test": "^1.62.1",
         "@types/bun": "^1.3.14",
         "prettier": "^3.9.6",
         "prettier-plugin-astro": "^0.14.1",
@@ -254,7 +254,7 @@
 
     "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
-    "@playwright/test": ["@playwright/test@1.62.0", "", { "dependencies": { "playwright": "1.62.0" }, "bin": { "playwright": "cli.js" } }, "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA=="],
+    "@playwright/test": ["@playwright/test@1.62.1", "", { "dependencies": { "playwright": "1.62.1" }, "bin": { "playwright": "cli.js" } }, "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
 
@@ -702,9 +702,9 @@
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
-    "playwright": ["playwright@1.62.0", "", { "dependencies": { "playwright-core": "1.62.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw=="],
+    "playwright": ["playwright@1.62.1", "", { "dependencies": { "playwright-core": "1.62.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg=="],
 
-    "playwright-core": ["playwright-core@1.62.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA=="],
+    "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
     "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",
-    "@playwright/test": "^1.62.0",
+    "@playwright/test": "^1.62.1",
     "@types/bun": "^1.3.14",
     "prettier": "^3.9.6",
     "prettier-plugin-astro": "^0.14.1",


### PR DESCRIPTION
Menggantikan #353, yang ditutup.

PR dependabot-nya **sudah benar** dan hanya gagal di gerbang changeset — `package.json` **tidak** dikecualikan dari gerbang itu di repo ini, dan changeset kosong ditolak, jadi ia tak akan pernah bisa hijau sendiri.

Berbeda dari stack Astro (#365), Playwright sengaja **tidak** di-pin di `awcms-family-compatibility.yaml`, jadi bump ini tak menyentuh apa pun selain lockfile: konsumen repo ini terikat pada **kontrak**-nya, bukan test runner-nya. Karena itu tak ada nilai `declared` yang perlu ikut bergerak.

## Verifikasi

- `bun install --frozen-lockfile` bersih
- Setara job `quality` CI: **0 fail**, 457 skip
- `lint`, `typecheck`, `family:conformance:check`, `build` hijau
- E2E smoke Playwright dijalankan CI pada PR ini

🤖 Generated with [Claude Code](https://claude.com/claude-code)