### PR TITLE
feat(auth): kredensial mesin kelas-tulis bisa DITERBITKAN — dan izinnya sendiri (ADR-0092, #423)

### DIFF
--- a/.changeset/machine-credential-write-issuance.md
+++ b/.changeset/machine-credential-write-issuance.md
@@ -1,0 +1,56 @@
+---
+"awcms": minor
+---
+
+feat(auth): kredensial mesin kelas-tulis bisa DITERBITKAN — dan izinnya sendiri (ADR-0092, #423)
+
+`sql/121` membuka kelas tulis di skema dan di chokepoint, lalu sengaja berhenti:
+kolomnya ada, gerbangnya menegakkannya, dan tidak ada rute yang bisa menerbitkan
+satu pun. Ini menutup celah itu — tercatat sebagai sisa #423 nomor 1 di
+`docs/PROJECT_STATE.md` §4.
+
+IZINNYA BARU, DAN ITU SELURUH KEPUTUSANNYA. Bentuk yang jelas adalah menerima
+`allowedWriteActions` pada `machine_credentials.create` yang sudah ada. Bentuk itu
+salah, dan salahnya hanya terlihat kalau ditanyakan dari sisi grant: setiap peran
+yang hari ini memegang `create` akan MENDAPAT hak mencetak kredensial yang mengubah
+data pada hari rilis — pelebaran tanpa satu grant pun disunting, tanpa satu baris pun
+di diff untuk di-review, dan tanpa apa pun di jejak audit yang menandainya. Program
+#423 dibangun di atas aturan sebaliknya. Jadi kelas tulis mendapat aktivitas ketiga,
+`machine_credentials_write.create` (`sql/122`), dan default-deny menahan sisanya:
+sampai seseorang memberikannya dengan sengaja, rute itu menjawab 403 untuk setiap
+permintaan tulis dan berperilaku persis seperti sebelum `sql/121`.
+
+`revoke` TIDAK ikut dipecah, dan itu keputusan: saat insiden, siapa pun yang bisa
+membunuh kredensial bocor harus bisa membunuh SETIAP kelasnya. Izin cabut yang
+berhenti di kelas baca adalah alat penahanan yang gagal justru pada kredensial yang
+paling perlu ditahan.
+
+CIDR PADA KREDENSIAL BACA DITOLAK, dan arah ini tidak dijaga apa pun selain validator
+ini. `isMachineCredentialWriteRefused` menjawab "tidak ditolak" untuk `read` SEBELUM
+ia menyentuh daftar CIDR — jadi menyimpan jaringan pada kredensial baca menggambarkan
+ikatan yang tidak pernah dikonsultasi. Basis data mengizinkannya, gerbang runtime
+tidak peduli, dan operator akan mengira ia mengikatnya. Ditolak, bukan dibuang
+diam-diam: membuangnya meninggalkan keyakinan yang sama.
+
+CIDR YANG TIDAK BISA DI-PARSE DITOLAK DI PENERBITAN, meski penegakan sudah aman
+terhadapnya. Keduanya sengaja menjawab pertanyaan berbeda: saat request, entri tak
+terbaca MENYEMPIT ke nol; saat penerbitan, penyempitan diam itu justru cacatnya —
+`10.0.0.0/33` menghasilkan kredensial yang terbaca terikat dan tidak pernah bisa
+lolos. `10.0.0.0/` ikut ditolak karena `Number("")` adalah 0, dan prefix nol adalah
+seluruh internet.
+
+SATU CACAT DITEMUKAN OLEH TEST-NYA SENDIRI. Kelas tulis awalnya diturunkan dari aksi
+yang LOLOS parse, bukan yang DIMINTA. Akibatnya permintaan ber-`delete` dengan CIDR
+yang benar dikembalikan sebagai read-only, lalu dimarahi soal CIDR-nya — satu
+kesalahan, dua pesan, dan yang kedua membantah apa yang jelas-jelas diminta.
+
+DIVERIFIKASI DENGAN MENJALANKAN. Tiga mutasi memerahkan test yang tepat: menghapus
+kolom dari satu dari TIGA daftar proyeksi (1 merah), menyamakan kedua cabang guard
+menjadi `machine_credentials` (4 merah), dan menghapus penolakan CIDR-pada-kelas-baca
+(6 merah). Kontrak konsumen ADR-0065 diregenerasi dengan sengaja — diff-nya hanya
+prosa plus dua properti OPSIONAL, nol rename, nol penghapusan, nol field menjadi
+wajib, sehingga build `awcms-astro` tidak bisa pecah karenanya.
+
+`NOT_YET_SCREENED` tumbuh 59 → 60. Kredensial mesin belum punya layar sama sekali,
+dan layar yang bisa mencetak kelas TULIS sementara kelas baca tetap panggilan API
+adalah layar yang salah untuk dibangun lebih dulu.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -39,7 +39,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > Keluarga hari ini dua repo, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (halaman publik + permukaan admin USER, ADR-0070). **KOREKSI:** versi sebelumnya menyatakan
 > implementasi ini "baru fondasi Sprint 1–2" dengan empat modul — itu **sudah
-> lama tidak benar**. Repo ini punya **22 modul terdaftar** dan `sql/001`–`sql/121`;
+> lama tidak benar**. Repo ini punya **22 modul terdaftar** dan `sql/001`–`sql/122`;
 > lihat [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) untuk daftar nyata.
 > Skill yang badannya masih menandai dirinya "BACAAN SAJA" tetap begitu — itu
 > per-skill, bukan pernyataan tentang repo secara keseluruhan.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Sebagai template yang di-ship, base menyediakan **modul fondasi reusable + kontr
 modul domain ERP (finance, inventory, procurement, manufacturing, hr-payroll, dst.)
 **ditambahkan langsung di `src/modules/` template ini** saat dipakai, bukan di repo
 ekstensi/turunan terpisah (jalur aplikasi-turunan DIHAPUS — lihat §Komposisi modul di
-bawah). Repo ini punya **22 modul terdaftar**, migration `sql/001`-`sql/121`, RLS
+bawah). Repo ini punya **22 modul terdaftar**, migration `sql/001`-`sql/122`, RLS
 `FORCE` di seluruh tabel tenant-scoped, pemisahan role database, dan admin UI read+write
 (Issue #166, #171). Dokumen ini menjelaskan apa yang **ada di kode saat ini**. Untuk detail
 per modul, lihat `README.md` masing-masing di `src/modules/<module>/`.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -107,7 +107,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Changeset menunggu (per tipe bump) | _jalankan perintah di kolom kanan_                                                      | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commit sejak rilis terakhir        | _jalankan perintah di kolom kanan_                                                      | `git rev-list --count v8.1.0..HEAD`                                                     |
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
-| Migrasi                            | **121** (`sql/001`–`121`)                                                               | `ls sql/`                                                                               |
+| Migrasi                            | **122** (`sql/001`–`122`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
 | Layar admin                        | **35** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Berkas `.astro`                    | **48** (26.424 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
@@ -355,6 +355,48 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN 13 Agustus 2026 (kedua puluh) — KREDENSIAL MESIN KELAS-TULIS BISA
+  DITERBITKAN, dan izinnya sendiri.**
+
+  Menutup sisa #423 nomor 1. `sql/122` + dua field opsional pada
+  `POST /api/v1/access/machine-credentials`; tanpa ADR baru, karena ADR-0092
+  §Konsekuensi sudah menamai permukaan ini sebagai pekerjaan lanjutan, bukan
+  keputusan yang belum diambil.
+
+  **Izinnya BARU, dan itu seluruh keputusannya.** Bentuk yang jelas adalah
+  menerima `allowedWriteActions` pada `machine_credentials.create` yang sudah
+  ada. Salahnya hanya terlihat kalau ditanyakan dari sisi grant: setiap peran
+  yang hari ini memegang `create` akan MENDAPAT hak mencetak kredensial yang
+  mengubah data pada hari rilis — pelebaran tanpa satu grant pun disunting, tanpa
+  satu baris di diff untuk di-review. Jadi kelas tulis mendapat aktivitas ketiga,
+  `machine_credentials_write.create`. `revoke` sengaja TIDAK ikut dipecah: saat
+  insiden, siapa pun yang bisa membunuh kredensial bocor harus bisa membunuh
+  setiap kelasnya.
+
+  **CIDR pada kredensial BACA ditolak, dan tidak ada apa pun selain validator itu
+  yang menjaga arah tersebut.** `isMachineCredentialWriteRefused` menjawab "tidak
+  ditolak" untuk `read` SEBELUM menyentuh daftar CIDR — basis data mengizinkan
+  baris seperti itu dan gerbang runtime tidak peduli, sehingga operator akan
+  mengira ia mengikat sesuatu yang tidak pernah dikonsultasi.
+
+  **Jebakan gerbang yang layak diingat, dan biayanya nyata:**
+  `access:permissions:enforcement:check` membaca guard sebagai **literal objek
+  ber-tiga-kunci**. Percobaan pertama menulis guard-nya sebagai satu literal
+  dengan ternary pada `activityCode`, dan gerbangnya melaporkan **kedua** izin
+  "enforced by nothing" — termasuk yang sudah ditegakkan sebelum PR ini. Bentuk
+  yang benar adalah dua literal UTUH di kedua cabang; melebarkan gerbangnya agar
+  muat pada preferensi penulisan adalah pertukaran yang salah arah.
+
+  **Satu cacat ditemukan oleh test-nya sendiri:** kelas tulis awalnya diturunkan
+  dari aksi yang LOLOS parse, bukan yang DIMINTA, sehingga permintaan ber-`delete`
+  dengan CIDR benar dikembalikan sebagai read-only lalu dimarahi soal CIDR-nya.
+  Satu kesalahan, dua pesan, dan yang kedua membantah permintaannya.
+
+  Kontrak konsumen ADR-0065 **diregenerasi dengan sengaja** — diff-nya prosa plus
+  dua properti OPSIONAL, nol rename, nol penghapusan, nol field menjadi wajib.
+  Teks "read-only" di kontrak sudah menjadi klaim palsu sejak ADR-0092 mendarat;
+  itu ikut dibetulkan di sini. `NOT_YET_SCREENED` 59 → 60.
 
 - **PUTARAN 13 Agustus 2026 (kesembilan belas) — TIGA CELAH ALUR DITUTUP.**
 

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -832,14 +832,18 @@ Gated on `identity_access.machine_credentials.read`. Returns derived `active`/`e
 | 401    | Missing or invalid session.                                 | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.                                 | [`ApiError`](#standard-error-envelope) |
 
-### `POST /api/v1/access/machine-credentials` — Issue a read-only machine credential (high-risk; audit-logged).
+### `POST /api/v1/access/machine-credentials` — Issue a machine credential (high-risk; audit-logged).
 
 - **operationId**: `accessIssueMachineCredential`
 - **Security**: bearerAuth + tenantHeader
 
-Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again. Gated on `identity_access.machine_credentials.create`.
+Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again.
 
-The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential. Requests authenticated this way are refused unless the action is read-only (ADR-0049 §3).
+The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential.
+
+TWO CLASSES, TWO PERMISSIONS. Omit `allowedWriteActions` and this is the read-only credential of ADR-0049 §3, gated on `identity_access.machine_credentials.create`; requests it makes are refused unless the action is `read`. Name write actions and it is the ADR-0092 write class, gated on `identity_access.machine_credentials_write.create` INSTEAD — a separate key so that opening this class does not hand write-minting authority to every role that already holds `create`.
+
+The write class is narrower in every other direction: only actions in the code ceiling (`create`, `update` — never a high-risk one), at least one `allowedIpCidrs` entry, at most 30 days, and a request whose caller IP is unknown is refused rather than exempted.
 
 Not idempotency-keyed, deliberately: replaying the response would mean persisting the plaintext token.
 
@@ -1513,7 +1517,7 @@ Every rejection — unknown client, non-allow-listed URI, a URI carrying a query
 - **operationId**: `redeemSessionHandoffCode`
 - **Security**: bearerAuth + tenantHeader
 
-ADR-0050. The only endpoint here authenticated by a **client secret** rather than a session: this is the request that obtains a session, so there is none to present yet. Not a machine credential either — those are read-only by construction (ADR-0049), and a read-only principal minting a human session would be an escalation path.
+ADR-0050. The only endpoint here authenticated by a **client secret** rather than a session: this is the request that obtains a session, so there is none to present yet. Not a machine credential either. ADR-0092 lets one write inside a narrow ceiling (`create`/`update`, never a high-risk action), and minting a human session is precisely the authority that ceiling exists to keep away from a non-human bearer.
 
 Call it from the BFF's SERVER. The token must never reach a browser: the BFF stores it server-side and gives the browser its own portal cookie.
 
@@ -9286,12 +9290,20 @@ sectionType cannot be changed after creation — omit it, do not send the old or
 
 ### Schema: IssueMachineCredentialRequest
 
-| Field                   | Type               | Required | Nullable | Description                                                                                                                                              |
-| ----------------------- | ------------------ | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                  | string             | yes      | no       | Operator-facing label, e.g. "awcms-astro build feed".                                                                                                    |
-| `tenantUserId`          | string (uuid)      | yes      | no       | An existing tenant user in THIS tenant (the service account).                                                                                            |
-| `allowedPermissionKeys` | array of string    | yes      | no       | Permission keys (`module.activity.action`) this credential may use. Required and non-empty — an empty list means "can do nothing", never "unrestricted". |
-| `expiresAt`             | string (date-time) | yes      | no       | Required, in the future, at most 365 days away. There is no perpetual credential.                                                                        |
+| Field                   | Type                              | Required | Nullable | Description                                                                                                                                                                        |
+| ----------------------- | --------------------------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                  | string                            | yes      | no       | Operator-facing label, e.g. "awcms-astro build feed".                                                                                                                              |
+| `tenantUserId`          | string (uuid)                     | yes      | no       | An existing tenant user in THIS tenant (the service account).                                                                                                                      |
+| `allowedPermissionKeys` | array of string                   | yes      | no       | Permission keys (`module.activity.action`) this credential may use. Required and non-empty — an empty list means "can do nothing", never "unrestricted".                           |
+| `allowedWriteActions`   | array of enum(`create`, `update`) | no       | no       | ADR-0092. OPTIONAL — omitting it (or sending an empty array) issues the read-only credential of ADR-0049, which is what every caller written before this class got and still gets. |
+
+Naming any action switches the guard to `identity_access.machine_credentials_write.create` and makes `allowedIpCidrs` mandatory. `read` is REJECTED here rather than accepted as a no-op: every credential may already read whatever its `allowedPermissionKeys` name, and accepting it would suggest otherwise.
+|
+| `allowedIpCidrs` | array of string | no | no | ADR-0092. IPv4/IPv6 literals or CIDR blocks. Required and non-empty when `allowedWriteActions` is non-empty, and REJECTED when it is empty — a read-only credential is not restricted by this list, so accepting one would describe a binding that is not enforced.
+
+Unparseable entries are refused at issuance. At request time an unreadable entry matches nothing, so the failure would otherwise be a credential that reads as bound and can never authenticate.
+|
+| `expiresAt` | string (date-time) | yes | no | Required, in the future, at most 365 days away — or at most 30 days when `allowedWriteActions` is non-empty. There is no perpetual credential. |
 
 **Example**
 
@@ -9300,6 +9312,8 @@ sectionType cannot be changed after creation — omit it, do not send the old or
   "name": "string",
   "tenantUserId": "00000000-0000-0000-0000-000000000000",
   "allowedPermissionKeys": ["string"],
+  "allowedWriteActions": ["create"],
+  "allowedIpCidrs": ["string"],
   "expiresAt": "2026-01-01T00:00:00.000Z"
 }
 ```

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -141,7 +141,7 @@
           "optional": false
         }
       ],
-      "permissionCount": 39,
+      "permissionCount": 40,
       "navigationCount": 7,
       "jobCount": 3,
       "hasHealthCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -8,11 +8,11 @@
 | Aspek                              | Nilai |
 | ---------------------------------- | ----- |
 | Modul terdaftar                    | 22    |
-| Migrasi                            | 121   |
+| Migrasi                            | 122   |
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 367   |
+| Berkas test                        | 368   |
 | Berkas route                       | 344   |
 | ADR                                | 93    |
 
@@ -168,6 +168,7 @@
 | 119 | `sql/119_awcms_partner_surface.sql`                                |
 | 120 | `sql/120_awcms_grant_outlives_engagement.sql`                      |
 | 121 | `sql/121_awcms_machine_credential_write_class.sql`                 |
+| 122 | `sql/122_awcms_identity_machine_credential_write_permissions.sql`  |
 
 ### Tabel & Row-Level Security
 
@@ -324,7 +325,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 313        |
+| `(root)`      | 314        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -531,11 +531,15 @@ paths:
       operationId: accessIssueMachineCredential
       tags:
         - Identity & Access
-      summary: Issue a read-only machine credential (high-risk; audit-logged).
+      summary: Issue a machine credential (high-risk; audit-logged).
       description: |
-        Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again. Gated on `identity_access.machine_credentials.create`.
+        Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again.
 
-        The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential. Requests authenticated this way are refused unless the action is read-only (ADR-0049 §3).
+        The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential.
+
+        TWO CLASSES, TWO PERMISSIONS. Omit `allowedWriteActions` and this is the read-only credential of ADR-0049 §3, gated on `identity_access.machine_credentials.create`; requests it makes are refused unless the action is `read`. Name write actions and it is the ADR-0092 write class, gated on `identity_access.machine_credentials_write.create` INSTEAD — a separate key so that opening this class does not hand write-minting authority to every role that already holds `create`.
+
+        The write class is narrower in every other direction: only actions in the code ceiling (`create`, `update` — never a high-risk one), at least one `allowedIpCidrs` entry, at most 30 days, and a request whose caller IP is unknown is refused rather than exempted.
 
         Not idempotency-keyed, deliberately: replaying the response would mean persisting the plaintext token.
       requestBody:
@@ -2685,7 +2689,7 @@ paths:
         - Identity & Access
       summary: Spend a one-time handoff code and receive a session token (server-to-server).
       description: |
-        ADR-0050. The only endpoint here authenticated by a **client secret** rather than a session: this is the request that obtains a session, so there is none to present yet. Not a machine credential either — those are read-only by construction (ADR-0049), and a read-only principal minting a human session would be an escalation path.
+        ADR-0050. The only endpoint here authenticated by a **client secret** rather than a session: this is the request that obtains a session, so there is none to present yet. Not a machine credential either. ADR-0092 lets one write inside a narrow ceiling (`create`/`update`, never a high-risk action), and minting a human session is precisely the authority that ceiling exists to keep away from a non-human bearer.
 
         Call it from the BFF's SERVER. The token must never reach a browser: the BFF stores it server-side and gives the browser its own portal cookie.
 
@@ -19659,10 +19663,31 @@ components:
           description: Permission keys (`module.activity.action`) this credential may use. Required and non-empty — an empty list means "can do nothing", never "unrestricted".
           items:
             type: string
+        allowedWriteActions:
+          type: array
+          maxItems: 2
+          description: |
+            ADR-0092. OPTIONAL — omitting it (or sending an empty array) issues the read-only credential of ADR-0049, which is what every caller written before this class got and still gets.
+
+            Naming any action switches the guard to `identity_access.machine_credentials_write.create` and makes `allowedIpCidrs` mandatory. `read` is REJECTED here rather than accepted as a no-op: every credential may already read whatever its `allowedPermissionKeys` name, and accepting it would suggest otherwise.
+          items:
+            type: string
+            enum:
+              - create
+              - update
+        allowedIpCidrs:
+          type: array
+          maxItems: 20
+          description: |
+            ADR-0092. IPv4/IPv6 literals or CIDR blocks. Required and non-empty when `allowedWriteActions` is non-empty, and REJECTED when it is empty — a read-only credential is not restricted by this list, so accepting one would describe a binding that is not enforced.
+
+            Unparseable entries are refused at issuance. At request time an unreadable entry matches nothing, so the failure would otherwise be a credential that reads as bound and can never authenticate.
+          items:
+            type: string
         expiresAt:
           type: string
           format: date-time
-          description: Required, in the future, at most 365 days away. There is no perpetual credential.
+          description: Required, in the future, at most 365 days away — or at most 30 days when `allowedWriteActions` is non-empty. There is no perpetual credential.
     IssueSessionHandoffRequest:
       type: object
       required:
@@ -19678,7 +19703,7 @@ components:
           description: Must appear EXACTLY in the client's registered allow-list. https only, no query, no fragment.
     MachineCredential:
       type: object
-      description: A read-only machine credential (ADR-0049). Never carries the token or its hash — an operator tracing a leak needs to know which credential is alive and whether anything still uses it, and none of that requires secret material.
+      description: A machine credential (ADR-0049; write class ADR-0092). Never carries the token or its hash — an operator tracing a leak needs to know which credential is alive and whether anything still uses it, and none of that requires secret material.
       properties:
         id:
           type: string
@@ -19692,6 +19717,16 @@ components:
         allowedPermissionKeys:
           type: array
           description: NARROWING filter — effective permissions are the intersection with what the service account holds. It can never widen them.
+          items:
+            type: string
+        allowedWriteActions:
+          type: array
+          description: ADR-0092. Empty on every read-only credential, which is every credential issued before the write class existed. Effective write actions are the intersection with the CODE ceiling, so this list can only narrow it.
+          items:
+            type: string
+        allowedIpCidrs:
+          type: array
+          description: ADR-0092. Non-empty if and only if allowedWriteActions is. Consulted ONLY for write actions — a read request is never restricted by it.
           items:
             type: string
         expiresAt:

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -591,11 +591,15 @@ paths:
       operationId: accessIssueMachineCredential
       tags:
         - Identity & Access
-      summary: Issue a read-only machine credential (high-risk; audit-logged).
+      summary: Issue a machine credential (high-risk; audit-logged).
       description: |
-        Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again. Gated on `identity_access.machine_credentials.create`.
+        Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again.
 
-        The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential. Requests authenticated this way are refused unless the action is read-only (ADR-0049 §3).
+        The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential.
+
+        TWO CLASSES, TWO PERMISSIONS. Omit `allowedWriteActions` and this is the read-only credential of ADR-0049 §3, gated on `identity_access.machine_credentials.create`; requests it makes are refused unless the action is `read`. Name write actions and it is the ADR-0092 write class, gated on `identity_access.machine_credentials_write.create` INSTEAD — a separate key so that opening this class does not hand write-minting authority to every role that already holds `create`.
+
+        The write class is narrower in every other direction: only actions in the code ceiling (`create`, `update` — never a high-risk one), at least one `allowedIpCidrs` entry, at most 30 days, and a request whose caller IP is unknown is refused rather than exempted.
 
         Not idempotency-keyed, deliberately: replaying the response would mean persisting the plaintext token.
       requestBody:
@@ -3094,7 +3098,7 @@ paths:
         - Identity & Access
       summary: Spend a one-time handoff code and receive a session token (server-to-server).
       description: |
-        ADR-0050. The only endpoint here authenticated by a **client secret** rather than a session: this is the request that obtains a session, so there is none to present yet. Not a machine credential either — those are read-only by construction (ADR-0049), and a read-only principal minting a human session would be an escalation path.
+        ADR-0050. The only endpoint here authenticated by a **client secret** rather than a session: this is the request that obtains a session, so there is none to present yet. Not a machine credential either. ADR-0092 lets one write inside a narrow ceiling (`create`/`update`, never a high-risk action), and minting a human session is precisely the authority that ceiling exists to keep away from a non-human bearer.
 
         Call it from the BFF's SERVER. The token must never reach a browser: the BFF stores it server-side and gives the browser its own portal cookie.
 
@@ -5269,7 +5273,7 @@ components:
           description: Inherited from the original login, never above it.
     MachineCredential:
       type: object
-      description: A read-only machine credential (ADR-0049). Never carries the token or its hash — an operator tracing a leak needs to know which credential is alive and whether anything still uses it, and none of that requires secret material.
+      description: A machine credential (ADR-0049; write class ADR-0092). Never carries the token or its hash — an operator tracing a leak needs to know which credential is alive and whether anything still uses it, and none of that requires secret material.
       properties:
         id:
           type: string
@@ -5283,6 +5287,16 @@ components:
         allowedPermissionKeys:
           type: array
           description: NARROWING filter — effective permissions are the intersection with what the service account holds. It can never widen them.
+          items:
+            type: string
+        allowedWriteActions:
+          type: array
+          description: ADR-0092. Empty on every read-only credential, which is every credential issued before the write class existed. Effective write actions are the intersection with the CODE ceiling, so this list can only narrow it.
+          items:
+            type: string
+        allowedIpCidrs:
+          type: array
+          description: ADR-0092. Non-empty if and only if allowedWriteActions is. Consulted ONLY for write actions — a read request is never restricted by it.
           items:
             type: string
         expiresAt:
@@ -5333,10 +5347,31 @@ components:
           description: Permission keys (`module.activity.action`) this credential may use. Required and non-empty — an empty list means "can do nothing", never "unrestricted".
           items:
             type: string
+        allowedWriteActions:
+          type: array
+          maxItems: 2
+          description: |
+            ADR-0092. OPTIONAL — omitting it (or sending an empty array) issues the read-only credential of ADR-0049, which is what every caller written before this class got and still gets.
+
+            Naming any action switches the guard to `identity_access.machine_credentials_write.create` and makes `allowedIpCidrs` mandatory. `read` is REJECTED here rather than accepted as a no-op: every credential may already read whatever its `allowedPermissionKeys` name, and accepting it would suggest otherwise.
+          items:
+            type: string
+            enum:
+              - create
+              - update
+        allowedIpCidrs:
+          type: array
+          maxItems: 20
+          description: |
+            ADR-0092. IPv4/IPv6 literals or CIDR blocks. Required and non-empty when `allowedWriteActions` is non-empty, and REJECTED when it is empty — a read-only credential is not restricted by this list, so accepting one would describe a binding that is not enforced.
+
+            Unparseable entries are refused at issuance. At request time an unreadable entry matches nothing, so the failure would otherwise be a credential that reads as bound and can never authenticate.
+          items:
+            type: string
         expiresAt:
           type: string
           format: date-time
-          description: Required, in the future, at most 365 days away. There is no perpetual credential.
+          description: Required, in the future, at most 365 days away — or at most 30 days when `allowedWriteActions` is non-empty. There is no perpetual credential.
     SessionIntrospection:
       type: object
       description: Safe claims for a live session (ADR-0049 §7). Deliberately excludes the raw login identifier that GET /api/v1/auth/me returns.

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -67,7 +67,7 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "form_drafts.draft.create",
   "form_drafts.draft.update",
 
-  // identity_access (19)
+  // identity_access (20)
   //
   // The four `invitations.*` keys are ADR-0082's, and they land here on the
   // same terms `tenant_admin.tenant_lifecycle.*` did: the surface exists and is
@@ -91,6 +91,11 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "identity_access.machine_credentials.create",
   "identity_access.machine_credentials.read",
   "identity_access.machine_credentials.revoke",
+  // ADR-0092. Joins its three siblings rather than being screened alone: there
+  // is no machine-credential page at all, and a screen that can mint the WRITE
+  // class while the read class stays an API call would be the wrong one to
+  // build first.
+  "identity_access.machine_credentials_write.create",
   "identity_access.sso_providers.create",
   "identity_access.sso_providers.delete",
   "identity_access.sso_providers.update",

--- a/sql/122_awcms_identity_machine_credential_write_permissions.sql
+++ b/sql/122_awcms_identity_machine_credential_write_permissions.sql
@@ -1,0 +1,46 @@
+-- Permission catalog seed for the machine-credential WRITE class (ADR-0092),
+-- wiring up the `machine_credentials_write` entry declared in
+-- `identity-access/module.ts`.
+--
+-- `sql/121` opened the class in the schema and the chokepoint; nothing could
+-- issue one. This migration seeds the key that the issuance route gates on when
+-- a request names `allowedWriteActions`.
+--
+-- Same shape/limitation as every prior permission-seed migration here (see
+-- `sql/083`): this extends the GLOBAL catalog only. An existing tenant's `owner`
+-- role does NOT retroactively gain it — only tenants created after this
+-- migration runs get it via `POST /api/v1/setup/initialize`. Backfilling live
+-- tenants stays a deployment step, not a migration side effect.
+--
+-- ## Why a NEW activity rather than a fourth action on `machine_credentials`
+--
+-- Because the alternative widens grants that nobody edited. Every role holding
+-- `machine_credentials.create` today can mint a credential that READS; folding
+-- the write class into that same action would hand all of them the ability to
+-- mint one that CHANGES data, on the day this deploys, with nothing in any diff
+-- to review and nothing in any audit trail to notice. The program this belongs
+-- to (Issue #423) is built on the opposite rule: no change may leave the tree
+-- with authorization looser than it found it.
+--
+-- Default-deny does the rest. Until an operator grants this key on purpose, the
+-- issuance route answers 403 for every write request and behaves exactly as it
+-- did before `sql/121` — which is the state every existing installation stays
+-- in until somebody decides otherwise.
+--
+-- ## Why there is no `read` and no `revoke` here
+--
+-- Issuance is a SUPERSET: a write credential also carries permission keys, so
+-- holding this key already implies being able to mint a read-only one. A `read`
+-- twin would list the same rows `machine_credentials.read` already lists.
+--
+-- `revoke` does NOT split, and that is a decision rather than an omission:
+-- during an incident, whoever can kill a leaked credential must be able to kill
+-- every class of it. A revoke permission that stops at the read class is a
+-- containment tool that fails on exactly the credentials worth containing.
+--
+-- `create` is a HIGH-RISK action, so this key additionally passes the SoD
+-- chokepoint in `authorizeInTransaction` — no extra wiring needed.
+INSERT INTO awcms_permissions (module_key, activity_code, action, description)
+VALUES
+  ('identity_access', 'machine_credentials_write', 'create', 'Issue a WRITE-capable machine credential (create/update only, IP-bound, at most 30 days) — audited')
+ON CONFLICT (module_key, activity_code, action) DO NOTHING;

--- a/src/modules/identity-access/application/machine-credential-directory.ts
+++ b/src/modules/identity-access/application/machine-credential-directory.ts
@@ -38,6 +38,14 @@ export type MachineCredentialSummary = {
   name: string;
   tenantUserId: string;
   allowedPermissionKeys: string[];
+  /**
+   * ADR-0092. Empty on every credential issued before the write class existed,
+   * and on every read-only one issued since. Projected rather than reduced to a
+   * boolean because the operational question during an incident is not "can
+   * this write" but "what can it write, and from where".
+   */
+  allowedWriteActions: string[];
+  allowedIpCidrs: string[];
   expiresAt: Date;
   lastUsedAt: Date | null;
   revokedAt: Date | null;
@@ -52,6 +60,8 @@ type MachineCredentialRow = {
   name: string;
   tenant_user_id: string;
   allowed_permission_keys: string[];
+  allowed_write_actions: string[];
+  allowed_ip_cidrs: string[];
   expires_at: Date;
   last_used_at: Date | null;
   revoked_at: Date | null;
@@ -68,6 +78,8 @@ function toSummary(
     name: row.name,
     tenantUserId: row.tenant_user_id,
     allowedPermissionKeys: row.allowed_permission_keys,
+    allowedWriteActions: row.allowed_write_actions,
+    allowedIpCidrs: row.allowed_ip_cidrs,
     expiresAt: row.expires_at,
     lastUsedAt: row.last_used_at,
     revokedAt: row.revoked_at,
@@ -90,7 +102,8 @@ export async function listMachineCredentials(
   // it is not — but because an endpoint that hands out per-credential secret
   // material is one refactor away from handing out something that is.
   const rows = (await tx`
-    SELECT id, name, tenant_user_id, allowed_permission_keys, expires_at,
+    SELECT id, name, tenant_user_id, allowed_permission_keys,
+           allowed_write_actions, allowed_ip_cidrs, expires_at,
            last_used_at, revoked_at, created_by_tenant_user_id, created_at
     FROM awcms_machine_credentials
     WHERE tenant_id = ${tenantId}
@@ -132,14 +145,21 @@ export async function issueMachineCredential(
   const rows = (await tx`
     INSERT INTO awcms_machine_credentials
       (tenant_id, tenant_user_id, name, token_hash, allowed_permission_keys,
+       allowed_write_actions, allowed_ip_cidrs,
        expires_at, created_by_tenant_user_id)
     VALUES (
       ${tenantId}, ${input.tenantUserId}, ${input.name},
       ${hashMachineCredentialToken(token)},
       ${toPostgresTextArray(input.allowedPermissionKeys)}::text[],
+      -- Both rendered, never omitted. sql/121 defaults them to the empty
+      -- array, so a write class that forgot one column would land as a
+      -- read-only credential and look like it worked.
+      ${toPostgresTextArray(input.allowedWriteActions)}::text[],
+      ${toPostgresTextArray(input.allowedIpCidrs)}::text[],
       ${input.expiresAt}, ${actorTenantUserId}
     )
-    RETURNING id, name, tenant_user_id, allowed_permission_keys, expires_at,
+    RETURNING id, name, tenant_user_id, allowed_permission_keys,
+              allowed_write_actions, allowed_ip_cidrs, expires_at,
               last_used_at, revoked_at, created_by_tenant_user_id, created_at
   `) as MachineCredentialRow[];
 
@@ -177,7 +197,8 @@ export async function revokeMachineCredential(
         revoked_by_tenant_user_id = ${actorTenantUserId},
         updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${credentialId} AND revoked_at IS NULL
-    RETURNING id, name, tenant_user_id, allowed_permission_keys, expires_at,
+    RETURNING id, name, tenant_user_id, allowed_permission_keys,
+              allowed_write_actions, allowed_ip_cidrs, expires_at,
               last_used_at, revoked_at, created_by_tenant_user_id, created_at
   `) as MachineCredentialRow[];
 

--- a/src/modules/identity-access/domain/machine-credential.ts
+++ b/src/modules/identity-access/domain/machine-credential.ts
@@ -133,6 +133,35 @@ export function isIpInAnyCidr(ip: string, cidrs: readonly string[]): boolean {
   return false;
 }
 
+/**
+ * Whether a string is an IP literal or a CIDR the matcher above can actually
+ * read — the ISSUANCE-time counterpart to `isIpInAnyCidr`, and deliberately a
+ * different question.
+ *
+ * At enforcement time an unreadable entry narrows to nothing, because a row the
+ * parser cannot read must never widen anything. At issuance time that same
+ * silence is the defect: an operator who typed `10.0.0.0/33` would be handed a
+ * credential that READS as IP-bound and is bound to nothing it can ever match,
+ * and would find out at the first request rather than at the form. Refusing
+ * here is the only moment where the typo is still cheap.
+ */
+export function isValidIpCidr(value: string): boolean {
+  const slash = value.indexOf("/");
+  const base = parseIpBytes(slash === -1 ? value : value.slice(0, slash));
+
+  if (!base) return false;
+  if (slash === -1) return true;
+
+  // A digits-only suffix, checked before `Number`: `Number("")` is 0 and
+  // `Number(" 8")` is 8, so `10.0.0.0/` and `10.0.0.0/ 8` would both slip
+  // through a bare numeric parse — the first as a prefix length of ZERO, which
+  // is every address on the internet.
+  const suffix = value.slice(slash + 1);
+  if (!/^\d{1,3}$/.test(suffix)) return false;
+
+  return Number(suffix) <= base.length * 8;
+}
+
 function sharesPrefix(a: Uint8Array, b: Uint8Array, bits: number): boolean {
   const fullBytes = Math.floor(bits / 8);
 
@@ -201,6 +230,13 @@ const PERMISSION_KEY_PATTERN =
 const NAME_MAX_LENGTH = 120;
 const ALLOWED_KEYS_MAX = 50;
 
+/**
+ * An allow-list is a thing an incident responder has to read out loud. Fifty
+ * permission keys is already a lot; fifty networks is a list nobody audits, and
+ * a write credential whose binding cannot be audited is not really bound.
+ */
+const ALLOWED_CIDRS_MAX = 20;
+
 export type MachineCredentialValidationError = {
   field: string;
   message: string;
@@ -210,6 +246,14 @@ export type IssueMachineCredentialInput = {
   name: string;
   tenantUserId: string;
   allowedPermissionKeys: string[];
+  /**
+   * ADR-0092. Empty on every credential ADR-0049 could issue, and empty is what
+   * an absent field means — the read-only class stays the default, never a
+   * thing the caller has to remember to ask for.
+   */
+  allowedWriteActions: AccessAction[];
+  /** Non-empty if and only if `allowedWriteActions` is (`sql/121` CHECK). */
+  allowedIpCidrs: string[];
   expiresAt: Date;
 };
 
@@ -286,6 +330,120 @@ export function validateIssueMachineCredentialInput(
     }
   }
 
+  // ADR-0092 — the write class. Absent means empty, and empty means the
+  // read-only credential ADR-0049 shipped: opening this class must not change
+  // what a request that does not mention it gets.
+  const rawWriteActions = input.allowedWriteActions ?? [];
+  const allowedWriteActions: AccessAction[] = [];
+  if (!Array.isArray(rawWriteActions)) {
+    errors.push({
+      field: "allowedWriteActions",
+      message: "allowedWriteActions must be an array of actions."
+    });
+  } else {
+    for (const action of rawWriteActions) {
+      if (
+        typeof action === "string" &&
+        isMachineCredentialAllowedAction(action as AccessAction)
+      ) {
+        // Named separately from the generic refusal below because it is the
+        // mistake an operator is most likely to make, and "read is not allowed"
+        // is a confusing thing to be told about a credential that can read.
+        errors.push({
+          field: "allowedWriteActions",
+          message:
+            "read is implicit — every credential may read whatever its allowedPermissionKeys name."
+        });
+        continue;
+      }
+
+      if (
+        typeof action !== "string" ||
+        !MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS.has(action as AccessAction)
+      ) {
+        errors.push({
+          field: "allowedWriteActions",
+          message: `Not a write action a machine credential may hold: ${
+            typeof action === "string" ? action : typeof action
+          }. Allowed: ${[...MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS].join(", ")}.`
+        });
+        continue;
+      }
+
+      const writeAction = action as AccessAction;
+      if (!allowedWriteActions.includes(writeAction))
+        allowedWriteActions.push(writeAction);
+    }
+  }
+
+  // Derived from what was ASKED FOR, not from what survived parsing.
+  //
+  // Deriving it from `allowedWriteActions` reads more natural and is wrong: a
+  // request naming `delete` with a perfectly good CIDR would end up with an
+  // EMPTY parsed list, be reclassified as read-only, and then be told its CIDR
+  // is the problem. One mistake, two errors, and the second one contradicts
+  // what the operator plainly asked for.
+  const writeClassRequested =
+    Array.isArray(rawWriteActions) && rawWriteActions.length > 0;
+
+  const rawCidrs = input.allowedIpCidrs ?? [];
+  const allowedIpCidrs: string[] = [];
+  if (!Array.isArray(rawCidrs)) {
+    errors.push({
+      field: "allowedIpCidrs",
+      message: "allowedIpCidrs must be an array of IP addresses or CIDR blocks."
+    });
+  } else if (!writeClassRequested && rawCidrs.length > 0) {
+    // The direction nothing else enforces. `isMachineCredentialWriteRefused`
+    // answers `false` for `read` BEFORE it looks at the CIDR list, so a
+    // read-only credential carrying networks is not restricted to them — it is
+    // a control that READS as enforced and is not. Refused rather than silently
+    // dropped: dropping it still leaves an operator believing they bound it.
+    //
+    // Reported INSTEAD OF per-entry parse errors, not in addition: "that is not
+    // a CIDR" is noise next to "this field does nothing here".
+    errors.push({
+      field: "allowedIpCidrs",
+      message:
+        "allowedIpCidrs is only enforced for credentials that can write; a read-only credential is not restricted by it."
+    });
+  } else if (rawCidrs.length > ALLOWED_CIDRS_MAX) {
+    errors.push({
+      field: "allowedIpCidrs",
+      message: `allowedIpCidrs must contain at most ${ALLOWED_CIDRS_MAX} entries.`
+    });
+  } else if (writeClassRequested && rawCidrs.length === 0) {
+    // Mirrors the `sql/121` CHECK rather than trusting it. A 422 naming the
+    // field is what an operator can act on; a 23514 is a stack trace.
+    errors.push({
+      field: "allowedIpCidrs",
+      message:
+        "A credential that can write must name at least one IP address or CIDR block."
+    });
+  } else {
+    for (const entry of rawCidrs) {
+      const trimmed = typeof entry === "string" ? entry.trim() : "";
+
+      if (!isValidIpCidr(trimmed)) {
+        errors.push({
+          field: "allowedIpCidrs",
+          message: `Not an IP address or CIDR block: ${
+            typeof entry === "string" ? entry : typeof entry
+          }.`
+        });
+        continue;
+      }
+
+      // Stored trimmed, because the matcher is what has to agree with this
+      // string later and it does not trim the prefix length.
+      if (!allowedIpCidrs.includes(trimmed)) allowedIpCidrs.push(trimmed);
+    }
+  }
+
+  const maxLifetimeDays = writeClassRequested
+    ? MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS
+    : MACHINE_CREDENTIAL_MAX_LIFETIME_DAYS;
+
   const expiresAtRaw = input.expiresAt;
   let expiresAt: Date | null = null;
   if (typeof expiresAtRaw !== "string") {
@@ -307,11 +465,13 @@ export function validateIssueMachineCredentialInput(
       });
     } else if (
       parsed.getTime() - now.getTime() >
-      MACHINE_CREDENTIAL_MAX_LIFETIME_DAYS * 24 * 60 * 60 * 1000
+      maxLifetimeDays * 24 * 60 * 60 * 1000
     ) {
       errors.push({
         field: "expiresAt",
-        message: `expiresAt must be at most ${MACHINE_CREDENTIAL_MAX_LIFETIME_DAYS} days away.`
+        message: writeClassRequested
+          ? `expiresAt must be at most ${maxLifetimeDays} days away for a credential that can write.`
+          : `expiresAt must be at most ${maxLifetimeDays} days away.`
       });
     } else {
       expiresAt = parsed;
@@ -328,6 +488,8 @@ export function validateIssueMachineCredentialInput(
       name: rawName,
       tenantUserId,
       allowedPermissionKeys,
+      allowedWriteActions,
+      allowedIpCidrs,
       expiresAt
     }
   };

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -333,6 +333,25 @@ export const identityAccessModule = defineModule({
       description:
         "Revoke a machine credential, effective on its next request — audited"
     },
+    // The WRITE class (ADR-0092, sql/121/122) — a THIRD activity rather than a
+    // fourth action on `machine_credentials`, and the reason is the same one
+    // that separated `machine_credentials` from `access_control` in the first
+    // place, applied to itself.
+    //
+    // Had the write class reused `machine_credentials.create`, every role that
+    // already holds it would have gained the ability to mint credentials that
+    // CHANGE data on the day this merged — a grant widening with no grant being
+    // edited, and nothing in any diff to review. Issuance is a superset:
+    // holding this key implies being able to mint a read-only credential too,
+    // which is why there is no separate `read` or `revoke` here. `revoke` does
+    // not split, deliberately — during an incident, whoever can kill a leaked
+    // credential must be able to kill EVERY class of it.
+    {
+      activityCode: "machine_credentials_write",
+      action: "create",
+      description:
+        "Issue a WRITE-capable machine credential (create/update only, IP-bound, at most 30 days) — audited"
+    },
     // Other people's sessions (Gelombang 2 PR 2.2 of #423, sql/101). A separate
     // activity from `access_control` for the reason `registration_requests` and
     // `machine_credentials` are: folding it in would make every role editor an

--- a/src/pages/api/v1/access/machine-credentials/index.ts
+++ b/src/pages/api/v1/access/machine-credentials/index.ts
@@ -38,9 +38,26 @@ export const GET = defineTenantRoute({
 });
 
 /**
- * `POST /api/v1/access/machine-credentials` (ADR-0049) — issues a READ-ONLY
- * credential bound to a service account, returning the plaintext token exactly
- * once.
+ * `POST /api/v1/access/machine-credentials` (ADR-0049) — issues a credential
+ * bound to a service account, returning the plaintext token exactly once.
+ *
+ * ## Two classes, and a DIFFERENT permission for the second (ADR-0092)
+ *
+ * A request that names no `allowedWriteActions` is the read-only credential
+ * ADR-0049 shipped, gated on `machine_credentials.create` exactly as before. A
+ * request that names some is the write class, and it is gated on
+ * `machine_credentials_write.create` instead.
+ *
+ * Reusing one permission for both was the obvious shape and the wrong one: it
+ * would hand write-minting authority, on merge day, to everybody who already
+ * holds `create` — a grant widening itself with no grant being edited. The
+ * program this endpoint belongs to (#423) is built on the rule that no change
+ * may leave the tree with authorization looser than it found it, and this is
+ * the cheapest place that rule could have been broken.
+ *
+ * The split is resolved from the parsed body via `defineTenantRoute`'s callback
+ * form of `authorize`, so the guard is decided BEFORE the transaction opens and
+ * the body cannot pick a weaker check than the thing it asks for.
  *
  * ## Deliberately NOT idempotency-keyed
  *
@@ -73,11 +90,14 @@ export const POST = defineTenantRoute<IssueMachineCredentialInput>({
 
     return validation.value;
   },
-  authorize: {
+  authorize: ({ prepared }) => ({
     moduleKey: "identity_access",
-    activityCode: "machine_credentials",
+    activityCode:
+      prepared.allowedWriteActions.length > 0
+        ? "machine_credentials_write"
+        : "machine_credentials",
     action: "create"
-  },
+  }),
   handler: async ({ tx, tenantId, auth, prepared, now }) => {
     const result = await issueMachineCredential(
       tx,
@@ -95,6 +115,8 @@ export const POST = defineTenantRoute<IssueMachineCredentialInput>({
       );
     }
 
+    const writeClass = result.credential.allowedWriteActions.length > 0;
+
     await recordAuditEvent(tx, {
       tenantId,
       actorTenantUserId: auth.context.tenantUserId,
@@ -102,14 +124,22 @@ export const POST = defineTenantRoute<IssueMachineCredentialInput>({
       action: "machine_credential.issued",
       resourceType: "machine_credential",
       resourceId: result.credential.id,
-      severity: "warning",
-      message: `Machine credential "${result.credential.name}" issued.`,
+      // A credential that can CHANGE data is not the same event as one that can
+      // read, and a reader filtering an audit trail by severity should not have
+      // to know this endpoint has two classes to find the ones that matter.
+      severity: writeClass ? "critical" : "warning",
+      message: writeClass
+        ? `Machine credential "${result.credential.name}" issued — WRITE class.`
+        : `Machine credential "${result.credential.name}" issued.`,
       // The token is NOT here, and `allowedPermissionKeys` is: the audit trail
       // must answer "what could this thing read" without ever being able to
-      // answer "what was its token".
+      // answer "what was its token". ADR-0092 adds the other two halves of the
+      // same question — what it could CHANGE, and from where.
       attributes: {
         tenantUserId: result.credential.tenantUserId,
         allowedPermissionKeys: result.credential.allowedPermissionKeys,
+        allowedWriteActions: result.credential.allowedWriteActions,
+        allowedIpCidrs: result.credential.allowedIpCidrs,
         expiresAt: result.credential.expiresAt.toISOString()
       }
     });

--- a/src/pages/api/v1/access/machine-credentials/index.ts
+++ b/src/pages/api/v1/access/machine-credentials/index.ts
@@ -90,14 +90,30 @@ export const POST = defineTenantRoute<IssueMachineCredentialInput>({
 
     return validation.value;
   },
-  authorize: ({ prepared }) => ({
-    moduleKey: "identity_access",
-    activityCode:
-      prepared.allowedWriteActions.length > 0
-        ? "machine_credentials_write"
-        : "machine_credentials",
-    action: "create"
-  }),
+  // TWO COMPLETE LITERALS, not one literal with a ternary `activityCode`.
+  //
+  // The shorter spelling costs a gate. `access:permissions:enforcement:check`
+  // reads guards as object LITERALS carrying all three keys, and a ternary in
+  // the `activityCode` position makes the whole guard unreadable to it — the
+  // first attempt here reported BOTH `machine_credentials.create` and
+  // `machine_credentials_write.create` as "enforced by nothing", which is the
+  // exact false alibi ADR-0058 §E records for `visitor_analytics`.
+  //
+  // The scanner already accommodates a ternary in the `action` position. Rather
+  // than widen a security gate to fit a formatting preference, the route says
+  // each guard once and in full.
+  authorize: ({ prepared }) =>
+    prepared.allowedWriteActions.length > 0
+      ? {
+          moduleKey: "identity_access",
+          activityCode: "machine_credentials_write",
+          action: "create"
+        }
+      : {
+          moduleKey: "identity_access",
+          activityCode: "machine_credentials",
+          action: "create"
+        },
   handler: async ({ tx, tenantId, auth, prepared, now }) => {
     const result = await issueMachineCredential(
       tx,

--- a/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
+++ b/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
@@ -44,11 +44,15 @@ paths:
       operationId: accessIssueMachineCredential
       tags:
         - Identity & Access
-      summary: Issue a read-only machine credential (high-risk; audit-logged).
+      summary: Issue a machine credential (high-risk; audit-logged).
       description: |
-        Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again. Gated on `identity_access.machine_credentials.create`.
+        Mints a bearer for a non-human caller, bound to an existing tenant user (a service account), and returns the plaintext token EXACTLY ONCE — no endpoint can return it again.
 
-        The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential. Requests authenticated this way are refused unless the action is read-only (ADR-0049 §3).
+        The credential AUTHENTICATES only: every request it makes still passes module-enabled, RBAC, ABAC (default-deny) and SoD. `allowedPermissionKeys` NARROWS — effective permissions are the intersection with what the service account holds, so granting that account another role never widens an already-issued credential.
+
+        TWO CLASSES, TWO PERMISSIONS. Omit `allowedWriteActions` and this is the read-only credential of ADR-0049 §3, gated on `identity_access.machine_credentials.create`; requests it makes are refused unless the action is `read`. Name write actions and it is the ADR-0092 write class, gated on `identity_access.machine_credentials_write.create` INSTEAD — a separate key so that opening this class does not hand write-minting authority to every role that already holds `create`.
+
+        The write class is narrower in every other direction: only actions in the code ceiling (`create`, `update` — never a high-risk one), at least one `allowedIpCidrs` entry, at most 30 days, and a request whose caller IP is unknown is refused rather than exempted.
 
         Not idempotency-keyed, deliberately: replaying the response would mean persisting the plaintext token.
       requestBody:
@@ -796,13 +800,34 @@ components:
           description: Permission keys (`module.activity.action`) this credential may use. Required and non-empty — an empty list means "can do nothing", never "unrestricted".
           items:
             type: string
+        allowedWriteActions:
+          type: array
+          maxItems: 2
+          description: |
+            ADR-0092. OPTIONAL — omitting it (or sending an empty array) issues the read-only credential of ADR-0049, which is what every caller written before this class got and still gets.
+
+            Naming any action switches the guard to `identity_access.machine_credentials_write.create` and makes `allowedIpCidrs` mandatory. `read` is REJECTED here rather than accepted as a no-op: every credential may already read whatever its `allowedPermissionKeys` name, and accepting it would suggest otherwise.
+          items:
+            type: string
+            enum:
+              - create
+              - update
+        allowedIpCidrs:
+          type: array
+          maxItems: 20
+          description: |
+            ADR-0092. IPv4/IPv6 literals or CIDR blocks. Required and non-empty when `allowedWriteActions` is non-empty, and REJECTED when it is empty — a read-only credential is not restricted by this list, so accepting one would describe a binding that is not enforced.
+
+            Unparseable entries are refused at issuance. At request time an unreadable entry matches nothing, so the failure would otherwise be a credential that reads as bound and can never authenticate.
+          items:
+            type: string
         expiresAt:
           type: string
           format: date-time
-          description: Required, in the future, at most 365 days away. There is no perpetual credential.
+          description: Required, in the future, at most 365 days away — or at most 30 days when `allowedWriteActions` is non-empty. There is no perpetual credential.
     MachineCredential:
       type: object
-      description: A read-only machine credential (ADR-0049). Never carries the token or its hash — an operator tracing a leak needs to know which credential is alive and whether anything still uses it, and none of that requires secret material.
+      description: A machine credential (ADR-0049; write class ADR-0092). Never carries the token or its hash — an operator tracing a leak needs to know which credential is alive and whether anything still uses it, and none of that requires secret material.
       properties:
         id:
           type: string
@@ -816,6 +841,16 @@ components:
         allowedPermissionKeys:
           type: array
           description: NARROWING filter — effective permissions are the intersection with what the service account holds. It can never widen them.
+          items:
+            type: string
+        allowedWriteActions:
+          type: array
+          description: ADR-0092. Empty on every read-only credential, which is every credential issued before the write class existed. Effective write actions are the intersection with the CODE ceiling, so this list can only narrow it.
+          items:
+            type: string
+        allowedIpCidrs:
+          type: array
+          description: ADR-0092. Non-empty if and only if allowedWriteActions is. Consulted ONLY for write actions — a read request is never restricted by it.
           items:
             type: string
         expiresAt:

--- a/tests/integration/deactivation-revokes-sessions.integration.test.ts
+++ b/tests/integration/deactivation-revokes-sessions.integration.test.ts
@@ -184,6 +184,8 @@ suite("deactivation revokes live access", () => {
           name: "target feed",
           tenantUserId: TARGET_USER,
           allowedPermissionKeys: ["blog_content.posts.read"],
+          allowedWriteActions: [],
+          allowedIpCidrs: [],
           expiresAt: new Date(Date.now() + 60 * 60 * 1000)
         },
         new Date()
@@ -241,6 +243,8 @@ suite("deactivation revokes live access", () => {
           name: "admin feed",
           tenantUserId: ADMIN_USER,
           allowedPermissionKeys: ["blog_content.posts.read"],
+          allowedWriteActions: [],
+          allowedIpCidrs: [],
           expiresAt: new Date(Date.now() + 60 * 60 * 1000)
         },
         new Date()

--- a/tests/integration/machine-credentials.integration.test.ts
+++ b/tests/integration/machine-credentials.integration.test.ts
@@ -160,7 +160,10 @@ async function issue(
   expiresAt = new Date(Date.now() + 60 * 60 * 1000),
   // ADR-0092. Defaulted to the read-only class so every pre-existing caller
   // below keeps issuing exactly what it issued before the write class existed.
-  writeClass: { allowedWriteActions?: AccessAction[]; allowedIpCidrs?: string[] } = {}
+  writeClass: {
+    allowedWriteActions?: AccessAction[];
+    allowedIpCidrs?: string[];
+  } = {}
 ): Promise<{ token: string; id: string }> {
   const runtime = getRuntimeSql();
 
@@ -569,6 +572,112 @@ suite("machine credentials + session introspection (ADR-0049)", () => {
     expect(JSON.stringify(items)).not.toContain("mc-sha256:");
     expect(Object.keys(items[0]!)).not.toContain("tokenHash");
     expect(items[0]!.status).toBe("active");
+  });
+
+  // ADR-0092 — the write class, issued through the real service rather than by
+  // hand. `sql/121` landed with no writer at all; these are the first rows in
+  // this repo that reach those two columns through a code path.
+
+  test("the write class round-trips both columns, and the read class stays empty", async () => {
+    await issue(["blog_content.posts.update"], undefined, {
+      allowedWriteActions: ["update"],
+      allowedIpCidrs: ["203.0.113.0/24"]
+    });
+    await issue(["blog_content.posts.read"]);
+
+    const items = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+      listMachineCredentials(tx, TENANT_A, new Date())
+    );
+
+    // Newest first, so the read-only one issued second comes back first.
+    expect(items).toHaveLength(2);
+    expect(items[0]!.allowedWriteActions).toEqual([]);
+    expect(items[0]!.allowedIpCidrs).toEqual([]);
+    expect(items[1]!.allowedWriteActions).toEqual(["update"]);
+    expect(items[1]!.allowedIpCidrs).toEqual(["203.0.113.0/24"]);
+  });
+
+  test("a write credential authorises `update` from inside its allow-list and not outside", async () => {
+    // The whole point of the surface, proven through `authorizeInTransaction`
+    // rather than through the row: a credential is only worth issuing if the
+    // chokepoint agrees with what was written. `update` rather than `create`
+    // because it is what the service account actually holds here — a guard the
+    // account cannot satisfy would answer 403 for a reason that has nothing to
+    // do with the write class, and pass for the wrong reason if it broke.
+    const { token } = await issue(["blog_content.posts.update"], undefined, {
+      allowedWriteActions: ["update"],
+      allowedIpCidrs: ["203.0.113.0/24"]
+    });
+
+    const inside = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+      authorizeInTransaction(
+        tx,
+        TENANT_A,
+        hashSessionToken(token),
+        new Date(),
+        UPDATE_GUARD,
+        { clientIp: "203.0.113.9" }
+      )
+    );
+    const outside = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+      authorizeInTransaction(
+        tx,
+        TENANT_A,
+        hashSessionToken(token),
+        new Date(),
+        UPDATE_GUARD,
+        { clientIp: "198.51.100.7" }
+      )
+    );
+    // A route that never learned to pass the address must not silently exempt
+    // itself — the refusal that is easiest to leave out.
+    const unknown = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+      authorizeInTransaction(
+        tx,
+        TENANT_A,
+        hashSessionToken(token),
+        new Date(),
+        UPDATE_GUARD
+      )
+    );
+
+    expect(inside.allowed).toBe(true);
+    expect(outside.allowed).toBe(false);
+    expect(unknown.allowed).toBe(false);
+  });
+
+  test("the database refuses the two shapes the validator also refuses", async () => {
+    const admin = getAdminSql();
+    const row = (
+      name: string,
+      writeActions: string[],
+      cidrs: string[],
+      expiry: string
+    ) => admin`
+      INSERT INTO awcms_machine_credentials
+        (tenant_id, tenant_user_id, name, token_hash, allowed_permission_keys,
+         allowed_write_actions, allowed_ip_cidrs, expires_at,
+         created_by_tenant_user_id)
+      VALUES (
+        ${TENANT_A}, ${SERVICE_USER_A}, ${name},
+        ${hashMachineCredentialToken(generateMachineCredentialToken(TENANT_A))},
+        ${toPostgresTextArray(["blog_content.posts.update"])}::text[],
+        ${toPostgresTextArray(writeActions)}::text[],
+        ${toPostgresTextArray(cidrs)}::text[],
+        now() + ${expiry}::interval, ${HUMAN_USER_A}
+      )
+    `;
+
+    // Asserted against the DATABASE, not the validator: a second writer is how
+    // a rule enforced only in TypeScript disappears.
+    await assertRejected(
+      row("unbound writer", ["update"], [], "7 days"),
+      "a write credential with no IP binding"
+    );
+    await assertRejected(
+      row("long-lived writer", ["update"], ["203.0.113.0/24"], "60 days"),
+      "a write credential outliving the 31-day ceiling"
+    );
   });
 
   test("the database refuses an empty allow-list and a session-shaped hash", async () => {

--- a/tests/integration/machine-credentials.integration.test.ts
+++ b/tests/integration/machine-credentials.integration.test.ts
@@ -49,6 +49,7 @@ import {
   hashMachineCredentialToken
 } from "../../src/lib/auth/machine-credential-token";
 import { authorizeInTransaction } from "../../src/modules/identity-access/application/access-guard";
+import type { AccessAction } from "../../src/modules/identity-access/domain/access-control";
 import {
   issueMachineCredential,
   listMachineCredentials,
@@ -156,7 +157,10 @@ async function seedFixtures(): Promise<void> {
 /** Issues a credential through the real service and returns its plaintext token. */
 async function issue(
   allowedPermissionKeys: string[],
-  expiresAt = new Date(Date.now() + 60 * 60 * 1000)
+  expiresAt = new Date(Date.now() + 60 * 60 * 1000),
+  // ADR-0092. Defaulted to the read-only class so every pre-existing caller
+  // below keeps issuing exactly what it issued before the write class existed.
+  writeClass: { allowedWriteActions?: AccessAction[]; allowedIpCidrs?: string[] } = {}
 ): Promise<{ token: string; id: string }> {
   const runtime = getRuntimeSql();
 
@@ -169,6 +173,8 @@ async function issue(
         name: "build feed",
         tenantUserId: SERVICE_USER_A,
         allowedPermissionKeys,
+        allowedWriteActions: writeClass.allowedWriteActions ?? [],
+        allowedIpCidrs: writeClass.allowedIpCidrs ?? [],
         expiresAt
       },
       new Date()

--- a/tests/machine-credential-write-issuance.test.ts
+++ b/tests/machine-credential-write-issuance.test.ts
@@ -1,0 +1,441 @@
+/**
+ * PENERBITAN kelas tulis — ADR-0092, tindak lanjut Gelombang 8 PR 8.5 (#423).
+ *
+ * `sql/121` membuka kelasnya di skema dan di chokepoint, dan sengaja tidak
+ * memberinya permukaan. Berkas ini menjaga permukaan itu, dan tiga sifatnya
+ * yang paling mudah hilang:
+ *
+ *   1. permintaan yang TIDAK menyebut kelas tulis harus menghasilkan persis
+ *      kredensial ADR-0049 yang sama seperti sebelum kelas ini ada;
+ *   2. kelas tulis digerbangi izin BERBEDA — kalau tidak, setiap peran yang
+ *      hari ini memegang `machine_credentials.create` melebar sendiri pada hari
+ *      perubahan ini dirilis, tanpa satu grant pun disunting;
+ *   3. ada TIGA daftar kolom terpisah di lapisan aplikasinya, dan melewatkan
+ *      satu membuat GET benar sementara POST mengembalikan `undefined`.
+ *
+ * Murni: tidak ada basis data. Pernyataan SQL-nya diperiksa dengan merekam
+ * tagged-template, bukan dengan menjalankannya — pola `principal-mfa-store`.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import { isHighRiskAction } from "../src/modules/identity-access/domain/access-control";
+import type { AccessAction } from "../src/modules/identity-access/domain/access-control";
+import {
+  MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS,
+  MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS,
+  isIpInAnyCidr,
+  isValidIpCidr,
+  validateIssueMachineCredentialInput
+} from "../src/modules/identity-access/domain/machine-credential";
+import {
+  issueMachineCredential,
+  listMachineCredentials,
+  revokeMachineCredential
+} from "../src/modules/identity-access/application/machine-credential-directory";
+
+const ROUTE = "src/pages/api/v1/access/machine-credentials/index.ts";
+const MIGRATION = "sql/122_awcms_identity_machine_credential_write_permissions.sql";
+
+const NOW = new Date("2026-08-13T00:00:00.000Z");
+const DAY = 24 * 60 * 60 * 1000;
+
+/** Real uuids: the token generator refuses anything else, by design. */
+const TENANT = "00000000-0000-4000-8000-000000000001";
+const ACTOR = "99999999-8888-7777-6666-555555555555";
+
+function body(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "deploy hook",
+    tenantUserId: "11111111-2222-3333-4444-555555555555",
+    allowedPermissionKeys: ["blog_content.posts.create"],
+    expiresAt: new Date(NOW.getTime() + 7 * DAY).toISOString(),
+    ...overrides
+  };
+}
+
+function validate(overrides: Record<string, unknown> = {}) {
+  return validateIssueMachineCredentialInput(body(overrides), NOW);
+}
+
+/** Every field the validator complained about, as a set. */
+function fieldsOf(result: ReturnType<typeof validate>): string[] {
+  return result.valid ? [] : [...new Set(result.errors.map((e) => e.field))];
+}
+
+describe("permintaan yang tidak menyebut kelas tulis tidak berubah sama sekali", () => {
+  test("field-nya absen → kedua daftar KOSONG, bukan undefined", () => {
+    const result = validate();
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.allowedWriteActions).toEqual([]);
+      expect(result.value.allowedIpCidrs).toEqual([]);
+    }
+  });
+
+  test("plafon umur kelas BACA tetap 365 hari untuknya", () => {
+    // Kalau plafon 30 hari bocor ke kelas baca, setiap build feed yang ada
+    // berhenti bisa diterbitkan ulang — regresi senyap dengan bentuk 422.
+    const result = validate({
+      expiresAt: new Date(NOW.getTime() + 300 * DAY).toISOString()
+    });
+
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("aksi tulis diterima persis sebanyak plafon KODE", () => {
+  test("setiap anggota plafon diterima — dihitung dari konstanta hidup", () => {
+    for (const action of MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS) {
+      const result = validate({
+        allowedWriteActions: [action],
+        allowedIpCidrs: ["203.0.113.0/24"]
+      });
+
+      expect(fieldsOf(result)).toEqual([]);
+      if (result.valid) {
+        expect(result.value.allowedWriteActions).toEqual([action]);
+      }
+    }
+  });
+
+  test("dan plafonnya tidak kosong — kalau tidak, asersi di atas hampa", () => {
+    expect(MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS.size).toBeGreaterThan(0);
+  });
+
+  test("aksi high-risk ditolak, dan yang dipakai sebagai contoh MEMANG high-risk", () => {
+    // Pasangan ini disengaja: tanpa asersi kedua, hari seseorang mengeluarkan
+    // `delete` dari daftar high-risk membuat test pertama menguji apa-apa.
+    expect(isHighRiskAction("delete" as AccessAction)).toBe(true);
+    expect(
+      fieldsOf(
+        validate({
+          allowedWriteActions: ["delete"],
+          allowedIpCidrs: ["203.0.113.0/24"]
+        })
+      )
+    ).toEqual(["allowedWriteActions"]);
+  });
+
+  test("`read` DITOLAK, dan pesannya menjelaskan kenapa alih-alih menyebutnya terlarang", () => {
+    const result = validate({
+      allowedWriteActions: ["read"],
+      allowedIpCidrs: ["203.0.113.0/24"]
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors[0]!.message).toContain("read is implicit");
+    }
+  });
+
+  test("duplikat diringkas, bukan ditolak", () => {
+    const result = validate({
+      allowedWriteActions: ["create", "create"],
+      allowedIpCidrs: ["203.0.113.5", "203.0.113.5"]
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.allowedWriteActions).toEqual(["create"]);
+      expect(result.value.allowedIpCidrs).toEqual(["203.0.113.5"]);
+    }
+  });
+});
+
+describe("ikatan IP — dua arah, dan arah kedua tidak dijaga apa pun selain ini", () => {
+  test("kelas tulis TANPA CIDR ditolak, mencerminkan CHECK sql/121", () => {
+    expect(fieldsOf(validate({ allowedWriteActions: ["create"] }))).toEqual([
+      "allowedIpCidrs"
+    ]);
+  });
+
+  test("CIDR pada kredensial BACA ditolak — ia tidak akan pernah dikonsultasi", () => {
+    // Arah yang tidak dijaga basis data maupun gerbang runtime.
+    // `isMachineCredentialWriteRefused` menjawab `false` untuk `read` SEBELUM
+    // menyentuh daftar CIDR, jadi menyimpannya menggambarkan ikatan yang tidak
+    // ditegakkan. Ditolak, bukan dibuang diam-diam: membuangnya tetap
+    // meninggalkan operator yang mengira ia mengikatnya.
+    expect(fieldsOf(validate({ allowedIpCidrs: ["203.0.113.0/24"] }))).toEqual([
+      "allowedIpCidrs"
+    ]);
+  });
+
+  test("CIDR yang tidak bisa di-parse ditolak DI PENERBITAN", () => {
+    for (const bad of ["not-a-cidr", "10.0.0.0/33", "10.0.0.0/", "999.0.0.1"]) {
+      expect(
+        fieldsOf(
+          validate({ allowedWriteActions: ["create"], allowedIpCidrs: [bad] })
+        )
+      ).toEqual(["allowedIpCidrs"]);
+    }
+  });
+
+  test("apa pun yang DITERIMA penerbitan bisa dicocokkan penegakan", () => {
+    // Sifat yang menghubungkan kedua fungsi. Kalau penerbitan menerima sesuatu
+    // yang `isIpInAnyCidr` tak pernah cocokkan, hasilnya kredensial yang
+    // terbaca terikat dan tidak pernah bisa lolos — kegagalan yang baru
+    // terlihat pada request pertama.
+    const accepted = [
+      ["203.0.113.7", "203.0.113.7"],
+      ["203.0.113.0/24", "203.0.113.9"],
+      ["10.0.0.0/8", "10.255.255.254"],
+      ["2001:db8::/32", "2001:db8::5"],
+      ["::1", "::1"]
+    ] as const;
+
+    for (const [entry, inside] of accepted) {
+      expect(isValidIpCidr(entry)).toBe(true);
+      expect(
+        validate({ allowedWriteActions: ["create"], allowedIpCidrs: [entry] })
+          .valid
+      ).toBe(true);
+      expect(isIpInAnyCidr(inside, [entry])).toBe(true);
+    }
+  });
+
+  test("`/0` diterima — melebarkan adalah keputusan operator, bukan kecelakaan parser", () => {
+    expect(isValidIpCidr("0.0.0.0/0")).toBe(true);
+    // Tetapi `10.0.0.0/` BUKAN `/0`. Suffix kosong dulu lolos `Number("") === 0`
+    // dan akan mengubah salah ketik menjadi "seluruh internet".
+    expect(isValidIpCidr("10.0.0.0/")).toBe(false);
+  });
+
+  test("entri di-trim sebelum disimpan, karena pencocoknya tidak men-trim prefix", () => {
+    const result = validate({
+      allowedWriteActions: ["create"],
+      allowedIpCidrs: ["  203.0.113.0/24  "]
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.allowedIpCidrs).toEqual(["203.0.113.0/24"]);
+    }
+  });
+});
+
+describe("umur kelas tulis", () => {
+  test("melebihi plafon ditolak, dan pesannya menyebut kelasnya", () => {
+    const result = validate({
+      allowedWriteActions: ["create"],
+      allowedIpCidrs: ["203.0.113.0/24"],
+      expiresAt: new Date(
+        NOW.getTime() + (MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS + 1) * DAY
+      ).toISOString()
+    });
+
+    expect(fieldsOf(result)).toEqual(["expiresAt"]);
+    if (!result.valid) {
+      expect(result.errors[0]!.message).toContain("can write");
+    }
+  });
+
+  test("tepat di bawah plafon diterima", () => {
+    expect(
+      validate({
+        allowedWriteActions: ["create"],
+        allowedIpCidrs: ["203.0.113.0/24"],
+        expiresAt: new Date(
+          NOW.getTime() + (MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS - 1) * DAY
+        ).toISOString()
+      }).valid
+    ).toBe(true);
+  });
+});
+
+/**
+ * Merekam tagged-template sebagai `Bun.SQL` — pernyataannya diperiksa sebagai
+ * teks, tanpa Postgres. Baris yang sama dikembalikan untuk setiap query, yang
+ * cukup: pencarian service account hanya butuh `id`, dan RETURNING butuh
+ * bentuk baris penuh.
+ */
+function recordingTx(rows: unknown[]): { tx: Bun.SQL; statements: string[] } {
+  const statements: string[] = [];
+
+  const tx = ((strings: TemplateStringsArray, ...args: unknown[]) => {
+    statements.push(
+      strings.raw
+        .map((part, i) => part + (i < args.length ? "?" : ""))
+        .join("")
+        .replace(/\s+/g, " ")
+        .trim()
+    );
+    return Promise.resolve(rows);
+  }) as unknown as Bun.SQL;
+
+  return { tx, statements };
+}
+
+const ROW = {
+  id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  name: "deploy hook",
+  tenant_user_id: "11111111-2222-3333-4444-555555555555",
+  allowed_permission_keys: ["blog_content.posts.create"],
+  allowed_write_actions: ["create"],
+  allowed_ip_cidrs: ["203.0.113.0/24"],
+  expires_at: new Date(NOW.getTime() + 7 * DAY),
+  last_used_at: null,
+  revoked_at: null,
+  created_by_tenant_user_id: "99999999-8888-7777-6666-555555555555",
+  created_at: NOW
+};
+
+describe("TIGA daftar kolom, dan tidak satu pun boleh terlewat", () => {
+  test("penerbitan, daftar, dan pencabutan semuanya memproyeksikan kedua kolom", async () => {
+    // Trap yang dijaga di sini: melewatkan satu daftar membuat GET benar
+    // sementara POST/revoke mengembalikan `undefined` untuk field baru — dan
+    // test yang hanya memeriksa daftar tidak akan pernah melihatnya.
+    const calls: [string, (tx: Bun.SQL) => Promise<unknown>][] = [
+      ["list", (tx) => listMachineCredentials(tx, TENANT, NOW)],
+      [
+        "issue",
+        (tx) =>
+          issueMachineCredential(
+            tx,
+            TENANT,
+            ACTOR,
+            {
+              name: "deploy hook",
+              tenantUserId: ROW.tenant_user_id,
+              allowedPermissionKeys: ["blog_content.posts.create"],
+              allowedWriteActions: ["create"],
+              allowedIpCidrs: ["203.0.113.0/24"],
+              expiresAt: ROW.expires_at
+            },
+            NOW
+          )
+      ],
+      ["revoke", (tx) => revokeMachineCredential(tx, TENANT, ROW.id, ACTOR, NOW)]
+    ];
+
+    for (const [label, call] of calls) {
+      const { tx, statements } = recordingTx([ROW]);
+      await call(tx);
+
+      const projecting = statements.filter(
+        (s) => s.includes("SELECT") || s.includes("RETURNING")
+      );
+      const withColumns = projecting.filter(
+        (s) =>
+          s.includes("allowed_write_actions") && s.includes("allowed_ip_cidrs")
+      );
+
+      expect(`${label}: ${withColumns.length}`).toBe(`${label}: 1`);
+    }
+  });
+
+  test("penerbitan MENULIS kedua kolom, dirender sebagai text[]", async () => {
+    const { tx, statements } = recordingTx([ROW]);
+
+    await issueMachineCredential(
+      tx,
+      TENANT,
+      ACTOR,
+      {
+        name: "deploy hook",
+        tenantUserId: ROW.tenant_user_id,
+        allowedPermissionKeys: ["blog_content.posts.create"],
+        allowedWriteActions: ["create"],
+        allowedIpCidrs: ["203.0.113.0/24"],
+        expiresAt: ROW.expires_at
+      },
+      NOW
+    );
+
+    const insert = statements.find((s) => s.includes("INSERT INTO"))!;
+
+    expect(insert).toContain("allowed_write_actions");
+    expect(insert).toContain("allowed_ip_cidrs");
+    // Bun.SQL tidak mem-bind array JS: `${array}` tiba sebagai teks
+    // gabung-koma dan Postgres menolaknya (22P02). Cast-nya adalah kontraknya.
+    expect(insert.match(/::text\[\]/g)?.length).toBe(3);
+  });
+
+  test("dan tetap tidak MEMINTA material rahasia", async () => {
+    const { tx, statements } = recordingTx([ROW]);
+    await listMachineCredentials(tx, TENANT, NOW);
+
+    // Bukan sekadar "tidak mengembalikannya" — tidak MEMINTANYA.
+    expect(statements[0]).not.toContain("token_hash");
+  });
+});
+
+describe("izin terpisah, dan ia benar-benar ada", () => {
+  test("rute memilih activityCode dari ADA-TIDAKNYA aksi tulis", async () => {
+    const source = await Bun.file(ROUTE).text();
+
+    // Diiris ke blok `authorize:` lebih dulu. Berkas ini juga menulis baris
+    // audit, dan asersi se-berkas atas nama izin akan mencampur keduanya —
+    // kegagalan yang persis dialami test kontrak `/admin/partners`.
+    const start = source.indexOf("  authorize: ({ prepared })");
+    const guard = source.slice(start, source.indexOf("  handler:", start));
+
+    expect(start).toBeGreaterThan(-1);
+    expect(guard).toContain("prepared.allowedWriteActions.length > 0");
+    expect(guard).toContain('"machine_credentials_write"');
+    expect(guard).toContain('"machine_credentials"');
+    expect(guard).toContain('action: "create"');
+  });
+
+  test("izinnya DIDEKLARASIKAN sebuah modul — kalau tidak, tak ada peran bisa memegangnya", () => {
+    const declared = listModules().flatMap((module) =>
+      (module.permissions ?? []).map(
+        (permission) =>
+          `${module.key}.${permission.activityCode}.${permission.action}`
+      )
+    );
+
+    expect(declared).toContain(
+      "identity_access.machine_credentials_write.create"
+    );
+  });
+
+  test("dan DISEED — aksi yang tak diseed menolak owner secara senyap", async () => {
+    // Katalog izin bersifat global dan hanya bertambah lewat migrasi. Sebuah
+    // deklarasi modul tanpa baris katalognya adalah izin yang tidak bisa
+    // diberikan siapa pun, dan gejalanya 403 yang tidak bisa dijelaskan.
+    const migration = await Bun.file(MIGRATION).text();
+
+    expect(migration).toContain("'machine_credentials_write'");
+    expect(migration).toContain("'identity_access'");
+    expect(migration).toContain("ON CONFLICT");
+  });
+
+  test("kelas BACA tetap di izin lamanya — kalau tidak, ini pelebaran senyap", async () => {
+    const source = await Bun.file(ROUTE).text();
+    const start = source.indexOf("  authorize: ({ prepared })");
+    const guard = source.slice(start, source.indexOf("  handler:", start));
+
+    // Cabang yang dipilih ketika daftar aksi tulis KOSONG harus tetap
+    // `machine_credentials`. Kalau keduanya menjadi `machine_credentials_write`
+    // setiap penerbit read-only yang ada kehilangan aksesnya; kalau keduanya
+    // menjadi `machine_credentials`, setiap penerbit read-only yang ada
+    // MENDAPAT hak mencetak kredensial tulis. Dua arah, satu asersi.
+    const writeAt = guard.indexOf('? "machine_credentials_write"');
+    const readAt = guard.indexOf(': "machine_credentials",');
+
+    expect(writeAt).toBeGreaterThan(-1);
+    expect(readAt).toBeGreaterThan(writeAt);
+  });
+});
+
+describe("jejak audit membedakan kedua kelas", () => {
+  test("severity dan atribut ikut kelasnya", async () => {
+    const source = await Bun.file(ROUTE).text();
+
+    expect(source).toContain("severity: writeClass ?");
+    expect(source).toContain('"critical"');
+    expect(source).toContain("allowedWriteActions: result.credential.allowedWriteActions");
+    expect(source).toContain("allowedIpCidrs: result.credential.allowedIpCidrs");
+  });
+
+  test("dan token-nya tetap TIDAK ada di sana", async () => {
+    const source = await Bun.file(ROUTE).text();
+    const auditAt = source.indexOf("recordAuditEvent(tx, {");
+    const audit = source.slice(auditAt, source.indexOf("});", auditAt));
+
+    expect(auditAt).toBeGreaterThan(-1);
+    expect(audit).not.toContain("result.token");
+  });
+});

--- a/tests/machine-credential-write-issuance.test.ts
+++ b/tests/machine-credential-write-issuance.test.ts
@@ -19,6 +19,10 @@
 import { describe, expect, test } from "bun:test";
 
 import { listModules } from "../src/modules";
+import {
+  collectGuardTriples,
+  resolveConstantsForSource
+} from "../src/modules/_shared/permission-enforcement-coverage";
 import { isHighRiskAction } from "../src/modules/identity-access/domain/access-control";
 import type { AccessAction } from "../src/modules/identity-access/domain/access-control";
 import {
@@ -35,7 +39,8 @@ import {
 } from "../src/modules/identity-access/application/machine-credential-directory";
 
 const ROUTE = "src/pages/api/v1/access/machine-credentials/index.ts";
-const MIGRATION = "sql/122_awcms_identity_machine_credential_write_permissions.sql";
+const MIGRATION =
+  "sql/122_awcms_identity_machine_credential_write_permissions.sql";
 
 const NOW = new Date("2026-08-13T00:00:00.000Z");
 const DAY = 24 * 60 * 60 * 1000;
@@ -44,7 +49,9 @@ const DAY = 24 * 60 * 60 * 1000;
 const TENANT = "00000000-0000-4000-8000-000000000001";
 const ACTOR = "99999999-8888-7777-6666-555555555555";
 
-function body(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+function body(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
   return {
     name: "deploy hook",
     tenantUserId: "11111111-2222-3333-4444-555555555555",
@@ -306,7 +313,10 @@ describe("TIGA daftar kolom, dan tidak satu pun boleh terlewat", () => {
             NOW
           )
       ],
-      ["revoke", (tx) => revokeMachineCredential(tx, TENANT, ROW.id, ACTOR, NOW)]
+      [
+        "revoke",
+        (tx) => revokeMachineCredential(tx, TENANT, ROW.id, ACTOR, NOW)
+      ]
     ];
 
     for (const [label, call] of calls) {
@@ -412,11 +422,34 @@ describe("izin terpisah, dan ia benar-benar ada", () => {
     // setiap penerbit read-only yang ada kehilangan aksesnya; kalau keduanya
     // menjadi `machine_credentials`, setiap penerbit read-only yang ada
     // MENDAPAT hak mencetak kredensial tulis. Dua arah, satu asersi.
-    const writeAt = guard.indexOf('? "machine_credentials_write"');
-    const readAt = guard.indexOf(': "machine_credentials",');
+    const writeAt = guard.indexOf('activityCode: "machine_credentials_write"');
+    const readAt = guard.indexOf('activityCode: "machine_credentials",');
 
     expect(writeAt).toBeGreaterThan(-1);
     expect(readAt).toBeGreaterThan(writeAt);
+  });
+
+  test("dan gerbang enforcement BISA MEMBACA keduanya", async () => {
+    // Dijalankan dengan logika gerbangnya sendiri, bukan ditiru dengan string
+    // matching. Percobaan pertama menulis guard ini sebagai SATU literal dengan
+    // ternary pada `activityCode`; `collectGuardTriples` tidak bisa membacanya
+    // dan melaporkan KEDUA izin "enforced by nothing" — alibi palsu yang sama
+    // yang ADR-0058 §E catat untuk `visitor_analytics`. Sebuah rute yang tak
+    // terbaca gerbang ini adalah rute yang izinnya bisa dicabut orang lain
+    // tanpa ada yang memerah.
+    const source = await Bun.file(ROUTE).text();
+    const keys = collectGuardTriples(
+      source,
+      // No cross-file constants: this route spells every guard field as a
+      // literal, and passing an empty map is how the test proves that rather
+      // than assuming it.
+      resolveConstantsForSource(source, new Map())
+    ).map(
+      (triple) => `${triple.moduleKey}.${triple.activityCode}.${triple.action}`
+    );
+
+    expect(keys).toContain("identity_access.machine_credentials.create");
+    expect(keys).toContain("identity_access.machine_credentials_write.create");
   });
 });
 
@@ -426,8 +459,12 @@ describe("jejak audit membedakan kedua kelas", () => {
 
     expect(source).toContain("severity: writeClass ?");
     expect(source).toContain('"critical"');
-    expect(source).toContain("allowedWriteActions: result.credential.allowedWriteActions");
-    expect(source).toContain("allowedIpCidrs: result.credential.allowedIpCidrs");
+    expect(source).toContain(
+      "allowedWriteActions: result.credential.allowedWriteActions"
+    );
+    expect(source).toContain(
+      "allowedIpCidrs: result.credential.allowedIpCidrs"
+    );
   });
 
   test("dan token-nya tetap TIDAK ada di sana", async () => {


### PR DESCRIPTION
Menutup **sisa #423 nomor 1** yang tercatat di `docs/PROJECT_STATE.md` §4: `sql/121` membuka kelas tulis di skema dan di chokepoint, lalu sengaja berhenti — kolomnya ada, gerbangnya menegakkannya, dan tidak ada rute yang bisa menerbitkan satu pun.

Tanpa ADR baru: ADR-0092 §Konsekuensi sudah menamai permukaan ini sebagai pekerjaan lanjutan. Yang tetap memicu ADR adalah **melebarkan plafon aksi**, bukan menerbitkan di dalam plafon yang ada.

## Izinnya BARU, dan itu seluruh keputusannya

Bentuk yang jelas adalah menerima `allowedWriteActions` pada `machine_credentials.create` yang sudah ada. Bentuk itu salah, dan salahnya hanya terlihat kalau ditanyakan dari sisi grant: setiap peran yang hari ini memegang `create` akan **mendapat** hak mencetak kredensial yang mengubah data pada hari rilis — pelebaran tanpa satu grant pun disunting, tanpa satu baris di diff untuk di-review, dan tanpa apa pun di jejak audit yang menandainya. Program #423 dibangun di atas aturan sebaliknya.

Jadi kelas tulis mendapat aktivitas ketiga: `identity_access.machine_credentials_write.create` (`sql/122`). Default-deny menahan sisanya — sampai seseorang memberikannya dengan sengaja, rute menjawab 403 untuk setiap permintaan tulis dan berperilaku persis seperti sebelum `sql/121`.

`revoke` **tidak** ikut dipecah, dan itu keputusan: saat insiden, siapa pun yang bisa membunuh kredensial bocor harus bisa membunuh setiap kelasnya.

## CIDR pada kredensial BACA ditolak

Arah yang tidak dijaga apa pun selain validator ini. `isMachineCredentialWriteRefused` menjawab "tidak ditolak" untuk `read` **sebelum** ia menyentuh daftar CIDR — basis data mengizinkan baris seperti itu, gerbang runtime tidak peduli, dan operator akan mengira ia mengikat sesuatu yang tidak pernah dikonsultasi. Ditolak, bukan dibuang diam-diam: membuangnya meninggalkan keyakinan yang sama.

CIDR tak-terbaca juga ditolak **di penerbitan**, meski penegakan sudah aman terhadapnya — keduanya menjawab pertanyaan berbeda. `10.0.0.0/` ikut ditolak karena `Number("")` adalah 0, dan prefix nol adalah seluruh internet.

## Jebakan gerbang, dan biayanya nyata

`access:permissions:enforcement:check` membaca guard sebagai **literal objek ber-tiga-kunci**. Percobaan pertama menulis guard sebagai satu literal dengan ternary pada `activityCode`, dan gerbang melaporkan **kedua** izin `enforced by nothing` — termasuk yang sudah ditegakkan sebelum PR ini. Itu alibi palsu yang sama yang ADR-0058 §E catat untuk `visitor_analytics`. Bentuk yang benar: dua literal utuh di kedua cabang. Sebuah test menjalankan `collectGuardTriples` yang asli terhadap berkas rute yang asli supaya bentuk itu tidak bisa runtuh diam-diam.

## Satu cacat ditemukan oleh test-nya sendiri

Kelas tulis awalnya diturunkan dari aksi yang **lolos parse**, bukan yang **diminta** — sehingga permintaan ber-`delete` dengan CIDR yang benar dikembalikan sebagai read-only lalu dimarahi soal CIDR-nya. Satu kesalahan, dua pesan, dan yang kedua membantah apa yang jelas-jelas diminta.

## Diverifikasi dengan menjalankan

- `DATABASE_URL="" bun run check` **hijau penuh** — 41 segmen, 4701 test, build.
- **Tiga mutasi memerahkan test yang tepat:** menghapus kolom dari satu dari TIGA daftar proyeksi (1 merah), menyamakan kedua cabang guard menjadi `machine_credentials` (4 merah), menghapus penolakan CIDR-pada-kelas-baca (6 merah).
- Kontrak konsumen ADR-0065 **diregenerasi dengan sengaja**; diff-nya prosa plus dua properti **opsional** — nol rename, nol penghapusan, nol field menjadi wajib, jadi build `awcms-astro` tidak bisa pecah karenanya. Teks "read-only" di kontrak sudah menjadi klaim palsu sejak ADR-0092 mendarat dan ikut dibetulkan.
- Test integrasi ber-Postgres baru: round-trip kedua kolom, `authorizeInTransaction` mengizinkan `update` dari dalam allow-list dan menolaknya dari luar **dan** saat IP tidak diketahui, plus dua `assertRejected` untuk CHECK `sql/121`. (Butuh DB — dijalankan di CI.)

`NOT_YET_SCREENED` tumbuh 59 → 60: kredensial mesin belum punya layar sama sekali, dan layar yang bisa mencetak kelas **tulis** sementara kelas baca tetap panggilan API adalah layar yang salah untuk dibangun lebih dulu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)