### PR TITLE
feat(gerbang): kelas "hanya bisa lewat `curl`" berhenti dicari dengan tangan — 54 permission tanpa layar jadi angka yang hanya boleh mengecil

### DIFF
--- a/.changeset/gerbang-cakupan-layar-admin.md
+++ b/.changeset/gerbang-cakupan-layar-admin.md
@@ -1,0 +1,82 @@
+---
+"awcms": patch
+---
+
+feat(gerbang): kelas "hanya bisa lewat `curl`" berhenti dicari dengan tangan — 54 permission tanpa layar jadi angka yang hanya boleh mengecil
+
+[ADR-0051](../docs/adr/0051-admin-screens-consolidated-in-awcms.md) memutuskan
+setiap layar admin SISTEM dibangun di repo ini, lalu **tidak memasang apa pun
+yang mengukur kepatuhannya**. Akibatnya "modul ini hanya bisa dipakai lewat
+`curl`" ditemukan dengan tangan — berulang kali, dan tiap kali terlambat.
+
+Pemeriksa yang tampak berdekatan menjawab pertanyaan lain:
+
+- `access:permissions:enforcement:check` — "apakah permission ini punya
+  **penegak**?" Sebuah rute sudah cukup. Permukaan `curl`-only lolos selamanya.
+- `tests/admin-navigation-registry.test.ts` — "apakah tiap entri `navigation`
+  menunjuk halaman, dan sebaliknya?" Modul tanpa `navigation` tak punya apa pun
+  untuk diperiksa.
+- contract test per-layar — "apakah layar INI menggerbangi key yang benar?" Ia
+  tak bisa melihat permission yang tak disebut layar mana pun.
+
+`bun run admin:screen-coverage:check` (murni, di rantai `check`, gerbang ke-36)
+menanyakan yang hilang: **apakah ada layar yang mengklaim permission ini?**
+Hasil pemindaian pertama: **32 layar mengklaim 133 dari 203 permission**; 16
+keputusan tertulis, **54 menunggu layar, tersebar di sembilan modul.**
+
+Dua daftar, dan pemisahannya adalah inti desainnya:
+
+- **`DELIBERATELY_UNSCREENED`** — keputusan ber-alasan ("operator memang tidak
+  seharusnya menggerakkan ini dari halaman"), bentuk yang sama dengan register
+  `permission-enforcement-check.ts`. Isinya diambil dari alasan yang **sudah
+  tertulis di kode**: keenam `workflow.definition.*` (butuh editor graf; textarea
+  JSON yang menerima graf rusak sampai `publish` menolaknya lebih buruk daripada
+  tak ada), unggah media tiga-langkah, saklar `enforcement` satu-arah,
+  `blog_content.ads.*` yang ADR-0044 pensiunkan jadi 410, dan tiga lainnya.
+- **`NOT_YET_SCREENED`** — ledger **satu arah** yang isinya bukan penilaian
+  apa-apa, hanya "belum ada yang membangunnya". Memberi sebuah permission layar
+  lalu meninggalkan barisnya di sini **memerahkan CI**, jadi angkanya selalu
+  angka yang sebenarnya. Itulah yang membuatnya layak ditulis: sebelum berkas
+  ini, "13 dari 21 modul tanpa layar" adalah kalimat yang harus diturunkan ulang
+  dengan tangan, dan pernah diturunkan **salah** lebih dari sekali.
+
+Mencampur keduanya akan membuat pekerjaan yang belum selesai memperoleh
+penampilan sebuah penilaian — persis cara ADR-0058 menemukan enam entri
+pengecualian yang ternyata enam bug.
+
+Dua kelompok terbesar di ledger bukan kosmetik, dan namanya disebut di
+berkasnya: seluruh key `email.suppression.*` (alamat yang di-suppress berhenti
+menerima email **termasuk reset password**, dan tak ada halaman untuk
+melihat/menghapusnya) dan seluruh `identity_access.business_scope_*` (assignment
+plus alur exception maker/checker tanpa inbox untuk checker-nya).
+`module_management.settings.*` adalah yang punya alibi palsu: tiga dokumen
+menyatakan panel setting generik `/admin/modules/{key}` sudah ada, dan satu
+memakai klaim itu untuk membenarkan tidak membangun editor. Layar itu tak pernah
+ada (dikoreksi di PR sebelumnya).
+
+**Matcher-nya menyelesaikan helper file-first, dan itu load-bearing.** Matcher
+yang hanya membaca triple literal `permissionKey("m","a","x")` melaporkan
+**delapan** permission `blog_content` yang ter-ship dan bekerja sebagai
+tak-terklaim, karena `blog-presentation.astro` mengikat
+`const can = (activity, action) => …permissionKey("blog_content", activity, action)`
+lalu memanggilnya delapan kali dengan literal. Diverifikasi dengan membuang
+resolusi itu: **8 false positive**. Scanner yang menjawab "tak tercakup" untuk
+yang tercakup lebih buruk daripada tak ada scanner — ia melatih pembacanya
+menambah pengecualian sampai gerbangnya tak menanyakan apa pun, dan
+`permission-enforcement-check.ts` butuh empat draf untuk mempelajarinya.
+Resolusinya sengaja **sempit**: helper hanya dihitung bila badannya mengikat
+module key sebagai LITERAL dan meneruskan kedua parameternya sendiri. Selain itu
+dibiarkan tak-terselesaikan — dan gagal ke arah "tak-terklaim", arah yang
+memaksa manusia melihat.
+
+**Batas yang dinyatakan di docblock-nya:** gerbang ini menjawab "apakah ada yang
+mengklaim?", **bukan** "apakah kontrolnya benar". Tombol Restore `/admin/blog`
+mengklaim `posts.restore` sambil dirender pada baris yang pasti 404 (#351);
+gerbang ini akan berkata "tercakup" sepanjang waktu itu. Kebenaran kontrol tetap
+tugas contract test per-layar.
+
+**Mutation-proven empat arah:** permission tanpa layar & tanpa entri → MERAH;
+entri ledger basi (layarnya sudah ada) → MERAH "only ever shrinks"; resolusi
+helper dibuang → 8 false positive; layar menggerbangi key yang tak dideklarasikan
+siapa pun → MERAH. Plus 15 unit test atas aturannya, digerakkan snapshot
+tertanam.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -111,7 +111,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | ADR                                | **0000**–**0071** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Berkas `.astro`                    | **43** (22.656 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
-| Gerbang                            | **35** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
+| Gerbang                            | **36** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
 <!-- project-state-inventory:selesai -->

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 315   |
+| Berkas test                        | 316   |
 | Berkas route                       | 309   |
 | ADR                                | 72    |
 
@@ -272,7 +272,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 267        |
+| `(root)`      | 268        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "skills:check": "bun scripts/skills-check.ts",
     "deps:audit:check": "bun scripts/dependency-audit-check.ts",
     "access:chokepoint:check": "bun scripts/access-chokepoint-check.ts",
+    "admin:screen-coverage:check": "bun scripts/admin-screen-coverage-check.ts",
     "edge-cache:purge": "bun scripts/edge-cache-purge.ts",
     "data-lifecycle:registry:check": "bun scripts/data-lifecycle-registry-check.ts",
     "analytics:rollup": "bun scripts/visitor-analytics-rollup.ts",
@@ -120,7 +121,7 @@
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
     "perf:cwv:lab": "bun --bun playwright test tests/e2e/cwv-lab.e2e.ts",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run repo:inventory:check && bun run project-state:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run api:consumer-contract:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run access:permissions:enforcement:check && bun run access:chokepoint:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run skills:check && bun run deps:audit:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run db:fk-index:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run repo:inventory:check && bun run project-state:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run api:consumer-contract:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run access:permissions:enforcement:check && bun run access:chokepoint:check && bun run admin:screen-coverage:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run skills:check && bun run deps:audit:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run db:fk-index:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ lalu membangun duplikatnya.
 
 <!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-76 target menjalankan berkas di `scripts/`; 31 di antaranya
+77 target menjalankan berkas di `scripts/`; 32 di antaranya
 ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
 terjadwal, atau oleh workflow CI tertentu.
 
@@ -31,6 +31,7 @@ terjadwal, atau oleh workflow CI tertentu.
 | ---------------------------------------- | ---------------------------------------------- | ---- |
 | `access:chokepoint:check`                | `access-chokepoint-check.ts`                   | ✅   |
 | `access:permissions:enforcement:check`   | `permission-enforcement-check.ts`              | ✅   |
+| `admin:screen-coverage:check`            | `admin-screen-coverage-check.ts`               | ✅   |
 | `analytics:purge`                        | `visitor-analytics-purge.ts`                   | —    |
 | `analytics:rollup`                       | `visitor-analytics-rollup.ts`                  | —    |
 | `api:consumer-contract:check`            | `api-consumer-contract.ts`                     | ✅   |

--- a/scripts/admin-screen-coverage-check.ts
+++ b/scripts/admin-screen-coverage-check.ts
@@ -1,0 +1,302 @@
+/**
+ * admin-screen-coverage-check.ts — `bun run admin:screen-coverage:check`.
+ *
+ * Every declared permission is claimed by an admin screen, or is a written
+ * decision, or sits on a ledger that may only shrink. Pure: registry + source
+ * text, no database, no network.
+ *
+ * ## The gap this closes
+ *
+ * [ADR-0051](../docs/adr/0051-admin-screens-consolidated-in-awcms.md) decided
+ * every SYSTEM admin screen belongs in this repo, and then nothing measured
+ * compliance. The checks that look adjacent answer different questions:
+ *
+ * - `access:permissions:enforcement:check` — "does this permission have an
+ *   ENFORCER?" A route counts. A `curl`-only surface passes it forever.
+ * - `tests/admin-navigation-registry.test.ts` — "does every `navigation` entry
+ *   point at a page, and vice versa?" A module with no `navigation` has nothing
+ *   to check.
+ * - per-screen contract tests — "does THIS screen gate the right keys?" They
+ *   cannot see a permission no screen mentions.
+ *
+ * So "usable only via `curl`" was found by hand, repeatedly, and each time it
+ * was found it was found late. One mechanical scan surfaces it in a second.
+ *
+ * ## What this gate does NOT answer
+ *
+ * It asks whether a screen CLAIMS a permission — never whether the control is
+ * correct. `/admin/blog`'s Restore button claimed `posts.restore` while being
+ * rendered on rows that could only 404 (#351); this gate would have said
+ * "covered" throughout. Correctness is the per-screen contract test's job, and
+ * the two answer different questions on purpose.
+ *
+ * ## Why the matcher resolves file-local helpers
+ *
+ * A matcher keyed on literal `permissionKey("mod","activity","action")` triples
+ * alone reports `blog_content`'s templates/menus/widgets/theme as unclaimed:
+ * `blog-presentation.astro` binds `const can = (activity, action) =>
+ * ssr.permissions.has(permissionKey("blog_content", activity, action))` and
+ * calls it eight times with literals. Reporting a claimed permission as
+ * unclaimed is the failure mode that has already cost this repo four rewrites of
+ * `permission-enforcement-check.ts` and two exception entries written up as
+ * decisions — a scanner that answers "uncovered" for something covered trains
+ * its readers to widen the exception list until it asks nothing.
+ *
+ * Resolution is therefore FILE-FIRST and deliberately narrow: a helper counts
+ * only when its body binds the module key as a LITERAL and forwards its own two
+ * parameters. Anything else is left unresolved rather than guessed at.
+ */
+import { listModules } from "../src/modules";
+
+const SCREEN_GLOB = "src/pages/admin/**/*.astro";
+
+/**
+ * Permissions with NO screen, on purpose, with the reason. A register of
+ * DECISIONS — the same shape `permission-enforcement-check.ts` uses, and for the
+ * same reason: an entry here is the visible act of saying "an operator should
+ * not drive this from a page", and the next reader can disagree with a sentence
+ * rather than with silence.
+ */
+const DELIBERATELY_UNSCREENED: Readonly<Record<string, string>> = {
+  // Six permissions, one decision: authoring a node/transition graph needs a
+  // real editor, and a JSON textarea that accepts a malformed graph until
+  // `publish` rejects it is a worse affordance than none.
+  // `tests/admin-approvals-page-contract.test.ts` pins them OUT of that screen.
+  "workflow.definition.read":
+    "no graph editor; see /admin/approvals contract test",
+  "workflow.definition.create":
+    "no graph editor; see /admin/approvals contract test",
+  "workflow.definition.update":
+    "no graph editor; see /admin/approvals contract test",
+  "workflow.definition.publish":
+    "no graph editor; see /admin/approvals contract test",
+  "workflow.definition.retire":
+    "no graph editor; see /admin/approvals contract test",
+  "workflow.definition.delete":
+    "no graph editor; see /admin/approvals contract test",
+
+  // Upload is a three-step browser flow (create -> PUT to R2 -> verify). A
+  // button that STARTS a session but cannot finish it leaves a `pending_upload`
+  // row on every misclick, so `/admin/media` browses and disposes only.
+  "media_library.media.create":
+    "three-step upload; a start-only button leaks pending_upload rows",
+  "media_library.media.verify":
+    "three-step upload; finalisation belongs to the uploading client",
+  "media_library.media.cancel":
+    "three-step upload; only the uploading client knows what to cancel",
+
+  // A ONE-WAY tenant policy switch, not an action on an object — it belongs
+  // with the other posture switches on `/admin/security`, not in an object
+  // console. Deliberately no `enforcement.disable` exists at all.
+  "media_library.enforcement.read":
+    "tenant posture switch; belongs with /admin/security, not an object console",
+  "media_library.enforcement.enable":
+    "tenant posture switch, one-way; belongs with /admin/security",
+
+  // The admin post list has its own search, which tolerates an empty query;
+  // the public search endpoint does not, and wiring the screen to it would make
+  // the empty state an error.
+  "blog_content.search.read":
+    "the admin list has its own search; the public endpoint rejects an empty query",
+
+  // ADR-0044 §4 closed the free-URL advertisement write path (410 Gone);
+  // `ad_placements` supersedes it. A screen for a permission whose endpoints
+  // answer 410 would be a control that cannot work.
+  "blog_content.ads.read":
+    "free-URL ad path retired by ADR-0044; endpoints answer 410",
+  "blog_content.ads.configure":
+    "free-URL ad path retired by ADR-0044; endpoints answer 410",
+
+  // Enqueues a notification to an explicit set of users — plausible as an
+  // inter-module API, and forcing a button onto it invents an affordance whose
+  // correct shape nobody has decided.
+  "email.notification.create": "inter-module API, not an operator affordance",
+
+  // The lookup surface other modules' forms consume, not a page of its own.
+  // `/admin/idn-regions` drives `dataset.read`/`dataset.configure` instead.
+  "idn_admin_regions.region.read":
+    "lookup API for other modules' forms; /admin/idn-regions drives dataset.*"
+};
+
+export type Coverage = {
+  claimed: ReadonlySet<string>;
+  declared: readonly string[];
+};
+
+/**
+ * Permission keys an admin screen gates on.
+ *
+ * Two spellings, both required — see this file's header for why the second
+ * exists and why it is narrow.
+ */
+export function extractScreenClaims(source: string): Set<string> {
+  const claims = new Set<string>();
+
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)"\s*,\s*"([a-z_]+)"\s*,\s*"([a-z_]+)"\s*\)/g
+  )) {
+    claims.add(`${match[1]}.${match[2]}.${match[3]}`);
+  }
+
+  for (const helper of source.matchAll(
+    /const\s+([A-Za-z_$][\w$]*)\s*=\s*\(\s*([A-Za-z_$][\w$]*)\s*(?::[^,)]+)?,\s*([A-Za-z_$][\w$]*)\s*(?::[^,)]+)?\)[^=]*=>[\s\S]{0,200}?permissionKey\(\s*"([a-z_]+)"\s*,\s*\2\s*,\s*\3\s*\)/g
+  )) {
+    const name = helper[1]!;
+    const moduleKey = helper[4]!;
+
+    for (const call of source.matchAll(
+      new RegExp(`\\b${name}\\(\\s*"([a-z_]+)"\\s*,\\s*"([a-z_]+)"\\s*\\)`, "g")
+    )) {
+      claims.add(`${moduleKey}.${call[1]}.${call[2]}`);
+    }
+  }
+
+  return claims;
+}
+
+export type CoverageProblem = string;
+
+/**
+ * The rule, over an injected snapshot so a test can drive it with a planted
+ * gap instead of the live registry.
+ */
+export function evaluateScreenCoverage(
+  coverage: Coverage,
+  decisions: Readonly<Record<string, string>>,
+  ledger: readonly string[]
+): CoverageProblem[] {
+  const problems: CoverageProblem[] = [];
+  const ledgerSet = new Set(ledger);
+
+  for (const key of coverage.declared) {
+    if (coverage.claimed.has(key)) continue;
+    if (key in decisions || ledgerSet.has(key)) continue;
+
+    problems.push(
+      `"${key}" is declared but no admin screen claims it. Give it a screen, ` +
+        "add it to DELIBERATELY_UNSCREENED with the reason an operator should " +
+        "not drive it from a page, or — if it is simply not built yet — to " +
+        "NOT_YET_SCREENED, which may only shrink."
+    );
+  }
+
+  // A claim for a permission nobody declares is a screen gating on a key no
+  // role can hold: the control is invisible to everyone, forever.
+  for (const key of coverage.claimed) {
+    if (!coverage.declared.includes(key)) {
+      problems.push(
+        `A screen gates on "${key}", which no module declares. No role can ` +
+          "hold it, so the control it guards can never appear."
+      );
+    }
+  }
+
+  for (const [key, reason] of Object.entries(decisions)) {
+    if (coverage.claimed.has(key)) {
+      problems.push(
+        `"${key}" is listed as deliberately unscreened ("${reason}") but a ` +
+          "screen now claims it. Remove the entry — a stale decision reads as " +
+          "reviewed judgement about code that moved on."
+      );
+    }
+
+    if (ledgerSet.has(key)) {
+      problems.push(
+        `"${key}" is in BOTH registers. A permission is either a decision or ` +
+          "unfinished work, never both."
+      );
+    }
+  }
+
+  for (const key of ledger) {
+    if (coverage.claimed.has(key)) {
+      problems.push(
+        `"${key}" is on NOT_YET_SCREENED but a screen now claims it. Delete ` +
+          "the line: the ledger only ever shrinks, and that is the only thing " +
+          "that makes its length mean something."
+      );
+    }
+
+    if (!coverage.declared.includes(key)) {
+      problems.push(
+        `"${key}" is on NOT_YET_SCREENED but no module declares it any more. ` +
+          "Delete the line."
+      );
+    }
+  }
+
+  return problems;
+}
+
+export async function collectCoverage(): Promise<
+  Coverage & { screens: string[] }
+> {
+  const screens: string[] = [];
+
+  for await (const file of new Bun.Glob(SCREEN_GLOB).scan({
+    cwd: process.cwd()
+  })) {
+    screens.push(file);
+  }
+
+  const claimed = new Set<string>();
+
+  for (const screen of screens.sort()) {
+    for (const key of extractScreenClaims(await Bun.file(screen).text())) {
+      claimed.add(key);
+    }
+  }
+
+  const declared = listModules().flatMap((module) =>
+    (module.permissions ?? []).map(
+      (permission) =>
+        `${module.key}.${permission.activityCode}.${permission.action}`
+    )
+  );
+
+  return { claimed, declared, screens };
+}
+
+async function main(): Promise<void> {
+  const { claimed, declared, screens } = await collectCoverage();
+  const problems: string[] = [];
+
+  // A corpus that resolved to nothing would make every rule pass vacuously.
+  if (screens.length === 0) {
+    problems.push(
+      `No admin screen matched \`${SCREEN_GLOB}\` — the check would pass vacuously.`
+    );
+  }
+
+  const { NOT_YET_SCREENED } = await import("./admin-screen-coverage-ledger");
+
+  problems.push(
+    ...evaluateScreenCoverage(
+      { claimed, declared },
+      DELIBERATELY_UNSCREENED,
+      NOT_YET_SCREENED
+    )
+  );
+
+  if (problems.length > 0) {
+    console.error("admin:screen-coverage:check FAILED");
+
+    for (const problem of problems) {
+      console.error(`  - ${problem}`);
+    }
+
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `admin:screen-coverage:check OK — ${screens.length} screens claim ` +
+      `${claimed.size} of ${declared.length} declared permissions; ` +
+      `${Object.keys(DELIBERATELY_UNSCREENED).length} deliberate, ` +
+      `${NOT_YET_SCREENED.length} awaiting a screen.`
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -1,0 +1,103 @@
+/**
+ * Permissions that have no admin screen YET — a one-way ledger, not a register
+ * of decisions.
+ *
+ * The difference is the whole point. `DELIBERATELY_UNSCREENED` in
+ * `admin-screen-coverage-check.ts` says "an operator should not drive this from
+ * a page", and each entry carries the reason. This list says nothing except
+ * "nobody has built it". Mixing the two would let unfinished work acquire the
+ * appearance of judgement, which is exactly how ADR-0058 found six exception
+ * entries that were really six bugs.
+ *
+ * **It may only shrink.** Giving a permission a screen and leaving its line here
+ * turns the gate RED, so the number below is always the real one. That property
+ * is what makes it worth writing down at all: before this file, "13 of 21
+ * modules have no screen" was a sentence somebody had to re-derive by hand, and
+ * it was re-derived wrongly more than once.
+ *
+ * Adding a line is allowed — a new module lands with endpoints before screens —
+ * but it is an edit somebody makes on purpose, in a file whose only content is
+ * work not done.
+ *
+ * Nine modules, and the two largest groups are worth naming because they are not
+ * cosmetic: every `email` suppression key (a suppressed address silently stops
+ * receiving mail, including password resets, and nothing can list or clear it
+ * from a page), and every `identity_access.business_scope_*` key (assignment
+ * plus a maker/checker exception flow with no inbox for the checker).
+ * `module_management.settings.*` is the one that had a false alibi: three
+ * documents claimed a generic `/admin/modules/{key}` settings panel existed,
+ * and one used that claim to justify not building an editor. It never existed.
+ */
+export const NOT_YET_SCREENED: readonly string[] = [
+  // blog_content (7)
+  "blog_content.ad_placements.configure",
+  "blog_content.ad_placements.read",
+  "blog_content.homepage_sections.configure",
+  "blog_content.homepage_sections.read",
+  "blog_content.internal_links.configure",
+  "blog_content.internal_links.preview",
+  "blog_content.internal_links.read",
+
+  // comments (3)
+  "comments.moderation.delete",
+  "comments.settings.read",
+  "comments.settings.update",
+
+  // email (9)
+  "email.announcement.create",
+  "email.message.cancel",
+  "email.message.read",
+  "email.suppression.create",
+  "email.suppression.delete",
+  "email.suppression.read",
+  "email.template.delete",
+  "email.template.restore",
+  "email.template.update",
+
+  // form_drafts (2)
+  "form_drafts.draft.create",
+  "form_drafts.draft.update",
+
+  // identity_access (15)
+  "identity_access.business_scope_assignments.create",
+  "identity_access.business_scope_assignments.read",
+  "identity_access.business_scope_assignments.revoke",
+  "identity_access.business_scope_conflicts.read",
+  "identity_access.business_scope_exceptions.approve",
+  "identity_access.business_scope_exceptions.create",
+  "identity_access.business_scope_exceptions.read",
+  "identity_access.business_scope_exceptions.reject",
+  "identity_access.business_scope_exceptions.revoke",
+  "identity_access.machine_credentials.create",
+  "identity_access.machine_credentials.read",
+  "identity_access.machine_credentials.revoke",
+  "identity_access.sso_providers.create",
+  "identity_access.sso_providers.delete",
+  "identity_access.sso_providers.update",
+
+  // module_management (8)
+  "module_management.health.check",
+  "module_management.health.read",
+  "module_management.jobs.read",
+  "module_management.modules.read",
+  "module_management.modules.sync",
+  "module_management.permissions.read",
+  "module_management.settings.read",
+  "module_management.settings.update",
+
+  // profile_identity (3)
+  "profile_identity.profile_management.delete",
+  "profile_identity.profile_management.restore",
+  "profile_identity.profile_management.update",
+
+  // tenant_admin (2)
+  "tenant_admin.tenant_settings.read",
+  "tenant_admin.tenant_settings.update",
+
+  // visitor_analytics (5)
+  "visitor_analytics.events.read",
+  "visitor_analytics.raw_detail.read",
+  "visitor_analytics.retention.purge",
+  "visitor_analytics.settings.read",
+  "visitor_analytics.settings.update"
+];

--- a/tests/admin-screen-coverage-check.test.ts
+++ b/tests/admin-screen-coverage-check.test.ts
@@ -1,0 +1,189 @@
+/**
+ * `bun run admin:screen-coverage:check` — the rule, driven with planted gaps.
+ *
+ * The live registry passing proves little: it passes today because the ledger
+ * was generated from today. What has to be proven is that each direction FAILS
+ * on the defect it exists for — and one direction in particular, because the
+ * repo has already paid for getting it wrong four times: a scanner that reports
+ * a COVERED permission as uncovered trains its readers to widen the exception
+ * list until the gate asks nothing.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  collectCoverage,
+  evaluateScreenCoverage,
+  extractScreenClaims
+} from "../scripts/admin-screen-coverage-check";
+import { NOT_YET_SCREENED } from "../scripts/admin-screen-coverage-ledger";
+
+const DECLARED = ["mod.thing.read", "mod.thing.write"];
+
+describe("extractScreenClaims", () => {
+  test("reads the literal triple", () => {
+    expect([
+      ...extractScreenClaims(
+        'permissionKey("comments", "moderation", "approve")'
+      )
+    ]).toEqual(["comments.moderation.approve"]);
+  });
+
+  test("resolves a file-local helper bound to a literal module key", () => {
+    // The real shape, from `blog-presentation.astro`. A matcher that stops at
+    // literal triples reports all eight of these as unclaimed — verified: eight
+    // false positives, every one of them a control that ships and works.
+    const source = [
+      "const can = (activity: string, action: string): boolean =>",
+      '  ssr.permissions.has(permissionKey("blog_content", activity, action));',
+      'const canReadWidgets = can("widgets", "read");',
+      'const canConfigureTheme = can("theme", "configure");'
+    ].join("\n");
+
+    expect([...extractScreenClaims(source)].sort()).toEqual([
+      "blog_content.theme.configure",
+      "blog_content.widgets.read"
+    ]);
+  });
+
+  test("does NOT resolve a helper whose module key is itself a variable", () => {
+    // Guessing there would trade one wrong answer for its opposite. Unresolved
+    // is the honest outcome, and it fails toward "unclaimed" — the direction a
+    // human then has to look at.
+    const source = [
+      "const can = (m: string, a: string) =>",
+      '  ssr.permissions.has(permissionKey(m, a, "read"));',
+      'const x = can("blog_content", "widgets");'
+    ].join("\n");
+
+    expect([...extractScreenClaims(source)]).toEqual([]);
+  });
+});
+
+describe("evaluateScreenCoverage", () => {
+  const claimed = (...keys: string[]) => ({
+    claimed: new Set(keys),
+    declared: DECLARED
+  });
+
+  test("a permission with a screen passes", () => {
+    expect(
+      evaluateScreenCoverage(
+        claimed("mod.thing.read", "mod.thing.write"),
+        {},
+        []
+      )
+    ).toEqual([]);
+  });
+
+  test("THE CASE: a permission no screen claims fails", () => {
+    const problems = evaluateScreenCoverage(claimed("mod.thing.read"), {}, []);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("mod.thing.write");
+  });
+
+  test("a written decision covers it", () => {
+    expect(
+      evaluateScreenCoverage(
+        claimed("mod.thing.read"),
+        {
+          "mod.thing.write": "machine-to-machine only"
+        },
+        []
+      )
+    ).toEqual([]);
+  });
+
+  test("the ledger covers it", () => {
+    expect(
+      evaluateScreenCoverage(claimed("mod.thing.read"), {}, ["mod.thing.write"])
+    ).toEqual([]);
+  });
+
+  test("a STALE ledger entry fails — this is what makes the ledger one-way", () => {
+    // Without this, the list would grow a tail of permissions that quietly got
+    // screens, and its length would stop meaning anything.
+    const problems = evaluateScreenCoverage(
+      claimed("mod.thing.read", "mod.thing.write"),
+      {},
+      ["mod.thing.write"]
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("only ever shrinks");
+  });
+
+  test("a stale DECISION fails too", () => {
+    const problems = evaluateScreenCoverage(
+      claimed("mod.thing.read", "mod.thing.write"),
+      { "mod.thing.write": "machine-to-machine only" },
+      []
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("stale decision");
+  });
+
+  test("a ledger entry for a permission nobody declares any more fails", () => {
+    const problems = evaluateScreenCoverage(
+      claimed("mod.thing.read", "mod.thing.write"),
+      {},
+      ["mod.removed.read"]
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("no module declares it");
+  });
+
+  test("being in BOTH registers fails", () => {
+    const problems = evaluateScreenCoverage(
+      claimed("mod.thing.read"),
+      { "mod.thing.write": "decided" },
+      ["mod.thing.write"]
+    );
+
+    expect(problems.some((p) => p.includes("BOTH registers"))).toBe(true);
+  });
+
+  test("a screen gating on an undeclared key fails", () => {
+    // A control nobody can ever see: no role can hold a key no module declares.
+    const problems = evaluateScreenCoverage(
+      {
+        claimed: new Set([...DECLARED, "mod.thing.teleport"]),
+        declared: DECLARED
+      },
+      {},
+      []
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]).toContain("no module declares");
+  });
+});
+
+describe("the live repo", () => {
+  test("the screen corpus is not empty", async () => {
+    const { screens, declared } = await collectCoverage();
+
+    expect(screens.length).toBeGreaterThanOrEqual(30);
+    expect(declared.length).toBeGreaterThanOrEqual(200);
+  });
+
+  test("the ledger holds only keys that are really declared and really unscreened", async () => {
+    const { claimed, declared } = await collectCoverage();
+
+    for (const key of NOT_YET_SCREENED) {
+      expect(declared).toContain(key);
+      expect(claimed.has(key)).toBe(false);
+    }
+  });
+
+  test("the gate passes against the repo as committed", () => {
+    const result = Bun.spawnSync([
+      "bun",
+      "scripts/admin-screen-coverage-check.ts"
+    ]);
+
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Apa yang hilang

[ADR-0051](docs/adr/0051-admin-screens-consolidated-in-awcms.md) memutuskan setiap layar
admin SISTEM dibangun di repo ini, lalu **tidak memasang apa pun yang mengukur
kepatuhannya**. Akibatnya "modul ini hanya bisa dipakai lewat `curl`" ditemukan dengan
tangan — berulang kali, dan tiap kali terlambat.

Pemeriksa yang tampak berdekatan menjawab pertanyaan lain:

| Pemeriksa | Pertanyaannya | Kenapa tidak cukup |
|---|---|---|
| `access:permissions:enforcement:check` | "apakah permission ini punya **penegak**?" | Sebuah rute sudah cukup — permukaan `curl`-only lolos selamanya |
| `tests/admin-navigation-registry.test.ts` | "apakah entri `navigation` menunjuk halaman?" | Modul tanpa `navigation` tak punya apa pun untuk diperiksa |
| contract test per-layar | "apakah layar INI menggerbangi key yang benar?" | Tak bisa melihat permission yang tak disebut layar mana pun |

`bun run admin:screen-coverage:check` (murni, gerbang **ke-36** di rantai `check`)
menanyakan yang hilang: **apakah ada layar yang mengklaim permission ini?**

Pemindaian pertama: **32 layar mengklaim 133 dari 203 permission** — 16 keputusan
tertulis, **54 menunggu layar, tersebar di sembilan modul.**

## Dua daftar, dan pemisahannya adalah desainnya

- **`DELIBERATELY_UNSCREENED`** — keputusan ber-alasan, bentuk yang sama dengan register
  `permission-enforcement-check.ts`. Diisi **hanya dari alasan yang sudah tertulis di
  kode**: keenam `workflow.definition.*` (butuh editor graf), unggah media tiga-langkah
  (tombol yang memulai tapi tak bisa menuntaskan meninggalkan baris `pending_upload` tiap
  salah klik), saklar `enforcement` satu-arah, `blog_content.ads.*` yang ADR-0044
  pensiunkan jadi 410, dan tiga lainnya.
- **`NOT_YET_SCREENED`** — ledger **satu arah** yang tidak menilai apa pun, hanya "belum
  ada yang membangunnya". Memberi sebuah permission layar lalu meninggalkan barisnya
  **memerahkan CI**, jadi angkanya selalu angka yang sebenarnya. Itulah yang membuatnya
  layak ditulis: sebelum berkas ini, "13 dari 21 modul tanpa layar" adalah kalimat yang
  harus diturunkan ulang dengan tangan — dan pernah diturunkan **salah** lebih dari sekali.

Mencampur keduanya akan membuat pekerjaan yang belum selesai memperoleh **penampilan
sebuah penilaian** — persis cara ADR-0058 menemukan enam entri pengecualian yang ternyata
enam bug.

Dua kelompok terbesar di ledger bukan kosmetik, dan namanya disebut di berkasnya:

- seluruh `email.suppression.*` — alamat yang di-suppress berhenti menerima email
  **termasuk reset password**, dan tak ada halaman untuk melihat atau menghapusnya;
- seluruh `identity_access.business_scope_*` — assignment plus alur exception
  maker/checker **tanpa inbox untuk checker-nya**;
- `module_management.settings.*` — yang punya **alibi palsu**: tiga dokumen menyatakan
  panel setting generik `/admin/modules/{key}` sudah ada, dan satu memakai klaim itu untuk
  membenarkan tidak membangun editor. Layar itu tak pernah ada (dikoreksi di #420).

## Matcher-nya menyelesaikan helper file-first, dan itu load-bearing

Matcher yang hanya membaca triple literal `permissionKey("m","a","x")` melaporkan
**delapan** permission `blog_content` yang **ter-ship dan bekerja** sebagai tak-terklaim,
karena `blog-presentation.astro` mengikat
`const can = (activity, action) => …permissionKey("blog_content", activity, action)` lalu
memanggilnya delapan kali dengan literal. Diverifikasi dengan membuang resolusi itu:
**8 false positive** (audit meramalkan 5).

Scanner yang menjawab "tak tercakup" untuk yang tercakup **lebih buruk daripada tak ada
scanner** — ia melatih pembacanya menambah pengecualian sampai gerbangnya tak menanyakan
apa pun, dan `permission-enforcement-check.ts` butuh empat draf untuk mempelajarinya.

Resolusinya sengaja **sempit**: helper dihitung hanya bila badannya mengikat module key
sebagai **literal** dan meneruskan kedua parameternya sendiri. Selain itu dibiarkan
tak-terselesaikan — dan gagal ke arah "tak-terklaim", arah yang memaksa manusia melihat.

## Batas yang dinyatakan di docblock-nya

Gerbang ini menjawab **"apakah ada yang mengklaim?"**, bukan "apakah kontrolnya benar".
Tombol Restore `/admin/blog` mengklaim `posts.restore` sambil dirender pada baris yang
pasti 404 (#351); gerbang ini akan berkata "tercakup" sepanjang waktu itu. Kebenaran
kontrol tetap tugas contract test per-layar, dan keduanya menjawab dua pertanyaan berbeda.

## Mutation proof — empat arah

- permission tanpa layar & tanpa entri → MERAH menyebut key-nya;
- entri ledger **basi** (layarnya sudah ada) → MERAH, "only ever shrinks";
- resolusi helper dibuang → **8 false positive**;
- layar menggerbangi key yang **tak dideklarasikan siapa pun** → MERAH (kontrol yang tak
  bisa dipegang role mana pun, jadi tak akan pernah muncul).

Plus 15 unit test atas aturannya, digerakkan snapshot tertanam, termasuk asersi bahwa
helper yang **module key-nya sendiri variabel** sengaja TIDAK diselesaikan.

`bun run check` PENUH hijau, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)