### PR TITLE
feat(auth): tiga konsol besar berlayar-tunggal melewati chokepoint (#450, R3)

### DIFF
--- a/.changeset/layar-admin-chokepoint-batch-5.md
+++ b/.changeset/layar-admin-chokepoint-batch-5.md
@@ -1,0 +1,36 @@
+---
+"awcms": minor
+---
+
+feat(auth): tiga konsol besar berlayar-tunggal melewati chokepoint (#450, R3)
+
+`blog`, `analytics`, `theming` berpindah ke `loadAdminScreen`. Ledger 12 → 9.
+
+Ketiganya ber-aktivitas-jamak tetapi **state penolakannya selalu satu
+permission** (`!canRead` / `!canView`), jadi menjadikan permission itu ENTRY
+tidak mengubah siapa yang ditolak — ia hanya MENAMBAH gerbang yang tidak pernah
+diterapkan pemeriksaan grant mentah. Itu yang membedakan ketiganya dari delapan
+layar sisa, yang menolak hanya bila SEMUA permission bacanya absen; layar-layar
+itu butuh rancangan tersendiri dan tidak dipaksakan ke sini.
+
+`blog.astro` menggerbangi sebelas permission — terbanyak di repo ini.
+
+## Satu gerbang sengaja TIDAK disentuh
+
+`analytics.astro` sudah lebih dulu menyelesaikan `raw_detail.read` lewat
+`evaluateFieldAccessInTransaction`, bukan `ssr.permissions.has(...)`. Ia
+keputusan tingkat-FIELD tentang kolom mana yang dibentuk pada sebuah baris
+(IP, user-agent, snapshot login), bukan tentang mencapai halaman — dan ia tidak
+pernah menjadi bagian dari cacat R3. Jadi ia tetap apa adanya: migrasi ini tidak
+punya alasan menulis ulang satu-satunya gerbang di layar itu yang sudah benar.
+
+`analytics` juga kini meneruskan `now` yang sama ke `loadAdminScreen` yang
+dipakainya menghitung rentang, jadi keputusan dan datanya dibaca pada satu jam.
+
+## Dua contract test diperbaiki
+
+`admin-blog-page-contract` dan `admin-theming-page-contract` mengekstrak klaim
+layar hanya dari `permissionKey(...)`. `theming` tidak bisa sekadar memakai
+ulang ekstraktor guard di berkasnya: yang itu mencocokkan ROUTE, yang menyusun
+guard-nya dari konstanta `THEMING_*_ACTIVITY_CODE`, sementara layar menuliskan
+kode aktivitasnya. Jadi ia mendapat matcher literal sendiri.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (22.972 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (23.035 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -84,18 +84,15 @@ const CHOKEPOINT_EXEMPTIONS: Readonly<Record<string, string>> = {
  * each a sentence would dress 31 open defects as 31 decisions.
  */
 export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
-  "analytics.astro",
   "approvals.astro",
   "blog-presentation.astro",
-  "blog.astro",
   "data-lifecycle.astro",
   "domain-events.astro",
   "reporting.astro",
   "security.astro",
   "seo.astro",
   "site-search.astro",
-  "sync.astro",
-  "theming.astro"
+  "sync.astro"
 ];
 
 /**

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -117,10 +117,8 @@ const WITH_TENANT_CALL_PATTERN =
 const NOT_YET_MIGRATED: readonly string[] = [
   // --- Layar admin (R3) — sedang dimigrasikan ke `loadAdminScreen`, Gelombang 1
   //     dari #423 (issue #450). Daftar ini menyusut tiap PR migrasi.
-  "src/pages/admin/analytics.astro",
   "src/pages/admin/approvals.astro",
   "src/pages/admin/blog-presentation.astro",
-  "src/pages/admin/blog.astro",
   "src/pages/admin/data-lifecycle.astro",
   "src/pages/admin/domain-events.astro",
   "src/pages/admin/reporting.astro",
@@ -128,7 +126,6 @@ const NOT_YET_MIGRATED: readonly string[] = [
   "src/pages/admin/seo.astro",
   "src/pages/admin/site-search.astro",
   "src/pages/admin/sync.astro",
-  "src/pages/admin/theming.astro",
 
   // --- Rute API.
   "src/pages/api/v1/abac/policies/[id].ts",

--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -20,9 +20,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import { evaluateFieldAccessInTransaction } from "../../modules/identity-access/application/access-guard";
 import { resolveVisitorAnalyticsConfig } from "../../modules/visitor-analytics/domain/visitor-analytics-config";
 import {
@@ -56,15 +55,6 @@ import {
 } from "../../modules/visitor-analytics/domain/dashboard-view";
 
 const ssr = Astro.locals.ssrContext!;
-const canView = ssr.permissions.has(
-  permissionKey("visitor_analytics", "dashboard", "read")
-);
-const canRealtime = ssr.permissions.has(
-  permissionKey("visitor_analytics", "realtime", "read")
-);
-const canSessions = ssr.permissions.has(
-  permissionKey("visitor_analytics", "sessions", "read")
-);
 
 // Raw-detail (IP/user-agent/login snapshot) visibility is resolved through the
 // ABAC evaluator inside `withTenant` below (see `rawDetailAllowed`), NOT a bare
@@ -83,8 +73,6 @@ const subjectContext = {
   identityId: ssr.identityId,
   roles: ssr.roles
 };
-let canRawDetail = false;
-
 const config = resolveVisitorAnalyticsConfig();
 const geoActive = config.geoEnabled && config.trustCloudflare;
 
@@ -94,87 +82,103 @@ const range: AnalyticsRange = isKnownAnalyticsRange(rangeParam)
   : DEFAULT_ANALYTICS_RANGE;
 const RANGE_OPTIONS: AnalyticsRange[] = ["24h", "7d", "30d", "12m"];
 
-let realtime: RealtimeStats | null = null;
-let summary: AnalyticsSummary | null = null;
-let pages: NamedCount[] = [];
-let browsers: NamedCount[] = [];
-let devices: NamedCount[] = [];
-let countries: NamedCount[] = [];
-let security: SecurityView | null = null;
-let sessions: VisitorSessionDto[] = [];
-let loadError = false;
+const now = new Date();
+const start = resolveRangeStart(range, now);
 
-if (canView) {
-  try {
-    const sql = getDatabaseClient();
-    const now = new Date();
-    const start = resolveRangeStart(range, now);
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. `dashboard.read` is the entry: this screen's
+// denied state has always been `!canView` alone.
+//
+// `rawDetailAllowed` deliberately keeps using `evaluateFieldAccessInTransaction`
+// rather than `can(...)`. It is a FIELD-level decision about which columns of a
+// row to shape, not a decision about reaching the page, and it was already
+// resolved through the ABAC evaluator — this migration has no reason to rewrite
+// the one gate on this screen that was never part of the defect.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "visitor_analytics",
+    activityCode: "dashboard",
+    action: "read"
+  },
+  now,
+  load: async ({ tx, can }) => {
+    // Sequential (one tx connection): concurrent queries would leak it.
+    const canRealtime = await can({
+      moduleKey: "visitor_analytics",
+      activityCode: "realtime",
+      action: "read"
+    });
+    const canSessions = await can({
+      moduleKey: "visitor_analytics",
+      activityCode: "sessions",
+      action: "read"
+    });
 
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      // Resolve raw-detail visibility through ABAC (deny-overrides-allow),
-      // reusing the SSR-resolved subject/permissions — only when sessions are
-      // shown at all (the sole place raw detail renders). Fail-closed otherwise.
-      const rawDetailAllowed = canSessions
-        ? await evaluateFieldAccessInTransaction(
-            tx,
-            ssr.tenantId,
-            subjectContext,
-            ssr.permissions,
-            RAW_DETAIL_GUARD,
-            now
-          )
-        : false;
+    // Reusing the SSR-resolved subject/permissions — only when sessions are
+    // shown at all (the sole place raw detail renders). Fail-closed otherwise.
+    const rawDetailAllowed = canSessions
+      ? await evaluateFieldAccessInTransaction(
+          tx,
+          ssr.tenantId,
+          subjectContext,
+          ssr.permissions,
+          RAW_DETAIL_GUARD,
+          now
+        )
+      : false;
 
-      // Sequential (one tx connection): concurrent queries would leak it.
-      const rt = canRealtime
+    return {
+      canRealtime,
+      canSessions,
+      rawDetailAllowed,
+      rt: canRealtime
         ? await fetchRealtimeStats(tx, ssr.tenantId, config.onlineWindowSeconds)
-        : null;
-      const sum = await fetchAnalyticsSummary(tx, ssr.tenantId, range, start);
-      const topPaths = await fetchTopPaths(tx, ssr.tenantId, start);
-      const topBrowsers = await fetchTopBrowsers(tx, ssr.tenantId, start);
-      const topDevices = await fetchTopDevices(tx, ssr.tenantId, start);
-      const topCountries = geoActive
+        : null,
+      sum: await fetchAnalyticsSummary(tx, ssr.tenantId, range, start),
+      topPaths: await fetchTopPaths(tx, ssr.tenantId, start),
+      topBrowsers: await fetchTopBrowsers(tx, ssr.tenantId, start),
+      topDevices: await fetchTopDevices(tx, ssr.tenantId, start),
+      topCountries: geoActive
         ? await fetchTopCountries(tx, ssr.tenantId, start)
-        : [];
-      const sec = await fetchSecurityView(tx, ssr.tenantId, range, start);
-      const sess = canSessions
+        : [],
+      sec: await fetchSecurityView(tx, ssr.tenantId, range, start),
+      sess: canSessions
         ? (await listVisitorSessions(tx, ssr.tenantId)).rows.map((row) =>
             shapeVisitorSession(row, rawDetailAllowed)
           )
-        : [];
-
-      return {
-        rt,
-        sum,
-        topPaths,
-        topBrowsers,
-        topDevices,
-        topCountries,
-        sec,
-        sess,
-        rawDetailAllowed
-      };
+        : []
+    };
+  },
+  onError: (error) => {
+    logAdminPageError("admin/analytics.astro: failed to load console", error, {
+      correlationId: Astro.locals.correlationId
     });
-
-    // `withTenant` returns a 503 `Response` when the DB circuit breaker is open
-    // / a work-class queue is saturated — degrade to an error notice.
-    if (result instanceof Response) {
-      loadError = true;
-    } else {
-      realtime = result.rt;
-      summary = result.sum;
-      pages = result.topPaths;
-      browsers = result.topBrowsers;
-      devices = result.topDevices;
-      countries = result.topCountries;
-      security = result.sec;
-      sessions = result.sess;
-      canRawDetail = result.rawDetailAllowed;
-    }
-  } catch {
-    loadError = true;
   }
-}
+});
+
+const canView = screen.state !== "denied";
+const loadError = screen.state === "error";
+const canRealtime = screen.state === "allowed" && screen.data.canRealtime;
+const canSessions = screen.state === "allowed" && screen.data.canSessions;
+const canRawDetail = screen.state === "allowed" && screen.data.rawDetailAllowed;
+const realtime: RealtimeStats | null =
+  screen.state === "allowed" ? screen.data.rt : null;
+const summary: AnalyticsSummary | null =
+  screen.state === "allowed" ? screen.data.sum : null;
+const pages: NamedCount[] =
+  screen.state === "allowed" ? screen.data.topPaths : [];
+const browsers: NamedCount[] =
+  screen.state === "allowed" ? screen.data.topBrowsers : [];
+const devices: NamedCount[] =
+  screen.state === "allowed" ? screen.data.topDevices : [];
+const countries: NamedCount[] =
+  screen.state === "allowed" ? screen.data.topCountries : [];
+const security: SecurityView | null =
+  screen.state === "allowed" ? screen.data.sec : null;
+const sessions: VisitorSessionDto[] =
+  screen.state === "allowed" ? screen.data.sess : [];
 
 const sessionCells = sessions.map((s) =>
   buildSessionRowCells(s, {

--- a/src/pages/admin/blog.astro
+++ b/src/pages/admin/blog.astro
@@ -82,10 +82,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listBlogPostsForAdmin,
   type ListBlogPostsForAdminResult
@@ -106,41 +104,6 @@ import {
 } from "../../modules/blog-content/domain/content-validation";
 
 const ssr = Astro.locals.ssrContext!;
-
-const canRead = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "read")
-);
-const canCreate = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "create")
-);
-// Also the gate on "submit for review" — there is no `posts.submit`.
-const canUpdate = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "update")
-);
-const canPublish = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "publish")
-);
-const canSchedule = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "schedule")
-);
-const canArchive = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "archive")
-);
-const canDelete = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "delete")
-);
-const canRestore = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "restore")
-);
-const canPurge = ssr.permissions.has(
-  permissionKey("blog_content", "posts", "purge")
-);
-const canReadRevisions = ssr.permissions.has(
-  permissionKey("blog_content", "revisions", "read")
-);
-const canRestoreRevisions = ssr.permissions.has(
-  permissionKey("blog_content", "revisions", "restore")
-);
 
 function readParam(name: string): string {
   return (Astro.url.searchParams.get(name) ?? "").trim();
@@ -180,42 +143,122 @@ const showsBin = readParam("view") === "deleted";
 /** `?post=<id>` opens the revision panel for one post, rather than N queries for a list nobody expanded. */
 const selectedPostId = readParam("post");
 
-let listing: ListBlogPostsForAdminResult | null = null;
-let revisions: BlogRevisionSummary[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      listing = await listBlogPostsForAdmin(tx, ssr.tenantId, {
-        search: searchFilter || undefined,
-        status: statusFilter,
-        deletedOnly: showsBin || undefined,
-        page: pageNumber
-      });
-
-      if (selectedPostId && canReadRevisions) {
-        // `listBlogRevisions` asserts the id is a UUID and throws otherwise,
-        // which the surrounding catch turns into the load-error notice — a
-        // hand-edited `?post=` must not 500 the page.
-        revisions = await listBlogRevisions(
-          tx,
-          ssr.tenantId,
-          "post",
-          selectedPostId
-        );
-      }
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. `posts.read` is the entry: this screen's denied
+// state has always been `!canRead` alone.
+//
+// The nine affordances are spelled out one by one rather than looped over an
+// action array: a loop would make them INVISIBLE to
+// `admin:screen-coverage:check`, whose matcher only sees literal triples.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "posts",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const listing = await listBlogPostsForAdmin(tx, ssr.tenantId, {
+      search: searchFilter || undefined,
+      status: statusFilter,
+      deletedOnly: showsBin || undefined,
+      page: pageNumber
     });
-  } catch (error) {
+
+    const canReadRevisions = await can({
+      moduleKey: "blog_content",
+      activityCode: "revisions",
+      action: "read"
+    });
+
+    return {
+      listing,
+      canReadRevisions,
+      // `listBlogRevisions` asserts the id is a UUID and throws otherwise,
+      // which `onError` turns into the load-error notice — a hand-edited
+      // `?post=` must not 500 the page.
+      revisions:
+        selectedPostId && canReadRevisions
+          ? await listBlogRevisions(tx, ssr.tenantId, "post", selectedPostId)
+          : [],
+      canRestoreRevisions: await can({
+        moduleKey: "blog_content",
+        activityCode: "revisions",
+        action: "restore"
+      }),
+      canCreate: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "create"
+      }),
+      // Also the gate on "submit for review" — there is no `posts.submit`.
+      canUpdate: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "update"
+      }),
+      canPublish: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "publish"
+      }),
+      canSchedule: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "schedule"
+      }),
+      canArchive: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "archive"
+      }),
+      canDelete: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "delete"
+      }),
+      canRestore: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "restore"
+      }),
+      canPurge: await can({
+        moduleKey: "blog_content",
+        activityCode: "posts",
+        action: "purge"
+      })
+    };
+  },
+  onError: (error) => {
     // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
     // must never render as "this tenant has no posts".
-    loadError = true;
     logAdminPageError("admin/blog.astro: failed to load posts", error, {
       correlationId: Astro.locals.correlationId
     });
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const listing: ListBlogPostsForAdminResult | null =
+  screen.state === "allowed" ? screen.data.listing : null;
+const revisions: BlogRevisionSummary[] =
+  screen.state === "allowed" ? screen.data.revisions : [];
+const canReadRevisions =
+  screen.state === "allowed" && screen.data.canReadRevisions;
+const canRestoreRevisions =
+  screen.state === "allowed" && screen.data.canRestoreRevisions;
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
+const canUpdate = screen.state === "allowed" && screen.data.canUpdate;
+const canPublish = screen.state === "allowed" && screen.data.canPublish;
+const canSchedule = screen.state === "allowed" && screen.data.canSchedule;
+const canArchive = screen.state === "allowed" && screen.data.canArchive;
+const canDelete = screen.state === "allowed" && screen.data.canDelete;
+const canRestore = screen.state === "allowed" && screen.data.canRestore;
+const canPurge = screen.state === "allowed" && screen.data.canPurge;
 
 const STATUS_VARIANT: Record<string, string> = {
   draft: "neutral",

--- a/src/pages/admin/theming.astro
+++ b/src/pages/admin/theming.astro
@@ -48,10 +48,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   fetchDraftVersion,
   fetchThemeTenantState,
@@ -73,52 +71,70 @@ if (!ssr) {
   );
 }
 
-const canRead = ssr.permissions.has(permissionKey("theming", "config", "read"));
-const canUpdate = ssr.permissions.has(
-  permissionKey("theming", "config", "update")
-);
-const canPublish = ssr.permissions.has(
-  permissionKey("theming", "version", "publish")
-);
-const canRollback = ssr.permissions.has(
-  permissionKey("theming", "version", "restore")
-);
-const canRetire = ssr.permissions.has(
-  permissionKey("theming", "version", "archive")
-);
-const canPreview = ssr.permissions.has(
-  permissionKey("theming", "preview", "create")
-);
-
 // Build-time, reviewed source — no I/O, so it is resolved before (and outside)
 // the tenant transaction.
 const themes = listThemeDescriptors();
 
-let state: ThemeTenantState | null = null;
-let draft: ThemeConfigVersion | null = null;
-let versions: ThemeConfigVersion[] = [];
-let loadError = false;
-
-if (canRead) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      // Sequential on purpose: one transaction connection, one query at a time.
-      const tenantState = await fetchThemeTenantState(tx, ssr.tenantId);
-      const draftVersion = await fetchDraftVersion(tx, ssr.tenantId);
-      const published = await listPublishedVersions(tx, ssr.tenantId, 50);
-      return { tenantState, draftVersion, published };
-    });
-    state = result.tenantState;
-    draft = result.draftVersion;
-    versions = result.published;
-  } catch (error) {
+// Issue #450 — the entry decision and the read share ONE transaction, and the
+// decision is the chokepoint's. `config.read` is the entry: this screen's
+// denied state has always been `!canRead` alone, so routing it through the
+// chokepoint changes who is refused only by ADDING the gates a bare grant check
+// never applied.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: { moduleKey: "theming", activityCode: "config", action: "read" },
+  load: async ({ tx, can }) => ({
+    // Sequential on purpose: one transaction connection, one query at a time.
+    tenantState: await fetchThemeTenantState(tx, ssr.tenantId),
+    draftVersion: await fetchDraftVersion(tx, ssr.tenantId),
+    published: await listPublishedVersions(tx, ssr.tenantId, 50),
+    canUpdate: await can({
+      moduleKey: "theming",
+      activityCode: "config",
+      action: "update"
+    }),
+    canPublish: await can({
+      moduleKey: "theming",
+      activityCode: "version",
+      action: "publish"
+    }),
+    canRollback: await can({
+      moduleKey: "theming",
+      activityCode: "version",
+      action: "restore"
+    }),
+    canRetire: await can({
+      moduleKey: "theming",
+      activityCode: "version",
+      action: "archive"
+    }),
+    canPreview: await can({
+      moduleKey: "theming",
+      activityCode: "preview",
+      action: "create"
+    })
+  }),
+  onError: (error) => {
     logAdminPageError("admin/theming.astro: failed to load console", error, {
       correlationId: Astro.locals.correlationId
     });
-    loadError = true;
   }
-}
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const state: ThemeTenantState | null =
+  screen.state === "allowed" ? screen.data.tenantState : null;
+const draft: ThemeConfigVersion | null =
+  screen.state === "allowed" ? screen.data.draftVersion : null;
+const versions: ThemeConfigVersion[] =
+  screen.state === "allowed" ? screen.data.published : [];
+const canUpdate = screen.state === "allowed" && screen.data.canUpdate;
+const canPublish = screen.state === "allowed" && screen.data.canPublish;
+const canRollback = screen.state === "allowed" && screen.data.canRollback;
+const canRetire = screen.state === "allowed" && screen.data.canRetire;
+const canPreview = screen.state === "allowed" && screen.data.canPreview;
 
 /**
  * Which descriptor the editor renders. An explicit `?theme=` wins (that is how

--- a/tests/admin-blog-page-contract.test.ts
+++ b/tests/admin-blog-page-contract.test.ts
@@ -90,8 +90,18 @@ function guardTriplesFrom(source: string): Set<Triple> {
   return found;
 }
 
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect. A contract
+ * test must pin the PROPERTY (this screen gates exactly the eleven), never the
+ * syntax that happened to express it.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
-  const found = new Set<Triple>();
+  const found = guardTriplesFrom(source);
   const pattern =
     /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 

--- a/tests/admin-theming-page-contract.test.ts
+++ b/tests/admin-theming-page-contract.test.ts
@@ -68,12 +68,29 @@ function guardTriplesFrom(source: string): Set<Triple> {
 }
 
 /** `permissionKey("theming", "version", "restore")` → the same shape. */
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals instead of `permissionKey(...)`.
+ *
+ * It cannot reuse `guardTriplesFrom` above — that one matches the ROUTES, which
+ * compose their guards from the `THEMING_*_ACTIVITY_CODE` constants, while the
+ * screen writes the activity codes out. Reading only the old spelling would
+ * have made this test demand the screen keep deciding access from the raw grant
+ * set, which is the defect.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 


### PR DESCRIPTION
Gelombang 1 dari #450. Ledger **12 → 9**.

## Kenapa ketiga ini boleh dibatch, dan delapan sisanya tidak

`blog`, `analytics`, `theming` ber-aktivitas-jamak tetapi state penolakannya **selalu satu permission** (`!canRead` / `!canView`). Jadi menjadikan permission itu ENTRY tidak mengubah siapa yang ditolak — ia hanya MENAMBAH gerbang yang tidak pernah diterapkan pemeriksaan grant mentah.

Delapan layar sisa (`approvals`, `data-lifecycle`, `domain-events`, `reporting`, `security`, `seo`, `site-search`, `sync`) menolak hanya bila **SEMUA** permission bacanya absen. Memilih salah satunya sebagai entry akan menolak seseorang yang hanya memegang panel lain — penyempitan akses nyata. Itu butuh rancangan tersendiri, jadi tidak dipaksakan ke sini.

`blog.astro` menggerbangi **sebelas** permission, terbanyak di repo ini.

## Satu gerbang sengaja TIDAK disentuh

`analytics.astro` sudah lebih dulu menyelesaikan `raw_detail.read` lewat `evaluateFieldAccessInTransaction`, bukan `ssr.permissions.has(...)`. Ia keputusan tingkat-**FIELD** tentang kolom mana yang dibentuk pada sebuah baris (IP, user-agent, snapshot login), bukan tentang mencapai halaman, dan **tidak pernah menjadi bagian dari cacat R3**. Menggantinya dengan `can(...)` akan menulis ulang satu-satunya gerbang di layar itu yang sudah benar, jadi ia tetap apa adanya.

`analytics` juga meneruskan `now` yang sama ke `loadAdminScreen` yang dipakainya menghitung rentang, jadi keputusan dan datanya dibaca pada satu jam.

## Dua contract test diperbaiki

Kelas yang sama dengan batch 1/4/platform-scope: ekstraktor klaim hanya membaca `permissionKey(...)`.

`theming` tidak bisa sekadar memakai ulang ekstraktor guard di berkasnya — yang itu mencocokkan **ROUTE**, yang menyusun guard-nya dari konstanta `THEMING_*_ACTIVITY_CODE`, sementara layar menuliskan kode aktivitasnya. Jadi ia mendapat matcher literal sendiri, dengan alasannya tertulis.

## Verifikasi

- `DATABASE_URL="" bun run test` — 3486 pass, 0 fail
- `bun run check` penuh — **exit 0**
- `access:chokepoint:check` — `32 admin screens, 9 still decide outside the chokepoint (ledger: 9)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)