### PR TITLE
fix(ci): 36 test DB-gated berhenti hijau-palsu — lima berkas tak pernah dijalankan pipeline mana pun

### DIFF
--- a/.changeset/daftar-db-gated-ci-lengkap.md
+++ b/.changeset/daftar-db-gated-ci-lengkap.md
@@ -1,0 +1,63 @@
+---
+"awcms": patch
+---
+
+fix(ci): 46 test DB-gated berhenti hijau-palsu — lima berkas yang tak pernah dijalankan pipeline mana pun
+
+Suite DB-gated di akar `tests/` tak bisa berjalan satu proses dengan
+`tests/integration/` (empiris: 26 tabrakan), jadi kedua pipeline menjalankannya
+sebagai step tersendiri dengan **daftar berkas eksplisit**. Daftar eksplisit
+memang keputusan yang benar di situ — `bun test` telanjang akan menumbuhkan
+kembali tabrakannya — tetapi daftar eksplisit **drift**, dan yang ini drift.
+
+Ia lahir dengan **10** entri (#176). Lima berkas DB-gated mendarat sesudahnya
+(#188, #189, #190, #191) dan **tak satu pun PR-nya menyentuh daftar itu**:
+
+- `tests/mfa-integration.test.ts` — atomisitas lockout & replay counter di
+  Postgres (CAS + `FOR UPDATE`), konsumsi recovery code sekali-pakai di bawah
+  konkurensi, RLS FORCE, penolakan lintas-tenant.
+- `tests/mfa-login-e2e.test.ts` — enforcement enrollment + step-up pada handler
+  login/step-up/admin-reset yang SEBENARNYA.
+- `tests/oidc-integration.test.ts` — penolakan lintas-tenant atas empat tabel
+  OIDC, validasi klaim ID token, guard SSRF terhadap issuer privat.
+- `tests/turnstile-login-e2e.test.ts` — Turnstile berjalan SEBELUM lookup
+  identitas/kerja password di handler nyata, gagal-tertutup, dan tiap rute
+  terikat action-nya sendiri.
+- `tests/openapi-office-response-schema-postgres.test.ts` — konformansi payload
+  respons terhadap schema `Office` di bundel OpenAPI.
+
+Hasilnya **46 test yang skip di setiap pipeline** sambil terbaca sebagai
+cakupan pada setiap run hijau. Dan bukan salah tafsir: header keempat berkas
+itu **menuliskan sendiri** bahwa mereka "runs in the dedicated legacy
+`bun test <files>` step" — step yang daftarnya tak pernah memanggil mereka.
+
+Tak ada yang bisa menangkapnya. `bun run check` memang berjalan dengan
+`DATABASE_URL` kosong, jadi berkas-berkas itu SEHARUSNYA skip di sana — skip
+bukan sinyal. Satu-satunya pengamat yang bisa membedakan "skip karena tak ada
+database" dari "skip selamanya" adalah pemeriksa yang membandingkan filesystem
+dengan workflow, dan pemeriksa itu **tidak butuh database**.
+
+Perbaikannya: kelimanya masuk daftar di **kedua** workflow (`ci.yml` dan
+`release.yml` — `release.yml` justru pipeline yang mereka tuju saat ditulis),
+komentar "These 9 files" yang sudah salah sejak lama dibetulkan jadi 15, dan
+`tests/db-gated-suite-ci-parity.test.ts` mengikat daftar itu ke filesystem
+**dua arah atas kedua workflow**:
+
+1. tiap berkas DB-gated di akar `tests/` wajib disebut;
+2. tiap entri wajib menunjuk berkas yang ADA dan MASIH DB-gated — entri yang
+   berhentinya DB-gated akan berjalan di step yang seluruh tujuannya isolasi
+   database sambil tak membuktikan apa pun;
+3. kedua pipeline wajib menjalankan himpunan yang SAMA — berkas yang ada di
+   `ci.yml` tapi tidak di `release.yml` lebih buruk daripada yang tak ada di
+   keduanya: PR hijau atas bukti yang rilis tak pernah periksa ulang, dan
+   itulah persis cara kelima entri ini bertahan.
+
+**Mutation-proven tiga kali:** mengembalikan cacat aslinya (buang lima entri)
+→ MERAH; entri menunjuk berkas tak-ada → MERAH; berkas berhenti DB-gated tapi
+tetap terdaftar → MERAH.
+
+Dan gerbangnya menangkap satu cacat pada dirinya sendiri sebelum di-commit:
+draf pertama mencocokkan seluruh dokumen YAML, sehingga **komentar** yang
+menyebut nama berkas ikut terbaca sebagai entri daftar. Itu kelas cacat yang
+ADR-0062 sudah catat untuk ekstraktor path `skills:check`. Baris komentar kini
+dibuang lebih dulu, dan alasannya ditulis di berkasnya.

--- a/.changeset/daftar-db-gated-ci-lengkap.md
+++ b/.changeset/daftar-db-gated-ci-lengkap.md
@@ -2,7 +2,7 @@
 "awcms": patch
 ---
 
-fix(ci): 46 test DB-gated berhenti hijau-palsu — lima berkas yang tak pernah dijalankan pipeline mana pun
+fix(ci): 36 test DB-gated berhenti hijau-palsu — lima berkas yang tak pernah dijalankan pipeline mana pun
 
 Suite DB-gated di akar `tests/` tak bisa berjalan satu proses dengan
 `tests/integration/` (empiris: 26 tabrakan), jadi kedua pipeline menjalankannya
@@ -26,7 +26,7 @@ Ia lahir dengan **10** entri (#176). Lima berkas DB-gated mendarat sesudahnya
 - `tests/openapi-office-response-schema-postgres.test.ts` — konformansi payload
   respons terhadap schema `Office` di bundel OpenAPI.
 
-Hasilnya **46 test yang skip di setiap pipeline** sambil terbaca sebagai
+Hasilnya **36 test yang skip di setiap pipeline** sambil terbaca sebagai
 cakupan pada setiap run hijau. Dan bukan salah tafsir: header keempat berkas
 itu **menuliskan sendiri** bahwa mereka "runs in the dedicated legacy
 `bun test <files>` step" — step yang daftarnya tak pernah memanggil mereka.
@@ -55,6 +55,16 @@ komentar "These 9 files" yang sudah salah sejak lama dibetulkan jadi 15, dan
 **Mutation-proven tiga kali:** mengembalikan cacat aslinya (buang lima entri)
 → MERAH; entri menunjuk berkas tak-ada → MERAH; berkas berhenti DB-gated tapi
 tetap terdaftar → MERAH.
+
+**Catatan menghitung, karena draf pertama perubahan ini salah menghitungnya.**
+Menjalankan kelima berkas dengan `DATABASE_URL` kosong melaporkan **46 skip**,
+dan 46 **bukan** jumlah test: bun ikut menghitung **hook** yang di-skip, dan
+kelimanya punya persis `beforeAll` + `afterAll` — 36 test + 10 hook. Yang jujur
+adalah jumlah deklarasi (`grep -cE '^\s*(test|it)\('`), dan itulah yang kini
+benar-benar dieksekusi pipeline: 14 + 3 + 9 + 1 + 9, diverifikasi per berkas
+dari log run yang memulihkannya, bukan disimpulkan. Nol di antaranya merah —
+90 migrasi berlalu sejak berkas-berkas itu ditulis, dan ternyata tak ada yang
+membusuk.
 
 Dan gerbangnya menangkap satu cacat pada dirinya sendiri sebelum di-commit:
 draf pertama mencocokkan seluruh dokumen YAML, sehingga **komentar** yang

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
         #
         # The list is EXPLICIT, so it drifts silently — and it did. It was born
         # with 10 entries and five more DB-gated files landed after it
-        # (#188/#189/#190/#191) without touching it, so 46 tests skipped in
+        # (#188/#189/#190/#191) without touching it, so 36 tests skipped in
         # every pipeline while looking like coverage: MFA lockout/replay
         # atomicity, cross-tenant denial on the four OIDC tables, Turnstile
         # enforcement on the real login handler, and the office

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,7 +277,7 @@ jobs:
         run: bun test tests/integration/ --timeout 60000
 
       - name: Run DB-gated integration tests (legacy ad-hoc suite)
-        # These 9 files each open their own ad-hoc `Bun.SQL(DATABASE_URL)`
+        # These 15 files each open their own ad-hoc `Bun.SQL(DATABASE_URL)`
         # connection to the SAME database this job's harness step just used,
         # and were designed to run together (that is release.yml's original,
         # pre-`tests/integration/` DB-gated suite) — but NOT concurrently with
@@ -285,17 +285,34 @@ jobs:
         # step above's comment). Listed explicitly rather than relying on a
         # bare `bun test` so this suite can't silently regrow the collision
         # by pulling in `tests/integration/` again.
+        #
+        # The list is EXPLICIT, so it drifts silently — and it did. It was born
+        # with 10 entries and five more DB-gated files landed after it
+        # (#188/#189/#190/#191) without touching it, so 46 tests skipped in
+        # every pipeline while looking like coverage: MFA lockout/replay
+        # atomicity, cross-tenant denial on the four OIDC tables, Turnstile
+        # enforcement on the real login handler, and the office
+        # response-vs-schema contract. Each of those five files even documents
+        # that it "runs in the dedicated legacy `bun test <files>` step" — the
+        # step right here. `tests/db-gated-suite-ci-parity.test.ts` now holds
+        # this list to the filesystem in BOTH directions, so the next one
+        # cannot land quietly.
         run: >-
           bun test
           tests/audit-log-purge.test.ts
           tests/family-conformance-db.test.ts
           tests/keyset-pagination-precision-postgres.test.ts
+          tests/mfa-integration.test.ts
+          tests/mfa-login-e2e.test.ts
           tests/office-directory-postgres.test.ts
+          tests/oidc-integration.test.ts
+          tests/openapi-office-response-schema-postgres.test.ts
           tests/reporting-projection-rebuild-lock.test.ts
           tests/security-readiness-failclosed.test.ts
           tests/security-readiness-rls.test.ts
           tests/security-readiness-worker-setup-grants.test.ts
           tests/sync-hmac-versioned.test.ts
+          tests/turnstile-login-e2e.test.ts
           tests/workflow-approval-concurrency.test.ts
 
   minimum-supported:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
         # rather than intended: `tests/db-gated-suite-ci-parity.test.ts` reads
         # BOTH workflows and both directions. The five MFA/OIDC/Turnstile/office
         # entries below were missing from here for months — a release could go
-        # out with 46 DB-gated tests never executed anywhere.
+        # out with 36 DB-gated tests never executed anywhere.
         run: >-
           bun test
           tests/audit-log-purge.test.ts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         run: bun test tests/integration/ --timeout 60000
 
       - name: Run DB-gated integration tests (legacy ad-hoc suite)
-        # These 9 files each open their own ad-hoc `Bun.SQL(DATABASE_URL)`
+        # These 15 files each open their own ad-hoc `Bun.SQL(DATABASE_URL)`
         # connection to the SAME database `db:migrate` just applied above,
         # and were designed to run together — this is what "release.yml is
         # where these actually execute" meant before `tests/integration/`
@@ -132,17 +132,28 @@ jobs:
         # `bun test` process. Listed explicitly rather than relying on the
         # bare `bun test` inside `bun run check` (which now runs with
         # DATABASE_URL unset, see the step above).
+        #
+        # Kept identical to `ci.yml`'s list, and that identity is now enforced
+        # rather than intended: `tests/db-gated-suite-ci-parity.test.ts` reads
+        # BOTH workflows and both directions. The five MFA/OIDC/Turnstile/office
+        # entries below were missing from here for months — a release could go
+        # out with 46 DB-gated tests never executed anywhere.
         run: >-
           bun test
           tests/audit-log-purge.test.ts
           tests/family-conformance-db.test.ts
           tests/keyset-pagination-precision-postgres.test.ts
+          tests/mfa-integration.test.ts
+          tests/mfa-login-e2e.test.ts
           tests/office-directory-postgres.test.ts
+          tests/oidc-integration.test.ts
+          tests/openapi-office-response-schema-postgres.test.ts
           tests/reporting-projection-rebuild-lock.test.ts
           tests/security-readiness-failclosed.test.ts
           tests/security-readiness-rls.test.ts
           tests/security-readiness-worker-setup-grants.test.ts
           tests/sync-hmac-versioned.test.ts
+          tests/turnstile-login-e2e.test.ts
           tests/workflow-approval-concurrency.test.ts
 
   build:

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 314   |
+| Berkas test                        | 315   |
 | Berkas route                       | 309   |
 | ADR                                | 72    |
 
@@ -272,7 +272,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 266        |
+| `(root)`      | 267        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/tests/db-gated-suite-ci-parity.test.ts
+++ b/tests/db-gated-suite-ci-parity.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Every DB-gated test file at the root of `tests/` is actually executed by a
+ * pipeline — and every file a pipeline names still exists and is still
+ * DB-gated. Both directions, over BOTH workflows.
+ *
+ * ## The failure this exists to stop
+ *
+ * The DB-gated suite at the root of `tests/` cannot run in the same `bun test`
+ * process as `tests/integration/` (empirically: 26 collisions), so both
+ * pipelines run it as a dedicated step with an EXPLICIT file list. An explicit
+ * list is the right call there — a bare `bun test` would silently regrow the
+ * collision — but an explicit list drifts, and this one did.
+ *
+ * It was born with ten entries. Five DB-gated files landed afterwards
+ * (`mfa-integration`, `mfa-login-e2e`, `oidc-integration`,
+ * `openapi-office-response-schema-postgres`, `turnstile-login-e2e`) and none of
+ * their PRs touched it. Result: **46 tests that skipped in every pipeline**
+ * while reading, on every green run, as coverage — MFA lockout/replay
+ * atomicity, cross-tenant denial on the OIDC tables, Turnstile enforcement on
+ * the real login handler, and the office response-vs-schema contract. Each of
+ * those five files' own header says it "runs in the dedicated legacy
+ * `bun test <files>` step". They were written for a step that never called
+ * them.
+ *
+ * Nothing could have caught it. `bun run check` runs with `DATABASE_URL` unset
+ * by design, so these files skip there and are SUPPOSED to; skipping is not a
+ * signal. The only observer that can tell "skipped because no database" from
+ * "skipped forever" is a check that compares the filesystem to the workflows —
+ * which is this file, and which needs no database to do it.
+ *
+ * ## Why the reverse direction is not decoration
+ *
+ * A list entry naming a file that was renamed or deleted makes `bun test` fail
+ * loudly, so that half is cheap. The one that matters is an entry naming a file
+ * that is no longer DB-gated: it would run in a step whose whole purpose is
+ * database isolation, quietly costing nothing and proving nothing. Both are
+ * asserted here.
+ */
+import { describe, expect, test } from "bun:test";
+
+const WORKFLOWS = [".github/workflows/ci.yml", ".github/workflows/release.yml"];
+
+/**
+ * The gating idiom, as the files actually write it: a `DATABASE_URL` read that
+ * decides between `describe` and `describe.skip`. Matching the READ plus the
+ * skip keeps a file that merely mentions the variable in a comment out of the
+ * set — the reason this is two conditions and not one.
+ */
+function isDatabaseGated(source: string): boolean {
+  return (
+    /process\.env\.DATABASE_URL/.test(source) &&
+    /describe\.skip|test\.skip|describeOrSkip|testOrSkip/.test(source)
+  );
+}
+
+async function gatedRootTestFiles(): Promise<string[]> {
+  const files: string[] = [];
+
+  for await (const file of new Bun.Glob("tests/*.test.ts").scan({
+    cwd: process.cwd()
+  })) {
+    if (isDatabaseGated(await Bun.file(file).text())) {
+      files.push(file);
+    }
+  }
+
+  return files.sort();
+}
+
+/**
+ * Every `tests/<name>.test.ts` a workflow hands to a `bun test` invocation.
+ *
+ * COMMENT LINES ARE STRIPPED FIRST, and that is load-bearing rather than tidy.
+ * The first draft of this file matched the whole document, so the two step
+ * comments that name this very file put it into the "listed" set — where it
+ * failed the reverse check for not being DB-gated, and split the two pipelines'
+ * sets because their prose differs. That is the same defect class ADR-0062
+ * records for `skills:check`'s path extractor: a scanner that reads
+ * documentation as if it were code answers confidently and wrongly. Here it
+ * answered wrongly in the safe direction; there is no reason to assume the next
+ * one will.
+ */
+function listedInWorkflow(source: string): string[] {
+  const executable = source
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+
+  return [...executable.matchAll(/tests\/[\w.-]+\.test\.ts/g)]
+    .map((match) => match[0])
+    .sort();
+}
+
+describe("DB-gated suite ↔ CI parity", () => {
+  test("the scan finds the suite it is meant to police", async () => {
+    const gated = await gatedRootTestFiles();
+
+    // A glob that resolved to nothing would make every assertion below pass
+    // vacuously — the failure mode `tests/module-absence-claims.test.ts`
+    // records from its own first draft.
+    expect(gated.length).toBeGreaterThanOrEqual(15);
+    expect(gated).toContain("tests/security-readiness-rls.test.ts");
+    expect(gated).toContain("tests/mfa-integration.test.ts");
+  });
+
+  test.each(WORKFLOWS)(
+    "%s runs every DB-gated root test file",
+    async (workflow) => {
+      const source = await Bun.file(workflow).text();
+      const listed = new Set(listedInWorkflow(source));
+      const missing = (await gatedRootTestFiles()).filter(
+        (file) => !listed.has(file)
+      );
+
+      expect(missing).toEqual([]);
+    }
+  );
+
+  test.each(WORKFLOWS)(
+    "%s names nothing that vanished or stopped being DB-gated",
+    async (workflow) => {
+      const source = await Bun.file(workflow).text();
+      const gated = new Set(await gatedRootTestFiles());
+      const stale: string[] = [];
+
+      for (const file of listedInWorkflow(source)) {
+        // Only ROOT files are this suite's business — `tests/integration/` is run
+        // by directory, by a different step, on purpose.
+        if (file.split("/").length !== 2) continue;
+
+        if (!(await Bun.file(file).exists())) {
+          stale.push(`${file} (no such file)`);
+          continue;
+        }
+
+        if (!gated.has(file)) {
+          stale.push(`${file} (no longer DB-gated)`);
+        }
+      }
+
+      expect(stale).toEqual([]);
+    }
+  );
+
+  test("both pipelines run the SAME set", async () => {
+    // A file listed in `ci.yml` but not `release.yml` is worse than one listed
+    // in neither: PRs go green on evidence a release never re-checks, which is
+    // exactly how the five missing entries survived — `release.yml` was the
+    // pipeline they were originally written for.
+    const [ci, release] = await Promise.all(
+      WORKFLOWS.map(async (workflow) =>
+        listedInWorkflow(await Bun.file(workflow).text()).filter(
+          (file) => file.split("/").length === 2
+        )
+      )
+    );
+
+    expect(ci).toEqual(release!);
+  });
+});

--- a/tests/db-gated-suite-ci-parity.test.ts
+++ b/tests/db-gated-suite-ci-parity.test.ts
@@ -14,13 +14,21 @@
  * It was born with ten entries. Five DB-gated files landed afterwards
  * (`mfa-integration`, `mfa-login-e2e`, `oidc-integration`,
  * `openapi-office-response-schema-postgres`, `turnstile-login-e2e`) and none of
- * their PRs touched it. Result: **46 tests that skipped in every pipeline**
+ * their PRs touched it. Result: **36 tests that skipped in every pipeline**
  * while reading, on every green run, as coverage — MFA lockout/replay
  * atomicity, cross-tenant denial on the OIDC tables, Turnstile enforcement on
  * the real login handler, and the office response-vs-schema contract. Each of
  * those five files' own header says it "runs in the dedicated legacy
  * `bun test <files>` step". They were written for a step that never called
  * them.
+ *
+ * COUNTING NOTE, because the first draft of this file got it wrong: running
+ * those five with `DATABASE_URL` unset reports **46 skip**, and 46 is not the
+ * number of tests. Bun counts skipped HOOKS in that total, and each of the five
+ * has exactly `beforeAll` + `afterAll` — 36 tests + 10 hooks. The declaration
+ * count (`grep -cE '^\s*(test|it)\(' `) is the honest one, and it is what the
+ * pipeline now executes: 14 + 3 + 9 + 1 + 9. Verified against the run that
+ * restored them, per file, not inferred.
  *
  * Nothing could have caught it. `bun run check` runs with `DATABASE_URL` unset
  * by design, so these files skip there and are SUPPOSED to; skipping is not a


### PR DESCRIPTION
## Apa yang salah

Suite DB-gated di akar `tests/` tak bisa berjalan satu proses dengan `tests/integration/`
(empiris: 26 tabrakan), jadi kedua pipeline menjalankannya sebagai step tersendiri dengan
**daftar berkas eksplisit**. Daftar eksplisit memang keputusan yang benar di situ — `bun
test` telanjang akan menumbuhkan kembali tabrakannya — tetapi daftar eksplisit **drift**,
dan yang ini drift.

Ia lahir dengan **10** entri (#176). Lima berkas DB-gated mendarat sesudahnya (#188, #189,
#190, #191) dan **tak satu pun PR-nya menyentuh daftar itu**:

| Berkas | Test | Yang tak pernah dibuktikan |
|---|---|---|
| `tests/mfa-integration.test.ts` | 14 | atomisitas lockout & replay counter di Postgres (CAS + `FOR UPDATE`), recovery code sekali-pakai di bawah konkurensi, RLS FORCE, penolakan lintas-tenant |
| `tests/oidc-integration.test.ts` | 9 | penolakan lintas-tenant atas empat tabel OIDC, validasi klaim ID token, guard SSRF issuer privat |
| `tests/turnstile-login-e2e.test.ts` | 9 | Turnstile berjalan SEBELUM lookup identitas/kerja password, gagal-tertutup, tiap rute terikat action-nya |
| `tests/mfa-login-e2e.test.ts` | 3 | enforcement enrollment + step-up pada handler login/step-up/admin-reset yang SEBENARNYA |
| `tests/openapi-office-response-schema-postgres.test.ts` | 1 | konformansi payload respons terhadap schema `Office` di bundel OpenAPI |

**36 test yang skip di setiap pipeline**, sambil terbaca sebagai cakupan pada setiap run
hijau. Dan bukan salah tafsir: header keempat berkas itu **menuliskan sendiri** bahwa
mereka "runs in the dedicated legacy `bun test <files>` step" — step yang daftarnya tak
pernah memanggil mereka.

Tak ada yang bisa menangkapnya. `bun run check` memang berjalan dengan `DATABASE_URL`
kosong, jadi berkas-berkas itu **seharusnya** skip di sana — skip bukan sinyal.
Satu-satunya pengamat yang bisa membedakan "skip karena tak ada database" dari "skip
selamanya" adalah pemeriksa yang membandingkan filesystem dengan workflow, dan pemeriksa
itu **tidak butuh database** — jadi ia berjalan di job `quality`, di setiap PR.

## Perbaikan

Kelimanya masuk daftar di **kedua** workflow (`release.yml` justru pipeline yang mereka
tuju saat ditulis), komentar `These 9 files` yang sudah salah sejak lama dibetulkan jadi
15, dan `tests/db-gated-suite-ci-parity.test.ts` mengikat daftar itu ke filesystem **dua
arah atas kedua workflow**:

1. tiap berkas DB-gated di akar `tests/` wajib disebut;
2. tiap entri wajib menunjuk berkas yang ADA dan **masih** DB-gated — entri yang berhenti
   DB-gated akan berjalan di step yang seluruh tujuannya isolasi database sambil tak
   membuktikan apa pun;
3. kedua pipeline wajib menjalankan himpunan yang **sama** — berkas yang ada di `ci.yml`
   tapi tidak di `release.yml` lebih buruk daripada yang tak ada di keduanya: PR hijau
   atas bukti yang rilis tak pernah periksa ulang, dan itulah persis cara kelima entri ini
   bertahan.

**Mutation-proven tiga kali:** kembalikan cacat aslinya → 2 MERAH; entri menunjuk berkas
tak-ada → 3 MERAH; berkas berhenti DB-gated tapi tetap terdaftar → 3 MERAH.

Dan gerbangnya menangkap satu cacat **pada dirinya sendiri** sebelum di-commit: draf
pertama mencocokkan seluruh dokumen YAML, sehingga **komentar** yang menyebut nama berkas
ikut terbaca sebagai entri daftar — kelas cacat yang ADR-0062 catat untuk ekstraktor path
`skills:check`. Baris komentar kini dibuang lebih dulu.

## Hasil di CI, dan satu koreksi angka

Job `Integration tests` sempat merah, **bukan karena test**: `docker pull postgres:18.4`
timeout tiga kali ke `registry-1.docker.io` — persis biaya yang PROJECT_STATE §6 catat
sudah diterima sejak tiga job jadi required. Setelah `gh run rerun --failed`:

- suite legacy: **15 berkas, 100 pass, 0 fail, 0 skip** (sebelumnya 10 berkas, 64 test);
- kelima berkas baru: 14 / 3 / 9 / 1 / 9 — **seluruh 36 test dieksekusi, nol merah.**
  90 migrasi berlalu sejak berkas-berkas itu ditulis, dan ternyata tak ada yang membusuk.

**Koreksi:** commit pertama PR ini menulis "46 test". Itu salah — 46 adalah hitungan
`skip` bun, yang **ikut menghitung hook**; kelima berkas punya persis `beforeAll` +
`afterAll`, jadi 36 test + 10 hook. Angka yang jujur adalah jumlah deklarasi, dan ia
diverifikasi per berkas dari log job. Dikoreksi di changeset, docblock gerbang, dan
komentar kedua workflow, dengan catatan cara menghitungnya ditulis di berkas gerbangnya.

`bun run check` PENUH hijau (3837 test, 0 fail), build + anggaran aset lolos. Nol
perubahan kode produksi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)