### PR TITLE
feat(auth): dua layar platform-scoped berhenti menyalin aturan ADR-0053 (#450, R3)

### DIFF
--- a/.changeset/layar-admin-chokepoint-platform-scope.md
+++ b/.changeset/layar-admin-chokepoint-platform-scope.md
@@ -1,0 +1,59 @@
+---
+"awcms": minor
+---
+
+feat(auth): dua layar platform-scoped berhenti menyalin aturan ADR-0053 (#450, R3)
+
+`tenants` dan `idn-regions` berpindah ke `loadAdminScreen`. Ledger 14 → 12.
+
+Keduanya bukan migrasi mekanis: masing-masing menyimpan **salinan kedua** aturan
+platform-scope ADR-0053, ditulis tangan di frontmatter sebagai
+`holds… && isPlatformTenant`, bebas menyimpang dari satu-satunya salinan yang
+mengikat di `access-guard.ts`.
+
+`authorizeInTransaction` memutuskan `platform_scope_required` **sebelum**
+permission dicari sama sekali. Itu lebih keras daripada yang disalin: baris grant
+yang sampai ke tenant yang salah — restore backup, INSERT tangan, jalur
+provisioning baru yang lupa `WHERE scope = 'tenant'` — menjadi inert, bukan
+mencukupi. Jadi salinan tangannya dihapus, tidak diporting.
+
+Asimetri keduanya berbeda dan itu yang membuat masing-masing menarik:
+
+- **`tenants`** — `tenant_provisioning.read` sendiri PLATFORM-scoped, jadi
+  keputusan masuknya sepenuhnya milik chokepoint.
+- **`idn-regions`** — `dataset.read` TENANT-scoped sementara `configure` dan
+  `restore` PLATFORM-scoped. `can(...)` menjalankan gerbang ADR-0053 yang sama
+  dengan endpoint-nya, jadi dua tombol tulisnya kini digerbangi kode yang sama,
+  bukan tiruannya.
+
+`resolvePlatformTenant` tetap dipanggil di kedua layar, kini **untuk TAMPILAN
+saja**: supaya layar bisa mengatakan MENGAPA sebuah kontrol tidak ada, bukan
+meninggalkan ruang kosong. Ia tetap di luar transaksi tenant — keduanya membaca
+tabel root bebas-RLS dan tidak butuh konteks tenant.
+
+## Satu kalimat yang berhenti mengklaim apa yang tak lagi diketahui
+
+Pemberitahuan scope di `/admin/tenants` berbunyi "Your role carries the
+permission; the action is refused because of where it is being made". Sesudah
+migrasi kalimat itu **tidak bisa lagi dibuktikan**: gerbang platform menolak
+sebelum permission dicari, jadi halaman ini tidak tahu apakah pembacanya
+benar-benar memegangnya. Diganti menjadi klaim yang tetap benar — penolakannya
+soal DI MANA aksi dilakukan, dan tidak ada grant di tenant ini yang bisa
+membukanya.
+
+Dua state penolakan kini dipisah jujur: bukan tenant platform → catatan scope;
+tenant platform tetapi ditolak → catatan permission.
+
+## Tiga test diperbaiki, dan alasannya sama dengan yang dihapus
+
+`tenant-provisioning` dan `admin-idn-regions-page-contract` mematok persis
+ekspresi `holds… && isPlatformTenant` yang menjadi cacatnya. Mempertahankannya
+akan menjadikan test itu alasan untuk MENYIMPAN duplikat aturan.
+
+Keduanya kini membuktikan sifat yang sama dari dua hal yang benar-benar
+menegakkannya: `scope` di deskriptor modul (data hidup — kalau
+`tenant_provisioning.read` pernah berubah menjadi `tenant`, layarnya diam-diam
+terbuka untuk setiap owner tenant, dan asersi atas teks halaman tidak akan
+menyadarinya) dan perutean lewat `loadAdminScreen`. Ekstraktor klaim
+`admin-idn-regions` juga digabungkan dengan bentuk objek-literal, sekelas dengan
+batch 1 dan 4.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (22.909 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (22.972 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -90,13 +90,11 @@ export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
   "blog.astro",
   "data-lifecycle.astro",
   "domain-events.astro",
-  "idn-regions.astro",
   "reporting.astro",
   "security.astro",
   "seo.astro",
   "site-search.astro",
   "sync.astro",
-  "tenants.astro",
   "theming.astro"
 ];
 

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -123,13 +123,11 @@ const NOT_YET_MIGRATED: readonly string[] = [
   "src/pages/admin/blog.astro",
   "src/pages/admin/data-lifecycle.astro",
   "src/pages/admin/domain-events.astro",
-  "src/pages/admin/idn-regions.astro",
   "src/pages/admin/reporting.astro",
   "src/pages/admin/security.astro",
   "src/pages/admin/seo.astro",
   "src/pages/admin/site-search.astro",
   "src/pages/admin/sync.astro",
-  "src/pages/admin/tenants.astro",
   "src/pages/admin/theming.astro",
 
   // --- Rute API.

--- a/src/pages/admin/idn-regions.astro
+++ b/src/pages/admin/idn-regions.astro
@@ -34,9 +34,8 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   resolvePlatformTenant,
   resolveTenancyMode,
@@ -56,59 +55,90 @@ if (!ssr) {
   );
 }
 
-const canReadDatasets = ssr.permissions.has(
-  permissionKey("idn_admin_regions", "dataset", "read")
-);
-const holdsActivate = ssr.permissions.has(
-  permissionKey("idn_admin_regions", "dataset", "configure")
-);
-const holdsRollback = ssr.permissions.has(
-  permissionKey("idn_admin_regions", "dataset", "restore")
-);
-
-let datasets: DatasetSummary[] = [];
+/**
+ * Resolved OUTSIDE any tenant transaction on purpose: both read RLS-free root
+ * tables (`awcms_tenants`, `awcms_setup_state`) and neither needs — or should
+ * imply — a tenant context.
+ *
+ * DISPLAY only, since #450. The DECISION about the two platform-scoped actions
+ * is the chokepoint's; this is here so the screen can say WHY a control is
+ * missing instead of leaving a blank space.
+ */
 let tenancyMode: TenancyMode = "single";
 let isPlatformTenant = false;
 let platformTenantCode: string | null = null;
-let loadError = false;
+let platformResolutionFailed = false;
 
-if (canReadDatasets || holdsActivate || holdsRollback) {
-  try {
-    const sql = getDatabaseClient();
-    const rows = canReadDatasets
-      ? await withTenantOrThrow(sql, ssr.tenantId, (tx) => listDatasets(tx))
-      : [];
+try {
+  const sql = getDatabaseClient();
+  const platformTenant = await resolvePlatformTenant(sql);
 
-    // Resolved OUTSIDE the tenant transaction on purpose: both read RLS-free
-    // root tables (`awcms_tenants`, `awcms_setup_state`) and neither needs — or
-    // should imply — a tenant context.
-    const platformTenant = await resolvePlatformTenant(sql);
-    tenancyMode = await resolveTenancyMode(sql);
+  tenancyMode = await resolveTenancyMode(sql);
+  isPlatformTenant = platformTenant?.tenantId === ssr.tenantId;
+  platformTenantCode = platformTenant?.tenantCode ?? null;
+} catch (error) {
+  logAdminPageError(
+    "admin/idn-regions.astro: failed to resolve platform tenant",
+    error,
+    { correlationId: Astro.locals.correlationId }
+  );
+  platformResolutionFailed = true;
+}
 
-    datasets = rows;
-    isPlatformTenant = platformTenant?.tenantId === ssr.tenantId;
-    platformTenantCode = platformTenant?.tenantCode ?? null;
-  } catch (error) {
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// `dataset.read` is TENANT-scoped; `dataset.configure` and `dataset.restore`
+// are PLATFORM-scoped (ADR-0052/0053). That is why the hand-written
+// `holds… && isPlatformTenant` mirroring is gone rather than ported: `can(...)`
+// runs the same ADR-0053 gate the endpoint runs, so the screen no longer keeps
+// a SECOND copy of the platform rule that could drift from the first.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "idn_admin_regions",
+    activityCode: "dataset",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    datasets: await listDatasets(tx),
+    canActivate: await can({
+      moduleKey: "idn_admin_regions",
+      activityCode: "dataset",
+      action: "configure"
+    }),
+    canRollback: await can({
+      moduleKey: "idn_admin_regions",
+      activityCode: "dataset",
+      action: "restore"
+    })
+  }),
+  onError: (error) => {
     logAdminPageError(
       "admin/idn-regions.astro: failed to load dataset console",
       error,
       { correlationId: Astro.locals.correlationId }
     );
-    loadError = true;
   }
-}
+});
+
+const canReadDatasets = screen.state !== "denied";
+const loadError = screen.state === "error" || platformResolutionFailed;
+const datasets: DatasetSummary[] =
+  screen.state === "allowed" ? screen.data.datasets : [];
+const canActivate = screen.state === "allowed" && screen.data.canActivate;
+const canRollback = screen.state === "allowed" && screen.data.canRollback;
 
 /**
- * Holding the permission is not enough — the chokepoint also requires the
- * acting tenant to BE the platform tenant. Mirroring both halves here means the
- * screen never renders a button whose request is already destined for a 403.
+ * Held the permission but is not the platform tenant — worth explaining, not
+ * hiding. The chokepoint has already refused the two actions by this point; the
+ * flag exists so the refusal is narrated rather than rendered as absence.
  */
-const canActivate = holdsActivate && isPlatformTenant;
-const canRollback = holdsRollback && isPlatformTenant;
-
-/** Held the permission but is not the platform tenant — worth explaining, not hiding. */
 const withheldByPlatformScope =
-  (holdsActivate || holdsRollback) && !isPlatformTenant;
+  canReadDatasets && !isPlatformTenant && !canActivate && !canRollback;
 
 const activeDataset = datasets.find((dataset) => dataset.status === "active");
 const hasPreviousDataset = datasets.some(
@@ -145,7 +175,7 @@ const numberFormatter = new Intl.NumberFormat("en-US");
   </header>
 
   {
-    !canReadDatasets && !holdsActivate && !holdsRollback && (
+    !canReadDatasets && (
       <p class="state-notice fade-in-up" id="idn-regions-denied">
         You do not have permission to view region datasets.
       </p>

--- a/src/pages/admin/tenants.astro
+++ b/src/pages/admin/tenants.astro
@@ -28,9 +28,8 @@
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
 import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   resolvePlatformTenant,
   resolveTenancyMode,
@@ -45,13 +44,6 @@ if (!ssr) {
   );
 }
 
-const holdsRead = ssr.permissions.has(
-  permissionKey("tenant_admin", "tenant_provisioning", "read")
-);
-const holdsCreate = ssr.permissions.has(
-  permissionKey("tenant_admin", "tenant_provisioning", "create")
-);
-
 type DirectoryEntry = {
   id: string;
   tenantCode: string;
@@ -60,61 +52,102 @@ type DirectoryEntry = {
   createdAt: Date;
 };
 
-let tenants: DirectoryEntry[] = [];
+/**
+ * Resolved OUTSIDE any tenant transaction: both read RLS-free root tables and
+ * neither needs — or should imply — a tenant context.
+ *
+ * DISPLAY only, since #450. `tenant_provisioning.read` is itself PLATFORM-scoped
+ * (ADR-0053), so the chokepoint below already refuses a non-platform tenant; the
+ * value of resolving it here is that the screen can name the platform tenant in
+ * its explanation rather than rendering a bare refusal.
+ */
 let tenancyMode: TenancyMode = "single";
 let isPlatformTenant = false;
 let platformTenantCode: string | null = null;
-let loadError = false;
+let platformResolutionFailed = false;
 
-if (holdsRead || holdsCreate) {
-  try {
-    const sql = getDatabaseClient();
+try {
+  const sql = getDatabaseClient();
+  const platformTenant = await resolvePlatformTenant(sql);
 
-    // Resolved OUTSIDE any tenant transaction: both read RLS-free root tables
-    // and neither needs — or should imply — a tenant context.
-    const platformTenant = await resolvePlatformTenant(sql);
-    isPlatformTenant = platformTenant?.tenantId === ssr.tenantId;
-    platformTenantCode = platformTenant?.tenantCode ?? null;
-    tenancyMode = await resolveTenancyMode(sql);
+  isPlatformTenant = platformTenant?.tenantId === ssr.tenantId;
+  platformTenantCode = platformTenant?.tenantCode ?? null;
+  tenancyMode = await resolveTenancyMode(sql);
+} catch (error) {
+  logAdminPageError(
+    "admin/tenants.astro: failed to resolve platform tenant",
+    error,
+    { correlationId: Astro.locals.correlationId }
+  );
+  platformResolutionFailed = true;
+}
 
-    if (holdsRead && isPlatformTenant) {
-      const rows = await withTenantOrThrow(
-        sql,
-        ssr.tenantId,
-        async (tx) =>
-          (await tx`
-            SELECT id, tenant_code, tenant_name, status, created_at
-            FROM awcms_tenants
-            ORDER BY created_at DESC
-            LIMIT 500
-          `) as {
-            id: string;
-            tenant_code: string;
-            tenant_name: string;
-            status: string;
-            created_at: Date;
-          }[]
-      );
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. It applies ADR-0053's platform gate BEFORE
+// permissions are looked up, which is the same rule this screen used to compute
+// by hand as `holdsRead && isPlatformTenant` — one rule now, not two.
+//
+// The directory query stays inside the transaction unchanged. `awcms_tenants`
+// is the deliberately RLS-free root table, so the tenant context does not
+// filter it; what makes the read safe is the platform gate above it, and that
+// is precisely the gate that was being re-implemented here.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "tenant_admin",
+    activityCode: "tenant_provisioning",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    rows: (await tx`
+      SELECT id, tenant_code, tenant_name, status, created_at
+      FROM awcms_tenants
+      ORDER BY created_at DESC
+      LIMIT 500
+    `) as {
+      id: string;
+      tenant_code: string;
+      tenant_name: string;
+      status: string;
+      created_at: Date;
+    }[],
+    canCreate: await can({
+      moduleKey: "tenant_admin",
+      activityCode: "tenant_provisioning",
+      action: "create"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError("admin/tenants.astro: failed to load directory", error, {
+      correlationId: Astro.locals.correlationId
+    });
+  }
+});
 
-      tenants = rows.map((row) => ({
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error" || platformResolutionFailed;
+const tenants: DirectoryEntry[] =
+  screen.state === "allowed"
+    ? screen.data.rows.map((row) => ({
         id: row.id,
         tenantCode: row.tenant_code,
         tenantName: row.tenant_name,
         status: row.status,
         createdAt: row.created_at
-      }));
-    }
-  } catch (error) {
-    logAdminPageError("admin/tenants.astro: failed to load directory", error, {
-      correlationId: Astro.locals.correlationId
-    });
-    loadError = true;
-  }
-}
+      }))
+    : [];
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
 
-const canRead = holdsRead && isPlatformTenant;
-const canCreate = holdsCreate && isPlatformTenant;
-const withheldByPlatformScope = (holdsRead || holdsCreate) && !isPlatformTenant;
+/**
+ * Refused, and the reason is the platform gate rather than a missing grant.
+ * Worth explaining: "you are not the platform tenant" and "you were never
+ * granted this" are different problems with different fixes, and a screen that
+ * renders both as the same blank page sends the operator to the wrong one.
+ */
+const withheldByPlatformScope = !canRead && !isPlatformTenant;
 
 function formatTimestamp(value: Date | null): string {
   if (!value) return "—";
@@ -141,7 +174,7 @@ function statusVariant(status: string): string {
   </header>
 
   {
-    !holdsRead && !holdsCreate && (
+    !canRead && isPlatformTenant && (
       <p class="state-notice fade-in-up" id="tenants-denied">
         You do not have permission to view the tenant directory.
       </p>
@@ -158,8 +191,8 @@ function statusVariant(status: string): string {
             (<span class="cell-code">{platformTenantCode}</span>)
           </>
         )}
-        , not to this one. Your role carries the permission; the action is
-        refused because of where it is being made, not who is making it.
+        , not to this one. The refusal is about WHERE the action is being made,
+        not who is making it — no grant on this tenant can unlock it.
       </p>
     )
   }

--- a/tests/admin-idn-regions-page-contract.test.ts
+++ b/tests/admin-idn-regions-page-contract.test.ts
@@ -29,13 +29,25 @@ const ROUTES = [
 
 type Triple = `${string}.${string}.${string}`;
 
-/** `permissionKey("idn_admin_regions", "dataset", "configure")` → the triple. */
+/**
+ * Permission triples the screen gates on, in BOTH spellings.
+ *
+ * Issue #450 is why the second exists: a screen routed through
+ * `loadAdminScreen` states its guards as `AccessRequest` object literals — the
+ * same shape the routes use — instead of `permissionKey(...)`.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 
@@ -89,20 +101,39 @@ describe("/admin/idn-regions permission gates", () => {
 
   test("write controls require the platform tenant, not just the permission", async () => {
     const page = await readFile(PAGE, "utf8");
+    const permissions =
+      listModules().find((module) => module.key === "idn_admin_regions")
+        ?.permissions ?? [];
+    const scopeOf = (action: string): string | undefined =>
+      permissions.find(
+        (permission) =>
+          permission.activityCode === "dataset" && permission.action === action
+      )?.scope;
 
-    // Both halves, ANDed. Rendering on the permission alone would produce
-    // buttons that are refused at the chokepoint for every non-platform tenant.
-    expect(page).toContain("resolvePlatformTenant");
-    expect(page).toMatch(
-      /const canActivate = holdsActivate && isPlatformTenant/
-    );
-    expect(page).toMatch(
-      /const canRollback = holdsRollback && isPlatformTenant/
-    );
+    // The PROPERTY, proven from the descriptor plus the chokepoint, not from a
+    // hand-written `holds… && isPlatformTenant` expression.
+    //
+    // That expression is what this used to pin, and issue #450 is why it is
+    // gone: it was a SECOND copy of ADR-0053's rule living in this template.
+    // `can(...)` runs `authorizeInTransaction`, which decides
+    // `platform_scope_required` before permissions are even looked up — so the
+    // two write controls are gated by the same code the endpoint uses, and the
+    // duplicate that could drift from it no longer exists.
+    expect(scopeOf("configure")).toBe("platform");
+    expect(scopeOf("restore")).toBe("platform");
+    expect(page).toMatch(/loadAdminScreen\(/);
+    expect(page).not.toMatch(/ssr\.permissions\.has\(/);
 
     // And the read panel must NOT be gated that way — every tenant is entitled
-    // to see which dataset version it is being served.
-    expect(page).toMatch(/canReadDatasets = ssr\.permissions\.has\(/);
+    // to see which dataset version it is being served. This is the asymmetry
+    // that makes the screen worth having on a non-platform tenant at all, so it
+    // is asserted from the descriptor rather than inferred from the page.
+    // `scope` is optional and absent MEANS tenant, so the claim is stated the
+    // way the chokepoint reads it: anything that is not `platform` is tenant.
+    expect(scopeOf("read")).not.toBe("platform");
+    expect(page).toMatch(
+      /authorize:\s*\{\s*moduleKey:\s*"idn_admin_regions",\s*activityCode:\s*"dataset",\s*action:\s*"read"/
+    );
   });
 
   test("the page never mutates directly — it posts to the guarded endpoints", async () => {

--- a/tests/tenant-provisioning.test.ts
+++ b/tests/tenant-provisioning.test.ts
@@ -175,9 +175,33 @@ describe("the route and screen behave", () => {
   test("the screen requires the platform tenant, not just the permission", async () => {
     const page = await readFile(PAGE, "utf8");
 
-    expect(page).toContain("resolvePlatformTenant");
-    expect(page).toMatch(/const canRead = holdsRead && isPlatformTenant/);
-    expect(page).toMatch(/const canCreate = holdsCreate && isPlatformTenant/);
+    // The PROPERTY, proven from the two things that actually enforce it, not
+    // from a hand-written `holds… && isPlatformTenant` expression.
+    //
+    // That expression is what this used to pin, and issue #450 is why it is
+    // gone: it was a SECOND copy of ADR-0053's rule living in a template, free
+    // to drift from the one in `access-guard.ts`. `authorizeInTransaction`
+    // decides `platform_scope_required` BEFORE permissions are looked up, so
+    // routing the screen through the chokepoint enforces it strictly harder —
+    // a grant row that reached the wrong tenant is inert rather than
+    // sufficient. Pinning the old spelling would have made this test a reason
+    // to keep the duplicate.
+    expect(page).toMatch(/loadAdminScreen\(/);
+    expect(page).not.toMatch(/ssr\.permissions\.has\(/);
+
+    const declared = listModules()
+      .find((module) => module.key === "tenant_admin")
+      ?.permissions?.find(
+        (permission) =>
+          permission.activityCode === "tenant_provisioning" &&
+          permission.action === "read"
+      );
+
+    // The half the chokepoint reads. If this ever became `tenant`, the screen
+    // would silently open to every tenant's owner, and no assertion about the
+    // page's own text would notice.
+    expect(declared?.scope).toBe("platform");
+
     expect(page).not.toMatch(
       /\b(INSERT\s+INTO|UPDATE\s+awcms_|DELETE\s+FROM)/i
     );


### PR DESCRIPTION
Gelombang 1 dari #450. Ledger **14 → 12**.

## Ini bukan migrasi mekanis

`tenants` dan `idn-regions` masing-masing menyimpan **salinan kedua** aturan platform-scope ADR-0053, ditulis tangan di frontmatter sebagai `holds… && isPlatformTenant` — bebas menyimpang dari satu-satunya salinan yang mengikat di `access-guard.ts`.

`authorizeInTransaction` memutuskan `platform_scope_required` **sebelum permission dicari sama sekali**. Itu lebih keras daripada yang disalin: sebuah baris grant yang sampai ke tenant yang salah (restore backup, INSERT tangan, jalur provisioning baru yang lupa `WHERE scope = 'tenant'`) menjadi **inert**, bukan mencukupi. Jadi salinan tangannya **dihapus, tidak diporting**.

Asimetri keduanya berbeda:

| Layar | Entry | Afordans tulis |
|---|---|---|
| `tenants` | `tenant_provisioning.read` — **platform** | `create` — platform |
| `idn-regions` | `dataset.read` — **tenant** | `configure`, `restore` — platform |

`idn-regions` justru yang paling bersih hasilnya: `can(...)` menjalankan gerbang ADR-0053 yang sama dengan endpoint-nya, jadi dua tombol tulisnya digerbangi kode yang sama, bukan tiruannya.

`resolvePlatformTenant` tetap dipanggil di kedua layar, kini **untuk TAMPILAN saja** — supaya layar bisa mengatakan MENGAPA sebuah kontrol tidak ada. Tetap di luar transaksi tenant.

## Satu kalimat yang berhenti mengklaim apa yang tak lagi diketahui

Pemberitahuan di `/admin/tenants` berbunyi *"Your role carries the permission; the action is refused because of where it is being made"*. Sesudah migrasi kalimat itu **tidak bisa lagi dibuktikan** — gerbang platform menolak sebelum permission dicari, jadi halaman ini tidak tahu apakah pembacanya memegangnya. Diganti dengan klaim yang tetap benar: penolakannya soal DI MANA aksi dilakukan, dan tidak ada grant di tenant ini yang bisa membukanya.

Dua state penolakan kini dipisah jujur: **bukan** tenant platform → catatan scope; **adalah** tenant platform tetapi ditolak → catatan permission.

## Tiga test diperbaiki, alasannya sama dengan yang dihapus

`tenant-provisioning` dan `admin-idn-regions-page-contract` mematok **persis** ekspresi `holds… && isPlatformTenant` yang menjadi cacatnya. Mempertahankannya menjadikan test itu alasan untuk MENYIMPAN duplikat aturan.

Keduanya kini membuktikan sifat yang sama dari dua hal yang benar-benar menegakkannya: **`scope` di deskriptor modul** (data hidup — kalau `tenant_provisioning.read` pernah berubah menjadi `tenant`, layarnya diam-diam terbuka untuk setiap owner tenant, dan asersi atas teks halaman tidak akan menyadarinya) dan **perutean lewat `loadAdminScreen`**.

Catatan kecil: `scope` opsional dan absen BERARTI tenant, jadi klaim sisi-baca ditulis `not.toBe("platform")` — cara chokepoint membacanya.

## Verifikasi

- `DATABASE_URL="" bun run test` — 3486 pass, 0 fail
- `bun run check` penuh — **exit 0**
- `access:chokepoint:check` — `32 admin screens, 12 still decide outside the chokepoint (ledger: 12)`

## Sisa 12

Sebelas layar multi-aktivitas (butuh keputusan per-layar tentang permission ENTRY) + `blog-presentation` (bentuk helper file-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)