### PR TITLE
docs(state): putaran kelima 11 Agustus — Gelombang 4 selesai (#423)

### DIFF
--- a/.changeset/putaran-kelima-gelombang-4.md
+++ b/.changeset/putaran-kelima-gelombang-4.md
@@ -1,0 +1,23 @@
+---
+"awcms": patch
+---
+
+docs(state): putaran kelima 11 Agustus — Gelombang 4 selesai
+
+`docs/PROJECT_STATE.md` §4 mencatat putaran ini: apa yang mendarat (ADR-0082,
+#512, #513), empat tempat rencana program tidak diikuti beserta alasannya yang
+diperiksa terhadap kode, dua cacat yang ditemukan dengan MENJALANKAN bukan
+membaca, tujuh penolakan, dan satu batas gerbang yang wajib dibaca sebelum
+config module berikutnya memakai pola `env: NodeJS.ProcessEnv = process.env`.
+
+Daftar ini ada DI SINI karena aturan yang sama dengan empat putaran sebelumnya:
+daftar yang tidak ditulis ke repo harus diturunkan ulang, dan menurunkan ulang
+berharga satu audit penuh sementara menuliskannya berharga satu paragraf.
+Penolakan ikut tertulis, karena penolakan yang tidak tercatat akan diusulkan
+lagi.
+
+`src/modules/identity-access/README.md` mendapat bagian Undangan. README modul
+adalah dokumen current-state yang menjelaskan setiap fitur lain modul ini;
+membiarkan permukaan sebesar ini tak tertulis di sana adalah bentuk penuaan yang
+persis dikeluhkan ADR-0062 tentang skill — dengan bedanya README dibaca, bukan
+diikuti.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -356,6 +356,108 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 ## 4. Backlog / langkah berikutnya
 
+- **PUTARAN 11 Agustus 2026 (kelima) — GELOMBANG 4 SELESAI.** Tiga PR
+  (#512/#513 + entri ini); nol PR terbuka. ADR-0082.
+
+  **Undangan mendarat utuh dalam dua PR.** `awcms_invitations` +
+  `awcms_invitation_policies` (`sql/106`, permission `sql/107`), lalu
+  penerimaan. Undangan menyebut alamat dan membawa peran yang akan dipegang
+  orang itu; peran itu **inert** sampai penerimaan memanggil `grantRolePolicy`,
+  penulis yang sama dengan setiap grant lain — sehingga `activeRoleGrants`
+  tidak pernah perlu tahu tabel ini ada, dan tak ada jalur grant kedua yang
+  lahir.
+
+  **Empat tempat rencana program tidak diikuti, semuanya dengan alasan yang
+  diperiksa terhadap kode:**
+
+  1. **Kolom scope ADA, tetapi DIPATOK** `CHECK (scope_type = 'tenant' AND
+scope_id = tenant_id)`. Ini jawaban atas batas yang ADR-0080 tulis
+     sendiri — PR yang menambahkan penulis grant ber-scope tak boleh mendarat
+     tanpa menjawabnya — dan jawabannya adalah **menolak menjadi penulis itu**.
+     Menghilangkan kolomnya juga dipertimbangkan: argumen "kolom yang diabaikan
+     penulisnya berbohong" benar untuk kolom TAK-dibatasi, dan CHECK
+     menghapusnya. Bentuk ADR-0078 dipertahankan, jadi pelebaran nanti satu
+     `DROP`/`ADD CONSTRAINT`.
+  2. **`resend` bukan action tersendiri.** Ia tidak ada di `AccessAction`, dan
+     menambahkannya berarti menyatakan mengirim ulang adalah otoritas berbeda
+     dari menerbitkan. Ia bukan — resend mencetak rahasia baru dengan daya yang
+     sama, jadi digerbangi `create`.
+  3. **Rate limit memakai `checkAuthRateLimit`, bukan `checkSharedRateLimit`
+     telanjang** seperti tertulis di rencana. Rencana itu mendahului #447:
+     header tenant adalah kunci yang bisa DIPILIH penyerang, dan
+     `checkAuthRateLimit` memeriksa plafon per-SUMBER lebih dulu. Prosanya
+     dikoreksi di ADR-0066 §C.
+  4. **`approveRegistrationRequest` TIDAK diarahkan ulang ke
+     `materializeMembership`.** Itu akan menjadikan PR penutup gelombang sebuah
+     refactor self-registration + SSO, dan memerahkan
+     `access-assignment-writers.test.ts` yang menyebut `self-registration.ts`
+     sebagai pemanggil langsung `grantRolePolicy`. Konvergensinya milik
+     Gelombang 7, yang memang menjadwalkannya.
+
+  **Dua cacat ditemukan, keduanya oleh MENJALANKAN bukan membaca:**
+
+  1. **Tautan undangan tak membawa tenant.** `buildInvitationUrl` hanya memuat
+     `?token=` sementara kedua endpoint publiknya menuntut header
+     `X-AWCMS-Tenant-ID` — tautannya menghasilkan halaman yang tak bisa
+     melakukan panggilan yang menjadi alasan keberadaannya. Ditemukan saat
+     MENULIS halamannya, bukan saat mereview penulisnya; 39 gerbang hijau
+     selama itu, karena tak satu pun gerbang menghubungkan bentuk tautan dengan
+     apa yang halamannya butuhkan.
+  2. **Satu asersi test saya sendiri salah, ke arah yang benar.** Saya menuntut
+     penerimaan konkuren yang kalah menjawab `identifier_taken`; ia menjawab
+     `invalid` — ia menunggu kunci baris, membaca ulang baris ber-`status =
+'accepted'`, dan **tak pernah sampai ke INSERT identity**. Itu jawaban
+     yang lebih baik, dan ia milik kuncinya: menghapus `FOR UPDATE OF i`
+     membuatnya MELEMPAR (23505 di tengah transaksi = 500 bagi orang yang
+     menekan tombol dua kali).
+
+  **Yang DITOLAK, dengan alasannya:**
+
+  1. **Penerimaan menerbitkan sesi** — akan melangkahi kebijakan MFA tenant
+     (`required_for_all` menghasilkan anggota ber-sesi penuh tanpa faktor
+     kedua), `isPasswordLoginDisabledForIdentity` pada tenant SSO-only, dan
+     rate limit login. Undangan mencetak AKUN; siapa boleh memegang sesi milik
+     `/login`.
+  2. **`410 Gone` untuk token kedaluwarsa** — memberi tahu pemegang token bahwa
+     token itu PERNAH sah. 404 seragam untuk kelima kelas kegagalan.
+  3. **Mengembalikan alamat di preview** — pemanggilnya tak terautentikasi.
+     Pemegang tautan sah sudah membacanya di mailbox-nya; pemegang tautan
+     CURIAN tidak.
+  4. **`recipientTenantUserId` yang nullable pada `AuthNotificationPort`** —
+     akan meninggalkan tiap pemanggil lama satu salah-ketik dari mengantre
+     pesan tanpa tujuan. Operasi KEDUA sebagai gantinya.
+  5. **`update` dan `delete` untuk undangan** — menyunting undangan yang sudah
+     terkirim membuat tautan di inbox seseorang tak lagi cocok dengan yang
+     di-review; menghapusnya menghancurkan satu-satunya catatan bahwa tawaran
+     pernah dibuat.
+  6. **Feature switch ala `AUTH_SELF_REGISTRATION_ENABLED`** — saklar itu ada
+     karena registrasi adalah endpoint PUBLIK yang menulis baris untuk pemanggil
+     anonim. Undangan hanya bisa diterbitkan pemegang permission, jadi tak ada
+     permukaan untuk dilindungi saklar.
+  7. **Deskriptor lifecycle tersendiri untuk `awcms_invitation_policies`** —
+     purge `generic` menghapus murni menurut usia, jadi ia akan melucuti peran
+     dari undangan yang masih pending dan menghasilkan penerimaan yang
+     diam-diam tak memberi apa pun. `BOUNDED_BY_DESIGN` + `ON DELETE CASCADE`.
+
+  **Gerbang yang tumbuh:** `BOUNDED_BY_DESIGN` 4 → 5 (plafonnya, dan kenaikan
+  berikutnya harus lebih sulit — ADR-0081 sudah menuliskan itu);
+  `NOT_YET_SCREENED` +4; `EXPECTED_PLATFORM_KEYS` +1; ledger rate limit 11 → 13
+  dan 7 → 9. Permission 214 → 218.
+
+  **Batas yang WAJIB dibaca.** `config:env:coverage:check` hanya mencocokkan
+  `process.env.X` dan **buta** terhadap `env.X` yang dilewatkan sebagai
+  parameter — batas yang gerbangnya catat sendiri di header. Tiga env undangan
+  dituliskan TANGAN di `.env.example` karena itu. Config module berikutnya yang
+  memakai pola `env: NodeJS.ProcessEnv = process.env` akan punya masalah yang
+  sama, dan tak ada yang akan memberitahunya.
+
+  **Titik-lanjut.** Gelombang 4 tuntas. Berikutnya **Gelombang 5**
+  (entitlement/SaaS — mendarat INERT). Tiga hal yang masih menggantung dari
+  gelombang sebelumnya dan belum dikerjakan: layar `/admin/invitations` (4
+  permission di ledger), permukaan admin untuk grant ber-scope (dengan jawaban
+  atas batas ADR-0080 — yang PR ini TUNDA, tidak selesaikan), dan keputusan
+  lifecycle `delete` grup. #430 tetap Gelombang 7.
+
 - **PUTARAN 10 Agustus 2026 (keempat) — GELOMBANG 3 SELESAI, dan tiga cacat
   hidup ditemukan sambil menutupnya.** Empat PR (#508/#509/#510 + entri ini);
   nol PR terbuka. ADR-0079, ADR-0080, ADR-0081.

--- a/src/modules/identity-access/README.md
+++ b/src/modules/identity-access/README.md
@@ -416,6 +416,75 @@ oleh pembacaan.
 server-side, cookie portal, CSRF, dan pemanggilan introspeksi per permintaan.
 Sisi `awcms` sudah lengkap.
 
+## Undangan (Gelombang 4, ADR-0082)
+
+Arah yang berlawanan dengan self-registration: registrasi adalah **tarik**
+(orang asing meminta, admin memutuskan), undangan adalah **dorong** (admin
+menawarkan, orang asing memutuskan). Keduanya tetap ada, masing-masing dengan
+permission dan cerita auditnya sendiri.
+
+- **Skema (`sql/106`, permission `sql/107`)** — `awcms_invitations` (tenant-scoped,
+  RLS `ENABLE`+`FORCE`) menyimpan `token_hash` sha256 dari 32 byte CSPRNG —
+  token mentah TIDAK PERNAH disimpan — plus `status`, `expires_at`,
+  `resend_count` (CHECK `<= 5`), dan `skip_email_confirmation`.
+  `awcms_invitation_policies` adalah grant yang dibawa tawaran itu.
+- **Sebuah tawaran BUKAN grant.** `activeRoleGrants` tidak membaca tabel ini dan
+  tak boleh diajari — subjek yang memegang peran karena sebuah baris menyatakan
+  ia pernah diundang adalah jalur grant KEDUA yang ADR-0079 runtuhkan.
+  Penerimaan memanggil `grantRolePolicy`, dan baris `awcms_access_policies`
+  yang dihasilkannya adalah satu-satunya yang dilihat pembaca mana pun.
+- **Mengundang dan MEMBERI PERAN dua otoritas.** Undangan ber-peran menuntut
+  `invitations.create` DAN `access_control.assign` (pemisahan ADR-0081, dengan
+  taruhan lebih tinggi: grant lewat undangan menjangkau orang yang belum ada).
+  Penolakan `is_system` diperiksa saat dibuat DAN lagi saat diterima — peran
+  bisa berubah di antara kedua momen itu.
+- **Scope dipatok tenant-wide** oleh CHECK basis data. Kolomnya ada supaya
+  pelebaran nanti satu `DROP`/`ADD CONSTRAINT`; CHECK-nya ada karena ADR-0080
+  melarang mengirim penulis grant ber-scope sebelum rute menyatakan required
+  scope-nya.
+- **`skip_email_confirmation` PLATFORM-scoped** (`invitations.configure`,
+  satu-satunya permission platform modul ini) kecuali alamatnya sudah memegang
+  identitas aktif di tenant ini. Ia menghapus satu-satunya bukti kendali
+  mailbox, dan setelah Gelombang 7 objek yang dicetaknya adalah principal
+  GLOBAL.
+- **Resend MEROTASI token** dan digerbangi `create`, bukan action tersendiri.
+  Tanpa rotasi, "kirim ulang" adalah permukaan perbanyakan token: satu undangan
+  menumbuhkan N tautan hidup dan mencabutnya berarti mencabut N rahasia yang tak
+  seorang pun hitung.
+- **Endpoint admin** — `GET`/`POST /api/v1/invitations` (list keyset + create,
+  `Idempotency-Key` wajib), `POST /api/v1/invitations/{id}/revoke`,
+  `POST /api/v1/invitations/{id}/resend`. Alamat SELALU ter-mask di list.
+- **Endpoint publik** — `GET /api/v1/auth/invitations/{token}` (preview:
+  nama tenant + nama pengundang, **tidak pernah** alamatnya) dan
+  `POST …/accept`. Keduanya `checkAuthRateLimit`; accept ber-Turnstile action
+  sendiri. Tak dikenal / tercabut / sudah diterima / kedaluwarsa / tenant salah
+  semuanya **404** — bukan 410, yang akan memberi tahu pemegang token bahwa
+  token itu pernah sah.
+- **Penerimaan tidak menerbitkan sesi.** Sesi dari sini melangkahi kebijakan MFA
+  tenant, `isPasswordLoginDisabledForIdentity` pada tenant SSO-only, dan rate
+  limit login. Undangan mencetak AKUN; `/login` yang memutuskan sesi.
+- **`materializeMembership()`** (`application/membership-materialization.ts`)
+  adalah SATU fungsi dengan satu pemanggil, sengaja: Gelombang 7 butuh persis
+  satu tempat untuk diarahkan ulang saat identity menjadi principal global.
+- **Kunci baris load-bearing** — `acceptInvitation` membaca `FOR UPDATE`.
+  Tanpanya dua penerimaan tautan yang sama sama-sama lolos cek status dan yang
+  kalah menabrak `awcms_identities_tenant_login_key` di tengah transaksi
+  (dibuktikan MERAH lewat mutasi di
+  `tests/integration/invitations.integration.test.ts`).
+- **Pengiriman lewat capability port** — `identity_access` tidak menulis
+  `awcms_email_*` (ADR-0013 §6). `AuthNotificationPort` mendapat operasi KEDUA
+  (`enqueueAuthAddressNotification`) karena undangan belum punya baris
+  `awcms_tenant_users` untuk dialamati. Tenant tanpa template `auth.invitation`
+  aktif → `delivery: "unavailable"` di respons (pemanggilnya admin
+  terautentikasi; menyembunyikannya hanya membuatnya menunggu tautan yang tak
+  akan pernah tiba).
+- **Belum ada layar admin** untuk undangan — keempat permission-nya duduk di
+  ledger `NOT_YET_SCREENED`, urutan yang sama dengan ADR-0056 (`media_library`
+  mendapat permukaan API lebih dulu, layarnya menyusul). Path-nya sengaja tidak
+  ditulis di sini: `skills:check` menuntut tiap URL `/admin/…` berbacktick
+  resolve ke halaman nyata, dan menyebutnya sekarang akan menjadi persis
+  kebohongan percaya diri yang gerbang itu ada untuk mencegah.
+
 ## Belum tersedia (Sprint 3+)
 
 Endpoint manajemen user/role lanjutan. Follow-up yang dicatat:


### PR DESCRIPTION
Penutup putaran. Mencatat Gelombang 4 (#512, #513, ADR-0082) di `docs/PROJECT_STATE.md` §4, dan memberi `identity-access/README.md` bagian Undangan.

## Kenapa daftarnya ada di repo

Aturan yang sama dengan empat putaran sebelumnya: daftar yang tidak ditulis ke repo harus **diturunkan ulang**, dan menurunkan ulang berharga satu audit penuh sementara menuliskannya berharga satu paragraf. Penolakan ikut tertulis, karena penolakan yang tidak tercatat akan diusulkan lagi.

Yang dicatat: empat tempat rencana program tidak diikuti beserta alasannya yang diperiksa terhadap kode, dua cacat yang ditemukan dengan MENJALANKAN bukan membaca, tujuh penolakan, gerbang yang tumbuh, dan satu batas yang wajib dibaca.

## Batas yang paling layak diingat dari putaran ini

`config:env:coverage:check` hanya mencocokkan `process.env.X` dan **buta** terhadap `env.X` yang dilewatkan sebagai parameter — batas yang gerbangnya catat sendiri di header berkasnya. Tiga env undangan karena itu dituliskan TANGAN di `.env.example`. Config module berikutnya yang memakai pola `env: NodeJS.ProcessEnv = process.env` akan punya masalah yang sama, dan **tak ada yang akan memberitahunya**.

## Draf README-nya sendiri memerahkan sebuah gerbang, dan itu benar

Draf pertama bagian Undangan menyebut `` `/admin/invitations` `` — layar yang tidak ada. `skills:check` menolaknya:

> `src/modules/identity-access/README.md` names admin screens that do not exist: /admin/invitations.

Itu persis kelas kebohongan percaya diri yang ADR-0062 bangun gerbang itu untuk mencegah, dan ia menangkapnya pada percobaan pertama. Path-nya dihapus; alasannya ditulis di tempatnya, supaya penulis berikutnya tahu kenapa kalimat itu berbentuk begitu.

## Verifikasi

`DATABASE_URL="" bun run check` penuh: 39 gerbang, 4419 test, 0 gagal, build selesai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)