### PR TITLE
chore(deps): pin postcss ^8.5.23 to close GHSA-fxqj-rqcc-2cmp

### DIFF
--- a/.changeset/postcss-override.md
+++ b/.changeset/postcss-override.md
@@ -1,0 +1,18 @@
+---
+"awcms": patch
+---
+
+Close GHSA-fxqj-rqcc-2cmp by pinning `postcss` to `^8.5.23` via `overrides`.
+
+`bun audit` reported one moderate advisory: PostCSS's incomplete fix of
+GHSA-6g55-p6wh-862q lets an attacker-controlled `sourceMappingURL` read
+arbitrary `.map` files when `from` is unset. It reaches this repo transitively
+through `astro › vite › postcss`, which resolved to 8.5.19.
+
+A dependency override rather than waiting for the upstream bump: the path is
+three levels deep, so nothing this repo declares can move it, and `overrides`
+is the same mechanism `awcms-astro` used to close its `fast-uri` advisory.
+
+Build-path only — PostCSS does not run at request time — so this is hygiene
+rather than an exposure. `bun audit` is now clean, and `bun install
+--frozen-lockfile` still resolves unchanged.

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,9 @@
       },
     },
   },
+  "overrides": {
+    "postcss": "^8.5.23",
+  },
   "packages": {
     "@astrojs/compiler": ["@astrojs/compiler@2.13.1", "", {}, "sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg=="],
 
@@ -706,7 +709,7 @@
 
     "playwright-core": ["playwright-core@1.62.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw=="],
 
-    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
+    "postcss": ["postcss@8.5.25", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw=="],
 
     "prettier": ["prettier@3.9.6", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g=="],
 

--- a/package.json
+++ b/package.json
@@ -126,6 +126,9 @@
     "typescript": "^7.0.2",
     "yaml": "^2.9.0"
   },
+  "overrides": {
+    "postcss": "^8.5.23"
+  },
   "dependencies": {
     "@astrojs/node": "^11.0.3",
     "astro": "^7.1.6"


### PR DESCRIPTION
Recommendation #5 from the [repo assessment](docs/awcms/repo-assessment-2026-08-04.md) §7 — the cheapest item on the list.

`bun audit` reported one moderate advisory: PostCSS's incomplete fix of GHSA-6g55-p6wh-862q, where an attacker-controlled `sourceMappingURL` reads arbitrary `.map` files when `from` is unset. It reaches this repo transitively through `astro › vite › postcss`, which resolved to **8.5.19**.

An `overrides` entry rather than waiting for the upstream bump: the path is three levels deep, so nothing this repo declares can move it. It is also the mechanism `awcms-astro` already used to close its own `fast-uri` advisory, so the family stays consistent.

**Build-path only** — PostCSS never runs at request time, so this is hygiene rather than a live exposure. Stated plainly because the advisory's severity would otherwise imply more than it does here.

## Verification

- `bun audit` → **No vulnerabilities found** (was 1 moderate).
- Lockfile resolves `postcss@8.5.25`.
- `bun install --frozen-lockfile` unchanged, typecheck and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)