### PR TITLE
feat(auth): R3 DITUTUP — ke-32 layar admin memutuskan di chokepoint (#450)

### DIFF
--- a/.changeset/layar-admin-chokepoint-r3-closed.md
+++ b/.changeset/layar-admin-chokepoint-r3-closed.md
@@ -1,0 +1,71 @@
+---
+"awcms": minor
+---
+
+feat(auth): R3 DITUTUP — ke-32 layar admin memutuskan di chokepoint (#450)
+
+Lima layar terakhir — `data-lifecycle`, `security`, `seo`, `site-search`,
+`blog-presentation` — berpindah ke `loadAdminScreen`. **Kedua ledger kini
+kosong**: `ADMIN_SCREEN_CHOKEPOINT_MIGRATION` dan bagian layar admin di
+`NOT_YET_MIGRATED`.
+
+Tidak ada lagi layar admin yang memutuskan akses dari `ssr.permissions.has(...)`.
+Setiap render kini melewati evaluasi kebijakan ABAC, `resolveModuleAvailability`,
+fakta business-scope, SoD saat-aksi, dan `recordDecisionLog`.
+
+## Tiga hal yang diporting VERBATIM, bukan "diperbaiki"
+
+`data-lifecycle` menerima **lima** request entry, dua di antaranya **tulis**
+(`legal_hold.create`, `plan.analyze`). Itulah `showAnything` selama ini: konsol
+ini mengizinkan siapa pun yang bisa melakukan apa pun di sini, termasuk orang
+yang boleh memasang legal hold tanpa bisa mendaftar hold yang sudah ada.
+Memangkasnya ke tiga baca akan diam-diam mengunci mereka.
+
+`security` memakai `mfa_admin.reset` sebagai gerbang BACA panel MFA. Modul ini
+tidak menyeed satu pun aksi baca MFA; permission reset itulah yang selama ini
+menggerbanginya. Diporting apa adanya, bukan "dikoreksi" ke permission yang
+tidak ada.
+
+`blog-presentation` memilih section aktif dari permission baca. Pemilihan itu
+pindah ke DALAM `load`, karena section mana yang tersedia kini jawaban
+chokepoint, dan fallback-nya harus dihitung dari jawaban yang sama. Helper
+file-local `can(activity, action)`-nya hilang — itu helper yang membuat
+`admin:screen-coverage:check` menumbuhkan matcher penyelesai-helper-nya.
+
+## Gerbangnya diperketat, karena mutasi membuktikan ia bocor
+
+Setelah ledger kosong, saya menanam bypass nyata ke `users.astro` untuk menguji
+gerbangnya. Ia **hijau**: keluar dengan kode 0 sambil baris ringkasannya sendiri
+berbunyi *"1 still decide outside the chokepoint"*.
+
+Sebabnya kelonggaran se-BERKAS: sebuah layar yang memanggil `loadAdminScreen`
+untuk entry-nya boleh tetap memutuskan sebuah AFFORDANCE dari
+`ssr.permissions.has(...)`. Itu benar selama migrasi — layar setengah-jadi tidak
+boleh dilaporkan dua kali — dan salah begitu layar terakhir mendarat: ia jalan
+masuk kembali, satu tombol demi satu tombol.
+
+Rute mempertahankan kelonggaran itu (`defineTenantRoute` membungkus di level
+modul dan memanggil chokepoint sendiri, jadi ia benar-benar menutupi tiap
+handler di berkas). Layar tidak: satu berkas `.astro` = satu jalur render, jadi
+tidak ada handler saudara yang pantas ikut tertutupi. Asimetrinya dipatok test
+di kedua arah.
+
+## Dua alarm yang menjadi inert pada nol, diganti
+
+Self-test detektor berbunyi "nol layar memutuskan sementara ledger tidak kosong
+= detektor rusak". Itu persis cek yang mati saat layar terakhir dimigrasikan:
+sejak itu nol adalah jawaban yang BENAR, dan nol dari detektor yang rusak tidak
+bisa dibedakan darinya. Diganti **probe sintetis** — `sliceScreen` ditanya
+tentang layar yang pasti bypass dan layar yang pasti tidak; keduanya harus
+benar, pada ukuran ledger berapa pun.
+
+Kedua, gerbang kini menuntut setiap layar benar-benar **TERUTE**, bukan sekadar
+diam: layar yang tidak membaca permission apa pun DAN tidak membuka chokepoint
+akan lolos filter bypass tanpa tertutupi apa pun.
+
+Aturan "hanya boleh menyusut" juga kehilangan penegaknya pada nol — entri basi
+adalah temuan, tetapi pada daftar kosong tidak ada yang bisa basi. Jadi
+`tests/access-chokepoint.test.ts` meng-assert kekosongan itu langsung.
+
+Ketiga arah kegagalan diuji dengan menanam cacatnya dan memastikan gerbangnya
+MERAH, bukan sekadar memastikan ia hijau hari ini.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **92** (`sql/001`–`092`)                                                              | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0073** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **32** berkas `.astro` di `src/pages/admin/`; **0 dari 21** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **43** (23.173 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **43** (23.321 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -70,26 +70,27 @@ const CHOKEPOINT_EXEMPTIONS: Readonly<Record<string, string>> = {
 
 /**
  * Admin screens that still decide from `ssr.permissions.has(...)` — R3, issue
- * #450. **May only shrink.**
+ * #450. **EMPTY, and that is the finished state.**
  *
- * Seeded with the 31 screens that were unmigrated when the second root landed
- * (32 minus `form-drafts.astro`, migrated in the same PR so the mechanism is
- * proven rather than merely provided). An entry whose screen no longer
- * bypasses is an error, not a tolerated leftover, so the list cannot rot into
- * an off-switch.
+ * It was seeded with the 31 screens unmigrated when the second root landed (32
+ * minus `form-drafts.astro`, migrated in the same PR so the mechanism was
+ * proven rather than merely provided) and drained to zero over eight PRs. All
+ * 32 screens now decide at `authorizeInTransaction`.
  *
- * Unlike `CHOKEPOINT_EXEMPTIONS` these carry no per-entry reason, and the
- * difference is deliberate: an exemption is a decision that this handler is
- * RIGHT to bypass, while these are debt that is WRONG and scheduled. Giving
- * each a sentence would dress 31 open defects as 31 decisions.
+ * **Do not add a line here.** While the list had entries, "may only shrink" was
+ * enforced by `findStaleLedgerEntries`: an entry whose screen no longer
+ * bypassed was a finding. At zero that alarm has nothing to fire on, so
+ * `tests/access-chokepoint.test.ts` asserts the emptiness directly instead. A
+ * new entry means a new screen decides access outside the chokepoint — silently
+ * losing ABAC policy evaluation, module availability, business-scope facts, SoD
+ * and the decision log — which is the entire defect this drained.
+ *
+ * Unlike `CHOKEPOINT_EXEMPTIONS` these carried no per-entry reason, and the
+ * difference was deliberate: an exemption is a decision that this handler is
+ * RIGHT to bypass, while these were debt that was WRONG and scheduled. Giving
+ * each a sentence would have dressed 31 open defects as 31 decisions.
  */
-export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [
-  "blog-presentation.astro",
-  "data-lifecycle.astro",
-  "security.astro",
-  "seo.astro",
-  "site-search.astro"
-];
+export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [];
 
 /**
  * Drops block comments and whole-line `//` comments before matching.
@@ -199,13 +200,28 @@ export function findChokepointBypasses(
   const scheduled = new Set(ledger);
 
   return handlers
-    .filter(
-      (handler) =>
-        handler.decidesPermissions &&
-        !handler.usesChokepoint &&
-        !(handler.id in exemptions) &&
-        !scheduled.has(handler.id)
-    )
+    .filter((handler) => {
+      if (!handler.decidesPermissions) return false;
+      if (handler.id in exemptions || scheduled.has(handler.id)) return false;
+
+      // Routes keep the FILE-WIDE allowance: `defineTenantRoute` wraps at module
+      // level and calls the chokepoint itself, so its presence covers every
+      // handler in the file.
+      //
+      // Screens no longer do, and the change is the point of this line. While
+      // the migration ledger had entries the allowance was correct — a
+      // half-migrated screen must not be reported twice — but it also meant a
+      // screen could call `loadAdminScreen` for its entry and still decide an
+      // AFFORDANCE from `ssr.permissions.has(...)`, with the gate green.
+      //
+      // That was found by mutation, not by reading: planting exactly that
+      // hybrid into `users.astro` left the gate at exit 0 while its own summary
+      // line said "1 still decide outside the chokepoint". With the ledger now
+      // empty and no screen reading the grant set at all, the allowance has
+      // nothing left to protect and only leaves a way back in one button at a
+      // time.
+      return !(handler.usesChokepoint && !handler.id.endsWith(".astro"));
+    })
     .map((handler) => ({
       handler: handler.id,
       // The two roots lose the same four things, but a reader fixing one is not
@@ -380,7 +396,6 @@ async function main(): Promise<void> {
   }
 
   const deciding = routes.filter((handler) => handler.decidesPermissions);
-  const decidingScreens = screens.filter((screen) => screen.decidesPermissions);
 
   // Issue #425 — the self-test.
   //
@@ -408,21 +423,56 @@ async function main(): Promise<void> {
     return;
   }
 
-  // The same self-test for the screen root, and it is not symmetry for its own
-  // sake: `.permissions.has(` is a shape, not an identifier, so it cannot be
-  // caught by a rename — it disappears when the LAST screen is migrated, and at
-  // that moment the ledger is empty too. Until then, zero deciding screens with
-  // a non-empty ledger means the detector broke.
+  // The screen-root self-test, and it had to change shape when R3 closed.
+  //
+  // It used to be "zero deciding screens while the ledger is non-empty means
+  // the detector broke" — which is exactly the check that goes inert the moment
+  // the last screen is migrated, because from then on zero deciding screens is
+  // the CORRECT answer and an identically zero answer from a broken detector is
+  // indistinguishable from it.
+  //
+  // So the probe is now synthetic: `sliceScreen` is asked about a screen that
+  // definitely bypasses, and about one that definitely does not. Both answers
+  // have to be right, at any ledger size.
+  const legacyProbe = sliceScreen(
+    "__probe__.astro",
+    "---\nconst canRead = ssr.permissions.has(permissionKey('m', 'a', 'read'));\n---"
+  );
+  const routedProbe = sliceScreen(
+    "__probe__.astro",
+    "---\nconst screen = await loadAdminScreen({ ssr });\n---"
+  );
+
   if (
-    decidingScreens.length === 0 &&
-    ADMIN_SCREEN_CHOKEPOINT_MIGRATION.length > 0
+    !legacyProbe.decidesPermissions ||
+    legacyProbe.usesChokepoint ||
+    routedProbe.decidesPermissions ||
+    !routedProbe.usesChokepoint
   ) {
     console.error(
-      "access:chokepoint:check FAILED — 0 admin screens were classified as deciding a " +
-        `permission while ${ADMIN_SCREEN_CHOKEPOINT_MIGRATION.length} are still on the ` +
-        "migration ledger. The signal `.permissions.has(` stopped matching under " +
-        `${SCREENS_ROOT}; fix \`sliceScreen\` rather than the ledger.`
+      "access:chokepoint:check FAILED — `sliceScreen` misread its own probes " +
+        `(legacy: decides=${legacyProbe.decidesPermissions} chokepoint=${legacyProbe.usesChokepoint}; ` +
+        `routed: decides=${routedProbe.decidesPermissions} chokepoint=${routedProbe.usesChokepoint}). ` +
+        `The signals stopped matching under ${SCREENS_ROOT}, so every screen would ` +
+        "pass vacuously. Fix `sliceScreen`."
     );
+
+    process.exitCode = 1;
+    return;
+  }
+
+  // And the corpus itself: every screen must be ROUTED, not merely silent. A
+  // screen that reads no permissions at all and opens no chokepoint would slip
+  // through the bypass filter above without being covered by anything.
+  const unrouted = screens.filter((screen) => !screen.usesChokepoint);
+
+  if (unrouted.length > 0) {
+    console.error(
+      "access:chokepoint:check FAILED — admin screens that do not call " +
+        "`loadAdminScreen` at all:"
+    );
+
+    for (const screen of unrouted) console.error(`  - ${screen.id}`);
 
     process.exitCode = 1;
     return;
@@ -432,8 +482,8 @@ async function main(): Promise<void> {
     `access:chokepoint:check OK — ${routes.length} route handlers, ` +
       `${deciding.length} decide permissions, ` +
       `${Object.keys(CHOKEPOINT_EXEMPTIONS).length} reasoned exemption(s); ` +
-      `${screens.length} admin screens, ${decidingScreens.length} still decide ` +
-      `outside the chokepoint (ledger: ${ADMIN_SCREEN_CHOKEPOINT_MIGRATION.length}, may only shrink).`
+      `${screens.length} admin screens, all routed through loadAdminScreen ` +
+      `(R3 closed; ledger: ${ADMIN_SCREEN_CHOKEPOINT_MIGRATION.length}).`
   );
 }
 

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -115,13 +115,10 @@ const WITH_TENANT_CALL_PATTERN =
  * — which is what this gate exists to prevent.
  */
 const NOT_YET_MIGRATED: readonly string[] = [
-  // --- Layar admin (R3) — sedang dimigrasikan ke `loadAdminScreen`, Gelombang 1
-  //     dari #423 (issue #450). Daftar ini menyusut tiap PR migrasi.
-  "src/pages/admin/blog-presentation.astro",
-  "src/pages/admin/data-lifecycle.astro",
-  "src/pages/admin/security.astro",
-  "src/pages/admin/seo.astro",
-  "src/pages/admin/site-search.astro",
+  // --- Layar admin (R3): KOSONG. Ke-32 layar sudah lewat `loadAdminScreen`
+  //     (issue #450, Gelombang 1 dari #423), jadi tidak ada satu pun yang
+  //     membuka transaksinya sendiri. Jangan menambahkan baris `src/pages/admin`
+  //     di sini — pakai `loadAdminScreen`.
 
   // --- Rute API.
   "src/pages/api/v1/abac/policies/[id].ts",

--- a/src/pages/admin/blog-presentation.astro
+++ b/src/pages/admin/blog-presentation.astro
@@ -54,10 +54,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listTemplates,
   type BlogTemplateView
@@ -82,39 +80,13 @@ import { BLOG_THEME_MODES } from "../../modules/blog-content/domain/theme-policy
 
 const ssr = Astro.locals.ssrContext!;
 
-const can = (activity: string, action: string): boolean =>
-  ssr.permissions.has(permissionKey("blog_content", activity, action));
-
-const canReadTemplates = can("templates", "read");
-const canConfigureTemplates = can("templates", "configure");
-const canReadMenus = can("menus", "read");
-const canConfigureMenus = can("menus", "configure");
-const canReadWidgets = can("widgets", "read");
-const canConfigureWidgets = can("widgets", "configure");
-const canReadTheme = can("theme", "read");
-const canConfigureTheme = can("theme", "configure");
-
 type Section = "templates" | "menus" | "widgets" | "theme";
-
-/** Only sections the operator can READ — see the header. */
-const availableSections: Section[] = [
-  ...(canReadTemplates ? (["templates"] as const) : []),
-  ...(canReadMenus ? (["menus"] as const) : []),
-  ...(canReadWidgets ? (["widgets"] as const) : []),
-  ...(canReadTheme ? (["theme"] as const) : [])
-];
 
 function readParam(name: string): string {
   return (Astro.url.searchParams.get(name) ?? "").trim();
 }
 
 const sectionRaw = readParam("section");
-// An unreadable or unknown section falls back to the first the operator CAN
-// read, rather than rendering a denial for a link the screen itself drew.
-const section: Section | null =
-  availableSections.find((entry) => entry === sectionRaw) ??
-  availableSections[0] ??
-  null;
 
 const positionRaw = readParam("position");
 const positionFilter = isWidgetPosition(positionRaw) ? positionRaw : undefined;
@@ -122,41 +94,130 @@ const positionFilter = isWidgetPosition(positionRaw) ? positionRaw : undefined;
 /** `?edit=<id>` opens the edit form for one row of the active section. */
 const editingId = readParam("edit");
 
-let templates: BlogTemplateView[] = [];
-let menus: BlogMenuView[] = [];
-let widgets: BlogWidgetView[] = [];
-let theme: BlogThemeSettings | null = null;
-let loadError = false;
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// This screen used a file-local `can(activity, action)` helper over
+// `ssr.permissions.has`, which is why `admin:screen-coverage:check` grew its
+// helper-resolving matcher (see that script's header). The helper is gone: the
+// guards are now stated as `AccessRequest` literals, the same shape the routes
+// use, so the special-case resolution is no longer what keeps these eight
+// permissions visible to that gate.
+//
+// ANY-OF over the four section reads. Section SELECTION moves inside `load`,
+// because which sections are available is now a chokepoint answer rather than a
+// grant-set lookup, and the fallback must be computed from the same answers.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    { moduleKey: "blog_content", activityCode: "templates", action: "read" },
+    { moduleKey: "blog_content", activityCode: "menus", action: "read" },
+    { moduleKey: "blog_content", activityCode: "widgets", action: "read" },
+    { moduleKey: "blog_content", activityCode: "theme", action: "read" }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [
+      readTemplates = false,
+      readMenus = false,
+      readWidgets = false,
+      readTheme = false
+    ] = entry;
 
-if (section !== null) {
-  try {
-    const sql = getDatabaseClient();
-    await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      // Sequential by section: only the visible one is read, and a single
-      // transaction connection cannot serve concurrent queries anyway.
-      if (section === "templates") {
-        templates = await listTemplates(tx, ssr.tenantId);
-      } else if (section === "menus") {
-        menus = await listMenus(tx, ssr.tenantId);
-      } else if (section === "widgets") {
-        widgets = await listWidgets(tx, ssr.tenantId, {
-          position: positionFilter
-        });
-      } else {
-        theme = await fetchBlogThemeSettings(tx, ssr.tenantId);
-      }
-    });
-  } catch (error) {
+    /** Only sections the operator can READ — see the header. */
+    const availableSections: Section[] = [
+      ...(readTemplates ? (["templates"] as const) : []),
+      ...(readMenus ? (["menus"] as const) : []),
+      ...(readWidgets ? (["widgets"] as const) : []),
+      ...(readTheme ? (["theme"] as const) : [])
+    ];
+
+    // An unreadable or unknown section falls back to the first the operator CAN
+    // read, rather than rendering a denial for a link the screen itself drew.
+    const active: Section | null =
+      availableSections.find((entry_) => entry_ === sectionRaw) ??
+      availableSections[0] ??
+      null;
+
+    // Sequential by section: only the visible one is read, and a single
+    // transaction connection cannot serve concurrent queries anyway.
+    return {
+      readTemplates,
+      readMenus,
+      readWidgets,
+      readTheme,
+      availableSections,
+      section: active,
+      templates:
+        active === "templates" ? await listTemplates(tx, ssr.tenantId) : [],
+      menus: active === "menus" ? await listMenus(tx, ssr.tenantId) : [],
+      widgets:
+        active === "widgets"
+          ? await listWidgets(tx, ssr.tenantId, { position: positionFilter })
+          : [],
+      theme:
+        active === "theme"
+          ? await fetchBlogThemeSettings(tx, ssr.tenantId)
+          : null,
+      canConfigureTemplates: await can({
+        moduleKey: "blog_content",
+        activityCode: "templates",
+        action: "configure"
+      }),
+      canConfigureMenus: await can({
+        moduleKey: "blog_content",
+        activityCode: "menus",
+        action: "configure"
+      }),
+      canConfigureWidgets: await can({
+        moduleKey: "blog_content",
+        activityCode: "widgets",
+        action: "configure"
+      }),
+      canConfigureTheme: await can({
+        moduleKey: "blog_content",
+        activityCode: "theme",
+        action: "configure"
+      })
+    };
+  },
+  onError: (error) => {
     // Includes `DatabaseBusyError` (pool/circuit-breaker refusal). A refusal
     // must never render as "this tenant has nothing configured".
-    loadError = true;
     logAdminPageError(
       "admin/blog-presentation.astro: failed to load presentation settings",
       error,
       { correlationId: Astro.locals.correlationId }
     );
   }
-}
+});
+
+const loadError = screen.state === "error";
+const canReadTemplates =
+  screen.state === "allowed" && screen.data.readTemplates;
+const canReadMenus = screen.state === "allowed" && screen.data.readMenus;
+const canReadWidgets = screen.state === "allowed" && screen.data.readWidgets;
+const canReadTheme = screen.state === "allowed" && screen.data.readTheme;
+const availableSections: Section[] =
+  screen.state === "allowed" ? screen.data.availableSections : [];
+const section: Section | null =
+  screen.state === "allowed" ? screen.data.section : null;
+const templates: BlogTemplateView[] =
+  screen.state === "allowed" ? screen.data.templates : [];
+const menus: BlogMenuView[] =
+  screen.state === "allowed" ? screen.data.menus : [];
+const widgets: BlogWidgetView[] =
+  screen.state === "allowed" ? screen.data.widgets : [];
+const theme: BlogThemeSettings | null =
+  screen.state === "allowed" ? screen.data.theme : null;
+const canConfigureTemplates =
+  screen.state === "allowed" && screen.data.canConfigureTemplates;
+const canConfigureMenus =
+  screen.state === "allowed" && screen.data.canConfigureMenus;
+const canConfigureWidgets =
+  screen.state === "allowed" && screen.data.canConfigureWidgets;
+const canConfigureTheme =
+  screen.state === "allowed" && screen.data.canConfigureTheme;
 
 function formatTimestamp(value: Date | null): string {
   return value ? value.toISOString() : "—";

--- a/src/pages/admin/data-lifecycle.astro
+++ b/src/pages/admin/data-lifecycle.astro
@@ -37,10 +37,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { listModules } from "../../modules";
 import { collectHighVolumeTableDescriptors } from "../../modules/data-lifecycle/domain/lifecycle-registry";
 import {
@@ -64,25 +62,6 @@ if (!ssr) {
   );
 }
 
-const canReadRegistry = ssr.permissions.has(
-  permissionKey("data_lifecycle", "registry", "read")
-);
-const canReadHolds = ssr.permissions.has(
-  permissionKey("data_lifecycle", "legal_hold", "read")
-);
-const canCreateHold = ssr.permissions.has(
-  permissionKey("data_lifecycle", "legal_hold", "create")
-);
-const canReleaseHold = ssr.permissions.has(
-  permissionKey("data_lifecycle", "legal_hold", "release")
-);
-const canPlan = ssr.permissions.has(
-  permissionKey("data_lifecycle", "plan", "analyze")
-);
-const canReadRuns = ssr.permissions.has(
-  permissionKey("data_lifecycle", "runs", "read")
-);
-
 // Code-declared metadata, identical for every tenant — the same values
 // `GET /api/v1/data-lifecycle/registry` returns. Computed unconditionally
 // because it touches nothing but the module registry; it is only RENDERED, and
@@ -92,33 +71,76 @@ const tenantDescriptors = descriptors.filter(
   (descriptor) => descriptor.scope === "tenant"
 );
 
-let holds: LegalHoldRow[] = [];
-let runs: LifecycleRunRow[] = [];
-let loadError = false;
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF over FIVE requests, and note that two of them are WRITES
+// (`legal_hold.create`, `plan.analyze`). That is what `showAnything` has always
+// been: this console admits anyone who can do anything here, including someone
+// who may place a hold without being able to list existing ones. Trimming the
+// list to the three reads would have quietly locked those operators out, so it
+// is ported exactly.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    { moduleKey: "data_lifecycle", activityCode: "registry", action: "read" },
+    { moduleKey: "data_lifecycle", activityCode: "legal_hold", action: "read" },
+    {
+      moduleKey: "data_lifecycle",
+      activityCode: "legal_hold",
+      action: "create"
+    },
+    { moduleKey: "data_lifecycle", activityCode: "plan", action: "analyze" },
+    { moduleKey: "data_lifecycle", activityCode: "runs", action: "read" }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [
+      readRegistry = false,
+      readHolds = false,
+      createHold = false,
+      plan = false,
+      readRuns = false
+    ] = entry;
 
-if (canReadHolds || canReadRuns) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      const heldRows = canReadHolds
-        ? await listLegalHolds(tx, ssr.tenantId)
-        : [];
-      const runRows = canReadRuns
-        ? await listLifecycleRuns(tx, ssr.tenantId)
-        : [];
-      return { heldRows, runRows };
-    });
-    holds = result.heldRows;
-    runs = result.runRows;
-  } catch (error) {
+    // One transaction, one awaited query at a time. Concurrent queries on a
+    // single transaction connection leak it, so nothing here runs in parallel.
+    return {
+      readRegistry,
+      readHolds,
+      createHold,
+      plan,
+      readRuns,
+      holds: readHolds ? await listLegalHolds(tx, ssr.tenantId) : [],
+      runs: readRuns ? await listLifecycleRuns(tx, ssr.tenantId) : [],
+      canReleaseHold: await can({
+        moduleKey: "data_lifecycle",
+        activityCode: "legal_hold",
+        action: "release"
+      })
+    };
+  },
+  onError: (error) => {
     logAdminPageError(
       "admin/data-lifecycle.astro: failed to load console",
       error,
       { correlationId: Astro.locals.correlationId }
     );
-    loadError = true;
   }
-}
+});
+
+const showAnything = screen.state !== "denied";
+const loadError = screen.state === "error";
+const canReadRegistry = screen.state === "allowed" && screen.data.readRegistry;
+const canReadHolds = screen.state === "allowed" && screen.data.readHolds;
+const canCreateHold = screen.state === "allowed" && screen.data.createHold;
+const canPlan = screen.state === "allowed" && screen.data.plan;
+const canReadRuns = screen.state === "allowed" && screen.data.readRuns;
+const canReleaseHold = screen.state === "allowed" && screen.data.canReleaseHold;
+const holds: LegalHoldRow[] =
+  screen.state === "allowed" ? screen.data.holds : [];
+const runs: LifecycleRunRow[] =
+  screen.state === "allowed" ? screen.data.runs : [];
 
 /** `2026-08-01T03:18:38.929Z` -> `2026-08-01 03:18` (UTC, no locale dependency). */
 function formatTimestamp(value: Date | string | null): string {
@@ -144,9 +166,6 @@ const activeHoldCount = holds.filter((hold) => hold.status === "active").length;
 const hasTenantWideHold = holds.some(
   (hold) => hold.status === "active" && hold.descriptorKey === null
 );
-
-const showAnything =
-  canReadRegistry || canReadHolds || canCreateHold || canPlan || canReadRuns;
 ---
 
 <AdminLayout title="Data lifecycle">

--- a/src/pages/admin/security.astro
+++ b/src/pages/admin/security.astro
@@ -33,8 +33,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
 import { isMfaFeatureEnabled } from "../../lib/auth/mfa-config";
 import { isSsoEnabled } from "../../lib/auth/sso-config";
 import {
@@ -45,7 +45,6 @@ import {
   isTurnstileEnabled,
   isTurnstileRequired
 } from "../../lib/security/turnstile";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   listAuthProviders,
   type AuthProviderView
@@ -63,24 +62,6 @@ import {
 
 const ssr = Astro.locals.ssrContext!;
 
-const canReadPolicy = ssr.permissions.has(
-  permissionKey("identity_access", "sso_policy", "read")
-);
-const canUpdatePolicy = ssr.permissions.has(
-  permissionKey("identity_access", "sso_policy", "update")
-);
-// `reset` IS the read gate for `GET /api/v1/auth/mfa/policy`. See the header.
-const canReadMfa = ssr.permissions.has(
-  permissionKey("identity_access", "mfa_admin", "reset")
-);
-const canConfigureMfa = ssr.permissions.has(
-  permissionKey("identity_access", "mfa_admin", "configure")
-);
-const canReadProviders = ssr.permissions.has(
-  permissionKey("identity_access", "sso_providers", "read")
-);
-const canReadAnything = canReadPolicy || canReadMfa || canReadProviders;
-
 const deployment = {
   onlineSecurityActive: isFullOnlineSecurityActive(),
   onlineSecurityProfile: resolveOnlineSecurityProfile(),
@@ -90,44 +71,92 @@ const deployment = {
   ssoEnabled: isSsoEnabled()
 };
 
-let policy: TenantAuthPolicyView | null = null;
-let mfaPolicy: TenantMfaPolicyView | null = null;
-let breakGlassCandidates: BreakGlassCandidateView[] = [];
-let providers: AuthProviderView[] = [];
-let loadError = false;
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF: three independently readable panels, refused only when all three are.
+// Note the middle one is `mfa_admin.reset`, not a `.read` — this module seeds
+// no MFA read action, and the reset permission is what has always gated the
+// panel. Ported verbatim rather than "corrected" to a permission that does not
+// exist.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    {
+      moduleKey: "identity_access",
+      activityCode: "sso_policy",
+      action: "read"
+    },
+    {
+      moduleKey: "identity_access",
+      activityCode: "mfa_admin",
+      action: "reset"
+    },
+    {
+      moduleKey: "identity_access",
+      activityCode: "sso_providers",
+      action: "read"
+    }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [readPolicy = false, readMfa = false, readProviders = false] = entry;
 
-if (canReadAnything) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => ({
-      // Each read is gated on its OWN permission, so a caller holding only one
-      // of the three does not silently pull the other two into memory.
-      policy: canReadPolicy
-        ? await getTenantAuthPolicy(tx, ssr.tenantId)
-        : null,
+    // Each read is gated on its OWN permission, so a caller holding only one of
+    // the three does not silently pull the other two into memory. One
+    // transaction, one awaited query at a time.
+    const canUpdatePolicy = await can({
+      moduleKey: "identity_access",
+      activityCode: "sso_policy",
+      action: "update"
+    });
+
+    return {
+      readPolicy,
+      readMfa,
+      readProviders,
+      canUpdatePolicy,
+      policy: readPolicy ? await getTenantAuthPolicy(tx, ssr.tenantId) : null,
       candidates: canUpdatePolicy
         ? await listBreakGlassCandidates(tx, ssr.tenantId)
         : [],
-      mfaPolicy: canReadMfa ? await getTenantMfaPolicy(tx, ssr.tenantId) : null,
-      providers: canReadProviders
-        ? await listAuthProviders(tx, ssr.tenantId)
-        : []
-    }));
-
-    // `withTenant` returns a 503 `Response` when the circuit breaker is open or
-    // a work-class queue is saturated — degrade to the error notice.
-    if (result instanceof Response) {
-      loadError = true;
-    } else {
-      policy = result.policy;
-      breakGlassCandidates = result.candidates;
-      mfaPolicy = result.mfaPolicy;
-      providers = result.providers;
-    }
-  } catch {
-    loadError = true;
+      mfaPolicy: readMfa ? await getTenantMfaPolicy(tx, ssr.tenantId) : null,
+      providers: readProviders ? await listAuthProviders(tx, ssr.tenantId) : [],
+      canConfigureMfa: await can({
+        moduleKey: "identity_access",
+        activityCode: "mfa_admin",
+        action: "configure"
+      })
+    };
+  },
+  onError: (error) => {
+    logAdminPageError("admin/security.astro: failed to load console", error, {
+      correlationId: Astro.locals.correlationId
+    });
   }
-}
+});
+
+const canReadAnything = screen.state !== "denied";
+// The old shape check existed because `withTenant` RETURNS a 503 `Response` on
+// circuit-open rather than throwing. `AdminScreenOutcome` separates the three
+// cases directly.
+const loadError = screen.state === "error";
+const canReadPolicy = screen.state === "allowed" && screen.data.readPolicy;
+const canReadMfa = screen.state === "allowed" && screen.data.readMfa;
+const canReadProviders =
+  screen.state === "allowed" && screen.data.readProviders;
+const canUpdatePolicy =
+  screen.state === "allowed" && screen.data.canUpdatePolicy;
+const canConfigureMfa =
+  screen.state === "allowed" && screen.data.canConfigureMfa;
+const policy: TenantAuthPolicyView | null =
+  screen.state === "allowed" ? screen.data.policy : null;
+const mfaPolicy: TenantMfaPolicyView | null =
+  screen.state === "allowed" ? screen.data.mfaPolicy : null;
+const breakGlassCandidates: BreakGlassCandidateView[] =
+  screen.state === "allowed" ? screen.data.candidates : [];
+const providers: AuthProviderView[] =
+  screen.state === "allowed" ? screen.data.providers : [];
 
 const MFA_LEVELS = [
   {

--- a/src/pages/admin/seo.astro
+++ b/src/pages/admin/seo.astro
@@ -59,10 +59,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import { decodeKeysetCursor } from "../../modules/_shared/keyset-pagination";
 import { fetchSeoTenantSettings } from "../../modules/seo-distribution/application/seo-config-directory";
 import {
@@ -90,31 +88,6 @@ import {
 } from "../../modules/seo-distribution/domain/redirect-rule";
 
 const ssr = Astro.locals.ssrContext!;
-
-const canReadConfig = ssr.permissions.has(
-  permissionKey("seo_distribution", "config", "read")
-);
-const canUpdateConfig = ssr.permissions.has(
-  permissionKey("seo_distribution", "config", "update")
-);
-const canReadRedirect = ssr.permissions.has(
-  permissionKey("seo_distribution", "redirect", "read")
-);
-const canCreateRedirect = ssr.permissions.has(
-  permissionKey("seo_distribution", "redirect", "create")
-);
-const canUpdateRedirect = ssr.permissions.has(
-  permissionKey("seo_distribution", "redirect", "update")
-);
-const canDeleteRedirect = ssr.permissions.has(
-  permissionKey("seo_distribution", "redirect", "delete")
-);
-const canReadNotFound = ssr.permissions.has(
-  permissionKey("seo_distribution", "not_found", "read")
-);
-const canUpdateNotFound = ssr.permissions.has(
-  permissionKey("seo_distribution", "not_found", "update")
-);
 
 const showRedirectActions = canUpdateRedirect || canDeleteRedirect;
 const showNotFoundActions = canUpdateNotFound;
@@ -162,53 +135,106 @@ const UUID_PATTERN =
 const recoverParam = params.get("recover") ?? "";
 const recoverId = UUID_PATTERN.test(recoverParam) ? recoverParam : "";
 
-let seoConfig: SeoTenantSettings = EMPTY_SEO_TENANT_SETTINGS;
-let redirectSettings: RedirectSettings = EMPTY_REDIRECT_SETTINGS;
-let redirects: RedirectRecord[] = [];
-let nextCursor: string | null = null;
-let observations: NotFoundObservation[] = [];
-let loadError = false;
+const filters: RedirectListFilters = {};
+if (stateFilter) filters.state = stateFilter;
+if (targetTypeFilter) filters.targetType = targetTypeFilter;
+if (qFilter.trim()) filters.q = qFilter.trim();
 
-if (canReadConfig || canReadRedirect || canReadNotFound) {
-  try {
-    const sql = getDatabaseClient();
-    const filters: RedirectListFilters = {};
-    if (stateFilter) filters.state = stateFilter;
-    if (targetTypeFilter) filters.targetType = targetTypeFilter;
-    if (qFilter.trim()) filters.q = qFilter.trim();
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF: three independently readable sections, refused only when all three
+// are. This screen renders a per-SECTION denial rather than one page-level
+// notice, so `entry` is what those notices read.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    { moduleKey: "seo_distribution", activityCode: "config", action: "read" },
+    { moduleKey: "seo_distribution", activityCode: "redirect", action: "read" },
+    { moduleKey: "seo_distribution", activityCode: "not_found", action: "read" }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [readConfig = false, readRedirect = false, readNotFound = false] =
+      entry;
 
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      // Sequential on purpose: one transaction owns one pooled connection, and
-      // firing these concurrently leaks it (idle in transaction). Each read is
-      // skipped entirely when the viewer cannot see that panel.
-      const config = canReadConfig
+    // Sequential on purpose: one transaction owns one pooled connection, and
+    // firing these concurrently leaks it (idle in transaction). Each read is
+    // skipped entirely when the viewer cannot see that panel.
+    return {
+      readConfig,
+      readRedirect,
+      readNotFound,
+      config: readConfig
         ? await fetchSeoTenantSettings(tx, ssr.tenantId)
-        : EMPTY_SEO_TENANT_SETTINGS;
-      const settings = canReadRedirect
+        : EMPTY_SEO_TENANT_SETTINGS,
+      settings: readRedirect
         ? await fetchRedirectSettings(tx, ssr.tenantId)
-        : EMPTY_REDIRECT_SETTINGS;
-      const rules = canReadRedirect
+        : EMPTY_REDIRECT_SETTINGS,
+      rules: readRedirect
         ? await listRedirects(tx, ssr.tenantId, filters, cursor ?? undefined)
-        : { redirects: [], nextCursor: null };
-      const notFound = canReadNotFound
+        : { redirects: [], nextCursor: null },
+      notFound: readNotFound
         ? await listNotFoundObservations(tx, ssr.tenantId, { unresolvedOnly })
-        : [];
-
-      return { config, settings, rules, notFound };
-    });
-
-    seoConfig = result.config;
-    redirectSettings = result.settings;
-    redirects = result.rules.redirects;
-    nextCursor = result.rules.nextCursor;
-    observations = result.notFound;
-  } catch (error) {
-    loadError = true;
+        : [],
+      canUpdateConfig: await can({
+        moduleKey: "seo_distribution",
+        activityCode: "config",
+        action: "update"
+      }),
+      canCreateRedirect: await can({
+        moduleKey: "seo_distribution",
+        activityCode: "redirect",
+        action: "create"
+      }),
+      canUpdateRedirect: await can({
+        moduleKey: "seo_distribution",
+        activityCode: "redirect",
+        action: "update"
+      }),
+      canDeleteRedirect: await can({
+        moduleKey: "seo_distribution",
+        activityCode: "redirect",
+        action: "delete"
+      }),
+      canUpdateNotFound: await can({
+        moduleKey: "seo_distribution",
+        activityCode: "not_found",
+        action: "update"
+      })
+    };
+  },
+  onError: (error) => {
     logAdminPageError("admin/seo.astro: failed to load the SEO screen", error, {
       correlationId: Astro.locals.correlationId
     });
   }
-}
+});
+
+const loadError = screen.state === "error";
+const canReadConfig = screen.state === "allowed" && screen.data.readConfig;
+const canReadRedirect = screen.state === "allowed" && screen.data.readRedirect;
+const canReadNotFound = screen.state === "allowed" && screen.data.readNotFound;
+const canUpdateConfig =
+  screen.state === "allowed" && screen.data.canUpdateConfig;
+const canCreateRedirect =
+  screen.state === "allowed" && screen.data.canCreateRedirect;
+const canUpdateRedirect =
+  screen.state === "allowed" && screen.data.canUpdateRedirect;
+const canDeleteRedirect =
+  screen.state === "allowed" && screen.data.canDeleteRedirect;
+const canUpdateNotFound =
+  screen.state === "allowed" && screen.data.canUpdateNotFound;
+const seoConfig: SeoTenantSettings =
+  screen.state === "allowed" ? screen.data.config : EMPTY_SEO_TENANT_SETTINGS;
+const redirectSettings: RedirectSettings =
+  screen.state === "allowed" ? screen.data.settings : EMPTY_REDIRECT_SETTINGS;
+const redirects: RedirectRecord[] =
+  screen.state === "allowed" ? screen.data.rules.redirects : [];
+const nextCursor: string | null =
+  screen.state === "allowed" ? screen.data.rules.nextCursor : null;
+const observations: NotFoundObservation[] =
+  screen.state === "allowed" ? screen.data.notFound : [];
 
 /** Next-page href: current filters preserved, cursor advanced. */
 function nextPageHref(token: string): string {

--- a/src/pages/admin/site-search.astro
+++ b/src/pages/admin/site-search.astro
@@ -24,10 +24,8 @@
  */
 import AdminLayout from "../../layouts/AdminLayout.astro";
 import "../../styles/admin-screens.css";
-import { getDatabaseClient } from "../../lib/database/client";
-import { withTenantOrThrow } from "../../lib/database/tenant-context";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
 import { logAdminPageError } from "../../lib/logging/error-log";
-import { permissionKey } from "../../modules/identity-access/domain/access-control";
 import {
   fetchIndexFailures,
   fetchIndexStatus,
@@ -55,57 +53,55 @@ if (!ssr) {
   );
 }
 
-const canReadIndex = ssr.permissions.has(
-  permissionKey("site_search", "index", "read")
-);
-const canReconcile = ssr.permissions.has(
-  permissionKey("site_search", "index", "reconcile")
-);
-const canRebuild = ssr.permissions.has(
-  permissionKey("site_search", "index", "rebuild")
-);
-const canReadSettings = ssr.permissions.has(
-  permissionKey("site_search", "settings", "read")
-);
-const canUpdateSettings = ssr.permissions.has(
-  permissionKey("site_search", "settings", "update")
-);
-const canReadDiagnostics = ssr.permissions.has(
-  permissionKey("site_search", "diagnostics", "read")
-);
+// Issue #450 — the entry decision and the reads share ONE transaction, and the
+// decision is the chokepoint's.
+//
+// ANY-OF: three independently readable panels, refused only when all three are.
+// Each fetch is awaited SEQUENTIALLY: concurrent queries on a single
+// transaction connection leak it (idle in transaction) — the same note the API
+// routes carry.
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: [
+    { moduleKey: "site_search", activityCode: "index", action: "read" },
+    { moduleKey: "site_search", activityCode: "settings", action: "read" },
+    { moduleKey: "site_search", activityCode: "diagnostics", action: "read" }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [readIndex = false, readSettings = false, readDiagnostics = false] =
+      entry;
 
-let status: IndexStatus | null = null;
-let recentRuns: IndexRunSummary[] = [];
-let failures: IndexFailureItem[] = [];
-let settings: SiteSearchSettings | null = null;
-let loadError = false;
-
-// One transaction for every panel this viewer is allowed to see. Each fetch is
-// awaited SEQUENTIALLY: concurrent queries on a single transaction connection
-// leak it (idle in transaction) — the same note the API routes carry.
-if (canReadIndex || canReadSettings || canReadDiagnostics) {
-  try {
-    const sql = getDatabaseClient();
-    const result = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-      const indexStatus = canReadIndex
-        ? await fetchIndexStatus(tx, ssr.tenantId)
-        : null;
-      const runs = canReadIndex
-        ? await fetchRecentRuns(tx, ssr.tenantId, 10)
-        : [];
-      const failed = canReadDiagnostics
+    return {
+      readIndex,
+      readSettings,
+      readDiagnostics,
+      indexStatus: readIndex ? await fetchIndexStatus(tx, ssr.tenantId) : null,
+      runs: readIndex ? await fetchRecentRuns(tx, ssr.tenantId, 10) : [],
+      failed: readDiagnostics
         ? await fetchIndexFailures(tx, ssr.tenantId, 100)
-        : [];
-      const config = canReadSettings
+        : [],
+      config: readSettings
         ? await fetchSiteSearchSettings(tx, ssr.tenantId)
-        : null;
-      return { indexStatus, runs, failed, config };
-    });
-    status = result.indexStatus;
-    recentRuns = result.runs;
-    failures = result.failed;
-    settings = result.config;
-  } catch (error) {
+        : null,
+      canReconcile: await can({
+        moduleKey: "site_search",
+        activityCode: "index",
+        action: "reconcile"
+      }),
+      canRebuild: await can({
+        moduleKey: "site_search",
+        activityCode: "index",
+        action: "rebuild"
+      }),
+      canUpdateSettings: await can({
+        moduleKey: "site_search",
+        activityCode: "settings",
+        action: "update"
+      })
+    };
+  },
+  onError: (error) => {
     logAdminPageError(
       "admin/site-search.astro: failed to load console",
       error,
@@ -113,9 +109,26 @@ if (canReadIndex || canReadSettings || canReadDiagnostics) {
         correlationId: Astro.locals.correlationId
       }
     );
-    loadError = true;
   }
-}
+});
+
+const loadError = screen.state === "error";
+const canReadIndex = screen.state === "allowed" && screen.data.readIndex;
+const canReadSettings = screen.state === "allowed" && screen.data.readSettings;
+const canReadDiagnostics =
+  screen.state === "allowed" && screen.data.readDiagnostics;
+const status: IndexStatus | null =
+  screen.state === "allowed" ? screen.data.indexStatus : null;
+const recentRuns: IndexRunSummary[] =
+  screen.state === "allowed" ? screen.data.runs : [];
+const failures: IndexFailureItem[] =
+  screen.state === "allowed" ? screen.data.failed : [];
+const settings: SiteSearchSettings | null =
+  screen.state === "allowed" ? screen.data.config : null;
+const canReconcile = screen.state === "allowed" && screen.data.canReconcile;
+const canRebuild = screen.state === "allowed" && screen.data.canRebuild;
+const canUpdateSettings =
+  screen.state === "allowed" && screen.data.canUpdateSettings;
 
 /** `2026-08-01T03:18:38.929Z` -> `2026-08-01 03:18` (UTC, no locale dependency). */
 function formatTimestamp(value: string | null): string {

--- a/tests/access-chokepoint.test.ts
+++ b/tests/access-chokepoint.test.ts
@@ -372,9 +372,20 @@ const screen = await loadAdminScreen({
     expect(slice.usesChokepoint).toBe(true);
   });
 
-  test("a screen that still reads the grant set for an affordance is covered by the helper", () => {
-    // Not a loophole being blessed: the file-wide rule is the same one
-    // `defineTenantRoute` gets, and the entry decision is what R3 is about.
+  test("a screen that reads the grant set for an affordance is a finding, even when routed", () => {
+    // This asserted the OPPOSITE while the migration ledger had entries, on the
+    // reasoning that the file-wide rule is the one `defineTenantRoute` gets and
+    // the entry decision is what R3 is about. That was right for a half-migrated
+    // screen and wrong the moment the last one landed: it let a routed screen
+    // decide an AFFORDANCE from raw RBAC with the gate green.
+    //
+    // It was found by mutation, not by reading — planting exactly this hybrid
+    // into `users.astro` left `access:chokepoint:check` at exit 0 while its own
+    // summary line said "1 still decide outside the chokepoint".
+    //
+    // Routes keep the file-wide allowance; screens do not. `.astro` is one
+    // render path per file, so there is no sibling handler for the coverage to
+    // legitimately extend to.
     const slice = sliceScreen(
       "hybrid.astro",
       `${MIGRATED_SCREEN}\nconst extra = ssr.permissions.has("x");`
@@ -382,7 +393,20 @@ const screen = await loadAdminScreen({
 
     expect(slice.decidesPermissions).toBe(true);
     expect(slice.usesChokepoint).toBe(true);
-    expect(findChokepointBypasses([slice], {}, [])).toEqual([]);
+    expect(findChokepointBypasses([slice], {}, [])).toHaveLength(1);
+  });
+
+  test("a ROUTE that decides in one handler is still covered file-wide by the factory", () => {
+    // The other half of the asymmetry above, pinned so the screen tightening
+    // cannot be generalised to routes by someone tidying the filter.
+    // `defineTenantRoute` wraps at module level and calls the chokepoint itself.
+    const route = {
+      id: "thing/index.ts#GET",
+      decidesPermissions: true,
+      usesChokepoint: true
+    };
+
+    expect(findChokepointBypasses([route], {}, [])).toEqual([]);
   });
 
   test("the signal is not matched inside a comment", () => {
@@ -459,5 +483,40 @@ ${MIGRATED_SCREEN.slice(4)}`
     expect(bypassing).toEqual([...ADMIN_SCREEN_CHOKEPOINT_MIGRATION].sort());
     // At least one screen went through: the mechanism is proven, not provided.
     expect(slices.some((slice) => slice.usesChokepoint)).toBe(true);
+  });
+
+  test("the ledger is EMPTY — R3 is closed, and closed is a thing to assert", () => {
+    // While the ledger had entries, "may only shrink" was enforced by the
+    // staleness check: an entry whose screen no longer bypassed was a finding.
+    // At zero that alarm has nothing to fire on, so growth back from zero would
+    // be silent. This asserts the end state directly.
+    //
+    // Adding a line here is not a merge conflict to resolve — it means a new
+    // admin screen decides access outside `authorizeInTransaction`, which is
+    // the entire defect #450 existed to remove.
+    expect([...ADMIN_SCREEN_CHOKEPOINT_MIGRATION]).toEqual([]);
+  });
+
+  test("every admin screen is routed, not merely absent from the ledger", () => {
+    // The pair that makes the assertion above mean something. An empty
+    // `bypassing` set is also what a BROKEN detector produces — `sliceScreen`
+    // returning `decidesPermissions: false` for everything reads identically to
+    // total success. The detector's own behaviour is pinned by the
+    // `LEGACY_SCREEN` cases at the top of this block; this one pins the corpus:
+    // all 32 screens actually call the helper.
+    return Array.fromAsync(
+      new Bun.Glob("**/*.astro").scan({ cwd: "src/pages/admin" })
+    ).then(async (files) => {
+      expect(files.length).toBeGreaterThan(0);
+
+      const unrouted: string[] = [];
+
+      for (const file of files) {
+        const source = await Bun.file(`src/pages/admin/${file}`).text();
+        if (!sliceScreen(file, source).usesChokepoint) unrouted.push(file);
+      }
+
+      expect(unrouted).toEqual([]);
+    });
   });
 });

--- a/tests/admin-blog-presentation-page-contract.test.ts
+++ b/tests/admin-blog-presentation-page-contract.test.ts
@@ -71,13 +71,31 @@ function expectCode(source: string, anchor: string): string {
   return stripped;
 }
 
+/**
+ * Permission triples the screen gates on.
+ *
+ * This screen used to bind a file-local `can(activity, action)` helper over
+ * `ssr.permissions.has`, and this matcher read those two-argument calls. Issue
+ * #450 removed the helper: the guards are now `AccessRequest` object literals,
+ * the same shape the routes use. Both forms are read so the assertion states
+ * the PROPERTY — this screen gates exactly these eight — rather than whichever
+ * syntax expressed it.
+ */
 function pageKeys(source: string): Set<string> {
   const found = new Set<string>();
+
   for (const match of source.matchAll(
     /can\(\s*"([a-z_]+)"\s*,\s*"([a-z_]+)"\s*\)/g
   )) {
     found.add(`blog_content.${match[1]}.${match[2]}`);
   }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}`);
+  }
+
   return found;
 }
 

--- a/tests/admin-data-lifecycle-page-contract.test.ts
+++ b/tests/admin-data-lifecycle-page-contract.test.ts
@@ -49,12 +49,27 @@ function guardTriplesFrom(source: string): Set<Triple> {
 }
 
 /** `permissionKey("data_lifecycle", "legal_hold", "release")` → the same shape. */
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect. A contract
+ * test pins the PROPERTY, never the syntax that happened to express it.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 

--- a/tests/admin-security-page-contract.test.ts
+++ b/tests/admin-security-page-contract.test.ts
@@ -44,12 +44,27 @@ function guardTriplesFrom(source: string): Set<Triple> {
 }
 
 /** `permissionKey("identity_access", "sso_policy", "read")` → the same shape. */
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect. A contract
+ * test pins the PROPERTY, never the syntax that happened to express it.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 

--- a/tests/admin-seo-page-contract.test.ts
+++ b/tests/admin-seo-page-contract.test.ts
@@ -110,12 +110,27 @@ function guardTriplesFrom(
 }
 
 /** `permissionKey("seo_distribution", "redirect", "read")` → `seo_distribution.redirect.read`. */
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect. A contract
+ * test pins the PROPERTY, never the syntax that happened to express it.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 
@@ -299,7 +314,13 @@ describe("/admin/seo writes only through the guarded endpoints", () => {
     // rule is asserted textually: a bare `withTenant(` here would open a
     // transaction whose 503 `Response` leaks into the render path.
     expect(page).not.toMatch(/[^r]\bwithTenant\(/);
-    expect(page).toContain("withTenantOrThrow(sql, ssr.tenantId");
+    // Issue #450: the screen no longer opens its own transaction at all — the
+    // entry decision and the reads share the ONE that `loadAdminScreen` opens.
+    // The old assertion demanded the literal `withTenantOrThrow(sql, ...)`,
+    // which after the migration is a demand to keep the transaction OUTSIDE the
+    // chokepoint. Both halves are pinned so it cannot drift back.
+    expect(page).toMatch(/loadAdminScreen\(/);
+    expect(page).not.toMatch(/\bwithTenantOrThrow\(/);
   });
 
   test("high-risk writes carry a fresh Idempotency-Key and the dry run does not", async () => {

--- a/tests/admin-site-search-page-contract.test.ts
+++ b/tests/admin-site-search-page-contract.test.ts
@@ -61,12 +61,27 @@ function guardTriplesFrom(source: string): Set<Triple> {
 }
 
 /** `permissionKey("site_search", "index", "read")` → the same shape. */
+/**
+ * Both spellings, and issue #450 is why the second exists: a screen routed
+ * through `loadAdminScreen` states its guards as `AccessRequest` object
+ * literals — the SAME shape the routes use — instead of `permissionKey(...)`.
+ *
+ * Reading only the old spelling would have made this test demand the screen
+ * keep deciding access from the raw grant set, which is the defect. A contract
+ * test pins the PROPERTY, never the syntax that happened to express it.
+ */
 function pageTriplesFrom(source: string): Set<Triple> {
   const found = new Set<Triple>();
-  const pattern =
-    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g;
 
-  for (const match of source.matchAll(pattern)) {
+  for (const match of source.matchAll(
+    /permissionKey\(\s*"([a-z_]+)",\s*"([a-z_]+)",\s*"([a-z_]+)"\s*\)/g
+  )) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  for (const match of source.matchAll(
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g
+  )) {
     found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
   }
 


### PR DESCRIPTION
Menutup #450. Ledger **5 → 0**, di **kedua** gerbang.

Lima layar terakhir: `data-lifecycle`, `security`, `seo`, `site-search`, `blog-presentation`.

Tidak ada lagi layar admin yang memutuskan akses dari `ssr.permissions.has(...)`. Setiap render kini melewati evaluasi kebijakan ABAC, `resolveModuleAvailability`, fakta business-scope, SoD saat-aksi, dan `recordDecisionLog`.

## Tiga hal diporting VERBATIM, bukan "diperbaiki"

**`data-lifecycle` menerima LIMA request entry, dua di antaranya TULIS** (`legal_hold.create`, `plan.analyze`). Itulah `showAnything` selama ini: konsol ini mengizinkan siapa pun yang bisa melakukan apa pun di sini — termasuk orang yang boleh memasang legal hold tanpa bisa mendaftar hold yang sudah ada. Memangkasnya ke tiga baca akan diam-diam mengunci mereka.

**`security` memakai `mfa_admin.reset` sebagai gerbang BACA panel MFA.** Modul ini tidak menyeed satu pun aksi baca MFA. Diporting apa adanya, bukan "dikoreksi" ke permission yang tidak ada.

**`blog-presentation`** memindahkan pemilihan section ke dalam `load` — section mana yang tersedia kini jawaban chokepoint, jadi fallback-nya harus dihitung dari jawaban yang sama. Helper file-local `can(activity, action)`-nya hilang; itu helper yang membuat `admin:screen-coverage:check` menumbuhkan matcher penyelesai-helper-nya.

## Gerbangnya diperketat, karena mutasi membuktikan ia bocor

Setelah ledger kosong saya menanam bypass nyata ke `users.astro`. Gerbangnya **hijau** — keluar dengan kode 0 sambil baris ringkasannya sendiri berbunyi *"1 still decide outside the chokepoint"*.

Sebabnya kelonggaran se-BERKAS: layar yang memanggil `loadAdminScreen` untuk entry-nya boleh tetap memutuskan sebuah AFFORDANCE dari `ssr.permissions.has(...)`. Benar selama migrasi — layar setengah-jadi tidak boleh dilaporkan dua kali — dan **salah begitu layar terakhir mendarat**: jalan masuk kembali, satu tombol demi satu tombol.

Rute mempertahankan kelonggaran itu (`defineTenantRoute` membungkus di level modul dan memanggil chokepoint sendiri). Layar tidak: satu berkas `.astro` = satu jalur render, tidak ada handler saudara yang pantas ikut tertutupi. **Asimetrinya dipatok test di kedua arah**, supaya tidak ada yang "merapikan" filternya jadi seragam.

## Dua alarm yang menjadi inert pada nol, diganti

Self-test detektor berbunyi *"nol layar memutuskan sementara ledger tidak kosong = detektor rusak"* — persis cek yang mati saat layar terakhir dimigrasikan: sejak itu nol adalah jawaban yang BENAR, dan nol dari detektor rusak tak bisa dibedakan darinya. Diganti **probe sintetis**: `sliceScreen` ditanya tentang layar yang pasti bypass dan yang pasti tidak; keduanya harus benar pada ukuran ledger berapa pun.

Gerbang juga kini menuntut tiap layar benar-benar **TERUTE** — layar yang tidak membaca permission apa pun DAN tidak membuka chokepoint akan lolos filter bypass tanpa tertutupi apa pun.

Aturan "hanya boleh menyusut" kehilangan penegaknya pada nol (entri basi adalah temuan, tetapi daftar kosong tak punya yang bisa basi), jadi kekosongannya di-assert langsung.

## Verifikasi — ketiga arah dibuktikan MERAH, bukan sekadar hijau

| Cacat ditanam | Hasil |
|---|---|
| `users.astro` routed + `ssr.permissions.has(...)` | **FAILED**, menamai layarnya |
| `loadAdminScreen` → `loadAdminScreenXX` (tak terute) | **FAILED**, menamai layarnya |
| dikembalikan | OK |

- `DATABASE_URL="" bun run test` — **3497 pass, 0 fail**
- `bun run check` penuh — **exit 0**
- `access:chokepoint:check` — `32 admin screens, all routed through loadAdminScreen (R3 closed; ledger: 0)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)