### PR TITLE
docs(state,program): putaran lanjutan dicatat, dan dokumen program berhenti menjanjikan helper yang tak pernah ada (#423)

### DIFF
--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -356,6 +356,77 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 ## 4. Backlog / langkah berikutnya
 
+- **PUTARAN 10 Agustus 2026 (lanjutan) — kedua pemblokir #468 diputuskan, #468
+  ditutup, dan satu cacat konkurensi ditemukan sambil jalan.** Empat PR
+  (#482/#484/#485 + entri ini), dua issue ditutup (#468, #483), satu issue baru
+  difile (#483) dari temuan yang tidak diminta siapa pun.
+
+  **Yang diputuskan, dan kenapa keduanya butuh jawaban berbeda.**
+  `TABLES_PREDATING_THE_RULE` tidak bisa membedakan tabel yang **belum**
+  dideskripsikan dari yang **tidak bisa**; keduanya satu baris, dan selama
+  begitu hitungannya berhenti bisa dibaca sebagai utang.
+  `awcms_edge_cache_purges` (#479) mendapat registry kedua ber-`ownerPath`
+  ([ADR-0076](adr/0076-infrastructure-tables-may-hold-lifecycle-descriptors.md)),
+  dengan `ownerOfFile()` — fungsi yang sama yang dipakai
+  `modules:table-writes:check` — sebagai penentu siapa boleh ada di sana;
+  `awcms_sync_outbox` (#477) pindah ke `BOUNDED_BY_DESIGN` sebagai entri
+  pertamanya, satu-satunya yang premisnya diperiksa mesin.
+
+  **Satu premis issue sendiri ternyata keliru.** #479 menulis bahwa tak ada yang
+  menghapus `awcms_edge_cache_purges`; `bun run edge-cache:purge` sudah
+  memangkas baris `done` sejak ADR-0042. Yang hilang adalah kemampuan
+  MENYATAKANNYA. Koreksi itu mengubah bentuk keputusannya — dari "tulis purge"
+  menjadi "beri kontraknya cara menyebut pemilik non-modul".
+
+  **Temuan yang tak diminta: lockout login bukan atomik** (#483). Jalur password
+  memakai read-modify-write di JS, jadi K percobaan gagal PARALEL berbiaya SATU
+  increment — diukur terhadap PostgreSQL nyata: empat percobaan → penghitung
+  `1`. Lebih buruk dari cacatnya: **empat dokumen menyatakannya "atomik di DB"**,
+  salah satunya menamai persis bentuk yang seharusnya dihindari, dan
+  `rate-limit.ts` menyandarkan postur fail-open Redis-nya pada kalimat itu.
+  Semua diperbaiki, dan kini menyebut statement-nya alih-alih kata "atomik".
+
+  **Gerbang yang hijau di atas jawaban yang salah, dua kali.**
+  `checkLoginLockoutImplemented` (severity `critical`) hanya memanggil fungsi
+  murni — hijau dua tahun di atas lockout yang bisa ditahan di satu; kini ia
+  memeriksa mekanismenya. Dan seluruh test lockout murni domain, **nol**
+  menaikkan penghitung lewat rute nyata, jadi suite-nya tidak akan pernah
+  melihat cacat itu maupun perbaikannya.
+
+  **Yang DITOLAK, dengan alasannya:**
+
+  1. **Melonggarkan `ownerModuleKey` menjadi opsional** — menghemat satu berkas
+     dan membuat setiap deskriptor modul kehilangan penjagaannya: deskriptor
+     yang LUPA menyebut pemilik berhenti jadi kesalahan dan mulai berarti
+     "infrastruktur". Kesalahan ketik menjadi klaim kepemilikan.
+  2. **Menetapkan `awcms_edge_cache_purges` ke salah satu dari tiga modul
+     penulisnya** — sudah ditolak putaran sebelumnya; tetap ditolak.
+  3. **Menjadikan `src/lib/edge-cache/` sebuah modul** —
+     [ADR-0043](adr/0043-lib-boundary-and-module-presentation-layer.md) memerahkan
+     namespace `src/lib/<x>/` yang bertabrakan dengan `moduleKey`, dan
+     `scripts/module-job-registry-check.ts` sudah menolak "buat modul demi
+     kenyamanan dokumentasi" untuk tabel yang sama. Tetap terbuka sebagai
+     keputusan arsitektural, bukan sebagai cara menghijaukan gerbang.
+  4. **Tabel lockout GLOBAL tanpa RLS untuk menutup #430 lebih awal** — ia
+     memberi penyerang senjata yang hari ini tidak ada: mengunci satu manusia
+     dari SEMUA tenant, dari konteks tenant mana pun, tanpa endpoint unlock dan
+     dengan password reset yang hanya membersihkan `awcms_identities`. #430
+     menunggu Gelombang 7, dan sensus `identity:principals:preflight` yang
+     menentukan besarnya pengganda nyata belum dijalankan pada data produksi.
+  5. **Mengubah deskripsi operasi `/sync/pull` di OpenAPI** — snapshot kontrak
+     pra-migrasi beku dan mewajibkan tiap path byte-identical. Notice-nya
+     dipindah ke deskripsi TAG, yang tidak dibekukan dan justru ter-render ke
+     `awcms/api-reference.md`.
+  6. **Menyunting `awcms/repo-assessment-2026-08-04.md`** yang mengulang klaim
+     "atomik" — ia catatan bertanggal, dan menyunting temuan lama adalah
+     memalsukan rekaman.
+
+  **Titik-lanjut.** Gelombang 1 program model keanggotaan **SUDAH TUTUP** (#450,
+  33 layar, dua ledger nol) — dokumen programnya dikoreksi di PR ini karena ia
+  masih menjanjikan helper bernama `defineAdminScreen` yang tidak pernah ada.
+  Berikutnya **Gelombang 2** (permukaan sesi & kredensial). #477 tetap terbuka
+  untuk keputusan sambung-atau-pensiunkan; #430 terjadwal Gelombang 7.
+
 - **PUTARAN 10 Agustus 2026 — program notifikasi push (#463) tuntas, retensi
   outbox 4 dari 6, SSE mendarat dengan ADR-nya.** Dua belas PR, semuanya
   ter-merge; lima issue ditutup (#464, #465, #466, #467, sebagian #468) dan tiga

--- a/docs/awcms/program-model-keanggotaan-2026-08-09.md
+++ b/docs/awcms/program-model-keanggotaan-2026-08-09.md
@@ -143,14 +143,37 @@ Tidak ada yang melebar; semuanya mengetatkan. Tiap PR bernilai sendiri.
 | 0.7 | #430        | `bun run identity:principals:preflight` — skrip **read-only**, nol migrasi: sensus tabrakan `lower(btrim(login_identifier))` **di dalam** satu tenant (legal hari ini, mustahil setelah principal), identifier non-email, identitas tanpa alamat yang bisa dikirimi surat. Prasyarat Gelombang 7, dijalankan berbulan-bulan sebelumnya                                                                                                                                                                                                                                                       | `scripts:inventory:check`                                                                  |
 | 0.8 | #431        | ADR: role menyatakan scope-nya (**menutup R8**). Migrasi: `awcms_roles.attachable_scope_types text[] DEFAULT '{tenant}'` + `permission_scope text DEFAULT 'tenant' CHECK IN ('tenant','platform')`. `listPermissionCatalog` mendapat predikat `scope`; `grantPermissionToRole` memeriksa ulang di server — picker adalah UI, cek adalah kontrolnya                                                                                                                                                                                                                                           | `tests/platform-scoped-permissions.test.ts`, `api:*:check`                                 |
 
-### Gelombang 1 — R3: 31 layar admin lewat chokepoint (1 + 7 PR)
+### Gelombang 1 — R3: layar admin lewat chokepoint — **SELESAI (#450)**
+
+> **Status per 10 Agustus 2026: TUTUP.** Diverifikasi dengan MENJALANKAN kedua
+> gerbangnya, bukan dengan membaca komentarnya —
+> `access:chokepoint:check` melaporkan _"33 admin screens, all routed through
+> loadAdminScreen (R3 closed; ledger: 0)"_ dan `admin:screen-coverage:check`
+> _"33 screens claim 137 of 208 declared permissions"_. Kedua ledger nol.
+>
+> **Tiga koreksi terhadap rencana di bawah**, dicatat karena pembaca berikutnya
+> bisa menyimpulkan gelombang ini belum mulai padahal ia sudah tutup:
+>
+> 1. helper-nya bernama **`loadAdminScreen`** (`src/lib/auth/admin-screen.ts`),
+>    bukan `defineAdminScreen` — nama diubah saat mendarat karena frontmatter
+>    `.astro` tidak punya handler untuk dibungkus, jadi "define" akan
+>    menjanjikan bentuk yang tidak ada; alasannya ditulis di header berkasnya;
+> 2. `extractScreenClaims` hidup di **`scripts/admin-screen-coverage-check.ts`**,
+>    bukan di `admin-screen-coverage-ledger.ts` — berkas itu tidak pernah ada;
+> 3. layarnya **33**, bukan 31 (32 top-level + `tenant/domains.astro`).
+>
+> Yang masih berlaku dari rencana ini adalah alasannya, dan ia menunjuk ke depan:
+> `ssr.permissions` (union RBAC mentah) masih dirakit tiap render dan masih
+> dibaca tiga tempat di dalam transaksi — mis.
+> `listProjectionSummariesForTenant(tx, tenantId, ssr.permissions)`. Begitu grant
+> membawa scope di Gelombang 3, union itu berhenti berarti "boleh membaca ini".
 
 **Wajib selesai sebelum Gelombang 3.** Setelah grant ber-scope,
 `ssr.permissions.has()` membaca union lintas-scope — R3 berubah dari "tanpa ABAC
 dan tanpa log" menjadi _over-disclosure_ sisi baca yang nyata.
 
 **PR 1.0** — helper `defineAdminScreen({ workClass, authorize, load })` di
-`src/lib/auth/`. Direktori itu sudah mengimpor `identity-access/application` dan
+`src/lib/auth/`. _(Mendarat sebagai `loadAdminScreen` — lihat koreksi di atas.)_ Direktori itu sudah mengimpor `identity-access/application` dan
 sudah masuk `SCAN_ROOTS` `logging:lint:check`, jadi tidak ada batas baru yang
 dilintasi. Helper **wajib** meniru `defineTenantRoute`: satu `withTenant`,
 `authorizeInTransaction`, dan `load` **di dalam transaksi yang sama** — kalau
@@ -168,10 +191,10 @@ kesalahan yang dicatat [ADR-0063](../adr/0063-ownership-grants-run-through-the-a
 Ledger `ADMIN_SCREEN_CHOKEPOINT_MIGRATION` hanya boleh menyusut, plus cek entri
 basi.
 
-**[R] wajib se-PR:** `extractScreenClaims` di
-`scripts/admin-screen-coverage-ledger.ts` harus mengenali bentuk objek-literal
-`defineAdminScreen({ authorize: { moduleKey: … } })`. Tanpa itu, 133 klaim
-permission runtuh dan gerbang memerah karena alasan yang salah.
+**[R] wajib se-PR:** `extractScreenClaims` harus mengenali bentuk objek-literal
+yang dipakai helper-nya. Tanpa itu, klaim permission runtuh dan gerbang memerah
+karena alasan yang salah. _(Mendarat: fungsi itu ada di
+`scripts/admin-screen-coverage-check.ts`, dan mengenali `loadAdminScreen`.)_
 
 **PR 1.1–1.7** — ±5 layar per PR, tiap PR menghapus barisnya dari ledger, berkas
 `admin-*-page-contract` **tidak** diubah.
@@ -599,7 +622,7 @@ konsumen log.
 | Gerbang / test                                                                           | Memerah di                        | Sebab                                                                                                                                                                                                                                                                            |
 | ---------------------------------------------------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `access:permissions:enforcement:check`                                                   | 0.6, 0.8, 2.1, 3.5, 4.1, 5.x, 8.x | daftar pengecualiannya **kosong** (skor 203/203); tiap permission baru butuh enforcer **di PR yang sama** — [ADR-0058](../adr/0058-unenforced-permissions-disposition.md) membuat satu entri pengecualian berharga satu ADR                                                      |
-| `admin:screen-coverage:check`                                                            | 0.6, 0.8, 1.0, 2.1, 3.5, 4.1, 5.4 | permission baru wajib diklaim layar atau masuk ledger satu-arah; **plus** `extractScreenClaims` harus mengenali `defineAdminScreen` di PR 1.0                                                                                                                                    |
+| `admin:screen-coverage:check`                                                            | 0.6, 0.8, 1.0, 2.1, 3.5, 4.1, 5.4 | permission baru wajib diklaim layar atau masuk ledger satu-arah; **plus** `extractScreenClaims` harus mengenali helper layar (mendarat sebagai `loadAdminScreen`)                                                                                                                |
 | `tests/access-assignment-writers.test.ts`                                                | 3.2                               | `WRITE_MARKER` menyebut tabel lama                                                                                                                                                                                                                                               |
 | `tests/shared-rate-limit.test.ts`                                                        | 4.2 (11→13), 7.4 (13→15)          | **paling mudah terlupa — ia tinggal di berkas test, bukan di `scripts/`**                                                                                                                                                                                                        |
 | `tests/repo-inventory.test.ts`                                                           | 5.1, 7.1                          | tiap tabel global baru wajib dideklarasikan di `GLOBAL_TABLE_FORBIDDEN_PRIVILEGES` **dan** peta hak `security-readiness.ts`                                                                                                                                                      |


### PR DESCRIPTION
Docs-only, bebas changeset. Dua hal.

## 1. Dokumen program menjanjikan sesuatu yang tidak ada

Gelombang 1 program model keanggotaan **sudah tutup** (#450). Saya memverifikasinya dengan **menjalankan** kedua gerbangnya, bukan membaca komentarnya — dan itu perlu, karena 10 berkas admin masih memuat teks `permissions.has(` dan 18 memuat `withTenantOrThrow`, seluruhnya di dalam komentar yang menjelaskan bahwa kodenya sudah tidak memakainya:

```
access:chokepoint:check OK — 340 route handlers, 6 decide permissions,
  2 reasoned exemption(s); 33 admin screens, all routed through
  loadAdminScreen (R3 closed; ledger: 0).
admin:screen-coverage:check OK — 33 screens claim 137 of 208 declared permissions.
```

Tetapi `docs/awcms/program-model-keanggotaan-2026-08-09.md` masih menjanjikan:

| Dokumen | Kenyataan |
|---|---|
| helper `defineAdminScreen` | **`loadAdminScreen`** (`src/lib/auth/admin-screen.ts`) — namanya diubah saat mendarat karena frontmatter `.astro` tak punya handler untuk dibungkus, jadi "define" akan menjanjikan bentuk yang tak ada |
| `scripts/admin-screen-coverage-ledger.ts` | berkas itu **tidak pernah ada**; `extractScreenClaims` di `admin-screen-coverage-check.ts` |
| 31 layar | **33** (32 top-level + `tenant/domains.astro`) |

Ini kelas cacat yang sudah tercatat di repo ini: dokumen yang menua **berlawanan arah** dengan koreksi biasa. Seorang pembaca yang mencari `defineAdminScreen` tidak menemukannya dan menyimpulkan gelombangnya **belum mulai** — lalu mulai membangun ulang sesuatu yang sudah berdiri.

Rencananya tidak dihapus, hanya diberi banner status + tiga koreksi. Alasan aslinya masih berlaku dan menunjuk ke depan: `ssr.permissions` (union RBAC mentah) masih dirakit tiap render dan dibaca tiga tempat di dalam transaksi — begitu grant membawa scope di Gelombang 3, union itu berhenti berarti *"boleh membaca ini"*.

## 2. Putaran lanjutan tercatat di PROJECT_STATE §4

Aturan yang sama seperti dua putaran sebelumnya: daftar yang tak ditulis ke repo harus diturunkan ulang, dan menurunkan ulang berharga satu audit penuh.

Isinya: kedua pemblokir #468 diputuskan (#479 → ADR-0076, #477 → `BOUNDED_BY_DESIGN`), #468 ditutup, dan #483 — lockout login yang bukan atomik — ditemukan sambil jalan.

**Enam penolakan ikut tertulis**, karena penolakan yang tak tercatat akan diusulkan lagi:

1. melonggarkan `ownerModuleKey` jadi opsional (kesalahan ketik menjadi klaim kepemilikan);
2. menetapkan `awcms_edge_cache_purges` ke salah satu modul penulisnya;
3. menjadikan `src/lib/edge-cache/` sebuah modul **demi menghijaukan gerbang** — ADR-0043 memerahkan namespace-nya, dan `module-job-registry-check.ts` sudah menolak alasan yang sama untuk tabel yang sama; tetap terbuka sebagai keputusan arsitektural;
4. tabel lockout **global tanpa RLS** untuk menutup #430 lebih awal — ia memberi penyerang senjata yang hari ini tidak ada: mengunci satu manusia dari SEMUA tenant, dari konteks tenant mana pun, tanpa endpoint unlock dan dengan password reset yang hanya membersihkan `awcms_identities`;
5. mengubah deskripsi operasi `/sync/pull` (snapshot kontrak beku);
6. menyunting `repo-assessment-2026-08-04.md` yang mengulang klaim "atomik" — catatan bertanggal, dan menyunting temuan lama adalah memalsukan rekaman.

`DATABASE_URL="" bun run check` **exit 0** — 3704 pass / 0 fail.

Titik-lanjut berikutnya: **Gelombang 2** (permukaan sesi & kredensial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
