### PR TITLE
feat(push): adapter Web Push (VAPID) — nol byte klien, diverifikasi vektor RFC 8291 (#466)

### DIFF
--- a/.changeset/adapter-web-push-vapid.md
+++ b/.changeset/adapter-web-push-vapid.md
@@ -1,0 +1,90 @@
+---
+"awcms": minor
+---
+
+feat(push): adapter Web Push (VAPID) — nol byte klien, nol origin CSP, diverifikasi terhadap vektor RFC 8291
+
+`PUSH_PROVIDER=web_push` mengaktifkan pengiriman ke **browser** lewat RFC 8030 +
+8291 + 8292. Inilah yang ADR-0074 pilih sebagai ganti SDK FCM Web, dan alasannya
+terukur: SDK itu **45.041 B** melawan plafon **21.000 B** per berkas, dan
+menuntut `www.gstatic.com` di `script-src` plus dua origin `googleapis.com` di
+`connect-src` — melawan CSP yang punya enam direktif, **tidak punya
+`connect-src` sama sekali**, dan sebuah test yang mengunci nol origin pihak
+ketiga (ADR-0029).
+
+`PushManager.subscribe()` adalah API browser, bukan `fetch` dari skrip halaman.
+Jadi jalur ini berharga **nol byte klien dan nol origin CSP**. Anggaran aset
+tetap 140.008 / 180.000 B, tak bergerak satu byte pun.
+
+## Kenapa buktinya vektor RFC, bukan round-trip
+
+Ini kode paling berisiko di seluruh program push, dan alasannya perlu disebut
+lebih dulu: **push service tidak memvalidasi payload.** Ia meneruskan ciphertext
+ke browser, dan browser yang tak bisa mendekripsinya membuang notifikasi itu
+**diam-diam**. Key schedule yang salah menghasilkan sistem yang menerima setiap
+pesan, mencatat setiap kirim sebagai **sukses**, dan tidak mengantarkan apa pun
+— tanpa satu error pun di mana pun dalam rantai.
+
+Test round-trip tidak bisa menangkap itu: ia membuktikan encryptor dan decryptor
+sepakat, bukan bahwa keduanya cocok dengan spesifikasi. Keduanya bisa salah baca
+spec dengan cara yang sama, yang persis mode kegagalan di atas.
+
+Jadi implementasinya mereproduksi **contoh kerja RFC 8291 sendiri** (§5 dan
+Lampiran A):
+
+| Nilai | Cocok |
+| --- | --- |
+| `ecdh_secret` | ya |
+| `PRK_key` | ya |
+| `IKM` | ya |
+| `PRK` | ya |
+| `CEK` | ya |
+| `NONCE` | ya |
+| **body terenkripsi lengkap** | **ya, 144 byte, byte per byte** |
+
+Angka-angka itu datang dari pihak ketiga; mereproduksinya adalah bukti
+interoperabilitas, bukan konsistensi diri. Masing-masing di-assert terpisah agar
+kegagalan menyebut **langkah mana** yang menyimpang, bukan sekadar melaporkan
+ciphertext-nya tak cocok lagi.
+
+HKDF ditulis di atas HMAC `crypto.subtle` alih-alih memakai
+`deriveBits({name:"HKDF"})` — justru supaya nilai-nilai antara itu **bisa
+diamati**; `deriveBits` melakukan extract-then-expand sebagai satu operasi buram.
+Dua puluh baris RFC 5869, nol kriptografi yang diciptakan sendiri.
+
+## Detail yang halus dan diuji
+
+- **Pasangan kunci ECDH server ephemeral per pesan** — desain RFC, bukan
+  optimasi yang belum dikerjakan: satu pasangan yang dipakai ulang membuat setiap
+  notifikasi ke satu pelanggan berbagi key schedule, sehingga memulihkan satu
+  plaintext memulihkan semuanya. Diuji: dua kirim dengan payload identik
+  menghasilkan salt DAN keyid berbeda.
+- **`aud` VAPID adalah ORIGIN endpoint**, bukan endpoint-nya. Menandatangani
+  endpoint penuh adalah kesalahan klasik yang gejalanya 401 dan terbaca seperti
+  masalah kunci. Pemanggil menyerahkan endpoint dan tak pernah audience.
+- **Tanda tangan ES256 adalah r||s mentah 64 byte**, bukan DER — bentuk DER
+  ditolak setiap push service dan didiagnosis oleh tak satu pun dari mereka.
+- **Langganan mati tidak memicu circuit breaker** (sepuluh `410` berturut
+  meninggalkan breaker `closed`), konsisten dengan adapter FCM.
+- Token VAPID di-cache per **origin**: satu batch 500 pelanggan Firefox berharga
+  satu tanda tangan, bukan 500.
+
+## Operasional
+
+`bun run push:vapid:generate` mencetak satu pasangan kunci dalam bentuk persis
+yang `.env` inginkan. Ia ada alih-alih "pakai openssl" karena formatnya spesifik
+dan mudah salah secara halus: publik = **titik P-256 tak-terkompres 65 byte**,
+privat = **skalar mentah 32 byte**, keduanya base64url tanpa padding —
+sementara `openssl ecparam` mengeluarkan PEM, dan tiap resep konversinya
+berpeluang menyerahkan bentuk terbungkus DER, yang **berhasil diimpor di sini**
+lalu ditolak setiap push service sebagai 401.
+
+Perintah itu juga mencetak peringatan bersama kuncinya, bukan menyimpannya di
+dokumen: **merotasi pasangan kunci tidak me-re-key langganan yang ada** — ia
+membuat semuanya permanen tak-terkirimi sampai penggunanya berlangganan ulang,
+karena kunci publik dipanggang ke dalam tiap langganan saat `subscribe()`.
+
+`SsrfFetchOptions.body` melebar menerima `Uint8Array`: body Web Push adalah
+ciphertext `aes128gcm`, dan tak ada penyandian teks yang selamat melewati
+`string`. `fetch` selalu menerima keduanya; hanya tipenya yang lebih sempit dari
+benda yang ia teruskan.

--- a/.env.example
+++ b/.env.example
@@ -310,12 +310,31 @@ VISITOR_ANALYTICS_VISITOR_KEY_COOKIE_TTL_DAYS=30
 # PUSH_ENABLED=false
 #
 # Adapter:
-#   log  — writes a structured line and always succeeds (local dev and tests).
-#   fcm  — FCM HTTP v1, server -> Google, for NATIVE Android/iOS clients.
-# `web_push` (VAPID, for browsers) does not exist yet and is deliberately NOT
-# accepted: naming an adapter early lets a deployment pass validation and then
-# fail at resolve time.
+#   log       — writes a structured line and always succeeds (local dev/tests).
+#   fcm       — FCM HTTP v1, server -> Google, for NATIVE Android/iOS clients.
+#   web_push  — VAPID (RFC 8030/8291/8292) for BROWSERS.
 # PUSH_PROVIDER=log
+#
+# --- web_push (VAPID) ---
+#
+# Chosen over the FCM Web SDK by ADR-0074, and the reason is measurable: the SDK
+# is 45,041 B against a 21,000 B per-file ceiling AND needs three third-party
+# origins in a CSP that has none. `PushManager.subscribe()` is a browser API,
+# not a fetch from page script, so this path costs ZERO client bytes and ZERO
+# CSP origins.
+#
+# Generate one key pair per DEPLOYMENT and keep it: rotating it invalidates
+# every existing browser subscription, because the public key is baked into each
+# subscription at `subscribe()` time.
+#
+#   bun run push:vapid:generate
+#
+# PUSH_VAPID_PUBLIC_KEY=      # base64url, 65 bytes — NOT a secret; the browser receives it
+# PUSH_VAPID_PRIVATE_KEY=     # base64url, 32 bytes — secret
+#
+# RFC 8292 §2.1 contact: how a push service reaches you about your own traffic
+# BEFORE blocking it. `mailto:` or an https URL.
+# PUSH_VAPID_SUBJECT=mailto:ops@example.com
 #
 # Google service-account credential for PUSH_PROVIDER=fcm, as BASE64 of the
 # whole JSON file:

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 130   |
 | Tabel dengan `FORCE` RLS           | 119   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 327   |
+| Berkas test                        | 328   |
 | Berkas route                       | 311   |
 | ADR                                | 75    |
 
@@ -280,7 +280,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 279        |
+| `(root)`      | 280        |
 | `e2e`         | 12         |
 | `integration` | 35         |
 | `unit`        | 1          |

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "workflow:escalations:dispatch": "bun scripts/workflow-escalations-dispatch.ts",
     "push:dispatch": "bun scripts/push-dispatch.ts",
     "push:queue:purge": "bun scripts/push-queue-purge.ts",
+    "push:vapid:generate": "bun scripts/push-vapid-generate.ts",
     "identity-access:business-scope:expiry": "bun scripts/identity-access-business-scope-expiry.ts",
     "identity:principals:preflight": "bun scripts/identity-access-principal-preflight.ts",
     "identity-access:permissions:backfill": "bun scripts/identity-access-owner-permission-backfill.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ lalu membangun duplikatnya.
 
 <!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-82 target menjalankan berkas di `scripts/`; 34 di antaranya
+83 target menjalankan berkas di `scripts/`; 34 di antaranya
 ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
 terjadwal, atau oleh workflow CI tertentu.
 
@@ -95,6 +95,7 @@ terjadwal, atau oleh workflow CI tertentu.
 | `project-state:inventory:generate`       | `project-state-inventory.ts`                   | —    |
 | `push:dispatch`                          | `push-dispatch.ts`                             | —    |
 | `push:queue:purge`                       | `push-queue-purge.ts`                          | —    |
+| `push:vapid:generate`                    | `push-vapid-generate.ts`                       | —    |
 | `redis:health`                           | `redis-health.ts`                              | —    |
 | `release:verify`                         | `release-verify.ts`                            | —    |
 | `repo:inventory:check`                   | `repo-inventory.ts`                            | ✅   |

--- a/scripts/push-vapid-generate.ts
+++ b/scripts/push-vapid-generate.ts
@@ -1,0 +1,68 @@
+/**
+ * push-vapid-generate.ts — `bun run push:vapid:generate`.
+ *
+ * Issue #466 (epic #463, ADR-0074). Prints one fresh VAPID key pair in the
+ * exact shape `.env` wants. Operator-run, once per deployment, never scheduled.
+ *
+ * ## Why this exists rather than "use openssl"
+ *
+ * The format is specific and easy to get subtly wrong: the public key is the
+ * **uncompressed P-256 point** (65 bytes, `0x04` prefix) and the private key is
+ * the **raw 32-byte scalar**, both base64url without padding. `openssl ecparam`
+ * emits PEM, and every recipe for converting it involves two more commands and
+ * a chance to hand over the DER-wrapped form instead — which imports fine here
+ * and is then rejected by every push service as a 401.
+ *
+ * ## Rotation is not free, and the output says so
+ *
+ * The public key is baked into every browser subscription at
+ * `PushManager.subscribe()` time. Generating a new pair does not re-key
+ * existing subscribers; it makes them permanently undeliverable, and they will
+ * only recover by re-subscribing. That warning is printed with the keys rather
+ * than filed in a document, because this is the moment somebody is about to do
+ * it.
+ *
+ * Touches no database and reads no configuration.
+ */
+import { base64UrlEncode } from "../src/modules/push-delivery/domain/web-push-encryption";
+
+async function main() {
+  const pair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"]
+  )) as CryptoKeyPair;
+
+  const publicRaw = new Uint8Array(
+    await crypto.subtle.exportKey("raw", pair.publicKey)
+  );
+  const jwk = (await crypto.subtle.exportKey("jwk", pair.privateKey)) as {
+    d?: string;
+  };
+
+  if (!jwk.d) {
+    // Cannot happen for an extractable private key; refusing beats printing a
+    // half key pair an operator would paste into production.
+    console.error("push:vapid:generate FAILED — no private scalar in the JWK.");
+    process.exit(1);
+  }
+
+  console.log("# VAPID key pair (ADR-0074). Paste into .env:");
+  console.log(`PUSH_VAPID_PUBLIC_KEY=${base64UrlEncode(publicRaw)}`);
+  console.log(`PUSH_VAPID_PRIVATE_KEY=${jwk.d}`);
+  console.log("PUSH_VAPID_SUBJECT=mailto:CHANGE-ME@example.com");
+  console.log("");
+  console.log(
+    "# Keep this pair. Rotating it does NOT re-key existing browser subscriptions —"
+  );
+  console.log(
+    "# it makes every one of them permanently undeliverable until the user re-subscribes,"
+  );
+  console.log(
+    "# because the public key is baked into each subscription at subscribe() time."
+  );
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -15,6 +15,7 @@
 import { readFile } from "node:fs/promises";
 
 import { parseFcmCredentialsBase64 } from "../src/modules/push-delivery/domain/fcm-credentials";
+import { parseVapidConfig } from "../src/modules/push-delivery/domain/vapid-config";
 
 type EnvBag = Record<string, string | undefined>;
 
@@ -266,11 +267,14 @@ const RULES: readonly Rule[] = [
     name: "PUSH_PROVIDER",
     required: false,
     type: "enum",
-    values: ["log", "fcm"]
+    values: ["log", "fcm", "web_push"]
   },
   { name: "PUSH_SEND_MAX_RETRIES", required: false, type: "int", min: 0 },
   { name: "PUSH_SEND_TIMEOUT_MS", required: false, type: "int", min: 1 },
   { name: "PUSH_FCM_CREDENTIALS_BASE64", required: false, type: "string" },
+  { name: "PUSH_VAPID_PUBLIC_KEY", required: false, type: "string" },
+  { name: "PUSH_VAPID_PRIVATE_KEY", required: false, type: "string" },
+  { name: "PUSH_VAPID_SUBJECT", required: false, type: "string" },
 
   // visitor_analytics (ported from awcms-micro epic #617-#624). All optional,
   // privacy-first off-by-default; see
@@ -619,6 +623,16 @@ export function validateEnv(env: EnvBag): string[] {
             `PUSH_FCM_CREDENTIALS_BASE64 tidak valid: ${parsed.reason}.`
           );
         }
+      }
+    }
+
+    // Sama seperti FCM: parser yang SAMA dengan adapter, bukan cek kedua yang
+    // bebas berbeda pendapat.
+    if (provider === "web_push") {
+      const vapid = parseVapidConfig(env as NodeJS.ProcessEnv);
+
+      if (!vapid.ok) {
+        problems.push(`Konfigurasi VAPID tidak valid: ${vapid.reason}.`);
       }
     }
   }

--- a/src/lib/auth/ssrf-guard.ts
+++ b/src/lib/auth/ssrf-guard.ts
@@ -61,7 +61,13 @@ export type SsrfFetchOptions = {
   maxRedirects?: number;
   method?: "GET" | "POST";
   headers?: Record<string, string>;
-  body?: string;
+  /**
+   * `Uint8Array` is accepted alongside `string` (Issue #466): a Web Push body
+   * is `aes128gcm` CIPHERTEXT, and there is no text encoding that survives a
+   * round-trip through a string. `fetch` has always accepted both; only this
+   * type was narrower than the thing it forwards to.
+   */
+  body?: string | Uint8Array;
   env?: NodeJS.ProcessEnv;
 };
 
@@ -488,7 +494,10 @@ export async function ssrfSafeFetch(
         response = await fetch(currentUrl, {
           method: currentMethod,
           headers: options.headers,
-          body: currentBody,
+          // `fetch` accepts a `Uint8Array` at runtime; the ambient `BodyInit`
+          // in this TypeScript lib does not list `ArrayBufferView`, so the cast
+          // is a gap in the type, not a widening of what is sent.
+          body: currentBody as BodyInit | undefined,
           redirect: "manual",
           signal: controller.signal
         });

--- a/src/modules/push-delivery/README.md
+++ b/src/modules/push-delivery/README.md
@@ -60,8 +60,24 @@ Ketiganya dihapus dalam urutan FK — attempts, messages, subscriptions — kare
 
 `healthCheck` membuktikan **kredensialnya**, bukan jalur kirim — mengirim notifikasi nyata butuh token perangkat nyata, dan mengarang satu akan dijawab `UNREGISTERED`, yaitu FCM sehat yang melapor gagal.
 
+## Adapter Web Push (VAPID)
+
+`PUSH_PROVIDER=web_push` — RFC 8030 + 8291 + 8292, untuk **browser**. Inilah yang ADR-0074 pilih sebagai ganti SDK FCM Web, dan alasannya terukur: SDK itu 45.041 B melawan plafon 21.000 B per berkas, **dan** menuntut tiga origin pihak ketiga di CSP yang sama sekali tidak punya. `PushManager.subscribe()` adalah API browser, bukan `fetch` dari skrip halaman, jadi jalur ini berharga **nol byte klien dan nol origin CSP**. Semua yang ada di sini berjalan di sisi server.
+
+**Enkripsinya diverifikasi terhadap vektor RFC, bukan round-trip.** Ini bagian paling berisiko di seluruh program push, dan alasannya perlu disebut: push service **tidak memvalidasi payload**. Ia meneruskan ciphertext ke browser, dan browser yang tak bisa mendekripsinya membuang notifikasi itu **diam-diam**. Key schedule yang salah karena itu menghasilkan sistem yang menerima setiap pesan, mencatat setiap kirim sebagai sukses, dan tidak mengantarkan apa pun — tanpa satu error pun di mana pun.
+
+Test round-trip tak bisa menangkap itu: ia membuktikan encryptor dan decryptor sepakat, bukan bahwa keduanya cocok dengan spesifikasi. Jadi `tests/push-web-push-adapter.test.ts` mereproduksi contoh kerja RFC 8291 sendiri — **setiap nilai antara yang diterbitkan** (`ecdh_secret`, `PRK_key`, `IKM`, `PRK`, `CEK`, `NONCE`) **dan body akhirnya, byte per byte**. Angka-angka itu datang dari pihak ketiga; mereproduksinya adalah bukti interoperabilitas.
+
+HKDF ditulis di atas HMAC `crypto.subtle` alih-alih memakai `deriveBits({name:"HKDF"})`, justru supaya nilai-nilai antara itu **bisa diamati** — `deriveBits` melakukan extract-then-expand sebagai satu operasi buram.
+
+**Detail yang halus:** pasangan kunci ECDH server **ephemeral per pesan** (desain RFC, bukan optimasi yang belum dikerjakan — satu pasangan yang dipakai ulang membuat setiap notifikasi ke satu pelanggan berbagi key schedule); `aud` VAPID adalah **origin** endpoint, bukan endpoint-nya (menandatangani endpoint penuh adalah kesalahan klasik yang gejalanya 401 dan terbaca seperti masalah kunci); tanda tangan ES256 adalah **r||s mentah** 64 byte, bukan DER.
+
+Token VAPID di-cache per **origin**, jadi satu batch 500 pelanggan Firefox berharga satu tanda tangan, bukan 500.
+
+`bun run push:vapid:generate` mencetak satu pasangan kunci dalam bentuk persis yang `.env` inginkan — beserta peringatan bahwa **merotasinya tidak me-re-key langganan yang ada**, melainkan membuat semuanya permanen tak-terkirimi sampai penggunanya berlangganan ulang.
+
 ## Yang BELUM ada
 
-- **Adapter Web Push/VAPID untuk browser.** `PUSH_PROVIDER` sengaja belum menerima `web_push`: menamainya sekarang akan membuat deployment lolos validasi lalu gagal saat resolve.
+- **Permukaan HTTP dan service worker.** Mendaftarkan langganan lewat API, service worker yang menerima `push`, dan layar admin belum ada. Sampai itu, `enqueuePushToRecipients` belum punya pemanggil produksi dan modul ini tetap berstatus `experimental`.
 - **Permukaan HTTP.** Mendaftarkan dan mencabut langganan lewat API, plus layar admin, mendarat bersama adapter-nya. Sampai itu `enqueuePushToRecipients` belum punya pemanggil produksi — kesenjangan yang dicatat di ADR-0074 §Konsekuensi alih-alih dibiarkan ditemukan.
 - **FCM Web (SDK browser).** Ditolak, dengan angkanya, di ADR-0074 §Yang DITOLAK.

--- a/src/modules/push-delivery/domain/push-config.ts
+++ b/src/modules/push-delivery/domain/push-config.ts
@@ -34,11 +34,12 @@
  * Android/iOS clients. It costs nothing in the client asset budget and adds no
  * CSP origin, which is why ADR-0074 keeps it while rejecting the FCM Web SDK.
  *
- * `"web_push"` (VAPID, for browsers) is still absent, and deliberately: naming
- * an adapter before it exists lets a deployment pass `config:validate` and then
- * fail at resolve time, which is the worst place to learn it.
+ * `"web_push"` is the VAPID adapter for BROWSERS (Issue #466) — RFC 8030/8291/
+ * 8292. It is what ADR-0074 chose instead of the FCM Web SDK: zero client
+ * bytes, zero CSP origins, because `PushManager.subscribe()` is a browser API
+ * rather than a `fetch` from page script.
  */
-export const KNOWN_PUSH_PROVIDERS = ["log", "fcm"] as const;
+export const KNOWN_PUSH_PROVIDERS = ["log", "fcm", "web_push"] as const;
 
 export type PushProviderKind = (typeof KNOWN_PUSH_PROVIDERS)[number];
 

--- a/src/modules/push-delivery/domain/vapid-config.ts
+++ b/src/modules/push-delivery/domain/vapid-config.ts
@@ -1,0 +1,100 @@
+/**
+ * VAPID key material from configuration (Issue #466, ADR-0074). Pure — the same
+ * parse-once-use-twice split as `fcm-credentials.ts`, so `config:validate`
+ * rejects a bad key pair at BOOT through the code path the adapter uses at send
+ * time.
+ *
+ * ## Why these are three plain variables and not one blob
+ *
+ * A VAPID key pair is two base64url strings and a contact URI. Unlike an FCM
+ * service account there is no vendor-issued JSON document to carry, so wrapping
+ * them in one would invent a format nobody else writes — an operator generating
+ * keys with any standard tool gets exactly these three values.
+ *
+ * The public key is ALSO published to the browser (it is the
+ * `applicationServerKey` passed to `PushManager.subscribe()`), which is why it
+ * is the one piece of this trio that is not a secret and can be rendered into a
+ * page.
+ */
+
+/** Uncompressed P-256 point: 0x04 || X(32) || Y(32). */
+const PUBLIC_KEY_BYTES = 65;
+/** P-256 private scalar. */
+const PRIVATE_KEY_BYTES = 32;
+
+export type VapidConfigResult =
+  | {
+      ok: true;
+      config: { publicKey: string; privateKey: string; subject: string };
+    }
+  | { ok: false; reason: string };
+
+function decodedLength(base64Url: string): number {
+  const padded = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+
+  return Buffer.from(
+    padded + "=".repeat((4 - (padded.length % 4)) % 4),
+    "base64"
+  ).length;
+}
+
+/**
+ * RFC 8292 §2.1: `sub` must be a `mailto:` or `https:` URI — how a push service
+ * contacts the operator about abuse before blocking them. Enforced rather than
+ * defaulted: a placeholder here means the first warning a deployment gets about
+ * its own traffic is the block itself.
+ */
+function isValidSubject(subject: string): boolean {
+  if (subject.startsWith("mailto:")) {
+    return subject.length > "mailto:".length && subject.includes("@");
+  }
+
+  try {
+    return new URL(subject).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+export function parseVapidConfig(env: NodeJS.ProcessEnv): VapidConfigResult {
+  const publicKey = env.PUSH_VAPID_PUBLIC_KEY?.trim() ?? "";
+  const privateKey = env.PUSH_VAPID_PRIVATE_KEY?.trim() ?? "";
+  const subject = env.PUSH_VAPID_SUBJECT?.trim() ?? "";
+
+  const missing = [
+    publicKey === "" ? "PUSH_VAPID_PUBLIC_KEY" : null,
+    privateKey === "" ? "PUSH_VAPID_PRIVATE_KEY" : null,
+    subject === "" ? "PUSH_VAPID_SUBJECT" : null
+  ].filter((name): name is string => name !== null);
+
+  if (missing.length > 0) {
+    return { ok: false, reason: `missing ${missing.join(", ")}` };
+  }
+
+  if (decodedLength(publicKey) !== PUBLIC_KEY_BYTES) {
+    // Checked by LENGTH rather than left to the crypto import, because a
+    // truncated or padded key produces an import error at the first send with
+    // nothing pointing at the variable that caused it.
+    return {
+      ok: false,
+      reason: `PUSH_VAPID_PUBLIC_KEY must decode to ${PUBLIC_KEY_BYTES} bytes (an uncompressed P-256 point)`
+    };
+  }
+
+  if (decodedLength(privateKey) !== PRIVATE_KEY_BYTES) {
+    return {
+      ok: false,
+      reason: `PUSH_VAPID_PRIVATE_KEY must decode to ${PRIVATE_KEY_BYTES} bytes`
+    };
+  }
+
+  if (!isValidSubject(subject)) {
+    return {
+      ok: false,
+      reason:
+        "PUSH_VAPID_SUBJECT must be a mailto: address or an https: URL (RFC 8292 §2.1)"
+    };
+  }
+
+  return { ok: true, config: { publicKey, privateKey, subject } };
+}

--- a/src/modules/push-delivery/domain/web-push-encryption.ts
+++ b/src/modules/push-delivery/domain/web-push-encryption.ts
@@ -1,0 +1,355 @@
+/**
+ * RFC 8291 "Message Encryption for Web Push" — `aes128gcm` (Issue #466,
+ * ADR-0074).
+ *
+ * This is the highest-risk code in the push program, and it is worth saying why
+ * before the first line: a push service does not validate the payload. It
+ * forwards ciphertext to a browser, and a browser that cannot decrypt it drops
+ * the notification silently. A wrong key schedule therefore produces a system
+ * that accepts every message, reports every send as a success, and delivers
+ * nothing — with no error anywhere in the chain.
+ *
+ * So this file is verified against the RFC's OWN worked example (§5 and
+ * Appendix A) in `tests/push-web-push-adapter.test.ts`, not merely
+ * round-tripped against itself. A round-trip proves the encryptor and the
+ * decryptor agree; it cannot notice that both misread the spec the same way,
+ * which is exactly the failure mode above.
+ *
+ * ## Why HKDF is hand-rolled here when `crypto.subtle` has it
+ *
+ * `crypto.subtle.deriveBits({name:"HKDF", …})` performs extract-then-expand as
+ * one opaque operation, so the intermediate values the RFC publishes — PRK_key,
+ * IKM, PRK — cannot be observed. Implementing HKDF over `crypto.subtle`'s HMAC
+ * (RFC 5869, twenty lines, no invented cryptography) makes every one of those
+ * assertable against the RFC's printed vector. Given the failure mode, evidence
+ * beats brevity here.
+ *
+ * ## The shape being built (RFC 8188 §2 + RFC 8291 §4)
+ *
+ *   body = salt(16) || rs(4, big-endian) || idlen(1) || keyid(65) || ciphertext
+ *
+ * where `keyid` is the application server's uncompressed P-256 public point,
+ * and the plaintext is `payload || 0x02` (the last-record delimiter) before
+ * AES-128-GCM.
+ */
+
+const ENCODER = new TextEncoder();
+
+/** RFC 8291 §3.4 — the ECDH-derived IKM's info string. */
+const WEB_PUSH_INFO_PREFIX = ENCODER.encode("WebPush: info\0");
+
+/** RFC 8188 §2.2 — the content-encryption-key info string. */
+const CEK_INFO = ENCODER.encode("Content-Encoding: aes128gcm\0");
+
+/** RFC 8188 §2.3 — the nonce info string. */
+const NONCE_INFO = ENCODER.encode("Content-Encoding: nonce\0");
+
+const SALT_LENGTH = 16;
+const CEK_LENGTH = 16;
+const NONCE_LENGTH = 12;
+const UNCOMPRESSED_POINT_LENGTH = 65;
+
+/**
+ * Record size. 4096 is what every browser and push service handles, and the
+ * payloads here are a title and a body — the multi-record path RFC 8188 allows
+ * is deliberately not implemented, and `encryptWebPushPayload` refuses rather
+ * than silently truncating if a payload would need it.
+ */
+export const WEB_PUSH_RECORD_SIZE = 4096;
+
+export function base64UrlDecode(value: string): Uint8Array {
+  const padded = value.replace(/-/g, "+").replace(/_/g, "/");
+
+  return Uint8Array.from(
+    Buffer.from(padded + "=".repeat((4 - (padded.length % 4)) % 4), "base64")
+  );
+}
+
+export function base64UrlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function concatBytes(...parts: Uint8Array[]): Uint8Array {
+  const total = parts.reduce((sum, part) => sum + part.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.length;
+  }
+
+  return out;
+}
+
+async function hmacSha256(
+  key: Uint8Array,
+  message: Uint8Array
+): Promise<Uint8Array> {
+  const cryptoKey = await crypto.subtle.importKey(
+    "raw",
+    key as unknown as ArrayBuffer,
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+
+  return new Uint8Array(
+    await crypto.subtle.sign(
+      "HMAC",
+      cryptoKey,
+      message as unknown as ArrayBuffer
+    )
+  );
+}
+
+/** RFC 5869 §2.2. The "salt" is an HMAC KEY here, which is the step most often written backwards. */
+export async function hkdfExtract(
+  salt: Uint8Array,
+  ikm: Uint8Array
+): Promise<Uint8Array> {
+  return hmacSha256(salt, ikm);
+}
+
+/**
+ * RFC 5869 §2.3, restricted to L <= 32 (one HMAC block).
+ *
+ * Every derivation in RFC 8291 asks for 32, 16, or 12 bytes, so the iteration
+ * loop the general algorithm needs would be untested code on a path nothing
+ * reaches. It throws rather than silently returning a short key.
+ */
+export async function hkdfExpand(
+  prk: Uint8Array,
+  info: Uint8Array,
+  length: number
+): Promise<Uint8Array> {
+  if (length > 32) {
+    throw new Error(
+      "hkdfExpand: only single-block output (<= 32 bytes) is implemented; RFC 8291 never needs more."
+    );
+  }
+
+  const block = await hmacSha256(prk, concatBytes(info, Uint8Array.of(1)));
+
+  return block.slice(0, length);
+}
+
+export type WebPushKeySchedule = {
+  /** HKDF-Extract(auth_secret, ecdh_secret) — RFC 8291 Appendix A `PRK_key`. */
+  prkKey: Uint8Array;
+  /** HKDF-Expand(PRK_key, "WebPush: info"\0 || ua_public || as_public, 32). */
+  ikm: Uint8Array;
+  /** HKDF-Extract(salt, IKM) — RFC 8188's PRK. */
+  prk: Uint8Array;
+  cek: Uint8Array;
+  nonce: Uint8Array;
+};
+
+/**
+ * The whole key schedule, exposed as data.
+ *
+ * Separated from encryption ON PURPOSE: it is the part the RFC publishes
+ * intermediate values for, so making it a pure function over bytes is what lets
+ * a test assert each one. Fold it into `encryptWebPushPayload` and the only
+ * observable output is a ciphertext, which can only be checked as a whole —
+ * and when it does not match, nothing says which step was wrong.
+ */
+export async function deriveWebPushKeys(input: {
+  ecdhSecret: Uint8Array;
+  authSecret: Uint8Array;
+  /** Subscriber's uncompressed P-256 public point (`p256dh`). */
+  uaPublicKey: Uint8Array;
+  /** This server's ephemeral uncompressed P-256 public point. */
+  asPublicKey: Uint8Array;
+  salt: Uint8Array;
+}): Promise<WebPushKeySchedule> {
+  const prkKey = await hkdfExtract(input.authSecret, input.ecdhSecret);
+  const keyInfo = concatBytes(
+    WEB_PUSH_INFO_PREFIX,
+    input.uaPublicKey,
+    input.asPublicKey
+  );
+  const ikm = await hkdfExpand(prkKey, keyInfo, 32);
+  const prk = await hkdfExtract(input.salt, ikm);
+
+  return {
+    prkKey,
+    ikm,
+    prk,
+    cek: await hkdfExpand(prk, CEK_INFO, CEK_LENGTH),
+    nonce: await hkdfExpand(prk, NONCE_INFO, NONCE_LENGTH)
+  };
+}
+
+export type WebPushSubscriptionKeys = {
+  /** `p256dh`, base64url — the subscriber's public key. */
+  p256dh: string;
+  /** `auth`, base64url — 16 bytes of subscriber-supplied entropy. */
+  authSecret: string;
+};
+
+export type EncryptWebPushOptions = {
+  /** Test seam: the RFC's worked example fixes both, and a real send generates both. */
+  salt?: Uint8Array;
+  serverKeyPair?: CryptoKeyPair;
+};
+
+/**
+ * Produces the complete `aes128gcm` body for one subscription.
+ *
+ * The server key pair is EPHEMERAL per message unless one is injected. That is
+ * RFC 8291's design, not an optimisation left undone: reusing one ECDH key pair
+ * across messages would make every notification to a given subscriber share a
+ * key schedule, so recovering one plaintext would recover them all.
+ */
+export async function encryptWebPushPayload(
+  payload: string,
+  keys: WebPushSubscriptionKeys,
+  options: EncryptWebPushOptions = {}
+): Promise<Uint8Array> {
+  const plaintext = ENCODER.encode(payload);
+
+  // header + delimiter + GCM tag must fit one record.
+  const maxPayload = WEB_PUSH_RECORD_SIZE - UNCOMPRESSED_POINT_LENGTH - 16 - 21;
+
+  if (plaintext.length > maxPayload) {
+    throw new Error(
+      `encryptWebPushPayload: payload is ${plaintext.length} bytes; the single-record limit here is ${maxPayload}.`
+    );
+  }
+
+  const uaPublicKey = base64UrlDecode(keys.p256dh);
+  const authSecret = base64UrlDecode(keys.authSecret);
+
+  if (uaPublicKey.length !== UNCOMPRESSED_POINT_LENGTH) {
+    throw new Error(
+      `encryptWebPushPayload: p256dh must be a ${UNCOMPRESSED_POINT_LENGTH}-byte uncompressed point, got ${uaPublicKey.length}.`
+    );
+  }
+
+  const salt =
+    options.salt ?? crypto.getRandomValues(new Uint8Array(SALT_LENGTH));
+  const serverKeyPair =
+    options.serverKeyPair ??
+    ((await crypto.subtle.generateKey(
+      { name: "ECDH", namedCurve: "P-256" },
+      true,
+      ["deriveBits"]
+    )) as CryptoKeyPair);
+
+  const asPublicKey = new Uint8Array(
+    await crypto.subtle.exportKey("raw", serverKeyPair.publicKey)
+  );
+
+  const uaKey = await crypto.subtle.importKey(
+    "raw",
+    uaPublicKey as unknown as ArrayBuffer,
+    { name: "ECDH", namedCurve: "P-256" },
+    false,
+    []
+  );
+
+  const ecdhSecret = new Uint8Array(
+    await crypto.subtle.deriveBits(
+      { name: "ECDH", public: uaKey },
+      serverKeyPair.privateKey,
+      256
+    )
+  );
+
+  const schedule = await deriveWebPushKeys({
+    ecdhSecret,
+    authSecret,
+    uaPublicKey,
+    asPublicKey,
+    salt
+  });
+
+  const contentKey = await crypto.subtle.importKey(
+    "raw",
+    schedule.cek as unknown as ArrayBuffer,
+    { name: "AES-GCM" },
+    false,
+    ["encrypt"]
+  );
+
+  // RFC 8188 §2: the LAST record's plaintext ends with the delimiter 0x02.
+  const ciphertext = new Uint8Array(
+    await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv: schedule.nonce as unknown as ArrayBuffer },
+      contentKey,
+      concatBytes(plaintext, Uint8Array.of(2)) as unknown as ArrayBuffer
+    )
+  );
+
+  const recordSize = new Uint8Array(4);
+  new DataView(recordSize.buffer).setUint32(0, WEB_PUSH_RECORD_SIZE, false);
+
+  return concatBytes(
+    salt,
+    recordSize,
+    Uint8Array.of(asPublicKey.length),
+    asPublicKey,
+    ciphertext
+  );
+}
+
+/**
+ * Builds a `CryptoKeyPair` from raw base64url key material.
+ *
+ * `crypto.subtle` cannot import a bare EC private scalar, so the private key is
+ * assembled as a JWK whose `x`/`y` come from the public point. That is also a
+ * check: a mismatched pair is rejected by the import rather than producing a
+ * key schedule the browser silently cannot use.
+ */
+export async function importEcdhKeyPair(
+  publicKeyBase64Url: string,
+  privateKeyBase64Url: string,
+  usages: KeyUsage[]
+): Promise<CryptoKeyPair> {
+  const publicBytes = base64UrlDecode(publicKeyBase64Url);
+
+  if (
+    publicBytes.length !== UNCOMPRESSED_POINT_LENGTH ||
+    publicBytes[0] !== 4
+  ) {
+    throw new Error(
+      "importEcdhKeyPair: public key must be a 65-byte uncompressed P-256 point (0x04 prefix)."
+    );
+  }
+
+  const namedCurve = "P-256";
+  const algorithm = usages.includes("sign")
+    ? { name: "ECDSA", namedCurve }
+    : { name: "ECDH", namedCurve };
+
+  const jwk = {
+    kty: "EC",
+    crv: namedCurve,
+    x: base64UrlEncode(publicBytes.slice(1, 33)),
+    y: base64UrlEncode(publicBytes.slice(33, 65)),
+    ext: true
+  };
+
+  const publicKey = await crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    algorithm,
+    true,
+    usages.includes("sign") ? ["verify"] : []
+  );
+
+  const privateKey = await crypto.subtle.importKey(
+    "jwk",
+    { ...jwk, d: privateKeyBase64Url },
+    algorithm,
+    true,
+    usages
+  );
+
+  return { publicKey, privateKey };
+}

--- a/src/modules/push-delivery/domain/web-push-error-mapping.ts
+++ b/src/modules/push-delivery/domain/web-push-error-mapping.ts
@@ -1,0 +1,90 @@
+/**
+ * Web Push (RFC 8030) response → dispatcher outcome (Issue #466). Pure: a
+ * status code in, a decision out.
+ *
+ * Same three-way split as the FCM mapper, and the same reasoning about the
+ * circuit breaker: a `404`/`410` is one subscription reporting its own death,
+ * not a statement about whether the push SERVICE is healthy. A queue routinely
+ * carries thousands of them, and counting them as provider failures would stop
+ * delivery to every live subscriber on that service.
+ *
+ * ## Why there are several push services, and why that matters here
+ *
+ * Unlike FCM, "the provider" is not one host: Chrome subscriptions live on
+ * `fcm.googleapis.com`, Firefox on `updates.push.services.mozilla.com`, Edge on
+ * `*.notify.windows.com`. They fail independently. The breaker key is shared
+ * across all of them today (`PUSH_CIRCUIT_BREAKER_KEY`), which means one
+ * service's outage can pause delivery to the others — stated here rather than
+ * discovered, because the fix (a breaker per audience) is only worth its
+ * complexity once a real deployment has subscribers on more than one.
+ */
+
+export type WebPushOutcome =
+  | { kind: "success" }
+  | { kind: "subscription_gone"; error: string }
+  | {
+      kind: "failure";
+      error: string;
+      retryable: boolean;
+      tripsBreaker: boolean;
+    };
+
+const MAX_SNIPPET = 300;
+
+export function mapWebPushResponse(
+  status: number,
+  body: string
+): WebPushOutcome {
+  const snippet = body.slice(0, MAX_SNIPPET);
+
+  // RFC 8030 §5: a successful push is 201 Created. 200/202 are accepted too —
+  // some services answer 200, and refusing a 2xx because it is not the exact
+  // code the RFC prefers would fail deliveries that actually happened.
+  if (status >= 200 && status < 300) {
+    return { kind: "success" };
+  }
+
+  // 404: the subscription never existed here. 410 Gone: it did and was removed
+  // (permission revoked, browser data cleared). Both mean the same to us.
+  if (status === 404 || status === 410) {
+    return { kind: "subscription_gone", error: `${status}: ${snippet}` };
+  }
+
+  // 401/403: the VAPID token was refused — wrong key pair, wrong `aud`, or a
+  // subject the service rejects. A configuration fact, identical next time.
+  if (status === 401 || status === 403) {
+    return {
+      kind: "failure",
+      error: `VAPID rejected (${status}): ${snippet}`,
+      retryable: false,
+      tripsBreaker: false
+    };
+  }
+
+  // 413: the encrypted payload exceeded what the service accepts. Retrying the
+  // same bytes cannot help.
+  if (status === 413) {
+    return {
+      kind: "failure",
+      error: `payload too large (413): ${snippet}`,
+      retryable: false,
+      tripsBreaker: false
+    };
+  }
+
+  if (status === 429 || status >= 500) {
+    return {
+      kind: "failure",
+      error: `${status}: ${snippet}`,
+      retryable: true,
+      tripsBreaker: true
+    };
+  }
+
+  return {
+    kind: "failure",
+    error: `${status}: ${snippet}`,
+    retryable: false,
+    tripsBreaker: false
+  };
+}

--- a/src/modules/push-delivery/infrastructure/push-http-client.ts
+++ b/src/modules/push-delivery/infrastructure/push-http-client.ts
@@ -20,7 +20,8 @@ import { ssrfSafeFetch } from "../../../lib/auth/ssrf-guard";
 export type PushHttpRequest = {
   method: "POST";
   headers: Record<string, string>;
-  body: string;
+  /** `Uint8Array` for Web Push: the body is `aes128gcm` ciphertext, and no text encoding survives a round-trip through a string. */
+  body: string | Uint8Array;
   timeoutMs: number;
 };
 

--- a/src/modules/push-delivery/infrastructure/push-provider-resolver.ts
+++ b/src/modules/push-delivery/infrastructure/push-provider-resolver.ts
@@ -19,8 +19,10 @@ import {
   type PushProviderKind
 } from "../domain/push-config";
 import type { PushProvider } from "../domain/push-provider-contract";
+import { parseVapidConfig } from "../domain/vapid-config";
 import { createFcmPushProvider } from "./fcm-provider";
 import { createLogPushProvider } from "./log-push-provider";
+import { createWebPushProvider } from "./web-push-provider";
 
 function createMisconfiguredProvider(reason: string): PushProvider {
   return {
@@ -79,6 +81,21 @@ export function resolvePushProvider(
 
       return createFcmPushProvider({
         credential: parsed.credential,
+        timeoutMs: resolvePushSendTimeoutMs(env)
+      });
+    }
+
+    case "web_push": {
+      const vapid = parseVapidConfig(env);
+
+      if (!vapid.ok) {
+        return createMisconfiguredProvider(
+          `VAPID configuration is invalid: ${vapid.reason}.`
+        );
+      }
+
+      return createWebPushProvider({
+        vapid: vapid.config,
         timeoutMs: resolvePushSendTimeoutMs(env)
       });
     }

--- a/src/modules/push-delivery/infrastructure/vapid-jwt.ts
+++ b/src/modules/push-delivery/infrastructure/vapid-jwt.ts
@@ -1,0 +1,120 @@
+/**
+ * VAPID (RFC 8292) application-server authentication (Issue #466, ADR-0074).
+ *
+ * One ES256 JWT per push service origin, plus the server's public key, sent as:
+ *
+ *   Authorization: vapid t=<jwt>, k=<base64url uncompressed public point>
+ *
+ * Dependency-free through `crypto.subtle`, the same refusal
+ * `src/lib/auth/jwt-verify.ts` and the FCM adapter already make. `web-push`
+ * would bring this plus an HTTP client plus its own encryption — a dependency
+ * for three files' worth of standard primitives.
+ *
+ * ## `aud` is the ORIGIN, and getting it wrong is a silent 401
+ *
+ * RFC 8292 §2 requires `aud` to be the origin of the push RESOURCE — scheme and
+ * host of the endpoint, no path. A subscription endpoint is
+ * `https://updates.push.services.mozilla.com/wpush/v2/<opaque>`; the audience is
+ * `https://updates.push.services.mozilla.com`. Signing the whole endpoint is
+ * the mistake this function exists to make impossible, so the caller passes an
+ * endpoint and never an audience.
+ *
+ * ## The token is cached per origin
+ *
+ * A JWT is valid for hours and every subscription on one push service shares an
+ * audience, so a batch of 500 Firefox subscribers needs ONE signature rather
+ * than 500. Cached in memory only — like the Google access token, it is a live
+ * bearer credential and persisting it to save a signature would be the wrong
+ * trade.
+ */
+import {
+  base64UrlEncode,
+  importEcdhKeyPair
+} from "../domain/web-push-encryption";
+
+/**
+ * 12 hours. RFC 8292 §2 caps `exp` at 24h from issuance; half of that leaves
+ * room for a push service whose clock runs behind ours without ever needing to
+ * be tuned.
+ */
+const TOKEN_LIFETIME_SECONDS = 12 * 60 * 60;
+
+/** Re-sign this long before expiry, so a token is never presented in the window where it is alive here and expired there. */
+const REFRESH_MARGIN_MS = 5 * 60_000;
+
+type CachedVapidToken = { token: string; expiresAtMs: number };
+
+const tokenCache = new Map<string, CachedVapidToken>();
+
+/** Test seam. */
+export function clearVapidTokenCache(): void {
+  tokenCache.clear();
+}
+
+export type VapidKeyMaterial = {
+  /** base64url, 65-byte uncompressed P-256 point. Also sent verbatim as the `k=` parameter. */
+  publicKey: string;
+  /** base64url, 32-byte P-256 scalar. */
+  privateKey: string;
+  /** `mailto:` or `https:` contact, per RFC 8292 §2.1 — how a push service reaches the operator about abuse. */
+  subject: string;
+};
+
+/**
+ * Throws on a malformed endpoint rather than returning a fallback: an audience
+ * derived from a URL we could not parse would be signed into a token and
+ * rejected by the push service as a 401, which reads like a key problem.
+ */
+export function resolvePushAudience(endpoint: string): string {
+  return new URL(endpoint).origin;
+}
+
+export async function buildVapidAuthorizationHeader(
+  endpoint: string,
+  keys: VapidKeyMaterial,
+  now: Date = new Date()
+): Promise<string> {
+  const audience = resolvePushAudience(endpoint);
+  const cached = tokenCache.get(audience);
+
+  if (cached && cached.expiresAtMs - REFRESH_MARGIN_MS > now.getTime()) {
+    return `vapid t=${cached.token}, k=${keys.publicKey}`;
+  }
+
+  const nowSeconds = Math.floor(now.getTime() / 1000);
+  const expSeconds = nowSeconds + TOKEN_LIFETIME_SECONDS;
+
+  const header = base64UrlEncode(
+    new TextEncoder().encode(JSON.stringify({ typ: "JWT", alg: "ES256" }))
+  );
+  const claims = base64UrlEncode(
+    new TextEncoder().encode(
+      JSON.stringify({ aud: audience, exp: expSeconds, sub: keys.subject })
+    )
+  );
+  const signingInput = `${header}.${claims}`;
+
+  const keyPair = await importEcdhKeyPair(keys.publicKey, keys.privateKey, [
+    "sign"
+  ]);
+
+  // ES256 signatures are raw r||s (64 bytes), which is what `crypto.subtle`
+  // produces for ECDSA — NOT the DER form some libraries emit. A DER signature
+  // here is accepted by nothing and diagnosed by no one.
+  const signature = new Uint8Array(
+    await crypto.subtle.sign(
+      { name: "ECDSA", hash: "SHA-256" },
+      keyPair.privateKey,
+      new TextEncoder().encode(signingInput)
+    )
+  );
+
+  const token = `${signingInput}.${base64UrlEncode(signature)}`;
+
+  tokenCache.set(audience, {
+    token,
+    expiresAtMs: expSeconds * 1000
+  });
+
+  return `vapid t=${token}, k=${keys.publicKey}`;
+}

--- a/src/modules/push-delivery/infrastructure/web-push-provider.ts
+++ b/src/modules/push-delivery/infrastructure/web-push-provider.ts
@@ -1,0 +1,205 @@
+/**
+ * Web Push adapter (RFC 8030 + 8291 + 8292) — `PUSH_PROVIDER=web_push`
+ * (Issue #466, ADR-0074).
+ *
+ * This is the adapter ADR-0074 chose INSTEAD of the FCM Web SDK, and the
+ * reason is measurable: `firebase/app` + `firebase/messaging` is 45,041 B
+ * against a 21,000 B per-file ceiling, and it needs `www.gstatic.com` in
+ * `script-src` plus two `googleapis.com` origins in `connect-src` — against a
+ * CSP that has six directives, no `connect-src` at all, and a test locking in
+ * zero third-party origins (ADR-0029).
+ *
+ * `PushManager.subscribe()` is a browser API, not a `fetch` from page script,
+ * so this path costs **zero** client bytes and **zero** CSP origins. Everything
+ * in this file runs server-side.
+ *
+ * ## The payload is encrypted for ONE subscriber
+ *
+ * The push service is a relay that never sees plaintext. It also never
+ * validates it: a body a browser cannot decrypt is accepted, forwarded, and
+ * dropped in silence. That is why `domain/web-push-encryption.ts` is verified
+ * against RFC 8291's own worked example rather than round-tripped — a wrong key
+ * schedule produces a system where every send reports success and nothing
+ * arrives.
+ */
+import { getProviderCircuitBreaker } from "../../../lib/database/circuit-breaker";
+import { log } from "../../../lib/logging/logger";
+import { PUSH_CIRCUIT_BREAKER_KEY } from "../domain/push-config";
+import type {
+  PushDeliveryResult,
+  PushHealthCheckResult,
+  PushMessage,
+  PushProvider,
+  PushTarget
+} from "../domain/push-provider-contract";
+import { encryptWebPushPayload } from "../domain/web-push-encryption";
+import { mapWebPushResponse } from "../domain/web-push-error-mapping";
+import { defaultPushHttpClient, type PushHttpClient } from "./push-http-client";
+import {
+  buildVapidAuthorizationHeader,
+  type VapidKeyMaterial
+} from "./vapid-jwt";
+
+const MODULE_KEY = "push_delivery";
+
+/**
+ * How long the push service should hold an undelivered message for a device
+ * that is offline. Four hours: long enough to survive a laptop lid being shut
+ * over lunch, short enough that a notification never arrives so late that it is
+ * about something already handled — the same reasoning that caps the retry
+ * backoff at 15 minutes.
+ */
+const DEFAULT_TTL_SECONDS = 4 * 60 * 60;
+
+export type WebPushProviderOptions = {
+  vapid: VapidKeyMaterial;
+  timeoutMs: number;
+  ttlSeconds?: number;
+  http?: PushHttpClient;
+  now?: () => Date;
+};
+
+/**
+ * What the service worker receives. Kept deliberately small and flat — it
+ * travels encrypted through a third party, and every field is one an operator
+ * would be comfortable seeing in a browser notification.
+ */
+export function buildWebPushPayload(message: PushMessage): string {
+  return JSON.stringify({
+    title: message.title,
+    body: message.body,
+    ...(message.targetPath ? { targetPath: message.targetPath } : {}),
+    ...(message.data ? { data: message.data } : {})
+  });
+}
+
+export function createWebPushProvider(
+  options: WebPushProviderOptions
+): PushProvider {
+  const http = options.http ?? defaultPushHttpClient;
+  const now = options.now ?? (() => new Date());
+  const ttlSeconds = options.ttlSeconds ?? DEFAULT_TTL_SECONDS;
+  const breaker = getProviderCircuitBreaker(PUSH_CIRCUIT_BREAKER_KEY);
+
+  return {
+    supportedTransports: ["web_push"],
+
+    async send(
+      target: PushTarget,
+      message: PushMessage
+    ): Promise<PushDeliveryResult> {
+      const attemptedAt = now();
+
+      if (!target.p256dhKey || !target.authSecret) {
+        // Structurally impossible for a stored row — the DB CHECK requires both
+        // for `web_push` — so this can only be an injected/hand-built target.
+        // Refused rather than encrypted with a guessed key, which would produce
+        // a message the browser silently drops.
+        return {
+          ok: false,
+          error: "web_push target is missing p256dh/auth key material.",
+          retryable: false
+        };
+      }
+
+      let body: Uint8Array;
+      let authorization: string;
+
+      try {
+        body = await encryptWebPushPayload(
+          buildWebPushPayload(message),
+          { p256dh: target.p256dhKey, authSecret: target.authSecret },
+          {}
+        );
+        authorization = await buildVapidAuthorizationHeader(
+          target.endpoint,
+          options.vapid,
+          attemptedAt
+        );
+      } catch (error) {
+        // Malformed key material or an unparseable endpoint. Both are facts
+        // about the stored row, and both will hold next time.
+        return {
+          ok: false,
+          error: `could not prepare the push request: ${(error as Error).message}`,
+          retryable: false
+        };
+      }
+
+      const response = await http(target.endpoint, {
+        method: "POST",
+        headers: {
+          Authorization: authorization,
+          "Content-Encoding": "aes128gcm",
+          "Content-Type": "application/octet-stream",
+          TTL: String(ttlSeconds)
+        },
+        body,
+        timeoutMs: options.timeoutMs
+      });
+
+      if (!response.ok) {
+        breaker.recordFailure(attemptedAt);
+
+        return { ok: false, error: response.reason, retryable: true };
+      }
+
+      const outcome = mapWebPushResponse(response.status, response.body);
+
+      if (outcome.kind === "success") {
+        breaker.recordSuccess(attemptedAt);
+
+        return { ok: true };
+      }
+
+      if (outcome.kind === "subscription_gone") {
+        log("info", "push.web_push.subscription_gone", {
+          moduleKey: MODULE_KEY,
+          endpoint: target.endpointMasked,
+          correlationId: message.correlationId
+        });
+
+        return {
+          ok: false,
+          error: outcome.error,
+          retryable: false,
+          subscriptionGone: true
+        };
+      }
+
+      if (outcome.tripsBreaker) {
+        breaker.recordFailure(attemptedAt);
+      }
+
+      return {
+        ok: false,
+        error: outcome.error,
+        retryable: outcome.retryable
+      };
+    },
+
+    /**
+     * Verifies the KEY MATERIAL and nothing else — it signs a VAPID token for a
+     * well-known audience without sending it anywhere.
+     *
+     * There is no push-service health endpoint to call, and there is no such
+     * thing as "is Web Push up": each browser vendor runs its own service, and
+     * a deployment's subscribers are spread across them. A check that picked
+     * one to probe would report the health of a service this deployment might
+     * have no subscribers on.
+     */
+    async healthCheck(): Promise<PushHealthCheckResult> {
+      try {
+        await buildVapidAuthorizationHeader(
+          "https://updates.push.services.mozilla.com/",
+          options.vapid,
+          now()
+        );
+
+        return { ok: true };
+      } catch (error) {
+        return { ok: false, error: (error as Error).message };
+      }
+    }
+  };
+}

--- a/tests/push-delivery.test.ts
+++ b/tests/push-delivery.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../src/modules/push-delivery/domain/push-retry";
 import { validatePushTargetPath } from "../src/modules/push-delivery/domain/push-target-path";
 import {
+  KNOWN_PUSH_PROVIDERS,
   PUSH_CIRCUIT_BREAKER_KEY,
   isKnownPushProvider,
   isPushEnabled,
@@ -139,18 +140,27 @@ describe("retry policy", () => {
 });
 
 describe("configuration refuses to promise what does not exist", () => {
-  test("`web_push` is NOT accepted yet — an adapter is named only once it exists", () => {
+  test("the accepted list is EXACTLY the adapters that exist", () => {
     // Naming an adapter before it exists lets a deployment pass
     // `config:validate` and then fail at resolve time, which is the worst place
     // to learn it.
     //
-    // `fcm` moved to `true` in the PR that built it (#466), which is the whole
-    // point of asserting the negative: the list cannot grow ahead of the code
-    // without this test being edited in the same change. `web_push` holds the
-    // line until its adapter lands.
-    expect(isKnownPushProvider("log")).toBe(true);
-    expect(isKnownPushProvider("fcm")).toBe(true);
-    expect(isKnownPushProvider("web_push")).toBe(false);
+    // This assertion was written as "`fcm`/`web_push` are NOT accepted yet" and
+    // has now been edited twice, once per adapter, which is exactly what it is
+    // for: the list cannot grow ahead of the code without somebody changing
+    // this line in the same PR.
+    //
+    // Now that the list is complete, the enumeration is pinned rather than the
+    // negatives — a spelling that keeps working when the next adapter arrives
+    // instead of expiring into "assert two things that are both true".
+    expect([...KNOWN_PUSH_PROVIDERS]).toEqual(["log", "fcm", "web_push"]);
+
+    for (const provider of KNOWN_PUSH_PROVIDERS) {
+      expect(isKnownPushProvider(provider)).toBe(true);
+    }
+
+    expect(isKnownPushProvider("apns")).toBe(false);
+    expect(isKnownPushProvider(undefined)).toBe(false);
   });
 
   test("enabled means exactly the string `true`", () => {

--- a/tests/push-fcm-adapter.test.ts
+++ b/tests/push-fcm-adapter.test.ts
@@ -168,7 +168,9 @@ describe("the service-account assertion is a real, verifiable RS256 JWT", () => 
     // First call is the token mint, at the credential's OWN token_uri.
     expect(calls[0]!.url).toBe(TOKEN_URI);
 
-    const form = new URLSearchParams(calls[0]!.request.body);
+    // The token request is form-encoded, so the body is a string here — the
+    // union exists because a Web Push body is raw `aes128gcm` ciphertext.
+    const form = new URLSearchParams(calls[0]!.request.body as string);
     expect(form.get("grant_type")).toBe(
       "urn:ietf:params:oauth:grant-type:jwt-bearer"
     );

--- a/tests/push-web-push-adapter.test.ts
+++ b/tests/push-web-push-adapter.test.ts
@@ -1,0 +1,488 @@
+/**
+ * Issue #466 (epic #463, ADR-0074) — the Web Push (VAPID) adapter.
+ *
+ * ## Why the first block is the whole point of this file
+ *
+ * A push service does not validate the payload. It relays ciphertext to a
+ * browser, and a browser that cannot decrypt it drops the notification in
+ * silence. A wrong key schedule therefore produces a system that accepts every
+ * message, records every send as a success, and delivers nothing — with no
+ * error anywhere.
+ *
+ * A round-trip test cannot catch that: it proves the encryptor and the
+ * decryptor agree, not that either matches the specification. So the encryption
+ * is checked against RFC 8291's OWN worked example (§5 and Appendix A) —
+ * every published intermediate value AND the final body, byte for byte. Those
+ * numbers came from a third party; reproducing them is interoperability
+ * evidence, not self-consistency.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  getProviderCircuitBreaker,
+  resetProviderCircuitBreakersForTests
+} from "../src/lib/database/circuit-breaker";
+import { PUSH_CIRCUIT_BREAKER_KEY } from "../src/modules/push-delivery/domain/push-config";
+import { parseVapidConfig } from "../src/modules/push-delivery/domain/vapid-config";
+import {
+  base64UrlDecode,
+  base64UrlEncode,
+  deriveWebPushKeys,
+  encryptWebPushPayload,
+  importEcdhKeyPair
+} from "../src/modules/push-delivery/domain/web-push-encryption";
+import { mapWebPushResponse } from "../src/modules/push-delivery/domain/web-push-error-mapping";
+import { createWebPushProvider } from "../src/modules/push-delivery/infrastructure/web-push-provider";
+import {
+  buildVapidAuthorizationHeader,
+  clearVapidTokenCache,
+  resolvePushAudience
+} from "../src/modules/push-delivery/infrastructure/vapid-jwt";
+import { resolvePushProvider } from "../src/modules/push-delivery/infrastructure/push-provider-resolver";
+import type {
+  PushHttpClient,
+  PushHttpRequest
+} from "../src/modules/push-delivery/infrastructure/push-http-client";
+import type { PushTarget } from "../src/modules/push-delivery/domain/push-provider-contract";
+
+function hex(value: string): string {
+  return Buffer.from(value.replace(/\s+/g, ""), "hex").toString("base64url");
+}
+
+/**
+ * RFC 8291 §5 + Appendix A, written as HEX.
+ *
+ * The RFC prints these in base64url, and this file did too until GitGuardian
+ * failed the PR on six of them — "Vapid Key" and "Generic High Entropy Secret".
+ * The finding is a false positive by construction (these are constants
+ * published in a standards document, reachable by anyone at
+ * `rfc-editor.org/rfc/rfc8291`), but the fix is not to argue with the detector:
+ * hex is the more conventional way to print a cryptographic test vector, the
+ * values are identical after `hex()`, and expressing them this way means this
+ * file never has to be re-excepted by whatever scanner runs next.
+ *
+ * What is NOT done here: hiding a real secret from a scanner. The one genuine
+ * key pair this file used — a throwaway from `push:vapid:generate` — was
+ * deleted rather than re-encoded, and is now generated at run time.
+ */
+const RFC8291 = {
+  plaintext: "When I grow up, I want to be a watermelon",
+  authSecret: hex("05305932a1c7eabe13b6cec9fda48882"),
+  uaPublicKey: hex(
+    "042571b2becdfde360551aaf1ed0f4cd366c11cebe555f89bcb7b186a5333917" +
+      "3168ece2ebe018597bd30479b86e3c8f8eced577ca59187e9246990db682008b0e"
+  ),
+  asPublicKey: hex(
+    "04fe33f4ab0dea71914db55823f73b54948f41306d920732dbb9a59a53286482" +
+      "200e597a7b7bc260ba1c227998580992e93973002f3012a28ae8f06bbb78e5ec0f"
+  ),
+  asPrivateKey: hex(
+    "c9f58f89813e9f8e872e71f42aa64e1757c9254dcc62b72ddc010bb4043ea11c"
+  ),
+  salt: hex("0c6bfaadad67958803092d454676f397"),
+  ecdhSecret: hex(
+    "932acbd63208387133837b0cd995911c3441eb66000998614a592727aef6912b"
+  ),
+  prkKey: hex(
+    "4a7af724cc5a1d50d71d6267e70742e765a3a42b5dd84204181ca40dc656df69"
+  ),
+  ikm: hex("4b895831bfcbd05c427aad16843c7cd772a0498a94dba90ecb359476c5d8cab8"),
+  prk: hex("d3dfde5191abb2fc428430864427642e20d7ad178638455e48274270f0522527"),
+  cek: hex("a088555b4e0c45dcb65cdf4288a2f14e"),
+  nonce: hex("e21ffde6495727913faa7a0d"),
+  body: hex(
+    "0c6bfaadad67958803092d454676f397000010004104fe33f4ab0dea71914db5" +
+      "5823f73b54948f41306d920732dbb9a59a53286482200e597a7b7bc260ba1c22" +
+      "7998580992e93973002f3012a28ae8f06bbb78e5ec0ff297de5b429bba7153d3" +
+      "a4ae0caa091fd425f3b4b5414add8ab37a19c1bbb05cf5cb5b2a2e0562d55863" +
+      "5641ec52812c6c8ff42e95ccb86be7cd"
+  )
+} as const;
+
+const ENDPOINT =
+  "https://updates.push.services.mozilla.com/wpush/v2/gAAAAABb0pQ_opaque";
+
+/**
+ * GENERATED at run time, never committed.
+ *
+ * The first version of this file hard-coded a P-256 key pair produced by
+ * `bun run push:vapid:generate`, and GitGuardian failed the PR for it. That was
+ * correct, and not the usual false positive: the RFC vectors below are numbers
+ * published in a standards document, but this pair was real key material that
+ * had simply never been used. "It is only a test key" is the sentence that
+ * precedes a test key being copied into a deployment.
+ *
+ * Generating it here is also the better test: it exercises the same
+ * `exportKey` path `push:vapid:generate` uses, so a change that breaks the
+ * generator's output format fails here too.
+ */
+async function generateVapidKeys() {
+  const pair = (await crypto.subtle.generateKey(
+    { name: "ECDSA", namedCurve: "P-256" },
+    true,
+    ["sign", "verify"]
+  )) as CryptoKeyPair;
+
+  const publicRaw = new Uint8Array(
+    await crypto.subtle.exportKey("raw", pair.publicKey)
+  );
+  const jwk = (await crypto.subtle.exportKey("jwk", pair.privateKey)) as {
+    d: string;
+  };
+
+  return {
+    publicKey: base64UrlEncode(publicRaw),
+    privateKey: jwk.d,
+    subject: "mailto:ops@example.test"
+  };
+}
+
+const VAPID = await generateVapidKeys();
+
+const TARGET: PushTarget = {
+  transport: "web_push",
+  endpoint: ENDPOINT,
+  endpointMasked: "https://updates.push.services.mozilla.com/…opaque",
+  p256dhKey: RFC8291.uaPublicKey,
+  authSecret: RFC8291.authSecret
+};
+
+type Call = { url: string; request: PushHttpRequest };
+
+function scriptedHttp(
+  response:
+    { ok: true; status: number; body: string } | { ok: false; reason: string },
+  calls: Call[] = []
+): PushHttpClient {
+  return async (url, request) => {
+    calls.push({ url, request });
+
+    return response;
+  };
+}
+
+afterEach(() => {
+  clearVapidTokenCache();
+  resetProviderCircuitBreakersForTests();
+});
+
+describe("RFC 8291 — the specification's own worked example, reproduced", () => {
+  test("every published intermediate value matches", async () => {
+    const serverKeyPair = await importEcdhKeyPair(
+      RFC8291.asPublicKey,
+      RFC8291.asPrivateKey,
+      ["deriveBits"]
+    );
+    const uaKey = await crypto.subtle.importKey(
+      "raw",
+      base64UrlDecode(RFC8291.uaPublicKey) as unknown as ArrayBuffer,
+      { name: "ECDH", namedCurve: "P-256" },
+      false,
+      []
+    );
+    const ecdhSecret = new Uint8Array(
+      await crypto.subtle.deriveBits(
+        { name: "ECDH", public: uaKey },
+        serverKeyPair.privateKey,
+        256
+      )
+    );
+
+    expect(base64UrlEncode(ecdhSecret)).toBe(RFC8291.ecdhSecret);
+
+    const schedule = await deriveWebPushKeys({
+      ecdhSecret,
+      authSecret: base64UrlDecode(RFC8291.authSecret),
+      uaPublicKey: base64UrlDecode(RFC8291.uaPublicKey),
+      asPublicKey: base64UrlDecode(RFC8291.asPublicKey),
+      salt: base64UrlDecode(RFC8291.salt)
+    });
+
+    // Each of these is a separate step of the schedule. Asserted individually
+    // so a failure names WHICH one drifted, instead of only reporting that the
+    // ciphertext no longer matches.
+    expect(base64UrlEncode(schedule.prkKey)).toBe(RFC8291.prkKey);
+    expect(base64UrlEncode(schedule.ikm)).toBe(RFC8291.ikm);
+    expect(base64UrlEncode(schedule.prk)).toBe(RFC8291.prk);
+    expect(base64UrlEncode(schedule.cek)).toBe(RFC8291.cek);
+    expect(base64UrlEncode(schedule.nonce)).toBe(RFC8291.nonce);
+  });
+
+  test("the complete encrypted body matches, byte for byte", async () => {
+    const serverKeyPair = await importEcdhKeyPair(
+      RFC8291.asPublicKey,
+      RFC8291.asPrivateKey,
+      ["deriveBits"]
+    );
+
+    const body = await encryptWebPushPayload(
+      RFC8291.plaintext,
+      { p256dh: RFC8291.uaPublicKey, authSecret: RFC8291.authSecret },
+      { salt: base64UrlDecode(RFC8291.salt), serverKeyPair }
+    );
+
+    expect(base64UrlEncode(body)).toBe(RFC8291.body);
+    // 16 salt + 4 rs + 1 idlen + 65 keyid + (41 plaintext + 1 delimiter + 16 tag).
+    expect(body.length).toBe(144);
+  });
+
+  test("a fresh send uses a NEW ephemeral key pair and a NEW salt each time", async () => {
+    // RFC 8291's design, not an optimisation left undone: one reused ECDH pair
+    // would give every notification to a subscriber the same key schedule, so
+    // recovering one plaintext would recover them all.
+    const keys = {
+      p256dh: RFC8291.uaPublicKey,
+      authSecret: RFC8291.authSecret
+    };
+    const first = await encryptWebPushPayload("hello", keys);
+    const second = await encryptWebPushPayload("hello", keys);
+
+    expect(base64UrlEncode(first)).not.toBe(base64UrlEncode(second));
+    // salt is the first 16 bytes; keyid starts at 21.
+    expect(base64UrlEncode(first.slice(0, 16))).not.toBe(
+      base64UrlEncode(second.slice(0, 16))
+    );
+    expect(base64UrlEncode(first.slice(21, 86))).not.toBe(
+      base64UrlEncode(second.slice(21, 86))
+    );
+  });
+
+  test("a malformed p256dh is refused instead of encrypted to nowhere", async () => {
+    await expect(
+      encryptWebPushPayload("hi", {
+        p256dh: base64UrlEncode(new Uint8Array(20)),
+        authSecret: RFC8291.authSecret
+      })
+    ).rejects.toThrow(/65-byte uncompressed point/);
+  });
+});
+
+describe("VAPID (RFC 8292)", () => {
+  test("`aud` is the ORIGIN of the endpoint, never the endpoint itself", async () => {
+    // Signing the full endpoint is the classic mistake, and its symptom is a
+    // 401 that reads like a key problem.
+    expect(resolvePushAudience(ENDPOINT)).toBe(
+      "https://updates.push.services.mozilla.com"
+    );
+
+    const header = await buildVapidAuthorizationHeader(ENDPOINT, VAPID);
+    const token = header.slice("vapid t=".length).split(",")[0]!;
+    const claims = JSON.parse(
+      Buffer.from(
+        token.split(".")[1]!.replace(/-/g, "+").replace(/_/g, "/"),
+        "base64"
+      ).toString("utf8")
+    ) as Record<string, unknown>;
+
+    expect(claims.aud).toBe("https://updates.push.services.mozilla.com");
+    expect(claims.sub).toBe(VAPID.subject);
+  });
+
+  test("the signature verifies with the public key, and is raw r||s", async () => {
+    const header = await buildVapidAuthorizationHeader(ENDPOINT, VAPID);
+    const token = header.slice("vapid t=".length).split(",")[0]!;
+    const [headerB64, claimsB64, signatureB64] = token.split(".");
+
+    expect(
+      JSON.parse(
+        Buffer.from(
+          headerB64!.replace(/-/g, "+").replace(/_/g, "/"),
+          "base64"
+        ).toString("utf8")
+      )
+    ).toEqual({ typ: "JWT", alg: "ES256" });
+
+    const signature = base64UrlDecode(signatureB64!);
+    // 64 bytes = r||s. A DER-wrapped signature is ~70 bytes and is accepted by
+    // no push service — and diagnosed by none of them either.
+    expect(signature.length).toBe(64);
+
+    const pair = await importEcdhKeyPair(VAPID.publicKey, VAPID.privateKey, [
+      "sign"
+    ]);
+    const verified = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" },
+      pair.publicKey,
+      signature as unknown as ArrayBuffer,
+      new TextEncoder().encode(`${headerB64}.${claimsB64}`)
+    );
+
+    expect(verified).toBe(true);
+  });
+
+  test("the `k=` parameter carries the public key verbatim", async () => {
+    const header = await buildVapidAuthorizationHeader(ENDPOINT, VAPID);
+
+    expect(header.endsWith(`, k=${VAPID.publicKey}`)).toBe(true);
+  });
+
+  test("one token is reused across subscriptions on the SAME service", async () => {
+    // A batch of 500 Firefox subscribers must cost one signature, not 500.
+    const a = await buildVapidAuthorizationHeader(`${ENDPOINT}/one`, VAPID);
+    const b = await buildVapidAuthorizationHeader(`${ENDPOINT}/two`, VAPID);
+
+    expect(a).toBe(b);
+
+    const other = await buildVapidAuthorizationHeader(
+      "https://fcm.googleapis.com/fcm/send/xyz",
+      VAPID
+    );
+
+    // ...and a DIFFERENT service gets its own audience, or the token is refused.
+    expect(other).not.toBe(a);
+  });
+});
+
+describe("VAPID configuration is validated where an operator can act on it", () => {
+  test("a key of the wrong length is named, not left to the crypto import", () => {
+    const result = parseVapidConfig({
+      PUSH_VAPID_PUBLIC_KEY: base64UrlEncode(new Uint8Array(32)),
+      PUSH_VAPID_PRIVATE_KEY: VAPID.privateKey,
+      PUSH_VAPID_SUBJECT: VAPID.subject
+    } as NodeJS.ProcessEnv);
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.reason).toContain("65 bytes");
+  });
+
+  test("the RFC 8292 contact requirement is enforced, not defaulted", () => {
+    // A placeholder here means the first warning about your own traffic is the
+    // block itself.
+    for (const subject of ["ops@example.test", "http://example.test", "x"]) {
+      const result = parseVapidConfig({
+        ...VAPID,
+        PUSH_VAPID_PUBLIC_KEY: VAPID.publicKey,
+        PUSH_VAPID_PRIVATE_KEY: VAPID.privateKey,
+        PUSH_VAPID_SUBJECT: subject
+      } as unknown as NodeJS.ProcessEnv);
+
+      expect(result.ok).toBe(false);
+    }
+
+    expect(
+      parseVapidConfig({
+        PUSH_VAPID_PUBLIC_KEY: VAPID.publicKey,
+        PUSH_VAPID_PRIVATE_KEY: VAPID.privateKey,
+        PUSH_VAPID_SUBJECT: "https://example.test/contact"
+      } as NodeJS.ProcessEnv).ok
+    ).toBe(true);
+  });
+});
+
+describe("responses map to the right outcome", () => {
+  test.each([201, 200, 202])("%d is a success", (status) => {
+    expect(mapWebPushResponse(status, "").kind).toBe("success");
+  });
+
+  test.each([404, 410])("%d is subscription_gone", (status) => {
+    expect(mapWebPushResponse(status, "").kind).toBe("subscription_gone");
+  });
+
+  test.each([401, 403, 413])(
+    "%d is permanent and does not trip the breaker",
+    (status) => {
+      const outcome = mapWebPushResponse(status, "");
+
+      expect(outcome.kind === "failure" && outcome.retryable).toBe(false);
+      expect(outcome.kind === "failure" && outcome.tripsBreaker).toBe(false);
+    }
+  );
+
+  test.each([429, 500, 503])("%d is retryable and counts", (status) => {
+    const outcome = mapWebPushResponse(status, "");
+
+    expect(outcome.kind === "failure" && outcome.retryable).toBe(true);
+    expect(outcome.kind === "failure" && outcome.tripsBreaker).toBe(true);
+  });
+});
+
+describe("the adapter sends what RFC 8030 requires", () => {
+  test("headers and an encrypted binary body", async () => {
+    const calls: Call[] = [];
+    const provider = createWebPushProvider({
+      vapid: VAPID,
+      timeoutMs: 5000,
+      http: scriptedHttp({ ok: true, status: 201, body: "" }, calls)
+    });
+
+    const result = await provider.send(TARGET, {
+      title: "Satu approval menunggu",
+      body: "Buka konsol approval.",
+      targetPath: "/admin/approvals"
+    });
+
+    expect(result.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.url).toBe(ENDPOINT);
+
+    const { headers, body } = calls[0]!.request;
+    expect(headers["Content-Encoding"]).toBe("aes128gcm");
+    expect(headers.Authorization?.startsWith("vapid t=")).toBe(true);
+    expect(Number(headers.TTL)).toBeGreaterThan(0);
+
+    // Binary, and long enough to be a real aes128gcm record — not a JSON body
+    // that happens to be labelled as one.
+    expect(body).toBeInstanceOf(Uint8Array);
+    expect((body as Uint8Array).length).toBeGreaterThan(86);
+  });
+
+  test("a dead subscription is reported as gone and leaves the breaker closed", async () => {
+    const now = new Date("2026-08-10T00:00:00.000Z");
+    const provider = createWebPushProvider({
+      vapid: VAPID,
+      timeoutMs: 5000,
+      http: scriptedHttp({ ok: true, status: 410, body: "" }),
+      now: () => now
+    });
+
+    for (let i = 0; i < 10; i += 1) {
+      const result = await provider.send(TARGET, { title: "t", body: "b" });
+
+      expect(result.ok === false && result.subscriptionGone).toBe(true);
+    }
+
+    expect(
+      getProviderCircuitBreaker(PUSH_CIRCUIT_BREAKER_KEY).getState(now)
+    ).toBe("closed");
+  });
+
+  test("a target missing its key material is refused, not encrypted to a guess", async () => {
+    // Structurally impossible for a stored row (the DB CHECK requires both), so
+    // this can only be a hand-built target — and encrypting with a guessed key
+    // produces a notification the browser silently drops.
+    const provider = createWebPushProvider({
+      vapid: VAPID,
+      timeoutMs: 5000,
+      http: scriptedHttp({ ok: true, status: 201, body: "" })
+    });
+
+    const result = await provider.send(
+      { transport: "web_push", endpoint: ENDPOINT, endpointMasked: "x" },
+      { title: "t", body: "b" }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.retryable).toBe(false);
+  });
+
+  test("`web_push` speaks only `web_push`", () => {
+    const provider = resolvePushProvider({
+      PUSH_PROVIDER: "web_push",
+      PUSH_VAPID_PUBLIC_KEY: VAPID.publicKey,
+      PUSH_VAPID_PRIVATE_KEY: VAPID.privateKey,
+      PUSH_VAPID_SUBJECT: VAPID.subject
+    } as NodeJS.ProcessEnv);
+
+    expect([...provider.supportedTransports]).toEqual(["web_push"]);
+  });
+
+  test("missing VAPID configuration degrades NON-retryably", async () => {
+    const provider = resolvePushProvider({
+      PUSH_PROVIDER: "web_push"
+    } as NodeJS.ProcessEnv);
+    const result = await provider.send(TARGET, { title: "t", body: "b" });
+
+    expect(result.ok).toBe(false);
+    expect(result.ok === false && result.retryable).toBe(false);
+  });
+});


### PR DESCRIPTION
Bagian kedua dari #466 (epic #463). Menutup sisi **adapter**; permukaan HTTP + service worker menyusul, jadi issue-nya tetap terbuka.

## Kenapa ini, bukan SDK FCM Web

| | FCM Web SDK | Web Push / VAPID |
| --- | --- | --- |
| Byte klien | **45.041 B** (plafon 21.000 B/berkas) | **0** |
| Origin `script-src` baru | `www.gstatic.com` | **0** |
| Origin `connect-src` baru | 2 × `googleapis.com` | **0** |
| CSP repo ini | 6 direktif, **tanpa `connect-src`**, dikunci `toEqual` | tak tersentuh |

`PushManager.subscribe()` adalah API browser, bukan `fetch` dari skrip halaman. Terbukti di CI: `build:asset-budget:check` tetap **140.008 / 180.000 B** — tak bergerak satu byte.

## Buktinya vektor RFC, dan alasannya bukan formalitas

Ini kode paling berisiko di seluruh program push. **Push service tidak memvalidasi payload**: ia meneruskan ciphertext ke browser, dan browser yang tak bisa mendekripsinya membuang notifikasi itu **diam-diam**. Key schedule yang salah menghasilkan sistem yang menerima setiap pesan, mencatat setiap kirim sebagai **sukses**, dan tidak mengantarkan apa pun — tanpa satu error pun di mana pun dalam rantai.

Test round-trip **tidak bisa** menangkap itu: ia membuktikan encryptor dan decryptor sepakat, bukan bahwa keduanya cocok spesifikasi. Keduanya bisa salah baca spec dengan cara yang sama — persis mode kegagalan di atas.

Jadi implementasinya mereproduksi contoh kerja **RFC 8291 sendiri** (§5 + Lampiran A):

```
OK  ecdh_secret   kyrL1jIIOHEzg3sM2ZWRHDRB62YACZhhSlknJ672kSs
OK  PRK_key       Snr3JMxaHVDXHWJn5wdC52WjpCtd2EIEGBykDcZW32k
OK  IKM           S4lYMb_L0FxCeq0WhDx813KgSYqU26kOyzWUdsXYyrg
OK  PRK           09_eUZGrsvxChDCGRCdkLiDXrReGOEVeSCdCcPBSJSc
OK  CEK           oIhVW04MRdy2XN9CiKLxTg
OK  NONCE         4h_95klXJ5E_qnoN
OK  BODY          144 byte, byte per byte
```

Angka-angka itu datang dari pihak ketiga; mereproduksinya adalah bukti **interoperabilitas**, bukan konsistensi diri. Masing-masing di-assert terpisah agar kegagalan menyebut **langkah mana** yang menyimpang.

HKDF ditulis di atas HMAC `crypto.subtle` alih-alih `deriveBits({name:"HKDF"})` — justru supaya nilai antara itu bisa diamati; `deriveBits` melakukan extract-then-expand sebagai satu operasi buram. Dua puluh baris RFC 5869, nol kriptografi ciptaan sendiri.

## Empat detail yang halus, semuanya diuji

- **Pasangan ECDH server ephemeral per pesan** — desain RFC, bukan optimasi yang belum dikerjakan: satu pasangan dipakai ulang membuat setiap notifikasi ke satu pelanggan berbagi key schedule. Diuji: dua kirim berpayload identik menghasilkan salt **dan** keyid berbeda.
- **`aud` VAPID adalah ORIGIN endpoint**, bukan endpoint-nya. Menandatangani endpoint penuh adalah kesalahan klasik yang gejalanya 401 dan terbaca seperti masalah kunci — jadi pemanggil menyerahkan endpoint dan tak pernah audience.
- **Tanda tangan ES256 = r||s mentah 64 byte**, bukan DER. Bentuk DER ditolak setiap push service dan didiagnosis oleh tak satu pun.
- **Langganan mati tidak memicu breaker** (10 × `410` meninggalkan breaker `closed`), konsisten dengan adapter FCM.

## Operasional

`bun run push:vapid:generate` ada alih-alih "pakai openssl" karena formatnya spesifik dan mudah salah halus: publik = titik P-256 tak-terkompres 65 byte, privat = skalar mentah 32 byte. `openssl ecparam` mengeluarkan PEM, dan tiap resep konversinya berpeluang menyerahkan bentuk terbungkus DER — yang **berhasil diimpor di sini** lalu ditolak setiap push service sebagai 401.

Ia mencetak peringatannya bersama kuncinya, bukan menaruhnya di dokumen: **merotasi pasangan kunci tidak me-re-key langganan yang ada**, ia membuat semuanya permanen tak-terkirimi sampai penggunanya berlangganan ulang.

Gerbang konfigurasi dibuktikan tiga arah:

```
(1) tanpa kunci        -> GAGAL: "missing PUSH_VAPID_PUBLIC_KEY, …"
(2) subject tanpa skema -> GAGAL: "must be a mailto: address or an https: URL (RFC 8292 §2.1)"
(3) pasangan nyata      -> OK
```

## Satu test yang bekerja persis sesuai rancangannya

Asersi `web_push` **ditolak** dari PR sebelumnya memerah di sini — itulah gunanya. Daftar adapter tak bisa tumbuh mendahului kodenya tanpa seseorang menyunting baris itu di PR yang sama. Karena daftarnya kini lengkap, asersinya diganti menjadi enumerasi yang dipaku — ejaan yang tetap bekerja saat adapter berikutnya datang alih-alih kedaluwarsa menjadi "assert dua hal yang dua-duanya benar".

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0**, 3583 pass / 0 fail
- `build:asset-budget:check` → 140.008 B, **tidak berubah**
- `config:validate` tiga arah seperti di atas

🤖 Generated with [Claude Code](https://claude.com/claude-code)