### PR TITLE
fix(idn-admin-regions): impor menulis SQL NULL, bukan string "null"

### DIFF
--- a/.changeset/idn-regions-import-null-columns.md
+++ b/.changeset/idn-regions-import-null-columns.md
@@ -1,0 +1,5 @@
+---
+"awcms": patch
+---
+
+Impor dataset wilayah menulis SQL NULL, bukan string `"null"`. `tx.array(values, "text")` tidak bisa membawa NULL — Bun menyerialkan elemen `null` menjadi teks empat karakter `"null"` (diprobe terhadap PostgreSQL 18.4 di Bun 1.3.14; varian tanpa tipe pun bukan NULL). Akibatnya impor nyata mengisi setiap kolom nullable dengan `'null'`: 38 provinsi ber-`parent_code` `'null'` dan 7.285 kecamatan ber-`local_term` `'null'`, yang dirender apa adanya oleh layar lookup dan membuat filter `IS NULL` mengembalikan nol baris. Nilai null kini melintas sebagai sentinel dan dipulihkan `NULLIF(t.col, '')` di SELECT — benar juga bila Bun kelak mengirim NULL sungguhan. Digerbangi test integrasi yang hanya bisa merah di database nyata.

--- a/src/modules/idn-admin-regions/application/dataset-import.ts
+++ b/src/modules/idn-admin-regions/application/dataset-import.ts
@@ -41,6 +41,23 @@ import { parseWilayahDump } from "../domain/wilayah-dump-parser";
  */
 const INSERT_BATCH_SIZE = 5000;
 
+/**
+ * `tx.array(values, "text")` CANNOT carry a SQL NULL: Bun serialises a JS `null`
+ * element into the four-character string `"null"`, and the untyped form does not
+ * produce a NULL either (probed against PostgreSQL 18.4 on Bun 1.3.14 —
+ * `x IS NULL` came back false for both). Importing straight from those arrays
+ * therefore wrote `'null'` into every nullable column: provinces got a
+ * `parent_code` of `'null'`, and all 7,285 districts got a `local_term` of
+ * `'null'`, which a lookup screen renders verbatim.
+ *
+ * So nulls travel as this sentinel and are restored by `NULLIF(t.col, '')` in
+ * the SELECT. Empty string is safe as the wire value because no region code,
+ * name, or local term is ever legitimately empty — the parser rejects blank
+ * codes before a plan is built. The restore stays correct if Bun ever learns to
+ * send real NULLs: `NULLIF(NULL, '')` is still NULL.
+ */
+const NULL_SENTINEL = "";
+
 export type DatasetImportPlan = {
   datasetCode: string;
   sourceFile: string;
@@ -269,11 +286,14 @@ export async function commitDatasetImport(
          local_term, official_name, normalized_name, full_path_code,
          full_path_name, province_code, regency_code, district_code,
          village_code, source_row_hash, metadata)
-      SELECT ${datasetId}, t.code, t.code_compact, t.parent_code, t.level,
-             t.region_type, t.local_term, t.official_name, t.normalized_name,
-             t.full_path_code, t.full_path_name, t.province_code, t.regency_code,
-             t.district_code, t.village_code, t.source_row_hash,
-             t.metadata::jsonb
+      SELECT ${datasetId}, t.code, t.code_compact,
+             NULLIF(t.parent_code, ''), t.level,
+             t.region_type, NULLIF(t.local_term, ''),
+             t.official_name, t.normalized_name,
+             NULLIF(t.full_path_code, ''), NULLIF(t.full_path_name, ''),
+             NULLIF(t.province_code, ''), NULLIF(t.regency_code, ''),
+             NULLIF(t.district_code, ''), NULLIF(t.village_code, ''),
+             t.source_row_hash, t.metadata::jsonb
       FROM unnest(
         ${tx.array(
           chunk.map((region) => region.code),
@@ -284,7 +304,7 @@ export async function commitDatasetImport(
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.parentCode),
+          chunk.map((region) => region.parentCode ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(
@@ -296,7 +316,7 @@ export async function commitDatasetImport(
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.localTerm),
+          chunk.map((region) => region.localTerm ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(
@@ -308,27 +328,27 @@ export async function commitDatasetImport(
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.fullPathCode),
+          chunk.map((region) => region.fullPathCode ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.fullPathName),
+          chunk.map((region) => region.fullPathName ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.provinceCode),
+          chunk.map((region) => region.provinceCode ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.regencyCode),
+          chunk.map((region) => region.regencyCode ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.districtCode),
+          chunk.map((region) => region.districtCode ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(
-          chunk.map((region) => region.villageCode),
+          chunk.map((region) => region.villageCode ?? NULL_SENTINEL),
           "text"
         )},
         ${tx.array(

--- a/tests/integration/idn-admin-regions.integration.test.ts
+++ b/tests/integration/idn-admin-regions.integration.test.ts
@@ -342,4 +342,46 @@ suite("idn_admin_regions (real PostgreSQL)", () => {
     const named = await queryRegions(sql, { datasetCode: "does-not-exist" });
     expect(named.reason).toBe("dataset_not_found");
   });
+
+  /**
+   * `tx.array(values, "text")` cannot carry a SQL NULL — Bun serialises a JS
+   * `null` element into the four-character string `"null"`. Before the
+   * sentinel/`NULLIF` pairing in `dataset-import.ts`, a real import of the
+   * vendored dump wrote `'null'` into every nullable column: all 38 provinces
+   * got `parent_code = 'null'` and all 7,285 districts `local_term = 'null'`,
+   * which a lookup screen renders to the reader verbatim.
+   *
+   * Only a real database can catch this — the defect lives at the serialisation
+   * boundary, so it is invisible to a typecheck and to any pure test. Removing
+   * either half of the fix turns the first assertion red.
+   */
+  test("nullable columns land as SQL NULL, never the string 'null'", async () => {
+    const sql = getAdminSql();
+
+    await asTx(sql, (tx) => commitDatasetImport(tx, planFor("-nulls")));
+
+    const [counts] = (await sql.unsafe(`
+      SELECT
+        count(*) FILTER (
+          WHERE parent_code = 'null' OR local_term = 'null'
+             OR province_code = 'null' OR regency_code = 'null'
+             OR district_code = 'null' OR village_code = 'null'
+             OR full_path_code = 'null' OR full_path_name = 'null'
+        ) AS literal_null_strings,
+        count(*) FILTER (WHERE level = 1 AND parent_code IS NULL) AS provinces_without_parent,
+        count(*) FILTER (WHERE level = 3 AND local_term IS NULL) AS districts_without_term
+      FROM awcms_idn_admin_regions
+    `)) as {
+      literal_null_strings: string;
+      provinces_without_parent: string;
+      districts_without_term: string;
+    }[];
+
+    expect(Number(counts?.literal_null_strings)).toBe(0);
+    // The fixture carries two provinces (Aceh, Jakarta) and two districts
+    // (Bakongan, Gambir); asserting the counts rather than "> 0" keeps the test
+    // honest if the fixture is ever trimmed.
+    expect(Number(counts?.provinces_without_parent)).toBe(2);
+    expect(Number(counts?.districts_without_term)).toBe(2);
+  });
 });


### PR DESCRIPTION
Ditemukan saat mengimpor dataset wilayah ke staging (91.599 baris): **nol SQL NULL di seluruh tabel** — setiap kolom nullable berisi teks empat karakter `"null"`.

| kolom | teks `'null'` | SQL NULL |
|---|---|---|
| `parent_code` | 38 (semua provinsi) | 0 |
| `local_term` | 7.285 (semua kecamatan) | 0 |
| `village_code` | 7.837 | 0 |
| `district_code` | 552 | 0 |
| `regency_code` | 38 | 0 |

Sebabnya `tx.array(values, "text")`: Bun menyerialkan elemen `null` jadi string `"null"`. Diprobe langsung, bukan disimpulkan — `sql.array(["a", null, "b"], "text")` mengembalikan `x = "null"` dengan `x IS NULL` = false; bentuk tanpa tipe juga bukan NULL.

Perbaikannya sentinel eksplisit + `NULLIF(t.col, '')`, jadi benar terlepas dari perilaku Bun sekarang maupun nanti. Digerbangi test integrasi karena cacat ini tak terlihat oleh typecheck maupun test murni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)