### PR TITLE
feat(blog-content): /admin/blog-taxonomy — the categories and tags console

### DIFF
--- a/.changeset/admin-blog-taxonomy-console.md
+++ b/.changeset/admin-blog-taxonomy-console.md
@@ -1,0 +1,22 @@
+---
+"awcms": minor
+---
+
+`/admin/blog-taxonomy` — the categories-and-tags console, third sibling of
+`/admin/blog` and `/admin/blog-pages`.
+
+Drives both `taxonomies.*` permissions. `configure` gates create, update AND
+delete together, because `sql/036` seeds no per-verb rows — the permission is
+the capability "manage taxonomy", not one flag per verb, and a screen that
+invented `taxonomies.create` would gate on authority nothing honours.
+
+Three deliberate absences, each held by the contract test:
+
+- **no bin view and no Restore.** Term soft delete is one-way BY DESIGN (no
+  restore route, no `taxonomies.restore` to build one against), so a bin would
+  imply a way back that does not exist. The confirmation states the finality
+  instead — copy promising recoverability is what made #351 hard to see;
+- **no re-parenting on edit.** Neither term route detects cycles, so pointing a
+  parent at its own descendant is accepted and every reader then walks forever.
+  Create still offers a parent: a term with no children cannot close a loop;
+- **no `Idempotency-Key`.** None of the three term endpoints reads it.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -29,7 +29,7 @@
         }
       ],
       "permissionCount": 41,
-      "navigationCount": 2,
+      "navigationCount": 3,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -105,6 +105,12 @@ export const blogContentModule = defineModule({
       path: "/admin/blog-pages",
       order: 37,
       requiredPermission: "blog_content.pages.read"
+    },
+    {
+      labelKey: "admin.layout.nav_blog_taxonomy",
+      path: "/admin/blog-taxonomy",
+      order: 38,
+      requiredPermission: "blog_content.taxonomies.read"
     }
   ],
   permissions: [

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -181,6 +181,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_idn_regions": "Region datasets",
   "admin.layout.nav_blog": "Blog posts",
   "admin.layout.nav_blog_pages": "Blog pages",
+  "admin.layout.nav_blog_taxonomy": "Blog taxonomy",
   "admin.layout.nav_media": "Media library",
   "admin.layout.nav_reporting": "Reporting operations",
   "admin.layout.nav_approvals": "Approvals",

--- a/src/pages/admin/blog-taxonomy.astro
+++ b/src/pages/admin/blog-taxonomy.astro
@@ -1,0 +1,687 @@
+---
+/**
+ * Blog taxonomy console — categories and tags.
+ *
+ * Third sibling of `/admin/blog` (posts) and `/admin/blog-pages` (pages). This
+ * one is smaller than both and deliberately so: taxonomy is low-cardinality
+ * configuration, not a queue, and `listBlogTerms` is a bounded `LIMIT 100`
+ * name-ascending read rather than a paginated listing.
+ *
+ * ## Scope: two permissions, and ONE of them gates three writes
+ *
+ * `taxonomies.read` and `taxonomies.configure` — that is the whole activity.
+ * `configure` gates create, update AND delete together, which is a decision the
+ * catalogue already made (`sql/036` seeds no `taxonomies.create`/`.update`/
+ * `.delete`), and the module README records the reasoning: the permission is
+ * the capability "manage taxonomy", not one flag per verb. The same shape as
+ * `sync_storage.conflict_resolution.approve` gating a whole resolve endpoint
+ * whatever its outcome.
+ *
+ * So there is no per-verb gating to do here, and inventing one would imply
+ * authority that no `authorizeInTransaction` call anywhere would honour.
+ *
+ * ## Delete is ONE WAY, and the screen has to say so
+ *
+ * `softDeleteBlogTerm` sets `deleted_at`, `listBlogTerms` filters
+ * `deleted_at IS NULL` hard, and there is no restore function and no restore
+ * route — because `sql/036` seeds no `taxonomies.restore`/`.purge`. This is a
+ * documented decision (module README §Taxonomy, and the `DELETE` route's own
+ * comment), NOT the defect #351 fixed on `/admin/blog`, where the endpoint
+ * existed and the screen called it on rows that could only 404.
+ *
+ * The consequence for this screen is the opposite of the pages console: there
+ * is deliberately **no bin view**, because a bin implies a way back. What the
+ * screen owes the operator instead is a confirmation that states the finality
+ * plainly, so a one-way action is never taken for a reversible one.
+ *
+ * ## Re-parenting is offered on CREATE and withheld on UPDATE
+ *
+ * Both routes verify a `parentId` exists and belongs to the tenant, and
+ * NEITHER performs cycle detection. On create that is harmless — a term being
+ * created has no children yet, so it cannot close a loop. On update it is not:
+ * pointing a parent at its own descendant produces a cycle the API accepts and
+ * every reader then walks forever.
+ *
+ * `/admin/blog-pages` withheld re-parenting for exactly this reason. The
+ * difference here is that create is genuinely safe, so the control appears
+ * where it cannot cause the defect and is absent where it can.
+ *
+ * A tag may not have a parent at all — `awcms_blog_terms_tag_no_parent_check`
+ * is a database CHECK, not a convention — so the parent control is bound to the
+ * category branch of the form.
+ *
+ * ## Reads / writes / gates
+ *
+ * The read goes through this module's own application function inside ONE
+ * `withTenantOrThrow`. Nothing here writes SQL; every mutation is a request to
+ * a guarded endpoint, so audit rows cannot be bypassed.
+ *
+ * **No `Idempotency-Key` anywhere on this screen**, and that mirrors the
+ * endpoints exactly: none of the three term routes reads the header. Sending
+ * one would imply a replay contract they never offered — the split is
+ * per-endpoint, not per-repo.
+ *
+ * Permission gates below are UX-only — `authorizeInTransaction` in the routes
+ * is the authority.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  listBlogTerms,
+  type BlogTermView
+} from "../../modules/blog-content/application/blog-taxonomy-directory";
+import {
+  isTaxonomyType,
+  type TaxonomyType
+} from "../../modules/blog-content/domain/taxonomy-policy";
+
+const ssr = Astro.locals.ssrContext!;
+
+const canRead = ssr.permissions.has(
+  permissionKey("blog_content", "taxonomies", "read")
+);
+/** One permission, three writes — see the header. */
+const canConfigure = ssr.permissions.has(
+  permissionKey("blog_content", "taxonomies", "configure")
+);
+
+function readParam(name: string): string {
+  return (Astro.url.searchParams.get(name) ?? "").trim();
+}
+
+const typeRaw = readParam("taxonomyType");
+// An unknown value is dropped rather than forwarded: a hand-edited query
+// string must not turn this screen into an error page.
+const typeFilter: TaxonomyType | undefined = isTaxonomyType(typeRaw)
+  ? typeRaw
+  : undefined;
+
+/** `?edit=<id>` opens the edit form for one term, below the table. */
+const editingTermId = readParam("edit");
+
+let terms: BlogTermView[] = [];
+let loadError = false;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
+      terms = await listBlogTerms(tx, ssr.tenantId, {
+        taxonomyType: typeFilter
+      });
+    });
+  } catch (error) {
+    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
+    // must never render as "this tenant has no terms".
+    loadError = true;
+    logAdminPageError(
+      "admin/blog-taxonomy.astro: failed to load terms",
+      error,
+      {
+        correlationId: Astro.locals.correlationId
+      }
+    );
+  }
+}
+
+function formatTimestamp(value: Date | null): string {
+  return value ? value.toISOString() : "—";
+}
+
+/** Rebuilds the current query string with keys replaced — keeps the filter across links. */
+function linkWith(overrides: Record<string, string | null>): string {
+  const params = new URLSearchParams(Astro.url.search);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) params.delete(key);
+    else params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `/admin/blog-taxonomy?${query}` : "/admin/blog-taxonomy";
+}
+
+const nameById = new Map(terms.map((term) => [term.id, term.name]));
+
+/**
+ * Only categories can be a parent, and only a category may have one. Built
+ * from the loaded list, so it is the same bounded 100 the table shows.
+ */
+const parentChoices = terms.filter((term) => term.taxonomyType === "category");
+
+const editingTerm = editingTermId
+  ? (terms.find((entry) => entry.id === editingTermId) ?? null)
+  : null;
+
+const showsRowActions = canConfigure;
+const termColumns = 5 + (showsRowActions ? 1 : 0);
+const hasFilter = typeFilter !== undefined;
+---
+
+<AdminLayout title="Blog taxonomy">
+  <header class="page-header fade-in-up">
+    <h1 id="taxonomy-heading">Blog taxonomy</h1>
+    <p class="page-description">
+      Categories and tags for <a href="/admin/blog">blog posts</a>. Categories
+      may nest; tags may not. Terms are assigned to a post from the post itself,
+      not from here.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="taxonomy-denied">
+        You do not have permission to view blog taxonomy.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="taxonomy-error">
+        Terms could not be loaded right now. This is a problem reading the list,
+        not an empty list — please try again later.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <p
+        id="taxonomy-action-error"
+        class="admin-create-error"
+        role="alert"
+        hidden
+      />
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <form method="get" class="admin-toolbar fade-in-up" id="term-filter-form">
+        <label for="filter-taxonomy-type">Type</label>
+        <select id="filter-taxonomy-type" name="taxonomyType">
+          <option value="" selected={typeFilter === undefined}>
+            Categories and tags
+          </option>
+          <option value="category" selected={typeFilter === "category"}>
+            category
+          </option>
+          <option value="tag" selected={typeFilter === "tag"}>
+            tag
+          </option>
+        </select>
+
+        <button type="submit">Apply filter</button>
+      </form>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="term-list-title"
+      >
+        <h2 class="admin-section-title" id="term-list-title">
+          Terms
+          <span class="count-pill">{terms.length}</span>
+        </h2>
+
+        {/* Bounded read, and the screen says so rather than implying the
+            tenant has no more. `listBlogTerms` is LIMIT 100. */}
+        {terms.length === 100 && (
+          <p class="state-notice" id="taxonomy-truncated">
+            Showing the first 100 terms by name. Filter by type to narrow the
+            list.
+          </p>
+        )}
+
+        <div class="data-table-scroll">
+          <table class="data-table data-table--stack" id="blog-terms-table">
+            <caption class="sr-only">
+              Blog categories and tags, by name.
+            </caption>
+            <thead>
+              <tr>
+                <th scope="col">Name</th>
+                <th scope="col">Type</th>
+                <th scope="col">Parent</th>
+                <th scope="col">Description</th>
+                <th scope="col">Updated</th>
+                {showsRowActions && <th scope="col">Actions</th>}
+              </tr>
+            </thead>
+            <tbody>
+              {terms.length === 0 ? (
+                <tr>
+                  <td class="data-table-empty" colspan={termColumns}>
+                    <div class="empty-state">
+                      <span class="empty-state-icon" aria-hidden="true">
+                        ▤
+                      </span>
+                      <span class="empty-state-title">
+                        {hasFilter
+                          ? "No terms of this type"
+                          : "No categories or tags yet"}
+                      </span>
+                      <span class="empty-state-text">
+                        {hasFilter
+                          ? "Clear the filter above to see every term."
+                          : "Create one below to start organising posts."}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              ) : (
+                terms.map((entry) => (
+                  <tr data-term-row={entry.id}>
+                    <td data-label="Name">
+                      <span set:text={entry.name} />
+                      <span class="cell-muted">
+                        {" "}
+                        · <span class="cell-code">{entry.slug}</span>
+                      </span>
+                    </td>
+                    <td data-label="Type">
+                      <span
+                        class="status-badge"
+                        data-variant={
+                          entry.taxonomyType === "category" ? "info" : "neutral"
+                        }
+                      >
+                        <span class="status-dot" aria-hidden="true" />
+                        {entry.taxonomyType}
+                      </span>
+                    </td>
+                    <td data-label="Parent">
+                      {entry.parentId ? (
+                        <span set:text={nameById.get(entry.parentId) ?? "—"} />
+                      ) : (
+                        <span class="cell-muted">—</span>
+                      )}
+                    </td>
+                    <td data-label="Description">
+                      {entry.description ? (
+                        <span set:text={entry.description} />
+                      ) : (
+                        <span class="cell-muted">—</span>
+                      )}
+                    </td>
+                    <td data-label="Updated">
+                      <span class="cell-muted">
+                        {formatTimestamp(entry.updatedAt)}
+                      </span>
+                    </td>
+                    {showsRowActions && (
+                      <td data-label="Actions">
+                        <div class="row-actions">
+                          <a
+                            class="quick-link"
+                            href={linkWith({ edit: entry.id })}
+                          >
+                            Edit
+                            <span class="quick-link-arrow" aria-hidden="true">
+                              →
+                            </span>
+                          </a>
+                          <button
+                            type="button"
+                            class="btn-inline term-delete-btn"
+                            data-term-id={entry.id}
+                            data-term-name={entry.name}
+                          >
+                            Delete
+                          </button>
+                        </div>
+                      </td>
+                    )}
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    )
+  }
+
+  {
+    canRead && !loadError && canConfigure && editingTerm && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="term-edit-title"
+      >
+        <h2 class="admin-section-title" id="term-edit-title">
+          Edit term
+        </h2>
+
+        <form class="admin-form" id="term-edit-form">
+          <input type="hidden" id="edit-term-id" value={editingTerm.id} />
+
+          <div class="admin-form-row">
+            <label for="edit-name">Name</label>
+            <input
+              id="edit-name"
+              name="name"
+              type="text"
+              required
+              value={editingTerm.name}
+            />
+          </div>
+
+          <div class="admin-form-row">
+            <label for="edit-slug">Slug</label>
+            <input
+              id="edit-slug"
+              name="slug"
+              type="text"
+              required
+              value={editingTerm.slug}
+            />
+          </div>
+
+          <div class="admin-form-row">
+            <label for="edit-description">Description</label>
+            <input
+              id="edit-description"
+              name="description"
+              type="text"
+              value={editingTerm.description ?? ""}
+            />
+          </div>
+
+          {/* Type and parent are READ-ONLY here, and for two different
+              reasons. Parent: neither route detects cycles, so pointing a
+              parent at its own descendant is accepted and every reader then
+              walks forever — the same call `/admin/blog-pages` made. Type: a
+              category with children flipping to `tag` would violate
+              `awcms_blog_terms_tag_no_parent_check` for its children, which
+              the API cannot express as one atomic edit. */}
+          <p class="form-hint" id="term-edit-immutable-hint">
+            Type is <strong set:text={editingTerm.taxonomyType} /> and parent is{" "}
+            <strong
+              set:text={
+                editingTerm.parentId
+                  ? (nameById.get(editingTerm.parentId) ?? "—")
+                  : "none"
+              }
+            />
+            . Neither can be changed after creation: the API performs no cycle
+            detection, so re-parenting here could create a loop no reader can
+            escape. Delete the term and create it again instead.
+          </p>
+
+          <p
+            class="admin-create-error"
+            id="term-edit-error"
+            role="alert"
+            hidden
+          />
+
+          <div class="admin-form-actions">
+            <button type="submit" id="term-edit-submit">
+              Save term
+            </button>
+            <a class="quick-link" href={linkWith({ edit: null })}>
+              Cancel
+            </a>
+          </div>
+        </form>
+      </section>
+    )
+  }
+
+  {
+    canRead && !loadError && canConfigure && !editingTerm && (
+      <section
+        class="admin-section fade-in-up"
+        aria-labelledby="term-create-title"
+      >
+        <h2 class="admin-section-title" id="term-create-title">
+          Create a term
+        </h2>
+
+        <form class="admin-form" id="term-create-form">
+          <div class="admin-form-row">
+            <label for="create-taxonomy-type">Type</label>
+            <select id="create-taxonomy-type" name="taxonomyType" required>
+              <option value="category">category</option>
+              <option value="tag">tag</option>
+            </select>
+          </div>
+
+          <div class="admin-form-row">
+            <label for="create-name">Name</label>
+            <input id="create-name" name="name" type="text" required />
+          </div>
+
+          <div class="admin-form-row">
+            <label for="create-slug">Slug</label>
+            <input id="create-slug" name="slug" type="text" required />
+          </div>
+
+          <div class="admin-form-row">
+            <label for="create-parent">Parent category</label>
+            <select id="create-parent" name="parentId">
+              <option value="">No parent</option>
+              {parentChoices.map((choice) => (
+                <option value={choice.id}>{choice.name}</option>
+              ))}
+            </select>
+            {/* Safe here in a way it is not on edit: a term being created has
+                no children, so it cannot close a loop. The client clears this
+                field for `tag`, which the database forbids from having one. */}
+            <p class="form-hint" id="term-create-parent-hint">
+              Categories only — a tag may not have a parent.
+            </p>
+          </div>
+
+          <div class="admin-form-row">
+            <label for="create-description">Description</label>
+            <input id="create-description" name="description" type="text" />
+          </div>
+
+          <p
+            class="admin-create-error"
+            id="term-create-error"
+            role="alert"
+            hidden
+          />
+
+          <div class="admin-form-actions">
+            <button type="submit" id="term-create-submit">
+              Create term
+            </button>
+          </div>
+        </form>
+      </section>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'`
+  // with no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const actionError = document.getElementById("taxonomy-action-error");
+
+  function showActionError(message: string): void {
+    if (!actionError) return;
+    actionError.textContent = message;
+    actionError.hidden = false;
+  }
+
+  // NOTE: no `idempotency()` helper on this screen, unlike `/admin/blog-pages`.
+  // None of the three term endpoints reads `Idempotency-Key`, and sending one
+  // would imply a replay contract they never offered.
+
+  document
+    .querySelectorAll<HTMLButtonElement>(".term-delete-btn")
+    .forEach((button) => {
+      button.addEventListener("click", async () => {
+        if (button.disabled) return;
+        const termId = button.dataset.termId;
+        if (!termId) return;
+
+        // States the finality, because it IS final: there is no restore route
+        // and no `taxonomies.restore` permission to build one against. Copy
+        // that promised "recoverable" is exactly what made #351 hard to spot.
+        const name = button.dataset.termName ?? "this term";
+        if (
+          !window.confirm(
+            `Delete "${name}"? This cannot be undone from the admin — there is ` +
+              `no restore for taxonomy terms. Posts keep their other terms.`
+          )
+        ) {
+          return;
+        }
+
+        if (actionError) actionError.hidden = true;
+        const unlock = lockElement(button, "Deleting…");
+
+        // `reason` is required by the endpoint, same convention as posts and
+        // pages. The screen supplies a constant rather than prompting: the
+        // operator already confirmed, and a second modal to type prose is
+        // friction that produces "asdf" in the audit trail.
+        const result = await sendJson(
+          "DELETE",
+          `/api/v1/blog/terms/${termId}`,
+          {
+            reason: "Deleted from the blog taxonomy console."
+          }
+        );
+
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+
+        // Generic copy only — never surface internal detail.
+        showActionError("Could not delete the term. Please try again.");
+        unlock();
+      });
+    });
+
+  const editForm = document.getElementById(
+    "term-edit-form"
+  ) as HTMLFormElement | null;
+
+  editForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "term-edit-submit"
+    ) as HTMLButtonElement | null;
+    const idField = document.getElementById(
+      "edit-term-id"
+    ) as HTMLInputElement | null;
+    if (!submit || submit.disabled || !idField) return;
+
+    const data = new FormData(editForm);
+    const errorElement = document.getElementById("term-edit-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Saving…");
+
+    const description = String(data.get("description") ?? "").trim();
+
+    // PATCH is a partial update, and `taxonomyType`/`parentId` are deliberately
+    // NOT sent: the form does not offer them, so it must not assert them.
+    const result = await sendJson(
+      "PATCH",
+      `/api/v1/blog/terms/${idField.value}`,
+      {
+        name: String(data.get("name") ?? "").trim(),
+        slug: String(data.get("slug") ?? "").trim(),
+        // Explicit `null` rather than omitted: clearing a description is a real
+        // edit, and omitting the key would silently keep the old one.
+        description: description === "" ? null : description
+      }
+    );
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    if (errorElement) {
+      errorElement.textContent =
+        result.errorCode === "CONFLICT"
+          ? "A term of this type already exists with that slug."
+          : "Could not save the term. Check the name and slug, then try again.";
+      errorElement.hidden = false;
+    }
+    unlock();
+  });
+
+  const createForm = document.getElementById(
+    "term-create-form"
+  ) as HTMLFormElement | null;
+
+  const createType = document.getElementById(
+    "create-taxonomy-type"
+  ) as HTMLSelectElement | null;
+  const createParent = document.getElementById(
+    "create-parent"
+  ) as HTMLSelectElement | null;
+
+  /**
+   * A tag may not have a parent — `awcms_blog_terms_tag_no_parent_check` is a
+   * database CHECK. Disabling the control keeps the browser from offering what
+   * the database will reject with a 400 the operator cannot act on.
+   */
+  function syncParentAvailability(): void {
+    if (!createType || !createParent) return;
+    const isTag = createType.value === "tag";
+    createParent.disabled = isTag;
+    if (isTag) createParent.value = "";
+  }
+
+  createType?.addEventListener("change", syncParentAvailability);
+  syncParentAvailability();
+
+  createForm?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const submit = document.getElementById(
+      "term-create-submit"
+    ) as HTMLButtonElement | null;
+    if (!submit || submit.disabled) return;
+
+    const data = new FormData(createForm);
+    const errorElement = document.getElementById("term-create-error");
+    if (errorElement) errorElement.hidden = true;
+    const unlock = lockElement(submit, "Creating…");
+
+    const taxonomyType = String(data.get("taxonomyType") ?? "category");
+    const parentId = String(data.get("parentId") ?? "").trim();
+    const description = String(data.get("description") ?? "").trim();
+
+    const result = await sendJson("POST", "/api/v1/blog/terms", {
+      taxonomyType,
+      name: String(data.get("name") ?? "").trim(),
+      slug: String(data.get("slug") ?? "").trim(),
+      // `null`, never "": the validator treats a parent as absent-or-uuid, and
+      // a tag must send `null` outright.
+      parentId: taxonomyType === "tag" || parentId === "" ? null : parentId,
+      description: description === "" ? null : description
+    });
+
+    if (result.ok) {
+      window.location.reload();
+      return;
+    }
+
+    if (errorElement) {
+      errorElement.textContent =
+        result.errorCode === "CONFLICT"
+          ? "A term of this type already exists with that slug."
+          : "Could not create the term. Check the name and slug, then try again.";
+      errorElement.hidden = false;
+    }
+    unlock();
+  });
+</script>

--- a/tests/admin-blog-page-contract.test.ts
+++ b/tests/admin-blog-page-contract.test.ts
@@ -365,26 +365,35 @@ describe("/admin/blog permission gates", () => {
     expect(nav!.requiredPermission).toBe("blog_content.posts.read");
     expect(declaredTriples().has(nav!.requiredPermission as Triple)).toBe(true);
 
-    // TWO entries for fifteen activity codes: the post lifecycle and the page
-    // lifecycle (ADR-0057). Taxonomy, presentation, settings and homepage
-    // composition still bring their own entries when their pages land. An
+    // THREE entries for fourteen activity codes: the post lifecycle, the page
+    // lifecycle (ADR-0057), and taxonomy. Presentation, settings and homepage
+    // composition still bring their own entries when their pages land — the
+    // count is pinned so each arrival is a line someone edits deliberately. An
     // entry appearing here without a page is what
     // `admin-navigation-registry.test.ts` catches.
     const navigation = listModules().find(
       (module) => module.key === "blog_content"
     )?.navigation;
 
-    expect(navigation).toHaveLength(2);
+    expect(navigation).toHaveLength(3);
     expect(navigation?.map((entry) => entry.path).sort()).toEqual([
       "/admin/blog",
-      "/admin/blog-pages"
+      "/admin/blog-pages",
+      "/admin/blog-taxonomy"
     ]);
 
     // Gated on their OWN permissions: an operator granted one and not the
-    // other must see exactly the screen they can use.
+    // others must see exactly the screens they can use.
     const pagesEntry = navigation?.find(
       (entry) => entry.path === "/admin/blog-pages"
     );
     expect(pagesEntry?.requiredPermission).toBe("blog_content.pages.read");
+
+    const taxonomyEntry = navigation?.find(
+      (entry) => entry.path === "/admin/blog-taxonomy"
+    );
+    expect(taxonomyEntry?.requiredPermission).toBe(
+      "blog_content.taxonomies.read"
+    );
   });
 });

--- a/tests/admin-blog-taxonomy-page-contract.test.ts
+++ b/tests/admin-blog-taxonomy-page-contract.test.ts
@@ -1,0 +1,251 @@
+/**
+ * `/admin/blog-taxonomy` gates against the endpoints it drives, and is explicit
+ * about what it deliberately does not offer.
+ *
+ * Third sibling of `tests/admin-blog-page-contract.test.ts` (posts) and
+ * `tests/admin-blog-pages-page-contract.test.ts` (pages). What is specific
+ * here:
+ *
+ * - **one permission gates three writes.** `taxonomies.configure` covers
+ *   create, update and delete, because `sql/036` seeds no per-verb rows. A
+ *   screen that invented `taxonomies.create` would gate on authority no
+ *   `authorizeInTransaction` call would ever honour — the latent-authz trap
+ *   this repo has shipped twice;
+ * - **delete is one-way BY DESIGN**, unlike posts and pages. There is no
+ *   restore route and no `taxonomies.restore` to build one against, so there
+ *   must be no bin view and no Restore control — and the confirmation must say
+ *   so. Copy promising recoverability is precisely what made #351 hard to see;
+ * - **no `Idempotency-Key` at all.** None of the three term endpoints reads it.
+ *   The split is per-endpoint, and a screen that sends one everywhere is
+ *   asserting a replay contract that does not exist.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/blog-taxonomy.astro";
+const LIST_ROUTE = "src/pages/api/v1/blog/terms/index.ts";
+const ITEM_ROUTE = "src/pages/api/v1/blog/terms/[id].ts";
+const ROUTES = [LIST_ROUTE, ITEM_ROUTE];
+
+/** Both, and only both — the whole `taxonomies` activity. */
+const TAXONOMY_KEYS = [
+  "blog_content.taxonomies.configure",
+  "blog_content.taxonomies.read"
+] as const;
+
+async function read(path: string): Promise<string> {
+  return readFile(path, "utf8");
+}
+
+/**
+ * Strips comments before asserting on absences.
+ *
+ * Not a nicety — the first draft of this file failed three of its own tests,
+ * all because the screen's prose EXPLAINS the very things the tests demand be
+ * absent ("no `Idempotency-Key`", "copy that promised recoverable"). A test
+ * that reads documentation as if it were code punishes a file for being
+ * well-commented and would pass the moment someone deleted the explanation.
+ *
+ * ## Line comments go FIRST, and the order is the whole bug
+ *
+ * The second draft stripped block comments first and silently ate 9,000
+ * characters — every admin screen carries the line
+ * `// … forces an external /_astro/*.js`, whose `/*` opens a block comment that
+ * then runs to the next `*​/` hundreds of lines below. The delete handler and
+ * the PATCH call both vanished, so two assertions failed and a third would have
+ * passed VACUOUSLY had it been phrased as an absence.
+ *
+ * That is the failure mode this repo has now hit in three separate scanners:
+ * over-stripping makes "not present" true for the wrong reason. Hence
+ * `expectCode` below — every caller proves the anchor it cares about survived.
+ *
+ * `[^:]` guards `https://`.
+ */
+function code(source: string): string {
+  return source
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ");
+}
+
+/**
+ * `code()` plus proof it did not eat the region under test. An absence
+ * assertion over an over-stripped file is not a weak test, it is a false one.
+ */
+function expectCode(source: string, anchor: string): string {
+  const stripped = code(source);
+  expect(stripped).toContain(anchor);
+  return stripped;
+}
+
+/** `permissionKey("a", "b", "c")` call sites in a screen. */
+function pageKeys(source: string): Set<string> {
+  const found = new Set<string>();
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)"\s*,\s*"([a-z_]+)"\s*,\s*"([a-z_]+)"/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}`);
+  }
+  return found;
+}
+
+/** Guard triples an API route constructs. */
+function guardKeys(source: string): Set<string> {
+  const found = new Set<string>();
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)"[\s\S]{0,120}?activityCode:\s*"([a-z_]+)"[\s\S]{0,120}?action:\s*"([a-z_]+)"/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}`);
+  }
+  return found;
+}
+
+describe("/admin/blog-taxonomy permission gates", () => {
+  test("the screen claims exactly the two taxonomy permissions", async () => {
+    const keys = pageKeys(await read(PAGE));
+
+    // Enumerated, so a permission quietly appearing on this screen — instead
+    // of on the sibling that should own it — fails here loudly.
+    expect([...keys].sort()).toEqual([...TAXONOMY_KEYS]);
+  });
+
+  test("and every one is declared by the descriptor, so a migration seeds it", async () => {
+    const declared = new Set(
+      listModules().flatMap((module) =>
+        (module.permissions ?? []).map(
+          (permission) =>
+            `${module.key}.${permission.activityCode}.${permission.action}`
+        )
+      )
+    );
+
+    for (const key of TAXONOMY_KEYS) {
+      expect(declared.has(key)).toBe(true);
+    }
+
+    // The latent-authz trap, stated as an assertion: a per-verb permission
+    // does NOT exist, so a screen must never gate on one.
+    for (const invented of [
+      "blog_content.taxonomies.create",
+      "blog_content.taxonomies.update",
+      "blog_content.taxonomies.delete",
+      "blog_content.taxonomies.restore",
+      "blog_content.taxonomies.purge"
+    ]) {
+      expect(declared.has(invented)).toBe(false);
+      expect(pageKeys(await read(PAGE)).has(invented)).toBe(false);
+    }
+  });
+
+  test("what the screen claims is what the routes actually enforce", async () => {
+    const enforced = new Set<string>();
+    for (const route of ROUTES) {
+      for (const key of guardKeys(await read(route))) enforced.add(key);
+    }
+
+    for (const key of pageKeys(await read(PAGE))) {
+      expect(enforced.has(key)).toBe(true);
+    }
+  });
+
+  test("no bin view and no Restore control — delete is one-way here", async () => {
+    const page = expectCode(await read(PAGE), "term-delete-btn");
+
+    // Posts and pages both have `?view=deleted`. This screen must not, because
+    // there is nothing to bring a row back with.
+    expect(page).not.toContain("view=deleted");
+    expect(page).not.toMatch(/term-restore-btn/);
+    expect(page).not.toMatch(/>\s*Restore\s*</);
+  });
+
+  test("the delete confirmation states the finality instead of promising recovery", async () => {
+    const page = expectCode(await read(PAGE), "window.confirm");
+
+    expect(page).toContain("window.confirm");
+    expect(page).toContain("cannot be undone");
+    // The #351 failure mode in one assertion: copy that tells the operator the
+    // row is coming back, on a screen where it cannot.
+    expect(page).not.toMatch(/recoverable|until it is purged|can be restored/i);
+  });
+
+  test("the screen sends no Idempotency-Key, because no term endpoint reads one", async () => {
+    expect(expectCode(await read(PAGE), "sendJson")).not.toContain(
+      "Idempotency-Key"
+    );
+
+    // Bound to the endpoints rather than trusted: if a term route later starts
+    // requiring the header, this fails and forces the screen to follow.
+    for (const route of ROUTES) {
+      expect(
+        expectCode(await read(route), "authorizeInTransaction").toLowerCase()
+      ).not.toContain("idempotency-key");
+    }
+  });
+
+  test("re-parenting is offered on create and withheld on update", async () => {
+    const page = await read(PAGE);
+
+    // Create may set a parent: a term with no children cannot close a cycle.
+    expect(page).toContain('id="create-parent"');
+
+    // Update may not: neither route detects cycles, so pointing a parent at
+    // its own descendant is accepted and every reader then walks forever.
+    const editForm = page.slice(
+      page.indexOf('id="term-edit-form"'),
+      page.indexOf('id="term-create-form"')
+    );
+    expect(editForm.length).toBeGreaterThan(0);
+    expect(editForm).not.toContain('name="parentId"');
+    expect(editForm).not.toContain('name="taxonomyType"');
+  });
+
+  test("the PATCH body carries no taxonomyType or parentId", async () => {
+    const page = await read(PAGE);
+
+    // The form not offering them is only half of it — the client must not
+    // assert them either, or a partial update silently rewrites the hierarchy.
+    //
+    // Anchored on the bare method literal, not `sendJson("PATCH"`: prettier
+    // wraps a three-argument call across lines, so the joined spelling exists
+    // only in an unformatted file.
+    // Bounded to the CALL, not to the next `sendJson`: the create handler
+    // further down legitimately sends both fields, so a slice that runs to
+    // `"POST"` swallows it and the assertion fails on the wrong code.
+    const body = expectCode(page, '"PATCH"');
+    const start = body.indexOf('"PATCH"');
+    const end = body.indexOf("\n    );", start);
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const patch = body.slice(start, end);
+    expect(patch).toContain("name:");
+    expect(patch).not.toContain("taxonomyType");
+    expect(patch).not.toContain("parentId");
+  });
+
+  test("the screen never mutates directly — it posts to the guarded endpoints", async () => {
+    const page = await read(PAGE);
+
+    expect(page).not.toMatch(
+      /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
+    );
+
+    expect(page).toContain('"/api/v1/blog/terms"');
+    expect(page).toContain("/api/v1/blog/terms/${termId}`");
+    expect(page).toContain("/api/v1/blog/terms/${idField.value}`");
+  });
+
+  test("the navigation entry exists and is gated on read", () => {
+    const blog = listModules().find((module) => module.key === "blog_content");
+    const entry = (blog?.navigation ?? []).find(
+      (item) => item.path === "/admin/blog-taxonomy"
+    );
+
+    expect(entry).toBeDefined();
+    expect(entry?.requiredPermission).toBe("blog_content.taxonomies.read");
+  });
+});


### PR DESCRIPTION
Layar saudara **ketiga** `blog_content`, setelah `/admin/blog` (#340) dan `/admin/blog-pages` (#352). Nol migrasi.

## Lingkup: dua permission, dan SATU di antaranya menggerbangi tiga tulis

`taxonomies.read` + `taxonomies.configure` — itu seluruh activity-nya. `configure` menggerbangi create, update, **dan** delete sekaligus, karena `sql/036` tak men-seed baris per-verb. Modul README mencatat alasannya: permission = kapabilitas "mengelola taksonomi", bukan satu flag per kata kerja.

Contract test menegaskannya sebagai asersi: `taxonomies.create`/`.update`/`.delete`/`.restore`/`.purge` **tidak** terdeklarasi dan **tidak** digerbangi layar ini. Itu jebakan latent-authz yang repo ini sudah dua kali kirim, ditulis sebagai test.

## Tiga ketiadaan yang disengaja, ketiganya mutation-proven

| Mutasi yang dikembalikan | Test yang merah |
| --- | --- |
| layar mengirim `Idempotency-Key` | `sends no Idempotency-Key` |
| PATCH mulai mengirim `parentId` | `PATCH body carries no taxonomyType or parentId` |
| konfirmasi menjanjikan pemulihan | `states the finality instead of promising recovery` |
| stripper komentar dibalik urutannya | dua test sekaligus |

**Tanpa bin, tanpa Restore.** Soft delete term itu **satu arah BY DESIGN** — tak ada fungsi restore, tak ada rute, tak ada permission untuk membangunnya. Ini terdokumentasi di README modul dan di komentar route `DELETE`, dan **bukan** cacat #351 (di sana endpoint-nya ADA dan layar memanggilnya pada baris yang pasti 404). Jadi bin justru akan menyiratkan jalan pulang yang tak ada; yang layar ini berutang adalah konfirmasi yang menyatakan finalitasnya. Test menolak kata-kata yang membuat #351 sulit terlihat.

**Tanpa re-parent saat edit.** Kedua route memverifikasi parent ada dan milik tenant, **tak satu pun mendeteksi siklus** — mengarahkan parent ke keturunannya sendiri diterima API dan tiap pembaca lalu berjalan selamanya. Keputusan yang sama dengan `/admin/blog-pages`. Create tetap menawarkan parent, karena term yang baru dibuat belum punya anak sehingga mustahil menutup loop. Body PATCH diasersikan tidak membawa `parentId`/`taxonomyType`: form yang tak menawarkan tapi klien yang tetap mengirim adalah bug yang sama dengan langkah tambahan.

**Tanpa `Idempotency-Key`.** Tak satu pun dari tiga endpoint term membacanya. Test mengikatnya ke route, jadi kalau kelak salah satu mulai menuntut header itu, layar dipaksa menyusul.

## Koreksi pada contract test — bagian yang lebih berguna dari PR ini

Draf pertama gagal pada tiga test-nya sendiri, dan penyebabnya bukan layar melainkan test: ia mencocokkan teks di dalam **komentar** yang justru MENJELASKAN ketiadaan yang diasersikan.

Draf kedua memperbaikinya dengan strip komentar — dan **menelan 9.000 karakter secara diam-diam**. Tiap layar admin memuat baris `// … forces an external /_astro/*.js`, dan `/*` di dalamnya membuka blok komentar palsu yang berjalan ratusan baris ke bawah. Handler delete dan pemanggilan PATCH ikut lenyap: dua asersi gagal, dan yang ketiga **akan lolos secara HAMPA** seandainya dirumuskan sebagai ketiadaan.

Perbaikannya dua bagian: komentar baris di-strip **lebih dulu**, dan tiap asersi-ketiadaan lewat `expectCode`, yang membuktikan anchor yang dipedulikannya selamat dari strip. Asersi-ketiadaan di atas berkas yang ter-over-strip bukan test yang lemah — ia test yang **salah**.

## Verifikasi

- 26 gate rantai `check` + `build` hijau
- Setara job `quality` CI: **0 fail**, 457 skip (3507 test)
- Gerbang lama `admin-blog-page-contract` mem-pin jumlah entri navigasi `blog_content` (2 → 3); diperbarui berikut alasan pin-nya, bukan dilonggarkan

> **Catatan lingkungan, dilaporkan apa adanya.** Suite DB-gated lokal jadi sangat lambat di akhir sesi ini (547 detik vs 81 detik sebelumnya, checkpoint Postgres 38 detik untuk 383 buffer — I/O host tersendat), dan `main` yang belum disentuh terkena **sama persis**. Jadi verifikasi DB pada PR ini bersandar pada job Integration CI, bukan pada run lokal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)