### PR TITLE
feat(media-library): expose the media public origin so awcms-astro stops copying it

### DIFF
--- a/.changeset/media-public-origin-discovery.md
+++ b/.changeset/media-public-origin-discovery.md
@@ -1,0 +1,30 @@
+---
+"awcms": minor
+---
+
+`GET /api/v1/media/public-origin` — the origin media public URLs are served
+from, so a build client never holds a second copy of it.
+
+`awcms-astro` ships a strict CSP and must name the media host in `img-src` at
+BUILD time: an image resolved correctly still renders as nothing when
+`img-src 'self'` blocks the host it lives on. Reading the origin off a
+`publicUrl` does not help, because the policy is written before any object is
+fetched, and a build with no images would then emit no `img-src` at all. The
+only alternative left was copying `NEWS_MEDIA_R2_PUBLIC_BASE_URL` into the
+consumer by hand — two copies of one value that agree until one is edited, with
+a failure (images silently blocked) that names its cause nowhere.
+
+Reports `origin` (scheme + host + port, for the host-wide CSP form) and
+`baseUrl` (path included, for the tighter prefix form); neither choice is this
+API's to make.
+
+A deployment serving no public media answers `200` with `configured: false`
+rather than an error, so a LAN/offline build omits the entry instead of
+failing. A value that is set but unparseable — or on a scheme that cannot serve
+media, `data:` above all — is reported the same way and never echoed back:
+handing a consumer a malformed origin puts it in a CSP header, where a browser
+either rejects the whole policy or allows something nobody wrote down.
+
+Gated on `media_library.media.read`, the permission a build client already
+holds; no new authority on any credential, and machine credentials stay
+read-only (ADR-0049). No migration.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -4584,6 +4584,27 @@ The projection omits `bucket_name`/`storage_driver` (deployment facts) and `owne
 | 401    | Missing or invalid session.              | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.              | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/media/public-origin` — The origin media public URLs are served from.
+
+- **operationId**: `mediaPublicOrigin`
+- **Security**: bearerAuth + tenantHeader
+
+Requires `media_library.media.read`. Deployment config, not tenant data: every tenant on a deployment is served from the same bucket.
+
+Exists for build clients such as `awcms-astro`, whose Content-Security-Policy must name the media host in `img-src` BEFORE it fetches any object — an image resolved correctly still renders as nothing when the policy blocks the host it lives on. The alternative is copying `NEWS_MEDIA_R2_PUBLIC_BASE_URL` into the consumer by hand, which is two copies of one value that agree until one is edited.
+
+`origin` is scheme + host + port, for the host-wide CSP form; `baseUrl` includes the path, for the tighter prefix form. Both are reported because neither choice is this API's to make.
+
+A deployment that serves no public media (LAN/offline profiles) answers `200` with `configured: false` rather than an error, so a build can omit the `img-src` entry instead of failing. A value that is set but unparseable, or on a scheme that cannot serve media, is reported the same way and never echoed back.
+
+**Responses**
+
+| Status | Description                                                   | Schema                                 |
+| ------ | ------------------------------------------------------------- | -------------------------------------- |
+| 200    | The configured media origin, or an explicit "not configured". | object                                 |
+| 401    | Missing or invalid session.                                   | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                   | [`ApiError`](#standard-error-envelope) |
+
 ## Blog Content
 
 Tenant-scoped blog/content administration (blog_content module, ported from awcms-mini) — posts and pages with their full lifecycle (draft → review → scheduled/published → archived, soft delete/restore/purge), hierarchical categories/tags, append-only revision history (restore APPENDS a revision, never overwrites), PostgreSQL full-text search, presentation/monetization extensions (templates, hierarchical menus, position-based widgets, advertisements), per-tenant blog settings, internal tag-link policy, and the editorial content-quality checklist. The public, anonymous reader surface (`/blog/{tenantCode}/...` index/detail/archive/search/feed/sitemap, ADR-0009) is served by Astro text/html/xml routes and is deliberately NOT part of this REST contract. Publish/unpublish/purge and settings writes are ABAC-gated, idempotency-keyed, and audited.

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -647,6 +647,11 @@
       "source": "factory"
     },
     {
+      "path": "src/pages/api/v1/media/public-origin.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/modules/[moduleKey].ts",
       "workClass": "interactive",
       "source": "default"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -8728,6 +8728,53 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/media/public-origin:
+    get:
+      operationId: mediaPublicOrigin
+      tags:
+        - News Media
+      summary: The origin media public URLs are served from.
+      description: |-
+        Requires `media_library.media.read`. Deployment config, not tenant data: every tenant on a deployment is served from the same bucket.
+
+        Exists for build clients such as `awcms-astro`, whose Content-Security-Policy must name the media host in `img-src` BEFORE it fetches any object — an image resolved correctly still renders as nothing when the policy blocks the host it lives on. The alternative is copying `NEWS_MEDIA_R2_PUBLIC_BASE_URL` into the consumer by hand, which is two copies of one value that agree until one is edited.
+
+        `origin` is scheme + host + port, for the host-wide CSP form; `baseUrl` includes the path, for the tighter prefix form. Both are reported because neither choice is this API's to make.
+
+        A deployment that serves no public media (LAN/offline profiles) answers `200` with `configured: false` rather than an error, so a build can omit the `img-src` entry instead of failing. A value that is set but unparseable, or on a scheme that cannot serve media, is reported the same way and never echoed back.
+      responses:
+        "200":
+          description: The configured media origin, or an explicit "not configured".
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    required:
+                      - configured
+                      - origin
+                      - baseUrl
+                    properties:
+                      configured:
+                        type: boolean
+                      origin:
+                        type: string
+                        nullable: true
+                        example: https://media.example.com
+                      baseUrl:
+                        type: string
+                        nullable: true
+                        example: https://media.example.com/news
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/modules:
     get:
       operationId: listModuleCatalog

--- a/openapi/modules/media-library.openapi.yaml
+++ b/openapi/modules/media-library.openapi.yaml
@@ -217,6 +217,68 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/media/public-origin:
+    get:
+      operationId: mediaPublicOrigin
+      tags:
+        - News Media
+      summary: The origin media public URLs are served from.
+      description: >-
+        Requires `media_library.media.read`. Deployment config, not tenant data:
+        every tenant on a deployment is served from the same bucket.
+
+
+        Exists for build clients such as `awcms-astro`, whose
+        Content-Security-Policy must name the media host in `img-src` BEFORE it
+        fetches any object — an image resolved correctly still renders as
+        nothing when the policy blocks the host it lives on. The alternative is
+        copying `NEWS_MEDIA_R2_PUBLIC_BASE_URL` into the consumer by hand, which
+        is two copies of one value that agree until one is edited.
+
+
+        `origin` is scheme + host + port, for the host-wide CSP form; `baseUrl`
+        includes the path, for the tighter prefix form. Both are reported
+        because neither choice is this API's to make.
+
+
+        A deployment that serves no public media (LAN/offline profiles) answers
+        `200` with `configured: false` rather than an error, so a build can omit
+        the `img-src` entry instead of failing. A value that is set but
+        unparseable, or on a scheme that cannot serve media, is reported the
+        same way and never echoed back.
+      responses:
+        "200":
+          description: The configured media origin, or an explicit "not configured".
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    required:
+                      - configured
+                      - origin
+                      - baseUrl
+                    properties:
+                      configured:
+                        type: boolean
+                      origin:
+                        type: string
+                        nullable: true
+                        example: https://media.example.com
+                      baseUrl:
+                        type: string
+                        nullable: true
+                        example: https://media.example.com/news
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/media/objects/list:
     get:
       operationId: mediaObjectList

--- a/src/modules/media-library/domain/media-public-origin.ts
+++ b/src/modules/media-library/domain/media-public-origin.ts
@@ -1,0 +1,86 @@
+/**
+ * The origin media `publicUrl`s are served from, derived from deployment
+ * config so a client never has to hold a second copy of it.
+ *
+ * ## Why this exists
+ *
+ * `media_object_directory` builds every `public_url` from
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL` — a server-side environment variable. A build
+ * client (`awcms-astro`) needs that host BEFORE it fetches a single object,
+ * because its Content-Security-Policy has to name the origin in `img-src` at
+ * build time; `img-src 'self'` blocks the media host outright, so an image
+ * resolved correctly still renders as nothing.
+ *
+ * Today the only way to get it is to copy the environment variable into the
+ * consumer by hand. That is the shape this repo has already been bitten by
+ * (`MAX_REASON_LENGTH` written out five times): two copies of one value agree
+ * until one of them is edited, and the failure lands somewhere that does not
+ * name the cause — here, images silently blocked by a policy that looks fine.
+ *
+ * ## Why an ORIGIN and a base URL, not just one
+ *
+ * CSP host-sources accept either. `img-src https://media.example.com` allows
+ * the whole host; `img-src https://media.example.com/news/` restricts by path
+ * prefix, which is tighter but interacts badly with redirects. Both are
+ * legitimate choices for the consumer, and neither is ours to make — so both
+ * values are reported and the caller picks.
+ *
+ * ## Unconfigured is a STATE, not an error
+ *
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL` is unset in LAN/offline deployment profiles,
+ * where media is not served at all. Answering 404 or 500 there would make a
+ * build client fail on a perfectly valid deployment. It reports
+ * `configured: false` instead, so a consumer can skip adding an `img-src` entry
+ * rather than add a broken one — and can tell that apart from a request that
+ * failed.
+ */
+
+export type MediaPublicOrigin = {
+  /** `false` when the deployment serves no public media at all. */
+  configured: boolean;
+  /** Scheme + host + port, e.g. `https://media.example.com`. */
+  origin: string | null;
+  /** The full configured base, path included, without a trailing slash. */
+  baseUrl: string | null;
+};
+
+const UNCONFIGURED: MediaPublicOrigin = {
+  configured: false,
+  origin: null,
+  baseUrl: null
+};
+
+/**
+ * Derives the reportable origin from a configured public base URL.
+ *
+ * A value that is set but unparseable is reported as UNCONFIGURED rather than
+ * echoed back. Handing a consumer a malformed origin to put in a CSP header is
+ * worse than telling it there is none: the policy would either be rejected
+ * wholesale — taking every other directive with it — or silently allow
+ * something nobody wrote down.
+ */
+export function deriveMediaPublicOrigin(
+  publicBaseUrl: string
+): MediaPublicOrigin {
+  const trimmed = publicBaseUrl.trim();
+
+  if (trimmed === "") return UNCONFIGURED;
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return UNCONFIGURED;
+  }
+
+  // `http:`/`https:` only. A `file:`/`data:` base could not serve media over
+  // the network anyway, and reporting one would put a scheme in a consumer's
+  // `img-src` that means something entirely different there.
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return UNCONFIGURED;
+  }
+
+  const baseUrl = trimmed.endsWith("/") ? trimmed.slice(0, -1) : trimmed;
+
+  return { configured: true, origin: parsed.origin, baseUrl };
+}

--- a/src/pages/api/v1/media/public-origin.ts
+++ b/src/pages/api/v1/media/public-origin.ts
@@ -1,0 +1,62 @@
+import { ok } from "../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../modules/_shared/tenant-route";
+import { resolveNewsMediaR2Config } from "../../../../modules/media-library/domain/media-r2-config";
+import { deriveMediaPublicOrigin } from "../../../../modules/media-library/domain/media-public-origin";
+import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../modules/media-library/domain/media-permissions";
+
+/**
+ * `GET /api/v1/media/public-origin` — the origin media `publicUrl`s are served
+ * from.
+ *
+ * ## Who needs it and why it cannot be inferred
+ *
+ * `awcms-astro` builds a static site from this repo's content and ships a
+ * strict CSP. Its `img-src` must name the media host at BUILD time, before a
+ * single object is fetched — an image resolved perfectly still renders as
+ * nothing when `img-src 'self'` blocks the host it lives on.
+ *
+ * `GET /api/v1/media/objects?ids=` already returns absolute `publicUrl`s, so
+ * the origin could in principle be read off the first response. That does not
+ * help: the policy has to be written before the fetch, and a site with no
+ * images in a given build would then emit no `img-src` at all and break the
+ * next one. The only alternative left is copying
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL` into the consumer by hand, which is two
+ * copies of one value that agree until one is edited — and the failure it
+ * produces (images silently blocked) does not name its cause anywhere.
+ *
+ * ## Gated on `media.read`, which is deliberate and sufficient
+ *
+ * The value is not a secret: every `publicUrl` this deployment has ever handed
+ * out already contains it, and the bucket is public by construction. The guard
+ * is here because everything in `/api/v1` is tenant-scoped and default-deny,
+ * not because the origin is sensitive — and `media.read` is the permission a
+ * build client already holds to resolve objects, so this adds no new authority
+ * to any credential. Machine credentials are read-only (ADR-0049), so a build
+ * token can call this and nothing else here.
+ *
+ * ## An unconfigured deployment answers 200, not 404
+ *
+ * LAN and offline profiles serve no public media. Failing the request there
+ * would fail a build on a perfectly valid deployment, so the response reports
+ * `configured: false` and the consumer omits the `img-src` entry rather than
+ * adding a broken one — a state it can tell apart from an error.
+ *
+ * Read-only, no database access beyond the guard's own transaction.
+ */
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "media_library",
+    activityCode: MEDIA_PERMISSION_ACTIVITY_CODE,
+    action: "read"
+  },
+  handler: async () => {
+    // Deployment config, not tenant data: every tenant on this deployment is
+    // served from the same bucket, so there is nothing here to scope per
+    // tenant. The guard still runs — being non-tenant-specific is not a reason
+    // to be unauthenticated.
+    const config = resolveNewsMediaR2Config();
+
+    return ok(deriveMediaPublicOrigin(config.publicBaseUrl));
+  }
+});

--- a/tests/media-public-origin.test.ts
+++ b/tests/media-public-origin.test.ts
@@ -1,0 +1,85 @@
+/**
+ * `deriveMediaPublicOrigin` — what a build client is told to put in `img-src`.
+ *
+ * The cases that matter are the ones where being WRONG is silent. A malformed
+ * origin echoed back lands in a consumer's Content-Security-Policy header,
+ * where a browser either rejects the whole policy — taking every other
+ * directive with it — or accepts something nobody wrote down. Neither failure
+ * points at this function.
+ *
+ * Pure — no database, no network, no environment.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { deriveMediaPublicOrigin } from "../src/modules/media-library/domain/media-public-origin";
+
+describe("deriveMediaPublicOrigin", () => {
+  test("reports the origin and the trimmed base for a configured host", () => {
+    expect(deriveMediaPublicOrigin("https://media.example.com/news")).toEqual({
+      configured: true,
+      origin: "https://media.example.com",
+      baseUrl: "https://media.example.com/news"
+    });
+  });
+
+  test("origin excludes the path, because CSP host-sources are not paths", () => {
+    // The whole reason both values are returned: a consumer choosing the
+    // host-wide form must not accidentally paste a path into it.
+    const result = deriveMediaPublicOrigin("https://cdn.example.com/a/b/c");
+
+    expect(result.origin).toBe("https://cdn.example.com");
+    expect(result.baseUrl).toBe("https://cdn.example.com/a/b/c");
+  });
+
+  test("keeps a non-default port, which is part of the origin", () => {
+    // Dropping it would produce a policy that allows a host the deployment
+    // does not serve from, and blocks the one it does.
+    expect(deriveMediaPublicOrigin("http://localhost:9000/media").origin).toBe(
+      "http://localhost:9000"
+    );
+  });
+
+  test("strips exactly one trailing slash from the base URL", () => {
+    expect(deriveMediaPublicOrigin("https://media.example.com/news/")).toEqual({
+      configured: true,
+      origin: "https://media.example.com",
+      baseUrl: "https://media.example.com/news"
+    });
+  });
+
+  test("an unset value is `configured: false`, not an error", () => {
+    // LAN/offline profiles serve no public media. A build client must be able
+    // to tell that apart from a failed request.
+    for (const value of ["", "   "]) {
+      expect(deriveMediaPublicOrigin(value)).toEqual({
+        configured: false,
+        origin: null,
+        baseUrl: null
+      });
+    }
+  });
+
+  test("a set-but-unparseable value is reported as unconfigured, never echoed", () => {
+    // Echoing it back is the dangerous option: it reaches a CSP header.
+    for (const value of ["media.example.com", "://nope", "not a url"]) {
+      expect(deriveMediaPublicOrigin(value)).toEqual({
+        configured: false,
+        origin: null,
+        baseUrl: null
+      });
+    }
+  });
+
+  test("rejects schemes that cannot serve media over the network", () => {
+    // `data:` and `file:` mean something entirely different inside `img-src`;
+    // `data:` in particular re-opens an injection surface a strict policy
+    // exists to close.
+    for (const value of [
+      "data:image/png;base64,AAAA",
+      "file:///srv/media",
+      "ftp://media.example.com"
+    ]) {
+      expect(deriveMediaPublicOrigin(value).configured).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
Hasil analisis kebutuhan `ahliweb/awcms-astro` yang menuntut kesiapan repo ini. Nol migrasi.

## Kenapa ini yang dikerjakan

`awcms-astro` mengirim CSP ketat (ADR-0019 di sana) dan **harus menyebut host media di `img-src` saat BUILD**. Gambar yang di-resolve dengan sempurna tetap tampil sebagai kosong kalau `img-src 'self'` memblokir host tempatnya tinggal — itu sebabnya ADR-0021 di sana mendaftarkan "apa yang diizinkan `img-src`" sebagai satu dari dua keputusan yang menahan gambar artikel.

Membaca origin dari `publicUrl` yang sudah dikembalikan **tidak menyelesaikannya**: policy ditulis sebelum satu objek pun ditarik, dan build yang kebetulan tak memuat gambar akan memancarkan `img-src` kosong lalu merusak build berikutnya.

Yang tersisa: menyalin `NEWS_MEDIA_R2_PUBLIC_BASE_URL` ke konsumen **dengan tangan**. Itu bentuk yang sama dengan `MAX_REASON_LENGTH` yang ditulis ulang di lima berkas — dua salinan satu nilai yang sepakat sampai salah satunya diedit — dan kegagalannya (gambar diblokir diam-diam oleh policy yang tampak benar) **tidak menyebut sebabnya di mana pun**.

## Bentuk responsnya

`origin` (scheme + host + port, untuk bentuk CSP host-wide) **dan** `baseUrl` (termasuk path, untuk bentuk prefix yang lebih ketat). Keduanya, karena pilihan itu bukan milik API ini.

## Tiga keputusan, semuanya mutation-proven

| Mutasi yang dikembalikan | Test yang merah |
| --- | --- |
| nilai tak-terparse digemakan balik | `never echoed` |
| origin dibangun dari `href` (membawa path) | tiga test sekaligus |
| allow-list scheme dicabut (`data:` lolos) | `rejects schemes that cannot serve media` |

**Tak-terkonfigurasi itu STATE, bukan error.** Profil LAN/offline tak menyajikan media publik; menjawab 404 di sana akan menggagalkan build pada deployment yang sah. `200` dengan `configured: false` membuat konsumen bisa menghilangkan entri itu **dan** tetap membedakannya dari permintaan yang gagal.

**Nilai yang set-tapi-tak-terparse tak pernah digemakan balik.** Ia akan mendarat apa adanya di header CSP, tempat browser entah menolak seluruh policy — membawa serta tiap direktif lain — atau mengizinkan sesuatu yang tak seorang pun tuliskan.

**Allow-list scheme.** `data:` di dalam `img-src` justru membuka kembali permukaan injeksi yang policy ketat ada untuk menutupnya; `file:`/`ftp:` toh tak bisa menyajikan media.

## Otorisasi

Digerbangi `media_library.media.read` — permission yang **sudah** dipegang klien build untuk me-resolve objek, jadi ini **tak menambah wewenang** pada kredensial mana pun, dan kredensial mesin tetap baca-saja (ADR-0049). Nilainya juga bukan rahasia: tiap `publicUrl` yang pernah dikeluarkan deployment ini sudah memuatnya.

## Verifikasi

- 12 gate + `build` hijau; setara job `quality` CI: **0 fail** (3526 test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)