### PR TITLE
feat(admin): layar Partner access — pencabutan berhenti menjadi panggilan API

### DIFF
--- a/.changeset/admin-partner-access-screen.md
+++ b/.changeset/admin-partner-access-screen.md
@@ -1,0 +1,44 @@
+---
+"awcms": minor
+---
+
+feat(admin): layar Partner access — pencabutan berhenti menjadi panggilan API
+
+`/admin/partners`, menutup tiga entri terakhir `partner_access` di
+`NOT_YET_SCREENED`. Alasannya bukan kelengkapan: **pencabutan adalah kontrol
+yang dicari pelanggan ketika ada yang salah**, dan sampai halaman ini ada ia
+adalah `DELETE` ke API — yang bekerja, dan yang tidak akan diingat siapa pun di
+bawah tekanan.
+
+Empat aksi, tiga permission, dan pemasangannya sengaja: menyewa dan memutus
+sama-sama `configure`; menyetujui dan mencabut sama-sama `assign`. Memisahkan
+salah satunya menghasilkan kombinasi yang tidak boleh ada — seseorang yang bisa
+memasukkan partner dan tidak bisa mengeluarkannya.
+
+TIDAK ADA PARTNER PICKER, DAN HALAMANNYA MENGATAKAN KENAPA. Sebuah `<select>`
+berisi partner akan menjadi direktori kemitraan lintas-tenant yang ADR-0089
+tolak sebagai tabel, dibangun ulang di UI. Pelanggan mengetikkan tenant id yang
+partnernya berikan di luar jalur — dan halaman menjelaskan itu alih-alih
+meninggalkan kolom UUID tanpa keterangan.
+
+KODE AKSES DITAMPILKAN SEKALI DAN HALAMANNYA TIDAK RELOAD. Ini satu-satunya
+layar admin yang membaca body respons alih-alih memuat ulang, karena respons
+persetujuan adalah satu-satunya tempat kode itu terbaca. Reload sesudah
+menyetujui berarti kredensial hilang dan grant yang harus dicabut lalu
+disetujui ulang. `sendJsonForData` ditambahkan untuk itu, dengan setengah
+error-nya tetap sempit: gagal berarti `data: null` dan `errorCode` yang sama,
+sehingga panggilan yang gagal tetap tidak bisa membocorkan apa pun.
+
+Role sistem disaring dari picker karena penebusan menolaknya
+(`materializeMembership`). Menawarkan `owner` akan gagal di ujung jauh
+penyerahan kode di luar jalur — momen terburuk untuk mengetahuinya.
+
+Test kontrak halamannya menemukan satu jebakan saat ditulis: asersi
+`not.toContain('action: "revoke"')` atas seluruh berkas GAGAL pada kode yang
+benar, karena rutenya juga menulis baris audit ber-`action: "revoke"`. **Action
+audit dan action guard adalah dua hal berbeda di repo ini** — permukaan restore
+office membuat pembedaan yang sama — dan test yang mencampurnya memerah pada
+kode yang benar, yang lebih buruk daripada tidak menguji. Asersinya kini membaca
+konstanta guard saja.
+
+`NOT_YET_SCREENED` menyusut dari 62 ke 59, dan itulah gunanya ia satu arah.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -109,8 +109,8 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
 | Migrasi                            | **121** (`sql/001`–`121`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
-| Layar admin                        | **34** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **47** (25.909 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Layar admin                        | **35** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Berkas `.astro`                    | **48** (26.424 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **41** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **3.1.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -355,6 +355,27 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN 13 Agustus 2026 (kedelapan belas) — layar `/admin/partners`:
+  pencabutan akses partner berhenti menjadi panggilan API.**
+
+  Menutup tiga entri terakhir `partner_access` di `NOT_YET_SCREENED` (62 → 59).
+  Yang mendorongnya bukan kelengkapan melainkan satu kalimat dari putaran
+  sebelumnya: pencabutan adalah kontrol yang dicari pelanggan ketika ada yang
+  salah, dan sampai halaman ini ada ia adalah `DELETE` yang tidak akan diingat
+  siapa pun di bawah tekanan.
+
+  **Tidak ada partner picker**, dan halamannya mengatakan kenapa — sebuah
+  `<select>` berisi partner adalah direktori lintas-tenant yang ADR-0089 tolak
+  sebagai tabel, dibangun ulang di UI. **Halaman ini juga tidak reload setelah
+  menyetujui**: respons persetujuan adalah satu-satunya tempat kode terbaca, dan
+  reload berarti kredensial hilang plus grant yang harus dicabut.
+
+  **Jebakan yang ditemukan saat menulis test kontraknya, dan layak diingat:**
+  asersi `not.toContain('action: "revoke"')` atas seluruh berkas rute GAGAL pada
+  kode yang BENAR, karena rutenya juga menulis baris audit ber-`action:
+"revoke"`. Action audit ≠ action guard; test yang mencampurnya memerah pada
+  kode yang benar.
 
 - **PUTARAN 13 Agustus 2026 (ketujuh belas) — ALUR PENGEMBANGAN PUNYA DOKUMEN
   KANONIK, dan satu langkahnya BERTENTANGAN dengan ADR yang berlaku.**

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -142,7 +142,7 @@
         }
       ],
       "permissionCount": 39,
-      "navigationCount": 6,
+      "navigationCount": 7,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 366   |
-| Berkas route                       | 343   |
+| Berkas test                        | 367   |
+| Berkas route                       | 344   |
 | ADR                                | 93    |
 
 ### Modul
@@ -324,7 +324,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 312        |
+| `(root)`      | 313        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |
@@ -334,7 +334,7 @@
 | Permukaan       | Berkas |
 | --------------- | ------ |
 | `/api/v1/**`    | 285    |
-| `/admin/**`     | 34     |
+| `/admin/**`     | 35     |
 | publik / anonim | 24     |
 
 <!-- END GENERATED: repo-inventory -->

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -118,22 +118,5 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "visitor_analytics.events.read",
   "visitor_analytics.retention.purge",
   "visitor_analytics.settings.read",
-  "visitor_analytics.settings.update",
-
-  // identity_access — partner access (3), Gelombang 8 PR 8.4 of #423.
-  //
-  // The endpoints landed with their permissions and no screen, which is exactly
-  // the case this ledger is for. Naming it plainly rather than reaching for
-  // `DELIBERATELY_UNSCREENED`: an operator absolutely SHOULD drive this from a
-  // page — approving a partner's access to your own tenant, and revoking it, is
-  // about as far from a machine-only operation as this repo has.
-  //
-  // One of the three carries more weight than an ordinary missing screen.
-  // Revocation is the control a customer reaches for when something is wrong,
-  // and today it is an API call. Until the screen exists, the runbook is
-  // `DELETE /api/v1/access/delegated-grants/{id}` — which works, and which
-  // nobody under pressure will remember.
-  "identity_access.partner_access.read",
-  "identity_access.partner_access.configure",
-  "identity_access.partner_access.assign"
+  "visitor_analytics.settings.update"
 ];

--- a/src/lib/ui/admin-form-client.ts
+++ b/src/lib/ui/admin-form-client.ts
@@ -97,3 +97,58 @@ export async function postJson(
 ): Promise<{ ok: boolean; errorCode: string | null }> {
   return sendJson("POST", url, body);
 }
+
+/**
+ * As {@link sendJson}, but ALSO returns the response `data` — for the one class
+ * of endpoint whose whole point is what it hands back.
+ *
+ * ## Why this is separate, and should stay rare
+ *
+ * `sendJson`'s narrow `{ ok, errorCode }` shape is deliberate (Issue #540):
+ * callers show a generic message keyed off `errorCode` and can never
+ * accidentally paint internal detail onto the page. Widening it for everyone
+ * would remove that property from 30-odd call sites to serve two.
+ *
+ * The exception exists for responses like the delegated-access approval, which
+ * returns a single-use code that appears EXACTLY ONCE and cannot be re-read.
+ * Discarding it would mean the operator has to revoke the grant and approve a
+ * new one — a worse outcome than the narrow shape protects against.
+ *
+ * The error half stays narrow: on failure this returns `data: null` and the
+ * same `errorCode`, so a failed call still cannot leak anything.
+ */
+export async function sendJsonForData<TData>(
+  method: "POST" | "PATCH" | "PUT" | "DELETE",
+  url: string,
+  body?: unknown,
+  extraHeaders?: Record<string, string>
+): Promise<{ ok: boolean; errorCode: string | null; data: TData | null }> {
+  try {
+    const hasBody = body !== undefined;
+    const headers: Record<string, string> = { ...extraHeaders };
+    if (hasBody) {
+      headers["Content-Type"] = "application/json";
+    }
+
+    const response = await fetch(url, {
+      method,
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+      body: hasBody ? JSON.stringify(body) : undefined,
+      credentials: "same-origin"
+    });
+
+    const payload = (await response.json().catch(() => null)) as {
+      success?: boolean;
+      data?: TData;
+      error?: { code?: string };
+    } | null;
+
+    if (response.ok && payload?.success === true) {
+      return { ok: true, errorCode: null, data: payload.data ?? null };
+    }
+
+    return { ok: false, errorCode: payload?.error?.code ?? null, data: null };
+  } catch {
+    return { ok: false, errorCode: "NETWORK_ERROR", data: null };
+  }
+}

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -137,6 +137,16 @@ export const identityAccessModule = defineModule({
       path: "/admin/security",
       order: 24,
       requiredPermission: "identity_access.sso_policy.read"
+    },
+    // ADR-0089/0090. Its own key, not the shared `access_control.read`: who
+    // from OUTSIDE the organisation can reach this tenant is a different
+    // question from the RBAC catalogue, and an operator who should see one need
+    // not see the other.
+    {
+      labelKey: "admin.layout.nav_partners",
+      path: "/admin/partners",
+      order: 26,
+      requiredPermission: "identity_access.partner_access.read"
     }
   ],
   jobs: [

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -205,6 +205,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_user_groups": "User groups",
   "admin.layout.nav_registrations": "Registration requests",
   "admin.layout.nav_security": "Authentication & security",
+  "admin.layout.nav_partners": "Partner access",
   "admin.layout.nav_seo": "SEO & distribution"
 };
 

--- a/src/pages/admin/partners.astro
+++ b/src/pages/admin/partners.astro
@@ -1,0 +1,515 @@
+---
+/**
+ * Partner access — ADR-0089/0090/0091, Gelombang 8 of Issue #423.
+ *
+ * The screen the wave shipped without, and the reason it mattered: revocation
+ * is the control a customer reaches for when something is wrong, and until this
+ * page existed it was a `DELETE` against the API — which works, and which
+ * nobody under pressure remembers.
+ *
+ * Every action posts to the real endpoints, so the ABAC guards, the audit rows
+ * and the session-killing all live there. The permission checks below decide
+ * what to RENDER, never what is allowed.
+ *
+ * ## Why engaging a partner asks for a UUID
+ *
+ * There is no partner picker, and there is not meant to be. ADR-0089 refused a
+ * readable directory of the platform's partners — a caller who could enumerate
+ * them would hold exactly the cross-tenant artefact the whole wave declined to
+ * build. The partner tells the customer their tenant id out of band, once. The
+ * page says so rather than leaving an unexplained UUID field.
+ *
+ * ## The access code is shown once, here, and never fetched again
+ *
+ * The approval response is the ONLY place the code exists in readable form.
+ * This screen therefore reads the response body (`sendJsonForData`) instead of
+ * reloading, and keeps the code on screen until the operator dismisses it. A
+ * reload after approval would be a lost credential and a grant to revoke.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { listRoles } from "../../modules/identity-access/application/access-directory";
+import {
+  listPartnerEngagements,
+  type PartnerEngagement
+} from "../../modules/identity-access/application/partner-engagement-store";
+import {
+  listDelegatedGrants,
+  type DelegatedGrantSummary
+} from "../../modules/identity-access/application/delegated-access-store";
+import { DELEGATED_ACCESS_MAX_TTL_DAYS } from "../../modules/identity-access/domain/delegated-access";
+
+const ssr = Astro.locals.ssrContext!;
+
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "partner_access",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time — concurrent queries on a
+    // single transaction connection leak it.
+    const engagements = await listPartnerEngagements(tx, ssr.tenantId);
+    const grants = await listDelegatedGrants(tx, ssr.tenantId);
+
+    const canConfigure = await can({
+      moduleKey: "identity_access",
+      activityCode: "partner_access",
+      action: "configure"
+    });
+    const canAssign = await can({
+      moduleKey: "identity_access",
+      activityCode: "partner_access",
+      action: "assign"
+    });
+
+    // System roles are dropped because redemption refuses them
+    // (`materializeMembership`). Offering `owner` here would present a control
+    // that fails in the operator's face at the far end of an out-of-band code
+    // handover — the worst possible moment to discover it.
+    const roles = canAssign
+      ? (await listRoles(tx, ssr.tenantId))
+          .filter((role) => !role.isSystem)
+          .map((role) => ({ id: role.id, roleCode: role.roleCode }))
+      : [];
+
+    return { engagements, grants, roles, canConfigure, canAssign };
+  },
+  onError: (error) => {
+    logAdminPageError(
+      "admin/partners.astro: failed to load partner access",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const engagements: PartnerEngagement[] =
+  screen.state === "allowed" ? screen.data.engagements : [];
+const grants: DelegatedGrantSummary[] =
+  screen.state === "allowed" ? screen.data.grants : [];
+const roles: { id: string; roleCode: string }[] =
+  screen.state === "allowed" ? screen.data.roles : [];
+const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
+const canAssign = screen.state === "allowed" && screen.data.canAssign;
+
+const partnerNames = new Map(
+  engagements.map((entry) => [entry.partnerTenantId, entry.partnerTenantName])
+);
+
+/** Live, expired, revoked — computed here so the table says it in one word. */
+function grantState(grant: DelegatedGrantSummary): string {
+  if (grant.revokedAt) return "Revoked";
+  if (grant.expiresAt.getTime() <= Date.now()) return "Expired";
+  return grant.redeemedAt ? "Active" : "Awaiting redemption";
+}
+
+function isLive(grant: DelegatedGrantSummary): boolean {
+  return !grant.revokedAt && grant.expiresAt.getTime() > Date.now();
+}
+
+const maxExpiry = new Date(
+  Date.now() + DELEGATED_ACCESS_MAX_TTL_DAYS * 24 * 60 * 60 * 1000
+)
+  .toISOString()
+  .slice(0, 10);
+---
+
+<AdminLayout title="Partner access">
+  <header class="page-header fade-in-up">
+    <h1 id="partners-heading">Partner access</h1>
+    <p class="page-description">
+      Who from outside this organisation can reach this tenant, and until when.
+      Severing a partnership revokes every grant under it — memberships
+      deactivated, sessions killed — in one step.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="partners-denied">
+        You do not have permission to view partner access.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="partners-load-error">
+        Could not load partner access. Please try again.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <>
+        <p
+          id="partners-action-error"
+          class="state-notice"
+          role="alert"
+          hidden
+        />
+
+        <section
+          class="fade-in-up"
+          aria-labelledby="partners-engagements-heading"
+        >
+          <h2 id="partners-engagements-heading">Partnerships</h2>
+
+          {canConfigure && (
+            <form id="engage-partner-form" class="admin-form">
+              <p class="page-description">
+                There is no partner directory to pick from, on purpose: a list
+                of every partnership on this platform is exactly the
+                cross-tenant artefact this design refuses to build. Ask your
+                partner for their tenant id.
+              </p>
+              <label for="engage-partner-tenant-id">Partner tenant id</label>
+              <input
+                id="engage-partner-tenant-id"
+                name="partnerTenantId"
+                type="text"
+                required
+                autocomplete="off"
+                placeholder="00000000-0000-0000-0000-000000000000"
+              />
+              <button type="submit" id="engage-partner-submit">
+                Engage partner
+              </button>
+            </form>
+          )}
+
+          {engagements.length === 0 ? (
+            <div class="empty-state" id="partners-engagements-empty">
+              <p class="empty-state-title">Nobody from outside</p>
+              <p class="empty-state-text">No partner reaches this tenant.</p>
+            </div>
+          ) : (
+            <div class="data-table-scroll">
+              <table class="data-table data-table--stack">
+                <thead>
+                  <tr>
+                    <th scope="col">Partner</th>
+                    <th scope="col">Tenant id</th>
+                    <th scope="col">Engaged</th>
+                    {canConfigure && <th scope="col">Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {engagements.map((entry) => (
+                    <tr>
+                      <th scope="row" data-label="Partner">
+                        {entry.partnerTenantName}
+                      </th>
+                      <td data-label="Tenant id">
+                        <code class="cell-code">{entry.partnerTenantId}</code>
+                      </td>
+                      <td data-label="Engaged">
+                        {entry.engagedAt.toISOString().slice(0, 10)}
+                      </td>
+                      {canConfigure && (
+                        <td data-label="Actions">
+                          <button
+                            type="button"
+                            class="js-sever-engagement"
+                            data-engagement-id={entry.id}
+                          >
+                            Sever
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+
+        <section class="fade-in-up" aria-labelledby="partners-grants-heading">
+          <h2 id="partners-grants-heading">Delegated access</h2>
+
+          <div
+            id="partners-access-code"
+            class="state-notice"
+            role="alert"
+            hidden
+          />
+
+          {canAssign && engagements.length > 0 && roles.length > 0 && (
+            <form id="approve-grant-form" class="admin-form">
+              <p class="page-description">
+                The code appears once, on this page, and cannot be read again.
+                Hand it to your partner out of band. Access lasts at most{" "}
+                {DELEGATED_ACCESS_MAX_TTL_DAYS} days.
+              </p>
+
+              <label for="approve-partner">Partner</label>
+              <select id="approve-partner" name="partnerTenantId" required>
+                {engagements.map((entry) => (
+                  <option value={entry.partnerTenantId}>
+                    {entry.partnerTenantName}
+                  </option>
+                ))}
+              </select>
+
+              <label for="approve-role">Role they will hold</label>
+              <select id="approve-role" name="roleId" required>
+                {roles.map((role) => (
+                  <option value={role.id}>{role.roleCode}</option>
+                ))}
+              </select>
+
+              <label for="approve-purpose">Why</label>
+              <input
+                id="approve-purpose"
+                name="purpose"
+                type="text"
+                required
+                maxlength="500"
+                placeholder="Incident 4711 — checkout errors"
+              />
+
+              <label for="approve-expires">Until</label>
+              <input
+                id="approve-expires"
+                name="expiresAt"
+                type="date"
+                required
+                max={maxExpiry}
+              />
+
+              <button type="submit" id="approve-grant-submit">
+                Approve access
+              </button>
+            </form>
+          )}
+
+          {grants.length === 0 ? (
+            <div class="empty-state" id="partners-grants-empty">
+              <p class="empty-state-title">No access granted</p>
+              <p class="empty-state-text">
+                Nobody outside this organisation has been given a way in.
+              </p>
+            </div>
+          ) : (
+            <div class="data-table-scroll">
+              <table class="data-table data-table--stack">
+                <thead>
+                  <tr>
+                    <th scope="col">Partner</th>
+                    <th scope="col">Why</th>
+                    <th scope="col">Until</th>
+                    <th scope="col">State</th>
+                    {canAssign && <th scope="col">Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {grants.map((grant) => (
+                    <tr>
+                      <th scope="row" data-label="Partner">
+                        {partnerNames.get(grant.partnerTenantId) ??
+                          grant.partnerTenantId}
+                      </th>
+                      <td data-label="Why">{grant.purpose}</td>
+                      <td data-label="Until">
+                        {grant.expiresAt.toISOString().slice(0, 10)}
+                      </td>
+                      <td data-label="State">{grantState(grant)}</td>
+                      {canAssign && (
+                        <td data-label="Actions">
+                          {isLive(grant) ? (
+                            <button
+                              type="button"
+                              class="js-revoke-grant"
+                              data-grant-id={grant.id}
+                            >
+                              Revoke
+                            </button>
+                          ) : (
+                            <span class="cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time). The
+  // import forces Astro to emit this EXTERNAL, where the app's
+  // `default-src 'self'` CSP allows it.
+  import {
+    lockElement,
+    sendJson,
+    sendJsonForData
+  } from "../../lib/ui/admin-form-client";
+
+  const errorBox = document.getElementById("partners-action-error");
+  const codeBox = document.getElementById("partners-access-code");
+
+  function showError(message: string): void {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.hidden = false;
+  }
+
+  function clearError(): void {
+    if (errorBox) errorBox.hidden = true;
+  }
+
+  document
+    .getElementById("engage-partner-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearError();
+
+      const input = document.getElementById(
+        "engage-partner-tenant-id"
+      ) as HTMLInputElement | null;
+      const button = document.getElementById(
+        "engage-partner-submit"
+      ) as HTMLButtonElement | null;
+      if (!input || !button) return;
+
+      const unlock = lockElement(button, "Please wait…");
+      const result = await sendJson(
+        "POST",
+        "/api/v1/access/partner-engagements",
+        {
+          partnerTenantId: input.value.trim()
+        }
+      );
+
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+
+      showError(
+        result.errorCode === "CONFLICT"
+          ? "That partner is already engaged for this tenant."
+          : result.errorCode === "NOT_FOUND"
+            ? "No such partner. Check the tenant id with them — it is not something this page can look up."
+            : "Could not engage that partner. Please try again."
+      );
+      unlock();
+    });
+
+  document
+    .getElementById("approve-grant-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearError();
+
+      const form = event.currentTarget as HTMLFormElement;
+      const button = document.getElementById(
+        "approve-grant-submit"
+      ) as HTMLButtonElement | null;
+      if (!button) return;
+
+      const data = new FormData(form);
+      const expiresAt = String(data.get("expiresAt") ?? "");
+
+      const unlock = lockElement(button, "Please wait…");
+      const result = await sendJsonForData<{ accessCode?: string }>(
+        "POST",
+        "/api/v1/access/delegated-grants",
+        {
+          partnerTenantId: String(data.get("partnerTenantId") ?? ""),
+          roleId: String(data.get("roleId") ?? ""),
+          purpose: String(data.get("purpose") ?? ""),
+          // A `date` input gives midnight LOCAL; send the end of that day in
+          // UTC so "until the 20th" does not silently mean "until the 19th
+          // evening" for anyone east of Greenwich.
+          expiresAt: expiresAt ? `${expiresAt}T23:59:00.000Z` : ""
+        }
+      );
+
+      if (result.ok && result.data?.accessCode) {
+        // NOT a reload. This is the only time the code is readable, and
+        // reloading would spend a grant that then has to be revoked.
+        if (codeBox) {
+          codeBox.textContent = `Access code (shown once — copy it now): ${result.data.accessCode}`;
+          codeBox.hidden = false;
+        }
+        unlock();
+        return;
+      }
+
+      showError(
+        result.errorCode === "NOT_FOUND"
+          ? "That partner is no longer engaged, or that role no longer exists here."
+          : result.errorCode === "VALIDATION_ERROR"
+            ? "Check the date and the reason — access cannot start in the past or run past the maximum."
+            : "Could not approve access. Please try again."
+      );
+      unlock();
+    });
+
+  document.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement | null)?.closest("button");
+    if (!(target instanceof HTMLButtonElement)) return;
+
+    if (target.classList.contains("js-sever-engagement")) {
+      const engagementId = target.dataset.engagementId;
+      if (!engagementId) return;
+
+      void (async () => {
+        clearError();
+        const unlock = lockElement(target, "Please wait…");
+        const result = await sendJson(
+          "DELETE",
+          `/api/v1/access/partner-engagements/${engagementId}`
+        );
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showError("Could not sever that partnership. Please try again.");
+        unlock();
+      })();
+      return;
+    }
+
+    if (target.classList.contains("js-revoke-grant")) {
+      const grantId = target.dataset.grantId;
+      if (!grantId) return;
+
+      void (async () => {
+        clearError();
+        const unlock = lockElement(target, "Please wait…");
+        const result = await sendJson(
+          "DELETE",
+          `/api/v1/access/delegated-grants/${grantId}`
+        );
+        if (result.ok) {
+          window.location.reload();
+          return;
+        }
+        showError(
+          result.errorCode === "NOT_FOUND"
+            ? "That access was already revoked or has expired."
+            : "Could not revoke that access. Please try again."
+        );
+        unlock();
+      })();
+    }
+  });
+</script>

--- a/tests/admin-partners-page-contract.test.ts
+++ b/tests/admin-partners-page-contract.test.ts
@@ -1,0 +1,165 @@
+/**
+ * `/admin/partners` gates against the endpoints it drives — ADR-0089/0090.
+ *
+ * Sibling of the other page-contract tests, for the same silent failure: a page
+ * gating on a permission key no migration seeds hides the control from EVERYONE
+ * — including the owner — while still looking like a working screen. This repo
+ * has shipped that bug twice by inventing a plausible action name.
+ *
+ * This screen sets two traps of its own:
+ *
+ * - **Engaging and severing share ONE permission**, `partner_access.configure`.
+ *   A page that gated Sever on a `partner_access.delete` it invented would hide
+ *   the control that ENDS another organisation's access — from the person most
+ *   likely to be reaching for it in a hurry.
+ * - **Approving and revoking share `partner_access.assign`**, not `create` and
+ *   not `revoke`. The permission is the authority to hand a role to somebody
+ *   outside, and taking it back is the same authority.
+ *
+ * It also pins the two properties that are the point of the whole surface: the
+ * access code is never re-fetched, and there is no partner directory.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/partners.astro";
+const ROUTES = [
+  "src/pages/api/v1/access/partner-engagements/index.ts",
+  "src/pages/api/v1/access/partner-engagements/[id].ts",
+  "src/pages/api/v1/access/delegated-grants/index.ts",
+  "src/pages/api/v1/access/delegated-grants/[id].ts"
+];
+
+const EXPECTED = [
+  "identity_access.partner_access.read",
+  "identity_access.partner_access.configure",
+  "identity_access.partner_access.assign"
+];
+
+describe("/admin/partners gates on keys that really exist", () => {
+  test("every key the page names is DECLARED by a module", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const declared = new Set<string>();
+    for (const module of listModules()) {
+      for (const permission of module.permissions ?? []) {
+        declared.add(
+          `${module.key}.${permission.activityCode}.${permission.action}`
+        );
+      }
+    }
+
+    for (const key of EXPECTED) {
+      const [, activityCode, action] = key.split(".");
+      // The page states its guards as `AccessRequest` object literals, the same
+      // shape the routes use.
+      expect(page).toContain(`activityCode: "${activityCode}"`);
+      expect(page).toContain(`action: "${action}"`);
+      expect(declared.has(key)).toBe(true);
+    }
+  });
+
+  test("the page and its four endpoints agree on the activity", async () => {
+    // A page gating on `partner_access` while an endpoint gates on something
+    // else is a control that renders and then 403s — the shape that reads as a
+    // broken product rather than a wrong gate.
+    for (const route of ROUTES) {
+      const source = await readFile(route, "utf8");
+      expect(source).toContain('activityCode: "partner_access"');
+    }
+  });
+
+  /**
+   * Reads the GUARD constant only.
+   *
+   * A whole-file `not.toContain` would be wrong here, and wrongly: both routes
+   * also write an audit row whose `action` is the DOMAIN verb (`delete`,
+   * `revoke`). Audit action and guard action are different things in this repo
+   * — the offices restore surface makes the same distinction — and a test that
+   * conflates them fails on correct code, which is worse than not testing.
+   */
+  function guardBlock(source: string, name: string): string {
+    const start = source.indexOf(`const ${name} = {`);
+    return source.slice(start, source.indexOf("} as const;", start));
+  }
+
+  test("severing is gated on `configure`, not an invented delete", async () => {
+    const guard = guardBlock(
+      await readFile(
+        "src/pages/api/v1/access/partner-engagements/[id].ts",
+        "utf8"
+      ),
+      "CONFIGURE_GUARD"
+    );
+
+    expect(guard).toContain('action: "configure"');
+    expect(guard).not.toContain('action: "delete"');
+  });
+
+  test("revoking is gated on `assign`, not an invented revoke", async () => {
+    const guard = guardBlock(
+      await readFile(
+        "src/pages/api/v1/access/delegated-grants/[id].ts",
+        "utf8"
+      ),
+      "ASSIGN_GUARD"
+    );
+
+    expect(guard).toContain('action: "assign"');
+    expect(guard).not.toContain('action: "revoke"');
+  });
+});
+
+describe("the two properties the surface exists to keep", () => {
+  test("approval does NOT reload — the code would be lost", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const approveBlock = page.slice(
+      page.indexOf('getElementById("approve-grant-form")'),
+      page.indexOf('document.addEventListener("click"')
+    );
+
+    // It reads the response body instead. A reload here spends a grant that
+    // then has to be revoked and re-approved.
+    expect(approveBlock).toContain("sendJsonForData");
+    expect(approveBlock).toContain("accessCode");
+    expect(approveBlock).not.toContain("window.location.reload()");
+  });
+
+  test("there is no partner picker, and the page says why", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // ADR-0089 refused a readable directory of the platform's partners. A
+    // `<select>` of partners here would be that directory, rebuilt in the UI.
+    expect(page).toContain("no partner directory to pick from");
+    expect(page).toContain('id="engage-partner-tenant-id"');
+  });
+
+  test("system roles never reach the role picker", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Redemption refuses them (`materializeMembership`). Offering `owner` would
+    // fail at the far end of an out-of-band code handover — the worst moment to
+    // find out.
+    expect(page).toContain("filter((role) => !role.isSystem)");
+  });
+});
+
+describe("the ledger shrank, and stayed shrunk", () => {
+  test("no `partner_access` key is left on NOT_YET_SCREENED", async () => {
+    const { NOT_YET_SCREENED } =
+      await import("../scripts/admin-screen-coverage-ledger");
+
+    // The ledger may only shrink, and this is what makes its length mean
+    // something: a screen that exists while its keys sit here is a claim that
+    // the work is undone when it is done.
+    expect(
+      NOT_YET_SCREENED.filter((key) => key.includes("partner_access"))
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
`/admin/partners`, menutup **tiga entri terakhir `partner_access`** di `NOT_YET_SCREENED` (62 → 59).

Alasannya bukan kelengkapan. Dari putaran sebelumnya: **pencabutan adalah kontrol yang dicari pelanggan ketika ada yang salah**, dan sampai halaman ini ada ia adalah `DELETE /api/v1/access/delegated-grants/{id}` — yang bekerja, dan yang tidak akan diingat siapa pun di bawah tekanan.

## Empat aksi, tiga permission, dan pemasangannya sengaja

| Aksi | Guard |
| --- | --- |
| Lihat kemitraan + grant | `partner_access.read` |
| Sewa partner / **putus** kemitraan | `partner_access.configure` |
| Setujui akses / **cabut** akses | `partner_access.assign` |

Memisahkan salah satu pasangan menghasilkan kombinasi yang tidak boleh ada: seseorang yang bisa memasukkan partner dan tidak bisa mengeluarkannya.

## Dua properti yang halaman ini ada untuk menjaga

**Tidak ada partner picker, dan halamannya mengatakan kenapa.** Sebuah `<select>` berisi partner adalah direktori kemitraan lintas-tenant yang [ADR-0089](docs/adr/0089-a-partner-is-an-ordinary-tenant.md) tolak sebagai tabel, dibangun ulang di UI. Pelanggan mengetikkan tenant id yang partnernya berikan di luar jalur — dan halaman menjelaskan itu alih-alih meninggalkan kolom UUID tanpa keterangan.

**Kode akses ditampilkan sekali, dan halamannya TIDAK reload.** Ini satu-satunya layar admin yang membaca body respons: respons persetujuan adalah satu-satunya tempat kode itu terbaca, dan reload sesudah menyetujui berarti kredensial hilang plus grant yang harus dicabut lalu disetujui ulang. `sendJsonForData` ditambahkan untuk itu — setengah error-nya tetap sempit (`data: null` + `errorCode` yang sama), jadi panggilan yang gagal tetap tidak bisa membocorkan apa pun.

Role sistem disaring dari picker karena penebusan menolaknya (`materializeMembership`). Menawarkan `owner` akan gagal di ujung jauh penyerahan kode di luar jalur — momen terburuk untuk mengetahuinya.

## Satu jebakan yang ditemukan saat menulis test kontraknya

Asersi `not.toContain('action: "revoke"')` atas **seluruh berkas rute** GAGAL pada kode yang **benar**: rutenya juga menulis baris audit ber-`action: "revoke"`.

**Action audit dan action guard adalah dua hal berbeda di repo ini** — permukaan restore office membuat pembedaan yang sama — dan test yang mencampurnya memerah pada kode yang benar, yang lebih buruk daripada tidak menguji. Asersinya kini membaca konstanta guard saja, dan alasannya ditulis di test supaya tidak "disederhanakan" kembali.

`bun run check` hijau (41 gerbang, **4072 test**, build). 35 layar admin kini mengklaim 146 dari 221 permission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)