### PR TITLE
feat(gerbang,auth): `access:chokepoint:check` mendapat root kedua — layar admin (#450, R3)

### DIFF
--- a/.changeset/gerbang-chokepoint-layar-admin.md
+++ b/.changeset/gerbang-chokepoint-layar-admin.md
@@ -1,0 +1,38 @@
+---
+"awcms": patch
+---
+
+`access:chokepoint:check` mendapat root kedua — layar admin — plus
+`loadAdminScreen` dan ledger migrasi satu-arah (#450, PROJECT_STATE §4 R3).
+
+Ke-32 layar `src/pages/admin/**/*.astro` memutuskan apa yang dirender dari
+`ssr.permissions.has(...)`, yaitu `fetchGrantedPermissionKeys` — **RBAC mentah**.
+Jalur itu melewati `authorizeInTransaction`, jadi ia melewati semua yang hanya
+ada di sana: policy `deny` ABAC yang ditulis tenant (ditegakkan di API, **inert
+di layar**), `resolveModuleAvailability` (tenant yang mematikan modulnya tetap
+melihat layarnya berisi data), fakta business-scope, SoD action-time, dan
+`recordDecisionLog` — sehingga sebuah pembacaan yang terjadi tidak meninggalkan
+satu baris pun yang mengatakannya. Yang **tidak** hilang, supaya temuannya tidak
+dibesar-besarkan: RBAC dasar tetap ditegakkan dan tidak pernah ada kebocoran
+lintas-tenant — `withTenantOrThrow` + FORCE RLS selalu ada di jalur itu.
+
+`loadAdminScreen` membuka SATU transaksi, memanggil chokepoint, lalu menjalankan
+`load` **di dalam transaksi yang sama**. Deny me-render state ditolak, bukan
+redirect. Refusal pool/circuit-breaker adalah state KETIGA — sebuah penolakan
+yang dirender sebagai "Anda tidak boleh melihat ini" adalah kebohongan ke arah
+yang diselidiki sebagai bug perizinan.
+
+Gerbangnya tetap SATU skrip: dua skrip berarti dua daftar pengecualian yang
+menyimpang, dan yang kedua selalu jadi yang longgar. Kedua root hanya berbeda di
+dua tempat — cara berkas diiris (`.astro` per-BERKAS: satu berkas = satu jalur
+render) dan apa yang dihitung sebagai memutuskan (`.permissions.has(`).
+
+`form-drafts.astro` ikut dimigrasikan supaya mekanismenya **dibuktikan**, bukan
+sekadar disediakan; ledger mendarat berisi 31, bukan 32.
+
+Dua koreksi yang muncul saat membangunnya: `stripComments` ditambahkan setelah
+sinyalnya cocok dengan komentar layar yang baru dimigrasikan yang menjelaskan
+bahwa ia TIDAK lagi memakai `ssr.permissions.has()`; dan `extractScreenClaims`
+menemukan bahwa `visitor_analytics.raw_detail.read` sudah lama diklaim layar
+`analytics.astro` lewat evaluator ABAC — satu baris `NOT_YET_SCREENED` yang basi
+sejak sebelum PR ini.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (22.664 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (22.671 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -2,7 +2,14 @@
  * access-chokepoint-check.ts — `bun run access:chokepoint:check`.
  *
  * Every handler that decides a tenant permission must decide it at the
- * chokepoint. Pure: no database, no network.
+ * chokepoint — across TWO roots since #450: `src/pages/api/v1` (route modules)
+ * and `src/pages/admin` (SSR screens). Pure: no database, no network.
+ *
+ * One script, not two, and that is the load-bearing choice: two scripts means
+ * two exemption lists that drift, and the second one always ends up the lenient
+ * one. The roots differ in exactly two places — how a file is sliced, and what
+ * counts as deciding — and both are written down at `sliceHandlers` and
+ * `sliceScreen` respectively.
  *
  * ## The defect this exists for
  *
@@ -46,6 +53,7 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 
 const ROUTES_ROOT = "src/pages/api/v1";
+const SCREENS_ROOT = "src/pages/admin";
 
 /**
  * Handlers allowed to decide access without the chokepoint, with the reason.
@@ -59,6 +67,79 @@ const CHOKEPOINT_EXEMPTIONS: Readonly<Record<string, string>> = {
   "access/evaluate.ts#POST":
     "self-introspection: reflects what `evaluateAccess` would decide for the CALLER'S OWN request and calls that same evaluator directly, so ABAC is applied rather than skipped. It requires a session but deliberately no specific permission."
 };
+
+/**
+ * Admin screens that still decide from `ssr.permissions.has(...)` — R3, issue
+ * #450. **May only shrink.**
+ *
+ * Seeded with the 31 screens that were unmigrated when the second root landed
+ * (32 minus `form-drafts.astro`, migrated in the same PR so the mechanism is
+ * proven rather than merely provided). An entry whose screen no longer
+ * bypasses is an error, not a tolerated leftover, so the list cannot rot into
+ * an off-switch.
+ *
+ * Unlike `CHOKEPOINT_EXEMPTIONS` these carry no per-entry reason, and the
+ * difference is deliberate: an exemption is a decision that this handler is
+ * RIGHT to bypass, while these are debt that is WRONG and scheduled. Giving
+ * each a sentence would dress 31 open defects as 31 decisions.
+ */
+const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
+  "abac-policies.astro",
+  "analytics.astro",
+  "approvals.astro",
+  "audit-trail.astro",
+  "blog-pages.astro",
+  "blog-presentation.astro",
+  "blog-settings.astro",
+  "blog-taxonomy.astro",
+  "blog.astro",
+  "comments.astro",
+  "data-lifecycle.astro",
+  "domain-events.astro",
+  "email-templates.astro",
+  "idn-regions.astro",
+  "index.astro",
+  "media.astro",
+  "modules.astro",
+  "offices.astro",
+  "profiles.astro",
+  "registrations.astro",
+  "reporting.astro",
+  "roles.astro",
+  "security.astro",
+  "seo.astro",
+  "sidebar-menu.astro",
+  "site-search.astro",
+  "sync.astro",
+  "tenant/domains.astro",
+  "tenants.astro",
+  "theming.astro",
+  "users.astro"
+];
+
+/**
+ * Drops block comments and whole-line `//` comments before matching.
+ *
+ * Not hygiene — a correctness fix caught on this gate's first run against the
+ * screen root. `form-drafts.astro` was migrated and then explained itself with
+ * "the decision is the chokepoint's, not `ssr.permissions.has()`", so the
+ * signal matched the sentence saying the code no longer does it. This repo has
+ * hit the same shape three times (`table-write-ownership-check` reporting
+ * itself, and PR #404's mutation probe matching its own comment), and it is
+ * always the FIX that plants the false positive, because a fix explains what it
+ * removed.
+ *
+ * Trailing `// ...` after code is left alone on purpose: stripping it would
+ * truncate any line containing `https://`, trading a false positive for a false
+ * negative.
+ */
+export function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((line) => !/^\s*(?:\/\/|\*)/.test(line))
+    .join("\n");
+}
 
 export type ChokepointProblem = { handler: string; message: string };
 
@@ -76,16 +157,17 @@ export function sliceHandlers(
 ): HandlerSlice[] {
   // `defineTenantRoute` wraps at module scope and calls the chokepoint itself,
   // so it covers every handler the file exports.
-  const fileWideChokepoint = /defineTenantRoute\(/.test(source);
+  const code = stripComments(source);
+  const fileWideChokepoint = /defineTenantRoute\(/.test(code);
 
   const marks = [
-    ...source.matchAll(/^export const (GET|POST|PATCH|PUT|DELETE)\b/gm)
+    ...code.matchAll(/^export const (GET|POST|PATCH|PUT|DELETE)\b/gm)
   ].map((match) => ({ method: match[1]!, index: match.index! }));
 
   return marks.map((mark, position) => {
     const end =
-      position + 1 < marks.length ? marks[position + 1]!.index : source.length;
-    const body = source.slice(mark.index, end);
+      position + 1 < marks.length ? marks[position + 1]!.index : code.length;
+    const body = code.slice(mark.index, end);
 
     return {
       id: `${relativeFile}#${mark.method}`,
@@ -96,26 +178,75 @@ export function sliceHandlers(
   });
 }
 
+/**
+ * An admin screen, classified — one slice per FILE, and that is not a shortcut.
+ *
+ * A route module exports several handlers that are separately reachable, which
+ * is why routes are split on `export const <METHOD>` (ADR-0063 §3, and the
+ * defect that prompted it: one file where `GET` and `DELETE` used the
+ * chokepoint and `PATCH` did not). An `.astro` page has ONE render path — the
+ * frontmatter runs top to bottom for every request — so the file IS the unit.
+ * Slicing it further would invent boundaries the runtime does not have.
+ *
+ * The signal differs from the routes' for the same reason the defect differs.
+ * A route decides by calling `fetchGrantedPermissionKeys`; a screen decides by
+ * reading the set that call already produced, handed to it as
+ * `Astro.locals.ssrContext`. So `.permissions.has(` is the screen-side
+ * equivalent, and it is just as narrow: it is the act of consulting raw RBAC,
+ * not an attempt to read intent from prose.
+ */
+export function sliceScreen(
+  relativeFile: string,
+  source: string
+): HandlerSlice {
+  const code = stripComments(source);
+
+  return {
+    // No prefix: a route id always contains `#<METHOD>` and a screen id always
+    // ends `.astro`, so the two namespaces cannot collide and the ledger below
+    // needs no second spelling of the same path.
+    id: relativeFile,
+    decidesPermissions: /\.permissions\.has\(/.test(code),
+    // `loadAdminScreen` opens the transaction and calls the chokepoint itself,
+    // so its presence covers the file — the same reasoning `defineTenantRoute`
+    // gets above. A screen that calls `authorizeInTransaction` by hand is
+    // covered too; it did the work, just without the helper.
+    usesChokepoint:
+      /loadAdminScreen\(/.test(code) || /authorizeInTransaction\(/.test(code)
+  };
+}
+
 /** The rule, over already-classified handlers. */
 export function findChokepointBypasses(
   handlers: readonly HandlerSlice[],
-  exemptions: Readonly<Record<string, string>> = CHOKEPOINT_EXEMPTIONS
+  exemptions: Readonly<Record<string, string>> = CHOKEPOINT_EXEMPTIONS,
+  ledger: readonly string[] = ADMIN_SCREEN_CHOKEPOINT_MIGRATION
 ): ChokepointProblem[] {
+  const scheduled = new Set(ledger);
+
   return handlers
     .filter(
       (handler) =>
         handler.decidesPermissions &&
         !handler.usesChokepoint &&
-        !(handler.id in exemptions)
+        !(handler.id in exemptions) &&
+        !scheduled.has(handler.id)
     )
     .map((handler) => ({
       handler: handler.id,
-      message:
-        "decides a permission (`fetchGrantedPermissionKeys`) without going through " +
-        "`authorizeInTransaction`/`defineTenantRoute`, so ABAC policy, the platform-scope " +
-        "gate, business-scope facts and SoD are all skipped for it. If the access rule is " +
-        "an ownership axis the catalogue cannot express, pass it as `ownershipGrant` " +
-        "(ADR-0063) instead of deciding outside the chokepoint."
+      // The two roots lose the same four things, but a reader fixing one is not
+      // reading about the other: naming a route mechanism in a screen finding
+      // sends them looking for an `export const GET` that is not there.
+      message: handler.id.endsWith(".astro")
+        ? "decides a permission from `ssr.permissions.has(...)` — raw RBAC — so ABAC " +
+          "policy, module availability, business-scope facts, SoD and the decision log " +
+          "are all skipped for it (R3, #450). Route it through `loadAdminScreen`, which " +
+          "decides and reads in one transaction."
+        : "decides a permission (`fetchGrantedPermissionKeys`) without going through " +
+          "`authorizeInTransaction`/`defineTenantRoute`, so ABAC policy, the platform-scope " +
+          "gate, business-scope facts and SoD are all skipped for it. If the access rule is " +
+          "an ownership axis the catalogue cannot express, pass it as `ownershipGrant` " +
+          "(ADR-0063) instead of deciding outside the chokepoint."
     }));
 }
 
@@ -153,6 +284,76 @@ export function findStaleExemptions(
   });
 }
 
+/**
+ * A ledger entry that no longer bypasses — or no longer exists — is reported,
+ * so the list can only ever shrink.
+ *
+ * This is the half that stops a one-way list becoming a one-way ratchet in the
+ * wrong direction: without it, a screen could be migrated and its line left
+ * behind, and the next screen to regress would land on a line that already
+ * excused it.
+ */
+export function findStaleLedgerEntries(
+  handlers: readonly HandlerSlice[],
+  ledger: readonly string[] = ADMIN_SCREEN_CHOKEPOINT_MIGRATION
+): ChokepointProblem[] {
+  const byId = new Map(handlers.map((handler) => [handler.id, handler]));
+
+  return ledger.flatMap((id) => {
+    const handler = byId.get(id);
+
+    if (!handler) {
+      return [
+        {
+          handler: id,
+          message:
+            "is on ADMIN_SCREEN_CHOKEPOINT_MIGRATION but no longer exists — remove the line."
+        }
+      ];
+    }
+
+    if (!handler.decidesPermissions || handler.usesChokepoint) {
+      return [
+        {
+          handler: id,
+          message:
+            "is on ADMIN_SCREEN_CHOKEPOINT_MIGRATION but no longer bypasses the chokepoint. Delete the line in the same PR: the ledger only ever shrinks, and that is the only thing that makes its length mean something."
+        }
+      ];
+    }
+
+    return [];
+  });
+}
+
+async function collectScreens(): Promise<HandlerSlice[]> {
+  const screens: HandlerSlice[] = [];
+
+  async function walk(dir: string): Promise<void> {
+    for (const entry of await readdir(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+
+      if (!entry.name.endsWith(".astro")) continue;
+
+      screens.push(
+        sliceScreen(
+          path.relative(SCREENS_ROOT, full),
+          await readFile(full, "utf8")
+        )
+      );
+    }
+  }
+
+  await walk(SCREENS_ROOT);
+
+  return screens;
+}
+
 async function collectHandlers(): Promise<HandlerSlice[]> {
   const handlers: HandlerSlice[] = [];
 
@@ -184,10 +385,13 @@ async function collectHandlers(): Promise<HandlerSlice[]> {
 }
 
 async function main(): Promise<void> {
-  const handlers = await collectHandlers();
+  const routes = await collectHandlers();
+  const screens = await collectScreens();
+  const handlers = [...routes, ...screens];
   const problems = [
     ...findChokepointBypasses(handlers),
-    ...findStaleExemptions(handlers)
+    ...findStaleExemptions(routes),
+    ...findStaleLedgerEntries(screens)
   ];
 
   if (problems.length > 0) {
@@ -201,7 +405,8 @@ async function main(): Promise<void> {
     return;
   }
 
-  const deciding = handlers.filter((handler) => handler.decidesPermissions);
+  const deciding = routes.filter((handler) => handler.decidesPermissions);
+  const decidingScreens = screens.filter((screen) => screen.decidesPermissions);
 
   // Issue #425 — the self-test.
   //
@@ -229,10 +434,32 @@ async function main(): Promise<void> {
     return;
   }
 
+  // The same self-test for the screen root, and it is not symmetry for its own
+  // sake: `.permissions.has(` is a shape, not an identifier, so it cannot be
+  // caught by a rename — it disappears when the LAST screen is migrated, and at
+  // that moment the ledger is empty too. Until then, zero deciding screens with
+  // a non-empty ledger means the detector broke.
+  if (
+    decidingScreens.length === 0 &&
+    ADMIN_SCREEN_CHOKEPOINT_MIGRATION.length > 0
+  ) {
+    console.error(
+      "access:chokepoint:check FAILED — 0 admin screens were classified as deciding a " +
+        `permission while ${ADMIN_SCREEN_CHOKEPOINT_MIGRATION.length} are still on the ` +
+        "migration ledger. The signal `.permissions.has(` stopped matching under " +
+        `${SCREENS_ROOT}; fix \`sliceScreen\` rather than the ledger.`
+    );
+
+    process.exitCode = 1;
+    return;
+  }
+
   console.log(
-    `access:chokepoint:check OK — ${handlers.length} handlers, ` +
+    `access:chokepoint:check OK — ${routes.length} route handlers, ` +
       `${deciding.length} decide permissions, ` +
-      `${Object.keys(CHOKEPOINT_EXEMPTIONS).length} reasoned exemption(s).`
+      `${Object.keys(CHOKEPOINT_EXEMPTIONS).length} reasoned exemption(s); ` +
+      `${screens.length} admin screens, ${decidingScreens.length} still decide ` +
+      `outside the chokepoint (ledger: ${ADMIN_SCREEN_CHOKEPOINT_MIGRATION.length}, may only shrink).`
   );
 }
 

--- a/scripts/admin-screen-coverage-check.ts
+++ b/scripts/admin-screen-coverage-check.ts
@@ -138,6 +138,20 @@ export function extractScreenClaims(source: string): Set<string> {
     claims.add(`${match[1]}.${match[2]}.${match[3]}`);
   }
 
+  // Issue #450 — a screen routed through `loadAdminScreen` states its guard as
+  // an `AccessRequest` object literal, the same shape the routes use, in both
+  // `authorize:` and the `can({...})` calls that decide its affordances.
+  //
+  // Without this the migration would collapse 133 permission claims one screen
+  // at a time and turn `admin:screen-coverage:check` red for the wrong reason:
+  // it would report a missing SCREEN for a permission whose screen exists and
+  // now gates on it more strictly than before.
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)"\s*,\s*activityCode:\s*"([a-z_]+)"\s*,\s*(?:\/\/[^\n]*\n\s*)*action:\s*"([a-z_]+)"/g
+  )) {
+    claims.add(`${match[1]}.${match[2]}.${match[3]}`);
+  }
+
   for (const helper of source.matchAll(
     /const\s+([A-Za-z_$][\w$]*)\s*=\s*\(\s*([A-Za-z_$][\w$]*)\s*(?::[^,)]+)?,\s*([A-Za-z_$][\w$]*)\s*(?::[^,)]+)?\)[^=]*=>[\s\S]{0,200}?permissionKey\(\s*"([a-z_]+)"\s*,\s*\2\s*,\s*\3\s*\)/g
   )) {

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -103,9 +103,8 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "tenant_admin.tenant_settings.read",
   "tenant_admin.tenant_settings.update",
 
-  // visitor_analytics (5)
+  // visitor_analytics (4)
   "visitor_analytics.events.read",
-  "visitor_analytics.raw_detail.read",
   "visitor_analytics.retention.purge",
   "visitor_analytics.settings.read",
   "visitor_analytics.settings.update"

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -123,7 +123,6 @@ const NOT_YET_MIGRATED: readonly string[] = [
   "src/pages/admin/data-lifecycle.astro",
   "src/pages/admin/domain-events.astro",
   "src/pages/admin/email-templates.astro",
-  "src/pages/admin/form-drafts.astro",
   "src/pages/admin/idn-regions.astro",
   "src/pages/admin/index.astro",
   "src/pages/admin/media.astro",

--- a/src/lib/auth/admin-screen.ts
+++ b/src/lib/auth/admin-screen.ts
@@ -1,0 +1,184 @@
+/**
+ * `loadAdminScreen` (issue #450, PROJECT_STATE §4 R3) — the one place an admin
+ * screen's access decision and its data read happen, in that order, inside one
+ * transaction.
+ *
+ * ## The defect
+ *
+ * All 32 `src/pages/admin/**\/*.astro` files decided what to render from
+ * `ssr.permissions.has(...)`. That set is `fetchGrantedPermissionKeys` — raw
+ * RBAC. It skips `authorizeInTransaction`, and therefore skips everything that
+ * only exists there: ABAC policy evaluation (a tenant's `deny` written through
+ * `/api/v1/access/policies` was enforced on the API and inert on the screen),
+ * `resolveModuleAvailability` (a tenant that disabled a module still saw its
+ * screen full of data), business-scope facts, action-time SoD, and
+ * `recordDecisionLog` — so a read that happened left no row saying it did.
+ *
+ * What was NOT lost, stated so the finding is not inflated: basic RBAC still
+ * held, and there was never cross-tenant leakage — `withTenantOrThrow` and
+ * FORCE RLS were always in the path.
+ *
+ * ## Why it must be fixed before scoped grants (Gelombang 3)
+ *
+ * Today `ssr.permissions` answers "is this key granted anywhere". Once a grant
+ * carries its own scope, that stops meaning "may read THIS", and R3 turns from
+ * a missing policy layer into real read-side over-disclosure.
+ *
+ * ## Why this EXECUTES instead of returning a wrapper
+ *
+ * `defineTenantRoute` returns an `APIRoute` because a route module exports a
+ * handler that something else calls. An `.astro` frontmatter has no handler to
+ * wrap — it is a script that runs top-to-bottom — so the honest shape is a
+ * function the page awaits. The program plan called this `defineAdminScreen`;
+ * the name changed rather than the shape being bent to fit it.
+ *
+ * ## One transaction, and the order inside it
+ *
+ * `authorizeInTransaction` and `load` share one `tx`. Splitting them would mean
+ * deciding against one snapshot and reading against another — and once grants
+ * carry scope, the scope filter a decision computed could be applied to rows
+ * fetched under a different one. It is also the same connection discipline
+ * `defineTenantRoute` documents: `tx` is ONE reserved connection, so `load`
+ * must `await` in sequence and never `Promise.all` over it.
+ *
+ * ## Deny RENDERS, it does not redirect
+ *
+ * Over twenty `tests/admin-*-page-contract.test.ts` assert a denied element id
+ * (`#users-denied`, `#form-drafts-denied`, …). A redirect would also hand a
+ * tenant that authored a `deny` policy a login loop instead of a refusal. So
+ * the outcome is data for the template, never a `Response`.
+ *
+ * ## `error` is a THIRD state, never a denial
+ *
+ * `withTenantOrThrow` throws when the pool or circuit breaker refuses. A
+ * refusal rendered as "you may not see this" is a lie in the direction that
+ * gets investigated as a permissions bug; rendered as "there are no rows" it is
+ * worse. Screens already distinguish this (`loadError`), and the type keeps
+ * them honest by making the three outcomes mutually exclusive.
+ */
+import type { WorkClass } from "../database/work-class";
+import { getDatabaseClient } from "../database/client";
+import { withTenantOrThrow } from "../database/tenant-context";
+import {
+  authorizeInTransaction,
+  type AuthorizeResult
+} from "../../modules/identity-access/application/access-guard";
+import type { AccessRequest } from "../../modules/identity-access/domain/access-control";
+import type { BusinessScopeHierarchyPort } from "../../modules/_shared/ports/business-scope-hierarchy-port";
+import type { SoDRuleDescriptor } from "../../modules/_shared/module-contract";
+import type { SsrContext } from "./ssr-session";
+
+/** The `allowed: true` half, so `auth.context.tenantUserId` reads as in a route. */
+export type AuthorizedScreenAccess = Extract<
+  AuthorizeResult,
+  { allowed: true }
+>;
+
+export type AdminScreenLoadContext = {
+  tx: Bun.TransactionSQL;
+  auth: AuthorizedScreenAccess;
+  /**
+   * A SECOND decision, for the affordances a screen shows or hides (a create
+   * form, a delete button) once the entry decision has allowed the page.
+   *
+   * It runs the full chokepoint on the same transaction, so a `deny` policy
+   * hides the button rather than merely failing when it is pressed. These
+   * remain UX-only in the sense that matters — the endpoint behind the button
+   * is still the authority — but "UX-only" is no longer an excuse for the
+   * affordance to be decided by a different rule than the endpoint uses.
+   */
+  can: (request: AccessRequest) => Promise<boolean>;
+};
+
+export type AdminScreenOutcome<TData> =
+  | { state: "allowed"; data: TData; auth: AuthorizedScreenAccess }
+  /**
+   * The chokepoint refused. `status` is the decision's own — 403 for a policy
+   * refusal, and NOT flattened, because a screen that wants to say something
+   * more specific later should not have to re-derive it.
+   */
+  | { state: "denied"; status: number }
+  /** The transaction never ran, or `load` threw. NOT a denial. */
+  | { state: "error" };
+
+export type AdminScreenConfig<TData> = {
+  /** The resolved session. `null` cannot happen behind the SSR guard, but see below. */
+  ssr: SsrContext;
+  /**
+   * REQUIRED, no default — the same reasoning `defineTenantRoute` writes down.
+   * Screens are `"interactive"` unless they run a genuinely heavy report.
+   */
+  workClass: WorkClass;
+  queueTimeoutMs?: number;
+  /** The screen's ENTRY permission: what it takes to see the page at all. */
+  authorize: AccessRequest;
+  authorizeOptions?: {
+    hierarchyPort?: BusinessScopeHierarchyPort;
+    sodRules?: readonly SoDRuleDescriptor[];
+  };
+  /** Runs inside the same transaction, only when access was ALLOWED. */
+  load: (context: AdminScreenLoadContext) => Promise<TData>;
+  /**
+   * Called with whatever was thrown, before `{ state: "error" }` is returned.
+   * Logging stays with the screen so `logAdminPageError`'s message names the
+   * page and carries its correlation id.
+   */
+  onError: (error: unknown) => void;
+  /** Injectable for tests. Defaults to the process-wide pool. */
+  sql?: Bun.SQL;
+  /** One clock for the whole render. */
+  now?: Date;
+};
+
+export async function loadAdminScreen<TData>(
+  config: AdminScreenConfig<TData>
+): Promise<AdminScreenOutcome<TData>> {
+  const now = config.now ?? new Date();
+  const sql = config.sql ?? getDatabaseClient();
+
+  try {
+    return await withTenantOrThrow(
+      sql,
+      config.ssr.tenantId,
+      async (tx): Promise<AdminScreenOutcome<TData>> => {
+        const auth = await authorizeInTransaction(
+          tx,
+          config.ssr.tenantId,
+          config.ssr.tokenHash,
+          now,
+          config.authorize,
+          config.authorizeOptions
+        );
+
+        if (!auth.allowed) {
+          // The refusal is already recorded — `authorizeInTransaction` writes
+          // the decision log itself, which is most of the point of routing
+          // screens through it. Nothing is re-derived here.
+          return { state: "denied", status: auth.denied.status };
+        }
+
+        const can = async (request: AccessRequest): Promise<boolean> => {
+          const secondary = await authorizeInTransaction(
+            tx,
+            config.ssr.tenantId,
+            config.ssr.tokenHash,
+            now,
+            request,
+            config.authorizeOptions
+          );
+
+          return secondary.allowed;
+        };
+
+        const data = await config.load({ tx, auth, can });
+
+        return { state: "allowed", data, auth };
+      },
+      { workClass: config.workClass, queueTimeoutMs: config.queueTimeoutMs }
+    );
+  } catch (error) {
+    config.onError(error);
+
+    return { state: "error" };
+  }
+}

--- a/src/lib/auth/ssr-session.ts
+++ b/src/lib/auth/ssr-session.ts
@@ -18,6 +18,16 @@ export type SsrContext = {
   identityId: string;
   roles: string[];
   permissions: Set<string>;
+  /**
+   * The session token's namespaced hash — the SAME value the API routes hand
+   * to `authorizeInTransaction` (ADR-0049 carries the bearer's KIND in the
+   * namespace, so nothing downstream has to be told which table to consult).
+   *
+   * Carried so an admin screen can reach the chokepoint at all (#450). It is
+   * the stored form, never the cookie value, and it never leaves the server:
+   * `Astro.locals` is not serialised into the rendered page.
+   */
+  tokenHash: string;
 };
 
 /**
@@ -74,7 +84,8 @@ export async function resolveSsrContext(
         tenantUserId: context.tenantUserId,
         identityId: context.identityId,
         roles: context.roles,
-        permissions
+        permissions,
+        tokenHash
       };
     });
 

--- a/src/pages/admin/form-drafts.astro
+++ b/src/pages/admin/form-drafts.astro
@@ -39,22 +39,14 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listFormDrafts,
   type FormDraftView
 } from "../../modules/form-drafts/application/form-draft-directory";
 
 const ssr = Astro.locals.ssrContext!;
-const canRead = ssr.permissions.has(
-  permissionKey("form_drafts", "draft", "read")
-);
-const canDelete = ssr.permissions.has(
-  permissionKey("form_drafts", "draft", "delete")
-);
 
 /** Mirrors `VALID_STATUSES` in `src/pages/api/v1/form-drafts/index.ts`. */
 const STATUS_OPTIONS = ["draft", "submitted", "abandoned", "expired"] as const;
@@ -83,30 +75,45 @@ const STATUS_VARIANT: Record<DraftStatus, string> = {
   expired: "warning"
 };
 
-let drafts: FormDraftView[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    // One transaction, one awaited query. Concurrent queries on a single
-    // transaction connection leak it, so nothing here runs in parallel.
-    drafts = await withTenantOrThrow(sql, ssr.tenantId, async (tx) =>
-      listFormDrafts(tx, ssr.tenantId, {
-        moduleKey: moduleKeyFilter || undefined,
-        wizardKey: wizardKeyFilter || undefined,
-        status: statusFilter || undefined
-      })
-    );
-  } catch (error) {
-    // Includes `DatabaseBusyError` (pool/circuit-breaker refusal) — a refusal
-    // must never be rendered as "there are no drafts".
-    loadError = true;
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's, not `ssr.permissions.has()`. `canDelete` is
+// decided the same way rather than from the raw grant set, so a tenant's ABAC
+// `deny` hides the button instead of only failing when it is pressed.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "form_drafts",
+    activityCode: "draft",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    drafts: await listFormDrafts(tx, ssr.tenantId, {
+      moduleKey: moduleKeyFilter || undefined,
+      wizardKey: wizardKeyFilter || undefined,
+      status: statusFilter || undefined
+    }),
+    canDelete: await can({
+      moduleKey: "form_drafts",
+      activityCode: "draft",
+      action: "delete"
+    })
+  }),
+  onError: (error) => {
     logAdminPageError("admin/form-drafts.astro: failed to list drafts", error, {
       correlationId: Astro.locals.correlationId
     });
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "there are no drafts" and NOT a denial.
+const loadError = screen.state === "error";
+const drafts: FormDraftView[] =
+  screen.state === "allowed" ? screen.data.drafts : [];
+const canDelete = screen.state === "allowed" && screen.data.canDelete;
 
 /** Rendered as a short, single-line preview beside the collapsed payload. */
 function payloadSummary(payload: Record<string, unknown>): string {

--- a/tests/access-chokepoint.test.ts
+++ b/tests/access-chokepoint.test.ts
@@ -28,7 +28,9 @@ import { describe, expect, test } from "bun:test";
 import {
   findChokepointBypasses,
   findStaleExemptions,
-  sliceHandlers
+  findStaleLedgerEntries,
+  sliceHandlers,
+  sliceScreen
 } from "../scripts/access-chokepoint-check";
 import {
   evaluateAccess,
@@ -324,5 +326,131 @@ describe("the live route tree", () => {
     const result = Bun.spawnSync(["bun", "scripts/access-chokepoint-check.ts"]);
 
     expect(result.exitCode).toBe(0);
+  });
+});
+
+/**
+ * The screen root — issue #450 / PROJECT_STATE §4 R3.
+ *
+ * The two roots share one script on purpose (two scripts means two exemption
+ * lists, and the second one always drifts lenient), so what has to be pinned is
+ * the two places they DIFFER: how a file is sliced, and what counts as
+ * deciding. Both directions of the migration ledger are planted here, because a
+ * one-way list that may rot is not one-way.
+ */
+describe("admin screens go through the chokepoint too (#450)", () => {
+  const LEGACY_SCREEN = `---
+const ssr = Astro.locals.ssrContext!;
+const canRead = ssr.permissions.has(permissionKey("form_drafts", "draft", "read"));
+---
+<p>{canRead}</p>`;
+
+  const MIGRATED_SCREEN = `---
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: { moduleKey: "form_drafts", activityCode: "draft", action: "read" },
+  load: async ({ tx }) => listFormDrafts(tx, ssr.tenantId, {}),
+  onError: () => {}
+});
+---
+<p>ok</p>`;
+
+  test("a screen reading the raw grant set is deciding a permission", () => {
+    const slice = sliceScreen("users.astro", LEGACY_SCREEN);
+
+    expect(slice.id).toBe("users.astro");
+    expect(slice.decidesPermissions).toBe(true);
+    expect(slice.usesChokepoint).toBe(false);
+  });
+
+  test("`loadAdminScreen` covers the file, the way `defineTenantRoute` does", () => {
+    const slice = sliceScreen("form-drafts.astro", MIGRATED_SCREEN);
+
+    expect(slice.decidesPermissions).toBe(false);
+    expect(slice.usesChokepoint).toBe(true);
+  });
+
+  test("a screen that still reads the grant set for an affordance is covered by the helper", () => {
+    // Not a loophole being blessed: the file-wide rule is the same one
+    // `defineTenantRoute` gets, and the entry decision is what R3 is about.
+    const slice = sliceScreen(
+      "hybrid.astro",
+      `${MIGRATED_SCREEN}\nconst extra = ssr.permissions.has("x");`
+    );
+
+    expect(slice.decidesPermissions).toBe(true);
+    expect(slice.usesChokepoint).toBe(true);
+    expect(findChokepointBypasses([slice], {}, [])).toEqual([]);
+  });
+
+  test("the signal is not matched inside a comment", () => {
+    // The exact false positive this gate produced on its first run against the
+    // screen root: a migrated page explaining that it no longer uses
+    // `ssr.permissions.has()` matched the sentence saying so.
+    const slice = sliceScreen(
+      "form-drafts.astro",
+      `---
+// the decision is the chokepoint's, not ssr.permissions.has()
+/* also not ssr.permissions.has() */
+${MIGRATED_SCREEN.slice(4)}`
+    );
+
+    expect(slice.decidesPermissions).toBe(false);
+  });
+
+  test("a screen finding names the SCREEN mechanism, not the route one", () => {
+    const [problem] = findChokepointBypasses(
+      [sliceScreen("users.astro", LEGACY_SCREEN)],
+      {},
+      []
+    );
+
+    expect(problem!.message).toContain("loadAdminScreen");
+    expect(problem!.message).not.toContain("defineTenantRoute");
+  });
+
+  test("a ledger entry excuses a bypass — and only while it bypasses", () => {
+    const slice = sliceScreen("users.astro", LEGACY_SCREEN);
+
+    expect(findChokepointBypasses([slice], {}, ["users.astro"])).toEqual([]);
+    expect(findStaleLedgerEntries([slice], ["users.astro"])).toEqual([]);
+  });
+
+  test("a migrated screen left on the ledger is a finding", () => {
+    const problems = findStaleLedgerEntries(
+      [sliceScreen("form-drafts.astro", MIGRATED_SCREEN)],
+      ["form-drafts.astro"]
+    );
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]!.message).toContain("only ever shrinks");
+  });
+
+  test("a ledger entry for a screen that no longer exists is a finding", () => {
+    const problems = findStaleLedgerEntries([], ["deleted.astro"]);
+
+    expect(problems).toHaveLength(1);
+    expect(problems[0]!.message).toContain("no longer exists");
+  });
+
+  test("the real screen root still has screens to migrate, or the detector broke", async () => {
+    // The screen-side self-test, asserted rather than only printed: if
+    // `.permissions.has(` stopped matching anything while the ledger is still
+    // long, the gate would report a clean tree it never inspected.
+    const files = await Array.fromAsync(
+      new Bun.Glob("**/*.astro").scan({ cwd: "src/pages/admin" })
+    );
+
+    expect(files.length).toBe(32);
+
+    const slices = await Promise.all(
+      files.map(async (file) =>
+        sliceScreen(file, await Bun.file(`src/pages/admin/${file}`).text())
+      )
+    );
+
+    expect(slices.filter((slice) => slice.decidesPermissions).length).toBe(31);
+    expect(slices.filter((slice) => slice.usesChokepoint).length).toBe(1);
   });
 });

--- a/tests/admin-form-drafts-page-contract.test.ts
+++ b/tests/admin-form-drafts-page-contract.test.ts
@@ -59,9 +59,18 @@ function guardTriplesFrom(source: string): Set<Triple> {
   return found;
 }
 
-/** `permissionKey("form_drafts", "draft", "read")` → `form_drafts.draft.read`. */
+/**
+ * Both spellings a page may use.
+ *
+ * `permissionKey("form_drafts", "draft", "read")` is the pre-#450 form, still
+ * used by the screens that have not been migrated. A screen routed through
+ * `loadAdminScreen` writes an `AccessRequest` object literal instead — the SAME
+ * shape `guardTriplesFrom` already parses out of the routes, which is the point:
+ * after R3 a page states its guard the way a route does, so one extractor reads
+ * both sides.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
-  const found = new Set<Triple>();
+  const found = new Set<Triple>(guardTriplesFrom(source));
   const pattern =
     /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
@@ -167,8 +176,15 @@ describe("/admin/form-drafts permission gates", () => {
     // (`db:tenant-context:check`) is asserted here too: the request-path
     // `withTenant` returns `T | Response`, which on an SSR page silently
     // renders a `Response` where rows are expected.
-    expect(page).toContain("withTenantOrThrow(");
+    //
+    // Since #450 the page opens no transaction of its own at all —
+    // `loadAdminScreen` owns it, uses the throwing form, and hands back a
+    // discriminated union in which the busy case is a THIRD state rather than
+    // an empty list. Asserting the old spelling here would have made this test
+    // a reason not to route the page through the chokepoint.
+    expect(page).toContain("loadAdminScreen(");
     expect(page).not.toMatch(/\bwithTenant\(/);
+    expect(page).not.toMatch(/\bwithTenantOrThrow\(/);
   });
 
   test("the sidebar entry points at a page that exists and is gated on read", async () => {


### PR DESCRIPTION
PR fondasi Gelombang 1. Menutup separuh #450; 31 layar tersisa di ledger.

## Temuannya

Ke-32 layar `src/pages/admin/**/*.astro` memutuskan apa yang dirender dari
`ssr.permissions.has(...)` — yaitu `fetchGrantedPermissionKeys`, **RBAC mentah**.
Jalur itu melewati `authorizeInTransaction`, dan karenanya melewati semua yang
hanya ada di sana:

| Yang dilewati | Akibatnya saat MEMBACA |
|---|---|
| `evaluateAccess` | policy `deny` tenant **inert di layar** — ditegakkan di API, diabaikan di UI |
| `resolveModuleAvailability` | tenant yang mematikan modulnya tetap melihat layarnya berisi data |
| fakta business-scope, SoD | grant ber-scope tidak menyempitkan apa yang terlihat |
| `recordDecisionLog` | **nol baris** — pembacaan yang terjadi tanpa jejak |

**Yang tidak hilang**, supaya tidak dibesar-besarkan: RBAC dasar tetap
ditegakkan, dan tidak pernah ada kebocoran lintas-tenant.

## Kenapa sekarang

Gelombang 3 mengubah sifatnya. Begitu satu grant membawa scope-nya sendiri,
`ssr.permissions` menjadi union lintas-scope: "punya kunci ini di suatu tempat"
berhenti berarti "boleh membaca **ini**". R3 berubah dari "tanpa ABAC & tanpa
log" menjadi **over-disclosure sisi baca yang nyata**.

## Bentuknya

`loadAdminScreen` membuka **satu** transaksi, memanggil chokepoint, lalu
menjalankan `load` di dalam transaksi yang sama. Memecahnya berarti memutuskan
atas satu snapshot dan membaca atas snapshot lain.

- **Deny me-render**, bukan redirect — 20+ `admin-*-page-contract` meng-assert
  `#users-denied`, dan redirect akan memberi tenant yang menulis `deny` sebuah
  loop login alih-alih penolakan.
- **`error` adalah state ketiga.** Refusal pool/circuit-breaker yang dirender
  sebagai "Anda tidak boleh melihat ini" adalah kebohongan ke arah yang
  diselidiki sebagai bug perizinan.

**Namanya berubah dari rencana** (`defineAdminScreen` → `loadAdminScreen`).
Frontmatter `.astro` tidak punya handler untuk dibungkus — ia skrip yang berjalan
top-to-bottom. Namanya yang menyesuaikan bentuknya, bukan sebaliknya.

**Satu skrip, bukan dua.** Dua skrip = dua daftar pengecualian yang menyimpang,
dan yang kedua selalu jadi yang longgar. Kedua root berbeda di tepat dua tempat,
dan keduanya tertulis: `.astro` diiris **per-berkas** (satu berkas = satu jalur
render), dan sinyalnya `.permissions.has(`.

`form-drafts.astro` ikut dimigrasikan supaya mekanismenya **dibuktikan**, bukan
disediakan. `canDelete`-nya kini juga diputuskan chokepoint, jadi `deny` tenant
**menyembunyikan** tombolnya alih-alih hanya menggagalkannya saat ditekan.

## Tiga hal yang ditemukan saat MEMBANGUN, bukan saat merencanakan

1. **`stripComments` wajib ada.** Run pertama terhadap root layar merah karena
   sinyalnya cocok dengan **komentar** di layar yang baru dimigrasikan yang
   menjelaskan bahwa ia tidak lagi memakai `ssr.permissions.has()`. Repo ini
   sudah kena bentuk yang sama tiga kali, dan selalu **perbaikannya** yang
   menanam false positive-nya — karena perbaikan menjelaskan apa yang dihapusnya.
2. **Satu baris `NOT_YET_SCREENED` ternyata sudah basi.** `extractScreenClaims`
   yang diperluas menemukan `visitor_analytics.raw_detail.read` sudah lama
   diklaim `analytics.astro` lewat evaluator ABAC.
3. **Ledger `api:tenant-route:check` (#433) ikut menyusut.** Dua gerbang berbeda
   menghitung utang yang sama dari dua sudut, dan keduanya bergerak bersama.

## Satu test kontrak DIUBAH, dan rencananya bilang tidak boleh

`admin-form-drafts-page-contract` meng-assert literal `withTenantOrThrow(` dan
`permissionKey(...)` di halamannya — **bentuk lama, bukan sifatnya**.
Mempertahankannya akan membuat test itu jadi alasan untuk **tidak** merutekan
halaman lewat chokepoint. Klaim yang ditegakkannya tidak berubah; satu extractor
kini membaca kedua ejaan, dan setelah R3 sebuah halaman menyatakan guard-nya
persis seperti sebuah rute.

## Bukti

Mutasi terhadap repo nyata:

| Mutasi | Hasil |
|---|---|
| hapus satu entri ledger | **EXIT 1**, menyebut `users.astro` dengan pesan sisi-**layar** |
| tambahkan layar yang sudah dimigrasikan ke ledger | **EXIT 1**, entri basi |
| kontrol | EXIT 0 |

Plus 10 test baru yang menanam kelima arah, termasuk yang mengunci false
positive komentar.

Nol migrasi. `bun run check` penuh hijau (3485 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)