### PR TITLE
fix(test,gerbang): asersi anti-regresi chokepoint berhenti lolos secara hampa saat rename

### DIFF
--- a/.changeset/asersi-chokepoint-rename-proof.md
+++ b/.changeset/asersi-chokepoint-rename-proof.md
@@ -1,0 +1,46 @@
+---
+"awcms": patch
+---
+
+fix(test,gerbang): asersi anti-regresi chokepoint berhenti lolos secara hampa saat rename
+
+Dua asersi di `tests/access-chokepoint.test.ts` menjaga invarian utama ADR-0063
+— `ownershipGrant` **melebarkan** himpunan kunci, tidak pernah men-*short-circuit*
+ke `allowed: true` — dengan `expect(source).not.toMatch(/ownershipGrant…/)`.
+
+Regex-nya berlabuh pada literal nama variabel. `not.toMatch` terhadap pola yang
+**tidak akan pernah cocok** selalu hijau, jadi sebuah rename membuat keduanya
+lolos tanpa menguji apa pun.
+
+Diverifikasi, bukan diduga. Dengan `ownershipGrant`/`ownershipApplied` di-rename
+habis di `access-guard.ts` (0 kemunculan nama lama, 7 nama baru), asersi lama
+tetap **HIJAU**; asersi baru **MERAH**.
+
+Penggantinya menamai kedua variabel itu nol kali: ambil badan
+`authorizeInTransaction` saja (bukan seluruh berkas — deklarasi tipe
+`AuthorizeResult` di atasnya sah menulis `allowed: true;`), lalu tuntut **tepat
+satu** `allowed: true` dan indeksnya **setelah** `evaluateAccess(`. Sebuah early
+allow adalah kecocokan kedua, apa pun nama variabelnya.
+
+Dipasangkan test kedua yang **menuntut identifier itu ADA**. Aturan yang
+diadopsi: asersi berbasis sumber wajib rename-proof, **atau** dipasangkan asersi
+keberadaan — kalau tidak, ia menjaga mekanisme yang mungkin sudah tidak ada.
+
+Dua asersi hampa lain ikut ditutup di jalan: `expect(evaluate).toBeGreaterThan(-1)`
+sebelum perbandingan indeks (tanpanya perbandingannya berbunyi `> -1` dan lolos
+untuk penempatan apa pun), dan `expect(start).toBeGreaterThan(-1)` di pengekstrak
+badan fungsi (tanpanya seluruh asersi menjangkau string kosong — cacat #425 lahir
+kembali di dalam perbaikannya sendiri).
+
+**Sisi gerbang.** `scripts/access-chokepoint-check.ts` mengklasifikasi handler
+lewat literal `fetchGrantedPermissionKeys(`. Rename fungsi itu membuat setiap
+`decidesPermissions` bernilai false, `findChokepointBypasses` mengembalikan
+kosong, dan gerbang mencetak **"0 handler memutuskan permission"** lalu keluar
+dengan **sukses**. Nama itu justru akan berubah bentuk di #423 (tipe kembalinya
+diubah) — momen ketika orang paling tergoda menggantinya.
+
+Sekarang `deciding.length === 0` adalah kegagalan dengan pesan yang menyebut
+sinyalnya. Diverifikasi: sinyal yang tak lagi cocok apa pun → **MERAH** (dulu
+hijau).
+
+Nol perubahan runtime.

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -203,6 +203,32 @@ async function main(): Promise<void> {
 
   const deciding = handlers.filter((handler) => handler.decidesPermissions);
 
+  // Issue #425 — the self-test.
+  //
+  // Every classification above keys on the literal `fetchGrantedPermissionKeys(`
+  // (`sliceHandlers`). That name is about to change shape: the grant redesign
+  // (#423) alters its RETURN TYPE, which is exactly the moment someone is
+  // tempted to rename it. A rename makes every `decidesPermissions` false, so
+  // `findChokepointBypasses` returns nothing, and this gate prints a cheerful
+  // OK while checking nothing at all — the class of failure PROJECT_STATE §4 R9
+  // records for five other gates.
+  //
+  // A gate that has only ever been observed passing has not been observed at
+  // all. There are handlers that genuinely decide permissions; if we can no
+  // longer find any, the detector is broken, not the tree.
+  if (deciding.length === 0) {
+    console.error(
+      "access:chokepoint:check FAILED — 0 handlers were classified as deciding a " +
+        "permission. That is not a clean tree, it is a blind detector: the signal " +
+        "`fetchGrantedPermissionKeys(` no longer matches anything under " +
+        `${ROUTES_ROOT}. If that function was renamed, update the signal in ` +
+        "`sliceHandlers` in the same commit."
+    );
+
+    process.exitCode = 1;
+    return;
+  }
+
   console.log(
     `access:chokepoint:check OK — ${handlers.length} handlers, ` +
       `${deciding.length} decide permissions, ` +

--- a/tests/access-chokepoint.test.ts
+++ b/tests/access-chokepoint.test.ts
@@ -238,27 +238,84 @@ export const POST: APIRoute = async () => {
   });
 });
 
+const GUARD_SOURCE_PATH =
+  "src/modules/identity-access/application/access-guard.ts";
+
+/**
+ * The body of one top-level `export`ed function, so assertions about "inside
+ * `authorizeInTransaction`" cannot be satisfied by code in a sibling function
+ * or by the `AuthorizeResult` type declaration above it (which legitimately
+ * writes `allowed: true;`).
+ */
+function exportedFunctionBody(source: string, name: string): string {
+  const start = source.indexOf(`export async function ${name}(`);
+
+  // Not a soft failure: a rename here would make every assertion below range
+  // over an empty string and pass vacuously — the exact defect Issue #425 is
+  // about, reproduced inside its own fix.
+  expect(start).toBeGreaterThan(-1);
+
+  const rest = source.slice(start + 1);
+  const nextExport = rest.search(
+    /\nexport (?:async function|function|type|const)\s/
+  );
+
+  return nextExport === -1 ? rest : rest.slice(0, nextExport);
+}
+
 describe("the guard widens, it never short-circuits", () => {
-  test("`ownershipApplied` only builds the key set — it never returns an allow", async () => {
+  /**
+   * Issue #425 — this was asserted with two `not.toMatch` regexes keyed on the
+   * literals `ownershipGrant` and `ownershipApplied`. A rename to anything else
+   * makes a `not.toMatch` over a pattern that can no longer occur **pass
+   * vacuously**, and the invariant ADR-0063 was written to protect would be
+   * unguarded with a green suite.
+   *
+   * Replaced by a structural claim that names neither variable, plus a separate
+   * identifier-existence test so a rename fails LOUDLY instead of silently
+   * voiding the guard. ADR-0063 lines 137-143 already record that an
+   * ordering-based safety claim survived a mutation with every test green; this
+   * is the same lesson applied one level up, to the assertion itself.
+   */
+  test("exactly one allow exists in the guard, and it is after the evaluator", async () => {
     // The wrong implementation is one line and passes every behavioural test of
     // `evaluateAccess`, because it never reaches it:
     //     if (options?.ownershipGrant?.granted) return { allowed: true, ... }
     // That would skip ABAC, the platform-scope gate, business scope and SoD —
-    // the exact four things ADR-0063 exists to preserve. Only the guard's own
-    // source can rule it out.
-    const source = await Bun.file(
-      "src/modules/identity-access/application/access-guard.ts"
-    ).text();
+    // the exact four things ADR-0063 exists to preserve.
+    const source = await Bun.file(GUARD_SOURCE_PATH).text();
+    const body = exportedFunctionBody(source, "authorizeInTransaction");
 
-    const applied = source.indexOf("const ownershipApplied");
-    const evaluate = source.indexOf("evaluateAccess(");
+    const allows = [...body.matchAll(/allowed:\s*true/g)];
+    const evaluate = body.indexOf("evaluateAccess(");
 
-    expect(applied).toBeGreaterThan(-1);
-    // The grant is computed BEFORE the evaluator, and the evaluator still runs.
-    expect(evaluate).toBeGreaterThan(applied);
-    // No early allow keyed on the grant, in any spelling.
-    expect(source).not.toMatch(/ownershipGrant[^\n]*\n[^\n]*allowed:\s*true/);
-    expect(source).not.toMatch(/ownershipApplied[\s\S]{0,120}?allowed:\s*true/);
+    // Without this the index comparison below reads `> -1` and passes for ANY
+    // placement — a vacuous assertion wearing the shape of a real one.
+    expect(evaluate).toBeGreaterThan(-1);
+
+    // One allow, not two: any early allow is a second match, whatever it is
+    // keyed on and whatever the variable is called.
+    expect(allows).toHaveLength(1);
+    expect(allows[0]!.index).toBeGreaterThan(evaluate);
+  });
+
+  test("the widening is a set union computed before the evaluator", async () => {
+    const source = await Bun.file(GUARD_SOURCE_PATH).text();
+    const body = exportedFunctionBody(source, "authorizeInTransaction");
+
+    // Identifier-existence, paired with the structural test above: if ADR-0063's
+    // mechanism is ever renamed, THIS fails with a clear message rather than
+    // leaving the structural test guarding a mechanism that no longer exists
+    // under that name.
+    expect(body).toContain("ownershipGrant");
+    expect(body).toContain("ownershipApplied");
+
+    // Machine credentials are excluded from the widening (ADR-0049 §3), and the
+    // grant is folded into the key set BEFORE `evaluateAccess` runs.
+    expect(body).toMatch(/ownershipApplied[\s\S]{0,200}?new Set\(/);
+    expect(body.indexOf("ownershipApplied")).toBeLessThan(
+      body.indexOf("evaluateAccess(")
+    );
   });
 });
 


### PR DESCRIPTION
Menutup #425. Gelombang 0 (PR 0.2) dari #423.

## Temuan

Dua asersi menjaga invarian utama ADR-0063 lewat `expect(source).not.toMatch(/ownershipGrant…/)`. Regex-nya berlabuh pada **literal nama variabel** — dan `not.toMatch` terhadap pola yang tidak akan pernah cocok **selalu hijau**.

## Bukti, bukan dugaan

Dengan `ownershipGrant`/`ownershipApplied` di-rename habis di `access-guard.ts` (**0** kemunculan nama lama, **7** nama baru):

| Asersi | Guard bersih | Mekanisme di-rename |
| --- | --- | --- |
| **lama** | HIJAU | **HIJAU** ← invarian tak terjaga, suite hijau |
| **baru** | HIJAU | **MERAH** |

Mutasi kedua — menyisipkan `return { allowed: true }` sebelum evaluator — juga **MERAH**.

## Penggantinya

Menamai kedua variabel itu **nol kali**: ambil badan `authorizeInTransaction` saja (bukan seluruh berkas — deklarasi tipe `AuthorizeResult` di atasnya sah menulis `allowed: true;`), lalu tuntut **tepat satu** `allowed: true` dengan indeks **setelah** `evaluateAccess(`. Early allow adalah kecocokan kedua, apa pun namanya.

Dipasangkan test kedua yang menuntut identifier itu **ada**. Aturan yang diadopsi: asersi berbasis sumber wajib rename-proof, **atau** dipasangkan asersi keberadaan — kalau tidak ia menjaga mekanisme yang mungkin sudah tidak ada.

**Dua asersi hampa lain ikut ditutup di jalan:**
- `expect(evaluate).toBeGreaterThan(-1)` sebelum perbandingan indeks — tanpanya ia berbunyi `> -1` dan lolos untuk penempatan apa pun.
- `expect(start).toBeGreaterThan(-1)` di pengekstrak badan fungsi — tanpanya seluruh asersi menjangkau string kosong, yaitu cacat #425 lahir kembali di dalam perbaikannya sendiri.

## Sisi gerbang

`access-chokepoint-check.ts` mengklasifikasi lewat literal `fetchGrantedPermissionKeys(`. Rename fungsi itu → setiap `decidesPermissions` false → `findChokepointBypasses` kosong → gerbang mencetak **"0 handler memutuskan permission"** dan keluar **sukses**.

Nama itu justru akan berubah bentuk di #423 (tipe kembalinya diubah) — momen ketika orang paling tergoda menggantinya. Sekarang `deciding.length === 0` adalah kegagalan bernarasi; diverifikasi **MERAH** (dulu hijau).

Nol perubahan runtime. `bun run check` penuh hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)