### PR TITLE
feat(access): setiap grant peran baru mendarat sebagai Policy (#423)

### DIFF
--- a/.changeset/penulis-grant-menulis-policy.md
+++ b/.changeset/penulis-grant-menulis-policy.md
@@ -1,0 +1,65 @@
+---
+"awcms": minor
+---
+
+feat(access): setiap grant peran baru mendarat sebagai Policy — dan pencabutan mencari di KEDUA tempat
+
+Gelombang 3 PR 3.2 dari #423, menutup unit komitmen yang dibuka
+[ADR-0078](../docs/adr/0078-a-grant-carries-its-own-scope.md). Sejak PR ini
+`awcms_access_policies` punya penulis produksi; tabel tanpa penulis adalah cacat
+yang ADR-0077 hapus, dan PROJECT_STATE §4 mencatat 3.1 dan 3.2 sebagai satu unit
+justru supaya keadaan itu tak pernah menetap.
+
+Tiga jalur pindah: `assignRole`, penerimaan pendaftaran mandiri, dan bootstrap
+tenant. `fetchGrantedPermissionKeys` membaca keduanya, jadi subjek yang diberi
+grant lewat jalur baru tak bisa dibedakan dari yang lewat tabel lama.
+
+**Ini BUKAN dual write.** ADR-0078 memilih tabel ketiga justru supaya
+expand/migrate/contract tidak butuh dual write. Satu grant baru mendarat di
+**satu** tabel. Menulis keduanya akan menghidupkan kembali kegagalan yang
+dihindari rancangan ini: dua tulis yang bisa berhasil terpisah, meninggalkan
+subjek yang memegang peran menurut satu tabel dan tidak menurut yang lain, tanpa
+cara menentukan mana yang benar.
+
+**Pencabutan harus mencari di kedua tempat.** `revokeRoleGrants` menghapus baris
+lama **dan** mencabut policy aktif, karena selama backfill (PR 3.3) belum jalan
+sebuah grant bisa hidup di mana saja. Penghapus yang hanya tahu tabel baru akan
+melaporkan sukses sementara perannya selamat — bentuk paling berbahaya yang
+tersedia di sini, karena ia gagal ke arah **AKSES TETAP ADA** dan tak ada yang
+mengamatinya.
+
+**Pemeriksaan duplikat tidak lagi gratis dari satu indeks unik**, jadi ia
+ditanyakan eksplisit terhadap kedua tabel sebelum menulis. Terjemahan 23505 tetap
+ada untuk satu kasus yang tersisa dan hanya itu: dua permintaan bersamaan yang
+memberi peran sama, di mana salah satunya kalah di indeks unik parsial.
+
+**Empat gerbang memerah dan tiap satunya benar:**
+
+1. `access:grant-readers:check` menangkap penulis bersama yang baru **dan**
+   entri basi untuk `self-registration.ts` yang berhenti menyebut tabel grant.
+   Persis dua arah yang dirancangkan gerbang itu, di PR pertama yang menggerakkannya.
+2. `modules:table-writes:check` menangkap `platform-bootstrap.ts` (milik
+   `tenant_admin`) menulis tabel `identity_access`. Pengecualiannya **dipindahkan
+   bersama** grant-nya alih-alih ditambahkan di sebelahnya: membiarkan tabel lama
+   terdaftar setelah tak ada yang menulisnya berarti memaafkan penulis yang tak
+   ada lagi.
+3. `tests/access-assignment-writers.test.ts` — penanda "penulis" harus berubah
+   **dua kali**: tabelnya pindah, DAN sebuah berkas kini bisa menyebabkan grant
+   tanpa memuat satu pun `INSERT`. Penanda yang cuma melihat INSERT akan
+   diam-diam mempersempit aturan empat-penulis menjadi dua, dan `user-admin.ts`
+   — pembawa penolakan system-role utama repo ini — akan keluar dari aturannya.
+4. Integrasi self-registration: helper `assignmentCount` menghitung satu tabel.
+   Ia kini menghitung **union**, karena asersi di sekitarnya bertanya "apakah
+   orang ini diberi grant", bukan "berapa baris di tabel ini" — dan salah satu
+   asersinya adalah asersi keamanan ("peran sistem ditolak, dan penerimaan tidak
+   menulis apa pun"), yang akan melaporkan nol untuk grant yang ada.
+
+`platform-bootstrap.ts` menulis INSERT-nya **inline** alih-alih memanggil penulis
+bersama: `tenant_admin` tidak boleh mengimpor kode aplikasi `identity_access` —
+DAG modul berjalan ke arah sebaliknya dan `modules:dag:check` menegakkannya.
+Duplikasinya dua INSERT dan dipatok test penulis di atas.
+
+Setiap grant yang ditulis hari ini **tenant-wide**. Scope yang lebih sempit bisa
+ditulis ketika PR 3.4 mengajari evaluasi mengualifikasinya — mengirimkan penulis
+untuk scope yang masih diabaikan evaluator berarti membagikan grant yang
+**terlihat sempit dan tidak**.

--- a/scripts/access-grant-readers-check.ts
+++ b/scripts/access-grant-readers-check.ts
@@ -103,9 +103,9 @@ export const GRANT_READERS: readonly GrantReaderEntry[] = [
       "The role-to-permission writer for `awcms_role_permissions` — the surface where an admin deliberately narrows a role, which is why the backfill may only re-grant catalogue rows newer than the role itself."
   },
   {
-    file: "src/modules/identity-access/application/self-registration.ts",
+    file: "src/modules/identity-access/application/access-policy-writer.ts",
     reason:
-      "Approving a registration mints the account's first assignment; it is the only admin path in this repo that materialises an identity."
+      "THE writer, since ADR-0078. Every path that used to INSERT a grant calls `grantRolePolicy`, and removal goes through `revokeRoleGrants` — which names the LEGACY table too, deliberately: until PR 3.3's backfill runs a grant may live in either, and a remover that knew only about the new one would report success while the role survived."
   },
   {
     file: "src/modules/identity-access/application/session-introspection.ts",

--- a/scripts/table-write-ownership-check.ts
+++ b/scripts/table-write-ownership-check.ts
@@ -126,7 +126,13 @@ export const DOCUMENTED_EXCEPTIONS: readonly {
     "awcms_tenant_users",
     "awcms_roles",
     "awcms_role_permissions",
-    "awcms_access_assignments"
+    "awcms_access_assignments",
+    // ADR-0078 moved the owner grant here. The exception moves WITH it rather
+    // than being added beside it: leaving the old table listed after nothing
+    // writes it would excuse a writer that no longer exists, and `sql/102` did
+    // not change who bootstraps a tenant — only which table records it.
+    "awcms_access_policies",
+    "awcms_access_policy_events"
   ].map((table) => ({
     table,
     excusedOwner: "tenant_admin",

--- a/src/modules/identity-access/application/access-policy-writer.ts
+++ b/src/modules/identity-access/application/access-policy-writer.ts
@@ -1,0 +1,164 @@
+/**
+ * The one place a role grant is written (ADR-0078, Gelombang 3 PR 3.2 of #423).
+ *
+ * Every path that used to `INSERT INTO awcms_access_assignments` now calls
+ * `grantRolePolicy`, and every path that removed a grant calls
+ * `revokeRoleGrants`. `fetchGrantedPermissionKeys` reads both tables, so a
+ * subject granted through here is indistinguishable from one granted through the
+ * old table — which is what lets the two coexist while PR 3.3 moves the
+ * remaining rows across.
+ *
+ * ## NOT a dual write
+ *
+ * ADR-0078 chose a third table precisely so expand/migrate/contract needs no
+ * dual write. A new grant lands in ONE table: `awcms_access_policies`. Legacy
+ * rows stay where they are and keep working through the union until the backfill
+ * moves them. Writing both would reintroduce the failure this design avoids —
+ * two writes that can succeed apart, leaving a subject holding a role according
+ * to one table and not the other, with no way to tell which is right.
+ *
+ * ## Removal has to look in both places
+ *
+ * `revokeRoleGrants` deletes the legacy row AND revokes any active policy,
+ * because for as long as the backfill has not run, a grant may live in either.
+ * A remover that only knew about the new table would report success while the
+ * role survived — the most dangerous shape available here, since it fails toward
+ * ACCESS RETAINED and nothing observes it.
+ */
+
+/** `scope_type` for a grant that is not confined to any business scope. */
+const TENANT_WIDE_SCOPE_TYPE = "tenant";
+
+export type GrantRolePolicyInput = {
+  tenantUserId: string;
+  roleId: string;
+  /** `null` for bootstrap, where no session exists yet to attribute it to. */
+  grantedByTenantUserId: string | null;
+  reason?: string;
+};
+
+/**
+ * Grants a role, tenant-wide, and records the `granted` lifecycle event.
+ *
+ * `scope_id` carries the tenant id, the convention `access-control.ts` documents
+ * for `TENANT_WIDE_SCOPE_TYPE` ("conventionally the tenant id, but coverage does
+ * not depend on it"). Every grant written today is tenant-wide: narrower scopes
+ * become writable when PR 3.4 teaches evaluation to qualify them, and shipping a
+ * writer for a scope the evaluator still ignores would hand out grants that look
+ * narrow and are not.
+ *
+ * Lets a unique violation propagate rather than translating it. The caller knows
+ * whether "already granted" is a `409` or an idempotent success, and — because
+ * the violation has already aborted the transaction — it must not write anything
+ * further before returning.
+ */
+export async function grantRolePolicy(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: GrantRolePolicyInput
+): Promise<{ id: string }> {
+  const rows = (await tx`
+    INSERT INTO awcms_access_policies
+      (tenant_id, subject_type, tenant_user_id, role_id, scope_type, scope_id,
+       granted_by_tenant_user_id, reason)
+    VALUES
+      (${tenantId}, 'tenant_user', ${input.tenantUserId}, ${input.roleId},
+       ${TENANT_WIDE_SCOPE_TYPE}, ${tenantId},
+       ${input.grantedByTenantUserId}, ${input.reason ?? null})
+    RETURNING id
+  `) as { id: string }[];
+
+  const policyId = rows[0]!.id;
+
+  await tx`
+    INSERT INTO awcms_access_policy_events
+      (tenant_id, policy_id, event_type, actor_tenant_user_id, reason)
+    VALUES (${tenantId}, ${policyId}, 'granted', ${input.grantedByTenantUserId}, ${input.reason ?? null})
+  `;
+
+  return { id: policyId };
+}
+
+/**
+ * Whether the subject already holds this role through EITHER table.
+ *
+ * The pre-check `assignRole` used to get for free from a unique index, which now
+ * only covers one of the two places a live grant can be. Without this, assigning
+ * a role somebody already holds through a legacy row would report success and
+ * mint a second, redundant grant.
+ */
+export async function subjectHoldsRole(
+  tx: Bun.SQL,
+  tenantId: string,
+  tenantUserId: string,
+  roleId: string
+): Promise<boolean> {
+  const rows = (await tx`
+    SELECT 1
+    FROM awcms_access_assignments
+    WHERE tenant_id = ${tenantId}
+      AND tenant_user_id = ${tenantUserId}
+      AND role_id = ${roleId}
+    UNION ALL
+    SELECT 1
+    FROM awcms_access_policies
+    WHERE tenant_id = ${tenantId}
+      AND tenant_user_id = ${tenantUserId}
+      AND role_id = ${roleId}
+      AND status = 'active'
+    LIMIT 1
+  `) as unknown[];
+
+  return rows.length > 0;
+}
+
+/**
+ * Removes a role grant from wherever it lives, and reports whether anything was
+ * actually removed.
+ *
+ * The legacy row is DELETEd (it has no lifecycle to transition to) while a
+ * policy is transitioned to `revoked` with its timestamp — the partial unique
+ * index is on active rows only, so a revoked policy does not block re-granting
+ * the same role later, which is the ordinary case rather than an edge one.
+ */
+export async function revokeRoleGrants(
+  tx: Bun.SQL,
+  tenantId: string,
+  tenantUserId: string,
+  roleId: string,
+  actorTenantUserId: string | null,
+  now: Date,
+  reason?: string
+): Promise<boolean> {
+  const legacy = (await tx`
+    DELETE FROM awcms_access_assignments
+    WHERE tenant_id = ${tenantId}
+      AND tenant_user_id = ${tenantUserId}
+      AND role_id = ${roleId}
+    RETURNING id
+  `) as { id: string }[];
+
+  const revoked = (await tx`
+    UPDATE awcms_access_policies
+    SET status = 'revoked',
+        revoked_at = ${now},
+        revoked_by_tenant_user_id = ${actorTenantUserId},
+        revoke_reason = ${reason ?? null},
+        updated_at = ${now}
+    WHERE tenant_id = ${tenantId}
+      AND tenant_user_id = ${tenantUserId}
+      AND role_id = ${roleId}
+      AND status = 'active'
+    RETURNING id
+  `) as { id: string }[];
+
+  for (const policy of revoked) {
+    await tx`
+      INSERT INTO awcms_access_policy_events
+        (tenant_id, policy_id, event_type, actor_tenant_user_id, reason)
+      VALUES (${tenantId}, ${policy.id}, 'revoked', ${actorTenantUserId}, ${reason ?? null})
+    `;
+  }
+
+  return legacy.length > 0 || revoked.length > 0;
+}

--- a/src/modules/identity-access/application/self-registration.ts
+++ b/src/modules/identity-access/application/self-registration.ts
@@ -48,6 +48,7 @@ import { hashPassword } from "../../../lib/auth/password";
 import { createPersonProfileForIdentity } from "../../profile-identity/application/person-profile";
 import type { AuthNotificationPort } from "../../_shared/ports/auth-notification-port";
 import { isMailableLoginIdentifier } from "../domain/password-reset-policy";
+import { grantRolePolicy } from "./access-policy-writer";
 import {
   requestPasswordReset,
   type RequestPasswordResetOptions
@@ -320,13 +321,23 @@ export async function approveRegistrationRequest(
   `) as { id: string }[];
   const tenantUserId = tenantUserRows[0]!.id;
 
-  if (options.roleIds.length > 0) {
-    await tx`
-      INSERT INTO awcms_access_assignments (tenant_id, tenant_user_id, role_id, assigned_by)
-      SELECT ${tenantId}, ${tenantUserId}, role_id, ${reviewerTenantUserId}
-      FROM unnest(${tx.array(options.roleIds, "uuid")}) AS role_id
-      ON CONFLICT (tenant_id, tenant_user_id, role_id) DO NOTHING
-    `;
+  // ADR-0078 — grants land in `awcms_access_policies`. Written one at a time
+  // rather than as a set-based INSERT: `grantRolePolicy` also records the
+  // `granted` lifecycle event, and a history that exists for grants made through
+  // the admin surface but not for grants made by approving a registration would
+  // be a gap exactly where an investigation looks first. The list is a handful of
+  // role ids chosen by a reviewer, not a batch.
+  //
+  // No `ON CONFLICT DO NOTHING` equivalent is needed: this runs immediately after
+  // the tenant user is created in the same transaction, so it can hold nothing
+  // yet, and duplicate role ids in one request are refused by validation.
+  for (const roleId of options.roleIds) {
+    await grantRolePolicy(tx, tenantId, {
+      tenantUserId,
+      roleId,
+      grantedByTenantUserId: reviewerTenantUserId,
+      reason: "self-registration approved"
+    });
   }
 
   await tx`

--- a/src/modules/identity-access/application/user-admin.ts
+++ b/src/modules/identity-access/application/user-admin.ts
@@ -20,6 +20,11 @@
  */
 import { recordAuditEvent } from "../../logging/application/audit-log";
 import { revokeAllSessionsForIdentity } from "./session-revocation";
+import {
+  grantRolePolicy,
+  revokeRoleGrants,
+  subjectHoldsRole
+} from "./access-policy-writer";
 
 const AUDIT_MODULE_KEY = "identity_access";
 const POSTGRES_UNIQUE_VIOLATION = "23505";
@@ -323,14 +328,27 @@ export async function assignRole(
     throw new SystemRoleAssignmentError();
   }
 
+  // ADR-0078 — the duplicate check no longer comes for free from one unique
+  // index, because a live grant can be in either table until PR 3.3's backfill
+  // runs. Asked BEFORE the write so "already assigned" stays a clean 409 rather
+  // than a unique violation that has already aborted the transaction.
+  if (await subjectHoldsRole(tx, tenantId, tenantUserId, roleId)) {
+    throw new DuplicateAssignmentError();
+  }
+
   let rows: Array<{ id: string }>;
   try {
-    rows = (await tx`
-      INSERT INTO awcms_access_assignments (tenant_id, tenant_user_id, role_id, assigned_by)
-      VALUES (${tenantId}, ${tenantUserId}, ${roleId}, ${actorTenantUserId})
-      RETURNING id
-    `) as Array<{ id: string }>;
+    rows = [
+      await grantRolePolicy(tx, tenantId, {
+        tenantUserId,
+        roleId,
+        grantedByTenantUserId: actorTenantUserId
+      })
+    ];
   } catch (error) {
+    // Still translated: the check above closes the window it can, and a
+    // concurrent grant of the same role can still lose the race at the partial
+    // unique index. That is the one case where 23505 is the honest answer.
     if (
       error instanceof Bun.SQL.PostgresError &&
       String(error.errno) === POSTGRES_UNIQUE_VIOLATION
@@ -381,15 +399,20 @@ export async function unassignRole(
     throw new SystemRoleAssignmentError();
   }
 
-  const rows = (await tx`
-    DELETE FROM awcms_access_assignments
-    WHERE tenant_id = ${tenantId}
-      AND tenant_user_id = ${tenantUserId}
-      AND role_id = ${roleId}
-    RETURNING id
-  `) as Array<{ id: string }>;
+  // Looks in BOTH tables (ADR-0078). A remover that only knew about the new one
+  // would report success while the role survived through a legacy row — the most
+  // dangerous shape available here, because it fails toward ACCESS RETAINED and
+  // nothing observes it.
+  const removed = await revokeRoleGrants(
+    tx,
+    tenantId,
+    tenantUserId,
+    roleId,
+    actorTenantUserId,
+    new Date()
+  );
 
-  if (rows.length === 0) return false;
+  if (!removed) return false;
 
   await recordAuditEvent(tx, {
     tenantId,

--- a/src/modules/tenant-admin/application/platform-bootstrap.ts
+++ b/src/modules/tenant-admin/application/platform-bootstrap.ts
@@ -131,9 +131,32 @@ export async function createTenantWithOwner(
     `;
   }
 
+  // ADR-0078 — the owner grant lands in `awcms_access_policies`, tenant-wide.
+  //
+  // Written inline rather than through `access-policy-writer.ts` for the reason
+  // this whole file exists: `tenant_admin` must not import `identity_access`
+  // application code (the module DAG runs the other way, and
+  // `modules:dag:check` enforces it). The duplication is two INSERTs and is
+  // pinned by `tests/access-assignment-writers.test.ts`, which scans for grant
+  // writers by table name and would report this one the moment it drifted.
+  //
+  // `granted_by` is the new owner themselves: bootstrap runs before any session
+  // exists, so there is no other actor it could name, and naming nobody would
+  // lose the fact that the grant was self-originating.
+  const bootstrapPolicy = (await tx`
+    INSERT INTO awcms_access_policies
+      (tenant_id, subject_type, tenant_user_id, role_id, scope_type, scope_id,
+       granted_by_tenant_user_id, reason)
+    VALUES
+      (${tenantId}, 'tenant_user', ${tenantUserId}, ${roleId}, 'tenant', ${tenantId},
+       ${tenantUserId}, 'tenant bootstrap')
+    RETURNING id
+  `) as { id: string }[];
+
   await tx`
-    INSERT INTO awcms_access_assignments (tenant_id, tenant_user_id, role_id, assigned_by)
-    VALUES (${tenantId}, ${tenantUserId}, ${roleId}, ${tenantUserId})
+    INSERT INTO awcms_access_policy_events
+      (tenant_id, policy_id, event_type, actor_tenant_user_id, reason)
+    VALUES (${tenantId}, ${bootstrapPolicy[0]!.id}, 'granted', ${tenantUserId}, 'tenant bootstrap')
   `;
 
   if (options.restoreTenantId) {

--- a/tests/access-assignment-writers.test.ts
+++ b/tests/access-assignment-writers.test.ts
@@ -1,14 +1,13 @@
 /**
- * Every writer of `awcms_access_assignments` refuses SYSTEM roles — or is a
- * named exception with a reason.
+ * Every writer of a role GRANT refuses SYSTEM roles — or is a named exception
+ * with a reason.
  *
  * ## Why this is a gate and not a code review note
  *
  * `owner` is a system role, and `tenant-admin/application/platform-bootstrap.ts`
  * seeds it with the tenant's ENTIRE permission catalogue. So "may this actor
- * write a row into `awcms_access_assignments` naming a system role?" is the
- * single question standing between a scoped permission and full tenant
- * control.
+ * cause a grant row naming a system role?" is the single question standing
+ * between a scoped permission and full tenant control.
  *
  * The ordinary path answered it correctly from the start:
  * `user-admin.ts#assignRole` throws `SystemRoleAssignmentError`, and its route
@@ -25,34 +24,55 @@
  * handler runs the guard chain. Both were green. Neither asks whether two
  * enforcement sites over one table agree about what may be written.
  *
+ * ## The definition of "writer" moved with the writers (ADR-0078)
+ *
+ * It used to be one string: a file containing `INSERT INTO
+ * awcms_access_assignments`. Gelombang 3 PR 3.2 moved grants to
+ * `awcms_access_policies` AND routed most of them through one shared function,
+ * so a file can now cause a grant without containing an INSERT at all.
+ *
+ * Both had to change together. A marker naming a table nothing writes any more
+ * leaves this file green by finding nothing — the exact failure its own first
+ * assertion exists to catch — and a marker that saw only the INSERT would have
+ * silently narrowed a four-writer rule down to two.
+ *
  * ## What "refuses" means here
  *
- * The scan is textual on purpose: it asks whether the file that writes the row
- * also reads `is_system`, which is the column the rule lives in. It cannot
- * prove the check is correct — that is what
+ * The scan is textual on purpose: it asks whether the file that causes the grant
+ * also reads `is_system`, which is the column the rule lives in. It cannot prove
+ * the check is correct — that is what
  * `tests/integration/self-registration.integration.test.ts` (system role
  * refused, zero rows) and the `assignRole` tests do against a real database.
- * This one closes the class: a THIRD writer landing tomorrow without any notion
- * of system roles turns it red on the day it lands, rather than on the day
- * someone reads it.
+ * This one closes the class: a writer landing tomorrow with no notion of system
+ * roles turns it red on the day it lands, rather than on the day someone reads
+ * it.
  */
 import { describe, expect, test } from "bun:test";
 
-const WRITE_MARKER = "INSERT INTO awcms_access_assignments";
+/** A file causes a grant if it INSERTs one, or calls the shared writer that does. */
+const WRITE_MARKERS = ["INSERT INTO awcms_access_policies", "grantRolePolicy("];
+
+const SHARED_WRITER =
+  "src/modules/identity-access/application/access-policy-writer.ts";
 
 /**
- * Writers that legitimately assign a system role, each with the reason that
- * makes it legitimate. A register of DECISIONS, not a backlog: adding an entry
- * here is the visible act of saying "this path may hand out `owner`".
+ * Writers that legitimately grant a system role, each with the reason that makes
+ * it legitimate. A register of DECISIONS, not a backlog: adding an entry here is
+ * the visible act of saying "this path may hand out `owner`".
  */
 const SYSTEM_ROLE_WRITERS: Record<string, string> = {
   "src/modules/tenant-admin/application/platform-bootstrap.ts":
     "Tenant bootstrap IS the act of creating the first owner. It runs once, " +
     "before any session exists, from the setup wizard and tenant provisioning " +
-    "— there is no actor whose privileges it could exceed."
+    "— there is no actor whose privileges it could exceed.",
+  [SHARED_WRITER]:
+    "The shared INSERT, and deliberately ignorant of system roles: it has no " +
+    "actor and no request context to judge against. The refusal belongs to " +
+    "each CALLER, which is what the second assertion below checks — so this " +
+    "entry excuses the mechanism, never a decision."
 };
 
-async function assignmentWriters(): Promise<string[]> {
+async function grantWriters(): Promise<string[]> {
   const files: string[] = [];
 
   for await (const file of new Bun.Glob("src/**/*.ts").scan({
@@ -60,7 +80,7 @@ async function assignmentWriters(): Promise<string[]> {
   })) {
     const source = await Bun.file(file).text();
 
-    if (source.includes(WRITE_MARKER)) {
+    if (WRITE_MARKERS.some((marker) => source.includes(marker))) {
       files.push(file);
     }
   }
@@ -68,35 +88,44 @@ async function assignmentWriters(): Promise<string[]> {
   return files.sort();
 }
 
-describe("writers of awcms_access_assignments", () => {
+describe("writers of awcms_access_policies", () => {
   test("the scan finds the writers it is meant to check", async () => {
-    const writers = await assignmentWriters();
+    const writers = await grantWriters();
 
     // A glob that resolves to nothing would make every assertion below pass
     // vacuously — the exact failure mode `tests/module-absence-claims.test.ts`
     // documents from its own first version.
-    expect(writers.length).toBeGreaterThanOrEqual(2);
+    expect(writers.length).toBeGreaterThanOrEqual(3);
     expect(writers).toContain(
       "src/modules/identity-access/application/user-admin.ts"
     );
     expect(writers).toContain(
       "src/modules/identity-access/application/self-registration.ts"
     );
+    expect(writers).toContain(SHARED_WRITER);
+  });
+
+  test("it finds a file that only CALLS the shared writer, not just ones that INSERT", async () => {
+    // `user-admin.ts` no longer contains an INSERT of its own. If the marker had
+    // stayed a single INSERT string, the file carrying the repo's primary
+    // system-role refusal would have dropped out of the rule entirely.
+    const source = await Bun.file(
+      "src/modules/identity-access/application/user-admin.ts"
+    ).text();
+
+    expect(source).not.toContain("INSERT INTO awcms_access_policies");
+    expect(source).toContain("grantRolePolicy(");
   });
 
   test("each one refuses system roles, or is a listed exception", async () => {
     const offenders: string[] = [];
 
-    for (const file of await assignmentWriters()) {
-      if (file in SYSTEM_ROLE_WRITERS) {
-        continue;
-      }
+    for (const file of await grantWriters()) {
+      if (file in SYSTEM_ROLE_WRITERS) continue;
 
       const source = await Bun.file(file).text();
 
-      if (!source.includes("is_system")) {
-        offenders.push(file);
-      }
+      if (!source.includes("is_system")) offenders.push(file);
     }
 
     expect(offenders).toEqual([]);
@@ -107,7 +136,7 @@ describe("writers of awcms_access_assignments", () => {
     // decision about code that no longer exists, and the next reader inherits
     // it as precedent. Same rule the permission-enforcement exception list
     // enforces on itself.
-    const writers = new Set(await assignmentWriters());
+    const writers = new Set(await grantWriters());
     const stale = Object.keys(SYSTEM_ROLE_WRITERS).filter(
       (file) => !writers.has(file)
     );

--- a/tests/integration/self-registration.integration.test.ts
+++ b/tests/integration/self-registration.integration.test.ts
@@ -141,13 +141,30 @@ async function seedRole(
   return rows[0]!.id;
 }
 
+/**
+ * Live grants in a tenant, counted across BOTH tables.
+ *
+ * ADR-0078 moved new grants to `awcms_access_policies` while legacy rows keep
+ * working through the union until PR 3.3's backfill. Counting one table would
+ * make this helper answer a question about storage; the assertions below are
+ * about whether the person was GRANTED anything, which is the union.
+ *
+ * That distinction is not academic here: the "system role is refused, and the
+ * approval writes nothing at all" assertion is a security assertion, and a
+ * helper that looked at the wrong table would report zero for a grant that
+ * exists.
+ */
 async function assignmentCount(tenantId: string): Promise<number> {
   const rows = (await getAdminSql()`
-    SELECT count(*)::int AS n FROM awcms_access_assignments
-    WHERE tenant_id = ${tenantId}
-  `) as { n: number }[];
+    SELECT
+      (SELECT count(*) FROM awcms_access_assignments WHERE tenant_id = ${tenantId})
+      +
+      (SELECT count(*) FROM awcms_access_policies
+       WHERE tenant_id = ${tenantId} AND status = 'active')
+      AS n
+  `) as { n: number | string }[];
 
-  return rows[0]!.n;
+  return Number(rows[0]!.n);
 }
 
 async function rowCount(tenantId: string): Promise<number> {

--- a/tests/mfa-login-e2e.test.ts
+++ b/tests/mfa-login-e2e.test.ts
@@ -136,6 +136,11 @@ describeOrSkip("MFA login flow (real PostgreSQL, route-level)", () => {
       await sql`DELETE FROM awcms_sessions WHERE tenant_id = ${tenantId}`;
       await sql`DELETE FROM awcms_audit_events WHERE tenant_id = ${tenantId}`;
       await sql`DELETE FROM awcms_abac_decision_logs WHERE tenant_id = ${tenantId}`;
+      // ADR-0078 — bootstrap's owner grant lands in `awcms_access_policies`,
+      // whose composite FK to `awcms_roles` blocks the role delete below unless
+      // the grant goes first. Its event table references the policy, so it leads.
+      await sql`DELETE FROM awcms_access_policy_events WHERE tenant_id = ${tenantId}`;
+      await sql`DELETE FROM awcms_access_policies WHERE tenant_id = ${tenantId}`;
       await sql`DELETE FROM awcms_access_assignments WHERE tenant_id = ${tenantId}`;
       await sql`DELETE FROM awcms_role_permissions WHERE tenant_id = ${tenantId}`;
       await sql`DELETE FROM awcms_roles WHERE tenant_id = ${tenantId}`;

--- a/tests/turnstile-login-e2e.test.ts
+++ b/tests/turnstile-login-e2e.test.ts
@@ -175,6 +175,12 @@ describeOrSkip(
         "awcms_sessions",
         "awcms_audit_events",
         "awcms_abac_decision_logs",
+        // ADR-0078 — bootstrap's owner grant now lands in
+        // `awcms_access_policies`, whose composite FK to `awcms_roles` makes the
+        // role delete below fail unless the grant goes first. Its append-only
+        // event table references the policy, so it leads.
+        "awcms_access_policy_events",
+        "awcms_access_policies",
         "awcms_access_assignments",
         "awcms_role_permissions",
         "awcms_roles",


### PR DESCRIPTION
Gelombang 3 PR 3.2 dari #423, menutup unit komitmen yang dibuka [ADR-0078](docs/adr/0078-a-grant-carries-its-own-scope.md) di #505. Sejak PR ini `awcms_access_policies` punya **penulis produksi** — tabel tanpa penulis adalah cacat yang ADR-0077 hapus, dan `docs/PROJECT_STATE.md` §4 mencatat 3.1 dan 3.2 sebagai satu unit justru supaya keadaan itu tak pernah menetap.

Tiga jalur pindah: `assignRole`, penerimaan pendaftaran mandiri, dan bootstrap tenant.

## Ini BUKAN dual write

ADR-0078 memilih tabel ketiga justru supaya expand/migrate/contract tidak butuh dual write. Satu grant baru mendarat di **satu** tabel; baris lama tetap di tempatnya dan tetap bekerja lewat union sampai backfill PR 3.3 memindahkannya.

Menulis keduanya akan menghidupkan kembali kegagalan yang dihindari rancangan ini: dua tulis yang bisa berhasil **terpisah**, meninggalkan subjek yang memegang peran menurut satu tabel dan tidak menurut yang lain, tanpa cara menentukan mana yang benar.

## Pencabutan harus mencari di kedua tempat

`revokeRoleGrants` menghapus baris lama **dan** mencabut policy aktif, karena selama backfill belum jalan sebuah grant bisa hidup di mana saja. Penghapus yang hanya tahu tabel baru akan melaporkan sukses sementara perannya selamat — bentuk paling berbahaya yang tersedia di sini, karena ia gagal ke arah **akses tetap ada** dan tak ada yang mengamatinya.

Pemeriksaan duplikat juga tidak lagi gratis dari satu indeks unik, jadi ditanyakan eksplisit terhadap kedua tabel sebelum menulis. Terjemahan 23505 tetap ada untuk satu kasus tersisa dan hanya itu: dua permintaan bersamaan yang memberi peran sama.

## Empat gerbang memerah, dan tiap satunya benar

| Gerbang | Yang ia tangkap |
| --- | --- |
| `access:grant-readers:check` | Penulis bersama yang baru **dan** entri basi untuk `self-registration.ts` yang berhenti menyebut tabel grant — persis dua arah yang dirancangkan gerbang itu (#500), di PR pertama yang menggerakkannya |
| `modules:table-writes:check` | `platform-bootstrap.ts` (milik `tenant_admin`) menulis tabel `identity_access`. Pengecualiannya **dipindahkan bersama** grant-nya, bukan ditambahkan di sebelahnya |
| `tests/access-assignment-writers.test.ts` | Penanda "penulis" harus berubah **dua kali** — lihat di bawah |
| Integrasi self-registration | Helper `assignmentCount` menghitung satu tabel |

**Penanda "penulis" adalah yang paling menarik.** Ia dulu satu string: berkas yang memuat `INSERT INTO awcms_access_assignments`. Dua hal berubah bersamaan — tabelnya pindah, **dan** sebuah berkas kini bisa menyebabkan grant tanpa memuat satu pun `INSERT`. Penanda yang hanya melihat INSERT akan diam-diam mempersempit aturan empat-penulis menjadi dua, dan `user-admin.ts` — pembawa penolakan system-role utama repo ini — akan **keluar dari aturannya sama sekali**. Ada asersi khusus untuk itu sekarang.

**Helper `assignmentCount`** kini menghitung union, karena asersi di sekitarnya bertanya "apakah orang ini diberi grant", bukan "berapa baris di tabel ini" — dan salah satunya adalah asersi keamanan ("peran sistem ditolak, dan penerimaan tidak menulis apa pun"), yang akan melaporkan nol untuk grant yang ada.

## Dua catatan

`platform-bootstrap.ts` menulis INSERT-nya **inline** alih-alih memanggil penulis bersama: `tenant_admin` tidak boleh mengimpor kode aplikasi `identity_access` — DAG modul berjalan ke arah sebaliknya dan `modules:dag:check` menegakkannya. Duplikasinya dua INSERT dan dipatok test penulis.

Setiap grant yang ditulis hari ini **tenant-wide**. Scope lebih sempit bisa ditulis ketika PR 3.4 mengajari evaluasi mengualifikasinya — mengirimkan penulis untuk scope yang masih diabaikan evaluator berarti membagikan grant yang **terlihat sempit dan tidak**.

## Verifikasi

- `DATABASE_URL="" bun run check` → **exit 0**.
- Integrasi terhadap PostgreSQL nyata (lokal, netns): **298 pass**; 4 kegagalan yang sudah ada sebelum sesi ini (diverifikasi pada `main` bersih — gagal identik; artefak harness lokal, hijau di CI).

Bagian dari #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)