### PR TITLE
chore(deps): astro 7.1.6 → 7.2.0 dan @astrojs/node 11.0.3 → 11.1.0

### DIFF
--- a/.changeset/bump-astro-7-2-0.md
+++ b/.changeset/bump-astro-7-2-0.md
@@ -1,0 +1,26 @@
+---
+"awcms": patch
+---
+
+chore(deps): astro 7.1.6 → 7.2.0 dan @astrojs/node 11.0.3 → 11.1.0
+
+Menggantikan dua PR dependabot (#488, #489) dengan satu.
+
+**Digabung karena keduanya tak bisa hijau sendirian.** `family:conformance:check`
+membandingkan `awcms-family-compatibility.yaml` dengan `package.json` field demi
+field, jadi menaikkan satu dependensi tanpa memperbarui manifesnya membuat
+gerbang itu **merah** — dan itulah yang terjadi pada kedua PR dependabot. Manifes
+diperbarui di sini untuk keduanya sekaligus; memperbaikinya dua kali berarti dua
+PR yang masing-masing merah sampai yang lain mendarat.
+
+Adapter node dan astro juga berpasangan: `@astrojs/node@11.1.0` menyatakan
+`peerDependencies: { astro: "^7.0.0" }`, dan `bun install` **tidak menolak**
+peer mismatch — ia memasang dan diam. Jadi bukti bahwa pasangan ini benar bukan
+lockfile-nya melainkan `bun run build` yang hijau, yang dijalankan rantai `check`.
+
+**Satu koreksi yang ikut mendarat.** Divergensi `astro-files-not-type-checked`
+menyatakan "42 berkas `.astro` (22.328 baris)"; angka sesungguhnya **44 berkas
+(24.359 baris)**. Divergensi itu ada untuk mencatat BESARNYA paparan yang tidak
+diperiksa `tsc`, jadi ringkasan yang mengecilkannya adalah satu-satunya jenis
+kesalahan yang benar-benar merugikan di entri itu. Diukur ulang
+(`find src -name '*.astro'`), bukan ditaksir.

--- a/awcms-family-compatibility.yaml
+++ b/awcms-family-compatibility.yaml
@@ -114,10 +114,10 @@ stack:
       declared: "1.3.0"
       source: .github/workflows/ci.yml minimum-supported job setup-bun (== engines floor)
   astro:
-    declared: "^7.1.6"
+    declared: "^7.2.0"
     source: package.json dependencies.astro
   astroNode:
-    declared: "^11.0.3"
+    declared: "^11.1.0"
     source: package.json dependencies["@astrojs/node"]
   typescript:
     declared: "^7.0.2"
@@ -160,7 +160,7 @@ intentionalDivergences:
     since: "2026-08-04"
 
   - id: astro-files-not-type-checked
-    summary: awcms-astro runs `astro check`; this repo cannot, so 42 `.astro` files (22,328 lines) have no type checker.
+    summary: awcms-astro runs `astro check`; this repo cannot, so 44 `.astro` files (24,359 lines) have no type checker.
     reason: >-
       Not a discipline gap — a toolchain one, and it points the opposite way from what the file counts
       suggest. `@astrojs/check` requires the TypeScript 6.x programmatic API; this repo is on TypeScript

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,8 @@
     "": {
       "name": "awcms",
       "dependencies": {
-        "@astrojs/node": "^11.0.3",
-        "astro": "^7.1.6",
+        "@astrojs/node": "^11.1.0",
+        "astro": "^7.2.0",
       },
       "devDependencies": {
         "@changesets/cli": "^2.31.1",
@@ -54,7 +54,7 @@
 
     "@astrojs/markdown-satteri": ["@astrojs/markdown-satteri@0.3.5", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.2", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "satteri": "^0.9.1" } }, "sha512-CvWVEFAbay7YO+i9SaqDJubipA5ckiVB89QWoMJ5XC0m5CtFg8JwZ7Kau6X9sYY7FZURH0w2l03ISH2jOS/RDQ=="],
 
-    "@astrojs/node": ["@astrojs/node@11.0.3", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.2", "send": "^1.2.1", "server-destroy": "^1.0.1" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-T5BLn3gh9qpWpPK4vcpsnCmFyU3TL4u7m1n33D+h1uEuUVMjmald5QryZI7B/PwlM9fk09s+DQupy6a61wfi9A=="],
+    "@astrojs/node": ["@astrojs/node@11.1.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.2", "send": "^1.2.1", "server-destroy": "^1.0.1" }, "peerDependencies": { "astro": "^7.0.0" } }, "sha512-utAqBE1eIcAhyIkBUnNIWrzj4vyTiOlbbqcjUSE2Yz5XrMu+9sQdBwp/UmZXfJ9wjaEIHf26HInNLUUmTOFeEw=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
 
@@ -294,8 +294,6 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
 
-    "@rollup/pluginutils": ["@rollup/pluginutils@5.4.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-walker": "^2.0.2", "picomatch": "^4.0.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0" }, "optionalPeers": ["rollup"] }, "sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg=="],
-
     "@shikijs/core": ["@shikijs/core@4.3.1", "", { "dependencies": { "@shikijs/primitive": "4.3.1", "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.3.1", "", { "dependencies": { "@shikijs/types": "4.3.1", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ=="],
@@ -386,7 +384,7 @@
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
-    "astro": ["astro@7.1.6", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.2", "@astrojs/internal-helpers": "0.10.2", "@astrojs/markdown-satteri": "0.3.5", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "@rollup/pluginutils": "^5.3.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.3.0", "jsonc-parser": "^3.3.1", "magic-string": "^1.0.0", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.2" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-83x9rYbHazMaZkYrAFRVZXSQx2moFkz0F7cjTDUF3GWfS0a3p2vZXG1ZdhV86rStHApQCodBJW+XTD37xISIrQ=="],
+    "astro": ["astro@7.2.0", "", { "dependencies": { "@astrojs/compiler-rs": "^0.3.2", "@astrojs/internal-helpers": "0.10.2", "@astrojs/markdown-satteri": "0.3.5", "@astrojs/telemetry": "3.3.3", "@capsizecss/unpack": "^4.0.0", "@clack/prompts": "^1.1.0", "@oslojs/encoding": "^1.1.0", "am-i-vibing": "^0.4.0", "aria-query": "^5.3.2", "axobject-query": "^4.1.0", "ci-info": "^4.4.0", "clsx": "^2.1.1", "common-ancestor-path": "^2.0.0", "cookie": "^2.0.1", "devalue": "^5.8.1", "diff": "^8.0.3", "dset": "^3.1.4", "es-module-lexer": "^2.0.0", "esbuild": "^0.28.0", "flattie": "^1.1.1", "fontace": "~0.4.1", "get-tsconfig": "5.0.0-beta.4", "github-slugger": "^2.0.0", "html-escaper": "3.0.3", "http-cache-semantics": "^4.2.0", "js-yaml": "^4.3.0", "jsonc-parser": "^3.3.1", "magic-string": "^1.0.0", "magicast": "^0.5.2", "mrmime": "^2.0.1", "neotraverse": "^1.0.1", "obug": "^2.1.1", "p-limit": "^7.3.0", "p-queue": "^9.1.0", "package-manager-detector": "^1.6.0", "piccolore": "^0.1.3", "picomatch": "^4.0.4", "semver": "^7.7.4", "shiki": "^4.0.2", "smol-toml": "^1.6.0", "svgo": "^4.0.1", "tinyclip": "^0.1.12", "tinyexec": "^1.0.4", "tinyglobby": "^0.2.15", "ultrahtml": "^1.6.0", "unifont": "~0.7.4", "unstorage": "^1.17.5", "vite": "^8.0.13", "vitefu": "^1.1.2", "xxhash-wasm": "^1.1.0", "yargs-parser": "^22.0.0", "zod": "^4.3.6" }, "optionalDependencies": { "sharp": "^0.34.0 || ^0.35.0" }, "peerDependencies": { "@astrojs/markdown-remark": "7.2.2" }, "optionalPeers": ["@astrojs/markdown-remark"], "bin": { "astro": "./bin/astro.mjs" } }, "sha512-lLTYzx3fOvCmtwD3JVBLQcbORbIOW1/j0R+3IvJx/XKwMGrk7mFnF0BYSOeRiNw1qHUR5mdA6+hRnyvyDfqrWQ=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
 
@@ -481,8 +479,6 @@
     "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
-    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
     "read-yaml-file": "^2.1.0"
   },
   "dependencies": {
-    "@astrojs/node": "^11.0.3",
-    "astro": "^7.1.6"
+    "@astrojs/node": "^11.1.0",
+    "astro": "^7.2.0"
   }
 }


### PR DESCRIPTION
Menggantikan **dua** PR dependabot dengan satu: #488, #489.

## Kenapa digabung

Keduanya tak bisa hijau sendirian. `family:conformance:check` membandingkan `awcms-family-compatibility.yaml` dengan `package.json` **field demi field**, jadi menaikkan satu dependensi tanpa memperbarui manifesnya membuat gerbang itu merah — persis yang terjadi pada kedua PR dependabot:

```
[FAIL] stack: Astro (declared ^7.1.6 vs actual ^7.2.0)
```

Memperbaikinya dua kali berarti dua PR yang masing-masing merah sampai yang lain mendarat. Manifes diperbarui di sini untuk keduanya sekaligus.

Adapter node dan astro juga berpasangan: `@astrojs/node@11.1.0` menyatakan `peerDependencies: { astro: "^7.0.0" }`, dan **`bun install` tidak menolak peer mismatch** — ia memasang dan diam. Jadi bukti bahwa pasangan ini benar bukan lockfile-nya melainkan `bun run build` yang hijau.

## Satu koreksi yang ikut mendarat

Divergensi `astro-files-not-type-checked` di manifes keluarga menyatakan *"42 berkas `.astro` (22.328 baris)"*. Angka sesungguhnya **44 berkas (24.359 baris)** — diukur ulang dengan `find src -name '*.astro'`, bukan ditaksir.

Entri itu ada untuk mencatat **besarnya paparan** yang tidak diperiksa `tsc`. Ringkasan yang mengecilkannya adalah satu-satunya jenis kesalahan yang benar-benar merugikan di sana, dan tak ada gerbang yang mengejarnya (`family:conformance:check` memeriksa keberadaan ADR-nya, bukan prosanya).

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0**, termasuk `bun run build` dengan astro 7.2.0 dan anggaran aset 153.839 B / 180.000 B (tak berubah).
- `family:conformance:check` → 29/29.

Menutup #488, #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)