### PR TITLE
feat(auth): `loadAdminScreen` mendapat entry ANY-OF, dan dua konsol pertama memakainya (#450, R3)

### DIFF
--- a/.changeset/layar-admin-any-of-entry.md
+++ b/.changeset/layar-admin-any-of-entry.md
@@ -1,0 +1,48 @@
+---
+"awcms": minor
+---
+
+feat(auth): `loadAdminScreen` mendapat entry ANY-OF, dan dua konsol pertama memakainya (#450, R3)
+
+Delapan konsol admin sisa punya bentuk yang sama: beberapa panel yang bisa
+dibaca secara independen, dan penolakan halaman hanya bila **semua** panel
+ditolak (`canSeeAnything = canReadNodes || canReadConflicts || canReadQueue`).
+
+Memaksa satu permission menjadi ENTRY untuk layar-layar itu akan menolak
+operator yang sah memegang baca satu panel dan bukan panel lain — **penyempitan
+akses nyata yang menyamar sebagai refactor**. Jadi helper-nya yang belajar
+bentuk itu, bukan layarnya yang dibengkokkan.
+
+`authorize` kini menerima array: diizinkan bila **setidaknya satu** diizinkan.
+Array KOSONG menolak — "tidak ada request yang mengotorisasi halaman ini" tidak
+boleh terbaca sebagai "request apa pun mengotorisasinya", penalaran fail-closed
+yang sama dengan tenant platform yang tak terselesaikan di `access-guard.ts`.
+
+Setiap request entry dievaluasi — daftarnya TIDAK di-short-circuit pada izin
+pertama — dan hasilnya dikembalikan lewat `entry: readonly boolean[]` mengikuti
+urutan deklarasi. Itu justru intinya: panel membaca jawabannya sendiri dari
+sana alih-alih bertanya lagi lewat `can()`, yang akan menulis baris
+`awcms_abac_decision_logs` KEDUA untuk keputusan identik dalam satu render —
+derau di jejak audit, bukan bukti.
+
+## Aturannya diuji sebagai fungsi murni
+
+`selectEntryOutcome` diekstrak supaya setiap cabangnya bisa diuji tanpa
+database, dan `tests/admin-screen-entry.test.ts` baru menguji delapan hal —
+termasuk mutasi yang paling berbahaya: menulis aturannya sebagai "tidak SEMUA
+request ditolak" meloloskan `[]`, karena `[].every(...)` bernilai **true**.
+Sebuah layar yang kehilangan request entry-nya dalam sebuah suntingan akan
+terbuka untuk setiap pengguna terautentikasi tenant itu, tanpa satu gerbang pun
+merah.
+
+Sampai PR ini helper-nya belum punya test perilaku sama sekali — hanya gerbang
+struktural yang membuktikan layar meruteinya.
+
+## Dua konsol pertama
+
+`sync` (tiga panel, enam permission) dan `domain-events` (tiga panel, lima
+permission). Ledger 9 → 7.
+
+Dua contract test-nya mengekstrak klaim hanya dari `permissionKey(...)`;
+ekstraktornya kini membaca kedua ejaan, sekelas dengan koreksi di batch 1, 4, 5
+dan platform-scope.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (23.035 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (23.096 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 127   |
 | Tabel dengan `FORCE` RLS           | 116   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 323   |
+| Berkas test                        | 324   |
 | Berkas route                       | 311   |
 | ADR                                | 74    |
 
@@ -275,7 +275,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 275        |
+| `(root)`      | 276        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -87,12 +87,10 @@ export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
   "approvals.astro",
   "blog-presentation.astro",
   "data-lifecycle.astro",
-  "domain-events.astro",
   "reporting.astro",
   "security.astro",
   "seo.astro",
-  "site-search.astro",
-  "sync.astro"
+  "site-search.astro"
 ];
 
 /**

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -120,12 +120,10 @@ const NOT_YET_MIGRATED: readonly string[] = [
   "src/pages/admin/approvals.astro",
   "src/pages/admin/blog-presentation.astro",
   "src/pages/admin/data-lifecycle.astro",
-  "src/pages/admin/domain-events.astro",
   "src/pages/admin/reporting.astro",
   "src/pages/admin/security.astro",
   "src/pages/admin/seo.astro",
   "src/pages/admin/site-search.astro",
-  "src/pages/admin/sync.astro",
 
   // --- Rute API.
   "src/pages/api/v1/abac/policies/[id].ts",

--- a/src/lib/auth/admin-screen.ts
+++ b/src/lib/auth/admin-screen.ts
@@ -78,6 +78,20 @@ export type AdminScreenLoadContext = {
   tx: Bun.TransactionSQL;
   auth: AuthorizedScreenAccess;
   /**
+   * One boolean per entry request, in the order `authorize` declared them.
+   *
+   * Only interesting for the any-of form: eight consoles show several
+   * independently-readable panels and refuse the page only when EVERY panel is
+   * refused, so each panel needs its own answer as well as the page-level one.
+   *
+   * Every entry request is evaluated — the array is not short-circuited at the
+   * first allow — precisely so a screen can read its panel answers from here
+   * instead of asking `can()` for something already decided. Re-asking would
+   * write a second `awcms_abac_decision_logs` row for the identical decision in
+   * the same render, which is noise in an audit trail, not evidence.
+   */
+  entry: readonly boolean[];
+  /**
    * A SECOND decision, for the affordances a screen shows or hides (a create
    * form, a delete button) once the entry decision has allowed the page.
    *
@@ -110,8 +124,21 @@ export type AdminScreenConfig<TData> = {
    */
   workClass: WorkClass;
   queueTimeoutMs?: number;
-  /** The screen's ENTRY permission: what it takes to see the page at all. */
-  authorize: AccessRequest;
+  /**
+   * The screen's ENTRY permission: what it takes to see the page at all.
+   *
+   * An ARRAY means any-of — allowed when at least one is allowed. That is not a
+   * convenience: eight consoles (`sync`, `domain-events`, `reporting`, …) show
+   * panels that are independently readable and have always refused the page
+   * only when EVERY panel is refused. Forcing a single entry on them would deny
+   * an operator who legitimately holds one panel's read and not another's — a
+   * real narrowing of access dressed up as a refactor.
+   *
+   * An EMPTY array denies. "No request authorizes this page" must never read as
+   * "any request does"; the same fail-closed reasoning as an unresolvable
+   * platform tenant in `access-guard.ts`.
+   */
+  authorize: AccessRequest | readonly AccessRequest[];
   authorizeOptions?: {
     hierarchyPort?: BusinessScopeHierarchyPort;
     sodRules?: readonly SoDRuleDescriptor[];
@@ -130,6 +157,44 @@ export type AdminScreenConfig<TData> = {
   now?: Date;
 };
 
+/**
+ * The any-of rule, as a pure function over already-evaluated results, so every
+ * branch is testable without a database.
+ *
+ * Kept separate from `loadAdminScreen` deliberately: the interesting part is
+ * not "does it call the chokepoint" — the gate proves that — but what it does
+ * with N answers, and that is where an off-by-one reads as an access grant.
+ */
+export function selectEntryOutcome(
+  results: readonly AuthorizeResult[]
+):
+  | { allowed: true; auth: AuthorizedScreenAccess; entry: readonly boolean[] }
+  | { allowed: false; status: number } {
+  // An empty list authorizes nothing. `Array.prototype.some` on `[]` is false
+  // and `every` is TRUE — writing this rule as "not every request denied" would
+  // hand a screen with no entry request to everyone, which is why it is stated
+  // as an explicit early return rather than left to a quantifier.
+  if (results.length === 0) return { allowed: false, status: 403 };
+
+  const auth = results.find(
+    (result): result is AuthorizedScreenAccess => result.allowed
+  );
+
+  if (!auth) {
+    // The FIRST request's status: screens list their primary read first, so the
+    // status describes the refusal an operator is most likely asking about, and
+    // it does not shift with the caller's grant shape.
+    const first = results[0]!;
+
+    return {
+      allowed: false,
+      status: first.allowed ? 403 : first.denied.status
+    };
+  }
+
+  return { allowed: true, auth, entry: results.map((r) => r.allowed) };
+}
+
 export async function loadAdminScreen<TData>(
   config: AdminScreenConfig<TData>
 ): Promise<AdminScreenOutcome<TData>> {
@@ -141,21 +206,38 @@ export async function loadAdminScreen<TData>(
       sql,
       config.ssr.tenantId,
       async (tx): Promise<AdminScreenOutcome<TData>> => {
-        const auth = await authorizeInTransaction(
-          tx,
-          config.ssr.tenantId,
-          config.ssr.tokenHash,
-          now,
-          config.authorize,
-          config.authorizeOptions
-        );
+        const requests = Array.isArray(config.authorize)
+          ? (config.authorize as readonly AccessRequest[])
+          : [config.authorize as AccessRequest];
 
-        if (!auth.allowed) {
-          // The refusal is already recorded — `authorizeInTransaction` writes
+        // Every request, not just up to the first allow — see `entry` on
+        // `AdminScreenLoadContext` for why the extra evaluations are the point
+        // rather than waste. Sequential: `tx` is ONE reserved connection.
+        const results: AuthorizeResult[] = [];
+
+        for (const request of requests) {
+          results.push(
+            await authorizeInTransaction(
+              tx,
+              config.ssr.tenantId,
+              config.ssr.tokenHash,
+              now,
+              request,
+              config.authorizeOptions
+            )
+          );
+        }
+
+        const outcome = selectEntryOutcome(results);
+
+        if (!outcome.allowed) {
+          // The refusals are already recorded — `authorizeInTransaction` writes
           // the decision log itself, which is most of the point of routing
           // screens through it. Nothing is re-derived here.
-          return { state: "denied", status: auth.denied.status };
+          return { state: "denied", status: outcome.status };
         }
+
+        const { auth, entry } = outcome;
 
         const can = async (request: AccessRequest): Promise<boolean> => {
           const secondary = await authorizeInTransaction(
@@ -170,7 +252,7 @@ export async function loadAdminScreen<TData>(
           return secondary.allowed;
         };
 
-        const data = await config.load({ tx, auth, can });
+        const data = await config.load({ tx, auth, can, entry });
 
         return { state: "allowed", data, auth };
       },

--- a/src/pages/admin/domain-events.astro
+++ b/src/pages/admin/domain-events.astro
@@ -39,10 +39,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listConsumerStates,
   type DomainEventConsumerView
@@ -59,26 +57,6 @@ import {
 } from "../../modules/domain-event-runtime/domain/reason-bounds";
 
 const ssr = Astro.locals.ssrContext!;
-
-const canReadEvents = ssr.permissions.has(
-  permissionKey("domain_event_runtime", "events", "read")
-);
-const canReadDeliveries = ssr.permissions.has(
-  permissionKey("domain_event_runtime", "deliveries", "read")
-);
-const canReplay = ssr.permissions.has(
-  permissionKey("domain_event_runtime", "deliveries", "replay")
-);
-const canReadConsumers = ssr.permissions.has(
-  permissionKey("domain_event_runtime", "consumers", "read")
-);
-// One permission covers pause AND resume. `consumers.pause`/`consumers.resume`
-// read better and are seeded nowhere.
-const canManageConsumers = ssr.permissions.has(
-  permissionKey("domain_event_runtime", "consumers", "manage")
-);
-
-const canSeeAnything = canReadEvents || canReadDeliveries || canReadConsumers;
 
 function readParam(name: string): string {
   return (Astro.url.searchParams.get(name) ?? "").trim();
@@ -103,45 +81,99 @@ const consumerFilter = readParam("consumer");
 const eventTypeFilter = readParam("eventType");
 const aggregateTypeFilter = readParam("aggregateType");
 
-let consumers: DomainEventConsumerView[] = [];
-let deliveries: DomainEventDeliveryView[] = [];
-let events: DomainEventView[] = [];
-let loadError = false;
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF: three independently readable panels, refused only when all three are.
+// `entry` carries each panel's own answer back, so no panel is re-asked and no
+// second decision-log row is written for the identical decision.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    {
+      moduleKey: "domain_event_runtime",
+      activityCode: "events",
+      action: "read"
+    },
+    {
+      moduleKey: "domain_event_runtime",
+      activityCode: "deliveries",
+      action: "read"
+    },
+    {
+      moduleKey: "domain_event_runtime",
+      activityCode: "consumers",
+      action: "read"
+    }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [readEvents = false, readDeliveries = false, readConsumers = false] =
+      entry;
 
-if (canSeeAnything) {
-  try {
-    const sql = getDatabaseClient();
-    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      if (canReadConsumers) {
-        consumers = await listConsumerStates(tx, ssr.tenantId);
-      }
-
-      if (canReadDeliveries) {
-        deliveries = await listDomainEventDeliveries(tx, ssr.tenantId, {
-          status: deliveryStatusFilter || undefined,
-          consumerName: consumerFilter || undefined,
-          eventType: eventTypeFilter || undefined
-        });
-      }
-
-      if (canReadEvents) {
-        events = await listDomainEvents(tx, ssr.tenantId, {
-          eventType: eventTypeFilter || undefined,
-          aggregateType: aggregateTypeFilter || undefined
-        });
-      }
-    });
-  } catch (error) {
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    return {
+      readEvents,
+      readDeliveries,
+      readConsumers,
+      consumers: readConsumers
+        ? await listConsumerStates(tx, ssr.tenantId)
+        : [],
+      deliveries: readDeliveries
+        ? await listDomainEventDeliveries(tx, ssr.tenantId, {
+            status: deliveryStatusFilter || undefined,
+            consumerName: consumerFilter || undefined,
+            eventType: eventTypeFilter || undefined
+          })
+        : [],
+      events: readEvents
+        ? await listDomainEvents(tx, ssr.tenantId, {
+            eventType: eventTypeFilter || undefined,
+            aggregateType: aggregateTypeFilter || undefined
+          })
+        : [],
+      canReplay: await can({
+        moduleKey: "domain_event_runtime",
+        activityCode: "deliveries",
+        action: "replay"
+      }),
+      // One permission covers pause AND resume. `consumers.pause`/
+      // `consumers.resume` read better and are seeded nowhere.
+      canManageConsumers: await can({
+        moduleKey: "domain_event_runtime",
+        activityCode: "consumers",
+        action: "manage"
+      })
+    };
+  },
+  onError: (error) => {
     // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
     // must never render as "there are no stuck deliveries".
-    loadError = true;
     logAdminPageError(
       "admin/domain-events.astro: failed to load the event runtime console",
       error,
       { correlationId: Astro.locals.correlationId }
     );
   }
-}
+});
+
+const canSeeAnything = screen.state !== "denied";
+const loadError = screen.state === "error";
+const canReadEvents = screen.state === "allowed" && screen.data.readEvents;
+const canReadDeliveries =
+  screen.state === "allowed" && screen.data.readDeliveries;
+const canReadConsumers =
+  screen.state === "allowed" && screen.data.readConsumers;
+const consumers: DomainEventConsumerView[] =
+  screen.state === "allowed" ? screen.data.consumers : [];
+const deliveries: DomainEventDeliveryView[] =
+  screen.state === "allowed" ? screen.data.deliveries : [];
+const events: DomainEventView[] =
+  screen.state === "allowed" ? screen.data.events : [];
+const canReplay = screen.state === "allowed" && screen.data.canReplay;
+const canManageConsumers =
+  screen.state === "allowed" && screen.data.canManageConsumers;
 
 const DELIVERY_VARIANT: Record<string, string> = {
   pending: "info",

--- a/src/pages/admin/sync.astro
+++ b/src/pages/admin/sync.astro
@@ -45,10 +45,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { decodeKeysetCursor } from "../../modules/_shared/keyset-pagination";
 import {
   fetchObjectQueueEntries,
@@ -60,29 +58,6 @@ import {
 } from "../../modules/sync-storage/application/sync-directory";
 
 const ssr = Astro.locals.ssrContext!;
-
-const canReadNodes = ssr.permissions.has(
-  permissionKey("sync_storage", "node_management", "read")
-);
-const canUpdateNodes = ssr.permissions.has(
-  permissionKey("sync_storage", "node_management", "update")
-);
-const canReadConflicts = ssr.permissions.has(
-  permissionKey("sync_storage", "conflict_resolution", "read")
-);
-// Resolving is `approve`, not a `resolve`/`update` that reads better and is
-// seeded nowhere.
-const canResolveConflicts = ssr.permissions.has(
-  permissionKey("sync_storage", "conflict_resolution", "approve")
-);
-const canReadQueue = ssr.permissions.has(
-  permissionKey("sync_storage", "object_queue", "read")
-);
-const canRetryQueue = ssr.permissions.has(
-  permissionKey("sync_storage", "object_queue", "retry")
-);
-
-const canSeeAnything = canReadNodes || canReadConflicts || canReadQueue;
 
 function readParam(name: string): string {
   return (Astro.url.searchParams.get(name) ?? "").trim();
@@ -110,50 +85,104 @@ const cursorParam = readParam("cursor");
 // string must not turn this screen into an error page.
 const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
 
-let nodes: SyncNodeSummary[] = [];
-let conflicts: SyncConflictSummary[] = [];
-let queue: ObjectQueueEntry[] = [];
-let queueNextCursor: string | null = null;
-let loadError = false;
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF, because that is what this screen has always done: three panels that
+// are independently readable, and a refusal only when all three are refused.
+// Naming one of them the entry would deny an operator who holds the queue read
+// and not the node read. `entry` carries each panel's own answer back, so no
+// panel is re-asked and no second decision-log row is written for it.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    {
+      moduleKey: "sync_storage",
+      activityCode: "node_management",
+      action: "read"
+    },
+    {
+      moduleKey: "sync_storage",
+      activityCode: "conflict_resolution",
+      action: "read"
+    },
+    { moduleKey: "sync_storage", activityCode: "object_queue", action: "read" }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [readNodes = false, readConflicts = false, readQueue = false] = entry;
 
-if (canSeeAnything) {
-  try {
-    const sql = getDatabaseClient();
-    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      if (canReadNodes) {
-        nodes = await fetchSyncNodes(tx, ssr.tenantId);
-      }
-
-      if (canReadConflicts) {
-        conflicts = await fetchSyncConflicts(
-          tx,
-          ssr.tenantId,
-          conflictStatusFilter
-        );
-      }
-
-      if (canReadQueue) {
-        const page = await fetchObjectQueueEntries(
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const nodes = readNodes ? await fetchSyncNodes(tx, ssr.tenantId) : [];
+    const conflicts = readConflicts
+      ? await fetchSyncConflicts(tx, ssr.tenantId, conflictStatusFilter)
+      : [];
+    const page = readQueue
+      ? await fetchObjectQueueEntries(
           tx,
           ssr.tenantId,
           queueStatusFilter,
           cursor ?? undefined
-        );
-        queue = page.objects;
-        queueNextCursor = page.nextCursor;
-      }
-    });
-  } catch (error) {
+        )
+      : null;
+
+    return {
+      readNodes,
+      readConflicts,
+      readQueue,
+      nodes,
+      conflicts,
+      queue: page?.objects ?? [],
+      queueNextCursor: page?.nextCursor ?? null,
+      canUpdateNodes: await can({
+        moduleKey: "sync_storage",
+        activityCode: "node_management",
+        action: "update"
+      }),
+      // Resolving is `approve`, not a `resolve`/`update` that reads better and
+      // is seeded nowhere.
+      canResolveConflicts: await can({
+        moduleKey: "sync_storage",
+        activityCode: "conflict_resolution",
+        action: "approve"
+      }),
+      canRetryQueue: await can({
+        moduleKey: "sync_storage",
+        activityCode: "object_queue",
+        action: "retry"
+      })
+    };
+  },
+  onError: (error) => {
     // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
     // must never render as "there are no conflicts".
-    loadError = true;
     logAdminPageError(
       "admin/sync.astro: failed to load the sync console",
       error,
       { correlationId: Astro.locals.correlationId }
     );
   }
-}
+});
+
+const canSeeAnything = screen.state !== "denied";
+const loadError = screen.state === "error";
+const canReadNodes = screen.state === "allowed" && screen.data.readNodes;
+const canReadConflicts =
+  screen.state === "allowed" && screen.data.readConflicts;
+const canReadQueue = screen.state === "allowed" && screen.data.readQueue;
+const nodes: SyncNodeSummary[] =
+  screen.state === "allowed" ? screen.data.nodes : [];
+const conflicts: SyncConflictSummary[] =
+  screen.state === "allowed" ? screen.data.conflicts : [];
+const queue: ObjectQueueEntry[] =
+  screen.state === "allowed" ? screen.data.queue : [];
+const queueNextCursor: string | null =
+  screen.state === "allowed" ? screen.data.queueNextCursor : null;
+const canUpdateNodes = screen.state === "allowed" && screen.data.canUpdateNodes;
+const canResolveConflicts =
+  screen.state === "allowed" && screen.data.canResolveConflicts;
+const canRetryQueue = screen.state === "allowed" && screen.data.canRetryQueue;
 
 /** Mirrors `VALID_RESOLUTIONS` in `sync-storage/domain/sync-validation.ts`. */
 const RESOLUTION_OPTIONS = [

--- a/tests/admin-domain-events-page-contract.test.ts
+++ b/tests/admin-domain-events-page-contract.test.ts
@@ -59,12 +59,27 @@ function guardTriplesFrom(source: string): Set<Triple> {
   return found;
 }
 
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect it exists to
+ * catch elsewhere. A contract test pins the PROPERTY, never the syntax.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 

--- a/tests/admin-screen-entry.test.ts
+++ b/tests/admin-screen-entry.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `selectEntryOutcome` — the any-of entry rule behind `loadAdminScreen`
+ * (issue #450, Gelombang 1).
+ *
+ * Eight admin consoles show panels that are independently readable and have
+ * always refused the PAGE only when every panel is refused. Routing them
+ * through the chokepoint therefore needs an any-of entry; forcing a single one
+ * would deny an operator who legitimately holds one panel's read and not
+ * another's — a narrowing of access dressed up as a refactor.
+ *
+ * The rule is tested here rather than through `loadAdminScreen` because the
+ * interesting part is not "does it call the chokepoint" (`access:chokepoint:check`
+ * proves that mechanically, across both roots) but what it does with N answers.
+ * That is where an off-by-one reads as an access grant.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { selectEntryOutcome } from "../src/lib/auth/admin-screen";
+import type { AuthorizeResult } from "../src/modules/identity-access/application/access-guard";
+
+function allow(tenantUserId = "tu-1"): AuthorizeResult {
+  return {
+    allowed: true,
+    context: { tenantUserId },
+    grantedPermissionKeys: new Set<string>()
+  } as unknown as AuthorizeResult;
+}
+
+function deny(status: number): AuthorizeResult {
+  return {
+    allowed: false,
+    denied: new Response(null, { status })
+  } as unknown as AuthorizeResult;
+}
+
+describe("the empty list denies", () => {
+  test("no entry request authorizes nothing, not everything", () => {
+    // The mutation this exists for: writing the rule as "not every request was
+    // denied" passes `[]` because `[].every(...)` is TRUE. A screen that lost
+    // its entry request in an edit would then open to every authenticated user
+    // of the tenant, with no gate red and no test failing.
+    const outcome = selectEntryOutcome([]);
+
+    expect(outcome.allowed).toBe(false);
+    expect(outcome.allowed === false && outcome.status).toBe(403);
+  });
+});
+
+describe("any-of", () => {
+  test("one allow among denials admits the page", () => {
+    const outcome = selectEntryOutcome([deny(403), allow(), deny(403)]);
+
+    expect(outcome.allowed).toBe(true);
+  });
+
+  test("every request's answer is reported, in the declared order", () => {
+    // The panels read their own answer from here. If this collapsed to the
+    // page-level boolean, a viewer holding one panel would be shown all of
+    // them — the exact over-disclosure R3 is about, reintroduced one layer up.
+    const outcome = selectEntryOutcome([deny(403), allow(), deny(403)]);
+
+    expect(outcome.allowed === true && outcome.entry).toEqual([
+      false,
+      true,
+      false
+    ]);
+  });
+
+  test("all denied refuses the page", () => {
+    const outcome = selectEntryOutcome([deny(403), deny(403)]);
+
+    expect(outcome.allowed).toBe(false);
+  });
+
+  test("the reported status is the FIRST request's, not the last", () => {
+    // Screens list their primary read first, so the operator is told about the
+    // refusal they are most likely asking about. Taking the last would make the
+    // status depend on how many panels a screen happens to have.
+    const outcome = selectEntryOutcome([deny(402), deny(403)]);
+
+    expect(outcome.allowed === false && outcome.status).toBe(402);
+  });
+});
+
+describe("the single-request form is the same rule", () => {
+  test("one allow admits", () => {
+    const outcome = selectEntryOutcome([allow()]);
+
+    expect(outcome.allowed).toBe(true);
+    expect(outcome.allowed === true && outcome.entry).toEqual([true]);
+  });
+
+  test("one denial refuses, carrying its own status", () => {
+    const outcome = selectEntryOutcome([deny(429)]);
+
+    expect(outcome.allowed).toBe(false);
+    expect(outcome.allowed === false && outcome.status).toBe(429);
+  });
+});
+
+describe("the authorized half handed to `load` is an ALLOWED one", () => {
+  test("the first allow is chosen, never a denial", () => {
+    // `load` reads `auth.context.tenantUserId`. Handing it a denied result
+    // would be a type error today and a null dereference the moment the shapes
+    // converge, so the choice is pinned rather than left to `find`'s ordering.
+    const outcome = selectEntryOutcome([deny(403), allow("tu-second")]);
+
+    expect(outcome.allowed === true && outcome.auth.allowed).toBe(true);
+    expect(outcome.allowed === true && outcome.auth.context.tenantUserId).toBe(
+      "tu-second"
+    );
+  });
+});

--- a/tests/admin-sync-page-contract.test.ts
+++ b/tests/admin-sync-page-contract.test.ts
@@ -66,12 +66,27 @@ function guardTriplesFrom(source: string): Set<Triple> {
   return found;
 }
 
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect it exists to
+ * catch elsewhere. A contract test pins the PROPERTY, never the syntax.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 


### PR DESCRIPTION
Gelombang 1 dari #450. Ledger **9 → 7**.

## Kenapa helper-nya yang berubah, bukan layarnya

Delapan konsol sisa punya bentuk yang sama: beberapa panel yang bisa dibaca **secara independen**, dan penolakan halaman hanya bila **semua** panel ditolak —

```ts
const canSeeAnything = canReadNodes || canReadConflicts || canReadQueue;
```

Memaksa satu permission menjadi ENTRY untuk layar-layar itu akan menolak operator yang sah memegang baca satu panel dan bukan panel lain. Itu **penyempitan akses nyata yang menyamar sebagai refactor**, jadi helper-nya yang belajar bentuk itu.

`authorize` kini menerima array: diizinkan bila **setidaknya satu** diizinkan. Array **KOSONG menolak** — "tidak ada request yang mengotorisasi halaman ini" tidak boleh terbaca sebagai "request apa pun mengotorisasinya"; penalaran fail-closed yang sama dengan tenant platform tak-terselesaikan di `access-guard.ts`.

## `entry` dan kenapa daftarnya TIDAK di-short-circuit

Setiap request entry dievaluasi, dan hasilnya kembali lewat `entry: readonly boolean[]` mengikuti urutan deklarasi.

Itu justru intinya: panel membaca jawabannya sendiri dari sana alih-alih bertanya lagi lewat `can()` — yang akan menulis baris `awcms_abac_decision_logs` **kedua** untuk keputusan identik dalam satu render. Derau di jejak audit, bukan bukti; dan #429 sudah mencatat pertumbuhan tabel itu sebagai masalah tersendiri.

## Aturannya diuji sebagai fungsi murni

`selectEntryOutcome` diekstrak supaya setiap cabang bisa diuji tanpa database. **Helper ini sebelumnya tidak punya satu pun test perilaku** — hanya gerbang struktural yang membuktikan layar meruteinya.

Delapan test baru, termasuk mutasi yang paling berbahaya:

> menulis aturannya sebagai *"tidak SEMUA request ditolak"* meloloskan `[]`, karena `[].every(...)` bernilai **true**. Sebuah layar yang kehilangan request entry-nya dalam sebuah suntingan akan terbuka untuk setiap pengguna terautentikasi tenant itu, tanpa satu gerbang pun merah dan tanpa satu test pun gagal.

Status yang dilaporkan adalah milik request **pertama**, bukan terakhir: layar mendaftarkan baca utamanya lebih dulu, jadi operator diberi tahu tentang penolakan yang paling mungkin ia tanyakan, dan statusnya tidak bergeser mengikuti bentuk grant pemanggil.

## Dua konsol pertama

`sync` (tiga panel, enam permission) dan `domain-events` (tiga panel, lima permission).

Dua contract test-nya mengekstrak klaim hanya dari `permissionKey(...)`; ekstraktornya kini membaca kedua ejaan — sekelas dengan koreksi di batch 1, 4, 5 dan platform-scope.

## Verifikasi

- `DATABASE_URL="" bun run test` — 3494 pass, 0 fail
- `bun run check` penuh — **exit 0**
- `access:chokepoint:check` — `32 admin screens, 7 still decide outside the chokepoint (ledger: 7)`

## Sisa 7

`approvals`, `data-lifecycle`, `reporting`, `security`, `seo`, `site-search` (semua any-of, kini punya mekanismenya) + `blog-presentation` (bentuk helper file-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)