### PR TITLE
feat(auth): lima layar admin berikutnya melewati chokepoint (#450, R3)

### DIFF
--- a/.changeset/layar-admin-chokepoint-batch-2.md
+++ b/.changeset/layar-admin-chokepoint-batch-2.md
@@ -1,0 +1,47 @@
+---
+"awcms": minor
+---
+
+feat(auth): lima layar admin berikutnya melewati chokepoint (#450, R3)
+
+Gelombang 1 batch 2. `registrations`, `modules`, `abac-policies`,
+`blog-settings`, dan `comments` berhenti memutuskan akses dari
+`ssr.permissions.has(...)` — himpunan RBAC mentah — dan berpindah ke
+`loadAdminScreen`, yang menjalankan `authorizeInTransaction` dan pembacaan
+datanya di dalam SATU transaksi.
+
+Yang dipulihkan pada kelima layar itu: evaluasi kebijakan ABAC (sebuah `deny`
+yang ditulis tenant lewat `/api/v1/abac/policies` ditegakkan di API dan **inert**
+di layar), `resolveModuleAvailability` (tenant yang mematikan modulnya sendiri
+tetap melihat layarnya penuh data), fakta business-scope, SoD saat-aksi, dan
+`recordDecisionLog` — sebuah pembacaan yang terjadi tidak meninggalkan baris yang
+menyatakan bahwa ia terjadi.
+
+`abac-policies.astro` adalah kasus yang paling tajam: ia layar tempat tenant
+**mengarang** kebijakannya, dan sampai sekarang kebijakan yang ditulisnya tidak
+berlaku pada halaman yang mendaftarkannya.
+
+Tiap afordans tulis (`approve`/`reject` registrasi, `enable`/`disable` modul,
+`configure` policy dan setelan blog, empat verb moderasi komentar) kini
+diputuskan lewat `can(...)` pada transaksi yang sama, bukan dari himpunan grant
+mentah — jadi `deny` menyembunyikan tombolnya alih-alih baru menolak saat
+ditekan. Endpoint tetap otoritasnya.
+
+Dua ledger menyusut bersama: `ADMIN_SCREEN_CHOKEPOINT_MIGRATION`
+(`access:chokepoint:check`) dan `NOT_YET_MIGRATED` (`api:tenant-route:check`),
+28 → 23. Keduanya menghitung utang yang sama dari sudut berbeda — "siapa
+memutuskan permission di luar chokepoint" versus "siapa membuka transaksinya
+sendiri" — dan catatan itu kini tertulis di header keduanya supaya PR migrasi
+berikutnya tidak menemukannya lewat gerbang merah.
+
+Teks remediasi `api:tenant-route:check` diperbaiki: ia masih berkata helper-nya
+"belum ada" dan menyuruh penulis layar baru **menunggu**. Banner "belum ada"
+menua ke arah sebaliknya dari koreksi biasa — ia menyuruh orang berhenti
+mengerjakan hal yang sudah bisa dikerjakan.
+
+Dua cabang mati ikut hilang: `registrations`, `modules`, dan `abac-policies`
+memeriksa `result instanceof Response` terhadap `withTenantOrThrow`, yang
+melempar dan tidak pernah mengembalikan `Response`. Ketiganya juga menelan
+kegagalan baca dengan `catch {}` kosong; kini kegagalan itu tercatat lewat
+`logAdminPageError` dengan `correlationId`, dan `error` tetap state ketiga yang
+tidak pernah dibaca sebagai penolakan.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (22.692 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (22.780 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -84,23 +84,18 @@ const CHOKEPOINT_EXEMPTIONS: Readonly<Record<string, string>> = {
  * each a sentence would dress 31 open defects as 31 decisions.
  */
 export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
-  "abac-policies.astro",
   "analytics.astro",
   "approvals.astro",
   "blog-pages.astro",
   "blog-presentation.astro",
-  "blog-settings.astro",
   "blog-taxonomy.astro",
   "blog.astro",
-  "comments.astro",
   "data-lifecycle.astro",
   "domain-events.astro",
   "idn-regions.astro",
   "index.astro",
   "media.astro",
-  "modules.astro",
   "offices.astro",
-  "registrations.astro",
   "reporting.astro",
   "roles.astro",
   "security.astro",

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -87,9 +87,9 @@ export const SCAN_ROOTS: readonly ScanRoot[] = [
     remediation:
       "Layar admin baru TIDAK BOLEH membuka transaksi tenant sendiri: ia memutuskan akses " +
       "dengan ssr.permissions.has() saja, melewati evaluateAccess, resolveModuleEnabled, dan " +
-      "recordDecisionLog (PROJECT_STATE §4 R3). Helper defineAdminScreen belum ada — ia " +
-      "Gelombang 1 dari #423. Sampai ia mendarat, layar yang butuh data tenant harus menunggu " +
-      "helper itu, BUKAN menambah barisnya di NOT_YET_MIGRATED."
+      "recordDecisionLog (PROJECT_STATE §4 R3). Pakai loadAdminScreen dari " +
+      "src/lib/auth/admin-screen.ts — ia membuka SATU transaksi dan menjalankan " +
+      "authorizeInTransaction serta load() di dalamnya. JANGAN menambah baris di NOT_YET_MIGRATED."
   }
 ];
 
@@ -102,31 +102,33 @@ const WITH_TENANT_CALL_PATTERN =
 /**
  * Files that still open their own transaction. API routes measured at
  * `b9931594`; the 32 admin screens added by Issue #424 at the head of
- * Gelombang 0.
+ * Gelombang 0, shrinking as issue #450 migrates them to `loadAdminScreen`.
+ *
+ * The screen half is counted a SECOND time, from a different angle, by
+ * `ADMIN_SCREEN_CHOKEPOINT_MIGRATION` in `access-chokepoint-check.ts`: this
+ * gate asks "who opens their own transaction", that one asks "who decides a
+ * permission outside the chokepoint". A migration PR must shrink BOTH, and
+ * neither list may grow.
  *
  * ONLY REMOVE LINES FROM THIS LIST. Never add one: a new entry means a new
  * route skipped `defineTenantRoute`, or a new admin screen added to R3's debt
  * — which is what this gate exists to prevent.
  */
 const NOT_YET_MIGRATED: readonly string[] = [
-  // --- Layar admin (R3) — menunggu `defineAdminScreen`, Gelombang 1 dari #423.
-  "src/pages/admin/abac-policies.astro",
+  // --- Layar admin (R3) — sedang dimigrasikan ke `loadAdminScreen`, Gelombang 1
+  //     dari #423 (issue #450). Daftar ini menyusut tiap PR migrasi.
   "src/pages/admin/analytics.astro",
   "src/pages/admin/approvals.astro",
   "src/pages/admin/blog-pages.astro",
   "src/pages/admin/blog-presentation.astro",
-  "src/pages/admin/blog-settings.astro",
   "src/pages/admin/blog-taxonomy.astro",
   "src/pages/admin/blog.astro",
-  "src/pages/admin/comments.astro",
   "src/pages/admin/data-lifecycle.astro",
   "src/pages/admin/domain-events.astro",
   "src/pages/admin/idn-regions.astro",
   "src/pages/admin/index.astro",
   "src/pages/admin/media.astro",
-  "src/pages/admin/modules.astro",
   "src/pages/admin/offices.astro",
-  "src/pages/admin/registrations.astro",
   "src/pages/admin/reporting.astro",
   "src/pages/admin/roles.astro",
   "src/pages/admin/security.astro",

--- a/src/pages/admin/abac-policies.astro
+++ b/src/pages/admin/abac-policies.astro
@@ -21,41 +21,59 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import {
   listAbacPolicies,
   type AbacPolicyView
 } from "../../modules/identity-access/application/access-directory";
 
 const ssr = Astro.locals.ssrContext!;
-const canRead = ssr.permissions.has(
-  permissionKey("identity_access", "access_control", "read")
-);
-// Both write surfaces gate on `configure` — the only seeded write action for
-// this activity (no `create`/`update` exist in the catalog).
-const canConfigure = ssr.permissions.has(
-  permissionKey("identity_access", "access_control", "configure")
-);
+
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. Note what that closes HERE in particular: this
+// is the screen a tenant authors its ABAC policies on, and until now the
+// policies it writes were enforced on `/api/v1/abac/policies` and inert on the
+// page listing them.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "access_control",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    policies: await listAbacPolicies(tx, ssr.tenantId),
+    // Both write surfaces gate on `configure` — the only seeded write action
+    // for this activity (no `create`/`update` exist in the catalog).
+    canConfigure: await can({
+      moduleKey: "identity_access",
+      activityCode: "access_control",
+      action: "configure"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError(
+      "admin/abac-policies.astro: failed to list ABAC policies",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "no policies" and NOT a denial — and on
+// this screen the difference matters most: an empty table is the documented
+// default posture, so an unreported load failure would read as normal.
+const loadError = screen.state === "error";
+const policies: AbacPolicyView[] =
+  screen.state === "allowed" ? screen.data.policies : [];
+const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
 const canCreate = canConfigure;
 const canUpdate = canConfigure;
-
-let policies: AbacPolicyView[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, (tx) =>
-      listAbacPolicies(tx, ssr.tenantId)
-    );
-    if (result instanceof Response) loadError = true;
-    else policies = result;
-  } catch {
-    loadError = true;
-  }
-}
 ---
 
 <AdminLayout title="ABAC policies">

--- a/src/pages/admin/blog-settings.astro
+++ b/src/pages/admin/blog-settings.astro
@@ -58,10 +58,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   fetchBlogSettings,
   type BlogSettingsView
@@ -69,34 +67,46 @@ import {
 
 const ssr = Astro.locals.ssrContext!;
 
-const canRead = ssr.permissions.has(
-  permissionKey("blog_content", "settings", "read")
-);
-
-// One permission gates every field on this form. `sql/036` seeds no
-// per-field write permission, so inventing one in the UI would imply an
-// authority no `authorizeInTransaction` call would honour.
-const canConfigure = ssr.permissions.has(
-  permissionKey("blog_content", "settings", "configure")
-);
-
-let settings: BlogSettingsView | null = null;
-let loadError: string | null = null;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-
-    settings = await withTenantOrThrow(sql, ssr.tenantId, async (tx) =>
-      fetchBlogSettings(tx, ssr.tenantId)
-    );
-  } catch (error) {
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's rather than `ssr.permissions.has()`, so a tenant
+// that disabled `blog_content` no longer sees its settings form full of data.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "settings",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    settings: await fetchBlogSettings(tx, ssr.tenantId),
+    // One permission gates every field on this form. `sql/036` seeds no
+    // per-field write permission, so inventing one in the UI would imply an
+    // authority no `authorizeInTransaction` call would honour.
+    canConfigure: await can({
+      moduleKey: "blog_content",
+      activityCode: "settings",
+      action: "configure"
+    })
+  }),
+  onError: (error) => {
     logAdminPageError("admin.blog_settings.load_failed", error, {
-      moduleKey: "blog_content"
+      moduleKey: "blog_content",
+      correlationId: Astro.locals.correlationId
     });
-    loadError = "Gagal memuat pengaturan blog.";
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+const settings: BlogSettingsView | null =
+  screen.state === "allowed" ? screen.data.settings : null;
+// A pool/circuit-breaker refusal is NOT a denial, and this screen already said
+// so with a message rather than a bare empty form.
+const loadError =
+  screen.state === "error" ? "Gagal memuat pengaturan blog." : null;
+const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
 
 const VISIBILITY_OPTIONS = ["public", "private"] as const;
 ---

--- a/src/pages/admin/comments.astro
+++ b/src/pages/admin/comments.astro
@@ -30,30 +30,13 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import { listModerationQueue } from "../../modules/comments/application/comment-moderation";
 import type { ModerationQueueItem } from "../../modules/comments/application/comment-moderation";
 import type { CommentStatus } from "../../modules/comments/domain/comment-status";
 
 const ssr = Astro.locals.ssrContext!;
-
-const canRead = ssr.permissions.has(
-  permissionKey("comments", "moderation", "read")
-);
-const canApprove = ssr.permissions.has(
-  permissionKey("comments", "moderation", "approve")
-);
-const canReject = ssr.permissions.has(
-  permissionKey("comments", "moderation", "reject")
-);
-const canArchive = ssr.permissions.has(
-  permissionKey("comments", "moderation", "archive")
-);
-const canRestore = ssr.permissions.has(
-  permissionKey("comments", "moderation", "restore")
-);
 
 const STATUS_TABS: readonly { value: CommentStatus; label: string }[] = [
   { value: "pending", label: "Pending" },
@@ -70,26 +53,70 @@ const activeStatus: CommentStatus = STATUS_TABS.some(
   ? (requestedStatus as CommentStatus)
   : "pending";
 
-let items: ModerationQueueItem[] = [];
-let loadFailed = false;
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. The four moderation verbs are decided the same
+// way, so a tenant's ABAC `deny` hides the button instead of only refusing the
+// POST behind it; the endpoints remain the authority either way.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "comments",
+    activityCode: "moderation",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const queue = await listModerationQueue(tx, ssr.tenantId, {
+      status: activeStatus,
+      limit: 50
+    });
 
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, (tx) =>
-      listModerationQueue(tx, ssr.tenantId, {
-        status: activeStatus,
-        limit: 50
+    return {
+      items: queue.items,
+      canApprove: await can({
+        moduleKey: "comments",
+        activityCode: "moderation",
+        action: "approve"
+      }),
+      canReject: await can({
+        moduleKey: "comments",
+        activityCode: "moderation",
+        action: "reject"
+      }),
+      canArchive: await can({
+        moduleKey: "comments",
+        activityCode: "moderation",
+        action: "archive"
+      }),
+      canRestore: await can({
+        moduleKey: "comments",
+        activityCode: "moderation",
+        action: "restore"
       })
+    };
+  },
+  onError: (error) => {
+    logAdminPageError(
+      "admin/comments.astro: failed to list the moderation queue",
+      error,
+      { correlationId: Astro.locals.correlationId }
     );
-    items = result.items;
-  } catch {
-    // A read failure renders an explicit notice rather than an empty queue —
-    // "nothing to moderate" and "we could not load the queue" must never look
-    // the same to a moderator.
-    loadFailed = true;
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+// A read failure renders an explicit notice rather than an empty queue —
+// "nothing to moderate" and "we could not load the queue" must never look the
+// same to a moderator, and neither may be confused with a denial.
+const loadFailed = screen.state === "error";
+const items: ModerationQueueItem[] =
+  screen.state === "allowed" ? screen.data.items : [];
+const canApprove = screen.state === "allowed" && screen.data.canApprove;
+const canReject = screen.state === "allowed" && screen.data.canReject;
+const canArchive = screen.state === "allowed" && screen.data.canArchive;
+const canRestore = screen.state === "allowed" && screen.data.canRestore;
 
 function formatTimestamp(value: string): string {
   const parsed = new Date(value);

--- a/src/pages/admin/modules.astro
+++ b/src/pages/admin/modules.astro
@@ -22,9 +22,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import { fetchTenantModuleEntries } from "../../modules/module-management/application/tenant-module-lifecycle";
 
 type ModuleRow = {
@@ -36,32 +35,51 @@ type ModuleRow = {
 };
 
 const ssr = Astro.locals.ssrContext!;
-const canRead = ssr.permissions.has(
-  permissionKey("module_management", "tenant_modules", "read")
-);
-const canEnable = ssr.permissions.has(
-  permissionKey("module_management", "tenant_modules", "enable")
-);
-const canDisable = ssr.permissions.has(
-  permissionKey("module_management", "tenant_modules", "disable")
-);
-const canToggle = canEnable || canDisable;
 
-let modules: ModuleRow[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      return (await fetchTenantModuleEntries(tx, ssr.tenantId)) as ModuleRow[];
-    });
-    if (result instanceof Response) loadError = true;
-    else modules = result;
-  } catch {
-    loadError = true;
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. The toggle's two permissions are decided the
+// same way, so a tenant's ABAC `deny` hides the button rather than only
+// refusing the POST behind it.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "module_management",
+    activityCode: "tenant_modules",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    modules: (await fetchTenantModuleEntries(tx, ssr.tenantId)) as ModuleRow[],
+    canEnable: await can({
+      moduleKey: "module_management",
+      activityCode: "tenant_modules",
+      action: "enable"
+    }),
+    canDisable: await can({
+      moduleKey: "module_management",
+      activityCode: "tenant_modules",
+      action: "disable"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError(
+      "admin/modules.astro: failed to list tenant modules",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "no modules" and NOT a denial.
+const loadError = screen.state === "error";
+const modules: ModuleRow[] =
+  screen.state === "allowed" ? screen.data.modules : [];
+const canEnable = screen.state === "allowed" && screen.data.canEnable;
+const canDisable = screen.state === "allowed" && screen.data.canDisable;
+const canToggle = canEnable || canDisable;
 ---
 
 <AdminLayout title="Modules">

--- a/src/pages/admin/registrations.astro
+++ b/src/pages/admin/registrations.astro
@@ -18,10 +18,9 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import { isSelfRegistrationEnabled } from "../../lib/auth/self-registration-config";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { listRoles } from "../../modules/identity-access/application/access-directory";
 import {
   listPendingRegistrations,
@@ -30,51 +29,67 @@ import {
 
 const ssr = Astro.locals.ssrContext!;
 
-const canRead = ssr.permissions.has(
-  permissionKey("identity_access", "registration_requests", "read")
-);
-const canApprove = ssr.permissions.has(
-  permissionKey("identity_access", "registration_requests", "approve")
-);
-const canReject = ssr.permissions.has(
-  permissionKey("identity_access", "registration_requests", "reject")
-);
-
 const selfRegistrationEnabled = isSelfRegistrationEnabled();
 
-let requests: PendingRegistrationView[] = [];
-let roles: { id: string; roleCode: string }[] = [];
-let loadError = false;
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. `approve`/`reject` are decided the same way, so
+// a tenant's ABAC `deny` hides the control instead of only failing when it is
+// pressed. The endpoints remain the authority either way.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "registration_requests",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const requests = await listPendingRegistrations(tx, ssr.tenantId);
+    const canApprove = await can({
+      moduleKey: "identity_access",
+      activityCode: "registration_requests",
+      action: "approve"
+    });
+    const canReject = await can({
+      moduleKey: "identity_access",
+      activityCode: "registration_requests",
+      action: "reject"
+    });
+    // Only needed to render the optional role picker on the approve control.
+    //
+    // System roles are dropped because the endpoint refuses them (409
+    // `ROLE_SYSTEM_PROTECTED`). Rendering `owner` in this picker offered a
+    // control that either escalated privilege or — once the service started
+    // refusing it — failed in the reviewer's face for no reason they could
+    // read. This is presentation only; the refusal is the endpoint's.
+    const roles = canApprove
+      ? (await listRoles(tx, ssr.tenantId))
+          .filter((role) => !role.isSystem)
+          .map((role) => ({ id: role.id, roleCode: role.roleCode }))
+      : [];
 
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => ({
-      requests: await listPendingRegistrations(tx, ssr.tenantId),
-      // Only needed to render the optional role picker on the approve control.
-      roles: canApprove ? await listRoles(tx, ssr.tenantId) : []
-    }));
-
-    if (result instanceof Response) {
-      loadError = true;
-    } else {
-      requests = result.requests;
-      // System roles are dropped here because the endpoint refuses them (409
-      // `ROLE_SYSTEM_PROTECTED`). Rendering `owner` in this picker offered a
-      // control that either escalated privilege or — once the service started
-      // refusing it — failed in the reviewer's face for no reason they could
-      // read. This is presentation only; the refusal is the endpoint's.
-      roles = result.roles
-        .filter((role) => !role.isSystem)
-        .map((role) => ({
-          id: role.id,
-          roleCode: role.roleCode
-        }));
-    }
-  } catch {
-    loadError = true;
+    return { requests, roles, canApprove, canReject };
+  },
+  onError: (error) => {
+    logAdminPageError(
+      "admin/registrations.astro: failed to list pending registrations",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "the queue is empty" and NOT a denial.
+const loadError = screen.state === "error";
+const requests: PendingRegistrationView[] =
+  screen.state === "allowed" ? screen.data.requests : [];
+const roles: { id: string; roleCode: string }[] =
+  screen.state === "allowed" ? screen.data.roles : [];
+const canApprove = screen.state === "allowed" && screen.data.canApprove;
+const canReject = screen.state === "allowed" && screen.data.canReject;
 
 const columnCount = canApprove || canReject ? 4 : 3;
 ---

--- a/tests/tenant-route-factory-check.test.ts
+++ b/tests/tenant-route-factory-check.test.ts
@@ -15,6 +15,7 @@
  * `scripts/`, which the script's own `main()` covers.
  */
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 
 import {
   SCAN_ROOTS,
@@ -170,11 +171,27 @@ describe("remediation is chosen by root, because the answer differs", () => {
     );
   });
 
-  test("an admin screen is NOT told to use defineTenantRoute — it has no factory yet", () => {
+  test("an admin screen is told to use loadAdminScreen, not defineTenantRoute", () => {
+    // Named, not merely "not the route factory": until #450 batch 2 this
+    // asserted `defineAdminScreen` — the name the program PLAN used for a
+    // helper that shipped as `loadAdminScreen`. So the gate's advice named
+    // something that does not exist while the test agreed with it, and the
+    // prose beside it still said "no factory yet" months after one existed.
+    // A remediation string is read by whoever just turned the gate red; one
+    // that names a missing helper tells them to stop and wait.
     const advice = remediationFor("src/pages/admin/thing.astro");
 
-    expect(advice).toContain("defineAdminScreen");
+    expect(advice).toContain("loadAdminScreen");
     expect(advice).not.toContain("defineTenantRoute(");
+  });
+
+  test("the advice names a helper that actually exists", () => {
+    // The assertion above can only prove the string is stable, not that it is
+    // TRUE — which is exactly how it went stale. This one fails if the helper
+    // is ever renamed or removed without the advice following it.
+    const helper = readFileSync("src/lib/auth/admin-screen.ts", "utf8");
+
+    expect(helper).toMatch(/export async function loadAdminScreen\b/);
   });
 
   test("the nested admin directory resolves to the admin root, not the API one", () => {
@@ -182,7 +199,7 @@ describe("remediation is chosen by root, because the answer differs", () => {
     // top-level `src/pages/admin/*.astro` glob — the same blind spot that made
     // Issue #424 say 31 when the real count is 32.
     expect(remediationFor("src/pages/admin/tenant/domains.astro")).toContain(
-      "defineAdminScreen"
+      "loadAdminScreen"
     );
   });
 });


### PR DESCRIPTION
Gelombang 1 batch 2 dari #450. Ledger **28 → 23**.

## Temuan yang ditutup

`registrations`, `modules`, `abac-policies`, `blog-settings`, `comments` memutuskan akses dari `ssr.permissions.has(...)` — himpunan RBAC mentah dari `fetchGrantedPermissionKeys`. Jalur itu melewati `evaluateAccess`, `resolveModuleAvailability`, fakta business-scope, SoD saat-aksi, dan `recordDecisionLog`.

`abac-policies.astro` adalah kasusnya yang paling tajam: ia layar tempat tenant **mengarang** kebijakan ABAC-nya, dan kebijakan yang ditulisnya ditegakkan di `/api/v1/abac/policies` tetapi **inert** pada halaman yang mendaftarkannya.

Yang **tidak** hilang, supaya temuannya tidak dibesar-besarkan: RBAC dasar tetap berlaku dan tidak pernah ada kebocoran lintas-tenant — `withTenantOrThrow` dan FORCE RLS selalu ada di jalur.

## Perubahan

Kelimanya kini lewat `loadAdminScreen`: satu transaksi, `authorizeInTransaction` lalu `load()` di dalamnya. Tiap afordans tulis (`approve`/`reject`, `enable`/`disable`, `configure`, empat verb moderasi) diputuskan lewat `can(...)` pada transaksi yang sama — `deny` menyembunyikan tombolnya alih-alih baru menolak saat ditekan. Endpoint tetap otoritasnya.

## Dua koreksi yang ditemukan saat mengerjakan

**Teks remediasi `api:tenant-route:check` sudah basi ke arah berbahaya.** Ia berkata `defineAdminScreen` "belum ada" dan menyuruh penulis layar baru **menunggu** — padahal helper-nya sudah mendarat di #451 dengan nama `loadAdminScreen`. Banner "belum ada" menua berlawanan arah dengan koreksi biasa: ia menyuruh orang berhenti mengerjakan yang sudah bisa dikerjakan.

**Dua test mematok nama yang tidak pernah ada.** `tests/tenant-route-factory-check.test.ts` meng-assert `defineAdminScreen` — nama dari dokumen rencana, bukan dari kode — sehingga test dan gerbang saling menyetujui sebuah string yang salah. Diperbaiki, plus asersi baru yang gagal bila nasihat itu menyebut helper yang tidak ada di `src/lib/auth/admin-screen.ts`.

## Kebersihan

- Cabang mati `result instanceof Response` terhadap `withTenantOrThrow` (yang melempar, tak pernah mengembalikan `Response`) dihapus di tiga layar.
- `catch {}` kosong → `logAdminPageError` ber-`correlationId`. Kegagalan baca tidak lagi senyap, dan `error` tetap state ketiga yang tidak pernah dibaca sebagai penolakan.

## Verifikasi

- `DATABASE_URL="" bun run test` — 3486 pass, 0 fail
- `bun run check` penuh (38 segmen + build) — **exit 0**
- `access:chokepoint:check` — `32 admin screens, 23 still decide outside the chokepoint (ledger: 23, may only shrink)`
- 15 klaim permission kelima layar diperiksa masih ter-ekstrak `extractScreenClaims` (bentuk objek-literal), bukan sekadar hijau karena diserap ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)