### PR TITLE
fix(gerbang): `api:tenant-route:check` berhenti buta terhadap 32 layar admin

### DIFF
--- a/.changeset/gerbang-tenant-route-melihat-layar-admin.md
+++ b/.changeset/gerbang-tenant-route-melihat-layar-admin.md
@@ -1,0 +1,36 @@
+---
+"awcms": patch
+---
+
+fix(gerbang): `api:tenant-route:check` berhenti buta terhadap 32 layar admin
+
+Ke-32 layar `src/pages/admin/**/*.astro` membuka `withTenantOrThrow` sendiri dan
+memutuskan akses dengan `ssr.permissions.has()` saja — PROJECT_STATE §4 **R3**.
+Mereka tak terlihat oleh `access:chokepoint:check` (root-nya `src/pages/api/v1`)
+**dan** tak terlihat di sini, karena root gerbang ini berhenti di `src/pages/api`.
+
+Gerbang ini sudah mencocokkan `withTenantOrThrow(` sejak awal. Ia hanya tidak
+pernah diarahkan ke direktori tempat ke-32 layar itu tinggal.
+
+`ROUTES_ROOT` tunggal menjadi `SCAN_ROOTS`, tiap root membawa ekstensinya sendiri
+(`.ts` untuk API, `.astro` untuk admin) dan kalimat perbaikannya sendiri — karena
+jawabannya berbeda: rute API harus memakai `defineTenantRoute`, sedangkan layar
+admin **belum punya** factory untuk dipakai. Ke-32 layar masuk `NOT_YET_MIGRATED`
+(236 entri, dari 204).
+
+**Ratchet, bukan migrasi.** `defineAdminScreen` belum ada — ia Gelombang 1 dari
+\#423. Nilainya adalah sejak commit ini sebuah layar admin BARU tidak bisa lagi
+menambah utang R3, berbulan-bulan sebelum utangnya sendiri dilunasi.
+
+Penjaga nol-berkas kini **per-root**. Total gabungan akan membiarkan satu root
+sehat menutupi root kedua yang memindai nol berkas — persis "OK yang ceria dan
+tak bermakna" yang diperingatkan header berkas ini, satu direktori kemudian.
+Diverifikasi dengan mutasi: mengarahkan root admin ke direktori yang tidak ada
+**merah**, dan mempertahankan root sambil mengganti ekstensinya juga **merah**.
+
+Angka di issue #424 tertulis 31; yang benar **32**. Glob `src/pages/admin/*.astro`
+melewatkan `src/pages/admin/tenant/domains.astro`, satu-satunya layar di
+subdirektori. `find -name "*.astro"` menemukannya, dan 32 cocok dengan hitungan
+R3 yang sudah tercatat.
+
+Nol perubahan runtime. Nol migrasi. Nol permission.

--- a/.claude/skills/awcms-new-endpoint/SKILL.md
+++ b/.claude/skills/awcms-new-endpoint/SKILL.md
@@ -40,12 +40,17 @@ export const GET = defineTenantRoute({
 - **Bentuk callback `authorize`:** tulis `prepare` SEBELUM `authorize` di object
   literal. TypeScript menyimpulkan `TPrepared` menurut urutan sumber; `authorize`
   duluan mem-pin-nya ke `undefined` dan errornya menyesatkan.
-- **Gate `bun run api:tenant-route:check`** menolak rute BARU yang memanggil
-  `withTenant` langsung. 204 rute lama ada di `NOT_YET_MIGRATED` — daftar yang
-  **hanya boleh menyusut**; entri basi juga menggagalkan gate. **Jangan pernah
-  menambah baris ke daftar itu.**
+- **Gate `bun run api:tenant-route:check`** menolak rute BARU yang membuka
+  transaksi tenant sendiri. Ia memindai **dua** root sejak Issue #424:
+  `src/pages/api` (`.ts`) dan `src/pages/admin` (`.astro`). `NOT_YET_MIGRATED`
+  memuat 236 berkas — rute API lama plus **32 layar admin** (PROJECT_STATE §4
+  R3). Daftar itu **hanya boleh menyusut**; entri basi juga menggagalkan gate.
+  **Jangan pernah menambah baris ke daftar itu.**
 - Migrasi rute lama: satu modul per PR, tanpa perubahan perilaku, hapus barisnya
   dari daftar.
+- **Layar admin belum bisa dimigrasi:** helper `defineAdminScreen` belum ada (ia
+  Gelombang 1 dari #423). Sampai ia mendarat, jangan menambah layar `/admin/*`
+  yang membuka transaksinya sendiri — gate akan menolaknya, dan itu disengaja.
 
 ## Aturan
 

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -40,11 +40,58 @@
  * The pattern deliberately matches `withTenant<T>(` as well as `withTenant(`:
  * `_shared/tenant-route.ts` itself writes the generic form, and a pattern that
  * missed it would let a copy of the factory's own body through.
+ *
+ * ## Why `src/pages/admin` is scanned too (Issue #424)
+ *
+ * All 32 admin screens open their own `withTenantOrThrow` and decide access
+ * with `ssr.permissions.has()` alone — PROJECT_STATE §4 **R3**. They are
+ * invisible to `access:chokepoint:check` (its root is `src/pages/api/v1`) and
+ * they WERE invisible here, because this root stopped at `src/pages/api`.
+ *
+ * That is the whole change: this gate already matched `withTenantOrThrow(`. It
+ * was simply never pointed at the directory where 32 of them live.
+ *
+ * The ledger cannot be migrated away yet — `defineAdminScreen` does not exist
+ * (it is Gelombang 1 of #423). Seeding the 32 here is therefore a **ratchet,
+ * not a migration**: from this commit a NEW admin screen cannot add to R3's
+ * debt, months before the debt itself is paid down. A gate that only stops the
+ * bleeding still stops the bleeding.
  */
 import { readdir } from "node:fs/promises";
 import path from "node:path";
 
-const ROUTES_ROOT = "src/pages/api";
+/**
+ * Each root carries its own extension set and its own remediation sentence,
+ * because the answer differs: an API route must use `defineTenantRoute`, while
+ * an admin screen has no factory to use yet.
+ */
+type ScanRoot = {
+  root: string;
+  extensions: readonly string[];
+  /** Printed when an UNLISTED file under this root opens its own transaction. */
+  remediation: string;
+};
+
+export const SCAN_ROOTS: readonly ScanRoot[] = [
+  {
+    root: "src/pages/api",
+    extensions: [".ts"],
+    remediation:
+      "Rute baru WAJIB memakai defineTenantRoute (src/modules/_shared/tenant-route.ts), " +
+      "yang membawa gerbang tenant/token, rantai guard penuh, dan work class yang WAJIB " +
+      "ditulis. Jangan tambahkan berkas ini ke NOT_YET_MIGRATED."
+  },
+  {
+    root: "src/pages/admin",
+    extensions: [".astro"],
+    remediation:
+      "Layar admin baru TIDAK BOLEH membuka transaksi tenant sendiri: ia memutuskan akses " +
+      "dengan ssr.permissions.has() saja, melewati evaluateAccess, resolveModuleEnabled, dan " +
+      "recordDecisionLog (PROJECT_STATE §4 R3). Helper defineAdminScreen belum ada — ia " +
+      "Gelombang 1 dari #423. Sampai ia mendarat, layar yang butuh data tenant harus menunggu " +
+      "helper itu, BUKAN menambah barisnya di NOT_YET_MIGRATED."
+  }
+];
 
 /** Matches `withTenant(`, `withTenant<T>(` AND `withTenantOrThrow(` — a route
  * that opens its own tenant transaction bypasses the factory under either
@@ -53,12 +100,50 @@ const WITH_TENANT_CALL_PATTERN =
   /\bwithTenant(?:OrThrow)?\s*(?:<[^()]*>)?\s*\(/;
 
 /**
- * Routes that still open their own transaction, measured at `b9931594`.
+ * Files that still open their own transaction. API routes measured at
+ * `b9931594`; the 32 admin screens added by Issue #424 at the head of
+ * Gelombang 0.
+ *
  * ONLY REMOVE LINES FROM THIS LIST. Never add one: a new entry means a new
- * route skipped `defineTenantRoute`, which is what this gate exists to
- * prevent.
+ * route skipped `defineTenantRoute`, or a new admin screen added to R3's debt
+ * — which is what this gate exists to prevent.
  */
 const NOT_YET_MIGRATED: readonly string[] = [
+  // --- Layar admin (R3) — menunggu `defineAdminScreen`, Gelombang 1 dari #423.
+  "src/pages/admin/abac-policies.astro",
+  "src/pages/admin/analytics.astro",
+  "src/pages/admin/approvals.astro",
+  "src/pages/admin/audit-trail.astro",
+  "src/pages/admin/blog-pages.astro",
+  "src/pages/admin/blog-presentation.astro",
+  "src/pages/admin/blog-settings.astro",
+  "src/pages/admin/blog-taxonomy.astro",
+  "src/pages/admin/blog.astro",
+  "src/pages/admin/comments.astro",
+  "src/pages/admin/data-lifecycle.astro",
+  "src/pages/admin/domain-events.astro",
+  "src/pages/admin/email-templates.astro",
+  "src/pages/admin/form-drafts.astro",
+  "src/pages/admin/idn-regions.astro",
+  "src/pages/admin/index.astro",
+  "src/pages/admin/media.astro",
+  "src/pages/admin/modules.astro",
+  "src/pages/admin/offices.astro",
+  "src/pages/admin/profiles.astro",
+  "src/pages/admin/registrations.astro",
+  "src/pages/admin/reporting.astro",
+  "src/pages/admin/roles.astro",
+  "src/pages/admin/security.astro",
+  "src/pages/admin/seo.astro",
+  "src/pages/admin/sidebar-menu.astro",
+  "src/pages/admin/site-search.astro",
+  "src/pages/admin/sync.astro",
+  "src/pages/admin/tenant/domains.astro",
+  "src/pages/admin/tenants.astro",
+  "src/pages/admin/theming.astro",
+  "src/pages/admin/users.astro",
+
+  // --- Rute API.
   "src/pages/api/v1/abac/policies/[id].ts",
   "src/pages/api/v1/abac/policies/index.ts",
   "src/pages/api/v1/access/assignments.ts",
@@ -265,13 +350,16 @@ const NOT_YET_MIGRATED: readonly string[] = [
   "src/pages/api/v1/workflows/tasks/index.ts"
 ];
 
-async function* walk(directory: string): AsyncGenerator<string> {
+async function* walk(
+  directory: string,
+  extensions: readonly string[]
+): AsyncGenerator<string> {
   for (const entry of await readdir(directory, { withFileTypes: true })) {
     const full = path.join(directory, entry.name);
 
     if (entry.isDirectory()) {
-      yield* walk(full);
-    } else if (entry.name.endsWith(".ts")) {
+      yield* walk(full, extensions);
+    } else if (extensions.some((ext) => entry.name.endsWith(ext))) {
       yield full;
     }
   }
@@ -329,25 +417,42 @@ export function evaluateTenantRouteMigration(
   };
 }
 
+/** Remediation sentence for the root that owns `file`, matched by longest prefix. */
+export function remediationFor(file: string): string {
+  const owner = SCAN_ROOTS.filter((scan) =>
+    file.startsWith(`${scan.root}/`)
+  ).sort((a, b) => b.root.length - a.root.length)[0];
+
+  return owner?.remediation ?? SCAN_ROOTS[0]!.remediation;
+}
+
 async function main(): Promise<void> {
   const files: { path: string; content: string }[] = [];
 
-  for await (const file of walk(ROUTES_ROOT)) {
-    files.push({
-      path: file.split(path.sep).join("/"),
-      content: await Bun.file(file).text()
-    });
-  }
+  // Each root is counted SEPARATELY. A combined total would let one healthy
+  // root mask a second that walked nothing — which is the exact "cheerful,
+  // meaningless OK" this guard was written for, one directory later.
+  for (const scan of SCAN_ROOTS) {
+    let scanned = 0;
 
-  // `ROUTES_ROOT` is repo-relative, so a run from the wrong working directory
-  // would walk nothing and report a cheerful, meaningless OK. This repo has
-  // already shipped gates that passed while scanning zero files.
-  if (files.length === 0) {
-    console.error(
-      `api:tenant-route:check GAGAL — scanned 0 files under ${ROUTES_ROOT}. ` +
-        "Run this from the repository root."
-    );
-    process.exit(1);
+    for await (const file of walk(scan.root, scan.extensions)) {
+      files.push({
+        path: file.split(path.sep).join("/"),
+        content: await Bun.file(file).text()
+      });
+      scanned += 1;
+    }
+
+    // Roots are repo-relative, so a run from the wrong working directory would
+    // walk nothing and report success. This repo has already shipped gates that
+    // passed while scanning zero files.
+    if (scanned === 0) {
+      console.error(
+        `api:tenant-route:check GAGAL — scanned 0 files under ${scan.root} ` +
+          `(${scan.extensions.join(", ")}). Run this from the repository root.`
+      );
+      process.exit(1);
+    }
   }
 
   const { unlisted, stale } = evaluateTenantRouteMigration(
@@ -357,31 +462,29 @@ async function main(): Promise<void> {
 
   if (unlisted.length === 0 && stale.length === 0) {
     console.log(
-      `api:tenant-route:check OK — ${files.length} rute di ${ROUTES_ROOT}: memakai ` +
-        `defineTenantRoute, atau salah satu dari ${NOT_YET_MIGRATED.length} rute yang masih ` +
-        "antre migrasi (Issue #255)."
+      `api:tenant-route:check OK — ${files.length} berkas di ` +
+        `${SCAN_ROOTS.map((scan) => scan.root).join(" + ")}: memakai defineTenantRoute, ` +
+        `atau salah satu dari ${NOT_YET_MIGRATED.length} berkas yang masih antre migrasi ` +
+        "(rute API: Issue #255; layar admin: R3 / Issue #424)."
     );
     process.exit(0);
   }
 
   for (const file of unlisted) {
     console.error(
-      `${file} — memanggil withTenant() langsung. Rute baru WAJIB memakai defineTenantRoute ` +
-        "(src/modules/_shared/tenant-route.ts), yang membawa gerbang tenant/token, rantai " +
-        "guard penuh, dan work class yang WAJIB ditulis. Jangan tambahkan berkas ini ke " +
-        "NOT_YET_MIGRATED."
+      `${file} — membuka transaksi tenant sendiri. ${remediationFor(file)}`
     );
   }
 
   for (const file of stale) {
     console.error(
-      `${file} — terdaftar di NOT_YET_MIGRATED tapi sudah tidak memanggil withTenant() ` +
-        "langsung (ter-migrasi atau terhapus). Hapus barisnya: daftar ini hanya boleh menyusut."
+      `${file} — terdaftar di NOT_YET_MIGRATED tapi sudah tidak membuka transaksi tenant ` +
+        "sendiri (ter-migrasi atau terhapus). Hapus barisnya: daftar ini hanya boleh menyusut."
     );
   }
 
   console.error(
-    `\napi:tenant-route:check GAGAL — ${unlisted.length} rute belum lewat factory, ` +
+    `\napi:tenant-route:check GAGAL — ${unlisted.length} berkas membuka transaksinya sendiri tanpa terdaftar, ` +
       `${stale.length} entri allowlist basi.`
   );
 

--- a/tests/tenant-route-factory-check.test.ts
+++ b/tests/tenant-route-factory-check.test.ts
@@ -16,7 +16,11 @@
  */
 import { describe, expect, test } from "bun:test";
 
-import { evaluateTenantRouteMigration } from "../scripts/tenant-route-factory-check";
+import {
+  SCAN_ROOTS,
+  evaluateTenantRouteMigration,
+  remediationFor
+} from "../scripts/tenant-route-factory-check";
 
 const DIRECT = `
 import { withTenant } from "../../../../lib/database/tenant-context";
@@ -110,5 +114,75 @@ export const GET = async () => withTenant<Response>(sql, tenantId, async (tx) =>
         []
       ).unlisted
     ).toEqual(["src/pages/api/v1/thing.ts"]);
+  });
+});
+
+/**
+ * Issue #424 — the second root.
+ *
+ * The 32 admin screens were invisible to BOTH `access:chokepoint:check` (root
+ * `src/pages/api/v1`) and this gate (root `src/pages/api`), which is what made
+ * PROJECT_STATE §4 R3 able to grow unobserved. These assert the extension, not
+ * just the ledger contents, because a ledger of 32 correct paths is worthless
+ * if the walker never produces a `.astro` file to match them against.
+ */
+describe("admin screens are a scanned root, not just ledger lines", () => {
+  const ADMIN_SCREEN = `---
+import { withTenantOrThrow } from "../../lib/database/tenant-context";
+const rows = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => load(tx));
+---
+<h1>Users</h1>
+`;
+
+  test("a `.astro` screen opening its own transaction is detected", () => {
+    expect(
+      evaluateTenantRouteMigration(
+        [{ path: "src/pages/admin/thing.astro", content: ADMIN_SCREEN }],
+        []
+      ).unlisted
+    ).toEqual(["src/pages/admin/thing.astro"]);
+  });
+
+  test("a listed screen is the debt, and delisting it is what fails", () => {
+    const listed = evaluateTenantRouteMigration(
+      [{ path: "src/pages/admin/thing.astro", content: ADMIN_SCREEN }],
+      ["src/pages/admin/thing.astro"]
+    );
+
+    expect(listed).toEqual({ unlisted: [], stale: [] });
+  });
+
+  test("`src/pages/admin` is actually walked, with `.astro` among its extensions", () => {
+    // Guards the two mutations a ledger test cannot see: pointing the root at a
+    // directory that does not exist, or keeping the root while dropping the
+    // extension. Either leaves 32 ledger entries intact and scans nothing.
+    const admin = SCAN_ROOTS.find((scan) => scan.root === "src/pages/admin");
+
+    expect(admin).toBeDefined();
+    expect(admin?.extensions).toContain(".astro");
+  });
+});
+
+describe("remediation is chosen by root, because the answer differs", () => {
+  test("an API route is told to use defineTenantRoute", () => {
+    expect(remediationFor("src/pages/api/v1/thing/index.ts")).toContain(
+      "defineTenantRoute"
+    );
+  });
+
+  test("an admin screen is NOT told to use defineTenantRoute — it has no factory yet", () => {
+    const advice = remediationFor("src/pages/admin/thing.astro");
+
+    expect(advice).toContain("defineAdminScreen");
+    expect(advice).not.toContain("defineTenantRoute(");
+  });
+
+  test("the nested admin directory resolves to the admin root, not the API one", () => {
+    // `src/pages/admin/tenant/domains.astro` is the one screen not matched by a
+    // top-level `src/pages/admin/*.astro` glob — the same blind spot that made
+    // Issue #424 say 31 when the real count is 32.
+    expect(remediationFor("src/pages/admin/tenant/domains.astro")).toContain(
+      "defineAdminScreen"
+    );
   });
 });


### PR DESCRIPTION
Menutup #424. Gelombang 0 (PR 0.1) dari #423.

## Temuan

Ke-32 layar `src/pages/admin/**/*.astro` membuka `withTenantOrThrow` sendiri dan memutuskan akses dengan `ssr.permissions.has()` saja (PROJECT_STATE §4 **R3**). **Dua** gerbang buta terhadapnya, bukan satu:

| Gerbang | Root | Akibat |
| --- | --- | --- |
| `access:chokepoint:check` | `src/pages/api/v1` | tidak melihat `.astro` sama sekali |
| `api:tenant-route:check` | `src/pages/api` | **sudah** mencocokkan `withTenantOrThrow(`, tapi berhenti sebelum `src/pages/admin` |

Itu seluruh perubahannya: gerbang ini tidak pernah diarahkan ke direktori tempat ke-32 layar itu tinggal.

## Yang berubah

`ROUTES_ROOT` tunggal → `SCAN_ROOTS`, tiap root membawa **ekstensi** dan **kalimat perbaikan** sendiri. Kalimatnya berbeda karena jawabannya berbeda: rute API harus memakai `defineTenantRoute`; layar admin belum punya factory. Menyalin kalimat API ke sana akan menyuruh orang memakai helper yang tidak ada.

Penjaga nol-berkas menjadi **per-root**. Total gabungan akan membiarkan satu root sehat menutupi root kedua yang memindai nol berkas — "OK yang ceria dan tak bermakna" yang sudah diperingatkan header berkas ini, satu direktori kemudian.

**Ratchet, bukan migrasi.** `defineAdminScreen` mendarat di Gelombang 1. Nilai PR ini: sejak sekarang layar admin **baru** tidak bisa menambah utang R3.

## Bukti — empat mutasi, semuanya merah

| Mutasi | Hasil |
| --- | --- |
| layar admin membuka transaksi, tidak terdaftar | **MERAH** |
| entri ledger untuk layar yang tak ada (basi) | **MERAH** |
| root admin diarahkan ke direktori tak ada | **MERAH** |
| root benar, ekstensi `.astro` diganti | **MERAH** |

Dua yang terakhir **hanya** bisa merah karena penjaganya per-root — di bawah total gabungan keduanya lolos.

## Koreksi terhadap issue

Issue menulis **31**; yang benar **32**. Glob `src/pages/admin/*.astro` melewatkan `src/pages/admin/tenant/domains.astro`, satu-satunya layar di subdirektori — blind spot yang sama bentuknya dengan temuan issue ini sendiri. 32 cocok dengan hitungan R3 yang sudah tercatat, dan satu test mengunci kasus nested itu.

## Cakupan

Nol perubahan runtime, nol migrasi, nol permission. Ledger 204 → 236 entri. Skill `awcms-new-endpoint` ikut diperbarui (ia masih mengklaim "204 rute" dan tidak menyebut root kedua).

`bun run check` penuh hijau: 3389 test lulus, 0 gagal, build OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)