### PR TITLE
docs(src): 23 rujukan jalur aplikasi-turunan yang ADR-0034 hapus, ditulis ulang per konteks

### DIFF
--- a/.changeset/sapu-jalur-turunan-di-src.md
+++ b/.changeset/sapu-jalur-turunan-di-src.md
@@ -1,0 +1,44 @@
+---
+"awcms": patch
+---
+
+docs(src): 23 rujukan ke jalur aplikasi-turunan yang ADR-0034 hapus, ditulis ulang per konteks
+
+[ADR-0034](../docs/adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md)
+menghapus jalur aplikasi-turunan seluruhnya — tidak ada lagi
+`src/modules/application-registry.ts`, `extension:check`, namespace migrasi
+`900+`, maupun manifest kompatibilitas turunan. `docs/PROJECT_STATE.md` §1
+menyatakan eksplisit bahwa dokumen yang masih menyebutnya sebagai jalur aktif
+adalah **usang**. Toh 29 situs di `src/` masih menyebutnya, dan hampir semuanya
+menjawab pertanyaan yang paling sering ditanyakan pembaca sebuah seam: **siapa
+yang menyediakan adapter/entri di sini?** — dengan jawaban yang tidak ada.
+
+23 ditulis ulang menjadi mekanisme yang benar-benar berlaku: **modul domain yang
+ditambahkan langsung di `src/modules/`**. Beberapa butuh kata yang berbeda karena
+konteksnya memang berbeda, dan itulah alasan ini tidak dikerjakan dengan `sed`:
+
+- `metrics-port.ts` / `prometheus-text-adapter.ts` — yang memasang adapter
+  observability adalah **deployment** lewat composition root, bukan modul.
+- `family-contract.ts` — yang bisa dirusak perubahan MAJOR adalah **konsumen**
+  kontrak keluarga (mis. `ahliweb/awcms-astro`), bukan "aplikasi turunan".
+- `logger.ts` baris kedua — "A derived app's sink" → "A registered sink":
+  kalimatnya tentang sink mana pun yang terdaftar, bukan tentang siapa
+  mendaftarkannya.
+- `email-template-categories.ts` — namespace `derived.*` dan fungsi
+  `registerDerivedEmailTemplateCategory` adalah **identifier nyata di kode** dan
+  TIDAK diubah; hanya prosa di sekitarnya.
+
+**Enam situs sengaja DIBIARKAN karena benar secara historis**, dan menghapusnya
+justru akan menghilangkan catatan kenapa jalur itu tidak ada:
+
+- `module-contract.ts` changelog `2.0.0` — ia menamai pencabutannya.
+- `business-scope-hierarchy-port.ts` (3 situs) — mengutip judul issue #180 dan
+  menjelaskan bahwa resolver itu "permanently unfillable once ADR-0034 deleted
+  that pathway". Prosa itu sudah tepat.
+- `email-template-categories.ts` — kutipan teks issue.
+- Satu catatan penanda yang ditambahkan perubahan ini sendiri.
+
+Nol perubahan perilaku: seluruhnya komentar dan satu baris JSDoc. Menyusul PR
+sebelumnya yang memperbaiki string `description` descriptor `reporting` — satu
+situs yang BUKAN komentar, karena `listModules()` membacanya dan ia tampil di
+layar Module Management.

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -47,8 +47,8 @@ export type LogEntry = {
  * not building a new one). `stdout`/`console.log` stays the source of truth
  * for every log line unconditionally (doc 20 §Batasan — capture/rotation is
  * a deployment-layer job: docker logging driver/systemd journal, not
- * application code) — this hook is purely *additive*: a derived application
- * (e.g. AWPOS) can register a consumer to forward already-redacted log
+ * application code) — this hook is purely *additive*: a domain module in
+ * `src/modules/` can register a consumer to forward already-redacted log
  * entries to its own alerting/export pipeline (ISO 27001 A.8.16) without
  * touching this file. Default is `null` (no-op) — zero behavior change for
  * every deployment that never calls `setLogSink`.
@@ -104,7 +104,7 @@ export function log(
     try {
       registeredSink(entry);
     } catch (error) {
-      // A derived app's sink is never allowed to break core logging. Issue
+      // A registered sink is never allowed to break core logging. Issue
       // #687 follow-up (PR #712 security review): this used to print
       // `error.message` raw — a broken sink could easily be one built
       // around a secret-bearing config (a webhook URL with an embedded

--- a/src/lib/observability/adapters/prometheus-text-adapter.ts
+++ b/src/lib/observability/adapters/prometheus-text-adapter.ts
@@ -4,7 +4,8 @@
  * WITHOUT coupling the core runtime to Prometheus, a SaaS, or a new
  * dependency (Bun-only, AGENTS.md rule 14 — this is plain TypeScript, no
  * `prom-client`/Node package). NOT registered anywhere by default; a
- * derived application wires it up itself:
+ * deployment wires it up itself (ADR-0034 removed the derived-application
+ * pathway; the wiring now happens at a composition root in this repo):
  *
  * ```ts
  * import { setMetricsPort } from "src/lib/observability/metrics-port";

--- a/src/lib/observability/metrics-port.ts
+++ b/src/lib/observability/metrics-port.ts
@@ -15,7 +15,7 @@
  * offline/LAN deployment that never calls `setMetricsPort` pays no runtime
  * cost and needs no external collector — satisfying the issue's "Offline/LAN
  * operation works with no external collector" guardrail by construction. A
- * derived application registers its own adapter (Prometheus text exposition,
+ * deployment registers its own adapter (Prometheus text exposition,
  * OpenTelemetry, anything else) via `setMetricsPort`; see
  * `./adapters/prometheus-text-adapter.ts` for a worked, dependency-free
  * example.

--- a/src/modules/_shared/family-contract.ts
+++ b/src/modules/_shared/family-contract.ts
@@ -30,7 +30,7 @@
  * version every pinned conformance fixture/snapshot is anchored to.
  *
  * - MAJOR — a reusable control's SEMANTIC contract is weakened or removed in a
- *   way that breaks a derived application written against the previous family
+ *   way that breaks a CONSUMER written against the previous family
  *   contract (default-deny/RLS/redaction/audit/idempotency/envelope/migration-
  *   immutability semantics change). Treat every such change as breaking.
  * - MINOR — a new contract is added to the family, or an existing one is

--- a/src/modules/_shared/idempotency.ts
+++ b/src/modules/_shared/idempotency.ts
@@ -6,7 +6,7 @@ import { createHash } from "node:crypto";
  * generic `awcms_idempotency_keys` table (migration 009 — awcms-mini numbers
  * it 012, which this comment used to cite by mistake), first
  * consumed by the workflow decision endpoint (Issue 11.1) — any future
- * high-risk mutation endpoint in a derived app can reuse the same table with
+ * high-risk mutation endpoint in a domain module can reuse the same table with
  * its own `requestScope` string.
  *
  * Flow: same key + same request hash -> replay the stored response; same key

--- a/src/modules/blog-content/application/ad-placement-directory.ts
+++ b/src/modules/blog-content/application/ad-placement-directory.ts
@@ -306,7 +306,7 @@ type ActiveAdPlacementRow = {
  * public-safe helper, wiring is a later issue's job" precedent
  * `listActiveAdsForPlacement` (#542) set, and `homepage-section-composer.ts`
  * (#637) explicitly deferred `ad_slot` integration to this issue's R2-only
- * ad system existing first. A derived app or a later issue's homepage/
+ * ad system existing first. A domain module or a later issue's homepage/
  * article template work calls `selectAndRenderActiveAdsForPlacement`
  * directly.
  */

--- a/src/modules/blog-content/application/ads-directory.ts
+++ b/src/modules/blog-content/application/ads-directory.ts
@@ -235,7 +235,7 @@ type ActiveAdRow = {
  * an unset bound means "no restriction on that side"). Not wired to any
  * route in this issue (same "tested public-safe helper, wiring is a later
  * issue's job" precedent `searchPublicBlogContent` set in #539) — a
- * derived app or #543's admin/public UI work calls this directly.
+ * domain module or #543's admin/public UI work calls this directly.
  */
 export async function listActiveAdsForPlacement(
   tx: Bun.SQL,

--- a/src/modules/blog-content/domain/content-block-rendering.ts
+++ b/src/modules/blog-content/domain/content-block-rendering.ts
@@ -37,7 +37,7 @@ import {
  * `sql/029_awcms_blog_content_presentation_schema.sql`'s header
  * comment), and `video_news` (Issue #639 — a safe, provider-allowlisted
  * video embed; never a raw stored `<iframe>`, see
- * `_shared/rendering/video-news-block-renderer.ts`'s header). A derived app
+ * `_shared/rendering/video-news-block-renderer.ts`'s header). A domain module
  * or later issue needing richer blocks (embed, table, ...) extends the
  * `switch` below, not a general raw-HTML escape hatch.
  */

--- a/src/modules/email/application/announcement-directory.ts
+++ b/src/modules/email/application/announcement-directory.ts
@@ -162,7 +162,7 @@ export async function resolveBoundedAnnouncementTargets(
   return { recipients, truncated };
 }
 
-/** Unchanged signature kept for existing callers (and derived apps) that only need the list. */
+/** Unchanged signature kept for existing callers (and domain modules) that only need the list. */
 export async function resolveAnnouncementTargets(
   tx: Bun.SQL,
   tenantId: string,

--- a/src/modules/email/domain/email-default-templates.ts
+++ b/src/modules/email/domain/email-default-templates.ts
@@ -9,7 +9,7 @@
  * explicitly, e.g. via `bun run email:templates:seed-defaults`).
  *
  * `derived.transactional` has no default here — it's an extension pattern
- * for derived apps to define their own copy, not a base default.
+ * for a domain module to define its own copy, not a base default.
  */
 import type { LocalizedTemplateTextInput } from "./email-template-validation";
 

--- a/src/modules/email/domain/email-template-categories.ts
+++ b/src/modules/email/domain/email-template-categories.ts
@@ -6,8 +6,8 @@
  *
  * Base categories are fixed here. `derived.*` is an **extension
  * namespace** (per the issue: "derived.transactional as an extension
- * category pattern for derived apps") — a derived application registers
- * its own `derived.<name>` categories via
+ * category pattern for derived apps") — a domain module in `src/modules/`
+ * registers its own `derived.<name>` categories via
  * `registerDerivedEmailTemplateCategory` before using them; an
  * unregistered `derived.*` category is rejected (fail-closed), not
  * implicitly allowed with an empty/unlimited allowlist.
@@ -57,7 +57,7 @@ const BASE_CATEGORY_ALLOWLISTS: Readonly<Record<string, readonly string[]>> = {
 const derivedCategoryAllowlists = new Map<string, readonly string[]>();
 
 /**
- * Derived apps call this once at startup to register their own
+ * A domain module calls this once at startup to register its own
  * `derived.<name>` category (e.g. `derived.order_confirmation`) with its
  * allowed variable names, before any template using that category is
  * created or rendered. Throws if `category` is not `derived.`-prefixed —

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -122,8 +122,9 @@ export type OwnershipGrant = {
  * coverage. If the guard opts in but NO port is supplied, `evaluateAccess`
  * default-denies (empty fact set) — fail-closed. Every existing 5-argument
  * call site (none of which sets a required scope) is completely unaffected.
- * The base ships only a no-op hierarchy adapter; a derived application passes
- * its own real resolver here.
+ * The base ships only a no-op hierarchy adapter; a domain module in
+ * `src/modules/` passes its own real resolver here (ADR-0034 removed the
+ * derived-application pathway that this sentence used to name).
  *
  * `options.sodRules` (Issue #181) is OPTIONAL — segregation-of-duties conflict
  * enforcement for HIGH-RISK actions runs at this chokepoint (deny-overrides-

--- a/src/modules/identity-access/application/business-scope-assignment-service.ts
+++ b/src/modules/identity-access/application/business-scope-assignment-service.ts
@@ -17,7 +17,8 @@
  * `awcms_sod_conflict_evaluations` regardless of outcome, and denies
  * (`sod_conflict`) an un-excepted conflict. The base registry declares no SoD
  * rules, so `deps.sodRules` is empty in a pure base and this is a no-op there;
- * a derived application (or the fixture) contributes the rules. This is the
+ * a domain module in `src/modules/` (or the fixture) contributes the rules —
+ * ADR-0034 removed the derived-application pathway. This is the
  * assignment-time complement to `high-risk-sod-guard.ts`'s action-time
  * enforcement.
  */

--- a/src/modules/identity-access/application/business-scope-facts.ts
+++ b/src/modules/identity-access/application/business-scope-facts.ts
@@ -90,8 +90,9 @@ function resolveHierarchyGuardConfig(): HierarchyGuardConfig {
  *   purely-SYNCHRONOUS CPU infinite loop inside the adapter cannot be
  *   interrupted from JavaScript — the event loop never regains control, so the
  *   timer never fires, and the `resolveScope()` call itself blocks before this
- *   race is even set up. That case remains the derived app's own
- *   responsibility.
+ *   race is even set up. That case remains the contributing domain module's
+ *   own responsibility (`src/modules/`; ADR-0034 removed the derived-app
+ *   pathway).
  * - COMBINED-LENGTH CAP (`AUTH_BUSINESS_SCOPE_HIERARCHY_MAX_RELATED_SCOPES`,
  *   default 5000): if `ancestorScopes.length + descendantScopes.length`
  *   exceeds the bound, the scope is treated as `resolved: false` — a runaway

--- a/src/modules/module-management/application/health-registry.ts
+++ b/src/modules/module-management/application/health-registry.ts
@@ -337,8 +337,9 @@ export async function fetchModuleHealthReport(
 /**
  * Placeholder for a live, bounded, network-calling provider health check. No
  * module in this base declares an external provider yet, so this signal is
- * always `not_applicable` — but the seam is kept so a derived application (or
- * a future provider-backed base module) can add a real, timeout-bounded,
+ * always `not_applicable` — but the seam is kept so a domain module in
+ * `src/modules/` (or a future provider-backed base module) can add a real,
+ * timeout-bounded,
  * error-truncating check here. When one is added it must stay
  * `POST .../health/check`-only (never the passive `GET`), and its `detail`
  * must always be a fixed, generic string — never a raw provider error.

--- a/src/modules/reporting/application/module-usage-report.ts
+++ b/src/modules/reporting/application/module-usage-report.ts
@@ -11,7 +11,8 @@ export type ModuleUsageEntry = {
  * Module usage summary (Issue 9.1, `GET /reports/module-usage`). Reports one
  * simple "has data" row-count signal per module registered in
  * `src/modules/index.ts` — deliberately generic, no domain-specific metrics
- * (derived applications add those in their own modules).
+ * (a domain module in `src/modules/` adds those in its own module — ADR-0034
+ * removed the derived-application pathway).
  *
  * `awcms_permissions` (the `reporting` module's own metric) is a
  * global, non-tenant-scoped catalog table (migration 005) — its count is

--- a/src/modules/sync-storage/domain/sync-conflict.ts
+++ b/src/modules/sync-storage/domain/sync-conflict.ts
@@ -6,7 +6,7 @@ export type SyncConflictEvaluation =
 /**
  * Optimistic-concurrency conflict check for a pushed event against an
  * aggregate's known version. Generic (no domain knowledge of what the
- * aggregate represents) — applies to any derived app's aggregates.
+ * aggregate represents) — applies to any domain module's aggregates.
  */
 export function evaluatePushEventConflict(
   currentVersion: number,

--- a/src/modules/workflow-approval/application/workflow-instance.ts
+++ b/src/modules/workflow-approval/application/workflow-instance.ts
@@ -2,8 +2,10 @@
  * Instance start (Issue #747, evolves Issue 11.1's linear
  * `startWorkflowInstance`). Internal-only application function — no
  * public HTTP route accepts arbitrary `graph`/`facts` input here; a
- * derived app's real business action (or a test fixture) calls this
+ * domain module's real business action (or a test fixture) calls this
  * directly, matching the existing module's own precedent (see README).
+ * ("Derived app" until ADR-0034 removed that pathway; a domain module now
+ * lives directly in `src/modules/`.)
  *
  * VERSION PINNING (Issue #747 acceptance criterion): resolves the
  * CURRENTLY `active` definition row for `workflowKey` at the moment this

--- a/src/modules/workflow-approval/infrastructure/condition-action-registry.ts
+++ b/src/modules/workflow-approval/infrastructure/condition-action-registry.ts
@@ -14,8 +14,9 @@
  * "foundation issue ships zero real business integrations" precedent
  * (#643 shipped zero real provider adapters; #742 shipped one
  * self-contained `sample.recorded` event + two reference consumers). A
- * derived application or a future base module adds its OWN entries here
- * when it has a real bounded predicate/side-effect to contribute.
+ * domain module added directly to `src/modules/` (ADR-0034 removed the
+ * derived-application pathway) adds its OWN entries here when it has a real
+ * bounded predicate/side-effect to contribute.
  */
 import type {
   WorkflowActionHandler,

--- a/src/pages/admin/email-templates.astro
+++ b/src/pages/admin/email-templates.astro
@@ -10,7 +10,7 @@
  * ABAC guard + `validateCreateEmailTemplateInput` (restricted `templateKey`
  * category, localized-text shape, unsafe-HTML rejection) are the real
  * authority; the form gate is UX-only. `templateKey` is a fixed select of the
- * base categories (a derived app registers its own `derived.*` in code, not
+ * base categories (a domain module registers its own `derived.*` in code, not
  * from this form); subject/body are captured for the `en` locale — the endpoint
  * accepts the full `{ locale: text }` map, this UI seeds one locale.
  */

--- a/src/pages/api/v1/identity/business-scope/assignments/index.ts
+++ b/src/pages/api/v1/identity/business-scope/assignments/index.ts
@@ -28,7 +28,7 @@ import { listModules } from "../../../../../../modules";
 const IDEMPOTENCY_SCOPE = "identity_access_business_scope_assignment_create";
 
 // SoD rule set for assignment-time conflict evaluation (Issue #181). Composed
-// from the registry (base + any derived application registry); the base
+// from the registry (base + any domain module that contributes rules); the base
 // declares no SoD rules, so this is empty in a pure base and conflict
 // detection is a no-op there.
 const SOD_RULES = collectSoDRuleDescriptors(listModules());

--- a/src/pages/api/v1/identity/business-scope/exceptions/index.ts
+++ b/src/pages/api/v1/identity/business-scope/exceptions/index.ts
@@ -26,8 +26,8 @@ import { listModules } from "../../../../../../modules";
 
 const IDEMPOTENCY_SCOPE = "identity_access_sod_conflict_exception_create";
 
-// The composed registry's SoD rules (base + any derived application registry).
-// The base declares none; a derived application (or the fixture) contributes
+// The composed registry's SoD rules (base + any domain module that contributes
+// rules). The base declares none; a domain module (or the fixture) contributes
 // them. An exception can only be created against a KNOWN rule that ALLOWS
 // exceptions.
 const SOD_RULES = collectSoDRuleDescriptors(listModules());


### PR DESCRIPTION
Tindak lanjut PR #414, yang memperbaiki **satu** situs (string `description` descriptor `reporting`) dan mencatat sisanya sebagai unit tersendiri. Ini unit itu.

## Masalah

[ADR-0034](../blob/main/docs/adr/0034-awcms-family-direct-use-templates-and-derived-pathway-removal.md) menghapus jalur aplikasi-turunan **seluruhnya** — tidak ada lagi `application-registry.ts`, `extension:check`, namespace migrasi `900+`, manifest kompatibilitas turunan. `docs/PROJECT_STATE.md` §1 menyatakan rujukan yang masih menyebutnya sebagai jalur aktif adalah **usang**.

Toh **29 situs** di `src/` masih menyebutnya, dan hampir semuanya menjawab pertanyaan yang paling sering ditanyakan pembaca sebuah seam — *"siapa yang menyediakan adapter/entri di sini?"* — dengan jawaban yang tidak ada. Contoh paling tajam, `identity-access/application/access-guard.ts`:

> The base ships only a no-op hierarchy adapter; **a derived application** passes its own real resolver here.

Pembaca yang mengikuti kalimat itu akan mencari jalur yang dihapus dua ADR lalu.

## Kenapa ini BUKAN pekerjaan `sed`

23 situs ditulis ulang menjadi mekanisme yang berlaku — **modul domain yang ditambahkan langsung di `src/modules/`** — tetapi beberapa butuh kata yang berbeda, karena konteksnya memang berbeda:

| Berkas | Kata yang benar, dan kenapa |
|---|---|
| `metrics-port.ts`, `prometheus-text-adapter.ts` | **deployment** lewat composition root — bukan modul yang memasang adapter observability |
| `_shared/family-contract.ts` | **konsumen** kontrak keluarga (mis. `ahliweb/awcms-astro`) — itu yang dirusak perubahan MAJOR |
| `logger.ts` (situs kedua) | "A derived app's sink" → "**A registered sink**" — kalimatnya tentang sink mana pun yang terdaftar, bukan tentang siapa mendaftarkannya |
| `email-template-categories.ts` | namespace `derived.*` dan `registerDerivedEmailTemplateCategory` adalah **identifier NYATA di kode** — tidak disentuh, hanya prosanya |

Penyapuan seragam akan merusak keempatnya, dan yang terakhir akan mengubah identifier.

## Enam situs sengaja DIBIARKAN

Semuanya benar secara historis, dan menghapusnya justru menghilangkan catatan **kenapa** jalur itu tidak ada:

- `_shared/module-contract.ts` changelog `2.0.0` — ia **menamai** pencabutannya.
- `_shared/ports/business-scope-hierarchy-port.ts` (3 situs) — mengutip judul issue #180, dan menjelaskan resolver itu *"permanently unfillable once ADR-0034 deleted that pathway"*. Prosa itu sudah tepat.
- `email-template-categories.ts` — kutipan teks issue.
- Satu catatan penanda yang ditambahkan perubahan ini sendiri.

## Verifikasi

`DATABASE_URL="" bun run check` **PENUH** hijau, `CHECK_EXIT=0`. Nol perubahan perilaku — seluruhnya komentar dan satu baris JSDoc. Base diverifikasi `2e749fda` = `origin/main`; satu commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
