### PR TITLE
feat(auth): `approvals` dan `reporting` memakai entry any-of (#450, R3)

### DIFF
--- a/.changeset/layar-admin-any-of-batch-2.md
+++ b/.changeset/layar-admin-any-of-batch-2.md
@@ -1,0 +1,26 @@
+---
+"awcms": minor
+---
+
+feat(auth): `approvals` dan `reporting` memakai entry any-of (#450, R3)
+
+Ledger 7 → 5.
+
+`approvals` (dua panel, delapan permission) dan `reporting` (tiga panel, tujuh
+permission) — keduanya bentuk any-of yang sama: panel yang bisa dibaca
+independen, penolakan halaman hanya bila semua panel ditolak.
+
+`approvals` layak disebut: ia inbox persetujuan, jadi keputusan tentang siapa
+boleh MELIHAT tugas yang menunggu keputusannya kini ikut tercatat di
+`awcms_abac_decision_logs`, dan `deny` ABAC tenant berlaku pada pembacaannya —
+bukan hanya pada tombol Approve. Enam afordans tulisnya, termasuk tiga jalur
+`recovery` (`reassign`, `cancel`, `force_decide`), diputuskan lewat `can(...)`
+pada transaksi yang sama.
+
+`reporting` menyimpan satu detail yang mudah rusak saat dipindahkan: peta
+`reconciliationsByKey` diisi dengan satu query per proyeksi, berurutan di dalam
+transaksi yang sama. Ia tetap begitu — `tx` satu koneksi ter-reserve, jadi
+sebuah `Promise.all` di sana akan membocorkannya.
+
+Dua contract test-nya mengekstrak klaim hanya dari `permissionKey(...)`;
+ekstraktornya kini membaca kedua ejaan.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (23.096 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (23.173 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -84,10 +84,8 @@ const CHOKEPOINT_EXEMPTIONS: Readonly<Record<string, string>> = {
  * each a sentence would dress 31 open defects as 31 decisions.
  */
 export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
-  "approvals.astro",
   "blog-presentation.astro",
   "data-lifecycle.astro",
-  "reporting.astro",
   "security.astro",
   "seo.astro",
   "site-search.astro"

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -117,10 +117,8 @@ const WITH_TENANT_CALL_PATTERN =
 const NOT_YET_MIGRATED: readonly string[] = [
   // --- Layar admin (R3) — sedang dimigrasikan ke `loadAdminScreen`, Gelombang 1
   //     dari #423 (issue #450). Daftar ini menyusut tiap PR migrasi.
-  "src/pages/admin/approvals.astro",
   "src/pages/admin/blog-presentation.astro",
   "src/pages/admin/data-lifecycle.astro",
-  "src/pages/admin/reporting.astro",
   "src/pages/admin/security.astro",
   "src/pages/admin/seo.astro",
   "src/pages/admin/site-search.astro",

--- a/src/pages/admin/approvals.astro
+++ b/src/pages/admin/approvals.astro
@@ -55,10 +55,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { decodeKeysetCursor } from "../../modules/_shared/keyset-pagination";
 import {
   listWorkflowInboxTasks,
@@ -76,31 +74,6 @@ import {
 } from "../../modules/workflow-approval/domain/reason-bounds";
 
 const ssr = Astro.locals.ssrContext!;
-
-const canRead = ssr.permissions.has(
-  permissionKey("workflow", "approval", "read")
-);
-const canDecide = ssr.permissions.has(
-  permissionKey("workflow", "approval", "approve")
-);
-const canReassign = ssr.permissions.has(
-  permissionKey("workflow", "recovery", "reassign")
-);
-const canCancel = ssr.permissions.has(
-  permissionKey("workflow", "recovery", "cancel")
-);
-const canForceDecide = ssr.permissions.has(
-  permissionKey("workflow", "recovery", "force_decide")
-);
-const canReadDelegations = ssr.permissions.has(
-  permissionKey("workflow", "delegation", "read")
-);
-const canCreateDelegation = ssr.permissions.has(
-  permissionKey("workflow", "delegation", "create")
-);
-const canRevokeDelegation = ssr.permissions.has(
-  permissionKey("workflow", "delegation", "revoke")
-);
 
 /** Mirrors `VALID_STATUSES` in `src/pages/api/v1/workflows/tasks/index.ts`. */
 const STATUS_OPTIONS = [
@@ -141,21 +114,29 @@ const cursorParam = readParam("cursor");
 // A malformed cursor is dropped rather than forwarded, for the same reason.
 const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
 
-let tasks: WorkflowTaskListItem[] = [];
-let nextCursor: string | null = null;
-let history: WorkflowInstanceHistoryEntry[] = [];
-let delegations: WorkflowDelegationRow[] = [];
-let loadError = false;
+const now = new Date();
 
-const canSeeAnything = canRead || canReadDelegations;
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF: the inbox and the delegation register are independently readable, and
+// this screen has always refused only when both are refused. `entry` carries
+// each panel's own answer back, so neither is re-asked.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  now,
+  authorize: [
+    { moduleKey: "workflow", activityCode: "approval", action: "read" },
+    { moduleKey: "workflow", activityCode: "delegation", action: "read" }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [readInbox = false, readDelegations = false] = entry;
 
-if (canSeeAnything) {
-  try {
-    const sql = getDatabaseClient();
-    const now = new Date();
-    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      if (canRead) {
-        const result = await listWorkflowInboxTasks(
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const inbox = readInbox
+      ? await listWorkflowInboxTasks(
           tx,
           ssr.tenantId,
           {
@@ -167,37 +148,92 @@ if (canSeeAnything) {
           },
           now,
           cursor
-        );
-        tasks = result.tasks;
-        nextCursor = result.nextCursor;
+        )
+      : null;
 
-        if (selectedInstanceId) {
-          // `listWorkflowInstanceHistory` asserts the id is a UUID and throws
-          // otherwise, which the surrounding catch turns into the load-error
-          // notice — a hand-edited `?instance=` must not 500 the page.
-          history = await listWorkflowInstanceHistory(
-            tx,
-            ssr.tenantId,
-            selectedInstanceId
-          );
-        }
-      }
-
-      if (canReadDelegations) {
-        delegations = await listWorkflowDelegations(tx, ssr.tenantId);
-      }
-    });
-  } catch (error) {
+    return {
+      readInbox,
+      readDelegations,
+      tasks: inbox?.tasks ?? [],
+      nextCursor: inbox?.nextCursor ?? null,
+      // `listWorkflowInstanceHistory` asserts the id is a UUID and throws
+      // otherwise, which `onError` turns into the load-error notice — a
+      // hand-edited `?instance=` must not 500 the page.
+      history:
+        readInbox && selectedInstanceId
+          ? await listWorkflowInstanceHistory(
+              tx,
+              ssr.tenantId,
+              selectedInstanceId
+            )
+          : [],
+      delegations: readDelegations
+        ? await listWorkflowDelegations(tx, ssr.tenantId)
+        : [],
+      canDecide: await can({
+        moduleKey: "workflow",
+        activityCode: "approval",
+        action: "approve"
+      }),
+      canReassign: await can({
+        moduleKey: "workflow",
+        activityCode: "recovery",
+        action: "reassign"
+      }),
+      canCancel: await can({
+        moduleKey: "workflow",
+        activityCode: "recovery",
+        action: "cancel"
+      }),
+      canForceDecide: await can({
+        moduleKey: "workflow",
+        activityCode: "recovery",
+        action: "force_decide"
+      }),
+      canCreateDelegation: await can({
+        moduleKey: "workflow",
+        activityCode: "delegation",
+        action: "create"
+      }),
+      canRevokeDelegation: await can({
+        moduleKey: "workflow",
+        activityCode: "delegation",
+        action: "revoke"
+      })
+    };
+  },
+  onError: (error) => {
     // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
     // must never render as "there is nothing to approve".
-    loadError = true;
     logAdminPageError(
       "admin/approvals.astro: failed to load the approval inbox",
       error,
       { correlationId: Astro.locals.correlationId }
     );
   }
-}
+});
+
+const canSeeAnything = screen.state !== "denied";
+const loadError = screen.state === "error";
+const canRead = screen.state === "allowed" && screen.data.readInbox;
+const canReadDelegations =
+  screen.state === "allowed" && screen.data.readDelegations;
+const tasks: WorkflowTaskListItem[] =
+  screen.state === "allowed" ? screen.data.tasks : [];
+const nextCursor: string | null =
+  screen.state === "allowed" ? screen.data.nextCursor : null;
+const history: WorkflowInstanceHistoryEntry[] =
+  screen.state === "allowed" ? screen.data.history : [];
+const delegations: WorkflowDelegationRow[] =
+  screen.state === "allowed" ? screen.data.delegations : [];
+const canDecide = screen.state === "allowed" && screen.data.canDecide;
+const canReassign = screen.state === "allowed" && screen.data.canReassign;
+const canCancel = screen.state === "allowed" && screen.data.canCancel;
+const canForceDecide = screen.state === "allowed" && screen.data.canForceDecide;
+const canCreateDelegation =
+  screen.state === "allowed" && screen.data.canCreateDelegation;
+const canRevokeDelegation =
+  screen.state === "allowed" && screen.data.canRevokeDelegation;
 
 function formatTimestamp(value: Date | string | null): string {
   if (value === null) return "—";

--- a/src/pages/admin/reporting.astro
+++ b/src/pages/admin/reporting.astro
@@ -60,10 +60,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   fetchEmailHealthReport,
   type EmailHealthReport
@@ -97,81 +95,124 @@ import {
 
 const ssr = Astro.locals.ssrContext!;
 
-const canReadDashboard = ssr.permissions.has(
-  permissionKey("reporting", "dashboard", "read")
-);
-const canReadProjections = ssr.permissions.has(
-  permissionKey("reporting", "projections", "read")
-);
-const canRebuild = ssr.permissions.has(
-  permissionKey("reporting", "projections", "rebuild")
-);
-const canReconcile = ssr.permissions.has(
-  permissionKey("reporting", "projections", "analyze")
-);
-const canReadExports = ssr.permissions.has(
-  permissionKey("reporting", "exports", "read")
-);
-const canConfigureExports = ssr.permissions.has(
-  permissionKey("reporting", "exports", "configure")
-);
-const canTriggerExport = ssr.permissions.has(
-  permissionKey("reporting", "exports", "export")
-);
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF: three independently readable panels, refused only when all three are.
+// `entry` carries each panel's own answer back, so no panel is re-asked.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    { moduleKey: "reporting", activityCode: "dashboard", action: "read" },
+    { moduleKey: "reporting", activityCode: "projections", action: "read" },
+    { moduleKey: "reporting", activityCode: "exports", action: "read" }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [
+      readDashboard = false,
+      readProjections = false,
+      readExports = false
+    ] = entry;
 
-const canSeeAnything = canReadDashboard || canReadProjections || canReadExports;
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    const emailHealth = readDashboard
+      ? await fetchEmailHealthReport(tx, ssr.tenantId)
+      : null;
 
-let emailHealth: EmailHealthReport | null = null;
-let projections: ProjectionSummaryView[] = [];
-let reconciliationsByKey = new Map<string, ReconciliationRunRow[]>();
-let rebuildRuns: RebuildRunRow[] = [];
-let exportConfigs: ScheduledExportRow[] = [];
-let exportRuns: ExportRunRow[] = [];
-let loadError = false;
-
-if (canSeeAnything) {
-  try {
-    const sql = getDatabaseClient();
-    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      if (canReadDashboard) {
-        emailHealth = await fetchEmailHealthReport(tx, ssr.tenantId);
-      }
-
-      if (canReadProjections) {
-        projections = await listProjectionSummariesForTenant(
+    const projections = readProjections
+      ? await listProjectionSummariesForTenant(
           tx,
           ssr.tenantId,
           ssr.permissions
+        )
+      : [];
+
+    const reconciliationsByKey = new Map<string, ReconciliationRunRow[]>();
+    if (readProjections) {
+      for (const projection of projections) {
+        reconciliationsByKey.set(
+          projection.key,
+          await listReconciliationRuns(tx, ssr.tenantId, projection.key)
         );
-
-        const byKey = new Map<string, ReconciliationRunRow[]>();
-        for (const projection of projections) {
-          byKey.set(
-            projection.key,
-            await listReconciliationRuns(tx, ssr.tenantId, projection.key)
-          );
-        }
-        reconciliationsByKey = byKey;
-
-        rebuildRuns = await listRebuildRuns(tx, ssr.tenantId);
       }
+    }
 
-      if (canReadExports) {
-        exportConfigs = await listScheduledExports(tx, ssr.tenantId);
-        exportRuns = await listExportRuns(tx, ssr.tenantId);
-      }
-    });
-  } catch (error) {
+    return {
+      readDashboard,
+      readProjections,
+      readExports,
+      emailHealth,
+      projections,
+      reconciliationsByKey,
+      rebuildRuns: readProjections
+        ? await listRebuildRuns(tx, ssr.tenantId)
+        : [],
+      exportConfigs: readExports
+        ? await listScheduledExports(tx, ssr.tenantId)
+        : [],
+      exportRuns: readExports ? await listExportRuns(tx, ssr.tenantId) : [],
+      canRebuild: await can({
+        moduleKey: "reporting",
+        activityCode: "projections",
+        action: "rebuild"
+      }),
+      canReconcile: await can({
+        moduleKey: "reporting",
+        activityCode: "projections",
+        action: "analyze"
+      }),
+      canConfigureExports: await can({
+        moduleKey: "reporting",
+        activityCode: "exports",
+        action: "configure"
+      }),
+      canTriggerExport: await can({
+        moduleKey: "reporting",
+        activityCode: "exports",
+        action: "export"
+      })
+    };
+  },
+  onError: (error) => {
     // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
     // must never render as "there are no projections".
-    loadError = true;
     logAdminPageError(
       "admin/reporting.astro: failed to load the reporting console",
       error,
       { correlationId: Astro.locals.correlationId }
     );
   }
-}
+});
+
+const canSeeAnything = screen.state !== "denied";
+const loadError = screen.state === "error";
+const canReadDashboard =
+  screen.state === "allowed" && screen.data.readDashboard;
+const canReadProjections =
+  screen.state === "allowed" && screen.data.readProjections;
+const canReadExports = screen.state === "allowed" && screen.data.readExports;
+const emailHealth: EmailHealthReport | null =
+  screen.state === "allowed" ? screen.data.emailHealth : null;
+const projections: ProjectionSummaryView[] =
+  screen.state === "allowed" ? screen.data.projections : [];
+const reconciliationsByKey =
+  screen.state === "allowed"
+    ? screen.data.reconciliationsByKey
+    : new Map<string, ReconciliationRunRow[]>();
+const rebuildRuns: RebuildRunRow[] =
+  screen.state === "allowed" ? screen.data.rebuildRuns : [];
+const exportConfigs: ScheduledExportRow[] =
+  screen.state === "allowed" ? screen.data.exportConfigs : [];
+const exportRuns: ExportRunRow[] =
+  screen.state === "allowed" ? screen.data.exportRuns : [];
+const canRebuild = screen.state === "allowed" && screen.data.canRebuild;
+const canReconcile = screen.state === "allowed" && screen.data.canReconcile;
+const canConfigureExports =
+  screen.state === "allowed" && screen.data.canConfigureExports;
+const canTriggerExport =
+  screen.state === "allowed" && screen.data.canTriggerExport;
 
 /** Freshness status -> `status-badge` variant. `rebuilding` is progress, not a fault. */
 const FRESHNESS_VARIANT: Record<string, string> = {

--- a/tests/admin-approvals-page-contract.test.ts
+++ b/tests/admin-approvals-page-contract.test.ts
@@ -62,12 +62,27 @@ function guardTriplesFrom(source: string): Set<Triple> {
 }
 
 /** `permissionKey("workflow", "recovery", "force_decide")` → the same shape. */
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect. A contract
+ * test pins the PROPERTY, never the syntax that happened to express it.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 

--- a/tests/admin-reporting-page-contract.test.ts
+++ b/tests/admin-reporting-page-contract.test.ts
@@ -61,12 +61,27 @@ function guardTriplesFrom(source: string): Set<Triple> {
 }
 
 /** `permissionKey("reporting", "projections", "analyze")` → the same shape. */
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect. A contract
+ * test pins the PROPERTY, never the syntax that happened to express it.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 


### PR DESCRIPTION
Gelombang 1 dari #450. Ledger **7 → 5**.

## Layar

`approvals` (dua panel, delapan permission) dan `reporting` (tiga panel, tujuh permission) — keduanya bentuk any-of yang mendarat di #459.

**`approvals` layak disebut**: ia inbox persetujuan. Keputusan tentang siapa boleh **melihat** tugas yang menunggu keputusannya kini ikut tercatat di `awcms_abac_decision_logs`, dan `deny` ABAC tenant berlaku pada pembacaannya — bukan hanya pada tombol Approve. Enam afordans tulisnya, termasuk tiga jalur `recovery` (`reassign`, `cancel`, `force_decide`), diputuskan lewat `can(...)` pada transaksi yang sama.

**`reporting`** menyimpan satu detail yang mudah rusak saat dipindahkan: peta `reconciliationsByKey` diisi dengan satu query per proyeksi, **berurutan**, di dalam transaksi yang sama. Ia tetap begitu — `tx` adalah satu koneksi ter-reserve, jadi `Promise.all` di sana akan membocorkannya. Bentuk loop-nya dipertahankan apa adanya.

## Contract test

Dua-duanya mengekstrak klaim layar hanya dari `permissionKey(...)`; ekstraktornya kini membaca kedua ejaan — kelas yang sama dengan batch 1, 4, 5, platform-scope, dan #459.

## Verifikasi

- `DATABASE_URL="" bun run test` — 3494 pass, 0 fail
- `bun run check` penuh — **exit 0**
- `access:chokepoint:check` — `32 admin screens, 5 still decide outside the chokepoint (ledger: 5)`

## Sisa 5

`data-lifecycle`, `security`, `seo`, `site-search` (any-of) + `blog-presentation` (helper file-local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)