### PR TITLE
feat(access): grandfathering entitlement, dan laporan blast-radius yang wajib dijalankan LEBIH DULU (ADR-0084, #423)

### DIFF
--- a/.changeset/grandfathering-entitlement.md
+++ b/.changeset/grandfathering-entitlement.md
@@ -1,0 +1,35 @@
+---
+"awcms": minor
+---
+
+feat(access): grandfathering entitlement, dan laporan blast-radius yang wajib dijalankan LEBIH DULU (ADR-0084, #423)
+
+Gelombang 5 PR 5.3. `bun run entitlements:backfill` (dry-run default, `--commit`
+menulis, `--tenant <code>` untuk rollout bertahap) plus cek baru di
+`bun run security:readiness`: _"N tenant akan mulai menerima 403
+ENTITLEMENT_REQUIRED untuk X"_.
+
+**Kenapa laporan itu ada di `security:readiness` dan bukan hanya di skripnya.**
+Skripnya mencetak angka yang sama, tetapi ia perintah yang harus Anda tahu ada —
+dan kesalahan yang ditangkap cek ini dibuat oleh orang yang tidak tahu.
+Severity-nya `warning`, tak pernah `critical`: tenant yang akan ditolak adalah
+fakta KOMERSIAL, dan gerbang kesiapan yang memblokir go-live karena seseorang
+belum membayar adalah alat keamanan yang mengambil keputusan tagihan.
+
+**Kenapa grandfathering boleh menjadi selimut di sini, padahal backfill
+permission tidak boleh.** `owner-permission-backfill.ts` menolak memberikan ulang
+apa pun yang LEBIH TUA dari peran owner, karena permission yang hilang bisa saja
+DICABUT sengaja dan backfill tak bisa membedakannya dari "tak pernah diberikan".
+Entitlement tak punya sejarah itu: skemanya mendarat KOSONG (`sql/109`), jadi
+baris yang absen hanya bisa berarti "sebelum entitlement ada".
+
+Asimetri itu KEDALUWARSA pada pencabutan pertama — dan di situlah aturan
+`tenant_newer_than_entitlement` menarik garisnya: tenant yang lebih baru dari
+baris katalog entitlement-nya DILAPORKAN, tak pernah diberikan ulang. Seri
+dihitung sebagai "lebih baru": tidak memberi bisa diperbaiki manusia, memberi
+diam-diam tidak.
+
+Laporan blast-radius DITURUNKAN dari rencana backfill yang sama, bukan dari query
+kedua yang ditulis agar mirip. Dua penurunan atas "siapa yang kekurangan ini"
+adalah dua kesempatan menjawab berbeda, dan seluruh nilai laporan ini adalah ia
+bisa dipercaya pada hari ia mengatakan nol.

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -143,7 +143,7 @@
       ],
       "permissionCount": 36,
       "navigationCount": 6,
-      "jobCount": 2,
+      "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,
       "deploymentProfiles": null

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 140   |
 | Tabel dengan `FORCE` RLS           | 126   |
 | Tabel RLS-free (global, by design) | 14    |
-| Berkas test                        | 355   |
+| Berkas test                        | 356   |
 | Berkas route                       | 335   |
 | ADR                                | 85    |
 
@@ -307,7 +307,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 301        |
+| `(root)`      | 302        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "identity-access:subscription-lifecycle": "bun scripts/identity-access-subscription-lifecycle.ts",
     "identity:principals:preflight": "bun scripts/identity-access-principal-preflight.ts",
     "identity-access:permissions:backfill": "bun scripts/identity-access-owner-permission-backfill.ts",
+    "entitlements:backfill": "bun scripts/identity-access-entitlement-backfill.ts",
     "blog:publish:scheduled": "bun scripts/blog-scheduled-publish.ts",
     "blog:ads:ingest": "bun scripts/blog-ads-ingest.ts",
     "blog:ads:drop-readiness": "bun scripts/blog-ads-drop-readiness.ts",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -23,7 +23,7 @@ lalu membangun duplikatnya.
 
 <!-- Dihasilkan `bun run scripts:inventory:generate`. JANGAN diedit tangan. -->
 
-89 target menjalankan berkas di `scripts/`; 36 di antaranya
+90 target menjalankan berkas di `scripts/`; 36 di antaranya
 ada di rantai `bun run check` (kolom **Gate**), sisanya dijalankan manual,
 terjadwal, atau oleh workflow CI tertentu.
 
@@ -72,6 +72,7 @@ terjadwal, atau oleh workflow CI tertentu.
 | `email:provider:health`                  | `email-provider-health.ts`                     | —    |
 | `email:queue:purge`                      | `email-queue-purge.ts`                         | —    |
 | `email:templates:seed-defaults`          | `email-templates-seed-defaults.ts`             | —    |
+| `entitlements:backfill`                  | `identity-access-entitlement-backfill.ts`      | —    |
 | `family:conformance:check`               | `family-conformance-check.ts`                  | ✅   |
 | `form-drafts:purge`                      | `form-draft-purge.ts`                          | —    |
 | `identity-access:business-scope:expiry`  | `identity-access-business-scope-expiry.ts`     | —    |

--- a/scripts/identity-access-entitlement-backfill.ts
+++ b/scripts/identity-access-entitlement-backfill.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env bun
+/**
+ * identity-access-entitlement-backfill.ts — `bun run entitlements:backfill`.
+ *
+ * ADR-0084, Gelombang 5 PR 5.3 of Issue #423. Grandfathers every tenant that
+ * PREDATES an entitlement onto it, so a descriptor declaring
+ * `requiresEntitlement` does not turn a working installation into a wall of
+ * `403 ENTITLEMENT_REQUIRED` on the day it merges.
+ *
+ * DRY-RUN BY DEFAULT. Pass `--commit` to write. `--tenant <code>` limits the
+ * pass to one tenant, for a staged rollout.
+ *
+ * ## Run this BEFORE the descriptor, not after
+ *
+ * The blast-radius report it prints — "N tenant(s) would start receiving 403
+ * ENTITLEMENT_REQUIRED for X" — is the check that catches the mistake while it
+ * is still cheap. Run after the descriptor merges, it describes an outage
+ * instead of preventing one. `bun run security:readiness` carries the same
+ * report so it is also reachable without knowing this script exists.
+ *
+ * ## Why a blanket grandfather is legitimate here
+ *
+ * `identity-access:permissions:backfill` refuses to re-grant anything older than
+ * the owner role, because a missing older permission may have been REVOKED and a
+ * backfill cannot tell that from "never granted". Entitlements have no such
+ * history: the schema landed empty (`sql/109`), so an absent row can only mean
+ * "before entitlements". That asymmetry is the whole argument, and it expires
+ * the moment the first revocation happens — which is why tenants NEWER than an
+ * entitlement's catalogue row are reported rather than granted.
+ */
+import { getDatabaseClient } from "../src/lib/database/client";
+import { runEntitlementBackfill } from "../src/modules/identity-access/application/entitlement-backfill-job";
+
+function parseArgs(argv: string[]): { commit: boolean; tenantCode?: string } {
+  const commit = argv.includes("--commit");
+  const tenantIndex = argv.indexOf("--tenant");
+  const tenantCode =
+    tenantIndex >= 0 ? (argv[tenantIndex + 1] ?? undefined) : undefined;
+
+  if (tenantIndex >= 0 && (!tenantCode || tenantCode.startsWith("--"))) {
+    throw new Error("--tenant requires a tenant code.");
+  }
+
+  return { commit, tenantCode };
+}
+
+const { commit, tenantCode } = parseArgs(process.argv.slice(2));
+const sql = getDatabaseClient();
+
+try {
+  const result = await runEntitlementBackfill(sql, {
+    commit,
+    now: new Date(),
+    tenantCode
+  });
+
+  if (result.requiredEntitlementKeys.length === 0) {
+    console.log(
+      "entitlements:backfill — no module declares `requiresEntitlement`, so " +
+        "there is nothing to grandfather. This is the state this base ships in " +
+        "(ADR-0084: the wave landed inert)."
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `entitlements:backfill — ${result.requiredEntitlementKeys.length} entitlement(s) required by the registry: ${result.requiredEntitlementKeys.join(", ")}`
+  );
+
+  console.log("\nBLAST RADIUS — who is refused if nothing is granted:");
+  for (const entry of result.blastRadius) {
+    console.log(
+      `  ${entry.entitlementKey} — ${entry.deniedTenantCount} tenant(s) would receive 403 ENTITLEMENT_REQUIRED: ${entry.deniedTenantCodes.join(", ")}`
+    );
+  }
+
+  const skippedByReason = new Map<string, number>();
+  for (const skip of result.plan.skipped) {
+    skippedByReason.set(
+      skip.reason,
+      (skippedByReason.get(skip.reason) ?? 0) + 1
+    );
+  }
+
+  console.log(
+    `\nPlan: ${result.plan.grants.length} grant(s), ${result.plan.skipped.length} skipped` +
+      (skippedByReason.size > 0
+        ? ` (${[...skippedByReason.entries()].map(([reason, count]) => `${reason}=${count}`).join(", ")})`
+        : "")
+  );
+
+  // Named individually rather than folded into the count: this is the one skip
+  // reason that means "a human decision may be involved", and a number cannot
+  // say which tenant to go and ask about.
+  const newer = result.plan.skipped.filter(
+    (skip) => skip.reason === "tenant_newer_than_entitlement"
+  );
+
+  if (newer.length > 0) {
+    console.log(
+      "\nNOT grandfathered — newer than the entitlement, so the absence is a fact about the tenant rather than about the feature. Re-granting these would risk undoing a revocation:"
+    );
+    for (const skip of newer) {
+      console.log(`  ${skip.tenantCode} — ${skip.entitlementKey}`);
+    }
+  }
+
+  console.log(
+    commit
+      ? `\nCOMMITTED — ${result.granted} entitlement(s) granted.`
+      : "\nDRY RUN — nothing was written. Re-run with --commit to apply."
+  );
+} finally {
+  await sql.close();
+}

--- a/scripts/security-readiness.ts
+++ b/scripts/security-readiness.ts
@@ -49,6 +49,10 @@ import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { hashPassword } from "../src/lib/auth/password";
 import { listModules } from "../src/modules";
 import {
+  collectRequiredEntitlementKeys,
+  runEntitlementBackfill
+} from "../src/modules/identity-access/application/entitlement-backfill-job";
+import {
   fetchEligibleBreakGlassIdentityIds,
   getTenantAuthPolicy
 } from "../src/modules/identity-access/application/tenant-auth-policy";
@@ -2659,6 +2663,87 @@ export async function checkResponseCompressionOwnership(
   };
 }
 
+/**
+ * ADR-0084 — who stops being served the moment an entitlement descriptor lands.
+ *
+ * Not a security control; a BLAST-RADIUS report, and it lives here because this
+ * is the command an operator already runs against a real database before a
+ * release. `bun run entitlements:backfill` prints the same numbers, but it is a
+ * command you have to know exists — and the mistake this catches is made by
+ * someone who does not.
+ *
+ * `warning`, never `critical`: a tenant that is about to be refused is a
+ * COMMERCIAL fact, and a readiness gate that blocks go-live because somebody has
+ * not paid would be a security tool making a billing decision. It reports and
+ * names; a human decides.
+ *
+ * PASSES LOUDLY when nothing is required, which is the state this base ships in.
+ * A silent pass here would be indistinguishable from a check that stopped
+ * looking — the exact failure this repo has recorded for coverage gates that go
+ * inert when their ledger empties.
+ */
+export async function checkEntitlementBlastRadius(): Promise<SecurityCheckResult> {
+  const name = "Entitlement blast radius is known before a descriptor lands";
+  const severity: CheckSeverity = "warning";
+
+  const requiredEntitlementKeys = collectRequiredEntitlementKeys();
+
+  if (requiredEntitlementKeys.length === 0) {
+    return {
+      name,
+      severity,
+      status: "pass",
+      evidence:
+        "No module declares `requiresEntitlement`, so no tenant can receive 403 ENTITLEMENT_REQUIRED (ADR-0084: the wave landed inert). The moment a descriptor declares one, this check reports exactly which tenants stop being served — run `bun run entitlements:backfill` BEFORE merging that descriptor, not after."
+    };
+  }
+
+  const sql = getDatabaseClient();
+
+  try {
+    const result = await runEntitlementBackfill(sql, {
+      commit: false,
+      now: new Date()
+    });
+
+    const denied = result.blastRadius.filter(
+      (entry) => entry.deniedTenantCount > 0
+    );
+
+    if (denied.length === 0) {
+      return {
+        name,
+        severity,
+        status: "pass",
+        evidence: `${requiredEntitlementKeys.length} entitlement(s) are required by the registry and every tenant holds all of them — no tenant would receive 403 ENTITLEMENT_REQUIRED.`
+      };
+    }
+
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `Tenants would start receiving 403 ENTITLEMENT_REQUIRED: ${denied
+        .map(
+          (entry) =>
+            `${entry.entitlementKey} -> ${entry.deniedTenantCount} tenant(s) (${entry.deniedTenantCodes.slice(0, 10).join(", ")}${entry.deniedTenantCodes.length > 10 ? ", …" : ""})`
+        )
+        .join(
+          "; "
+        )}. Run \`bun run entitlements:backfill --commit\` to grandfather the tenants that predate each entitlement, or decide deliberately that these tenants are not entitled — this check reports, it does not decide.`
+    };
+  } catch (error) {
+    return {
+      name,
+      severity,
+      status: "fail",
+      evidence: `Could not compute the entitlement blast radius: ${errorMessage(error)}. A report that cannot run is not a report that found nothing.`
+    };
+  } finally {
+    await sql.close();
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Out-of-scope items — printed as their own report section, never silently
 // dropped.
@@ -2806,7 +2891,8 @@ export async function runSecurityReadinessChecks(): Promise<
     checkTurnstileReady(),
     checkLoginRateLimitImplemented(),
     checkSecurityHeadersBuilt(),
-    await checkResponseCompressionOwnership()
+    await checkResponseCompressionOwnership(),
+    await checkEntitlementBlastRadius()
   ];
 }
 

--- a/src/modules/identity-access/application/entitlement-backfill-job.ts
+++ b/src/modules/identity-access/application/entitlement-backfill-job.ts
@@ -1,0 +1,172 @@
+/**
+ * Entitlement grandfathering — ADR-0084, Gelombang 5 PR 5.3 of Issue #423.
+ *
+ * DRY-RUN BY DEFAULT; `--commit` writes. The accident this guards against is
+ * widening what every tenant holds in one command, and that must not be
+ * reachable by typing something that looks read-only —
+ * `identity-access:permissions:backfill` established the convention and the
+ * reason.
+ *
+ * The DECISION is `domain/entitlement-backfill.ts`, pure; this file reads rows
+ * and applies the plan. Same split as the subscription ladder, for the same
+ * reason: the interesting half gets tested without a database.
+ */
+import { withTenantOrThrow } from "../../../lib/database/tenant-context";
+import { listModules } from "../../index";
+import { requiredEntitlementForModule } from "../domain/entitlement";
+import {
+  GRANDFATHER_GRANT_REASON,
+  planEntitlementBackfill,
+  summarizeBlastRadius,
+  type EntitlementBackfillPlan,
+  type EntitlementBlastRadius
+} from "../domain/entitlement-backfill";
+
+/**
+ * Every entitlement key some registered module currently requires.
+ *
+ * Reads the SAME resolver the chokepoint uses, so a module whose declaration the
+ * guard would ignore (an `isCore` one) is ignored here too. A backfill that
+ * grandfathered a key nothing enforces would write rows nobody reads, and a
+ * backfill that MISSED a key the guard enforces would leave tenants denied — the
+ * two failures the shared resolver makes impossible.
+ */
+export function collectRequiredEntitlementKeys(): string[] {
+  const modules = listModules();
+
+  return [
+    ...new Set(
+      modules
+        .map((module) => requiredEntitlementForModule(module.key, modules))
+        .filter((key): key is string => key !== null)
+    )
+  ].sort();
+}
+
+export type EntitlementBackfillResult = {
+  requiredEntitlementKeys: string[];
+  plan: EntitlementBackfillPlan;
+  blastRadius: EntitlementBlastRadius[];
+  granted: number;
+  committed: boolean;
+};
+
+type TenantRow = { id: string; tenant_code: string; created_at: Date };
+
+export async function runEntitlementBackfill(
+  sql: Bun.SQL,
+  options: { commit: boolean; now: Date; tenantCode?: string }
+): Promise<EntitlementBackfillResult> {
+  const requiredEntitlementKeys = collectRequiredEntitlementKeys();
+
+  if (requiredEntitlementKeys.length === 0) {
+    // The state this base ships in. Reported as an empty plan rather than
+    // short-circuited silently, so a run that finds nothing is visibly a run
+    // that found nothing rather than one that failed to look.
+    return {
+      requiredEntitlementKeys,
+      plan: { grants: [], skipped: [] },
+      blastRadius: [],
+      granted: 0,
+      committed: options.commit
+    };
+  }
+
+  const tenantRows = (await sql`
+    SELECT id, tenant_code, created_at
+    FROM awcms_tenants
+    WHERE status <> 'deleted'
+      AND (${options.tenantCode ?? null}::text IS NULL
+           OR tenant_code = ${options.tenantCode ?? null})
+    ORDER BY created_at
+  `) as TenantRow[];
+
+  const catalogueRows = (await sql`
+    SELECT entitlement_key, created_at FROM awcms_entitlements
+  `) as { entitlement_key: string; created_at: Date }[];
+
+  const catalogueCreatedAt = new Map(
+    catalogueRows.map((row) => [row.entitlement_key, row.created_at])
+  );
+
+  const heldByTenant = new Map<string, Set<string>>();
+
+  for (const tenant of tenantRows) {
+    // Per-tenant, inside `withTenantOrThrow`: `awcms_tenant_entitlements` is
+    // FORCE RLS, so a single cross-tenant SELECT would return nothing at all
+    // rather than everything — the failure that reads as "no tenant holds
+    // anything" and grandfathers the whole installation twice.
+    const held = await withTenantOrThrow(
+      sql,
+      tenant.id,
+      async (tx) => {
+        const rows = (await tx`
+          SELECT entitlement_key FROM awcms_tenant_entitlements
+          WHERE tenant_id = ${tenant.id}
+            AND (expires_at IS NULL OR expires_at > ${options.now})
+        `) as { entitlement_key: string }[];
+
+        return new Set(rows.map((row) => row.entitlement_key));
+      },
+      { workClass: "maintenance" }
+    );
+
+    heldByTenant.set(tenant.id, held);
+  }
+
+  const plan = planEntitlementBackfill({
+    requiredEntitlementKeys,
+    catalogueCreatedAt,
+    tenants: tenantRows.map((row) => ({
+      tenantId: row.id,
+      tenantCode: row.tenant_code,
+      createdAt: row.created_at
+    })),
+    heldByTenant
+  });
+
+  const blastRadius = summarizeBlastRadius(plan);
+
+  if (!options.commit) {
+    return {
+      requiredEntitlementKeys,
+      plan,
+      blastRadius,
+      granted: 0,
+      committed: false
+    };
+  }
+
+  let granted = 0;
+
+  for (const grant of plan.grants) {
+    await withTenantOrThrow(
+      sql,
+      grant.tenantId,
+      async (tx) => {
+        // `ON CONFLICT DO NOTHING` against the (tenant, entitlement) unique
+        // index: a second run, or a concurrent hand-grant, must be a no-op
+        // rather than a 23505 that aborts the transaction — the shape `sql/074`
+        // and `sql/106` both chose for the same reason.
+        await tx`
+          INSERT INTO awcms_tenant_entitlements
+            (tenant_id, entitlement_key, grant_reason)
+          VALUES (${grant.tenantId}, ${grant.entitlementKey},
+                  ${GRANDFATHER_GRANT_REASON})
+          ON CONFLICT (tenant_id, entitlement_key) DO NOTHING
+        `;
+      },
+      { workClass: "maintenance" }
+    );
+
+    granted += 1;
+  }
+
+  return {
+    requiredEntitlementKeys,
+    plan,
+    blastRadius,
+    granted,
+    committed: true
+  };
+}

--- a/src/modules/identity-access/domain/entitlement-backfill.ts
+++ b/src/modules/identity-access/domain/entitlement-backfill.ts
@@ -1,0 +1,159 @@
+/**
+ * Grandfathering, decided purely — ADR-0084, Gelombang 5 PR 5.3 of Issue #423.
+ *
+ * ## Why this may be a blanket migration when the permission backfill may not
+ *
+ * `owner-permission-backfill.ts` refuses to re-grant anything OLDER than the
+ * owner role, because a missing older permission may have been REVOKED
+ * deliberately, and a backfill that cannot tell "never granted" from "taken
+ * away" would silently undo a security decision.
+ *
+ * Entitlements have no such history, and that asymmetry is the whole argument:
+ * this schema landed empty (`sql/109`), so no entitlement has ever existed to be
+ * revoked. An absent row therefore cannot mean a decision — it can only mean
+ * "before entitlements". Grandfathering every existing tenant is not overriding
+ * anybody; it is stating what was already true.
+ *
+ * That stops being true the moment the first revocation happens, which is why
+ * `planEntitlementBackfill` grandfathers only tenants that predate the
+ * entitlement's own catalogue row, and reports — never silently re-grants — a
+ * tenant that is NEWER and still lacks it. From then on the same
+ * "never-granted vs taken-away" discipline the permission backfill uses applies
+ * here too.
+ *
+ * Pure: the caller reads the rows, this decides what they mean.
+ */
+
+export type EntitlementBackfillInput = {
+  /** Every entitlement key some registered module currently requires. */
+  requiredEntitlementKeys: readonly string[];
+  /** `entitlement_key -> awcms_entitlements.created_at`. Absent = no catalogue row. */
+  catalogueCreatedAt: ReadonlyMap<string, Date>;
+  tenants: readonly { tenantId: string; tenantCode: string; createdAt: Date }[];
+  /** Keys each tenant already holds directly (`awcms_tenant_entitlements`). */
+  heldByTenant: ReadonlyMap<string, ReadonlySet<string>>;
+};
+
+export type EntitlementBackfillGrant = {
+  tenantId: string;
+  tenantCode: string;
+  entitlementKey: string;
+};
+
+export type EntitlementBackfillSkip = {
+  tenantId: string;
+  tenantCode: string;
+  entitlementKey: string;
+  reason: "already_held" | "no_catalogue_row" | "tenant_newer_than_entitlement";
+};
+
+export type EntitlementBackfillPlan = {
+  grants: EntitlementBackfillGrant[];
+  skipped: EntitlementBackfillSkip[];
+};
+
+/**
+ * The reason string written to `awcms_tenant_entitlements.grant_reason`.
+ *
+ * Fixed, and a constant rather than a literal at the call site: a support
+ * engineer three years from now reading "why does this tenant have this" needs
+ * the answer to be the same sentence for every row this job ever wrote, so it
+ * can be grepped and so a hand-granted row is distinguishable at a glance.
+ */
+export const GRANDFATHER_GRANT_REASON =
+  "Grandfathered: the tenant predates this entitlement (ADR-0084 backfill).";
+
+export function planEntitlementBackfill(
+  input: EntitlementBackfillInput
+): EntitlementBackfillPlan {
+  const grants: EntitlementBackfillGrant[] = [];
+  const skipped: EntitlementBackfillSkip[] = [];
+
+  for (const tenant of input.tenants) {
+    const held = input.heldByTenant.get(tenant.tenantId) ?? new Set<string>();
+
+    for (const entitlementKey of input.requiredEntitlementKeys) {
+      const base = {
+        tenantId: tenant.tenantId,
+        tenantCode: tenant.tenantCode,
+        entitlementKey
+      };
+
+      if (held.has(entitlementKey)) {
+        skipped.push({ ...base, reason: "already_held" });
+        continue;
+      }
+
+      const catalogued = input.catalogueCreatedAt.get(entitlementKey);
+
+      if (catalogued === undefined) {
+        // A module declares it, the catalogue has never heard of it. Grandfathering
+        // would need a row this job may not create — `awcms_entitlements` is
+        // migration-only (ADR-0084) — and inventing one here would put a request
+        // path's worth of authority in a cron script.
+        skipped.push({ ...base, reason: "no_catalogue_row" });
+        continue;
+      }
+
+      if (tenant.createdAt.getTime() >= catalogued.getTime()) {
+        // Newer than the entitlement, so its absence is a fact about THIS
+        // tenant rather than about the feature not existing yet — possibly a
+        // revocation, possibly a plan it was never sold. Reported, never
+        // re-granted: the discipline `owner-permission-backfill.ts` established.
+        skipped.push({ ...base, reason: "tenant_newer_than_entitlement" });
+        continue;
+      }
+
+      grants.push(base);
+    }
+  }
+
+  return { grants, skipped };
+}
+
+/**
+ * The question `bun run security:readiness` must be able to answer BEFORE a
+ * descriptor declaring `requiresEntitlement` is merged: who stops being served
+ * the moment it lands.
+ *
+ * Deliberately computed from the SAME plan the backfill produces, rather than by
+ * a second query written to look similar. Two derivations of "who is missing
+ * this" is two chances to answer the question differently, and the whole value
+ * of this report is that it is trustworthy on the day it says zero.
+ */
+export type EntitlementBlastRadius = {
+  entitlementKey: string;
+  deniedTenantCount: number;
+  deniedTenantCodes: string[];
+};
+
+export function summarizeBlastRadius(
+  plan: EntitlementBackfillPlan
+): EntitlementBlastRadius[] {
+  const byKey = new Map<string, Set<string>>();
+
+  const record = (entitlementKey: string, tenantCode: string): void => {
+    const codes = byKey.get(entitlementKey) ?? new Set<string>();
+    codes.add(tenantCode);
+    byKey.set(entitlementKey, codes);
+  };
+
+  // A tenant is denied if it does not hold the key — which is every planned
+  // grant (not yet applied) plus every skip that is NOT `already_held`.
+  for (const grant of plan.grants) {
+    record(grant.entitlementKey, grant.tenantCode);
+  }
+
+  for (const skip of plan.skipped) {
+    if (skip.reason === "already_held") continue;
+    record(skip.entitlementKey, skip.tenantCode);
+  }
+
+  return [...byKey.entries()]
+    .map(([entitlementKey, codes]) => ({
+      entitlementKey,
+      deniedTenantCount: codes.size,
+      deniedTenantCodes: [...codes].sort()
+    }))
+    .sort((a, b) => a.entitlementKey.localeCompare(b.entitlementKey));
+}

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -146,6 +146,16 @@ export const identityAccessModule = defineModule({
       safeInOfflineLan: true
     },
     {
+      command: "bun run entitlements:backfill",
+      purpose:
+        "Grandfathers every tenant that PREDATES an entitlement onto it (ADR-0084), and prints the blast radius — how many tenants would start receiving 403 ENTITLEMENT_REQUIRED — for each entitlement the registry requires. Dry-run by default; --commit writes; --tenant <code> stages the rollout.",
+      recommendedSchedule:
+        "NOT scheduled. Operator-run, and run BEFORE merging a descriptor that declares requiresEntitlement — run afterwards it describes an outage instead of preventing one. `bun run security:readiness` carries the same report for anyone who does not know this command exists.",
+      environmentNotes:
+        "Database-only, no external network dependency. Grandfathers only tenants OLDER than an entitlement's catalogue row; a newer tenant that lacks it is reported and never re-granted, because after the entitlement existed its absence may be a revocation.",
+      safeInOfflineLan: true
+    },
+    {
       command: "bun run identity-access:subscription-lifecycle",
       purpose:
         "Walks each tenant's subscription one rung down the trialing -> active -> past_due -> grace -> suspended ladder when its own dates say so (ADR-0084), auditing every transition in that tenant's own trail. Never moves a subscription up — restoring service is a payment event, not a clock event — and never writes awcms_tenants: a run that would cost more than MAX_ENTITLEMENT_LOSSES_PER_RUN tenants their plan entitlements applies none of them and reports instead.",

--- a/tests/entitlement-backfill.test.ts
+++ b/tests/entitlement-backfill.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Grandfathering — ADR-0084, Gelombang 5 PR 5.3 of Issue #423.
+ *
+ * The claim under test is not "the backfill grants things". It is the ASYMMETRY
+ * that makes a blanket grandfather legitimate here while
+ * `owner-permission-backfill.ts` refuses one: an entitlement has never existed
+ * to be revoked, so an absent row cannot mean a decision — until the first
+ * revocation, which is exactly what the `tenant_newer_than_entitlement` rule
+ * draws the line at.
+ *
+ * Pure. No database.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  GRANDFATHER_GRANT_REASON,
+  planEntitlementBackfill,
+  summarizeBlastRadius,
+  type EntitlementBackfillInput
+} from "../src/modules/identity-access/domain/entitlement-backfill";
+import { collectRequiredEntitlementKeys } from "../src/modules/identity-access/application/entitlement-backfill-job";
+
+const JAN = new Date("2026-01-01T00:00:00.000Z");
+const JUN = new Date("2026-06-01T00:00:00.000Z");
+const DEC = new Date("2026-12-01T00:00:00.000Z");
+
+function input(
+  overrides: Partial<EntitlementBackfillInput> = {}
+): EntitlementBackfillInput {
+  return {
+    requiredEntitlementKeys: ["site_search"],
+    catalogueCreatedAt: new Map([["site_search", JUN]]),
+    tenants: [{ tenantId: "t-old", tenantCode: "old", createdAt: JAN }],
+    heldByTenant: new Map(),
+    ...overrides
+  };
+}
+
+describe("the wave shipped inert, so there is nothing to grandfather", () => {
+  test("no registered module requires an entitlement", () => {
+    expect(collectRequiredEntitlementKeys()).toEqual([]);
+  });
+});
+
+describe("who gets grandfathered", () => {
+  test("a tenant older than the entitlement is granted it", () => {
+    const plan = planEntitlementBackfill(input());
+
+    expect(plan.grants).toEqual([
+      { tenantId: "t-old", tenantCode: "old", entitlementKey: "site_search" }
+    ]);
+  });
+
+  test("a tenant NEWER than the entitlement is reported, never re-granted", () => {
+    // The line where the asymmetry expires. After the entitlement existed, an
+    // absent row is a fact about THIS tenant — possibly a revocation — and
+    // re-granting it would silently undo a decision.
+    const plan = planEntitlementBackfill(
+      input({
+        tenants: [{ tenantId: "t-new", tenantCode: "new", createdAt: DEC }]
+      })
+    );
+
+    expect(plan.grants).toEqual([]);
+    expect(plan.skipped).toEqual([
+      {
+        tenantId: "t-new",
+        tenantCode: "new",
+        entitlementKey: "site_search",
+        reason: "tenant_newer_than_entitlement"
+      }
+    ]);
+  });
+
+  test("a tenant created at the exact catalogue instant counts as NEWER", () => {
+    // Ties go to the conservative side: not granting is recoverable by a human,
+    // granting silently is not.
+    const plan = planEntitlementBackfill(
+      input({
+        tenants: [{ tenantId: "t-tie", tenantCode: "tie", createdAt: JUN }]
+      })
+    );
+
+    expect(plan.grants).toEqual([]);
+    expect(plan.skipped[0]!.reason).toBe("tenant_newer_than_entitlement");
+  });
+
+  test("a tenant that already holds it is skipped, not double-granted", () => {
+    const plan = planEntitlementBackfill(
+      input({ heldByTenant: new Map([["t-old", new Set(["site_search"])]]) })
+    );
+
+    expect(plan.grants).toEqual([]);
+    expect(plan.skipped[0]!.reason).toBe("already_held");
+  });
+
+  test("a key with no catalogue row is skipped rather than invented", () => {
+    // `awcms_entitlements` is migration-only (ADR-0084). A job that created a
+    // row here would put a request path's worth of authority in a cron script.
+    const plan = planEntitlementBackfill(
+      input({ catalogueCreatedAt: new Map() })
+    );
+
+    expect(plan.grants).toEqual([]);
+    expect(plan.skipped[0]!.reason).toBe("no_catalogue_row");
+  });
+
+  test("the grant reason is one fixed sentence, so a hand-granted row is distinguishable", () => {
+    expect(GRANDFATHER_GRANT_REASON).toContain("Grandfathered");
+    expect(GRANDFATHER_GRANT_REASON).toContain("ADR-0084");
+  });
+});
+
+describe("the blast-radius report", () => {
+  const threeTenants = input({
+    requiredEntitlementKeys: ["site_search", "custom_domain"],
+    catalogueCreatedAt: new Map([
+      ["site_search", JUN],
+      ["custom_domain", JUN]
+    ]),
+    tenants: [
+      { tenantId: "t1", tenantCode: "alpha", createdAt: JAN },
+      { tenantId: "t2", tenantCode: "beta", createdAt: DEC },
+      { tenantId: "t3", tenantCode: "gamma", createdAt: JAN }
+    ],
+    heldByTenant: new Map([["t3", new Set(["site_search"])]])
+  });
+
+  test("counts every tenant that does NOT hold the key, whatever the reason", () => {
+    const radius = summarizeBlastRadius(planEntitlementBackfill(threeTenants));
+
+    // `custom_domain`: nobody holds it -> all three.
+    // `site_search`: gamma holds it -> alpha (grantable) + beta (too new).
+    expect(radius).toEqual([
+      {
+        entitlementKey: "custom_domain",
+        deniedTenantCount: 3,
+        deniedTenantCodes: ["alpha", "beta", "gamma"]
+      },
+      {
+        entitlementKey: "site_search",
+        deniedTenantCount: 2,
+        deniedTenantCodes: ["alpha", "beta"]
+      }
+    ]);
+  });
+
+  test("it is derived from the SAME plan, so it cannot disagree with the backfill", () => {
+    // Two derivations of "who is missing this" is two chances to answer
+    // differently, and the value of this report is being trustworthy on the day
+    // it says zero. Asserted structurally: every grant and every non-held skip
+    // is accounted for exactly once.
+    const plan = planEntitlementBackfill(threeTenants);
+    const radius = summarizeBlastRadius(plan);
+
+    const fromPlan =
+      plan.grants.length +
+      plan.skipped.filter((skip) => skip.reason !== "already_held").length;
+    const fromRadius = radius.reduce(
+      (total, entry) => total + entry.deniedTenantCount,
+      0
+    );
+
+    expect(fromRadius).toBe(fromPlan);
+  });
+
+  test("a tenant holding everything contributes nothing", () => {
+    const radius = summarizeBlastRadius(
+      planEntitlementBackfill(
+        input({ heldByTenant: new Map([["t-old", new Set(["site_search"])]]) })
+      )
+    );
+
+    expect(radius).toEqual([]);
+  });
+});

--- a/tests/module-management-job-registry.test.ts
+++ b/tests/module-management-job-registry.test.ts
@@ -102,6 +102,7 @@ describe("fetchModuleJobs", () => {
         "bun run email:provider:health",
         "bun run email:queue:purge",
         "bun run email:templates:seed-defaults",
+        "bun run entitlements:backfill",
         "bun run form-drafts:purge",
         "bun run identity-access:business-scope:expiry",
         "bun run identity-access:subscription-lifecycle",


### PR DESCRIPTION
Gelombang 5 PR 5.3 dari #423.

> **Bertumpuk di atas #517 dan #518.** Selama keduanya belum di-merge, diff PR ini juga memuat perubahan keduanya. Base-nya `main` supaya CI benar-benar berjalan — PR ber-base cabang lain memicu NOL gerbang di repo ini.

`bun run entitlements:backfill` (dry-run default, `--commit` menulis, `--tenant <code>` untuk rollout bertahap) plus cek baru di `bun run security:readiness`: *"N tenant akan mulai menerima 403 ENTITLEMENT_REQUIRED untuk X"*.

## Kenapa laporannya juga ada di `security:readiness`

Skripnya mencetak angka yang sama, tetapi ia perintah yang **harus Anda tahu ada** — dan kesalahan yang ditangkap cek ini dibuat oleh orang yang tidak tahu.

Severity `warning`, **tak pernah** `critical`: tenant yang akan ditolak adalah fakta **komersial**, dan gerbang kesiapan yang memblokir go-live karena seseorang belum membayar adalah alat keamanan yang mengambil keputusan tagihan. Ia melapor dan menyebut nama; manusia yang memutuskan.

Ia **lulus dengan lantang** saat tak ada entitlement yang diminta — keadaan yang base ini kirimkan hari ini. Lulus diam-diam tak bisa dibedakan dari cek yang berhenti melihat, yaitu mode kegagalan yang sudah tercatat di repo ini untuk gerbang cakupan yang menjadi inert begitu ledger-nya kosong.

## Kenapa grandfathering boleh menjadi selimut di sini, padahal backfill permission tidak

`owner-permission-backfill.ts` menolak memberikan ulang apa pun yang **lebih tua** dari peran owner, karena permission yang hilang bisa saja **dicabut** sengaja dan backfill tak bisa membedakannya dari "tak pernah diberikan".

Entitlement tak punya sejarah itu: skemanya mendarat **kosong** (`sql/109`), jadi baris yang absen hanya bisa berarti "sebelum entitlement ada". Grandfathering setiap tenant lama bukan menimpa keputusan siapa pun — ia menyatakan apa yang sudah benar.

Asimetri itu **kedaluwarsa pada pencabutan pertama**, dan di situlah aturan `tenant_newer_than_entitlement` menarik garisnya: tenant yang lebih baru dari baris katalog entitlement-nya **dilaporkan, tak pernah diberikan ulang**. Seri dihitung sebagai "lebih baru" — tidak memberi bisa diperbaiki manusia, memberi diam-diam tidak.

## Laporan diturunkan dari rencana yang sama

Bukan dari query kedua yang ditulis agar mirip. Dua penurunan atas "siapa yang kekurangan ini" adalah dua kesempatan menjawab berbeda, dan seluruh nilai laporan ini adalah ia **bisa dipercaya pada hari ia mengatakan nol**. Diuji secara struktural (setiap grant dan setiap skip non-`already_held` terhitung tepat sekali), bukan dengan mencocokkan angka harapan.

## Dua gerbang menagih, dan keduanya benar

- `modules:jobs:check` menuntut deskriptor job, supaya operator bisa **menemukan** perintah ini — tanpanya, satu-satunya cara mengetahuinya adalah membaca skripnya.
- `db:work-class:check` menolak entri untuk skrip yang memakai koneksi **app** alih-alih worker. Registry itu memang hanya tentang koneksi worker/setup — persis seperti `owner-permission-backfill` yang juga tidak ada di sana.

## Verifikasi

`bun run check` **PENUH** hijau — 40 segmen.

Bagian dari #423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)