### PR TITLE
fix(gerbang): `scripts:inventory:check` membandingkan blok, bukan hanya barisnya (#442)

### DIFF
--- a/.changeset/gerbang-inventaris-skrip-membandingkan-blok.md
+++ b/.changeset/gerbang-inventaris-skrip-membandingkan-blok.md
@@ -1,0 +1,31 @@
+---
+"awcms": patch
+---
+
+`scripts:inventory:check` membandingkan SELURUH blok ter-generate, bukan hanya
+baris tabelnya (#442).
+
+`renderInventory()` menulis dua hal: kalimat hitungan dan tabel. Pemeriksanya
+memanggil `parseInventoryBlock()`, yang menyaring `line.startsWith("| \`")` —
+jadi kalimat di atas tabel dihasilkan lalu tidak pernah dibandingkan dengan
+apa pun. `main` hari ini berbunyi "78 target … 32 di antaranya" sementara
+tabelnya memuat 79 baris dan kebenarannya 79/33.
+
+Yang membuat ini layak diperbaiki bukan angkanya, melainkan **siapa yang
+menuliskannya**: git, bukan manusia. #435 dan #440 lahir dari base yang sama,
+masing-masing menambah satu target, jadi keduanya mengubah baris kalimat itu
+menjadi teks yang IDENTIK. Rebase yang kedua di atas yang pertama tidak
+menemukan konflik pada baris yang kedua sisinya sama, menggabungkan baris
+tabel yang berbeda dengan benar, dan menghasilkan blok yang separuhnya benar
+— nol konflik, nol gerbang merah.
+
+Arah itulah temuannya: pemeriksa lama meliputi tepat bagian yang git TIDAK
+BISA salah gabung dan melewatkan bagian yang BISA. Karena itu unit
+pembandingnya kini blok, dinormalisasi hanya terhadap apa yang prettier
+tulis ulang (padding kolom + garis pemisah) — sehingga apa pun yang
+generatornya diajari tulis berikutnya ikut tercakup tanpa ada yang perlu
+mengingatnya.
+
+Buktinya bukan test yang ditulis untuk hijau: gerbang yang sudah diperbaiki
+dijalankan terhadap `main` apa adanya dan MERAH pada cacat yang benar-benar
+ada di sana, lalu hijau setelah regenerasi. Nol perubahan runtime.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ lalu membangun duplikatnya.
 
 <!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-78 target menjalankan berkas di `scripts/`; 32 di antaranya
+79 target menjalankan berkas di `scripts/`; 33 di antaranya
 ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
 terjadwal, atau oleh workflow CI tertentu.
 

--- a/scripts/scripts-inventory.ts
+++ b/scripts/scripts-inventory.ts
@@ -23,13 +23,32 @@
  * A `.generated` artefact WITHOUT that pair is a false claim that reads more
  * authoritative than prose.
  *
- * ## Why the check parses instead of comparing bytes
+ * ## Why the check normalizes instead of comparing bytes
  *
  * Prettier owns markdown formatting here and pads table columns to align them.
  * A byte-for-byte comparison would therefore fail immediately after every
- * `bun run lint`, and the two would fight forever. So the check parses the
- * block back into rows and compares CONTENT — which is the property worth
- * asserting anyway. Padding is not drift.
+ * `bun run lint`, and the two would fight forever. So the check NORMALIZES the
+ * block — dropping exactly what prettier rewrites, which is column padding and
+ * the dashes in the separator row — and compares the rest. Padding is not
+ * drift.
+ *
+ * ## Why it normalizes the WHOLE block and not just the rows
+ *
+ * It used to compare only the rows, and that let the block go half-stale in a
+ * way nobody could see: the counts sentence above the table was generated and
+ * never checked. Issue #442 is how it actually happened, and git wrote it, not
+ * a human. Two PRs branched from the same base, each adding one target; both
+ * regenerated, so both turned `77 … 31` into the IDENTICAL text `78 … 32`.
+ * Rebasing the second onto the first found no conflict on a line where the two
+ * sides agreed, merged the differing table rows into 79, and produced a block
+ * whose table was right and whose sentence was wrong.
+ *
+ * That is the direction worth noticing: the old comparison covered exactly the
+ * part git CANNOT silently merge wrong (differing rows either conflict or union
+ * correctly) and skipped the part it can (identical lines whose meaning
+ * changed). So the unit of comparison is the block, and anything the generator
+ * writes is covered by construction — including whatever it is taught to write
+ * next.
  */
 const README_PATH = "scripts/README.md";
 const BEGIN = "<!-- BEGIN GENERATED: script-inventory -->";
@@ -130,6 +149,31 @@ export function parseInventoryBlock(block: string): InventoryRow[] {
     });
 }
 
+/**
+ * The block reduced to what the generator DECIDED, with what prettier decides
+ * removed: blank lines, column padding, and the separator row whose dashes are
+ * stretched to match the widest cell.
+ *
+ * Everything else survives — so the counts sentence, and any future prose the
+ * generator emits, is compared without anyone having to remember to add it.
+ */
+export function normalizeInventoryBlock(block: string): string {
+  return block
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .filter((line) => !/^\|[\s|:-]+\|$/.test(line))
+    .map((line) =>
+      line.startsWith("|")
+        ? line
+            .split("|")
+            .map((cell) => cell.trim())
+            .join("|")
+        : line
+    )
+    .join("\n");
+}
+
 export function extractInventoryBlock(readme: string): string {
   const begin = readme.indexOf(BEGIN);
   const end = readme.indexOf(END);
@@ -191,13 +235,27 @@ async function main(): Promise<void> {
 
   const failures: string[] = [];
 
-  const present = parseInventoryBlock(extractInventoryBlock(readme));
+  const block = extractInventoryBlock(readme);
+  const present = parseInventoryBlock(block);
   const expected = buildInventory(packageScripts);
 
+  // Baris dulu, karena pesannya bisa menyebut angka yang berguna.
   if (JSON.stringify(present) !== JSON.stringify(expected)) {
     failures.push(
       `${README_PATH} tidak cocok dengan regenerasi segar dari package.json ` +
         `(${present.length} baris tercatat vs ${expected.length} target nyata). ` +
+        "Jalankan `bun run scripts:inventory:generate` dan commit hasilnya."
+    );
+  } else if (
+    normalizeInventoryBlock(block) !== normalizeInventoryBlock(rendered)
+  ) {
+    // Barisnya cocok, bloknya tidak: yang basi ada di LUAR tabel — hari ini
+    // kalimat hitungannya (#442). Pesannya menyebut itu, karena "regenerasi
+    // saja" tanpa menyebut apa yang berbeda adalah cara temuan ini terlewat
+    // pertama kali.
+    failures.push(
+      `${README_PATH}: barisnya cocok tetapi blok ter-generate TIDAK — ` +
+        "yang basi ada di luar tabel (kalimat hitungan di atasnya). " +
         "Jalankan `bun run scripts:inventory:generate` dan commit hasilnya."
     );
   }

--- a/tests/scripts-inventory.test.ts
+++ b/tests/scripts-inventory.test.ts
@@ -1,5 +1,5 @@
 /**
- * `scripts:inventory:check` — the two ways `scripts/README.md` went wrong.
+ * `scripts:inventory:check` — the three ways `scripts/README.md` went wrong.
  *
  * The table it replaces listed 12 of 52 scripts, and its companion "not yet
  * ported" table named fifteen tools that had already landed — several of them
@@ -12,6 +12,10 @@
  *    exist yet, and it does. This is the dangerous direction: a negative claim
  *    gets more wrong with time and never fails on its own, so a reader
  *    concludes `db:work-class:check` still needs building and builds a second.
+ * 3. **Half-stale generation** (#442) — the table is right and the counts
+ *    sentence above it is not. Nobody typed that; two rebased branches wrote
+ *    the identical sentence from different bases and git merged only the rows.
+ *    The old check compared rows, so it had nothing to say.
  *
  * Every case plants a violation.
  */
@@ -21,6 +25,7 @@ import {
   buildInventory,
   extractInventoryBlock,
   findFalseAbsenceClaims,
+  normalizeInventoryBlock,
   parseInventoryBlock,
   readPackageScripts,
   renderInventory,
@@ -113,6 +118,58 @@ describe("the generated block", () => {
   });
 });
 
+describe("the counts sentence is compared too (#442)", () => {
+  // The rows-only comparison covered exactly what git cannot silently merge
+  // wrong and skipped what it can. Every case here plants the drift that
+  // actually shipped: a table that is right above a sentence that is not.
+  const rendered = renderInventory(buildInventory(SCRIPTS));
+
+  test("a mutation of ONLY the counts sentence is drift", () => {
+    const mutated = rendered.replace(
+      "2 target menjalankan",
+      "1 target menjalankan"
+    );
+
+    expect(mutated).not.toBe(rendered);
+    // The rows are untouched, so the old comparison had nothing to say.
+    expect(parseInventoryBlock(mutated)).toEqual(parseInventoryBlock(rendered));
+    expect(normalizeInventoryBlock(mutated)).not.toBe(
+      normalizeInventoryBlock(rendered)
+    );
+  });
+
+  test("a mutation of ONLY the gated count is drift", () => {
+    const mutated = rendered.replace("; 1 di antaranya", "; 0 di antaranya");
+
+    expect(mutated).not.toBe(rendered);
+    expect(parseInventoryBlock(mutated)).toEqual(parseInventoryBlock(rendered));
+    expect(normalizeInventoryBlock(mutated)).not.toBe(
+      normalizeInventoryBlock(rendered)
+    );
+  });
+
+  test("what prettier rewrites is still not drift", () => {
+    // Padding and the stretched separator dashes must survive normalization,
+    // or the gate fights `bun run lint` forever — the reason it parsed in the
+    // first place.
+    const padded = rendered
+      .replace("| Target | Skrip | Gate |", "| Target      | Skrip | Gate |")
+      .replace("| ------ | ----- | ---- |", "| ----------- | ----- | ---- |")
+      .replace("| `db:migrate` |", "| `db:migrate`  |");
+
+    expect(padded).not.toBe(rendered);
+    expect(normalizeInventoryBlock(padded)).toBe(
+      normalizeInventoryBlock(rendered)
+    );
+  });
+
+  test("a blank line added by an editor is not drift either", () => {
+    expect(normalizeInventoryBlock(`${rendered}\n\n`)).toBe(
+      normalizeInventoryBlock(rendered)
+    );
+  });
+});
+
 describe("findFalseAbsenceClaims", () => {
   test("flags the defect this gate exists for: a shipped tool listed as not-yet-ported", () => {
     const readme = [
@@ -190,6 +247,34 @@ describe("the real repository", () => {
     for (const row of rows) {
       expect(listed.has(row.target)).toBe(true);
     }
+  });
+
+  test("the counts sentence states the truth, not a remembered number", async () => {
+    // Derived here from package.json rather than from renderInventory, so the
+    // assertion survives the generator and the checker being wrong together.
+    const readme = await Bun.file("scripts/README.md").text();
+    const scripts = await readPackageScripts();
+    const targets = Object.entries(scripts).filter(([, command]) =>
+      /scripts\//.test(command)
+    );
+    const chain = (scripts.check ?? "")
+      .split("&&")
+      .map((segment) => segment.trim().replace(/^bun run /, ""));
+    const gated = targets.filter(([target]) => chain.includes(target));
+
+    expect(extractInventoryBlock(readme)).toContain(
+      `${targets.length} target menjalankan berkas di \`scripts/\`; ${gated.length} di antaranya`
+    );
+  });
+
+  test("the whole generated block matches a fresh render, not only its rows", async () => {
+    const readme = await Bun.file("scripts/README.md").text();
+
+    expect(normalizeInventoryBlock(extractInventoryBlock(readme))).toBe(
+      normalizeInventoryBlock(
+        renderInventory(buildInventory(await readPackageScripts()))
+      )
+    );
   });
 
   test("is wired into `bun run check`", async () => {


### PR DESCRIPTION
Menutup #442.

## Apa yang salah

`renderInventory()` menulis **dua** hal ke dalam blok ter-generate: kalimat
hitungan dan tabelnya. Pemeriksanya memanggil `parseInventoryBlock()`, yang
menyaring ``line.startsWith("| `")`` — jadi ia membandingkan **tabelnya saja**.
Kalimat di atas tabel dihasilkan lalu tidak pernah dibandingkan dengan apa pun.

`main` sebelum PR ini berbunyi `78 target … 32 di antaranya` sementara tabel di
bawahnya memuat **79** baris. Kebenarannya 79/33.

## Kenapa ini layak satu PR

Bukan karena angkanya. Karena **git yang menuliskannya, bukan manusia.**

#435 dan #440 lahir dari base yang sama dan masing-masing menambah satu target.
Keduanya meregenerasi blok, jadi keduanya mengubah baris kalimat dari `77 … 31`
menjadi teks yang **identik**: `78 … 32`. Saat yang kedua di-rebase di atas yang
pertama, git tidak melihat konflik pada baris yang kedua sisinya sama,
menggabungkan baris tabel yang berbeda dengan benar, dan menghasilkan blok yang
separuhnya benar — nol konflik, nol gerbang merah.

Itu arah yang penting: pemeriksa lama meliputi tepat bagian yang git **tidak
bisa** salah gabung dan melewatkan bagian yang **bisa**. Jadi unit
pembandingnya kini blok, dan apa pun yang generatornya diajari tulis berikutnya
ikut tercakup tanpa ada yang perlu mengingatnya.

## Bukti — bukan test yang ditulis untuk hijau

Gerbang yang sudah diperbaiki dijalankan terhadap `main` **apa adanya**:

```
$ bun run scripts:inventory:check
scripts/README.md: barisnya cocok tetapi blok ter-generate TIDAK — yang basi
ada di luar tabel (kalimat hitungan di atasnya). Jalankan
`bun run scripts:inventory:generate` dan commit hasilnya.
EXIT=1
```

lalu hijau setelah regenerasi. Cacat yang dipakai membuktikannya adalah cacat
**asli** yang ada di repo, bukan yang ditanam untuk keperluan test.

Empat test mutasi menahannya: mengubah **hanya** angka pertama, **hanya** angka
kedua — keduanya meninggalkan baris tabel identik, jadi pemeriksa lama diam —
sementara padding prettier dan baris kosong tetap **bukan** drift. Satu test
lagi menurunkan kedua angka dari `package.json` sendiri, supaya asersinya
selamat bila generator dan pemeriksanya salah bersamaan.

## Batasnya, dinyatakan

Normalisasi membuang tepat apa yang prettier tulis ulang: padding kolom dan
garis pemisah yang direntangkan. Alasan pemeriksa lama mem-parsing alih-alih
membandingkan byte tetap berlaku dan ditulis ulang di docblock — gerbang yang
berkelahi dengan `bun run lint` selamanya tidak berguna.

Ini **tidak** menutup R9 secara umum. Empat gerbang lain yang menjanjikan
cakupan yang tak mereka periksa masih berdiri, dan #437 masih terbuka.

Nol migrasi, nol perubahan runtime. `bun run check` penuh hijau (37 segmen).

Bagian dari #423 (Gelombang 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)