### PR TITLE
feat(auth): ganti password sendiri — step-up hanya diminta dari orang yang punya faktor kedua (#423)

### DIFF
--- a/.changeset/ganti-password-sendiri.md
+++ b/.changeset/ganti-password-sendiri.md
@@ -1,0 +1,60 @@
+---
+"awcms": minor
+---
+
+feat(auth): ganti password sendiri — dan step-up hanya diminta dari orang yang punya faktor kedua
+
+Gelombang 2 PR 2.4 dari #423. `POST /api/v1/auth/password/change`: pasangan dari
+`password/reset` — yang itu melayani orang yang **tidak bisa** masuk dan
+membuktikan penguasaan kotak surat; yang ini melayani orang yang **sudah** masuk
+dan membuktikan penguasaan kredensialnya. Self-service, nol izin baru.
+
+**Rencana program menulis "step-up aal2 + password lama". Bagian aal2-nya
+mendarat BERSYARAT, dan itu koreksi terhadap rencana, bukan penyederhanaan.**
+`requireStepUp` menolak setiap sesi yang tidak sedang `aal2`, dan orang tanpa
+faktor terdaftar **tidak akan pernah** bisa mencapai `aal2`. Mengirimkannya
+tanpa syarat berarti setiap pengguna tanpa MFA permanen tak bisa mengganti
+passwordnya — dan yang paling mungkin butuh justru mereka yang baru saja tahu
+passwordnya bocor. Itu jebakan ADR-0058 §E dengan baju berbeda: gerbang yang
+terbaca benar sambil menolak semua orang.
+
+Jadi aturannya bersyarat dan tiap bagian menanggung bebannya sendiri: **password
+lama adalah re-autentikasi untuk semua orang**, dan **faktor kedua yang segar
+diminta tambahan dari siapa pun yang punya**. Tak ada yang diminta kurang dari
+yang bisa ia berikan, dan tak ada yang diminta sesuatu yang tak bisa ia berikan.
+
+Step-up dievaluasi **sebelum** verifikasi argon2id: jauh lebih murah, dan menjaga
+penolakan step-up basi tidak sekalian menjadi jawaban apakah `currentPassword`
+yang dikirim benar.
+
+**Kebijakan SSO-only diperiksa ulang di sini**, tidak dipercaya dari waktu login:
+tenant bisa saja berpindah ke SSO-only sejak sesi ini terbit, dan seluruh maksud
+kebijakan itu adalah password tidak bisa dipakai masuk. Menulis password baru
+berarti menulis kredensial yang menurut kebijakan tak boleh bekerja. → `409`.
+
+**Sesi pemanggil selamat, sisanya mati.** Ganti password yang mengeluarkan Anda
+dari tab tempat Anda menggantinya terbaca sebagai kegagalan, sementara properti
+keamanannya tidak berubah — sesi pencuri termasuk yang mati. Penghitung lockout
+dibersihkan, alasan yang sama dipakai jalur reset: siapa pun yang menyerahkan
+password saat ini sudah membuktikan penguasaan kredensial, sinyal yang lebih kuat
+dari penghitung yang menguncinya; penyerang yang bisa sampai ke cabang itu sudah
+tahu passwordnya.
+
+**Dibatasi laju meski sudah terautentikasi.** `currentPassword` adalah rahasia
+yang bisa ditebak, jadi ini permukaan tebak-kredensial bahkan di balik sesi —
+kasus yang penting adalah sesi pinjaman atau curian dipakai memburu password yang
+tidak ikut terbawa. Di-key ke **sumber**, bukan ke akun: bucket ber-key identifier
+di sini memberi siapa pun yang bisa menjangkau endpoint tuas menahan ganti
+password satu orang — keberatan yang persis sama sudah tercatat menolak bucket
+login ber-key identifier.
+
+Sukses **dan** gagal sama-sama diaudit: `currentPassword` yang salah dikirim lewat
+sesi hidup adalah sinyal bahwa sebuah sesi dipakai orang yang tak tahu kredensial
+di belakangnya. Atributnya membawa bentuk perangkat dan pseudonim IP, dan **tak
+membawa password — bahkan panjangnya**. Asersinya berjalan terhadap nilai
+`attributes:` itu sendiri, bukan terhadap seluruh berkas: docblock menyebut kedua
+field, dan prosa tak boleh memutuskan test tentang perilaku.
+
+Password yang tidak berubah ditolak sebagai **validation error**, bukan dijawab
+sukses no-op: "berhasil diganti" dibaca orang sebagai "password lama saya sudah
+tidak berlaku", dan itu tidak akan benar.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -1160,6 +1160,36 @@ Authenticated by possession of the mfaChallengeToken from POST /auth/login, not 
 | 429    | Too many verification attempts from this source. | [`ApiError`](#standard-error-envelope) |
 | 500    | MFA misconfigured.                               | [`ApiError`](#standard-error-envelope) |
 
+### `POST /api/v1/auth/password/change` — Change your own password while signed in (self-service, no permission).
+
+- **operationId**: `changeOwnAuthPassword`
+- **Security**: bearerAuth + tenantHeader
+
+The counterpart to /api/v1/auth/password/reset: that endpoint serves someone who CANNOT sign in and proves control of a mailbox, this one serves someone who is signed in and proves control of the credential. Self-service by construction — the subject is the session bearer and the route accepts no parameter naming anybody else.
+A fresh second factor is required ONLY from callers who have one enrolled. Requiring aal2 unconditionally would permanently prevent every user without MFA from changing their password, and the users most likely to need to are the ones who just learned it leaked. The current password is the re-authentication for everyone; the second factor is additional for those who can supply it.
+On success the password is replaced, the lockout counters are cleared (whoever supplied the current password proved control of the credential), and every OTHER session of that identity is revoked — the calling one survives, because a password change that signs you out of the tab you changed it in reads as a failure and the security property is unaffected.
+Rate limited on the SOURCE despite being authenticated: `currentPassword` is a guessable secret, so this is a credential-guessing surface whenever a session is used by someone who does not know the password behind it. An identifier-keyed bucket would instead let anyone reaching the endpoint hold one person's own password change hostage.
+Audited on both the success and the failure, with the device shape and IP pseudonym, and with no password-shaped attribute — not even a length.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Request body** (required): object
+
+**Responses**
+
+| Status | Description                                                                                                     | Schema                                 |
+| ------ | --------------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 200    | Password changed; the other sessions were revoked.                                                              | object                                 |
+| 400    | Validation failed, or currentPassword did not match (INVALID_CREDENTIALS).                                      | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                                                                     | [`ApiError`](#standard-error-envelope) |
+| 403    | MFA is enrolled and this session is not currently stepped up (STEP_UP_REQUIRED).                                | [`ApiError`](#standard-error-envelope) |
+| 409    | The tenant policy signs this identity in through SSO; there is no password to change (PASSWORD_LOGIN_DISABLED). | [`ApiError`](#standard-error-envelope) |
+| 429    | Too many password change attempts from this source.                                                             | [`ApiError`](#standard-error-envelope) |
+
 ### `POST /api/v1/auth/password/forgot` — Request a password reset link (account-enumeration-safe).
 
 - **operationId**: `postAuthPasswordForgot`

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 129   |
 | Tabel dengan `FORCE` RLS           | 118   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 339   |
-| Berkas route                       | 323   |
+| Berkas test                        | 340   |
+| Berkas route                       | 324   |
 | ADR                                | 78    |
 
 ### Modul
@@ -287,7 +287,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 290        |
+| `(root)`      | 291        |
 | `e2e`         | 12         |
 | `integration` | 36         |
 | `unit`        | 1          |
@@ -296,7 +296,7 @@
 
 | Permukaan       | Berkas |
 | --------------- | ------ |
-| `/api/v1/**`    | 268    |
+| `/api/v1/**`    | 269    |
 | `/admin/**`     | 33     |
 | publik / anonim | 22     |
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -1863,6 +1863,84 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/auth/password/change:
+    post:
+      operationId: changeOwnAuthPassword
+      tags:
+        - Identity & Access
+      summary: Change your own password while signed in (self-service, no permission).
+      description: |-
+        The counterpart to /api/v1/auth/password/reset: that endpoint serves someone who CANNOT sign in and proves control of a mailbox, this one serves someone who is signed in and proves control of the credential. Self-service by construction — the subject is the session bearer and the route accepts no parameter naming anybody else.
+        A fresh second factor is required ONLY from callers who have one enrolled. Requiring aal2 unconditionally would permanently prevent every user without MFA from changing their password, and the users most likely to need to are the ones who just learned it leaked. The current password is the re-authentication for everyone; the second factor is additional for those who can supply it.
+        On success the password is replaced, the lockout counters are cleared (whoever supplied the current password proved control of the credential), and every OTHER session of that identity is revoked — the calling one survives, because a password change that signs you out of the tab you changed it in reads as a failure and the security property is unaffected.
+        Rate limited on the SOURCE despite being authenticated: `currentPassword` is a guessable secret, so this is a credential-guessing surface whenever a session is used by someone who does not know the password behind it. An identifier-keyed bucket would instead let anyone reaching the endpoint hold one person's own password change hostage.
+        Audited on both the success and the failure, with the device shape and IP pseudonym, and with no password-shaped attribute — not even a length.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - currentPassword
+                - newPassword
+              properties:
+                currentPassword:
+                  type: string
+                newPassword:
+                  type: string
+                  minLength: 8
+                  description: Must differ from currentPassword — an unchanged password is refused as a validation error, never answered as a no-op success.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Password changed; the other sessions were revoked.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      changed:
+                        type: boolean
+                        enum:
+                          - true
+                      revokedSessionCount:
+                        type: integer
+                        minimum: 0
+        "400":
+          description: Validation failed, or currentPassword did not match (INVALID_CREDENTIALS).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: MFA is enrolled and this session is not currently stepped up (STEP_UP_REQUIRED).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: The tenant policy signs this identity in through SSO; there is no password to change (PASSWORD_LOGIN_DISABLED).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Too many password change attempts from this source.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/auth/password/forgot:
     post:
       operationId: postAuthPasswordForgot

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -1402,6 +1402,104 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/auth/password/change:
+    post:
+      operationId: changeOwnAuthPassword
+      tags:
+        - Identity & Access
+      summary: Change your own password while signed in (self-service, no permission).
+      description: >-
+        The counterpart to /api/v1/auth/password/reset: that endpoint serves
+        someone who CANNOT sign in and proves control of a mailbox, this one
+        serves someone who is signed in and proves control of the credential.
+        Self-service by construction — the subject is the session bearer and the
+        route accepts no parameter naming anybody else.
+
+        A fresh second factor is required ONLY from callers who have one
+        enrolled. Requiring aal2 unconditionally would permanently prevent every
+        user without MFA from changing their password, and the users most likely
+        to need to are the ones who just learned it leaked. The current password
+        is the re-authentication for everyone; the second factor is additional
+        for those who can supply it.
+
+        On success the password is replaced, the lockout counters are cleared
+        (whoever supplied the current password proved control of the credential),
+        and every OTHER session of that identity is revoked — the calling one
+        survives, because a password change that signs you out of the tab you
+        changed it in reads as a failure and the security property is unaffected.
+
+        Rate limited on the SOURCE despite being authenticated: `currentPassword`
+        is a guessable secret, so this is a credential-guessing surface whenever a
+        session is used by someone who does not know the password behind it. An
+        identifier-keyed bucket would instead let anyone reaching the endpoint
+        hold one person's own password change hostage.
+
+        Audited on both the success and the failure, with the device shape and IP
+        pseudonym, and with no password-shaped attribute — not even a length.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - currentPassword
+                - newPassword
+              properties:
+                currentPassword:
+                  type: string
+                newPassword:
+                  type: string
+                  minLength: 8
+                  description: Must differ from currentPassword — an unchanged password is refused as a validation error, never answered as a no-op success.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Password changed; the other sessions were revoked.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      changed:
+                        type: boolean
+                        enum: [true]
+                      revokedSessionCount:
+                        type: integer
+                        minimum: 0
+        "400":
+          description: Validation failed, or currentPassword did not match (INVALID_CREDENTIALS).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          description: MFA is enrolled and this session is not currently stepped up (STEP_UP_REQUIRED).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: The tenant policy signs this identity in through SSO; there is no password to change (PASSWORD_LOGIN_DISABLED).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Too many password change attempts from this source.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/auth/register:
     post:
       operationId: postAuthRegister

--- a/src/modules/identity-access/application/password-change.ts
+++ b/src/modules/identity-access/application/password-change.ts
@@ -1,0 +1,131 @@
+/**
+ * A person changing their OWN password while signed in (Gelombang 2 PR 2.4 of
+ * #423).
+ *
+ * The reset flow (`password-reset.ts`) exists for someone who cannot sign in and
+ * proves control of the mailbox instead. This one is the opposite situation:
+ * they are signed in and prove control of the CREDENTIAL. Both end with the
+ * password replaced and stray sessions gone; what differs is what was proven and
+ * therefore what may be believed afterwards.
+ *
+ * ## Step-up is required only when the person HAS a second factor
+ *
+ * The program plan said "step-up aal2 + old password". Shipping the aal2 half
+ * unconditionally would have been the ADR-0058 §E trap wearing different
+ * clothes: `requireStepUp` denies any session that is not currently `aal2`, and
+ * a person with no enrolled factor can never reach `aal2` — so every user
+ * without MFA would be permanently unable to change their password, and the
+ * ones most likely to need to are the ones who just learned it leaked.
+ *
+ * So the rule is conditional and each half carries its own weight: the current
+ * password is the re-authentication for everyone, and a fresh second factor is
+ * additionally required from anyone who has one. Nobody is ever asked for less
+ * than they can supply, and nobody is asked for something they cannot.
+ *
+ * ## Order inside the function
+ *
+ * Step-up is evaluated BEFORE the argon2id verification. It is far cheaper, and
+ * it keeps a stale-step-up refusal from also being an answer about whether the
+ * submitted `currentPassword` was right.
+ */
+import { hashPassword, verifyPassword } from "../../../lib/auth/password";
+import { getMfaStatus } from "./mfa";
+import { requireStepUp } from "./mfa-session-assurance";
+import { revokeOtherOwnSessions } from "./session-directory";
+import { isPasswordLoginDisabledForIdentity } from "./tenant-auth-policy";
+
+export type ChangeOwnPasswordResult =
+  | { outcome: "changed"; identityId: string; revokedSessionCount: number }
+  /** The bearer names no live session. */
+  | { outcome: "unauthenticated" }
+  /** MFA is enrolled and this session is not currently stepped up. */
+  | { outcome: "step_up_required" }
+  /** The tenant policy says this identity signs in by SSO; there is no password to change. */
+  | { outcome: "password_login_disabled" }
+  /** `currentPassword` did not match. */
+  | { outcome: "invalid_credentials" };
+
+/**
+ * Replaces the caller's password.
+ *
+ * On success it also clears `failed_login_count` / `locked_until`, exactly as
+ * the reset path does and for the same reason: whoever submitted the current
+ * password proved control of the credential, which is a stronger signal than the
+ * failed-attempt counter that locked it. An attacker who could reach this branch
+ * already knows the password, so the lockout was protecting nothing from them.
+ *
+ * Other sessions are revoked; the CALLING one survives. A password change that
+ * signs you out of the tab you changed it in reads as a failure, and the
+ * security property is unaffected — a thief's session is among the ones that
+ * die.
+ */
+export async function changeOwnPassword(
+  tx: Bun.SQL,
+  tenantId: string,
+  tokenHash: string,
+  input: { currentPassword: string; newPassword: string },
+  now: Date
+): Promise<ChangeOwnPasswordResult> {
+  const sessionRows = (await tx`
+    SELECT identity_id FROM awcms_sessions
+    WHERE tenant_id = ${tenantId}
+      AND token_hash = ${tokenHash}
+      AND revoked_at IS NULL
+      AND expires_at > ${now}
+  `) as { identity_id: string }[];
+  const identityId = sessionRows[0]?.identity_id;
+
+  if (!identityId) return { outcome: "unauthenticated" };
+
+  const mfa = await getMfaStatus(tx, tenantId, identityId);
+
+  if (mfa.enabled) {
+    // The `denied` Response it builds is discarded on purpose: the wire shape of
+    // a refusal belongs to the route, and returning one from here would put a
+    // second response-builder inside the application layer.
+    const stepUp = await requireStepUp(tx, tenantId, tokenHash, now);
+
+    if (!stepUp.ok) return { outcome: "step_up_required" };
+  }
+
+  // Re-checked here rather than trusted from login time: the tenant may have
+  // switched to SSO-only since this session was issued, and the whole point of
+  // that policy is that a password cannot be used to get in. Writing a new one
+  // would be writing a credential the policy says must not work.
+  if (await isPasswordLoginDisabledForIdentity(tx, tenantId, identityId)) {
+    return { outcome: "password_login_disabled" };
+  }
+
+  const identityRows = (await tx`
+    SELECT password_hash FROM awcms_identities
+    WHERE tenant_id = ${tenantId} AND id = ${identityId} AND status = 'active'
+  `) as { password_hash: string }[];
+  const passwordHash = identityRows[0]?.password_hash;
+
+  // A live session whose identity is gone or deactivated: reported as
+  // unauthenticated, not as a bad password. The session is what stopped being
+  // valid.
+  if (!passwordHash) return { outcome: "unauthenticated" };
+
+  if (!(await verifyPassword(input.currentPassword, passwordHash))) {
+    return { outcome: "invalid_credentials" };
+  }
+
+  await tx`
+    UPDATE awcms_identities
+    SET password_hash = ${await hashPassword(input.newPassword)},
+        failed_login_count = 0,
+        locked_until = NULL,
+        updated_at = ${now}
+    WHERE tenant_id = ${tenantId} AND id = ${identityId}
+  `;
+
+  const revocation = await revokeOtherOwnSessions(tx, tenantId, tokenHash, now);
+
+  return {
+    outcome: "changed",
+    identityId,
+    revokedSessionCount:
+      revocation.outcome === "revoked" ? revocation.revokedCount : 0
+  };
+}

--- a/src/modules/identity-access/domain/credential-change-validation.ts
+++ b/src/modules/identity-access/domain/credential-change-validation.ts
@@ -1,0 +1,76 @@
+/**
+ * Pure request validation for `POST /api/v1/auth/password/change` (Gelombang 2
+ * PR 2.4 of #423). No I/O.
+ *
+ * Named `validateCredentialChangeInput`, NOT `validatePasswordChangeInput`, for
+ * the reason `password-reset-validation.ts` records in full: CodeQL's
+ * `js/insufficient-password-hash` query treats the return value of any function
+ * whose name contains "password" as password-flavoured regardless of what it
+ * returns. The genuinely password-bearing fields keep their accurate names and
+ * are hashed with argon2id via `hashPassword`. Nothing here weakens real
+ * password handling.
+ */
+import {
+  MIN_PASSWORD_LENGTH,
+  type ValidationError
+} from "./password-reset-validation";
+
+export type CredentialChangeInput = {
+  currentPassword: string;
+  newPassword: string;
+};
+
+type Result<T> =
+  { valid: true; value: T } | { valid: false; errors: ValidationError[] };
+
+export function validateCredentialChangeInput(
+  body: unknown
+): Result<CredentialChangeInput> {
+  const record = (body ?? {}) as Record<string, unknown>;
+  const errors: ValidationError[] = [];
+
+  if (
+    typeof record.currentPassword !== "string" ||
+    record.currentPassword.length === 0
+  ) {
+    errors.push({
+      field: "currentPassword",
+      message: "currentPassword is required."
+    });
+  }
+
+  // The floor is the same one the reset path enforces, imported rather than
+  // restated: two constants that must agree are two constants that eventually
+  // will not.
+  if (
+    typeof record.newPassword !== "string" ||
+    record.newPassword.length < MIN_PASSWORD_LENGTH
+  ) {
+    errors.push({
+      field: "newPassword",
+      message: `newPassword must be at least ${MIN_PASSWORD_LENGTH} characters.`
+    });
+  }
+
+  // Refused as a VALIDATION error rather than answered as a no-op success.
+  // "Changed" is what a person reads as "my old password no longer works", and
+  // it would not be true.
+  if (errors.length === 0 && record.currentPassword === record.newPassword) {
+    errors.push({
+      field: "newPassword",
+      message: "newPassword must differ from currentPassword."
+    });
+  }
+
+  if (errors.length > 0) {
+    return { valid: false, errors };
+  }
+
+  return {
+    valid: true,
+    value: {
+      currentPassword: record.currentPassword as string,
+      newPassword: record.newPassword as string
+    }
+  };
+}

--- a/src/pages/api/v1/auth/password/change.ts
+++ b/src/pages/api/v1/auth/password/change.ts
@@ -1,0 +1,215 @@
+import {
+  fail,
+  jsonResponse
+} from "../../../../../modules/_shared/api-response";
+import { defineSelfServiceTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import { isMachineCredentialToken } from "../../../../../lib/auth/machine-credential-token";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../lib/security/request-body-limit";
+import {
+  checkSharedRateLimit,
+  resolveClientIp
+} from "../../../../../lib/security/rate-limit";
+import {
+  hashClientIp,
+  summarizeUserAgent
+} from "../../../../../lib/security/client-fingerprint";
+import { changeOwnPassword } from "../../../../../modules/identity-access/application/password-change";
+import { validateCredentialChangeInput } from "../../../../../modules/identity-access/domain/credential-change-validation";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/auth/password/change` (Gelombang 2 PR 2.4 of #423) — change my
+ * own password while signed in.
+ *
+ * The counterpart to `reset.ts`: that endpoint serves someone who CANNOT sign in
+ * and proves control of a mailbox; this one serves someone who is signed in and
+ * proves control of the credential. Self-service and unpermissioned for the same
+ * reason as the session endpoints — the subject is the bearer, and there is no
+ * parameter with which to name anybody else.
+ *
+ * ## Second factor only from people who have one
+ *
+ * `password-change.ts` records the argument in full. In short: requiring `aal2`
+ * unconditionally would permanently prevent every user without MFA from changing
+ * their password, and the ones most likely to need to are the ones who just
+ * learned it leaked.
+ *
+ * ## Rate limited despite being authenticated
+ *
+ * `currentPassword` is a guessable secret, so this is a credential-guessing
+ * surface even behind a session — the case that matters is a borrowed or stolen
+ * session being used to hunt for the password it did not come with. Keyed on the
+ * SOURCE, not the account: an identifier-keyed bucket here would let anyone who
+ * can reach the endpoint hold one person's own password change hostage.
+ *
+ * ## Audited, with no password-shaped attribute anywhere
+ *
+ * A credential change is a security event, so it is recorded like one — with the
+ * device shape and IP pseudonym that make an investigation possible, and with
+ * neither password, not even a length.
+ */
+const NO_STORE_HEADERS = { "cache-control": "private, no-store" };
+
+const RATE_LIMIT = { maxAttempts: 5, windowMs: 900_000 };
+
+function authRequired(): Response {
+  return fail(
+    401,
+    "AUTH_REQUIRED",
+    "Authentication required.",
+    {},
+    undefined,
+    NO_STORE_HEADERS
+  );
+}
+
+export const POST = defineSelfServiceTenantRoute({
+  workClass: "interactive",
+  onUnauthenticated: (reason) =>
+    reason === "tenant"
+      ? fail(
+          400,
+          "TENANT_REQUIRED",
+          "Tenant header `x-awcms-tenant-id` is required.",
+          {},
+          undefined,
+          NO_STORE_HEADERS
+        )
+      : authRequired(),
+  beforeTransaction: async ({ request, token, clientAddress }) => {
+    // A machine credential has no password to change, and ADR-0049 keeps it
+    // read-only regardless.
+    if (isMachineCredentialToken(token)) return authRequired();
+
+    const clientIp = resolveClientIp(request, clientAddress);
+    const rateLimit = await checkSharedRateLimit(
+      `auth-password-change:${clientIp}`,
+      RATE_LIMIT
+    );
+
+    if (rateLimit.allowed) return undefined;
+
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many password change attempts from this source. Try again later.",
+      {},
+      undefined,
+      {
+        ...NO_STORE_HEADERS,
+        "retry-after": String(rateLimit.retryAfterSec)
+      }
+    );
+  },
+  handler: async ({ tx, tenantId, tokenHash, request, clientAddress, now }) => {
+    const body = await readJsonBody(request);
+
+    if (body.tooLarge) return bodyTooLargeResponse(body.limitBytes);
+
+    const validation = validateCredentialChangeInput(body.value);
+
+    if (!validation.valid) {
+      return fail(
+        400,
+        "VALIDATION_ERROR",
+        "currentPassword and newPassword are required.",
+        {},
+        validation.errors,
+        NO_STORE_HEADERS
+      );
+    }
+
+    const result = await changeOwnPassword(
+      tx,
+      tenantId,
+      tokenHash,
+      validation.value,
+      now
+    );
+
+    if (result.outcome === "unauthenticated") return authRequired();
+
+    if (result.outcome === "step_up_required") {
+      return fail(
+        403,
+        "STEP_UP_REQUIRED",
+        "This action requires recent multi-factor verification. Complete a step-up and retry.",
+        {},
+        undefined,
+        NO_STORE_HEADERS
+      );
+    }
+
+    if (result.outcome === "password_login_disabled") {
+      return fail(
+        409,
+        "PASSWORD_LOGIN_DISABLED",
+        "This account signs in through your identity provider; there is no password to change.",
+        {},
+        undefined,
+        NO_STORE_HEADERS
+      );
+    }
+
+    const source = {
+      ipHash: hashClientIp(resolveClientIp(request, clientAddress)),
+      userAgent: summarizeUserAgent(request)
+    };
+
+    if (result.outcome === "invalid_credentials") {
+      // Audited from INSIDE the transaction, which commits — the same shape
+      // `reset.ts` uses for a failed redemption. A wrong current password
+      // submitted through a live session is the signal that a session is being
+      // used by someone who does not know the credential behind it, and it is
+      // worth exactly as much as the successful change below.
+      await recordAuditEvent(tx, {
+        tenantId,
+        moduleKey: "identity_access",
+        action: "password_change_failed",
+        resourceType: "identity",
+        severity: "warning",
+        message:
+          "Password change attempt failed: currentPassword did not match.",
+        attributes: source
+      });
+
+      return fail(
+        400,
+        "INVALID_CREDENTIALS",
+        "The current password is incorrect.",
+        {},
+        undefined,
+        NO_STORE_HEADERS
+      );
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      moduleKey: "identity_access",
+      action: "password_changed",
+      resourceType: "identity",
+      resourceId: result.identityId,
+      severity: "warning",
+      message: `Password changed by its owner; ${result.revokedSessionCount} other session(s) revoked.`,
+      attributes: {
+        revokedSessionCount: result.revokedSessionCount,
+        ...source
+      }
+    });
+
+    return jsonResponse(
+      {
+        success: true,
+        data: {
+          changed: true,
+          revokedSessionCount: result.revokedSessionCount
+        },
+        meta: {}
+      },
+      { status: 200, headers: NO_STORE_HEADERS }
+    );
+  }
+});

--- a/tests/password-change.test.ts
+++ b/tests/password-change.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Changing your own password while signed in (Gelombang 2 PR 2.4 of #423).
+ *
+ * The load-bearing property is the CONDITIONAL step-up: the program plan asked
+ * for `aal2` unconditionally, which would have permanently locked every user
+ * without an enrolled factor out of changing their own password. Several tests
+ * below exist only to keep that from being quietly re-tightened.
+ *
+ * Pure: no database, no network. The step-up and MFA lookups are exercised
+ * through the recording fake's staged rows, so the ORDER of the queries — which
+ * is where the cheap check must come before the expensive one — is observable.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+import { changeOwnPassword } from "../src/modules/identity-access/application/password-change";
+import { validateCredentialChangeInput } from "../src/modules/identity-access/domain/credential-change-validation";
+import { hashPassword } from "../src/lib/auth/password";
+
+type Call = { sql: string; values: unknown[] };
+
+function recordingTx(responses: unknown[][]) {
+  const calls: Call[] = [];
+  let index = 0;
+
+  const tx = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+    calls.push({ sql: strings.join(" ? "), values });
+
+    return Promise.resolve(responses[index++] ?? []);
+  }) as unknown as Bun.SQL;
+
+  return { tx, calls };
+}
+
+const NOW = new Date("2026-08-10T00:00:00.000Z");
+const TENANT = "tenant-1";
+const TOKEN_HASH = "hash-of-the-calling-token";
+const CURRENT = "correct horse battery";
+const NEXT = "staple correct horse";
+
+/**
+ * Query 1 resolves the session, 2 reads MFA factors (none), 3 probes the
+ * tenant's auth policy (absent = password login allowed), 4 reads the stored
+ * hash. `extra` continues from there: the identity UPDATE, then the two queries
+ * `revokeOtherOwnSessions` issues.
+ */
+function stageThrough(
+  passwordHash: string,
+  extra: unknown[][] = []
+): unknown[][] {
+  return [
+    [{ identity_id: "identity-7" }],
+    [],
+    [],
+    [{ password_hash: passwordHash }],
+    ...extra
+  ];
+}
+
+/** The tail after the identity UPDATE, revoking `sessionIds` other sessions. */
+function stageRevocation(sessionIds: string[]): unknown[][] {
+  return [
+    [],
+    [{ identity_id: "identity-7" }],
+    sessionIds.map((id) => ({ id }))
+  ];
+}
+
+describe("input validation refuses before anything is hashed", () => {
+  test("an unchanged password is a validation error, not a no-op success", () => {
+    // "Changed" is what a person reads as "my old password no longer works",
+    // and it would not be true.
+    const result = validateCredentialChangeInput({
+      currentPassword: CURRENT,
+      newPassword: CURRENT
+    });
+
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.errors.map((error) => error.field)).toContain("newPassword");
+  });
+
+  test("the length floor is the reset path's, imported rather than restated", async () => {
+    const { MIN_PASSWORD_LENGTH } =
+      await import("../src/modules/identity-access/domain/password-reset-validation");
+    const source = readFileSync(
+      "src/modules/identity-access/domain/credential-change-validation.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("MIN_PASSWORD_LENGTH");
+    // Two constants that must agree are two constants that eventually will not.
+    expect(source).not.toMatch(/newPassword\.length\s*<\s*\d/);
+
+    const result = validateCredentialChangeInput({
+      currentPassword: CURRENT,
+      newPassword: "x".repeat(MIN_PASSWORD_LENGTH - 1)
+    });
+
+    expect(result.valid).toBe(false);
+  });
+
+  test("both fields are required", () => {
+    expect(validateCredentialChangeInput({}).valid).toBe(false);
+    expect(validateCredentialChangeInput({ newPassword: NEXT }).valid).toBe(
+      false
+    );
+    expect(
+      validateCredentialChangeInput({ currentPassword: CURRENT }).valid
+    ).toBe(false);
+  });
+});
+
+describe("step-up is asked for only when there is a factor to ask for", () => {
+  test("a caller with NO enrolled factor is never asked to step up", async () => {
+    // This is the whole reason the plan's unconditional aal2 was not shipped:
+    // `requireStepUp` denies any session that is not currently aal2, and a
+    // person with no factor can never reach aal2. Shipping it would have locked
+    // every non-MFA user out of changing their own password, permanently.
+    const hash = await hashPassword(CURRENT);
+    const { tx, calls } = recordingTx(
+      stageThrough(hash, stageRevocation(["session-2"]))
+    );
+
+    const result = await changeOwnPassword(
+      tx,
+      TENANT,
+      TOKEN_HASH,
+      { currentPassword: CURRENT, newPassword: NEXT },
+      NOW
+    );
+
+    expect(result.outcome).toBe("changed");
+    // No assurance lookup happened at all — the MFA status query answered
+    // "none" and the step-up path was skipped rather than satisfied.
+    expect(calls.some((call) => call.sql.includes("assurance_level"))).toBe(
+      false
+    );
+  });
+
+  test("a caller WITH a factor and a stale step-up is refused, and nothing is written", async () => {
+    const { tx, calls } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [{ factor_type: "totp", activated_at: NOW }],
+      // `resolveSessionAssurance` finds no live stepped-up session row.
+      []
+    ]);
+
+    expect(
+      await changeOwnPassword(
+        tx,
+        TENANT,
+        TOKEN_HASH,
+        { currentPassword: CURRENT, newPassword: NEXT },
+        NOW
+      )
+    ).toEqual({ outcome: "step_up_required" });
+
+    expect(calls.some((call) => call.sql.includes("UPDATE"))).toBe(false);
+  });
+
+  test("the step-up check runs BEFORE the argon2id verification", async () => {
+    // Cheaper first, and it keeps a stale-step-up refusal from doubling as an
+    // answer about whether the submitted currentPassword was right.
+    const source = readFileSync(
+      "src/modules/identity-access/application/password-change.ts",
+      "utf8"
+    );
+
+    expect(source.indexOf("requireStepUp(")).toBeLessThan(
+      source.indexOf("verifyPassword(")
+    );
+  });
+});
+
+describe("the write happens only after the credential is proven", () => {
+  test("a wrong current password writes nothing", async () => {
+    const hash = await hashPassword(CURRENT);
+    const { tx, calls } = recordingTx(stageThrough(hash));
+
+    expect(
+      await changeOwnPassword(
+        tx,
+        TENANT,
+        TOKEN_HASH,
+        { currentPassword: "not it", newPassword: NEXT },
+        NOW
+      )
+    ).toEqual({ outcome: "invalid_credentials" });
+
+    expect(calls.some((call) => call.sql.includes("UPDATE"))).toBe(false);
+  });
+
+  test("success replaces the hash, clears the lockout, and revokes the OTHER sessions", async () => {
+    const hash = await hashPassword(CURRENT);
+    const { tx, calls } = recordingTx(
+      stageThrough(hash, stageRevocation(["s2", "s3"]))
+    );
+
+    expect(
+      await changeOwnPassword(
+        tx,
+        TENANT,
+        TOKEN_HASH,
+        { currentPassword: CURRENT, newPassword: NEXT },
+        NOW
+      )
+    ).toEqual({
+      outcome: "changed",
+      identityId: "identity-7",
+      revokedSessionCount: 2
+    });
+
+    const update = calls.find((call) =>
+      call.sql.includes("UPDATE awcms_identities")
+    )!;
+
+    expect(update.sql).toContain("password_hash =");
+    // Whoever supplied the current password proved control of the credential —
+    // a stronger signal than the counter that locked it, and an attacker who
+    // reached this branch already knows the password.
+    expect(update.sql).toContain("failed_login_count = 0");
+    expect(update.sql).toContain("locked_until = NULL");
+    // The plaintext must never appear in a statement's values.
+    expect(update.values).not.toContain(NEXT);
+    expect(update.values).not.toContain(CURRENT);
+
+    const revoke = calls.find((call) =>
+      call.sql.includes("UPDATE awcms_sessions")
+    )!;
+
+    expect(revoke.sql).toContain("token_hash <>");
+    expect(revoke.values).toContain(TOKEN_HASH);
+  });
+
+  test("an SSO-only identity is refused before the password is even read", async () => {
+    // Re-checked here rather than trusted from login: the tenant may have
+    // switched to SSO-only since this session was issued, and writing a new
+    // password would be writing a credential the policy says must not work.
+    const { tx, calls } = recordingTx([
+      [{ identity_id: "identity-7" }],
+      [],
+      // The tenant turned password login off and this identity is not
+      // break-glass.
+      [{ password_login_enabled: false, break_glass_identity_ids: [] }]
+    ]);
+
+    expect(
+      await changeOwnPassword(
+        tx,
+        TENANT,
+        TOKEN_HASH,
+        { currentPassword: CURRENT, newPassword: NEXT },
+        NOW
+      )
+    ).toEqual({ outcome: "password_login_disabled" });
+
+    expect(calls.some((call) => call.sql.includes("UPDATE"))).toBe(false);
+    // And the stored hash was never even read.
+    expect(calls.some((call) => call.sql.includes("password_hash"))).toBe(
+      false
+    );
+  });
+
+  test("a bearer naming no live session stops at the first query", async () => {
+    const { tx, calls } = recordingTx([[]]);
+
+    expect(
+      await changeOwnPassword(
+        tx,
+        TENANT,
+        TOKEN_HASH,
+        { currentPassword: CURRENT, newPassword: NEXT },
+        NOW
+      )
+    ).toEqual({ outcome: "unauthenticated" });
+    expect(calls).toHaveLength(1);
+  });
+});
+
+describe("the route is self-service and leaks no password anywhere", () => {
+  const source = readFileSync(
+    "src/pages/api/v1/auth/password/change.ts",
+    "utf8"
+  );
+
+  test("it uses the self-service seam and names no permission", () => {
+    // ADR-0049 §7 and ADR-0058 §E: a permission for "change your own password"
+    // would be a wall in front of the feature AND an action nothing seeds,
+    // which denies everyone including the tenant owner.
+    expect(source).toContain("defineSelfServiceTenantRoute");
+    expect(source).not.toContain("authorizeInTransaction");
+    expect(source).not.toContain("activityCode");
+  });
+
+  test("the audit attributes carry no password and no length of one", () => {
+    // Asserted against the `attributes:` values themselves, not against the
+    // whole file: the docblock names both fields, and prose must not be able to
+    // decide a test about behaviour.
+    //
+    // A length is a meaningful narrowing of a search space, and it is exactly
+    // the kind of field that gets added because it "seems harmless".
+    const attributeBlocks = [
+      ...source.matchAll(/attributes:\s*(\{[\s\S]*?\}|\w+)/g)
+    ].map((match) => match[1]!);
+
+    expect(attributeBlocks.length).toBeGreaterThan(1);
+
+    for (const block of attributeBlocks) {
+      expect(block.toLowerCase()).not.toContain("password");
+    }
+
+    expect(source).not.toContain("newPassword.length");
+    expect(source).not.toMatch(/passwordLength/);
+  });
+
+  test("both the success and the failure are audited", () => {
+    expect(source).toContain("password_changed");
+    expect(source).toContain("password_change_failed");
+  });
+
+  test("it is rate limited on the SOURCE, never on the account", () => {
+    // An identifier-keyed bucket would let anyone who can reach the endpoint
+    // hold one person's own password change hostage — the same objection
+    // already recorded against an identifier-keyed login bucket.
+    expect(source).toContain("auth-password-change:${clientIp}");
+    expect(source).toContain("isMachineCredentialToken");
+  });
+
+  test("every response, including the refusals, is uncacheable", () => {
+    expect(source).toContain('"cache-control": "private, no-store"');
+    expect(source).not.toMatch(/\breturn ok\(/);
+  });
+});


### PR DESCRIPTION
Gelombang 2 PR 2.4 dari #423, dan penutup Gelombang 2. `POST /api/v1/auth/password/change` — pasangan dari `password/reset`: yang itu melayani orang yang **tidak bisa** masuk dan membuktikan penguasaan kotak surat; yang ini melayani orang yang **sudah** masuk dan membuktikan penguasaan kredensialnya. Self-service, nol izin baru.

## Rencana program menulis "step-up aal2 + password lama" — bagian aal2-nya mendarat BERSYARAT

Ini koreksi terhadap rencana, bukan penyederhanaan. `requireStepUp` menolak setiap sesi yang tidak sedang `aal2`, dan orang tanpa faktor terdaftar **tidak akan pernah** bisa mencapai `aal2`. Mengirimkannya tanpa syarat berarti setiap pengguna tanpa MFA permanen tak bisa mengganti passwordnya — dan yang paling mungkin butuh justru mereka yang baru saja tahu passwordnya bocor.

Itu jebakan ADR-0058 §E dengan baju berbeda: gerbang yang terbaca benar sambil menolak semua orang.

Jadi aturannya bersyarat dan tiap bagian menanggung bebannya sendiri: **password lama adalah re-autentikasi untuk semua orang**, dan **faktor kedua yang segar diminta tambahan dari siapa pun yang punya**. Tak ada yang diminta kurang dari yang bisa ia berikan, dan tak ada yang diminta sesuatu yang tak bisa ia berikan.

Step-up dievaluasi **sebelum** verifikasi argon2id: jauh lebih murah, dan menjaga penolakan step-up basi tidak sekalian menjadi jawaban apakah `currentPassword` yang dikirim benar. Diuji di level sumber, karena test perilaku bisa dipuaskan oleh kedua urutan.

## Empat keputusan lain

- **Kebijakan SSO-only diperiksa ulang di sini**, tidak dipercaya dari waktu login: tenant bisa berpindah ke SSO-only sejak sesi ini terbit, dan menulis password baru berarti menulis kredensial yang menurut kebijakan tak boleh bekerja. → `409`.
- **Sesi pemanggil selamat, sisanya mati.** Ganti password yang mengeluarkan Anda dari tab tempat Anda menggantinya terbaca sebagai kegagalan, sementara properti keamanannya tidak berubah — sesi pencuri termasuk yang mati. Penghitung lockout dibersihkan, alasan yang sama dipakai jalur reset.
- **Dibatasi laju ke SUMBER meski sudah terautentikasi.** `currentPassword` adalah rahasia yang bisa ditebak; kasus yang penting adalah sesi pinjaman atau curian dipakai memburu password yang tidak ikut terbawa. Bucket ber-key identifier di sini memberi siapa pun yang bisa menjangkau endpoint tuas menahan ganti password satu orang — keberatan yang persis sama sudah tercatat menolak bucket login ber-key identifier.
- **Password yang tidak berubah ditolak sebagai validation error**, bukan dijawab sukses no-op: "berhasil diganti" dibaca orang sebagai "password lama saya sudah tidak berlaku", dan itu tidak akan benar.

Sukses **dan** gagal sama-sama diaudit — `currentPassword` yang salah lewat sesi hidup adalah sinyal bahwa sebuah sesi dipakai orang yang tak tahu kredensial di belakangnya. Atributnya membawa bentuk perangkat dan pseudonim IP, dan **tak membawa password, bahkan panjangnya**; asersinya berjalan terhadap nilai `attributes:` itu sendiri, bukan terhadap seluruh berkas.

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0** (37 segmen penuh termasuk `build`).
- `tests/password-change.test.ts` 15 pass.
- **Mutasi diuji:** mengubah `if (mfa.enabled)` menjadi `if (true)` — yaitu persis bentuk yang diminta rencana — membuat **4 test merah**. Pembatalan koreksi ini tak bisa mendarat diam-diam.
- Validator dinamai `validateCredentialChangeInput`, bukan `validate*Password*Input`, mengikuti preseden yang sudah ditulis `password-reset-validation.ts` untuk menghindari false positive `js/insufficient-password-hash` CodeQL. Batas panjangnya **diimpor** dari sana, tidak disalin.

Menutup Gelombang 2 dari #423 (#491 → #496 → #497 → ini).

🤖 Generated with [Claude Code](https://claude.com/claude-code)