### PR TITLE
docs(skills): correct two catalogue claims that stopped being true

### DIFF
--- a/.changeset/skills-sync-awcms-astro.md
+++ b/.changeset/skills-sync-awcms-astro.md
@@ -1,0 +1,21 @@
+---
+"awcms": patch
+---
+
+Skill catalogue: correct two claims that stopped being true
+
+`.claude/skills/README.md` told readers `repo:inventory:*` is "genuinely absent"
+and that `package.json` has 75 scripts. Both landed since: #374 shipped
+`repo:inventory:generate`/`:check` with the generator for `awcms/repo-inventory.md`,
+and the script count is 82. A catalogue that names a real script as missing sends
+the next reader to build what already exists — the same failure shape ADR-0062
+gates for `SKILL.md`, in the one file that gate does not read.
+
+`awcms-jualanku-porting` carried two more. Its description said the registry is
+"still 20 modules" (it is 21), and its first binding decision described the
+ADR-0030 scope-hierarchy port as base returning `resolved: false` fail-closed —
+true until ADR-0060 gave it a provider, and misleading after. What is still open
+is narrower and now stated: the merchant scope SHAPE needs its own admission ADR.
+
+Verified against code, not memory: `Object.keys(scripts).length`, the module
+registry, and the ADR files themselves.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -38,15 +38,21 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > Skill yang badannya masih menandai dirinya "BACAAN SAJA" tetap begitu — itu
 > per-skill, bukan pernyataan tentang repo secara keseluruhan.
 
-> **Verifikasi command sebelum menjalankannya.** `package.json` kini punya **75
-> script**, termasuk yang dulu ditandai belum ada (`openapi:bundle`,
-> `data-lifecycle:*`, `reporting:*`, dan — **koreksi 2026-07-27** —
-> `db:work-class:generate`/`db:work-class:check`, yang catatan sebelumnya masih
-> menyebut tidak ada). Yang masih **benar-benar tidak ada**: `repo:inventory:*`
-> (yang ada `modules:composition:inventory:*`, cakupannya lain), `i18n:*`, dan
-> `extension:check` (yang terakhir **DIHAPUS** oleh ADR-0034, bukan tertunda —
-> jangan merujuknya). Tetap cek `package.json` sebelum mengeksekusi command dari
-> sebuah skill; daftar ini bergerak tiap kali modul baru mendarat.
+> **Verifikasi command sebelum menjalankannya.** `package.json` kini punya **82
+> script** (diperiksa 4 Agustus 2026), termasuk yang dulu ditandai belum ada:
+> `openapi:bundle`, `data-lifecycle:*`, `reporting:*`,
+> `db:work-class:generate`/`db:work-class:check`, dan — **koreksi 4 Agustus
+> 2026** — `repo:inventory:generate`/`repo:inventory:check`, yang catatan
+> sebelumnya masih menyebut "benar-benar tidak ada". Keduanya mendarat di #374
+> bersama generator `awcms/repo-inventory.md`.
+>
+> Yang masih benar-benar tidak ada: `i18n:*`, dan `extension:check` (yang
+> terakhir **DIHAPUS** oleh ADR-0034, bukan tertunda — jangan merujuknya).
+>
+> Tetap cek `package.json` sebelum mengeksekusi command dari sebuah skill;
+> daftar ini bergerak tiap kali modul baru mendarat, dan **paragraf ini bukan
+> yang digerbangi** — `skills:check` (ADR-0062) menegakkan `SKILL.md`, bukan
+> berkas ini.
 
 ## Katalog
 

--- a/.claude/skills/awcms-jualanku-porting/SKILL.md
+++ b/.claude/skills/awcms-jualanku-porting/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: awcms-jualanku-porting
-description: "RENCANA — porting Jualanku.info (direktori merchant + portal penjual + portal affiliate) ke keluarga AWCMS, diputuskan [ADR-0045](../../../docs/adr/0045-jualanku-porting-awcms-system-of-record-astro-bff.md) di repo ini + ADR-0014/0015 di `awcms-astro`. BELUM ADA KODE: tidak ada modul/tabel/migrasi/rute/permission `jualanku_*`, dan registry tetap 20 modul. Gunakan saat mengerjakan bagian mana pun dari Jualanku — ia memuat keputusan yang TIDAK bisa disimpulkan dari kode: merchant dimodelkan sebagai BUSINESS SCOPE (bukan atribut ABAC baru — allow-list ABAC TERTUTUP), RLS memisahkan tenant BUKAN merchant, browser tidak pernah memanggil awcms langsung (BFF di awcms-astro), lima bounded context bukan tujuh, dan gap sesi yang sebenarnya adalah introspeksi lintas-origin bukan dukungan cookie. Rancangan lengkap: `docs/awcms/jualanku/`."
+description: "RENCANA — porting Jualanku.info (direktori merchant + portal penjual + portal affiliate) ke keluarga AWCMS, diputuskan [ADR-0045](../../../docs/adr/0045-jualanku-porting-awcms-system-of-record-astro-bff.md) di repo ini + ADR-0014/0015 di `awcms-astro`. BELUM ADA KODE: tidak ada modul/tabel/migrasi/rute/permission `jualanku_*`, dan registry kini 21 modul (bukan 20 — diperiksa 4 Agustus 2026). Gunakan saat mengerjakan bagian mana pun dari Jualanku — ia memuat keputusan yang TIDAK bisa disimpulkan dari kode: merchant dimodelkan sebagai BUSINESS SCOPE (bukan atribut ABAC baru — allow-list ABAC TERTUTUP), RLS memisahkan tenant BUKAN merchant, browser tidak pernah memanggil awcms langsung (BFF di awcms-astro), lima bounded context bukan tujuh, dan gap sesi yang sebenarnya adalah introspeksi lintas-origin bukan dukungan cookie. Rancangan lengkap: `docs/awcms/jualanku/`."
 ---
 
 # AWCMS — Porting Jualanku.info (rencana, belum ada kode)
@@ -28,8 +28,14 @@ Rancangan penuh ada di [`docs/awcms/jualanku/`](../../../docs/awcms/jualanku/REA
    evaluasi. `subject.merchantIds`/`resource.merchantId` **tidak ada di sana**
    dan **tidak boleh ditambahkan** — melebarkannya untuk satu produk menghapus
    properti yang membuatnya bernilai. Yang dipakai: `resource.businessScopeId`
-   (sudah ada) + port hierarki scope ADR-0030 yang base-nya mengembalikan
-   `resolved: false` **fail-closed**. `jualanku_directory` yang mengisinya.
+   (sudah ada) + port hierarki scope ADR-0030. **Base-nya tidak lagi NO-OP:**
+   [ADR-0060](../../../docs/adr/0060-business-scope-hierarchy-provided-by-tenant-admin.md)
+   (4 Agustus 2026) membuat `tenant_admin` menyelesaikan hierarki scope kantor,
+   jadi port itu punya penyedia. Yang belum: **bentuk scope MERCHANT** —
+   memetakan merchant Jualanku ke scope tetap butuh ADR admission-nya sendiri,
+   dan `jualanku_directory` yang akan mengisinya. Catatan sebelumnya di sini
+   berbunyi "base-nya mengembalikan `resolved: false` fail-closed"; itu benar
+   sampai ADR-0060 dan menyesatkan sesudahnya.
 2. **RLS memisahkan tenant, bukan merchant.** Satu tenant penyelenggara
    (`JUALANKU_MAIN`), banyak merchant. Isolasi merchant butuh TIGA lapis: RLS
    tenant + grant scope ber-effective-dating + **predikat kepemilikan di setiap


### PR DESCRIPTION
Complementary to #377, which gates `SKILL.md` against the code it describes. **Neither of these is inside that gate's reach.**

## `.claude/skills/README.md` — the one file `skills:check` does not read

It told readers `repo:inventory:*` is *"genuinely absent (what exists is `modules:composition:inventory:*`, different scope)"*, and that `package.json` has 75 scripts.

Both landed since: **#374** shipped `repo:inventory:generate`/`:check` together with the generator for `awcms/repo-inventory.md`, and `Object.keys(scripts).length` is **82**.

A catalogue that names a real script as missing sends the next reader to build what already exists — the same failure shape ADR-0062 exists to gate, in the file that gate does not read. The corrected paragraph now says so explicitly, so nobody mistakes it for gated text.

## `awcms-jualanku-porting` carried two more

- **Description:** *"registry tetap 20 modul"*. It is **21**.
- **Binding decision 1** described the ADR-0030 scope-hierarchy port as base returning `resolved: false` fail-closed, with `jualanku_directory` as the thing that would fill it. True until **ADR-0060 (#373)** made `tenant_admin` resolve office business scopes; misleading after.

  Corrected — and the part that **is** still open is now stated narrowly: the merchant scope **shape** needs its own admission ADR. That distinction matters, because *"no provider at all"* and *"a provider exists but not for merchants"* point at different work.

## Verifikasi

Diperiksa ke kode, bukan ke ingatan: `Object.keys(scripts).length`, registry modul, dan berkas ADR-nya sendiri. `bun run check:docs` hijau.

## Konteks

Ditemukan saat menyinkronkan `ahliweb/awcms-astro` dengan repo ini — di sana penahanan ADR-0021 selesai karena **kedua** indikatornya terpenuhi, dan §Kesiapan `awcms-astro` di `PROJECT_STATE.md` yang menutupnya (*"Yang tersisa DAN milik repo ini: nol"*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
