### PR TITLE
feat(auth): registri partner punya penulis — GET/POST /api/v1/partners (ADR-0089, #423)

### DIFF
--- a/.changeset/partner-registration-surface.md
+++ b/.changeset/partner-registration-surface.md
@@ -1,0 +1,56 @@
+---
+"awcms": minor
+---
+
+feat(auth): registri partner punya penulis — `GET`/`POST /api/v1/partners` (ADR-0089, #423)
+
+`sql/116` mengirim `awcms_partners` tanpa penulis: satu-satunya cara membuat baris
+partner adalah operator dengan prompt psql, dan suite E2E gelombang itu
+menuliskannya sendiri dengan komentar "belum ada jalur request untuk ini". Ini
+menutup sisa #423 nomor 3.
+
+KEDUANYA BER-SCOPE PLATFORM, DAN `read` BUKAN KELALAIAN. `create` menyatakan siapa
+yang BOLEH MENJADI partner — paruh platform dari pemisahan yang ADR-0089 jaga
+terhadap `partner_access.configure` milik pelanggan ("partner mana yang menjangkau
+tenant SAYA"). Tidak ada satu aktor pun yang memegang keduanya. `read` mendaftar
+SELURUH partner, dan versi tenant-scoped-nya adalah persis direktori lintas-tenant
+yang ADR yang sama tolak sebagai tabel — dibangun ulang sebagai permission. Dua
+mekanisme independen menjaganya: RLS menaruh setiap baris di tenant platform, dan
+chokepoint menolak permission ber-scope platform kecuali tenant yang bertindak
+MEMANG tenant platform.
+
+TIDAK ADA `DELETE`, DAN ITU KEPUTUSAN. `awcms_partners.partner_tenant_id` adalah
+target FK dari keterlibatan DAN dari grant terdelegasi yang `sql/120` buat sengaja
+HIDUP LEBIH LAMA dari kemitraannya. DELETE akan gagal begitu satu kemitraan pernah
+ada, dan "memperbaikinya" dengan `ON DELETE CASCADE` memutus setiap kemitraan di
+instalasi. Pensiun adalah perubahan `status`, dan `status` dipatok `sql/116` sampai
+ada yang MEMBACA suspensi — jadi permukaan ini juga tidak menerima `status` sama
+sekali. Field yang diterima API lalu ditolak basis data lebih buruk daripada tidak
+ada field; field yang diterima dan disimpan sementara tak ada yang membacanya lebih
+buruk lagi.
+
+KONFLIK DISELESAIKAN TANPA MEMBACA SQLSTATE. Kedua kunci naturalnya punya index unik
+GLOBAL, jadi pendaftaran ganda bisa kalah pada salah satu dari dua index — dan
+membedakannya lewat error driver berarti membaca SQLSTATE dari tempat yang di repo
+ini bukan `error.code`. `ON CONFLICT DO NOTHING` menghindari pertanyaannya dan
+menjaga transaksi tetap bisa dipakai untuk satu pembacaan yang memberi tahu kunci
+MANA yang terpakai. Karena itu juga tidak ber-`Idempotency-Key`: submit ganda adalah
+409, bukan baris kedua, jadi tidak ada hasil untuk diputar ulang.
+
+`partnerCode` divalidasi di aplikasi meski `sql/116` tidak memberinya CHECK, dan
+alasannya index uniknya global tanpa normalisasi apa pun: `Acme-Digital` dan
+`acme-digital` adalah dua partner bagi Postgres dan satu partner bagi manusia yang
+membaca daftarnya.
+
+DIVERIFIKASI DENGAN MENJALANKAN. `bun run check` penuh hijau (41 segmen). Empat
+mutasi memerahkan test yang tepat: INSERT ikut menulis `status`, seed grant berjalan
+di atas `awcms_tenants` alih-alih `awcms_setup_state` (cacat asli yang ADR-0053
+tutup), `partnerCode` menerima huruf besar, dan pendaftaran diri sendiri diloloskan.
+Suite E2E partner kini MEMULAI seluruh alurnya dari penulis ini alih-alih dari INSERT
+tangan — lewat `withTenantOrThrow`, karena `set_config` bersifat per-koneksi dan tiga
+pernyataan pada pool tidak akan selamat seperti satu pernyataan selamat.
+
+`NOT_YET_SCREENED` tumbuh 60 → 62. Layarnya BUKAN `/admin/partners`: halaman itu
+adalah pandangan PELANGGAN atas siapa yang menjangkau tenant-nya sendiri, dan
+menaruh registri di sana menaruh daftar setiap kemitraan platform di depan setiap
+pelanggan.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -39,7 +39,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > Keluarga hari ini dua repo, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (halaman publik + permukaan admin USER, ADR-0070). **KOREKSI:** versi sebelumnya menyatakan
 > implementasi ini "baru fondasi Sprint 1–2" dengan empat modul — itu **sudah
-> lama tidak benar**. Repo ini punya **22 modul terdaftar** dan `sql/001`–`sql/122`;
+> lama tidak benar**. Repo ini punya **22 modul terdaftar** dan `sql/001`–`sql/123`;
 > lihat [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) untuk daftar nyata.
 > Skill yang badannya masih menandai dirinya "BACAAN SAJA" tetap begitu — itu
 > per-skill, bukan pernyataan tentang repo secara keseluruhan.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ Sebagai template yang di-ship, base menyediakan **modul fondasi reusable + kontr
 modul domain ERP (finance, inventory, procurement, manufacturing, hr-payroll, dst.)
 **ditambahkan langsung di `src/modules/` template ini** saat dipakai, bukan di repo
 ekstensi/turunan terpisah (jalur aplikasi-turunan DIHAPUS — lihat §Komposisi modul di
-bawah). Repo ini punya **22 modul terdaftar**, migration `sql/001`-`sql/122`, RLS
+bawah). Repo ini punya **22 modul terdaftar**, migration `sql/001`-`sql/123`, RLS
 `FORCE` di seluruh tabel tenant-scoped, pemisahan role database, dan admin UI read+write
 (Issue #166, #171). Dokumen ini menjelaskan apa yang **ada di kode saat ini**. Untuk detail
 per modul, lihat `README.md` masing-masing di `src/modules/<module>/`.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -107,7 +107,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Changeset menunggu (per tipe bump) | _jalankan perintah di kolom kanan_                                                      | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commit sejak rilis terakhir        | _jalankan perintah di kolom kanan_                                                      | `git rev-list --count v8.1.0..HEAD`                                                     |
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
-| Migrasi                            | **122** (`sql/001`–`122`)                                                               | `ls sql/`                                                                               |
+| Migrasi                            | **123** (`sql/001`–`123`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
 | Layar admin                        | **35** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Berkas `.astro`                    | **48** (26.424 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
@@ -355,6 +355,45 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN 13 Agustus 2026 (kedua puluh satu) — REGISTRI PARTNER PUNYA PENULIS.**
+
+  Menutup sisa #423 nomor 3. `sql/123` + `GET`/`POST /api/v1/partners`; tanpa
+  ADR baru — ADR-0089 sudah menamai permukaan ini, dan `sql/116` sengaja
+  mengirim tabelnya tanpa penulis. Bukti bahwa itu terasa: suite E2E Gelombang 8
+  menuliskan barisnya sendiri, dengan komentar "belum ada jalur request untuk
+  ini". Komentar itu kini hilang, dan alurnya dimulai dari penulis yang sama.
+
+  **Kedua izinnya ber-scope platform, dan `read` bukan kelalaian.** `create`
+  menyatakan siapa yang BOLEH MENJADI partner — paruh platform dari pemisahan
+  yang ADR-0089 jaga terhadap `partner_access.configure` milik pelanggan. `read`
+  mendaftar SELURUH partner, dan versi tenant-scoped-nya adalah direktori
+  lintas-tenant yang ADR yang sama tolak sebagai tabel, dibangun ulang sebagai
+  permission.
+
+  **Tidak ada `DELETE`, dan itu keputusan.** Barisnya target FK dari
+  keterlibatan DAN dari grant terdelegasi yang `sql/120` buat sengaja hidup
+  lebih lama darinya; DELETE gagal begitu satu kemitraan pernah ada, dan
+  `ON DELETE CASCADE` memutus setiap kemitraan di instalasi. Pensiun adalah
+  perubahan `status` — dan `status` tetap dipatok, jadi permukaan ini tidak
+  menerimanya sama sekali.
+
+  **Konflik diselesaikan tanpa membaca SQLSTATE.** Kedua kunci naturalnya punya
+  index unik GLOBAL, jadi membedakan kedua 23505-nya lewat error driver berarti
+  membaca SQLSTATE dari tempat yang di repo ini bukan `error.code`.
+  `ON CONFLICT DO NOTHING` plus satu pembacaan penentu menghindari pertanyaannya
+  — dan itu pula alasan rute ini tidak ber-`Idempotency-Key`.
+
+  **Jebakan yang ditemukan saat menyambungkan E2E:** `set_config` bersifat
+  SESSION-scoped, jadi pada klien ber-pool pernyataan kedua bisa mendarat di
+  koneksi yang tak pernah melihatnya. Tulisan satu-pernyataan yang ada di suite
+  itu selamat karena kebetulan; tiga pernyataan tidak akan. Pemanggilannya
+  dibungkus `withTenantOrThrow`.
+
+  `NOT_YET_SCREENED` 60 → 62. Layarnya BUKAN `/admin/partners` — halaman itu
+  pandangan PELANGGAN atas siapa yang menjangkau tenant-nya sendiri, dan menaruh
+  registri di sana menaruh daftar setiap kemitraan platform di depan setiap
+  pelanggan.
 
 - **PUTARAN 13 Agustus 2026 (kedua puluh) — KREDENSIAL MESIN KELAS-TULIS BISA
   DITERBITKAN, dan izinnya sendiri.**

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -2238,6 +2238,44 @@ ADR-0089. Served by a narrow SECURITY DEFINER function (`sql/119`), because the 
 | 401    | Missing or invalid session.       | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.       | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/partners` — PLATFORM: the partner registry.
+
+- **operationId**: `listRegisteredPartners`
+- **Security**: bearerAuth + tenantHeader
+
+ADR-0089. Lists every partner registered on the deployment, and is PLATFORM-scoped for exactly that reason: a tenant-scoped version of this read is the cross-tenant directory the same ADR refused as a table. Reachable only when the acting tenant IS the platform tenant, and every row carries the platform tenant's `tenant_id` so FORCE RLS hides them from any other session even if a grant row existed. Both mechanisms are load-bearing; neither is a backstop for the other.
+
+**Responses**
+
+| Status | Description                             | Schema                                 |
+| ------ | --------------------------------------- | -------------------------------------- |
+| 200    | The registry, newest first (limit 200). | object                                 |
+| 401    | Missing or invalid session.             | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.             | [`ApiError`](#standard-error-envelope) |
+
+### `POST /api/v1/partners` — PLATFORM: register an existing tenant as a partner (audit-logged).
+
+- **operationId**: `registerPartner`
+- **Security**: bearerAuth + tenantHeader
+
+ADR-0089. Declares who may BE a partner — the platform's half of a split this ADR keeps apart from the customer's `partner_access.configure` ("which partners reach MY tenant"). No single actor holds both.
+It creates nothing but a row. A partner is an ordinary tenant: the one named here must already exist, this does not provision it, and the row grants nothing. It is the PRECONDITION a customer's engagement checks through a foreign key, and `activeRoleGrants` never reads it.
+`status` is not accepted — `sql/116` pins it to `active` until something reads suspension. There is no DELETE: the row is the target of foreign keys from engagements and from delegated grants that deliberately outlive them, so retirement will be a status change, not a removal.
+Not idempotency-keyed: both natural keys are globally unique, so a duplicate submit is a 409 naming which one was taken rather than a second row.
+
+**Request body** (required): [`RegisterPartnerRequest`](#schema-registerpartnerrequest)
+
+**Responses**
+
+| Status | Description                                                                                                | Schema                                 |
+| ------ | ---------------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| 201    | The registered partner.                                                                                    | object                                 |
+| 401    | Missing or invalid session.                                                                                | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                                                                | [`ApiError`](#standard-error-envelope) |
+| 404    | No such tenant on this deployment (TENANT_NOT_FOUND).                                                      | [`ApiError`](#standard-error-envelope) |
+| 409    | The tenant is already a partner, the partnerCode is taken, or the platform tenant named itself (CONFLICT). | [`ApiError`](#standard-error-envelope) |
+| 422    | The registration failed validation (VALIDATION_FAILED); `error.details` lists every offending field.       | [`ApiError`](#standard-error-envelope) |
+
 ### `GET /api/v1/registration-requests` — Pending self-registration requests for this tenant.
 
 - **operationId**: `listRegistrationRequests`
@@ -9394,6 +9432,24 @@ Enum values: `web_push`, `fcm`.
   "clientSecret": "string",
   "code": "string",
   "redirectUri": "string"
+}
+```
+
+### Schema: RegisterPartnerRequest
+
+| Field             | Type          | Required | Nullable | Description                                                                                                                                                                                                                                                                               |
+| ----------------- | ------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `partnerTenantId` | string (uuid) | yes      | no       | An EXISTING tenant on this deployment, and not the platform tenant itself. The platform learns this id out of band — there is no picker and there is not meant to be.                                                                                                                     |
+| `partnerCode`     | string        | yes      | no       | Lower-case letters, digits and hyphens; starts and ends with a letter or digit. Globally unique. The format is enforced in the application rather than by a CHECK because the uniqueness index is global: a stray capital produces a second row that reads like the first one to a human. |
+| `displayName`     | string        | yes      | no       |                                                                                                                                                                                                                                                                                           |
+
+**Example**
+
+```json
+{
+  "partnerTenantId": "00000000-0000-0000-0000-000000000000",
+  "partnerCode": "string",
+  "displayName": "string"
 }
 ```
 

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -141,7 +141,7 @@
           "optional": false
         }
       ],
-      "permissionCount": 40,
+      "permissionCount": 42,
       "navigationCount": 7,
       "jobCount": 3,
       "hasHealthCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -8,12 +8,12 @@
 | Aspek                              | Nilai |
 | ---------------------------------- | ----- |
 | Modul terdaftar                    | 22    |
-| Migrasi                            | 122   |
+| Migrasi                            | 123   |
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 368   |
-| Berkas route                       | 344   |
+| Berkas test                        | 369   |
+| Berkas route                       | 345   |
 | ADR                                | 93    |
 
 ### Modul
@@ -169,6 +169,7 @@
 | 120 | `sql/120_awcms_grant_outlives_engagement.sql`                      |
 | 121 | `sql/121_awcms_machine_credential_write_class.sql`                 |
 | 122 | `sql/122_awcms_identity_machine_credential_write_permissions.sql`  |
+| 123 | `sql/123_awcms_partner_registry_permissions.sql`                   |
 
 ### Tabel & Row-Level Security
 
@@ -325,7 +326,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 314        |
+| `(root)`      | 315        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |
@@ -334,7 +335,7 @@
 
 | Permukaan       | Berkas |
 | --------------- | ------ |
-| `/api/v1/**`    | 285    |
+| `/api/v1/**`    | 286    |
 | `/admin/**`     | 35     |
 | publik / anonim | 24     |
 

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -767,6 +767,11 @@
       "source": "factory"
     },
     {
+      "path": "src/pages/api/v1/partners/index.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/profiles/[id].ts",
       "workClass": "interactive",
       "source": "default"

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -10791,6 +10791,91 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/partners:
+    get:
+      operationId: listRegisteredPartners
+      tags:
+        - Identity & Access
+      summary: "PLATFORM: the partner registry."
+      description: "ADR-0089. Lists every partner registered on the deployment, and is PLATFORM-scoped for exactly that reason: a tenant-scoped version of this read is the cross-tenant directory the same ADR refused as a table. Reachable only when the acting tenant IS the platform tenant, and every row carries the platform tenant's `tenant_id` so FORCE RLS hides them from any other session even if a grant row existed. Both mechanisms are load-bearing; neither is a backstop for the other."
+      responses:
+        "200":
+          description: The registry, newest first (limit 200).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/RegisteredPartner"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      operationId: registerPartner
+      tags:
+        - Identity & Access
+      summary: "PLATFORM: register an existing tenant as a partner (audit-logged)."
+      description: |-
+        ADR-0089. Declares who may BE a partner — the platform's half of a split this ADR keeps apart from the customer's `partner_access.configure` ("which partners reach MY tenant"). No single actor holds both.
+        It creates nothing but a row. A partner is an ordinary tenant: the one named here must already exist, this does not provision it, and the row grants nothing. It is the PRECONDITION a customer's engagement checks through a foreign key, and `activeRoleGrants` never reads it.
+        `status` is not accepted — `sql/116` pins it to `active` until something reads suspension. There is no DELETE: the row is the target of foreign keys from engagements and from delegated grants that deliberately outlive them, so retirement will be a status change, not a removal.
+        Not idempotency-keyed: both natural keys are globally unique, so a duplicate submit is a 409 naming which one was taken rather than a second row.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterPartnerRequest"
+      responses:
+        "201":
+          description: The registered partner.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      partner:
+                        $ref: "#/components/schemas/RegisteredPartner"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: No such tenant on this deployment (TENANT_NOT_FOUND).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: The tenant is already a partner, the partnerCode is taken, or the platform tenant named itself (CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: The registration failed validation (VALIDATION_FAILED); `error.details` lists every offending field.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/profiles:
     get:
       operationId: listProfiles
@@ -20666,6 +20751,51 @@ components:
           type: string
           format: uri
           description: Must equal the URI the code was issued against.
+    RegisteredPartner:
+      type: object
+      description: A row of the platform's partner registry (ADR-0089). `tenantCode` and `tenantName` come from `awcms_tenants` through a join rather than being denormalised here, so the registry can never hold a stale copy of a tenant's name.
+      properties:
+        id:
+          type: string
+          format: uuid
+        partnerTenantId:
+          type: string
+          format: uuid
+          description: The tenant that IS the partner. It already existed; this row did not create it.
+        partnerCode:
+          type: string
+        displayName:
+          type: string
+        status:
+          type: string
+          description: Pinned to `active` by `sql/116` until something reads suspension.
+          enum:
+            - active
+        registeredAt:
+          type: string
+          format: date-time
+        tenantCode:
+          type: string
+        tenantName:
+          type: string
+    RegisterPartnerRequest:
+      type: object
+      required:
+        - partnerTenantId
+        - partnerCode
+        - displayName
+      properties:
+        partnerTenantId:
+          type: string
+          format: uuid
+          description: An EXISTING tenant on this deployment, and not the platform tenant itself. The platform learns this id out of band — there is no picker and there is not meant to be.
+        partnerCode:
+          type: string
+          maxLength: 64
+          description: "Lower-case letters, digits and hyphens; starts and ends with a letter or digit. Globally unique. The format is enforced in the application rather than by a CHECK because the uniqueness index is global: a stray capital produces a second row that reads like the first one to a human."
+        displayName:
+          type: string
+          maxLength: 160
     RegistrationRequest:
       type: object
       description: A pending self-registration request. The login identifier is masked — the raw address is never returned in a list.

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -4859,6 +4859,113 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/partners:
+    get:
+      operationId: listRegisteredPartners
+      tags:
+        - Identity & Access
+      summary: "PLATFORM: the partner registry."
+      description: >-
+        ADR-0089. Lists every partner registered on the deployment, and is
+        PLATFORM-scoped for exactly that reason: a tenant-scoped version of this
+        read is the cross-tenant directory the same ADR refused as a table.
+        Reachable only when the acting tenant IS the platform tenant, and every
+        row carries the platform tenant's `tenant_id` so FORCE RLS hides them
+        from any other session even if a grant row existed. Both mechanisms are
+        load-bearing; neither is a backstop for the other.
+      responses:
+        "200":
+          description: The registry, newest first (limit 200).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      items:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/RegisteredPartner"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+    post:
+      operationId: registerPartner
+      tags:
+        - Identity & Access
+      summary: "PLATFORM: register an existing tenant as a partner (audit-logged)."
+      description: >-
+        ADR-0089. Declares who may BE a partner — the platform's half of a split
+        this ADR keeps apart from the customer's `partner_access.configure`
+        ("which partners reach MY tenant"). No single actor holds both.
+
+        It creates nothing but a row. A partner is an ordinary tenant: the one
+        named here must already exist, this does not provision it, and the row
+        grants nothing. It is the PRECONDITION a customer's engagement checks
+        through a foreign key, and `activeRoleGrants` never reads it.
+
+        `status` is not accepted — `sql/116` pins it to `active` until something
+        reads suspension. There is no DELETE: the row is the target of foreign
+        keys from engagements and from delegated grants that deliberately
+        outlive them, so retirement will be a status change, not a removal.
+
+        Not idempotency-keyed: both natural keys are globally unique, so a
+        duplicate submit is a 409 naming which one was taken rather than a
+        second row.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterPartnerRequest"
+      responses:
+        "201":
+          description: The registered partner.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      partner:
+                        $ref: "#/components/schemas/RegisteredPartner"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          description: No such tenant on this deployment (TENANT_NOT_FOUND).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "409":
+          description: >-
+            The tenant is already a partner, the partnerCode is taken, or the
+            platform tenant named itself (CONFLICT).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
+        "422":
+          description: The registration failed validation (VALIDATION_FAILED); `error.details` lists every offending field.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/partner/tenants:
     get:
       operationId: listManagedTenants
@@ -5977,6 +6084,63 @@ components:
           type: string
           format: uuid
           nullable: true
+    RegisteredPartner:
+      type: object
+      description: >-
+        A row of the platform's partner registry (ADR-0089). `tenantCode` and
+        `tenantName` come from `awcms_tenants` through a join rather than being
+        denormalised here, so the registry can never hold a stale copy of a
+        tenant's name.
+      properties:
+        id:
+          type: string
+          format: uuid
+        partnerTenantId:
+          type: string
+          format: uuid
+          description: The tenant that IS the partner. It already existed; this row did not create it.
+        partnerCode:
+          type: string
+        displayName:
+          type: string
+        status:
+          type: string
+          description: Pinned to `active` by `sql/116` until something reads suspension.
+          enum:
+            - active
+        registeredAt:
+          type: string
+          format: date-time
+        tenantCode:
+          type: string
+        tenantName:
+          type: string
+    RegisterPartnerRequest:
+      type: object
+      required:
+        - partnerTenantId
+        - partnerCode
+        - displayName
+      properties:
+        partnerTenantId:
+          type: string
+          format: uuid
+          description: >-
+            An EXISTING tenant on this deployment, and not the platform tenant
+            itself. The platform learns this id out of band — there is no picker
+            and there is not meant to be.
+        partnerCode:
+          type: string
+          maxLength: 64
+          description: >-
+            Lower-case letters, digits and hyphens; starts and ends with a
+            letter or digit. Globally unique. The format is enforced in the
+            application rather than by a CHECK because the uniqueness index is
+            global: a stray capital produces a second row that reads like the
+            first one to a human.
+        displayName:
+          type: string
+          maxLength: 160
     ManagedTenant:
       type: object
       description: >-

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -67,7 +67,7 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "form_drafts.draft.create",
   "form_drafts.draft.update",
 
-  // identity_access (20)
+  // identity_access (22)
   //
   // The four `invitations.*` keys are ADR-0082's, and they land here on the
   // same terms `tenant_admin.tenant_lifecycle.*` did: the surface exists and is
@@ -96,6 +96,14 @@ export const NOT_YET_SCREENED: readonly string[] = [
   // class while the read class stays an API call would be the wrong one to
   // build first.
   "identity_access.machine_credentials_write.create",
+  // ADR-0089. The PLATFORM half of partnership, and its screen is not
+  // `/admin/partners` — that page is the CUSTOMER's view of who reaches its own
+  // tenant, and putting a registry there would put the platform's list of every
+  // partnership in front of every customer. Its home is a platform screen
+  // alongside `/admin/tenants`, and that is its own change; the API landing
+  // first is the ordering ADR-0056 used for `media_library`.
+  "identity_access.partner_registry.create",
+  "identity_access.partner_registry.read",
   "identity_access.sso_providers.create",
   "identity_access.sso_providers.delete",
   "identity_access.sso_providers.update",

--- a/sql/123_awcms_partner_registry_permissions.sql
+++ b/sql/123_awcms_partner_registry_permissions.sql
@@ -1,0 +1,77 @@
+-- ADR-0089 — permission PLATFORM untuk registri partner.
+--
+-- `sql/116` membuat `awcms_partners` dan sengaja tidak memberinya penulis:
+-- barisnya hanya bisa dibuat operator lewat psql. Migrasi ini menyeed izin yang
+-- digerbangi `GET`/`POST /api/v1/partners`, permukaan pertama yang bisa
+-- menulisnya.
+--
+-- ## Kenapa keduanya `platform`, bukan `tenant`
+--
+-- `partner_registry.create` menyatakan siapa yang BOLEH MENJADI partner di
+-- deployment ini. Itu bukan aksi sebuah tenant atas datanya sendiri, dan
+-- ADR-0089 memisahkannya dengan sengaja dari `partner_access.configure`
+-- (tenant-scoped, ditulis PELANGGAN, "partner mana yang menjangkau tenant
+-- SAYA"). Menyatukannya memberi satu aktor kedua paruh — peleburan yang seluruh
+-- ADR itu ada untuk mencegahnya.
+--
+-- `partner_registry.read` mendaftar SELURUH partner. Versi tenant-scoped-nya
+-- adalah persis artefak yang ADR-0089 §Ditolak sebut sebagai "direktori setiap
+-- kemitraan komersial di instalasi ini, terbaca oleh setiap tenant" — dibangun
+-- ulang sebagai permission alih-alih sebagai tabel global.
+--
+-- Karena keduanya `scope = 'platform'`, `createTenantWithOwner` dan job
+-- backfill owner (keduanya menyaring `WHERE scope = 'tenant'`) tidak akan
+-- pernah memberikannya ke tenant mana pun — termasuk tenant partner itu
+-- sendiri. Sifat itulah yang membuat registri tidak bisa dibaca oleh yang
+-- terdaftar di dalamnya.
+--
+-- ## Grant
+--
+-- Sama seperti `sql/086`: ke role `owner` milik `awcms_setup_state.tenant_id`,
+-- dan hanya itu. Bentuk yang terbaca "lebih rapi" — grant yang berjalan di atas
+-- `awcms_tenants` — adalah cacat asli yang ADR-0053 tutup, dan gerbang
+-- `tests/platform-scoped-permissions.test.ts` menolaknya secara mekanis.
+--
+-- Deployment yang mengarahkan `PLATFORM_TENANT_ID` ke tenant lain memberikannya
+-- sendiri; `bun run security:readiness` melaporkan ketidakcocokan itu alih-alih
+-- membiarkannya ditemukan lewat 403.
+--
+-- ## Tidak ada perubahan skema
+--
+-- `awcms_partners` sudah lengkap sejak `sql/116`, dan berkas itu SUDAH TERAPAN
+-- — menyuntingnya, bahkan komentarnya, memblokir `db:migrate` pada deployment
+-- yang berjalan. CHECK `status = 'active'` juga TIDAK dilebarkan di sini:
+-- pelebarannya hanya boleh terjadi di PR yang sama dengan PEMBACA suspensi,
+-- kalau tidak ia adalah kontrol yang terbaca sebagai ditegakkan padahal tidak.
+--
+-- Idempotent: `ON CONFLICT` pada kunci natural, dan grant-nya anti-join.
+
+INSERT INTO awcms_permissions (module_key, activity_code, action, description, scope)
+VALUES
+  ('identity_access', 'partner_registry', 'read',
+   'PLATFORM: list every partner registered on the deployment',
+   'platform'),
+  ('identity_access', 'partner_registry', 'create',
+   'PLATFORM: register an existing tenant as a partner — audited. Grants nothing; it is the precondition a customer''s engagement checks',
+   'platform')
+ON CONFLICT (module_key, activity_code, action) DO UPDATE
+  SET scope = EXCLUDED.scope,
+      description = EXCLUDED.description;
+
+INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+SELECT s.tenant_id, r.id, p.id
+FROM awcms_setup_state s
+JOIN awcms_roles r
+  ON r.tenant_id = s.tenant_id
+ AND r.role_code = 'owner'
+ AND r.deleted_at IS NULL
+JOIN awcms_permissions p
+  ON p.module_key = 'identity_access'
+ AND p.activity_code = 'partner_registry'
+ AND p.action IN ('read', 'create')
+WHERE s.id = true
+  AND s.tenant_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM awcms_role_permissions existing
+    WHERE existing.role_id = r.id AND existing.permission_id = p.id
+  );

--- a/src/modules/identity-access/application/partner-registry-store.ts
+++ b/src/modules/identity-access/application/partner-registry-store.ts
@@ -1,0 +1,164 @@
+import type { RegisterPartnerInput } from "../domain/partner-registration";
+
+/**
+ * The ONLY writer of `awcms_partners` (ADR-0089). Reads and writes live here
+ * rather than in the route because `modules:table-writes:check` resolves table
+ * ownership from the file a write appears in, and a page or a second module
+ * writing this table would register as a second owner.
+ *
+ * Every function takes the acting tenant as `platformTenantId` and means it:
+ * the chokepoint has already refused the request unless the acting tenant IS
+ * the platform tenant (ADR-0053), so there is no second resolution here and no
+ * opportunity for the two to disagree.
+ */
+
+export type PartnerSummary = {
+  id: string;
+  partnerTenantId: string;
+  partnerCode: string;
+  displayName: string;
+  status: string;
+  registeredAt: Date;
+  /**
+   * From `awcms_tenants`, not denormalised. Reading the partner's own code and
+   * name through the join is what `partner-engagement-store.ts` already does
+   * for the customer side, and it keeps `awcms_partners` from becoming a second
+   * place a tenant's name is stored and can go stale.
+   */
+  tenantCode: string;
+  tenantName: string;
+};
+
+type PartnerRow = {
+  id: string;
+  partner_tenant_id: string;
+  partner_code: string;
+  display_name: string;
+  status: string;
+  registered_at: Date;
+  tenant_code: string;
+  tenant_name: string;
+};
+
+function toSummary(row: PartnerRow): PartnerSummary {
+  return {
+    id: row.id,
+    partnerTenantId: row.partner_tenant_id,
+    partnerCode: row.partner_code,
+    displayName: row.display_name,
+    status: row.status,
+    registeredAt: row.registered_at,
+    tenantCode: row.tenant_code,
+    tenantName: row.tenant_name
+  };
+}
+
+/**
+ * The registry, newest first.
+ *
+ * Two independent things keep this from being the cross-tenant directory
+ * ADR-0089 refused: RLS (every row carries the platform tenant's `tenant_id`,
+ * so no other tenant's session can see one) and the platform gate at the
+ * chokepoint. Removing either — a `SECURITY DEFINER` helper for a "partner
+ * picker", a view without RLS — rebuilds the artefact that was rejected.
+ */
+export async function listPartners(
+  tx: Bun.SQL,
+  platformTenantId: string
+): Promise<PartnerSummary[]> {
+  const rows = (await tx`
+    SELECT p.id, p.partner_tenant_id, p.partner_code, p.display_name,
+           p.status, p.registered_at, t.tenant_code, t.tenant_name
+    FROM awcms_partners p
+    JOIN awcms_tenants t ON t.id = p.partner_tenant_id
+    WHERE p.tenant_id = ${platformTenantId}
+    ORDER BY p.created_at DESC
+    LIMIT 200
+  `) as PartnerRow[];
+
+  return rows.map(toSummary);
+}
+
+export type RegisterPartnerResult =
+  | { outcome: "registered"; partner: PartnerSummary }
+  | { outcome: "tenant_not_found" }
+  | { outcome: "self" }
+  | { outcome: "already_registered" }
+  | { outcome: "code_taken" };
+
+/**
+ * Registers an EXISTING tenant as a partner.
+ *
+ * It creates nothing but a row. A partner is an ordinary tenant (ADR-0089) —
+ * this does not provision one, does not grant it anything, and is never read by
+ * `activeRoleGrants`. The row is a PRECONDITION for a customer to engage this
+ * partner, not a conferral of authority, and teaching authorization to read it
+ * would recreate the second grant path ADR-0079 removed.
+ */
+export async function registerPartner(
+  tx: Bun.SQL,
+  platformTenantId: string,
+  input: RegisterPartnerInput
+): Promise<RegisterPartnerResult> {
+  // Refused here as well as by `awcms_partners_not_self_check`, because a 23514
+  // is a stack trace where the honest answer is a sentence. The CHECK stays the
+  // thing that actually enforces it.
+  if (input.partnerTenantId === platformTenantId) return { outcome: "self" };
+
+  // `awcms_tenants` is the RLS-free root table, so this read is possible — and
+  // the caller is the platform, which already lists every tenant through
+  // `tenant_provisioning.read`. Checked explicitly so a missing tenant answers
+  // "no such tenant" rather than a raw 23503 from the foreign key.
+  const tenantRows = (await tx`
+    SELECT id FROM awcms_tenants WHERE id = ${input.partnerTenantId}
+  `) as { id: string }[];
+
+  if (!tenantRows[0]) return { outcome: "tenant_not_found" };
+
+  // `ON CONFLICT DO NOTHING` covers BOTH global unique indexes at once
+  // (`partner_tenant_id` and `partner_code`). Letting them raise instead would
+  // mean telling the two 23505s apart from a driver whose `code` is its own
+  // constant rather than the SQLSTATE — the trap this repo has already paid
+  // for. A conflict here leaves the transaction usable, so the disambiguating
+  // read below can run and the 409 can say WHICH key was taken.
+  const inserted = (await tx`
+    INSERT INTO awcms_partners
+      (tenant_id, partner_tenant_id, partner_code, display_name)
+    VALUES (
+      ${platformTenantId}, ${input.partnerTenantId},
+      ${input.partnerCode}, ${input.displayName}
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING id
+  `) as { id: string }[];
+
+  if (!inserted[0]) {
+    const clash = (await tx`
+      SELECT bool_or(partner_tenant_id = ${input.partnerTenantId}) AS tenant_taken
+      FROM awcms_partners
+      WHERE partner_tenant_id = ${input.partnerTenantId}
+         OR partner_code = ${input.partnerCode}
+    `) as { tenant_taken: boolean | null }[];
+
+    return clash[0]?.tenant_taken
+      ? { outcome: "already_registered" }
+      : { outcome: "code_taken" };
+  }
+
+  // Re-read through `listPartners`' shape rather than RETURNING the row: the
+  // summary carries the partner tenant's code and name, which the INSERT has no
+  // way to produce, and two spellings of one projection is how they diverge.
+  const rows = (await tx`
+    SELECT p.id, p.partner_tenant_id, p.partner_code, p.display_name,
+           p.status, p.registered_at, t.tenant_code, t.tenant_name
+    FROM awcms_partners p
+    JOIN awcms_tenants t ON t.id = p.partner_tenant_id
+    WHERE p.tenant_id = ${platformTenantId} AND p.id = ${inserted[0].id}
+  `) as PartnerRow[];
+
+  const row = rows[0];
+
+  if (!row) throw new Error("Partner insert returned no readable row.");
+
+  return { outcome: "registered", partner: toSummary(row) };
+}

--- a/src/modules/identity-access/domain/partner-registration.ts
+++ b/src/modules/identity-access/domain/partner-registration.ts
@@ -1,0 +1,108 @@
+/**
+ * Pure rules for registering a partner (ADR-0089). No I/O.
+ *
+ * `awcms_partners` is the registry the platform writes and nobody else can
+ * read: the FK from `awcms_partner_managed_tenants` bypasses RLS, so a customer
+ * can NAME a partner whose row it will never be able to see. That is what makes
+ * "registered partners only" enforceable without handing anybody a directory of
+ * the platform's commercial relationships.
+ *
+ * Until this file existed the registry had exactly one writer — an operator
+ * with a psql prompt.
+ */
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Lower-case slug, the spelling `tenant_code` already uses. Not enforced by a
+ * CHECK in `sql/116` — which is exactly why it is enforced here: `partner_code`
+ * carries a GLOBAL unique index, so a stray space or capital produces a second
+ * row that reads like the first one to a human and is a different key to
+ * Postgres.
+ */
+const PARTNER_CODE_PATTERN = /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+const PARTNER_CODE_MAX_LENGTH = 64;
+const DISPLAY_NAME_MAX_LENGTH = 160;
+
+export type PartnerRegistrationError = { field: string; message: string };
+
+export type RegisterPartnerInput = {
+  partnerTenantId: string;
+  partnerCode: string;
+  displayName: string;
+};
+
+export type RegisterPartnerValidation =
+  | { valid: true; value: RegisterPartnerInput }
+  | { valid: false; errors: PartnerRegistrationError[] };
+
+/**
+ * Collects EVERY problem rather than failing on the first — the same choice
+ * `validateIssueMachineCredentialInput` makes, for the same reason: an operator
+ * registering a partner is filling in a form.
+ *
+ * `status` is deliberately NOT accepted. `sql/116` pins it to `'active'` with a
+ * CHECK, and it stays pinned until the PR that ships a READER of suspension
+ * widens it. A field the API accepts and the database refuses is worse than no
+ * field, and a field the API accepts and the database stores while nothing
+ * consults it is worse still.
+ */
+export function validateRegisterPartnerInput(
+  body: unknown
+): RegisterPartnerValidation {
+  if (typeof body !== "object" || body === null) {
+    return {
+      valid: false,
+      errors: [{ field: "body", message: "Body must be a JSON object." }]
+    };
+  }
+
+  const input = body as Record<string, unknown>;
+  const errors: PartnerRegistrationError[] = [];
+
+  const partnerTenantId =
+    typeof input.partnerTenantId === "string"
+      ? input.partnerTenantId.trim()
+      : "";
+  if (!UUID_PATTERN.test(partnerTenantId)) {
+    errors.push({
+      field: "partnerTenantId",
+      message:
+        "partnerTenantId must be the uuid of an existing tenant on this deployment."
+    });
+  }
+
+  const partnerCode =
+    typeof input.partnerCode === "string" ? input.partnerCode.trim() : "";
+  if (partnerCode.length === 0) {
+    errors.push({ field: "partnerCode", message: "partnerCode is required." });
+  } else if (partnerCode.length > PARTNER_CODE_MAX_LENGTH) {
+    errors.push({
+      field: "partnerCode",
+      message: `partnerCode must be at most ${PARTNER_CODE_MAX_LENGTH} characters.`
+    });
+  } else if (!PARTNER_CODE_PATTERN.test(partnerCode)) {
+    errors.push({
+      field: "partnerCode",
+      message:
+        "partnerCode must be lower-case letters, digits and hyphens, starting and ending with a letter or digit."
+    });
+  }
+
+  const displayName =
+    typeof input.displayName === "string" ? input.displayName.trim() : "";
+  if (displayName.length === 0) {
+    errors.push({ field: "displayName", message: "displayName is required." });
+  } else if (displayName.length > DISPLAY_NAME_MAX_LENGTH) {
+    errors.push({
+      field: "displayName",
+      message: `displayName must be at most ${DISPLAY_NAME_MAX_LENGTH} characters.`
+    });
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+
+  return { valid: true, value: { partnerTenantId, partnerCode, displayName } };
+}

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -27,9 +27,17 @@ export const identityAccessModule = defineModule({
       "/api/v1/registration-requests",
       "/api/v1/user-groups",
       "/api/v1/invitations",
-      // ADR-0089 PR 8.4 — the partner's own view of its book. It reads nothing
-      // of any customer's data; acting inside a customer tenant happens through
-      // the delegated membership, under that tenant's own chokepoint.
+      // ADR-0089 — TWO partner surfaces, and this one prefix covers both
+      // because `resolveOwner` matches by prefix. Named here so the second one
+      // is a stated claim rather than a coincidence of spelling:
+      //
+      //   `/api/v1/partner/**`  — the partner's own view of its book. It reads
+      //     nothing of any customer's data; acting inside a customer tenant
+      //     happens through the delegated membership, under that tenant's own
+      //     chokepoint.
+      //   `/api/v1/partners`    — the platform's REGISTRY of who may be a
+      //     partner at all. Platform-scoped, and deliberately unreadable by any
+      //     customer: ADR-0089 refused a tenant-readable partner directory.
       "/api/v1/partner",
       "/login",
       "/forgot-password",
@@ -485,6 +493,32 @@ export const identityAccessModule = defineModule({
       action: "assign",
       description:
         "Approve delegated access for a partner at a chosen role, and revoke it — audited"
+    },
+    // The partner REGISTRY (ADR-0089, sql/116 + sql/123) — a different activity
+    // from `partner_access` above, and a different SCOPE, because they answer
+    // the two questions ADR-0089 kept apart on purpose.
+    //
+    // `partner_access.*` is tenant-scoped and answers "which partners reach MY
+    // tenant" — written by the customer. These two answer "who may be a partner
+    // at all" — written by the platform, and never by a customer. Folding them
+    // together would give one actor both halves, which is the merge the whole
+    // ADR exists to prevent.
+    //
+    // `read` is platform-scoped for the same reason `tenant_provisioning.read`
+    // is: it lists EVERY partner. A tenant-scoped read here would be the
+    // cross-tenant directory ADR-0089 refused, rebuilt as a permission.
+    {
+      activityCode: "partner_registry",
+      action: "read",
+      scope: "platform",
+      description: "PLATFORM: list every partner registered on the deployment"
+    },
+    {
+      activityCode: "partner_registry",
+      action: "create",
+      scope: "platform",
+      description:
+        "PLATFORM: register an existing tenant as a partner — audited. Grants nothing; it is the precondition a customer's engagement checks"
     }
   ],
   /**

--- a/src/pages/api/v1/partners/index.ts
+++ b/src/pages/api/v1/partners/index.ts
@@ -1,0 +1,142 @@
+import { defineTenantRoute } from "../../../../modules/_shared/tenant-route";
+import {
+  fail,
+  jsonResponse,
+  ok
+} from "../../../../modules/_shared/api-response";
+import {
+  bodyTooLargeResponse,
+  readJsonBody
+} from "../../../../lib/security/request-body-limit";
+import { recordAuditEvent } from "../../../../modules/logging/application/audit-log";
+import {
+  listPartners,
+  registerPartner
+} from "../../../../modules/identity-access/application/partner-registry-store";
+import {
+  validateRegisterPartnerInput,
+  type RegisterPartnerInput
+} from "../../../../modules/identity-access/domain/partner-registration";
+
+/**
+ * `GET` and `POST /api/v1/partners` (ADR-0089) — the partner REGISTRY, which
+ * until now could only be written by an operator with a psql prompt.
+ *
+ * ## Both are PLATFORM-scoped, and `read` is not an oversight
+ *
+ * The same reasoning `/api/v1/tenants` records. `create` names a new party to
+ * the deployment's commercial arrangements, which is not something a tenant
+ * does to its own data. `read` lists EVERY partner, and ADR-0089 refused
+ * exactly that list as a tenant-readable artefact: "a directory of every
+ * commercial partnership on this installation, readable by every tenant".
+ *
+ * Two independent mechanisms keep it that way, and both are load-bearing. RLS
+ * puts every row under the platform tenant, so no customer session can see one
+ * even holding a grant. The chokepoint refuses a platform-scoped permission
+ * unless the acting tenant IS the platform tenant, so no grant row makes it
+ * reachable. `tenantId` below is therefore the platform tenant by construction.
+ *
+ * ## What this endpoint deliberately does NOT do
+ *
+ * It does not provision a tenant — a partner is an ordinary tenant, and the one
+ * it names must already exist. It does not grant anything: the row is the
+ * PRECONDITION a customer's engagement checks through a foreign key, never a
+ * conferral, and `activeRoleGrants` must never learn to read it.
+ *
+ * There is no `DELETE`, and that is a decision. `awcms_partners.partner_tenant_id`
+ * is the target of foreign keys from both engagements and delegated grants, and
+ * ADR-0091/`sql/120` made a grant deliberately OUTLIVE its engagement. A delete
+ * would fail as soon as one partnership had ever existed, and "fixing" that
+ * with `ON DELETE CASCADE` would silently cut every partnership on the
+ * installation. Retirement is a `status` change, and `status` is pinned by
+ * `sql/116` until something reads suspension.
+ *
+ * ## Not idempotency-keyed
+ *
+ * Both natural keys carry GLOBAL unique indexes, so a duplicate submit is a 409
+ * naming which key was taken rather than a second row. There is no outcome to
+ * replay.
+ */
+const REGISTRY_GUARD = {
+  moduleKey: "identity_access",
+  activityCode: "partner_registry"
+} as const;
+
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: { ...REGISTRY_GUARD, action: "read" },
+  handler: async ({ tx, tenantId }) => {
+    return ok({ items: await listPartners(tx, tenantId) });
+  }
+});
+
+export const POST = defineTenantRoute<RegisterPartnerInput>({
+  workClass: "interactive",
+  prepare: async ({ request }) => {
+    const body = await readJsonBody(request);
+
+    if (body.tooLarge) return bodyTooLargeResponse(body.limitBytes);
+
+    const validation = validateRegisterPartnerInput(body.value);
+
+    if (!validation.valid) {
+      return fail(
+        422,
+        "VALIDATION_FAILED",
+        "Partner registration is invalid.",
+        {},
+        validation.errors
+      );
+    }
+
+    return validation.value;
+  },
+  authorize: { ...REGISTRY_GUARD, action: "create" },
+  handler: async ({ tx, tenantId, auth, prepared }) => {
+    const result = await registerPartner(tx, tenantId, prepared);
+
+    if (result.outcome === "tenant_not_found") {
+      return fail(
+        404,
+        "TENANT_NOT_FOUND",
+        "No such tenant on this deployment."
+      );
+    }
+
+    if (result.outcome === "self") {
+      return fail(
+        409,
+        "CONFLICT",
+        "The platform tenant cannot be registered as a partner of itself."
+      );
+    }
+
+    if (result.outcome === "already_registered") {
+      return fail(409, "CONFLICT", "That tenant is already a partner.");
+    }
+
+    if (result.outcome === "code_taken") {
+      return fail(409, "CONFLICT", "That partnerCode is already in use.");
+    }
+
+    await recordAuditEvent(tx, {
+      tenantId,
+      actorTenantUserId: auth.context.tenantUserId,
+      moduleKey: "identity_access",
+      action: "partner.registered",
+      resourceType: "partner",
+      resourceId: result.partner.id,
+      severity: "warning",
+      message: `Tenant registered as partner "${result.partner.partnerCode}".`,
+      attributes: {
+        partnerTenantId: result.partner.partnerTenantId,
+        partnerCode: result.partner.partnerCode
+      }
+    });
+
+    return jsonResponse(
+      { success: true, data: { partner: result.partner }, meta: {} },
+      { status: 201 }
+    );
+  }
+});

--- a/tests/invitation-contract.test.ts
+++ b/tests/invitation-contract.test.ts
@@ -232,15 +232,29 @@ describe("sql/107 — the permission seed", () => {
     expect(sql).not.toContain("'invitations', 'delete'");
   });
 
-  test("configure is seeded at PLATFORM scope, and it is the only one", () => {
+  test("configure is seeded at PLATFORM scope, and it is the only INVITATION one", () => {
     expect(sql).toMatch(/'invitations', 'configure',[\s\S]*?'platform'/);
 
+    // Scoped to `invitations`, not to the module. It used to read the module
+    // and assert a single entry, which was true and said more than it meant:
+    // ADR-0089's `partner_registry.*` is platform-scoped for reasons of its
+    // own, and this test turned red on a change that has nothing to do with
+    // invitations. What it is FOR is that the other three invitation
+    // permissions stay tenant-scoped — a platform-scoped `create` would put
+    // inviting into somebody else's company out of every tenant's reach and
+    // into the platform's alone.
     const declared = listModules()
       .find((module) => module.key === "identity_access")!
-      .permissions!.filter((entry) => entry.scope === "platform")
-      .map((entry) => `${entry.activityCode}.${entry.action}`);
+      .permissions!.filter((entry) => entry.activityCode === "invitations")
+      .map((entry) => `${entry.action}:${entry.scope ?? "tenant"}`)
+      .sort();
 
-    expect(declared).toEqual(["invitations.configure"]);
+    expect(declared).toEqual([
+      "configure:platform",
+      "create:tenant",
+      "read:tenant",
+      "revoke:tenant"
+    ]);
   });
 });
 

--- a/tests/partner-delegated-access-e2e.test.ts
+++ b/tests/partner-delegated-access-e2e.test.ts
@@ -36,6 +36,11 @@ import {
 } from "../src/pages/api/v1/access/partner-engagements/index";
 import { DELETE as severDELETE } from "../src/pages/api/v1/access/partner-engagements/[id]";
 import {
+  listPartners,
+  registerPartner
+} from "../src/modules/identity-access/application/partner-registry-store";
+import { withTenantOrThrow } from "../src/lib/database/tenant-context";
+import {
   GET as listGrantsGET,
   POST as approvePOST
 } from "../src/pages/api/v1/access/delegated-grants/index";
@@ -112,6 +117,7 @@ describeOrSkip("partnership and delegated access (real PostgreSQL)", () => {
   let customerTenantId = "";
   let otherCustomerTenantId = "";
 
+  let partnerCode = "";
   let customerAdmin = { tenantUserId: "", token: "" };
   let partnerStaff = { tenantUserId: "", token: "", principalId: "" };
   let supportRoleId = "";
@@ -133,15 +139,78 @@ describeOrSkip("partnership and delegated access (real PostgreSQL)", () => {
     ownerRoleId = await createRole(customerTenantId, "sysrole", true);
     foreignRoleId = await createRole(otherCustomerTenantId, "support", false);
 
-    // The platform registers the partner. There is no request path for this
-    // yet — the plan places partner registration behind a platform-scoped
-    // surface that does not exist — so the test writes the row the way an
-    // operator migration would.
-    await sql`SELECT set_config('app.current_tenant_id', ${platformTenantId}, false)`;
-    await sql`
-      INSERT INTO awcms_partners (tenant_id, partner_tenant_id, partner_code, display_name)
-      VALUES (${platformTenantId}, ${partnerTenantId}, ${`px-${Date.now()}`}, 'Partner X')
-    `;
+    // The platform registers the partner — through the REGISTRY WRITER, not by
+    // hand. Until `sql/123` there was no writer at all and this block wrote the
+    // row the way an operator migration would; the whole arc below now starts
+    // from the same code path a platform admin drives.
+    //
+    // The application function rather than the HTTP route on purpose: the route
+    // is platform-SCOPE gated, and satisfying that here would mean repointing
+    // `PLATFORM_TENANT_ID` for a process this suite shares with every other
+    // file. The gate itself is proven where it lives.
+    //
+    // Through `withTenantOrThrow`, not a bare `set_config` on the pool: the
+    // writer issues three statements, and `set_config(..., false)` is
+    // SESSION-scoped — on a pooled client the second statement can land on a
+    // connection that never saw it. The existing one-statement writes here got
+    // away with it; three would not, reliably.
+    partnerCode = `px-${platformTenantId.slice(0, 8)}`;
+    const registered = await withTenantOrThrow(sql, platformTenantId, (tx) =>
+      registerPartner(tx, platformTenantId, {
+        partnerTenantId,
+        partnerCode,
+        displayName: "Partner X"
+      })
+    );
+
+    if (registered.outcome !== "registered") {
+      throw new Error(`partner registration failed: ${registered.outcome}`);
+    }
+  });
+
+  test("the registry writer refuses the three things the schema also refuses", async () => {
+    // Both global unique indexes, told apart — the reason the writer uses
+    // `ON CONFLICT DO NOTHING` plus a disambiguating read instead of catching a
+    // 23505 whose SQLSTATE this driver puts somewhere other than `code`.
+    const sameTenant = await withTenantOrThrow(sql, platformTenantId, (tx) =>
+      registerPartner(tx, platformTenantId, {
+        partnerTenantId,
+        partnerCode: `${partnerCode}-other`,
+        displayName: "Partner X again"
+      })
+    );
+    const sameCode = await withTenantOrThrow(sql, platformTenantId, (tx) =>
+      registerPartner(tx, platformTenantId, {
+        partnerTenantId: customerTenantId,
+        partnerCode,
+        displayName: "Someone else"
+      })
+    );
+    const itself = await withTenantOrThrow(sql, platformTenantId, (tx) =>
+      registerPartner(tx, platformTenantId, {
+        partnerTenantId: platformTenantId,
+        partnerCode: `${partnerCode}-self`,
+        displayName: "The platform"
+      })
+    );
+
+    expect(sameTenant.outcome).toBe("already_registered");
+    expect(sameCode.outcome).toBe("code_taken");
+    expect(itself.outcome).toBe("self");
+  });
+
+  test("the registry lists what it wrote, with the partner tenant's own name", async () => {
+    const items = await withTenantOrThrow(sql, platformTenantId, (tx) =>
+      listPartners(tx, platformTenantId)
+    );
+    const entry = items.find((row) => row.partnerCode === partnerCode);
+
+    expect(entry).toBeDefined();
+    expect(entry!.partnerTenantId).toBe(partnerTenantId);
+    // Joined from `awcms_tenants`, never denormalised — so the registry cannot
+    // hold a stale copy of a tenant's name.
+    expect(entry!.tenantCode.length).toBeGreaterThan(0);
+    expect(entry!.status).toBe("active");
   });
 
   afterAll(async () => {

--- a/tests/partner-registration.test.ts
+++ b/tests/partner-registration.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Registri partner — permukaan pendaftarannya (ADR-0089, `sql/116` + `sql/123`).
+ *
+ * `sql/116` mengirim tabelnya tanpa penulis: satu-satunya cara membuat baris
+ * partner adalah operator dengan prompt psql. Berkas ini menjaga permukaan yang
+ * menutup celah itu, dan terutama tiga hal yang mudah runtuh diam-diam:
+ *
+ *   1. kedua izinnya ber-scope PLATFORM — versi tenant-scoped dari `read`
+ *      adalah direktori lintas-tenant yang ADR-0089 tolak, dibangun ulang
+ *      sebagai permission;
+ *   2. seed grant-nya berjalan di atas `awcms_setup_state`, BUKAN
+ *      `awcms_tenants` — bentuk kedua adalah cacat asli yang ADR-0053 tutup;
+ *   3. `status` tidak pernah ditulis permukaan ini, karena `sql/116`
+ *      mematoknya sampai ada yang MEMBACA suspensi.
+ *
+ * Murni: tidak ada basis data. SQL-nya diperiksa dengan merekam
+ * tagged-template — pola `principal-mfa-store`.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import {
+  isPlatformScopedPermissionKey,
+  resetPlatformScopeCacheForTests
+} from "../src/modules/identity-access/domain/platform-scope";
+import { validateRegisterPartnerInput } from "../src/modules/identity-access/domain/partner-registration";
+import {
+  listPartners,
+  registerPartner
+} from "../src/modules/identity-access/application/partner-registry-store";
+
+const ROUTE = "src/pages/api/v1/partners/index.ts";
+const MIGRATION = "sql/123_awcms_partner_registry_permissions.sql";
+
+const PLATFORM = "00000000-0000-4000-8000-000000000001";
+const PARTNER = "00000000-0000-4000-8000-000000000002";
+
+function body(
+  overrides: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    partnerTenantId: PARTNER,
+    partnerCode: "acme-digital",
+    displayName: "Acme Digital",
+    ...overrides
+  };
+}
+
+function fieldsOf(
+  result: ReturnType<typeof validateRegisterPartnerInput>
+): string[] {
+  return result.valid ? [] : [...new Set(result.errors.map((e) => e.field))];
+}
+
+describe("validasi pendaftaran", () => {
+  test("bentuk yang benar diterima dan di-trim", () => {
+    const result = validateRegisterPartnerInput(
+      body({ partnerCode: "  acme-digital  ", displayName: "  Acme  " })
+    );
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.value.partnerCode).toBe("acme-digital");
+      expect(result.value.displayName).toBe("Acme");
+    }
+  });
+
+  test("partnerCode ditolak untuk bentuk yang MEMBUAT baris kedua yang terbaca sama", () => {
+    // Index unik-nya GLOBAL dan tanpa normalisasi apa pun, jadi "Acme-Digital"
+    // dan "acme-digital" adalah dua partner berbeda bagi Postgres dan satu
+    // partner bagi manusia yang membaca daftarnya.
+    for (const bad of [
+      "Acme-Digital",
+      "acme digital",
+      "-acme",
+      "acme-",
+      "acme_digital",
+      ""
+    ]) {
+      expect(
+        fieldsOf(validateRegisterPartnerInput(body({ partnerCode: bad })))
+      ).toEqual(["partnerCode"]);
+    }
+  });
+
+  test("partnerTenantId wajib uuid", () => {
+    expect(
+      fieldsOf(validateRegisterPartnerInput(body({ partnerTenantId: "acme" })))
+    ).toEqual(["partnerTenantId"]);
+  });
+
+  test("displayName wajib ada", () => {
+    expect(
+      fieldsOf(validateRegisterPartnerInput(body({ displayName: "   " })))
+    ).toEqual(["displayName"]);
+  });
+
+  test("`status` DIABAIKAN, tidak diterima — ia dipatok sampai ada pembacanya", () => {
+    const result = validateRegisterPartnerInput(body({ status: "suspended" }));
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(Object.keys(result.value).sort()).toEqual([
+        "displayName",
+        "partnerCode",
+        "partnerTenantId"
+      ]);
+    }
+  });
+
+  test("setiap masalah dilaporkan sekaligus, bukan satu per satu", () => {
+    expect(
+      fieldsOf(
+        validateRegisterPartnerInput({
+          partnerTenantId: "x",
+          partnerCode: "BAD",
+          displayName: ""
+        })
+      ).sort()
+    ).toEqual(["displayName", "partnerCode", "partnerTenantId"]);
+  });
+});
+
+/** Tagged-template palsu: satu array baris per pemanggilan, berurutan. */
+function recordingTx(rowsByCall: unknown[][]): {
+  tx: Bun.SQL;
+  statements: string[];
+} {
+  const statements: string[] = [];
+  let call = 0;
+
+  const tx = ((strings: TemplateStringsArray, ...args: unknown[]) => {
+    statements.push(
+      strings.raw
+        .map((part, i) => part + (i < args.length ? "?" : ""))
+        .join("")
+        .replace(/\s+/g, " ")
+        .trim()
+    );
+    const rows = rowsByCall[call] ?? [];
+    call += 1;
+    return Promise.resolve(rows);
+  }) as unknown as Bun.SQL;
+
+  return { tx, statements };
+}
+
+const PARTNER_ROW = {
+  id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+  partner_tenant_id: PARTNER,
+  partner_code: "acme-digital",
+  display_name: "Acme Digital",
+  status: "active",
+  registered_at: new Date("2026-08-13T00:00:00.000Z"),
+  tenant_code: "acme",
+  tenant_name: "Acme Sdn Bhd"
+};
+
+describe("penulisannya, dibaca sebagai SQL", () => {
+  test("INSERT tidak pernah menyebut `status`", async () => {
+    const { tx, statements } = recordingTx([
+      [{ id: PARTNER }],
+      [{ id: PARTNER_ROW.id }],
+      [PARTNER_ROW]
+    ]);
+
+    await registerPartner(tx, PLATFORM, {
+      partnerTenantId: PARTNER,
+      partnerCode: "acme-digital",
+      displayName: "Acme Digital"
+    });
+
+    const insert = statements.find((s) => s.includes("INSERT INTO"))!;
+
+    expect(insert).toContain("awcms_partners");
+    // Kalau permukaan ini mulai menulis `status`, ia menulis satu-satunya nilai
+    // yang CHECK izinkan — dan pada hari CHECK-nya dilebarkan, ia diam-diam
+    // menjadi permukaan yang bisa men-suspend tanpa ada yang memutuskannya.
+    expect(insert).not.toContain("status");
+  });
+
+  test("konflik diselesaikan TANPA membaca SQLSTATE dari driver", async () => {
+    // Bun mengisi `error.code` dengan konstantanya sendiri untuk setiap error
+    // server, jadi `code === "23505"` tidak pernah benar di repo ini; SQLSTATE
+    // hidup di `errno`. `ON CONFLICT DO NOTHING` menghindari pertanyaannya
+    // sekaligus menjaga transaksi tetap bisa dipakai untuk membedakan KEDUA
+    // index unik globalnya.
+    const { tx, statements } = recordingTx([
+      [{ id: PARTNER }],
+      [], // INSERT ... ON CONFLICT DO NOTHING → nol baris
+      [{ tenant_taken: true }]
+    ]);
+
+    const result = await registerPartner(tx, PLATFORM, {
+      partnerTenantId: PARTNER,
+      partnerCode: "acme-digital",
+      displayName: "Acme Digital"
+    });
+
+    expect(result.outcome).toBe("already_registered");
+    expect(statements[1]).toContain("ON CONFLICT DO NOTHING");
+  });
+
+  test("kode terpakai dibedakan dari tenant terdaftar", async () => {
+    const { tx } = recordingTx([
+      [{ id: PARTNER }],
+      [],
+      [{ tenant_taken: false }]
+    ]);
+
+    const result = await registerPartner(tx, PLATFORM, {
+      partnerTenantId: PARTNER,
+      partnerCode: "acme-digital",
+      displayName: "Acme Digital"
+    });
+
+    expect(result.outcome).toBe("code_taken");
+  });
+
+  test("pendaftaran diri sendiri ditolak SEBELUM menyentuh basis data", async () => {
+    const { tx, statements } = recordingTx([]);
+
+    const result = await registerPartner(tx, PLATFORM, {
+      partnerTenantId: PLATFORM,
+      partnerCode: "self",
+      displayName: "Self"
+    });
+
+    expect(result.outcome).toBe("self");
+    expect(statements).toEqual([]);
+  });
+
+  test("tenant yang tidak ada menjawab sendiri, bukan lewat 23503", async () => {
+    const { tx } = recordingTx([[]]);
+
+    const result = await registerPartner(tx, PLATFORM, {
+      partnerTenantId: PARTNER,
+      partnerCode: "acme-digital",
+      displayName: "Acme Digital"
+    });
+
+    expect(result.outcome).toBe("tenant_not_found");
+  });
+
+  test("daftar disaring ke tenant platform DAN mengambil nama dari awcms_tenants", async () => {
+    const { tx, statements } = recordingTx([[PARTNER_ROW]]);
+
+    await listPartners(tx, PLATFORM);
+
+    // Filter `tenant_id` ditulis meski RLS sudah melakukannya: query yang benar
+    // hanya karena kebijakan basis data adalah query yang salah pada hari
+    // seseorang menjalankannya sebagai role yang mem-bypass RLS.
+    expect(statements[0]).toContain("WHERE p.tenant_id = ?");
+    expect(statements[0]).toContain("JOIN awcms_tenants");
+  });
+});
+
+describe("scope PLATFORM, dan seed yang menegakkannya", () => {
+  test("kedua izin ber-scope platform, dibaca dari registry hidup", () => {
+    resetPlatformScopeCacheForTests();
+
+    expect(
+      isPlatformScopedPermissionKey("identity_access.partner_registry.read")
+    ).toBe(true);
+    expect(
+      isPlatformScopedPermissionKey("identity_access.partner_registry.create")
+    ).toBe(true);
+  });
+
+  test("dan `partner_access` milik PELANGGAN tetap tenant-scoped", () => {
+    resetPlatformScopeCacheForTests();
+
+    // Pemisahan yang membuat ADR-0089 bekerja: tidak ada satu aktor pun yang
+    // memegang kedua paruh. Kalau `partner_access.configure` ikut menjadi
+    // platform, pelanggan kehilangan kendali atas siapa yang menjangkaunya.
+    expect(
+      isPlatformScopedPermissionKey("identity_access.partner_access.configure")
+    ).toBe(false);
+  });
+
+  test("modul mendeklarasikan keduanya", () => {
+    const declared = listModules().flatMap((module) =>
+      (module.permissions ?? []).map(
+        (permission) =>
+          `${module.key}.${permission.activityCode}.${permission.action}`
+      )
+    );
+
+    expect(declared).toContain("identity_access.partner_registry.read");
+    expect(declared).toContain("identity_access.partner_registry.create");
+  });
+
+  test("seed menulis scope 'platform' dan grant-nya lewat awcms_setup_state", async () => {
+    const migration = await Bun.file(MIGRATION).text();
+
+    expect(migration).toContain("'platform'");
+    // Bentuk yang terbaca "lebih rapi" — grant di atas `awcms_tenants` — adalah
+    // cacat asli yang ADR-0053 tutup: ia memberi izin platform kepada SETIAP
+    // owner tenant.
+    expect(migration).toContain("FROM awcms_setup_state");
+    expect(migration).not.toContain("FROM awcms_tenants");
+  });
+});
+
+describe("rutenya", () => {
+  test("kedua guard menyebut aktivitas registry, bukan partner_access", async () => {
+    const source = await Bun.file(ROUTE).text();
+
+    expect(source).toContain('activityCode: "partner_registry"');
+    expect(source).toContain('action: "read"');
+    expect(source).toContain('action: "create"');
+  });
+
+  test("tidak ada DELETE — barisnya target FK yang sengaja hidup lebih lama", async () => {
+    // `awcms_partners.partner_tenant_id` direferensi keterlibatan DAN grant
+    // terdelegasi, dan `sql/120` membuat grant sengaja hidup lebih lama dari
+    // kemitraannya. DELETE akan gagal begitu satu kemitraan pernah ada, dan
+    // "memperbaikinya" dengan ON DELETE CASCADE memutus setiap kemitraan di
+    // instalasi.
+    const source = await Bun.file(ROUTE).text();
+
+    expect(source).not.toContain("export const DELETE");
+  });
+});

--- a/tests/platform-scoped-permissions.test.ts
+++ b/tests/platform-scoped-permissions.test.ts
@@ -56,7 +56,15 @@ const EXPECTED_PLATFORM_KEYS = [
   // manufacture one for another company's address; after Gelombang 7 that
   // object is a GLOBAL principal, which is the one place it matters. The
   // deliberate edit, again.
-  "identity_access.invitations.configure"
+  "identity_access.invitations.configure",
+  // ADR-0089 — the partner REGISTRY, and both halves are deliberate. `create`
+  // names who may be a partner at all, which is the platform's half of a split
+  // that ADR kept apart from the customer's `partner_access.configure`. `read`
+  // lists EVERY partner, and a tenant-scoped version of it is the cross-tenant
+  // directory the same ADR refused as a table — rebuilt as a permission. The
+  // deliberate edit, again.
+  "identity_access.partner_registry.read",
+  "identity_access.partner_registry.create"
 ];
 
 describe("platform-scoped permission declaration", () => {


### PR DESCRIPTION
Menutup **sisa #423 nomor 3** yang tercatat di `docs/PROJECT_STATE.md` §4: `sql/116` mengirim `awcms_partners` tanpa penulis, sehingga satu-satunya cara membuat baris partner adalah operator dengan prompt psql.

Bukti bahwa itu terasa ada di repo: suite E2E Gelombang 8 menuliskan barisnya sendiri, dengan komentar *"There is no request path for this yet."* Komentar itu kini hilang, dan seluruh alur E2E dimulai dari penulis yang sama.

Tanpa ADR baru — ADR-0089 sudah menamai permukaan ini; yang belum ada adalah kodenya.

## Kedua izinnya ber-scope PLATFORM, dan `read` bukan kelalaian

`create` menyatakan siapa yang **boleh menjadi** partner — paruh platform dari pemisahan yang ADR-0089 jaga terhadap `partner_access.configure` milik pelanggan ("partner mana yang menjangkau tenant **saya**"). Tidak ada satu aktor pun yang memegang keduanya.

`read` mendaftar **seluruh** partner, dan versi tenant-scoped-nya adalah persis direktori lintas-tenant yang ADR yang sama tolak sebagai tabel — dibangun ulang sebagai permission. Dua mekanisme independen menjaganya, dan keduanya menanggung beban: RLS menaruh setiap baris di tenant platform, dan chokepoint menolak permission ber-scope platform kecuali tenant yang bertindak **memang** tenant platform.

## Tidak ada `DELETE`, dan itu keputusan

`awcms_partners.partner_tenant_id` adalah target FK dari keterlibatan **dan** dari grant terdelegasi yang `sql/120` buat sengaja hidup lebih lama darinya. DELETE akan gagal begitu satu kemitraan pernah ada, dan "memperbaikinya" dengan `ON DELETE CASCADE` memutus setiap kemitraan di instalasi. Pensiun adalah perubahan `status` — dan `status` tetap dipatok `sql/116` sampai ada yang **membaca** suspensi, jadi permukaan ini tidak menerimanya sama sekali.

## Konflik diselesaikan tanpa membaca SQLSTATE

Kedua kunci naturalnya punya index unik **global**, jadi pendaftaran ganda bisa kalah pada salah satu dari dua index — dan membedakannya lewat error driver berarti membaca SQLSTATE dari tempat yang di repo ini bukan `error.code`. `ON CONFLICT DO NOTHING` menghindari pertanyaannya dan menjaga transaksi tetap bisa dipakai untuk satu pembacaan yang memberi tahu kunci **mana** yang terpakai. Itu pula alasan rute ini tidak ber-`Idempotency-Key`: submit ganda adalah 409, bukan baris kedua.

## Satu test yang mengklaim lebih dari maksudnya

`tests/invitation-contract.test.ts` meng-assert `invitations.configure` adalah **satu-satunya** izin platform di `identity_access` — benar saat ditulis, dan lebih luas dari yang ia maksud. Ia memerah pada perubahan yang tak ada hubungannya dengan undangan. Dipersempit ke `invitations.*` sambil MENGUATKAN maksud aslinya: ketiga izin undangan lain kini di-assert tenant-scoped secara eksplisit, bukan tersirat.

## Diverifikasi dengan menjalankan

- `DATABASE_URL="" bun run check` **hijau penuh** — 41 segmen, 4721 test, build.
- **Empat mutasi memerahkan test yang tepat:** INSERT ikut menulis `status` (kolom yang dipatok), seed grant berjalan di atas `awcms_tenants` alih-alih `awcms_setup_state` (cacat asli yang ADR-0053 tutup), `partnerCode` menerima huruf besar, dan pendaftaran diri sendiri diloloskan.
- **Jebakan yang ditemukan saat menyambungkan E2E:** `set_config` bersifat SESSION-scoped, jadi pada klien ber-pool pernyataan kedua bisa mendarat di koneksi yang tak pernah melihatnya. Tulisan satu-pernyataan yang sudah ada di suite itu selamat karena kebetulan; tiga pernyataan tidak akan. Pemanggilannya dibungkus `withTenantOrThrow`.

`NOT_YET_SCREENED` 60 → 62. Layarnya **bukan** `/admin/partners`: halaman itu adalah pandangan **pelanggan** atas siapa yang menjangkau tenant-nya sendiri, dan menaruh registri di sana menaruh daftar setiap kemitraan platform di depan setiap pelanggan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)