### PR TITLE
feat(admin): layar Invitations — undangan berhenti menjadi kumpulan endpoint (#541)

### DIFF
--- a/.changeset/admin-invitations-screen.md
+++ b/.changeset/admin-invitations-screen.md
@@ -1,0 +1,42 @@
+---
+"awcms": minor
+---
+
+feat(admin): layar Invitations — undangan berhenti menjadi kumpulan endpoint (#541)
+
+Permukaannya mendarat lengkap di Gelombang 4 (ADR-0082) dan tanpa halaman. Empat
+kuncinya duduk di `NOT_YET_SCREENED` dengan alasan yang ledger itu tulis sendiri:
+endpoint-nya ADA dan ditegakkan, yang hilang halamannya.
+
+MEMBUAT SATU UNDANGAN MENJALANKAN SAMPAI TIGA GERBANG, dan formnya mengatakan yang
+mana. `invitations.create`, lalu `access_control.assign` begitu peran disebut, lalu
+`invitations.configure` ber-scope platform untuk `skipEmailConfirmation` pada alamat
+tanpa akun terbukti. Masing-masing otorisasi penuh dengan baris decision log sendiri.
+Form yang menggerbangi semuanya pada `create` saja menawarkan dua kontrol yang 403
+saat submit; yang ini menyembunyikan pemilih peran dan kotak skip-confirmation
+kecuali kuncinya sendiri dipegang.
+
+`delivery: "unavailable"` DITAMPILKAN, TIDAK DITELAN — dan ini temuan, bukan sekadar
+penanganan error. Respons pembuatan menyebut apakah surelnya DIANTREKAN, dan tidak
+ada endpoint yang mengembalikan tautan undangan. Jadi undangan yang dibuat saat
+pengiriman email belum dikonfigurasi itu ADA, VALID, dan tidak bisa diserahkan kepada
+siapa pun — mengirim ulang gagal dengan cara yang sama. Halaman ini melaporkannya apa
+adanya alih-alih menampilkan sukses yang bukan sukses. Membuat tautannya bisa diambil
+adalah keputusan tentang di mana token undangan boleh muncul, dan itu bukan keputusan
+layar ini.
+
+`Idempotency-Key` DIKIRIM TEPAT SEKALI. Endpoint pembuatan MEWAJIBKANNYA (400 tanpa
+itu); `resend` justru MENOLAKNYA, dan dokumentasinya menjelaskan kenapa: memutar ulang
+sebuah resend harus mengembalikan token yang sudah dirotasinya pergi, atau
+mempersistenkan plaintext-nya di `awcms_idempotency_keys`. Ia dibatasi dengan cara
+lain — UPDATE-nya membawa `resend_count < 5`, sama dengan CHECK basis datanya.
+
+Role sistem tidak ditawarkan: `createInvitation` menolaknya, dan mengetahuinya setelah
+menyusun seluruh undangan adalah saat terburuk untuk mengetahuinya.
+
+DIVERIFIKASI DENGAN MENJALANKAN. `bun run check` penuh hijau. Lima mutasi memerahkan
+test yang tepat: `Idempotency-Key` ikut dikirim pada resend, `delivery: unavailable`
+di-reload menjadi sukses palsu, gerbang kedua tidak diperiksa halaman, role sistem
+ikut ditawarkan, dan satu kunci ditinggal di ledger.
+
+`NOT_YET_SCREENED` **menyusut 55 → 51**.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -109,8 +109,8 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
 | Migrasi                            | **123** (`sql/001`–`123`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
-| Layar admin                        | **37** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **50** (27.331 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Layar admin                        | **38** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Berkas `.astro`                    | **51** (27.808 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **41** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **3.1.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -355,6 +355,29 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN 13 Agustus 2026 (kedua puluh empat) — LAYAR INVITATIONS (#541).**
+
+  Menutup 4 kunci, **55 → 51**. Permukaannya mendarat lengkap di Gelombang 4 dan
+  tanpa halaman, persis alasan yang ledger tulis untuk keempatnya.
+
+  **Membuat satu undangan menjalankan sampai TIGA gerbang**, dan formnya
+  mengatakan yang mana: `invitations.create`, lalu `access_control.assign`
+  begitu peran disebut, lalu `invitations.configure` ber-scope platform untuk
+  `skipEmailConfirmation`. Form yang menggerbangi semuanya pada `create`
+  menawarkan dua kontrol yang 403 saat submit.
+
+  **Temuan: undangan yang dibuat saat email mati adalah undangan mati.** Respons
+  pembuatan menyebut `delivery`, dan tidak ada endpoint yang mengembalikan
+  tautannya — jadi undangan itu ada, valid, dan tak bisa diserahkan kepada siapa
+  pun; mengirim ulang gagal dengan cara yang sama. Halaman melaporkannya apa
+  adanya. Membuat tautannya bisa diambil adalah keputusan tentang di mana token
+  undangan boleh muncul, dan sengaja TIDAK diambil di sini.
+
+  **`Idempotency-Key` dikirim tepat sekali**, dan asimetrinya disengaja di kedua
+  sisi: pembuatan mewajibkannya, `resend` menolaknya karena memutar ulang harus
+  mengembalikan token yang sudah dirotasi pergi. Ia dibatasi lewat
+  `resend_count < 5` di UPDATE-nya, bukan lewat header.
 
 - **PUTARAN 13 Agustus 2026 (kedua puluh tiga) — LAYAR EMAIL SUPPRESSION (#544).**
 

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -142,7 +142,7 @@
         }
       ],
       "permissionCount": 42,
-      "navigationCount": 8,
+      "navigationCount": 9,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 371   |
-| Berkas route                       | 347   |
+| Berkas test                        | 372   |
+| Berkas route                       | 348   |
 | ADR                                | 93    |
 
 ### Modul
@@ -326,7 +326,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 317        |
+| `(root)`      | 318        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |
@@ -336,7 +336,7 @@
 | Permukaan       | Berkas |
 | --------------- | ------ |
 | `/api/v1/**`    | 286    |
-| `/admin/**`     | 37     |
+| `/admin/**`     | 38     |
 | publik / anonim | 24     |
 
 <!-- END GENERATED: repo-inventory -->

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -64,18 +64,8 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "form_drafts.draft.create",
   "form_drafts.draft.update",
 
-  // identity_access (18)
+  // identity_access (14)
   //
-  // The four `invitations.*` keys are ADR-0082's, and they land here on the
-  // same terms `tenant_admin.tenant_lifecycle.*` did: the surface exists and is
-  // enforced, what is missing is the page. `/admin/invitations` is its own
-  // change — the ordering ADR-0056 used for `media_library`, whose API landed
-  // first and whose screen followed — and bundling it into the PR that
-  // introduces the schema would have made a schema review into a UI review.
-  "identity_access.invitations.configure",
-  "identity_access.invitations.create",
-  "identity_access.invitations.read",
-  "identity_access.invitations.revoke",
   "identity_access.business_scope_assignments.create",
   "identity_access.business_scope_assignments.read",
   "identity_access.business_scope_assignments.revoke",

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -166,6 +166,17 @@ export const identityAccessModule = defineModule({
       path: "/admin/machine-credentials",
       order: 27,
       requiredPermission: "identity_access.machine_credentials.read"
+    },
+    // ADR-0082, #541. Gated on `invitations.read`, which seeds its own `read`
+    // — an onboarding reviewer should reach the list of outstanding offers
+    // without also being handed the RBAC catalogue. 28, and 28 is free: two
+    // entries sharing an order leave the sidebar's sequence to whatever the
+    // sort happened to do that build.
+    {
+      labelKey: "admin.layout.nav_invitations",
+      path: "/admin/invitations",
+      order: 28,
+      requiredPermission: "identity_access.invitations.read"
     }
   ],
   jobs: [

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -208,6 +208,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_security": "Authentication & security",
   "admin.layout.nav_partners": "Partner access",
   "admin.layout.nav_machine_credentials": "Machine credentials",
+  "admin.layout.nav_invitations": "Invitations",
   "admin.layout.nav_seo": "SEO & distribution"
 };
 

--- a/src/pages/admin/invitations.astro
+++ b/src/pages/admin/invitations.astro
@@ -1,0 +1,477 @@
+---
+/**
+ * Invitations — ADR-0082 (Gelombang 4 of #423), Issue #541.
+ *
+ * The surface landed complete and without a page. Its four keys sat on
+ * `NOT_YET_SCREENED` on the terms the ledger records: the endpoints exist and
+ * are enforced, what was missing is the page — the ordering ADR-0056 used for
+ * `media_library`, because bundling a screen into the PR that introduces a
+ * schema turns a schema review into a UI review.
+ *
+ * Every action posts to the real endpoints, so the ABAC guards, the audit rows
+ * and the idempotency bookkeeping live there. The permission checks below
+ * decide what to RENDER, never what is allowed.
+ *
+ * ## Creating one needs up to THREE permissions, and the form says which
+ *
+ * `POST /api/v1/invitations` runs `invitations.create`, then
+ * `access_control.assign` when roles are named, then the platform-scoped
+ * `invitations.configure` when `skipEmailConfirmation` is asked for on an
+ * address with no proven account. Each is a full authorization with its own
+ * decision-log row. A form that gated everything on `create` alone would offer
+ * two controls that 403 at submit; this one hides the role picker and the
+ * skip-confirmation box unless their own key is held.
+ *
+ * ## `delivery: "unavailable"` is shown, not swallowed
+ *
+ * The response says whether the mail was QUEUED, and there is no endpoint that
+ * returns an invitation link. So an invitation created while email delivery is
+ * unconfigured exists, is valid, and cannot be handed to anybody — resending it
+ * fails the same way. The page reports that outcome plainly instead of showing
+ * a success that is not one; making the link retrievable is a decision about
+ * where invitation tokens may appear, and it is not this screen's to take.
+ *
+ * ## Roles offered here exclude system roles
+ *
+ * `createInvitation` refuses them (`system_role`). Offering `owner` would fail
+ * in the operator's face after they had composed the whole invitation.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import { listRoles } from "../../modules/identity-access/application/access-directory";
+import {
+  listInvitations,
+  type InvitationView
+} from "../../modules/identity-access/application/invitation-admin";
+
+const ssr = Astro.locals.ssrContext!;
+
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "invitations",
+    action: "read"
+  },
+  load: async ({ tx, can }) => {
+    // One transaction, one awaited query at a time — concurrent queries on a
+    // single transaction connection leak it.
+    const page = await listInvitations(tx, ssr.tenantId);
+
+    const canCreate = await can({
+      moduleKey: "identity_access",
+      activityCode: "invitations",
+      action: "create"
+    });
+    const canRevoke = await can({
+      moduleKey: "identity_access",
+      activityCode: "invitations",
+      action: "revoke"
+    });
+    const canConfigure = await can({
+      moduleKey: "identity_access",
+      activityCode: "invitations",
+      action: "configure"
+    });
+    // The SECOND guard `POST` runs when roles are named. Without it the picker
+    // is a control that composes an invitation and then 403s.
+    const canAssign = await can({
+      moduleKey: "identity_access",
+      activityCode: "access_control",
+      action: "assign"
+    });
+
+    const roles =
+      canCreate && canAssign
+        ? (await listRoles(tx, ssr.tenantId))
+            .filter((role) => !role.isSystem)
+            .map((role) => ({ id: role.id, roleCode: role.roleCode }))
+        : [];
+
+    return {
+      invitations: page.invitations,
+      hasMore: page.nextCursor !== null,
+      roles,
+      canCreate,
+      canRevoke,
+      canConfigure,
+      canAssign
+    };
+  },
+  onError: (error) => {
+    logAdminPageError(
+      "admin/invitations.astro: failed to list invitations",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const invitations: InvitationView[] =
+  screen.state === "allowed" ? screen.data.invitations : [];
+const hasMore = screen.state === "allowed" && screen.data.hasMore;
+const roles: { id: string; roleCode: string }[] =
+  screen.state === "allowed" ? screen.data.roles : [];
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
+const canRevoke = screen.state === "allowed" && screen.data.canRevoke;
+const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
+const canAssign = screen.state === "allowed" && screen.data.canAssign;
+
+/** Only a pending invitation can be resent or revoked. */
+function isPending(invitation: InvitationView): boolean {
+  return invitation.status === "pending";
+}
+---
+
+<AdminLayout title="Invitations">
+  <header class="page-header fade-in-up">
+    <h1 id="invitations-heading">Invitations</h1>
+    <p class="page-description">
+      Offers of an account in this tenant. An invitation names the roles its
+      holder will get, and those roles stay inert until it is accepted — nothing
+      here grants anything on its own.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="invitations-denied">
+        You do not have permission to view invitations.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="invitations-load-error">
+        Could not load invitations. Please try again.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <>
+        <p
+          id="invitations-action-error"
+          class="state-notice"
+          role="alert"
+          hidden
+        />
+        <p id="invitations-notice" class="state-notice" role="status" hidden />
+
+        {canCreate && (
+          <section class="fade-in-up" aria-labelledby="invitations-new-heading">
+            <h2 id="invitations-new-heading">Invite somebody</h2>
+
+            <form id="create-invitation-form" class="admin-form">
+              <label for="create-invitation-address">Email address</label>
+              <input
+                id="create-invitation-address"
+                name="loginIdentifier"
+                type="email"
+                required
+                autocomplete="off"
+              />
+
+              <label for="create-invitation-name">Display name</label>
+              <input
+                id="create-invitation-name"
+                name="displayName"
+                type="text"
+                required
+                maxlength="120"
+              />
+
+              {canAssign ? (
+                <>
+                  <label for="create-invitation-roles">
+                    Roles on acceptance
+                  </label>
+                  <select
+                    id="create-invitation-roles"
+                    name="roleIds"
+                    multiple
+                    size="6"
+                  >
+                    {roles.map((role) => (
+                      <option value={role.id}>{role.roleCode}</option>
+                    ))}
+                  </select>
+                  <p class="page-description">
+                    System roles are not offered: an invitation cannot grant
+                    one, and finding that out after composing the invitation is
+                    the worst moment to learn it.
+                  </p>
+                </>
+              ) : (
+                <p class="page-description" id="invitations-no-role-picker">
+                  You may invite people, but not choose their roles — granting a
+                  role is a separate permission. The invitation will carry none,
+                  and somebody with that permission can assign one afterwards.
+                </p>
+              )}
+
+              {canConfigure && (
+                <label class="admin-checkbox">
+                  <input
+                    id="create-invitation-skip"
+                    type="checkbox"
+                    name="skipEmailConfirmation"
+                  />
+                  Skip email confirmation
+                </label>
+              )}
+              {canConfigure && (
+                <p class="page-description">
+                  Only for an address you have already proven belongs to this
+                  person. It mints an account with no evidence its holder
+                  controls the address.
+                </p>
+              )}
+
+              <button id="create-invitation-submit" type="submit">
+                Send invitation
+              </button>
+            </form>
+          </section>
+        )}
+
+        <section class="fade-in-up" aria-labelledby="invitations-list-heading">
+          <h2 id="invitations-list-heading">Sent invitations</h2>
+
+          {invitations.length === 0 ? (
+            <div class="empty-state">
+              <p id="invitations-empty">
+                Nobody has been invited to this tenant yet.
+              </p>
+            </div>
+          ) : (
+            <div class="data-table-scroll">
+              <table class="data-table data-table--stack">
+                <thead>
+                  <tr>
+                    <th scope="col">Address</th>
+                    <th scope="col">Name</th>
+                    <th scope="col">Roles</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Expires</th>
+                    <th scope="col">Resent</th>
+                    {(canCreate || canRevoke) && <th scope="col">Actions</th>}
+                  </tr>
+                </thead>
+                <tbody>
+                  {invitations.map((invitation) => (
+                    <tr>
+                      <th scope="row" data-label="Address">
+                        {invitation.loginIdentifierMasked}
+                      </th>
+                      <td data-label="Name">{invitation.displayName}</td>
+                      <td data-label="Roles">
+                        {invitation.roleCodes.length === 0 ? (
+                          <span class="cell-muted">none</span>
+                        ) : (
+                          invitation.roleCodes.join(", ")
+                        )}
+                      </td>
+                      <td data-label="Status">{invitation.status}</td>
+                      <td data-label="Expires">
+                        {invitation.expiresAt.slice(0, 10)}
+                      </td>
+                      <td data-label="Resent">{invitation.resendCount}</td>
+                      {(canCreate || canRevoke) && (
+                        <td data-label="Actions">
+                          {isPending(invitation) ? (
+                            <>
+                              {canCreate && (
+                                <button
+                                  type="button"
+                                  class="js-resend-invitation"
+                                  data-invitation-id={invitation.id}
+                                >
+                                  Resend
+                                </button>
+                              )}
+                              {canRevoke && (
+                                <button
+                                  type="button"
+                                  class="js-revoke-invitation"
+                                  data-invitation-id={invitation.id}
+                                >
+                                  Revoke
+                                </button>
+                              )}
+                            </>
+                          ) : (
+                            <span class="cell-muted">—</span>
+                          )}
+                        </td>
+                      )}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {hasMore && (
+            <p class="page-description" id="invitations-more">
+              Showing the newest page. Older invitations are reachable through
+              <code>GET /api/v1/invitations</code> with its cursor.
+            </p>
+          )}
+        </section>
+      </>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time). The
+  // import forces Astro to emit this EXTERNAL, where the app's
+  // `default-src 'self'` CSP allows it.
+  import { lockElement, sendJsonForData } from "../../lib/ui/admin-form-client";
+
+  const errorBox = document.getElementById("invitations-action-error");
+  const noticeBox = document.getElementById("invitations-notice");
+
+  function showError(message: string): void {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.hidden = false;
+  }
+
+  function clearBoxes(): void {
+    if (errorBox) errorBox.hidden = true;
+    if (noticeBox) noticeBox.hidden = true;
+  }
+
+  document
+    .getElementById("create-invitation-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearBoxes();
+
+      const form = event.currentTarget as HTMLFormElement;
+      const button = document.getElementById(
+        "create-invitation-submit"
+      ) as HTMLButtonElement | null;
+      if (!button) return;
+
+      const data = new FormData(form);
+      const rolesSelect = document.getElementById(
+        "create-invitation-roles"
+      ) as HTMLSelectElement | null;
+
+      const unlock = lockElement(button, "Please wait…");
+      const result = await sendJsonForData<{ delivery?: string }>(
+        "POST",
+        "/api/v1/invitations",
+        {
+          loginIdentifier: String(data.get("loginIdentifier") ?? "").trim(),
+          displayName: String(data.get("displayName") ?? "").trim(),
+          roleIds: rolesSelect
+            ? [...rolesSelect.selectedOptions].map((option) => option.value)
+            : [],
+          skipEmailConfirmation: data.get("skipEmailConfirmation") === "on"
+        },
+        // REQUIRED by the endpoint — it answers 400 without one. A fresh id per
+        // submit, so a retry after a network error replays rather than invites
+        // twice.
+        { "Idempotency-Key": crypto.randomUUID() }
+      );
+
+      // The invitation exists either way. Saying "sent" when nothing was sent
+      // would leave somebody waiting for mail that was never queued, and no
+      // endpoint can hand over the link afterwards.
+      if (result.ok && result.data?.delivery === "unavailable") {
+        if (noticeBox) {
+          noticeBox.textContent =
+            "Invitation created, but NOT sent — email delivery is not configured for this tenant. There is no way to retrieve the link, so configure delivery and invite again.";
+          noticeBox.hidden = false;
+        }
+        unlock();
+        return;
+      }
+
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+
+      showError(
+        result.errorCode === "IDENTIFIER_TAKEN"
+          ? "That address already has an account in this tenant."
+          : result.errorCode === "INVITATION_ALREADY_PENDING"
+            ? "That address already has a pending invitation. Resend it instead."
+            : result.errorCode === "ROLE_SYSTEM_PROTECTED"
+              ? "A system role cannot be granted through an invitation."
+              : result.errorCode === "UNKNOWN_ROLE"
+                ? "One of those roles no longer exists here."
+                : result.errorCode === "ACCESS_DENIED"
+                  ? "You may not invite with those roles, or skip confirmation for that address."
+                  : "Could not send that invitation. Please try again."
+      );
+      unlock();
+    });
+
+  document.addEventListener("click", (event) => {
+    const target = (event.target as HTMLElement | null)?.closest("button");
+    if (!(target instanceof HTMLButtonElement)) return;
+
+    const invitationId = target.dataset.invitationId;
+    if (!invitationId) return;
+
+    const resending = target.classList.contains("js-resend-invitation");
+    const revoking = target.classList.contains("js-revoke-invitation");
+    if (!resending && !revoking) return;
+
+    void (async () => {
+      clearBoxes();
+      const unlock = lockElement(target, "Please wait…");
+      // NO `Idempotency-Key` on either, and that is the endpoints' decision
+      // rather than an omission. `resend` documents refusing it: replaying one
+      // would have to return a token it has already rotated away, or persist
+      // the plaintext in `awcms_idempotency_keys`. It is bounded another way —
+      // the UPDATE carries `resend_count < 5`, matching the database CHECK.
+      const result = await sendJsonForData<{ delivery?: string }>(
+        "POST",
+        resending
+          ? `/api/v1/invitations/${invitationId}/resend`
+          : `/api/v1/invitations/${invitationId}/revoke`,
+        {}
+      );
+
+      if (result.ok && resending && result.data?.delivery === "unavailable") {
+        if (noticeBox) {
+          noticeBox.textContent =
+            "Nothing was sent — email delivery is not configured for this tenant.";
+          noticeBox.hidden = false;
+        }
+        unlock();
+        return;
+      }
+
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+
+      showError(
+        result.errorCode === "RESOURCE_NOT_FOUND"
+          ? "That invitation is no longer pending."
+          : result.errorCode === "INVITATION_RESEND_LIMIT"
+            ? "This invitation has been resent the maximum number of times. Revoke it and issue a new one."
+            : resending
+              ? "Could not resend that invitation. Please try again."
+              : "Could not revoke that invitation. Please try again."
+      );
+      unlock();
+    })();
+  });
+</script>

--- a/tests/admin-invitations-page-contract.test.ts
+++ b/tests/admin-invitations-page-contract.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `/admin/invitations` gates against the endpoints it drives — ADR-0082, #541.
+ *
+ * Sibling of the other page-contract tests, for the same silent failure: a page
+ * gating on a permission key no migration seeds hides the control from EVERYONE
+ * — including the owner — while still looking like a working screen.
+ *
+ * Three traps are specific to this surface:
+ *
+ * - **Creating one runs up to THREE guards.** `invitations.create`, then
+ *   `access_control.assign` when roles are named, then `invitations.configure`
+ *   for `skipEmailConfirmation`. A form gated on `create` alone offers two
+ *   controls that 403 at submit.
+ * - **`Idempotency-Key` is REQUIRED on create and REFUSED on resend.** Not a
+ *   style choice either way: create replays its stored response, and replaying
+ *   a resend would have to return a token it has already rotated away.
+ * - **`delivery: "unavailable"` is a real outcome.** The invitation exists, no
+ *   mail was queued, and no endpoint can hand over the link afterwards. A page
+ *   that reloaded on it would report success for something nobody received.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+
+const PAGE = "src/pages/admin/invitations.astro";
+const CREATE_ROUTE = "src/pages/api/v1/invitations/index.ts";
+const RESEND_ROUTE = "src/pages/api/v1/invitations/[id]/resend.ts";
+const REVOKE_ROUTE = "src/pages/api/v1/invitations/[id]/revoke.ts";
+
+const EXPECTED = [
+  "identity_access.invitations.read",
+  "identity_access.invitations.create",
+  "identity_access.invitations.revoke",
+  "identity_access.invitations.configure"
+];
+
+/** Collapses runs of whitespace — see `admin-machine-credentials-page-contract`. */
+function squashed(source: string): string {
+  return source.replace(/\s+/g, " ");
+}
+
+describe("/admin/invitations gates on keys that really exist", () => {
+  test("every key the page names is DECLARED by a module", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const declared = new Set<string>();
+    for (const module of listModules()) {
+      for (const permission of module.permissions ?? []) {
+        declared.add(
+          `${module.key}.${permission.activityCode}.${permission.action}`
+        );
+      }
+    }
+
+    for (const key of EXPECTED) {
+      const [, activityCode, action] = key.split(".");
+      expect(page).toContain(`activityCode: "${activityCode}"`);
+      expect(page).toContain(`action: "${action}"`);
+      expect(declared.has(key)).toBe(true);
+    }
+  });
+
+  test("the page also checks the SECOND guard create runs", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const route = await readFile(CREATE_ROUTE, "utf8");
+
+    // `access_control.assign`, not an invitation key at all. Without it the
+    // role picker composes an invitation that the endpoint then refuses.
+    expect(route).toContain('activityCode: "access_control"');
+    expect(route).toContain('action: "assign"');
+    expect(page).toContain('activityCode: "access_control"');
+    expect(page).toContain("canAssign");
+  });
+
+  test("revoking is gated on `revoke`, resending on `create`", async () => {
+    const resend = await readFile(RESEND_ROUTE, "utf8");
+    const revoke = await readFile(REVOKE_ROUTE, "utf8");
+
+    // Resend MINTS A NEW TOKEN, which is the authority `create` already names.
+    // A separate `resend` permission would let somebody hand fresh credentials
+    // to everyone previously invited while holding no authority to invite.
+    expect(resend).toContain('action: "create"');
+    expect(resend).not.toContain('action: "resend"');
+    expect(revoke).toContain('action: "revoke"');
+  });
+});
+
+describe("the three properties this screen has to get right", () => {
+  test("create carries an Idempotency-Key; resend and revoke do NOT", async () => {
+    const page = squashed(await readFile(PAGE, "utf8"));
+
+    // Exactly one occurrence. `create` requires the header (400 without it);
+    // `resend` documents refusing it, because replaying one would have to
+    // return a token it has already rotated away.
+    expect(page.split('"Idempotency-Key"').length - 1).toBe(1);
+    expect(page).toContain('"Idempotency-Key": crypto.randomUUID()');
+  });
+
+  test("`delivery: unavailable` is reported, not reloaded away", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const createBlock = page.slice(
+      page.indexOf('getElementById("create-invitation-form")'),
+      page.indexOf('document.addEventListener("click"')
+    );
+
+    expect(createBlock).toContain('delivery === "unavailable"');
+    expect(createBlock).toContain("NOT sent");
+    expect(createBlock.indexOf('delivery === "unavailable"')).toBeLessThan(
+      createBlock.indexOf("window.location.reload()")
+    );
+  });
+
+  test("system roles never reach the role picker", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // `createInvitation` refuses them (`system_role`). Offering `owner` would
+    // fail after the operator had composed the whole invitation.
+    expect(page).toContain("filter((role) => !role.isSystem)");
+  });
+
+  test("no raw invitee address is rendered", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // `listInvitations` masks the address; the raw one is never projected.
+    expect(page).toContain("invitation.loginIdentifierMasked");
+    expect(page).not.toContain("invitation.loginIdentifier}");
+  });
+});
+
+describe("the ledger shrank, and stayed shrunk", () => {
+  test("no `invitations` key is left on NOT_YET_SCREENED", async () => {
+    const { NOT_YET_SCREENED } =
+      await import("../scripts/admin-screen-coverage-ledger");
+
+    expect(
+      NOT_YET_SCREENED.filter((key) =>
+        key.startsWith("identity_access.invitations.")
+      )
+    ).toEqual([]);
+  });
+
+  test("and the four keys are exactly the ones this page claims", () => {
+    // Paired with the assertion above so neither passes vacuously.
+    expect(EXPECTED).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
Closes #541.

Permukaannya mendarat **lengkap** di Gelombang 4 (ADR-0082) dan tanpa halaman. Empat kuncinya duduk di `NOT_YET_SCREENED` dengan alasan yang ledger itu tulis sendiri: endpoint-nya ada dan ditegakkan, yang hilang halamannya.

## Membuat satu undangan menjalankan sampai TIGA gerbang

`invitations.create`, lalu `access_control.assign` begitu peran disebut, lalu `invitations.configure` ber-scope platform untuk `skipEmailConfirmation` pada alamat tanpa akun terbukti. Masing-masing otorisasi penuh dengan baris decision log sendiri.

Form yang menggerbangi semuanya pada `create` saja menawarkan dua kontrol yang **403 saat submit**. Yang ini menyembunyikan pemilih peran dan kotak skip-confirmation kecuali kuncinya sendiri dipegang — dan mengatakan kepada yang tidak memegangnya bahwa undangannya akan berangkat tanpa peran.

## Temuan: undangan yang dibuat saat email mati adalah undangan MATI

Respons pembuatan menyebut apakah surelnya diantrekan (`delivery`), dan **tidak ada endpoint yang mengembalikan tautan undangan**. Jadi undangan yang dibuat saat pengiriman email belum dikonfigurasi itu ada, valid, dan tidak bisa diserahkan kepada siapa pun — mengirim ulang gagal dengan cara yang sama.

Halaman ini melaporkannya apa adanya alih-alih menampilkan sukses yang bukan sukses. Membuat tautannya bisa diambil adalah keputusan tentang **di mana token undangan boleh muncul**, dan itu bukan keputusan layar ini untuk diambil.

## `Idempotency-Key` dikirim tepat sekali, dan asimetrinya disengaja

Endpoint pembuatan **mewajibkannya** (400 tanpa itu). `resend` justru **menolaknya**, dan dokumentasinya menjelaskan kenapa: memutar ulang sebuah resend harus mengembalikan token yang sudah dirotasinya pergi, atau mempersistenkan plaintext-nya di `awcms_idempotency_keys`. Ia dibatasi dengan cara lain — UPDATE-nya membawa `resend_count < 5`, sama dengan CHECK basis datanya.

## Diverifikasi dengan menjalankan

- `DATABASE_URL="" bun run check` **hijau penuh**.
- **Lima mutasi memerahkan test yang tepat:** `Idempotency-Key` ikut dikirim pada resend, `delivery: unavailable` di-reload menjadi sukses palsu, gerbang kedua tidak diperiksa halaman, role sistem ikut ditawarkan, dan satu kunci ditinggal di ledger.

`NOT_YET_SCREENED` **menyusut 55 → 51**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)