### PR TITLE
feat(push): adapter FCM HTTP v1 — tanpa dependensi, tanpa origin CSP baru (#466)

### DIFF
--- a/.changeset/adapter-fcm-http-v1.md
+++ b/.changeset/adapter-fcm-http-v1.md
@@ -1,0 +1,65 @@
+---
+"awcms": minor
+---
+
+feat(push): adapter FCM HTTP v1 — tanpa dependensi, tanpa satu pun origin CSP baru
+
+`PUSH_PROVIDER=fcm` mengaktifkan pengiriman ke klien **native** Android/iOS.
+Server → Google, jadi ia tidak menyentuh browser: nol byte di anggaran aset
+klien dan nol origin CSP baru. Itulah pembagian yang ADR-0074 tetapkan —
+FCM HTTP v1 ditahan, SDK FCM Web ditolak.
+
+**Tanpa menambah dependensi.** `google-auth-library` dan `firebase-admin`
+sama-sama melakukan ini, dan keduanya akan jadi dependensi runtime baru di repo
+yang hidup dengan dua. Presedennya sudah tertulis: `src/lib/auth/jwt-verify.ts`
+melakukan verifikasi JWT tanpa `jose`. Assertion service-account (RFC 7523)
+ditandatangani RS256 lewat `crypto.subtle`, tak pernah implementasi RSA
+tangan-sendiri.
+
+Test yang paling menanggung beban bukan percabangan status — itu mudah benar dan
+mudah diuji. Yang bisa salah secara halus dan senyap adalah assertion-nya: JWT
+yang ditolak Google terlihat persis seperti masalah kredensial, dan "tambahkan
+`google-auth-library`" adalah kesimpulan yang akan diambil siapa pun setelah
+satu jam begitu. Jadi assertion-nya tidak sekadar dihasilkan — ia
+**diverifikasi**, dengan kunci publik pasangannya, lewat `crypto.subtle`.
+Pasangan kunci RSA nyata dibangkitkan di dalam test, diekspor ke bentuk PEM
+PKCS#8 yang sama dengan terbitan Google, dan dilewatkan parser sungguhan.
+
+**Kredensial wajib base64.** `config:validate` mem-parse `.env` baris demi
+baris, dan `private_key` adalah blok PEM multi-baris — ditempel mentah ia
+terpotong diam-diam dan kegagalannya muncul saat kirim pertama, bukan saat boot.
+Parser-nya pure dan dipakai **kedua** sisi, jadi validator tak bisa berbeda
+pendapat dengan benda yang ia validasi. Pesan kegagalannya menyebut **nama
+field**, tak pernah nilai: ada test yang meng-assert `private_key` tak muncul.
+
+**Tiga keputusan yang halus:**
+
+- **Token mati tidak memicu circuit breaker.** Antrean normal membawa ribuan
+  token basi; kalau itu dihitung sebagai kegagalan provider, satu batch
+  registrasi lama menghentikan pengiriman ke setiap perangkat sehat — dan
+  gejalanya menunjuk ke FCM. Diuji dua arah: sepuluh `UNREGISTERED` berturut
+  meninggalkan breaker `closed`, lima `UNAVAILABLE` membukanya.
+- **Kode error dibaca SEBELUM status.** Versi pertama memeriksa `status === 401`
+  lebih dulu, dan **test menangkapnya**: `THIRD_PARTY_AUTH_ERROR` (juga HTTP
+  401) dilaporkan sebagai "token kadaluwarsa", sehingga adapter mencetak token
+  baru dan mengulang — menghabiskan satu round-trip untuk ditolak dengan alasan
+  sama, dan melabeli kesalahan konfigurasi permanen sebagai kedaluwarsa.
+- **401 disegarkan tepat sekali.** Token yang mati di tengah batch berharga satu
+  panggilan tambahan, bukan seluruh sisa batch; token baru yang tetap ditolak
+  adalah masalah kredensial dan berhenti di situ (non-retryable).
+
+Setiap panggilan keluar lewat `ssrfSafeFetch`, bukan `fetch` telanjang: tujuannya
+diturunkan dari `token_uri` sebuah kredensial dan dari baris langganan — nilai
+yang datang dari luar kode ini. Seam-nya sebuah TIPE, bukan pembungkus `fetch`,
+supaya test menggerakkan adapter tanpa jaringan **dan tanpa harus mematikan
+guard-nya** — test yang harus mematikan guard sedang menguji jalur berbeda dari
+yang dijalankan produksi.
+
+`healthCheck` membuktikan kredensialnya, bukan jalur kirim: mengirim notifikasi
+nyata butuh token perangkat nyata, dan mengarang satu akan dijawab
+`UNREGISTERED` — FCM sehat yang melapor gagal.
+
+`web_push` masih **belum** diterima `PUSH_PROVIDER`. Test yang dulu meng-assert
+`fcm` ditolak kini meng-assert `fcm` diterima dan `web_push` tidak — itulah guna
+meng-assert yang negatif: daftarnya tak bisa tumbuh mendahului kodenya tanpa
+test itu ikut disunting di perubahan yang sama.

--- a/.env.example
+++ b/.env.example
@@ -309,19 +309,37 @@ VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS=30
 # per-tenant override and there is not meant to be one.
 # PUSH_ENABLED=false
 #
-# Adapter. Only `log` exists today (writes a structured line, always succeeds —
-# for local development and tests). `fcm` and `web_push` land with Issue #466
-# and are deliberately NOT accepted yet: naming them early would let a
-# deployment pass validation and then fail at resolve time.
+# Adapter:
+#   log  — writes a structured line and always succeeds (local dev and tests).
+#   fcm  — FCM HTTP v1, server -> Google, for NATIVE Android/iOS clients.
+# `web_push` (VAPID, for browsers) does not exist yet and is deliberately NOT
+# accepted: naming an adapter early lets a deployment pass validation and then
+# fail at resolve time.
 # PUSH_PROVIDER=log
+#
+# Google service-account credential for PUSH_PROVIDER=fcm, as BASE64 of the
+# whole JSON file:
+#
+#   base64 -w0 service-account.json
+#
+# Base64 and not the raw JSON, because `config:validate` parses `.env` line by
+# line and the credential's `private_key` is a multi-line PEM block — pasted
+# raw, it is silently truncated at the first newline and the failure surfaces at
+# the first send instead of at boot.
+#
+# Per-DEPLOYMENT, never per-tenant: the credential authenticates this SERVER to
+# one Firebase project. There is no per-tenant override and there is not meant
+# to be one.
+# PUSH_FCM_CREDENTIALS_BASE64=
 #
 # Retry ceiling. `0` is a legitimate value meaning "never retry" and is honoured
 # as such; an EMPTY value is treated as unset, not as zero.
 # PUSH_SEND_MAX_RETRIES=3
 #
-# There is no PUSH_SEND_TIMEOUT_MS yet, on purpose — a send timeout only means
-# something to an adapter that makes a network call, and the only adapter today
-# is `log`. It arrives with the real ones (#466).
+# TOTAL wall-clock budget for one outbound call, including reading the body. A
+# send can spend it twice in one attempt (mint an access token, then call FCM):
+# two hops that can each hang independently.
+# PUSH_SEND_TIMEOUT_MS=10000
 
 # --- Data lifecycle (ADR-0037) ---
 # Filesystem root for the offline/local archive adapter (JSONL/CSV + SHA-256)

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 130   |
 | Tabel dengan `FORCE` RLS           | 119   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 326   |
+| Berkas test                        | 327   |
 | Berkas route                       | 311   |
 | ADR                                | 75    |
 
@@ -280,7 +280,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 278        |
+| `(root)`      | 279        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -14,6 +14,8 @@
  */
 import { readFile } from "node:fs/promises";
 
+import { parseFcmCredentialsBase64 } from "../src/modules/push-delivery/domain/fcm-credentials";
+
 type EnvBag = Record<string, string | undefined>;
 
 type Rule = {
@@ -260,8 +262,15 @@ const RULES: readonly Rule[] = [
   // listing them early would let a deployment pass validation here and then
   // fail at resolve time, which is the worst place to learn it.
   { name: "PUSH_ENABLED", required: false, type: "bool" },
-  { name: "PUSH_PROVIDER", required: false, type: "enum", values: ["log"] },
+  {
+    name: "PUSH_PROVIDER",
+    required: false,
+    type: "enum",
+    values: ["log", "fcm"]
+  },
   { name: "PUSH_SEND_MAX_RETRIES", required: false, type: "int", min: 0 },
+  { name: "PUSH_SEND_TIMEOUT_MS", required: false, type: "int", min: 1 },
+  { name: "PUSH_FCM_CREDENTIALS_BASE64", required: false, type: "string" },
 
   // visitor_analytics (ported from awcms-micro epic #617-#624). All optional,
   // privacy-first off-by-default; see
@@ -587,6 +596,30 @@ export function validateEnv(env: EnvBag): string[] {
       problems.push(
         "PUSH_PROVIDER wajib diisi saat PUSH_ENABLED=true (tanpa adapter, setiap notifikasi yang diantre langsung menjadi `failed`)."
       );
+    }
+
+    // Memakai parser yang SAMA dengan adapter (`parseFcmCredentialsBase64`),
+    // bukan cek terpisah. Validator yang mengimplementasikan ulang pemeriksaan
+    // bebas berbeda pendapat dengan benda yang ia validasi — dan akan berbeda,
+    // persis pada kasus yang tak diuji siapa pun.
+    if (provider === "fcm") {
+      const raw = env.PUSH_FCM_CREDENTIALS_BASE64?.trim() ?? "";
+
+      if (raw === "") {
+        problems.push(
+          "PUSH_FCM_CREDENTIALS_BASE64 wajib diisi saat PUSH_PROVIDER=fcm."
+        );
+      } else {
+        const parsed = parseFcmCredentialsBase64(raw);
+
+        if (!parsed.ok) {
+          // `reason` menyebut NAMA field dan bentuk, tidak pernah nilai —
+          // parser-nya ditulis supaya `private_key` tak bisa sampai ke pesan.
+          problems.push(
+            `PUSH_FCM_CREDENTIALS_BASE64 tidak valid: ${parsed.reason}.`
+          );
+        }
+      }
     }
   }
 

--- a/src/modules/push-delivery/README.md
+++ b/src/modules/push-delivery/README.md
@@ -44,8 +44,24 @@ Tanpa `PUSH_ENABLED=true`, `dispatchPushQueue` **tidak mengklaim satu baris pun*
 
 Ketiganya dihapus dalam urutan FK — attempts, messages, subscriptions — karena masing-masing anak dari berikutnya.
 
+## Adapter FCM HTTP v1
+
+`PUSH_PROVIDER=fcm` — server → Google, untuk klien **native** Android/iOS. Ia tidak pernah menyentuh browser, jadi nol byte di anggaran aset klien dan nol origin CSP baru; itulah sebabnya ADR-0074 menahan FCM HTTP v1 sambil menolak SDK FCM Web.
+
+**Tanpa dependensi.** Assertion service-account (RFC 7523) ditandatangani RS256 lewat `crypto.subtle`, meniru preseden `src/lib/auth/jwt-verify.ts` yang menolak menambah `jose` untuk verifikasi JWT. Access token di-cache per-proses, dikunci `client_email`, dan tidak pernah ditulis ke Redis/Postgres — ia kredensial bearer hidup, dan menyimpannya at-rest demi menghemat satu panggilan HTTP per jam adalah pertukaran yang salah arah.
+
+**Kredensial wajib base64** (`PUSH_FCM_CREDENTIALS_BASE64`): `config:validate` mem-parse `.env` baris demi baris, dan `private_key` sebuah service account adalah blok PEM multi-baris — ditempel mentah, ia terpotong diam-diam di baris pertama dan kegagalannya muncul saat kirim pertama, bukan saat boot. Parser-nya **pure** dan dipakai `config:validate` maupun adapter, jadi validator tak bisa berbeda pendapat dengan benda yang ia validasi.
+
+**Tiga hal yang halus dan sengaja:**
+
+- **Token mati TIDAK memicu circuit breaker.** Antrean normal membawa ribuan token basi; kalau itu dihitung sebagai kegagalan provider, satu batch registrasi lama akan menghentikan pengiriman ke setiap perangkat sehat — dan gejalanya ("push berhenti") menunjuk ke FCM. Hanya sinyal tentang LAYANAN yang memicunya: kegagalan transport, 429, dan 5xx.
+- **Kode error dibaca sebelum status.** FCM meng-overload status dua arah, dan 401 adalah kasus paling tajam: ia sekaligus "access token kadaluwarsa" (tanpa kode) dan `THIRD_PARTY_AUTH_ERROR` (kredensial APNs/web yang harus diperbaiki operator). Versi pertama fungsi ini memeriksa status lebih dulu, dan test menangkapnya.
+- **401 disegarkan tepat SEKALI.** Token yang kadaluwarsa di tengah batch berharga satu panggilan tambahan, bukan seluruh sisa batch; token baru yang tetap ditolak adalah masalah kredensial dan berhenti di situ.
+
+`healthCheck` membuktikan **kredensialnya**, bukan jalur kirim — mengirim notifikasi nyata butuh token perangkat nyata, dan mengarang satu akan dijawab `UNREGISTERED`, yaitu FCM sehat yang melapor gagal.
+
 ## Yang BELUM ada
 
-- **Adapter nyata.** Hanya `log` yang ada. FCM HTTP v1 dan Web Push/VAPID mendarat di #466. `PUSH_PROVIDER` sengaja belum menerima `fcm`/`web_push`: menamainya sekarang akan membuat deployment lolos validasi lalu gagal saat resolve.
+- **Adapter Web Push/VAPID untuk browser.** `PUSH_PROVIDER` sengaja belum menerima `web_push`: menamainya sekarang akan membuat deployment lolos validasi lalu gagal saat resolve.
 - **Permukaan HTTP.** Mendaftarkan dan mencabut langganan lewat API, plus layar admin, mendarat bersama adapter-nya. Sampai itu `enqueuePushToRecipients` belum punya pemanggil produksi — kesenjangan yang dicatat di ADR-0074 §Konsekuensi alih-alih dibiarkan ditemukan.
 - **FCM Web (SDK browser).** Ditolak, dengan angkanya, di ADR-0074 §Yang DITOLAK.

--- a/src/modules/push-delivery/domain/fcm-credentials.ts
+++ b/src/modules/push-delivery/domain/fcm-credentials.ts
@@ -1,0 +1,150 @@
+/**
+ * FCM service-account credential parsing (Issue #466, ADR-0074). Pure — no
+ * `process.env` reads, no network, no crypto. Given a string, it either yields
+ * a validated credential or a reason it is not one.
+ *
+ * ## Why the value arrives base64
+ *
+ * A Google service-account credential is a JSON document whose `private_key`
+ * is a PEM block — multi-line by nature. `scripts/validate-env.ts` parses
+ * `.env` LINE BY LINE with its own parser, so a multi-line value is silently
+ * truncated at the first newline: the variable would appear to be set, the JSON
+ * would fail to parse, and the failure would surface at the first send rather
+ * than at boot.
+ *
+ * So `PUSH_FCM_CREDENTIALS_BASE64` carries base64 of the whole JSON — one line,
+ * no escaping, and the same shape `AUTH_MFA_SECRET_ENCRYPTION_KEY` already
+ * establishes for binary key material.
+ *
+ * ## Why parsing is separated from using
+ *
+ * Everything here is a pure function over a string, which is what lets
+ * `config:validate` reject a malformed credential at BOOT with the same code
+ * path the adapter uses at send time. A validator that re-implemented the
+ * checks would be free to disagree with the thing it validates, and would, in
+ * exactly the case nobody tests.
+ */
+
+/** Only the fields this adapter needs. A real credential carries more; extra keys are ignored, not rejected. */
+export type FcmServiceAccount = {
+  projectId: string;
+  clientEmail: string;
+  /** PEM, PKCS#8 (`-----BEGIN PRIVATE KEY-----`). Never logged, never included in an error. */
+  privateKeyPem: string;
+  /** Google's OAuth2 token endpoint, taken from the credential rather than hardcoded — the credential is what names it. */
+  tokenUri: string;
+};
+
+export type FcmCredentialParseResult =
+  { ok: true; credential: FcmServiceAccount } | { ok: false; reason: string };
+
+const REQUIRED_FIELDS = [
+  "project_id",
+  "client_email",
+  "private_key",
+  "token_uri"
+] as const;
+
+/**
+ * PKCS#8 only. Google issues PKCS#8 (`BEGIN PRIVATE KEY`); the older PKCS#1
+ * form (`BEGIN RSA PRIVATE KEY`) is rejected HERE with a message that names the
+ * difference, because `crypto.subtle.importKey("pkcs8", …)` would otherwise
+ * fail at the first send with an opaque `DataError`.
+ */
+const PKCS8_HEADER = "-----BEGIN PRIVATE KEY-----";
+const PKCS1_HEADER = "-----BEGIN RSA PRIVATE KEY-----";
+
+export function parseFcmCredentialsBase64(
+  raw: string
+): FcmCredentialParseResult {
+  const trimmed = raw.trim();
+
+  if (trimmed === "") {
+    return { ok: false, reason: "credential is empty" };
+  }
+
+  let json: string;
+
+  try {
+    json = Buffer.from(trimmed, "base64").toString("utf8");
+  } catch {
+    return { ok: false, reason: "credential is not valid base64" };
+  }
+
+  // `Buffer.from(…, "base64")` never throws on garbage — it decodes what it can
+  // and drops the rest. So "did it decode" is not a real check; "did it decode
+  // to something parseable" is.
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return {
+      ok: false,
+      reason:
+        "credential does not base64-decode to JSON (a raw, un-encoded service-account file is the usual cause)"
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { ok: false, reason: "credential JSON is not an object" };
+  }
+
+  const record = parsed as Record<string, unknown>;
+  const missing = REQUIRED_FIELDS.filter(
+    (field) => typeof record[field] !== "string" || record[field] === ""
+  );
+
+  if (missing.length > 0) {
+    // Field NAMES only. The value of `private_key` must never reach a log line,
+    // an error message, or a validation report.
+    return {
+      ok: false,
+      reason: `credential JSON is missing field(s): ${missing.join(", ")}`
+    };
+  }
+
+  const privateKeyPem = record.private_key as string;
+
+  if (privateKeyPem.includes(PKCS1_HEADER)) {
+    return {
+      ok: false,
+      reason:
+        "private_key is PKCS#1 (`BEGIN RSA PRIVATE KEY`); this adapter needs PKCS#8 (`BEGIN PRIVATE KEY`), which is what Google issues"
+    };
+  }
+
+  if (!privateKeyPem.includes(PKCS8_HEADER)) {
+    return {
+      ok: false,
+      reason: "private_key is not a PKCS#8 PEM block"
+    };
+  }
+
+  const tokenUri = record.token_uri as string;
+
+  if (!tokenUri.startsWith("https://")) {
+    // A credential naming an http:// token endpoint would send a signed
+    // assertion — a bearer grant — in the clear.
+    return { ok: false, reason: "token_uri must be https" };
+  }
+
+  return {
+    ok: true,
+    credential: {
+      projectId: record.project_id as string,
+      clientEmail: record.client_email as string,
+      privateKeyPem,
+      tokenUri
+    }
+  };
+}
+
+/** `https://fcm.googleapis.com/v1/projects/{projectId}/messages:send` — built from the credential, never from configuration, so the two cannot disagree about which project is being addressed. */
+export function buildFcmSendUrl(credential: FcmServiceAccount): string {
+  return `https://fcm.googleapis.com/v1/projects/${encodeURIComponent(credential.projectId)}/messages:send`;
+}
+
+/** The single OAuth2 scope this adapter needs. Narrower than `cloud-platform`, which would grant the whole project. */
+export const FCM_OAUTH_SCOPE =
+  "https://www.googleapis.com/auth/firebase.messaging";

--- a/src/modules/push-delivery/domain/fcm-error-mapping.ts
+++ b/src/modules/push-delivery/domain/fcm-error-mapping.ts
@@ -1,0 +1,164 @@
+/**
+ * FCM HTTP v1 response → dispatcher outcome (Issue #466). Pure: a status code
+ * and a body string in, a decision out. No network, no clock, no I/O — which is
+ * what lets every branch below be tested against real FCM error bodies instead
+ * of being reasoned about.
+ *
+ * ## Three outcomes, not two
+ *
+ * `subscriptionGone` is separate from `retryable: false` (ADR-0074). FCM
+ * answers `UNREGISTERED` for a token whose app was uninstalled or whose
+ * registration was rotated — that is the subscription reporting its own death,
+ * and the dispatcher disables it. Treating it as an ordinary permanent failure
+ * would leave a tombstone token collecting one failure per message forever.
+ *
+ * ## `tripsBreaker` is the decision most likely to be got wrong
+ *
+ * The circuit breaker exists to stop hammering a provider that is DOWN. A
+ * per-message rejection — a dead token, a malformed payload — says nothing
+ * about whether FCM is healthy, and there can be thousands of them in a normal
+ * queue. If those tripped the breaker, one batch of stale tokens would stop
+ * delivery to every healthy device in the tenant, and the symptom ("push
+ * stopped") would point at FCM rather than at the tokens.
+ *
+ * So only signals about the SERVICE trip it: transport failures, 429, and 5xx.
+ * A 401 does not, either — it means our access token was rejected, which the
+ * adapter fixes by minting a new one.
+ *
+ * ## Order matters, and a test proved it
+ *
+ * The error CODE is read before the status. FCM overloads statuses in both
+ * directions, and 401 is the sharpest case: it is BOTH "your access token
+ * expired" (no error code) and `THIRD_PARTY_AUTH_ERROR` (APNs/web credentials
+ * an operator has to fix). Checking the status first turned the second into the
+ * first — a fresh token minted and replayed, refused for the same reason, and a
+ * standing configuration fault reported as an expiry.
+ */
+
+export type FcmOutcome =
+  | { kind: "success" }
+  | { kind: "subscription_gone"; error: string }
+  | {
+      kind: "failure";
+      error: string;
+      retryable: boolean;
+      tripsBreaker: boolean;
+    }
+  /** The access token was rejected — drop the cached one and retry. */
+  | { kind: "unauthorized"; error: string };
+
+/** Error codes FCM returns in `error.details[].errorCode`, and what each means for us. */
+const SUBSCRIPTION_GONE_CODES = new Set(["UNREGISTERED"]);
+
+const PERMANENT_CODES = new Set([
+  // The payload or the target is wrong, and will be wrong next time too.
+  "INVALID_ARGUMENT",
+  // The token belongs to a different sender/project — a configuration mistake.
+  "SENDER_ID_MISMATCH",
+  // APNs/web credentials rejected by the third party — an operator fix.
+  "THIRD_PARTY_AUTH_ERROR"
+]);
+
+const RETRYABLE_CODES = new Set(["UNAVAILABLE", "INTERNAL", "QUOTA_EXCEEDED"]);
+
+/** Pulls `error.details[].errorCode` out of an FCM v1 error body; `null` when the body is not one. */
+export function extractFcmErrorCode(body: string): string | null {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return null;
+  }
+
+  const details = (
+    parsed as { error?: { details?: { errorCode?: unknown }[] } }
+  )?.error?.details;
+
+  if (!Array.isArray(details)) {
+    return null;
+  }
+
+  for (const detail of details) {
+    if (typeof detail?.errorCode === "string") {
+      return detail.errorCode;
+    }
+  }
+
+  return null;
+}
+
+const MAX_SNIPPET = 300;
+
+export function mapFcmResponse(status: number, body: string): FcmOutcome {
+  if (status >= 200 && status < 300) {
+    return { kind: "success" };
+  }
+
+  const code = extractFcmErrorCode(body);
+  const snippet = body.slice(0, MAX_SNIPPET);
+  const described = code ? `${code}: ${snippet}` : snippet;
+
+  // The error CODE is consulted before the status, because FCM overloads
+  // statuses in both directions: 404 is `UNREGISTERED` but a 400 can carry it
+  // too, and 401 is BOTH "our access token expired" (no error code) and
+  // `THIRD_PARTY_AUTH_ERROR` (APNs/web credentials the operator must fix).
+  //
+  // An earlier version of this function checked `status === 401` first, and a
+  // test caught it: `THIRD_PARTY_AUTH_ERROR` was reported as `unauthorized`,
+  // so the adapter would mint a fresh token and replay — spending a round-trip
+  // to be refused for the same reason, and labelling a standing configuration
+  // fault as an expiry. The code is the specific signal; the status is the
+  // fallback, and never the other way round.
+  if (code && SUBSCRIPTION_GONE_CODES.has(code)) {
+    return { kind: "subscription_gone", error: described };
+  }
+
+  if (code && PERMANENT_CODES.has(code)) {
+    return {
+      kind: "failure",
+      error: described,
+      retryable: false,
+      tripsBreaker: false
+    };
+  }
+
+  if (code && RETRYABLE_CODES.has(code)) {
+    return {
+      kind: "failure",
+      error: described,
+      retryable: true,
+      // QUOTA_EXCEEDED and UNAVAILABLE/INTERNAL are all statements about the
+      // service, so they do count toward the breaker.
+      tripsBreaker: true
+    };
+  }
+
+  // No FCM error code, so this is Google's own auth layer refusing the bearer
+  // token rather than FCM refusing the message.
+  if (status === 401) {
+    return { kind: "unauthorized", error: described };
+  }
+
+  if (status === 404) {
+    return { kind: "subscription_gone", error: described };
+  }
+
+  if (status === 429 || status >= 500) {
+    return {
+      kind: "failure",
+      error: described,
+      retryable: true,
+      tripsBreaker: true
+    };
+  }
+
+  // Every other 4xx: the request was understood and refused. Retrying an
+  // identical request would be refused identically.
+  return {
+    kind: "failure",
+    error: described,
+    retryable: false,
+    tripsBreaker: false
+  };
+}

--- a/src/modules/push-delivery/domain/push-config.ts
+++ b/src/modules/push-delivery/domain/push-config.ts
@@ -30,11 +30,15 @@
  * rule `email` already follows: provider off means the provider is never
  * touched).
  *
- * `"fcm"` and `"web_push"` are the real adapters and land in Issue #466.
- * Naming them here now would let `PUSH_PROVIDER=fcm` pass validation and then
- * fail at resolve time, so they are deliberately absent until they exist.
+ * `"fcm"` is the FCM HTTP v1 adapter (Issue #466) — server → Google, for native
+ * Android/iOS clients. It costs nothing in the client asset budget and adds no
+ * CSP origin, which is why ADR-0074 keeps it while rejecting the FCM Web SDK.
+ *
+ * `"web_push"` (VAPID, for browsers) is still absent, and deliberately: naming
+ * an adapter before it exists lets a deployment pass `config:validate` and then
+ * fail at resolve time, which is the worst place to learn it.
  */
-export const KNOWN_PUSH_PROVIDERS = ["log"] as const;
+export const KNOWN_PUSH_PROVIDERS = ["log", "fcm"] as const;
 
 export type PushProviderKind = (typeof KNOWN_PUSH_PROVIDERS)[number];
 
@@ -66,16 +70,34 @@ export const DEFAULT_PUSH_SEND_MAX_RETRIES = 3;
  */
 export const PUSH_CIRCUIT_BREAKER_KEY = "push-delivery";
 
-/**
- * There is deliberately no `PUSH_SEND_TIMEOUT_MS` resolver yet. A send timeout
- * is meaningful only to an adapter that makes a network call, and the only
- * adapter today is `log`. Shipping the knob now would put a variable in
- * `.env.example` that an operator can set and that changes nothing — the kind
- * of configuration that teaches people their settings are decorative. It lands
- * with the first real adapter (#466).
- */
+export const DEFAULT_PUSH_SEND_TIMEOUT_MS = 10_000;
+
 export function isPushEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
   return env.PUSH_ENABLED === "true";
+}
+
+/**
+ * Now that a network adapter exists (#466), this knob does something. It was
+ * deliberately absent while `log` was the only adapter — a variable an operator
+ * can set that changes nothing teaches people their settings are decorative.
+ *
+ * The budget is TOTAL wall-clock for the outbound call, including the body
+ * read, because that is what `ssrfSafeFetch` enforces. A send can spend it
+ * twice in one attempt (token mint, then the FCM call), which is intended: they
+ * are two hops that can each hang independently.
+ */
+export function resolvePushSendTimeoutMs(
+  env: NodeJS.ProcessEnv = process.env
+): number {
+  const configured = env.PUSH_SEND_TIMEOUT_MS?.trim();
+
+  if (!configured) {
+    return DEFAULT_PUSH_SEND_TIMEOUT_MS;
+  }
+
+  const raw = Number(configured);
+
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_PUSH_SEND_TIMEOUT_MS;
 }
 
 /**

--- a/src/modules/push-delivery/infrastructure/fcm-provider.ts
+++ b/src/modules/push-delivery/infrastructure/fcm-provider.ts
@@ -1,0 +1,226 @@
+/**
+ * FCM HTTP v1 adapter (Issue #466, ADR-0074) — `PUSH_PROVIDER=fcm`.
+ *
+ * Server → Google, and only that. It never touches the browser, so it costs
+ * nothing in the client asset budget and adds no CSP origin — which is exactly
+ * why ADR-0074 keeps FCM HTTP v1 while rejecting the FCM Web SDK.
+ *
+ * Structure mirrors `email/infrastructure/mailketing-provider.ts`: the adapter
+ * is the ONLY thing that feeds the circuit breaker, and the dispatcher only
+ * reads it. The key comes from `PUSH_CIRCUIT_BREAKER_KEY` rather than a literal
+ * so the two sides cannot drift apart silently.
+ *
+ * ## What this adapter deliberately does not do
+ *
+ * It does not fan out, batch, or dedupe. One call, one token, one notification
+ * — the queue owns fan-out, and a batch API would make partial failure
+ * unrepresentable in a table where every row already IS one delivery unit.
+ */
+import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
+import { log } from "../../../lib/logging/logger";
+import {
+  buildFcmSendUrl,
+  type FcmServiceAccount
+} from "../domain/fcm-credentials";
+import { mapFcmResponse } from "../domain/fcm-error-mapping";
+import { PUSH_CIRCUIT_BREAKER_KEY } from "../domain/push-config";
+import type {
+  PushDeliveryResult,
+  PushHealthCheckResult,
+  PushMessage,
+  PushProvider,
+  PushTarget
+} from "../domain/push-provider-contract";
+import {
+  getGoogleAccessToken,
+  invalidateGoogleAccessToken
+} from "./google-access-token";
+import { defaultPushHttpClient, type PushHttpClient } from "./push-http-client";
+
+const MODULE_KEY = "push_delivery";
+
+export type FcmProviderOptions = {
+  credential: FcmServiceAccount;
+  timeoutMs: number;
+  /** Injectable so tests drive the adapter without network access — and without having to defeat the SSRF guard, which would test a different code path than production runs. */
+  http?: PushHttpClient;
+  now?: () => Date;
+};
+
+/**
+ * FCM `data` values must all be strings. `targetPath` rides here rather than in
+ * `notification`, because a native client decides for itself what to do with a
+ * click; `webpush.fcm_options.link` is the browser-side equivalent and is not
+ * set, since browsers are served by the Web Push adapter, not this one.
+ */
+function buildDataPayload(message: PushMessage): Record<string, string> {
+  const data: Record<string, string> = { ...(message.data ?? {}) };
+
+  if (message.targetPath) {
+    data.target_path = message.targetPath;
+  }
+
+  if (message.correlationId) {
+    data.correlation_id = message.correlationId;
+  }
+
+  return data;
+}
+
+export function createFcmPushProvider(
+  options: FcmProviderOptions
+): PushProvider {
+  const http = options.http ?? defaultPushHttpClient;
+  const now = options.now ?? (() => new Date());
+  const breaker = getProviderCircuitBreaker(PUSH_CIRCUIT_BREAKER_KEY);
+  const sendUrl = buildFcmSendUrl(options.credential);
+
+  async function post(
+    accessToken: string,
+    target: PushTarget,
+    message: PushMessage
+  ) {
+    const data = buildDataPayload(message);
+
+    return http(sendUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify({
+        message: {
+          token: target.endpoint,
+          notification: { title: message.title, body: message.body },
+          ...(Object.keys(data).length > 0 ? { data } : {})
+        }
+      }),
+      timeoutMs: options.timeoutMs
+    });
+  }
+
+  return {
+    supportedTransports: ["fcm"],
+
+    async send(
+      target: PushTarget,
+      message: PushMessage
+    ): Promise<PushDeliveryResult> {
+      const attemptedAt = now();
+
+      const token = await getGoogleAccessToken(options.credential, {
+        http,
+        timeoutMs: options.timeoutMs,
+        now: attemptedAt
+      });
+
+      if (!token.ok) {
+        // A token failure that is retryable means the token endpoint itself was
+        // unreachable or erroring, which IS a statement about the upstream —
+        // so it counts toward the breaker. A rejected assertion is a
+        // configuration fact and does not.
+        if (token.retryable) {
+          breaker.recordFailure(attemptedAt);
+        }
+
+        return { ok: false, error: token.error, retryable: token.retryable };
+      }
+
+      let response = await post(token.accessToken, target, message);
+
+      if (!response.ok) {
+        breaker.recordFailure(attemptedAt);
+
+        return { ok: false, error: response.reason, retryable: true };
+      }
+
+      let outcome = mapFcmResponse(response.status, response.body);
+
+      // ONE retry, and only for 401. Google rejected the token we hold; minting
+      // a fresh one and replaying is the whole fix, and doing it here means a
+      // token that expired mid-batch costs one extra call instead of failing
+      // every remaining message in the pass. Bounded to a single attempt so a
+      // credential that is simply wrong cannot loop.
+      if (outcome.kind === "unauthorized") {
+        invalidateGoogleAccessToken(options.credential.clientEmail);
+
+        const refreshed = await getGoogleAccessToken(options.credential, {
+          http,
+          timeoutMs: options.timeoutMs,
+          now: attemptedAt
+        });
+
+        if (!refreshed.ok) {
+          return {
+            ok: false,
+            error: refreshed.error,
+            retryable: refreshed.retryable
+          };
+        }
+
+        response = await post(refreshed.accessToken, target, message);
+
+        if (!response.ok) {
+          breaker.recordFailure(attemptedAt);
+
+          return { ok: false, error: response.reason, retryable: true };
+        }
+
+        outcome = mapFcmResponse(response.status, response.body);
+
+        if (outcome.kind === "unauthorized") {
+          // A freshly minted token was refused too. That is a credential
+          // problem, not an expiry, and retrying the message will not fix it.
+          return { ok: false, error: outcome.error, retryable: false };
+        }
+      }
+
+      if (outcome.kind === "success") {
+        breaker.recordSuccess(attemptedAt);
+
+        return { ok: true, providerMessageId: response.body.slice(0, 200) };
+      }
+
+      if (outcome.kind === "subscription_gone") {
+        log("info", "push.fcm.subscription_gone", {
+          moduleKey: MODULE_KEY,
+          endpoint: target.endpointMasked,
+          correlationId: message.correlationId
+        });
+
+        return {
+          ok: false,
+          error: outcome.error,
+          retryable: false,
+          subscriptionGone: true
+        };
+      }
+
+      if (outcome.tripsBreaker) {
+        breaker.recordFailure(attemptedAt);
+      }
+
+      return {
+        ok: false,
+        error: outcome.error,
+        retryable: outcome.retryable
+      };
+    },
+
+    /**
+     * Proves the CREDENTIAL, not the send path: it mints an access token and
+     * stops. Sending a real notification to prove health would require a real
+     * device token, and inventing one would answer `UNREGISTERED` — a healthy
+     * FCM reporting a failure, which is worse than not checking.
+     */
+    async healthCheck(): Promise<PushHealthCheckResult> {
+      const token = await getGoogleAccessToken(options.credential, {
+        http,
+        timeoutMs: options.timeoutMs,
+        now: now()
+      });
+
+      return token.ok ? { ok: true } : { ok: false, error: token.error };
+    }
+  };
+}

--- a/src/modules/push-delivery/infrastructure/google-access-token.ts
+++ b/src/modules/push-delivery/infrastructure/google-access-token.ts
@@ -1,0 +1,247 @@
+/**
+ * Google OAuth2 access tokens from a service account, WITHOUT a dependency
+ * (Issue #466, ADR-0074).
+ *
+ * `google-auth-library` and `firebase-admin` both do this, and both would be a
+ * new runtime dependency in a repo that ships with two. The precedent for
+ * refusing is already written down: `src/lib/auth/jwt-verify.ts` does
+ * dependency-free JWT VERIFICATION through `crypto.subtle` rather than adding
+ * `jose`. This is the same size of problem in the other direction — a JWT
+ * bearer assertion (RFC 7523) is a header, a claim set, and one RS256
+ * signature.
+ *
+ * The flow, in full:
+ *
+ *   1. build `{alg:"RS256",typ:"JWT"}` . `{iss,scope,aud,exp,iat}`;
+ *   2. sign it with the service account's PKCS#8 private key via
+ *      `crypto.subtle` — never a hand-rolled RSA implementation;
+ *   3. POST it to the credential's own `token_uri` as
+ *      `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer`;
+ *   4. cache the returned access token until shortly before it expires.
+ *
+ * ## The cache, and why it is keyed the way it is
+ *
+ * Google's access tokens last an hour. Minting one per notification would add
+ * an RSA signature and a full HTTPS round-trip to every send, and would hit the
+ * token endpoint's own rate limits on any real volume.
+ *
+ * The cache is keyed by `clientEmail` — the identity the token speaks as —
+ * rather than by "the configured credential". Those are the same thing today
+ * (credentials are per-deployment, ADR-0074), and if they ever stop being the
+ * same thing, keying by identity is the version that stays correct instead of
+ * handing one project's token to another.
+ *
+ * It is per-PROCESS, in memory. Deliberately: an access token is a live bearer
+ * credential, and putting it in Redis or Postgres would persist a credential at
+ * rest to save an HTTP call per hour per process. `awcms_bff_clients`'s schema
+ * comment makes the same trade in the same direction.
+ */
+import { log } from "../../../lib/logging/logger";
+import {
+  FCM_OAUTH_SCOPE,
+  type FcmServiceAccount
+} from "../domain/fcm-credentials";
+import type { PushHttpClient } from "./push-http-client";
+
+const MODULE_KEY = "push_delivery";
+
+/** How long an assertion is valid. Google allows up to an hour; short is fine — it is used once, immediately. */
+const ASSERTION_LIFETIME_SECONDS = 300;
+
+/**
+ * Refresh this long before the token actually expires. Covers clock skew
+ * between us and Google plus the round-trip itself, so a token is never used in
+ * the window where it is technically alive here and already dead there — a
+ * failure that would surface as an intermittent 401 on a fraction of sends.
+ */
+const REFRESH_MARGIN_MS = 60_000;
+
+type CachedToken = { accessToken: string; expiresAtMs: number };
+
+const tokenCache = new Map<string, CachedToken>();
+
+/** Test seam. Never called in production — the cache is per-process and short-lived by design. */
+export function clearGoogleAccessTokenCache(): void {
+  tokenCache.clear();
+}
+
+function base64Url(bytes: Uint8Array | ArrayBuffer): string {
+  return Buffer.from(bytes as ArrayBuffer)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function base64UrlJson(value: unknown): string {
+  return base64Url(new TextEncoder().encode(JSON.stringify(value)));
+}
+
+/**
+ * PEM → DER. `crypto.subtle.importKey("pkcs8", …)` takes the raw DER bytes, so
+ * the armour and every newline have to come off first. Guarded by
+ * `parseFcmCredentialsBase64`, which has already rejected a PKCS#1 block with a
+ * message that names the difference — without that, this produces DER that
+ * imports as `DataError` with nothing pointing at the cause.
+ */
+function pemToPkcs8Der(pem: string): ArrayBuffer {
+  const body = pem
+    .replace(/-----BEGIN PRIVATE KEY-----/, "")
+    .replace(/-----END PRIVATE KEY-----/, "")
+    .replace(/\s+/g, "");
+
+  return Uint8Array.from(Buffer.from(body, "base64")).buffer;
+}
+
+export type MintAccessTokenOptions = {
+  http: PushHttpClient;
+  timeoutMs: number;
+  now?: Date;
+};
+
+export type AccessTokenResult =
+  | { ok: true; accessToken: string }
+  | { ok: false; error: string; retryable: boolean };
+
+async function signAssertion(
+  credential: FcmServiceAccount,
+  nowSeconds: number
+): Promise<string> {
+  const header = base64UrlJson({ alg: "RS256", typ: "JWT" });
+  const claims = base64UrlJson({
+    iss: credential.clientEmail,
+    scope: FCM_OAUTH_SCOPE,
+    aud: credential.tokenUri,
+    iat: nowSeconds,
+    exp: nowSeconds + ASSERTION_LIFETIME_SECONDS
+  });
+  const signingInput = `${header}.${claims}`;
+
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToPkcs8Der(credential.privateKeyPem),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  const signature = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    key,
+    new TextEncoder().encode(signingInput)
+  );
+
+  return `${signingInput}.${base64Url(signature)}`;
+}
+
+/**
+ * Returns a usable access token, from cache when one is still comfortably
+ * valid.
+ *
+ * `retryable` on failure distinguishes "Google said no" from "the call did not
+ * land": a rejected assertion (`invalid_grant` — wrong key, wrong clock, wrong
+ * account) will be rejected identically on every retry, and retrying it burns
+ * every queued notification's budget against a condition only an operator can
+ * fix.
+ */
+export async function getGoogleAccessToken(
+  credential: FcmServiceAccount,
+  options: MintAccessTokenOptions
+): Promise<AccessTokenResult> {
+  const now = options.now ?? new Date();
+  const cached = tokenCache.get(credential.clientEmail);
+
+  if (cached && cached.expiresAtMs - REFRESH_MARGIN_MS > now.getTime()) {
+    return { ok: true, accessToken: cached.accessToken };
+  }
+
+  let assertion: string;
+
+  try {
+    assertion = await signAssertion(
+      credential,
+      Math.floor(now.getTime() / 1000)
+    );
+  } catch (error) {
+    // An import/sign failure is a malformed key: the same key will fail the
+    // same way next minute.
+    return {
+      ok: false,
+      error: `could not sign the service-account assertion: ${(error as Error).name}`,
+      retryable: false
+    };
+  }
+
+  const response = await options.http(credential.tokenUri, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+      assertion
+    }).toString(),
+    timeoutMs: options.timeoutMs
+  });
+
+  if (!response.ok) {
+    return { ok: false, error: response.reason, retryable: true };
+  }
+
+  if (response.status !== 200) {
+    // The body can name the reason (`invalid_grant`, `invalid_scope`) and never
+    // contains the key, so it is safe to surface — but only 4xx is treated as
+    // permanent. A 5xx from Google's token endpoint is an outage.
+    const retryable = response.status >= 500 || response.status === 429;
+
+    log("error", "push.fcm.token_request_failed", {
+      moduleKey: MODULE_KEY,
+      httpStatus: response.status,
+      retryable
+    });
+
+    return {
+      ok: false,
+      error: `token endpoint returned ${response.status}: ${response.body.slice(0, 200)}`,
+      retryable
+    };
+  }
+
+  let payload: { access_token?: unknown; expires_in?: unknown };
+
+  try {
+    payload = JSON.parse(response.body) as typeof payload;
+  } catch {
+    return {
+      ok: false,
+      error: "token endpoint returned a non-JSON body",
+      retryable: true
+    };
+  }
+
+  if (typeof payload.access_token !== "string" || payload.access_token === "") {
+    return {
+      ok: false,
+      error: "token endpoint returned no access_token",
+      retryable: true
+    };
+  }
+
+  // Missing/odd `expires_in` falls back to a conservative 30 minutes rather
+  // than to Google's documented hour: caching a token LONGER than it lives
+  // produces 401s that look like a credential problem.
+  const expiresInSeconds =
+    typeof payload.expires_in === "number" && payload.expires_in > 0
+      ? payload.expires_in
+      : 1800;
+
+  tokenCache.set(credential.clientEmail, {
+    accessToken: payload.access_token,
+    expiresAtMs: now.getTime() + expiresInSeconds * 1000
+  });
+
+  return { ok: true, accessToken: payload.access_token };
+}
+
+/** Drops the cached token for one identity — called when FCM answers 401, so the next attempt mints a fresh one instead of replaying a token Google has already rejected. */
+export function invalidateGoogleAccessToken(clientEmail: string): void {
+  tokenCache.delete(clientEmail);
+}

--- a/src/modules/push-delivery/infrastructure/push-http-client.ts
+++ b/src/modules/push-delivery/infrastructure/push-http-client.ts
@@ -1,0 +1,66 @@
+/**
+ * The one outbound HTTP seam for push adapters (Issue #466).
+ *
+ * Every network call this module makes goes through `ssrfSafeFetch`
+ * (`src/lib/auth/ssrf-guard.ts`) rather than bare `fetch`. That is not
+ * ceremony: the destinations here are resolved from a service-account
+ * credential (`token_uri`) and from a subscription row (a Web Push endpoint
+ * URL), and both are values that arrive from outside this code. A hostile or
+ * merely wrong one pointing at `169.254.169.254` or at a loopback admin port
+ * would otherwise be fetched by the worker with whatever network position it
+ * holds — and the worker holds a database connection.
+ *
+ * The seam is a TYPE, not a wrapper around `fetch`, so tests can drive an
+ * adapter without network access and without having to defeat the guard. A
+ * test that had to disable the guard to run would be testing a different code
+ * path than production runs.
+ */
+import { ssrfSafeFetch } from "../../../lib/auth/ssrf-guard";
+
+export type PushHttpRequest = {
+  method: "POST";
+  headers: Record<string, string>;
+  body: string;
+  timeoutMs: number;
+};
+
+export type PushHttpResult =
+  { ok: true; status: number; body: string } | { ok: false; reason: string };
+
+export type PushHttpClient = (
+  url: string,
+  request: PushHttpRequest
+) => Promise<PushHttpResult>;
+
+/**
+ * Deliberately caps the response body. Neither Google's token endpoint nor
+ * FCM's send endpoint returns anything large, and an adapter that would buffer
+ * a multi-megabyte reply from a host it was redirected to is a memory
+ * amplification the guard cannot see.
+ */
+const MAX_RESPONSE_BYTES = 64 * 1024;
+
+/**
+ * A non-2xx is NOT a transport failure — it is a response, and the adapters
+ * need its status and body to decide retryable/non-retryable/subscription-gone.
+ * Only a guard denial or a network error yields `ok: false` here.
+ */
+export const defaultPushHttpClient: PushHttpClient = async (url, request) => {
+  const result = await ssrfSafeFetch(url, {
+    method: request.method,
+    headers: request.headers,
+    body: request.body,
+    timeoutMs: request.timeoutMs,
+    maxResponseBytes: MAX_RESPONSE_BYTES
+  });
+
+  if (!result.ok) {
+    return { ok: false, reason: `outbound request refused: ${result.reason}` };
+  }
+
+  return {
+    ok: true,
+    status: result.response.status,
+    body: await result.response.text()
+  };
+};

--- a/src/modules/push-delivery/infrastructure/push-provider-resolver.ts
+++ b/src/modules/push-delivery/infrastructure/push-provider-resolver.ts
@@ -1,22 +1,25 @@
 /**
- * Production resolver (Issue #465) — mirrors
+ * Production resolver (Issue #465, extended #466) — mirrors
  * `email/infrastructure/email-provider-resolver.ts`: picks the concrete
  * `PushProvider` from configuration and DEGRADES to a clean failed-result
  * provider on misconfiguration rather than throwing. One misconfigured
  * deployment must not crash the dispatcher; `bun run config:validate` is where
  * that should have been caught at boot.
  *
- * The degraded provider returns `retryable: false`. A missing or unknown
- * `PUSH_PROVIDER` will not fix itself between now and the next pass, so
- * retrying would burn the whole retry budget of every queued row against a
- * condition only an operator can change — and then bury the real cause under
- * `retry_count` exhaustion.
+ * The degraded provider returns `retryable: false`. A missing `PUSH_PROVIDER`,
+ * or a credential that does not parse, will not fix itself between now and the
+ * next pass, so retrying would burn the whole retry budget of every queued row
+ * against a condition only an operator can change — and then bury the real
+ * cause under `retry_count` exhaustion.
  */
+import { parseFcmCredentialsBase64 } from "../domain/fcm-credentials";
 import {
   isKnownPushProvider,
+  resolvePushSendTimeoutMs,
   type PushProviderKind
 } from "../domain/push-config";
 import type { PushProvider } from "../domain/push-provider-contract";
+import { createFcmPushProvider } from "./fcm-provider";
 import { createLogPushProvider } from "./log-push-provider";
 
 function createMisconfiguredProvider(reason: string): PushProvider {
@@ -45,13 +48,39 @@ export function resolvePushProvider(
     );
   }
 
-  // Exhaustive over `PushProviderKind`. When Issue #466 adds `fcm`/`web_push`,
-  // the compiler flags this switch rather than letting a new kind fall through
-  // to `log` and silently succeed without ever sending anything.
+  // Exhaustive over `PushProviderKind`. When `web_push` joins it, the compiler
+  // flags this switch rather than letting a new kind fall through and silently
+  // succeed without ever sending anything.
   const kind: PushProviderKind = provider;
 
   switch (kind) {
     case "log":
       return createLogPushProvider();
+
+    case "fcm": {
+      const raw = env.PUSH_FCM_CREDENTIALS_BASE64;
+
+      if (!raw) {
+        return createMisconfiguredProvider(
+          "PUSH_FCM_CREDENTIALS_BASE64 is not set."
+        );
+      }
+
+      const parsed = parseFcmCredentialsBase64(raw);
+
+      if (!parsed.ok) {
+        // The reason names FIELDS and shapes, never a value — the parser is
+        // written so `private_key` cannot reach a message, and this is the path
+        // where such a message would end up in a log.
+        return createMisconfiguredProvider(
+          `PUSH_FCM_CREDENTIALS_BASE64 is invalid: ${parsed.reason}.`
+        );
+      }
+
+      return createFcmPushProvider({
+        credential: parsed.credential,
+        timeoutMs: resolvePushSendTimeoutMs(env)
+      });
+    }
   }
 }

--- a/tests/push-delivery.test.ts
+++ b/tests/push-delivery.test.ts
@@ -139,12 +139,17 @@ describe("retry policy", () => {
 });
 
 describe("configuration refuses to promise what does not exist", () => {
-  test("`fcm`/`web_push` are NOT accepted yet", () => {
+  test("`web_push` is NOT accepted yet — an adapter is named only once it exists", () => {
     // Naming an adapter before it exists lets a deployment pass
     // `config:validate` and then fail at resolve time, which is the worst place
-    // to learn it. Issue #466 adds both, and this assertion with them.
+    // to learn it.
+    //
+    // `fcm` moved to `true` in the PR that built it (#466), which is the whole
+    // point of asserting the negative: the list cannot grow ahead of the code
+    // without this test being edited in the same change. `web_push` holds the
+    // line until its adapter lands.
     expect(isKnownPushProvider("log")).toBe(true);
-    expect(isKnownPushProvider("fcm")).toBe(false);
+    expect(isKnownPushProvider("fcm")).toBe(true);
     expect(isKnownPushProvider("web_push")).toBe(false);
   });
 

--- a/tests/push-fcm-adapter.test.ts
+++ b/tests/push-fcm-adapter.test.ts
@@ -1,0 +1,528 @@
+/**
+ * Issue #466 (epic #463, ADR-0074) — the FCM HTTP v1 adapter, with no network.
+ *
+ * The load-bearing test here is the FIRST one. Everything else in this adapter
+ * is branching on a status code, which is easy to get right and easy to test.
+ * The part that could be subtly, silently wrong is the dependency-free RS256
+ * service-account assertion: a JWT that Google rejects looks exactly like a
+ * credential problem, and "add `google-auth-library`" is the conclusion anyone
+ * would reach after an hour of that.
+ *
+ * So the assertion is not merely produced — it is VERIFIED, with the matching
+ * public key, through `crypto.subtle`. A real RSA key pair is generated in the
+ * test, exported to the same PKCS#8 PEM shape Google issues, fed through the
+ * real parser, and the resulting JWT's signature is checked. If the framing,
+ * the base64url, or the algorithm were wrong, that verification fails.
+ *
+ * The second thing worth stating: `UNREGISTERED` must NOT trip the circuit
+ * breaker. A queue routinely carries thousands of dead tokens, and if those
+ * counted as provider failures, one batch of stale registrations would stop
+ * delivery to every healthy device — with the symptom pointing at FCM.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  getProviderCircuitBreaker,
+  resetProviderCircuitBreakersForTests
+} from "../src/lib/database/circuit-breaker";
+import {
+  buildFcmSendUrl,
+  parseFcmCredentialsBase64,
+  type FcmServiceAccount
+} from "../src/modules/push-delivery/domain/fcm-credentials";
+import { mapFcmResponse } from "../src/modules/push-delivery/domain/fcm-error-mapping";
+import { PUSH_CIRCUIT_BREAKER_KEY } from "../src/modules/push-delivery/domain/push-config";
+import { createFcmPushProvider } from "../src/modules/push-delivery/infrastructure/fcm-provider";
+import { clearGoogleAccessTokenCache } from "../src/modules/push-delivery/infrastructure/google-access-token";
+import { resolvePushProvider } from "../src/modules/push-delivery/infrastructure/push-provider-resolver";
+import type {
+  PushHttpClient,
+  PushHttpRequest
+} from "../src/modules/push-delivery/infrastructure/push-http-client";
+import type { PushTarget } from "../src/modules/push-delivery/domain/push-provider-contract";
+
+const TOKEN_URI = "https://oauth2.googleapis.com/token";
+const TARGET: PushTarget = {
+  transport: "fcm",
+  endpoint: "device-registration-token",
+  endpointMasked: "device-…token"
+};
+
+type Call = { url: string; request: PushHttpRequest };
+
+/** Generates a real RSA key pair and returns it in the exact shape a Google credential carries. */
+async function makeCredentialMaterial(): Promise<{
+  base64: string;
+  publicKey: CryptoKey;
+}> {
+  const pair = await crypto.subtle.generateKey(
+    {
+      name: "RSASSA-PKCS1-v1_5",
+      modulusLength: 2048,
+      publicExponent: new Uint8Array([1, 0, 1]),
+      hash: "SHA-256"
+    },
+    true,
+    ["sign", "verify"]
+  );
+
+  const pkcs8 = await crypto.subtle.exportKey("pkcs8", pair.privateKey);
+  const body = Buffer.from(pkcs8)
+    .toString("base64")
+    .replace(/(.{64})/g, "$1\n");
+  const pem = `-----BEGIN PRIVATE KEY-----\n${body}\n-----END PRIVATE KEY-----\n`;
+
+  const json = JSON.stringify({
+    type: "service_account",
+    project_id: "awcms-test",
+    client_email: "push@awcms-test.iam.gserviceaccount.com",
+    private_key: pem,
+    token_uri: TOKEN_URI
+  });
+
+  return {
+    base64: Buffer.from(json, "utf8").toString("base64"),
+    publicKey: pair.publicKey
+  };
+}
+
+function scriptedHttp(
+  responses: (
+    { ok: true; status: number; body: string } | { ok: false; reason: string }
+  )[],
+  calls: Call[]
+): PushHttpClient {
+  let index = 0;
+
+  return async (url, request) => {
+    calls.push({ url, request });
+
+    const response = responses[Math.min(index, responses.length - 1)]!;
+    index += 1;
+
+    return response;
+  };
+}
+
+const TOKEN_OK = {
+  ok: true as const,
+  status: 200,
+  body: JSON.stringify({ access_token: "ya29.fake", expires_in: 3600 })
+};
+
+const SEND_OK = {
+  ok: true as const,
+  status: 200,
+  body: JSON.stringify({ name: "projects/awcms-test/messages/1" })
+};
+
+function fcmError(status: number, errorCode?: string) {
+  return {
+    ok: true as const,
+    status,
+    body: JSON.stringify({
+      error: {
+        code: status,
+        status: "ERROR",
+        ...(errorCode
+          ? {
+              details: [
+                {
+                  "@type":
+                    "type.googleapis.com/google.firebase.fcm.v1.FcmError",
+                  errorCode
+                }
+              ]
+            }
+          : {})
+      }
+    })
+  };
+}
+
+afterEach(() => {
+  clearGoogleAccessTokenCache();
+  resetProviderCircuitBreakersForTests();
+});
+
+describe("the service-account assertion is a real, verifiable RS256 JWT", () => {
+  test("Google's public key would accept it — signature, framing, and claims", async () => {
+    const { base64, publicKey } = await makeCredentialMaterial();
+    const parsed = parseFcmCredentialsBase64(base64);
+
+    expect(parsed.ok).toBe(true);
+    const credential = (parsed as { ok: true; credential: FcmServiceAccount })
+      .credential;
+
+    const calls: Call[] = [];
+    const provider = createFcmPushProvider({
+      credential,
+      timeoutMs: 5000,
+      http: scriptedHttp([TOKEN_OK, SEND_OK], calls),
+      now: () => new Date("2026-08-10T00:00:00.000Z")
+    });
+
+    const result = await provider.send(TARGET, { title: "t", body: "b" });
+    expect(result.ok).toBe(true);
+
+    // First call is the token mint, at the credential's OWN token_uri.
+    expect(calls[0]!.url).toBe(TOKEN_URI);
+
+    const form = new URLSearchParams(calls[0]!.request.body);
+    expect(form.get("grant_type")).toBe(
+      "urn:ietf:params:oauth:grant-type:jwt-bearer"
+    );
+
+    const assertion = form.get("assertion")!;
+    const [headerB64, claimsB64, signatureB64] = assertion.split(".");
+
+    const decode = (segment: string) =>
+      Buffer.from(
+        segment.replace(/-/g, "+").replace(/_/g, "/") +
+          "=".repeat((4 - (segment.length % 4)) % 4),
+        "base64"
+      );
+
+    expect(JSON.parse(decode(headerB64!).toString("utf8"))).toEqual({
+      alg: "RS256",
+      typ: "JWT"
+    });
+
+    const claims = JSON.parse(decode(claimsB64!).toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(claims.iss).toBe(credential.clientEmail);
+    expect(claims.aud).toBe(TOKEN_URI);
+    expect(claims.scope).toBe(
+      "https://www.googleapis.com/auth/firebase.messaging"
+    );
+    // Bounded lifetime — an assertion good for a day is a bearer grant left lying around.
+    expect((claims.exp as number) - (claims.iat as number)).toBe(300);
+
+    // THE assertion this file exists for.
+    const verified = await crypto.subtle.verify(
+      "RSASSA-PKCS1-v1_5",
+      publicKey,
+      decode(signatureB64!),
+      new TextEncoder().encode(`${headerB64}.${claimsB64}`)
+    );
+
+    expect(verified).toBe(true);
+  });
+
+  test("the send URL names the project from the CREDENTIAL, not from configuration", async () => {
+    const { base64 } = await makeCredentialMaterial();
+    const parsed = parseFcmCredentialsBase64(base64) as {
+      ok: true;
+      credential: FcmServiceAccount;
+    };
+
+    // Two sources for "which project" is how a deployment ends up authenticated
+    // as one project and addressing another.
+    expect(buildFcmSendUrl(parsed.credential)).toBe(
+      "https://fcm.googleapis.com/v1/projects/awcms-test/messages:send"
+    );
+  });
+
+  test("the access token is CACHED — a second send does not re-mint", async () => {
+    const { base64 } = await makeCredentialMaterial();
+    const credential = (
+      parseFcmCredentialsBase64(base64) as {
+        ok: true;
+        credential: FcmServiceAccount;
+      }
+    ).credential;
+
+    const calls: Call[] = [];
+    const provider = createFcmPushProvider({
+      credential,
+      timeoutMs: 5000,
+      http: scriptedHttp([TOKEN_OK, SEND_OK, SEND_OK], calls)
+    });
+
+    await provider.send(TARGET, { title: "a", body: "b" });
+    await provider.send(TARGET, { title: "c", body: "d" });
+
+    // token, send, send — not token, send, token, send.
+    expect(calls.map((call) => call.url)).toEqual([
+      TOKEN_URI,
+      buildFcmSendUrl(credential),
+      buildFcmSendUrl(credential)
+    ]);
+  });
+});
+
+describe("credential parsing refuses the shapes that fail LATER", () => {
+  test("raw JSON (not base64) is named as the usual cause", () => {
+    const result = parseFcmCredentialsBase64(
+      '{"project_id":"x","client_email":"y","private_key":"z","token_uri":"https://t"}'
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toContain("un-encoded");
+  });
+
+  test("PKCS#1 is rejected by NAME, not by an opaque import failure", () => {
+    // `crypto.subtle.importKey("pkcs8", …)` would throw `DataError` on this,
+    // at the first send, with nothing pointing at the cause.
+    const json = JSON.stringify({
+      project_id: "p",
+      client_email: "e",
+      private_key:
+        "-----BEGIN RSA PRIVATE KEY-----\nAAAA\n-----END RSA PRIVATE KEY-----",
+      token_uri: TOKEN_URI
+    });
+    const result = parseFcmCredentialsBase64(
+      Buffer.from(json).toString("base64")
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toContain("PKCS#1");
+  });
+
+  test("an http token_uri is refused — a signed assertion is a bearer grant", () => {
+    const json = JSON.stringify({
+      project_id: "p",
+      client_email: "e",
+      private_key:
+        "-----BEGIN PRIVATE KEY-----\nAAAA\n-----END PRIVATE KEY-----",
+      token_uri: "http://oauth2.googleapis.com/token"
+    });
+    const result = parseFcmCredentialsBase64(
+      Buffer.from(json).toString("base64")
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toContain("https");
+  });
+
+  test("a missing field is reported by NAME and the key value never appears", () => {
+    const json = JSON.stringify({
+      project_id: "p",
+      private_key:
+        "-----BEGIN PRIVATE KEY-----\nSECRET\n-----END PRIVATE KEY-----"
+    });
+    const result = parseFcmCredentialsBase64(
+      Buffer.from(json).toString("base64")
+    );
+
+    expect(result.ok).toBe(false);
+    const reason = result.ok === false ? result.reason : "";
+    expect(reason).toContain("client_email");
+    expect(reason).toContain("token_uri");
+    expect(reason).not.toContain("SECRET");
+  });
+});
+
+describe("FCM responses map to the RIGHT of three outcomes", () => {
+  test("UNREGISTERED is subscription_gone, not a failure to retry", () => {
+    expect(mapFcmResponse(404, fcmError(404, "UNREGISTERED").body).kind).toBe(
+      "subscription_gone"
+    );
+    // FCM overloads statuses: the CODE wins over the status.
+    expect(mapFcmResponse(400, fcmError(400, "UNREGISTERED").body).kind).toBe(
+      "subscription_gone"
+    );
+  });
+
+  test.each([
+    ["INVALID_ARGUMENT", 400],
+    ["SENDER_ID_MISMATCH", 403],
+    ["THIRD_PARTY_AUTH_ERROR", 401]
+  ])("%s is permanent and does not trip the breaker", (code, status) => {
+    const outcome = mapFcmResponse(status, fcmError(status, code).body);
+
+    expect(outcome.kind).toBe("failure");
+    expect(outcome.kind === "failure" && outcome.retryable).toBe(false);
+    expect(outcome.kind === "failure" && outcome.tripsBreaker).toBe(false);
+  });
+
+  test.each([
+    ["QUOTA_EXCEEDED", 429],
+    ["UNAVAILABLE", 503],
+    ["INTERNAL", 500]
+  ])("%s is retryable AND counts toward the breaker", (code, status) => {
+    const outcome = mapFcmResponse(status, fcmError(status, code).body);
+
+    expect(outcome.kind === "failure" && outcome.retryable).toBe(true);
+    expect(outcome.kind === "failure" && outcome.tripsBreaker).toBe(true);
+  });
+
+  test("a 401 is its own outcome — the token is refreshable, the message is not lost", () => {
+    expect(mapFcmResponse(401, "{}").kind).toBe("unauthorized");
+  });
+
+  test("an unparseable body still lands somewhere sensible", () => {
+    // A proxy returning HTML must not crash the mapper.
+    expect(mapFcmResponse(502, "<html>bad gateway</html>").kind).toBe(
+      "failure"
+    );
+    expect(mapFcmResponse(418, "not json").kind).toBe("failure");
+  });
+});
+
+describe("the circuit breaker measures the SERVICE, not the tokens", () => {
+  const now = new Date("2026-08-10T00:00:00.000Z");
+
+  test("a batch of dead tokens leaves the breaker closed", async () => {
+    const { base64 } = await makeCredentialMaterial();
+    const credential = (
+      parseFcmCredentialsBase64(base64) as {
+        ok: true;
+        credential: FcmServiceAccount;
+      }
+    ).credential;
+
+    const provider = createFcmPushProvider({
+      credential,
+      timeoutMs: 5000,
+      http: scriptedHttp([TOKEN_OK, fcmError(404, "UNREGISTERED")], []),
+      now: () => now
+    });
+
+    // The default provider threshold is 5 consecutive failures.
+    for (let i = 0; i < 10; i += 1) {
+      const result = await provider.send(TARGET, { title: "t", body: "b" });
+
+      expect(result.ok).toBe(false);
+      expect(result.ok === false && result.subscriptionGone).toBe(true);
+    }
+
+    expect(
+      getProviderCircuitBreaker(PUSH_CIRCUIT_BREAKER_KEY).getState(now)
+    ).toBe("closed");
+  });
+
+  test("a real outage DOES open it", async () => {
+    const { base64 } = await makeCredentialMaterial();
+    const credential = (
+      parseFcmCredentialsBase64(base64) as {
+        ok: true;
+        credential: FcmServiceAccount;
+      }
+    ).credential;
+
+    const provider = createFcmPushProvider({
+      credential,
+      timeoutMs: 5000,
+      http: scriptedHttp([TOKEN_OK, fcmError(503, "UNAVAILABLE")], []),
+      now: () => now
+    });
+
+    for (let i = 0; i < 5; i += 1) {
+      await provider.send(TARGET, { title: "t", body: "b" });
+    }
+
+    expect(
+      getProviderCircuitBreaker(PUSH_CIRCUIT_BREAKER_KEY).getState(now)
+    ).toBe("open");
+  });
+});
+
+describe("a 401 is refreshed exactly ONCE", () => {
+  test("an expired token costs one extra call, not the rest of the batch", async () => {
+    const { base64 } = await makeCredentialMaterial();
+    const credential = (
+      parseFcmCredentialsBase64(base64) as {
+        ok: true;
+        credential: FcmServiceAccount;
+      }
+    ).credential;
+
+    const calls: Call[] = [];
+    let step = 0;
+    const http: PushHttpClient = async (url, request) => {
+      calls.push({ url, request });
+      step += 1;
+
+      // token → send(401) → token → send(200)
+      if (step === 1 || step === 3) return TOKEN_OK;
+      if (step === 2) return { ok: true, status: 401, body: "{}" };
+
+      return SEND_OK;
+    };
+
+    const provider = createFcmPushProvider({
+      credential,
+      timeoutMs: 5000,
+      http
+    });
+    const result = await provider.send(TARGET, { title: "t", body: "b" });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(4);
+  });
+
+  test("a FRESH token refused too is permanent — it is a credential problem, not expiry", async () => {
+    const { base64 } = await makeCredentialMaterial();
+    const credential = (
+      parseFcmCredentialsBase64(base64) as {
+        ok: true;
+        credential: FcmServiceAccount;
+      }
+    ).credential;
+
+    let step = 0;
+    const http: PushHttpClient = async () => {
+      step += 1;
+
+      if (step === 1 || step === 3) return TOKEN_OK;
+
+      return { ok: true, status: 401, body: "{}" };
+    };
+
+    const provider = createFcmPushProvider({
+      credential,
+      timeoutMs: 5000,
+      http
+    });
+    const result = await provider.send(TARGET, { title: "t", body: "b" });
+
+    expect(result.ok).toBe(false);
+    // Not retryable: looping on a wrong credential would burn every message.
+    expect(result.ok === false && result.retryable).toBe(false);
+  });
+});
+
+describe("resolution degrades rather than throwing", () => {
+  test("PUSH_PROVIDER=fcm without a credential fails NON-retryably", async () => {
+    const provider = resolvePushProvider({
+      PUSH_PROVIDER: "fcm"
+    } as NodeJS.ProcessEnv);
+    const result = await provider.send(TARGET, { title: "t", body: "b" });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.retryable).toBe(false);
+  });
+
+  test("a malformed credential names the field, never the key", async () => {
+    const json = JSON.stringify({
+      project_id: "p",
+      private_key:
+        "-----BEGIN PRIVATE KEY-----\nSECRET\n-----END PRIVATE KEY-----"
+    });
+    const provider = resolvePushProvider({
+      PUSH_PROVIDER: "fcm",
+      PUSH_FCM_CREDENTIALS_BASE64: Buffer.from(json).toString("base64")
+    } as NodeJS.ProcessEnv);
+    const result = await provider.send(TARGET, { title: "t", body: "b" });
+
+    expect(result.ok).toBe(false);
+    const error = result.ok === false ? result.error : "";
+    expect(error).toContain("client_email");
+    expect(error).not.toContain("SECRET");
+  });
+
+  test("`fcm` speaks only `fcm` — a web_push row must not be handed to it", async () => {
+    const { base64 } = await makeCredentialMaterial();
+    const provider = resolvePushProvider({
+      PUSH_PROVIDER: "fcm",
+      PUSH_FCM_CREDENTIALS_BASE64: base64
+    } as NodeJS.ProcessEnv);
+
+    // The dispatcher checks this before calling, so a mismatch is a
+    // configuration error caught with a clear message rather than a wire error.
+    expect([...provider.supportedTransports]).toEqual(["fcm"]);
+  });
+});


### PR DESCRIPTION
Bagian pertama dari #466 (epic #463). Adapter Web Push/VAPID untuk browser menyusul di PR terpisah; issue-nya tetap terbuka sampai itu mendarat.

## Apa yang mendarat

`PUSH_PROVIDER=fcm` mengaktifkan pengiriman ke klien **native** Android/iOS. Server → Google, jadi ia tidak menyentuh browser: **nol byte** di anggaran aset klien dan **nol origin CSP baru**. Itulah pembagian yang ADR-0074 tetapkan — FCM HTTP v1 ditahan, SDK FCM Web ditolak dengan angkanya.

## Tanpa menambah dependensi

`google-auth-library` dan `firebase-admin` sama-sama melakukan ini, dan keduanya akan jadi dependensi runtime baru di repo yang hidup dengan **dua**. Presedennya sudah tertulis: `src/lib/auth/jwt-verify.ts` melakukan verifikasi JWT tanpa `jose`. Assertion service-account (RFC 7523) ditandatangani RS256 lewat `crypto.subtle`.

**Test yang paling menanggung beban bukan percabangan status** — itu mudah benar dan mudah diuji. Yang bisa salah secara halus dan senyap adalah assertion-nya: JWT yang ditolak Google terlihat persis seperti masalah kredensial, dan "tambahkan `google-auth-library`" adalah kesimpulan yang akan diambil siapa pun setelah satu jam begitu.

Jadi assertion-nya tidak sekadar dihasilkan — ia **diverifikasi dengan kunci publik pasangannya** lewat `crypto.subtle`. Pasangan RSA nyata dibangkitkan di dalam test, diekspor ke bentuk PEM PKCS#8 yang sama dengan terbitan Google, dan dilewatkan parser sungguhan. Kalau framing, base64url, atau algoritmanya salah, verifikasi itu gagal.

## Satu bug urutan yang ditangkap test

Versi pertama `mapFcmResponse` memeriksa `status === 401` **sebelum** kode error. `THIRD_PARTY_AUTH_ERROR` juga datang dengan HTTP 401, jadi kesalahan kredensial APNs/web permanen dilaporkan sebagai "token kadaluwarsa" — adapter mencetak token baru, menghabiskan satu round-trip untuk ditolak dengan alasan sama, dan melabeli kesalahan konfigurasi berdiri sebagai kedaluwarsa.

Docblock fungsi itu **sudah** mengklaim urutan yang benar ("the error CODE is consulted before the status"). Kodenya tidak. Sekarang keduanya sepakat, dan alasannya tertulis di sana supaya tidak dibalik lagi.

## Tiga keputusan yang halus, semuanya diuji

| Keputusan | Kalau tidak |
| --- | --- |
| Token mati **tidak** memicu circuit breaker | Satu batch registrasi basi menghentikan pengiriman ke setiap perangkat sehat — dan gejalanya menunjuk ke FCM, bukan ke tokennya |
| Kode error dibaca **sebelum** status | Lihat di atas |
| 401 disegarkan tepat **sekali** | Token mati di tengah batch menggagalkan seluruh sisa batch; atau kredensial yang salah memutar tanpa henti |

Dibuktikan dua arah: sepuluh `UNREGISTERED` berturut meninggalkan breaker `closed`, lima `UNAVAILABLE` membukanya.

## Kredensial

Wajib **base64** (`PUSH_FCM_CREDENTIALS_BASE64`): `config:validate` mem-parse `.env` baris demi baris, dan `private_key` adalah blok PEM multi-baris — ditempel mentah ia terpotong diam-diam dan kegagalannya muncul saat kirim pertama, bukan saat boot.

Parser-nya **pure** dan dipakai `config:validate` **maupun** adapter. Validator yang mengimplementasikan ulang pemeriksaan bebas berbeda pendapat dengan benda yang ia validasi — dan akan berbeda, persis pada kasus yang tak diuji siapa pun.

Dibuktikan tiga arah terhadap `bun run config:validate --file`:

```
(1) fcm tanpa kredensial   -> GAGAL: "PUSH_FCM_CREDENTIALS_BASE64 wajib diisi saat PUSH_PROVIDER=fcm."
(2) JSON mentah, tak base64 -> GAGAL: "…(a raw, un-encoded service-account file is the usual cause)"
(3) kredensial valid        -> OK
```

Pesan kegagalannya menyebut **nama field**, tak pernah nilai — ada test yang meng-assert `private_key` tidak muncul di pesan mana pun.

## SSRF

Setiap panggilan keluar lewat `ssrfSafeFetch`, bukan `fetch` telanjang: tujuannya diturunkan dari `token_uri` sebuah kredensial dan (nanti) dari baris langganan — nilai yang datang dari luar kode ini, dan worker yang memanggilnya sedang memegang koneksi database.

Seam-nya sebuah **tipe**, bukan pembungkus `fetch`, supaya test menggerakkan adapter tanpa jaringan **dan tanpa mematikan guard-nya**. Test yang harus mematikan guard sedang menguji jalur berbeda dari yang dijalankan produksi.

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0**, 3557 pass / 0 fail
- `config:validate` tiga arah seperti di atas
- test yang dulu meng-assert `fcm` **ditolak** kini meng-assert `fcm` diterima dan `web_push` tidak — itulah guna meng-assert yang negatif: daftar adapter tak bisa tumbuh mendahului kodenya tanpa test itu ikut disunting di perubahan yang sama

🤖 Generated with [Claude Code](https://claude.com/claude-code)