### PR TITLE
feat(auth): undangan diterima, dan keanggotaan lahir di satu fungsi (ADR-0082, #423)

### DIFF
--- a/.changeset/penerimaan-undangan.md
+++ b/.changeset/penerimaan-undangan.md
@@ -1,0 +1,56 @@
+---
+"awcms": minor
+---
+
+feat(auth): undangan diterima, dan keanggotaan lahir di satu fungsi (ADR-0082, #423)
+
+Gelombang 4 PR 4.2, penutup gelombang. Dua endpoint publik —
+`GET /api/v1/auth/invitations/{token}` (preview) dan
+`POST /api/v1/auth/invitations/{token}/accept` — plus halaman
+`/accept-invitation`.
+
+**`materializeMembership()` sengaja SATU fungsi dengan SATU pemanggil.** Sudah
+ada tiga tempat yang melahirkan keanggotaan di repo ini
+(`approveRegistrationRequest`, `jitProvisionIdentity`, `bootstrapPlatformTenant`),
+dan ketiganya pernah menyimpang sekali pada detail yang paling penting
+(`verification_status`). Yang keempat ini ditulis sebagai satu fungsi supaya
+Gelombang 7 punya persis satu tempat untuk diarahkan ulang saat identity menjadi
+principal global. Mengarahkan ulang ketiganya SEKARANG akan menjadikan PR ini
+refactor self-registration dan SSO sekaligus — dan memerahkan
+`tests/access-assignment-writers.test.ts`, yang menyebut `self-registration.ts`
+sebagai pemanggil langsung `grantRolePolicy` di asersi non-hampanya.
+
+**Penolakan `is_system` diperiksa kedua kalinya di sini**, bukan seremonial:
+sebuah peran bisa ditandai system, di-soft-delete, atau keluar dari katalog di
+antara saat undangan dikirim dan saat ia diterima. Test integrasi mengubah peran
+itu di antara kedua momen dan menuntut penerimaannya ditolak — plus bahwa TIDAK
+ADA akun setengah jadi yang tertinggal.
+
+**Penerimaan tidak menerbitkan sesi.** Undangan yang mencetak sesi akan
+melangkahi kebijakan MFA tenant (`required_for_all` akan menghasilkan anggota
+ber-sesi penuh tanpa faktor kedua), melangkahi
+`isPasswordLoginDisabledForIdentity` pada tenant SSO-only, dan melangkahi rate
+limit login. Undangan mencetak AKUN; siapa yang boleh memegang sesi adalah
+keputusan `/login`.
+
+**Kedaluwarsa dijawab 404, bukan 410.** Tak dikenal, tercabut, sudah diterima,
+kedaluwarsa, dan milik tenant lain semuanya menjawab identik. Preview
+mengembalikan nama tenant dan nama pengundang, dan **tidak pernah** alamatnya.
+
+**Satu cacat PR 4.1 diperbaiki di sini, ditemukan saat menulis halamannya:**
+`buildInvitationUrl` hanya memuat `?token=`, sementara kedua endpoint publiknya
+menuntut header `X-AWCMS-Tenant-ID` — jadi tautannya menghasilkan halaman yang
+tak bisa melakukan panggilan yang menjadi alasan keberadaannya. Kini ia membawa
+tenant juga, disegel AES-256-GCM jadi satu `?p=` bila
+`AUTH_URL_PARAM_ENCRYPTION_KEY` diset, persis seperti tautan reset password.
+
+Ledger `tests/shared-rate-limit.test.ts` naik **11 → 13** dan
+`tests/auth-source-rate-limit.test.ts` **7 → 9**; prosa ADR-0066 §C yang menulis
+"sebelas" diberi catatan pembaruan alih-alih dibiarkan menua sendirian — angka
+itu hidup di berkas test, bukan di `scripts/`, jadi ia yang paling mudah
+terlupa.
+
+Diverifikasi terhadap PostgreSQL nyata: 16 test integrasi baru lulus, dan kunci
+barisnya dibuktikan load-bearing — menghapus `FOR UPDATE OF i` membuat penerimaan
+kedua MELEMPAR (tabrakan 23505 di tengah transaksi, yaitu 500 bagi orang yang
+menekan tombol dua kali) alih-alih ditolak bersih.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **107** (`sql/001`–`107`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0082** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-11).**) | `ls docs/adr/`                                                                          |
 | Layar admin                        | **34** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **45** (24.722 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **46** (25.107 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **39** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **2.5.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/adr/0066-shared-rate-limiting-and-full-auth-surface-coverage.md
+++ b/docs/adr/0066-shared-rate-limiting-and-full-auth-surface-coverage.md
@@ -78,6 +78,13 @@ Ketiga endpoint tanpa limiter mendapatkannya. Cakupannya kini: `login`,
 test yang juga menegakkan bahwa tak ada rute yang masih memakai limiter
 per-instans secara langsung.
 
+> **Diperbarui (ADR-0082, Gelombang 4 PR 4.2):** sebelas menjadi **tiga belas**.
+> `auth/invitations/{token}` dan `auth/invitations/{token}/accept` keduanya
+> tak-terautentikasi dan ber-token, dan yang kedua MENCETAK AKUN — permukaan
+> tulis tak-terautentikasi paling berkonsekuensi di modul ini. Angka itu hidup
+> di `tests/shared-rate-limit.test.ts`, bukan di `scripts/`, jadi ia yang paling
+> mudah terlupa; kalimat ini ada supaya prosanya tidak menua sendirian.
+
 ## Konsekuensi
 
 **Yang didapat.** Batas rate menjadi properti deployment, bukan properti satu

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -939,6 +939,62 @@ Returns what `evaluateAccess` would decide for a hypothetical subject/request/en
 | 401    | Missing or invalid session.                  | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.                  | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/auth/invitations/{token}` — Preview an invitation (public, token-bearing).
+
+- **operationId**: `getAuthInvitationPreview`
+- **Security**: none (public endpoint)
+
+Returns the tenant's name, the inviter's name, and the expiry — and **never the invited address**. Whoever legitimately holds this link read that address in their own mailbox; whoever holds a stolen one did not.
+Unknown, revoked, already-accepted, expired and belonging-to-another-tenant all answer one identical `404`. **404, not 410**: `410 Gone` would tell a token holder that the token was once valid, which is an oracle worth having if you are working through addresses you scraped. The real reason is written to the tenant's audit trail, never to the response.
+Rate-limited through the shared limiter's source ceiling before any database work.
+
+**Parameters**
+
+| Name                | In     | Required | Type          | Description |
+| ------------------- | ------ | -------- | ------------- | ----------- |
+| `X-Correlation-ID`  | header | no       | string        |             |
+| `X-AWCMS-Tenant-ID` | header | yes      | string (uuid) |             |
+| `token`             | path   | yes      | string        |             |
+
+**Responses**
+
+| Status | Description                                         | Schema                                 |
+| ------ | --------------------------------------------------- | -------------------------------------- |
+| 200    | The invitation is live and may be accepted.         | object                                 |
+| 400    | Validation error.                                   | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                 | [`ApiError`](#standard-error-envelope) |
+| 429    | Rate limited (RATE_LIMITED). Carries `retry-after`. | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/auth/invitations/{token}/accept` — Accept an invitation, creating the membership (public, token-bearing).
+
+- **operationId**: `postAuthInvitationAccept`
+- **Security**: none (public endpoint)
+
+Creates the profile, identity and tenant user, and materializes the roles the invitation carried. Those roles are read from `awcms_invitation_policies` — **never** from this request body, which declares no privilege field at all. A role that has since become `is_system`, been soft-deleted, or left the catalogue refuses the whole acceptance rather than granting a subset.
+**No session is issued.** The invitee signs in at `/login` afterwards, so the tenant's MFA policy, its SSO-only policy, and the login rate limit all still stand between the new account and a signed-in browser.
+Every refusal — unknown, revoked, already accepted, expired, wrong tenant, or an address that acquired an account in the meantime — answers the same `404`.
+Turnstile-gated with its own action, so a token solved on any other form cannot be spent here.
+
+**Parameters**
+
+| Name                | In     | Required | Type          | Description |
+| ------------------- | ------ | -------- | ------------- | ----------- |
+| `X-Correlation-ID`  | header | no       | string        |             |
+| `X-AWCMS-Tenant-ID` | header | yes      | string (uuid) |             |
+| `token`             | path   | yes      | string        |             |
+
+**Request body** (required): object
+
+**Responses**
+
+| Status | Description                                                   | Schema                                 |
+| ------ | ------------------------------------------------------------- | -------------------------------------- |
+| 200    | The membership exists. Sign in at /login.                     | object                                 |
+| 400    | Validation error.                                             | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                           | [`ApiError`](#standard-error-envelope) |
+| 413    | The request body exceeded the size limit (PAYLOAD_TOO_LARGE). | [`ApiError`](#standard-error-envelope) |
+| 429    | Rate limited (RATE_LIMITED). Carries `retry-after`.           | [`ApiError`](#standard-error-envelope) |
+
 ### `POST /api/v1/auth/login` — Authenticate with a login identifier and password; issues a session token.
 
 - **operationId**: `postAuthLogin`

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 135   |
 | Tabel dengan `FORCE` RLS           | 124   |
 | Tabel RLS-free (global, by design) | 11    |
-| Berkas test                        | 350   |
-| Berkas route                       | 331   |
+| Berkas test                        | 351   |
+| Berkas route                       | 334   |
 | ADR                                | 83    |
 
 ### Modul
@@ -301,16 +301,16 @@
 | ------------- | ---------- |
 | `(root)`      | 297        |
 | `e2e`         | 12         |
-| `integration` | 40         |
+| `integration` | 41         |
 | `unit`        | 1          |
 
 ### Routes
 
 | Permukaan       | Berkas |
 | --------------- | ------ |
-| `/api/v1/**`    | 275    |
+| `/api/v1/**`    | 277    |
 | `/admin/**`     | 34     |
-| publik / anonim | 22     |
+| publik / anonim | 23     |
 
 <!-- END GENERATED: repo-inventory -->
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -1285,6 +1285,132 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/auth/invitations/{token}:
+    get:
+      operationId: getAuthInvitationPreview
+      tags:
+        - Identity & Access
+      summary: Preview an invitation (public, token-bearing).
+      security: []
+      description: |-
+        Returns the tenant's name, the inviter's name, and the expiry — and **never the invited address**. Whoever legitimately holds this link read that address in their own mailbox; whoever holds a stolen one did not.
+        Unknown, revoked, already-accepted, expired and belonging-to-another-tenant all answer one identical `404`. **404, not 410**: `410 Gone` would tell a token holder that the token was once valid, which is an oracle worth having if you are working through addresses you scraped. The real reason is written to the tenant's audit trail, never to the response.
+        Rate-limited through the shared limiter's source ceiling before any database work.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: X-AWCMS-Tenant-ID
+          in: header
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The invitation is live and may be accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/InvitationPreview"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          description: Rate limited (RATE_LIMITED). Carries `retry-after`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/auth/invitations/{token}/accept:
+    post:
+      operationId: postAuthInvitationAccept
+      tags:
+        - Identity & Access
+      summary: Accept an invitation, creating the membership (public, token-bearing).
+      security: []
+      description: |-
+        Creates the profile, identity and tenant user, and materializes the roles the invitation carried. Those roles are read from `awcms_invitation_policies` — **never** from this request body, which declares no privilege field at all. A role that has since become `is_system`, been soft-deleted, or left the catalogue refuses the whole acceptance rather than granting a subset.
+        **No session is issued.** The invitee signs in at `/login` afterwards, so the tenant's MFA policy, its SSO-only policy, and the login rate limit all still stand between the new account and a signed-in browser.
+        Every refusal — unknown, revoked, already accepted, expired, wrong tenant, or an address that acquired an account in the meantime — answers the same `404`.
+        Turnstile-gated with its own action, so a token solved on any other form cannot be spent here.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: X-AWCMS-Tenant-ID
+          in: header
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - password
+              properties:
+                password:
+                  type: string
+                  minLength: 8
+                displayName:
+                  type: string
+                  maxLength: 120
+                  description: Lets the invitee correct the name the inviter typed for them. Omitted, the inviter's version stands.
+                turnstileToken:
+                  type: string
+      responses:
+        "200":
+          description: The membership exists. Sign in at /login.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      accepted:
+                        type: boolean
+                        enum:
+                          - true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "413":
+          description: The request body exceeded the size limit (PAYLOAD_TOO_LARGE).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Rate limited (RATE_LIMITED). Carries `retry-after`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/auth/login:
     post:
       operationId: postAuthLogin
@@ -18906,6 +19032,22 @@ components:
           type: array
           items:
             type: string
+    InvitationPreview:
+      type: object
+      description: Deliberately carries NO email address — see the operation description.
+      required:
+        - tenantName
+        - inviterName
+        - expiresAt
+      properties:
+        tenantName:
+          type: string
+        inviterName:
+          type: string
+          description: Empty when the inviter's account has since been deactivated, so the shape stays stable.
+        expiresAt:
+          type: string
+          format: date-time
     InvitationSummary:
       type: object
       required:

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -4233,8 +4233,169 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/auth/invitations/{token}:
+    get:
+      operationId: getAuthInvitationPreview
+      tags:
+        - Identity & Access
+      summary: Preview an invitation (public, token-bearing).
+      security: []
+      description: >-
+        Returns the tenant's name, the inviter's name, and the expiry — and
+        **never the invited address**. Whoever legitimately holds this link read
+        that address in their own mailbox; whoever holds a stolen one did not.
+
+        Unknown, revoked, already-accepted, expired and belonging-to-another-tenant
+        all answer one identical `404`. **404, not 410**: `410 Gone` would tell a
+        token holder that the token was once valid, which is an oracle worth
+        having if you are working through addresses you scraped. The real reason
+        is written to the tenant's audit trail, never to the response.
+
+        Rate-limited through the shared limiter's source ceiling before any
+        database work.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: X-AWCMS-Tenant-ID
+          in: header
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The invitation is live and may be accepted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/InvitationPreview"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          description: Rate limited (RATE_LIMITED). Carries `retry-after`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+  /api/v1/auth/invitations/{token}/accept:
+    post:
+      operationId: postAuthInvitationAccept
+      tags:
+        - Identity & Access
+      summary: Accept an invitation, creating the membership (public, token-bearing).
+      security: []
+      description: >-
+        Creates the profile, identity and tenant user, and materializes the roles
+        the invitation carried. Those roles are read from
+        `awcms_invitation_policies` — **never** from this request body, which
+        declares no privilege field at all. A role that has since become
+        `is_system`, been soft-deleted, or left the catalogue refuses the whole
+        acceptance rather than granting a subset.
+
+        **No session is issued.** The invitee signs in at `/login` afterwards, so
+        the tenant's MFA policy, its SSO-only policy, and the login rate limit
+        all still stand between the new account and a signed-in browser.
+
+        Every refusal — unknown, revoked, already accepted, expired, wrong
+        tenant, or an address that acquired an account in the meantime — answers
+        the same `404`.
+
+        Turnstile-gated with its own action, so a token solved on any other form
+        cannot be spent here.
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: X-AWCMS-Tenant-ID
+          in: header
+          required: true
+          schema:
+            type: string
+            format: uuid
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - password
+              properties:
+                password:
+                  type: string
+                  minLength: 8
+                displayName:
+                  type: string
+                  maxLength: 120
+                  description: Lets the invitee correct the name the inviter typed for them. Omitted, the inviter's version stands.
+                turnstileToken:
+                  type: string
+      responses:
+        "200":
+          description: The membership exists. Sign in at /login.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      accepted:
+                        type: boolean
+                        enum: [true]
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "413":
+          description: The request body exceeded the size limit (PAYLOAD_TOO_LARGE).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "429":
+          description: Rate limited (RATE_LIMITED). Carries `retry-after`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
 components:
   schemas:
+    InvitationPreview:
+      type: object
+      description: Deliberately carries NO email address — see the operation description.
+      required:
+        - tenantName
+        - inviterName
+        - expiresAt
+      properties:
+        tenantName:
+          type: string
+        inviterName:
+          type: string
+          description: Empty when the inviter's account has since been deactivated, so the shape stays stable.
+        expiresAt:
+          type: string
+          format: date-time
     InvitationSummary:
       type: object
       required:

--- a/scripts/api-spec-check.ts
+++ b/scripts/api-spec-check.ts
@@ -97,7 +97,37 @@ const ALLOWED_PUBLIC_OPERATIONS = new Set([
   // separate, permissioned admin action. An already-registered address, an
   // already-pending request and a fresh one all return the identical 200, so it
   // is not an account-existence oracle.
-  "postAuthRegister"
+  "postAuthRegister",
+  // Invitations (ADR-0082, Gelombang 4 PR 4.2) — unauthenticated for the same
+  // structural reason self-registration is: the recipient has no account yet,
+  // which is what the invitation exists to change. `getAuthInvitationPreview`
+  // renders the page; `postAuthInvitationAccept` creates the membership.
+  //
+  // What keeps them safe is not authentication:
+  //
+  // Nobody reaches either without a 256-bit CSPRNG token that is stored only as
+  // a sha256 hash, is single-use, expires, and is ROTATED by every resend — so
+  // an invitation cannot be issued by anyone but a holder of
+  // `identity_access.invitations.create`, and a superseded link is dead.
+  //
+  // Both are tenant-bound and rate-limited through `checkAuthRateLimit`, whose
+  // SOURCE ceiling is keyed on something the caller cannot choose (#447), and
+  // the accept path is additionally Turnstile-gated with its OWN action so a
+  // token solved on the login form cannot be spent here.
+  //
+  // Neither is an oracle. Unknown, revoked, already-accepted, expired and
+  // wrong-tenant all answer one identical 404 — 404 rather than 410, because
+  // 410 would say the token was once valid. The preview returns the tenant name
+  // and the inviter's name and NEVER the invited address.
+  //
+  // Acceptance accepts no privilege field: what the invitee may hold was
+  // decided by the administrator who invited them and is read from
+  // `awcms_invitation_policies`. It grants no `is_system` role — checked at
+  // issue AND re-checked here — and it issues NO SESSION, so the tenant's MFA
+  // policy, its SSO-only policy and the login rate limit all still stand
+  // between the new account and a signed-in browser.
+  "getAuthInvitationPreview",
+  "postAuthInvitationAccept"
 ]);
 
 /**

--- a/src/lib/security/turnstile.ts
+++ b/src/lib/security/turnstile.ts
@@ -74,6 +74,18 @@ export const PASSWORD_RESET_TURNSTILE_ACTION = "password_reset";
  * any other form must not be spendable here.
  */
 export const REGISTER_TURNSTILE_ACTION = "register";
+/**
+ * Invitation acceptance (ADR-0082). Its own action for the same reason again,
+ * and here the stake is highest of the four: `POST /auth/invitations/{token}/accept`
+ * is unauthenticated and CREATES AN ACCOUNT, so a token solved on any other
+ * form must not be spendable against it.
+ *
+ * The preview (`GET`) takes no Turnstile token — it is a read that writes
+ * nothing, and demanding a challenge to look at the invitation you were sent
+ * would put a widget in front of the one screen that explains what the widget
+ * is for.
+ */
+export const INVITATION_ACCEPT_TURNSTILE_ACTION = "invitation_accept";
 
 /**
  * Env vars required only when `TURNSTILE_ENABLED=true` (validated by

--- a/src/modules/identity-access/application/invitation-acceptance.ts
+++ b/src/modules/identity-access/application/invitation-acceptance.ts
@@ -1,0 +1,225 @@
+/**
+ * The public half of the invitation flow — preview and acceptance (ADR-0082,
+ * Gelombang 4 PR 4.2 of #423).
+ *
+ * Both callers are UNAUTHENTICATED, so the whole file is written around one
+ * rule: the response must not vary with anything the caller did not already
+ * know. Unknown, revoked, already-accepted, expired, and
+ * belongs-to-another-tenant all produce the same refusal, and the reason lives
+ * only in the audit row.
+ *
+ * ## Preview never returns the address
+ *
+ * It returns the tenant's name, the inviter's name, and the expiry. Whoever
+ * legitimately holds the link read the address in their own mailbox; whoever
+ * holds a STOLEN link did not, and this surface is not going to tell them.
+ *
+ * ## The row lock is load-bearing
+ *
+ * `claimInvitation` reads `FOR UPDATE`. Without it, two concurrent acceptances
+ * of the same link both pass the status check and the second collides on
+ * `awcms_identities_tenant_login_key` mid-transaction — a 500 for a user who
+ * did nothing wrong, and a rollback that takes the audit row with it. This is
+ * the defect `approveRegistrationRequest`'s `FOR UPDATE` was mutation-proven
+ * against, and `completePasswordReset` repeats it for the same reason.
+ *
+ * ## Acceptance does NOT issue a session
+ *
+ * The invitee signs in at `/login` afterwards, like anyone else. Minting a
+ * session here would route around the tenant's own MFA policy (a tenant with
+ * `required_for_all` would get a member holding a full session and no second
+ * factor), around `isPasswordLoginDisabledForIdentity` for an SSO-only tenant,
+ * and around the login rate limit. The endpoint that creates an account is not
+ * the place to decide who may hold a session.
+ */
+import { hashInviteToken } from "../../../lib/auth/invitation-token";
+import { evaluateInvitation } from "../domain/invitation-policy";
+import { materializeMembership } from "./membership-materialization";
+import type { InvitationDenyReason } from "../domain/invitation-policy";
+
+export type InvitationPreview = {
+  tenantName: string;
+  inviterName: string;
+  expiresAt: string;
+};
+
+export type PreviewInvitationResult =
+  | { outcome: "found"; preview: InvitationPreview }
+  | { outcome: "invalid"; reason: InvitationDenyReason };
+
+export type AcceptInvitationResult =
+  | {
+      outcome: "accepted";
+      invitationId: string;
+      identityId: string;
+      tenantUserId: string;
+      grantedRoleCodes: string[];
+    }
+  | { outcome: "invalid"; reason: InvitationDenyReason }
+  | { outcome: "identifier_taken" }
+  | { outcome: "unknown_role" }
+  | { outcome: "system_role"; roleCodes: string[] };
+
+type InvitationRow = {
+  id: string;
+  login_identifier: string;
+  display_name: string;
+  status: string;
+  expires_at: Date;
+  skip_email_confirmation: boolean;
+  tenant_name: string;
+  inviter_name: string | null;
+};
+
+/**
+ * Reads the invitation named by a raw token.
+ *
+ * The lookup is `tenant_id = ? AND token_hash = ?`, so an otherwise valid token
+ * presented with a different tenant header simply finds nothing — the header
+ * selects the RLS scope, and the token proves the claim. A mismatch collapses
+ * into `not_found` like everything else rather than announcing itself.
+ */
+async function findInvitation(
+  tx: Bun.SQL,
+  tenantId: string,
+  rawToken: string,
+  lock: boolean
+): Promise<InvitationRow | null> {
+  // Two statements rather than one parameterized by a boolean: `FOR UPDATE`
+  // cannot be bound, and interpolating it would be the one place in this file
+  // where a caller's flag reaches SQL text.
+  const rows = lock
+    ? ((await tx`
+        SELECT
+          i.id, i.login_identifier, i.display_name, i.status, i.expires_at,
+          i.skip_email_confirmation,
+          t.tenant_name,
+          p.display_name AS inviter_name
+        FROM awcms_invitations i
+        JOIN awcms_tenants t ON t.id = i.tenant_id
+        LEFT JOIN awcms_tenant_users tu
+          ON tu.tenant_id = i.tenant_id AND tu.id = i.invited_by_tenant_user_id
+        LEFT JOIN awcms_identities ident
+          ON ident.tenant_id = tu.tenant_id AND ident.id = tu.identity_id
+        LEFT JOIN awcms_profiles p
+          ON p.tenant_id = ident.tenant_id AND p.id = ident.profile_id
+        WHERE i.tenant_id = ${tenantId}
+          AND i.token_hash = ${hashInviteToken(rawToken)}
+        FOR UPDATE OF i
+      `) as InvitationRow[])
+    : ((await tx`
+        SELECT
+          i.id, i.login_identifier, i.display_name, i.status, i.expires_at,
+          i.skip_email_confirmation,
+          t.tenant_name,
+          p.display_name AS inviter_name
+        FROM awcms_invitations i
+        JOIN awcms_tenants t ON t.id = i.tenant_id
+        LEFT JOIN awcms_tenant_users tu
+          ON tu.tenant_id = i.tenant_id AND tu.id = i.invited_by_tenant_user_id
+        LEFT JOIN awcms_identities ident
+          ON ident.tenant_id = tu.tenant_id AND ident.id = tu.identity_id
+        LEFT JOIN awcms_profiles p
+          ON p.tenant_id = ident.tenant_id AND p.id = ident.profile_id
+        WHERE i.tenant_id = ${tenantId}
+          AND i.token_hash = ${hashInviteToken(rawToken)}
+      `) as InvitationRow[]);
+
+  return rows[0] ?? null;
+}
+
+export async function previewInvitation(
+  tx: Bun.SQL,
+  tenantId: string,
+  rawToken: string,
+  now: Date
+): Promise<PreviewInvitationResult> {
+  const row = await findInvitation(tx, tenantId, rawToken, false);
+  const evaluation = evaluateInvitation(
+    row === null ? null : { status: row.status, expiresAt: row.expires_at },
+    now
+  );
+
+  if (evaluation.outcome === "invalid") {
+    return { outcome: "invalid", reason: evaluation.reason };
+  }
+
+  return {
+    outcome: "found",
+    preview: {
+      tenantName: row!.tenant_name,
+      // An inviter whose account was since deactivated leaves the join empty.
+      // An empty string keeps the response shape stable rather than making the
+      // page render "null invited you".
+      inviterName: row!.inviter_name ?? "",
+      expiresAt: row!.expires_at.toISOString()
+    }
+  };
+}
+
+export async function acceptInvitation(
+  tx: Bun.SQL,
+  tenantId: string,
+  rawToken: string,
+  input: { password: string; displayName?: string },
+  now: Date
+): Promise<AcceptInvitationResult> {
+  const row = await findInvitation(tx, tenantId, rawToken, true);
+  const evaluation = evaluateInvitation(
+    row === null ? null : { status: row.status, expiresAt: row.expires_at },
+    now
+  );
+
+  if (evaluation.outcome === "invalid") {
+    return { outcome: "invalid", reason: evaluation.reason };
+  }
+
+  const invitation = row!;
+
+  const roleRows = (await tx`
+    SELECT role_id FROM awcms_invitation_policies
+    WHERE tenant_id = ${tenantId} AND invitation_id = ${invitation.id}
+  `) as { role_id: string }[];
+
+  const materialized = await materializeMembership(tx, tenantId, {
+    loginIdentifier: invitation.login_identifier,
+    // The invitee may correct the name the inviter typed for them; if they do
+    // not, the inviter's version stands.
+    displayName: input.displayName ?? invitation.display_name,
+    password: input.password,
+    // Accepting through a link sent to that mailbox IS proof of control, so an
+    // ordinary acceptance verifies the profile. `skip_email_confirmation`
+    // matters for the OTHER direction — it is what let the invitation be issued
+    // without demanding this proof at all.
+    emailVerified: true,
+    roleIds: roleRows.map((role) => role.role_id),
+    reason: `invitation ${invitation.id} accepted`
+  });
+
+  if (materialized.outcome !== "created") {
+    return materialized;
+  }
+
+  // `AND status = 'pending'` is redundant under the row lock and kept anyway:
+  // it is the predicate that makes this UPDATE correct on its own terms, and a
+  // future caller that reaches it without the lock would otherwise be wrong
+  // silently.
+  await tx`
+    UPDATE awcms_invitations
+    SET status = 'accepted',
+        accepted_at = ${now},
+        accepted_tenant_user_id = ${materialized.tenantUserId},
+        updated_at = ${now}
+    WHERE tenant_id = ${tenantId}
+      AND id = ${invitation.id}
+      AND status = 'pending'
+  `;
+
+  return {
+    outcome: "accepted",
+    invitationId: invitation.id,
+    identityId: materialized.identityId,
+    tenantUserId: materialized.tenantUserId,
+    grantedRoleCodes: materialized.grantedRoleCodes
+  };
+}

--- a/src/modules/identity-access/application/invitation-admin.ts
+++ b/src/modules/identity-access/application/invitation-admin.ts
@@ -32,6 +32,7 @@ import {
   generateInviteToken,
   hashInviteToken
 } from "../../../lib/auth/invitation-token";
+import { sealUrlParams } from "../../../lib/security/secure-url-params";
 import { recordAuditEvent } from "../../logging/application/audit-log";
 import {
   encodeKeysetCursor,
@@ -126,8 +127,30 @@ function maskAddress(value: string): string {
   return `${head}${"*".repeat(Math.max(local.length - 1, 1))}${domain}`;
 }
 
-function buildInvitationUrl(base: string, rawToken: string): string {
-  return `${base}?token=${encodeURIComponent(rawToken)}`;
+/**
+ * The emailed link.
+ *
+ * It carries the TENANT as well as the token, and that is not decoration: both
+ * public invitation endpoints are tenant-scoped under FORCE RLS and demand
+ * `X-AWCMS-Tenant-ID`, so a link without it produces a page that cannot make
+ * the call it exists to make. `requestPasswordReset` carries the tenant for the
+ * same reason.
+ *
+ * Sealed with AES-256-GCM into one opaque `?p=` when
+ * `AUTH_URL_PARAM_ENCRYPTION_KEY` is set, plain otherwise. The plain fallback
+ * is not a weakness: the token is already 256 bits of CSPRNG and a tenant id is
+ * not a secret.
+ */
+function buildInvitationUrl(
+  base: string,
+  rawToken: string,
+  tenantId: string
+): string {
+  const sealed = sealUrlParams({ token: rawToken, tenantId });
+
+  return sealed
+    ? `${base}?p=${sealed}`
+    : `${base}?token=${encodeURIComponent(rawToken)}&tenantId=${tenantId}`;
 }
 
 /**
@@ -170,7 +193,8 @@ async function deliverInvitation(
         tenantName: input.tenantName,
         invitationUrl: buildInvitationUrl(
           options.invitationUrlBase,
-          input.rawToken
+          input.rawToken,
+          tenantId
         ),
         expiresInHours: String(options.tokenTtlHours)
       },

--- a/src/modules/identity-access/application/membership-materialization.ts
+++ b/src/modules/identity-access/application/membership-materialization.ts
@@ -1,0 +1,150 @@
+/**
+ * `materializeMembership()` — turning an accepted offer into an account
+ * (ADR-0082, Gelombang 4 PR 4.2 of #423).
+ *
+ * ## Why this is ONE function
+ *
+ * There are already three places in this repository that bring a membership
+ * into existence: `approveRegistrationRequest`, `jitProvisionIdentity`, and
+ * `bootstrapPlatformTenant`. They agree on the shape — profile, then identity,
+ * then tenant user — and they have already drifted once on the detail that
+ * matters most (`verification_status`), which is what produced
+ * `createPersonProfileForIdentity` as a single writer.
+ *
+ * This is the fourth, and it is deliberately written as one function with one
+ * caller rather than as a helper the others are re-pointed at. Gelombang 7
+ * replaces the identity row with a global principal, and it needs exactly one
+ * place to redirect. Re-pointing the existing three now would make this PR a
+ * refactor of self-registration and SSO on top of everything else — and would
+ * turn `tests/access-assignment-writers.test.ts` red for a reason unrelated to
+ * invitations, since its non-vacuity assertion names `self-registration.ts` by
+ * path as a direct caller of `grantRolePolicy`.
+ *
+ * ## The system-role refusal happens HERE too
+ *
+ * `createInvitation` already refused a role marked `is_system`. This checks
+ * again, because the two moments can be days apart: a role can be marked
+ * system, soft-deleted, or dropped from the catalogue in between, and the
+ * invitation would still be carrying its id. `approveRegistrationRequest` sets
+ * the precedent — and the program doc requires the check at both ends.
+ *
+ * ## Every refusal precedes every write
+ *
+ * A 4xx returned from inside `withTenant` COMMITs. Each refusal below is
+ * resolved before the first INSERT, so a rejected acceptance leaves nothing
+ * behind but its audit row.
+ */
+import { hashPassword } from "../../../lib/auth/password";
+import { createPersonProfileForIdentity } from "../../profile-identity/application/person-profile";
+import { grantRolePolicy } from "./access-policy-writer";
+
+export type MaterializeMembershipInput = {
+  loginIdentifier: string;
+  displayName: string;
+  password: string;
+  /** Marks the profile `verified` — gated by the invitation's own `skip_email_confirmation`, which the platform permission guards at issue time. */
+  emailVerified: boolean;
+  roleIds: readonly string[];
+  /** Recorded on each grant, so `awcms_access_policy_events` says WHY the role was held. */
+  reason: string;
+};
+
+export type MaterializeMembershipResult =
+  | {
+      outcome: "created";
+      identityId: string;
+      tenantUserId: string;
+      grantedRoleCodes: string[];
+    }
+  | { outcome: "identifier_taken" }
+  | { outcome: "unknown_role" }
+  | { outcome: "system_role"; roleCodes: string[] };
+
+export async function materializeMembership(
+  tx: Bun.SQL,
+  tenantId: string,
+  input: MaterializeMembershipInput
+): Promise<MaterializeMembershipResult> {
+  // 1. The address must still be free. Exact equality, never lowercased — the
+  //    comparison every other lookup on the auth path uses.
+  const existing = (await tx`
+    SELECT 1 FROM awcms_identities
+    WHERE tenant_id = ${tenantId}
+      AND login_identifier = ${input.loginIdentifier}
+  `) as unknown[];
+
+  if (existing.length > 0) {
+    return { outcome: "identifier_taken" };
+  }
+
+  // 2. The roles must still resolve, and none of them may be a system role.
+  //    Re-derived from the database rather than trusted from the invitation:
+  //    the row carries ids, and what those ids MEAN can have changed.
+  let grantedRoleCodes: string[] = [];
+  if (input.roleIds.length > 0) {
+    const found = (await tx`
+      SELECT id, role_code, is_system FROM awcms_roles
+      WHERE tenant_id = ${tenantId}
+        AND id = ANY(${tx.array([...input.roleIds], "uuid")})
+        AND deleted_at IS NULL
+    `) as { id: string; role_code: string; is_system: boolean }[];
+
+    if (found.length !== input.roleIds.length) {
+      return { outcome: "unknown_role" };
+    }
+
+    const systemRoles = found.filter((row) => row.is_system);
+    if (systemRoles.length > 0) {
+      return {
+        outcome: "system_role",
+        roleCodes: systemRoles.map((row) => row.role_code).sort()
+      };
+    }
+
+    grantedRoleCodes = found.map((row) => row.role_code).sort();
+  }
+
+  // 3. Profile through the single writer that owns `awcms_profiles`
+  //    (ADR-0013 §6) — a fresh INSERT here would also redden
+  //    `modules:table-writes:check`, and the drift that gate exists to stop is
+  //    exactly the `verification_status` disagreement this parameter carries.
+  const profileId = await createPersonProfileForIdentity(tx, tenantId, {
+    displayName: input.displayName,
+    emailVerified: input.emailVerified
+  });
+
+  const identityRows = (await tx`
+    INSERT INTO awcms_identities
+      (tenant_id, profile_id, login_identifier, password_hash, status)
+    VALUES
+      (${tenantId}, ${profileId}, ${input.loginIdentifier},
+       ${await hashPassword(input.password)}, 'active')
+    RETURNING id
+  `) as { id: string }[];
+
+  const identityId = identityRows[0]!.id;
+
+  const tenantUserRows = (await tx`
+    INSERT INTO awcms_tenant_users (tenant_id, identity_id, status)
+    VALUES (${tenantId}, ${identityId}, 'active')
+    RETURNING id
+  `) as { id: string }[];
+
+  const tenantUserId = tenantUserRows[0]!.id;
+
+  // 4. One call per role rather than a set-based INSERT: the shared writer also
+  //    writes the `granted` lifecycle event, and a grant with no provenance row
+  //    is a hole exactly where an investigation starts.
+  for (const roleId of input.roleIds) {
+    await grantRolePolicy(tx, tenantId, {
+      tenantUserId,
+      roleId,
+      // No actor: the invitee granted themselves nothing. The administrator who
+      // decided this is named by the invitation, and by its audit row.
+      grantedByTenantUserId: null,
+      reason: input.reason
+    });
+  }
+
+  return { outcome: "created", identityId, tenantUserId, grantedRoleCodes };
+}

--- a/src/pages/accept-invitation.astro
+++ b/src/pages/accept-invitation.astro
@@ -1,0 +1,385 @@
+---
+/**
+ * Invitation acceptance page (ADR-0082, Gelombang 4 PR 4.2 of #423). Previews
+ * the invitation, then posts `{ password, displayName? }` plus the tenant
+ * header to `POST /api/v1/auth/invitations/{token}/accept`.
+ *
+ * ## Where the token and tenant come from
+ *
+ * `buildInvitationUrl` emails either the sealed `?p=<opaque>` shape (when
+ * `AUTH_URL_PARAM_ENCRYPTION_KEY` is set — token and tenant sealed together
+ * with AES-256-GCM) or the plain `?token=…&tenantId=…`. Unsealing happens
+ * SERVER-SIDE in this frontmatter; the key never reaches the browser. A `?p=`
+ * that fails to open yields no token and this page renders its invalid state
+ * rather than falling through to the plain branch — which is what would let a
+ * tampered link be retried as an empty one. `reset-password.astro` set that
+ * shape.
+ *
+ * The tenant travels in the link because both invitation endpoints are
+ * tenant-scoped under FORCE RLS and demand `X-AWCMS-Tenant-ID`.
+ *
+ * ## The preview is fetched by the BROWSER, not here
+ *
+ * This frontmatter opens no transaction. `.astro` files are the blind spot of
+ * every type-based gate in this repo (`tsc` cannot parse them), so the less
+ * database code lives in one the better — and the preview endpoint is
+ * rate-limited on its own terms, which an SSR call from this page would
+ * bypass by arriving from the server's own address.
+ *
+ * ## Generic failure, mirroring the endpoint
+ *
+ * The API answers one 404 for unknown, revoked, already-accepted, expired and
+ * wrong-tenant. This page shows one message for all of them; reconstructing a
+ * specific reason in the UI would rebuild the oracle the endpoint removed.
+ *
+ * ## Stable DOM contract (do not rename — E2E specs depend on these)
+ *
+ * `#invitation-form`, `#invitation-token`, `#invitation-tenant`,
+ * `#invitation-password`, `#invitation-confirm`, `#invitation-display-name`,
+ * `#invitation-submit`, `#invitation-error`, `#invitation-notice`,
+ * `#invitation-summary`.
+ */
+import "../styles/tokens.css";
+import "../styles/motion.css";
+import "../styles/auth.css";
+import { openUrlParams } from "../lib/security/secure-url-params";
+import { MIN_PASSWORD_LENGTH } from "../modules/identity-access/domain/password-reset-validation";
+
+const sealed = Astro.url.searchParams.get("p")?.trim() ?? "";
+let token = "";
+let tenantId = "";
+
+if (sealed) {
+  const opened = openUrlParams(sealed);
+  token = opened?.token?.trim() ?? "";
+  tenantId = opened?.tenantId?.trim() ?? "";
+} else {
+  token = Astro.url.searchParams.get("token")?.trim() ?? "";
+  tenantId = Astro.url.searchParams.get("tenantId")?.trim() ?? "";
+}
+
+const hasToken = token.length > 0;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="robots" content="noindex, nofollow" />
+    <title>Accept your invitation · AWCMS</title>
+  </head>
+  <body class="auth-body">
+    <main class="auth">
+      <div class="auth-card">
+        <div class="auth-head">
+          <div class="auth-brand">
+            <span class="auth-mark" aria-hidden="true">A</span>
+            <span class="auth-wordmark">AWCMS</span>
+          </div>
+          <h1 class="auth-title">Accept your invitation</h1>
+          <p class="auth-subtitle" id="invitation-summary">
+            Choose a password to finish setting up your account.
+          </p>
+        </div>
+
+        {
+          !hasToken ? (
+            <>
+              <p class="auth-error" role="alert">
+                This invitation link is invalid or has expired.
+              </p>
+              <nav class="auth-links" aria-label="Account access">
+                <a href="/login">Back to sign in</a>
+              </nav>
+            </>
+          ) : (
+            <>
+              <form id="invitation-form" class="auth-form" novalidate>
+                <p
+                  id="invitation-error"
+                  class="auth-error"
+                  role="alert"
+                  hidden
+                />
+
+                <input
+                  id="invitation-token"
+                  name="token"
+                  type="hidden"
+                  value={token}
+                />
+
+                {tenantId ? (
+                  <input
+                    id="invitation-tenant"
+                    name="tenantId"
+                    type="hidden"
+                    value={tenantId}
+                  />
+                ) : (
+                  <div class="auth-field">
+                    <label for="invitation-tenant">Tenant ID</label>
+                    <input
+                      id="invitation-tenant"
+                      name="tenantId"
+                      type="text"
+                      required
+                      autocomplete="off"
+                      spellcheck={false}
+                    />
+                  </div>
+                )}
+
+                <div class="auth-field">
+                  <label for="invitation-display-name">Your name</label>
+                  <input
+                    id="invitation-display-name"
+                    name="displayName"
+                    type="text"
+                    autocomplete="name"
+                    maxlength={120}
+                  />
+                  <p class="auth-hint">
+                    Optional. Leave it blank to keep the name you were invited
+                    under.
+                  </p>
+                </div>
+
+                <div class="auth-field">
+                  <label for="invitation-password">Password</label>
+                  <div class="auth-password">
+                    <input
+                      id="invitation-password"
+                      name="password"
+                      type="password"
+                      required
+                      autocomplete="new-password"
+                      minlength={MIN_PASSWORD_LENGTH}
+                    />
+                    <button
+                      type="button"
+                      id="invitation-password-toggle"
+                      class="auth-password-toggle"
+                      aria-pressed="false"
+                      aria-label="Show password"
+                    >
+                      <span class="auth-password-toggle-label">Show</span>
+                    </button>
+                  </div>
+                  <p class="auth-hint">
+                    At least {MIN_PASSWORD_LENGTH} characters.
+                  </p>
+                </div>
+
+                <div class="auth-field">
+                  <label for="invitation-confirm">Confirm password</label>
+                  <input
+                    id="invitation-confirm"
+                    name="confirmPassword"
+                    type="password"
+                    required
+                    autocomplete="new-password"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  id="invitation-submit"
+                  class="auth-submit"
+                >
+                  Accept invitation
+                </button>
+              </form>
+
+              <p
+                id="invitation-notice"
+                class="auth-notice"
+                role="status"
+                hidden
+              />
+
+              <nav
+                class="auth-links"
+                id="invitation-login-link"
+                aria-label="Account access"
+                hidden
+              >
+                <a href="/login">Sign in to your new account</a>
+              </nav>
+            </>
+          )
+        }
+
+        <p class="auth-foot">Secured workspace access · AWCMS</p>
+      </div>
+    </main>
+
+    <script>
+      // The import is deliberate — it forces Astro to bundle this script to an
+      // external file (an import-free script would be inlined, and inline
+      // scripts are blocked by this app's CSP). See admin-form-client.ts.
+      import { lockElement } from "../lib/ui/admin-form-client";
+      import { MIN_PASSWORD_LENGTH } from "../modules/identity-access/domain/password-reset-validation";
+
+      const form = document.getElementById(
+        "invitation-form"
+      ) as HTMLFormElement | null;
+      const errorBox = document.getElementById("invitation-error");
+      const noticeBox = document.getElementById("invitation-notice");
+      const summary = document.getElementById("invitation-summary");
+      const loginLink = document.getElementById("invitation-login-link");
+      const submitButton = document.getElementById(
+        "invitation-submit"
+      ) as HTMLButtonElement | null;
+      const passwordInput = document.getElementById(
+        "invitation-password"
+      ) as HTMLInputElement | null;
+      const passwordToggle = document.getElementById(
+        "invitation-password-toggle"
+      ) as HTMLButtonElement | null;
+      const passwordToggleLabel = passwordToggle?.querySelector(
+        ".auth-password-toggle-label"
+      );
+
+      const tokenField = document.getElementById(
+        "invitation-token"
+      ) as HTMLInputElement | null;
+      const tenantField = document.getElementById(
+        "invitation-tenant"
+      ) as HTMLInputElement | null;
+
+      const GENERIC_INVALID = "This invitation link is invalid or has expired.";
+
+      passwordToggle?.addEventListener("click", () => {
+        if (!passwordInput) return;
+        const show = passwordInput.type === "password";
+        passwordInput.type = show ? "text" : "password";
+        passwordToggle.setAttribute("aria-pressed", String(show));
+        passwordToggle.setAttribute(
+          "aria-label",
+          show ? "Hide password" : "Show password"
+        );
+        if (passwordToggleLabel) {
+          passwordToggleLabel.textContent = show ? "Hide" : "Show";
+        }
+      });
+
+      function reveal(element: HTMLElement | null, message: string): void {
+        if (!element) return;
+        element.textContent = message;
+        element.hidden = false;
+      }
+
+      // The preview is best-effort decoration: it names who invited you and to
+      // which workspace. A failure here is NOT reported as an error, because
+      // the accept call is the one that decides, and pre-announcing a refusal
+      // would turn this page into the status oracle the API refuses to be.
+      async function loadPreview(): Promise<void> {
+        const token = tokenField?.value ?? "";
+        const tenantId = tenantField?.value.trim() ?? "";
+        if (!token || !tenantId) return;
+
+        try {
+          const response = await fetch(
+            `/api/v1/auth/invitations/${encodeURIComponent(token)}`,
+            {
+              headers: { "X-AWCMS-Tenant-ID": tenantId },
+              credentials: "same-origin"
+            }
+          );
+          const payload = await response.json().catch(() => null);
+          if (!response.ok || !payload || payload.success !== true) return;
+
+          const { tenantName, inviterName } = payload.data ?? {};
+          if (!tenantName) return;
+
+          reveal(
+            summary,
+            inviterName
+              ? `${inviterName} invited you to ${tenantName}. Choose a password to finish setting up your account.`
+              : `You have been invited to ${tenantName}. Choose a password to finish setting up your account.`
+          );
+        } catch {
+          // Network failure: leave the default subtitle in place.
+        }
+      }
+
+      void loadPreview();
+
+      form?.addEventListener("submit", async (event) => {
+        event.preventDefault();
+
+        if (!submitButton || submitButton.disabled) return;
+        if (errorBox) errorBox.hidden = true;
+
+        const formData = new FormData(form);
+        const token = String(formData.get("token") ?? "");
+        const tenantId = String(formData.get("tenantId") ?? "").trim();
+        const password = String(formData.get("password") ?? "");
+        const confirmPassword = String(formData.get("confirmPassword") ?? "");
+        const displayName = String(formData.get("displayName") ?? "").trim();
+
+        // Client-side guards are UX only — the server re-validates the length,
+        // the token, and every role the invitation carries, and is the only
+        // authority on any of them.
+        if (password.length < MIN_PASSWORD_LENGTH) {
+          reveal(
+            errorBox,
+            `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`
+          );
+          return;
+        }
+
+        if (password !== confirmPassword) {
+          reveal(errorBox, "The two passwords do not match.");
+          return;
+        }
+
+        const unlock = lockElement(submitButton, "Please wait…");
+
+        try {
+          const response = await fetch(
+            `/api/v1/auth/invitations/${encodeURIComponent(token)}/accept`,
+            {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "X-AWCMS-Tenant-ID": tenantId
+              },
+              credentials: "same-origin",
+              body: JSON.stringify(
+                displayName ? { password, displayName } : { password }
+              )
+            }
+          );
+
+          const payload = await response.json().catch(() => null);
+
+          if (!response.ok || !payload || payload.success !== true) {
+            // One generic message: the server refuses to say WHY an invitation
+            // was refused, and the UI must not invent a reason.
+            reveal(
+              errorBox,
+              response.status === 429
+                ? "Too many attempts. Please wait a few minutes and try again."
+                : GENERIC_INVALID
+            );
+            unlock();
+            return;
+          }
+
+          form.hidden = true;
+          reveal(
+            noticeBox,
+            "Your account is ready. Sign in with the password you just chose."
+          );
+          if (loginLink) loginLink.hidden = false;
+        } catch {
+          reveal(errorBox, "Network error. Please try again.");
+          unlock();
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/src/pages/api/v1/auth/invitations/[token].ts
+++ b/src/pages/api/v1/auth/invitations/[token].ts
@@ -1,0 +1,114 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../../../lib/database/client";
+import {
+  hashClientIp,
+  summarizeUserAgent
+} from "../../../../../lib/security/client-fingerprint";
+import { resolveClientIp } from "../../../../../lib/security/rate-limit";
+import { checkAuthRateLimit } from "../../../../../lib/security/auth-rate-limit";
+import { resolveInvitationRateLimit } from "../../../../../lib/auth/invitation-config";
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { previewInvitation } from "../../../../../modules/identity-access/application/invitation-acceptance";
+import { withPublicAuthTenant } from "../../../../../modules/identity-access/application/public-auth-tenant";
+import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
+
+/**
+ * `GET /api/v1/auth/invitations/{token}` — preview (ADR-0082, Gelombang 4 PR
+ * 4.2 of #423).
+ *
+ * ## What it returns, and what it will not
+ *
+ * The tenant's name, the inviter's name, and the expiry. **Never the email
+ * address.** Whoever legitimately holds this link read the address in their own
+ * mailbox; whoever holds a stolen one did not, and this endpoint is not going
+ * to tell them.
+ *
+ * ## 404, not 410
+ *
+ * Unknown, revoked, already-accepted, expired, and belonging-to-another-tenant
+ * all answer identically. `410 Gone` would tell a token holder that the token
+ * was once VALID — an oracle worth having if you are working through addresses
+ * you scraped. The reason is recorded in the audit row, which is tenant-scoped
+ * and RLS-protected, and never in the response.
+ *
+ * This differs from `POST /auth/password/reset`, which answers
+ * `400 PASSWORD_RESET_INVALID` for the equivalent set. Both are right for their
+ * shape: a reset token arrives in the BODY of a POST, where 404 would mean "no
+ * such route", while an invitation token arrives in the PATH, where 404 is the
+ * same answer a mistyped URL gets.
+ *
+ * Not routed through `defineTenantRoute` — there is no session to authorize.
+ */
+const GENERIC_INVALID_MESSAGE =
+  "This invitation link is invalid or has expired.";
+
+export const GET: APIRoute = async ({ request, params, clientAddress }) => {
+  const tenantId = request.headers.get("x-awcms-tenant-id");
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token = params.token;
+  if (!token) {
+    return fail(404, "RESOURCE_NOT_FOUND", GENERIC_INVALID_MESSAGE);
+  }
+
+  // Before any database work. `checkAuthRateLimit` checks the SOURCE ceiling
+  // first (`auth-source:${clientIp}`, a key the caller cannot choose) and only
+  // then the per-tenant bucket — the #447 fix, without which a rotated tenant
+  // header buys a fresh bucket every request.
+  const clientIp = resolveClientIp(request, clientAddress);
+  const limits = resolveInvitationRateLimit();
+  const rateLimit = await checkAuthRateLimit({
+    clientIp,
+    tenantId,
+    scope: "invitation-preview",
+    config: limits
+  });
+  if (!rateLimit.allowed) {
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many requests. Please try again later.",
+      {},
+      undefined,
+      { "retry-after": String(rateLimit.retryAfterSec) }
+    );
+  }
+
+  const sql = getDatabaseClient();
+
+  return withPublicAuthTenant(
+    sql,
+    tenantId,
+    { workClass: "interactive" },
+    async (tx) => {
+      const now = new Date();
+      const result = await previewInvitation(tx, tenantId, token, now);
+
+      if (result.outcome === "invalid") {
+        await recordAuditEvent(tx, {
+          tenantId,
+          moduleKey: "identity_access",
+          action: "invitation_preview_failed",
+          resourceType: "invitation",
+          severity: "info",
+          message: "An invitation link was previewed and refused.",
+          attributes: {
+            reason: result.reason,
+            ipHash: hashClientIp(clientIp),
+            userAgent: summarizeUserAgent(request)
+          }
+        });
+
+        // Returned from INSIDE the transaction, which COMMITS — deliberately.
+        // The audit row above is the record of a refused preview and must
+        // survive; nothing else was mutated on this path.
+        return fail(404, "RESOURCE_NOT_FOUND", GENERIC_INVALID_MESSAGE);
+      }
+
+      return ok(result.preview);
+    }
+  );
+};

--- a/src/pages/api/v1/auth/invitations/[token]/accept.ts
+++ b/src/pages/api/v1/auth/invitations/[token]/accept.ts
@@ -1,0 +1,182 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../../../../lib/database/client";
+import {
+  hashClientIp,
+  summarizeUserAgent
+} from "../../../../../../lib/security/client-fingerprint";
+import { resolveClientIp } from "../../../../../../lib/security/rate-limit";
+import { checkAuthRateLimit } from "../../../../../../lib/security/auth-rate-limit";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../../../lib/security/request-body-limit";
+import {
+  enforceTurnstileIfRequired,
+  INVITATION_ACCEPT_TURNSTILE_ACTION
+} from "../../../../../../lib/security/turnstile";
+import { resolveInvitationRateLimit } from "../../../../../../lib/auth/invitation-config";
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { acceptInvitation } from "../../../../../../modules/identity-access/application/invitation-acceptance";
+import { withPublicAuthTenant } from "../../../../../../modules/identity-access/application/public-auth-tenant";
+import { validateAcceptInvitationInput } from "../../../../../../modules/identity-access/domain/invitation-policy";
+import { MIN_PASSWORD_LENGTH } from "../../../../../../modules/identity-access/domain/password-reset-validation";
+import { recordAuditEvent } from "../../../../../../modules/logging/application/audit-log";
+
+/**
+ * `POST /api/v1/auth/invitations/{token}/accept` (ADR-0082, Gelombang 4 PR 4.2
+ * of #423).
+ *
+ * The unauthenticated endpoint that CREATES AN ACCOUNT, which is why it carries
+ * the fullest set of pre-flight refusals in this module: rate limit before any
+ * database work, its own Turnstile action so a token solved on another form
+ * cannot be spent here, and a body that declares no privilege field at all —
+ * what the invitee may hold was decided by the administrator who invited them
+ * and is read from `awcms_invitation_policies`, never from this request.
+ *
+ * ## It does not issue a session
+ *
+ * The invitee signs in at `/login` afterwards. Minting a session here would
+ * route around the tenant's MFA policy, around `isPasswordLoginDisabledForIdentity`
+ * for an SSO-only tenant, and around the login rate limit — three decisions
+ * that belong to the login path and not to the endpoint that creates the
+ * account.
+ *
+ * ## One refusal for everything
+ *
+ * Unknown, revoked, already-accepted, expired, wrong tenant, and an address
+ * that acquired an account in the meantime all answer `404` with the same body.
+ * Only the audit row distinguishes them.
+ */
+const GENERIC_INVALID_MESSAGE =
+  "This invitation link is invalid or has expired.";
+
+export const POST: APIRoute = async ({ request, params, clientAddress }) => {
+  const tenantId = request.headers.get("x-awcms-tenant-id");
+  if (!tenantId) {
+    return fail(400, "TENANT_REQUIRED", "Tenant header is required.");
+  }
+
+  const token = params.token;
+  if (!token) {
+    return fail(404, "RESOURCE_NOT_FOUND", GENERIC_INVALID_MESSAGE);
+  }
+
+  const clientIp = resolveClientIp(request, clientAddress);
+  const rateLimit = await checkAuthRateLimit({
+    clientIp,
+    tenantId,
+    scope: "invitation-accept",
+    config: resolveInvitationRateLimit()
+  });
+  if (!rateLimit.allowed) {
+    return fail(
+      429,
+      "RATE_LIMITED",
+      "Too many requests. Please try again later.",
+      {},
+      undefined,
+      { "retry-after": String(rateLimit.retryAfterSec) }
+    );
+  }
+
+  const bodyRead = await readJsonBody(request);
+  if (bodyRead.tooLarge) return bodyTooLargeResponse(bodyRead.limitBytes);
+  const rawBody = bodyRead.value;
+
+  const validation = validateAcceptInvitationInput(rawBody, (password) =>
+    password.length < MIN_PASSWORD_LENGTH
+      ? {
+          field: "password",
+          message: `password must be at least ${MIN_PASSWORD_LENGTH} characters.`
+        }
+      : null
+  );
+  if (!validation.valid) {
+    return fail(
+      400,
+      "VALIDATION_ERROR",
+      "Invitation acceptance input is invalid.",
+      {},
+      validation.errors
+    );
+  }
+
+  const turnstileResult = await enforceTurnstileIfRequired(
+    (rawBody as Record<string, unknown> | null)?.turnstileToken,
+    clientIp,
+    { action: INVITATION_ACCEPT_TURNSTILE_ACTION }
+  );
+  if (!turnstileResult.ok) {
+    return fail(
+      400,
+      turnstileResult.code,
+      turnstileResult.code === "TURNSTILE_REQUIRED"
+        ? "Turnstile verification token is required."
+        : "Turnstile verification failed."
+    );
+  }
+
+  const sql = getDatabaseClient();
+
+  return withPublicAuthTenant(
+    sql,
+    tenantId,
+    { workClass: "interactive" },
+    async (tx) => {
+      const now = new Date();
+      const result = await acceptInvitation(
+        tx,
+        tenantId,
+        token,
+        validation.value,
+        now
+      );
+
+      const source = {
+        ipHash: hashClientIp(clientIp),
+        userAgent: summarizeUserAgent(request)
+      };
+
+      if (result.outcome !== "accepted") {
+        await recordAuditEvent(tx, {
+          tenantId,
+          moduleKey: "identity_access",
+          action: "invitation_accept_failed",
+          resourceType: "invitation",
+          severity: "warning",
+          message: "An invitation acceptance was refused.",
+          attributes: {
+            reason:
+              result.outcome === "invalid" ? result.reason : result.outcome,
+            ...source
+          }
+        });
+
+        // Returned from INSIDE the transaction, which COMMITS — deliberately.
+        // The audit row above is the record of a failed acceptance and must
+        // survive; every refusal in `acceptInvitation` precedes its first
+        // write, so nothing else was mutated on this path.
+        return fail(404, "RESOURCE_NOT_FOUND", GENERIC_INVALID_MESSAGE);
+      }
+
+      await recordAuditEvent(tx, {
+        tenantId,
+        moduleKey: "identity_access",
+        action: "invitation_accepted",
+        resourceType: "invitation",
+        resourceId: result.invitationId,
+        severity: "warning",
+        message: "An invitation was accepted and a membership was created.",
+        attributes: {
+          identityId: result.identityId,
+          tenantUserId: result.tenantUserId,
+          roleCodes: result.grantedRoleCodes,
+          ...source
+        }
+      });
+
+      return ok({ accepted: true });
+    }
+  );
+};

--- a/tests/auth-source-rate-limit.test.ts
+++ b/tests/auth-source-rate-limit.test.ts
@@ -165,10 +165,14 @@ describe("no route can take half of it", () => {
     expect(offenders).toEqual([]);
   });
 
-  test("the seven auth routes go through the paired helper", async () => {
+  test("the nine auth routes go through the paired helper", async () => {
     // Seven, not the six the issue listed. The structural test above found
     // `sso/[providerKey]/start.ts` after the first six were converted by hand —
     // which is the argument for having it, in one line.
+    //
+    // Nine since ADR-0082: the two invitation routes are tenant-header-bound
+    // and unauthenticated, which is exactly the shape #447 exploited, so they
+    // take the paired helper rather than `checkSharedRateLimit` directly.
     const routes = [
       "src/pages/api/v1/auth/login.ts",
       "src/pages/api/v1/auth/register.ts",
@@ -176,7 +180,9 @@ describe("no route can take half of it", () => {
       "src/pages/api/v1/auth/mfa/totp/verify.ts",
       "src/pages/api/v1/auth/password/forgot.ts",
       "src/pages/api/v1/auth/password/reset.ts",
-      "src/pages/api/v1/auth/sso/[providerKey]/start.ts"
+      "src/pages/api/v1/auth/sso/[providerKey]/start.ts",
+      "src/pages/api/v1/auth/invitations/[token].ts",
+      "src/pages/api/v1/auth/invitations/[token]/accept.ts"
     ];
 
     for (const route of routes) {

--- a/tests/integration/invitations.integration.test.ts
+++ b/tests/integration/invitations.integration.test.ts
@@ -1,0 +1,603 @@
+/**
+ * An invitation carries its own Policy (ADR-0082, Gelombang 4 of #423),
+ * against a real PostgreSQL.
+ *
+ * ## The failures this file is written against
+ *
+ * 1. **A grant that exists before it should.** An invitation records roles, and
+ *    the whole design rests on those roles being INERT until acceptance. A
+ *    reader that could see them early would be a second grant path — the one
+ *    ADR-0079 collapsed. So the first assertion is that a pending invitation
+ *    grants the invitee nothing, asked of the real reader rather than of the
+ *    table.
+ *
+ * 2. **Two acceptances of one link.** Without the row lock in
+ *    `acceptInvitation`, both pass the status check and the second collides on
+ *    `awcms_identities_tenant_login_key` mid-transaction — a 500 for someone who
+ *    double-clicked. This is the defect `approveRegistrationRequest`'s
+ *    `FOR UPDATE` was mutation-proven against; removing `FOR UPDATE OF i` turns
+ *    the concurrency test below red.
+ *
+ * 3. **A resent link that did not replace the old one.** Rotation is what makes
+ *    resend safe, and a test that only checks the NEW link works would pass just
+ *    as happily if the old one still did too.
+ *
+ * 4. **A role that changed between issue and acceptance.** The `is_system`
+ *    refusal is checked twice for exactly this, and only a test that changes the
+ *    role in between can tell the second check from decoration.
+ *
+ * Every grant is written by the real writer and every read goes through the
+ * real reader — a fixture that INSERTed its own rows could put them wherever
+ * the reader happens to look, which is how a suite passes while the product is
+ * broken (`grant-readers.integration.test.ts` §fixtures).
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { fetchGrantedPermissionKeys } from "../../src/modules/identity-access/application/auth-context";
+import {
+  acceptInvitation,
+  previewInvitation
+} from "../../src/modules/identity-access/application/invitation-acceptance";
+import {
+  createInvitation,
+  listInvitations,
+  resendInvitation,
+  revokeInvitation
+} from "../../src/modules/identity-access/application/invitation-admin";
+import type { AuthNotificationPort } from "../../src/modules/_shared/ports/auth-notification-port";
+
+const TENANT = "f7777777-7777-4777-8777-777777777777";
+const OTHER_TENANT = "f8888888-8888-4888-8888-888888888888";
+const INVITER = "f7000000-0000-4000-8000-000000000001";
+const EDITOR_ROLE = "f7000000-0000-4000-8000-0000000000a1";
+const SYSTEM_ROLE = "f7000000-0000-4000-8000-0000000000a2";
+
+const INVITEE = "newcomer@example.test";
+const PASSWORD = "a-sufficiently-long-password";
+const GRANTED_KEY = "blog_content.posts.read";
+
+/**
+ * Captures the link instead of mailing it. The RAW TOKEN never leaves the
+ * writer any other way — the row holds only its hash — so this is also how the
+ * tests get one, which is exactly the property being relied on.
+ */
+type Sent = { address: string; url: string }[];
+
+function stubPort(sent: Sent, enqueued = true): AuthNotificationPort {
+  return {
+    async enqueueAuthNotification() {
+      throw new Error(
+        "an invitation must address a raw address, not an account"
+      );
+    },
+    async enqueueAuthAddressNotification(_tx, request) {
+      sent.push({
+        address: request.recipientAddress,
+        url: request.variables.invitationUrl ?? ""
+      });
+      return { enqueued };
+    }
+  };
+}
+
+function tokenOf(url: string): string {
+  const parsed = new URL(url);
+  return parsed.searchParams.get("token") ?? "";
+}
+
+function deliveryOptions(sent: Sent, enqueued = true) {
+  return {
+    tokenTtlHours: 168,
+    invitationUrlBase: "https://example.test/accept-invitation",
+    notifications: stubPort(sent, enqueued)
+  };
+}
+
+async function seedTenantUser(
+  tenantId: string,
+  id: string,
+  label: string
+): Promise<void> {
+  const admin = getAdminSql();
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${tenantId}, 'person', ${`Display ${label}`})
+    RETURNING id
+  `) as { id: string }[];
+
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${tenantId}, ${profile[0]!.id}, ${`${label}@example.test`}, 'x')
+    RETURNING id
+  `) as { id: string }[];
+
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${id}, ${tenantId}, ${identity[0]!.id})
+  `;
+}
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'invite-tenant', 'Invite Tenant')
+  `;
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${OTHER_TENANT}, 'other-tenant', 'Other Tenant')
+  `;
+
+  await seedTenantUser(TENANT, INVITER, "inviter");
+
+  await admin`
+    INSERT INTO awcms_roles (id, tenant_id, role_code, role_name)
+    VALUES (${EDITOR_ROLE}, ${TENANT}, 'editor', 'Editor')
+  `;
+  await admin`
+    INSERT INTO awcms_roles (id, tenant_id, role_code, role_name, is_system)
+    VALUES (${SYSTEM_ROLE}, ${TENANT}, 'owner', 'Owner', true)
+  `;
+
+  const permission = (await admin`
+    SELECT id FROM awcms_permissions
+    WHERE module_key = 'blog_content' AND activity_code = 'posts' AND action = 'read'
+  `) as { id: string }[];
+
+  await admin`
+    INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+    VALUES (${TENANT}, ${EDITOR_ROLE}, ${permission[0]!.id})
+  `;
+}
+
+/** Issues an invitation carrying `editor`, through the real writer, and returns its raw token. */
+async function issueInvitation(
+  sent: Sent,
+  roleIds: string[] = [EDITOR_ROLE]
+): Promise<{ id: string; token: string }> {
+  return withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+    const result = await createInvitation(
+      tx,
+      TENANT,
+      INVITER,
+      {
+        loginIdentifier: INVITEE,
+        displayName: "Newcomer",
+        roleIds,
+        skipEmailConfirmation: false
+      },
+      new Date(),
+      deliveryOptions(sent)
+    );
+
+    if (result.outcome !== "created") {
+      throw new Error(`expected created, got ${result.outcome}`);
+    }
+
+    return {
+      id: result.invitationId,
+      token: tokenOf(sent[sent.length - 1]!.url)
+    };
+  });
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("an invitation carries its own Policy (ADR-0082)", () => {
+  beforeAll(setupIntegrationDatabase);
+  afterAll(teardownIntegrationDatabase);
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("the emailed link carries the tenant as well as the token", async () => {
+    // Without it the acceptance page has no `X-AWCMS-Tenant-ID` to send, and
+    // both public endpoints refuse. Caught by writing the page, not by reading
+    // the writer.
+    const sent: Sent = [];
+    await issueInvitation(sent);
+
+    const url = new URL(sent[0]!.url);
+    const carriesTenant =
+      url.searchParams.get("tenantId") === TENANT || url.searchParams.has("p");
+
+    expect(carriesTenant).toBe(true);
+  });
+
+  test("a PENDING invitation grants the invitee nothing", async () => {
+    // Asked of the real reader. If `activeRoleGrants` ever learned to read the
+    // invitation tables, this is the assertion that would notice.
+    const sent: Sent = [];
+    await issueInvitation(sent);
+
+    const rows = (await getAdminSql()`
+      SELECT count(*)::int AS n FROM awcms_access_policies WHERE tenant_id = ${TENANT}
+    `) as { n: number }[];
+
+    expect(rows[0]!.n).toBe(0);
+  });
+
+  test("acceptance materializes the membership AND the grant", async () => {
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    const accepted = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      acceptInvitation(
+        tx,
+        TENANT,
+        invitation.token,
+        { password: PASSWORD },
+        new Date()
+      )
+    );
+
+    expect(accepted.outcome).toBe("accepted");
+
+    // The grant reaches the reader every guarded request uses — not the table
+    // it happens to live in.
+    const keys = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      fetchGrantedPermissionKeys(
+        tx,
+        TENANT,
+        accepted.outcome === "accepted" ? accepted.tenantUserId : ""
+      )
+    );
+
+    expect(keys.has(GRANTED_KEY)).toBe(true);
+
+    const row = (await getAdminSql()`
+      SELECT status, accepted_tenant_user_id FROM awcms_invitations
+      WHERE tenant_id = ${TENANT} AND id = ${invitation.id}
+    `) as { status: string; accepted_tenant_user_id: string }[];
+
+    expect(row[0]!.status).toBe("accepted");
+    expect(row[0]!.accepted_tenant_user_id).toBe(
+      accepted.outcome === "accepted" ? accepted.tenantUserId : ""
+    );
+  });
+
+  test("two concurrent acceptances of one link: exactly one wins", async () => {
+    // The row lock is what makes this true. Without `FOR UPDATE OF i` both
+    // transactions pass the status check and the loser hits 23505 on
+    // `awcms_identities_tenant_login_key` mid-transaction — a 500 rather than a
+    // clean refusal.
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    const attempt = () =>
+      withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+        acceptInvitation(
+          tx,
+          TENANT,
+          invitation.token,
+          { password: PASSWORD },
+          new Date()
+        )
+      ).catch((error: unknown) => ({ outcome: "threw", error }) as const);
+
+    const [first, second] = await Promise.all([attempt(), attempt()]);
+    const outcomes = [first.outcome, second.outcome].sort();
+
+    // `accepted` + `invalid`, NOT `accepted` + `identifier_taken`, and the
+    // difference is the lock doing its job. The loser blocks on `FOR UPDATE OF i`
+    // until the winner commits, then re-reads the row it was waiting for and
+    // finds `status = 'accepted'` — so `evaluateInvitation` refuses it before it
+    // ever reaches the identity INSERT. `identifier_taken` is what you get from
+    // the version WITHOUT the lock, where both transactions pass the status
+    // check and the loser discovers the collision at
+    // `awcms_identities_tenant_login_key` instead. Refusing at the invitation is
+    // the better answer, and it is the one the lock produces.
+    expect(outcomes).toEqual(["accepted", "invalid"]);
+
+    const identities = (await getAdminSql()`
+      SELECT count(*)::int AS n FROM awcms_identities
+      WHERE tenant_id = ${TENANT} AND login_identifier = ${INVITEE}
+    `) as { n: number }[];
+
+    expect(identities[0]!.n).toBe(1);
+  });
+
+  test("resend ROTATES: the previous link stops working", async () => {
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+    const firstToken = invitation.token;
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      resendInvitation(
+        tx,
+        TENANT,
+        invitation.id,
+        INVITER,
+        new Date(),
+        deliveryOptions(sent)
+      )
+    );
+
+    const secondToken = tokenOf(sent[sent.length - 1]!.url);
+    expect(secondToken).not.toBe(firstToken);
+
+    const stale = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      previewInvitation(tx, TENANT, firstToken, new Date())
+    );
+    expect(stale.outcome).toBe("invalid");
+
+    const fresh = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      previewInvitation(tx, TENANT, secondToken, new Date())
+    );
+    expect(fresh.outcome).toBe("found");
+  });
+
+  test("the resend ceiling is enforced, and by the database", async () => {
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const result = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+        resendInvitation(
+          tx,
+          TENANT,
+          invitation.id,
+          INVITER,
+          new Date(),
+          deliveryOptions(sent)
+        )
+      );
+      expect(result.outcome).toBe("resent");
+    }
+
+    const sixth = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      resendInvitation(
+        tx,
+        TENANT,
+        invitation.id,
+        INVITER,
+        new Date(),
+        deliveryOptions(sent)
+      )
+    );
+
+    expect(sixth.outcome).toBe("resend_limit_reached");
+  });
+
+  test("a revoked invitation cannot be previewed or accepted", async () => {
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      revokeInvitation(
+        tx,
+        TENANT,
+        invitation.id,
+        INVITER,
+        new Date(),
+        "changed our mind"
+      )
+    );
+
+    const preview = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      previewInvitation(tx, TENANT, invitation.token, new Date())
+    );
+    expect(preview).toEqual({ outcome: "invalid", reason: "revoked" });
+
+    const accept = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      acceptInvitation(
+        tx,
+        TENANT,
+        invitation.token,
+        { password: PASSWORD },
+        new Date()
+      )
+    );
+    expect(accept.outcome).toBe("invalid");
+  });
+
+  test("an expired invitation is refused from the COLUMN, with no job having run", async () => {
+    // Nothing sweeps `status` to 'expired'. The row is still literally
+    // `pending`, and the refusal has to come from `expires_at`.
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    // BOTH columns move: `awcms_invitations_expiry_check` requires
+    // `expires_at > issued_at`, so backdating only the expiry is refused by the
+    // schema — which is itself the constraint working, and worth not
+    // mistaking for a test-harness quirk.
+    await getAdminSql()`
+      UPDATE awcms_invitations
+      SET issued_at = now() - interval '2 hours',
+          expires_at = now() - interval '1 hour'
+      WHERE tenant_id = ${TENANT} AND id = ${invitation.id}
+    `;
+
+    const still = (await getAdminSql()`
+      SELECT status FROM awcms_invitations WHERE tenant_id = ${TENANT} AND id = ${invitation.id}
+    `) as { status: string }[];
+    expect(still[0]!.status).toBe("pending");
+
+    const preview = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      previewInvitation(tx, TENANT, invitation.token, new Date())
+    );
+    expect(preview).toEqual({ outcome: "invalid", reason: "expired" });
+  });
+
+  test("a token issued for one tenant is invisible to another", async () => {
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    const preview = await withTenantOrThrow(
+      getRuntimeSql(),
+      OTHER_TENANT,
+      (tx) => previewInvitation(tx, OTHER_TENANT, invitation.token, new Date())
+    );
+
+    expect(preview).toEqual({ outcome: "invalid", reason: "not_found" });
+  });
+
+  test("a role that BECOMES a system role between issue and acceptance is refused", async () => {
+    // This is what the second `is_system` check exists for. With the re-check
+    // removed, the acceptance succeeds and hands out a system role that the
+    // ordinary assignment path refuses.
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    await getAdminSql()`
+      UPDATE awcms_roles SET is_system = true
+      WHERE tenant_id = ${TENANT} AND id = ${EDITOR_ROLE}
+    `;
+
+    const accept = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      acceptInvitation(
+        tx,
+        TENANT,
+        invitation.token,
+        { password: PASSWORD },
+        new Date()
+      )
+    );
+
+    expect(accept.outcome).toBe("system_role");
+
+    // And it refused BEFORE writing: no half-made account is left behind.
+    const identities = (await getAdminSql()`
+      SELECT count(*)::int AS n FROM awcms_identities
+      WHERE tenant_id = ${TENANT} AND login_identifier = ${INVITEE}
+    `) as { n: number }[];
+    expect(identities[0]!.n).toBe(0);
+  });
+
+  test("a system role is refused at ISSUE time too", async () => {
+    const sent: Sent = [];
+
+    const result = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      createInvitation(
+        tx,
+        TENANT,
+        INVITER,
+        {
+          loginIdentifier: INVITEE,
+          displayName: "Newcomer",
+          roleIds: [SYSTEM_ROLE],
+          skipEmailConfirmation: false
+        },
+        new Date(),
+        deliveryOptions(sent)
+      )
+    );
+
+    expect(result.outcome).toBe("system_role");
+    expect(sent).toEqual([]);
+  });
+
+  test("a second pending invitation to the same address is refused, not raised", async () => {
+    // `ON CONFLICT … DO NOTHING` rather than a 23505: a raised error would
+    // abort the transaction and take the audit row with it.
+    const sent: Sent = [];
+    await issueInvitation(sent);
+
+    const second = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      createInvitation(
+        tx,
+        TENANT,
+        INVITER,
+        {
+          loginIdentifier: INVITEE,
+          displayName: "Newcomer again",
+          roleIds: [],
+          skipEmailConfirmation: false
+        },
+        new Date(),
+        deliveryOptions(sent)
+      )
+    );
+
+    expect(second.outcome).toBe("already_pending");
+  });
+
+  test("the listing masks the address and never returns it raw", async () => {
+    const sent: Sent = [];
+    await issueInvitation(sent);
+
+    const page = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      listInvitations(tx, TENANT)
+    );
+
+    expect(page.invitations).toHaveLength(1);
+    expect(page.invitations[0]!.loginIdentifierMasked).not.toBe(INVITEE);
+    expect(JSON.stringify(page)).not.toContain(INVITEE);
+    expect(page.invitations[0]!.roleCodes).toEqual(["editor"]);
+  });
+
+  test("the preview names the tenant and the inviter, and NEVER the address", async () => {
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    const preview = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      previewInvitation(tx, TENANT, invitation.token, new Date())
+    );
+
+    expect(preview.outcome).toBe("found");
+    if (preview.outcome !== "found") return;
+
+    expect(preview.preview.tenantName).toBe("Invite Tenant");
+    expect(preview.preview.inviterName).toBe("Display inviter");
+    expect(JSON.stringify(preview)).not.toContain(INVITEE);
+  });
+
+  test("deleting an invitation takes its policies with it", async () => {
+    // The `ON DELETE CASCADE` the generic purge depends on. Without it the
+    // purge aborts on this foreign key and the retention silently never runs.
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    await getAdminSql()`
+      DELETE FROM awcms_invitations WHERE tenant_id = ${TENANT} AND id = ${invitation.id}
+    `;
+
+    const orphans = (await getAdminSql()`
+      SELECT count(*)::int AS n FROM awcms_invitation_policies
+      WHERE tenant_id = ${TENANT} AND invitation_id = ${invitation.id}
+    `) as { n: number }[];
+
+    expect(orphans[0]!.n).toBe(0);
+  });
+
+  test("a scoped invitation policy is refused by the database", async () => {
+    // ADR-0080's limit, made unrepresentable rather than merely unwritten.
+    const sent: Sent = [];
+    const invitation = await issueInvitation(sent);
+
+    let refused = false;
+    try {
+      await getAdminSql()`
+        INSERT INTO awcms_invitation_policies
+          (tenant_id, invitation_id, role_id, scope_type, scope_id)
+        VALUES (${TENANT}, ${invitation.id}, ${EDITOR_ROLE}, 'office', ${TENANT})
+      `;
+    } catch {
+      refused = true;
+    }
+
+    expect(refused).toBe(true);
+  });
+});

--- a/tests/shared-rate-limit.test.ts
+++ b/tests/shared-rate-limit.test.ts
@@ -144,7 +144,12 @@ describe("every authentication surface is limited", () => {
     ["auth/session-handoff/issue.ts"],
     ["auth/session-handoff/redeem.ts"],
     ["auth/sso/[providerKey]/start.ts"],
-    ["auth/sso/[providerKey]/callback.ts"]
+    ["auth/sso/[providerKey]/callback.ts"],
+    // ADR-0082 — eleven became thirteen. Both are unauthenticated and
+    // token-bearing, and the second of them CREATES AN ACCOUNT, which makes it
+    // the most consequential unauthenticated write in this module.
+    ["auth/invitations/[token].ts"],
+    ["auth/invitations/[token]/accept.ts"]
   ])("%s calls the shared limiter", async (route) => {
     // ASVS V11.2 wants anti-automation across the WHOLE authentication surface,
     // not most of it. Three of these had none before ADR-0066.


### PR DESCRIPTION
Gelombang 4 PR 4.2 dari #423 — penutup gelombang. ADR-0082, menyusul #512.

Dua endpoint publik (`GET /api/v1/auth/invitations/{token}`, `POST …/accept`) plus halaman `/accept-invitation`.

## `materializeMembership()` sengaja SATU fungsi dengan SATU pemanggil

Sudah ada tiga tempat yang melahirkan keanggotaan di repo ini — `approveRegistrationRequest`, `jitProvisionIdentity`, `bootstrapPlatformTenant` — dan ketiganya pernah menyimpang sekali pada detail yang paling penting (`verification_status`), yang justru melahirkan `createPersonProfileForIdentity` sebagai penulis tunggal.

Yang keempat ditulis sebagai satu fungsi dengan satu pemanggil supaya **Gelombang 7 punya persis satu tempat untuk diarahkan ulang** saat identity menjadi principal global. Mengarahkan ulang ketiganya sekarang akan menjadikan PR ini refactor self-registration dan SSO sekaligus — dan memerahkan `tests/access-assignment-writers.test.ts`, yang menyebut `self-registration.ts` sebagai pemanggil langsung `grantRolePolicy` di asersi non-hampanya.

## Penolakan `is_system` yang KEDUA bukan seremonial

Sebuah peran bisa ditandai system, di-soft-delete, atau keluar dari katalog di antara saat undangan dikirim dan saat ia diterima — undangan tetap membawa id-nya. Test integrasi mengubah peran itu **di antara** kedua momen, menuntut penerimaannya ditolak, dan menuntut **nol akun setengah jadi** tertinggal.

## Penerimaan TIDAK menerbitkan sesi

Mencetak sesi di sini akan melangkahi kebijakan MFA tenant (`required_for_all` menghasilkan anggota ber-sesi penuh tanpa faktor kedua), melangkahi `isPasswordLoginDisabledForIdentity` pada tenant SSO-only, dan melangkahi rate limit login. Undangan mencetak AKUN; siapa yang boleh memegang sesi adalah keputusan `/login`.

## Satu cacat PR 4.1 diperbaiki di sini

Ditemukan saat menulis halamannya, bukan saat membaca kodenya: `buildInvitationUrl` hanya memuat `?token=`, sementara kedua endpoint publiknya menuntut header `X-AWCMS-Tenant-ID` — jadi tautannya menghasilkan halaman yang **tidak bisa melakukan panggilan yang menjadi alasan keberadaannya**. Kini ia membawa tenant juga, disegel AES-256-GCM jadi satu `?p=` bila `AUTH_URL_PARAM_ENCRYPTION_KEY` diset, persis seperti tautan reset password.

## Ledger

`tests/shared-rate-limit.test.ts` **11 → 13**, `tests/auth-source-rate-limit.test.ts` **7 → 9**. Prosa ADR-0066 §C yang menulis "sebelas" diberi catatan pembaruan alih-alih dibiarkan menua sendirian — angka itu hidup di berkas test, bukan di `scripts/`, jadi ia yang paling mudah terlupa (ledger gerbang program menandainya begitu).

## Verifikasi

`DATABASE_URL="" bun run check` penuh: 39 gerbang, 4419 test, 0 gagal, build selesai.

**Dijalankan terhadap PostgreSQL nyata** (container, netns bersama): 16 test integrasi baru, semuanya lulus. Suite integrasi penuh 322 → 338 lulus dengan 4 kegagalan yang TIDAK berubah — keempatnya sudah ada di `main` tanpa perubahan ini (suite yang menuntut database `DATABASE_URL` ter-migrasi, yang container polos ini bukan).

Kunci barisnya dibuktikan load-bearing, bukan diklaim: menghapus `FOR UPDATE OF i` membuat penerimaan kedua **MELEMPAR** — tabrakan 23505 di tengah transaksi, yaitu 500 bagi orang yang menekan tombol dua kali — alih-alih ditolak bersih. Dan satu asersi saya sendiri ternyata salah ke arah yang benar: penerimaan yang kalah menjawab `invalid` (ia menunggu kunci, lalu membaca ulang baris ber-`status = 'accepted'`) dan tak pernah sampai ke INSERT identity sama sekali. Itu jawaban yang lebih baik daripada `identifier_taken` yang saya harapkan, dan ia milik kuncinya.

🤖 Generated with [Claude Code](https://claude.com/claude-code)