### PR TITLE
chore(docs): generate repo-inventory.md instead of claiming it is generated

### DIFF
--- a/.changeset/repo-inventory-generator.md
+++ b/.changeset/repo-inventory-generator.md
@@ -1,0 +1,13 @@
+---
+"awcms": patch
+---
+
+Make `docs/awcms/repo-inventory.md` an actually-generated document (`bun run repo:inventory:generate|:check`).
+
+It carried a "GENERATED FILE — jangan diedit manual" banner while no generator existed, and it aged in the direction that does the most damage: the body said "belum ada tabel" and "belum ada test file" against 126 tables and 295 test files, gave the migration count as **45** in one paragraph and **89** in another, and listed **20** modules where the registry holds 21. A negative claim is the dangerous kind — "X does not exist yet" gets more wrong with time and never fails on its own.
+
+The derivable half is now derived and the prose half is not, following `scripts-inventory.ts` exactly: everything between the markers comes from the module registry, `sql/*.sql`, `tests/`, `src/pages/` and `docs/adr/`, and `repo:inventory:check` joins the `check` chain. The check parses the block back into rows rather than comparing bytes, because prettier owns markdown padding and the two would otherwise fight forever.
+
+RLS state is parsed from the migrations, not read from a database, so the inventory is available where it is most useful (CI, a fresh clone, a review). That parse is cumulative and order-sensitive on purpose: `sql/020` toggles `NO FORCE` on `awcms_offices` for a data repair and turns it back on 40 lines later, so a parser reading the first or last statement alone would report the opposite of the truth. `security-readiness.ts` remains the authority for a live deployment.
+
+One cross-artefact test ships with it, and it is the part with teeth: the set of tables the generator derives as RLS-free must equal the keys of `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES` in `security-readiness.ts` — one side derived from the migrations, the other hand-maintained with a reason per entry. A disagreement means either a new global table shipped without declaring which privileges `awcms_app` must not hold on it, or a tenant-scoped table shipped without RLS. Today both sides are the same eleven.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -127,9 +127,12 @@ Modul (21, urutan `src/modules/index.ts`): `logging`, `tenant-admin`,
 `idn-admin-regions` (#312, ADR-0046) **bukan** hasil port — ia modul pertama yang
 dirintis langsung di sini setelah pembekuan ADR-0047.)
 
-> Catatan: generator `repo:inventory` **belum diport** dari `awcms-mini`, jadi
-> [`awcms/repo-inventory.md`](awcms/repo-inventory.md) adalah placeholder — jangan
-> jadikan sumber angka. Gunakan ARCHITECTURE.md / registry / `sql/`.
+> Catatan: [`awcms/repo-inventory.md`](awcms/repo-inventory.md) kini
+> **ter-generate** (`bun run repo:inventory:generate`, gerbang `:check` di rantai
+> `check`) — angka modul/migrasi/tabel-RLS/test/route di sana diturunkan dari
+> repo, jadi ia boleh dipakai sebagai sumber angka. Tabel §2 di atas tidak
+> digerbangi apa pun dan tetap harus diverifikasi dengan perintah di kolom
+> "Sumber kebenaran".
 
 ## 3. Yang sudah selesai (jangan dibangun ulang)
 
@@ -794,7 +797,22 @@ NULL`, jadi pencarian publik untuk page **selalu** nol baris — di atas index
   ada (21 modul, `src/components/ui` tidak ada), tapi tak satu pun memblokir
   `awcms-astro`.
 
-- **Port generator `repo:inventory`** dari mini agar `repo-inventory.md` jadi ter-generate.
+- **~~Port generator `repo:inventory`~~ — SELESAI, dan dibangun di sini (bukan
+  port).** `bun run repo:inventory:generate|:check` (`scripts/repo-inventory.ts`)
+  mengisi blok ber-penanda di [`awcms/repo-inventory.md`](awcms/repo-inventory.md)
+  dari registry modul, `sql/`, `tests/`, `src/pages/`, dan `docs/adr/`;
+  `:check` masuk rantai `bun run check`. Dokumen itu sebelumnya membawa banner
+  "GENERATED FILE" tanpa generator, dan isinya menua ke arah paling merugikan:
+  "belum ada tabel"/"belum ada test file" terhadap 126 tabel dan 296 berkas
+  test, jumlah migrasi **45** di satu paragraf dan **89** di paragraf lain,
+  serta **20** modul saat registry memuat 21. Status RLS diparse dari teks
+  migrasi secara **kumulatif** (sql/020 mematikan FORCE untuk perbaikan data
+  lalu menyalakannya lagi — pembaca statement pertama ATAU terakhir saja akan
+  melaporkan kebalikan dari kebenaran); `security:readiness` tetap otoritas
+  untuk deployment nyata. Satu test lintas-artefak menjaga klaimnya: himpunan
+  tabel RLS-free yang diturunkan generator wajib SAMA dengan kunci
+  `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES` — satu sisi diturunkan dari migrasi, satu
+  sisi dideklarasikan manusia dengan alasan per entri.
 - **~~Seam yang menunggu penyedia~~ — business-scope resolver SUDAH PUNYA PENYEDIA
   ([ADR-0060](adr/0060-business-scope-hierarchy-provided-by-tenant-admin.md)).**
   `tenant_admin` me-resolve scope type `office` terhadap `awcms_offices`; NO-OP

--- a/docs/awcms/13_final_master_index_traceability.md
+++ b/docs/awcms/13_final_master_index_traceability.md
@@ -136,10 +136,10 @@ flowchart LR
 
 Sumber: `docs/awcms/repo-inventory.md` §Migrations dan
 `src/modules/index.ts`, keduanya dibaca ulang saat menulis tabel ini.
-`repo-inventory.md` saat ini **hand-maintained** (bukan hasil generate
-nyata) — `bun run repo:inventory:generate` dan
-`scripts/repo-inventory-generate.ts` belum ada di repo ini; lihat
-disclaimer di puncak `repo-inventory.md` sendiri untuk statusnya. **79 file migration nyata** di
+`repo-inventory.md` kini **benar-benar di-generate**: tabel di antara penandanya
+diproduksi `bun run repo:inventory:generate` (`scripts/repo-inventory.ts`) dari
+registry modul, `sql/`, `tests/`, `src/pages/`, dan `docs/adr/`, dan
+`bun run repo:inventory:check` ada di rantai `bun run check`. **79 file migration nyata** di
 `sql/` (`001`..`081`), dipetakan ke **21 modul terdaftar** (urutan
 `src/modules/index.ts`: `logging`, `tenant-admin`, `profile-identity`,
 `identity-access`, `module-management`, `domain-event-runtime`,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -1,76 +1,309 @@
 # AWCMS Repository Inventory (generated)
 
-> **Status dokumen:** standar/template, BUKAN hasil generate nyata — dan **isi body di bawah kini USANG**. Body masih menyatakan "belum ada modul" dan "belum ada migrasi"; itu **tidak lagi benar** — repo `awcms` sekarang punya **21 modul** (urutan `src/modules/index.ts`: `logging`, `tenant-admin`, `profile-identity`, `identity-access`, `module-management`, `domain-event-runtime`, `sync-storage`, `workflow-approval`, `email`, `reporting`, `theming`, `media-library`, `blog-content`, `tenant-domain`, `visitor-analytics`, `data-lifecycle`, `seo-distribution`, `form-drafts`, `site-search`, `comments`) dan **89 migrasi** (`sql/001`–`089`). Sumber kebenaran keadaan kode saat ini adalah [`../ARCHITECTURE.md`](../ARCHITECTURE.md), bukan berkas ini. Tabel di bawah adalah **struktur target** yang baru akan terisi akurat begitu `scripts/repo-inventory-generate.ts` (`bun run repo:inventory:generate`) diimplementasikan/di-port dari `awcms-mini`. Mekanisme (generated-file, freshness check, sumber data) diadaptasi dari basis `awcms-mini` yang sudah menjalankannya secara nyata.
+> **GENERATED BLOCK — jangan edit tabel di bawah penanda secara manual.** Tabel
+> di antara `<!-- BEGIN GENERATED: repo-inventory -->
 
-> **GENERATED FILE — jangan diedit manual.** Setelah diimplementasikan, dokumen ini akan diproduksi oleh `bun run repo:inventory:generate` (`scripts/repo-inventory-generate.ts`) dari module registry repo sendiri, migrasi `sql/*.sql`, `tests/`, dan kontrak OpenAPI yang di-bundle — jangan pernah diedit langsung. `bun run repo:inventory:check` (bagian dari `bun run check`) wajib menggagalkan build bila berkas ini basi relatif terhadap regenerasi baru.
+### Ringkasan
 
-**Freshness.** Dokumen ini sengaja tidak menyertakan timestamp generasi (stempel wall-clock akan membuat setiap regenerasi ter-diff meski tidak ada perubahan bermakna). Ia selalu mendeskripsikan state repository **pada commit tempat ia di-commit** — checkout tag/commit mana pun dan berkas ini (atau `bun run repo:inventory:generate` yang segar) mendeskripsikan state itu, tidak pernah state lain. State issue/label/milestone GitHub dilacak terpisah di `docs/awcms/github/` (menyusul, di-refresh on-demand lewat `bun run github:snapshot:refresh` — panggilan jaringan langsung, sengaja di luar `bun run check`).
+| Aspek                              | Nilai |
+| ---------------------------------- | ----- |
+| Modul terdaftar                    | 21    |
+| Migrasi                            | 89    |
+| Tabel `awcms_*`                    | 126   |
+| Tabel dengan `FORCE` RLS           | 115   |
+| Tabel RLS-free (global, by design) | 11    |
+| Berkas test                        | 296   |
+| Berkas route                       | 312   |
+| ADR                                | 61    |
 
-## Modul
+### Modul
 
-Repo ini kini punya **21 modul aktif** yang terdaftar di `src/modules/index.ts`'s `listModules()`. Nilai akurat per-kolom (version/status/type/dependencies) dibaca dari registry nyata — sumber kebenaran keadaan kode saat ini adalah [`../ARCHITECTURE.md`](../ARCHITECTURE.md) dan registry itu sendiri, bukan tabel statis di bawah. Urutan `src/modules/index.ts`: `logging`, `tenant-admin`, `profile-identity`, `identity-access`, `module-management`, `domain-event-runtime`, `sync-storage`, `workflow-approval`, `email`, `reporting`, `theming`, `media-library`, `blog-content`, `tenant-domain`, `visitor-analytics`, `data-lifecycle`, `seo-distribution`, `form-drafts`, `site-search`, `comments`. Begitu `bun run repo:inventory:generate` diimplementasikan/di-port, tabel ini akan diisi otomatis dengan bentuk yang sama seperti basis:
+| Key                    | Version | Status | Type   | Core  | Dependencies                                                                                       |
+| ---------------------- | ------- | ------ | ------ | ----- | -------------------------------------------------------------------------------------------------- |
+| `logging`              | 1.0.0   | active | —      | tidak | `tenant_admin`                                                                                     |
+| `tenant_admin`         | 1.0.0   | active | —      | tidak | —                                                                                                  |
+| `profile_identity`     | 1.0.0   | active | —      | tidak | `tenant_admin`                                                                                     |
+| `identity_access`      | 1.0.0   | active | —      | tidak | `tenant_admin`, `profile_identity`                                                                 |
+| `module_management`    | 0.1.0   | active | system | ya    | `tenant_admin`, `identity_access`                                                                  |
+| `domain_event_runtime` | 0.1.0   | active | system | tidak | `tenant_admin`, `identity_access`, `logging`                                                       |
+| `sync_storage`         | 1.0.0   | active | system | tidak | `tenant_admin`                                                                                     |
+| `workflow`             | 2.0.0   | active | system | tidak | `tenant_admin`, `identity_access`, `domain_event_runtime`                                          |
+| `email`                | 0.5.0   | active | —      | tidak | `tenant_admin`, `profile_identity`, `identity_access`                                              |
+| `reporting`            | 1.2.0   | active | —      | tidak | `tenant_admin`, `identity_access`, `sync_storage`, `email`, `domain_event_runtime`                 |
+| `theming`              | 1.0.0   | active | domain | tidak | `tenant_admin`, `identity_access`, `module_management`                                             |
+| `media_library`        | 0.1.0   | active | system | tidak | `tenant_admin`, `identity_access`                                                                  |
+| `blog_content`         | 0.12.0  | active | domain | tidak | `tenant_admin`, `identity_access`, `module_management`, `logging`                                  |
+| `tenant_domain`        | 0.1.0   | active | domain | tidak | `tenant_admin`, `identity_access`                                                                  |
+| `visitor_analytics`    | 0.1.0   | active | system | tidak | `tenant_admin`, `identity_access`, `logging`, `data_lifecycle`, `module_management`                |
+| `data_lifecycle`       | 0.1.0   | active | system | tidak | `tenant_admin`, `identity_access`, `logging`                                                       |
+| `seo_distribution`     | 0.2.0   | active | domain | tidak | `tenant_admin`, `identity_access`, `module_management`                                             |
+| `form_drafts`          | 0.1.0   | active | system | tidak | `identity_access`                                                                                  |
+| `site_search`          | 0.1.0   | active | domain | tidak | `tenant_admin`, `identity_access`, `module_management`                                             |
+| `comments`             | 0.1.0   | active | domain | tidak | `tenant_admin`, `identity_access`, `module_management`, `profile_identity`, `domain_event_runtime` |
+| `idn_admin_regions`    | 0.1.0   | active | system | tidak | `tenant_admin`, `identity_access`                                                                  |
 
-| Key                      | Version | Status | Type | Dependencies |
-| ------------------------ | ------- | ------ | ---- | ------------ |
-| _(lihat registry nyata)_ | —       | —      | —    | —            |
+### Migrasi
 
-Urutan modul yang direncanakan (lihat `AGENTS.md` §Peta modul, [`01_canvas_induk.md`](01_canvas_induk.md)):
+| #   | File                                                               |
+| --- | ------------------------------------------------------------------ |
+| 1   | `sql/001_awcms_foundation_schema.sql`                              |
+| 2   | `sql/002_awcms_tenant_office_schema.sql`                           |
+| 3   | `sql/003_awcms_central_profile_schema.sql`                         |
+| 4   | `sql/004_awcms_identity_login_schema.sql`                          |
+| 5   | `sql/005_awcms_abac_access_control_schema.sql`                     |
+| 6   | `sql/006_awcms_setup_wizard_schema.sql`                            |
+| 7   | `sql/007_awcms_audit_logging_schema.sql`                           |
+| 8   | `sql/008_awcms_module_management_schema.sql`                       |
+| 9   | `sql/009_awcms_domain_event_runtime_schema.sql`                    |
+| 10  | `sql/010_awcms_sync_storage_outbox_inbox_schema.sql`               |
+| 11  | `sql/011_awcms_sync_storage_conflict_schema.sql`                   |
+| 12  | `sql/012_awcms_object_sync_queue_schema.sql`                       |
+| 13  | `sql/013_awcms_workflow_approval_schema.sql`                       |
+| 14  | `sql/014_awcms_email_schema.sql`                                   |
+| 15  | `sql/015_awcms_reporting_projections_schema.sql`                   |
+| 16  | `sql/016_awcms_reporting_permissions.sql`                          |
+| 17  | `sql/017_awcms_enforce_rls_force.sql`                              |
+| 18  | `sql/018_awcms_workflow_concurrency.sql`                           |
+| 19  | `sql/019_awcms_db_role_separation.sql`                             |
+| 20  | `sql/020_awcms_offices_tenant_scoped_fk.sql`                       |
+| 21  | `sql/021_awcms_db_role_grants_narrow.sql`                          |
+| 22  | `sql/022_awcms_db_worker_setup_roles.sql`                          |
+| 23  | `sql/023_awcms_seed_office_management_delete_permission.sql`       |
+| 24  | `sql/024_awcms_mfa_totp_schema.sql`                                |
+| 25  | `sql/025_awcms_oidc_sso_schema.sql`                                |
+| 26  | `sql/026_awcms_seed_sso_permissions.sql`                           |
+| 27  | `sql/027_awcms_business_scope_assignments_schema.sql`              |
+| 28  | `sql/028_awcms_business_scope_permissions.sql`                     |
+| 29  | `sql/029_awcms_sod_schema.sql`                                     |
+| 30  | `sql/030_awcms_sod_permissions.sql`                                |
+| 31  | `sql/031_awcms_abac_policy_dsl_schema.sql`                         |
+| 32  | `sql/032_awcms_abac_policy_admin_permissions.sql`                  |
+| 33  | `sql/033_awcms_theming_config_schema.sql`                          |
+| 34  | `sql/034_awcms_theming_permissions.sql`                            |
+| 35  | `sql/035_awcms_blog_content_schema.sql`                            |
+| 36  | `sql/036_awcms_blog_content_permissions.sql`                       |
+| 37  | `sql/037_awcms_blog_content_presentation_schema.sql`               |
+| 38  | `sql/038_awcms_blog_content_presentation_permissions.sql`          |
+| 39  | `sql/039_awcms_blog_content_internal_tag_links_schema.sql`         |
+| 40  | `sql/040_awcms_blog_content_internal_tag_links_permissions.sql`    |
+| 41  | `sql/041_awcms_news_media_object_registry_schema.sql`              |
+| 42  | `sql/042_awcms_news_media_permissions.sql`                         |
+| 43  | `sql/043_awcms_news_portal_tenant_state_schema.sql`                |
+| 44  | `sql/044_awcms_news_portal_homepage_sections_schema.sql`           |
+| 45  | `sql/045_awcms_news_portal_ad_placements_schema.sql`               |
+| 46  | `sql/046_awcms_tenant_domain_schema.sql`                           |
+| 47  | `sql/047_awcms_tenant_domain_permissions.sql`                      |
+| 48  | `sql/048_awcms_tenant_domain_lookup_function.sql`                  |
+| 49  | `sql/049_awcms_visitor_analytics_permissions.sql`                  |
+| 50  | `sql/050_awcms_visitor_analytics_schema.sql`                       |
+| 51  | `sql/051_awcms_visitor_analytics_session_lookup_index.sql`         |
+| 52  | `sql/052_awcms_media_library_permission_ownership.sql`             |
+| 53  | `sql/053_awcms_media_library_tenant_state_schema.sql`              |
+| 54  | `sql/054_awcms_media_library_enforcement_permissions.sql`          |
+| 55  | `sql/055_awcms_data_lifecycle_schema.sql`                          |
+| 56  | `sql/056_awcms_data_lifecycle_permissions.sql`                     |
+| 57  | `sql/057_awcms_seo_distribution_config_schema.sql`                 |
+| 58  | `sql/058_awcms_seo_distribution_config_permissions.sql`            |
+| 59  | `sql/059_awcms_seo_distribution_feed_config_schema.sql`            |
+| 60  | `sql/060_awcms_seo_distribution_redirect_schema.sql`               |
+| 61  | `sql/061_awcms_seo_distribution_redirect_permissions.sql`          |
+| 62  | `sql/062_awcms_form_drafts_schema.sql`                             |
+| 63  | `sql/063_awcms_form_drafts_permissions.sql`                        |
+| 64  | `sql/064_awcms_site_search_schema.sql`                             |
+| 65  | `sql/065_awcms_site_search_permissions.sql`                        |
+| 66  | `sql/066_awcms_comments_schema.sql`                                |
+| 67  | `sql/067_awcms_comments_permissions.sql`                           |
+| 68  | `sql/068_awcms_edge_cache_purge_queue.sql`                         |
+| 69  | `sql/069_awcms_tenant_domains_worker_read.sql`                     |
+| 70  | `sql/070_awcms_edge_cache_purges_tenant_guc_fix.sql`               |
+| 71  | `sql/071_awcms_sidebar_menu_schema.sql`                            |
+| 72  | `sql/072_awcms_sidebar_menu_permissions.sql`                       |
+| 73  | `sql/073_awcms_identity_password_reset_schema.sql`                 |
+| 74  | `sql/074_awcms_identity_self_registration_schema.sql`              |
+| 75  | `sql/075_awcms_identity_self_registration_permissions.sql`         |
+| 76  | `sql/076_awcms_blog_content_absorbs_news_portal_permissions.sql`   |
+| 77  | `sql/077_awcms_drop_inert_news_portal_tenant_state.sql`            |
+| 78  | `sql/078_awcms_ad_placement_targeting.sql`                         |
+| 79  | `sql/079_awcms_legacy_ad_ingest_provenance.sql`                    |
+| 80  | `sql/080_awcms_idn_admin_regions_schema.sql`                       |
+| 81  | `sql/081_awcms_idn_admin_regions_permissions.sql`                  |
+| 82  | `sql/082_awcms_identity_machine_credentials_schema.sql`            |
+| 83  | `sql/083_awcms_identity_machine_credentials_permissions.sql`       |
+| 84  | `sql/084_awcms_idn_admin_regions_revoke_lifecycle_permissions.sql` |
+| 85  | `sql/085_awcms_platform_scoped_permissions.sql`                    |
+| 86  | `sql/086_awcms_tenant_provisioning_permissions.sql`                |
+| 87  | `sql/087_awcms_media_library_revoke_attach_detach_permissions.sql` |
+| 88  | `sql/088_awcms_session_handoff_schema.sql`                         |
+| 89  | `sql/089_awcms_blog_content_revoke_seo_export_permissions.sql`     |
 
-1. **Fondasi** (dari basis `awcms-mini`): `tenant_admin`, `identity_access`, `profile_identity`, `logging`, `sync_storage`, `workflow`, `reporting`, `module_management`.
-2. **ERP — Finance**: general ledger, AP/AR, ekspor pajak/Coretax.
-3. **ERP — Inventory**: gudang, penyesuaian stok, transfer.
-4. **ERP — Procurement**: purchase request/order, manajemen vendor.
-5. **ERP — Manufacturing**: BOM, production order.
-6. **ERP — HR/Payroll**: employee, payroll run, absensi.
-7. **Integrasi**: payment gateway, marketplace, logistik, Coretax.
+### Tabel & Row-Level Security
 
-Modul baru wajib mengikuti struktur modular monolith yang sama dengan basis (`module.ts` + `domain/`/`application/`/`infrastructure/`/`api/`) dan didaftarkan di `src/modules/index.ts` supaya generator inventaris ini mendeteksinya otomatis.
+| Tabel                                    | Dibuat di                                                  | RLS   | FORCE |
+| ---------------------------------------- | ---------------------------------------------------------- | ----- | ----- |
+| `awcms_abac_decision_logs`               | `sql/005_awcms_abac_access_control_schema.sql`             | ya    | ya    |
+| `awcms_abac_policies`                    | `sql/005_awcms_abac_access_control_schema.sql`             | ya    | ya    |
+| `awcms_access_assignments`               | `sql/005_awcms_abac_access_control_schema.sql`             | ya    | ya    |
+| `awcms_audit_events`                     | `sql/007_awcms_audit_logging_schema.sql`                   | ya    | ya    |
+| `awcms_auth_providers`                   | `sql/025_awcms_oidc_sso_schema.sql`                        | ya    | ya    |
+| `awcms_bff_clients`                      | `sql/088_awcms_session_handoff_schema.sql`                 | ya    | ya    |
+| `awcms_blog_ad_placements`               | `sql/037_awcms_blog_content_presentation_schema.sql`       | ya    | ya    |
+| `awcms_blog_ads`                         | `sql/037_awcms_blog_content_presentation_schema.sql`       | ya    | ya    |
+| `awcms_blog_internal_tag_link_settings`  | `sql/039_awcms_blog_content_internal_tag_links_schema.sql` | ya    | ya    |
+| `awcms_blog_menu_items`                  | `sql/037_awcms_blog_content_presentation_schema.sql`       | ya    | ya    |
+| `awcms_blog_menus`                       | `sql/037_awcms_blog_content_presentation_schema.sql`       | ya    | ya    |
+| `awcms_blog_pages`                       | `sql/035_awcms_blog_content_schema.sql`                    | ya    | ya    |
+| `awcms_blog_post_terms`                  | `sql/035_awcms_blog_content_schema.sql`                    | ya    | ya    |
+| `awcms_blog_posts`                       | `sql/035_awcms_blog_content_schema.sql`                    | ya    | ya    |
+| `awcms_blog_redirects`                   | `sql/035_awcms_blog_content_schema.sql`                    | ya    | ya    |
+| `awcms_blog_revisions`                   | `sql/035_awcms_blog_content_schema.sql`                    | ya    | ya    |
+| `awcms_blog_settings`                    | `sql/035_awcms_blog_content_schema.sql`                    | ya    | ya    |
+| `awcms_blog_templates`                   | `sql/037_awcms_blog_content_presentation_schema.sql`       | ya    | ya    |
+| `awcms_blog_terms`                       | `sql/035_awcms_blog_content_schema.sql`                    | ya    | ya    |
+| `awcms_blog_theme_settings`              | `sql/037_awcms_blog_content_presentation_schema.sql`       | ya    | ya    |
+| `awcms_blog_widgets`                     | `sql/037_awcms_blog_content_presentation_schema.sql`       | ya    | ya    |
+| `awcms_business_scope_assignment_events` | `sql/027_awcms_business_scope_assignments_schema.sql`      | ya    | ya    |
+| `awcms_business_scope_assignments`       | `sql/027_awcms_business_scope_assignments_schema.sql`      | ya    | ya    |
+| `awcms_comments_abuse_events`            | `sql/066_awcms_comments_schema.sql`                        | ya    | ya    |
+| `awcms_comments_comments`                | `sql/066_awcms_comments_schema.sql`                        | ya    | ya    |
+| `awcms_comments_moderation_events`       | `sql/066_awcms_comments_schema.sql`                        | ya    | ya    |
+| `awcms_comments_reply_subscriptions`     | `sql/066_awcms_comments_schema.sql`                        | ya    | ya    |
+| `awcms_comments_reports`                 | `sql/066_awcms_comments_schema.sql`                        | ya    | ya    |
+| `awcms_comments_settings`                | `sql/066_awcms_comments_schema.sql`                        | ya    | ya    |
+| `awcms_comments_threads`                 | `sql/066_awcms_comments_schema.sql`                        | ya    | ya    |
+| `awcms_data_lifecycle_archive_manifests` | `sql/055_awcms_data_lifecycle_schema.sql`                  | ya    | ya    |
+| `awcms_data_lifecycle_cursors`           | `sql/055_awcms_data_lifecycle_schema.sql`                  | ya    | ya    |
+| `awcms_data_lifecycle_legal_holds`       | `sql/055_awcms_data_lifecycle_schema.sql`                  | ya    | ya    |
+| `awcms_data_lifecycle_runs`              | `sql/055_awcms_data_lifecycle_schema.sql`                  | ya    | ya    |
+| `awcms_domain_event_activity_daily`      | `sql/009_awcms_domain_event_runtime_schema.sql`            | ya    | ya    |
+| `awcms_domain_event_consumer_effects`    | `sql/009_awcms_domain_event_runtime_schema.sql`            | ya    | ya    |
+| `awcms_domain_event_consumer_state`      | `sql/009_awcms_domain_event_runtime_schema.sql`            | ya    | ya    |
+| `awcms_domain_event_deliveries`          | `sql/009_awcms_domain_event_runtime_schema.sql`            | ya    | ya    |
+| `awcms_domain_event_replays`             | `sql/009_awcms_domain_event_runtime_schema.sql`            | ya    | ya    |
+| `awcms_domain_events`                    | `sql/009_awcms_domain_event_runtime_schema.sql`            | ya    | ya    |
+| `awcms_edge_cache_purges`                | `sql/068_awcms_edge_cache_purge_queue.sql`                 | ya    | ya    |
+| `awcms_email_delivery_attempts`          | `sql/014_awcms_email_schema.sql`                           | ya    | ya    |
+| `awcms_email_messages`                   | `sql/014_awcms_email_schema.sql`                           | ya    | ya    |
+| `awcms_email_suppression_list`           | `sql/014_awcms_email_schema.sql`                           | ya    | ya    |
+| `awcms_email_templates`                  | `sql/014_awcms_email_schema.sql`                           | ya    | ya    |
+| `awcms_external_identities`              | `sql/025_awcms_oidc_sso_schema.sql`                        | ya    | ya    |
+| `awcms_form_drafts`                      | `sql/062_awcms_form_drafts_schema.sql`                     | ya    | ya    |
+| `awcms_idempotency_keys`                 | `sql/009_awcms_domain_event_runtime_schema.sql`            | ya    | ya    |
+| `awcms_identities`                       | `sql/004_awcms_identity_login_schema.sql`                  | ya    | ya    |
+| `awcms_identity_mfa_factors`             | `sql/024_awcms_mfa_totp_schema.sql`                        | ya    | ya    |
+| `awcms_identity_mfa_recovery_codes`      | `sql/024_awcms_mfa_totp_schema.sql`                        | ya    | ya    |
+| `awcms_idn_admin_regions`                | `sql/080_awcms_idn_admin_regions_schema.sql`               | tidak | tidak |
+| `awcms_idn_region_datasets`              | `sql/080_awcms_idn_admin_regions_schema.sql`               | tidak | tidak |
+| `awcms_machine_credentials`              | `sql/082_awcms_identity_machine_credentials_schema.sql`    | ya    | ya    |
+| `awcms_media_library_tenant_state`       | `sql/053_awcms_media_library_tenant_state_schema.sql`      | ya    | ya    |
+| `awcms_mfa_challenges`                   | `sql/024_awcms_mfa_totp_schema.sql`                        | ya    | ya    |
+| `awcms_module_dependencies`              | `sql/008_awcms_module_management_schema.sql`               | tidak | tidak |
+| `awcms_module_health_checks`             | `sql/008_awcms_module_management_schema.sql`               | tidak | tidak |
+| `awcms_module_jobs`                      | `sql/008_awcms_module_management_schema.sql`               | tidak | tidak |
+| `awcms_module_navigation`                | `sql/008_awcms_module_management_schema.sql`               | tidak | tidak |
+| `awcms_module_settings`                  | `sql/008_awcms_module_management_schema.sql`               | ya    | ya    |
+| `awcms_modules`                          | `sql/001_awcms_foundation_schema.sql`                      | tidak | tidak |
+| `awcms_news_media_objects`               | `sql/041_awcms_news_media_object_registry_schema.sql`      | ya    | ya    |
+| `awcms_news_portal_ad_placements`        | `sql/045_awcms_news_portal_ad_placements_schema.sql`       | ya    | ya    |
+| `awcms_news_portal_homepage_sections`    | `sql/044_awcms_news_portal_homepage_sections_schema.sql`   | ya    | ya    |
+| `awcms_object_sync_queue`                | `sql/012_awcms_object_sync_queue_schema.sql`               | ya    | ya    |
+| `awcms_offices`                          | `sql/002_awcms_tenant_office_schema.sql`                   | ya    | ya    |
+| `awcms_oidc_auth_requests`               | `sql/025_awcms_oidc_sso_schema.sql`                        | ya    | ya    |
+| `awcms_password_reset_tokens`            | `sql/073_awcms_identity_password_reset_schema.sql`         | ya    | ya    |
+| `awcms_permissions`                      | `sql/005_awcms_abac_access_control_schema.sql`             | tidak | tidak |
+| `awcms_profile_entity_links`             | `sql/003_awcms_central_profile_schema.sql`                 | ya    | ya    |
+| `awcms_profile_identifiers`              | `sql/003_awcms_central_profile_schema.sql`                 | ya    | ya    |
+| `awcms_profiles`                         | `sql/003_awcms_central_profile_schema.sql`                 | ya    | ya    |
+| `awcms_registration_requests`            | `sql/074_awcms_identity_self_registration_schema.sql`      | ya    | ya    |
+| `awcms_reporting_export_runs`            | `sql/015_awcms_reporting_projections_schema.sql`           | ya    | ya    |
+| `awcms_reporting_projection_cursors`     | `sql/015_awcms_reporting_projections_schema.sql`           | ya    | ya    |
+| `awcms_reporting_projection_metrics`     | `sql/015_awcms_reporting_projections_schema.sql`           | ya    | ya    |
+| `awcms_reporting_projection_state`       | `sql/015_awcms_reporting_projections_schema.sql`           | ya    | ya    |
+| `awcms_reporting_rebuild_runs`           | `sql/015_awcms_reporting_projections_schema.sql`           | ya    | ya    |
+| `awcms_reporting_reconciliation_runs`    | `sql/015_awcms_reporting_projections_schema.sql`           | ya    | ya    |
+| `awcms_reporting_scheduled_exports`      | `sql/015_awcms_reporting_projections_schema.sql`           | ya    | ya    |
+| `awcms_role_permissions`                 | `sql/005_awcms_abac_access_control_schema.sql`             | ya    | ya    |
+| `awcms_roles`                            | `sql/005_awcms_abac_access_control_schema.sql`             | ya    | ya    |
+| `awcms_schema_migrations`                | `sql/001_awcms_foundation_schema.sql`                      | tidak | tidak |
+| `awcms_seo_not_found_observations`       | `sql/060_awcms_seo_distribution_redirect_schema.sql`       | ya    | ya    |
+| `awcms_seo_redirect_settings`            | `sql/060_awcms_seo_distribution_redirect_schema.sql`       | ya    | ya    |
+| `awcms_seo_redirects`                    | `sql/060_awcms_seo_distribution_redirect_schema.sql`       | ya    | ya    |
+| `awcms_seo_tenant_settings`              | `sql/057_awcms_seo_distribution_config_schema.sql`         | ya    | ya    |
+| `awcms_session_handoff_codes`            | `sql/088_awcms_session_handoff_schema.sql`                 | ya    | ya    |
+| `awcms_sessions`                         | `sql/004_awcms_identity_login_schema.sql`                  | ya    | ya    |
+| `awcms_setup_state`                      | `sql/006_awcms_setup_wizard_schema.sql`                    | tidak | tidak |
+| `awcms_sidebar_menu_items`               | `sql/071_awcms_sidebar_menu_schema.sql`                    | ya    | ya    |
+| `awcms_sidebar_menu_types`               | `sql/071_awcms_sidebar_menu_schema.sql`                    | ya    | ya    |
+| `awcms_site_search_documents`            | `sql/064_awcms_site_search_schema.sql`                     | ya    | ya    |
+| `awcms_site_search_index_failures`       | `sql/064_awcms_site_search_schema.sql`                     | ya    | ya    |
+| `awcms_site_search_index_runs`           | `sql/064_awcms_site_search_schema.sql`                     | ya    | ya    |
+| `awcms_site_search_query_log`            | `sql/064_awcms_site_search_schema.sql`                     | ya    | ya    |
+| `awcms_site_search_settings`             | `sql/064_awcms_site_search_schema.sql`                     | ya    | ya    |
+| `awcms_sod_conflict_evaluations`         | `sql/029_awcms_sod_schema.sql`                             | ya    | ya    |
+| `awcms_sod_conflict_exceptions`          | `sql/029_awcms_sod_schema.sql`                             | ya    | ya    |
+| `awcms_sync_aggregate_versions`          | `sql/011_awcms_sync_storage_conflict_schema.sql`           | ya    | ya    |
+| `awcms_sync_conflicts`                   | `sql/011_awcms_sync_storage_conflict_schema.sql`           | ya    | ya    |
+| `awcms_sync_inbox`                       | `sql/010_awcms_sync_storage_outbox_inbox_schema.sql`       | ya    | ya    |
+| `awcms_sync_nodes`                       | `sql/010_awcms_sync_storage_outbox_inbox_schema.sql`       | ya    | ya    |
+| `awcms_sync_outbox`                      | `sql/010_awcms_sync_storage_outbox_inbox_schema.sql`       | ya    | ya    |
+| `awcms_sync_push_batches`                | `sql/010_awcms_sync_storage_outbox_inbox_schema.sql`       | ya    | ya    |
+| `awcms_tenant_auth_policies`             | `sql/025_awcms_oidc_sso_schema.sql`                        | ya    | ya    |
+| `awcms_tenant_domains`                   | `sql/046_awcms_tenant_domain_schema.sql`                   | ya    | ya    |
+| `awcms_tenant_mfa_policies`              | `sql/024_awcms_mfa_totp_schema.sql`                        | ya    | ya    |
+| `awcms_tenant_modules`                   | `sql/008_awcms_module_management_schema.sql`               | ya    | ya    |
+| `awcms_tenant_settings`                  | `sql/002_awcms_tenant_office_schema.sql`                   | ya    | ya    |
+| `awcms_tenant_users`                     | `sql/004_awcms_identity_login_schema.sql`                  | ya    | ya    |
+| `awcms_tenants`                          | `sql/002_awcms_tenant_office_schema.sql`                   | tidak | tidak |
+| `awcms_theming_config_versions`          | `sql/033_awcms_theming_config_schema.sql`                  | ya    | ya    |
+| `awcms_theming_preview_sessions`         | `sql/033_awcms_theming_config_schema.sql`                  | ya    | ya    |
+| `awcms_theming_tenant_state`             | `sql/033_awcms_theming_config_schema.sql`                  | ya    | ya    |
+| `awcms_visit_events`                     | `sql/050_awcms_visitor_analytics_schema.sql`               | ya    | ya    |
+| `awcms_visitor_daily_rollups`            | `sql/050_awcms_visitor_analytics_schema.sql`               | ya    | ya    |
+| `awcms_visitor_sessions`                 | `sql/050_awcms_visitor_analytics_schema.sql`               | ya    | ya    |
+| `awcms_workflow_decisions`               | `sql/013_awcms_workflow_approval_schema.sql`               | ya    | ya    |
+| `awcms_workflow_definitions`             | `sql/013_awcms_workflow_approval_schema.sql`               | ya    | ya    |
+| `awcms_workflow_delegations`             | `sql/013_awcms_workflow_approval_schema.sql`               | ya    | ya    |
+| `awcms_workflow_instances`               | `sql/013_awcms_workflow_approval_schema.sql`               | ya    | ya    |
+| `awcms_workflow_join_arrivals`           | `sql/013_awcms_workflow_approval_schema.sql`               | ya    | ya    |
+| `awcms_workflow_task_assignments`        | `sql/013_awcms_workflow_approval_schema.sql`               | ya    | ya    |
+| `awcms_workflow_tasks`                   | `sql/013_awcms_workflow_approval_schema.sql`               | ya    | ya    |
 
-## Migrasi
-
-Repo ini kini punya **45 berkas migrasi** di `sql/` (`001`–`045`). Konvensi penomoran: seluruh migrasi berurutan sekuensial mulai `001`. Reserved namespace `900+` untuk jalur aplikasi-turunan **sudah dicabut oleh ADR-0034** (keluarga AWCMS = template dipakai-langsung, tidak ada repo derivatif) — modul domain/website ditambahkan langsung ke `src/modules/` dan migrasinya melanjutkan penomoran sekuensial yang sama. Daftar file lengkap dibaca dari `sql/*.sql`; sumber kebenaran adalah filesystem `sql/`, bukan tabel statis di bawah.
-
-| #                     | File |
-| --------------------- | ---- |
-| _(lihat `sql/*.sql`)_ | —    |
-
-## Tabel & Row-Level Security
-
-Belum ada tabel. Begitu migrasi pertama diterapkan, standar wajib (`AGENTS.md` "PostgreSQL + RLS wajib") berlaku untuk setiap tabel tenant-scoped maupun entitas bisnis ERP (ledger, payroll, inventory, dst.): setiap tabel semacam itu wajib punya `ENABLE ROW LEVEL SECURITY` (dan `FORCE ROW LEVEL SECURITY` untuk peran aplikasi least-privilege — lihat [`deployment-profiles.md`](deployment-profiles.md) §Model dua-peran basis data) atau masuk daftar exempt yang direview eksplisit.
-
-**Kandidat allow-list exempt RLS** (pola yang sama seperti basis — hanya berlaku untuk tabel infra/registry global, bukan data bisnis):
-
-| Tabel (pola)              | Alasan                                                                               |
-| ------------------------- | ------------------------------------------------------------------------------------ |
-| `awcms_schema_migrations` | Ledger migrasi — infra bookkeeping, bukan data tenant.                               |
-| `awcms_tenants`           | Registry tenant itu sendiri — tabel root yang direferensikan `tenant_id` tabel lain. |
-| `awcms_permissions`       | Katalog permission — global, RLS-free.                                               |
-| `awcms_modules`           | Registry modul — katalog global yang sama untuk setiap tenant.                       |
-
-Tidak ada tabel bisnis ERP (jurnal, transaksi stok, payroll run, dst.) yang boleh masuk daftar exempt ini — seluruh tabel semacam itu wajib RLS+FORCE tanpa pengecualian.
-
-## Tests
-
-Belum ada test file di `tests/`. Struktur direktori target (mengikuti pola basis):
+### Tests
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 0          |
-| `e2e`         | 0          |
-| `integration` | 0          |
-| `modules`     | 0          |
-| `unit`        | 0          |
+| `(root)`      | 250        |
+| `e2e`         | 11         |
+| `integration` | 34         |
+| `unit`        | 1          |
 
-## Routes / Operations (ringkasan)
+### Routes
 
-Belum ada kontrak OpenAPI yang di-bundle (`bun run openapi:bundle`, menyusul). Route<->contract parity akan ditegakkan `bun run api:spec:check`'s route-parity check begitu diimplementasikan — dokumen ini hanya akan jadi ringkasan read-only, bukan enforcement terpisah.
+| Permukaan       | Berkas |
+| --------------- | ------ |
+| `/api/v1/**`    | 255    |
+| `/admin/**`     | 31     |
+| publik / anonim | 26     |
 
-## GitHub issue/label/milestone snapshot
+<!-- END GENERATED: repo-inventory -->
 
-Dilacak terpisah di `docs/awcms/github/` (menyusul) — di-refresh on-demand lewat `bun run github:snapshot:refresh` (panggilan `gh` API langsung, bukan bagian `bun run check`). Regenerasi sebelum setiap rilis/audit, bukan pada jadwal tetap.
+## Catatan non-generated
+
+- **Penomoran migrasi** sekuensial mulai `001`. Namespace `900+` untuk jalur
+  aplikasi-turunan **sudah dicabut** ([ADR-0034](../adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md)):
+  modul domain/website ditambahkan langsung ke `src/modules/` dan migrasinya
+  melanjutkan penomoran yang sama.
+- **Tabel RLS-free** di tabel di atas (kolom `RLS` = tidak) adalah tabel GLOBAL
+  by design — ledger migrasi, registry modul, katalog permission, registry
+  tenant, singleton setup state, dan dataset wilayah global. Daftar berikut
+  otoritatifnya ada di `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES`
+  (`scripts/security-readiness.ts`), yang juga menyatakan privilege mana yang
+  DILARANG dipegang `awcms_app` atas masing-masing. Tak ada tabel bisnis yang
+  boleh masuk ke sana.
+- **Snapshot GitHub** (issue/label/milestone) dilacak terpisah di
+  `docs/awcms/github/`, di-refresh on-demand — sengaja di luar `bun run check`.
 
 ## Lihat juga
 
-- `AGENTS.md` — aturan wajib RLS/RBAC-ABAC/idempotency/audit yang menentukan bentuk tabel/modul yang akan diinventarisasi dokumen ini.
-- [`01_canvas_induk.md`](01_canvas_induk.md) — peta modul dan tahapan pengembangan yang direncanakan.
-- [`deployment-profiles.md`](deployment-profiles.md) — model dua-peran basis data dan penegakan RLS yang berlaku untuk setiap tabel yang akan didaftar di sini.
+- [`../ARCHITECTURE.md`](../ARCHITECTURE.md) — penjelasan per-subsistem atas apa yang ada di kode.
+- [`../PROJECT_STATE.md`](../PROJECT_STATE.md) — state proyek + backlog (titik-lanjut).
+- [`deployment-profiles.md`](deployment-profiles.md) — model dua-peran basis data dan penegakan RLS.

--- a/package.json
+++ b/package.json
@@ -98,6 +98,8 @@
     "db:work-class:check": "bun scripts/work-class-registry-check.ts",
     "config:env:coverage:check": "bun scripts/env-contract-coverage-check.ts",
     "config:validate": "bun scripts/validate-env.ts",
+    "repo:inventory:generate": "bun scripts/repo-inventory.ts",
+    "repo:inventory:check": "bun scripts/repo-inventory.ts --check",
     "scripts:inventory:generate": "bun scripts/scripts-inventory.ts",
     "scripts:inventory:check": "bun scripts/scripts-inventory.ts --check",
     "security:readiness": "bun scripts/security-readiness.ts",
@@ -108,7 +110,7 @@
     "test:coverage": "bun test --coverage",
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run access:permissions:enforcement:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run repo:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run access:permissions:enforcement:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ lalu membangun duplikatnya.
 
 <!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-65 target menjalankan berkas di `scripts/`; 24 di antaranya
+67 target menjalankan berkas di `scripts/`; 25 di antaranya
 ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
 terjadwal, atau oleh workflow CI tertentu.
 
@@ -83,6 +83,8 @@ terjadwal, atau oleh workflow CI tertentu.
 | `openapi:bundle`                         | `openapi-bundle.ts`                            | —    |
 | `redis:health`                           | `redis-health.ts`                              | —    |
 | `release:verify`                         | `release-verify.ts`                            | —    |
+| `repo:inventory:check`                   | `repo-inventory.ts`                            | ✅   |
+| `repo:inventory:generate`                | `repo-inventory.ts`                            | —    |
 | `reporting:exports:dispatch`             | `reporting-exports-dispatch.ts`                | —    |
 | `reporting:projections:refresh`          | `reporting-projections-refresh.ts`             | —    |
 | `reporting:projections:registry:check`   | `reporting-projection-registry-check.ts`       | ✅   |
@@ -143,14 +145,13 @@ menjalankan target `modules:sync` — perintah yang tak pernah ada di repo ini
 (mekanisme sesungguhnya `POST /api/v1/modules/sync`) — sementara `bun run check`
 tetap hijau karena gate lamanya hanya membaca lima berkas markdown akar.
 
-| Target acuan                                    | Prasyarat yang belum ada                                                    |
-| ----------------------------------------------- | --------------------------------------------------------------------------- |
-| `repo:inventory:generate` / `:check`            | Generator inventaris repo lintas-artefak (OpenAPI + komposisi modul + docs) |
-| `config:docs:check`                             | Rekonsiliasi tiga-arah `.env.example` ↔ doc 18 ↔ `validate-env.ts`          |
-| `i18n:extract` / `:pot:check` / `:parity:check` | Setup i18n (`.po`/`.pot`) + UI                                              |
-| `database:capacity:check`                       | Validasi kapasitas lintas-instance (preflight)                              |
-| `production:preflight`, `resilience:dr-drill`   | Mengagregasi gate di atas + server berjalan                                 |
-| `performance:*`                                 | Harness beban + environment berukuran produksi                              |
+| Target acuan                                    | Prasyarat yang belum ada                                           |
+| ----------------------------------------------- | ------------------------------------------------------------------ |
+| `config:docs:check`                             | Rekonsiliasi tiga-arah `.env.example` ↔ doc 18 ↔ `validate-env.ts` |
+| `i18n:extract` / `:pot:check` / `:parity:check` | Setup i18n (`.po`/`.pot`) + UI                                     |
+| `database:capacity:check`                       | Validasi kapasitas lintas-instance (preflight)                     |
+| `production:preflight`, `resilience:dr-drill`   | Mengagregasi gate di atas + server berjalan                        |
+| `performance:*`                                 | Harness beban + environment berukuran produksi                     |
 
 Lihat peta sprint di
 [`docs/awcms/11_implementation_blueprint.md`](../docs/awcms/11_implementation_blueprint.md)

--- a/scripts/repo-inventory.ts
+++ b/scripts/repo-inventory.ts
@@ -1,0 +1,459 @@
+#!/usr/bin/env bun
+/**
+ * `docs/awcms/repo-inventory.md`'s inventory tables, derived from the repo.
+ *
+ * ## Why this exists, and why it is not the whole file
+ *
+ * The document it fills has been a placeholder since the base was created, and
+ * it aged the way placeholders do — while claiming, in a `> GENERATED FILE —
+ * jangan diedit manual` banner, to be something it was not. Its body said "Belum
+ * ada tabel" and "Belum ada test file" against 118 tables and 288 test files; it
+ * gave the migration count as 45 in one paragraph and 89 in another; and it
+ * listed 20 modules when the registry held 21. Three different numbers for
+ * things a single `ls` answers.
+ *
+ * So the derivable half is now derived and the prose half is not, exactly as
+ * `scripts-inventory.ts` does for `scripts/README.md`: everything between the
+ * markers is generated from the registry, `sql/`, `tests/` and `src/pages/`,
+ * and the surrounding prose stays human-owned.
+ *
+ * ## Why the check parses instead of comparing bytes
+ *
+ * Prettier owns markdown formatting here and pads table columns. A byte
+ * comparison would fail immediately after every `bun run lint`, so the check
+ * parses the block back into rows and compares CONTENT. Padding is not drift —
+ * the same reasoning `scripts-inventory.ts` records for itself.
+ *
+ * ## Why RLS state is parsed from the migrations, not read from a database
+ *
+ * This runs inside `bun run check`, which has no database. Reading `pg_class`
+ * would make the inventory unavailable exactly where it is most useful (CI, a
+ * fresh clone, a review). The parse is CUMULATIVE and order-sensitive because
+ * the migrations are: `sql/020` deliberately toggles `NO FORCE` on
+ * `awcms_offices` to run a data repair and turns it back on 40 lines later, so
+ * a parser that took the first or the last statement alone would report the
+ * opposite of the truth for that table. `security-readiness.ts` answers the
+ * same question against a live database and stays the authority for
+ * deployments; this one answers it for the repo.
+ *
+ * Two commands, one file: `bun run repo:inventory:generate` rewrites the block,
+ * `bun run repo:inventory:check` fails when it is stale.
+ */
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { listModules } from "../src/modules";
+import { routeOf } from "./validate-module-routes";
+
+const DOC_PATH = "docs/awcms/repo-inventory.md";
+const BEGIN = "<!-- BEGIN GENERATED: repo-inventory -->";
+const END = "<!-- END GENERATED: repo-inventory -->";
+
+const MIGRATIONS_DIR = "sql";
+const TESTS_DIR = "tests";
+const PAGES_DIR = "src/pages";
+const ADR_DIR = "docs/adr";
+
+// ---------------------------------------------------------------------------
+// Modules
+// ---------------------------------------------------------------------------
+
+export type ModuleRow = {
+  key: string;
+  version: string;
+  status: string;
+  /**
+   * `null` when the descriptor declares none. NOT defaulted to `"base"` here:
+   * `module-composition.ts` carries a missing `type` through as `null` too, and
+   * inventing a value would make this document assert a classification the
+   * registry never made.
+   */
+  type: string | null;
+  core: boolean;
+  dependencies: string[];
+};
+
+export function collectModuleRows(
+  modules: readonly {
+    key: string;
+    version: string;
+    status: string;
+    type?: string;
+    isCore?: boolean;
+    dependencies?: readonly string[];
+  }[]
+): ModuleRow[] {
+  return modules.map((module) => ({
+    key: module.key,
+    version: module.version,
+    status: module.status,
+    type: module.type ?? null,
+    core: module.isCore ?? false,
+    dependencies: [...(module.dependencies ?? [])]
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Migrations + tables/RLS
+// ---------------------------------------------------------------------------
+
+export type TableRlsState = {
+  table: string;
+  /** The migration file that created it — the answer to "where did this come from". */
+  createdIn: string;
+  rowLevelSecurity: boolean;
+  force: boolean;
+};
+
+const CREATE_TABLE =
+  /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-z0-9_."]+)/gi;
+const DROP_TABLE = /DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?([a-z0-9_."]+)/gi;
+const ALTER_RLS =
+  /ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?([a-z0-9_."]+)\s+(ENABLE|DISABLE|FORCE|NO\s+FORCE)\s+ROW\s+LEVEL\s+SECURITY/gi;
+
+function normalizeTableName(raw: string): string {
+  return raw
+    .replace(/"/g, "")
+    .replace(/^public\./, "")
+    .toLowerCase();
+}
+
+/**
+ * Strip `--` line comments and `/* … *​/` block comments before matching, so a
+ * commented-out `CREATE TABLE` in a migration header — this repo's migrations
+ * are heavily commented, several of them quoting the very DDL they replace —
+ * never lands in the inventory as a real table.
+ */
+export function stripSqlComments(sql: string): string {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/--[^\n]*/g, " ");
+}
+
+/**
+ * Fold every migration, in filename order, into the end-state of each
+ * `awcms_%` table. Order is load-bearing: a table may be created, have RLS
+ * enabled, have FORCE toggled off for a repair and back on, or be dropped
+ * outright — and only the last statement about it is true.
+ */
+export function deriveTableRlsStates(
+  files: readonly { name: string; sql: string }[]
+): TableRlsState[] {
+  const states = new Map<string, TableRlsState>();
+
+  for (const file of [...files].sort((a, b) => a.name.localeCompare(b.name))) {
+    const sql = stripSqlComments(file.sql);
+
+    for (const match of sql.matchAll(CREATE_TABLE)) {
+      const table = normalizeTableName(match[1]!);
+      if (!table.startsWith("awcms_") || states.has(table)) continue;
+      states.set(table, {
+        table,
+        createdIn: file.name,
+        rowLevelSecurity: false,
+        force: false
+      });
+    }
+
+    for (const match of sql.matchAll(ALTER_RLS)) {
+      const table = normalizeTableName(match[1]!);
+      const state = states.get(table);
+      if (!state) continue;
+
+      const verb = match[2]!.toUpperCase().replace(/\s+/g, " ");
+      if (verb === "ENABLE") state.rowLevelSecurity = true;
+      else if (verb === "DISABLE") state.rowLevelSecurity = false;
+      else if (verb === "FORCE") state.force = true;
+      else if (verb === "NO FORCE") state.force = false;
+    }
+
+    for (const match of sql.matchAll(DROP_TABLE)) {
+      states.delete(normalizeTableName(match[1]!));
+    }
+  }
+
+  return [...states.values()].sort((a, b) => a.table.localeCompare(b.table));
+}
+
+// ---------------------------------------------------------------------------
+// Tests + routes
+// ---------------------------------------------------------------------------
+
+export type CountRow = { label: string; count: number };
+
+function listFilesRecursive(dir: string): string[] {
+  const out: string[] = [];
+
+  const walk = (current: string): void => {
+    for (const entry of readdirSync(current, { withFileTypes: true })) {
+      const full = path.join(current, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else out.push(full);
+    }
+  };
+
+  walk(dir);
+  return out;
+}
+
+/**
+ * Test files per top-level directory under `tests/`. Only files that a test
+ * runner would actually pick up (`*.test.ts`, `*.e2e.ts`) count — fixtures and
+ * the harness are support code, and counting them would inflate the one number
+ * a reader uses to judge coverage breadth.
+ */
+export function collectTestCounts(files: readonly string[]): CountRow[] {
+  const counts = new Map<string, number>();
+
+  for (const file of files) {
+    if (!/\.(test|e2e)\.ts$/.test(file)) continue;
+    const relative = path.relative(TESTS_DIR, file);
+    const segments = relative.split(path.sep);
+    const label = segments.length > 1 ? segments[0]! : "(root)";
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+  }
+
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/**
+ * Route files under `src/pages`, grouped by the surface a reader cares about:
+ * the versioned API, the admin shell, and everything else (public/anonymous).
+ */
+export function collectRouteCounts(files: readonly string[]): CountRow[] {
+  let api = 0;
+  let admin = 0;
+  let publicRoutes = 0;
+
+  for (const file of files) {
+    if (!/\.(ts|astro)$/.test(file)) continue;
+    const route = routeOf(file.split(path.sep).join("/"));
+    if (route.startsWith("/api/")) api += 1;
+    else if (route.startsWith("/admin")) admin += 1;
+    else publicRoutes += 1;
+  }
+
+  return [
+    { label: "`/api/v1/**`", count: api },
+    { label: "`/admin/**`", count: admin },
+    { label: "publik / anonim", count: publicRoutes }
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Rendering + parsing
+// ---------------------------------------------------------------------------
+
+export type InventoryData = {
+  modules: ModuleRow[];
+  migrations: string[];
+  tables: TableRlsState[];
+  tests: CountRow[];
+  routes: CountRow[];
+  adrCount: number;
+};
+
+function renderSummary(data: InventoryData): string {
+  const forced = data.tables.filter((t) => t.force).length;
+  const rlsFree = data.tables.filter((t) => !t.rowLevelSecurity).length;
+  const testFiles = data.tests.reduce((sum, row) => sum + row.count, 0);
+  const routeFiles = data.routes.reduce((sum, row) => sum + row.count, 0);
+
+  return [
+    "| Aspek | Nilai |",
+    "| ----- | ----- |",
+    `| Modul terdaftar | ${data.modules.length} |`,
+    `| Migrasi | ${data.migrations.length} |`,
+    `| Tabel \`awcms_*\` | ${data.tables.length} |`,
+    `| Tabel dengan \`FORCE\` RLS | ${forced} |`,
+    `| Tabel RLS-free (global, by design) | ${rlsFree} |`,
+    `| Berkas test | ${testFiles} |`,
+    `| Berkas route | ${routeFiles} |`,
+    `| ADR | ${data.adrCount} |`
+  ].join("\n");
+}
+
+export function renderInventoryBlock(data: InventoryData): string {
+  const sections: string[] = [];
+
+  sections.push("### Ringkasan\n\n" + renderSummary(data));
+
+  sections.push(
+    "### Modul\n\n" +
+      [
+        "| Key | Version | Status | Type | Core | Dependencies |",
+        "| --- | ------- | ------ | ---- | ---- | ------------ |",
+        ...data.modules.map(
+          (module) =>
+            `| \`${module.key}\` | ${module.version} | ${module.status} | ${module.type ?? "—"} | ${module.core ? "ya" : "tidak"} | ${
+              module.dependencies.length > 0
+                ? module.dependencies.map((dep) => `\`${dep}\``).join(", ")
+                : "—"
+            } |`
+        )
+      ].join("\n")
+  );
+
+  sections.push(
+    "### Migrasi\n\n" +
+      [
+        "| # | File |",
+        "| - | ---- |",
+        ...data.migrations.map(
+          (file, index) => `| ${index + 1} | \`sql/${file}\` |`
+        )
+      ].join("\n")
+  );
+
+  sections.push(
+    "### Tabel & Row-Level Security\n\n" +
+      [
+        "| Tabel | Dibuat di | RLS | FORCE |",
+        "| ----- | --------- | --- | ----- |",
+        ...data.tables.map(
+          (table) =>
+            `| \`${table.table}\` | \`sql/${table.createdIn}\` | ${
+              table.rowLevelSecurity ? "ya" : "tidak"
+            } | ${table.force ? "ya" : "tidak"} |`
+        )
+      ].join("\n")
+  );
+
+  sections.push(
+    "### Tests\n\n" +
+      [
+        "| Direktori | Test files |",
+        "| --------- | ---------- |",
+        ...data.tests.map((row) => `| \`${row.label}\` | ${row.count} |`)
+      ].join("\n")
+  );
+
+  sections.push(
+    "### Routes\n\n" +
+      [
+        "| Permukaan | Berkas |",
+        "| --------- | ------ |",
+        ...data.routes.map((row) => `| ${row.label} | ${row.count} |`)
+      ].join("\n")
+  );
+
+  return sections.join("\n\n");
+}
+
+/**
+ * Parse a rendered block back into its rows — cell content only, padding and
+ * alignment discarded. Used by `--check`, which compares this against a fresh
+ * render of the same shape.
+ */
+export function parseInventoryRows(block: string): string[][] {
+  return block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("|"))
+    .filter((line) => !/^\|[\s\-|]+\|$/.test(line))
+    .map((line) =>
+      line
+        .slice(1, -1)
+        .split("|")
+        .map((cell) => cell.trim())
+    );
+}
+
+export function extractBlock(markdown: string): string | null {
+  const start = markdown.indexOf(BEGIN);
+  const end = markdown.indexOf(END);
+  if (start === -1 || end === -1 || end < start) return null;
+  return markdown.slice(start + BEGIN.length, end).trim();
+}
+
+export function replaceBlock(markdown: string, block: string): string {
+  const start = markdown.indexOf(BEGIN);
+  const end = markdown.indexOf(END);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(
+      `${DOC_PATH} is missing the "${BEGIN}" / "${END}" markers — the generated block has no home.`
+    );
+  }
+
+  return (
+    markdown.slice(0, start + BEGIN.length) +
+    "\n\n" +
+    block +
+    "\n\n" +
+    markdown.slice(end)
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Collection from disk
+// ---------------------------------------------------------------------------
+
+export function collectInventory(): InventoryData {
+  const migrationFiles = readdirSync(MIGRATIONS_DIR)
+    .filter((name) => name.endsWith(".sql"))
+    .sort((a, b) => a.localeCompare(b));
+
+  const tables = deriveTableRlsStates(
+    migrationFiles.map((name) => ({
+      name,
+      sql: readFileSync(path.join(MIGRATIONS_DIR, name), "utf8")
+    }))
+  );
+
+  const adrCount = readdirSync(ADR_DIR).filter(
+    (name) => /^\d{4}-/.test(name) && name.endsWith(".md")
+  ).length;
+
+  return {
+    modules: collectModuleRows(listModules()),
+    migrations: migrationFiles,
+    tables,
+    tests: collectTestCounts(listFilesRecursive(TESTS_DIR)),
+    routes: collectRouteCounts(listFilesRecursive(PAGES_DIR)),
+    adrCount
+  };
+}
+
+async function main(): Promise<void> {
+  const check = process.argv.includes("--check");
+  const markdown = readFileSync(DOC_PATH, "utf8");
+  const fresh = renderInventoryBlock(collectInventory());
+
+  if (!check) {
+    writeFileSync(DOC_PATH, replaceBlock(markdown, fresh), "utf8");
+    console.log(
+      `Diperbarui: ${DOC_PATH}. Jalankan \`bun run repo:inventory:check\` untuk verifikasi.`
+    );
+    return;
+  }
+
+  const current = extractBlock(markdown);
+
+  if (current === null) {
+    console.error(
+      `repo:inventory:check GAGAL — ${DOC_PATH} tidak memuat penanda blok ter-generate.`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const currentRows = JSON.stringify(parseInventoryRows(current));
+  const freshRows = JSON.stringify(parseInventoryRows(fresh));
+
+  if (currentRows === freshRows) {
+    console.log(
+      "repo:inventory:check OK — inventaris modul/migrasi/tabel-RLS/test/route sinkron dengan repo."
+    );
+    return;
+  }
+
+  console.error(
+    `repo:inventory:check GAGAL — ${DOC_PATH} basi terhadap repo. ` +
+      "Jalankan `bun run repo:inventory:generate` lalu `bun run format`."
+  );
+  process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -459,7 +459,7 @@ export function checkLoginLockoutImplemented(): SecurityCheckResult {
  * deliberate edit here, with a reason — the correct place to force that
  * conversation.
  */
-const GLOBAL_TABLE_FORBIDDEN_PRIVILEGES: Record<string, string[]> = {
+export const GLOBAL_TABLE_FORBIDDEN_PRIVILEGES: Record<string, string[]> = {
   // Module registry (sql/008) — global, code-derived, full DML kept by design.
   awcms_modules: [],
   awcms_module_dependencies: [],

--- a/tests/repo-inventory.test.ts
+++ b/tests/repo-inventory.test.ts
@@ -1,0 +1,277 @@
+/**
+ * `bun run repo:inventory:generate|:check` — the derivation, not the file.
+ *
+ * The RLS parse gets the most attention here because it is the one thing in
+ * this generator that can be confidently wrong: the migrations toggle FORCE off
+ * and back on within a single file (`sql/020`), create tables in one and drop
+ * them in another (`sql/077`), and quote DDL inside comments. A parser that
+ * took the first or the last statement about a table, or that read commented
+ * DDL, would produce an inventory that looks authoritative and says the
+ * opposite of the truth — which is precisely the failure mode this document
+ * spent months in.
+ *
+ * The last test is a CROSS-ARTEFACT check rather than a self-check: the set of
+ * tables this generator derives as RLS-free must equal the set a human declared
+ * in `security-readiness.ts`. One side is derived from the migrations, the
+ * other is hand-maintained with a reason per entry, so a disagreement means
+ * either a new global table shipped without its privilege declaration or a
+ * tenant table shipped without RLS.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectModuleRows,
+  collectRouteCounts,
+  collectTestCounts,
+  deriveTableRlsStates,
+  extractBlock,
+  parseInventoryRows,
+  renderInventoryBlock,
+  replaceBlock,
+  stripSqlComments,
+  type InventoryData
+} from "../scripts/repo-inventory";
+import { GLOBAL_TABLE_FORBIDDEN_PRIVILEGES } from "../scripts/security-readiness";
+import { collectInventory } from "../scripts/repo-inventory";
+
+describe("deriveTableRlsStates", () => {
+  test("folds ENABLE then FORCE into the end state", () => {
+    const states = deriveTableRlsStates([
+      {
+        name: "001_a.sql",
+        sql: `CREATE TABLE awcms_widgets (id uuid);
+              ALTER TABLE awcms_widgets ENABLE ROW LEVEL SECURITY;`
+      },
+      {
+        name: "002_b.sql",
+        sql: `ALTER TABLE awcms_widgets FORCE ROW LEVEL SECURITY;`
+      }
+    ]);
+
+    expect(states).toEqual([
+      {
+        table: "awcms_widgets",
+        createdIn: "001_a.sql",
+        rowLevelSecurity: true,
+        force: true
+      }
+    ]);
+  });
+
+  test("a FORCE toggled off for a repair and back on ends FORCED (the sql/020 shape)", () => {
+    const states = deriveTableRlsStates([
+      {
+        name: "001_a.sql",
+        sql: `CREATE TABLE awcms_offices (id uuid);
+              ALTER TABLE awcms_offices ENABLE ROW LEVEL SECURITY;
+              ALTER TABLE awcms_offices FORCE ROW LEVEL SECURITY;`
+      },
+      {
+        name: "020_repair.sql",
+        sql: `ALTER TABLE awcms_offices NO FORCE ROW LEVEL SECURITY;
+              UPDATE awcms_offices SET parent_office_id = NULL;
+              ALTER TABLE awcms_offices FORCE ROW LEVEL SECURITY;`
+      }
+    ]);
+
+    expect(states[0]!.force).toBe(true);
+  });
+
+  test("a FORCE dropped and never restored ends UNFORCED — the answer that matters", () => {
+    const states = deriveTableRlsStates([
+      {
+        name: "001_a.sql",
+        sql: `CREATE TABLE awcms_offices (id uuid);
+              ALTER TABLE awcms_offices ENABLE ROW LEVEL SECURITY;
+              ALTER TABLE awcms_offices FORCE ROW LEVEL SECURITY;`
+      },
+      {
+        name: "020_repair.sql",
+        sql: `ALTER TABLE awcms_offices NO FORCE ROW LEVEL SECURITY;`
+      }
+    ]);
+
+    expect(states[0]!.force).toBe(false);
+  });
+
+  test("a dropped table leaves the inventory", () => {
+    const states = deriveTableRlsStates([
+      { name: "001_a.sql", sql: `CREATE TABLE awcms_gone (id uuid);` },
+      { name: "077_drop.sql", sql: `DROP TABLE IF EXISTS awcms_gone;` }
+    ]);
+
+    expect(states).toEqual([]);
+  });
+
+  test("DDL inside comments is not a table", () => {
+    const states = deriveTableRlsStates([
+      {
+        name: "001_a.sql",
+        sql: `-- CREATE TABLE awcms_commented (id uuid);
+              /* CREATE TABLE awcms_blocked (id uuid); */
+              CREATE TABLE awcms_real (id uuid);`
+      }
+    ]);
+
+    expect(states.map((state) => state.table)).toEqual(["awcms_real"]);
+  });
+
+  test("non-awcms tables are out of scope", () => {
+    const states = deriveTableRlsStates([
+      { name: "001_a.sql", sql: `CREATE TABLE other_thing (id uuid);` }
+    ]);
+
+    expect(states).toEqual([]);
+  });
+
+  test("the creating migration is the FIRST one, not the last that mentions it", () => {
+    const states = deriveTableRlsStates([
+      { name: "001_a.sql", sql: `CREATE TABLE awcms_x (id uuid);` },
+      {
+        name: "050_b.sql",
+        sql: `CREATE TABLE IF NOT EXISTS awcms_x (id uuid);`
+      }
+    ]);
+
+    expect(states[0]!.createdIn).toBe("001_a.sql");
+  });
+});
+
+describe("stripSqlComments", () => {
+  test("removes line and block comments, keeps statements", () => {
+    expect(
+      stripSqlComments("SELECT 1; -- note\n/* block */ SELECT 2;")
+    ).toContain("SELECT 2;");
+    expect(
+      stripSqlComments("SELECT 1; -- note\n/* block */ SELECT 2;")
+    ).not.toContain("note");
+  });
+});
+
+describe("collectModuleRows", () => {
+  test("a descriptor without `type` reports none rather than inventing one", () => {
+    const rows = collectModuleRows([
+      { key: "a", version: "1.0.0", status: "active", dependencies: ["b"] },
+      {
+        key: "b",
+        version: "2.0.0",
+        status: "active",
+        type: "domain",
+        isCore: true
+      }
+    ]);
+
+    expect(rows[0]).toEqual({
+      key: "a",
+      version: "1.0.0",
+      status: "active",
+      type: null,
+      core: false,
+      dependencies: ["b"]
+    });
+    expect(rows[1]!.type).toBe("domain");
+    expect(rows[1]!.core).toBe(true);
+  });
+});
+
+describe("collectTestCounts / collectRouteCounts", () => {
+  test("counts only real test files, grouped by top-level directory", () => {
+    const counts = collectTestCounts([
+      "tests/foo.test.ts",
+      "tests/integration/bar.integration.test.ts",
+      "tests/e2e/baz.e2e.ts",
+      "tests/integration/harness.ts",
+      "tests/fixtures/example/module.ts"
+    ]);
+
+    expect(counts).toEqual([
+      { label: "(root)", count: 1 },
+      { label: "e2e", count: 1 },
+      { label: "integration", count: 1 }
+    ]);
+  });
+
+  test("splits routes into api, admin and public surfaces", () => {
+    const counts = collectRouteCounts([
+      "src/pages/api/v1/health.ts",
+      "src/pages/admin/index.astro",
+      "src/pages/news/[slug].ts",
+      "src/pages/robots.txt.ts"
+    ]);
+
+    expect(counts).toEqual([
+      { label: "`/api/v1/**`", count: 1 },
+      { label: "`/admin/**`", count: 1 },
+      { label: "publik / anonim", count: 2 }
+    ]);
+  });
+});
+
+describe("render/parse round trip", () => {
+  const data: InventoryData = {
+    modules: [
+      {
+        key: "a",
+        version: "1.0.0",
+        status: "active",
+        type: null,
+        core: false,
+        dependencies: []
+      }
+    ],
+    migrations: ["001_a.sql"],
+    tables: [
+      {
+        table: "awcms_a",
+        createdIn: "001_a.sql",
+        rowLevelSecurity: true,
+        force: true
+      }
+    ],
+    tests: [{ label: "(root)", count: 1 }],
+    routes: [{ label: "`/api/v1/**`", count: 1 }],
+    adrCount: 61
+  };
+
+  test("the check compares CONTENT, so prettier's column padding is not drift", () => {
+    const rendered = renderInventoryBlock(data);
+    const padded = rendered
+      .split("\n")
+      .map((line) =>
+        line.startsWith("|") ? line.replace(/\| /g, "|      ") : line
+      )
+      .join("\n");
+
+    expect(parseInventoryRows(padded)).toEqual(parseInventoryRows(rendered));
+  });
+
+  test("replaceBlock round-trips through extractBlock", () => {
+    const doc =
+      "# Title\n\n<!-- BEGIN GENERATED: repo-inventory -->\n\nold\n\n<!-- END GENERATED: repo-inventory -->\n\ntail\n";
+    const updated = replaceBlock(doc, renderInventoryBlock(data));
+
+    expect(extractBlock(updated)).toBe(renderInventoryBlock(data));
+    expect(updated).toContain("# Title");
+    expect(updated).toContain("tail");
+  });
+
+  test("replaceBlock refuses a document with no markers rather than appending", () => {
+    expect(() => replaceBlock("# no markers\n", "x")).toThrow(/markers/);
+  });
+});
+
+describe("cross-artefact: derived RLS-free set == declared global tables", () => {
+  test("every table this inventory derives as RLS-free is a declared global table, and vice versa", () => {
+    const derived = collectInventory()
+      .tables.filter((table) => !table.rowLevelSecurity)
+      .map((table) => table.table)
+      .sort();
+
+    const declared = Object.keys(GLOBAL_TABLE_FORBIDDEN_PRIVILEGES).sort();
+
+    // A table on ONE side only is a real defect in one of two directions: a new
+    // global table that shipped without declaring which privileges `awcms_app`
+    // must not hold on it, or a tenant-scoped table that shipped without RLS.
+    expect(derived).toEqual(declared);
+  });
+});


### PR DESCRIPTION
Closes the `repo:inventory` generator item in `docs/PROJECT_STATE.md` §4 — built here rather than ported, per ADR-0055.

## The document was lying, with a banner on top saying it couldn't

`docs/awcms/repo-inventory.md` has carried **"GENERATED FILE — jangan diedit manual"** since the base was created, while no generator existed. What it actually said:

| Claim in the file | Reality |
| --- | --- |
| "Belum ada tabel" | 126 `awcms_*` tables |
| "Belum ada test file di `tests/`" | 296 test files |
| "**45** berkas migrasi" (§Migrasi) | 89 — and its own header paragraph said **89** |
| 20 modules listed | 21 in the registry |

A negative claim is the dangerous kind: "X does not exist yet" gets more wrong with time and never fails on its own, unlike a positive claim that breaks the moment the code moves. The same lesson `scripts-inventory.ts` recorded when it replaced a hand-written table that listed fifteen already-shipped tools as "not yet ported".

## What lands

`scripts/repo-inventory.ts`, two modes — `bun run repo:inventory:generate` rewrites the marked block, `bun run repo:inventory:check` (now in the `check` chain) fails when it is stale. Prose outside the markers stays human-owned.

Generated: a summary table, the module registry (key/version/status/type/core/deps), every migration, every `awcms_*` table with its creating migration and its RLS/FORCE state, test files per directory, and route files per surface.

Three decisions worth reviewing:

- **The check parses rows, it does not compare bytes.** Prettier pads markdown table columns, so a byte comparison would fail after every `bun run lint` and the two would fight forever. Padding is not drift.
- **RLS is parsed from the migrations, not read from a database** — the check runs in CI with no database, and an inventory unavailable in review is an inventory nobody reads. The parse is **cumulative and order-sensitive** because the migrations are: `sql/020` toggles `NO FORCE` on `awcms_offices` to run a data repair and restores it 40 lines later, so a parser reading the first *or* the last statement alone reports the opposite of the truth for that table. `security-readiness.ts` (live `pg_class`) stays the authority for a deployment.
- **A missing `type` renders `—`, not `base`.** `module-composition.ts` carries a missing type through as `null`; inventing a value would make this document assert a classification the registry never made.

## The test with teeth

Beyond the parser unit tests, one **cross-artefact** assertion: the RLS-free set this generator derives must equal the keys of `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES` in `security-readiness.ts`. One side is derived from the migrations, the other is hand-maintained with a reason per entry — so a disagreement means either a new global table shipped without declaring which privileges `awcms_app` must not hold on it, or a tenant-scoped table shipped without RLS. Today both sides are the same eleven, which is also the independent confirmation that the parser is right about 126 tables.

## Verification

- `bun run check` full — green. The new gate proved itself mid-PR: adding `tests/repo-inventory.test.ts` changed the test count and `repo:inventory:check` went red until the doc was regenerated.
- Parser mutation-proven: dropping `NO FORCE` handling and dropping `DROP TABLE` handling each turn their test red (confirmed, then restored).
- `scripts/README.md`'s "not yet available" table no longer lists `repo:inventory:*`, and `13_final_master_index_traceability.md` no longer says the script does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)