### PR TITLE
chore(actions): bump docker/login-action to 4.6.0

### DIFF
--- a/.changeset/docker-login-action-4-6-0.md
+++ b/.changeset/docker-login-action-4-6-0.md
@@ -1,0 +1,9 @@
+---
+"awcms": patch
+---
+
+Bump `docker/login-action` from 4.5.1 to 4.6.0 in the release workflow (both
+call sites).
+
+Release-workflow only — it authenticates the GHCR push during
+sign/attest/publish and has no effect on any PR build.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -257,7 +257,7 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Log in to ghcr.io
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
Menggantikan #357, yang ditutup.

Check milik PR itu sendiri sebenarnya sehat — ia hanya gagal di gerbang **changeset**, yang `.github/workflows/*.yml` **tidak** dikecualikan darinya di repo ini.

Kedua call site di `release.yml` bergerak bersama: itu action yang sama, di-pin dua kali (login GHCR untuk dua job build/publish), jadi bump separuh akan membuat workflow mengautentikasi lewat dua versi berbeda tanpa alasan.

**Release-workflow saja** — ia mengautentikasi push GHCR saat sign/attest/publish dan tidak menyentuh build PR mana pun. Konsekuensinya: PR ini tidak bisa membuktikan sendiri bahwa versi barunya bekerja; pembuktiannya baru terjadi pada rilis berikutnya, dan itu memang sifat setiap bump action rilis di repo ini.

🤖 Generated with [Claude Code](https://claude.com/claude-code)