### PR TITLE
feat(admin): layar Machine credentials — mencabut token bocor berhenti menjadi panggilan API (#539)

### DIFF
--- a/.changeset/admin-machine-credentials-screen.md
+++ b/.changeset/admin-machine-credentials-screen.md
@@ -1,0 +1,50 @@
+---
+"awcms": minor
+---
+
+feat(admin): layar Machine credentials — mencabut token bocor berhenti menjadi panggilan API (#539)
+
+Permukaannya ada sejak `sql/082` dan tidak pernah punya halaman. Alasan membangunnya
+adalah kalimat yang sama yang menutup `/admin/partners`: **pencabutan adalah kontrol
+yang dicari orang ketika sebuah token bocor, dan sampai halaman ini ada ia adalah
+`POST` yang tidak akan diingat siapa pun di bawah tekanan.** #537 mempertajamnya
+dengan membuka kelas yang bisa MENGUBAH data — dan sampai sekarang tidak ada tempat
+untuk melihat kredensial mana yang bisa.
+
+DUA IZIN, SATU FORM, DAN ITU BUKAN KOSMETIK. `machine_credentials.create` mencetak
+kelas baca; `machine_credentials_write.create` mencetak kelas tulis. Fieldset tulis
+hanya dirender bagi pemegang kunci kedua. Kalau halaman ini menurunkan keduanya dari
+satu izin, pemisahan yang ADR-0092 buat justru untuk mencegah pelebaran grant akan
+dibatalkan lagi — kali ini di UI, di mana tak ada gerbang yang melihatnya.
+
+CHECKBOX AKSI TULISNYA DITURUNKAN dari `MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS`,
+bukan ditulis tangan. Sepasang checkbox `create`/`update` yang ditulis tangan akan
+tetap benar hari ini dan diam-diam tertinggal pada hari sebuah ADR melebarkan plafon
+itu — form yang tertinggal dari konstanta, tanpa apa pun memerah.
+
+TOKENNYA TAMPIL SEKALI, dan halaman ini karena itu **tidak reload** sesudah
+menerbitkan — respons penerbitan adalah satu-satunya tempat plaintext-nya ada, dan
+reload mencetak kredensial yang tak bisa dipakai siapa pun lalu harus dicabut. Sama
+persis bentuk `/admin/partners` untuk kode akses.
+
+CIDR HANYA DIKIRIM BERSAMA KELAS TULIS. API menolak `allowedIpCidrs` pada kredensial
+baca karena gerbangnya tak pernah mengkonsultasinya di sana; halaman yang selalu
+mengirim field itu akan mengubah penolakan jujur tersebut menjadi 422 pada setiap
+penerbitan baca. Plafon kadaluwarsa ikut menyempit ke 30 hari begitu satu aksi tulis
+dicentang — ditegakkan server, ditampilkan di sini supaya batasnya terlihat saat
+memilih, bukan sesudah form terisi.
+
+DAFTAR IZINNYA ADALAH SELURUH KATALOG, dan halamannya mengatakan artinya.
+`allowedPermissionKeys` MENYEMPITKAN: himpunan efektifnya adalah irisan dengan yang
+dipegang akun layanan, jadi menyebut kunci yang tak dipegang akun tidak memberi
+apa-apa. Menampilkan hanya kunci milik akun butuh endpoint per-akun yang tidak ada;
+menyiratkan bahwa daftar itu sebuah pemberian jauh lebih buruk.
+
+DIVERIFIKASI DENGAN MENJALANKAN. `bun run check` penuh hijau. Lima mutasi memerahkan
+test yang tepat: penerbitan me-reload (token hilang), fieldset tulis digerbangi izin
+baca, checkbox ditulis tangan alih-alih diturunkan, CIDR selalu dikirim, dan satu
+kunci ditinggal di ledger padahal layarnya ada. Dua asersi sumber sengaja dibuat
+tahan-whitespace — asersi yang terikat indentasi memerah pada kode yang benar begitu
+formatter memindahkan satu baris, kegagalan yang `/admin/partners` sudah catat sekali.
+
+`NOT_YET_SCREENED` **menyusut 62 → 58**, dan itulah gunanya angka itu.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -109,8 +109,8 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
 | Migrasi                            | **123** (`sql/001`–`123`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
-| Layar admin                        | **35** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **48** (26.424 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Layar admin                        | **36** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Berkas `.astro`                    | **49** (26.999 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **41** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **3.1.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -355,6 +355,40 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN 13 Agustus 2026 (kedua puluh dua) — EPIC #423 DITUTUP, BACKLOGNYA
+  PINDAH KE ISSUE, dan layar `/admin/machine-credentials` mendarat.**
+
+  **#423 ditutup.** Kriteria yang issue itu tulis sendiri ("TERBUKA sampai
+  Gelombang 8") terpenuhi, dan ketiga tindak lanjut Gelombang 8 tertutup (#535,
+  #537, #538). Epic yang tetap terbuka sesudah cakupannya habis berhenti berarti
+  apa-apa.
+
+  **Sisanya menjadi delapan issue** (#539–#546), bukan prosa di §4 ini. Alasannya
+  mekanis: repo ini akan punya NOL issue terbuka sementara backlog nyatanya hidup
+  sebagai paragraf yang harus dibaca seluruhnya untuk tahu apa yang tersisa. §4
+  tetap tempat KEPUTUSAN dan penolakan ditulis; issue adalah yang bisa di-assign
+  dan ditutup satu per satu.
+
+  **Layar kredensial mesin (#539) menutup 4 kunci, 62 → 58.** Argumennya sama
+  dengan `/admin/partners`: pencabutan adalah kontrol yang dicari saat token
+  bocor, dan sampai halaman ini ada ia `POST` yang tak akan diingat siapa pun di
+  bawah tekanan. #537 mempertajamnya — sampai sekarang tak ada tempat untuk
+  melihat kredensial mana yang bisa MENULIS.
+
+  **Dua izin, satu form, dan itu bukan kosmetik.** Kalau halaman menurunkan
+  fieldset tulis dari `machine_credentials.create`, pemisahan yang ADR-0092 buat
+  justru untuk mencegah pelebaran grant dibatalkan lagi — kali ini di UI, tempat
+  tak ada gerbang yang melihatnya. Checkbox aksinya **diturunkan** dari
+  `MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS`, karena sepasang checkbox tulis
+  tangan tetap benar hari ini dan tertinggal diam-diam saat plafonnya dilebarkan.
+
+  **Pelajaran test yang berlaku untuk setiap layar berikutnya:** asersi sumber
+  yang terikat INDENTASI memerah pada kode yang benar begitu formatter memindah
+  satu baris. Dua asersi di sini tentang ADJACENCY (verb di sebelah URL-nya,
+  ternary yang menguji daftar tulis) dinormalisasi whitespace-nya lebih dulu.
+  Kegagalan sekerabat sudah tercatat di putaran kedelapan belas — di sana
+  penyebabnya mencampur action audit dengan action guard.
 
 - **PUTARAN 13 Agustus 2026 (kedua puluh satu) — REGISTRI PARTNER PUNYA PENULIS.**
 

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -142,7 +142,7 @@
         }
       ],
       "permissionCount": 42,
-      "navigationCount": 7,
+      "navigationCount": 8,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 369   |
-| Berkas route                       | 345   |
+| Berkas test                        | 370   |
+| Berkas route                       | 346   |
 | ADR                                | 93    |
 
 ### Modul
@@ -326,7 +326,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 315        |
+| `(root)`      | 316        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |
@@ -336,7 +336,7 @@
 | Permukaan       | Berkas |
 | --------------- | ------ |
 | `/api/v1/**`    | 286    |
-| `/admin/**`     | 35     |
+| `/admin/**`     | 36     |
 | publik / anonim | 24     |
 
 <!-- END GENERATED: repo-inventory -->

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -67,7 +67,7 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "form_drafts.draft.create",
   "form_drafts.draft.update",
 
-  // identity_access (22)
+  // identity_access (18)
   //
   // The four `invitations.*` keys are ADR-0082's, and they land here on the
   // same terms `tenant_admin.tenant_lifecycle.*` did: the surface exists and is
@@ -88,14 +88,6 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "identity_access.business_scope_exceptions.read",
   "identity_access.business_scope_exceptions.reject",
   "identity_access.business_scope_exceptions.revoke",
-  "identity_access.machine_credentials.create",
-  "identity_access.machine_credentials.read",
-  "identity_access.machine_credentials.revoke",
-  // ADR-0092. Joins its three siblings rather than being screened alone: there
-  // is no machine-credential page at all, and a screen that can mint the WRITE
-  // class while the read class stays an API call would be the wrong one to
-  // build first.
-  "identity_access.machine_credentials_write.create",
   // ADR-0089. The PLATFORM half of partnership, and its screen is not
   // `/admin/partners` — that page is the CUSTOMER's view of who reaches its own
   // tenant, and putting a registry there would put the platform's list of every

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -155,6 +155,17 @@ export const identityAccessModule = defineModule({
       path: "/admin/partners",
       order: 26,
       requiredPermission: "identity_access.partner_access.read"
+    },
+    // ADR-0049/0092, #539. Gated on `machine_credentials.read`, which seeds its
+    // own `read` — a caller who may see WHICH non-human bearers exist need not
+    // also be handed the RBAC catalogue, and the reverse is more important:
+    // this page can mint one, so it must not appear for everybody who can edit
+    // a role.
+    {
+      labelKey: "admin.layout.nav_machine_credentials",
+      path: "/admin/machine-credentials",
+      order: 27,
+      requiredPermission: "identity_access.machine_credentials.read"
     }
   ],
   jobs: [

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -206,6 +206,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_registrations": "Registration requests",
   "admin.layout.nav_security": "Authentication & security",
   "admin.layout.nav_partners": "Partner access",
+  "admin.layout.nav_machine_credentials": "Machine credentials",
   "admin.layout.nav_seo": "SEO & distribution"
 };
 

--- a/src/pages/admin/machine-credentials.astro
+++ b/src/pages/admin/machine-credentials.astro
@@ -1,0 +1,575 @@
+---
+/**
+ * Machine credentials — ADR-0049 (read class), ADR-0092 (write class), #539.
+ *
+ * The surface has existed since `sql/082` and had no page at all. The argument
+ * for building one is the argument `/admin/partners` recorded: revocation is
+ * the control somebody reaches for when a token has leaked, and until this page
+ * existed it was a `POST` against the API that nobody under pressure remembers.
+ * #537 made it sharper by opening a class that can CHANGE data.
+ *
+ * Every action posts to the real endpoints, so the ABAC guards, the audit rows
+ * and the `sql/121` CHECKs all live there. The permission checks below decide
+ * what to RENDER, never what is allowed.
+ *
+ * ## The token is shown once, here, and can never be fetched again
+ *
+ * The issuance response is the ONLY place the plaintext exists. This screen
+ * therefore reads the response body instead of reloading, and keeps the token
+ * on screen until it is dismissed. A reload would spend a credential that then
+ * has to be revoked — the same shape `/admin/partners` has for access codes.
+ *
+ * ## Two permissions, one form
+ *
+ * `machine_credentials.create` mints the read-only class;
+ * `machine_credentials_write.create` mints the write class. They are separate
+ * because reusing one would have handed write-minting authority to everybody
+ * who already held `create` (ADR-0092). The write fieldset therefore renders
+ * only for a holder of the second key — and its action checkboxes are derived
+ * from `MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS`, so widening that ceiling
+ * later cannot leave the form behind.
+ *
+ * ## Why the permission list is the whole catalogue
+ *
+ * `allowedPermissionKeys` NARROWS: the effective set is the intersection with
+ * what the service account holds, so naming a key the account lacks grants
+ * nothing. Showing only the account's own keys would need a per-account
+ * endpoint that does not exist; the page says what the intersection means
+ * instead of implying the list is a grant.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { listModules } from "../../modules";
+import {
+  listTenantUsers,
+  type TenantUserView
+} from "../../modules/identity-access/application/access-directory";
+import {
+  listMachineCredentials,
+  type MachineCredentialSummary
+} from "../../modules/identity-access/application/machine-credential-directory";
+import {
+  MACHINE_CREDENTIAL_MAX_LIFETIME_DAYS,
+  MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS,
+  MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS
+} from "../../modules/identity-access/domain/machine-credential";
+
+const ssr = Astro.locals.ssrContext!;
+
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "machine_credentials",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time — concurrent queries on a
+    // single transaction connection leak it.
+    const credentials = await listMachineCredentials(
+      tx,
+      ssr.tenantId,
+      new Date()
+    );
+
+    const canCreate = await can({
+      moduleKey: "identity_access",
+      activityCode: "machine_credentials",
+      action: "create"
+    });
+    const canCreateWrite = await can({
+      moduleKey: "identity_access",
+      activityCode: "machine_credentials_write",
+      action: "create"
+    });
+    const canRevoke = await can({
+      moduleKey: "identity_access",
+      activityCode: "machine_credentials",
+      action: "revoke"
+    });
+
+    // Only when the form will actually be rendered. A credential is bound to a
+    // tenant user, and reading the directory to populate a picker nobody can
+    // use is a query and a disclosure for nothing.
+    const serviceAccounts =
+      canCreate || canCreateWrite
+        ? await listTenantUsers(tx, ssr.tenantId)
+        : [];
+
+    return {
+      credentials,
+      serviceAccounts,
+      canCreate,
+      canCreateWrite,
+      canRevoke
+    };
+  },
+  onError: (error) => {
+    logAdminPageError(
+      "admin/machine-credentials.astro: failed to load machine credentials",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const credentials: MachineCredentialSummary[] =
+  screen.state === "allowed" ? screen.data.credentials : [];
+const serviceAccounts: TenantUserView[] =
+  screen.state === "allowed" ? screen.data.serviceAccounts : [];
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
+const canCreateWrite = screen.state === "allowed" && screen.data.canCreateWrite;
+const canRevoke = screen.state === "allowed" && screen.data.canRevoke;
+
+const accountLabels = new Map(
+  serviceAccounts.map((account) => [account.id, account.loginIdentifierMasked])
+);
+
+/**
+ * Every permission key the composed registry declares, grouped by module.
+ * Build-time constant — no query, and no way for the form to offer a key that
+ * no role could ever hold.
+ */
+const permissionGroups = listModules()
+  .map((module) => ({
+    moduleKey: module.key,
+    keys: (module.permissions ?? []).map(
+      (permission) =>
+        `${module.key}.${permission.activityCode}.${permission.action}`
+    )
+  }))
+  .filter((group) => group.keys.length > 0);
+
+/** Derived from the live ceiling, so a widened ceiling cannot outrun the form. */
+const writeActions = [...MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS];
+
+function isoDay(daysFromNow: number): string {
+  return new Date(Date.now() + daysFromNow * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+}
+
+const maxReadExpiry = isoDay(MACHINE_CREDENTIAL_MAX_LIFETIME_DAYS);
+const maxWriteExpiry = isoDay(MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS);
+const defaultExpiry = isoDay(30);
+
+/** Read-only, or exactly what it may change — the question an incident asks. */
+function credentialClass(credential: MachineCredentialSummary): string {
+  return credential.allowedWriteActions.length === 0
+    ? "Read-only"
+    : `Write: ${credential.allowedWriteActions.join(", ")}`;
+}
+
+function isLive(credential: MachineCredentialSummary): boolean {
+  return credential.status === "active";
+}
+---
+
+<AdminLayout title="Machine credentials">
+  <header class="page-header fade-in-up">
+    <h1 id="machine-credentials-heading">Machine credentials</h1>
+    <p class="page-description">
+      Bearers for callers with no human behind them — build feeds, deploy hooks,
+      integrations. A credential authenticates only: every request it makes
+      still passes the same permission and policy checks a person's would.
+      Revoking one takes effect on its next request.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="machine-credentials-denied">
+        You do not have permission to view machine credentials.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="machine-credentials-load-error">
+        Could not load machine credentials. Please try again.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <>
+        <p
+          id="machine-credentials-action-error"
+          class="state-notice"
+          role="alert"
+          hidden
+        />
+
+        <p
+          id="machine-credentials-token"
+          class="state-notice"
+          role="status"
+          hidden
+        />
+
+        {canCreate && (
+          <section
+            class="fade-in-up"
+            aria-labelledby="machine-credentials-issue-heading"
+          >
+            <h2 id="machine-credentials-issue-heading">Issue a credential</h2>
+
+            <form id="issue-credential-form" class="admin-form">
+              <label for="issue-credential-name">Name</label>
+              <input
+                id="issue-credential-name"
+                name="name"
+                type="text"
+                maxlength="120"
+                required
+                placeholder="awcms-astro build feed"
+              />
+
+              <label for="issue-credential-account">Service account</label>
+              <select
+                id="issue-credential-account"
+                name="tenantUserId"
+                required
+              >
+                <option value="">Choose an account…</option>
+                {serviceAccounts.map((account) => (
+                  <option value={account.id}>
+                    {account.loginIdentifierMasked}
+                    {account.status === "active" ? "" : ` (${account.status})`}
+                  </option>
+                ))}
+              </select>
+              <p class="page-description">
+                The credential acts AS this account. It can never do more than
+                the account can — the permissions below narrow that, they never
+                widen it.
+              </p>
+
+              <label for="issue-credential-keys">Permissions</label>
+              <select
+                id="issue-credential-keys"
+                name="allowedPermissionKeys"
+                multiple
+                size="10"
+                required
+              >
+                {permissionGroups.map((group) => (
+                  <optgroup label={group.moduleKey}>
+                    {group.keys.map((key) => (
+                      <option value={key}>{key}</option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+              <p class="page-description">
+                At most 50. Choosing a permission the account does not hold
+                grants nothing — the credential gets the intersection.
+              </p>
+
+              {canCreateWrite && (
+                <fieldset id="issue-credential-write">
+                  <legend>Let it write (optional)</legend>
+                  <p class="page-description">
+                    A credential that can change data is bound to an address
+                    range and expires within{" "}
+                    {MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS} days. Leave
+                    this empty for the read-only credential.
+                  </p>
+                  {writeActions.map((action) => (
+                    <label class="admin-checkbox">
+                      <input
+                        type="checkbox"
+                        class="js-write-action"
+                        name="allowedWriteActions"
+                        value={action}
+                      />
+                      {action}
+                    </label>
+                  ))}
+
+                  <label for="issue-credential-cidrs">
+                    Allowed addresses (CIDR)
+                  </label>
+                  <input
+                    id="issue-credential-cidrs"
+                    name="allowedIpCidrs"
+                    type="text"
+                    placeholder="203.0.113.0/24, 2001:db8::/32"
+                  />
+                  <p class="page-description">
+                    Required when it can write, and refused when it cannot — a
+                    read-only credential is not restricted by this list, so
+                    storing one here would describe a binding that is not
+                    enforced.
+                  </p>
+                </fieldset>
+              )}
+
+              <label for="issue-credential-expires">Expires</label>
+              <input
+                id="issue-credential-expires"
+                name="expiresAt"
+                type="date"
+                required
+                value={defaultExpiry}
+                max={maxReadExpiry}
+                data-max-read={maxReadExpiry}
+                data-max-write={maxWriteExpiry}
+              />
+
+              <button id="issue-credential-submit" type="submit">
+                Issue credential
+              </button>
+            </form>
+          </section>
+        )}
+
+        <section
+          class="fade-in-up"
+          aria-labelledby="machine-credentials-list-heading"
+        >
+          <h2 id="machine-credentials-list-heading">Issued credentials</h2>
+
+          {credentials.length === 0 ? (
+            <div class="empty-state">
+              <p id="machine-credentials-empty">
+                No machine credential has ever been issued for this tenant.
+              </p>
+            </div>
+          ) : (
+            <div class="data-table-scroll">
+              <table class="data-table data-table--stack">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Acts as</th>
+                    <th scope="col">Class</th>
+                    <th scope="col">From</th>
+                    <th scope="col">Expires</th>
+                    <th scope="col">Last used</th>
+                    <th scope="col">State</th>
+                    {canRevoke && <th scope="col">Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {credentials.map((credential) => (
+                    <tr>
+                      <th scope="row" data-label="Name">
+                        {credential.name}
+                      </th>
+                      <td data-label="Acts as">
+                        {accountLabels.get(credential.tenantUserId) ??
+                          credential.tenantUserId}
+                      </td>
+                      <td data-label="Class">{credentialClass(credential)}</td>
+                      <td data-label="From">
+                        {credential.allowedIpCidrs.length === 0 ? (
+                          <span class="cell-muted">anywhere</span>
+                        ) : (
+                          credential.allowedIpCidrs.join(", ")
+                        )}
+                      </td>
+                      <td data-label="Expires">
+                        {credential.expiresAt.toISOString().slice(0, 10)}
+                      </td>
+                      <td data-label="Last used">
+                        {credential.lastUsedAt ? (
+                          credential.lastUsedAt.toISOString().slice(0, 10)
+                        ) : (
+                          <span class="cell-muted">never</span>
+                        )}
+                      </td>
+                      <td data-label="State">{credential.status}</td>
+                      {canRevoke && (
+                        <td data-label="Actions">
+                          {isLive(credential) ? (
+                            <button
+                              type="button"
+                              class="js-revoke-credential"
+                              data-credential-id={credential.id}
+                            >
+                              Revoke
+                            </button>
+                          ) : (
+                            <span class="cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </section>
+      </>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time). The
+  // import forces Astro to emit this EXTERNAL, where the app's
+  // `default-src 'self'` CSP allows it.
+  import {
+    lockElement,
+    sendJson,
+    sendJsonForData
+  } from "../../lib/ui/admin-form-client";
+
+  const errorBox = document.getElementById("machine-credentials-action-error");
+  const tokenBox = document.getElementById("machine-credentials-token");
+
+  function showError(message: string): void {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.hidden = false;
+  }
+
+  function clearError(): void {
+    if (errorBox) errorBox.hidden = true;
+  }
+
+  const expiresInput = document.getElementById(
+    "issue-credential-expires"
+  ) as HTMLInputElement | null;
+
+  function writeActionsChosen(): string[] {
+    return [...document.querySelectorAll<HTMLInputElement>(".js-write-action")]
+      .filter((box) => box.checked)
+      .map((box) => box.value);
+  }
+
+  // The ceiling narrows to 30 days the moment a write action is ticked. Done
+  // here as well as on the server so the operator sees the shorter limit while
+  // choosing, rather than as a 422 after filling the form in.
+  function syncExpiryCeiling(): void {
+    if (!expiresInput) return;
+
+    const writing = writeActionsChosen().length > 0;
+    const max = writing
+      ? (expiresInput.dataset.maxWrite ?? "")
+      : (expiresInput.dataset.maxRead ?? "");
+
+    expiresInput.max = max;
+    if (max && expiresInput.value > max) expiresInput.value = max;
+  }
+
+  for (const box of document.querySelectorAll<HTMLInputElement>(
+    ".js-write-action"
+  )) {
+    box.addEventListener("change", syncExpiryCeiling);
+  }
+  syncExpiryCeiling();
+
+  document
+    .getElementById("issue-credential-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearError();
+
+      const form = event.currentTarget as HTMLFormElement;
+      const button = document.getElementById(
+        "issue-credential-submit"
+      ) as HTMLButtonElement | null;
+      const keysSelect = document.getElementById(
+        "issue-credential-keys"
+      ) as HTMLSelectElement | null;
+      const cidrsInput = document.getElementById(
+        "issue-credential-cidrs"
+      ) as HTMLInputElement | null;
+      if (!button || !keysSelect) return;
+
+      const data = new FormData(form);
+      const day = String(data.get("expiresAt") ?? "");
+      const allowedWriteActions = writeActionsChosen();
+
+      // Sent ONLY when the write class was asked for. An empty array would
+      // still read as "read-only" to the server, but sending the CIDR field
+      // alongside it is refused by design — the two must travel together or
+      // not at all.
+      const cidrs = allowedWriteActions.length
+        ? (cidrsInput?.value ?? "")
+            .split(/[,\n]/)
+            .map((entry) => entry.trim())
+            .filter((entry) => entry.length > 0)
+        : [];
+
+      const unlock = lockElement(button, "Please wait…");
+      const result = await sendJsonForData<{ token?: string }>(
+        "POST",
+        "/api/v1/access/machine-credentials",
+        {
+          name: String(data.get("name") ?? "").trim(),
+          tenantUserId: String(data.get("tenantUserId") ?? ""),
+          allowedPermissionKeys: [...keysSelect.selectedOptions].map(
+            (option) => option.value
+          ),
+          allowedWriteActions,
+          allowedIpCidrs: cidrs,
+          // A `date` input gives midnight LOCAL; send the end of that day in
+          // UTC so "until the 20th" does not silently mean "until the 19th
+          // evening" for anyone east of Greenwich.
+          expiresAt: day ? `${day}T23:59:00.000Z` : ""
+        }
+      );
+
+      if (result.ok && result.data?.token) {
+        // NOT a reload. This is the only time the token is readable, and
+        // reloading would mint a credential nobody can use and somebody has to
+        // revoke.
+        if (tokenBox) {
+          tokenBox.textContent = `Token (shown once — copy it now, then reload this page): ${result.data.token}`;
+          tokenBox.hidden = false;
+        }
+        unlock();
+        return;
+      }
+
+      showError(
+        result.errorCode === "VALIDATION_FAILED"
+          ? "Check the form: a credential that can write needs at least one address range and expires within 30 days, and address ranges are refused on a read-only one."
+          : result.errorCode === "TENANT_USER_NOT_FOUND"
+            ? "That service account no longer exists in this tenant."
+            : result.errorCode === "ACCESS_DENIED"
+              ? "You may issue read-only credentials, but not ones that can write."
+              : "Could not issue that credential. Please try again."
+      );
+      unlock();
+    });
+
+  document.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement | null)?.closest("button");
+    if (!(target instanceof HTMLButtonElement)) return;
+    if (!target.classList.contains("js-revoke-credential")) return;
+
+    const credentialId = target.dataset.credentialId;
+    if (!credentialId) return;
+
+    void (async () => {
+      clearError();
+      const unlock = lockElement(target, "Please wait…");
+      const result = await sendJson(
+        "POST",
+        `/api/v1/access/machine-credentials/${credentialId}/revoke`
+      );
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+      showError(
+        result.errorCode === "NOT_FOUND"
+          ? "That credential was already revoked, or no longer exists."
+          : "Could not revoke that credential. Please try again."
+      );
+      unlock();
+    })();
+  });
+</script>

--- a/tests/admin-machine-credentials-page-contract.test.ts
+++ b/tests/admin-machine-credentials-page-contract.test.ts
@@ -1,0 +1,175 @@
+/**
+ * `/admin/machine-credentials` gates against the endpoints it drives — ADR-0049,
+ * ADR-0092, #539.
+ *
+ * Sibling of the other page-contract tests, for the same silent failure: a page
+ * gating on a permission key no migration seeds hides the control from EVERYONE
+ * — including the owner — while still looking like a working screen. This repo
+ * has shipped that bug twice by inventing a plausible action name.
+ *
+ * This screen sets three traps of its own:
+ *
+ * - **Issuing spans TWO permissions.** `machine_credentials.create` mints the
+ *   read-only class and `machine_credentials_write.create` mints the write one.
+ *   A page that gated the whole form on either alone would either hide issuance
+ *   from everybody who may only mint read credentials, or offer a write control
+ *   that 403s at submit.
+ * - **The token is readable exactly once.** A reload after issuing spends a
+ *   credential nobody can use and somebody has to revoke.
+ * - **Revoke is a `POST` to `/revoke`, not a `DELETE`.** A page that guessed
+ *   the verb would render a working-looking button that answers 405 at the one
+ *   moment it matters.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import { MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS } from "../src/modules/identity-access/domain/machine-credential";
+
+const PAGE = "src/pages/admin/machine-credentials.astro";
+const LIST_ROUTE = "src/pages/api/v1/access/machine-credentials/index.ts";
+const REVOKE_ROUTE =
+  "src/pages/api/v1/access/machine-credentials/[id]/revoke.ts";
+
+/**
+ * Collapses runs of whitespace.
+ *
+ * Two assertions below are about ADJACENCY — that a verb sits next to its URL,
+ * that a ternary tests the write list — and the formatter decides where those
+ * break across lines. Matching raw source would make prettier's line-wrapping a
+ * reason for this file to go red on correct code, which is the failure mode
+ * `/admin/partners` already recorded once.
+ */
+function squashed(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+const EXPECTED = [
+  "identity_access.machine_credentials.read",
+  "identity_access.machine_credentials.create",
+  "identity_access.machine_credentials.revoke",
+  "identity_access.machine_credentials_write.create"
+];
+
+describe("/admin/machine-credentials gates on keys that really exist", () => {
+  test("every key the page names is DECLARED by a module", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const declared = new Set<string>();
+    for (const module of listModules()) {
+      for (const permission of module.permissions ?? []) {
+        declared.add(
+          `${module.key}.${permission.activityCode}.${permission.action}`
+        );
+      }
+    }
+
+    for (const key of EXPECTED) {
+      const [, activityCode, action] = key.split(".");
+      expect(page).toContain(`activityCode: "${activityCode}"`);
+      expect(page).toContain(`action: "${action}"`);
+      expect(declared.has(key)).toBe(true);
+    }
+  });
+
+  test("the page names BOTH issuance activities, not one standing in for both", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // The whole point of ADR-0092's split. If the page resolved the write
+    // fieldset from `machine_credentials.create`, every holder of the read
+    // permission would be shown a control they cannot use — and the split that
+    // kept the grant from widening would be undone in the UI instead.
+    expect(page).toContain('activityCode: "machine_credentials_write"');
+    expect(page).toContain('activityCode: "machine_credentials"');
+    expect(page).toContain("canCreateWrite");
+  });
+
+  test("the page and its endpoints agree on the activity", async () => {
+    for (const route of [LIST_ROUTE, REVOKE_ROUTE]) {
+      const source = await readFile(route, "utf8");
+      expect(source).toContain('activityCode: "machine_credentials"');
+    }
+  });
+
+  test("revoking is gated on `revoke`, and it is a POST to /revoke", async () => {
+    const page = squashed(await readFile(PAGE, "utf8"));
+    const route = await readFile(REVOKE_ROUTE, "utf8");
+
+    // `revoke` is split from `create` on purpose (ADR-0049): during an incident
+    // somebody must be able to kill a leaked credential without also being able
+    // to mint one.
+    expect(route).toContain('action: "revoke"');
+    expect(route).toContain("export const POST");
+    expect(page).toContain(
+      '"POST", `/api/v1/access/machine-credentials/${credentialId}/revoke`'
+    );
+  });
+});
+
+describe("the three properties this surface exists to keep", () => {
+  test("issuing does NOT reload — the token would be lost", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const issueBlock = page.slice(
+      page.indexOf('getElementById("issue-credential-form")'),
+      page.indexOf('document.addEventListener("click"')
+    );
+
+    expect(issueBlock).toContain("sendJsonForData");
+    expect(issueBlock).toContain("result.data?.token");
+    expect(issueBlock).not.toContain("window.location.reload()");
+  });
+
+  test("the write-action checkboxes are DERIVED from the live ceiling", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // A hand-written pair of checkboxes would still render `create`/`update`
+    // correctly today and silently omit whatever a future ADR adds — the form
+    // falling behind the constant, with nothing red.
+    expect(page).toContain("MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS");
+    expect(page).toContain("writeActions.map(");
+    for (const action of MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS) {
+      expect(page).not.toContain(`value="${action}"`);
+    }
+  });
+
+  test("CIDRs are sent ONLY with a write class, matching what the API accepts", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // The API refuses `allowedIpCidrs` on a read-only credential, because the
+    // guard never consults them there — a binding that reads as enforced and is
+    // not. A page that always sent the field would turn that honest refusal
+    // into a 422 on every read-only issuance.
+    expect(squashed(page)).toContain("allowedWriteActions.length ?");
+  });
+
+  test("the expiry ceiling narrows with the write class", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Server-enforced either way; done here so the shorter limit is visible
+    // while choosing rather than as a 422 after the form is filled in.
+    expect(page).toContain("MACHINE_CREDENTIAL_WRITE_MAX_LIFETIME_DAYS");
+    expect(page).toContain("syncExpiryCeiling");
+    expect(page).toContain("dataset.maxWrite");
+  });
+});
+
+describe("the ledger shrank, and stayed shrunk", () => {
+  test("no machine-credential key is left on NOT_YET_SCREENED", async () => {
+    const { NOT_YET_SCREENED } =
+      await import("../scripts/admin-screen-coverage-ledger");
+
+    expect(
+      NOT_YET_SCREENED.filter((key) => key.includes("machine_credential"))
+    ).toEqual([]);
+  });
+
+  test("and the four keys are exactly the ones this page claims", () => {
+    // Paired with the assertion above so neither can pass vacuously: an empty
+    // ledger slice proves nothing if the page stopped naming the keys.
+    expect(EXPECTED).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
Closes #539.

Permukaannya ada sejak `sql/082` dan tidak pernah punya halaman. Alasan membangunnya adalah kalimat yang sama yang menutup `/admin/partners`: **pencabutan adalah kontrol yang dicari orang ketika sebuah token bocor, dan sampai halaman ini ada ia `POST` yang tidak akan diingat siapa pun di bawah tekanan.** #537 mempertajamnya dengan membuka kelas yang bisa **mengubah data** — dan sampai sekarang tidak ada tempat untuk melihat kredensial mana yang bisa.

## Dua izin, satu form, dan itu bukan kosmetik

`machine_credentials.create` mencetak kelas baca; `machine_credentials_write.create` mencetak kelas tulis. Fieldset tulis hanya dirender bagi pemegang kunci kedua.

Kalau halaman ini menurunkan keduanya dari satu izin, pemisahan yang ADR-0092 buat **justru untuk mencegah pelebaran grant** akan dibatalkan lagi — kali ini di UI, di mana tidak ada gerbang yang melihatnya.

Checkbox aksi tulisnya **diturunkan** dari `MACHINE_CREDENTIAL_WRITE_ALLOWED_ACTIONS`, bukan ditulis tangan: sepasang checkbox `create`/`update` tulis tangan tetap benar hari ini dan diam-diam tertinggal pada hari sebuah ADR melebarkan plafon itu.

## Tiga sifat yang halaman ini ada untuk menjaga

- **Token tampil sekali**, jadi penerbitan **tidak reload**. Respons penerbitan satu-satunya tempat plaintext-nya ada; reload mencetak kredensial yang tak bisa dipakai siapa pun lalu harus dicabut.
- **CIDR hanya dikirim bersama kelas tulis.** API menolaknya pada kredensial baca karena gerbangnya tak pernah mengkonsultasinya di sana — halaman yang selalu mengirim field itu mengubah penolakan jujur tersebut menjadi 422 pada setiap penerbitan baca.
- **Plafon kadaluwarsa menyempit ke 30 hari** begitu satu aksi tulis dicentang. Ditegakkan server; ditampilkan di sini supaya batasnya terlihat saat memilih.

## Daftar izinnya seluruh katalog, dan halamannya mengatakan artinya

`allowedPermissionKeys` **menyempitkan**: himpunan efektifnya adalah irisan dengan yang dipegang akun layanan, jadi menyebut kunci yang tak dipegang akun tidak memberi apa-apa. Menampilkan hanya kunci milik akun butuh endpoint per-akun yang tidak ada; menyiratkan bahwa daftar itu sebuah pemberian jauh lebih buruk.

## Diverifikasi dengan menjalankan

- `DATABASE_URL="" bun run check` **hijau penuh** — 41 segmen, build ikut me-render halaman baru.
- **Lima mutasi memerahkan test yang tepat:** penerbitan me-reload (token hilang), fieldset tulis digerbangi izin baca, checkbox ditulis tangan alih-alih diturunkan, CIDR selalu dikirim, dan satu kunci ditinggal di ledger padahal layarnya ada.
- Dua asersi sumber sengaja dibuat **tahan-whitespace**: asersi yang terikat indentasi memerah pada kode yang benar begitu formatter memindahkan satu baris — kegagalan sekerabat yang putaran kedelapan belas sudah catat sekali (di sana penyebabnya mencampur action audit dengan action guard).

`NOT_YET_SCREENED` **menyusut 62 → 58**, dan itulah gunanya angka itu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)