### PR TITLE
fix(admin,auth): panel sesi yang tak bisa ditutup di ponsel, dan body yang dibaca di dalam transaksi

### DIFF
--- a/.changeset/panel-sesi-dan-body-di-luar-transaksi.md
+++ b/.changeset/panel-sesi-dan-body-di-luar-transaksi.md
@@ -1,0 +1,52 @@
+---
+"awcms": patch
+---
+
+fix(admin,auth): panel sesi yang tak bisa ditutup di ponsel, dan body yang dibaca di dalam transaksi
+
+Dua cacat dari review terhadap PR yang mendarat hari ini (#496, #498). Keduanya
+hijau di seluruh 38 gerbang, dan keduanya hanya terlihat dengan membaca dua
+berkas bersamaan.
+
+**1. `<tr hidden>` TIDAK tersembunyi di dalam tabel stacked.** `admin.css`
+mengubah tiap baris `.data-table--stack` menjadi kartu di bawah `--bp-md`
+lewat `.data-table--stack tr { display: block }`. Selektor itu berspesifisitas
+(0,1,1); aturan user-agent yang membuat atribut `hidden` bekerja —
+`[hidden] { display: none }` — berspesifisitas (0,1,0). Aturan author menang,
+jadi `hidden` **diam-diam berhenti menyembunyikan**, dan berhentinya persis di
+layout yang tak diperiksa siapa pun lebih dulu.
+
+Akibatnya bukan kosmetik seperti kedengarannya: baris detail yang tak bisa
+menutup akan me-render isinya untuk **setiap** baris tabel sekaligus, dan tombol
+yang seharusnya membukanya tidak melakukan apa pun yang terlihat. Panel sesi di
+`/admin/users` mendarat dengan persis itu.
+
+Perbaikannya `.session-panel-row[hidden] { display: none }` — (0,2,0), menang
+dua arah — dan **di luar** media query, karena media query tak menambah
+spesifisitas sehingga satu aturan meliputi kedua layout.
+
+Test regresinya menegakkan sifat UMUM, bukan satu berkas: tiap layar admin yang
+memakai tabel stacked **dan** menyembunyikan baris dengan atribut `hidden` wajib
+membawa aturan `[hidden] { display: none }`-nya sendiri. Draf pertamanya
+**dipuaskan oleh komentar CSS-nya sendiri** yang mengutip aturan itu verbatim —
+mutasi yang MENGHAPUS perbaikannya tetap hijau. Komentar kini dibuang sebelum
+pencocokan; ini kali keenam bentuk itu muncul di repo ini, dan selalu
+PERBAIKAN-lah yang menanam false positive, karena sebuah perbaikan menjelaskan
+apa yang ia hapus.
+
+**2. `POST /auth/password/change` membaca body di DALAM transaksi.**
+`await request.json()` menunggu **klien**. Melakukannya di dalam `withTenant`
+menahan satu koneksi pool tercadang — berikut slot work-class-nya — selama
+pemanggil memilih untuk mengirim body-nya, sehingga satu permintaan lambat
+menjadi koneksi yang ditahan terhadap setiap permintaan lain di pool.
+`queueTimeoutMs` membatasi **memperoleh** koneksi, tak pernah **menahan**-nya.
+
+`defineTenantRoute` punya `prepare` justru untuk ini; seam self-service tidak
+punya, jadi rutenya tak punya tempat lain. Seam-nya kini punya `prepare` yang
+sama bentuknya — penambahan murni, nol call site berubah. `beforeTransaction`
+tidak bisa mengerjakannya: ia hanya mengembalikan `Response | undefined`, jadi
+body yang di-parse di sana tak punya tempat tujuan dan harus di-parse dua kali.
+
+Asersinya **posisional**, bukan "apakah muncul": `prepare` dan `handler`
+sama-sama menyinggung body dengan satu atau lain cara, dan pertanyaannya adalah
+di sisi mana batas transaksi pembacaan itu berada.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **101** (`sql/001`–`101`)                                                             | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0077** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **33** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **44** (24.359 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **44** (24.372 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **39** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 129   |
 | Tabel dengan `FORCE` RLS           | 118   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 341   |
+| Berkas test                        | 342   |
 | Berkas route                       | 324   |
 | ADR                                | 78    |
 
@@ -287,7 +287,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 292        |
+| `(root)`      | 293        |
 | `e2e`         | 12         |
 | `integration` | 36         |
 | `unit`        | 1          |

--- a/src/modules/_shared/tenant-route.ts
+++ b/src/modules/_shared/tenant-route.ts
@@ -194,7 +194,7 @@ export type TenantRouteConfig<TPrepared> = {
  * requirements (one response shape for several different failures) that a
  * shared default would quietly flatten.
  */
-export type SelfServiceTenantRouteConfig = {
+export type SelfServiceTenantRouteConfig<TPrepared = undefined> = {
   /** REQUIRED, same reasoning as `defineTenantRoute`. */
   workClass: WorkClass;
   queueTimeoutMs?: number;
@@ -210,18 +210,40 @@ export type SelfServiceTenantRouteConfig = {
   beforeTransaction?: (
     context: TenantRouteRequestContext & { token: string }
   ) => Response | undefined | Promise<Response | undefined>;
+  /**
+   * Reads and validates the request BODY, before the transaction opens.
+   *
+   * The mirror of `defineTenantRoute`'s `prepare`, and it exists for the same
+   * non-cosmetic reason: `await request.json()` waits on the CLIENT. Doing it
+   * inside `withTenant` holds a reserved pool connection — and its work-class
+   * slot — for as long as a caller chooses to take sending its body, which turns
+   * a slow request into a connection held against every other request in the
+   * pool. `queueTimeoutMs` bounds ACQUIRING a connection, never holding one.
+   *
+   * Returning a `Response` short-circuits; anything else is handed to `handler`
+   * as `prepared`.
+   *
+   * `beforeTransaction` cannot do this job: it returns only `Response |
+   * undefined`, so a body parsed there has nowhere to go and would have to be
+   * parsed a second time.
+   */
+  prepare?: (
+    context: TenantRouteRequestContext & { token: string }
+  ) => TPrepared | Response | Promise<TPrepared | Response>;
   handler: (
     context: TenantRouteRequestContext & {
       tx: Bun.TransactionSQL;
       token: string;
       /** Kind-tagged hash (`session-token.ts`) — machine vs session already distinguished. */
       tokenHash: string;
+      /** Whatever `prepare` returned (`undefined` when there is no `prepare`). */
+      prepared: TPrepared;
     }
   ) => Response | Promise<Response>;
 };
 
-export function defineSelfServiceTenantRoute(
-  config: SelfServiceTenantRouteConfig
+export function defineSelfServiceTenantRoute<TPrepared = undefined>(
+  config: SelfServiceTenantRouteConfig<TPrepared>
 ): APIRoute {
   return async ({ request, cookies, url, params, locals, clientAddress }) => {
     const { tenantId, token } = resolveAuthInputs(request, cookies);
@@ -247,6 +269,18 @@ export function defineSelfServiceTenantRoute(
 
     if (short) return short;
 
+    let prepared = undefined as TPrepared;
+
+    if (config.prepare) {
+      const prepareResult = await config.prepare({ ...requestContext, token });
+
+      if (prepareResult instanceof Response) {
+        return prepareResult;
+      }
+
+      prepared = prepareResult;
+    }
+
     return withTenant<Response>(
       sqlClientForRoute(),
       tenantId,
@@ -255,7 +289,8 @@ export function defineSelfServiceTenantRoute(
           ...requestContext,
           tx,
           token,
-          tokenHash: hashSessionToken(token)
+          tokenHash: hashSessionToken(token),
+          prepared
         }),
       {
         workClass: config.workClass,

--- a/src/pages/admin/users.astro
+++ b/src/pages/admin/users.astro
@@ -585,6 +585,19 @@ const showActions =
     gap: var(--sp-2);
   }
 
+  /* Load-bearing, not defensive.
+     `admin.css` turns every row of a `.data-table--stack` into a card below
+     `--bp-md` with `.data-table--stack tr { display: block }`. That selector
+     (0,1,1) outranks the user-agent `[hidden] { display: none }` (0,1,0), so
+     on a phone the collapsed panel below is NOT collapsed: every user row grows
+     a permanently-open, empty session strip that no button can close.
+     `.session-panel-row[hidden]` is (0,2,0) and wins in both directions, and it
+     lives outside the media query on purpose — media queries add no
+     specificity, so one rule covers both layouts. */
+  .session-panel-row[hidden] {
+    display: none;
+  }
+
   .session-panel-row > td {
     background: var(--color-surface-2);
   }

--- a/src/pages/api/v1/auth/password/change.ts
+++ b/src/pages/api/v1/auth/password/change.ts
@@ -17,7 +17,10 @@ import {
   summarizeUserAgent
 } from "../../../../../lib/security/client-fingerprint";
 import { changeOwnPassword } from "../../../../../modules/identity-access/application/password-change";
-import { validateCredentialChangeInput } from "../../../../../modules/identity-access/domain/credential-change-validation";
+import {
+  validateCredentialChangeInput,
+  type CredentialChangeInput
+} from "../../../../../modules/identity-access/domain/credential-change-validation";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 
 /**
@@ -66,7 +69,7 @@ function authRequired(): Response {
   );
 }
 
-export const POST = defineSelfServiceTenantRoute({
+export const POST = defineSelfServiceTenantRoute<CredentialChangeInput>({
   workClass: "interactive",
   onUnauthenticated: (reason) =>
     reason === "tenant"
@@ -104,7 +107,11 @@ export const POST = defineSelfServiceTenantRoute({
       }
     );
   },
-  handler: async ({ tx, tenantId, tokenHash, request, clientAddress, now }) => {
+  // Reading the body waits on the CLIENT, so it happens BEFORE the transaction
+  // opens: doing it inside `withTenant` would hold a reserved pool connection —
+  // and its work-class slot — for as long as a caller chooses to take sending
+  // its body. `queueTimeoutMs` bounds acquiring a connection, never holding one.
+  prepare: async ({ request }) => {
     const body = await readJsonBody(request);
 
     if (body.tooLarge) return bodyTooLargeResponse(body.limitBytes);
@@ -122,11 +129,22 @@ export const POST = defineSelfServiceTenantRoute({
       );
     }
 
+    return validation.value;
+  },
+  handler: async ({
+    tx,
+    tenantId,
+    tokenHash,
+    prepared,
+    request,
+    clientAddress,
+    now
+  }) => {
     const result = await changeOwnPassword(
       tx,
       tenantId,
       tokenHash,
-      validation.value,
+      prepared,
       now
     );
 

--- a/tests/admin-stacked-table-hidden-rows.test.ts
+++ b/tests/admin-stacked-table-hidden-rows.test.ts
@@ -1,0 +1,97 @@
+/**
+ * A `<tr hidden>` inside a stacked admin table is NOT hidden on a phone.
+ *
+ * `admin.css` turns every row of a `.data-table--stack` into a card below
+ * `--bp-md`:
+ *
+ *     @media (max-width: 767.98px) {
+ *       .data-table--stack tr { display: block; }
+ *     }
+ *
+ * That selector has specificity (0,1,1). The user-agent rule that makes the
+ * `hidden` attribute work — `[hidden] { display: none }` — has (0,1,0). The
+ * author rule wins, so `hidden` silently stops hiding, and it stops on exactly
+ * the layout nobody checks first.
+ *
+ * The failure is not cosmetic in the way it sounds: a collapsed detail row that
+ * cannot collapse renders its content for EVERY row of the table at once, and
+ * the control that is supposed to open it does nothing visible. The session
+ * panel on `/admin/users` (Gelombang 2 PR 2.2 of #423) shipped with exactly
+ * this, and it is the kind of defect a desktop review cannot see.
+ *
+ * So: any admin screen that both uses the stacked table and hides a row with
+ * the `hidden` attribute must carry its own `[hidden] { display: none }` rule
+ * for that row. Pure: source text only.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SCREEN_ROOT = "src/pages/admin";
+
+function collectScreens(directory: string, into: string[] = []): string[] {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name);
+
+    if (entry.isDirectory()) {
+      collectScreens(path, into);
+      continue;
+    }
+
+    if (path.endsWith(".astro")) into.push(path);
+  }
+
+  return into;
+}
+
+/** `<tr ... hidden>` — the attribute on a row, in either attribute order. */
+const HIDDEN_ROW = /<tr\b[^>]*\bhidden\b/;
+
+/**
+ * Block comments go before matching, and the first draft of this test proved
+ * why: the CSS comment explaining the override quotes `[hidden] { display: none
+ * }` verbatim, so the guard matched its own explanation and a mutation that
+ * DELETED the rule still passed. Same shape `access-chokepoint-check.ts`
+ * records — it is always the fix that plants the false positive, because a fix
+ * explains what it removed.
+ */
+function stripBlockComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+describe("stacked tables cannot rely on the user agent to hide a row", () => {
+  const screens = collectScreens(SCREEN_ROOT).map((file) => ({
+    file,
+    source: stripBlockComments(readFileSync(file, "utf8"))
+  }));
+
+  test("there are admin screens to check at all", () => {
+    // A collector that silently found nothing would make every assertion below
+    // vacuously true.
+    expect(screens.length).toBeGreaterThan(20);
+  });
+
+  test("every screen with a stacked table AND a hidden row overrides `[hidden]` itself", () => {
+    const offenders = screens
+      .filter(
+        ({ source }) =>
+          source.includes("data-table--stack") && HIDDEN_ROW.test(source)
+      )
+      .filter(
+        ({ source }) => !/\[hidden\][^{]*\{[^}]*display:\s*none/.test(source)
+      )
+      .map(({ file }) => file);
+
+    expect(offenders).toEqual([]);
+  });
+
+  test("the rule this test is about really is in admin.css, in a media query", () => {
+    // If the base stylesheet ever stops turning rows into blocks, this whole
+    // test becomes noise — and it should be deleted rather than left to pass
+    // for a reason that no longer exists.
+    const base = readFileSync("src/styles/admin.css", "utf8");
+
+    expect(base).toContain(".data-table--stack tr");
+    expect(base).toContain("@media (max-width: 767.98px)");
+  });
+});

--- a/tests/password-change.test.ts
+++ b/tests/password-change.test.ts
@@ -331,4 +331,30 @@ describe("the route is self-service and leaks no password anywhere", () => {
     expect(source).toContain('"cache-control": "private, no-store"');
     expect(source).not.toMatch(/\breturn ok\(/);
   });
+
+  test("the body is read BEFORE the transaction, never inside it", () => {
+    // `await request.json()` waits on the CLIENT. Reading it inside
+    // `withTenant` holds a reserved pool connection — and its work-class slot —
+    // for as long as a caller chooses to take sending its body, which turns one
+    // slow request into a connection held against every other request in the
+    // pool. `queueTimeoutMs` bounds ACQUIRING a connection, never holding one.
+    //
+    // Asserted positionally rather than by "does it appear": both `prepare` and
+    // `handler` mention the body one way or another, and the question is which
+    // side of the transaction boundary the read sits on.
+    const code = source
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+
+    const prepareAt = code.indexOf("prepare:");
+    const handlerAt = code.indexOf("handler:");
+    const readAt = code.indexOf("readJsonBody(");
+
+    expect(prepareAt).toBeGreaterThan(-1);
+    expect(readAt).toBeGreaterThan(prepareAt);
+    expect(readAt).toBeLessThan(handlerAt);
+    // And the handler receives the parsed value rather than re-parsing it.
+    expect(code.slice(handlerAt)).toContain("prepared");
+    expect(code.slice(handlerAt)).not.toContain("readJsonBody");
+  });
 });


### PR DESCRIPTION
Dua cacat yang ditemukan dari **review terhadap PR yang mendarat hari ini** (#496, #498). Keduanya hijau di seluruh 38 gerbang, dan keduanya hanya terlihat dengan membaca dua berkas bersamaan.

## 1. `<tr hidden>` tidak tersembunyi di dalam tabel stacked

`admin.css` mengubah tiap baris `.data-table--stack` menjadi kartu di bawah `--bp-md`:

```css
@media (max-width: 767.98px) {
  .data-table--stack tr { display: block; }
}
```

Selektor itu berspesifisitas **(0,1,1)**. Aturan user-agent yang membuat atribut `hidden` bekerja — `[hidden] { display: none }` — berspesifisitas **(0,1,0)**. Aturan author menang, jadi `hidden` **diam-diam berhenti menyembunyikan** — dan berhentinya persis di layout yang tak diperiksa siapa pun lebih dulu.

Akibatnya bukan kosmetik seperti kedengarannya: baris detail yang tak bisa menutup me-render isinya untuk **setiap** baris tabel sekaligus, dan tombol yang seharusnya membukanya tidak melakukan apa pun yang terlihat.

Perbaikannya `.session-panel-row[hidden] { display: none }` — (0,2,0), menang dua arah — dan **di luar** media query, karena media query tak menambah spesifisitas sehingga satu aturan meliputi kedua layout.

**Test regresinya menegakkan sifat UMUM**, bukan satu berkas: tiap layar admin yang memakai tabel stacked **dan** menyembunyikan baris dengan `hidden` wajib membawa aturan `[hidden] { display: none }`-nya sendiri.

Draf pertama test itu **dipuaskan oleh komentar CSS-nya sendiri**, yang mengutip aturan itu verbatim — mutasi yang MENGHAPUS perbaikannya tetap hijau. Komentar kini dibuang sebelum pencocokan. Ini kali keenam bentuk itu muncul di repo ini, dan selalu **perbaikan**-lah yang menanam false positive, karena sebuah perbaikan menjelaskan apa yang ia hapus.

## 2. `POST /auth/password/change` membaca body di dalam transaksi

`await request.json()` menunggu **klien**. Melakukannya di dalam `withTenant` menahan satu koneksi pool tercadang — berikut slot work-class-nya — selama pemanggil memilih untuk mengirim body-nya, sehingga satu permintaan lambat menjadi koneksi yang ditahan terhadap setiap permintaan lain di pool. `queueTimeoutMs` membatasi **memperoleh** koneksi, tak pernah **menahan**-nya.

`defineTenantRoute` punya `prepare` justru untuk ini; seam self-service tidak punya, jadi rutenya tak punya tempat lain. Seam-nya kini punya `prepare` yang sama bentuknya — **penambahan murni, nol call site berubah**.

`beforeTransaction` tidak bisa mengerjakannya: ia hanya mengembalikan `Response | undefined`, jadi body yang di-parse di sana tak punya tempat tujuan dan harus di-parse dua kali.

Asersinya **posisional**, bukan "apakah muncul": `prepare` dan `handler` sama-sama menyinggung body dengan satu atau lain cara, dan pertanyaannya adalah di sisi mana batas transaksi pembacaan itu berada.

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0**.
- **Mutasi diuji:** menghapus `.session-panel-row[hidden]` dari `users.astro` membuat `tests/admin-stacked-table-hidden-rows.test.ts` **merah** dan menamai berkasnya.
- `tests/password-change.test.ts` 16 pass (naik dari 15).

Bagian dari #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)