### PR TITLE
chore(actions): codeql-action 4.37.4 → 4.37.6 dan attest-build-provenance 4.1.1 → 4.2.2

### DIFF
--- a/.changeset/bump-actions-2026-08-10.md
+++ b/.changeset/bump-actions-2026-08-10.md
@@ -1,0 +1,25 @@
+---
+"awcms": patch
+---
+
+chore(actions): `codeql-action` 4.37.4 → 4.37.6 dan `attest-build-provenance` 4.1.1 → 4.2.2
+
+Menggantikan tiga PR dependabot (#493, #494, #495) dengan satu.
+
+**`codeql-action/init` dan `codeql-action/analyze` WAJIB satu PR.** Dependabot
+memecahnya per-path, sehingga tiap PR memindahkan satu langkah ke SHA baru dan
+meninggalkan pasangannya di SHA lama — dan CodeQL menolak jalan dengan
+`init`/`analyze` yang tak sepadan. Keduanya di sini pindah ke SHA yang sama
+(`5595ccaf…`), yang memang SHA yang diusulkan kedua PR itu.
+
+Ini bukan preferensi gaya: dua PR yang masing-masing memerahkan `Analyze` tak
+bisa di-merge berurutan, karena yang pertama merah **sampai** yang kedua
+mendarat. Satu-satunya urutan yang hijau adalah satu PR.
+
+`attest-build-provenance` dinaikkan di **dua** langkah `release.yml` sekaligus
+(attest image + attest SBOM); membiarkan salah satunya berarti satu rilis
+menandatangani dua artefak dengan dua versi penanda tangan.
+
+Semua pin tetap SHA-pinned dengan komentar versi — bentuk yang sudah dipakai
+seluruh workflow di repo ini, dan yang membuat tag yang dipindahkan tidak bisa
+mengubah apa yang berjalan.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,14 +56,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,14 +287,14 @@ jobs:
         run: cosign sign --yes "${{ needs.build.outputs.image-ref }}@${{ needs.build.outputs.image-digest }}"
 
       - name: Attest build provenance — image
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ${{ needs.build.outputs.image-repo }}
           subject-digest: ${{ needs.build.outputs.image-digest }}
           push-to-registry: true
 
       - name: Attest build provenance — source artifacts
-        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: |
             CHECKSUMS.txt


### PR DESCRIPTION
Menggantikan **tiga** PR dependabot dengan satu: #493, #494, #495.

## Kenapa digabung, bukan di-merge berurutan

**`codeql-action/init` dan `codeql-action/analyze` wajib satu PR.** Dependabot memecahnya per-path, sehingga tiap PR memindahkan satu langkah ke SHA baru dan meninggalkan pasangannya di SHA lama — dan CodeQL menolak jalan dengan `init`/`analyze` yang tak sepadan. Itulah sebabnya **keduanya** merah hari ini pada `Analyze (actions)` dan `Analyze (javascript-typescript)`.

Ini bukan preferensi gaya: dua PR yang masing-masing memerahkan `Analyze` tak bisa di-merge berurutan, karena yang pertama tetap merah **sampai** yang kedua mendarat. Satu-satunya urutan yang hijau adalah satu PR. Keduanya pindah ke SHA yang sama (`5595ccaf…`) — memang SHA yang diusulkan kedua PR itu.

**`attest-build-provenance` dinaikkan di dua langkah `release.yml` sekaligus** (attest image + attest SBOM). Membiarkan salah satunya berarti satu rilis menandatangani dua artefak dengan dua versi penanda tangan.

Ketiganya juga merah pada `Changeset required for behavior changes`: workflow **tidak** dikecualikan gate changeset di repo ini. Changeset-nya ada di sini.

Semua pin tetap SHA-pinned dengan komentar versi — bentuk yang dipakai seluruh workflow di repo ini, dan yang membuat tag yang dipindahkan tidak bisa mengubah apa yang berjalan.

## Verifikasi

`DATABASE_URL="" bun run check` → **exit 0**. Bukti sesungguhnya untuk PR ini adalah `Analyze (actions)` + `Analyze (javascript-typescript)` yang hijau di sini sementara keduanya merah di #493/#494.

Menutup #493, #494, #495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)