### PR TITLE
feat(admin): layar Email suppression — alamat yang diam-diam berhenti menerima surat kini bisa dilihat (#544)

### DIFF
--- a/.changeset/admin-email-suppression-screen.md
+++ b/.changeset/admin-email-suppression-screen.md
@@ -1,0 +1,42 @@
+---
+"awcms": minor
+---
+
+feat(admin): layar Email suppression — alamat yang diam-diam berhenti menerima surat kini bisa dilihat (#544)
+
+Ledger cakupan layar menamai kelompok ini sendiri sebagai salah satu dari dua yang
+**bukan kosmetik**: sebuah alamat yang di-suppress diam-diam berhenti menerima surat,
+**termasuk reset password**, dan tidak ada yang bisa mendaftar atau membersihkannya
+dari sebuah halaman.
+
+Itu mode kegagalan dukungan yang lengkap: orang tidak bisa masuk, meminta reset,
+tidak menerima apa-apa, dan tidak seorang pun di sisi operator punya cara melihat
+kenapa. Diagnosisnya sampai sekarang adalah query SQL yang harus diketahui
+keberadaannya.
+
+`alreadySuppressed` ADALAH JAWABAN, BUKAN ERROR — dan itu yang membentuk halamannya.
+Daftar suppression hanya menyimpan alamat ter-MASK (tak pernah yang mentah) dan
+dibatasi 100 baris, jadi "apakah alamat INI di-suppress?" tidak bisa dijawab dengan
+membaca tabelnya. Endpoint-nya menjawab 200 ber-`alreadySuppressed` alih-alih 409,
+sehingga satu request melayani "tambahkan" DAN "sudah ada belum". Halaman ini
+memunculkan jawaban itu sebagai pemeriksaan yang memang ia lakukan; me-reload di
+cabang itu akan membuang satu-satunya hal yang ditanyakan operator. Bukan
+pengungkapan baru — itu yang selalu dibalas `POST` — tetapi membiarkannya tanpa label
+membuat pertanyaan dukungan paling umum tampak tak terjawab.
+
+SELECT ALASANNYA DITURUNKAN, bukan disalin. `SUPPRESSION_REASONS` kini diekspor dari
+domain dan `KNOWN_REASONS` diturunkan darinya, sehingga hanya ada SATU tempat untuk
+disunting. Salinan empat nilai di halaman akan tetap benar hari ini dan tertinggal
+diam-diam pada hari nilai kelima ditambahkan — form menawarkan empat dari lima, tanpa
+apa pun memerah.
+
+Layar tersendiri, bukan bagian dari `/admin/email-templates`: orang yang menjangkau
+ini sedang menjawab "kenapa surat kami tidak sampai", bukan menyunting teks — dan
+kontrol yang tidak bisa DITEMUKAN sama saja dengan yang tidak ada.
+
+DIVERIFIKASI DENGAN MENJALANKAN. `bun run check` penuh hijau. Empat mutasi
+memerahkan test yang tepat: cabang `alreadySuppressed` diganti reload, satu `<option>`
+ditulis tangan alih-alih diturunkan, daftar alasan domain dikosongkan (membuktikan
+asersi "diturunkan" tidak hampa), dan satu kunci ditinggal di ledger.
+
+`NOT_YET_SCREENED` **menyusut 58 → 55**.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -109,8 +109,8 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
 | Migrasi                            | **123** (`sql/001`–`123`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
-| Layar admin                        | **36** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **49** (26.999 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Layar admin                        | **37** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Berkas `.astro`                    | **50** (27.331 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **41** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **3.1.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -355,6 +355,29 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN 13 Agustus 2026 (kedua puluh tiga) — LAYAR EMAIL SUPPRESSION (#544).**
+
+  Menutup 3 kunci, **58 → 55**. Kelompok kedua yang ledger cakupan layar namai
+  sendiri sebagai bukan kosmetik: alamat yang di-suppress diam-diam berhenti
+  menerima surat, TERMASUK reset password, dan tak ada yang bisa mendaftar atau
+  membersihkannya dari halaman. Diagnosisnya sampai sekarang query SQL yang harus
+  diketahui keberadaannya.
+
+  **`alreadySuppressed` adalah JAWABAN, bukan error — dan itu yang membentuk
+  halamannya.** Daftarnya hanya menyimpan alamat ter-mask dan dibatasi 100 baris,
+  jadi "apakah alamat INI di-suppress?" tidak bisa dijawab dengan membacanya.
+  Endpoint-nya menjawab 200 ber-`alreadySuppressed` alih-alih 409, sehingga satu
+  request melayani "tambahkan" DAN "sudah ada belum"; me-reload di cabang itu
+  membuang satu-satunya hal yang ditanyakan operator.
+
+  **`SUPPRESSION_REASONS` diekspor, dan `KNOWN_REASONS` diturunkan darinya.**
+  Perubahan kecil dengan aturan yang sama seperti checkbox kelas-tulis satu
+  putaran lalu: sebuah daftar yang disalin ke UI tetap benar hari ini dan
+  tertinggal diam-diam saat nilai berikutnya ditambahkan. Bentuk mutasi yang
+  membuktikannya juga sama, dan yang paling berguna adalah **mengosongkan daftar
+  sumbernya** — asersi "diturunkan" yang tidak memerah pada daftar kosong adalah
+  asersi hampa.
 
 - **PUTARAN 13 Agustus 2026 (kedua puluh dua) — EPIC #423 DITUTUP, BACKLOGNYA
   PINDAH KE ISSUE, dan layar `/admin/machine-credentials` mendarat.**

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -99,7 +99,7 @@
       "capabilitiesProvided": ["auth_notification"],
       "capabilitiesConsumed": [],
       "permissionCount": 12,
-      "navigationCount": 1,
+      "navigationCount": 2,
       "jobCount": 4,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 370   |
-| Berkas route                       | 346   |
+| Berkas test                        | 371   |
+| Berkas route                       | 347   |
 | ADR                                | 93    |
 
 ### Modul
@@ -326,7 +326,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 316        |
+| `(root)`      | 317        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |
@@ -336,7 +336,7 @@
 | Permukaan       | Berkas |
 | --------------- | ------ |
 | `/api/v1/**`    | 286    |
-| `/admin/**`     | 36     |
+| `/admin/**`     | 37     |
 | publik / anonim | 24     |
 
 <!-- END GENERATED: repo-inventory -->

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -52,13 +52,10 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "comments.settings.read",
   "comments.settings.update",
 
-  // email (9)
+  // email (6)
   "email.announcement.create",
   "email.message.cancel",
   "email.message.read",
-  "email.suppression.create",
-  "email.suppression.delete",
-  "email.suppression.read",
   "email.template.delete",
   "email.template.restore",
   "email.template.update",

--- a/src/modules/email/domain/suppression-validation.ts
+++ b/src/modules/email/domain/suppression-validation.ts
@@ -22,12 +22,23 @@ export type SuppressionInput = {
   reason: SuppressionReason;
 };
 
-const KNOWN_REASONS: ReadonlySet<string> = new Set([
+/**
+ * The reasons, in the order an operator should see them offered.
+ *
+ * Exported so `/admin/email-suppression` renders its `<select>` from THIS list
+ * rather than repeating it. A hand-written copy in the page would stay correct
+ * today and fall silently behind the day a reason is added — the form offering
+ * three of four options, with nothing red. `KNOWN_REASONS` below is derived
+ * from it for the same reason, so there is exactly one place to edit.
+ */
+export const SUPPRESSION_REASONS: readonly SuppressionReason[] = [
   "bounced",
   "complained",
   "manual",
   "unsubscribed"
-]);
+];
+
+const KNOWN_REASONS: ReadonlySet<string> = new Set(SUPPRESSION_REASONS);
 
 const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 

--- a/src/modules/email/module.ts
+++ b/src/modules/email/module.ts
@@ -49,6 +49,17 @@ export const emailModule = defineModule({
       path: "/admin/email-templates",
       order: 32,
       requiredPermission: "email.template.read"
+    },
+    // Issue #544. Its own entry rather than a section on the templates screen:
+    // an operator reaching for this is answering "why did our mail not arrive",
+    // not editing copy, and a control they cannot FIND is the same as one that
+    // does not exist. 33, not 32 — two entries sharing an order leave the
+    // sidebar's sequence to whatever the sort happened to do that build.
+    {
+      labelKey: "admin.layout.nav_email_suppression",
+      path: "/admin/email-suppression",
+      order: 33,
+      requiredPermission: "email.suppression.read"
     }
   ],
   /**

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -182,6 +182,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_site_search": "Site search",
   "admin.layout.nav_theming": "Theming",
   "admin.layout.nav_email_templates": "Email templates",
+  "admin.layout.nav_email_suppression": "Email suppression",
   "admin.layout.nav_audit_trail": "Audit trail",
   "admin.layout.nav_comments": "Moderation queue",
   "admin.layout.nav_visitor_analytics": "Visitor analytics",

--- a/src/pages/admin/email-suppression.astro
+++ b/src/pages/admin/email-suppression.astro
@@ -1,0 +1,332 @@
+---
+/**
+ * Email suppression — Issue #544.
+ *
+ * Three keys sat on `NOT_YET_SCREENED` and the ledger named this group itself
+ * as one of two that are not cosmetic:
+ *
+ * > a suppressed address silently stops receiving mail, INCLUDING password
+ * > resets, and nothing can list or clear it from a page.
+ *
+ * That is a complete support failure with no diagnosis: somebody cannot sign
+ * in, asks for a reset, receives nothing, and nobody on the operator's side has
+ * a way to see why. Until this page the answer lived in a SQL query somebody
+ * had to know existed.
+ *
+ * ## The list is masked, and bounded at 100
+ *
+ * `listSuppressions` returns `recipient_masked` — the raw address is never
+ * stored in readable form and never returned. So "is THIS address suppressed?"
+ * cannot be answered by reading the table, and the page says so rather than
+ * implying the list is a search.
+ *
+ * The honest way to ask is to try to add it: the endpoint answers
+ * `alreadySuppressed` instead of creating a duplicate, and this page surfaces
+ * that answer as the check it actually is. That is not a new disclosure — it is
+ * what `POST` has always replied — but leaving it unlabelled would make the
+ * most common support question look unanswerable.
+ *
+ * ## Reasons come from the domain, not from here
+ *
+ * The `<select>` is rendered from `SUPPRESSION_REASONS`. A copy of the four
+ * values in this file would stay correct today and fall behind the day a fifth
+ * is added, offering an operator four of five options with nothing red.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import {
+  listSuppressions,
+  type SuppressionEntry
+} from "../../modules/email/application/suppression-directory";
+import { SUPPRESSION_REASONS } from "../../modules/email/domain/suppression-validation";
+
+const ssr = Astro.locals.ssrContext!;
+
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "email",
+    activityCode: "suppression",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // One transaction, one awaited query at a time.
+    entries: await listSuppressions(tx, ssr.tenantId),
+    canCreate: await can({
+      moduleKey: "email",
+      activityCode: "suppression",
+      action: "create"
+    }),
+    canDelete: await can({
+      moduleKey: "email",
+      activityCode: "suppression",
+      action: "delete"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError(
+      "admin/email-suppression.astro: failed to list suppressions",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const entries: SuppressionEntry[] =
+  screen.state === "allowed" ? screen.data.entries : [];
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
+const canDelete = screen.state === "allowed" && screen.data.canDelete;
+
+/** Rendered from the domain list — see this file's header. */
+const reasons = [...SUPPRESSION_REASONS];
+---
+
+<AdminLayout title="Email suppression">
+  <header class="page-header fade-in-up">
+    <h1 id="email-suppression-heading">Email suppression</h1>
+    <p class="page-description">
+      Addresses this tenant will not send to. A suppressed address receives
+      nothing — including password resets — so an account can look broken when
+      it is only unreachable. This is where to check, and where to undo it.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="email-suppression-denied">
+        You do not have permission to view the suppression list.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="email-suppression-load-error">
+        Could not load the suppression list. Please try again.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <>
+        <p
+          id="email-suppression-action-error"
+          class="state-notice"
+          role="alert"
+          hidden
+        />
+        <p
+          id="email-suppression-notice"
+          class="state-notice"
+          role="status"
+          hidden
+        />
+
+        {canCreate && (
+          <section
+            class="fade-in-up"
+            aria-labelledby="email-suppression-add-heading"
+          >
+            <h2 id="email-suppression-add-heading">
+              Suppress an address — or check one
+            </h2>
+
+            <form id="add-suppression-form" class="admin-form">
+              <p class="page-description">
+                The list below shows masked addresses only, so it cannot be
+                searched. Submitting an address that is already suppressed does
+                not add a second entry — it tells you it is already there, which
+                is how to answer "why is this person not getting our mail?".
+              </p>
+
+              <label for="add-suppression-recipient">Email address</label>
+              <input
+                id="add-suppression-recipient"
+                name="recipient"
+                type="email"
+                required
+                autocomplete="off"
+                placeholder="somebody@example.com"
+              />
+
+              <label for="add-suppression-reason">Reason</label>
+              <select id="add-suppression-reason" name="reason" required>
+                {reasons.map((reason) => (
+                  <option value={reason}>{reason}</option>
+                ))}
+              </select>
+
+              <button id="add-suppression-submit" type="submit">
+                Suppress address
+              </button>
+            </form>
+          </section>
+        )}
+
+        <section
+          class="fade-in-up"
+          aria-labelledby="email-suppression-list-heading"
+        >
+          <h2 id="email-suppression-list-heading">Suppressed addresses</h2>
+
+          {entries.length === 0 ? (
+            <div class="empty-state">
+              <p id="email-suppression-empty">
+                Nothing is suppressed. Every address this tenant sends to can
+                receive mail.
+              </p>
+            </div>
+          ) : (
+            <div class="data-table-scroll">
+              <table class="data-table data-table--stack">
+                <thead>
+                  <tr>
+                    <th scope="col">Address</th>
+                    <th scope="col">Reason</th>
+                    <th scope="col">Added</th>
+                    {canDelete && <th scope="col">Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {entries.map((entry) => (
+                    <tr>
+                      <th scope="row" data-label="Address">
+                        {entry.recipientMasked}
+                      </th>
+                      <td data-label="Reason">{entry.reason}</td>
+                      <td data-label="Added">{entry.createdAt.slice(0, 10)}</td>
+                      {canDelete && (
+                        <td data-label="Actions">
+                          <button
+                            type="button"
+                            class="js-remove-suppression"
+                            data-suppression-id={entry.id}
+                          >
+                            Allow again
+                          </button>
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <p class="page-description">
+            Newest 100. An address removed here can receive mail from the next
+            send onwards; messages already skipped are not resent.
+          </p>
+        </section>
+      </>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time). The
+  // import forces Astro to emit this EXTERNAL, where the app's
+  // `default-src 'self'` CSP allows it.
+  import {
+    lockElement,
+    sendJson,
+    sendJsonForData
+  } from "../../lib/ui/admin-form-client";
+
+  const errorBox = document.getElementById("email-suppression-action-error");
+  const noticeBox = document.getElementById("email-suppression-notice");
+
+  function showError(message: string): void {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.hidden = false;
+  }
+
+  function clearBoxes(): void {
+    if (errorBox) errorBox.hidden = true;
+    if (noticeBox) noticeBox.hidden = true;
+  }
+
+  document
+    .getElementById("add-suppression-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearBoxes();
+
+      const form = event.currentTarget as HTMLFormElement;
+      const button = document.getElementById(
+        "add-suppression-submit"
+      ) as HTMLButtonElement | null;
+      if (!button) return;
+
+      const data = new FormData(form);
+      const unlock = lockElement(button, "Please wait…");
+      const result = await sendJsonForData<{ alreadySuppressed?: boolean }>(
+        "POST",
+        "/api/v1/email/suppressions",
+        {
+          recipient: String(data.get("recipient") ?? "").trim(),
+          reason: String(data.get("reason") ?? "")
+        }
+      );
+
+      // The endpoint answers 200 with `alreadySuppressed` rather than 409, so
+      // the CHECK and the ADD are the same request. Reloading on that answer
+      // would throw away the only thing the operator asked for.
+      if (result.ok && result.data?.alreadySuppressed) {
+        if (noticeBox) {
+          noticeBox.textContent =
+            "That address is already suppressed — nothing was changed. It is in the list below, masked.";
+          noticeBox.hidden = false;
+        }
+        unlock();
+        return;
+      }
+
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+
+      showError(
+        result.errorCode === "VALIDATION_ERROR"
+          ? "Check the address and the reason."
+          : "Could not suppress that address. Please try again."
+      );
+      unlock();
+    });
+
+  document.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement | null)?.closest("button");
+    if (!(target instanceof HTMLButtonElement)) return;
+    if (!target.classList.contains("js-remove-suppression")) return;
+
+    const suppressionId = target.dataset.suppressionId;
+    if (!suppressionId) return;
+
+    void (async () => {
+      clearBoxes();
+      const unlock = lockElement(target, "Please wait…");
+      const result = await sendJson(
+        "DELETE",
+        `/api/v1/email/suppressions/${suppressionId}`
+      );
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+      showError(
+        result.errorCode === "RESOURCE_NOT_FOUND"
+          ? "That entry was already removed."
+          : "Could not remove that entry. Please try again."
+      );
+      unlock();
+    })();
+  });
+</script>

--- a/tests/admin-email-suppression-page-contract.test.ts
+++ b/tests/admin-email-suppression-page-contract.test.ts
@@ -1,0 +1,137 @@
+/**
+ * `/admin/email-suppression` gates against the endpoints it drives — Issue #544.
+ *
+ * Sibling of the other page-contract tests, for the same silent failure: a page
+ * gating on a permission key no migration seeds hides the control from EVERYONE
+ * — including the owner — while still looking like a working screen.
+ *
+ * This screen has two properties of its own worth pinning:
+ *
+ * - **`alreadySuppressed` is an ANSWER, not an error.** The endpoint replies 200
+ *   with that flag instead of 409, which makes one request serve as both "add"
+ *   and "is this address already on the list?". Reloading on it would throw away
+ *   the only thing the operator asked for — and the masked, bounded list cannot
+ *   answer the question any other way.
+ * - **No raw address is ever rendered.** The store returns `recipient_masked`
+ *   and nothing else; a page that reached for a raw field would be reaching for
+ *   one that does not exist, but the assertion is what keeps it that way if one
+ *   ever appears.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import { SUPPRESSION_REASONS } from "../src/modules/email/domain/suppression-validation";
+
+const PAGE = "src/pages/admin/email-suppression.astro";
+const LIST_ROUTE = "src/pages/api/v1/email/suppressions/index.ts";
+const ENTRY_ROUTE = "src/pages/api/v1/email/suppressions/[id].ts";
+
+const EXPECTED = [
+  "email.suppression.read",
+  "email.suppression.create",
+  "email.suppression.delete"
+];
+
+describe("/admin/email-suppression gates on keys that really exist", () => {
+  test("every key the page names is DECLARED by a module", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const declared = new Set<string>();
+    for (const module of listModules()) {
+      for (const permission of module.permissions ?? []) {
+        declared.add(
+          `${module.key}.${permission.activityCode}.${permission.action}`
+        );
+      }
+    }
+
+    for (const key of EXPECTED) {
+      const [, activityCode, action] = key.split(".");
+      expect(page).toContain(`activityCode: "${activityCode}"`);
+      expect(page).toContain(`action: "${action}"`);
+      expect(declared.has(key)).toBe(true);
+    }
+  });
+
+  test("the page and both endpoints agree on the activity", async () => {
+    for (const route of [LIST_ROUTE, ENTRY_ROUTE]) {
+      const source = await readFile(route, "utf8");
+      expect(source).toContain('activityCode: "suppression"');
+    }
+  });
+
+  test("removing an entry is a DELETE gated on `delete`", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const route = await readFile(ENTRY_ROUTE, "utf8");
+
+    expect(route).toContain('action: "delete"');
+    expect(route).toContain("export const DELETE");
+    expect(page).toContain('"DELETE",');
+  });
+});
+
+describe("the two properties this screen exists to keep", () => {
+  test("`alreadySuppressed` is surfaced, not reloaded away", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const addBlock = page.slice(
+      page.indexOf('getElementById("add-suppression-form")'),
+      page.indexOf('document.addEventListener("click"')
+    );
+
+    // The check and the add are one request. A page that reloaded here would
+    // answer the operator's question by discarding it — and the list is masked
+    // and capped at 100, so there is no second way to ask.
+    expect(addBlock).toContain("alreadySuppressed");
+    expect(addBlock).toContain("already suppressed");
+    expect(addBlock.indexOf("alreadySuppressed")).toBeLessThan(
+      addBlock.indexOf("window.location.reload()")
+    );
+  });
+
+  test("the reason select is DERIVED from the domain list", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // A copy of the four values here would stay correct today and fall behind
+    // the day a fifth is added — the form offering four of five, nothing red.
+    expect(page).toContain("SUPPRESSION_REASONS");
+    expect(page).toContain("reasons.map(");
+    for (const reason of SUPPRESSION_REASONS) {
+      expect(page).not.toContain(`value="${reason}"`);
+    }
+  });
+
+  test("and the domain list is non-empty — otherwise the assertion above is vacuous", () => {
+    expect(SUPPRESSION_REASONS.length).toBeGreaterThan(0);
+  });
+
+  test("no raw recipient is ever rendered", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // The store returns `recipient_masked` and never the address. This holds
+    // the page to it if a raw field is ever added to the projection.
+    expect(page).toContain("entry.recipientMasked");
+    expect(page).not.toContain("entry.recipient}");
+    expect(page).not.toContain("recipientHash");
+  });
+});
+
+describe("the ledger shrank, and stayed shrunk", () => {
+  test("no `email.suppression` key is left on NOT_YET_SCREENED", async () => {
+    const { NOT_YET_SCREENED } =
+      await import("../scripts/admin-screen-coverage-ledger");
+
+    expect(
+      NOT_YET_SCREENED.filter((key) => key.startsWith("email.suppression."))
+    ).toEqual([]);
+  });
+
+  test("and the three keys are exactly the ones this page claims", () => {
+    // Paired with the assertion above so neither passes vacuously.
+    expect(EXPECTED).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
Closes #544.

Ledger cakupan layar menamai kelompok ini sendiri sebagai salah satu dari dua yang **bukan kosmetik**:

> sebuah alamat yang di-suppress diam-diam berhenti menerima surat, **termasuk reset password**, dan tidak ada yang bisa mendaftar atau membersihkannya dari sebuah halaman.

Itu mode kegagalan dukungan yang lengkap: orang tidak bisa masuk, meminta reset, tidak menerima apa-apa, dan tidak seorang pun di sisi operator punya cara melihat kenapa. Diagnosisnya sampai sekarang adalah query SQL yang harus diketahui keberadaannya.

## `alreadySuppressed` adalah JAWABAN, bukan error

Dan itu yang membentuk halamannya. Daftar suppression hanya menyimpan alamat ter-**mask** — yang mentah tidak pernah disimpan dalam bentuk terbaca — dan dibatasi 100 baris. Jadi "apakah alamat **ini** di-suppress?" tidak bisa dijawab dengan membaca tabelnya.

Endpoint-nya menjawab 200 ber-`alreadySuppressed` alih-alih 409, sehingga satu request melayani "tambahkan" **dan** "sudah ada belum". Halaman ini memunculkan jawaban itu sebagai pemeriksaan yang memang ia lakukan; me-reload di cabang itu akan membuang satu-satunya hal yang ditanyakan operator. Bukan pengungkapan baru — itu yang selalu dibalas `POST` — tetapi membiarkannya tanpa label membuat pertanyaan dukungan paling umum tampak tak terjawab.

## Select alasannya DITURUNKAN, bukan disalin

`SUPPRESSION_REASONS` kini diekspor dari domain dan `KNOWN_REASONS` diturunkan darinya, sehingga hanya ada **satu** tempat untuk disunting. Salinan empat nilai di halaman akan tetap benar hari ini dan tertinggal diam-diam pada hari nilai kelima ditambahkan — form menawarkan empat dari lima, tanpa apa pun memerah. Aturan yang sama yang dipakai checkbox kelas-tulis di #547.

## Layar tersendiri, bukan bagian dari `/admin/email-templates`

Orang yang menjangkau ini sedang menjawab "kenapa surat kami tidak sampai", bukan menyunting teks — dan kontrol yang tidak bisa **ditemukan** sama saja dengan yang tidak ada.

## Diverifikasi dengan menjalankan

- `DATABASE_URL="" bun run check` **hijau penuh**.
- **Empat mutasi memerahkan test yang tepat:** cabang `alreadySuppressed` diganti reload, satu `<option>` ditulis tangan alih-alih diturunkan, **daftar alasan domain dikosongkan** (membuktikan asersi "diturunkan" tidak hampa), dan satu kunci ditinggal di ledger.

`NOT_YET_SCREENED` **menyusut 58 → 55**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)