### PR TITLE
fix(typecheck): kode mati berhenti lolos ke `main` — `tsc` menolak local & parameter tak terpakai (CodeQL #147)

### DIFF
--- a/.changeset/mean-pugs-repeat.md
+++ b/.changeset/mean-pugs-repeat.md
@@ -1,0 +1,41 @@
+---
+"awcms": patch
+---
+
+fix(typecheck): kode mati berhenti lolos ke `main` — `tsc` menolak local & parameter tak terpakai
+
+CodeQL alert #147 (`js/unused-local-variable`) melaporkan impor mati
+`MEDIA_PERMISSIONS` di `src/pages/api/v1/media/objects/index.ts` — di `main`,
+seminggu setelah ia merge. Tidak ada satu pun dari 34 gerbang rantai `check`
+yang bersuara: `lint` adalah `prettier --check` yang memformat dan tidak pernah
+menganalisis, dan repo ini tidak memakai ESLint/oxlint. `tsc` sudah berjalan di
+setiap PR dan akan menangkapnya dalam hitungan detik, tetapi `tsconfig.json`
+meng-`extends` `astro/tsconfigs/strict`, sementara `noUnusedLocals` dan
+`noUnusedParameters` berada satu tingkat di atas di `strictest`. Repo sudah
+memetik `noUncheckedIndexedAccess` dan `noImplicitOverride` dari `strictest`;
+dua ini sekadar tidak ikut terbawa.
+
+Menyalakan keduanya memunculkan temuan kedua yang TIDAK dilaporkan CodeQL:
+flag `timedOut` di `src/lib/jobs/job-runner.ts`, ditulis oleh timer timeout job
+dan tidak pernah dibaca, bersebelahan dengan klasifikasi status yang justru
+menyimpulkan `"timeout"` lewat eliminasi (`terminatedBy ? "terminated" :
+"timeout"`). Flag itu dihapus, dan invarian yang membuat eliminasi tersebut
+sahih kini ditulis eksplisit di tempatnya: `controller` tidak pernah keluar dari
+fungsi kecuali sebagai `signal` read-only, jadi hanya ada dua pemanggil
+`abort()`. Sumber abort ketiga wajib mengembalikan klasifikasi menjadi positif —
+kalau tidak, abort-nya akan tercatat di log job sebagai timeout yang tak pernah
+terjadi.
+
+Perubahan perilaku: tidak ada. `timedOut` tidak pernah dibaca, sehingga
+menghapusnya tidak dapat mengubah status job mana pun; dua parameter di
+`seo-distribution/application/redirect-resolution-service.ts` hanya diberi
+awalan garis bawah karena kedua strategi redirect sengaja berbagi satu
+signature (`resolveLegacyBlogRedirect` mengenali tenant dari PATH, bukan dari
+HOST). Yang berubah adalah kelas cacat ini sekarang gagal secara lokal dan di
+PR, bukan muncul sebagai alert keamanan mingguan setelah mendarat.
+
+`tests/typecheck-unused-code-gate.test.ts` menjaga keduanya — setelan compiler
+dapat dihapus dalam commit yang sama dengan galat yang mengganggu seseorang,
+tanpa sinyal apa pun. Kedua sisi diuji karena masing-masing inert sendirian:
+flag tak berarti bila tidak ada perintah yang menjalankan `tsc`, dan
+menjalankan `tsc` tak membuktikan apa pun bila flag-nya hilang.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 311   |
+| Berkas test                        | 312   |
 | Berkas route                       | 312   |
 | ADR                                | 70    |
 
@@ -272,7 +272,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 262        |
+| `(root)`      | 263        |
 | `e2e`         | 12         |
 | `integration` | 36         |
 | `unit`        | 1          |

--- a/src/lib/jobs/job-runner.ts
+++ b/src/lib/jobs/job-runner.ts
@@ -297,11 +297,23 @@ export async function runJob(
   }
 
   const controller = new AbortController();
-  let timedOut = false;
+  // `terminatedBy` is the ONLY abort-cause variable, deliberately. There used
+  // to be a `timedOut` flag beside it, written by the timer below and never
+  // read once — the classification at the `race === "aborted"` branch derives
+  // "timeout" by elimination instead. Two writers where only one is read is
+  // how a status flag rots into a lie, so the unread one is gone rather than
+  // kept "for symmetry".
+  //
+  // The invariant that makes elimination sound, stated here because it is what
+  // a third abort source would silently break: `controller` is created in this
+  // function and never escapes it except as the read-only `signal` handed to
+  // `definition.handler`, so the ONLY two `abort()` callers are the timer
+  // immediately below and the signal handlers immediately after. Anything
+  // adding a third MUST make the classification positive again — otherwise its
+  // aborts are reported to the job log as timeouts that never happened.
   let terminatedBy: NodeJS.Signals | null = null;
 
   const timer = setTimeout(() => {
-    timedOut = true;
     controller.abort();
   }, timeoutMs);
   // Never let this timer alone keep the process alive.

--- a/src/modules/seo-distribution/application/redirect-resolution-service.ts
+++ b/src/modules/seo-distribution/application/redirect-resolution-service.ts
@@ -99,12 +99,21 @@ async function isSeoDistributionEnabled(
  * awcms (no `/news` route family, policy off by default). Returns a redirect
  * resolution or `null` (not a legacy path / policy off / no canonical host — fall
  * through to normal serving).
+ *
+ * `_request`/`_env` are unused ON PURPOSE and keep the underscore rather than
+ * being dropped: both strategies are called through the same
+ * `(sql, request, options, env)` shape by `resolvePublicRedirect` below, and
+ * strategy 1 identifies its tenant from the PATH (`/blog/{tenantCode}`) while
+ * strategy 2 identifies it from the request HOST. Trimming the parameters here
+ * would make the two call sites diverge and force the dispatcher to remember
+ * which strategy takes what. The underscore is what tells `noUnusedParameters`
+ * — and the next reader — that this is a shared signature, not an oversight.
  */
 async function resolveLegacyBlogRedirect(
   sql: Bun.SQL,
-  request: Request,
+  _request: Request,
   options: ResolveRedirectOptions,
-  env: NodeJS.ProcessEnv
+  _env: NodeJS.ProcessEnv
 ): Promise<RedirectResolution | null> {
   const parsed = parseLegacyBlogPath(options.pathname);
   if (!parsed) return null;

--- a/src/pages/api/v1/media/objects/index.ts
+++ b/src/pages/api/v1/media/objects/index.ts
@@ -1,9 +1,6 @@
 import { fail, ok } from "../../../../../modules/_shared/api-response";
 import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
-import {
-  MEDIA_PERMISSION_ACTIVITY_CODE,
-  MEDIA_PERMISSIONS
-} from "../../../../../modules/media-library/domain/media-permissions";
+import { MEDIA_PERMISSION_ACTIVITY_CODE } from "../../../../../modules/media-library/domain/media-permissions";
 import { mediaLibraryPortAdapter } from "../../../../../modules/media-library/application/media-library-port-adapter";
 
 /**

--- a/tests/typecheck-unused-code-gate.test.ts
+++ b/tests/typecheck-unused-code-gate.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `tsc` refuses unused locals and unused parameters, and the chain actually
+ * runs it.
+ *
+ * ## Why this guard exists
+ *
+ * CodeQL alert #147 (`js/unused-local-variable`) reported an unused
+ * `MEDIA_PERMISSIONS` import in `src/pages/api/v1/media/objects/index.ts` — on
+ * `main`, a week after it merged. Nothing in the 34-gate `check` chain had
+ * anything to say about it: `lint` is `prettier --check`, which formats and
+ * never analyses, and this repo carries no ESLint/oxlint. `tsc` was already
+ * running on every PR and would have caught it in under a second, but
+ * `tsconfig.json` extends `astro/tsconfigs/strict`, and `noUnusedLocals` /
+ * `noUnusedParameters` live one level up in `strictest`. The repo had already
+ * cherry-picked `noUncheckedIndexedAccess` and `noImplicitOverride` out of
+ * `strictest`; these two were simply never picked up with them.
+ *
+ * Turning them on surfaced a second finding CodeQL had NOT reported — a
+ * `timedOut` flag in `src/lib/jobs/job-runner.ts`, written by the job timeout
+ * timer and read nowhere, beside a status classification that derives
+ * "timeout" by elimination. That is the shape this gate is really for: dead
+ * state sitting next to live state, which reads as deliberate until someone
+ * checks.
+ *
+ * ## Why a test and not just the setting
+ *
+ * A compiler flag can be deleted in the same commit as the error that
+ * annoyed someone, with no signal anywhere. Both halves are asserted because
+ * either alone is inert: the flag does nothing if no command runs `tsc`, and
+ * running `tsc` proves nothing if the flag is gone. Same reasoning, and the
+ * same failure mode, as `codeql-coverage-statement.test.ts`.
+ *
+ * Note for whoever hits this next: an intentionally-unused parameter is
+ * spelled with a leading underscore (see `resolveLegacyBlogRedirect` in
+ * `seo-distribution/application/redirect-resolution-service.ts`, where two
+ * strategies share one call signature). Reach for that before reaching for
+ * this file.
+ *
+ * Plain file reads: no compiler run, no network.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+const tsconfig = JSON.parse(
+  readFileSync(path.join(ROOT, "tsconfig.json"), "utf8")
+) as { compilerOptions?: Record<string, unknown> };
+
+const packageJson = JSON.parse(
+  readFileSync(path.join(ROOT, "package.json"), "utf8")
+) as { scripts?: Record<string, string> };
+
+describe("unused-code typecheck gate", () => {
+  test("tsconfig.json refuses unused locals", () => {
+    expect(tsconfig.compilerOptions?.noUnusedLocals).toBe(true);
+  });
+
+  test("tsconfig.json refuses unused parameters", () => {
+    expect(tsconfig.compilerOptions?.noUnusedParameters).toBe(true);
+  });
+
+  // The flags are only worth anything because something runs the compiler.
+  // `astro/tsconfigs/strict` is the base, so neither flag is inherited — they
+  // have to be spelled out above, and `check` has to reach `typecheck`.
+  test("the check chain runs the type checker that enforces them", () => {
+    expect(packageJson.scripts?.typecheck).toContain("tsc");
+    expect(packageJson.scripts?.typecheck).toContain("--noEmit");
+    expect(packageJson.scripts?.check).toContain("bun run typecheck");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
     "types": ["bun"],
     "checkJs": true,
     "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true
+    "noImplicitOverride": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
   },
   "include": [".astro/types.d.ts", "scripts/**/*", "src/**/*", "tests/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Masalah

Halaman **Security → Code scanning** punya satu alert `open`: **#147 `js/unused-local-variable`** — impor mati `MEDIA_PERMISSIONS` di `src/pages/api/v1/media/objects/index.ts`. Ia terdeteksi **di `main`**, seminggu setelah merge.

Yang lebih penting daripada impornya adalah **mengapa ia bisa sampai ke `main`**. Rantai `check` punya 34 gerbang, dan tidak satu pun bersuara:

- `lint` = `prettier --check` — memformat, tidak pernah menganalisis.
- Repo ini tidak memakai ESLint/oxlint sama sekali.
- `tsc` **sudah** berjalan di setiap PR dan akan menangkapnya dalam hitungan detik — tetapi `tsconfig.json` meng-`extends` `astro/tsconfigs/strict`, sedangkan `noUnusedLocals`/`noUnusedParameters` berada satu tingkat di atas di `strictest`. Repo sudah memetik `noUncheckedIndexedAccess` dan `noImplicitOverride` dari `strictest`; dua ini sekadar tidak ikut terbawa.

Jadi kelas cacat ini ditangkap oleh **pemindai keamanan mingguan setelah mendarat**, bukan oleh type-checker yang sudah dibayar biayanya di setiap PR.

## Temuan kedua, yang tidak dilaporkan CodeQL

Menyalakan flag itu memunculkan cacat yang **tidak muncul di halaman code-scanning**: flag `timedOut` di `src/lib/jobs/job-runner.ts`, ditulis oleh timer timeout job dan **tidak pernah dibaca**, bersebelahan dengan klasifikasi status yang justru menyimpulkan `"timeout"` lewat eliminasi:

```ts
const status: JobStatus = terminatedBy ? "terminated" : "timeout";
```

Ini bentuk "state mati bersebelahan dengan state hidup" — terbaca seperti disengaja sampai ada yang memeriksa. Flag-nya dihapus, dan invarian yang membuat eliminasi tersebut **sahih** kini ditulis eksplisit di tempatnya: `controller` tidak pernah keluar dari fungsi kecuali sebagai `signal` read-only ke handler, sehingga hanya ada dua pemanggil `abort()`. Sumber abort ketiga wajib mengembalikan klasifikasi menjadi positif — kalau tidak, abort-nya tercatat di log job sebagai **timeout yang tak pernah terjadi**.

## Perubahan perilaku: tidak ada

- `timedOut` tidak pernah dibaca, sehingga menghapusnya tidak dapat mengubah status job mana pun.
- Dua parameter di `seo-distribution/application/redirect-resolution-service.ts` hanya diberi awalan garis bawah. Keduanya tak terpakai **dengan sengaja**: dua strategi redirect berbagi satu signature `(sql, request, options, env)`, dan strategi 1 mengenali tenant dari **PATH** (`/blog/{tenantCode}`) sementara strategi 2 dari **HOST**. Memangkas parameternya justru membuat kedua call site divergen.

Yang berubah: kelas cacat ini sekarang gagal **secara lokal dan di PR**, bukan muncul sebagai alert keamanan setelah mendarat.

## Bukti — mutasi, bukan sekadar hijau

Setiap perbaikan dibuktikan dengan menanam kembali **cacat ASLI** satu per satu:

| Mutasi | Hasil |
|---|---|
| Kembalikan impor `MEDIA_PERMISSIONS` | `objects/index.ts(5,3): error TS6133` |
| Kembalikan `let timedOut = false;` | `job-runner.ts(315,7): error TS6133` |
| Buang garis bawah dari `_request`/`_env` | `redirect-resolution-service.ts(114,3)` + `(116,3)`: `error TS6133` |
| Lepas `noUnusedLocals` dari `tsconfig.json` | `tests/typecheck-unused-code-gate.test.ts` merah (1 fail) |

Percobaan mutasi kedua sempat **gagal ditanam** pada usaha pertama dan pengecekan `grep`-nya keliru melaporkan sukses (kata `timedOut` muncul di komentar baru); mutasi itu diulang dengan anchor yang di-`assert` unik sebelum diterima.

`tests/typecheck-unused-code-gate.test.ts` menguji **kedua sisi** karena masing-masing inert sendirian: flag tak berarti bila tak ada perintah yang menjalankan `tsc`, dan menjalankan `tsc` tak membuktikan apa pun bila flag-nya hilang.

## Alert lain di halaman itu

Diperiksa, tidak ada yang perlu diubah:

- **#144/#145/#146 `js/insufficient-password-hash`** (dismissed, false positive) — **masih sahih terhadap kode hari ini**. Ketiganya meng-hash `randomBytes(32)` (token opaque CSPRNG 256-bit), bukan password pengguna; KDF lambat tidak menambah apa pun di atas entropi 256-bit, dan pada `oauth-state-token.ts` sha256 justru **diwajibkan** RFC 7636 PKCE S256. Dismissal tidak otomatis kembali kalau kode bergerak, jadi ini diverifikasi ulang, bukan diasumsikan.
- Sisanya (143) berstatus `fixed`. Tidak ada galat tool pada analisis CodeQL; `default-setup` sengaja `not-configured` karena repo memakai workflow advanced.
- Batas cakupan `.astro` (CodeQL tidak punya extractor Astro) tidak tersentuh PR ini — sudah tercatat sebagai gap C16/C4 dan dijaga `tests/codeql-coverage-statement.test.ts`.

## Verifikasi

`DATABASE_URL="" bun run check` **PENUH** hijau — `CHECK_EXIT=0`, 3801 test (3304 pass / 497 skip / **0 fail**), build + asset budget lolos. `docs/awcms/repo-inventory.md` diregenerasi karena ada berkas test baru.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
