### PR TITLE
fix(release): artefak rilis bertahan lebih lama dari gerbang yang menunggunya

### DIFF
--- a/.changeset/release-artifacts-outlive-approval-gate.md
+++ b/.changeset/release-artifacts-outlive-approval-gate.md
@@ -1,0 +1,13 @@
+---
+"awcms": patch
+---
+
+Artefak rilis bertahan lebih lama dari gerbang persetujuan yang menunggunya
+
+`release.yml` mengunggah SBOM, tarball sumber, dan checksum dengan `retention-days: 1`, lalu menggantung job penerbitan di balik gerbang environment `release` yang **tidak punya batas waktu sama sekali**. Setiap persetujuan yang datang lebih dari 24 jam setelah build karena itu menerbitkan apa-apa: artefaknya sudah hilang.
+
+Itu bukan skenario teoretis. Run v7.0.0 mati persis begitu — build selesai 5 Agustus 08:43 UTC, artefaknya kedaluwarsa 24 jam kemudian, dan persetujuan yang tiba 8 Agustus langsung menabrak `Artifact not found for name: release-artifacts`. Yang membuatnya mahal: tidak ada satu pun kalimat di teks kegagalan yang menyebut retensi, jadi kegagalannya terbaca seperti masalah unggah, bukan seperti run yang sudah tidak mungkin diterbitkan sejak dua hari sebelumnya. Rilis itu menggantung 63 jam sebelum ada yang menyentuhnya, dan pada jam ke-24 ia sebenarnya sudah mati.
+
+Retensi dinaikkan ke 30 hari — sama dengan batas GitHub sendiri untuk berapa lama sebuah run boleh menunggu persetujuan. Dengan begitu setiap gerbang yang masih bisa disetujui punya artefak untuk disetujui, dan kedua batas itu berhenti saling bertentangan.
+
+`ci.yml` memakai `retention-days: 5` dan tidak diubah: tidak ada job di sana yang menunggu di balik gerbang, jadi retensinya tidak pernah berlomba dengan keputusan manusia.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,16 @@ jobs:
             sbom-image.cdx.json
             source.tar.gz
             CHECKSUMS.txt
-          retention-days: 1
+          # Must outlive the `release` environment approval gate below, which has
+          # no time limit of its own. At `retention-days: 1` the v7.0.0 run died
+          # exactly this way: build finished 2026-08-05 08:43 UTC, the artifacts
+          # expired 24 h later, and the approval that arrived on 2026-08-08 hit
+          # `Artifact not found for name: release-artifacts` — a run that can
+          # never publish, with nothing in the failure text naming the cause.
+          # 30 days matches GitHub's own ceiling for how long a run may sit
+          # waiting for approval, so any gate that can still be approved now has
+          # artifacts to approve.
+          retention-days: 30
 
   sign-attest-publish:
     name: Sign, attest, publish


### PR DESCRIPTION
`release.yml` mengunggah SBOM, tarball sumber, dan checksum dengan `retention-days: 1`, lalu menggantung job penerbitan di balik gerbang environment `release` yang **tidak punya batas waktu sama sekali**. Setiap persetujuan yang datang lebih dari 24 jam setelah build karena itu tidak menerbitkan apa-apa: artefaknya sudah hilang.

## Ini bukan skenario teoretis

Run v7.0.0 mati persis begitu.

| | |
|---|---|
| Build selesai | 5 Agu 08:43:38 UTC |
| Artefak kedaluwarsa | 6 Agu 08:43:37 UTC |
| Persetujuan tiba | **8 Agu** |
| Hasil | `Artifact not found for name: release-artifacts` |

Yang membuatnya mahal bukan kegagalannya, tapi **cara ia gagal**: tidak ada satu pun kalimat di teks kegagalan yang menyebut retensi. Ia terbaca seperti masalah unggah — bukan seperti run yang sudah mustahil diterbitkan sejak dua hari sebelumnya. Rilis itu menggantung 63 jam sebelum ada yang menyentuhnya, dan pada jam ke-24 ia sebenarnya sudah mati. Siapa pun yang menandai rilis lalu pergi sehari akan menemukan hal yang sama.

## Perubahan

`retention-days: 1` → `30`, sama dengan batas GitHub sendiri untuk berapa lama sebuah run boleh menunggu persetujuan. Dengan begitu setiap gerbang yang **masih bisa** disetujui punya artefak untuk disetujui, dan kedua batas itu berhenti saling bertentangan. Komentar di tempatnya merekam kejadian v7.0.0 supaya angka 30 tidak terbaca sebagai pilihan sembarang.

## Cakupan

`ci.yml` (`retention-days: 5`) sengaja **tidak** diubah. Disurvei: `release.yml` adalah satu-satunya workflow yang punya `environment:` gate, jadi ia satu-satunya tempat retensi artefak pernah berlomba dengan keputusan manusia. Menaikkan retensi `ci.yml` hanya akan menambah penyimpanan tanpa menutup mode kegagalan apa pun.

## Verifikasi

- `bun run check` penuh lokal: **3.301 pass, 0 fail**, 34 gate hijau, build sukses, nol warning prettier
- YAML workflow di-parse ulang: 3 job utuh (`validate`, `build`, `sign-attest-publish`), satu-satunya `upload-artifact` kini `retention-days: 30`, gerbang `sign-attest-publish -> release` tak tersentuh

🤖 Generated with [Claude Code](https://claude.com/claude-code)