### PR TITLE
feat(edge-cache): root discovery surfaces are cacheable (ADR-0061 §B)

### DIFF
--- a/.changeset/edge-cache-discovery-surfaces.md
+++ b/.changeset/edge-cache-discovery-surfaces.md
@@ -1,0 +1,37 @@
+---
+"awcms": minor
+---
+
+The root discovery surfaces are edge-cacheable, and aggregate surfaces are now
+invalidated by the modules that author them (ADR-0061 §B).
+
+`serveDiscovery` accepts Astro's `locals` and publishes the resolved tenant after
+`build(ctx)` produces a payload; all six routes (`/robots.txt`, `/sitemap.xml`,
+`/sitemap-{n}.xml`, `/feed.xml`, `/atom.xml`, `/feed.json`) forward it. Three
+registry entries follow: `seo-robots` (600s, config-derived and the most stable),
+`seo-sitemap` (300s, index and child pages), `seo-feed` (300s, RSS/Atom/JSON with
+`?locale=` as the only permitted parameter).
+
+Publishing after the payload check matters here even more than it did for
+`/news/**`: `build` returns `null` for "sitemaps disabled", "feeds disabled" and
+"page out of range", all of which collapse into the same generic 404 as an
+unknown host. It also means `/sitemap-99999.xml` matches the surface but never
+publishes a tenant, so walking page numbers cannot fill the cache.
+
+Discovery bodies turn out to have two authors, and only one of them owned the
+surface. `PUT /api/v1/seo/config` now enqueues a purge — the tenant-wide
+`noindex` switch alone rewrites `/robots.txt`. But the bodies are aggregated from
+every `seo_facts` provider, so publishing a post changes `/sitemap.xml` without
+touching anything `seo_distribution` writes, and a module purge tags
+`t:<tenant>:m:<moduleKey>`, so `blog_content`'s purge could not reach it. Left
+alone that would have purged `/blog/{code}/feed.xml` on publish while `/feed.xml`
+— the same content — sat stale until TTL, with nothing reporting it.
+
+`enqueueModuleContentPurge` therefore also covers modules that declare a
+`consumes` dependency on the changing module and own a declared surface. It is
+read from the module registry, so `blog_content` never names `seo_distribution`;
+and it is limited to surface owners, because a ban on a key that tags no cached
+object matches nothing while the queue reports success.
+
+No migration, no permission, no OpenAPI change. With `EDGE_CACHE_MODE` unset the
+subsystem remains a no-op.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -720,10 +720,25 @@ NULL`, jadi pencarian publik untuk page **selalu** nol baris — di atas index
   `/blog/{tenantCode}/**` (bentuk warisan) dan **tidak menyentuh** satu pun
   permukaan host-resolved.
 
-  **§A SELESAI** — keluarga `/news/**` (3 entri registry, dimiliki `blog_content`
-  yang purge modulnya sudah terpasang). **§B BELUM** — enam rute discovery root;
-  butuh `locals` mengalir lewat `serveDiscovery` + call site purge
-  `seo_distribution`.
+  **SELESAI SELURUHNYA.** §A — keluarga `/news/**` (3 entri, dimiliki
+  `blog_content`). §B — enam rute discovery root (`seo-robots`/`seo-sitemap`/
+  `seo-feed`); `serveDiscovery` menerima `locals` dan mempublikasikan setelah
+  `build(ctx)` memberi payload, sehingga `/sitemap-99999.xml` cocok pola tapi tak
+  pernah menerbitkan tenant — menyusuri nomor halaman tak bisa mengisi cache.
+
+  **Temuan §B yang berlaku untuk setiap surface agregat berikutnya: badan
+  discovery punya DUA penulis.** Konfigurasinya milik `seo_distribution`
+  (`PUT /api/v1/seo/config` kini mem-purge), tetapi ISI-nya diagregasi dari setiap
+  penyedia `seo_facts` — menerbitkan post mengubah `/sitemap.xml` tanpa menyentuh
+  satu baris pun milik `seo_distribution`, dan purge modul menandai
+  `t:<tenant>:m:<moduleKey>` sehingga purge `blog_content` tak menjangkaunya.
+  Tanpa perbaikan: `/blog/{code}/feed.xml` ter-purge saat publish sementara
+  `/feed.xml` — konten sama, ejaan host-resolved — basi sampai TTL, tanpa satu
+  pun laporan. `enqueueModuleContentPurge` kini juga mem-purge modul yang
+  `consumes` modul yang berubah DAN memiliki surface: dibaca dari REGISTRY (jadi
+  `blog_content` tak pernah menyebut `seo_distribution`) dan dibatasi ke pemilik
+  surface (ban untuk key yang tak menandai objek apa pun = upacara yang terlihat
+  seperti cakupan, aturan yang sama yang sudah dipakai untuk `media_library`).
 
   > **Dua jebakan yang tak terbaca dari kode, keduanya kini ditegakkan test.**
   > (1) Prasyarat "VCL mem-hash `Host`" itu **dua** properti: `hash_data(req.http.host)`

--- a/docs/adr/0061-host-resolved-public-surfaces-are-edge-cacheable.md
+++ b/docs/adr/0061-host-resolved-public-surfaces-are-edge-cacheable.md
@@ -138,15 +138,55 @@ sebagai kontrak yang dijaga test — bukan sebagai konvensi.
    `/news/../admin` — pola host-resolved satu segmen lebih pendek daripada
    pasangan path-scoped-nya, jadi probe `/blog` tidak menurunkannya.
 
-### §B — Rute discovery root (menyusul)
+### §B — Rute discovery root (SELESAI)
 
-Alirkan `locals` melalui `serveDiscovery` dan enam pemanggilnya, publikasikan
-dari konteks yang sudah ter-resolusi di dalamnya, tambahkan entri registry, dan
-beri `seo_distribution` call site purge yang `findOwnersWithoutPurges` akan
-menuntutnya begitu ia memiliki surface — kandidat call site-nya
-`PUT /api/v1/seo/config` dan mutasi redirect, karena keduanyalah yang mengubah
-badan `robots.txt`/sitemap. Dikerjakan terpisah supaya §A tidak menunggu
-perubahan tanda tangan lintas tujuh berkas.
+`serveDiscovery` menerima `locals` opsional dan mempublikasikan **setelah**
+`build(ctx)` mengembalikan payload; keenam rutenya meneruskan `locals`. Aturan
+waktu §3 berlaku identik di sini dan cabang `null`-nya bahkan LEBIH banyak —
+`build` mengembalikan `null` untuk "sitemap dimatikan", "feed dimatikan", dan
+"halaman di luar jangkauan", ketiganya runtuh ke 404 generik yang sama dengan
+host tak dikenal. Efek sampingnya menyenangkan: `/sitemap-99999.xml` cocok
+dengan pola surface tetapi tak pernah menerbitkan tenant, jadi berjalan menyusuri
+nomor halaman tak bisa dipakai mengisi cache.
+
+Tiga entri: `seo-robots` (600s — berbasis konfigurasi, paling stabil),
+`seo-sitemap` (300s, mencakup indeks DAN anak `-{n}`), `seo-feed` (300s, satu
+pola untuk RSS/Atom/JSON, `?locale=` satu-satunya query yang diizinkan dan sudah
+divalidasi `parseDiscoveryLocaleParam`). Probe never-cacheable ikut menegakkan
+bahwa pola anak-sitemap menolak bentuk yang `Number()` justru terima
+(`1e3`/`0x10`/`-abc`) — daftar yang sama dengan yang ditolak berkas rutenya.
+
+#### Temuan §B: badan discovery punya DUA penulis
+
+`PUT /api/v1/seo/config` mendapat call site purge — `findOwnersWithoutPurges`
+menuntutnya begitu modul memiliki surface, dan saklar `noindex` tenant-wide saja
+sudah menulis ulang `/robots.txt`. Tapi itu **hanya separuh** pemicunya.
+
+Badan sitemap dan feed diagregasi dari setiap penyedia `seo_facts`, jadi
+**menerbitkan sebuah post mengubahnya tanpa menyentuh satu baris pun yang ditulis
+`seo_distribution`.** Karena purge modul menandai `t:<tenant>:m:<moduleKey>`,
+purge publish milik `blog_content` tak bisa menjangkau objek bertanda
+`m:seo_distribution`. Yang tersisa akan berupa asimetri yang tak dilaporkan
+apa pun: `/blog/{code}/feed.xml` ter-purge saat publish, sementara `/feed.xml` —
+konten yang sama, ejaan host-resolved — basi sampai TTL.
+
+`enqueueModuleContentPurge` karena itu **juga** mem-purge modul yang
+mendeklarasikan `consumes` terhadap modul yang berubah **dan** memiliki surface
+terdeklarasi. Kedua syarat itu penting:
+
+- **Dibaca dari registry, bukan di-hardcode.** `blog_content` tidak pernah
+  menyebut `seo_distribution` di mana pun; deklarasi `capabilities.consumes`
+  milik konsumennya sendiri yang menjadi kabelnya. Penyedia `seo_facts`
+  berikutnya mewarisi ini, dan konsumen `blog_content` berikutnya tercakup pada
+  hari ia mendeklarasikan diri.
+- **Hanya konsumen yang memiliki surface.** Ban untuk module key yang tak
+  menandai objek ter-cache mana pun tidak cocok dengan apa pun sementara antrean
+  melaporkan sukses — persis "upacara yang terlihat seperti cakupan" yang
+  gerbang kepemilikan sudah tolak untuk `media_library`. Kewajibannya muncul
+  sendiri saat konsumen mendeklarasikan surface pertamanya.
+
+Keduanya tetap SATU statement enqueue, jadi purge commit atomik bersama
+perubahan kontennya.
 
 ## Konsekuensi
 

--- a/docs/awcms/edge-cache-architecture.md
+++ b/docs/awcms/edge-cache-architecture.md
@@ -151,16 +151,25 @@ atas `default.vcl`.
   `bun run edge-cache:surfaces:check` menuntut emisi purge dari **setiap modul
   yang memiliki surface**, dan gagal bila salah satu tidak punya.
 
-- **Surface discovery ber-resolusi-host** (`/robots.txt`, `/sitemap.xml`,
-  `/feed.xml`, `/atom.xml`, `/feed.json`). Kandidat terbaik, tetapi
-  `serveDiscovery(request, …)` tidak menerima `locals` sehingga rute tak bisa
-  mempublikasikan tenant-nya. Menyambungkannya
-  ([ADR-0061](../adr/0061-host-resolved-public-surfaces-are-edge-cacheable.md) §B):
-  alirkan `locals` melalui `serveDiscovery` + enam pemanggilnya, set
-  `edgeCacheTenantId`, tambahkan entri registry, DAN beri `seo_distribution` call
-  site purge — begitu ia memiliki surface, `findOwnersWithoutPurges` menuntutnya
-  (kandidat: `PUT /api/v1/seo/config` + mutasi redirect, karena keduanyalah yang
-  mengubah badan `robots.txt`/sitemap).
+- ~~**Surface discovery ber-resolusi-host**~~ **SUDAH** (ADR-0061 §B). Tiga entri
+  — `seo-robots` (600s), `seo-sitemap` (300s, indeks + anak `-{n}`), `seo-feed`
+  (300s, RSS/Atom/JSON, `?locale=` satu-satunya query). `serveDiscovery` menerima
+  `locals` opsional dan mempublikasikan tenant SETELAH `build(ctx)` memberi
+  payload; keenam rutenya meneruskan `locals`.
+
+  **Yang ditemukan saat menyambungkannya, dan ini berlaku untuk setiap surface
+  agregat berikutnya: badan discovery punya DUA penulis.** Konfigurasinya milik
+  `seo_distribution` (`PUT /api/v1/seo/config` kini mem-purge), tetapi ISI-nya
+  diagregasi dari setiap penyedia `seo_facts` — jadi menerbitkan sebuah post
+  mengubah `/sitemap.xml` tanpa menyentuh satu baris pun milik
+  `seo_distribution`. Karena purge modul menandai `t:<tenant>:m:<moduleKey>`,
+  purge `blog_content` tak menjangkaunya, dan hasilnya akan berupa asimetri yang
+  tak dilaporkan apa pun: `/blog/{code}/feed.xml` ter-purge saat publish,
+  `/feed.xml` basi sampai TTL. `enqueueModuleContentPurge` kini juga mem-purge
+  modul yang mendeklarasikan `consumes` terhadap modul yang berubah DAN memiliki
+  surface — dibaca dari registry (jadi `blog_content` tak pernah menyebut
+  `seo_distribution`), dan dibatasi ke pemilik surface (ban untuk key yang tak
+  menandai apa pun = upacara yang terlihat seperti cakupan).
 
 - ~~**Keluarga konten host-resolved `/news/**`**~~ **SUDAH** (ADR-0061 §A).
   Tiga entri — `news-index`/`news-taxonomy`/`news-post` — mencerminkan TTL dan

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 297   |
+| Berkas test                        | 298   |
 | Berkas route                       | 312   |
 | ADR                                | 62    |
 
@@ -271,7 +271,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 251        |
+| `(root)`      | 252        |
 | `e2e`         | 11         |
 | `integration` | 34         |
 | `unit`        | 1          |

--- a/scripts/edge-cache-surfaces-check.ts
+++ b/scripts/edge-cache-surfaces-check.ts
@@ -136,6 +136,19 @@ export const MUST_NEVER_MATCH = [
   "/news/category/..",
   "/news/tag/%2e%2e",
   "/news/search",
+  // Root discovery (ADR-0061 §B). The child-sitemap pattern is the only one in
+  // this registry with a numeric segment, and `/sitemap-{page}.xml.ts` documents
+  // that a bare `Number()` would accept `1e3`/`0x10`/` 5 ` — so the SURFACE is
+  // probed for the same shapes the route rejects. A pattern that accepted them
+  // would hand a stranger an unbounded set of cache keys under one surface.
+  "/sitemap-abc.xml",
+  "/sitemap-1e3.xml",
+  "/sitemap-0x10.xml",
+  "/sitemap-.xml",
+  "/sitemap-1.xml.bak",
+  "/feed.rss",
+  "/robots.txt.bak",
+  "/api/v1/seo/config",
   "/theming/preview/abc123",
   "/theming/preview-tokens/abc123.css",
   "/search",

--- a/src/lib/edge-cache/content-purge.ts
+++ b/src/lib/edge-cache/content-purge.ts
@@ -25,18 +25,90 @@
  * in `buildScopesForSurface` in the same change — one without the other is a
  * purge that silently misses.
  *
+ * ## Why the owning module is not always enough (ADR-0061 §B)
+ *
+ * A surface's body can be authored by a module that does not own it. The root
+ * discovery surfaces (`/sitemap.xml`, `/feed.xml`, …) belong to
+ * `seo_distribution`, which owns their routes and the config that shapes them —
+ * but their CONTENT is aggregated from every `seo_facts` provider. Publishing a
+ * post therefore changes those bodies without touching a single row
+ * `seo_distribution` writes.
+ *
+ * Because a module purge tags `t:<tenant>:m:<moduleKey>`, `blog_content`'s
+ * publish purge cannot reach an object tagged `m:seo_distribution`. The visible
+ * result would have been an asymmetry nobody would report: the path-scoped
+ * `/blog/{code}/feed.xml` purged on publish, the host-resolved `/feed.xml` — the
+ * same content — stale until TTL.
+ *
+ * So a purge for module M also covers every registered module that BOTH declares
+ * a `consumes` dependency on M and owns a declared cache surface. Both halves of
+ * that condition matter:
+ *
+ * - **Read from the registry, not hard-coded.** `blog_content` never names
+ *   `seo_distribution` anywhere; the consumer's own `capabilities.consumes`
+ *   declaration is the wiring. A future `seo_facts` provider inherits this, and
+ *   a future consumer of `blog_content` is covered the day it declares itself.
+ * - **Only consumers that own a surface.** A ban on a module key that tags no
+ *   cached object matches nothing while the queue reports success — the same
+ *   "ceremony that looks like coverage" this file's owner gate refuses for
+ *   `media_library`. The obligation appears by itself when a consumer declares
+ *   its first surface.
+ *
  * ## No-op when the edge cache is off
  *
  * Guarded on `EDGE_CACHE_MODE`. Without the guard every publish on every
  * deployment would append rows to a queue no worker drains, growing forever for
  * a feature the operator never enabled.
  */
+import { listModules } from "../../modules";
 import { loadEdgeCacheConfig } from "./config";
 import { enqueueEdgeCachePurge, type SqlExecutor } from "./purge-queue";
+import { PUBLIC_CACHE_SURFACES } from "./surface-registry";
 import type { SurrogateKeyScope } from "./surrogate-keys";
 
+/** Minimal shape this file needs from a module descriptor — kept structural so the resolver is testable with plain literals. */
+export type PurgeFanOutModule = {
+  key: string;
+  capabilities?: {
+    consumes?: readonly { providedBy: string }[];
+  };
+};
+
 /**
- * Enqueue invalidation for a module's cached surfaces for one tenant.
+ * The module keys a purge for `moduleKey` must ALSO cover: registered modules
+ * that consume a capability from it AND own a declared cache surface.
+ *
+ * Exported for its own test, because the interesting cases are the ones the live
+ * registry does not currently contain — a consumer with no surface (must be
+ * excluded), and a consumer of a module nobody else consumes (must yield
+ * nothing).
+ */
+export function resolveDerivedSurfaceModuleKeys(
+  moduleKey: string,
+  modules: readonly PurgeFanOutModule[] = listModules(),
+  surfaces: readonly { moduleKey: string | null }[] = PUBLIC_CACHE_SURFACES
+): string[] {
+  const surfaceOwners = new Set(
+    surfaces
+      .map((surface) => surface.moduleKey)
+      .filter((key): key is string => Boolean(key))
+  );
+
+  return modules
+    .filter(
+      (module) =>
+        module.key !== moduleKey &&
+        surfaceOwners.has(module.key) &&
+        (module.capabilities?.consumes ?? []).some(
+          (dependency) => dependency.providedBy === moduleKey
+        )
+    )
+    .map((module) => module.key);
+}
+
+/**
+ * Enqueue invalidation for a module's cached surfaces for one tenant, plus the
+ * surfaces of any module whose declared content it feeds.
  *
  * Returns the number of keys enqueued (`0` when the subsystem is off), and never
  * throws for a disabled subsystem — callers are content write paths, and a cache
@@ -54,7 +126,16 @@ export async function enqueueModuleContentPurge(
     return 0;
   }
 
-  const scopes: SurrogateKeyScope[] = [{ kind: "module", tenantId, moduleKey }];
+  const scopes: SurrogateKeyScope[] = [
+    { kind: "module", tenantId, moduleKey },
+    ...resolveDerivedSurfaceModuleKeys(moduleKey).map(
+      (derived): SurrogateKeyScope => ({
+        kind: "module",
+        tenantId,
+        moduleKey: derived
+      })
+    )
+  ];
 
   return enqueueEdgeCachePurge(tx, tenantId, scopes, reason);
 }

--- a/src/lib/edge-cache/surface-registry.ts
+++ b/src/lib/edge-cache/surface-registry.ts
@@ -37,9 +37,10 @@
  *
  * ## Host-resolved surfaces (ADR-0061)
  *
- * The `/news/**` family (ADR-0059) resolves its tenant from the request, not
- * from a path segment, so middleware cannot derive it from the URL — source (2)
- * in `tenant-key.ts` does not apply. Its four routes publish
+ * Two families here resolve their tenant from the request rather than from a
+ * path segment — the `/news/**` content routes (ADR-0059) and the root
+ * discovery routes (ADR-0038) — so middleware cannot derive it from the URL and
+ * source (2) in `tenant-key.ts` does not apply. Their routes publish
  * `locals.edgeCacheTenantId` instead, via `publishEdgeCacheTenant`, and only on
  * the path that actually serves the resource; see that file for why the timing
  * of the publish is a disclosure question rather than a style question.
@@ -47,37 +48,38 @@
  * Two properties had to hold before these entries were safe, and both are
  * asserted rather than assumed:
  *
- * - **The edge keys on `Host`.** `/news/hello-world` is the same path for every
- *   tenant, so a cache that keys on path alone would serve one tenant's article
- *   to another's visitors. `infra/varnish/default.vcl`'s `vcl_hash` hashes
- *   `req.http.host` explicitly (and does not `return (lookup)`, so builtin
- *   `req.url` hashing still runs). `tests/edge-cache.test.ts` asserts that line
- *   still exists.
- * - **An unpublished tenant fails closed.** `requiresTenant` is true for all
- *   three, so any request whose tenant did not resolve — or whose route chose
- *   not to publish — is refused with `tenant_unresolved` rather than cached
- *   under a guessed key.
+ * - **The edge keys on `Host`.** `/news/hello-world` and `/sitemap.xml` are the
+ *   same path for every tenant, so a cache that keys on path alone would serve
+ *   one tenant's article — or one tenant's entire URL inventory — to another's
+ *   visitors. `infra/varnish/default.vcl`'s `vcl_hash` hashes `req.http.host`
+ *   explicitly (and does not `return (lookup)`, so builtin `req.url` hashing
+ *   still runs). `tests/edge-cache.test.ts` asserts both halves.
+ * - **An unpublished tenant fails closed.** `requiresTenant` is true for every
+ *   one of them, so any request whose tenant did not resolve — or whose route
+ *   chose not to publish — is refused with `tenant_unresolved` rather than
+ *   cached under a guessed key.
  *
- * ## Deferred, and precisely why (not an oversight)
+ * ### Discovery bodies have TWO authors, and that shapes invalidation
  *
- * The **host-resolved root discovery surfaces** — `/robots.txt`, `/sitemap.xml`,
- * `/sitemap-{n}.xml`, `/feed.xml`, `/atom.xml`, `/feed.json` — are the single
- * best caching target in the codebase (identical body for every anonymous
- * reader, rebuilt from a content roll-up on each request). They are still absent
- * here: `serveDiscovery(request, …)` does not receive Astro's `locals`, so those
- * routes have no way to publish their tenant, and declaring them regardless
- * would produce surfaces that match, resolve no tenant, and are refused on every
- * single request — a registry entry that reads as "cached" while caching
- * nothing. A dead declaration is worse than an honest omission.
+ * The `seo-*` surfaces below are owned by `seo_distribution`, which is right for
+ * ownership (it owns the routes and the config that shapes them) and incomplete
+ * for invalidation: their bodies are aggregated from every `seo_facts` provider,
+ * so publishing a post changes `/sitemap.xml` and `/feed.xml` without touching
+ * anything `seo_distribution` writes.
  *
- * Wiring them is ADR-0061 §B: thread `locals` through `serveDiscovery` and its
- * six callers, publish from the resolved context, add the entries, and give
- * `seo_distribution` the purge call site that `findOwnersWithoutPurges` will
- * then require of it. Tracked in `docs/awcms/edge-cache-architecture.md`.
+ * A module purge tags `t:<tenant>:m:<moduleKey>`, so `blog_content`'s existing
+ * publish purge cannot reach an object tagged `m:seo_distribution`. Left there,
+ * `/blog/{code}/feed.xml` would be purged on publish while `/feed.xml` — the
+ * same content, the host-resolved spelling — sat stale until TTL, an asymmetry
+ * nothing would report. `enqueueModuleContentPurge` closes it by ALSO purging
+ * the modules that declare a `consumes` dependency on the changing module and
+ * own a declared surface. That is read from the module registry, so
+ * `blog_content` never names `seo_distribution`; the consumer's own `consumes`
+ * declaration is what wires it.
  *
  * The path-scoped blog feed and sitemap below (`/blog/{tenantCode}/feed.xml`,
- * `/blog/{tenantCode}/sitemap-blog.xml`) ARE covered, so tenants on the ADR-0009
- * path-scoped surface get feed caching today.
+ * `/blog/{tenantCode}/sitemap-blog.xml`) remain covered separately, so tenants
+ * on the ADR-0009 path-scoped surface keep the caching they already had.
  */
 
 /** A declared cacheable public surface. */
@@ -189,6 +191,36 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     allowedQueryParams: [],
     rationale:
       "A single published post at its host-resolved URL — the page every canonical, `<loc>` and feed link points at once the family is live. Purged by the same `blog_content` module purge that already covers `blog-post`."
+  },
+  {
+    key: "seo-robots",
+    moduleKey: "seo_distribution",
+    pattern: /^\/robots\.txt$/,
+    ttlSeconds: 600,
+    requiresTenant: true,
+    allowedQueryParams: [],
+    rationale:
+      "The tenant's crawl policy at its verified primary domain root. Derived from config rather than content — it changes only when an operator edits SEO settings, which enqueues the module purge — so it carries the longest TTL here alongside theming tokens."
+  },
+  {
+    key: "seo-sitemap",
+    moduleKey: "seo_distribution",
+    pattern: /^\/sitemap(-\d+)?\.xml$/,
+    ttlSeconds: 300,
+    requiresTenant: true,
+    allowedQueryParams: [],
+    rationale:
+      "The sitemap index and its bounded child pages. Identical for every anonymous reader and rebuilt from a content roll-up on each request today, which is the single most repeated piece of database work on the public surface."
+  },
+  {
+    key: "seo-feed",
+    moduleKey: "seo_distribution",
+    pattern: /^\/(feed\.xml|atom\.xml|feed\.json)$/,
+    ttlSeconds: 300,
+    requiresTenant: true,
+    allowedQueryParams: ["locale"],
+    rationale:
+      "RSS, Atom and JSON syndication of the latest published items. `locale` is the only permitted parameter and it is already validated to a short BCP-47-ish shape by `parseDiscoveryLocaleParam`, so the key space stays small and finite."
   },
   {
     key: "theming-tokens",

--- a/src/modules/seo-distribution/presentation/discovery-route.ts
+++ b/src/modules/seo-distribution/presentation/discovery-route.ts
@@ -19,6 +19,10 @@
  * fixed generic error body (no message/stack), same discipline as `/blog/{tenantCode}`.
  */
 import { getDatabaseClient } from "../../../lib/database/client";
+import {
+  publishEdgeCacheTenant,
+  type EdgeCacheTenantPublisher
+} from "../../../lib/edge-cache/publish-tenant";
 import { log } from "../../../lib/logging/logger";
 import { withSeoPublicTenant } from "../application/public-seo-tenant-resolution";
 import {
@@ -89,12 +93,20 @@ export function finalizeDiscoveryResponse(
   return new Response(payload.body, { status: 200, headers });
 }
 
-/** Run the full discovery pipeline for one surface and return its Response. */
+/**
+ * Run the full discovery pipeline for one surface and return its Response.
+ *
+ * `locals` is optional and exists solely so the route can publish its resolved
+ * tenant to the edge-cache layer (ADR-0061 §B). These surfaces are
+ * HOST-resolved, so middleware cannot derive the tenant from the URL — a call
+ * that omits `locals` still serves correctly and is simply never cached.
+ */
 export async function serveDiscovery(
   request: Request,
   logEvent: string,
   build: DiscoveryBuilder,
-  fallbacks: DiscoveryFallbacks
+  fallbacks: DiscoveryFallbacks,
+  locals?: EdgeCacheTenantPublisher
 ): Promise<Response> {
   try {
     const sql = getDatabaseClient();
@@ -118,7 +130,22 @@ export async function serveDiscovery(
           mediaLibrary
         };
 
-        return build(ctx);
+        const built = await build(ctx);
+
+        // Published only when a payload EXISTS, and that condition is the whole
+        // rule (ADR-0061 §3). `build` returns `null` for "sitemaps disabled",
+        // "feeds disabled" and "page out of range" — all of which collapse into
+        // the same generic 404 as an unresolved host, and 404 is a cacheable
+        // status. Publishing before this check would annotate the
+        // surface-disabled 404 with `Surrogate-Control` while the unknown-host
+        // 404 gets `private, no-store`, which answers "does this hostname map to
+        // a live tenant?" through the channel `padUnresolvedSeoTenantLatency`
+        // exists to close.
+        if (built) {
+          publishEdgeCacheTenant(locals, tenant.tenantId);
+        }
+
+        return built;
       }
     );
 

--- a/src/pages/api/v1/seo/config.ts
+++ b/src/pages/api/v1/seo/config.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../lib/database/client";
 import { withTenant } from "../../../../lib/database/tenant-context";
+import { enqueueModuleContentPurge } from "../../../../lib/edge-cache/content-purge";
 import {
   authorizeInTransaction,
   resolveAuthInputs
@@ -206,6 +207,19 @@ export const PUT: APIRoute = async ({ request, cookies, locals }) => {
           correlationId
         });
       }
+    );
+
+    // In the SAME transaction as the write (ADR-0042 §9): this config shapes
+    // every discovery body — the tenant-wide `noindex` switch alone rewrites
+    // `/robots.txt` and can withdraw the sitemap — so a committed change that
+    // did not enqueue its purge would leave the old crawl policy being served
+    // to crawlers until TTL, which is the one staleness here with a lasting
+    // consequence.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      SEO_MODULE_KEY,
+      "seo_distribution.config.update"
     );
 
     const successResponse = ok(saved);

--- a/src/pages/atom.xml.ts
+++ b/src/pages/atom.xml.ts
@@ -16,12 +16,13 @@ import { buildFeedPayload } from "../modules/seo-distribution/application/seo-di
  * entry identity. Optional `?locale=`. 404 when feeds are disabled. Public,
  * cacheable (ETag/Last-Modified/304).
  */
-export const GET: APIRoute = ({ request, url }) => {
+export const GET: APIRoute = ({ locals, request, url }) => {
   const locale = parseDiscoveryLocaleParam(url.searchParams.get("locale"));
   return serveDiscovery(
     request,
     "seo_discovery.atom.failed",
     (ctx) => buildFeedPayload(ctx, "atom", locale),
-    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse }
+    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse },
+    locals
   );
 };

--- a/src/pages/feed.json.ts
+++ b/src/pages/feed.json.ts
@@ -17,12 +17,13 @@ import { buildFeedPayload } from "../modules/seo-distribution/application/seo-di
  * `?locale=`. 404 when feeds are disabled. Public, cacheable
  * (ETag/Last-Modified/304).
  */
-export const GET: APIRoute = ({ request, url }) => {
+export const GET: APIRoute = ({ locals, request, url }) => {
   const locale = parseDiscoveryLocaleParam(url.searchParams.get("locale"));
   return serveDiscovery(
     request,
     "seo_discovery.jsonfeed.failed",
     (ctx) => buildFeedPayload(ctx, "jsonfeed", locale),
-    { notFound: notFoundTextResponse, serverError: serverErrorTextResponse }
+    { notFound: notFoundTextResponse, serverError: serverErrorTextResponse },
+    locals
   );
 };

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -18,12 +18,13 @@ import { buildFeedPayload } from "../modules/seo-distribution/application/seo-di
  * Optional `?locale=` narrows to one locale. 404 when feeds are disabled. Public,
  * cacheable (ETag/Last-Modified/304).
  */
-export const GET: APIRoute = ({ request, url }) => {
+export const GET: APIRoute = ({ locals, request, url }) => {
   const locale = parseDiscoveryLocaleParam(url.searchParams.get("locale"));
   return serveDiscovery(
     request,
     "seo_discovery.rss.failed",
     (ctx) => buildFeedPayload(ctx, "rss", locale),
-    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse }
+    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse },
+    locals
   );
 };

--- a/src/pages/robots.txt.ts
+++ b/src/pages/robots.txt.ts
@@ -17,10 +17,11 @@ import { buildRobotsPayload } from "../modules/seo-distribution/application/seo-
  * `withSeoPublicTenant`, and cache validators (ETag/Last-Modified/304) in
  * `serveDiscovery`.
  */
-export const GET: APIRoute = ({ request }) =>
+export const GET: APIRoute = ({ locals, request }) =>
   serveDiscovery(
     request,
     "seo_discovery.robots.failed",
     (ctx) => buildRobotsPayload(ctx),
-    { notFound: notFoundTextResponse, serverError: serverErrorTextResponse }
+    { notFound: notFoundTextResponse, serverError: serverErrorTextResponse },
+    locals
   );

--- a/src/pages/sitemap-[page].xml.ts
+++ b/src/pages/sitemap-[page].xml.ts
@@ -22,13 +22,14 @@ import { buildSitemapPagePayload } from "../modules/seo-distribution/application
  * A `^\d+$` gate rejects those up front (→ `NaN` → the builder's `< 1` guard →
  * generic 404).
  */
-export const GET: APIRoute = ({ request, params }) => {
+export const GET: APIRoute = ({ locals, request, params }) => {
   const raw = params.page ?? "";
   const page = /^\d+$/.test(raw) ? Number(raw) : Number.NaN;
   return serveDiscovery(
     request,
     "seo_discovery.sitemap_page.failed",
     (ctx) => buildSitemapPagePayload(ctx, page),
-    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse }
+    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse },
+    locals
   );
 };

--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -15,10 +15,11 @@ import { buildSitemapIndexPayload } from "../modules/seo-distribution/applicatio
  * host. 404 (as a generic XML error) when the tenant disables sitemaps. Public,
  * cacheable (ETag/Last-Modified/304 via `serveDiscovery`).
  */
-export const GET: APIRoute = ({ request }) =>
+export const GET: APIRoute = ({ locals, request }) =>
   serveDiscovery(
     request,
     "seo_discovery.sitemap_index.failed",
     (ctx) => buildSitemapIndexPayload(ctx),
-    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse }
+    { notFound: notFoundXmlResponse, serverError: serverErrorXmlResponse },
+    locals
   );

--- a/tests/discovery-routes-edge-cache-contract.test.ts
+++ b/tests/discovery-routes-edge-cache-contract.test.ts
@@ -1,0 +1,85 @@
+/**
+ * ADR-0061 §B — the contract between the root discovery routes and the edge
+ * cache, asserted over source text for the same reason its `/news/**`
+ * counterpart is (`news-routes-edge-cache-contract.test.ts`): both orderings
+ * compile, both serve identical bytes, and the difference appears only in a
+ * response header on a request that 404s.
+ *
+ * The six routes are thin delegators, so the rule lives in ONE place —
+ * `serveDiscovery` publishes, after `build(ctx)` returns a payload. That makes
+ * two things checkable, and both are needed:
+ *
+ * 1. `serveDiscovery` publishes only on the payload path. `build` returns `null`
+ *    for "sitemaps disabled", "feeds disabled" and "page out of range", each of
+ *    which collapses into the same generic 404 as an unresolved host — and 404
+ *    is a cacheable status.
+ * 2. All six callers actually forward `locals`. A route that forgets is not
+ *    broken, just never cached, which is precisely the kind of regression that
+ *    survives review: nothing fails, a surface silently stops being fast.
+ */
+import { describe, expect, test } from "bun:test";
+
+const PIPELINE = "src/modules/seo-distribution/presentation/discovery-route.ts";
+
+/** The six root discovery routes ADR-0038 serves, all host-resolved. */
+const DISCOVERY_ROUTES = [
+  "src/pages/robots.txt.ts",
+  "src/pages/sitemap.xml.ts",
+  "src/pages/sitemap-[page].xml.ts",
+  "src/pages/feed.xml.ts",
+  "src/pages/atom.xml.ts",
+  "src/pages/feed.json.ts"
+] as const;
+
+describe("root discovery routes publish their tenant", () => {
+  test("serveDiscovery publishes only when a payload was built", async () => {
+    const source = await Bun.file(PIPELINE).text();
+
+    const buildIndex = source.indexOf("const built = await build(ctx)");
+    const guardIndex = source.indexOf("if (built)");
+    const publishIndex = source.indexOf("publishEdgeCacheTenant(locals,");
+
+    expect(buildIndex).toBeGreaterThan(-1);
+    expect(guardIndex).toBeGreaterThan(buildIndex);
+    expect(publishIndex).toBeGreaterThan(guardIndex);
+  });
+
+  test("serveDiscovery publishes exactly once", async () => {
+    // A second, unguarded call anywhere in the pipeline would restore the leak
+    // while leaving the correct guarded call in place to read as the rule.
+    const source = await Bun.file(PIPELINE).text();
+
+    expect(source.split("publishEdgeCacheTenant(").length - 1).toBe(1);
+  });
+
+  test.each(DISCOVERY_ROUTES.map((file) => [file] as const))(
+    "%s forwards locals to serveDiscovery",
+    async (file) => {
+      const source = await Bun.file(file).text();
+
+      // Both halves: destructured from the Astro context AND passed on. A route
+      // that destructures without passing would satisfy a laxer check while
+      // caching nothing.
+      expect(source).toMatch(/APIRoute = \(\{[^}]*\blocals\b[^}]*\}\)/);
+      expect(source).toMatch(/,\s*\n\s*locals\s*\n\s*\)/);
+    }
+  );
+
+  test("every serveDiscovery caller is covered by this test", async () => {
+    // Guards against a seventh discovery route inheriting none of the above.
+    const found: string[] = [];
+
+    for (const entry of await Array.fromAsync(
+      new Bun.Glob("**/*.ts").scan({ cwd: "src/pages" })
+    )) {
+      const path = `src/pages/${entry}`;
+      const source = await Bun.file(path).text();
+
+      if (source.includes("serveDiscovery(")) {
+        found.push(path);
+      }
+    }
+
+    expect(found.sort()).toEqual([...DISCOVERY_ROUTES].sort());
+  });
+});

--- a/tests/edge-cache-content-purge.test.ts
+++ b/tests/edge-cache-content-purge.test.ts
@@ -8,7 +8,10 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import { enqueueModuleContentPurge } from "../src/lib/edge-cache/content-purge";
+import {
+  enqueueModuleContentPurge,
+  resolveDerivedSurfaceModuleKeys
+} from "../src/lib/edge-cache/content-purge";
 import type { SqlExecutor } from "../src/lib/edge-cache/purge-queue";
 
 /** Records the parameter arrays passed to the tagged-template executor. */
@@ -51,7 +54,7 @@ describe("enqueueModuleContentPurge", () => {
     }
   });
 
-  test("enqueues exactly the module-scoped key when enabled", async () => {
+  test("enqueues the owning module's key plus its derived consumers", async () => {
     const { tx, calls } = recordingTx();
     const previous = process.env.EDGE_CACHE_MODE;
 
@@ -65,15 +68,23 @@ describe("enqueueModuleContentPurge", () => {
         "blog.post.published"
       );
 
-      expect(enqueued).toBe(1);
+      expect(enqueued).toBe(2);
+      // Still ONE statement: the two keys go in a single enqueue, so the purge
+      // commits atomically with the content change rather than half-committing.
       expect(calls).toHaveLength(1);
 
       // Module scope, NOT a resource key: cached responses are tagged with
       // tenant/surface/module only, so a resource-scoped ban would match no
       // object and the page would stay stale until its TTL expired.
+      //
+      // `seo_distribution` rides along (ADR-0061 §B) because it declares
+      // `consumes: seo_facts providedBy blog_content` AND owns surfaces whose
+      // bodies aggregate that content. Without it, publishing a post would purge
+      // `/blog/{code}/feed.xml` and leave `/feed.xml` — the same content, the
+      // host-resolved spelling — stale until TTL.
       expect(calls[0]).toEqual([
         TENANT,
-        [`t:${TENANT}:m:blog_content`],
+        [`t:${TENANT}:m:blog_content`, `t:${TENANT}:m:seo_distribution`],
         "blog.post.published"
       ]);
     } finally {
@@ -83,6 +94,87 @@ describe("enqueueModuleContentPurge", () => {
         process.env.EDGE_CACHE_MODE = previous;
       }
     }
+  });
+});
+
+describe("derived-surface fan-out (ADR-0061 §B)", () => {
+  const SURFACES = [{ moduleKey: "owner" }, { moduleKey: "consumer" }];
+
+  test("a consumer that owns a surface is covered", () => {
+    expect(
+      resolveDerivedSurfaceModuleKeys(
+        "owner",
+        [
+          { key: "owner" },
+          {
+            key: "consumer",
+            capabilities: { consumes: [{ providedBy: "owner" }] }
+          }
+        ],
+        SURFACES
+      )
+    ).toEqual(["consumer"]);
+  });
+
+  test("a consumer that owns NO surface is excluded", () => {
+    // The condition this repo already applies to `media_library`: a ban on a
+    // module key that tags no cached object matches nothing while the queue
+    // reports success. Adding it would be ceremony that reads as coverage.
+    expect(
+      resolveDerivedSurfaceModuleKeys(
+        "owner",
+        [
+          { key: "owner" },
+          {
+            key: "surfaceless",
+            capabilities: { consumes: [{ providedBy: "owner" }] }
+          }
+        ],
+        [{ moduleKey: "owner" }]
+      )
+    ).toEqual([]);
+  });
+
+  test("a surface owner that consumes nothing from the changing module is excluded", () => {
+    expect(
+      resolveDerivedSurfaceModuleKeys(
+        "owner",
+        [
+          { key: "owner" },
+          {
+            key: "consumer",
+            capabilities: { consumes: [{ providedBy: "somebody_else" }] }
+          }
+        ],
+        SURFACES
+      )
+    ).toEqual([]);
+  });
+
+  test("the changing module never fans out to itself", () => {
+    // It is already scope #1. A duplicate key would enqueue the same ban twice.
+    expect(
+      resolveDerivedSurfaceModuleKeys(
+        "owner",
+        [
+          {
+            key: "owner",
+            capabilities: { consumes: [{ providedBy: "owner" }] }
+          }
+        ],
+        SURFACES
+      )
+    ).toEqual([]);
+  });
+
+  test("against the LIVE registry, blog_content reaches seo_distribution and theming does not", () => {
+    // The literals above prove the rule; this proves the rule is wired to the
+    // real declarations. `theming` feeds no aggregator, so it must stay a
+    // single-key purge — otherwise the fan-out is over-broad rather than exact.
+    expect(resolveDerivedSurfaceModuleKeys("blog_content")).toEqual([
+      "seo_distribution"
+    ]);
+    expect(resolveDerivedSurfaceModuleKeys("theming")).toEqual([]);
   });
 });
 
@@ -99,7 +191,12 @@ describe("content write paths emit a purge", () => {
     // declare one.
     ["src/pages/api/v1/theming/publish.ts", 1],
     ["src/pages/api/v1/theming/rollback.ts", 1],
-    ["src/pages/api/v1/theming/retire.ts", 1]
+    ["src/pages/api/v1/theming/retire.ts", 1],
+    // `seo_distribution` owns the three `seo-*` discovery surfaces as of
+    // ADR-0061 §B, so its own config write must purge them: the tenant-wide
+    // `noindex` switch alone rewrites `/robots.txt`, and serving a stale crawl
+    // policy to crawlers is the one staleness here with a lasting consequence.
+    ["src/pages/api/v1/seo/config.ts", 1]
   ])(
     "%s calls enqueueModuleContentPurge %i time(s)",
     async (path, expected) => {

--- a/tests/edge-cache.test.ts
+++ b/tests/edge-cache.test.ts
@@ -337,7 +337,15 @@ describe("surface registry", () => {
     ["/news/", "news-index"],
     ["/news/hello-world", "news-post"],
     ["/news/category/announcements", "news-taxonomy"],
-    ["/news/tag/bun", "news-taxonomy"]
+    ["/news/tag/bun", "news-taxonomy"],
+    // Root discovery (ADR-0061 §B).
+    ["/robots.txt", "seo-robots"],
+    ["/sitemap.xml", "seo-sitemap"],
+    ["/sitemap-1.xml", "seo-sitemap"],
+    ["/sitemap-42.xml", "seo-sitemap"],
+    ["/feed.xml", "seo-feed"],
+    ["/atom.xml", "seo-feed"],
+    ["/feed.json", "seo-feed"]
   ])("%s resolves to %s", (path, expected) => {
     expect(matchPublicCacheSurface(path)?.key).toBe(expected);
   });
@@ -360,7 +368,13 @@ describe("surface registry", () => {
     ["/news/%2E%2E"],
     ["/news/category/.."],
     ["/news/search"],
-    ["/robots.txt"]
+    // Shapes `Number()` would coerce but `^\d+$` — and the surface pattern —
+    // must not. The route file documents the same list.
+    ["/sitemap-1e3.xml"],
+    ["/sitemap-0x10.xml"],
+    ["/sitemap-abc.xml"],
+    ["/sitemap-.xml"],
+    ["/feed.rss"]
   ])("%s is not cacheable", (path) => {
     expect(matchPublicCacheSurface(path)).toBeNull();
   });
@@ -390,12 +404,40 @@ describe("surface registry", () => {
     expect(matchPublicCacheSurface("/news/category")?.key).toBe("news-post");
   });
 
+  test("a feed caches with ?locale= but not with anything else", () => {
+    const surface = matchPublicCacheSurface("/feed.xml")!;
+
+    expect(
+      decide({ surface, searchParams: new URLSearchParams({ locale: "id" }) })
+    ).toMatchObject({ cacheable: true });
+    expect(
+      decide({
+        surface,
+        searchParams: new URLSearchParams({ utm_source: "x" })
+      })
+    ).toMatchObject({ cacheable: false, reason: "query_not_allowed" });
+  });
+
+  test("robots.txt is not cached alongside the sitemap it advertises", () => {
+    // Same owner, different TTLs and different surrogate keys on purpose: robots
+    // is config-derived and stable, the sitemap is content-derived. Merging them
+    // into one entry would give the volatile body the stable body's TTL.
+    expect(matchPublicCacheSurface("/robots.txt")?.ttlSeconds).toBe(600);
+    expect(matchPublicCacheSurface("/sitemap.xml")?.ttlSeconds).toBe(300);
+    expect(matchPublicCacheSurface("/robots.txt")?.key).not.toBe(
+      matchPublicCacheSurface("/sitemap.xml")?.key
+    );
+  });
+
   test("every host-resolved surface requires a tenant, so an unpublished one is refused", () => {
-    // The whole safety argument for `/news/**` rests on this: middleware cannot
-    // derive the tenant from the URL, so a route that does not publish must fall
-    // through to `tenant_unresolved` rather than be cached under a guessed key.
-    for (const surface of PUBLIC_CACHE_SURFACES.filter((entry) =>
-      entry.key.startsWith("news-")
+    // The whole safety argument for the host-resolved families rests on this:
+    // middleware cannot derive the tenant from the URL, so a route that does not
+    // publish must fall through to `tenant_unresolved` rather than be cached
+    // under a guessed key. That is also what keeps an out-of-range
+    // `/sitemap-99999.xml` from filling the cache: its builder returns null, so
+    // nothing is published and nothing is stored.
+    for (const surface of PUBLIC_CACHE_SURFACES.filter(
+      (entry) => entry.key.startsWith("news-") || entry.key.startsWith("seo-")
     )) {
       expect(surface.requiresTenant).toBe(true);
       expect(


### PR DESCRIPTION
Completes ADR-0061. §A ([#375](https://github.com/ahliweb/awcms/pull/375)) wired `/news/**`; this wires the six root discovery routes — `/robots.txt`, `/sitemap.xml`, `/sitemap-{n}.xml`, `/feed.xml`, `/atom.xml`, `/feed.json` — which the surface registry has long called the best caching target in the codebase.

## The mechanical half

`serveDiscovery` takes an optional `locals` and publishes the resolved tenant **after** `build(ctx)` produces a payload; all six routes forward it. Three entries: `seo-robots` (600s — config-derived, the most stable body here), `seo-sitemap` (300s, index and child pages), `seo-feed` (300s, one pattern for RSS/Atom/JSON, `?locale=` the only permitted parameter and already validated by `parseDiscoveryLocaleParam`).

The publish-after-payload rule from §A carries more weight here, because `build` has *more* null branches: "sitemaps disabled", "feeds disabled", "page out of range" — each collapsing into the same generic 404 as an unknown host, and 404 is a cacheable status. A pleasant side effect: `/sitemap-99999.xml` matches the surface but never publishes a tenant, so walking page numbers cannot fill the cache.

## The half that was not mechanical

Wiring the purge call site the ownership gate demands turned up something the backlog entry did not anticipate: **discovery bodies have two authors, and only one of them owns the surface.**

`PUT /api/v1/seo/config` now enqueues a purge, and it must — the tenant-wide `noindex` switch alone rewrites `/robots.txt`. But the sitemap and feed bodies are aggregated from every `seo_facts` provider, so **publishing a post changes `/sitemap.xml` without touching a single row `seo_distribution` writes.** A module purge tags `t:<tenant>:m:<moduleKey>`, so `blog_content`'s publish purge cannot reach an object tagged `m:seo_distribution`.

Left there, the result would have been an asymmetry nothing reports: `/blog/{code}/feed.xml` purged on publish, `/feed.xml` — the same content, the host-resolved spelling — stale until TTL.

`enqueueModuleContentPurge` now also covers modules that declare a `consumes` dependency on the changing module **and** own a declared surface. Both halves of that condition are load-bearing:

- **Read from the module registry, not hard-coded.** `blog_content` never names `seo_distribution` anywhere; the consumer's own `capabilities.consumes` declaration is the wiring. The next `seo_facts` provider inherits this, and the next consumer of `blog_content` is covered the day it declares itself.
- **Limited to surface owners.** A ban on a module key that tags no cached object matches nothing while the queue reports success — the same "ceremony that looks like coverage" this repo already refuses for `media_library`. The obligation appears by itself when a consumer declares its first surface.

Both keys go in **one** enqueue, so the purge still commits atomically with the content change.

## Verification

Zero migrations, zero permissions, zero OpenAPI change. `EDGE_CACHE_MODE` unset (every deployment's default) keeps the subsystem a no-op.

- All 26 gates green — `edge-cache:surfaces:check` now reports 11 surfaces, 29 never-cacheable probes, 3 surface-owning modules emitting purges — plus typecheck and build.
- Three mutations proven RED then reverted: hoisting the publish above the payload guard, dropping the surface-owner filter from the fan-out (making it over-broad), and removing the `seo/config` purge call site (which the ownership gate catches by name).
- New probes assert the child-sitemap pattern refuses what `Number()` accepts (`1e3`, `0x10`, `-abc`) — the same list the route file rejects, now enforced at the surface too.
- Full suite against real Postgres: 3498 pass. The 6 failures are pre-existing and identical to the pre-change run (2 git-less-container artifacts, 4 reproducing on a clean tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
