### PR TITLE
fix(release): potong catatan rilis ke batas body GitHub, jangan jatuhkan penerbitan

### DIFF
--- a/.changeset/release-notes-truncated-to-github-body-limit.md
+++ b/.changeset/release-notes-truncated-to-github-body-limit.md
@@ -1,0 +1,13 @@
+---
+"awcms": patch
+---
+
+Catatan rilis dipotong ke batas body GitHub alih-alih menjatuhkan penerbitan
+
+`release.yml` menyalin satu seksi `CHANGELOG.md` mentah-mentah menjadi body GitHub Release. GitHub menolak body di atas 125.000 karakter dengan `HTTP 422: body is too long` — dan penolakan itu datang **setelah** penandatanganan, attestation, dan push image semuanya berhasil. Hasilnya run yang mati dengan image tertandatangani dan ter-attest di registry, tetapi tanpa rilis yang menunjuk kepadanya.
+
+v7.0.0 gagal persis di sini: seksinya 186.449 karakter, 49% di atas batas. Ini juga bukan kejutan mendadak — v6.0.0 sudah 103.262 karakter, jadi langit-langitnya sudah didekati beberapa rilis tanpa ada apa pun yang melaporkan jaraknya.
+
+Sekarang langkah ekstraksi mengukur hasilnya dan memotong bila perlu, menyisipkan pemisah plus tautan ke `CHANGELOG.md` pada tag itu supaya teks utuhnya selalu satu klik jauhnya. Anggarannya dihitung dalam **byte** melawan langit-langit **karakter**: untuk UTF-8 byte selalu lebih besar atau sama dengan karakter, jadi anggaran byte hanya bisa terlalu berhati-hati, tidak pernah melampaui. Pemotongan mundur ke batas baris terakhir supaya body tak pernah berakhir di tengah karakter atau di tengah markdown.
+
+Diuji terhadap seksi v7.0.0 yang sesungguhnya: 186.449 byte turun menjadi 117.351 karakter, UTF-8 utuh, berakhir rapi. Seksi berukuran normal (v6.4.0, v6.3.0, v6.0.0) melewatinya tanpa disentuh.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,35 @@ jobs:
             found { print }
           ' CHANGELOG.md > release-notes.md
 
+          # GitHub rejects a release body over 125,000 characters with a bare
+          # `HTTP 422: body is too long`, AFTER signing, attestation, and the
+          # image push have already succeeded — so the run dies with a published,
+          # signed, attested image and no release to point at it. v7.0.0's
+          # section was 186,449 characters and failed exactly here; v6.0.0's was
+          # 103,262, so the ceiling had been approaching for several releases
+          # without anything reporting the distance to it.
+          #
+          # Budget in BYTES against a 125,000-CHARACTER ceiling: for UTF-8 bytes
+          # are always >= characters, so a byte budget can only ever undercount,
+          # never overshoot. The margin also covers the footer appended below.
+          LIMIT=118000
+          SIZE=$(wc -c < release-notes.md)
+          echo "release notes: ${SIZE} bytes (ceiling 125000 chars)"
+          if [ "$SIZE" -gt "$LIMIT" ]; then
+            echo "::warning::Release notes ${SIZE} B exceed ${LIMIT} B; truncating. Full text stays in CHANGELOG.md."
+            # head -c can split a UTF-8 sequence; cut back to the last complete
+            # line so the body never ends mid-character or mid-markdown.
+            head -c "$LIMIT" release-notes.md | head -n -1 > release-notes.trunc.md
+            {
+              printf '\n\n---\n\n'
+              printf '**Catatan rilis dipotong.** Isi lengkapnya %s karakter, di atas batas %s karakter milik GitHub.\n\n' "$SIZE" "125000"
+              printf 'Teks utuh: [CHANGELOG.md pada %s](https://github.com/%s/blob/%s/CHANGELOG.md)\n' \
+                "${GITHUB_REF_NAME}" "${GITHUB_REPOSITORY}" "${GITHUB_REF_NAME}"
+            } >> release-notes.trunc.md
+            mv release-notes.trunc.md release-notes.md
+            echo "truncated to $(wc -c < release-notes.md) bytes"
+          fi
+
       - name: Publish GitHub Release (real release only)
         if: github.event_name == 'push'
         env:


### PR DESCRIPTION
`release.yml` menyalin satu seksi `CHANGELOG.md` mentah-mentah menjadi body GitHub Release. GitHub menolak body di atas **125.000 karakter** dengan `HTTP 422: body is too long`.

## Bentuk kegagalannya yang membuatnya mahal

Penolakan itu datang **setelah** penandatanganan, attestation, dan push image semuanya berhasil:

| langkah | v7.0.0 |
|---|---|
| Keyless sign image digest | ✅ |
| Attest build provenance (image + source) | ✅ |
| Attest SBOM (image) | ✅ |
| Extract CHANGELOG section | ✅ |
| **Publish GitHub Release** | ❌ `422 body is too long` |

Hasilnya run yang mati dengan image **tertandatangani dan ter-attest sudah ada di registry**, tetapi tanpa rilis yang menunjuk kepadanya — keadaan setengah jadi yang tak bisa dibereskan dengan rerun, karena workflow untuk trigger tag selalu diambil dari ref tag itu sendiri.

Dan ini bukan kejutan mendadak:

| versi | ukuran seksi |
|---|---|
| v7.0.0 | **186.449** — 49% di atas batas |
| v6.0.0 | 103.262 — sudah 83% batas |
| v6.2.0 | 23.012 |
| v6.4.0 | 4.951 |

Langit-langitnya sudah didekati beberapa rilis tanpa ada apa pun yang melaporkan jaraknya.

## Perubahan

Langkah ekstraksi kini mengukur hasilnya, memotong bila melewati anggaran, lalu menyisipkan pemisah plus tautan ke `CHANGELOG.md` pada tag itu supaya teks utuhnya selalu satu klik jauhnya. Ia juga menulis ukuran ke log tiap kali, jadi jarak ke batas berhenti tak terlihat.

Dua detail yang sengaja:

- **Anggaran dihitung dalam byte melawan langit-langit karakter.** Untuk UTF-8 byte selalu ≥ karakter, jadi anggaran byte hanya bisa terlalu berhati-hati, tidak pernah melampaui. Terbukti pada uji: 117.932 byte = 117.351 karakter.
- **Pemotongan mundur ke batas baris terakhir** (`head -n -1`). `head -c` sendirian bisa membelah satu urutan UTF-8; tanpa ini body bisa berakhir di tengah karakter atau di tengah markdown.

## Verifikasi

Diuji terhadap seksi v7.0.0 yang **sesungguhnya** — teks yang baru saja menjatuhkan rilis:

- 186.449 byte → 117.932 byte / **117.351 karakter**, aman di bawah 125.000
- UTF-8 ter-decode bersih, berakhir rapi di footer
- Seksi berukuran normal lewat **tanpa disentuh**: v6.4.0 (4.969 B), v6.3.0 (10.771 B), v6.0.0 (103.709 B)

Plus `bun run check` penuh lokal: **3.301 pass, 0 fail**, 34 gate hijau, nol warning prettier; YAML workflow di-parse ulang dan ketiga job utuh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)