### PR TITLE
feat(admin): layar `/admin/blog-settings` — pengaturan blog berhenti hanya bisa lewat `curl`

### DIFF
--- a/.changeset/layar-admin-blog-settings.md
+++ b/.changeset/layar-admin-blog-settings.md
@@ -1,0 +1,48 @@
+---
+"awcms": minor
+---
+
+feat(admin): layar `/admin/blog-settings` — pengaturan blog berhenti hanya bisa diubah lewat `curl`
+
+`GET`/`PATCH /api/v1/blog/settings` mendarat lengkap bersama Issue #543 —
+ter-guard di dalam `withTenant`, ter-audit, tervalidasi — dan punya **nol
+konsumen UI**. `rssEnabled` dan `sitemapEnabled` menentukan apakah feed dan
+sitemap tenant dilayani sama sekali, dan sampai sekarang satu-satunya cara
+mengubahnya adalah `curl`. Kapabilitas yang tak bisa dijangkau operator adalah
+kapabilitas yang sebenarnya tidak dimiliki deployment.
+
+**Ini BUKAN layar setting modul, dan bedanya load-bearing.**
+`/admin/modules/blog_content` (Module Management, generik) menulis
+`awcms_module_settings` — override per-tenant atas `settings.defaults`
+descriptor, yang hari ini tinggal `legacyTenantRouteEnabled`. Layar ini menulis
+`awcms_blog_settings`, tabel berbeda dengan permission berbeda
+(`blog_content.settings.*`) dan endpoint berbeda. README modul mencatat
+pemisahan dua-store itu sebagai keputusan.
+
+Risikonya karena itu bukan store yang hilang, melainkan **kontrol yang
+terduplikasi**: dua layar yang sama-sama tampak menawarkan "pengaturan blog"
+sambil menulis baris yang berbeda. Layar ini karena itu **tidak merender apa pun**
+dari store setting modul dan hanya menautkan ke layar generiknya. Field yang
+dicerminkan dua layar adalah field yang basi diam-diam, karena layar yang diedit
+belakangan menang dan tak satu pun mengatakannya.
+
+Dua field endpoint sengaja TIDAK ada di form, dan disebutkan namanya supaya
+absennya terbaca sebagai keputusan: `contentQualityChecklistPolicy` (peta
+override severity bersarang — menaruh kebijakan pemblokir-publish di balik
+textarea JSON tanpa umpan balik per-rule bukan kontrol yang layak) dan
+`socialPreviewFallbackImageMediaId` (mengetik UUID bukan media picker;
+`/admin/media` sudah memiliki pemilihan objek, dan field id mentah justru
+mengundang menempel id milik tenant lain yang endpoint-nya tolak sebagai galat
+validasi yang tak bisa ditindaklanjuti operator).
+
+Satu permission menggerbangi seluruh field (`settings.configure`) karena
+`sql/036` tidak men-seed permission tulis per-field — mengarang gerbang per-field
+di UI akan menyiratkan wewenang yang tak akan dihormati `authorizeInTransaction`
+mana pun.
+
+Entri navigasi digerbangi `settings.read`, bukan salah satu dari empat entri
+`blog_content` yang sudah ada: operator bisa memegang authoring blog tanpa
+memegang saklar discovery tenant. `tests/admin-blog-page-contract.test.ts`
+mematok jumlah entri navigasi persis supaya tiap kedatangan layar baru menjadi
+baris yang diedit dengan sengaja — dan ia memang memerah saat layar ini mendarat,
+lalu dinaikkan dari empat ke lima.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -109,8 +109,8 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base                         | **21** (lihat daftar di ARCHITECTURE.md)                                              | `src/modules/index.ts`                                                                  |
 | Migrasi                            | **90** (`sql/001`–`090`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0071** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
-| Layar admin                        | **31** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **42** (22.328 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Berkas `.astro`                    | **43** (22.649 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **35** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -29,7 +29,7 @@
         }
       ],
       "permissionCount": 41,
-      "navigationCount": 4,
+      "navigationCount": 5,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -13,7 +13,7 @@
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
 | Berkas test                        | 313   |
-| Berkas route                       | 308   |
+| Berkas route                       | 309   |
 | ADR                                | 72    |
 
 ### Modul
@@ -282,7 +282,7 @@
 | Permukaan       | Berkas |
 | --------------- | ------ |
 | `/api/v1/**`    | 255    |
-| `/admin/**`     | 31     |
+| `/admin/**`     | 32     |
 | publik / anonim | 22     |
 
 <!-- END GENERATED: repo-inventory -->

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -117,6 +117,16 @@ export const blogContentModule = defineModule({
       path: "/admin/blog-presentation",
       order: 39,
       requiredPermission: "blog_content.templates.read"
+    },
+    {
+      // Gated on `settings.read`, not on any of the four above: an operator
+      // may hold blog authoring without holding the tenant's discovery
+      // switches, and `rssEnabled`/`sitemapEnabled` decide whether the feed
+      // and sitemap are served at all.
+      labelKey: "admin.layout.nav_blog_settings",
+      path: "/admin/blog-settings",
+      order: 40,
+      requiredPermission: "blog_content.settings.read"
     }
   ],
   permissions: [

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -186,6 +186,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_blog_pages": "Blog pages",
   "admin.layout.nav_blog_taxonomy": "Blog taxonomy",
   "admin.layout.nav_blog_presentation": "Blog presentation",
+  "admin.layout.nav_blog_settings": "Blog settings",
   "admin.layout.nav_media": "Media library",
   "admin.layout.nav_reporting": "Reporting operations",
   "admin.layout.nav_approvals": "Approvals",

--- a/src/pages/admin/blog-settings.astro
+++ b/src/pages/admin/blog-settings.astro
@@ -1,0 +1,321 @@
+---
+/**
+ * Blog settings console — tenant blog identity, listing, and discovery flags.
+ *
+ * Fifth sibling of `/admin/blog` (posts), `/admin/blog-pages` (pages),
+ * `/admin/blog-taxonomy` (terms), and `/admin/blog-presentation`.
+ *
+ * ## Why this screen had to exist
+ *
+ * `GET`/`PATCH /api/v1/blog/settings` shipped complete with Issue #543 —
+ * guarded inside `withTenant`, audited, validated — and had **zero UI
+ * consumers**. `rssEnabled`/`sitemapEnabled` decide whether a tenant's feed and
+ * sitemap are served at all, and until now the only way to change either was
+ * `curl`. A capability an operator cannot reach is a capability the deployment
+ * does not really have.
+ *
+ * ## This is NOT the module-settings screen, and the difference is load-bearing
+ *
+ * `/admin/modules/blog_content` (Module Management, generic) writes
+ * `awcms_module_settings` — the per-tenant override of the module descriptor's
+ * `settings.defaults`, which today is `legacyTenantRouteEnabled` alone. THIS
+ * screen writes `awcms_blog_settings`, a different table with a different
+ * permission (`blog_content.settings.*`) and a different endpoint.
+ *
+ * The module README records that two-store split as a deliberate decision
+ * ("**two** existing, already-authoritative stores — deliberately not a third
+ * one"), so the risk here is not a missing store but a duplicated CONTROL: two
+ * screens offering what looks like "blog settings" while writing different
+ * rows. This screen therefore renders **nothing** from the module-settings
+ * store and links to the generic screen for it, rather than mirroring the
+ * field. A mirrored field is the one that goes stale silently, because whichever
+ * screen is edited second wins and neither says so.
+ *
+ * ## Fields deliberately NOT on this screen
+ *
+ * The endpoint accepts more than this form sends, and the absences are choices:
+ *
+ * - `contentQualityChecklistPolicy` — a nested override map of per-rule
+ *   severities. Rendering it as a JSON textarea (the pattern
+ *   `/admin/blog-presentation` uses for its complex sub-arrays) would put a
+ *   publish-blocking policy behind a free-text field with no per-rule
+ *   validation feedback. It deserves its own control, not a corner of this one.
+ * - `socialPreviewFallbackImageMediaId` — a media object id. Typing a UUID is
+ *   not a media picker, and `/admin/media` already owns choosing an object.
+ *   Offering a raw id field here would invite pasting an id from another
+ *   tenant, which the endpoint correctly rejects — as a validation error the
+ *   operator cannot act on.
+ *
+ * Both remain reachable through the API, and both are named here so their
+ * absence reads as a decision rather than an oversight.
+ *
+ * ## Writes go through the endpoint, never the database
+ *
+ * Same rule as every sibling console: SSR reads through the application layer,
+ * every mutation is a client `fetch()` to the guarded/audited endpoint. The
+ * page's own permission checks are defence in depth — enforcement stays in
+ * `authorizeInTransaction` inside the route.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { getDatabaseClient } from "../../lib/database/client";
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import {
+  fetchBlogSettings,
+  type BlogSettingsView
+} from "../../modules/blog-content/application/blog-settings-directory";
+
+const ssr = Astro.locals.ssrContext!;
+
+const canRead = ssr.permissions.has(
+  permissionKey("blog_content", "settings", "read")
+);
+
+// One permission gates every field on this form. `sql/036` seeds no
+// per-field write permission, so inventing one in the UI would imply an
+// authority no `authorizeInTransaction` call would honour.
+const canConfigure = ssr.permissions.has(
+  permissionKey("blog_content", "settings", "configure")
+);
+
+let settings: BlogSettingsView | null = null;
+let loadError: string | null = null;
+
+if (canRead) {
+  try {
+    const sql = getDatabaseClient();
+
+    settings = await withTenantOrThrow(sql, ssr.tenantId, async (tx) =>
+      fetchBlogSettings(tx, ssr.tenantId)
+    );
+  } catch (error) {
+    logAdminPageError("admin.blog_settings.load_failed", error, {
+      moduleKey: "blog_content"
+    });
+    loadError = "Gagal memuat pengaturan blog.";
+  }
+}
+
+const VISIBILITY_OPTIONS = ["public", "private"] as const;
+---
+
+<AdminLayout title="Blog settings">
+  <h1>Blog settings</h1>
+
+  {
+    !canRead && (
+      <p class="admin-empty">
+        Anda tidak punya permission <code>blog_content.settings.read</code>.
+      </p>
+    )
+  }
+
+  {loadError && <p class="admin-error">{loadError}</p>}
+
+  {
+    canRead && settings && (
+      <>
+        {!canConfigure && (
+          <p class="admin-note">
+            Hanya baca — mengubah butuh{" "}
+            <code>blog_content.settings.configure</code>.
+          </p>
+        )}
+
+        <p class="admin-error" id="settings-error" hidden />
+        <p class="admin-note" id="settings-ok" hidden>
+          Tersimpan.
+        </p>
+
+        <form id="blog-settings-form" class="admin-form">
+          <fieldset disabled={!canConfigure}>
+            <legend>Identitas</legend>
+
+            <label>
+              Judul blog
+              <input
+                type="text"
+                name="blogTitle"
+                maxlength="200"
+                required
+                value={settings.blogTitle}
+              />
+            </label>
+
+            <label>
+              Deskripsi
+              <textarea name="blogDescription" maxlength="500" rows="3">
+                {settings.blogDescription ?? ""}
+              </textarea>
+            </label>
+
+            <legend>Daftar</legend>
+
+            <label>
+              Post per halaman
+              <input
+                type="number"
+                name="postsPerPage"
+                min="1"
+                max="100"
+                required
+                value={String(settings.postsPerPage)}
+              />
+            </label>
+
+            <label>
+              Locale bawaan
+              <input
+                type="text"
+                name="defaultLocale"
+                required
+                value={settings.defaultLocale}
+              />
+            </label>
+
+            <label>
+              Visibilitas bawaan
+              <select name="defaultVisibility">
+                {VISIBILITY_OPTIONS.map((option) => (
+                  <option
+                    value={option}
+                    selected={settings!.defaultVisibility === option}
+                  >
+                    {option}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <legend>Discovery</legend>
+
+            {/*
+              These two decide whether `seo_distribution` serves this tenant's
+              feed and sitemap at all. They are the reason the screen exists.
+            */}
+            <label class="admin-checkbox">
+              <input
+                type="checkbox"
+                name="rssEnabled"
+                checked={settings.rssEnabled}
+              />
+              RSS aktif
+            </label>
+
+            <label class="admin-checkbox">
+              <input
+                type="checkbox"
+                name="sitemapEnabled"
+                checked={settings.sitemapEnabled}
+              />
+              Sitemap aktif
+            </label>
+
+            <legend>SEO bawaan</legend>
+
+            <label>
+              Judul SEO bawaan
+              <input
+                type="text"
+                name="seoDefaultTitle"
+                maxlength="200"
+                value={settings.seoDefaultTitle ?? ""}
+              />
+            </label>
+
+            <label>
+              Deskripsi SEO bawaan
+              <textarea name="seoDefaultDescription" maxlength="300" rows="2">
+                {settings.seoDefaultDescription ?? ""}
+              </textarea>
+            </label>
+
+            <button type="submit" id="blog-settings-save">
+              Simpan
+            </button>
+          </fieldset>
+        </form>
+
+        <p class="admin-note">
+          Saklar rute publik <code>legacyTenantRouteEnabled</code> BUKAN di sini
+          — ia setting modul, disimpan di <code>awcms_module_settings</code> dan
+          diedit lewat{" "}
+          <a href="/admin/modules/blog_content">/admin/modules/blog_content</a>.
+          Dicantumkan sebagai tautan, bukan disalin ke form ini: field yang
+          dicerminkan dua layar adalah field yang basi diam-diam.
+        </p>
+      </>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // The import is load-bearing for CSP, not just DRY: Astro inlines a hoisted
+  // `<script>` with no imports, and this app's CSP is `default-src 'self'`
+  // with no `'unsafe-inline'` — an inlined script is blocked and the page's
+  // behaviour dies silently. Importing forces an external `/_astro/*.js`.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const form = document.getElementById(
+    "blog-settings-form"
+  ) as HTMLFormElement | null;
+  const errorBox = document.getElementById("settings-error");
+  const okBox = document.getElementById("settings-ok");
+
+  function show(element: HTMLElement | null, message?: string): void {
+    if (!element) return;
+    if (message !== undefined) element.textContent = message;
+    element.hidden = false;
+  }
+
+  function hide(element: HTMLElement | null): void {
+    if (element) element.hidden = true;
+  }
+
+  form?.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    hide(errorBox);
+    hide(okBox);
+
+    const data = new FormData(form);
+    const text = (name: string): string => String(data.get(name) ?? "").trim();
+
+    // Empty optional text fields are sent as `null`, not `""`. The endpoint
+    // treats `null` as "clear it" and `""` as a validation error on the
+    // non-empty fields — sending `""` would surface as a rejection the
+    // operator cannot interpret from a blank box they never typed in.
+    const optional = (name: string): string | null => text(name) || null;
+
+    const body = {
+      blogTitle: text("blogTitle"),
+      blogDescription: optional("blogDescription"),
+      postsPerPage: Number(text("postsPerPage")),
+      defaultLocale: text("defaultLocale"),
+      defaultVisibility: text("defaultVisibility"),
+      rssEnabled: data.get("rssEnabled") !== null,
+      sitemapEnabled: data.get("sitemapEnabled") !== null,
+      seoDefaultTitle: optional("seoDefaultTitle"),
+      seoDefaultDescription: optional("seoDefaultDescription")
+    };
+
+    const button = document.getElementById(
+      "blog-settings-save"
+    ) as HTMLButtonElement | null;
+    const unlock = lockElement(button);
+
+    try {
+      const result = await sendJson("PATCH", "/api/v1/blog/settings", body);
+
+      if (!result.ok) {
+        show(errorBox, result.message ?? "Gagal menyimpan pengaturan.");
+        return;
+      }
+
+      show(okBox);
+    } finally {
+      unlock();
+    }
+  });
+</script>

--- a/tests/admin-blog-page-contract.test.ts
+++ b/tests/admin-blog-page-contract.test.ts
@@ -365,21 +365,23 @@ describe("/admin/blog permission gates", () => {
     expect(nav!.requiredPermission).toBe("blog_content.posts.read");
     expect(declaredTriples().has(nav!.requiredPermission as Triple)).toBe(true);
 
-    // FOUR entries for fourteen activity codes: the post lifecycle, the page
-    // lifecycle (ADR-0057), taxonomy, and presentation (templates/menus/
-    // widgets/theme). Settings and homepage composition still bring their own
-    // entries when their pages land — the count is pinned so each arrival is a
-    // line someone edits deliberately. An entry appearing here without a page
-    // is what `admin-navigation-registry.test.ts` catches.
+    // FIVE entries: the post lifecycle, the page lifecycle (ADR-0057),
+    // taxonomy, presentation (templates/menus/widgets/theme), and — arriving
+    // 8 August 2026 — settings. Homepage composition still brings its own
+    // entry when its page lands; the count stays pinned so each arrival is a
+    // line someone edits deliberately, which is exactly what this assertion
+    // forced when `/admin/blog-settings` landed. An entry appearing here
+    // without a page is what `admin-navigation-registry.test.ts` catches.
     const navigation = listModules().find(
       (module) => module.key === "blog_content"
     )?.navigation;
 
-    expect(navigation).toHaveLength(4);
+    expect(navigation).toHaveLength(5);
     expect(navigation?.map((entry) => entry.path).sort()).toEqual([
       "/admin/blog",
       "/admin/blog-pages",
       "/admin/blog-presentation",
+      "/admin/blog-settings",
       "/admin/blog-taxonomy"
     ]);
 


### PR DESCRIPTION
Rekomendasi 5 dari asesmen kondisi repo — celah layar terakhir yang jalurnya bersih.

## Masalah

`GET`/`PATCH /api/v1/blog/settings` mendarat **lengkap** bersama Issue #543 — ter-guard di dalam `withTenant`, ter-audit, tervalidasi — dan punya **nol konsumen UI**. `rssEnabled` dan `sitemapEnabled` menentukan apakah feed dan sitemap tenant dilayani sama sekali. Sampai sekarang satu-satunya cara mengubahnya adalah `curl`.

Nol migrasi, nol permission baru, nol endpoint baru.

## Kendala duplikasi — ini yang paling banyak memakan pemikiran

`/admin/modules/blog_content` (Module Management, generik) sudah ada dan menulis `awcms_module_settings`. Layar ini menulis `awcms_blog_settings`: **tabel berbeda, permission berbeda (`blog_content.settings.*`), endpoint berbeda.** README modul mencatat pemisahan dua-store itu sebagai keputusan.

Jadi risikonya bukan store yang hilang, melainkan **kontrol yang terduplikasi** — dua layar sama-sama tampak menawarkan "pengaturan blog" sambil menulis baris berbeda. Layar ini karena itu **tidak merender apa pun** dari store setting modul dan hanya **menautkan** ke layar generiknya:

> Saklar rute publik `legacyTenantRouteEnabled` BUKAN di sini — ia setting modul… Dicantumkan sebagai tautan, bukan disalin ke form ini: field yang dicerminkan dua layar adalah field yang basi diam-diam.

Field yang dicerminkan dua layar adalah field yang basi diam-diam, karena layar yang diedit belakangan menang dan tak satu pun mengatakannya.

## Yang sengaja TIDAK ada di form

Disebut namanya di header berkas supaya absennya terbaca sebagai keputusan:

- **`contentQualityChecklistPolicy`** — peta override severity bersarang. Merendernya sebagai textarea JSON (pola `/admin/blog-presentation`) menaruh kebijakan **pemblokir-publish** di balik free-text tanpa umpan balik per-rule.
- **`socialPreviewFallbackImageMediaId`** — mengetik UUID bukan media picker; `/admin/media` sudah memiliki pemilihan objek. Field id mentah justru mengundang menempel id milik tenant lain, yang endpoint tolak sebagai galat validasi yang tak bisa ditindaklanjuti operator.

Satu permission (`settings.configure`) menggerbangi seluruh field, karena `sql/036` tidak men-seed permission tulis per-field — mengarang gerbang per-field di UI menyiratkan wewenang yang tak akan dihormati `authorizeInTransaction` mana pun.

## Dua jebakan repo yang ditangani eksplisit

1. **CSP.** Skrip klien meng-`import` dari `lib/ui/admin-form-client`. Astro meng-**inline** `<script>` tanpa import, dan CSP di sini `default-src 'self'` tanpa `'unsafe-inline'` — skrip inline diblokir dan perilaku halaman mati **senyap**. Terbukti ter-bundel eksternal: anggaran aset naik 45 → 46 berkas (139.048 → 140.008 B, masih di dalam 180.000 B).
2. **Navigasi digerbangi `settings.read`**, bukan salah satu dari empat entri `blog_content` yang sudah ada — operator bisa memegang authoring blog tanpa memegang saklar discovery tenant.

## Test yang memang dirancang untuk memerah di sini

`tests/admin-blog-page-contract.test.ts` mematok jumlah entri navigasi persis, dengan komentar: *"Settings and homepage composition still bring their own entries when their pages land — the count is pinned so each arrival is a line someone edits deliberately."*

Ia **memang memerah** saat layar ini mendarat (`Expected length: 4, Received length: 5`), lalu dinaikkan ke 5 dengan daftar path yang dienumerasi. Gerbang itu bekerja persis sebagaimana dirancang.

## Verifikasi

`DATABASE_URL="" bun run check` **PENUH** hijau, `CHECK_EXIT=0`. Base diverifikasi `27e6074f` = `origin/main` sebelum push, dan PR ini satu commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
