### PR TITLE
feat(auth): "keluarkan saya dari semua perangkat lain" — tanpa flag yang nilai satunya adalah logout lebih buruk (#423)

### DIFF
--- a/.changeset/sesi-cabut-semua-selain-ini.md
+++ b/.changeset/sesi-cabut-semua-selain-ini.md
@@ -1,0 +1,44 @@
+---
+"awcms": minor
+---
+
+feat(auth): "keluarkan saya dari semua perangkat lain" — tanpa flag yang nilai satunya adalah logout yang lebih buruk
+
+Gelombang 2 PR 2.3 dari #423. `POST /api/v1/auth/sessions/revoke-all` mengakhiri
+setiap sesi hidup milik identitas pemanggil **kecuali** yang sedang dipakai.
+Self-service, nol izin baru, sejalan dengan dua endpoint di sebelahnya.
+
+**Flag `?exceptCurrent=true` dari rencana program tidak ikut mendarat.** Boolean
+itu hanya punya satu nilai yang jujur di sini: nilai satunya juga mengakhiri sesi
+yang sedang meminta, dan itu `POST /api/v1/auth/logout` — yang **juga**
+membersihkan cookie yang tak bisa dilihat rute ini. Jadi menerima flag-nya berarti
+mengirimkan logout kedua yang lebih buruk, yang satu-satunya ciri khasnya adalah
+meninggalkan pemanggil memegang cookie mati. Default yang tak boleh dibalik lebih
+jujur ditulis sebagai tiadanya parameter.
+
+Ini endpoint yang dicari orang setelah "sepertinya password saya bocor". Ia harus
+bekerja **sementara** mereka masih masuk, atau mereka memakainya lalu menemukan
+tak bisa mengganti password sesudahnya.
+
+**Ia tidak menyentuh kredensial dan tidak menyentuh penghitung lockout.**
+`completePasswordReset` mencabut sesi sebagai **akibat** perubahan kredensial; yang
+ini kebalikannya dan tetap begitu. Orang yang membereskan sesi liar belum
+membuktikan apa pun yang baru tentang kredensialnya, jadi tak ada yang
+membersihkan `failed_login_count` atau `locked_until` di sini — menyatukan keduanya
+akan menjadikan kebersihan sesi sebuah oracle reset lockout. Ada test yang
+meng-assert nol query menyebut `awcms_identities`.
+
+**Tidak diaudit, sengaja.** `awcms_audit_events` mencatat apa yang dilakukan
+**administrator terhadap orang lain**; endjoint admin pasangannya
+(`POST /api/v1/users/{id}/sessions/revoke-all`, PR 2.2) menulis entrinya. Orang
+yang merapikan sesinya sendiri bukan tindakan administratif atas siapa pun, dan
+mencatat tiap pembersihan self-service akan memenuhi jejak yang dibaca investigator
+dengan entri tentang orang yang bertindak atas dirinya sendiri.
+
+Jawabannya `200` dengan **angka**, bukan `204` kosong: "katanya berhasil, tapi
+apakah saya masih masuk di ponsel" adalah pertanyaan berikutnya, dan nol adalah
+jawaban nyata (memang tak ada yang lain) alih-alih kegagalan.
+
+Asersi "tanpa flag" dijalankan terhadap **kode dengan komentar dibuang** — docblock
+menyebut penolakannya dengan nama, dan sebutan dalam prosa tak boleh bisa
+memerahkan test tentang perilaku, maupun menghijaukannya.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -1360,6 +1360,30 @@ Ownership is enforced in the UPDATE's WHERE clause, never by a preceding read. U
 | 409    | The id names the session making this request (SESSION_IS_CURRENT) — use POST /api/v1/auth/logout. | [`ApiError`](#standard-error-envelope) |
 | 429    | Too many revocation requests from this source.                                                    | [`ApiError`](#standard-error-envelope) |
 
+### `POST /api/v1/auth/sessions/revoke-all` — Sign the caller out of every OTHER session (self-service, no permission).
+
+- **operationId**: `revokeOtherOwnAuthSessions`
+- **Security**: bearerAuth + tenantHeader
+
+Ends every live session of the caller's identity except the one making the request. Self-service by construction — the subject is the session bearer and the route accepts no parameter with which to name anybody else — and unpermissioned for the same reason as the two endpoints beside it: this is what a person reaches for after "I think my password leaked", which is exactly when a permission wall is most expensive.
+There is deliberately no `exceptCurrent` flag. The only other value would also end the requesting session, which is `POST /api/v1/auth/logout` — that endpoint additionally clears the cookies this one cannot see, so the flag would ship a second, worse logout whose distinguishing feature is leaving the caller holding a dead cookie.
+It changes no credential and clears no lockout counter: ending stray sessions proves nothing new about the password, and folding the two together would make session hygiene a lockout-reset oracle. Not audited — `awcms_audit_events` records what administrators do to OTHER people; the paired admin endpoint under /api/v1/users/{id}/sessions/revoke-all writes that entry.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                                                     | Schema                                 |
+| ------ | --------------------------------------------------------------- | -------------------------------------- |
+| 200    | How many other sessions were ended. Zero means there were none. | object                                 |
+| 400    | Validation error.                                               | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                     | [`ApiError`](#standard-error-envelope) |
+| 429    | Too many revocation requests from this source.                  | [`ApiError`](#standard-error-envelope) |
+
 ### `GET /api/v1/auth/sso-policy` — Read the tenant authentication policy (password/SSO/JIT/break-glass).
 
 - **operationId**: `getSsoPolicy`

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -13,7 +13,7 @@
 | Tabel dengan `FORCE` RLS           | 118   |
 | Tabel RLS-free (global, by design) | 11    |
 | Berkas test                        | 339   |
-| Berkas route                       | 322   |
+| Berkas route                       | 323   |
 | ADR                                | 78    |
 
 ### Modul
@@ -296,7 +296,7 @@
 
 | Permukaan       | Berkas |
 | --------------- | ------ |
-| `/api/v1/**`    | 267    |
+| `/api/v1/**`    | 268    |
 | `/admin/**`     | 33     |
 | publik / anonim | 22     |
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -2264,6 +2264,46 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/auth/sessions/revoke-all:
+    post:
+      operationId: revokeOtherOwnAuthSessions
+      tags:
+        - Identity & Access
+      summary: Sign the caller out of every OTHER session (self-service, no permission).
+      description: |-
+        Ends every live session of the caller's identity except the one making the request. Self-service by construction — the subject is the session bearer and the route accepts no parameter with which to name anybody else — and unpermissioned for the same reason as the two endpoints beside it: this is what a person reaches for after "I think my password leaked", which is exactly when a permission wall is most expensive.
+        There is deliberately no `exceptCurrent` flag. The only other value would also end the requesting session, which is `POST /api/v1/auth/logout` — that endpoint additionally clears the cookies this one cannot see, so the flag would ship a second, worse logout whose distinguishing feature is leaving the caller holding a dead cookie.
+        It changes no credential and clears no lockout counter: ending stray sessions proves nothing new about the password, and folding the two together would make session hygiene a lockout-reset oracle. Not audited — `awcms_audit_events` records what administrators do to OTHER people; the paired admin endpoint under /api/v1/users/{id}/sessions/revoke-all writes that entry.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: How many other sessions were ended. Zero means there were none.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      revokedCount:
+                        type: integer
+                        minimum: 0
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          description: Too many revocation requests from this source.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/auth/sso-policy:
     get:
       operationId: getSsoPolicy

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -2911,6 +2911,61 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/auth/sessions/revoke-all:
+    post:
+      operationId: revokeOtherOwnAuthSessions
+      tags:
+        - Identity & Access
+      summary: Sign the caller out of every OTHER session (self-service, no permission).
+      description: >-
+        Ends every live session of the caller's identity except the one making
+        the request. Self-service by construction — the subject is the session
+        bearer and the route accepts no parameter with which to name anybody
+        else — and unpermissioned for the same reason as the two endpoints beside
+        it: this is what a person reaches for after "I think my password leaked",
+        which is exactly when a permission wall is most expensive.
+
+        There is deliberately no `exceptCurrent` flag. The only other value would
+        also end the requesting session, which is `POST /api/v1/auth/logout` —
+        that endpoint additionally clears the cookies this one cannot see, so the
+        flag would ship a second, worse logout whose distinguishing feature is
+        leaving the caller holding a dead cookie.
+
+        It changes no credential and clears no lockout counter: ending stray
+        sessions proves nothing new about the password, and folding the two
+        together would make session hygiene a lockout-reset oracle. Not audited —
+        `awcms_audit_events` records what administrators do to OTHER people; the
+        paired admin endpoint under /api/v1/users/{id}/sessions/revoke-all writes
+        that entry.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: How many other sessions were ended. Zero means there were none.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      revokedCount:
+                        type: integer
+                        minimum: 0
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "429":
+          description: Too many revocation requests from this source.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/auth/sessions/{id}:
     delete:
       operationId: revokeOwnAuthSession

--- a/src/modules/identity-access/application/session-directory.ts
+++ b/src/modules/identity-access/application/session-directory.ts
@@ -145,3 +145,56 @@ export async function revokeOwnSession(
 
   return revoked.length > 0 ? { outcome: "revoked" } : { outcome: "not_found" };
 }
+
+export type RevokeOtherOwnSessionsResult =
+  { outcome: "revoked"; revokedCount: number } | { outcome: "unauthenticated" };
+
+/**
+ * "Sign me out everywhere else" — every live session of the caller's identity
+ * except the one making the request.
+ *
+ * ## Why the current session is EXCLUDED rather than offered as a flag
+ *
+ * The program plan drafted this as `?exceptCurrent=true`, i.e. a caller-supplied
+ * boolean. It ships without one. A parameter that can end the requesting session
+ * has exactly one honest value here — the other one duplicates
+ * `POST /auth/logout`, which additionally clears the cookies this route cannot
+ * see. Accepting the flag would mean shipping a second, worse logout whose only
+ * distinguishing feature is that it leaves the caller holding a dead cookie, and
+ * a default that must never be flipped is better expressed as no parameter.
+ *
+ * This is the endpoint someone reaches for after "I think my password leaked".
+ * It has to work while they are still signed in, or they will use it and then
+ * find they cannot change the password afterwards.
+ *
+ * ## Why it does NOT touch the password or the lockout counters
+ *
+ * `completePasswordReset` revokes sessions as a CONSEQUENCE of a credential
+ * change. This one is the reverse and stays that way: a person who ends stray
+ * sessions has not proven anything new about their credential, so nothing here
+ * clears `failed_login_count` or `locked_until`. Folding the two together would
+ * make session hygiene a lockout-reset oracle.
+ */
+export async function revokeOtherOwnSessions(
+  tx: Bun.SQL,
+  tenantId: string,
+  tokenHash: string,
+  now: Date
+): Promise<RevokeOtherOwnSessionsResult> {
+  const identityId = await resolveCallerIdentity(tx, tenantId, tokenHash, now);
+
+  if (!identityId) return { outcome: "unauthenticated" };
+
+  const revoked = (await tx`
+    UPDATE awcms_sessions
+    SET revoked_at = ${now}
+    WHERE tenant_id = ${tenantId}
+      AND identity_id = ${identityId}
+      AND token_hash <> ${tokenHash}
+      AND revoked_at IS NULL
+      AND expires_at > ${now}
+    RETURNING id
+  `) as { id: string }[];
+
+  return { outcome: "revoked", revokedCount: revoked.length };
+}

--- a/src/pages/api/v1/auth/sessions/revoke-all.ts
+++ b/src/pages/api/v1/auth/sessions/revoke-all.ts
@@ -1,0 +1,107 @@
+import {
+  fail,
+  jsonResponse
+} from "../../../../../modules/_shared/api-response";
+import { defineSelfServiceTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import { isMachineCredentialToken } from "../../../../../lib/auth/machine-credential-token";
+import {
+  checkSharedRateLimit,
+  resolveClientIp
+} from "../../../../../lib/security/rate-limit";
+import { revokeOtherOwnSessions } from "../../../../../modules/identity-access/application/session-directory";
+
+/**
+ * `POST /api/v1/auth/sessions/revoke-all` — sign me out everywhere else
+ * (Gelombang 2 PR 2.3 of #423).
+ *
+ * ## No permission, and no `exceptCurrent` flag
+ *
+ * Self-service for the same reason as the two endpoints beside it: the subject
+ * is the session bearer and there is no parameter with which to name anybody
+ * else. It is also the one people reach for after "I think my password leaked",
+ * which is precisely when a permission wall is most expensive.
+ *
+ * The program plan drafted `?exceptCurrent=true`. It ships without the flag —
+ * see `revokeOtherOwnSessions` for why a boolean whose other value duplicates
+ * `POST /auth/logout` (badly) is better expressed as no boolean at all.
+ *
+ * ## Not audited here, deliberately
+ *
+ * `awcms_audit_events` records what ADMINISTRATORS do to other people; the
+ * paired admin endpoint `POST /api/v1/users/{id}/sessions/revoke-all` writes
+ * one. A person tidying up their own sessions is not an administrative act on
+ * anybody, and logging every self-service cleanup would fill the trail an
+ * investigator reads with entries about people acting on themselves.
+ *
+ * ## Rate limited on the source, not the subject
+ *
+ * Same shape as the list and single-revoke routes. The bound is low because
+ * there is no legitimate reason to call this in a loop — the second call in a
+ * row necessarily revokes nothing.
+ */
+const NO_STORE_HEADERS = { "cache-control": "private, no-store" };
+
+const RATE_LIMIT = { maxAttempts: 10, windowMs: 60_000 };
+
+function authRequired(): Response {
+  return fail(
+    401,
+    "AUTH_REQUIRED",
+    "Authentication required.",
+    {},
+    undefined,
+    NO_STORE_HEADERS
+  );
+}
+
+export const POST = defineSelfServiceTenantRoute({
+  workClass: "interactive",
+  onUnauthenticated: (reason) =>
+    reason === "tenant"
+      ? fail(
+          400,
+          "TENANT_REQUIRED",
+          "Tenant header `x-awcms-tenant-id` is required.",
+          {},
+          undefined,
+          NO_STORE_HEADERS
+        )
+      : authRequired(),
+  beforeTransaction: async ({ request, token, clientAddress }) => {
+    // A machine credential has no sessions of its own to end.
+    if (isMachineCredentialToken(token)) return authRequired();
+
+    const clientIp = resolveClientIp(request, clientAddress);
+    const rateLimit = await checkSharedRateLimit(
+      `auth-sessions-revoke-all:${clientIp}`,
+      RATE_LIMIT
+    );
+
+    if (rateLimit.allowed) return undefined;
+
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many revocation requests from this source. Try again later.",
+      {},
+      undefined,
+      {
+        ...NO_STORE_HEADERS,
+        "retry-after": String(rateLimit.retryAfterSec)
+      }
+    );
+  },
+  handler: async ({ tx, tenantId, tokenHash, now }) => {
+    const result = await revokeOtherOwnSessions(tx, tenantId, tokenHash, now);
+
+    if (result.outcome === "unauthenticated") return authRequired();
+
+    // A count, not a bare 204: "it says it worked but am I still signed in on
+    // my phone" is the immediate next question, and zero is a real answer
+    // (there was nothing else) rather than a failure.
+    return jsonResponse(
+      { success: true, data: { revokedCount: result.revokedCount }, meta: {} },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  }
+});

--- a/tests/session-directory.test.ts
+++ b/tests/session-directory.test.ts
@@ -14,6 +14,7 @@ import { readFileSync } from "node:fs";
 
 import {
   listOwnSessions,
+  revokeOtherOwnSessions,
   revokeOwnSession
 } from "../src/modules/identity-access/application/session-directory";
 
@@ -170,33 +171,122 @@ describe("revocation refuses in one shape", () => {
   });
 });
 
+describe("bulk revocation spares the session making the call", () => {
+  test("the UPDATE excludes the caller's own token hash and nothing else can", async () => {
+    // The exclusion is the whole endpoint. Without it this is a worse
+    // `POST /auth/logout` — one that leaves the caller holding a dead cookie
+    // because it cannot clear them.
+    const { tx, calls } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [{ id: "session-2" }, { id: "session-3" }]
+    ]);
+
+    expect(await revokeOtherOwnSessions(tx, TENANT, TOKEN_HASH, NOW)).toEqual({
+      outcome: "revoked",
+      revokedCount: 2
+    });
+
+    const update = calls.at(-1)!;
+
+    expect(update.sql).toContain("UPDATE awcms_sessions");
+    expect(update.sql).toContain("token_hash <>");
+    expect(update.sql).toContain("identity_id =");
+    expect(update.values).toContain(TOKEN_HASH);
+    expect(update.values).toContain("identity-7");
+    // Restamping an already-revoked row would move the only timestamp an
+    // investigation has for when that access actually ended.
+    expect(update.sql).toContain("revoked_at IS NULL");
+  });
+
+  test("having nothing else to end is a success with zero, not a refusal", async () => {
+    const { tx } = recordingTx([[{ identity_id: "identity-7" }], []]);
+
+    expect(await revokeOtherOwnSessions(tx, TENANT, TOKEN_HASH, NOW)).toEqual({
+      outcome: "revoked",
+      revokedCount: 0
+    });
+  });
+
+  test("an unresolved caller never reaches the UPDATE", async () => {
+    const { tx, calls } = recordingTx([[]]);
+
+    expect(await revokeOtherOwnSessions(tx, TENANT, TOKEN_HASH, NOW)).toEqual({
+      outcome: "unauthenticated"
+    });
+    expect(calls).toHaveLength(1);
+  });
+
+  test("it touches no credential and no lockout counter", async () => {
+    // A person ending stray sessions has proven nothing new about their
+    // password. Clearing `failed_login_count` here would make session hygiene a
+    // lockout-reset oracle.
+    const { tx, calls } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [{ id: "session-2" }]
+    ]);
+
+    await revokeOtherOwnSessions(tx, TENANT, TOKEN_HASH, NOW);
+
+    for (const call of calls) {
+      expect(call.sql).not.toContain("awcms_identities");
+      expect(call.sql).not.toContain("failed_login_count");
+      expect(call.sql).not.toContain("locked_until");
+      expect(call.sql).not.toContain("password_hash");
+    }
+  });
+});
+
 describe("the routes carry no permission, on purpose", () => {
   const list = readFileSync("src/pages/api/v1/auth/sessions/index.ts", "utf8");
   const revoke = readFileSync("src/pages/api/v1/auth/sessions/[id].ts", "utf8");
+  const revokeAll = readFileSync(
+    "src/pages/api/v1/auth/sessions/revoke-all.ts",
+    "utf8"
+  );
 
-  test("both use the self-service seam and never call the chokepoint", () => {
+  test("the bulk route takes no caller-supplied flag", () => {
+    // The program plan drafted `?exceptCurrent=true`. A parameter whose other
+    // value duplicates `POST /auth/logout` — badly, since this route cannot
+    // clear cookies — is better expressed as no parameter.
+    //
+    // Asserted against the CODE with comments stripped: the docblock explains
+    // the rejection by name, and a prose mention must not be able to fail a
+    // test about behaviour (nor to satisfy one).
+    const code = revokeAll
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+
+    expect(code).not.toContain("exceptCurrent");
+    expect(code).not.toContain("searchParams");
+    // `url` is destructured by nothing here; reading it is the only way a flag
+    // could arrive, since the route accepts no body either.
+    expect(code).not.toMatch(/\burl\b/);
+    expect(code).not.toContain("readJsonBody");
+  });
+
+  test("all three use the self-service seam and never call the chokepoint", () => {
     // ADR-0049 §7. A permission for "your own sessions" would be a wall in
     // front of the feature AND a latent-authz trap: an action nothing seeds
     // denies everyone including the tenant owner (ADR-0058 §E).
-    for (const source of [list, revoke]) {
+    for (const source of [list, revoke, revokeAll]) {
       expect(source).toContain("defineSelfServiceTenantRoute");
       expect(source).not.toContain("authorizeInTransaction");
       expect(source).not.toContain("moduleKey:");
     }
   });
 
-  test("neither reads a caller-supplied subject — the identity comes from the token", () => {
+  test("none reads a caller-supplied subject — the identity comes from the token", () => {
     // The self-service seam hands the route a `tokenHash`, never a subject, and
-    // both resolve the identity from it inside the transaction. A route that
+    // each resolves the identity from it inside the transaction. A route that
     // accepted an id would be an admin surface with a friendly name.
-    for (const source of [list, revoke]) {
+    for (const source of [list, revoke, revokeAll]) {
       expect(source).toContain("tokenHash");
       expect(source).not.toMatch(/body\.\s*tenantUserId|params\.tenantUserId/);
     }
   });
 
   test("a machine credential is refused before any database work", () => {
-    for (const source of [list, revoke]) {
+    for (const source of [list, revoke, revokeAll]) {
       expect(source).toContain("isMachineCredentialToken");
       expect(source.indexOf("isMachineCredentialToken")).toBeLessThan(
         source.indexOf("handler:")
@@ -205,7 +295,7 @@ describe("the routes carry no permission, on purpose", () => {
   });
 
   test("every response is uncacheable, including the failures", () => {
-    for (const source of [list, revoke]) {
+    for (const source of [list, revoke, revokeAll]) {
       expect(source).toContain('"cache-control": "private, no-store"');
     }
   });


### PR DESCRIPTION
Gelombang 2 PR 2.3 dari #423. `POST /api/v1/auth/sessions/revoke-all` mengakhiri setiap sesi hidup milik identitas pemanggil **kecuali** yang sedang dipakai. Self-service, nol izin baru, sejalan dengan dua endpoint di sebelahnya (#491).

## Flag `?exceptCurrent=true` dari rencana program tidak ikut mendarat

Boolean itu hanya punya satu nilai yang jujur di sini. Nilai satunya juga mengakhiri sesi yang sedang meminta — dan itu `POST /api/v1/auth/logout`, yang **juga** membersihkan cookie yang tak bisa dilihat rute ini. Jadi menerima flag-nya berarti mengirimkan logout kedua yang lebih buruk, yang satu-satunya ciri khasnya adalah meninggalkan pemanggil memegang cookie mati. Default yang tak boleh dibalik lebih jujur ditulis sebagai tiadanya parameter.

Ini endpoint yang dicari orang setelah "sepertinya password saya bocor". Ia harus bekerja **sementara** mereka masih masuk, atau mereka memakainya lalu menemukan tak bisa mengganti password sesudahnya.

## Tidak menyentuh kredensial, tidak menyentuh lockout

`completePasswordReset` mencabut sesi sebagai **akibat** perubahan kredensial; yang ini kebalikannya dan tetap begitu. Orang yang membereskan sesi liar belum membuktikan apa pun yang baru tentang kredensialnya, jadi tak ada yang membersihkan `failed_login_count` atau `locked_until` di sini — menyatukan keduanya akan menjadikan kebersihan sesi sebuah **oracle reset lockout**. Ada test yang meng-assert nol query menyebut `awcms_identities`.

## Tidak diaudit, sengaja

`awcms_audit_events` mencatat apa yang dilakukan **administrator terhadap orang lain**; endpoint admin pasangannya (`POST /api/v1/users/{id}/sessions/revoke-all`, #496) menulis entrinya. Orang yang merapikan sesinya sendiri bukan tindakan administratif atas siapa pun, dan mencatat tiap pembersihan self-service akan memenuhi jejak yang dibaca investigator dengan entri tentang orang yang bertindak atas dirinya sendiri.

Jawabannya `200` dengan **angka**, bukan `204` kosong: "katanya berhasil, tapi apakah saya masih masuk di ponsel" adalah pertanyaan berikutnya, dan nol adalah jawaban nyata alih-alih kegagalan.

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0** (37 segmen penuh termasuk `build`).
- `tests/session-directory.test.ts` 19 pass (naik dari 15).
- **Mutasi diuji:** menghapus `AND token_hash <> ${tokenHash}` dari `UPDATE` membuat suite **merah**.
- Asersi "tanpa flag" dijalankan terhadap kode dengan **komentar dibuang** — docblock menyebut penolakannya dengan nama, dan sebutan dalam prosa tak boleh bisa memerahkan test tentang perilaku, maupun menghijaukannya. (Versi pertama asersi ini memerah karena docblock-nya sendiri; itu koreksinya.)

Bagian dari #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)