### PR TITLE
feat(auth): lima layar admin berikutnya melewati chokepoint (#450, R3)

### DIFF
--- a/.changeset/layar-admin-chokepoint-batch-3.md
+++ b/.changeset/layar-admin-chokepoint-batch-3.md
@@ -1,0 +1,39 @@
+---
+"awcms": minor
+---
+
+feat(auth): lima layar admin berikutnya melewati chokepoint (#450, R3)
+
+Gelombang 1 batch 3. `users`, `roles`, `offices`, `sidebar-menu`, dan
+`tenant/domains` berpindah dari `ssr.permissions.has(...)` ke `loadAdminScreen`:
+`authorizeInTransaction` dan pembacaan datanya kini di dalam SATU transaksi.
+
+`users.astro` dan `roles.astro` adalah pasangan yang paling berarti di batch
+ini: keduanya **mendaftarkan siapa memegang apa**. Sampai sekarang membaca
+roster akses sebuah tenant tidak melewati evaluasi ABAC dan tidak meninggalkan
+satu baris pun di `awcms_abac_decision_logs` — sebuah `deny` yang ditulis tenant
+tentang `access_control` berlaku saat MENGUBAH keanggotaan dan tidak berlaku saat
+MEMBACANYA.
+
+`tenant/domains.astro` adalah satu-satunya layar yang tidak tertangkap glob
+`src/pages/admin/*.astro` tingkat-atas — blind spot yang sama yang membuat #424
+menyebut 31 padahal jumlah sebenarnya 32. Ia ikut di batch ini justru supaya
+tidak menjadi sisa terakhir yang terlupa.
+
+Enam afordans tulisnya (`create`, `update`, `delete`, `verify`, `set_primary`)
+kini diputuskan lewat `can(...)` pada transaksi yang sama.
+
+`roles.astro` mempertahankan logika R8-nya utuh — katalog permission masih
+disaring `includePlatformScoped` terhadap `resolvePlatformTenant(tx)`, dan
+pemuatan katalog itu tetap hanya terjadi bila `configure` diizinkan; bedanya
+sekarang izin itu jawaban chokepoint, bukan pembacaan himpunan grant mentah.
+
+Dua ledger menyusut bersama, 23 → 18: `ADMIN_SCREEN_CHOKEPOINT_MIGRATION` dan
+`NOT_YET_MIGRATED`.
+
+Kebersihan: cabang mati `result instanceof Response` terhadap
+`withTenantOrThrow` dihapus di empat layar, dan pemeriksaan bentuk di
+`sidebar-menu.astro` (`"entries" in result`) — yang ada persis karena
+`Response` itu truthy — tidak lagi diperlukan sebab tipe `AdminScreenOutcome`
+membedakan `allowed`/`denied`/`error` secara langsung. `catch {}` kosong diganti
+`logAdminPageError` ber-`correlationId`.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (22.780 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (22.856 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -95,18 +95,13 @@ export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
   "idn-regions.astro",
   "index.astro",
   "media.astro",
-  "offices.astro",
   "reporting.astro",
-  "roles.astro",
   "security.astro",
   "seo.astro",
-  "sidebar-menu.astro",
   "site-search.astro",
   "sync.astro",
-  "tenant/domains.astro",
   "tenants.astro",
-  "theming.astro",
-  "users.astro"
+  "theming.astro"
 ];
 
 /**

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -128,18 +128,13 @@ const NOT_YET_MIGRATED: readonly string[] = [
   "src/pages/admin/idn-regions.astro",
   "src/pages/admin/index.astro",
   "src/pages/admin/media.astro",
-  "src/pages/admin/offices.astro",
   "src/pages/admin/reporting.astro",
-  "src/pages/admin/roles.astro",
   "src/pages/admin/security.astro",
   "src/pages/admin/seo.astro",
-  "src/pages/admin/sidebar-menu.astro",
   "src/pages/admin/site-search.astro",
   "src/pages/admin/sync.astro",
-  "src/pages/admin/tenant/domains.astro",
   "src/pages/admin/tenants.astro",
   "src/pages/admin/theming.astro",
-  "src/pages/admin/users.astro",
 
   // --- Rute API.
   "src/pages/api/v1/abac/policies/[id].ts",

--- a/src/pages/admin/offices.astro
+++ b/src/pages/admin/offices.astro
@@ -24,9 +24,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import {
   listDeletedOffices,
   listOffices
@@ -41,56 +40,74 @@ type OfficeRow = {
 };
 
 const ssr = Astro.locals.ssrContext!;
-const canRead = ssr.permissions.has(
-  permissionKey("tenant_admin", "office_management", "read")
-);
-const canCreate = ssr.permissions.has(
-  permissionKey("tenant_admin", "office_management", "create")
-);
-const canUpdate = ssr.permissions.has(
-  permissionKey("tenant_admin", "office_management", "update")
-);
-const canDelete = ssr.permissions.has(
-  permissionKey("tenant_admin", "office_management", "delete")
-);
 
 const OFFICE_STATUS_OPTIONS = ["active", "inactive"];
 
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's rather than `ssr.permissions.has()`.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "tenant_admin",
+    activityCode: "office_management",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const page = await listOffices(tx, ssr.tenantId, null);
+    const canCreate = await can({
+      moduleKey: "tenant_admin",
+      activityCode: "office_management",
+      action: "create"
+    });
+    const canUpdate = await can({
+      moduleKey: "tenant_admin",
+      activityCode: "office_management",
+      action: "update"
+    });
+    const canDelete = await can({
+      moduleKey: "tenant_admin",
+      activityCode: "office_management",
+      action: "delete"
+    });
+    // Only fetch the deleted set for viewers who can act on it (restore is
+    // gated on `update`); otherwise it is noise they cannot use.
+    const deleted = canUpdate ? await listDeletedOffices(tx, ssr.tenantId) : [];
+
+    return {
+      active: page.items as OfficeRow[],
+      deleted: deleted as OfficeRow[],
+      canCreate,
+      canUpdate,
+      canDelete
+    };
+  },
+  onError: (error) => {
+    logAdminPageError(
+      "admin/offices.astro: failed to load the office directory",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "no offices" and NOT a denial — the
+// same degradation the old `result instanceof Response` branch aimed at, except
+// `withTenantOrThrow` throws rather than returning one, so that branch was dead.
+const loadError = screen.state === "error";
+const offices: OfficeRow[] =
+  screen.state === "allowed" ? screen.data.active : [];
+const deletedOffices: OfficeRow[] =
+  screen.state === "allowed" ? screen.data.deleted : [];
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
+const canUpdate = screen.state === "allowed" && screen.data.canUpdate;
+const canDelete = screen.state === "allowed" && screen.data.canDelete;
+
 // One action column is rendered when the viewer can edit and/or delete.
 const showActions = canUpdate || canDelete;
-
-let offices: OfficeRow[] = [];
-let deletedOffices: OfficeRow[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      const page = await listOffices(tx, ssr.tenantId, null);
-      // Only fetch the deleted set for viewers who can act on it (restore is
-      // gated on `update`); otherwise it is noise they cannot use.
-      const deleted = canUpdate
-        ? await listDeletedOffices(tx, ssr.tenantId)
-        : [];
-      return {
-        active: page.items as OfficeRow[],
-        deleted: deleted as OfficeRow[]
-      };
-    });
-    // `withTenant` returns a 503 `Response` when the DB circuit breaker is
-    // open / a work-class queue is saturated — degrade to an error notice
-    // rather than letting a Response leak where rows are expected.
-    if (result instanceof Response) {
-      loadError = true;
-    } else {
-      offices = result.active;
-      deletedOffices = result.deleted;
-    }
-  } catch {
-    loadError = true;
-  }
-}
 ---
 
 <AdminLayout title="Offices">

--- a/src/pages/admin/roles.astro
+++ b/src/pages/admin/roles.astro
@@ -19,9 +19,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import {
   listRoles,
   type RoleView
@@ -36,12 +35,6 @@ import {
 } from "../../modules/identity-access/application/role-admin";
 
 const ssr = Astro.locals.ssrContext!;
-const canRead = ssr.permissions.has(
-  permissionKey("identity_access", "access_control", "read")
-);
-const canConfigure = ssr.permissions.has(
-  permissionKey("identity_access", "access_control", "configure")
-);
 
 type RolePermRow = {
   role: RoleView;
@@ -49,58 +42,80 @@ type RolePermRow = {
   available: PermissionCatalogEntry[];
 };
 
-let roles: RoleView[] = [];
-let rolePerms: RolePermRow[] = [];
-let deletedRoles: DeletedRoleView[] = [];
-let loadError = false;
-
 function permLabel(p: PermissionCatalogEntry): string {
   return `${p.moduleKey}.${p.activityCode}.${p.action}`;
 }
 
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      const liveRoles = await listRoles(tx, ssr.tenantId);
-      if (!canConfigure) {
-        return {
-          liveRoles,
-          rolePerms: [] as RolePermRow[],
-          deletedRoles: [] as DeletedRoleView[]
-        };
-      }
-      // R8 — the picker offers only what this tenant may actually hold. Platform
-      // permissions (ADR-0053) are refused at runtime for everyone else, so
-      // listing them here invites a grant that can never take effect.
-      const platformTenant = await resolvePlatformTenant(tx);
-      const catalog = await listPermissionCatalog(tx, {
-        includePlatformScoped:
-          platformTenant !== null && platformTenant.tenantId === ssr.tenantId
-      });
-      const perms: RolePermRow[] = [];
-      for (const role of liveRoles) {
-        const granted = await listRolePermissions(tx, ssr.tenantId, role.id);
-        const grantedIds = new Set(granted.map((p) => p.id));
-        const available = catalog.filter((p) => !grantedIds.has(p.id));
-        perms.push({ role, granted, available });
-      }
-      const deleted = await listDeletedRoles(tx, ssr.tenantId);
-      return { liveRoles, rolePerms: perms, deletedRoles: deleted };
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's rather than `ssr.permissions.has()`.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "access_control",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const liveRoles = await listRoles(tx, ssr.tenantId);
+    const canConfigure = await can({
+      moduleKey: "identity_access",
+      activityCode: "access_control",
+      action: "configure"
     });
-    // `withTenant` returns a 503 `Response` when the DB circuit breaker is open
-    // / a work-class queue is saturated — degrade to an error notice.
-    if (result instanceof Response) {
-      loadError = true;
-    } else {
-      roles = result.liveRoles;
-      rolePerms = result.rolePerms;
-      deletedRoles = result.deletedRoles;
+
+    if (!canConfigure) {
+      return {
+        liveRoles,
+        rolePerms: [] as RolePermRow[],
+        deletedRoles: [] as DeletedRoleView[],
+        canConfigure
+      };
     }
-  } catch {
-    loadError = true;
+
+    // R8 — the picker offers only what this tenant may actually hold. Platform
+    // permissions (ADR-0053) are refused at runtime for everyone else, so
+    // listing them here invites a grant that can never take effect.
+    const platformTenant = await resolvePlatformTenant(tx);
+    const catalog = await listPermissionCatalog(tx, {
+      includePlatformScoped:
+        platformTenant !== null && platformTenant.tenantId === ssr.tenantId
+    });
+    const perms: RolePermRow[] = [];
+    for (const role of liveRoles) {
+      const granted = await listRolePermissions(tx, ssr.tenantId, role.id);
+      const grantedIds = new Set(granted.map((p) => p.id));
+      const available = catalog.filter((p) => !grantedIds.has(p.id));
+      perms.push({ role, granted, available });
+    }
+
+    return {
+      liveRoles,
+      rolePerms: perms,
+      deletedRoles: await listDeletedRoles(tx, ssr.tenantId),
+      canConfigure
+    };
+  },
+  onError: (error) => {
+    logAdminPageError("admin/roles.astro: failed to load roles", error, {
+      correlationId: Astro.locals.correlationId
+    });
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "this tenant has no roles" and NOT a
+// denial — an empty role list would misdescribe who can do what.
+const loadError = screen.state === "error";
+const roles: RoleView[] =
+  screen.state === "allowed" ? screen.data.liveRoles : [];
+const rolePerms: RolePermRow[] =
+  screen.state === "allowed" ? screen.data.rolePerms : [];
+const deletedRoles: DeletedRoleView[] =
+  screen.state === "allowed" ? screen.data.deletedRoles : [];
+const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
 
 // A uniform row list so the table renders the same whether or not the viewer
 // can configure (a read-only viewer gets empty grant/available lists).

--- a/src/pages/admin/sidebar-menu.astro
+++ b/src/pages/admin/sidebar-menu.astro
@@ -20,10 +20,8 @@
  * unarrangeable, which reads as data loss to whoever can see it.
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   buildSidebarEditorModel,
   fetchSidebarArrangement,
@@ -42,35 +40,43 @@ if (!ssr) {
   );
 }
 
-const canRead = ssr.permissions.has(
-  permissionKey("module_management", "navigation", "read")
-);
-const canConfigure = ssr.permissions.has(
-  permissionKey("module_management", "navigation", "configure")
-);
-
-let model: SidebarEditorModel | null = null;
-let loadFailed = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) =>
-      buildSidebarEditorModel(await fetchSidebarArrangement(tx, ssr.tenantId))
-    );
-
-    // Shape check, not truthiness: `withTenant` RETURNS a 503 `Response` on
-    // circuit-open rather than throwing, and a `Response` is truthy.
-    model =
-      result && typeof result === "object" && "entries" in result
-        ? (result as SidebarEditorModel)
-        : null;
-    loadFailed = model === null;
-  } catch (error) {
-    loadFailed = true;
-    logAdminPageError("/admin/sidebar-menu", error);
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's rather than `ssr.permissions.has()`.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "module_management",
+    activityCode: "navigation",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    model: buildSidebarEditorModel(
+      await fetchSidebarArrangement(tx, ssr.tenantId)
+    ),
+    canConfigure: await can({
+      moduleKey: "module_management",
+      activityCode: "navigation",
+      action: "configure"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError("/admin/sidebar-menu", error, {
+      correlationId: Astro.locals.correlationId
+    });
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+// The old shape check existed because `withTenant` RETURNS a 503 `Response` on
+// circuit-open rather than throwing, and a `Response` is truthy. The outcome
+// type now carries that distinction directly, so no shape sniffing is needed.
+const loadFailed = screen.state === "error";
+const model: SidebarEditorModel | null =
+  screen.state === "allowed" ? screen.data.model : null;
+const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
 
 const itemOverrides = new Map(
   (model?.arrangement.items ?? []).map((item) => [item.entryKey, item])

--- a/src/pages/admin/tenant/domains.astro
+++ b/src/pages/admin/tenant/domains.astro
@@ -17,9 +17,8 @@
  */
 import AdminLayout from "../../../layouts/AdminLayout.astro";
 import "../../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../../lib/database/client";
-import { withTenantOrThrow } from "../../../lib/database/tenant-context";
-import { permissionKey } from "../../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../../lib/logging/error-log";
 import {
   listTenantDomains,
   type TenantDomainView
@@ -31,46 +30,69 @@ import {
 } from "../../../modules/tenant-domain/domain/tenant-domain-validation";
 
 const ssr = Astro.locals.ssrContext!;
-const canRead = ssr.permissions.has(
-  permissionKey("tenant_domain", "domains", "read")
-);
-const canCreate = ssr.permissions.has(
-  permissionKey("tenant_domain", "domains", "create")
-);
-const canUpdate = ssr.permissions.has(
-  permissionKey("tenant_domain", "domains", "update")
-);
-const canDelete = ssr.permissions.has(
-  permissionKey("tenant_domain", "domains", "delete")
-);
-const canVerify = ssr.permissions.has(
-  permissionKey("tenant_domain", "domains", "verify")
-);
-const canSetPrimary = ssr.permissions.has(
-  permissionKey("tenant_domain", "domains", "set_primary")
-);
+
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. Five write affordances are decided the same
+// way; `normalizePublicHost()` via the API remains the enforcement point.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "tenant_domain",
+    activityCode: "domains",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    domains: (await listTenantDomains(tx, ssr.tenantId)).domains,
+    canCreate: await can({
+      moduleKey: "tenant_domain",
+      activityCode: "domains",
+      action: "create"
+    }),
+    canUpdate: await can({
+      moduleKey: "tenant_domain",
+      activityCode: "domains",
+      action: "update"
+    }),
+    canDelete: await can({
+      moduleKey: "tenant_domain",
+      activityCode: "domains",
+      action: "delete"
+    }),
+    canVerify: await can({
+      moduleKey: "tenant_domain",
+      activityCode: "domains",
+      action: "verify"
+    }),
+    canSetPrimary: await can({
+      moduleKey: "tenant_domain",
+      activityCode: "domains",
+      action: "set_primary"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError(
+      "admin/tenant/domains.astro: failed to list tenant domains",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "no domains" and NOT a denial.
+const loadError = screen.state === "error";
+const domains: TenantDomainView[] =
+  screen.state === "allowed" ? screen.data.domains : [];
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
+const canUpdate = screen.state === "allowed" && screen.data.canUpdate;
+const canDelete = screen.state === "allowed" && screen.data.canDelete;
+const canVerify = screen.state === "allowed" && screen.data.canVerify;
+const canSetPrimary = screen.state === "allowed" && screen.data.canSetPrimary;
 
 const showActions = canUpdate || canDelete || canVerify || canSetPrimary;
-
-let domains: TenantDomainView[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      const page = await listTenantDomains(tx, ssr.tenantId);
-      return page.domains;
-    });
-    if (result instanceof Response) {
-      loadError = true;
-    } else {
-      domains = result;
-    }
-  } catch {
-    loadError = true;
-  }
-}
 
 function statusVariant(status: string): string {
   if (status === "active") return "success";

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -18,9 +18,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import {
   listRoles,
   listTenantUsers,
@@ -29,36 +28,53 @@ import {
 } from "../../modules/identity-access/application/access-directory";
 
 const ssr = Astro.locals.ssrContext!;
-const canRead = ssr.permissions.has(
-  permissionKey("identity_access", "access_control", "read")
-);
-const canConfigure = ssr.permissions.has(
-  permissionKey("identity_access", "access_control", "configure")
-);
-const canAssign = ssr.permissions.has(
-  permissionKey("identity_access", "access_control", "assign")
-);
 
-let users: TenantUserView[] = [];
-let roles: RoleView[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => ({
-      users: await listTenantUsers(tx, ssr.tenantId),
-      roles: await listRoles(tx, ssr.tenantId)
-    }));
-    if (result instanceof Response) loadError = true;
-    else {
-      users = result.users;
-      roles = result.roles;
-    }
-  } catch {
-    loadError = true;
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. This screen lists who holds what in the tenant,
+// so a `deny` a tenant wrote about `access_control` now applies to READING the
+// roster, not only to changing it.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "access_control",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    users: await listTenantUsers(tx, ssr.tenantId),
+    roles: await listRoles(tx, ssr.tenantId),
+    canConfigure: await can({
+      moduleKey: "identity_access",
+      activityCode: "access_control",
+      action: "configure"
+    }),
+    canAssign: await can({
+      moduleKey: "identity_access",
+      activityCode: "access_control",
+      action: "assign"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError(
+      "admin/users.astro: failed to load the tenant user directory",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+// A pool/circuit-breaker refusal is NOT "this tenant has no users" and NOT a
+// denial — an empty roster would be a lie about who holds access.
+const loadError = screen.state === "error";
+const users: TenantUserView[] =
+  screen.state === "allowed" ? screen.data.users : [];
+const roles: RoleView[] = screen.state === "allowed" ? screen.data.roles : [];
+const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
+const canAssign = screen.state === "allowed" && screen.data.canAssign;
 
 // role code -> role id, so a user's assigned role codes can be turned into
 // removable controls carrying the id the unassign endpoint expects.


### PR DESCRIPTION
Gelombang 1 batch 3 dari #450. Ledger **23 → 18**.

## Layar

`users`, `roles`, `offices`, `sidebar-menu`, `tenant/domains` — dari `ssr.permissions.has(...)` ke `loadAdminScreen`.

**`users` + `roles` adalah pasangan yang paling berarti di batch ini.** Keduanya mendaftarkan **siapa memegang apa**. Sampai sekarang membaca roster akses sebuah tenant tidak melewati evaluasi ABAC dan tidak meninggalkan satu baris pun di `awcms_abac_decision_logs`: sebuah `deny` tenant tentang `access_control` berlaku saat MENGUBAH keanggotaan, tidak saat MEMBACANYA.

**`tenant/domains`** satu-satunya layar yang tidak tertangkap glob `src/pages/admin/*.astro` tingkat-atas — blind spot yang sama yang membuat #424 menyebut 31 padahal 32. Dimasukkan sekarang supaya ia tidak jadi sisa terakhir yang terlupa. Enam afordans tulisnya kini lewat `can(...)`.

**`roles`** mempertahankan logika R8 utuh: katalog permission masih disaring `includePlatformScoped` terhadap `resolvePlatformTenant(tx)`, dan pemuatan katalog itu tetap hanya terjadi bila `configure` diizinkan — bedanya izin itu kini jawaban chokepoint.

## Kebersihan

- Cabang mati `result instanceof Response` terhadap `withTenantOrThrow` (yang melempar) dihapus di empat layar.
- `sidebar-menu.astro` memeriksa bentuk (`"entries" in result`) justru karena `Response` itu truthy; `AdminScreenOutcome` membedakan `allowed`/`denied`/`error` secara langsung, jadi pemeriksaan itu hilang.
- `catch {}` kosong → `logAdminPageError` ber-`correlationId`.

## Yang sengaja TIDAK di batch ini

`tenants.astro` punya nuansa perilaku nyata: ia membedakan **ditolak** dari **ditahan karena bukan tenant platform** (ADR-0053/0054) dan merender penjelasan spesifik, bukan tabel kosong. Merutekannya lewat chokepoint menggabungkan dua keadaan itu kalau tidak dirancang, jadi ia dapat PR sendiri.

## Verifikasi

- `DATABASE_URL="" bun run test` — 3486 pass, 0 fail
- `bun run check` penuh — **exit 0**
- `access:chokepoint:check` — `32 admin screens, 18 still decide outside the chokepoint (ledger: 18)`
- 19 klaim permission kelima layar diperiksa masih ter-ekstrak `extractScreenClaims`

🤖 Generated with [Claude Code](https://claude.com/claude-code)