### PR TITLE
fix(keamanan): permission `scope: 'platform'` berhenti bisa dilekatkan ke role tenant biasa (R8)

### DIFF
--- a/.changeset/tutup-r8-permission-scope-role-editor.md
+++ b/.changeset/tutup-r8-permission-scope-role-editor.md
@@ -1,0 +1,47 @@
+---
+"awcms": patch
+---
+
+fix(keamanan): permission ber-`scope: 'platform'` berhenti bisa dilekatkan ke role tenant biasa (R8)
+
+`listPermissionCatalog` mengembalikan **seluruh** katalog global tanpa predikat
+`scope`, jadi editor role menawarkan permission ber-`scope: "platform"`
+(ADR-0053) kepada tenant mana pun, dan `grantPermissionToRole` menerimanya.
+
+**Ini bukan privilege escalation, dan penting untuk mengatakannya.** Gerbang
+platform di chokepoint selalu menolaknya saat runtime, dan ia memutuskan dari
+deklarasi **sisi kode** — jadi tidak ada baris basis data yang bisa mengangkatnya.
+
+Yang hilang adalah **redundansi**, dan **kejujuran**. Seorang administrator bisa
+memberikan permission itu, melihatnya tercantum di role, lalu menyimpulkan bahwa
+ia berlaku. Ia tidak. Grant yang **tampak diberikan** tetapi tidak akan pernah
+berlaku adalah jawaban yang salah untuk "siapa bisa melakukan apa" — persis
+jawaban yang harus dipercaya review akses berikutnya. ADR-0058 menghabiskan satu
+dokumen penuh pada kelas ambiguitas itu.
+
+**Nol migrasi.** Rancangan pertama memberi tiap role kolom `permission_scope`.
+Itu pemisahan yang lebih halus — ia akan membedakan role di dalam tenant platform
+yang boleh dan tidak boleh memegang permission platform — tetapi **bukan R8**, dan
+ia menuntut migrasi, kolom baru, serta penegakannya sendiri.
+
+Batasan yang R8 gambarkan lebih sederhana dan sudah diputuskan: permission
+platform hanya boleh **dijalankan** oleh tenant platform. Jadi filter yang jujur
+adalah *"apakah tenant yang bertindak adalah tenant platform"* — tanpa perubahan
+skema sama sekali, dan persis predikat yang sudah dipakai gerbang runtime. Kolom
+per-role tetap tersedia untuk hari ketika least privilege **di dalam** tenant
+platform menjadi pertanyaannya.
+
+Dua sisi, dan yang kedua yang jadi kontrolnya:
+
+- `listPermissionCatalog(tx, { includePlatformScoped })` — **wajib** dinyatakan,
+  bukan flag opsional ber-default permisif: pemanggil yang lupa mendapat compile
+  error, bukan picker yang diam-diam melebar.
+- `grantPermissionToRole` memeriksa ulang di server dan menolak dengan
+  `409 PLATFORM_SCOPE_REQUIRED`. Menyaring dropdown menghentikan kecelakaan,
+  bukan permintaan yang ditulis tangan.
+
+Permission id yang tidak dikenal **tidak** ditolak di sini — ia jatuh ke foreign
+key yang melempar `PermissionNotFoundError`. Satu tempat memutuskan "apakah ini
+ada", dan bukan fungsi ini.
+
+Menutup PROJECT_STATE §4 **R8**.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **90** (`sql/001`–`090`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0071** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (22.656 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (22.664 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **37** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -467,9 +467,11 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
     **HARUS DIPECAH** — 1 PR helper+gerbang+ledger, lalu ~6–8 PR migrasi.
   - **R7 — kredensial mesin, suppression email, komposer homepage tanpa layar.**
     Kini otomatis terlihat di ledger R6, jadi ia bisa mendarat bertahap.
-  - **R8 — permission platform bisa diberikan lewat editor role**
-    (`listPermissionCatalog` tanpa predikat `scope`; ADR-0053 tetap menolak di
-    `access-guard.ts`, jadi yang hilang adalah redundansinya).
+  - ~~**R8 — permission platform bisa diberikan lewat editor role**~~ —
+    **DITUTUP** (#431). `listPermissionCatalog` kini menuntut keputusan `scope`
+    yang eksplisit dan `grantPermissionToRole` memeriksa ulang di server dengan
+    409 `PLATFORM_SCOPE_REQUIRED`. Nol migrasi: batasannya tentang TENANT mana
+    yang boleh memegang permission platform, bukan tentang role.
   - **R9 — lima gerbang menjanjikan cakupan yang tak mereka periksa**, mis.
     `logging:lint:check` yang `SCAN_ROOTS`-nya melewatkan `src/middleware.ts`
     dan seluruh `src/pages` (probe identik: `src/lib/` → EXIT 1,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 126   |
 | Tabel dengan `FORCE` RLS           | 115   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 318   |
+| Berkas test                        | 319   |
 | Berkas route                       | 309   |
 | ADR                                | 72    |
 
@@ -272,7 +272,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 270        |
+| `(root)`      | 271        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/src/modules/identity-access/application/role-admin.ts
+++ b/src/modules/identity-access/application/role-admin.ts
@@ -20,6 +20,7 @@
  * `deleted_at IS NULL`.
  */
 import { recordAuditEvent } from "../../logging/application/audit-log";
+import { resolvePlatformTenant } from "../../../lib/tenant/platform-tenant";
 
 const AUDIT_MODULE_KEY = "identity_access";
 const AUDIT_RESOURCE_TYPE_ROLE = "role";
@@ -160,18 +161,56 @@ type PermissionRow = {
 };
 
 /**
- * The whole global permission catalog (`awcms_permissions` has no `tenant_id`;
- * it is platform-wide reference data). Bounded and low-cardinality, so no
- * cursor. Used to render the "add permission" picker.
+ * The global permission catalog (`awcms_permissions` has no `tenant_id`; it is
+ * platform-wide reference data), filtered to what the ACTING tenant may
+ * actually hold. Bounded and low-cardinality, so no cursor.
+ *
+ * ## Why the filter exists — PROJECT_STATE §4 R8
+ *
+ * This used to return every row, so the role editor offered `scope: "platform"`
+ * permissions (ADR-0053) to ordinary tenants, and `grantPermissionToRole`
+ * accepted them.
+ *
+ * That was never privilege escalation: the chokepoint's platform gate still
+ * refuses them at runtime, and it decides from a CODE-side declaration, so a
+ * database row cannot lift it. What was missing is redundancy — and honesty. An
+ * administrator could grant one, see it listed on the role, and conclude it
+ * applies. It does not. A grant that appears given but can never take effect is
+ * a wrong answer to "who can do what", which is exactly the answer the next
+ * access review has to trust. ADR-0058 spent a whole document on that class.
+ *
+ * ## Why the question is about the TENANT, not the role
+ *
+ * A first design gave each role a `permission_scope` column. That is a finer
+ * separation — it would let the platform tenant keep some roles that may hold
+ * platform permissions and some that may not — but it is not R8, and it needs a
+ * migration, a new column, and its own enforcement.
+ *
+ * The constraint R8 describes is simpler and already decided: a platform
+ * permission may only ever be EXERCISED by the platform tenant. So the honest
+ * filter is "is the acting tenant the platform tenant", which needs no schema
+ * change at all and is exactly the predicate the runtime gate already applies.
+ * The per-role column stays available for the day least privilege INSIDE the
+ * platform tenant is the question being asked.
  */
 export async function listPermissionCatalog(
-  tx: Bun.SQL
+  tx: Bun.SQL,
+  options: { includePlatformScoped: boolean }
 ): Promise<PermissionCatalogEntry[]> {
-  const rows = (await tx`
-    SELECT id, module_key, activity_code, action, description
-    FROM awcms_permissions
-    ORDER BY module_key, activity_code, action
-  `) as PermissionRow[];
+  const rows = (
+    options.includePlatformScoped
+      ? await tx`
+          SELECT id, module_key, activity_code, action, description
+          FROM awcms_permissions
+          ORDER BY module_key, activity_code, action
+        `
+      : await tx`
+          SELECT id, module_key, activity_code, action, description
+          FROM awcms_permissions
+          WHERE scope = 'tenant'
+          ORDER BY module_key, activity_code, action
+        `
+  ) as PermissionRow[];
 
   return rows.map((row) => ({
     id: row.id,
@@ -398,7 +437,36 @@ export async function restoreRole(
 export type GrantResult =
   | { outcome: "granted" }
   | { outcome: "role_not_found" }
-  | { outcome: "system_blocked" };
+  | { outcome: "system_blocked" }
+  /** The permission is `scope: "platform"` and this is not the platform tenant. */
+  | { outcome: "platform_scope_blocked" };
+
+/**
+ * Whether `tenantId` may hold `permissionId` at all.
+ *
+ * `scope: "tenant"` permissions: always. `scope: "platform"` permissions: only
+ * the platform tenant, which is the same predicate the chokepoint applies at
+ * runtime (ADR-0053). An unknown permission id answers TRUE and falls through
+ * to the INSERT, whose foreign key raises `PermissionNotFoundError` — one place
+ * decides "does this exist", and it is not this function.
+ */
+async function mayTenantHoldPermission(
+  tx: Bun.SQL,
+  tenantId: string,
+  permissionId: string
+): Promise<boolean> {
+  const rows = (await tx`
+    SELECT scope FROM awcms_permissions WHERE id = ${permissionId}
+  `) as { scope: string }[];
+
+  const scope = rows[0]?.scope;
+
+  if (scope !== "platform") return true;
+
+  const platformTenant = await resolvePlatformTenant(tx);
+
+  return platformTenant !== null && platformTenant.tenantId === tenantId;
+}
 
 /**
  * Grants a catalogued permission to a live role.
@@ -423,6 +491,14 @@ export async function grantPermissionToRole(
   const role = await fetchLiveRoleById(tx, tenantId, roleId);
   if (!role) return { outcome: "role_not_found" };
   if (role.isSystem) return { outcome: "system_blocked" };
+
+  // R8, server side. The picker above is a UI; THIS is the control. Filtering a
+  // dropdown stops an accident, not a hand-written request — and the whole point
+  // of the finding is that a grant which can never take effect is a lie in the
+  // access review, however it was made.
+  if (!(await mayTenantHoldPermission(tx, tenantId, permissionId))) {
+    return { outcome: "platform_scope_blocked" };
+  }
 
   try {
     await tx`

--- a/src/pages/admin/roles.astro
+++ b/src/pages/admin/roles.astro
@@ -26,6 +26,7 @@ import {
   listRoles,
   type RoleView
 } from "../../modules/identity-access/application/access-directory";
+import { resolvePlatformTenant } from "../../lib/tenant/platform-tenant";
 import {
   listDeletedRoles,
   listPermissionCatalog,
@@ -69,7 +70,14 @@ if (canRead) {
           deletedRoles: [] as DeletedRoleView[]
         };
       }
-      const catalog = await listPermissionCatalog(tx);
+      // R8 — the picker offers only what this tenant may actually hold. Platform
+      // permissions (ADR-0053) are refused at runtime for everyone else, so
+      // listing them here invites a grant that can never take effect.
+      const platformTenant = await resolvePlatformTenant(tx);
+      const catalog = await listPermissionCatalog(tx, {
+        includePlatformScoped:
+          platformTenant !== null && platformTenant.tenantId === ssr.tenantId
+      });
       const perms: RolePermRow[] = [];
       for (const role of liveRoles) {
         const granted = await listRolePermissions(tx, ssr.tenantId, role.id);

--- a/src/pages/api/v1/roles/[id]/permissions.ts
+++ b/src/pages/api/v1/roles/[id]/permissions.ts
@@ -92,6 +92,17 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
           "System roles have an immutable permission set."
         );
       }
+      // PROJECT_STATE §4 R8. Not an escalation that got through — the runtime
+      // gate (ADR-0053) always refused these. What was missing is that the
+      // grant APPEARED to have been made, which makes the role's permission
+      // list a wrong answer to "who can do what".
+      if (result.outcome === "platform_scope_blocked") {
+        return fail(
+          409,
+          "PLATFORM_SCOPE_REQUIRED",
+          "This permission is platform-scoped and may only be held by the platform tenant."
+        );
+      }
       return ok({ roleId, permissionId: validation.value.permissionId });
     } catch (error) {
       // Caught INSIDE `withTenant`. `DuplicateRolePermissionError` follows the

--- a/tests/role-permission-scope.test.ts
+++ b/tests/role-permission-scope.test.ts
@@ -1,0 +1,101 @@
+/**
+ * PROJECT_STATE §4 **R8** — a platform-scoped permission may not be attached to
+ * an ordinary tenant's role.
+ *
+ * ## What this was, and what it was not
+ *
+ * It was never privilege escalation. The chokepoint's platform gate (ADR-0053)
+ * always refused these at runtime, and it decides from a CODE-side declaration,
+ * so no database row could lift it.
+ *
+ * What was missing is REDUNDANCY, and honesty: an administrator could grant one,
+ * see it listed on the role, and reasonably conclude it applies. A grant that
+ * appears given but can never take effect is a wrong answer to "who can do
+ * what" — the answer the next access review has to trust. ADR-0058 is a whole
+ * document about that class of ambiguity.
+ *
+ * The behavioural half (grant refused with 409 against a real database) is
+ * DB-gated. What is asserted here is that the filter and the server-side
+ * re-check both exist, and that neither was written as a UI-only courtesy.
+ */
+import { describe, expect, test } from "bun:test";
+
+const ROLE_ADMIN = "src/modules/identity-access/application/role-admin.ts";
+const ROLE_PERMISSIONS_ROUTE = "src/pages/api/v1/roles/[id]/permissions.ts";
+const ROLES_SCREEN = "src/pages/admin/roles.astro";
+
+describe("the catalog picker is filtered", () => {
+  test("listPermissionCatalog requires an explicit scope decision", async () => {
+    // Not an optional flag with a permissive default: a caller that forgets it
+    // is a compile error, not a silently widened picker.
+    const source = await Bun.file(ROLE_ADMIN).text();
+
+    expect(source).toContain("includePlatformScoped: boolean");
+    expect(source).toContain("WHERE scope = 'tenant'");
+  });
+
+  test("the screen decides it from the acting tenant, not from a constant", async () => {
+    const source = await Bun.file(ROLES_SCREEN).text();
+
+    expect(source).toContain("resolvePlatformTenant(");
+    expect(source).toContain("includePlatformScoped:");
+  });
+});
+
+describe("the server re-checks — a filtered dropdown is not a control", () => {
+  test("grantPermissionToRole can refuse on scope", async () => {
+    const source = await Bun.file(ROLE_ADMIN).text();
+
+    expect(source).toContain("platform_scope_blocked");
+    expect(source).toContain("mayTenantHoldPermission(");
+  });
+
+  test("the check runs BEFORE the insert, not after", async () => {
+    // After the insert it would be a cleanup, and cleanups leave a window.
+    const source = await Bun.file(ROLE_ADMIN).text();
+    const grantAt = source.indexOf(
+      "export async function grantPermissionToRole"
+    );
+    const body = source.slice(grantAt);
+
+    const check = body.indexOf("mayTenantHoldPermission(");
+    const insert = body.indexOf("INSERT INTO awcms_role_permissions");
+
+    expect(check).toBeGreaterThan(-1);
+    expect(insert).toBeGreaterThan(-1);
+    expect(check).toBeLessThan(insert);
+  });
+
+  test("the refusal reaches the API as a distinct 409, not a generic error", async () => {
+    const source = await Bun.file(ROLE_PERMISSIONS_ROUTE).text();
+
+    expect(source).toContain("platform_scope_blocked");
+    expect(source).toContain("PLATFORM_SCOPE_REQUIRED");
+  });
+});
+
+describe("the predicate is about the TENANT, not the role", () => {
+  test("an unknown permission id falls through to the FK, not to a refusal", async () => {
+    // One place decides "does this permission exist", and it is the foreign
+    // key. A second existence check here would drift from it and would turn a
+    // `PermissionNotFoundError` into a confusing scope refusal.
+    const source = await Bun.file(ROLE_ADMIN).text();
+    const fnAt = source.indexOf("async function mayTenantHoldPermission");
+    const body = source.slice(fnAt, source.indexOf("\n}", fnAt));
+
+    expect(body).toContain('scope !== "platform"');
+    expect(body).toContain("return true");
+  });
+
+  test("a tenant-scoped permission is never blocked", async () => {
+    const source = await Bun.file(ROLE_ADMIN).text();
+    const fnAt = source.indexOf("async function mayTenantHoldPermission");
+    const body = source.slice(fnAt, source.indexOf("\n}", fnAt));
+
+    // The early return for the non-platform case comes before any platform
+    // resolution, so an ordinary grant never pays for the lookup either.
+    expect(body.indexOf('scope !== "platform"')).toBeLessThan(
+      body.indexOf("resolvePlatformTenant(")
+    );
+  });
+});


### PR DESCRIPTION
Menutup #431 dan **PROJECT_STATE §4 R8**. Gelombang 0 (PR 0.8) dari #423.

## Temuan

`listPermissionCatalog` mengembalikan **seluruh** katalog global tanpa predikat `scope`, jadi editor role menawarkan permission ber-`scope: "platform"` (ADR-0053) kepada tenant mana pun — dan `grantPermissionToRole` menerimanya.

## Ini BUKAN privilege escalation, dan itu penting

Gerbang platform di chokepoint **selalu** menolaknya saat runtime, dan ia memutuskan dari deklarasi **sisi kode** — tidak ada baris basis data yang bisa mengangkatnya.

Yang hilang adalah **redundansi**, dan **kejujuran**. Administrator bisa memberikan permission itu, melihatnya tercantum di role, lalu menyimpulkan ia berlaku. Ia tidak. Grant yang **tampak diberikan** tetapi tak akan pernah berlaku adalah jawaban yang salah untuk *"siapa bisa melakukan apa"* — persis jawaban yang harus dipercaya review akses berikutnya. ADR-0058 menghabiskan satu dokumen penuh pada kelas ambiguitas itu.

## Nol migrasi — dan itu koreksi terhadap rancangan saya sendiri

Rencana awal memberi tiap role kolom `permission_scope` + `attachable_scope_types`. Setelah membaca ulang: itu pemisahan yang lebih halus (role mana **di dalam** tenant platform yang boleh memegang permission platform) tetapi **bukan R8**, dan menuntut migrasi, kolom baru, serta penegakannya sendiri.

Batasan yang R8 gambarkan lebih sederhana dan **sudah diputuskan**: permission platform hanya boleh **dijalankan** oleh tenant platform. Filter yang jujur karena itu *"apakah tenant yang bertindak adalah tenant platform"* — **tanpa perubahan skema**, dan persis predikat yang sudah dipakai gerbang runtime.

`attachable_scope_types` sengaja **tidak** didaratkan: ia belum punya apa pun untuk ditegakkan (tabel Policy baru ada di Gelombang 3), dan kolom yang dideklarasikan tanpa penegak adalah kelas cacat yang sama dengan yang PR ini tutup.

## Dua sisi, dan yang kedua yang jadi kontrolnya

- `listPermissionCatalog(tx, { includePlatformScoped })` — **wajib** dinyatakan, bukan flag opsional ber-default permisif: pemanggil yang lupa mendapat **compile error**, bukan picker yang diam-diam melebar.
- `grantPermissionToRole` memeriksa ulang di server → `409 PLATFORM_SCOPE_REQUIRED`. Menyaring dropdown menghentikan **kecelakaan**, bukan permintaan yang ditulis tangan. Satu test mengunci bahwa cek itu ada **sebelum** INSERT, bukan sesudahnya.

Permission id tak dikenal **tidak** ditolak di sini — ia jatuh ke foreign key yang melempar `PermissionNotFoundError`. Satu tempat memutuskan *"apakah ini ada"*, dan bukan fungsi ini.

7 test unit. `bun run check` penuh hijau.

🤖 Generated with [Claude Code](https://claude.com/claude-code)