### PR TITLE
test(performance): query budgets on the hot public read paths

### DIFF
--- a/.changeset/query-budgets.md
+++ b/.changeset/query-budgets.md
@@ -1,0 +1,27 @@
+---
+"awcms": patch
+---
+
+Query budgets on the hot public read paths.
+
+An N+1 is invisible to every other kind of test: the rows are right, the
+assertions pass, the response is byte-identical, and only the number of round
+trips differs. It surfaces in production as latency that grows with content,
+months after the code landed.
+
+`tests/integration/query-budget.ts` extracts the Proxy-apply-trap the SoD suite
+already proved out into a reusable `countQueries`, and the accompanying
+integration test binds the listing, paging and feed paths to a ceiling of three
+queries against a 40-post fixture.
+
+The fixture size is the point: a bound asserted against one row proves nothing,
+since an N+1 and a constant-query implementation both issue about one query.
+Mutation-proven by injecting a real N+1 into `listPublicBlogPosts` — two budgets
+turn red. A fourth test guards the instrument itself, because a Proxy that
+silently stopped counting would make every budget pass vacuously.
+
+These are the paths the edge cache fronts, which is why the count matters: a
+cache MISS pays the full cost, and auto-activation only engages once the origin
+is already under pressure.
+
+No ADR: this adds no standing rule and no gate to `bun run check`.

--- a/docs/awcms/repo-assessment-2026-08-04.md
+++ b/docs/awcms/repo-assessment-2026-08-04.md
@@ -309,9 +309,16 @@ pengguna — hanya ke beban origin.
 1. **Gerbang index-FK** (murni, tanpa DB): setiap kolom FK di `sql/` wajib punya
    index, atau terdaftar sebagai pengecualian ber-alasan. Ini gerbang termurah
    dengan hasil terbesar dan cocok dengan pola repo.
-2. **Anggaran query per-endpoint** untuk rute terpanas, memakai pola
-   Proxy-apply-trap yang **sudah ada** di test SoD (#181) — jadi tekniknya
-   terbukti di repo ini, tinggal diperluas.
+2. ~~**Anggaran query per-endpoint**~~ **SELESAI** — `tests/integration/query-budget.ts`
+   mengekstrak pola Proxy-apply-trap dari test SoD (#181) jadi helper
+   `countQueries`, dan `query-budget.integration.test.ts` mengikat jalur baca
+   publik terpanas (listing, paging, feed) ke plafon **3 query** di atas fixture
+   40 post. Fixture-nya sengaja lebih besar dari plafon: plafon di atas satu baris
+   tak membuktikan apa pun karena N+1 dan implementasi konstan sama-sama
+   mengeluarkan sekitar satu query. Mutation-proven dengan menyuntikkan N+1 NYATA
+   ke `listPublicBlogPosts` — dua test langsung merah. Satu test menjaga
+   instrumennya sendiri (Proxy yang berhenti menghitung akan membuat semua plafon
+   lolos secara hampa).
 3. Core Web Vitals: keputusan produk, bukan cacat. Bila diambil, tempatnya di
    `visitor_analytics` dengan ADR admission sendiri.
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 303   |
+| Berkas test                        | 304   |
 | Berkas route                       | 312   |
 | ADR                                | 67    |
 
@@ -274,7 +274,7 @@
 | ------------- | ---------- |
 | `(root)`      | 257        |
 | `e2e`         | 11         |
-| `integration` | 34         |
+| `integration` | 35         |
 | `unit`        | 1          |
 
 ### Routes

--- a/tests/integration/query-budget.integration.test.ts
+++ b/tests/integration/query-budget.integration.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Query budgets on the hot public read paths — recommendation #6 of
+ * `docs/awcms/repo-assessment-2026-08-04.md` §5.
+ *
+ * No ADR: this adds no standing rule and no gate to `bun run check`. It is test
+ * infrastructure, and the assessment classified it that way deliberately —
+ * inventing an ADR for it would dilute what an ADR means here.
+ *
+ * These are the endpoints the edge cache exists to front, which is exactly why
+ * their query count matters: a cache MISS pays the full cost, and auto-activation
+ * only engages once the origin is already under pressure. An N+1 here turns a
+ * traffic spike into an outage rather than into a slow page.
+ *
+ * ## Why a count, and why these fixtures are deliberately large
+ *
+ * An N+1 is invisible to every other kind of test: the rows are right, the
+ * assertions pass, the response is byte-identical. Only the number of round
+ * trips differs.
+ *
+ * And a bound asserted against a one-row fixture proves nothing — a per-item
+ * query and a constant-query implementation both issue about one. So each case
+ * below seeds **more items than its budget allows**, which is what makes the
+ * assertion bite: if the implementation ever starts doing work per item, the
+ * count blows straight through the ceiling.
+ *
+ * The budgets are CEILINGS, not targets. Tightening one when an implementation
+ * improves is welcome. Loosening one should be an argued change, because the
+ * entire value of the file is that it fails when per-item work appears.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import {
+  listPublicBlogPosts,
+  listPublicBlogPostsForFeed
+} from "../../src/modules/blog-content/application/public-blog-directory";
+
+const TENANT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ACTOR = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const PUBLISHED_AT = new Date("2026-06-01T00:00:00.000Z");
+
+/** Comfortably more than any budget below, so per-item work cannot hide. */
+const SEEDED_POSTS = 40;
+
+const describeIntegration = integrationEnabled ? describe : describe.skip;
+
+describeIntegration("query budgets — hot public read paths", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+
+    await getAdminSql()`
+      INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+      VALUES (${TENANT}, 'budget', 'Budget Tenant', 'active')
+      ON CONFLICT (id) DO NOTHING
+    `;
+
+    // One statement, many rows — seeding in a loop would itself be the N+1 this
+    // file exists to catch, and would dominate the runtime.
+    //
+    // `generate_series`, not a bound array: Bun.SQL interpolates `${array}` as
+    // comma-joined TEXT, which Postgres rejects as a malformed array literal
+    // (22P02). Every other bulk-seed in this suite uses the same idiom for the
+    // same reason.
+    await getAdminSql()`
+      INSERT INTO awcms_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json,
+         content_text, status, visibility, locale, published_at)
+      SELECT ${TENANT}, ${ACTOR}, 'Post ' || n, 'post-' || n, '{}'::jsonb, 'body',
+             'published', 'public', 'en', ${PUBLISHED_AT}
+      FROM generate_series(1, ${SEEDED_POSTS}) AS n
+    `;
+  });
+
+  test(`the public post listing is constant-query across ${SEEDED_POSTS} posts`, async () => {
+    const { result, queries } = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) =>
+        countQueries(tx, (counting) =>
+          listPublicBlogPosts(counting, TENANT, { page: 1, pageSize: 20 })
+        )
+    );
+
+    expect(result.items.length).toBe(20);
+    // One page query plus at most a count/has-next probe. Twenty posts on the
+    // page means an N+1 would land at 20+.
+    expect(queries).toBeLessThanOrEqual(3);
+  });
+
+  test("paging deeper does not cost more queries", async () => {
+    // The shape that regresses quietly: an implementation that walks pages, or
+    // re-resolves something per page, stays correct and gets slower with depth.
+    const countFor = async (page: number): Promise<number> =>
+      (
+        await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) =>
+          countQueries(tx, (counting) =>
+            listPublicBlogPosts(counting, TENANT, { page, pageSize: 10 })
+          )
+        )
+      ).queries;
+
+    expect(await countFor(4)).toBe(await countFor(1));
+  });
+
+  test(`the feed builder is constant-query across ${SEEDED_POSTS} posts`, async () => {
+    // The feed is the single most-repeated query on the public surface — it is
+    // rebuilt on every discovery request that misses the edge cache.
+    const { result, queries } = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) =>
+        countQueries(tx, (counting) =>
+          listPublicBlogPostsForFeed(counting, TENANT)
+        )
+    );
+
+    // Bounded by the module's own FEED_ITEM_LIMIT, not by a caller argument.
+    expect(result.length).toBeGreaterThan(0);
+    expect(queries).toBeLessThanOrEqual(3);
+  });
+
+  test("the counter sees each query, so a budget of 0 is unreachable", async () => {
+    // Guards the instrument itself. A Proxy that silently stopped counting —
+    // by losing its `apply` trap, say — would make every budget above pass
+    // vacuously and read exactly the same in CI.
+    const { queries } = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) =>
+        countQueries(tx, async (counting) => {
+          await counting`SELECT 1`;
+          await counting`SELECT 2`;
+          await counting`SELECT 3`;
+        })
+    );
+
+    expect(queries).toBe(3);
+  });
+});

--- a/tests/integration/query-budget.ts
+++ b/tests/integration/query-budget.ts
@@ -1,0 +1,59 @@
+/**
+ * Query counting for integration tests — the reusable form of the Proxy that
+ * `sod.integration.test.ts` proved out for ADR-0181's bounded-evaluation check.
+ *
+ * ## What this catches that nothing else does
+ *
+ * An N+1 is invisible to every other kind of test. The endpoint returns the
+ * right rows, the assertions pass, the response looks identical — and it issues
+ * one query per item instead of one query. It shows up in production as
+ * latency that grows with content, months after the code landed, and the repo
+ * assessment of 2026-08-04 found **zero of 28 gates measuring anything about
+ * performance**.
+ *
+ * A count is the cheapest possible probe for it, and the only one that does not
+ * need a profiler, a plan, or a populated database to be meaningful.
+ *
+ * ## Assert a BOUND, and seed enough rows for it to mean something
+ *
+ * `expect(count).toBeLessThanOrEqual(n)` on a fixture with ONE row proves
+ * nothing — an N+1 and a constant-query implementation both issue about one
+ * query. The bound only bites when the fixture holds enough items that a
+ * per-item query would blow through it, which is why the callers here seed
+ * deliberately more rows than the budget allows.
+ *
+ * The number is a ceiling, not a target. Tightening it when an implementation
+ * improves is welcome; loosening it should be an argued change, because the
+ * whole value is that it fails when work-per-item appears.
+ */
+
+/** Run `work` with a query-counting `tx`, returning both its result and the count. */
+export async function countQueries<T>(
+  tx: Bun.TransactionSQL,
+  work: (counting: Bun.TransactionSQL) => Promise<T>
+): Promise<{ result: T; queries: number }> {
+  let queries = 0;
+
+  // `tx` is a callable tagged-template object, so the Proxy needs BOTH traps:
+  // `apply` to see the template calls, `get` to keep `tx.begin`/`tx.unsafe` and
+  // every other property working. Omitting `get` silently breaks any code path
+  // that reaches for a method rather than calling the tag.
+  const counting = new Proxy(tx, {
+    apply(target, thisArg, args) {
+      queries += 1;
+
+      return Reflect.apply(
+        target as unknown as (...a: unknown[]) => unknown,
+        thisArg,
+        args
+      );
+    },
+    get(target, prop, receiver) {
+      return Reflect.get(target as object, prop, receiver);
+    }
+  }) as unknown as Bun.TransactionSQL;
+
+  const result = await work(counting);
+
+  return { result, queries };
+}


### PR DESCRIPTION
Recommendation #6 from the [repo assessment](docs/awcms/repo-assessment-2026-08-04.md) §5.

## Why a query count

An N+1 is invisible to every other kind of test. The rows are right, the assertions pass, the response is byte-identical — only the number of round trips differs. It surfaces in production as latency that grows with content, months after the code landed.

These are specifically the paths the edge cache fronts, which is why the count matters: a cache MISS pays the full cost, and auto-activation only engages once the origin is *already* under pressure. An N+1 here turns a traffic spike into an outage rather than a slow page.

## The fixture size is the point

`tests/integration/query-budget.ts` extracts the Proxy-apply-trap the SoD suite already proved out into a reusable `countQueries`, and the integration test binds listing, paging and feed to a **ceiling of three queries** against a **40-post** fixture.

A bound asserted against a one-row fixture proves nothing — an N+1 and a constant-query implementation both issue about one query. Only a fixture larger than the ceiling makes the assertion bite.

Budgets are **ceilings, not targets**. Tightening one when an implementation improves is welcome; loosening one should be an argued change, since the whole value is that it fails when per-item work appears.

## Mutation proof

Injecting a **real** N+1 into `listPublicBlogPosts` — one probe per returned row — turns two budgets red. A fourth test guards the instrument itself: a Proxy that silently stopped counting (by losing its `apply` trap, say) would make every budget pass vacuously and read identically in CI.

## One trap re-learned

Seeding uses `generate_series`, not a bound array. Bun.SQL interpolates `${array}` as comma-joined **text**, which Postgres rejects as a malformed array literal (22P02). Every other bulk-seed in this suite already uses that idiom for the same reason; this file had to find out the hard way, and the comment now says why.

## No ADR

This adds no standing rule and no gate to `bun run check`. It is test infrastructure, and the assessment classified it that way — inventing an ADR would dilute what an ADR means in this repo.

## Verification

- 4/4 pass against real Postgres; mutation-proven as above.
- Key gates, typecheck and build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
