### PR TITLE
docs(assessment): repo-wide review against four axes, and the skill fixes it found

### DIFF
--- a/.changeset/repo-assessment-and-skills-rule-4.md
+++ b/.changeset/repo-assessment-and-skills-rule-4.md
@@ -1,0 +1,48 @@
+---
+"awcms": patch
+---
+
+Repo-wide assessment against four axes, and the skill corrections it produced.
+
+[`docs/awcms/repo-assessment-2026-08-04.md`](../docs/awcms/repo-assessment-2026-08-04.md)
+measures the repo against AWCMS's own development standards, its relationship
+with `ahliweb/awcms-astro`, international performance standards (ISO/IEC 25010,
+RFC 9111/5861, Core Web Vitals) and international security standards (OWASP Top
+10 2021, OWASP API Security Top 10 2023, OWASP ASVS 4.0, ISO/IEC 27001:2022
+Annex A). Every finding is verified against code, with file and line.
+
+Three findings change the backlog:
+
+- **P0 — one route bypasses the authorization chokepoint.**
+  `POST /api/v1/blog/posts/{id}/submit-review` never calls
+  `authorizeInTransaction`, so ABAC policy evaluation, the platform-scope gate,
+  business-scope facts and SoD are all skipped for a permission that
+  `PATCH /{id}` evaluates in full. An explicit ABAC `deny` on
+  `blog_content.posts.update` is honoured on one route and silently ignored on
+  the other. `access:permissions:enforcement:check` cannot see it: it asks
+  whether a permission has an enforcer, not whether every enforcement site uses
+  the chokepoint.
+- **P1 — nothing tests the contract `awcms-astro` consumes.** The frozen
+  OpenAPI snapshot is the pre-#182-migration baseline; all five surfaces that
+  repo actually calls landed after it. Changing any response shape is green here
+  and breaks the build there.
+- **P1 — the rate limiter is an in-process `Map`**, so with N replicas the
+  effective limit is N × configured. Redis is already in the repo.
+
+Also: zero of the 28 `check` gates measure performance, and `bun audit` reports
+one moderate transitive advisory (postcss via astro › vite).
+
+`skills:check` gains **rule 4**: every `bun run <target>` a skill names must
+exist in `package.json` or be declared deferred in `scripts/README.md` §Ditunda.
+Deliberately narrow — that section explicitly permits skills to name deferred
+reference targets, so the rule only catches targets that are neither. It found
+two, one of which told readers to run a refresh command that never existed while
+the real `gh` invocations sat on the same page.
+
+Skills corrected: `awcms-abac-guard` now leads with the chokepoint rule that the
+P0 finding shows was never written down; `awcms-performance` warns that its
+commands do not exist yet; `awcms-security-hardening` carries the three open
+findings; `awcms-github-snapshot` and `awcms-data-lifecycle` lose their ghost
+commands.
+
+No migrations, no permissions, no runtime change.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -15,6 +15,10 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > 3. **Skill untuk kode yang TIDAK ada wajib terdaftar** di `ASPIRATIONAL_SKILLS`
 >    (`scripts/skills-check.ts`) dengan alasan: `target-spec`, `historical`, atau
 >    `cross-cutting`.
+> 4. **Setiap `bun run <target>` wajib ada** di `package.json` atau terdaftar di
+>    [`scripts/README.md`](../../scripts/README.md) §Ditunda. §Ditunda memang
+>    mengizinkan skill menyebut target acuan yang belum dibangun — aturan ini
+>    hanya menangkap yang bukan keduanya.
 >
 > **Menulis path milik repo ARSIP?** Tulis `` `awcms-mini:src/…` `` /
 > `` `awcms-micro:src/…` ``, bukan `` `src/…` ``. Badan banyak skill di sini

--- a/.claude/skills/awcms-abac-guard/SKILL.md
+++ b/.claude/skills/awcms-abac-guard/SKILL.md
@@ -7,6 +7,41 @@ description: Terapkan kontrol akses RBAC+ABAC default-deny plus RLS pada endpoin
 
 Ikuti `docs/awcms/03_srs_detail_per_modul.md`, `docs/awcms/10_template_kode_coding_standard.md`, dan **`docs/awcms/17_default_seed_rbac_abac.md`** (matriks role→permission & default ABAC policy). Mekanisme RLS/tenant context konkret: `docs/awcms/16_backend_data_access_integration.md`.
 
+## ATURAN PERTAMA — satu chokepoint, `authorizeInTransaction`
+
+**Setiap keputusan otorisasi untuk permission tenant WAJIB lewat
+`authorizeInTransaction`** (`src/modules/identity-access/application/access-guard.ts`),
+atau lewat `defineTenantRoute` yang memanggilnya. Jangan menyusun jalur sendiri
+dari `resolveTenantContext` + `fetchGrantedPermissionKeys` + aturan domain.
+
+Alasannya bukan kerapian. Chokepoint itu adalah SATU-SATUNYA tempat berikut ini
+dievaluasi, dan jalur buatan sendiri melewatkan **semuanya** tanpa satu pun
+error:
+
+| Lapisan                                    | Kalau dilewati                                           |
+| ------------------------------------------ | -------------------------------------------------------- |
+| `evaluateAccess` — evaluator ABAC DSL      | **policy `deny` eksplisit milik tenant tidak dihormati** |
+| `isPlatformScopedPermissionKey` (ADR-0053) | aksi lintas-tenant tak digerbangi                        |
+| `resolveBusinessScopeFacts` (ADR-0060)     | cakupan bisnis tak ikut memutuskan                       |
+| `isHighRiskAction` + SoD (#181)            | konflik segregation-of-duties tak diperiksa              |
+
+Aturan kepemilikan domain (mis. `evaluatePostUpdateAccess`) adalah lapisan
+**TAMBAHAN di atas** chokepoint, bukan pengganti. Pola benarnya ada di
+`src/pages/api/v1/blog/posts/[id].ts`: `authorizeInTransaction` dulu, aturan
+kepemilikan sesudah.
+
+> **Ini bukan aturan hipotetis.** Asesmen 4 Agustus 2026
+> ([`docs/awcms/repo-assessment-2026-08-04.md`](../../../docs/awcms/repo-assessment-2026-08-04.md) §2)
+> menemukan `POST /api/v1/blog/posts/{id}/submit-review` menegakkan permission
+> yang SAMA dengan `PATCH /{id}` tanpa memanggil chokepoint sama sekali —
+> sehingga policy ABAC dihormati di satu rute dan diabaikan di rute lain.
+> `access:permissions:enforcement:check` tidak menangkapnya: ia bertanya "apakah
+> permission ini punya penegak", bukan "apakah SETIAP situs penegakan memakai
+> chokepoint".
+
+Satu-satunya pengecualian sah adalah jalur **pra-autentikasi** (`auth/login.ts`),
+yang secara definisi belum punya subjek untuk diotorisasi.
+
 ## Prinsip
 
 1. **Default deny** — tidak ada policy yang mengizinkan = tolak.

--- a/.claude/skills/awcms-data-lifecycle/SKILL.md
+++ b/.claude/skills/awcms-data-lifecycle/SKILL.md
@@ -85,7 +85,7 @@ ownership matrix — "no shared-table write").
        executionMode: "delegated", // ATAU "generic" — lihat pilihan di bawah
        existingAdopter: {
          // WAJIB bila executionMode "delegated", DILARANG bila "generic"
-         jobCommand: "bun run your:purge:job",
+         jobCommand: "bun run <modul>:purge", // ganti dengan target NYATA di package.json
          purgeFunctionRef:
            "src/modules/your_module/application/your-purge.ts#purgeYourTable",
          description: "..."

--- a/.claude/skills/awcms-github-snapshot/SKILL.md
+++ b/.claude/skills/awcms-github-snapshot/SKILL.md
@@ -35,7 +35,8 @@ sudah salah.
 
 ```bash
 gh auth status
-bun run github:snapshot:refresh   # default repo ahliweb/awcms
+# TIDAK ADA target `bun run` untuk ini — refresh dilakukan MANUAL dengan `gh`
+# (lihat perintah di bawah), lalu hasilnya ditulis ke docs/awcms/github/.
 ```
 
 `scripts/github-snapshot-refresh.ts` (Issue #464) meregenerasi bagian
@@ -71,7 +72,7 @@ menit kemudian bila baris itu perlu nilai terbaru.
 
 ```mermaid
 flowchart LR
-  A[gh auth status] --> B[bun run github:snapshot:refresh]
+  A[gh auth status] --> B["gh issue/pr list --json (manual)"]
   B --> C[bun run format]
   C --> D[bun run check:docs]
   D --> E{Narasi manual perlu update?}

--- a/.claude/skills/awcms-performance/SKILL.md
+++ b/.claude/skills/awcms-performance/SKILL.md
@@ -3,6 +3,19 @@ name: awcms-performance
 description: Audit dan tingkatkan performa aplikasi & database AWCMS. Gunakan saat diminta "optimasi performa/query", ada endpoint lambat, N+1, masalah indexing/pagination, tuning connection pool, atau perencanaan materialized view/caching. Menegakkan pola akses data doc 16, pooling/backpressure, dan pagination keyset.
 ---
 
+> **PERINGATAN — perintah di halaman ini BELUM ADA di repo ini.**
+> `performance:suite`, `performance:query-plan:check`, `database:capacity:check`
+> terdaftar di [`scripts/README.md`](../../../scripts/README.md) §Ditunda sebagai
+> target acuan, bukan skrip nyata. Menjalankannya akan gagal. Pakai halaman ini
+> sebagai **daftar periksa manual + spesifikasi target**, bukan runbook.
+>
+> Asesmen 4 Agustus 2026 ([`docs/awcms/repo-assessment-2026-08-04.md`](../../../docs/awcms/repo-assessment-2026-08-04.md) §5)
+> mencatat konsekuensinya: **nol dari 28 gerbang `bun run check` memeriksa
+> performa**, jadi query N+1 atau kolom FK tanpa index mendarat dengan CI hijau
+> penuh. Rekomendasi termurah-berdampak-terbesar di sana: gerbang index-FK murni
+> (tanpa DB), lalu anggaran query per-endpoint memakai pola Proxy-apply-trap yang
+> SUDAH terbukti di test SoD (#181).
+
 # AWCMS — Performance & Database Tuning
 
 Sumber kebenaran: **`docs/awcms/16_backend_data_access_integration.md`** (lapisan akses data, pooling/backpressure, transaction), **`docs/awcms/database-pooling.md`**, dan **`docs/awcms/07_sprint_testing_production_readiness.md`** (target performa). Skill ini **peningkatan**: ukur → temukan bottleneck → perbaiki → ukur ulang.

--- a/.claude/skills/awcms-security-hardening/SKILL.md
+++ b/.claude/skills/awcms-security-hardening/SKILL.md
@@ -3,6 +3,26 @@ name: awcms-security-hardening
 description: Audit keamanan berbasis standar (OWASP Top 10, OWASP ASVS, ISO/IEC 27001 Annex A) untuk AWCMS. Gunakan saat diminta "security hardening", audit OWASP/ASVS/ISO, penilaian kepatuhan, atau pengerasan menjelang go-live/audit eksternal. Berbeda dari awcms-security-review (checklist DoD per modul) — skill ini memetakan kontrol ke kerangka standar industri.
 ---
 
+> **Asesmen terbaru: 4 Agustus 2026 — [`docs/awcms/repo-assessment-2026-08-04.md`](../../../docs/awcms/repo-assessment-2026-08-04.md).**
+> Postur dasar KUAT dan sudah diverifikasi ke kode (security headers lengkap
+> termasuk CSP/HSTS/`X-Frame-Options: DENY`, 141 pernyataan RLS `FORCE` diuji
+> sebagai `awcms_app`, ABAC default-deny + decision log, MFA/OIDC/Turnstile/SoD,
+> kredensial mesin baca-saja, cakupan penegakan permission 203/203 nol
+> pengecualian). Tiga temuan terbuka yang WAJIB dibaca sebelum audit berikutnya:
+>
+> 1. **A01/API5 — satu rute melewati chokepoint otorisasi.**
+>    `POST /api/v1/blog/posts/{id}/submit-review` tidak memanggil
+>    `authorizeInTransaction`, sehingga ABAC/platform-scope/business-scope/SoD
+>    dilewati untuk permission yang rute lain evaluasi penuh. Severity moderat
+>    (blast radius sempit); KELASNYA yang serius. Lihat `awcms-abac-guard`
+>    §ATURAN PERTAMA.
+> 2. **API4/ASVS V11.2 — rate limiter `Map` dalam-proses.** Dengan N replika,
+>    batas efektif jadi N × batas terkonfigurasi. Redis sudah ada di repo. Tiga
+>    endpoint auth belum ber-limiter (`session-handoff/issue`/`redeem`,
+>    `sso/{providerKey}/callback`).
+> 3. **Rantai pasok — `bun audit` melaporkan 1 moderate** (`postcss <=8.5.22`
+>    transitif lewat `astro › vite › postcss`, GHSA-fxqj-rqcc-2cmp; jalur build).
+
 # AWCMS — Security Hardening (OWASP / ASVS / ISO)
 
 Sumber kebenaran: **`docs/awcms/20_threat_model_security_architecture.md`** (STRIDE, kontrol berlapis, trust boundary, **§Matrix kepatuhan OWASP/ASVS/ISO 27001** — matrix nyata dengan bukti per baris sudah ditulis di Issue #437, pakai sebagai template/precedent saat audit ulang atau menambah kontrol baru), **`docs/awcms/10_template_kode_coding_standard.md`** (guardrail), dan **`docs/awcms/13_final_master_index_traceability.md`** (matrix kontrol). Skill ini **memetakan** kontrol proyek ke kerangka standar; pakai bersama `awcms-security-review` (checklist per modul) dan subagent `awcms-security-auditor`.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -302,6 +302,50 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 ## 4. Backlog / langkah berikutnya
 
+- **ASESMEN MENYELURUH 4 Agustus 2026 — [`awcms/repo-assessment-2026-08-04.md`](awcms/repo-assessment-2026-08-04.md).**
+  Repo dinilai terhadap empat sumbu (standar AWCMS, hubungan `awcms-astro`, performa
+  internasional, keamanan internasional). Tujuh rekomendasi berperingkat; tiga
+  teratas dicatat di sini karena mengubah backlog:
+
+  - **P0 — satu rute MELEWATI chokepoint otorisasi.**
+    `POST /api/v1/blog/posts/{id}/submit-review` tidak memanggil
+    `authorizeInTransaction` sama sekali; ia menyusun jalurnya sendiri
+    (`fetchGrantedPermissionKeys` + `evaluatePostUpdateAccess`). Yang dilewati:
+    **evaluator ABAC** (`evaluateAccess`), gerbang platform-scope (ADR-0053),
+    business-scope facts (ADR-0060), dan SoD (#181). Akibat konkretnya —
+    **policy ABAC `deny` atas `blog_content.posts.update` dihormati di
+    `PATCH /{id}` dan diam-diam diabaikan di rute ini.** Severity moderat (blast
+    radius sempit, RBAC + aturan kepemilikan tetap berlaku); yang serius adalah
+    KELASNYA. `access:permissions:enforcement:check` tak bisa melihatnya: ia
+    bertanya "apakah permission ini punya penegak", bukan "apakah setiap situs
+    penegakan memakai chokepoint" — pengulangan persis pelajaran PR #351.
+    Perbaikannya dua bagian: routekan lewat chokepoint, DAN gerbangi kelasnya.
+    Himpunan pelanggar hari ini **tepat dua** berkas, satu di antaranya
+    (`auth/login.ts`) memang pra-autentikasi — jadi daftar pengecualiannya lahir
+    dengan satu entri.
+  - **P1 — kontrak yang dipakai `awcms-astro` tidak dijaga test apa pun.**
+    Snapshot OpenAPI beku adalah snapshot **PRA-migrasi #182**, sedangkan kelima
+    permukaan yang benar-benar dikonsumsi repo itu mendarat SESUDAHNYA
+    (`/auth/session`, `/media/objects`, `/media/public-origin`,
+    `/access/machine-credentials`, dan traversal `/blog/posts`). Diverifikasi: nol
+    kemunculan di berkas snapshot. Mengubah bentuk respons salah satunya **hijau di
+    CI sini dan merusak build repo sana** — kegagalan yang muncul di tempat orang
+    yang menyebabkannya tidak melihat. Perbaikan: snapshot kontrak KONSUMEN kedua
+    (jangan perluas yang pra-migrasi — tugasnya berbeda dan ia harus tetap beku).
+  - **P1 — rate limiter tidak bertahan lintas instans.** `src/lib/security/rate-limit.ts`
+    memakai `Map` dalam-proses (berkasnya sendiri mencatatnya): dengan N replika,
+    batas efektif jadi N × batas terkonfigurasi, sehingga deployment yang paling
+    butuh perlindungan justru paling lemah. Redis SUDAH ada di repo. Tiga endpoint
+    autentikasi belum ber-limiter sama sekali (`session-handoff/issue`/`redeem`,
+    `sso/{providerKey}/callback`) — kelengkapan, bukan lubang (masing-masing punya
+    mitigasi lain), tapi ASVS menuntut anti-automation di seluruh permukaan auth.
+
+  Sisanya (gerbang index-FK, `overrides` postcss untuk GHSA-fxqj-rqcc-2cmp,
+  anggaran query, Core Web Vitals) ada di dokumen asesmen dengan urutan eksekusi
+  yang disarankan. Catatan penting dari asesmen: **nol dari 28 gerbang repo ini
+  memeriksa performa** — sebuah query N+1 atau FK tanpa index mendarat dengan CI
+  hijau penuh.
+
 - **Layar admin yang masih kosong (lanjutan langsung ADR-0051).** Gelombang kedua
   (PR #335–#338, 2 Agustus 2026) menutup EMPAT dari tujuh — verifikasi ulang dengan
   `grep -L 'navigation:' src/modules/*/module.ts`, bukan dari daftar ini:

--- a/docs/adr/0062-skills-are-gated-against-the-code-they-describe.md
+++ b/docs/adr/0062-skills-are-gated-against-the-code-they-describe.md
@@ -79,6 +79,20 @@ sebuah spesifikasi target disunting lalu berhenti dibaca; daftar skill hanya
 berubah ketika sebuah skill berubah SIFAT — persis saat seseorang memang harus
 melihat.
 
+**Aturan 4 — perintah yang disuruh dijalankan harus ada.** Setiap
+`bun run <target>` di sebuah skill wajib ada di `package.json` ATAU terdaftar di
+`scripts/README.md` §Ditunda. Aturan ini **sengaja sempit**: §Ditunda secara
+eksplisit MENGIZINKAN skill menyebut target acuan yang belum dibangun, jadi
+gerbang ini tidak menggugat kebijakan itu — ia hanya menangkap target yang bukan
+keduanya. Hari ini itu tepat dua, dan salah satunya menyuruh pembacanya
+menjalankan `github:snapshot:refresh` yang tak pernah ada padahal mekanismenya
+`gh` CLI di halaman yang sama.
+
+Ini kelas yang sama yang `check:docs` sudah tangkap di komentar kode: enam
+komentar di `src/modules/module-management/` menyuruh menjalankan `modules:sync`,
+perintah yang tak pernah ada di sini. Itu sudah diperbaiki di `src/` — dan skill
+untuk modul yang SAMA masih menyebutnya, karena skill ada di luar semua gerbang.
+
 ### Entri mati juga gagal
 
 Dua cara sebuah entri `ASPIRATIONAL_SKILLS` jadi tak bermakna, dan yang kedua

--- a/docs/awcms/repo-assessment-2026-08-04.md
+++ b/docs/awcms/repo-assessment-2026-08-04.md
@@ -1,0 +1,328 @@
+# Asesmen repo `awcms` — 4 Agustus 2026
+
+> **Untuk apa dokumen ini.** Penilaian menyeluruh terhadap repo pada satu titik
+> waktu, diukur terhadap **empat sumbu**: standar pengembangan AWCMS sendiri
+> ([`../../AGENTS.md`](../../AGENTS.md) + `docs/adr/`), hubungannya dengan
+> [`ahliweb/awcms-astro`](https://github.com/ahliweb/awcms-astro), standar
+> performa internasional, dan standar keamanan internasional.
+>
+> **Setiap temuan di bawah diverifikasi ke KODE**, bukan ke dokumen. Repo ini
+> punya sejarah panjang temuan yang ditulis dari dugaan lalu tersalin jadi
+> keputusan (ADR-0058 §1, ADR-0059, ADR-0060) — jadi tiap klaim membawa berkas
+> dan barisnya, dan klaim yang tidak bisa dibuktikan tidak ditulis.
+
+## 1. Skala terukur
+
+| Dimensi                           | Angka      |
+| --------------------------------- | ---------- |
+| Modul terdaftar                   | 22         |
+| Migrasi `sql/`                    | 89         |
+| Tabel (`CREATE TABLE`)            | 130        |
+| Pernyataan RLS `ENABLE` / `FORCE` | 118 / 141  |
+| Rute API `/api/v1`                | 255 berkas |
+| Layar admin                       | 31         |
+| Berkas test                       | 292        |
+| Baris `src/` (ts + astro)         | ~156.000   |
+| Gerbang di rantai `bun run check` | 28         |
+| ADR                               | 63         |
+| Index database                    | 253        |
+
+Ini bukan repo muda. Kepadatan gerbangnya (28) tinggi untuk ukurannya, dan itu
+konteks penting untuk seluruh bagian berikut: **temuan di bawah bukan hal yang
+lolos karena tidak ada yang memeriksa — melainkan hal yang tidak ada
+pemeriksanya.**
+
+## 2. Temuan P0 — satu rute melewati chokepoint otorisasi
+
+### Apa yang ditemukan
+
+`POST /api/v1/blog/posts/{id}/submit-review`
+([`src/pages/api/v1/blog/posts/[id]/submit-review.ts`](../../src/pages/api/v1/blog/posts/[id]/submit-review.ts))
+**tidak memanggil `authorizeInTransaction` sama sekali.** Ia menyusun
+otorisasinya sendiri:
+
+```
+resolveTenantContext → resolveModuleEnabled → fetchGrantedPermissionKeys
+  → evaluatePostUpdateAccess → recordDecisionLog
+```
+
+Bandingkan dengan `PATCH /api/v1/blog/posts/{id}`, yang menegakkan **permission
+yang SAMA** (`blog_content.posts.update`) dan memanggil `authorizeInTransaction`
+lebih dulu, **lalu** `evaluatePostUpdateAccess` sebagai aturan kepemilikan
+tambahan.
+
+### Yang hilang di jalur itu
+
+`authorizeInTransaction`
+([`src/modules/identity-access/application/access-guard.ts`](../../src/modules/identity-access/application/access-guard.ts))
+adalah tempat berikut ini hidup — semuanya dilewati oleh rute di atas:
+
+| Lapisan                         | ADR                                                                          | Akibat dilewati                                                                                                   |
+| ------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `evaluateAccess` (ABAC DSL)     | #179                                                                         | **Policy ABAC `deny` eksplisit atas `blog_content.posts.update` DIHORMATI di `PATCH`, TIDAK di `submit-review`.** |
+| `isPlatformScopedPermissionKey` | [ADR-0053](../adr/0053-platform-scoped-permissions.md)                       | Gerbang lintas-tenant tak dievaluasi                                                                              |
+| `resolveBusinessScopeFacts`     | [ADR-0060](../adr/0060-business-scope-hierarchy-provided-by-tenant-admin.md) | Cakupan bisnis tak ikut memutuskan                                                                                |
+| `isHighRiskAction` + SoD        | #181                                                                         | Konflik segregation-of-duties tak diperiksa                                                                       |
+
+`evaluatePostUpdateAccess` sendiri menyatakan di docblock-nya bahwa ia **bukan**
+`evaluateAccess` bersama — ia aturan kepemilikan domain, bukan evaluator
+kebijakan.
+
+### Kenapa tidak ada gerbang yang menangkapnya
+
+`bun run access:permissions:enforcement:check` ([ADR-0057](../adr/0057-blog-page-lifecycle.md) §F,
+[ADR-0058](../adr/0058-unenforced-permissions-disposition.md)) bertanya
+**"apakah permission ini punya penegak?"** — dan `blog_content.posts.update`
+punya: `PATCH /{id}`. Gerbang itu **tidak** bertanya "apakah SETIAP situs
+penegakan memakai chokepoint". Ini pengulangan persis pelajaran PR #351: _gerbang
+cakupan permission dan kebenaran situs penegakan menjawab dua pertanyaan
+berbeda, dan sebuah kontrol bisa lulus yang pertama sambil salah di yang kedua._
+
+### Pemetaan standar
+
+- **OWASP Top 10 2021 — A01 Broken Access Control** (jalur otorisasi paralel yang
+  lebih lemah), **A04 Insecure Design** (dua evaluator untuk satu permission).
+- **OWASP API Security Top 10 2023 — API5 Broken Function Level Authorization.**
+- **OWASP ASVS v4.0.3 — V4.1.3** (least privilege ditegakkan konsisten),
+  **V1.4.4** (satu mekanisme akses terpusat, tidak di-bypass).
+- **ISO/IEC 27001:2022 Annex A — A.8.3** (pembatasan akses informasi),
+  **A.8.26** (persyaratan keamanan aplikasi).
+
+### Severity yang jujur
+
+**Moderat, bukan kritis.** Blast radius rute itu sempit — transisi
+`draft` → `review` pada satu post, dan RBAC + aturan kepemilikan TETAP berlaku.
+Yang bocor bukan data, melainkan **konsistensi kebijakan**: sebuah tenant yang
+menulis policy ABAC untuk menahan `posts.update` akan mendapati policy-nya
+dihormati di satu rute dan diam-diam diabaikan di rute lain. Kelasnya yang
+serius, bukan instansnya.
+
+### Rekomendasi
+
+1. Routekan `submit-review` lewat `authorizeInTransaction` (pola `PATCH /{id}`
+   sudah jadi cetakannya: chokepoint dulu, aturan kepemilikan sesudah).
+2. **Tambah gerbang untuk KELASNYA**, bukan hanya instansnya: setiap berkas rute
+   di `src/pages/api/v1/**` yang menyentuh `fetchGrantedPermissionKeys` tanpa
+   `authorizeInTransaction` / `defineTenantRoute` gagal, dengan daftar
+   pengecualian ber-alasan. Hari ini himpunan itu **tepat dua** berkas —
+   `submit-review.ts` dan `auth/login.ts` (yang memang pra-autentikasi, sehingga
+   jadi satu-satunya entri daftar). Nilai daftar yang berisi satu entri sama
+   dengan yang ADR-0058 catat: entri BERIKUTNYA tak bisa masuk tanpa terlihat.
+
+## 3. Temuan P1 — rate limiter tidak bertahan di lebih dari satu instans
+
+### Apa yang ditemukan
+
+[`src/lib/security/rate-limit.ts`](../../src/lib/security/rate-limit.ts)
+menyimpan counter di **`Map` dalam-proses** (baris 21). Berkasnya sendiri
+mencatat ini sebagai keterbatasan yang diketahui — jadi ini bukan cacat
+tersembunyi, melainkan **utang yang belum jatuh tempo sampai deployment
+diskalakan horizontal**.
+
+Konsekuensi aritmetiknya: dengan **N** instans aplikasi di belakang load
+balancer, batas efektif menjadi **N × batas terkonfigurasi**. Untuk
+`POST /api/v1/auth/login` itu berarti anti-brute-force melemah linier terhadap
+jumlah replika — dan justru deployment yang paling butuh perlindungan (trafik
+tinggi → banyak replika) yang paling lemah.
+
+**Redis sudah ada di repo** (`src/lib/redis/client.ts`, `cache.ts`, `config.ts`),
+jadi ini bukan kemampuan baru — hanya penyambungan.
+
+### Cakupan limiter hari ini
+
+| Endpoint                          | `checkRateLimit` |
+| --------------------------------- | ---------------- |
+| `auth/login`                      | ada              |
+| `auth/register`                   | ada              |
+| `auth/mfa/totp/verify`            | ada              |
+| `auth/password/forgot`            | ada              |
+| `auth/password/reset`             | ada              |
+| `auth/session-handoff/issue`      | **tidak ada**    |
+| `auth/session-handoff/redeem`     | **tidak ada**    |
+| `auth/sso/{providerKey}/callback` | **tidak ada**    |
+
+Ketiga yang kosong punya mitigasi lain (kode handoff ≤60 detik + sekali pakai +
+`redeem` menuntut client secret; callback SSO terikat state), jadi ini
+**kelengkapan, bukan lubang**. Tetapi ASVS menuntut anti-automation pada seluruh
+permukaan autentikasi, bukan sebagian.
+
+### Pemetaan standar
+
+- **OWASP API Security Top 10 2023 — API4 Unrestricted Resource Consumption.**
+- **OWASP ASVS v4.0.3 — V11.2.1/V11.2.2** (anti-automation), **V2.2.1**
+  (kontrol anti-brute-force pada autentikasi).
+- **ISO/IEC 27001:2022 Annex A — A.8.5** (autentikasi aman), **A.8.6**
+  (manajemen kapasitas).
+
+### Rekomendasi
+
+Pindahkan penyimpanan counter ke Redis **bila dan hanya bila** deployment
+multi-instans, dengan fail-open yang eksplisit: Redis mati **tidak boleh**
+menutup login (ketersediaan menang atas pengetatan di jalur ini), tapi harus
+melaporkan diri lewat `security:readiness`. Lalu lengkapi ketiga endpoint yang
+kosong.
+
+## 4. Temuan P1 — kontrak yang dipakai `awcms-astro` tidak dijaga test apa pun
+
+### Hubungan kedua repo hari ini
+
+`awcms-astro` **sudah tidak tertahan**: ADR-0027 di sana menutup penahanan
+ADR-0021 karena kedua indikatornya terpenuhi. Repo itu memanggil **enam
+permukaan** repo ini:
+
+| Permukaan                                                            | Mendarat di |
+| -------------------------------------------------------------------- | ----------- |
+| `GET /api/v1/blog/posts` (traversal `view=full`, cursor, `?locale=`) | #317        |
+| `GET /api/v1/blog/posts/{id}`                                        | —           |
+| `GET /api/v1/media/objects`                                          | #318        |
+| `GET /api/v1/media/public-origin`                                    | #370        |
+| `GET /api/v1/auth/session`                                           | ADR-0049    |
+| `POST /api/v1/access/machine-credentials`                            | ADR-0049    |
+
+### Cacatnya
+
+Snapshot OpenAPI beku
+([`tests/fixtures/openapi-pre-migration-snapshot.openapi.yaml`](../../tests/fixtures/openapi-pre-migration-snapshot.openapi.yaml),
+ditegakkan `tests/openapi-bundle.test.ts`) adalah snapshot **PRA-migrasi #182**.
+Ia menjamin sifat _add-only_ terhadap baseline itu — dan **kelima permukaan yang
+benar-benar dikonsumsi `awcms-astro` mendarat SESUDAHNYA**, sehingga tak satu pun
+ada di dalamnya. Diverifikasi: pencarian `/auth/session`, `/media/objects`,
+`/media/public-origin`, `/access/machine-credentials` di berkas snapshot
+mengembalikan **nol**.
+
+Artinya: **mengubah bentuk respons salah satu dari lima permukaan itu hijau di CI
+repo ini, dan merusak build `awcms-astro`.** Tidak ada satu pun gerbang yang
+menanyakannya, dan kegagalannya muncul di repo LAIN — tempat orang yang
+mengubahnya tidak melihat.
+
+Ini persis bentuk cacat yang [ADR-0062](../adr/0062-skills-are-gated-against-the-code-they-describe.md)
+baru saja tutup untuk skill: sebuah klaim yang bisa diperiksa, di lapisan yang
+tidak ada yang memeriksa.
+
+### Pemetaan standar
+
+- **ISO/IEC 25010 — Compatibility / Interoperability.**
+- **OWASP ASVS v4.0.3 — V13.1.1** (kontrak API terdefinisi & ditegakkan).
+- Praktik konsumen-kontrak (consumer-driven contract testing) sebagai norma
+  industri untuk batas antar-layanan.
+
+### Rekomendasi
+
+Tambahkan **snapshot kontrak konsumen kedua** — bukan memperluas snapshot
+pra-migrasi (ia punya tugas berbeda dan harus tetap beku). Isinya HANYA enam
+permukaan di atas, dengan aturan add-only yang sama, dan komentar yang menyebut
+`awcms-astro` sebagai pemilik alasannya. Biayanya kecil; yang dibeli adalah CI
+repo ini menjawab pertanyaan yang saat ini hanya bisa dijawab oleh build repo
+lain yang gagal.
+
+## 5. Performa — posturnya kuat, dua celah yang jujur
+
+### Yang sudah benar
+
+- **Cache tepi Varnish** ([ADR-0042](../adr/0042-varnish-edge-cache-auto-activation.md),
+  [ADR-0061](../adr/0061-host-resolved-public-surfaces-are-edge-cacheable.md)):
+  11 surface ter-deklarasi, allow-list fail-closed, TTL ber-ramp otomatis,
+  invalidasi lewat surrogate key + antrean tahan-lama. Sesuai **RFC 9111**
+  (HTTP caching) dan **RFC 5861** (`stale-while-revalidate`).
+- **Validator kondisional** ETag/`Last-Modified` → 304 di seluruh rute discovery.
+- **Pagination keyset** dipakai 26 berkas, dengan kursor teks presisi mikrodetik
+  (jebakan #158 sudah ditutup dan diuji).
+- **Pagination offset** dipakai 10 berkas TAPI **berbatas** (`MAX_PAGE_NUMBER`
+  10.000, clamp dua sisi) — jadi bukan permukaan serangan amplifikasi.
+- **253 index** dan `bun run db:work-class:check` untuk pemisahan kelas kerja
+  pool.
+- **Redis** cache-aside tersedia dengan fail-open.
+
+### Celah 1 — tidak ada gerbang performa sama sekali
+
+Tidak ada `*:check` untuk index coverage, query budget, atau anggaran ukuran
+bundel. Repo ini menggerbangi 28 hal; **nol** di antaranya performa. Konsekuensi
+praktis: sebuah query N+1 atau kolom FK tanpa index bisa mendarat dengan seluruh
+CI hijau.
+
+`scripts/README.md` §Ditunda memang mencatat `performance:*` sebagai tooling yang
+belum ada — jadi ini **kesenjangan yang diketahui**, bukan yang terlupakan.
+
+- **ISO/IEC 25010 — Performance efficiency** (time behaviour, resource
+  utilization) tidak punya bukti terotomasi.
+
+### Celah 2 — Core Web Vitals tidak pernah diukur
+
+Repo ini melayani HTML nyata (`/news/**`, `/blog/{tenantCode}/**`, 31 layar
+admin) tetapi tak ada pengukuran **LCP / INP / CLS** di mana pun, dan tak ada
+anggaran ukuran aset. `visitor_analytics` mengumpulkan kunjungan, bukan vitals.
+
+Untuk halaman publik yang justru jadi alasan cache tepi dibangun, tidak
+mengukurnya berarti keuntungan cache-nya tak pernah dibuktikan ke pengalaman
+pengguna — hanya ke beban origin.
+
+### Rekomendasi performa
+
+1. **Gerbang index-FK** (murni, tanpa DB): setiap kolom FK di `sql/` wajib punya
+   index, atau terdaftar sebagai pengecualian ber-alasan. Ini gerbang termurah
+   dengan hasil terbesar dan cocok dengan pola repo.
+2. **Anggaran query per-endpoint** untuk rute terpanas, memakai pola
+   Proxy-apply-trap yang **sudah ada** di test SoD (#181) — jadi tekniknya
+   terbukti di repo ini, tinggal diperluas.
+3. Core Web Vitals: keputusan produk, bukan cacat. Bila diambil, tempatnya di
+   `visitor_analytics` dengan ADR admission sendiri.
+
+## 6. Keamanan — postur dasar kuat
+
+Diverifikasi ada dan benar, bukan diasumsikan:
+
+| Kontrol                             | Bukti                                                                                                                                                                                                          |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Security headers lengkap            | [`src/lib/security/security-headers.ts`](../../src/lib/security/security-headers.ts) — CSP, HSTS (ber-gerbang TLS), `X-Content-Type-Options`, `X-Frame-Options: DENY`, `Referrer-Policy`, `Permissions-Policy` |
+| RLS `FORCE` + role non-owner        | 141 pernyataan `FORCE`; diuji sebagai `awcms_app` LOGIN, bukan superuser                                                                                                                                       |
+| ABAC default-deny + decision log    | `evaluateAccess`, `recordDecisionLog`                                                                                                                                                                          |
+| MFA/TOTP, OIDC, Turnstile, SoD      | #184/#185/#186/#181                                                                                                                                                                                            |
+| Kredensial mesin baca-saja          | [ADR-0049](../adr/0049-machine-credentials-and-session-introspection.md)                                                                                                                                       |
+| Handoff sesi sekali-pakai ≤60 detik | [ADR-0050](../adr/0050-bff-session-handoff-code.md)                                                                                                                                                            |
+| Permission platform-scoped          | [ADR-0053](../adr/0053-platform-scoped-permissions.md)                                                                                                                                                         |
+| Cakupan penegakan permission        | 203/203, **nol** pengecualian ([ADR-0058](../adr/0058-unenforced-permissions-disposition.md))                                                                                                                  |
+
+Pemetaan ke **OWASP Top 10 2021**: A01 tertutup kecuali temuan §2; A02 (crypto)
+lewat hashing sesi + enkripsi rahasia MFA; A03 lewat tagged-template Bun.SQL
+(tidak ada konkatenasi SQL); A05 lewat `validate-env` + `security:readiness`;
+A07 lewat MFA/lockout atomik-di-DB; A09 lewat audit log + decision log +
+correlation ID.
+
+### Satu temuan dependensi
+
+`bun audit`: **1 moderate** — `postcss <=8.5.22` transitif lewat
+`astro › vite › postcss` (GHSA-fxqj-rqcc-2cmp, baca `.map` arbitrer saat `from`
+tak diset). Jalur build, bukan runtime produksi. Rekomendasi: `overrides` ke
+`postcss ^8.5.23`, pola yang sama dengan yang `awcms-astro` pakai untuk
+`fast-uri`.
+
+## 7. Rekomendasi berperingkat
+
+| #   | Rekomendasi                                                                    | Sumbu                           | Butuh ADR?                       |
+| --- | ------------------------------------------------------------------------------ | ------------------------------- | -------------------------------- |
+| 1   | Routekan `submit-review` lewat `authorizeInTransaction` **+ gerbang kelasnya** | Keamanan (A01/API5/ASVS V1.4.4) | Ya — gerbang = perubahan standar |
+| 2   | Snapshot kontrak konsumen untuk enam permukaan `awcms-astro`                   | Interop (ASVS V13.1.1)          | Ya                               |
+| 3   | Rate limiter berbagi (Redis) + lengkapi 3 endpoint                             | Keamanan (API4/ASVS V11.2)      | Ya                               |
+| 4   | Gerbang index-FK                                                               | Performa (ISO 25010)            | Tidak — gerbang murni            |
+| 5   | `overrides` postcss                                                            | Rantai pasok                    | Tidak                            |
+| 6   | Anggaran query per-endpoint                                                    | Performa                        | Tidak                            |
+| 7   | Core Web Vitals di `visitor_analytics`                                         | Performa/produk                 | Ya                               |
+
+**Urutan yang disarankan: 1 → 2 → 5 → 4 → 3 → 6 → 7.** Nomor 1 lebih dulu karena
+ia satu-satunya yang menyangkut kebenaran kontrol keamanan; nomor 2 kedua karena
+kegagalannya muncul di repo lain, tempat orang yang menyebabkannya tidak
+melihatnya; nomor 5 disisipkan lebih awal hanya karena biayanya satu baris.
+
+## 8. Yang TIDAK direkomendasikan, dan kenapa
+
+- **Menaikkan cakupan test demi angka.** 292 berkas test dengan pola
+  mutation-proven yang konsisten sudah lebih bernilai daripada persentase.
+- **Menggerbangi `docs/awcms/`** seperti `.claude/skills/`. Isinya sengaja
+  campuran sejarah + spesifikasi, dan tidak dieksekusi sebagai instruksi —
+  ADR-0062 §3 sudah menyatakan batas itu.
+- **Mengaktifkan `EDGE_CACHE_MODE` sebagai default.** Default MATI adalah
+  keputusan ADR-0042 dan tetap benar: cache bersama di depan aplikasi
+  multi-tenant adalah mesin kebocoran bila salah dikonfigurasi.
+- **Membangun `newsletter`/`social-publishing` sekarang.** Keduanya butuh ADR
+  admission, dan tak satu pun memblokir `awcms-astro` — itu kesimpulan kedua repo,
+  bukan penilaian sepihak.

--- a/scripts/skills-check.ts
+++ b/scripts/skills-check.ts
@@ -104,7 +104,88 @@ const ASPIRATIONAL_SKILLS: Readonly<Record<string, string>> = {
     "historical: ADR-0055 retired the mini-first pathway; the skill is kept as the record of how ports were done."
 };
 
+/**
+ * Reference targets `scripts/README.md` §Ditunda declares as legitimately
+ * absent, which that section **explicitly permits** skills to name:
+ *
+ * > Nama-nama ini boleh disebut sebagai **target** di `docs/awcms/` dan
+ * > `.claude/skills/` … tetapi tidak boleh muncul sebagai `bun run <target>` di
+ * > berkas **current-state**.
+ *
+ * So rule 4 below is deliberately NARROW: it does not re-litigate that policy,
+ * it only catches targets that are neither real nor deferred — pure ghosts.
+ *
+ * Kept here as an explicit list rather than parsed out of the README (the
+ * section mixes full names, `performance:*` wildcards and `:pot:check`
+ * shorthand, and a parser for that would fail in the quiet direction). A test
+ * binds every entry back to the README so the two cannot drift.
+ */
+const DEFERRED_TARGET_PREFIXES: readonly string[] = [
+  "config:docs:check",
+  "database:capacity:check",
+  "i18n:",
+  "modules:sync",
+  "performance:",
+  "production:preflight",
+  "resilience:dr-drill"
+];
+
 export type SkillProblem = { skill: string; message: string };
+
+/** True when a `bun run` target is real, or declared deferred by `scripts/README.md` §Ditunda. */
+export function isKnownRunTarget(
+  target: string,
+  packageScripts: ReadonlySet<string>,
+  deferred: readonly string[] = DEFERRED_TARGET_PREFIXES
+): boolean {
+  if (packageScripts.has(target)) {
+    return true;
+  }
+
+  return deferred.some((entry) =>
+    entry.endsWith(":") ? target.startsWith(entry) : target === entry
+  );
+}
+
+/** Extract every `bun run <target>` a skill tells its reader to run. */
+export function extractCitedRunTargets(source: string): string[] {
+  return [
+    ...new Set(
+      [...source.matchAll(/bun run ([a-z0-9:_-]+)/g)].map((match) => match[1]!)
+    )
+  ];
+}
+
+/**
+ * Rule 4 — a skill must not tell its reader to run a command that neither
+ * exists nor is a declared deferred target.
+ *
+ * This is the same defect `check:docs` was widened to catch in source comments:
+ * six comments under `src/modules/module-management/` told readers to run
+ * `modules:sync`, a command that never existed here (the real mechanism is
+ * `POST /api/v1/modules/sync`). That was fixed in `src/` — and the skill for
+ * that same module still said it, because skills were outside every gate.
+ */
+export function checkCitedRunTargets(
+  skill: string,
+  citedTargets: readonly string[],
+  packageScripts: ReadonlySet<string>,
+  skillIsAspirational: boolean
+): SkillProblem[] {
+  if (skillIsAspirational) {
+    return [];
+  }
+
+  return citedTargets
+    .filter((target) => !isKnownRunTarget(target, packageScripts))
+    .map((target) => ({
+      skill,
+      message:
+        `tells the reader to run \`bun run ${target}\`, which is not in package.json and is not ` +
+        "listed as a deferred target in `scripts/README.md` §Ditunda. Name the real mechanism, or " +
+        "write the placeholder so it cannot be mistaken for a command."
+    }));
+}
 
 /** A skill directory's subject module key: `awcms-blog-content` → `blog_content`. */
 export function subjectModuleKey(skillName: string): string {
@@ -188,6 +269,15 @@ export function checkCitedAdrs(
 
 async function main(): Promise<void> {
   const liveModuleKeys = new Set(listModules().map((module) => module.key));
+  const packageScripts = new Set(
+    Object.keys(
+      (
+        JSON.parse(await readFile("package.json", "utf8")) as {
+          scripts?: Record<string, string>;
+        }
+      ).scripts ?? {}
+    )
+  );
   const adrNumbers = new Set(
     (await readdir(ADR_ROOT))
       .map((file) => /^(\d{4})-/.exec(file)?.[1])
@@ -218,7 +308,13 @@ async function main(): Promise<void> {
         moduleIsLive,
         existsSync
       ),
-      ...checkCitedAdrs(skill, extractCitedAdrNumbers(source), adrNumbers)
+      ...checkCitedAdrs(skill, extractCitedAdrNumbers(source), adrNumbers),
+      ...checkCitedRunTargets(
+        skill,
+        extractCitedRunTargets(source),
+        packageScripts,
+        skill in ASPIRATIONAL_SKILLS
+      )
     );
   }
 
@@ -261,7 +357,7 @@ async function main(): Promise<void> {
   console.log(
     `skills:check OK — ${skillDirs.length} skills, ` +
       `${Object.keys(ASPIRATIONAL_SKILLS).length} declared aspirational/historical, ` +
-      `every cited src path and ADR resolves.`
+      `every cited src path, ADR and \`bun run\` target resolves.`
   );
 }
 

--- a/tests/skills-check.test.ts
+++ b/tests/skills-check.test.ts
@@ -15,8 +15,11 @@ import { describe, expect, test } from "bun:test";
 import {
   checkCitedAdrs,
   checkCitedPaths,
+  checkCitedRunTargets,
   extractCitedAdrNumbers,
+  extractCitedRunTargets,
   extractCitedSourcePaths,
+  isKnownRunTarget,
   subjectModuleKey
 } from "../scripts/skills-check";
 
@@ -152,6 +155,74 @@ describe("rule 2 — cited ADRs exist", () => {
     expect(
       checkCitedAdrs("awcms-example", ["0042"], new Set(["0042"]))
     ).toEqual([]);
+  });
+});
+
+describe("rule 4 — cited `bun run` targets are real or declared deferred", () => {
+  const scripts = new Set(["check", "skills:check"]);
+
+  test("extraction finds targets and deduplicates", () => {
+    expect(
+      extractCitedRunTargets(
+        "run `bun run check` then `bun run skills:check`, then `bun run check`"
+      )
+    ).toEqual(["check", "skills:check"]);
+  });
+
+  test("a real target passes", () => {
+    expect(isKnownRunTarget("check", scripts)).toBe(true);
+  });
+
+  test("a target declared deferred in scripts/README §Ditunda passes", () => {
+    // `scripts/README.md` §Ditunda EXPLICITLY permits skills to name these, so
+    // the rule must not re-litigate that policy.
+    expect(isKnownRunTarget("production:preflight", scripts)).toBe(true);
+    expect(isKnownRunTarget("performance:suite", scripts)).toBe(true);
+    expect(isKnownRunTarget("i18n:extract", scripts)).toBe(true);
+  });
+
+  test("a pure ghost fails", () => {
+    expect(isKnownRunTarget("github:snapshot:refresh", scripts)).toBe(false);
+
+    const problems = checkCitedRunTargets(
+      "awcms-github-snapshot",
+      ["github:snapshot:refresh"],
+      scripts,
+      false
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]!.message).toContain("Ditunda");
+  });
+
+  test("an aspirational skill may name its future tooling", () => {
+    expect(
+      checkCitedRunTargets(
+        "awcms-social-publishing",
+        ["social-publishing:dispatch"],
+        scripts,
+        true
+      )
+    ).toEqual([]);
+  });
+
+  test("every deferred prefix is actually documented in scripts/README §Ditunda", async () => {
+    // Binds the gate's explicit list back to the doc it claims to mirror. Without
+    // this, the list could quietly grow into a way to silence the rule.
+    const readme = await Bun.file("scripts/README.md").text();
+    const deferredSection = readme.slice(readme.indexOf("## Ditunda"));
+
+    for (const prefix of [
+      "config:docs:check",
+      "database:capacity:check",
+      "i18n:",
+      "modules:sync",
+      "performance:",
+      "production:preflight",
+      "resilience:dr-drill"
+    ]) {
+      expect(deferredSection).toContain(prefix.replace(/:$/, ""));
+    }
   });
 });
 


### PR DESCRIPTION
Full assessment of the repo against the four axes requested: AWCMS's own development standards, the relationship with `ahliweb/awcms-astro`, international performance standards, and international security standards.

[`docs/awcms/repo-assessment-2026-08-04.md`](docs/awcms/repo-assessment-2026-08-04.md) is the deliverable. Every finding is verified against code with file and line — this repo has a documented history of findings written from inference and then copied into decisions (ADR-0058 §1, ADR-0059, ADR-0060), so claims that could not be proven were left out.

## Headline: the repo is in strong shape, and that is the context for the findings

22 modules, 89 migrations, 141 RLS `FORCE` statements, 255 API routes, 292 test files, **28 gates** in `bun run check`, 63 ADRs. Security posture verified rather than assumed: full security headers (CSP, HSTS, `X-Frame-Options: DENY`, Referrer-Policy, Permissions-Policy), ABAC default-deny with decision log, MFA/OIDC/Turnstile/SoD, read-only machine credentials, permission enforcement 203/203 with zero exceptions.

So the findings below are not things that slipped past a check. **They are things nothing checks.**

## P0 — one route bypasses the authorization chokepoint

`POST /api/v1/blog/posts/{id}/submit-review` never calls `authorizeInTransaction`. It assembles its own path from `fetchGrantedPermissionKeys` + a domain ownership rule.

`PATCH /api/v1/blog/posts/{id}` enforces the **same permission** and calls the chokepoint first, then the ownership rule.

What the bypass skips — all of it silently:

| Layer | Consequence |
| --- | --- |
| `evaluateAccess` (ABAC DSL) | **an explicit ABAC `deny` on `blog_content.posts.update` is honoured on `PATCH` and ignored here** |
| `isPlatformScopedPermissionKey` (ADR-0053) | cross-tenant gate unevaluated |
| `resolveBusinessScopeFacts` (ADR-0060) | business scope does not participate |
| `isHighRiskAction` + SoD (#181) | conflicts unchecked |

**Severity moderate, stated honestly.** The blast radius is one `draft → review` transition and RBAC plus ownership still apply. What leaks is *policy consistency*: a tenant who writes an ABAC policy finds it enforced on one route and quietly ignored on another. The class is the problem, not the instance.

`access:permissions:enforcement:check` cannot catch this — it asks *"does this permission have an enforcer?"* and `blog_content.posts.update` does. It does not ask *"does every enforcement site use the chokepoint?"* Exactly the lesson of PR #351: a control can pass a coverage gate while being wrong at the site.

Maps to OWASP A01/A04, API5, ASVS V1.4.4/V4.1.3, ISO 27001 A.8.3/A.8.26.

## P1 — nothing tests the contract `awcms-astro` consumes

That repo is no longer held (its ADR-0027 closed the ADR-0021 hold) and calls six surfaces here. The frozen OpenAPI snapshot is the **pre-#182-migration** baseline — and all five of the surfaces it actually depends on landed *after* it. Verified: zero occurrences of `/auth/session`, `/media/objects`, `/media/public-origin`, `/access/machine-credentials` in the snapshot file.

Changing any of those response shapes is **green in this repo's CI and breaks the build in the other one** — a failure that surfaces where the person who caused it is not looking.

Recommendation: a second, consumer-contract snapshot covering exactly those six. Do not widen the pre-migration snapshot; it has a different job and must stay frozen.

## P1 — the rate limiter does not survive more than one instance

`src/lib/security/rate-limit.ts` counts in an in-process `Map` (the file says so itself). With N replicas the effective limit is **N × configured**, so the deployments that most need protection are the weakest. Redis is already in the repo. Three auth endpoints have no limiter at all (`session-handoff/issue`/`redeem`, `sso/{providerKey}/callback`) — completeness rather than a hole, since each has other mitigations, but ASVS wants anti-automation across the whole auth surface.

## Performance

Genuinely strong: 11 edge-cache surfaces with fail-closed allow-list, ETag/304 across discovery, keyset pagination in 26 files, offset pagination bounded at 10,000, 253 indexes, work-class pool separation.

Two honest gaps: **zero of the 28 gates measure performance** (an N+1 or an unindexed FK lands with CI fully green), and Core Web Vitals are never measured despite serving real HTML. Cheapest high-value fix proposed: a pure FK-index gate, then per-endpoint query budgets using the Proxy-apply-trap pattern already proven in the SoD tests.

## What also came out of it: `skills:check` rule 4

Auditing the skills surfaced 13 naming 22 non-existent `bun run` targets. But `scripts/README.md` §Ditunda **explicitly permits** skills to name deferred reference targets — so a blanket rule would have contradicted standing policy. Narrowed to targets that are neither real nor deferred: **two**, one of which told readers to run a refresh command that never existed while the real `gh` invocations sat on the same page.

That is the same defect class `check:docs` was widened to catch in source comments (`modules:sync` under `src/modules/module-management/`) — fixed in `src/`, still present in that module's own skill, because skills were outside every gate.

Skills corrected: **`awcms-abac-guard` now leads with the chokepoint rule** — the P0 finding exists partly because that rule was never written down anywhere an agent would read before writing a guard. Plus `awcms-performance` (its commands do not exist), `awcms-security-hardening` (carries the open findings), and the two ghost commands.

## Verification

- All 27 gates green, typecheck, build.
- 22 unit tests on the gate; rule 4 mutation-proven by restoring the original `github:snapshot:refresh` ghost.
- One test binds the deferred-target list back to `scripts/README.md` §Ditunda so the two cannot drift.
- Full suite against real Postgres: 3520 pass; the 6 failures are pre-existing and identical to the four prior runs.

No migrations, no permissions, no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
