### PR TITLE
fix(gerbang,docs): klaim "modul ini belum ada" berhenti bersembunyi di `src/modules/`

### DIFF
--- a/.changeset/gerbang-klaim-absen-menjangkau-src-modules.md
+++ b/.changeset/gerbang-klaim-absen-menjangkau-src-modules.md
@@ -1,0 +1,62 @@
+---
+"awcms": patch
+---
+
+fix(gerbang,docs): klaim "modul ini belum ada" berhenti bersembunyi di `src/modules/`
+
+`tests/module-absence-claims.test.ts` dibangun karena tiga skill menyatakan modul
+yang ada di `listModules()` sebagai tidak ada — klaim yang membuat agen tidak
+mencarinya, tidak memanggilnya, dan dengan senang hati men-stub ulang sesuatu
+yang sudah bekerja. Gerbang itu memindai `.claude/skills/*/SKILL.md` dan
+`docs/awcms/*.md`.
+
+**Kalimat yang sama persis ternyata ada di `src/modules/data-lifecycle/README.md`**
+— "`form_drafts`/`newsletter`/`comments` (unported in this base) are not
+registered as adopters here" — sementara `form_drafts` dan `comments` keduanya
+mendeklarasikan descriptor `dataLifecycle` nyata. Ia duduk **satu direktori di
+luar** korpus gerbangnya. README dan header descriptor sebuah modul justru
+tempat paling load-bearing untuk klaim semacam ini, karena itulah yang dibaca
+orang sebelum menyentuh modul tersebut.
+
+Dua pelebaran, dan yang kedua diperlukan agar yang pertama tidak sia-sia:
+
+1. Korpus ditambah `src/modules/*/README.md` dan `src/modules/*/module.ts`,
+   di-assert terpisah supaya glob yang resolve ke nol tidak lolos secara hampa —
+   mode kegagalan yang persis pernah terjadi pada `dot: true`.
+2. Daftar frasa ditambah bentuk **Inggris** (`not ported`, `unported`,
+   `does not exist in this base`, `no longer exists`). Berkas di `src/modules/`
+   ditulis dalam bahasa Inggris, jadi daftar Indonesia-saja akan memindai berkas
+   baru itu sambil **tidak mencocokkan apa pun** di dalamnya.
+
+Dibuktikan lewat dua mutasi: mengembalikan kalimat ASLI membuat gerbang merah
+dan menyebut kedua modul; mempertahankan cacat itu **tetap tertanam** sementara
+frasa Inggris dilepas membuat gerbang **hijau** — jadi penambahan frasa itu
+load-bearing, bukan hiasan.
+
+**Tujuh dokumen yang membantah kodenya sendiri diperbaiki**, tiap klaim
+diverifikasi ke kode lebih dulu:
+
+- `media-library/module.ts` menyatakan `/api/v1/media/objects/*` dan
+  `/admin/media` "NOT ported here" dan "declares no `navigation` yet (the
+  `/admin/media` page it would point at does not exist in this base)" —
+  keduanya ADA, dan entri `navigation`-nya dideklarasikan **40 baris di bawah**
+  paragraf itu di berkas yang sama. Bukan cacat fungsional (layarnya
+  terjangkau), tetapi deskripsi descriptor adalah yang dibaca `listModules()`
+  dan tampil di layar Module Management.
+- `data-lifecycle/README.md` — di atas.
+- `blog-content/module.ts` masih menulis "Two entries … Taxonomy, presentation,
+  settings and homepage composition are still sibling screens" setelah lima
+  entri mendarat. Ini kelalaian saya sendiri dari PR sebelumnya.
+- `absorb-awcms-micro-roadmap.md` memesan `2.4.0` untuk
+  `newsletterContentSources`; slot itu sudah dipakai `api.routes` (#267) dan
+  `2.5.0` oleh ADR-0053. Kini `2.6.0`.
+- `module-contract.ts` melompati **entri changelog `2.4.0`** seluruhnya
+  (2.3.0 → 2.5.0) — dan justru itulah sebab roadmap memesan slot yang sudah
+  terpakai. Ditambahkan.
+- `docs/ARCHITECTURE.md` masih membingkai `newsletter`/`social-publishing`/dll.
+  sebagai "belum di-port … urutan porting". ADR-0055 mencabut jalur itu:
+  mini/micro ARSIP, kapabilitas DIBANGUN di sini lewat ADR admission sendiri.
+- `docs/adr/0067` menyebut `/news/**` sebagai permukaan HTML repo ini. Kalimat
+  aslinya **dipertahankan** dengan catatan supersession — ia benar saat ditulis,
+  dan ADR adalah catatan keputusan, bukan dokumen current-state. **Hanya
+  kalimat konteks itu** yang disentuh; keputusan RUM di ADR yang sama tidak.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,11 +68,16 @@ src/modules/<module>/
 
 - **`idn-admin-regions`** (`type: "system"`) — dirintis langsung di sini ([ADR-0046](adr/0046-idn-admin-regions-module-admission.md), #312, `sql/080` skema + `sql/081` permission): master data wilayah administratif Indonesia (provinsi/kabupaten-kota/kecamatan/desa-kelurahan) **ber-versi & ter-provenance**, disumber dari dataset komunitas `cahyadsn/wilayah` (MIT) yang di-**vendor** di `data/idn-admin-regions/`. Dua tabelnya (`awcms_idn_region_datasets`, `awcms_idn_admin_regions`) **GLOBAL** — tanpa `tenant_id`, tanpa RLS, seperti `awcms_permissions`/`awcms_modules` — karena provinsi "Aceh" adalah baris yang sama untuk setiap tenant; keduanya terdaftar di `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES` (`scripts/security-readiness.ts`) sehingga privilese per-role wajib dideklarasikan eksplisit, bukan diwarisi DML massal. Yang global adalah **barisnya**, bukan izinnya: setiap endpoint tetap melewati sesi + konteks tenant + ABAC default-deny. Impor 91.599 baris adalah **job deployment** (`bun run idn-regions:import`, dry-run secara default, berjalan sebagai `awcms_worker`) — bukan panggilan HTTP; **aktivasi/rollback** versi dataset kini juga **job operator** (`bun run idn-regions:activate`/`:rollback`, [ADR-0052](adr/0052-idn-region-dataset-lifecycle-is-an-operator-job.md) — endpoint HTTP-nya dihapus dan permission-nya dicabut dari katalog, `sql/084`). Lookup baca-saja di `/api/v1/idn-regions/*`. Kini **punya `navigation`** dan layar admin `/admin/idn-regions` (PR #332): ADR-0048 di-supersede [ADR-0051](adr/0051-admin-screens-consolidated-in-awcms.md), seluruh layar admin **SISTEM** dibangun di repo ini (dipersempit [ADR-0070](adr/0070-peran-keluarga-awcms-astro-memikul-publik-dan-admin-user.md); `idn_admin_regions` adalah contoh murninya — dataset yang dilayani ke banyak tenant tidak akan pernah menjadi pekerjaan USER).
 
-Modul lain di ekosistem keluarga (mis. `newsletter`,
-`social-publishing`, `document-infrastructure`, `integration-hub`)
-**belum di-port** ke repo ini — lihat
-skill masing-masing (ditandai "BACAAN SAJA") + [`awcms/absorb-awcms-micro-roadmap.md`](awcms/absorb-awcms-micro-roadmap.md)
-untuk spesifikasi target & urutan porting.
+Kapabilitas lain di ekosistem keluarga (mis. `newsletter`,
+`social-publishing`, `document-infrastructure`, `integration-hub`) **belum ada**
+di repo ini. Sejak [ADR-0055](adr/0055-development-confined-to-awcms-and-awcms-astro.md)
+kata "**port**" tidak lagi berlaku untuk apa pun di daftar ini: `awcms-mini` dan
+`awcms-micro` adalah **ARSIP**, boleh dibaca sebagai spesifikasi tetapi bukan
+sumber port, dan kapabilitas baru **DIBANGUN di sini** lewat ADR admission-nya
+sendiri. Skill masing-masing (ditandai "BACAAN SAJA") dan
+[`awcms/absorb-awcms-micro-roadmap.md`](awcms/absorb-awcms-micro-roadmap.md)
+karena itu dibaca sebagai **daftar kebutuhan + spesifikasi target**, bukan
+antrean porting.
 
 ### Komposisi & validasi registry modul (ADR-0034)
 

--- a/docs/adr/0067-core-web-vitals-collection.md
+++ b/docs/adr/0067-core-web-vitals-collection.md
@@ -19,7 +19,11 @@
 
 ### 1. Yang benar-benar hilang
 
-Repo ini melayani HTML nyata: `/news/**` (ADR-0059), `/blog/{tenantCode}/**`
+Repo ini melayani HTML nyata: `/news/**` (ADR-0059 — **sudah tidak berlaku**,
+[ADR-0071](0071-kosakata-url-publik-dibelah-blog-di-sini-news-di-awcms-astro.md)
+menghapus keluarga rute itu dari repo ini pada 8 Agustus 2026; kalimat aslinya
+dipertahankan karena ia benar saat ADR ini ditulis dan ruang lingkup keputusan
+di bawah menyusut karenanya), `/blog/{tenantCode}/**`
 (ADR-0009), dan 31 layar admin. **LCP / INP / CLS tidak pernah diukur di mana
 pun**, dan tidak ada anggaran ukuran aset.
 

--- a/docs/awcms/absorb-awcms-micro-roadmap.md
+++ b/docs/awcms/absorb-awcms-micro-roadmap.md
@@ -48,7 +48,7 @@ Setiap penyerapan = **satu PR atomic**, **adaptasi bukan salin**:
 `MODULE_CONTRACT_VERSION` **naik satu MINOR aditif per seam kontribusi baru** yang
 penyerapan ini butuhkan — perkiraan awal "tidak ada kenaikan kontrak" ternyata keliru.
 Dari `2.0.0` (ADR-0034): `2.1.0` `dataLifecycle` (#222), `2.2.0` `searchSources` (#231),
-`2.3.0` `commentableResources` (in-flight). `newsletterContentSources` akan jadi `2.4.0`.
+`2.3.0` `commentableResources`. `2.4.0` `api.routes` (#267) dan `2.5.0` `ModulePermissionDescriptor.scope` (ADR-0053) SUDAH memakai slot berikutnya, jadi `newsletterContentSources` akan jadi `2.6.0` — bukan `2.4.0` seperti tertulis sebelumnya.
 Tiap kenaikan **wajib** disertai pembaruan pin `contracts.moduleDescriptorContractVersion`
 di `awcms-family-compatibility.yaml`, atau `bun run family:conformance:check` merah.
 

--- a/src/modules/_shared/module-contract.ts
+++ b/src/modules/_shared/module-contract.ts
@@ -760,6 +760,15 @@ export type HighVolumeTableDescriptor = {
  * every base `module.ts` that omits `commentableResources` stays valid
  * unchanged.
  *
+ * `2.4.0` (Issue #256, PR #267) — added `ModuleApiContract.routes`, making
+ * route ownership DERIVABLE instead of inferred from a single `basePath`.
+ * `tenant_admin` had declared `basePath: "/api/v1"` — a prefix of every route
+ * in the application — so longest-prefix resolution handed it 36 routes it does
+ * not own. MINOR: purely additive, `basePath` keeps its display/docs meaning.
+ * This entry was MISSING from this changelog until 8 August 2026, which is how
+ * `absorb-awcms-micro-roadmap.md` came to reserve `2.4.0` for a seam that had
+ * not landed while the slot was already taken.
+ *
  * `2.5.0` (ADR-0053) — added the optional `ModulePermissionDescriptor.scope`
  * field plus the `ModulePermissionScope` exported type — MINOR: purely
  * additive, and omitting it means `"tenant"`, which is exactly what every

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -84,10 +84,11 @@ export const blogContentModule = defineModule({
    * `tests/admin-navigation-registry.test.ts` now fails on any entry whose
    * path has no page, in both directions.
    *
-   * Two entries for fifteen activity codes: the post lifecycle and the page
-   * lifecycle. Taxonomy, presentation, settings and homepage composition are
-   * still sibling screens, and each brings its own entry when its page lands —
-   * not before.
+   * FIVE entries for fifteen activity codes: the post lifecycle, the page
+   * lifecycle, taxonomy, presentation, and settings. Homepage composition is
+   * the one sibling screen still to come, and it brings its own entry when its
+   * page lands — not before. `tests/admin-blog-page-contract.test.ts` pins the
+   * count, so each arrival is a line someone edits deliberately.
    *
    * The pages entry is gated on `pages.read` rather than `posts.read`: they
    * are separate permissions, and an operator granted one and not the other

--- a/src/modules/data-lifecycle/README.md
+++ b/src/modules/data-lifecycle/README.md
@@ -282,6 +282,11 @@ var (e.g. `AUDIT_LOG_RETENTION_DAYS`) — never re-declared here.
   holding both a `critical` conflict. Real archive/purge remains job-only — the
   screen has no control for it because there is no HTTP surface to call.
 - **Partitioning is guidance only**: no automation.
-- **Deferred consumers**: `form_drafts`/`newsletter`/`comments` (unported in this
-  base) are not registered as adopters here; re-add their descriptors + guard
-  wiring when those modules land.
+- **Adopters**: `form_drafts` and `comments` ARE registered here — both declare
+  real `dataLifecycle` descriptors (`form-drafts/module.ts`,
+  `comments/module.ts`). This bullet used to read "unported in this base … not
+  registered as adopters", the same sentence
+  `tests/module-absence-claims.test.ts` was built to catch in skills; it sat one
+  directory outside that gate's corpus until the corpus was widened to
+  `src/modules/**`. `newsletter` is the only one still absent, and under
+  ADR-0055 it is BUILT here with its own admission ADR, not ported.

--- a/src/modules/media-library/module.ts
+++ b/src/modules/media-library/module.ts
@@ -36,11 +36,12 @@ import {
  *
  * PORT NOTES vs awcms-micro: this base ports the ownership inversion + the
  * enforcement-enable switch (micro step 5a). The media lifecycle/browser surface
- * (`/api/v1/media/objects/*`, `/admin/media` — micro step 5d), the responsive
- * `srcset` render path (step 5b), and the PDF media type (step 5c) are NOT ported
- * here, so this module declares no `navigation` yet (the `/admin/media` page it
- * would point at does not exist in this base) and its allowed MIME set stays the
- * four raster types.
+ * (`/api/v1/media/objects/*`, `/admin/media`) SINCE LANDED here — ADR-0056 built
+ * `/admin/media`, and `GET /api/v1/media/objects` resolves media references over
+ * HTTP — so this module DOES declare `navigation` (see the entry ~40 lines
+ * below, which contradicted this paragraph until 8 August 2026). Still absent:
+ * the responsive `srcset` render path and the PDF media type, so the allowed
+ * MIME set stays the four raster types.
  */
 export const mediaLibraryModule = defineModule({
   key: "media_library",
@@ -48,7 +49,7 @@ export const mediaLibraryModule = defineModule({
   version: "0.1.0",
   status: "active",
   description:
-    "Tenant-scoped media object registry and upload flow, reusable by every website module (ADR-0036, System Foundation). Owns `awcms_news_media_objects` (migrations 041/042/045) — a generic registry keyed by `module_key` with `owner_resource_type`/`owner_resource_id` references, direct-to-R2 presigned upload with real magic-byte MIME sniffing and server-side SHA-256 checksum verification, orphan lifecycle, and R2 reconciliation (the `news-media:reconcile` job). The table keeps its `news_media` name deliberately (ADR-0036 §3): it is referenced by three migrations and a hard composite FK from `awcms_news_portal_ad_placements`, so renaming would trade a cosmetic annoyance for real risk. Provides the `media_library` capability (`_shared/ports/media-library-port.ts`), whose sole consumer since ADR-0044 is `blog_content` — required, because the ad placements it absorbed from the retired `news_portal` module hold a real FK to a media object, while its post/page media handling no-ops for any tenant that has not switched enforcement on: media reference safety, resolution, and whether managed-media enforcement is active for a tenant (this module's own readiness plus its own per-tenant flag, migration 053) — so a brochure site gets managed media without a news portal. Turning that flag ON is a dedicated, readiness-gated, one-way switch (`POST /api/v1/media/enforcement`, migration 054). This module never transcodes bytes inside a DB transaction (ADR-0006), and is deliberately not a CDN, image proxy, or DAM. PORT DROPS vs awcms-micro: the media lifecycle/browser surface (`/api/v1/media/objects/*`, `/admin/media`), responsive `srcset` render, and PDF media type are not ported to this base.",
+    "Tenant-scoped media object registry and upload flow, reusable by every website module (ADR-0036, System Foundation). Owns `awcms_news_media_objects` (migrations 041/042/045) — a generic registry keyed by `module_key` with `owner_resource_type`/`owner_resource_id` references, direct-to-R2 presigned upload with real magic-byte MIME sniffing and server-side SHA-256 checksum verification, orphan lifecycle, and R2 reconciliation (the `news-media:reconcile` job). The table keeps its `news_media` name deliberately (ADR-0036 §3): it is referenced by three migrations and a hard composite FK from `awcms_news_portal_ad_placements`, so renaming would trade a cosmetic annoyance for real risk. Provides the `media_library` capability (`_shared/ports/media-library-port.ts`), whose sole consumer since ADR-0044 is `blog_content` — required, because the ad placements it absorbed from the retired `news_portal` module hold a real FK to a media object, while its post/page media handling no-ops for any tenant that has not switched enforcement on: media reference safety, resolution, and whether managed-media enforcement is active for a tenant (this module's own readiness plus its own per-tenant flag, migration 053) — so a brochure site gets managed media without a news portal. Turning that flag ON is a dedicated, readiness-gated, one-way switch (`POST /api/v1/media/enforcement`, migration 054). This module never transcodes bytes inside a DB transaction (ADR-0006), and is deliberately not a CDN, image proxy, or DAM. STILL ABSENT vs awcms-micro: responsive `srcset` render and the PDF media type. The media lifecycle/browser surface (`/api/v1/media/objects/*`, `/admin/media`) is NO LONGER absent — ADR-0056 built the admin screen and the object endpoints resolve media references over HTTP.",
   dependencies: ["tenant_admin", "identity_access"],
   type: "system",
   isCore: false,

--- a/tests/module-absence-claims.test.ts
+++ b/tests/module-absence-claims.test.ts
@@ -48,7 +48,16 @@ import { listModules } from "../src/modules";
  * after a module key so an unrelated "belum ada" later in a long paragraph is
  * not attributed to it.
  */
-const ABSENCE = "(belum di-?port|belum ada|tidak ada di base)";
+const ABSENCE =
+  "(belum di-?port|belum ada|tidak ada di base|" +
+  // English phrasings, added 8 August 2026. The corpus grew to include
+  // `src/modules/**` (see targetFiles()), and module headers/READMEs are
+  // written in English — so the Indonesian-only list would have scanned the
+  // new files while matching nothing in them, which is the same
+  // silently-covers-nothing failure the `dot: true` note below records.
+  // Every phrasing here is one this repo actually used to deny a module that
+  // exists, not a hypothetical.
+  "not ported|unported|does not exist in this base|no longer exists)";
 
 /**
  * Files whose absence claims are legitimately frozen in time. Detected by
@@ -89,7 +98,19 @@ const EXONERATING = /SUDAH|kini |komponen|pustaka|Versi sebelumnya|no longer/i;
 async function targetFiles(): Promise<string[]> {
   const files: string[] = [];
 
-  for (const pattern of [".claude/skills/*/SKILL.md", "docs/awcms/*.md"]) {
+  for (const pattern of [
+    ".claude/skills/*/SKILL.md",
+    "docs/awcms/*.md",
+    // Added 8 August 2026. `data-lifecycle/README.md` carried the SAME
+    // sentence this gate was built to catch — "`form_drafts`/`newsletter`/
+    // `comments` (unported in this base) are not registered as adopters" —
+    // while both are real `dataLifecycle` adopters in `listModules()`. It sat
+    // one directory outside the corpus. A module's own README and descriptor
+    // header are the MOST load-bearing place for this claim, because they are
+    // what a reader consults before touching that module.
+    "src/modules/*/README.md",
+    "src/modules/*/module.ts"
+  ]) {
     for await (const file of new Bun.Glob(pattern).scan({
       cwd: process.cwd(),
       dot: true
@@ -117,6 +138,11 @@ describe("docs and skills do not deny registered modules", () => {
     expect(files.filter((f) => f.startsWith("docs/")).length).toBeGreaterThan(
       20
     );
+    // Third corpus asserted separately for the same reason as the first two:
+    // a glob that resolves to zero passes every check below vacuously.
+    expect(
+      files.filter((f) => f.startsWith("src/modules/")).length
+    ).toBeGreaterThan(20);
 
     for (const file of files) {
       const body = await readFile(file, "utf8");


### PR DESCRIPTION
Sisa paket "dokumen yang membantah kodenya sendiri" dari asesmen, plus gerbang yang mencegahnya berulang.

## Gerbang yang ada punya titik buta satu direktori

`tests/module-absence-claims.test.ts` dibangun karena tiga skill menyatakan modul yang **ada** di `listModules()` sebagai tidak ada — klaim yang membuat agen tidak mencarinya, tidak memanggilnya, dan men-stub ulang sesuatu yang sudah bekerja. Ia memindai `.claude/skills/*/SKILL.md` dan `docs/awcms/*.md`.

Kalimat yang **sama persis** ternyata ada di `src/modules/data-lifecycle/README.md`:

> `form_drafts`/`newsletter`/`comments` (unported in this base) are not registered as adopters here

Keduanya mendeklarasikan descriptor `dataLifecycle` **nyata**. README dan header descriptor sebuah modul justru tempat paling load-bearing untuk klaim semacam ini — itulah yang dibaca orang sebelum menyentuh modul tersebut.

## Dua pelebaran, dan yang kedua diperlukan agar yang pertama tidak sia-sia

1. **Korpus** ditambah `src/modules/*/README.md` dan `src/modules/*/module.ts`, di-assert **terpisah** supaya glob yang resolve ke nol tidak lolos secara hampa — mode kegagalan yang persis pernah terjadi pada `dot: true` dan sudah tercatat di header berkas itu.
2. **Frasa Inggris** ditambahkan (`not ported`, `unported`, `does not exist in this base`, `no longer exists`). Berkas di `src/modules/` ditulis dalam bahasa Inggris, jadi daftar Indonesia-saja akan memindai berkas baru itu sambil **tidak mencocokkan apa pun** di dalamnya.

## Bukti — dua mutasi

| Mutasi | Hasil |
|---|---|
| Kembalikan kalimat ASLI `data-lifecycle/README.md` | **MERAH**, menyebut `form_drafts` DAN `comments` |
| Cacat **tetap tertanam**, frasa Inggris dilepas dari gerbang | **HIJAU** — membuktikan penambahan frasa itu load-bearing, bukan hiasan |

Gerbang yang diperluas **langsung merah pada cacat nyata** sebelum satu dokumen pun saya sentuh.

Catatan jujur soal cakupan: gerbang ini **tidak** menandai `media-library/module.ts`, dan itu benar — klaim di sana tentang *permukaan* (`/admin/media` tidak ada), bukan tentang keberadaan modul. Gerbangnya sengaja sempit; melebarkannya ke "apakah dokumen ini menjelaskan modul dengan akurat" tidak bisa dimekanisasi.

## Tujuh dokumen yang membantah kodenya sendiri

Tiap klaim diverifikasi ke kode lebih dulu, bukan dipercaya dari daftar asesmen.

| Berkas | Yang salah |
|---|---|
| `media-library/module.ts` | Menyatakan `/api/v1/media/objects/*` + `/admin/media` "NOT ported here" dan "declares no `navigation` yet (the page … does not exist in this base)" — keduanya ADA, dan entri `navigation`-nya dideklarasikan **40 baris di bawah** paragraf itu di berkas yang sama |
| `data-lifecycle/README.md` | Di atas |
| `blog-content/module.ts` | Masih "Two entries … settings … still sibling screens" setelah lima entri mendarat — **kelalaian saya sendiri** dari PR #412 |
| `absorb-awcms-micro-roadmap.md` | Memesan `2.4.0` untuk `newsletterContentSources`; slot itu sudah dipakai `api.routes` (#267), dan `2.5.0` oleh ADR-0053 → kini `2.6.0` |
| `module-contract.ts` | Melompati **entri changelog `2.4.0` seluruhnya** (2.3.0 → 2.5.0) — dan justru itulah **sebab** roadmap memesan slot yang sudah terpakai |
| `docs/ARCHITECTURE.md` | Masih membingkai `newsletter`/`social-publishing`/dll. sebagai "belum di-port … urutan porting"; ADR-0055 mencabut jalur itu (mini/micro ARSIP, kapabilitas DIBANGUN di sini lewat ADR admission sendiri) |
| `docs/adr/0067` | Menyebut `/news/**` sebagai permukaan HTML repo ini |

**Verifikasi `/admin/media` bukan cacat fungsional**: entri `navigation` ada, layarnya terjangkau dari sidebar. Yang rusak hanya prosanya — tetapi deskripsi descriptor adalah yang dibaca `listModules()` dan tampil di layar Module Management, jadi operator membacanya sebagai daftar kapabilitas.

**ADR-0067 hanya disentuh pada satu kalimat KONTEKS.** Kalimat aslinya **dipertahankan** dengan catatan supersession — ia benar saat ditulis, dan ADR adalah catatan keputusan, bukan dokumen current-state. **Keputusan RUM di ADR yang sama tidak disentuh.**

## Verifikasi

`DATABASE_URL="" bun run check` **PENUH** hijau, `CHECK_EXIT=0`. Base diverifikasi `9d148765` = `origin/main` sebelum push; satu commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
