### PR TITLE
feat(auth): sesi orang lain bisa dilihat dan diakhiri — `read` jadi izin yang lebih mahal dari `revoke` (#423)

### DIFF
--- a/.changeset/permukaan-sesi-orang-lain.md
+++ b/.changeset/permukaan-sesi-orang-lain.md
@@ -1,0 +1,73 @@
+---
+"awcms": minor
+---
+
+feat(auth): sesi orang lain bisa dilihat dan diakhiri — dengan `read` sebagai izin yang LEBIH mahal dari `revoke`
+
+Gelombang 2 PR 2.2 dari #423. `GET /api/v1/users/{id}/sessions` dan
+`POST /api/v1/users/{id}/sessions/revoke-all`, ditambah panel sesi di
+`/admin/users`. Pasangan self-service yang mendarat di PR 2.1 menyelesaikan
+subjeknya dari token pemanggil dan tak bisa diarahkan ke siapa pun; dua endpoint
+ini melakukan kebalikannya — subjeknya disebut di URL — jadi keduanya digerbangi,
+diaudit, dan dipecah ke **dua** izin.
+
+**Pemecahannya terbalik dari `machine_credentials`, dan justru itu isinya.**
+`sql/083` memisah `create`/`revoke` karena hanya satu dari keduanya MENCIPTAKAN
+kapabilitas. Di sini yang memisah adalah kebalikannya: hanya satu dari keduanya
+MENGUNGKAPKAN sesuatu. `read` adalah jendela permanen ke gerak-gerik seorang
+kolega — kapan ia masuk, dari berapa bentuk perangkat, jam berapa — dan itu tetap
+bahan pengawasan ketika yang membacanya administrator. `revoke` menghancurkan
+akses dan mengembalikan sebuah angka.
+
+Jadi yang dibeli pemecahan ini adalah arah yang penting saat insiden: seorang
+responder bisa diberi kemampuan mengeluarkan akun yang diduga jebol dari
+mana-mana **tanpa** sekalian diberi pandangan ke pergerakan semua orang. Satu izin
+yang mencakup keduanya membuat tindakan darurat yang aman berharga izin permanen
+yang tidak aman.
+
+**Sesi pemanggil tidak pernah ikut mati.** `UPDATE`-nya membawa
+`token_hash <> ${callerTokenHash}`, dan untuk target selain tenant user pemanggil
+sendiri klausa itu tidak mencocoki apa pun — hash token pemanggil tak bisa muncul
+di antara sesi identitas lain. Jadi ia gratis di kasus normal dan membeli satu
+properti di kasus tidak normal: administrator yang sedang membereskan insiden tak
+bisa mengeluarkan dirinya dari konsol yang sedang ia pakai dengan menekan baris
+yang kebetulan miliknya. `keptCallerSession` melaporkannya alih-alih diam —
+operator yang diberi tahu "3 diakhiri" sementara konsolnya masih hidup perlu tahu
+sebabnya, atau ia menyimpulkan kontrolnya tidak bekerja.
+
+Itu bukan lubang: mengeluarkan diri sendiri dari mana-mana adalah
+`DELETE /api/v1/auth/sessions/{id}` dan `POST /api/v1/auth/logout`, keduanya tanpa
+izin. Endpoint ini menolak menjadi cara ketiga untuk hal yang sudah dilakukan dua
+endpoint tak-berizin, dalam satu-satunya susunan di mana melakukannya adalah
+kecelakaan.
+
+**Aktivitas `user_sessions` baru, bukan `access_control` yang diperluas** — alasan
+yang sama ditulis `sql/075` untuk `registration_requests` dan `sql/083` untuk
+`machine_credentials`: melipatnya ke `access_control.read` akan menjadikan setiap
+pembaca katalog RBAC seorang pengamat gerak-gerik koleganya, sebagai efek samping,
+tanpa satu migrasi pun mengatakannya.
+
+**Empat keputusan yang lebih kecil:**
+
+- **Id yang tak berbentuk UUID dijawab 404, bukan 400.** 400 untuk "bukan uuid"
+  plus 404 untuk "tak ada usernya" bersama-sama memberi tahu pemanggil id mana yang
+  berbentuk benar DAN id mana yang ada.
+- **User nonaktif didaftar kosong, bukan 404.** `setTenantUserStatus` sudah
+  mencabut sesinya, jadi daftar kosong adalah jawaban yang diharapkan — dan itulah
+  yang sedang diperiksa operator saat itu. 404 tak bisa dibedakan dari salah id.
+- **Diaudit meski nol sesi diakhiri.** "Seseorang mencoba mengeluarkan akun ini
+  dan tak ada yang tersisa untuk diakhiri" justru entri yang paling dicari
+  investigasi; jejak audit yang hanya mencatat aksi efektif tak bisa
+  membedakannya dari tak ada yang pernah melihat.
+- **Tanpa `Idempotency-Key`.** Panggilan kedua tidak menemukan apa pun yang hidup
+  dan melaporkan `revokedCount: 0` — tak ada duplikat untuk ditekan, jadi tak ada
+  yang perlu dilindungi respons tersimpan.
+
+`tokenHash` kini ikut diserahkan `defineTenantRoute` ke handler-nya. Nilainya sudah
+dihitung seam itu untuk `authorizeInTransaction`; menurunkannya kedua kali di dalam
+rute adalah cara dua turunan satu nilai mulai berbeda pendapat.
+
+`sql/101` hanya memperluas katalog global — tenant lama mendapatkannya lewat
+`bun run identity-access:permissions:backfill`, yang memberi tepat baris katalog
+yang LEBIH BARU dari role-nya sehingga tak bisa menghidupkan kembali izin yang
+sengaja dicabut admin.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -39,7 +39,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > Keluarga hari ini dua repo, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (halaman publik + permukaan admin USER, ADR-0070). **KOREKSI:** versi sebelumnya menyatakan
 > implementasi ini "baru fondasi Sprint 1–2" dengan empat modul — itu **sudah
-> lama tidak benar**. Repo ini punya **22 modul terdaftar** dan `sql/001`–`sql/100`;
+> lama tidak benar**. Repo ini punya **22 modul terdaftar** dan `sql/001`–`sql/101`;
 > lihat [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) untuk daftar nyata.
 > Skill yang badannya masih menandai dirinya "BACAAN SAJA" tetap begitu — itu
 > per-skill, bukan pernyataan tentang repo secara keseluruhan.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Sebagai template yang di-ship, base menyediakan **modul fondasi reusable + kontr
 modul domain ERP (finance, inventory, procurement, manufacturing, hr-payroll, dst.)
 **ditambahkan langsung di `src/modules/` template ini** saat dipakai, bukan di repo
 ekstensi/turunan terpisah (jalur aplikasi-turunan DIHAPUS — lihat §Komposisi modul di
-bawah). Repo ini punya **22 modul terdaftar**, migration `sql/001`-`sql/100`, RLS
+bawah). Repo ini punya **22 modul terdaftar**, migration `sql/001`-`sql/101`, RLS
 `FORCE` di seluruh tabel tenant-scoped, pemisahan role database, dan admin UI read+write
 (Issue #166, #171). Dokumen ini menjelaskan apa yang **ada di kode saat ini**. Untuk detail
 per modul, lihat `README.md` masing-masing di `src/modules/<module>/`.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -107,10 +107,10 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Changeset menunggu (per tipe bump) | _jalankan perintah di kolom kanan_                                                    | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commit sejak rilis terakhir        | _jalankan perintah di kolom kanan_                                                    | `git rev-list --count v7.0.1..HEAD`                                                     |
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                              | `src/modules/index.ts`                                                                  |
-| Migrasi                            | **100** (`sql/001`–`100`)                                                             | `ls sql/`                                                                               |
+| Migrasi                            | **101** (`sql/001`–`101`)                                                             | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0077** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **33** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **44** (24.148 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **44** (24.359 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **38** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -2064,6 +2064,57 @@ Sets the tenant user's status. `awcms_tenant_users` has no `deleted_at`, so deac
 | 403    | Access denied by RBAC/ABAC.   | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.           | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/users/{id}/sessions` — List one tenant user's live sessions (identity_access.user_sessions.read).
+
+- **operationId**: `listTenantUserSessions`
+- **Security**: bearerAuth + tenantHeader
+
+Where is this person signed in? Gated on `identity_access.user_sessions.read` — the SENSITIVE half of the pair, because it is a standing window into a colleague's movements. The revoke endpoint beside it destroys access instead of disclosing anything, which is why the two are separate permissions and why an incident responder can hold the second without the first.
+Returns no token, no token hash, no raw IP and no raw User-Agent. `isCallerSession` is true only when an administrator points this at their own tenant user. A malformed id, an id from another tenant and an unknown id all answer 404 — distinguishing them would make this a probe for which tenant user ids exist.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Responses**
+
+| Status | Description                                    | Schema                                 |
+| ------ | ---------------------------------------------- | -------------------------------------- |
+| 200    | The tenant user's live sessions, newest first. | object                                 |
+| 400    | Validation error.                              | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                    | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                    | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                            | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/users/{id}/sessions/revoke-all` — End every live session of one tenant user (identity_access.user_sessions.revoke, audited).
+
+- **operationId**: `revokeAllTenantUserSessions`
+- **Security**: bearerAuth + tenantHeader
+
+The incident control. Effective on the next request of every revoked session, because authentication reads the same row. Grantable WITHOUT `user_sessions.read`: stopping a suspected-compromised account should not cost a standing window into where everyone is signed in.
+The CALLER's own session is never revoked — the exclusion matches nothing for any target other than the caller's own tenant user, and stops an administrator from signing themselves out of the console mid-incident by clicking their own row. `keptCallerSession` reports when that happened; signing yourself out everywhere is the unpermissioned self-service surface under `/api/v1/auth/sessions`.
+No `Idempotency-Key`: the second call finds nothing live and reports `revokedCount: 0`, so there is no duplicate to suppress. Audited even when it revokes nothing.
+
+**Parameters**
+
+| Name               | In     | Required | Type          | Description |
+| ------------------ | ------ | -------- | ------------- | ----------- |
+| `id`               | path   | yes      | string (uuid) |             |
+| `X-Correlation-ID` | header | no       | string        |             |
+
+**Responses**
+
+| Status | Description                   | Schema                                 |
+| ------ | ----------------------------- | -------------------------------------- |
+| 200    | How many sessions were ended. | object                                 |
+| 400    | Validation error.             | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.   | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.   | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.           | [`ApiError`](#standard-error-envelope) |
+
 ## Profile Identity
 
 Canonical person/organization profile lifecycle, identifiers, and entity links.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -141,7 +141,7 @@
           "optional": false
         }
       ],
-      "permissionCount": 26,
+      "permissionCount": 28,
       "navigationCount": 5,
       "jobCount": 1,
       "hasHealthCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -8,12 +8,12 @@
 | Aspek                              | Nilai |
 | ---------------------------------- | ----- |
 | Modul terdaftar                    | 22    |
-| Migrasi                            | 100   |
+| Migrasi                            | 101   |
 | Tabel `awcms_*`                    | 129   |
 | Tabel dengan `FORCE` RLS           | 118   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 338   |
-| Berkas route                       | 320   |
+| Berkas test                        | 339   |
+| Berkas route                       | 322   |
 | ADR                                | 78    |
 
 ### Modul
@@ -147,6 +147,7 @@
 | 98  | `sql/098_awcms_sync_outbox_not_connected_comment.sql`              |
 | 99  | `sql/099_awcms_sync_outbox_retire.sql`                             |
 | 100 | `sql/100_awcms_session_fingerprint.sql`                            |
+| 101 | `sql/101_awcms_identity_user_sessions_permissions.sql`             |
 
 ### Tabel & Row-Level Security
 
@@ -286,7 +287,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 289        |
+| `(root)`      | 290        |
 | `e2e`         | 12         |
 | `integration` | 36         |
 | `unit`        | 1          |
@@ -295,7 +296,7 @@
 
 | Permukaan       | Berkas |
 | --------------- | ------ |
-| `/api/v1/**`    | 265    |
+| `/api/v1/**`    | 267    |
 | `/admin/**`     | 33     |
 | publik / anonim | 22     |
 

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -1132,6 +1132,16 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/users/[id]/sessions/index.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
+      "path": "src/pages/api/v1/users/[id]/sessions/revoke-all.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/users/index.ts",
       "workClass": "interactive",
       "source": "default"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -15044,6 +15044,97 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/users/{id}/sessions:
+    get:
+      operationId: listTenantUserSessions
+      tags:
+        - Identity & Access
+      summary: List one tenant user's live sessions (identity_access.user_sessions.read).
+      description: |-
+        Where is this person signed in? Gated on `identity_access.user_sessions.read` — the SENSITIVE half of the pair, because it is a standing window into a colleague's movements. The revoke endpoint beside it destroys access instead of disclosing anything, which is why the two are separate permissions and why an incident responder can hold the second without the first.
+        Returns no token, no token hash, no raw IP and no raw User-Agent. `isCallerSession` is true only when an administrator points this at their own tenant user. A malformed id, an id from another tenant and an unknown id all answer 404 — distinguishing them would make this a probe for which tenant user ids exist.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The tenant user's live sessions, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      sessions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/TenantUserSessionSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/users/{id}/sessions/revoke-all:
+    post:
+      operationId: revokeAllTenantUserSessions
+      tags:
+        - Identity & Access
+      summary: End every live session of one tenant user (identity_access.user_sessions.revoke, audited).
+      description: |-
+        The incident control. Effective on the next request of every revoked session, because authentication reads the same row. Grantable WITHOUT `user_sessions.read`: stopping a suspected-compromised account should not cost a standing window into where everyone is signed in.
+        The CALLER's own session is never revoked — the exclusion matches nothing for any target other than the caller's own tenant user, and stops an administrator from signing themselves out of the console mid-incident by clicking their own row. `keptCallerSession` reports when that happened; signing yourself out everywhere is the unpermissioned self-service surface under `/api/v1/auth/sessions`.
+        No `Idempotency-Key`: the second call finds nothing live and reports `revokedCount: 0`, so there is no duplicate to suppress. Audited even when it revokes nothing.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: How many sessions were ended.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      revokedCount:
+                        type: integer
+                        minimum: 0
+                      keptCallerSession:
+                        type: boolean
+                        description: True when the target was the caller's own tenant user, so their current session was left alive.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/workflows/definitions:
     get:
       tags:
@@ -20372,6 +20463,50 @@ components:
           items:
             type: string
           description: Assigned role codes (empty when the user holds no role).
+    TenantUserSessionSummary:
+      type: object
+      description: One live session of a named tenant user, as seen by an administrator. Same exclusions as OwnSessionSummary — no token, no raw IP, no raw User-Agent.
+      required:
+        - id
+        - issuedAt
+        - expiresAt
+        - assuranceLevel
+        - originAuth
+        - isCallerSession
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        issuedAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        assuranceLevel:
+          type: string
+          enum:
+            - aal1
+            - aal2
+        originAuth:
+          type: string
+          enum:
+            - password
+            - sso
+            - handoff
+        clientIpHash:
+          type:
+            - string
+            - "null"
+          description: Keyed, non-reversible pseudonym of the client IP. null when the deployment has no stable AUTH_IP_HASH_SECRET.
+        userAgentSummary:
+          type:
+            - string
+            - "null"
+        isCallerSession:
+          type: boolean
+          description: True only when the endpoint is pointed at the caller's own tenant user AND this row is the session making the request.
     ThemeConfigRequest:
       type: object
       description: A tenant's DATA-only theme configuration. Every key/value is validated against the chosen theme descriptor; unknown tokens/slots/assets/sections are rejected, and token values are validated by rejection against strict CSS grammars (no url()/expression()/@import/javascript:/comment-breakout).

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -2663,6 +2663,117 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/users/{id}/sessions:
+    get:
+      operationId: listTenantUserSessions
+      tags:
+        - Identity & Access
+      summary: List one tenant user's live sessions (identity_access.user_sessions.read).
+      description: >-
+        Where is this person signed in? Gated on
+        `identity_access.user_sessions.read` — the SENSITIVE half of the pair,
+        because it is a standing window into a colleague's movements. The revoke
+        endpoint beside it destroys access instead of disclosing anything, which
+        is why the two are separate permissions and why an incident responder can
+        hold the second without the first.
+
+        Returns no token, no token hash, no raw IP and no raw User-Agent.
+        `isCallerSession` is true only when an administrator points this at their
+        own tenant user. A malformed id, an id from another tenant and an unknown
+        id all answer 404 — distinguishing them would make this a probe for which
+        tenant user ids exist.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The tenant user's live sessions, newest first.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      sessions:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/TenantUserSessionSummary"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /api/v1/users/{id}/sessions/revoke-all:
+    post:
+      operationId: revokeAllTenantUserSessions
+      tags:
+        - Identity & Access
+      summary: End every live session of one tenant user (identity_access.user_sessions.revoke, audited).
+      description: >-
+        The incident control. Effective on the next request of every revoked
+        session, because authentication reads the same row. Grantable WITHOUT
+        `user_sessions.read`: stopping a suspected-compromised account should not
+        cost a standing window into where everyone is signed in.
+
+        The CALLER's own session is never revoked — the exclusion matches nothing
+        for any target other than the caller's own tenant user, and stops an
+        administrator from signing themselves out of the console mid-incident by
+        clicking their own row. `keptCallerSession` reports when that happened;
+        signing yourself out everywhere is the unpermissioned self-service
+        surface under `/api/v1/auth/sessions`.
+
+        No `Idempotency-Key`: the second call finds nothing live and reports
+        `revokedCount: 0`, so there is no duplicate to suppress. Audited even
+        when it revokes nothing.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: How many sessions were ended.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      revokedCount:
+                        type: integer
+                        minimum: 0
+                      keptCallerSession:
+                        type: boolean
+                        description: True when the target was the caller's own tenant user, so their current session was left alive.
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/auth/session-handoff/issue:
     post:
       operationId: issueSessionHandoffCode
@@ -3455,6 +3566,41 @@ components:
         current:
           type: boolean
           description: True for the session this request is authenticated by.
+    TenantUserSessionSummary:
+      type: object
+      description: One live session of a named tenant user, as seen by an administrator. Same exclusions as OwnSessionSummary — no token, no raw IP, no raw User-Agent.
+      required:
+        - id
+        - issuedAt
+        - expiresAt
+        - assuranceLevel
+        - originAuth
+        - isCallerSession
+      additionalProperties: false
+      properties:
+        id:
+          type: string
+          format: uuid
+        issuedAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        assuranceLevel:
+          type: string
+          enum: [aal1, aal2]
+        originAuth:
+          type: string
+          enum: [password, sso, handoff]
+        clientIpHash:
+          type: [string, "null"]
+          description: Keyed, non-reversible pseudonym of the client IP. null when the deployment has no stable AUTH_IP_HASH_SECRET.
+        userAgentSummary:
+          type: [string, "null"]
+        isCallerSession:
+          type: boolean
+          description: True only when the endpoint is pointed at the caller's own tenant user AND this row is the session making the request.
     IssueSessionHandoffRequest:
       type: object
       required:

--- a/sql/101_awcms_identity_user_sessions_permissions.sql
+++ b/sql/101_awcms_identity_user_sessions_permissions.sql
@@ -1,0 +1,47 @@
+-- Permission catalog seed for the admin session surface (Gelombang 2 PR 2.2 of
+-- Issue #423), wiring up the `user_sessions` entries declared in
+-- `identity-access/module.ts`.
+--
+-- ## Why a NEW activity rather than reusing `access_control`
+--
+-- `access_control` seeds `read`/`assign`/`configure` — the RBAC catalog itself.
+-- Seeing where a colleague is signed in is a different authority: folding it
+-- into `access_control.read` would make every role viewer an observer of their
+-- colleagues' movements by side effect, with no migration anywhere saying so.
+-- Same reasoning `sql/075` recorded for `registration_requests` and `sql/083`
+-- for `machine_credentials`.
+--
+-- ## Why `read` and `revoke` are separate — with the sides swapped
+--
+-- `sql/083` split `create`/`revoke` because only one of them CREATES a
+-- capability. This pair splits for the mirror-image reason: only one of them
+-- DISCLOSES anything. `read` returns a standing view of when and from how many
+-- device shapes a named person signs in; `revoke` destroys access and returns a
+-- count. So the grant that matters during an incident — end this account's
+-- sessions now — can be handed out without the surveillance view attached, and
+-- an operator who only ever needs to look is not also able to sign the room out.
+--
+-- Both action literals already exist in the `AccessAction` union
+-- (`business_scope_assignments` uses `read` and `revoke`), so nothing new is
+-- invented here. An unseeded action would deny even the owner — the latent-authz
+-- trap ADR-0058 §E describes.
+--
+-- `revoke` is a HIGH-RISK action, so it additionally passes the SoD chokepoint
+-- in `authorizeInTransaction` with no extra wiring.
+--
+-- ## Reach, stated plainly
+--
+-- Same shape/limitation as every prior permission-seed migration here: this
+-- extends the GLOBAL catalog only. An existing tenant's `owner` role does NOT
+-- retroactively gain these — only tenants created after this migration runs get
+-- them from the bootstrap's `INSERT INTO awcms_role_permissions … SELECT …
+-- FROM awcms_permissions`. Live tenants are covered by running
+-- `bun run identity-access:permissions:backfill`, which grants exactly the
+-- catalog rows NEWER than the role (so it cannot resurrect a permission an
+-- admin deliberately removed). That is a deployment step, not a migration side
+-- effect.
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('identity_access', 'user_sessions', 'read', 'List another tenant user''s live sessions (never their tokens, IPs, or User-Agents)'),
+  ('identity_access', 'user_sessions', 'revoke', 'End every live session of another tenant user, effective on their next request — audited')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/_shared/tenant-route.ts
+++ b/src/modules/_shared/tenant-route.ts
@@ -110,6 +110,16 @@ export type TenantRouteHandlerContext<TPrepared> = TenantRouteRequestContext & {
   tx: Bun.TransactionSQL;
   /** Already narrowed to allowed — a deny was returned before `handler` ran. */
   auth: AuthorizedAccess;
+  /**
+   * Kind-tagged hash of the calling bearer (`session-token.ts`) — the same value
+   * the seam handed `authorizeInTransaction`, exposed so a handler that needs to
+   * recognise the CALLING session (rather than the calling person) does not
+   * re-derive it from `request`/`cookies`. Two derivations of one value is how
+   * they come to disagree.
+   *
+   * It is a hash of a live credential: compare it, never return it.
+   */
+  tokenHash: string;
   /** Whatever `prepare` returned (`undefined` when there is no `prepare`). */
   prepared: TPrepared;
 };
@@ -604,7 +614,13 @@ export function defineTenantRoute<TPrepared = undefined>(
           return auth.denied;
         }
 
-        return config.handler({ ...requestContext, tx, auth, prepared });
+        return config.handler({
+          ...requestContext,
+          tx,
+          auth,
+          tokenHash,
+          prepared
+        });
       },
       {
         workClass: config.workClass,

--- a/src/modules/identity-access/application/admin-session-directory.ts
+++ b/src/modules/identity-access/application/admin-session-directory.ts
@@ -1,0 +1,229 @@
+/**
+ * Somebody ELSE's sessions — list and revoke (Gelombang 2 PR 2.2 of #423).
+ *
+ * The self-service pair in `session-directory.ts` resolves its subject from the
+ * calling token and can be pointed at nobody else. These two do the opposite:
+ * the subject is named in the URL, so they are guarded, audited, and split
+ * across two permissions.
+ *
+ * ## Why `read` and `revoke` are separate permissions
+ *
+ * The same argument `sql/083` recorded for machine credentials, with the sides
+ * swapped — and the swap is the interesting part. There, `create` was the
+ * consequential one and `read` the cheap one. Here, **`read` is the sensitive
+ * one**: a list of where a colleague is signed in, from which device shape, at
+ * what hour, is surveillance material, and it stays surveillance material when
+ * the reader is an administrator. `revoke` is the incident control — it destroys
+ * access rather than disclosing anything.
+ *
+ * So the split buys the direction that matters during an incident: a responder
+ * can be granted the ability to sign a suspected-compromised account out of
+ * everywhere **without** being granted a window into everyone's movements. A
+ * single permission covering both would make the safe emergency action cost the
+ * unsafe standing one.
+ *
+ * ## Why a new activity rather than `access_control`
+ *
+ * `access_control` seeds `read`/`assign`/`configure` — the RBAC catalog. Folding
+ * session inspection into it would make every role editor an observer of where
+ * their colleagues are signed in, by side effect, with no seed migration saying
+ * so. `sql/075` and `sql/083` recorded the same reasoning for
+ * `registration_requests` and `machine_credentials`.
+ */
+
+/**
+ * One live session of a named tenant user. Carries no token, no token hash, no
+ * raw IP and no raw `User-Agent` — the same exclusions the self-service view
+ * makes, for the same reason: none of them is needed to decide "end that one".
+ */
+export type TenantUserSessionSummary = {
+  id: string;
+  issuedAt: string;
+  expiresAt: string;
+  assuranceLevel: string;
+  originAuth: string;
+  /** Keyed pseudonym, or `null` when the deployment has no stable key (`sql/100`). */
+  clientIpHash: string | null;
+  userAgentSummary: string | null;
+  /**
+   * True only when the row IS the session making this request — which can only
+   * happen when an administrator points the endpoint at their own tenant user.
+   * For anybody else's sessions it is always false.
+   */
+  isCallerSession: boolean;
+};
+
+type SessionRow = {
+  id: string;
+  token_hash: string;
+  issued_at: Date;
+  expires_at: Date;
+  assurance_level: string;
+  origin_auth: string;
+  client_ip_hash: string | null;
+  user_agent_summary: string | null;
+};
+
+/**
+ * Resolves a tenant user id to the identity behind it, or `null` when this
+ * tenant has no such user.
+ *
+ * `awcms_sessions` keys on `identity_id` and the admin surface names a
+ * `tenant_user_id`, so the hop is unavoidable. It is also the membership check:
+ * an identity that is not a user of this tenant produces no row, so the caller
+ * cannot reach a session by naming an identity that merely exists elsewhere.
+ * FORCE RLS already confines both tables to the current tenant; the explicit
+ * `tenant_id =` predicate is the same belt-and-braces every other query here
+ * carries.
+ */
+async function resolveIdentityForTenantUser(
+  tx: Bun.SQL,
+  tenantId: string,
+  tenantUserId: string
+): Promise<string | null> {
+  const rows = (await tx`
+    SELECT identity_id FROM awcms_tenant_users
+    WHERE tenant_id = ${tenantId} AND id = ${tenantUserId}
+  `) as { identity_id: string }[];
+
+  return rows[0]?.identity_id ?? null;
+}
+
+export type ListTenantUserSessionsResult =
+  | { outcome: "not_found" }
+  | { outcome: "ok"; sessions: TenantUserSessionSummary[] };
+
+/**
+ * Live sessions of one tenant user, newest first.
+ *
+ * A deactivated tenant user is listed, not hidden. `setTenantUserStatus` already
+ * revokes their sessions, so the expected answer is an empty array — and an
+ * operator checking that deactivation actually took effect needs to see the
+ * empty array rather than a 404 that could equally mean "wrong id".
+ */
+export async function listSessionsForTenantUser(
+  tx: Bun.SQL,
+  tenantId: string,
+  tenantUserId: string,
+  callerTokenHash: string,
+  now: Date
+): Promise<ListTenantUserSessionsResult> {
+  const identityId = await resolveIdentityForTenantUser(
+    tx,
+    tenantId,
+    tenantUserId
+  );
+
+  if (!identityId) return { outcome: "not_found" };
+
+  const rows = (await tx`
+    SELECT id, token_hash, issued_at, expires_at, assurance_level, origin_auth,
+           client_ip_hash, user_agent_summary
+    FROM awcms_sessions
+    WHERE tenant_id = ${tenantId}
+      AND identity_id = ${identityId}
+      AND revoked_at IS NULL
+      AND expires_at > ${now}
+    ORDER BY issued_at DESC
+  `) as SessionRow[];
+
+  return {
+    outcome: "ok",
+    sessions: rows.map((row) => ({
+      id: row.id,
+      issuedAt: row.issued_at.toISOString(),
+      expiresAt: row.expires_at.toISOString(),
+      assuranceLevel: row.assurance_level,
+      originAuth: row.origin_auth,
+      clientIpHash: row.client_ip_hash,
+      userAgentSummary: row.user_agent_summary,
+      // Compared here, never returned: the token hash does not leave this
+      // function, because a client that received one could replay it.
+      isCallerSession: row.token_hash === callerTokenHash
+    }))
+  };
+}
+
+export type RevokeTenantUserSessionsResult =
+  | { outcome: "not_found" }
+  | {
+      outcome: "revoked";
+      revokedCount: number;
+      /**
+       * True when the target was the caller's own tenant user and their current
+       * session was therefore left alive. Reported rather than silent: an
+       * operator told "revoked 3" who still has a working console needs to know
+       * why, or they will conclude the control does not work.
+       */
+      keptCallerSession: boolean;
+    };
+
+/**
+ * Ends every live session of one tenant user — except the one making the call.
+ *
+ * ## Why the caller's own session survives
+ *
+ * The exclusion is `token_hash <> callerTokenHash`, and for every target other
+ * than the caller's own tenant user it matches nothing: the caller's token hash
+ * cannot appear among another identity's sessions. So it costs nothing in the
+ * normal case and buys one property in the abnormal one — an administrator
+ * cleaning up after an incident cannot log themselves out of the console they
+ * are cleaning up from, mid-incident, by clicking the row that happens to be
+ * their own.
+ *
+ * It is not a hole: signing yourself out everywhere is
+ * `DELETE /api/v1/auth/sessions/{id}` and `POST /api/v1/auth/logout`, neither of
+ * which needs a permission. This endpoint declines to be the third way to do a
+ * thing two unprivileged endpoints already do, in the one arrangement where
+ * doing it is an accident.
+ *
+ * ## Already-revoked rows keep their first revocation instant
+ *
+ * `AND revoked_at IS NULL`, exactly as `revokeAllSessionsForIdentity` does:
+ * restamping a row that was revoked an hour ago would move the only timestamp an
+ * investigation has for when access actually ended.
+ */
+export async function revokeSessionsForTenantUser(
+  tx: Bun.SQL,
+  tenantId: string,
+  tenantUserId: string,
+  callerTokenHash: string,
+  now: Date
+): Promise<RevokeTenantUserSessionsResult> {
+  const identityId = await resolveIdentityForTenantUser(
+    tx,
+    tenantId,
+    tenantUserId
+  );
+
+  if (!identityId) return { outcome: "not_found" };
+
+  // Asked BEFORE the update, because after it the row is still live (it is the
+  // one row the update excludes) but the question "was it in scope" is easier to
+  // answer wrongly by inspecting the result set.
+  const callerRows = (await tx`
+    SELECT 1 FROM awcms_sessions
+    WHERE tenant_id = ${tenantId}
+      AND identity_id = ${identityId}
+      AND token_hash = ${callerTokenHash}
+      AND revoked_at IS NULL
+      AND expires_at > ${now}
+  `) as unknown[];
+
+  const revoked = (await tx`
+    UPDATE awcms_sessions
+    SET revoked_at = ${now}
+    WHERE tenant_id = ${tenantId}
+      AND identity_id = ${identityId}
+      AND token_hash <> ${callerTokenHash}
+      AND revoked_at IS NULL
+      AND expires_at > ${now}
+    RETURNING id
+  `) as { id: string }[];
+
+  return {
+    outcome: "revoked",
+    revokedCount: revoked.length,
+    keptCallerSession: callerRows.length > 0
+  };
+}

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -284,6 +284,31 @@ export const identityAccessModule = defineModule({
       action: "revoke",
       description:
         "Revoke a machine credential, effective on its next request — audited"
+    },
+    // Other people's sessions (Gelombang 2 PR 2.2 of #423, sql/101). A separate
+    // activity from `access_control` for the reason `registration_requests` and
+    // `machine_credentials` are: folding it in would make every role editor an
+    // observer of where their colleagues are signed in, by side effect.
+    //
+    // `read` and `revoke` split with the sides SWAPPED relative to
+    // `machine_credentials`, and that is the point. Here `read` is the sensitive
+    // one — a standing window into a colleague's movements — while `revoke`
+    // destroys access rather than disclosing anything. The split buys the
+    // direction that matters during an incident: sign a suspected-compromised
+    // account out of everywhere WITHOUT also being handed the surveillance view.
+    // The caller's own live session is never among the casualties; see
+    // `admin-session-directory.ts`.
+    {
+      activityCode: "user_sessions",
+      action: "read",
+      description:
+        "List another tenant user's live sessions (never their tokens, IPs, or User-Agents)"
+    },
+    {
+      activityCode: "user_sessions",
+      action: "revoke",
+      description:
+        "End every live session of another tenant user, effective on their next request — audited"
     }
   ],
   /**

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -55,6 +55,20 @@ const screen = await loadAdminScreen({
       moduleKey: "identity_access",
       activityCode: "access_control",
       action: "assign"
+    }),
+    // Gelombang 2 PR 2.2 (#423) — two SEPARATE keys, asked separately, because
+    // they are separately grantable on purpose: an incident responder may hold
+    // `revoke` without `read`, and the page must then show the button that ends
+    // sessions and NOT the one that lists them.
+    canReadSessions: await can({
+      moduleKey: "identity_access",
+      activityCode: "user_sessions",
+      action: "read"
+    }),
+    canRevokeSessions: await can({
+      moduleKey: "identity_access",
+      activityCode: "user_sessions",
+      action: "revoke"
     })
   }),
   onError: (error) => {
@@ -75,11 +89,16 @@ const users: TenantUserView[] =
 const roles: RoleView[] = screen.state === "allowed" ? screen.data.roles : [];
 const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
 const canAssign = screen.state === "allowed" && screen.data.canAssign;
+const canReadSessions =
+  screen.state === "allowed" && screen.data.canReadSessions;
+const canRevokeSessions =
+  screen.state === "allowed" && screen.data.canRevokeSessions;
 
 // role code -> role id, so a user's assigned role codes can be turned into
 // removable controls carrying the id the unassign endpoint expects.
 const roleIdByCode = new Map(roles.map((role) => [role.roleCode, role.id]));
-const showActions = canConfigure || canAssign;
+const showActions =
+  canConfigure || canAssign || canReadSessions || canRevokeSessions;
 ---
 
 <AdminLayout title="Users">
@@ -145,96 +164,139 @@ const showActions = canConfigure || canAssign;
                 </tr>
               ) : (
                 users.map((user) => (
-                  <tr>
-                    <td data-label="Login identifier">
-                      <span class="cell-code">
-                        {user.loginIdentifierMasked}
-                      </span>
-                    </td>
-                    <td data-label="Status">
-                      <span
-                        class="status-badge"
-                        data-variant={
-                          user.status === "active" ? "success" : "neutral"
-                        }
-                      >
-                        <span class="status-dot" aria-hidden="true" />
-                        {user.status}
-                      </span>
-                    </td>
-                    <td data-label="Roles" class="stacked-block">
-                      {user.roles.length === 0 ? (
-                        <span class="cell-muted">—</span>
-                      ) : (
-                        <ul class="role-chip-list">
-                          {user.roles.map((code) => (
-                            <li>
-                              <span class="role-chip">{code}</span>
-                              {canAssign && roleIdByCode.has(code) && (
-                                <button
-                                  type="button"
-                                  class="link-button js-unassign-role"
-                                  data-user-id={user.id}
-                                  data-role-id={roleIdByCode.get(code)}
-                                  aria-label={`Remove role ${code}`}
-                                >
-                                  Remove
-                                </button>
-                              )}
-                            </li>
-                          ))}
-                        </ul>
-                      )}
-                    </td>
-                    {showActions && (
-                      <td data-label="Actions" class="stacked-block">
-                        <div class="row-actions">
-                          {canConfigure && (
-                            <button
-                              type="button"
-                              class="module-toggle js-user-status"
-                              data-user-id={user.id}
-                              data-next-status={
-                                user.status === "active" ? "inactive" : "active"
-                              }
-                            >
-                              {user.status === "active"
-                                ? "Deactivate"
-                                : "Activate"}
-                            </button>
-                          )}
-                          {canAssign && roles.length > 0 && (
-                            <span class="assign-role-control">
-                              <label
-                                class="visually-hidden"
-                                for={`assign-role-${user.id}`}
-                              >
-                                Role to assign
-                              </label>
-                              <select
-                                id={`assign-role-${user.id}`}
-                                class="js-assign-role-select"
-                              >
-                                {roles.map((role) => (
-                                  <option value={role.id}>
-                                    {role.roleCode}
-                                  </option>
-                                ))}
-                              </select>
+                  <>
+                    <tr>
+                      <td data-label="Login identifier">
+                        <span class="cell-code">
+                          {user.loginIdentifierMasked}
+                        </span>
+                      </td>
+                      <td data-label="Status">
+                        <span
+                          class="status-badge"
+                          data-variant={
+                            user.status === "active" ? "success" : "neutral"
+                          }
+                        >
+                          <span class="status-dot" aria-hidden="true" />
+                          {user.status}
+                        </span>
+                      </td>
+                      <td data-label="Roles" class="stacked-block">
+                        {user.roles.length === 0 ? (
+                          <span class="cell-muted">—</span>
+                        ) : (
+                          <ul class="role-chip-list">
+                            {user.roles.map((code) => (
+                              <li>
+                                <span class="role-chip">{code}</span>
+                                {canAssign && roleIdByCode.has(code) && (
+                                  <button
+                                    type="button"
+                                    class="link-button js-unassign-role"
+                                    data-user-id={user.id}
+                                    data-role-id={roleIdByCode.get(code)}
+                                    aria-label={`Remove role ${code}`}
+                                  >
+                                    Remove
+                                  </button>
+                                )}
+                              </li>
+                            ))}
+                          </ul>
+                        )}
+                      </td>
+                      {showActions && (
+                        <td data-label="Actions" class="stacked-block">
+                          <div class="row-actions">
+                            {canConfigure && (
                               <button
                                 type="button"
-                                class="module-toggle js-assign-role"
+                                class="module-toggle js-user-status"
                                 data-user-id={user.id}
-                                data-select-id={`assign-role-${user.id}`}
+                                data-next-status={
+                                  user.status === "active"
+                                    ? "inactive"
+                                    : "active"
+                                }
                               >
-                                Assign
+                                {user.status === "active"
+                                  ? "Deactivate"
+                                  : "Activate"}
                               </button>
-                            </span>
-                          )}
-                        </div>
-                      </td>
+                            )}
+                            {canAssign && roles.length > 0 && (
+                              <span class="assign-role-control">
+                                <label
+                                  class="visually-hidden"
+                                  for={`assign-role-${user.id}`}
+                                >
+                                  Role to assign
+                                </label>
+                                <select
+                                  id={`assign-role-${user.id}`}
+                                  class="js-assign-role-select"
+                                >
+                                  {roles.map((role) => (
+                                    <option value={role.id}>
+                                      {role.roleCode}
+                                    </option>
+                                  ))}
+                                </select>
+                                <button
+                                  type="button"
+                                  class="module-toggle js-assign-role"
+                                  data-user-id={user.id}
+                                  data-select-id={`assign-role-${user.id}`}
+                                >
+                                  Assign
+                                </button>
+                              </span>
+                            )}
+                            {canReadSessions && (
+                              <button
+                                type="button"
+                                class="module-toggle js-user-sessions"
+                                data-user-id={user.id}
+                                aria-expanded="false"
+                                aria-controls={`sessions-${user.id}`}
+                              >
+                                Sessions
+                              </button>
+                            )}
+                            {canRevokeSessions && (
+                              <button
+                                type="button"
+                                class="module-toggle js-user-sessions-revoke"
+                                data-user-id={user.id}
+                              >
+                                Sign out everywhere
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      )}
+                    </tr>
+                    {canReadSessions && (
+                      <tr
+                        class="session-panel-row"
+                        id={`sessions-${user.id}`}
+                        hidden
+                      >
+                        <td colspan={4}>
+                          <p
+                            class="cell-muted js-session-status"
+                            data-user-id={user.id}
+                            role="status"
+                          />
+                          <ul
+                            class="session-list js-session-list"
+                            data-user-id={user.id}
+                          />
+                        </td>
+                      </tr>
                     )}
-                  </tr>
+                  </>
                 ))
               )}
             </tbody>
@@ -279,9 +341,137 @@ const showActions = canConfigure || canAssign;
     unlock();
   }
 
+  type SessionSummary = {
+    id: string;
+    issuedAt: string;
+    expiresAt: string;
+    assuranceLevel: string;
+    originAuth: string;
+    clientIpHash: string | null;
+    userAgentSummary: string | null;
+    isCallerSession: boolean;
+  };
+
+  /**
+   * Reads one tenant user's live sessions. Page-local rather than a shared
+   * helper for the same reason `data-lifecycle.astro` keeps its own: `sendJson`
+   * deliberately discards the response body, and a GET whose whole purpose is
+   * the body needs its own narrow shape.
+   */
+  async function fetchSessions(
+    userId: string
+  ): Promise<SessionSummary[] | null> {
+    try {
+      const response = await fetch(`/api/v1/users/${userId}/sessions`, {
+        credentials: "same-origin"
+      });
+      const payload = (await response.json().catch(() => null)) as {
+        success?: boolean;
+        data?: { sessions?: SessionSummary[] };
+      } | null;
+
+      if (response.ok && payload?.success === true) {
+        return payload.data?.sessions ?? [];
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Built with `createElement` + `textContent`, never `innerHTML`. Every field
+   * here is server-derived and already coarse (`summarizeUserAgent` emits a
+   * bounded label, `clientIpHash` is hex), but a list of session metadata is
+   * exactly the kind of surface where "it is safe today" quietly stops being
+   * true, and the safe construction costs nothing.
+   */
+  function renderSessions(list: HTMLUListElement, sessions: SessionSummary[]) {
+    list.replaceChildren();
+
+    for (const session of sessions) {
+      const item = document.createElement("li");
+      item.className = "session-list-item";
+
+      const when = document.createElement("span");
+      when.className = "cell-code";
+      when.textContent = new Date(session.issuedAt).toLocaleString();
+      item.append(when);
+
+      const details = document.createElement("span");
+      details.className = "cell-muted";
+      details.textContent = [
+        session.userAgentSummary ?? "unknown device",
+        session.originAuth,
+        session.assuranceLevel,
+        // Null when the deployment has no stable hash key — say so rather than
+        // rendering an empty gap the reader has to interpret.
+        session.clientIpHash
+          ? `ip ${session.clientIpHash.slice(0, 12)}`
+          : "ip not recorded",
+        session.isCallerSession ? "this session" : null
+      ]
+        .filter((part) => part !== null)
+        .join(" · ");
+      item.append(details);
+
+      list.append(item);
+    }
+  }
+
+  async function toggleSessions(button: HTMLButtonElement): Promise<void> {
+    const userId = button.dataset.userId;
+    if (!userId) return;
+
+    const panel = document.getElementById(`sessions-${userId}`);
+    const list = panel?.querySelector(".js-session-list");
+    const status = panel?.querySelector(".js-session-status");
+    if (!panel || !(list instanceof HTMLUListElement) || !status) return;
+
+    if (!panel.hidden) {
+      panel.hidden = true;
+      button.setAttribute("aria-expanded", "false");
+      return;
+    }
+
+    panel.hidden = false;
+    button.setAttribute("aria-expanded", "true");
+    status.textContent = "Loading sessions…";
+    list.replaceChildren();
+
+    const sessions = await fetchSessions(userId);
+
+    if (sessions === null) {
+      status.textContent = "Sessions could not be loaded.";
+      return;
+    }
+
+    status.textContent =
+      sessions.length === 0
+        ? "No live sessions."
+        : `${sessions.length} live session(s).`;
+    renderSessions(list, sessions);
+  }
+
   document.addEventListener("click", (event) => {
     const target = (event.target as HTMLElement | null)?.closest("button");
     if (!(target instanceof HTMLButtonElement)) return;
+
+    if (target.classList.contains("js-user-sessions")) {
+      void toggleSessions(target);
+      return;
+    }
+
+    if (target.classList.contains("js-user-sessions-revoke")) {
+      const userId = target.dataset.userId;
+      if (!userId) return;
+      void run(
+        target,
+        () => sendJson("POST", `/api/v1/users/${userId}/sessions/revoke-all`),
+        "Could not end this user's sessions. Please try again."
+      );
+      return;
+    }
 
     if (target.classList.contains("js-user-status")) {
       const userId = target.dataset.userId;
@@ -393,6 +583,27 @@ const showActions = canConfigure || canAssign;
     flex-wrap: wrap;
     align-items: center;
     gap: var(--sp-2);
+  }
+
+  .session-panel-row > td {
+    background: var(--color-surface-2);
+  }
+
+  .session-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-1);
+    margin: var(--sp-2) 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .session-list-item {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--sp-2);
+    font-size: var(--fs-xs);
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/pages/api/v1/users/[id]/sessions/index.ts
+++ b/src/pages/api/v1/users/[id]/sessions/index.ts
@@ -1,0 +1,80 @@
+import {
+  fail,
+  jsonResponse
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import { listSessionsForTenantUser } from "../../../../../../modules/identity-access/application/admin-session-directory";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * `GET /api/v1/users/{id}/sessions` (Gelombang 2 PR 2.2 of #423) — where is
+ * this tenant user signed in?
+ *
+ * ## Why this is the SENSITIVE half of the pair
+ *
+ * `identity_access.user_sessions.read` is a standing window into a colleague's
+ * movements — when they sign in, from how many device shapes, at what hours.
+ * The revoke endpoint beside it destroys access instead of disclosing anything,
+ * which is why the two are separate permissions and why an incident responder
+ * can be given the second without the first. `admin-session-directory.ts`
+ * records the full argument.
+ *
+ * ## `private, no-store`, on every path including the refusals
+ *
+ * The body describes live credentials of a named person. A 404 gets the header
+ * too — a cache that stores the refusal and not the answer is still a cache
+ * holding a statement about somebody's account.
+ */
+const NO_STORE_HEADERS = { "cache-control": "private, no-store" };
+
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "user_sessions",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, params, tokenHash, now }) => {
+    const tenantUserId = params.id ?? "";
+
+    // Shape-checked before the query, and answered as 404 rather than 400: a
+    // malformed id and an id belonging to another tenant should be
+    // indistinguishable, or the endpoint becomes a probe for which ids exist.
+    if (!UUID_PATTERN.test(tenantUserId)) {
+      return fail(
+        404,
+        "NOT_FOUND",
+        "No such tenant user.",
+        {},
+        undefined,
+        NO_STORE_HEADERS
+      );
+    }
+
+    const result = await listSessionsForTenantUser(
+      tx,
+      tenantId,
+      tenantUserId,
+      tokenHash,
+      now
+    );
+
+    if (result.outcome === "not_found") {
+      return fail(
+        404,
+        "NOT_FOUND",
+        "No such tenant user.",
+        {},
+        undefined,
+        NO_STORE_HEADERS
+      );
+    }
+
+    return jsonResponse(
+      { success: true, data: { sessions: result.sessions }, meta: {} },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  }
+});

--- a/src/pages/api/v1/users/[id]/sessions/revoke-all.ts
+++ b/src/pages/api/v1/users/[id]/sessions/revoke-all.ts
@@ -1,0 +1,109 @@
+import {
+  fail,
+  jsonResponse
+} from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+import { revokeSessionsForTenantUser } from "../../../../../../modules/identity-access/application/admin-session-directory";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * `POST /api/v1/users/{id}/sessions/revoke-all` (Gelombang 2 PR 2.2 of #423) —
+ * sign a tenant user out of everywhere.
+ *
+ * This is the incident control, and `identity_access.user_sessions.revoke` is
+ * deliberately grantable WITHOUT `user_sessions.read`: stopping a
+ * suspected-compromised account should not cost a standing window into where
+ * everyone is signed in. Effective on the next request of every revoked session,
+ * because authentication reads the same row — the property an opaque hashed
+ * session token buys that a self-contained token cannot.
+ *
+ * ## No `Idempotency-Key`
+ *
+ * Unlike the high-risk mutations that mint something, this one is idempotent by
+ * construction: the second call finds `revoked_at IS NULL` false everywhere and
+ * revokes nothing, reporting `revokedCount: 0`. There is no duplicate to
+ * suppress and therefore nothing for a stored response to protect.
+ *
+ * ## Success is a 200 with a count, never a bare 204
+ *
+ * "How many sessions did that actually end" is the question an operator asks
+ * immediately afterwards, and `keptCallerSession` answers the other one — why
+ * their own console still works when they pointed this at themselves.
+ */
+const NO_STORE_HEADERS = { "cache-control": "private, no-store" };
+
+export const POST = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "user_sessions",
+    action: "revoke"
+  },
+  handler: async ({ tx, tenantId, params, auth, tokenHash, now }) => {
+    const tenantUserId = params.id ?? "";
+
+    if (!UUID_PATTERN.test(tenantUserId)) {
+      return fail(
+        404,
+        "NOT_FOUND",
+        "No such tenant user.",
+        {},
+        undefined,
+        NO_STORE_HEADERS
+      );
+    }
+
+    const result = await revokeSessionsForTenantUser(
+      tx,
+      tenantId,
+      tenantUserId,
+      tokenHash,
+      now
+    );
+
+    if (result.outcome === "not_found") {
+      return fail(
+        404,
+        "NOT_FOUND",
+        "No such tenant user.",
+        {},
+        undefined,
+        NO_STORE_HEADERS
+      );
+    }
+
+    // Audited even when it revoked nothing. "Somebody tried to sign this
+    // account out and there was nothing to end" is the entry an investigation
+    // wants most, and an audit trail that only records effective actions cannot
+    // distinguish it from nobody having looked.
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "identity_access",
+      action: "user_sessions.revoked_all",
+      resourceType: "tenant_user",
+      resourceId: tenantUserId,
+      severity: "warning",
+      message: `Revoked ${result.revokedCount} live session(s) for tenant user ${tenantUserId}.`,
+      attributes: {
+        revokedCount: result.revokedCount,
+        keptCallerSession: result.keptCallerSession
+      }
+    });
+
+    return jsonResponse(
+      {
+        success: true,
+        data: {
+          revokedCount: result.revokedCount,
+          keptCallerSession: result.keptCallerSession
+        },
+        meta: {}
+      },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  }
+});

--- a/tests/admin-session-directory.test.ts
+++ b/tests/admin-session-directory.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Other people's sessions — the guarded, audited half of the pair (Gelombang 2
+ * PR 2.2 of #423).
+ *
+ * The properties worth defending are all about what the SQL excludes and what
+ * the two routes refuse to share, so the assertions run against a recording fake
+ * and against the route sources. What Postgres does with a correct statement is
+ * not in question; whether the statement carries the exclusion at all is.
+ *
+ * Pure: no database, no network.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import {
+  listSessionsForTenantUser,
+  revokeSessionsForTenantUser
+} from "../src/modules/identity-access/application/admin-session-directory";
+import { identityAccessModule } from "../src/modules/identity-access/module";
+
+type Call = { sql: string; values: unknown[] };
+
+/** Answers each call from a queue, so a test can stage "user resolves, then rows". */
+function recordingTx(responses: unknown[][]) {
+  const calls: Call[] = [];
+  let index = 0;
+
+  const tx = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+    calls.push({ sql: strings.join(" ? "), values });
+
+    return Promise.resolve(responses[index++] ?? []);
+  }) as unknown as Bun.SQL;
+
+  return { tx, calls };
+}
+
+const NOW = new Date("2026-08-10T00:00:00.000Z");
+const TENANT = "tenant-1";
+const CALLER_TOKEN_HASH = "hash-of-the-calling-token";
+const TARGET_USER = "tenant-user-9";
+
+function sessionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "session-1",
+    token_hash: "hash-of-some-other-token",
+    issued_at: NOW,
+    expires_at: new Date(NOW.getTime() + 3_600_000),
+    assurance_level: "aal1",
+    origin_auth: "password",
+    client_ip_hash: null,
+    user_agent_summary: null,
+    ...overrides
+  };
+}
+
+describe("the subject is resolved through tenant membership", () => {
+  test("an id this tenant does not own is `not_found`, and nothing else runs", async () => {
+    const { tx, calls } = recordingTx([[]]);
+
+    expect(
+      await listSessionsForTenantUser(
+        tx,
+        TENANT,
+        TARGET_USER,
+        CALLER_TOKEN_HASH,
+        NOW
+      )
+    ).toEqual({ outcome: "not_found" });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("the membership hop is the tenant check — sessions are keyed on the RESOLVED identity", async () => {
+    // `awcms_sessions` keys on `identity_id` while the surface names a
+    // `tenant_user_id`, so the hop is unavoidable. It is also what stops a
+    // caller reaching sessions by naming an identity that merely exists.
+    const { tx, calls } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [sessionRow()]
+    ]);
+
+    await listSessionsForTenantUser(
+      tx,
+      TENANT,
+      TARGET_USER,
+      CALLER_TOKEN_HASH,
+      NOW
+    );
+
+    expect(calls[0]!.sql).toContain("awcms_tenant_users");
+    expect(calls[0]!.values).toContain(TENANT);
+    expect(calls[0]!.values).toContain(TARGET_USER);
+
+    expect(calls[1]!.sql).toContain("identity_id =");
+    expect(calls[1]!.values).toContain("identity-7");
+    expect(calls[1]!.values).toContain(TENANT);
+  });
+
+  test("revocation resolves through the same hop and refuses the same way", async () => {
+    const { tx, calls } = recordingTx([[]]);
+
+    expect(
+      await revokeSessionsForTenantUser(
+        tx,
+        TENANT,
+        TARGET_USER,
+        CALLER_TOKEN_HASH,
+        NOW
+      )
+    ).toEqual({ outcome: "not_found" });
+    // No UPDATE may be issued against an unresolved subject.
+    expect(calls.some((call) => call.sql.includes("UPDATE"))).toBe(false);
+  });
+});
+
+describe("listing discloses the minimum that supports the decision", () => {
+  test("no token hash reaches the caller, and `isCallerSession` is computed internally", async () => {
+    const { tx } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [
+        sessionRow({ id: "theirs", token_hash: "someone-elses" }),
+        sessionRow({ id: "mine", token_hash: CALLER_TOKEN_HASH })
+      ]
+    ]);
+
+    const result = await listSessionsForTenantUser(
+      tx,
+      TENANT,
+      TARGET_USER,
+      CALLER_TOKEN_HASH,
+      NOW
+    );
+
+    expect(result.outcome).toBe("ok");
+    if (result.outcome !== "ok") return;
+
+    expect(result.sessions.map((session) => session.isCallerSession)).toEqual([
+      false,
+      true
+    ]);
+    // A hash that reached a client could be replayed as a bearer.
+    expect(JSON.stringify(result.sessions)).not.toContain(CALLER_TOKEN_HASH);
+    expect(JSON.stringify(result.sessions)).not.toContain("someone-elses");
+  });
+
+  test("revoked and expired rows are excluded by the query, not by the caller", async () => {
+    const { tx, calls } = recordingTx([[{ identity_id: "identity-7" }], []]);
+
+    await listSessionsForTenantUser(
+      tx,
+      TENANT,
+      TARGET_USER,
+      CALLER_TOKEN_HASH,
+      NOW
+    );
+
+    expect(calls[1]!.sql).toContain("revoked_at IS NULL");
+    expect(calls[1]!.sql).toContain("expires_at >");
+  });
+
+  test("a deactivated user lists empty rather than 404 — the two mean different things", async () => {
+    // `setTenantUserStatus` already revokes their sessions, so empty is the
+    // expected answer; a 404 would be indistinguishable from a wrong id, which
+    // is the check an operator is making at that moment.
+    const { tx } = recordingTx([[{ identity_id: "identity-7" }], []]);
+
+    expect(
+      await listSessionsForTenantUser(
+        tx,
+        TENANT,
+        TARGET_USER,
+        CALLER_TOKEN_HASH,
+        NOW
+      )
+    ).toEqual({ outcome: "ok", sessions: [] });
+  });
+});
+
+describe("revocation never ends the session making the call", () => {
+  test("the UPDATE excludes the caller's own token hash", async () => {
+    const { tx, calls } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [],
+      [{ id: "session-1" }, { id: "session-2" }]
+    ]);
+
+    const result = await revokeSessionsForTenantUser(
+      tx,
+      TENANT,
+      TARGET_USER,
+      CALLER_TOKEN_HASH,
+      NOW
+    );
+
+    expect(result).toEqual({
+      outcome: "revoked",
+      revokedCount: 2,
+      keptCallerSession: false
+    });
+
+    const update = calls.at(-1)!;
+
+    expect(update.sql).toContain("UPDATE awcms_sessions");
+    expect(update.sql).toContain("token_hash <>");
+    expect(update.values).toContain(CALLER_TOKEN_HASH);
+    // Restamping an already-revoked row would move the only timestamp an
+    // investigation has for when access actually ended.
+    expect(update.sql).toContain("revoked_at IS NULL");
+  });
+
+  test("pointing it at yourself reports the kept session instead of hiding it", async () => {
+    // An operator told "revoked 1" whose console still works needs to know why,
+    // or they conclude the control does not work.
+    const { tx } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [{ "?column?": 1 }],
+      [{ id: "session-2" }]
+    ]);
+
+    expect(
+      await revokeSessionsForTenantUser(
+        tx,
+        TENANT,
+        TARGET_USER,
+        CALLER_TOKEN_HASH,
+        NOW
+      )
+    ).toEqual({
+      outcome: "revoked",
+      revokedCount: 1,
+      keptCallerSession: true
+    });
+  });
+
+  test("revoking nothing is still a success with a count, not a 404", async () => {
+    const { tx } = recordingTx([[{ identity_id: "identity-7" }], [], []]);
+
+    expect(
+      await revokeSessionsForTenantUser(
+        tx,
+        TENANT,
+        TARGET_USER,
+        CALLER_TOKEN_HASH,
+        NOW
+      )
+    ).toEqual({
+      outcome: "revoked",
+      revokedCount: 0,
+      keptCallerSession: false
+    });
+  });
+});
+
+describe("the two permissions are declared, and separately", () => {
+  const permissions = identityAccessModule.permissions ?? [];
+
+  test("`user_sessions` seeds read and revoke as distinct entries", () => {
+    const actions = permissions
+      .filter((permission) => permission.activityCode === "user_sessions")
+      .map((permission) => permission.action)
+      .sort();
+
+    expect(actions).toEqual(["read", "revoke"]);
+  });
+
+  test("neither route names the other's action", () => {
+    // The whole value of the split is that `revoke` is grantable without
+    // `read`. A route that guarded on both — or on one activity covering both —
+    // would erase it while every test above still passed.
+    const list = readFileSync(
+      "src/pages/api/v1/users/[id]/sessions/index.ts",
+      "utf8"
+    );
+    const revoke = readFileSync(
+      "src/pages/api/v1/users/[id]/sessions/revoke-all.ts",
+      "utf8"
+    );
+
+    expect(list).toContain('action: "read"');
+    expect(list).not.toContain('action: "revoke"');
+    expect(revoke).toContain('action: "revoke"');
+    expect(revoke).not.toContain('action: "read"');
+
+    for (const source of [list, revoke]) {
+      expect(source).toContain('activityCode: "user_sessions"');
+      expect(source).toContain("defineTenantRoute");
+    }
+  });
+
+  test("both are seeded by a migration, or the owner is denied by default", () => {
+    // ADR-0058 §E — an action nothing seeds denies everyone including the
+    // tenant owner, while the calling code reads as correctly guarded.
+    const migration = readFileSync(
+      "sql/101_awcms_identity_user_sessions_permissions.sql",
+      "utf8"
+    );
+
+    expect(migration).toContain("'user_sessions', 'read'");
+    expect(migration).toContain("'user_sessions', 'revoke'");
+  });
+});
+
+describe("neither route leaks session metadata into a cache", () => {
+  const list = readFileSync(
+    "src/pages/api/v1/users/[id]/sessions/index.ts",
+    "utf8"
+  );
+  const revoke = readFileSync(
+    "src/pages/api/v1/users/[id]/sessions/revoke-all.ts",
+    "utf8"
+  );
+
+  test("every response, including the refusals, carries private, no-store", () => {
+    for (const source of [list, revoke]) {
+      expect(source).toContain('"cache-control": "private, no-store"');
+      // Every `fail(`/`jsonResponse(` in these files must be the header-bearing
+      // form; a bare `ok(...)` would answer without it.
+      expect(source).not.toMatch(/\breturn ok\(/);
+    }
+  });
+
+  test("a malformed id answers 404, never 400", () => {
+    // A 400 for "not a uuid" and a 404 for "no such user" together tell a
+    // caller which ids are well-formed AND which exist.
+    for (const source of [list, revoke]) {
+      expect(source).toContain("UUID_PATTERN");
+      expect(source).not.toContain("VALIDATION_ERROR");
+    }
+  });
+
+  test("the revocation is audited", () => {
+    expect(revoke).toContain("recordAuditEvent");
+    expect(revoke).toContain("user_sessions.revoked_all");
+  });
+});


### PR DESCRIPTION
Gelombang 2 PR 2.2 dari #423. `GET /api/v1/users/{id}/sessions` dan `POST /api/v1/users/{id}/sessions/revoke-all`, ditambah panel sesi di `/admin/users`.

Pasangan self-service yang mendarat di PR 2.1 (#491) menyelesaikan subjeknya dari token pemanggil dan tak bisa diarahkan ke siapa pun. Dua endpoint ini melakukan kebalikannya — subjeknya disebut di URL — jadi keduanya digerbangi, diaudit, dan dipecah ke **dua** izin.

## Pemecahannya terbalik dari `machine_credentials`, dan itu isinya

`sql/083` memisah `create`/`revoke` karena hanya satu dari keduanya **menciptakan** kapabilitas. Di sini yang memisah adalah kebalikannya: hanya satu dari keduanya **mengungkapkan** sesuatu.

`read` adalah jendela permanen ke gerak-gerik seorang kolega — kapan ia masuk, dari berapa bentuk perangkat, jam berapa — dan itu tetap bahan pengawasan ketika yang membacanya administrator. `revoke` menghancurkan akses dan mengembalikan sebuah angka.

Jadi yang dibeli pemecahan ini adalah arah yang penting saat insiden: seorang responder bisa diberi kemampuan mengeluarkan akun yang diduga jebol dari mana-mana **tanpa** sekalian diberi pandangan ke pergerakan semua orang. Satu izin yang mencakup keduanya membuat tindakan darurat yang aman berharga izin permanen yang tidak aman.

Aktivitas `user_sessions` **baru**, bukan `access_control` yang diperluas — alasan yang sama ditulis `sql/075` untuk `registration_requests` dan `sql/083` untuk `machine_credentials`.

## Sesi pemanggil tidak pernah ikut mati

`UPDATE`-nya membawa `token_hash <> ${callerTokenHash}`. Untuk target selain tenant user pemanggil sendiri klausa itu tidak mencocoki apa pun — hash token pemanggil tak bisa muncul di antara sesi identitas lain. Jadi ia gratis di kasus normal dan membeli satu properti di kasus tidak normal: administrator yang sedang membereskan insiden tak bisa mengeluarkan dirinya dari konsol yang sedang ia pakai dengan menekan baris yang kebetulan miliknya.

`keptCallerSession` melaporkannya alih-alih diam — operator yang diberi tahu "3 diakhiri" sementara konsolnya masih hidup perlu tahu sebabnya, atau ia menyimpulkan kontrolnya tidak bekerja.

Itu bukan lubang: mengeluarkan diri sendiri dari mana-mana adalah `DELETE /api/v1/auth/sessions/{id}` dan `POST /api/v1/auth/logout`, keduanya tanpa izin.

## Empat keputusan yang lebih kecil

- **Id yang tak berbentuk UUID dijawab 404, bukan 400.** 400 untuk "bukan uuid" plus 404 untuk "tak ada usernya" bersama-sama memberi tahu pemanggil id mana yang berbentuk benar DAN id mana yang ada.
- **User nonaktif didaftar kosong, bukan 404.** `setTenantUserStatus` sudah mencabut sesinya, jadi daftar kosong adalah jawaban yang diharapkan — dan itulah yang sedang diperiksa operator saat itu.
- **Diaudit meski nol sesi diakhiri.** "Seseorang mencoba mengeluarkan akun ini dan tak ada yang tersisa" justru entri yang paling dicari investigasi.
- **Tanpa `Idempotency-Key`.** Panggilan kedua melaporkan `revokedCount: 0` — tak ada duplikat untuk ditekan.

## Perubahan seam

`tokenHash` kini ikut diserahkan `defineTenantRoute` ke handler-nya. Nilainya sudah dihitung seam itu untuk `authorizeInTransaction`; menurunkannya kedua kali di dalam rute adalah cara dua turunan satu nilai mulai berbeda pendapat. Penambahan murni — nol call site berubah.

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0** (37 segmen penuh, termasuk `build`).
- 3746 pass / 0 fail; `tests/admin-session-directory.test.ts` 15 pass.
- **Mutasi diuji:** menghapus `AND token_hash <> ${callerTokenHash}` dari `UPDATE` membuat asersi "the UPDATE excludes the caller's own token hash" **merah** — gerbangnya mengikat, bukan sekadar hijau.
- `access:permissions:enforcement:check` dan `admin:screen-coverage:check` hijau tanpa entri pengecualian baru: kedua izin ditegakkan rute DAN diklaim layar, jadi ledger `NOT_YET_SCREENED` tidak tumbuh.
- `sql/101` hanya memperluas katalog global; tenant lama dijangkau `bun run identity-access:permissions:backfill`.

Bagian dari #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)