### PR TITLE
fix(keamanan): approve registrasi berhenti bisa memberikan role `owner`

### DIFF
--- a/.changeset/approve-registrasi-tolak-system-role.md
+++ b/.changeset/approve-registrasi-tolak-system-role.md
@@ -1,0 +1,67 @@
+---
+"awcms": minor
+---
+
+fix(keamanan): approve registrasi berhenti bisa memberikan role `owner`
+
+`POST /api/v1/registration-requests/{id}/approve` memvalidasi `roleIds` hanya
+dengan `SELECT id FROM awcms_roles WHERE tenant_id = … AND deleted_at IS NULL`
+(`identity-access/application/self-registration.ts`), lalu menulis langsung ke
+`awcms_access_assignments`. Tidak ada penyaringan `is_system`.
+
+`owner` **adalah** system role, dan `tenant-admin/application/platform-bootstrap.ts`
+men-seed-nya dengan **seluruh** katalog permission tenant. Jadi prinsipal yang
+hanya memegang `identity_access.registration_requests.{read,approve}` — peran
+yang docblock rutenya sendiri rancang agar **tidak** menyentuh katalog RBAC
+("the authority to admit someone to a tenant is not the authority to edit
+roles") — bisa meng-approve dengan `roleIds: [<id owner>]` dan mencetak akun
+ber-izin penuh. Dan bukan lewat `curl` saja: `/admin/registrations` merender
+picker dari `listRoles`, yang tidak menyaring `is_system`, sehingga `owner`
+tampil sebagai salah satu opsi di dropdown.
+
+Jalur resmi menolaknya sejak awal: `user-admin.ts#assignRole` melempar
+`SystemRoleAssignmentError` dan rutenya digerbangi `access_control.assign`
+(→ `409 ROLE_SYSTEM_PROTECTED`). **Dua penulis satu tabel dengan dua aturan
+berbeda** — itu kelas cacatnya, bukan satu baris yang terlewat.
+
+Perbaikannya:
+
+- Service menolak sebelum menulis apa pun (`outcome: "system_role"` +
+  `roleCodes`). Sengaja **bukan** dikolapskan ke `unknown_role`: role-nya ada
+  dan layar reviewer baru saja merendernya, jadi menjawab "tidak ada" adalah
+  kebohongan tentang baris yang mereka lihat. Ia juga tidak membocorkan apa pun
+  — `registration_requests.read` sudah menampilkan daftar role tenant itu.
+- Route memetakannya ke **`409 ROLE_SYSTEM_PROTECTED`**, kode yang SAMA dengan
+  `POST /api/v1/access/assignments` untuk penolakan yang sama.
+- Baris audit `registration_approved` kini membawa `roleCodes`, bukan hanya
+  `roleCount`. Approval yang memberi role adalah pemberian privilese, dan
+  `roleCount: 1` tak bisa menjawab satu-satunya pertanyaan auditor tentangnya.
+- Picker di `/admin/registrations` tidak lagi menawarkan system role —
+  presentasi saja; otoritasnya tetap endpoint.
+
+Gerbang yang ikut mendarat, dan ia menutup KELASNYA bukan kejadiannya:
+`tests/access-assignment-writers.test.ts` menuntut **setiap** berkas `src/**`
+yang memuat `INSERT INTO awcms_access_assignments` juga membaca `is_system`,
+atau terdaftar sebagai pengecualian ber-alasan (hari ini tepat satu:
+`platform-bootstrap.ts` — bootstrap tenant memang perbuatan membuat owner
+pertama, berjalan sebelum ada sesi mana pun). Entri basi ikut memerahkan.
+Mutation-proven: mengembalikan cacat aslinya membuatnya MERAH dan menyebut
+berkasnya; menghapus filter picker memerahkan contract test.
+Dua test integrasi (`system_role` → nol baris `awcms_access_assignments`, nol
+identitas, request tetap `pending`; role biasa tetap diberikan dan disebut
+namanya) menjaga sisi database — arah kedua itu perlu, karena
+`AND is_system = false` yang salah tulis bisa menolak **semua** role sambil
+membuat test pertama tetap hijau.
+
+**Yang SENGAJA tidak dikerjakan di sini, dan alasannya.** Approval tetap boleh
+memberikan role NON-system tanpa pemanggilnya memegang
+`access_control.assign`. Itu desain yang tertulis eksplisit di docblock rutenya,
+dan menyempitkannya adalah perubahan **otoritas** — tempatnya ADR, bukan
+perbaikan bug. Konsekuensinya dinyatakan, bukan disembunyikan: tenant yang
+membuat role non-system ber-izin besar membuat pemegang `approve` bisa
+memberikannya. Yang ditutup PR ini adalah eskalasi ke katalog PENUH lewat role
+yang tak seorang pun bisa buat lewat API (`role-admin.ts#createRole` menulis
+`is_system` sebagai `false` tetap).
+
+Nol migrasi: kolom, katalog permission, dan proteksi system-role di jalur
+sebelah sudah ada — yang hilang hanya penegakannya di penulis kedua.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **90** (`sql/001`–`090`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0071** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (22.649 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (22.656 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **35** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -1735,7 +1735,7 @@ Oldest first, bounded. Login identifiers are MASKED — a reviewer decides on a 
 - **operationId**: `approveRegistrationRequest`
 - **Security**: bearerAuth + tenantHeader
 
-The only path that materializes profile + identity + tenant_user, hence its own permission (`registration_requests.approve`), separate from `reject`. The account is created with an UNUSABLE password and the applicant is emailed a password-reset link; `delivery` reports whether that link could actually be queued. `roleIds` is optional and defaults to none — an approval never grants a role by default.
+The only path that materializes profile + identity + tenant_user, hence its own permission (`registration_requests.approve`), separate from `reject`. The account is created with an UNUSABLE password and the applicant is emailed a password-reset link; `delivery` reports whether that link could actually be queued. `roleIds` is optional and defaults to none — an approval never grants a role by default, and a SYSTEM role (`owner`) is refused with 409 `ROLE_SYSTEM_PROTECTED`: admitting a person to a tenant is not the authority to hand out the tenant's whole permission catalogue.
 
 **Parameters**
 
@@ -1747,14 +1747,14 @@ The only path that materializes profile + identity + tenant_user, hence its own 
 
 **Responses**
 
-| Status | Description                                           | Schema                                 |
-| ------ | ----------------------------------------------------- | -------------------------------------- |
-| 200    | Account created.                                      | object                                 |
-| 400    | Validation error.                                     | [`ApiError`](#standard-error-envelope) |
-| 401    | Missing or invalid session.                           | [`ApiError`](#standard-error-envelope) |
-| 403    | Access denied by RBAC/ABAC.                           | [`ApiError`](#standard-error-envelope) |
-| 404    | Resource not found.                                   | [`ApiError`](#standard-error-envelope) |
-| 409    | An account with that login identifier already exists. | [`ApiError`](#standard-error-envelope) |
+| Status | Description                                                                                                                                                                | Schema                                 |
+| ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Account created.                                                                                                                                                           | object                                 |
+| 400    | Validation error.                                                                                                                                                          | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                                                                                | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                                                                                | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                                                                                                                        | [`ApiError`](#standard-error-envelope) |
+| 409    | `IDENTIFIER_TAKEN` — an account with that login identifier already exists; or `ROLE_SYSTEM_PROTECTED` — one of `roleIds` names a system role, which no approval may grant. | [`ApiError`](#standard-error-envelope) |
 
 ### `POST /api/v1/registration-requests/{id}/reject` — Reject a request. Creates nothing and notifies nobody.
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 313   |
+| Berkas test                        | 314   |
 | Berkas route                       | 309   |
 | ADR                                | 72    |
 
@@ -272,7 +272,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 265        |
+| `(root)`      | 266        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -10200,7 +10200,7 @@ paths:
       tags:
         - Identity & Access
       summary: Approve a request, creating a real account.
-      description: The only path that materializes profile + identity + tenant_user, hence its own permission (`registration_requests.approve`), separate from `reject`. The account is created with an UNUSABLE password and the applicant is emailed a password-reset link; `delivery` reports whether that link could actually be queued. `roleIds` is optional and defaults to none — an approval never grants a role by default.
+      description: "The only path that materializes profile + identity + tenant_user, hence its own permission (`registration_requests.approve`), separate from `reject`. The account is created with an UNUSABLE password and the applicant is emailed a password-reset link; `delivery` reports whether that link could actually be queued. `roleIds` is optional and defaults to none — an approval never grants a role by default, and a SYSTEM role (`owner`) is refused with 409 `ROLE_SYSTEM_PROTECTED`: admitting a person to a tenant is not the authority to hand out the tenant's whole permission catalogue."
       parameters:
         - name: id
           in: path
@@ -10257,7 +10257,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: An account with that login identifier already exists.
+          description: "`IDENTIFIER_TAKEN` — an account with that login identifier already exists; or `ROLE_SYSTEM_PROTECTED` — one of `roleIds` names a system role, which no approval may grant."
           content:
             application/json:
               schema:

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -1527,7 +1527,10 @@ paths:
         `reject`. The account is created with an UNUSABLE password and the
         applicant is emailed a password-reset link; `delivery` reports whether
         that link could actually be queued. `roleIds` is optional and defaults
-        to none — an approval never grants a role by default.
+        to none — an approval never grants a role by default, and a SYSTEM role
+        (`owner`) is refused with 409 `ROLE_SYSTEM_PROTECTED`: admitting a
+        person to a tenant is not the authority to hand out the tenant's whole
+        permission catalogue.
       parameters:
         - name: id
           in: path
@@ -1584,7 +1587,10 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          description: An account with that login identifier already exists.
+          description: >-
+            `IDENTIFIER_TAKEN` — an account with that login identifier already
+            exists; or `ROLE_SYSTEM_PROTECTED` — one of `roleIds` names a system
+            role, which no approval may grant.
           content:
             application/json:
               schema:

--- a/src/modules/identity-access/application/self-registration.ts
+++ b/src/modules/identity-access/application/self-registration.ts
@@ -14,6 +14,16 @@
  *   Approval is the ONLY path that materializes profile + identity +
  *   tenant_user, and therefore the single point at which a self-registered
  *   applicant becomes able to sign in.
+ * - Approval REFUSES system roles. It is the second writer of
+ *   `awcms_access_assignments` in this repo, and it sits behind a different
+ *   permission than the first one (`access_control.assign`, whose service
+ *   `user-admin.ts#assignRole` throws `SystemRoleAssignmentError`). Two writers
+ *   with two rule sets is how `owner` — a system role holding the entire tenant
+ *   catalogue — became reachable from a permission whose stated purpose is that
+ *   it does NOT edit roles. What it still does NOT do is demand
+ *   `access_control.assign` for granting an ordinary role at approval time:
+ *   that is the deliberate design recorded in the route's docblock, and
+ *   narrowing it is an authority change that belongs in an ADR, not here.
  *
  * ## Approval issues a credential the applicant must claim
  *
@@ -171,10 +181,20 @@ export type ApproveRegistrationResult =
       tenantUserId: string;
       /** Whether the applicant's password-reset link was actually queued. */
       delivery: "queued" | "unavailable";
+      /** Role codes actually granted, sorted — empty on the default (no role) path. */
+      grantedRoleCodes: string[];
     }
   | { outcome: "not_found" }
   | { outcome: "identifier_taken" }
-  | { outcome: "unknown_role" };
+  | { outcome: "unknown_role" }
+  /**
+   * At least one requested role is a SYSTEM role (`owner`). Distinct from
+   * `unknown_role` on purpose: the role exists and the reviewer's own screen
+   * just rendered it, so answering "does not exist" would be a lie about a row
+   * they can see. It leaks nothing they do not already hold — listing this
+   * tenant's roles is what `registration_requests.read` already showed them.
+   */
+  | { outcome: "system_role"; roleCodes: string[] };
 
 export type ApproveRegistrationOptions = {
   roleIds: string[];
@@ -227,19 +247,45 @@ export async function approveRegistrationRequest(
     return { outcome: "identifier_taken" };
   }
 
+  // Carried into the audit row: `roleCount` alone cannot answer "which role did
+  // this approval hand out?", and that is the only question an auditor has
+  // about an approval that granted one.
+  let grantedRoleCodes: string[] = [];
+
   if (options.roleIds.length > 0) {
     const found = (await tx`
-      SELECT id FROM awcms_roles
+      SELECT id, role_code, is_system FROM awcms_roles
       WHERE tenant_id = ${tenantId}
         AND id = ANY(${tx.array(options.roleIds, "uuid")})
         AND deleted_at IS NULL
-    `) as { id: string }[];
+    `) as { id: string; role_code: string; is_system: boolean }[];
 
     // All-or-nothing: a partially-valid role list must not silently grant the
     // subset that happened to resolve.
     if (found.length !== options.roleIds.length) {
       return { outcome: "unknown_role" };
     }
+
+    // A system role is `owner`, and `owner` holds the WHOLE tenant catalogue
+    // (`tenant-admin/application/platform-bootstrap.ts` seeds it that way). The
+    // ordinary assignment path already refuses this — `user-admin.ts#assignRole`
+    // throws `SystemRoleAssignmentError` and its route is gated on
+    // `access_control.assign`. Approval writes the same table
+    // (`awcms_access_assignments`) behind a DIFFERENT permission, so without
+    // this check a principal holding only `registration_requests.{read,approve}`
+    // — a role whose whole point is that it does NOT edit the RBAC catalogue —
+    // could mint an `owner`. Refused BEFORE any write: this function returns
+    // from inside the tenant transaction and a returned 4xx COMMITs.
+    const systemRoles = found.filter((role) => role.is_system);
+
+    if (systemRoles.length > 0) {
+      return {
+        outcome: "system_role",
+        roleCodes: systemRoles.map((role) => role.role_code)
+      };
+    }
+
+    grantedRoleCodes = found.map((role) => role.role_code).sort();
   }
 
   // Not `emailVerified`: an approving reviewer confirmed the person should have
@@ -314,7 +360,8 @@ export async function approveRegistrationRequest(
     outcome: "approved",
     identityId,
     tenantUserId,
-    delivery: reset.outcome === "enqueued" ? "queued" : "unavailable"
+    delivery: reset.outcome === "enqueued" ? "queued" : "unavailable",
+    grantedRoleCodes
   };
 }
 

--- a/src/pages/admin/registrations.astro
+++ b/src/pages/admin/registrations.astro
@@ -59,10 +59,17 @@ if (canRead) {
       loadError = true;
     } else {
       requests = result.requests;
-      roles = result.roles.map((role) => ({
-        id: role.id,
-        roleCode: role.roleCode
-      }));
+      // System roles are dropped here because the endpoint refuses them (409
+      // `ROLE_SYSTEM_PROTECTED`). Rendering `owner` in this picker offered a
+      // control that either escalated privilege or — once the service started
+      // refusing it — failed in the reviewer's face for no reason they could
+      // read. This is presentation only; the refusal is the endpoint's.
+      roles = result.roles
+        .filter((role) => !role.isSystem)
+        .map((role) => ({
+          id: role.id,
+          roleCode: role.roleCode
+        }));
     }
   } catch {
     loadError = true;

--- a/src/pages/api/v1/registration-requests/[id]/approve.ts
+++ b/src/pages/api/v1/registration-requests/[id]/approve.ts
@@ -24,6 +24,13 @@ type ApproveBody = {
  * that silently granted a default role would make "approve" mean more than the
  * reviewer read it as.
  *
+ * SYSTEM roles are refused (409 `ROLE_SYSTEM_PROTECTED`). The sentence above
+ * about admission not being role-editing is exactly why: `owner` is a system
+ * role holding the whole tenant catalogue, so letting this permission hand it
+ * out would make `registration_requests.approve` a superset of the permission
+ * it was separated from. The refusal lives in the service, before any write —
+ * see `application/self-registration.ts`.
+ *
  * The applicant receives a password-reset link, not a password: the account is
  * created with an unusable credential (see
  * `application/self-registration.ts`). `delivery` is reported back so the admin
@@ -108,6 +115,17 @@ export const POST = defineTenantRoute({
         );
       }
 
+      if (result.outcome === "system_role") {
+        // Same code the ordinary assignment path returns for the same refusal
+        // (`POST /api/v1/access/assignments` → 409 ROLE_SYSTEM_PROTECTED), so a
+        // reviewer who meets it in either place reads one answer, not two.
+        return fail(
+          409,
+          "ROLE_SYSTEM_PROTECTED",
+          "A system role cannot be granted through an approval."
+        );
+      }
+
       return fail(400, "UNKNOWN_ROLE", "One or more roles do not exist.");
     }
 
@@ -125,6 +143,10 @@ export const POST = defineTenantRoute({
         identityId: result.identityId,
         tenantUserId: result.tenantUserId,
         roleCount: prepared.roleIds.length,
+        // WHICH role, not just how many. An approval that granted a role is a
+        // privilege grant, and `roleCount: 1` cannot tell an auditor whether
+        // the account got `viewer` or something far larger.
+        roleCodes: result.grantedRoleCodes,
         delivery: result.delivery
       },
       correlationId: locals.correlationId

--- a/tests/access-assignment-writers.test.ts
+++ b/tests/access-assignment-writers.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Every writer of `awcms_access_assignments` refuses SYSTEM roles — or is a
+ * named exception with a reason.
+ *
+ * ## Why this is a gate and not a code review note
+ *
+ * `owner` is a system role, and `tenant-admin/application/platform-bootstrap.ts`
+ * seeds it with the tenant's ENTIRE permission catalogue. So "may this actor
+ * write a row into `awcms_access_assignments` naming a system role?" is the
+ * single question standing between a scoped permission and full tenant
+ * control.
+ *
+ * The ordinary path answered it correctly from the start:
+ * `user-admin.ts#assignRole` throws `SystemRoleAssignmentError`, and its route
+ * is gated on `access_control.assign`. Approval of a self-registration became a
+ * SECOND writer, behind a DIFFERENT permission
+ * (`registration_requests.approve`), and it validated `roleIds` with
+ * `deleted_at IS NULL` alone. The result was a principal whose role exists
+ * precisely so that it does NOT edit the RBAC catalogue being able to mint an
+ * `owner` — and the audit row said only `roleCount: 1`.
+ *
+ * Nothing detected that, because the checks this repo already had answer
+ * adjacent questions: `access:permissions:enforcement:check` asks whether a
+ * permission has an enforcer, and `access:chokepoint:check` asks whether a
+ * handler runs the guard chain. Both were green. Neither asks whether two
+ * enforcement sites over one table agree about what may be written.
+ *
+ * ## What "refuses" means here
+ *
+ * The scan is textual on purpose: it asks whether the file that writes the row
+ * also reads `is_system`, which is the column the rule lives in. It cannot
+ * prove the check is correct — that is what
+ * `tests/integration/self-registration.integration.test.ts` (system role
+ * refused, zero rows) and the `assignRole` tests do against a real database.
+ * This one closes the class: a THIRD writer landing tomorrow without any notion
+ * of system roles turns it red on the day it lands, rather than on the day
+ * someone reads it.
+ */
+import { describe, expect, test } from "bun:test";
+
+const WRITE_MARKER = "INSERT INTO awcms_access_assignments";
+
+/**
+ * Writers that legitimately assign a system role, each with the reason that
+ * makes it legitimate. A register of DECISIONS, not a backlog: adding an entry
+ * here is the visible act of saying "this path may hand out `owner`".
+ */
+const SYSTEM_ROLE_WRITERS: Record<string, string> = {
+  "src/modules/tenant-admin/application/platform-bootstrap.ts":
+    "Tenant bootstrap IS the act of creating the first owner. It runs once, " +
+    "before any session exists, from the setup wizard and tenant provisioning " +
+    "— there is no actor whose privileges it could exceed."
+};
+
+async function assignmentWriters(): Promise<string[]> {
+  const files: string[] = [];
+
+  for await (const file of new Bun.Glob("src/**/*.ts").scan({
+    cwd: process.cwd()
+  })) {
+    const source = await Bun.file(file).text();
+
+    if (source.includes(WRITE_MARKER)) {
+      files.push(file);
+    }
+  }
+
+  return files.sort();
+}
+
+describe("writers of awcms_access_assignments", () => {
+  test("the scan finds the writers it is meant to check", async () => {
+    const writers = await assignmentWriters();
+
+    // A glob that resolves to nothing would make every assertion below pass
+    // vacuously — the exact failure mode `tests/module-absence-claims.test.ts`
+    // documents from its own first version.
+    expect(writers.length).toBeGreaterThanOrEqual(2);
+    expect(writers).toContain(
+      "src/modules/identity-access/application/user-admin.ts"
+    );
+    expect(writers).toContain(
+      "src/modules/identity-access/application/self-registration.ts"
+    );
+  });
+
+  test("each one refuses system roles, or is a listed exception", async () => {
+    const offenders: string[] = [];
+
+    for (const file of await assignmentWriters()) {
+      if (file in SYSTEM_ROLE_WRITERS) {
+        continue;
+      }
+
+      const source = await Bun.file(file).text();
+
+      if (!source.includes("is_system")) {
+        offenders.push(file);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test("no exception outlives the writer it excuses", async () => {
+    // A stale entry is worse than a missing one: it reads as a reviewed
+    // decision about code that no longer exists, and the next reader inherits
+    // it as precedent. Same rule the permission-enforcement exception list
+    // enforces on itself.
+    const writers = new Set(await assignmentWriters());
+    const stale = Object.keys(SYSTEM_ROLE_WRITERS).filter(
+      (file) => !writers.has(file)
+    );
+
+    expect(stale).toEqual([]);
+  });
+});

--- a/tests/integration/self-registration.integration.test.ts
+++ b/tests/integration/self-registration.integration.test.ts
@@ -121,6 +121,35 @@ function approve(
   );
 }
 
+/**
+ * A role row, seeded through the ADMIN channel so `is_system` can be set
+ * directly — `role-admin.ts#createRole` hardcodes `false`, which is precisely
+ * why the only system role a tenant ever has is the one
+ * `platform-bootstrap.ts` seeds.
+ */
+async function seedRole(
+  tenantId: string,
+  roleCode: string,
+  isSystem: boolean
+): Promise<string> {
+  const rows = (await getAdminSql()`
+    INSERT INTO awcms_roles (tenant_id, role_code, role_name, is_system)
+    VALUES (${tenantId}, ${roleCode}, ${roleCode}, ${isSystem})
+    RETURNING id
+  `) as { id: string }[];
+
+  return rows[0]!.id;
+}
+
+async function assignmentCount(tenantId: string): Promise<number> {
+  const rows = (await getAdminSql()`
+    SELECT count(*)::int AS n FROM awcms_access_assignments
+    WHERE tenant_id = ${tenantId}
+  `) as { n: number }[];
+
+  return rows[0]!.n;
+}
+
 async function rowCount(tenantId: string): Promise<number> {
   const rows = (await getAdminSql()`
     SELECT count(*)::int AS n FROM awcms_registration_requests WHERE tenant_id = ${tenantId}
@@ -285,6 +314,64 @@ suite("self-registration integration (Wave 2 delta auth)", () => {
     `) as { n: number }[];
     expect(identities[0]!.n).toBe(0);
     expect(sent).toEqual([]);
+  });
+
+  test("a system role is refused, and the approval writes nothing at all", async () => {
+    // The original defect: `approveRegistrationRequest` validated `roleIds`
+    // with `deleted_at IS NULL` alone, so a principal holding only
+    // `registration_requests.{read,approve}` could approve with
+    // `roleIds: [<owner>]` and mint an account carrying the tenant's ENTIRE
+    // permission catalogue — the one thing that permission was separated from
+    // `access_control.assign` in order not to do. Drop `is_system` from the
+    // filter in `self-registration.ts` and this test fails on the first
+    // assertion, with an `awcms_access_assignments` row to prove it.
+    const sent: Sent = [];
+    const roleId = await seedRole(TENANT_A, "owner", true);
+    const request = await submit(TENANT_A);
+
+    const result = await approve(TENANT_A, request.requestId!, sent, [roleId]);
+
+    expect(result.outcome).toBe("system_role");
+    expect(result.outcome === "system_role" && result.roleCodes).toEqual([
+      "owner"
+    ]);
+
+    // Refused BEFORE any write — this function returns from inside the tenant
+    // transaction, and a returned 4xx COMMITs, so "no rows" is the assertion
+    // that matters rather than "rolled back".
+    expect(await assignmentCount(TENANT_A)).toBe(0);
+
+    const identities = (await getAdminSql()`
+      SELECT count(*)::int AS n FROM awcms_identities
+      WHERE tenant_id = ${TENANT_A} AND login_identifier = ${APPLICANT}
+    `) as { n: number }[];
+    expect(identities[0]!.n).toBe(0);
+    expect(sent).toEqual([]);
+
+    // Still claimable: a refused approval must leave the request reviewable.
+    const rows = (await getAdminSql()`
+      SELECT status FROM awcms_registration_requests
+      WHERE tenant_id = ${TENANT_A} AND id = ${request.requestId!}
+    `) as { status: string }[];
+    expect(rows[0]!.status).toBe("pending");
+  });
+
+  test("an ordinary role is still granted, and the result names it", async () => {
+    // The other half of the same rule: refusing system roles must not turn
+    // into refusing roles. Without this, `AND is_system = false` could be
+    // written as a filter that drops every row and the suite above would still
+    // be green.
+    const sent: Sent = [];
+    const roleId = await seedRole(TENANT_A, "editor", false);
+    const request = await submit(TENANT_A);
+
+    const result = await approve(TENANT_A, request.requestId!, sent, [roleId]);
+
+    expect(result.outcome).toBe("approved");
+    expect(result.outcome === "approved" && result.grantedRoleCodes).toEqual([
+      "editor"
+    ]);
+    expect(await assignmentCount(TENANT_A)).toBe(1);
   });
 
   test("rejection creates nothing and closes the queue entry", async () => {

--- a/tests/self-registration-contract.test.ts
+++ b/tests/self-registration-contract.test.ts
@@ -135,6 +135,44 @@ describe("the admin routes", () => {
     expect(approve).not.toMatch(/action:\s*"reject"/);
   });
 
+  test("approval refuses system roles, with the code the other path already uses", async () => {
+    const route = await readFile(
+      "src/pages/api/v1/registration-requests/[id]/approve.ts",
+      "utf8"
+    );
+
+    // 409 `ROLE_SYSTEM_PROTECTED` is what `POST /api/v1/access/assignments`
+    // answers for the same refusal. Two codes for one rule would make the
+    // screen have to explain which path the reviewer happened to take.
+    expect(route).toContain('"system_role"');
+    expect(route).toContain('"ROLE_SYSTEM_PROTECTED"');
+    expect(route).toMatch(/system_role[\s\S]{0,400}409/);
+  });
+
+  test("the approval audit row names the role, not just how many", async () => {
+    const route = await readFile(
+      "src/pages/api/v1/registration-requests/[id]/approve.ts",
+      "utf8"
+    );
+
+    // An approval that granted a role is a privilege grant. `roleCount: 1`
+    // cannot answer the only question an auditor asks about one.
+    expect(route).toMatch(/action:\s*"registration_approved"/);
+    expect(route).toContain("roleCodes: result.grantedRoleCodes");
+  });
+
+  test("the approve screen offers no role the endpoint would refuse", async () => {
+    const screen = await readFile(
+      "src/pages/admin/registrations.astro",
+      "utf8"
+    );
+
+    // UX-only — the endpoint stays the authority. But a picker that lists
+    // `owner` is either an escalation or a button that always fails, and both
+    // read to the operator as a broken screen.
+    expect(screen).toMatch(/filter\(\s*\(role\)\s*=>\s*!role\.isSystem\s*\)/);
+  });
+
   test("rejection notifies nobody", async () => {
     const reject = await readFile(
       "src/pages/api/v1/registration-requests/[id]/reject.ts",


### PR DESCRIPTION
## Apa yang salah

`POST /api/v1/registration-requests/{id}/approve` memvalidasi `roleIds` hanya dengan
`SELECT id FROM awcms_roles WHERE tenant_id = … AND deleted_at IS NULL`, lalu menulis
langsung ke `awcms_access_assignments`. **Nol penyaringan `is_system`.**

`owner` **adalah** system role, dan `tenant-admin/application/platform-bootstrap.ts`
men-seed-nya dengan **seluruh** katalog permission tenant. Jadi prinsipal yang hanya
memegang `identity_access.registration_requests.{read,approve}` — peran yang docblock
rute itu sendiri rancang agar **tidak** menyentuh katalog RBAC ("the authority to admit
someone to a tenant is not the authority to edit roles") — bisa meng-approve dengan
`roleIds: [<id owner>]` dan mencetak akun ber-izin penuh.

Dan bukan lewat `curl` saja: `/admin/registrations` merender picker dari `listRoles`,
yang tidak menyaring `is_system`, sehingga **`owner` tampil sebagai salah satu opsi di
dropdown**.

Jalur resmi menolaknya sejak awal — `user-admin.ts#assignRole` melempar
`SystemRoleAssignmentError` dan rutenya digerbangi `access_control.assign` (→ 409
`ROLE_SYSTEM_PROTECTED`). **Dua penulis satu tabel dengan dua aturan berbeda** — itu
kelas cacatnya, bukan satu baris yang terlewat.

Prasyarat `AUTH_SELF_REGISTRATION_ENABLED=true` (default mati), tetapi pelanggaran
pemisahan wewenangnya tidak bergantung pada saklar itu.

## Perbaikan

- **Service menolak sebelum menulis apa pun** (`outcome: "system_role"` + `roleCodes`).
  Sengaja **bukan** dikolapskan ke `unknown_role`: role-nya ada dan layar reviewer baru
  saja merendernya, jadi menjawab "tidak ada" adalah kebohongan tentang baris yang mereka
  lihat — dan ia tak membocorkan apa pun, karena `registration_requests.read` sudah
  menampilkan daftar role tenant itu.
- **Route → 409 `ROLE_SYSTEM_PROTECTED`**, kode yang SAMA dengan
  `POST /api/v1/access/assignments` untuk penolakan yang sama.
- **Audit `registration_approved` membawa `roleCodes`**, bukan hanya `roleCount`.
  `roleCount: 1` tak bisa menjawab satu-satunya pertanyaan auditor tentang sebuah
  pemberian privilese.
- **Picker tak lagi menawarkan system role** — presentasi saja; otoritasnya tetap endpoint.

## Gerbang yang ikut mendarat

`tests/access-assignment-writers.test.ts` menutup **kelasnya**: setiap berkas `src/**`
yang memuat `INSERT INTO awcms_access_assignments` wajib juga membaca `is_system`, atau
terdaftar sebagai pengecualian ber-alasan — hari ini tepat satu (`platform-bootstrap.ts`:
bootstrap tenant memang perbuatan membuat owner pertama, berjalan sebelum ada sesi mana
pun). Entri basi ikut memerahkan, dan glob yang resolve ke nol tidak bisa lolos hampa.

Kenapa tak ada yang menangkapnya sebelumnya: `access:permissions:enforcement:check`
bertanya "apakah permission ini punya penegak" dan `access:chokepoint:check` bertanya
"apakah handler ini menjalankan rantai guard". Keduanya HIJAU. Tak satu pun bertanya
apakah dua situs penegakan atas satu tabel **sepakat tentang apa yang boleh ditulis**.

**Mutation-proven, dua arah:**
- kembalikan cacat aslinya (buang cek `is_system` dari service) → gerbang MERAH dan
  menyebut berkasnya;
- hapus filter picker di `.astro` → contract test MERAH.

Dua test integrasi menjaga sisi database: system role → **nol** baris
`awcms_access_assignments`, nol identitas, request tetap `pending`; dan arah sebaliknya —
role biasa tetap diberikan dan namanya disebut, karena `AND is_system = false` yang salah
tulis bisa menolak **semua** role sambil membuat test pertama tetap hijau.

## Yang SENGAJA tidak dikerjakan di sini

Approval tetap boleh memberikan role **non-system** tanpa pemanggilnya memegang
`access_control.assign`. Itu desain yang tertulis eksplisit di docblock rutenya, dan
menyempitkannya adalah perubahan **otoritas** — tempatnya ADR, bukan perbaikan bug.
Konsekuensinya dinyatakan, bukan disembunyikan: tenant yang membuat role non-system
ber-izin besar membuat pemegang `approve` bisa memberikannya. Yang ditutup PR ini adalah
eskalasi ke katalog **penuh** lewat role yang tak seorang pun bisa buat lewat API
(`role-admin.ts#createRole` tetap menulis `is_system` sebagai `false`).

## Verifikasi

`bun run check` PENUH hijau (35 gerbang): **3342 pass / 0 fail / 489 skip** (DB-gated),
`build` + `build:asset-budget:check` lolos. Nol migrasi — kolom, katalog permission, dan
proteksi system-role di jalur sebelah sudah ada; yang hilang hanya penegakannya di
penulis kedua. Artefak ter-generate ikut diperbarui (`openapi:bundle`,
`api:docs:generate`, `repo:inventory`, `project-state:inventory`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)