### PR TITLE
feat(gerbang): `access:decision-log:coverage:check` mengunci jejak keputusan otorisasi

### DIFF
--- a/.changeset/gerbang-cakupan-decision-log.md
+++ b/.changeset/gerbang-cakupan-decision-log.md
@@ -1,0 +1,57 @@
+---
+"awcms": patch
+---
+
+feat(gerbang): `access:decision-log:coverage:check` mengunci jejak keputusan otorisasi
+
+`authorizeInTransaction` menulis satu baris `awcms_abac_decision_logs` di setiap
+jalur terminal. Properti itulah yang membuat sistem ini bisa menjawab "kenapa
+permintaan ini ditolak" dari sebuah tabel alih-alih dari tebakan — dan ia
+ditopang **kebiasaan review saja**.
+
+Program model keanggotaan menambahkan **tiga** cabang keluar baru ke fungsi yang
+sama: `TENANT_SUSPENDED`, `ENTITLEMENT_REQUIRED`, dan penolakan
+principal/delegasi. Regresi paling mungkin di seluruh program adalah salah satu
+darinya kembali lebih awal tanpa menulis log. Tidak ada yang akan menangkapnya:
+suite default berjalan **tanpa** PostgreSQL, jadi "sebuah baris ditulis" tidak
+bisa di-assert di sana; permintaannya tetap ditolak dengan benar, jadi tidak ada
+test yang gagal dan tidak ada pengguna yang mengeluh. Yang hilang hanya jejaknya
+— pada penolakan yang paling perlu dijelaskan ke pelanggan.
+
+Gerbang ini **hijau hari ini**. Nilainya bukan menemukan cacat sekarang,
+melainkan mengunci properti sebelum tiga cabang baru mendarat di atasnya.
+
+**Aturan naif salah, dan membaca guard-nya yang menunjukkan itu.** "Setiap
+`return` didahului `recordDecisionLog(`" keliru di dua arah sekaligus:
+
+- Return `401 AUTH_REQUIRED` **tidak bisa** menulis log — ia menyala ketika
+  `context` bernilai null, jadi tidak ada `tenantUserId` untuk mengatribusikan
+  barisnya. Menuntut log di sana berarti menuntut baris yang mustahil. Ia masuk
+  daftar pengecualian ber-alasan.
+- Return `403 SOD_CONFLICT` didahului `recordDecisionLog` yang mencatat sebuah
+  **allow** — keputusan ABAC-nya memang allow, dan SoD adalah deny aditif yang
+  dicatat di `awcms_sod_conflict_evaluations`. Aturan "log tepat sebelum return"
+  meluluskannya karena alasan yang salah; aturan "log di blok yang sama"
+  menggagalkannya karena alasan yang salah.
+
+Jadi aturannya **dominansi**, diaproksimasi secara leksikal: untuk sebuah return,
+telusuri rantai blok yang melingkupinya dan cari `recordDecisionLog(` pada
+kedalaman blok itu sendiri, sebelum posisi return-nya. Log di dalam
+`if (machine && …) { … }` karena itu mencakup return cabang itu dan **tidak**
+mencakup return di luarnya.
+
+Lima mutasi memerahkan gerbang, diverifikasi lokal. Yang paling menentukan:
+memindahkan panggilan log ke **cabang saudara** — ia tetap ada di berkas dan
+tetap tekstual lebih dulu dari return-nya, dan gerbangnya tetap **MERAH**. Itu
+yang membedakan dominansi dari regex. Empat lainnya: cabang keluar baru tanpa
+log; log dominan dihapus; fungsi target di-rename (gerbang tidak boleh diam-diam
+OK); dan pengecualian basi untuk kode yang kini sudah menulis log.
+
+Batas yang ditulis, bukan disembunyikan: pengecualian di-key oleh **kode error**
+(bukan offset baris, yang membusuk tiap kali ada suntingan di atasnya), sehingga
+return kedua yang memakai kode yang sudah dikecualikan akan mewarisi
+pengecualiannya. Dan gerbang ini menalar **satu** fungsi —
+`evaluateFieldAccessInTransaction` sengaja di luar cakupan dan sengaja tidak
+menulis log.
+
+Nol perubahan runtime. Rantai `check` 36 → 37 segmen.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -111,7 +111,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | ADR                                | **0000**–**0071** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Berkas `.astro`                    | **43** (22.656 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
-| Gerbang                            | **36** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
+| Gerbang                            | **37** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
 <!-- project-state-inventory:selesai -->

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 316   |
+| Berkas test                        | 317   |
 | Berkas route                       | 309   |
 | ADR                                | 72    |
 
@@ -272,7 +272,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 268        |
+| `(root)`      | 269        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "skills:check": "bun scripts/skills-check.ts",
     "deps:audit:check": "bun scripts/dependency-audit-check.ts",
     "access:chokepoint:check": "bun scripts/access-chokepoint-check.ts",
+    "access:decision-log:coverage:check": "bun scripts/access-decision-log-coverage-check.ts",
     "admin:screen-coverage:check": "bun scripts/admin-screen-coverage-check.ts",
     "edge-cache:purge": "bun scripts/edge-cache-purge.ts",
     "data-lifecycle:registry:check": "bun scripts/data-lifecycle-registry-check.ts",
@@ -121,7 +122,7 @@
     "test:e2e": "bun --bun playwright test",
     "test:e2e:install": "bun --bun playwright install --with-deps chromium",
     "perf:cwv:lab": "bun --bun playwright test tests/e2e/cwv-lab.e2e.ts",
-    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run repo:inventory:check && bun run project-state:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run api:consumer-contract:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run access:permissions:enforcement:check && bun run access:chokepoint:check && bun run admin:screen-coverage:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run skills:check && bun run deps:audit:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run db:fk-index:check && bun run typecheck && bun run test && bun run build",
+    "check": "bun run lint && bun run check:docs && bun run check:docs:translation && bun run scripts:inventory:check && bun run repo:inventory:check && bun run project-state:inventory:check && bun run config:env:coverage:check && bun run api:spec:check && bun run api:docs:check && bun run api:consumer-contract:check && bun run modules:dag:check && bun run modules:routes:check && bun run modules:table-writes:check && bun run modules:jobs:check && bun run modules:compose:check && bun run modules:composition:inventory:check && bun run reporting:projections:registry:check && bun run identity-access:sod-registry:check && bun run access:permissions:enforcement:check && bun run access:chokepoint:check && bun run access:decision-log:coverage:check && bun run admin:screen-coverage:check && bun run data-lifecycle:registry:check && bun run site-search:sources:check && bun run comments:resources:check && bun run edge-cache:surfaces:check && bun run skills:check && bun run deps:audit:check && bun run family:conformance:check && bun run logging:lint:check && bun run api:tenant-route:check && bun run db:tenant-context:check && bun run db:work-class:check && bun run db:fk-index:check && bun run typecheck && bun run test && bun run build",
     "changeset": "changeset",
     "changeset:version": "changeset version",
     "changeset:status": "changeset status"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -30,6 +30,7 @@ terjadwal, atau oleh workflow CI tertentu.
 | Target                                   | Skrip                                          | Gate |
 | ---------------------------------------- | ---------------------------------------------- | ---- |
 | `access:chokepoint:check`                | `access-chokepoint-check.ts`                   | ✅   |
+| `access:decision-log:coverage:check`     | `access-decision-log-coverage-check.ts`        | ✅   |
 | `access:permissions:enforcement:check`   | `permission-enforcement-check.ts`              | ✅   |
 | `admin:screen-coverage:check`            | `admin-screen-coverage-check.ts`               | ✅   |
 | `analytics:purge`                        | `visitor-analytics-purge.ts`                   | —    |

--- a/scripts/access-decision-log-coverage-check.ts
+++ b/scripts/access-decision-log-coverage-check.ts
@@ -1,0 +1,317 @@
+#!/usr/bin/env bun
+/**
+ * `bun run access:decision-log:coverage:check` — Issue #426.
+ *
+ * Every terminal decision of `authorizeInTransaction` writes a row to
+ * `awcms_abac_decision_logs`. That property is what lets this system answer
+ * "why was this request refused" from a table instead of a guess — and it is
+ * currently held up by review habit alone.
+ *
+ * ## Why a gate, and why now
+ *
+ * The program in `docs/awcms/program-model-keanggotaan-2026-08-09.md` adds
+ * THREE new exit branches to this one function: `TENANT_SUSPENDED` (#429),
+ * `ENTITLEMENT_REQUIRED`, and the principal/delegated refusals. The most likely
+ * regression in the whole program is one of them returning early without
+ * logging.
+ *
+ * Nothing would catch it. The default suite runs WITHOUT PostgreSQL, so "a row
+ * was written" is not assertable there; the DB-gated suite is a separate
+ * workflow. And the request is still refused correctly, so no behavioural test
+ * fails and no user complains. Only the trail is missing — on exactly the
+ * refusals that most need explaining to a customer.
+ *
+ * This gate is GREEN today. Its value is not finding a defect now; it is
+ * locking the property before three new branches land on top of it.
+ *
+ * ## The rule, and why the naive version is wrong
+ *
+ * Naive rule: "every `return` is preceded by `recordDecisionLog(`". It is wrong
+ * in both directions here, and reading the guard is what shows it:
+ *
+ * - The `401 AUTH_REQUIRED` return CANNOT log. It fires when `context` is null,
+ *   so there is no `tenantUserId` to attribute a row to. Demanding a log there
+ *   would demand an impossible row.
+ * - The `403 SOD_CONFLICT` return is preceded by a `recordDecisionLog` that
+ *   recorded an **allow** — the ABAC decision genuinely was allow, and SoD is an
+ *   additive deny recorded in `awcms_sod_conflict_evaluations` by
+ *   `checkHighRiskSoDConflicts`. A textual "log immediately before the return"
+ *   rule would pass it for the wrong reason; a "log in the same block" rule
+ *   would fail it for the wrong reason.
+ *
+ * So the rule is DOMINANCE, approximated lexically: for a terminal return at
+ * position `i`, walk the chain of blocks enclosing it and look for a
+ * `recordDecisionLog(` call that sits at THAT block's own depth (not nested
+ * deeper inside a sibling branch) at a position before `i`.
+ *
+ * A `recordDecisionLog` inside `if (machine && …) { … }` therefore covers that
+ * branch's own return, and does NOT cover a return outside it — which is the
+ * distinction the naive rule cannot make and the whole reason this is not a
+ * three-line regex.
+ *
+ * ## Honest limits
+ *
+ * Lexical, not an AST. Two consequences, both stated rather than hidden:
+ *
+ * 1. Exemptions are keyed by the ERROR CODE in the return (`AUTH_REQUIRED`), not
+ *    by line offset — offsets rot on every edit above them. The cost is that a
+ *    SECOND unlogged return reusing an already-exempt code would inherit the
+ *    exemption. That is a narrow hole and a deliberate trade for a key that
+ *    cannot go stale; the alternative was a ledger that breaks on unrelated
+ *    edits, which is how ledgers become off-switches.
+ * 2. It reasons about ONE function. `evaluateFieldAccessInTransaction` is
+ *    deliberately out of scope and deliberately logs nothing: it is a projection
+ *    refinement of an already-logged decision, not a separate resource-access
+ *    decision. Widening this gate to it would demand rows that ADR-0049 §6
+ *    argues should not exist.
+ */
+import { readFile } from "node:fs/promises";
+
+const GUARD_SOURCE = "src/modules/identity-access/application/access-guard.ts";
+const GUARDED_FUNCTION = "authorizeInTransaction";
+
+/**
+ * The detection signal, named once. Issue #425 is the reason it is a constant
+ * rather than a literal buried in a loop: a signal that silently stops matching
+ * turns a gate green-and-blind, and the only defence is that the name it keys on
+ * is visible in one place next to the failure message that quotes it.
+ */
+const LOG_CALL_PATTERN = /recordDecisionLog\(/g;
+
+/**
+ * Terminal returns that legitimately write no decision row, keyed by the error
+ * code they carry. Each entry is a DECISION and must say why the row is
+ * impossible or wrong — not why it was inconvenient.
+ */
+export const DECISION_LOG_EXEMPTIONS: Readonly<Record<string, string>> = {
+  AUTH_REQUIRED:
+    "Fires when `context` is null — unknown, expired, revoked, or a machine " +
+    "credential whose service account is gone. There is no `tenantUserId` to " +
+    "attribute the row to, and `awcms_abac_decision_logs.tenant_user_id` is the " +
+    "column an auditor reads. A row here would be attributable to nobody. The " +
+    "authentication failure is already covered by the login/audit trail."
+};
+
+export type DecisionReturn = {
+  /** `AUTH_REQUIRED`, `MODULE_DISABLED`, … or `ALLOW` for the success return. */
+  code: string;
+  index: number;
+  logged: boolean;
+};
+
+export type DecisionLogProblem = {
+  code: string;
+  message: string;
+};
+
+/**
+ * The body of one top-level exported function. Exported so the extraction
+ * itself is testable — an extractor that silently returns "" would make every
+ * assertion below vacuous.
+ */
+export function sliceFunctionBody(source: string, name: string): string | null {
+  const start = source.indexOf(`export async function ${name}(`);
+
+  if (start === -1) {
+    return null;
+  }
+
+  const rest = source.slice(start + 1);
+  const nextExport = rest.search(
+    /\nexport (?:async function|function|type|const)\s/
+  );
+
+  return nextExport === -1 ? rest : rest.slice(0, nextExport);
+}
+
+/**
+ * Depth of every character, where the function body's own statements sit at
+ * depth 1 (depth 0 is outside the opening brace).
+ */
+function depthMap(body: string): number[] {
+  const depths: number[] = new Array(body.length);
+  let depth = 0;
+
+  for (let i = 0; i < body.length; i += 1) {
+    const char = body[i];
+
+    if (char === "}") {
+      depth -= 1;
+    }
+
+    depths[i] = depth;
+
+    if (char === "{") {
+      depth += 1;
+    }
+  }
+
+  return depths;
+}
+
+/**
+ * True when some `recordDecisionLog(` call DOMINATES `index`: it appears before
+ * it, at the depth of one of the blocks enclosing it, so every path reaching
+ * `index` through that block ran the call.
+ */
+function isDominatedByLog(
+  body: string,
+  depths: number[],
+  index: number
+): boolean {
+  const returnDepth = depths[index] ?? 0;
+
+  for (const match of body.matchAll(LOG_CALL_PATTERN)) {
+    const at = match.index!;
+
+    if (at >= index) {
+      continue;
+    }
+
+    const logDepth = depths[at] ?? 0;
+
+    // At or above the return's own block chain. A log nested DEEPER than the
+    // return sits inside a sibling branch and dominates nothing.
+    if (logDepth > returnDepth) {
+      continue;
+    }
+
+    // The block the log sits in must still be open at `index` — otherwise it
+    // closed before the return and belongs to a branch that was not taken.
+    let closed = false;
+
+    for (let i = at; i < index; i += 1) {
+      if ((depths[i] ?? 0) < logDepth) {
+        closed = true;
+        break;
+      }
+    }
+
+    if (!closed) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/** Every terminal `return { allowed: … }` in the body, with its coverage. */
+export function collectDecisionReturns(body: string): DecisionReturn[] {
+  const depths = depthMap(body);
+  const returns: DecisionReturn[] = [];
+
+  for (const match of body.matchAll(/return\s*\{\s*allowed:\s*(true|false)/g)) {
+    const index = match.index!;
+    const tail = body.slice(index, index + 400);
+    const failCode = tail.match(/fail\(\s*\d+\s*,\s*"([A-Z_]+)"/);
+
+    returns.push({
+      code: match[1] === "true" ? "ALLOW" : (failCode?.[1] ?? "UNKNOWN"),
+      index,
+      logged: isDominatedByLog(body, depths, index)
+    });
+  }
+
+  return returns;
+}
+
+/** The rule, over already-classified returns. */
+export function findUnloggedDecisions(
+  returns: readonly DecisionReturn[],
+  exemptions: Readonly<Record<string, string>> = DECISION_LOG_EXEMPTIONS
+): DecisionLogProblem[] {
+  return returns
+    .filter((entry) => !entry.logged && !(entry.code in exemptions))
+    .map((entry) => ({
+      code: entry.code,
+      message:
+        `terminal return \`${entry.code}\` is not dominated by a ` +
+        "`recordDecisionLog(` call, so this decision leaves no row in " +
+        "`awcms_abac_decision_logs`. The request is still refused correctly, " +
+        "which is why no behavioural test catches this — only the trail is " +
+        "missing, on exactly the refusal that most needs explaining. Either log " +
+        "before returning, or add a reasoned entry to DECISION_LOG_EXEMPTIONS " +
+        "saying why the row is impossible."
+    }));
+}
+
+/** An exemption whose code no longer appears unlogged is a stale claim. */
+export function findStaleExemptions(
+  returns: readonly DecisionReturn[],
+  exemptions: Readonly<Record<string, string>> = DECISION_LOG_EXEMPTIONS
+): DecisionLogProblem[] {
+  const unlogged = new Set(
+    returns.filter((entry) => !entry.logged).map((entry) => entry.code)
+  );
+
+  return Object.keys(exemptions)
+    .filter((code) => !unlogged.has(code))
+    .map((code) => ({
+      code,
+      message:
+        "is exempt from the decision-log rule but no longer returns without " +
+        "logging (it now logs, or the branch is gone). Delete the entry: an " +
+        "exemption list that keeps entries it no longer needs is how a gate " +
+        "turns into an off switch."
+    }));
+}
+
+async function main(): Promise<void> {
+  const source = await readFile(GUARD_SOURCE, "utf8");
+  const body = sliceFunctionBody(source, GUARDED_FUNCTION);
+
+  // A rename or a move would make every assertion below range over nothing and
+  // report a cheerful OK. This repo has already shipped gates that passed while
+  // scanning zero files.
+  if (!body) {
+    console.error(
+      `access:decision-log:coverage:check FAILED — could not find ` +
+        `\`export async function ${GUARDED_FUNCTION}(\` in ${GUARD_SOURCE}. ` +
+        "If the chokepoint moved or was renamed, update this gate in the same commit."
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const returns = collectDecisionReturns(body);
+
+  // Same reasoning one level down: zero returns means the pattern went stale,
+  // not that the guard stopped deciding things.
+  if (returns.length === 0) {
+    console.error(
+      "access:decision-log:coverage:check FAILED — 0 terminal returns found in " +
+        `${GUARDED_FUNCTION}. That is a blind detector, not a clean function ` +
+        `(coverage signal: ${LOG_CALL_PATTERN.source}).`
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const problems = [
+    ...findUnloggedDecisions(returns),
+    ...findStaleExemptions(returns)
+  ];
+
+  if (problems.length > 0) {
+    console.error("access:decision-log:coverage:check FAILED");
+
+    for (const problem of problems) {
+      console.error(`  - ${problem.code} ${problem.message}`);
+    }
+
+    process.exitCode = 1;
+    return;
+  }
+
+  const logged = returns.filter((entry) => entry.logged).length;
+
+  console.log(
+    `access:decision-log:coverage:check OK — ${returns.length} terminal decisions in ` +
+      `${GUARDED_FUNCTION}, ${logged} write a decision log, ` +
+      `${Object.keys(DECISION_LOG_EXEMPTIONS).length} reasoned exemption(s).`
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tests/access-decision-log-coverage.test.ts
+++ b/tests/access-decision-log-coverage.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Issue #426 — the decision-log coverage gate, proven in both directions.
+ *
+ * A gate that has only ever been observed passing has not been observed at all,
+ * and this one is green on the day it lands: its whole value is locking a
+ * property before three new deny branches (#429 and the entitlement/principal
+ * work) land on top of it. So the assertions here are about the DETECTOR, not
+ * about today's tree.
+ *
+ * The load-bearing case is `dominance`. A `recordDecisionLog` that sits in a
+ * sibling branch is textually earlier than the return and still covers nothing;
+ * a regex over "is there a log before this return" passes it. That distinction
+ * is the entire reason this gate is not three lines.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  DECISION_LOG_EXEMPTIONS,
+  collectDecisionReturns,
+  findStaleExemptions,
+  findUnloggedDecisions,
+  sliceFunctionBody
+} from "../scripts/access-decision-log-coverage-check";
+
+const LOGGED_BRANCH = `
+  if (machine && !allowedAction(guard.action)) {
+    await recordDecisionLog(tx, tenantId, userId, guard, decision, machine.id);
+
+    return {
+      allowed: false,
+      denied: fail(403, "ACCESS_DENIED", decision.reason)
+    };
+  }
+`;
+
+const UNLOGGED_BRANCH = `
+  if (!context) {
+    return {
+      allowed: false,
+      denied: fail(401, "AUTH_REQUIRED", "Session is invalid or expired.")
+    };
+  }
+`;
+
+function body(...parts: string[]): string {
+  return `authorizeInTransaction(): Promise<AuthorizeResult> {\n${parts.join("\n")}\n}\n`;
+}
+
+describe("coverage is decided by dominance, not by text order", () => {
+  test("a log in the SAME branch covers that branch's return", () => {
+    const returns = collectDecisionReturns(body(LOGGED_BRANCH));
+
+    expect(returns).toHaveLength(1);
+    expect(returns[0]!.code).toBe("ACCESS_DENIED");
+    expect(returns[0]!.logged).toBe(true);
+  });
+
+  test("a log in a SIBLING branch covers nothing — the case a regex gets wrong", () => {
+    // The log is textually EARLIER than the return and syntactically valid. A
+    // "is there a recordDecisionLog before this return" rule passes this; the
+    // branch it lives in may simply not be taken.
+    const source = body(`
+  if (somethingElse) {
+    await recordDecisionLog(tx, tenantId, userId, guard, decision, machine?.id);
+  }
+
+  if (!decision.allowed) {
+    return {
+      allowed: false,
+      denied: fail(403, "ACCESS_DENIED", decision.reason)
+    };
+  }
+`);
+
+    expect(source.indexOf("recordDecisionLog(")).toBeLessThan(
+      source.indexOf("return {")
+    );
+    expect(collectDecisionReturns(source)[0]!.logged).toBe(false);
+  });
+
+  test("a log at function-body depth covers returns nested below it", () => {
+    // This is the real SOD_CONFLICT shape: the ABAC decision is logged at the
+    // top level, then a nested `if` returns a deny that the log still dominates.
+    const returns = collectDecisionReturns(
+      body(`
+  await recordDecisionLog(tx, tenantId, userId, guard, decision, machine?.id);
+
+  if (isHighRiskAction(guard.action)) {
+    if (sodCheck.blocked) {
+      return {
+        allowed: false,
+        denied: fail(403, "SOD_CONFLICT", sodCheck.reason)
+      };
+    }
+  }
+
+  return { allowed: true, context, grantedPermissionKeys };
+`)
+    );
+
+    expect(returns.map((entry) => entry.code)).toEqual([
+      "SOD_CONFLICT",
+      "ALLOW"
+    ]);
+    expect(returns.every((entry) => entry.logged)).toBe(true);
+  });
+});
+
+describe("the rule fails in both directions", () => {
+  test("an unlogged, unexempt return is reported", () => {
+    const problems = findUnloggedDecisions(
+      collectDecisionReturns(body(UNLOGGED_BRANCH)),
+      {}
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]!.code).toBe("AUTH_REQUIRED");
+  });
+
+  test("an unlogged return with a reasoned exemption passes", () => {
+    expect(
+      findUnloggedDecisions(collectDecisionReturns(body(UNLOGGED_BRANCH)), {
+        AUTH_REQUIRED: "no tenantUserId exists to attribute the row to"
+      })
+    ).toEqual([]);
+  });
+
+  test("an exemption whose branch now logs is stale and fails", () => {
+    // The direction that stops the list rotting into an off switch.
+    const problems = findStaleExemptions(
+      collectDecisionReturns(body(LOGGED_BRANCH)),
+      { ACCESS_DENIED: "claims this does not log — it does" }
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]!.code).toBe("ACCESS_DENIED");
+  });
+
+  test("an exemption whose branch vanished is stale the same way", () => {
+    expect(findStaleExemptions([], { GONE: "removed branch" })).toHaveLength(1);
+  });
+});
+
+describe("the extractor cannot pass vacuously", () => {
+  test("a missing function yields null, never an empty body", () => {
+    // An extractor returning "" would make every assertion above range over
+    // nothing and report success — the defect this gate exists to prevent,
+    // reproduced inside the gate itself.
+    expect(
+      sliceFunctionBody("export const x = 1;\n", "authorizeInTransaction")
+    ).toBeNull();
+  });
+
+  test("the body stops at the next top-level export", () => {
+    const source = `
+export async function authorizeInTransaction(): Promise<AuthorizeResult> {
+  return { allowed: true, context, grantedPermissionKeys };
+}
+
+export async function evaluateFieldAccessInTransaction(): Promise<boolean> {
+  return { allowed: false, denied: fail(403, "LEAKED", "x") };
+}
+`;
+
+    const extracted = sliceFunctionBody(source, "authorizeInTransaction");
+
+    expect(extracted).not.toBeNull();
+    expect(extracted).not.toContain("LEAKED");
+    expect(collectDecisionReturns(extracted!)).toHaveLength(1);
+  });
+});
+
+describe("the live guard", () => {
+  test("every exemption names a real reason, not a TODO", () => {
+    for (const [code, reason] of Object.entries(DECISION_LOG_EXEMPTIONS)) {
+      expect(reason.length).toBeGreaterThan(60);
+      expect(reason.toLowerCase()).not.toContain("todo");
+      expect(code).toMatch(/^[A-Z_]+$/);
+    }
+  });
+
+  test("access:decision-log:coverage:check passes as committed", () => {
+    const result = Bun.spawnSync([
+      "bun",
+      "scripts/access-decision-log-coverage-check.ts"
+    ]);
+
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
Menutup #426. Gelombang 0 (PR 0.3) dari #423.

## Kenapa sekarang, padahal hijau hari ini

`authorizeInTransaction` menulis satu baris `awcms_abac_decision_logs` di **setiap** jalur terminal — properti yang ditopang **kebiasaan review saja**.

Program #423 menambahkan **tiga** cabang keluar baru ke fungsi yang sama (`TENANT_SUSPENDED`, `ENTITLEMENT_REQUIRED`, penolakan principal/delegasi). Regresi paling mungkin di seluruh program adalah salah satunya kembali lebih awal tanpa log — dan **tidak ada yang menangkapnya**: suite default berjalan tanpa PostgreSQL, permintaannya tetap ditolak dengan benar, jadi tak ada test yang gagal dan tak ada pengguna yang mengeluh. Yang hilang hanya jejaknya.

Nilai PR ini bukan menemukan cacat sekarang; ia mengunci properti **sebelum** tiga cabang itu mendarat.

## Aturan naif salah — di dua arah

| Return | Aturan naif | Kenyataan |
| --- | --- | --- |
| `401 AUTH_REQUIRED` | tuntut log | **tidak bisa** log — `context` null, tak ada `tenantUserId` untuk mengatribusikan baris. Masuk pengecualian ber-alasan |
| `403 SOD_CONFLICT` | "log tepat sebelum return" meluluskan | log sebelumnya mencatat sebuah **allow** (ABAC-nya memang allow; SoD deny aditif di tabel lain). Lulus karena alasan yang salah; "log di blok yang sama" **gagal** karena alasan yang salah |

Jadi aturannya **dominansi**: telusuri rantai blok yang melingkupi return, cari `recordDecisionLog(` pada kedalaman blok itu sendiri, sebelum posisi return-nya.

## Bukti — lima mutasi, semuanya merah

| Mutasi | Hasil |
| --- | --- |
| **log dipindah ke cabang saudara** | **MERAH** ← log masih ada di berkas & tekstual lebih dulu |
| cabang keluar baru tanpa log | MERAH |
| log dominan dihapus | MERAH |
| fungsi target di-rename | MERAH |
| pengecualian basi (kode yang kini menulis log) | MERAH |

Yang pertama adalah alasan gerbang ini bukan tiga baris regex.

## Batas, ditulis bukan disembunyikan

- Pengecualian di-key **kode error**, bukan offset baris (offset membusuk tiap ada suntingan di atasnya). Konsekuensinya: return kedua dengan kode yang sudah dikecualikan mewarisi pengecualiannya. Trade sadar — alternatifnya ledger yang patah karena suntingan tak terkait, yaitu cara ledger berubah jadi off-switch.
- Menalar **satu** fungsi. `evaluateFieldAccessInTransaction` sengaja di luar cakupan dan sengaja tidak menulis log — melebarkan gerbang ke sana akan menuntut baris yang ADR-0049 §6 justru berargumen tidak boleh ada.

Nol perubahan runtime. Rantai `check` 36 → 37 segmen. `bun run check` penuh hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)