### PR TITLE
feat(admin): layar Partner registry — PLATFORM, dan sengaja bukan di /admin/partners (#540)

### DIFF
--- a/.changeset/admin-partner-registry-screen.md
+++ b/.changeset/admin-partner-registry-screen.md
@@ -1,0 +1,40 @@
+---
+"awcms": minor
+---
+
+feat(admin): layar Partner registry — PLATFORM, dan sengaja bukan di /admin/partners (#540)
+
+Registri mendapat penulis di #538 dan tidak punya halaman. Ini halamannya, dan hal
+terpenting tentangnya adalah di mana ia TIDAK berada.
+
+`/admin/partners` adalah pandangan PELANGGAN atas siapa yang menjangkau tenant-nya
+sendiri. Menaruh registri di sana menaruh daftar setiap kemitraan platform di depan
+setiap pelanggan — direktori lintas-tenant yang ADR-0089 tolak sebagai tabel,
+dibangun ulang sebagai layar. Test kontraknya menegakkan pemisahan itu dari KEDUA
+arah: halaman pelanggan tidak boleh menyebut `partner_registry`, dan halaman registri
+tidak boleh menyebut `partner_access`.
+
+DUA MEKANISME MENJAGANYA TETAP PLATFORM-ONLY, dan keduanya menanggung beban. FORCE
+RLS menaruh setiap baris di tenant platform, jadi sesi pelanggan mana pun tak bisa
+membacanya bahkan sambil memegang grant. Chokepoint menolak izin ber-scope platform
+kecuali tenant yang bertindak MEMANG tenant platform. Tak satu pun cadangan bagi yang
+lain, dan link nav-nya digerbangi izin platform itu sendiri dengan alasan yang
+`/admin/tenants` catat: tidak ada paruh screen ini yang bisa dibaca tenant biasa, jadi
+link ber-gerbang kunci pelanggan hanya akan menaruh entri sidebar yang selalu 403.
+
+TIDAK ADA PICKER TENANT, dan halamannya mengatakan kenapa: daftar tenant yang bisa
+dipilih adalah direktori yang desain ini menolak menyerahkannya. `/admin/tenants` ada
+untuk operator platform yang perlu mencarinya — dan itulah batas izin yang seharusnya
+memutuskan, bukan sebuah `<select>`.
+
+TIDAK ADA DELETE, dan itu keputusan. Barisnya target FK dari keterlibatan dan dari
+grant terdelegasi yang `sql/120` sengaja buat hidup lebih lama darinya. `status` juga
+tidak pernah dikirim form ini: ia dipatok `sql/116` sampai ada yang MEMBACA suspensi
+(#543).
+
+DIVERIFIKASI DENGAN MENJALANKAN. `bun run check` penuh hijau. Lima mutasi memerahkan
+test yang tepat: registri diselipkan ke layar pelanggan, izinnya dijadikan
+tenant-scoped, link nav digerbangi kunci pelanggan, form ikut mengirim `status`, dan
+satu kunci ditinggal di ledger.
+
+`NOT_YET_SCREENED` **menyusut 51 → 49**.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -109,8 +109,8 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
 | Migrasi                            | **123** (`sql/001`–`123`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
-| Layar admin                        | **38** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **51** (27.808 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Layar admin                        | **39** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Berkas `.astro`                    | **52** (28.096 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **41** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **3.1.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -355,6 +355,23 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN 13 Agustus 2026 (kedua puluh lima) — LAYAR PARTNER REGISTRY (#540).**
+
+  Menutup 2 kunci, **51 → 49**. Hal terpenting tentang layar ini adalah di mana
+  ia TIDAK berada: `/admin/partners` adalah pandangan PELANGGAN, dan registri di
+  sana menaruh daftar setiap kemitraan platform di depan setiap pelanggan.
+  Test kontraknya menegakkan pemisahan itu dari KEDUA arah.
+
+  **Keputusan nav yang issue-nya khawatirkan ternyata tidak ada.** Pengelompokan
+  sidebar per-MODUL, bukan per-scope, dan platform-ness dinyatakan lewat
+  `requiredPermission` ber-scope platform — persis cara `/admin/tenants`. Layar
+  platform kedua karena itu tidak menuntut mekanisme baru.
+
+  **Tidak ada picker tenant, dan itu bukan kekurangan:** daftar tenant yang bisa
+  dipilih adalah direktori yang ADR-0089 tolak. `/admin/tenants` ada untuk
+  operator platform yang perlu mencarinya, dan batas IZIN yang seharusnya
+  memutuskan, bukan sebuah `<select>`.
 
 - **PUTARAN 13 Agustus 2026 (kedua puluh empat) — LAYAR INVITATIONS (#541).**
 

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -142,7 +142,7 @@
         }
       ],
       "permissionCount": 42,
-      "navigationCount": 9,
+      "navigationCount": 10,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 372   |
-| Berkas route                       | 348   |
+| Berkas test                        | 373   |
+| Berkas route                       | 349   |
 | ADR                                | 93    |
 
 ### Modul
@@ -326,7 +326,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 318        |
+| `(root)`      | 319        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |
@@ -336,7 +336,7 @@
 | Permukaan       | Berkas |
 | --------------- | ------ |
 | `/api/v1/**`    | 286    |
-| `/admin/**`     | 38     |
+| `/admin/**`     | 39     |
 | publik / anonim | 24     |
 
 <!-- END GENERATED: repo-inventory -->

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -64,7 +64,7 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "form_drafts.draft.create",
   "form_drafts.draft.update",
 
-  // identity_access (14)
+  // identity_access (12)
   //
   "identity_access.business_scope_assignments.create",
   "identity_access.business_scope_assignments.read",
@@ -75,14 +75,6 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "identity_access.business_scope_exceptions.read",
   "identity_access.business_scope_exceptions.reject",
   "identity_access.business_scope_exceptions.revoke",
-  // ADR-0089. The PLATFORM half of partnership, and its screen is not
-  // `/admin/partners` — that page is the CUSTOMER's view of who reaches its own
-  // tenant, and putting a registry there would put the platform's list of every
-  // partnership in front of every customer. Its home is a platform screen
-  // alongside `/admin/tenants`, and that is its own change; the API landing
-  // first is the ordering ADR-0056 used for `media_library`.
-  "identity_access.partner_registry.create",
-  "identity_access.partner_registry.read",
   "identity_access.sso_providers.create",
   "identity_access.sso_providers.delete",
   "identity_access.sso_providers.update",

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -177,6 +177,19 @@ export const identityAccessModule = defineModule({
       path: "/admin/invitations",
       order: 28,
       requiredPermission: "identity_access.invitations.read"
+    },
+    // ADR-0089, #540. PLATFORM-scoped, and the link is gated on the platform
+    // permission ITSELF for the reason `/admin/tenants` records: unlike
+    // `/admin/idn-regions` there is no tenant-readable half of this screen, so
+    // an ordinary tenant has nothing here to see. It is deliberately NOT a
+    // section of `/admin/partners` — that page is the CUSTOMER's view of who
+    // reaches its own tenant, and the registry there would put the platform's
+    // list of every partnership in front of every customer.
+    {
+      labelKey: "admin.layout.nav_partner_registry",
+      path: "/admin/partner-registry",
+      order: 35,
+      requiredPermission: "identity_access.partner_registry.read"
     }
   ],
   jobs: [

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -207,6 +207,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_registrations": "Registration requests",
   "admin.layout.nav_security": "Authentication & security",
   "admin.layout.nav_partners": "Partner access",
+  "admin.layout.nav_partner_registry": "Partner registry",
   "admin.layout.nav_machine_credentials": "Machine credentials",
   "admin.layout.nav_invitations": "Invitations",
   "admin.layout.nav_seo": "SEO & distribution"

--- a/src/pages/admin/partner-registry.astro
+++ b/src/pages/admin/partner-registry.astro
@@ -1,0 +1,288 @@
+---
+/**
+ * Partner registry — ADR-0089, Issue #540. PLATFORM-scoped.
+ *
+ * The registry gained a writer in #538 and had no page. This is that page, and
+ * the most important thing about it is where it is NOT: `/admin/partners` is
+ * the CUSTOMER's view of who reaches its own tenant, and putting the registry
+ * there would put the platform's list of every partnership in front of every
+ * customer — the cross-tenant directory ADR-0089 refused as a table, rebuilt as
+ * a screen.
+ *
+ * ## Two independent things keep this platform-only, and both are load-bearing
+ *
+ * FORCE RLS puts every row under the platform tenant, so no customer session
+ * can read one even holding a grant. The chokepoint refuses a platform-scoped
+ * permission unless the acting tenant IS the platform tenant. Neither is a
+ * backstop for the other, and the nav link is gated on the platform permission
+ * itself for the reason `/admin/tenants` records: there is no tenant-readable
+ * half of this screen, so an ordinary tenant has nothing here to see.
+ *
+ * ## Registering asks for a UUID, and the page says why
+ *
+ * The tenant being named must already exist — this does not provision one. And
+ * there is no picker, for the same reason `/admin/partners` has none: a
+ * selectable list of every tenant is the directory the design declines to hand
+ * out. The platform operator has `/admin/tenants` if they need to look one up,
+ * which is exactly the permission boundary that should decide it.
+ *
+ * ## No delete, and it is a decision
+ *
+ * `awcms_partners.partner_tenant_id` is the target of foreign keys from
+ * engagements and from delegated grants that `sql/120` deliberately made
+ * OUTLIVE their engagement. A delete would fail as soon as one partnership had
+ * ever existed, and `ON DELETE CASCADE` would silently cut every partnership on
+ * the installation. Retirement is a `status` change — and `status` is pinned by
+ * `sql/116` until something reads suspension (#543).
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import {
+  listPartners,
+  type PartnerSummary
+} from "../../modules/identity-access/application/partner-registry-store";
+
+const ssr = Astro.locals.ssrContext!;
+
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "identity_access",
+    activityCode: "partner_registry",
+    action: "read"
+  },
+  load: async ({ tx, can }) => ({
+    // `ssr.tenantId` IS the platform tenant here: the chokepoint above refused
+    // the request otherwise, so there is no second resolution and no chance of
+    // the two disagreeing.
+    partners: await listPartners(tx, ssr.tenantId),
+    canCreate: await can({
+      moduleKey: "identity_access",
+      activityCode: "partner_registry",
+      action: "create"
+    })
+  }),
+  onError: (error) => {
+    logAdminPageError(
+      "admin/partner-registry.astro: failed to load the partner registry",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const partners: PartnerSummary[] =
+  screen.state === "allowed" ? screen.data.partners : [];
+const canCreate = screen.state === "allowed" && screen.data.canCreate;
+---
+
+<AdminLayout title="Partner registry">
+  <header class="page-header fade-in-up">
+    <h1 id="partner-registry-heading">Partner registry</h1>
+    <p class="page-description">
+      Which tenants on this deployment may be engaged as partners. A row here
+      grants nothing — it is the precondition a customer's engagement checks.
+      Whether a partner actually reaches a customer is that customer's decision,
+      taken on their own Partner access screen.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="partner-registry-denied">
+        You do not have permission to view the partner registry. It is
+        platform-scoped: only the platform tenant can reach it.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="partner-registry-load-error">
+        Could not load the partner registry. Please try again.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <>
+        <p
+          id="partner-registry-action-error"
+          class="state-notice"
+          role="alert"
+          hidden
+        />
+
+        {canCreate && (
+          <section
+            class="fade-in-up"
+            aria-labelledby="partner-registry-add-heading"
+          >
+            <h2 id="partner-registry-add-heading">Register a partner</h2>
+
+            <form id="register-partner-form" class="admin-form">
+              <p class="page-description">
+                The tenant must already exist — this does not create one. There
+                is no picker on purpose: a selectable list of every tenant is
+                the directory this design declines to hand out. Look the id up
+                on the Tenants screen if you need it.
+              </p>
+
+              <label for="register-partner-tenant-id">Partner tenant id</label>
+              <input
+                id="register-partner-tenant-id"
+                name="partnerTenantId"
+                type="text"
+                required
+                autocomplete="off"
+                placeholder="00000000-0000-0000-0000-000000000000"
+              />
+
+              <label for="register-partner-code">Partner code</label>
+              <input
+                id="register-partner-code"
+                name="partnerCode"
+                type="text"
+                required
+                maxlength="64"
+                pattern="[a-z0-9]([a-z0-9\-]*[a-z0-9])?"
+                placeholder="acme-digital"
+              />
+              <p class="page-description">
+                Lower-case letters, digits and hyphens, unique across the
+                deployment. Case matters to the index and not to a human, so a
+                stray capital would make a second partner that reads like the
+                first one.
+              </p>
+
+              <label for="register-partner-name">Display name</label>
+              <input
+                id="register-partner-name"
+                name="displayName"
+                type="text"
+                required
+                maxlength="160"
+              />
+
+              <button id="register-partner-submit" type="submit">
+                Register partner
+              </button>
+            </form>
+          </section>
+        )}
+
+        <section
+          class="fade-in-up"
+          aria-labelledby="partner-registry-list-heading"
+        >
+          <h2 id="partner-registry-list-heading">Registered partners</h2>
+
+          {partners.length === 0 ? (
+            <div class="empty-state">
+              <p id="partner-registry-empty">
+                No tenant on this deployment is registered as a partner. Nobody
+                can be engaged until one is.
+              </p>
+            </div>
+          ) : (
+            <div class="data-table-scroll">
+              <table class="data-table data-table--stack">
+                <thead>
+                  <tr>
+                    <th scope="col">Partner code</th>
+                    <th scope="col">Display name</th>
+                    <th scope="col">Tenant</th>
+                    <th scope="col">Status</th>
+                    <th scope="col">Registered</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {partners.map((partner) => (
+                    <tr>
+                      <th scope="row" data-label="Partner code">
+                        {partner.partnerCode}
+                      </th>
+                      <td data-label="Display name">{partner.displayName}</td>
+                      <td data-label="Tenant">
+                        {partner.tenantName} ({partner.tenantCode})
+                      </td>
+                      <td data-label="Status">{partner.status}</td>
+                      <td data-label="Registered">
+                        {partner.registeredAt.toISOString().slice(0, 10)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          <p class="page-description">
+            There is no way to remove a partner here, and that is deliberate:
+            engagements and delegated grants reference these rows, and grants
+            are built to outlive the partnership that produced them. Retiring a
+            partner will be a status change once something reads suspension.
+          </p>
+        </section>
+      </>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time). The
+  // import forces Astro to emit this EXTERNAL, where the app's
+  // `default-src 'self'` CSP allows it.
+  import { lockElement, sendJson } from "../../lib/ui/admin-form-client";
+
+  const errorBox = document.getElementById("partner-registry-action-error");
+
+  function showError(message: string): void {
+    if (!errorBox) return;
+    errorBox.textContent = message;
+    errorBox.hidden = false;
+  }
+
+  document
+    .getElementById("register-partner-form")
+    ?.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      if (errorBox) errorBox.hidden = true;
+
+      const form = event.currentTarget as HTMLFormElement;
+      const button = document.getElementById(
+        "register-partner-submit"
+      ) as HTMLButtonElement | null;
+      if (!button) return;
+
+      const data = new FormData(form);
+      const unlock = lockElement(button, "Please wait…");
+      const result = await sendJson("POST", "/api/v1/partners", {
+        partnerTenantId: String(data.get("partnerTenantId") ?? "").trim(),
+        partnerCode: String(data.get("partnerCode") ?? "").trim(),
+        displayName: String(data.get("displayName") ?? "").trim()
+      });
+
+      if (result.ok) {
+        window.location.reload();
+        return;
+      }
+
+      showError(
+        result.errorCode === "TENANT_NOT_FOUND"
+          ? "No tenant on this deployment has that id. It must already exist — this screen does not create one."
+          : result.errorCode === "CONFLICT"
+            ? "That tenant is already a partner, that code is taken, or you named the platform tenant itself."
+            : result.errorCode === "VALIDATION_FAILED"
+              ? "Check the id, the code and the name. The code is lower-case letters, digits and hyphens."
+              : "Could not register that partner. Please try again."
+      );
+      unlock();
+    });
+</script>

--- a/tests/admin-partner-registry-page-contract.test.ts
+++ b/tests/admin-partner-registry-page-contract.test.ts
@@ -1,0 +1,147 @@
+/**
+ * `/admin/partner-registry` gates against the endpoint it drives — ADR-0089, #540.
+ *
+ * Sibling of the other page-contract tests, plus one thing none of them have to
+ * check: this screen is PLATFORM-scoped, and the two mechanisms that keep it so
+ * are independent. FORCE RLS puts every row under the platform tenant; the
+ * chokepoint refuses a platform-scoped permission unless the acting tenant IS
+ * the platform tenant. Neither is a backstop for the other.
+ *
+ * The trap specific to this surface is a placement one, and it is the whole
+ * reason the issue existed: the registry must NOT live on `/admin/partners`.
+ * That page is the customer's view of who reaches its own tenant, and the
+ * registry there would put the platform's list of every partnership in front of
+ * every customer — the cross-tenant directory ADR-0089 refused as a table,
+ * rebuilt as a screen.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { listModules } from "../src/modules";
+import {
+  isPlatformScopedPermissionKey,
+  resetPlatformScopeCacheForTests
+} from "../src/modules/identity-access/domain/platform-scope";
+
+const PAGE = "src/pages/admin/partner-registry.astro";
+const CUSTOMER_PAGE = "src/pages/admin/partners.astro";
+const ROUTE = "src/pages/api/v1/partners/index.ts";
+
+const EXPECTED = [
+  "identity_access.partner_registry.read",
+  "identity_access.partner_registry.create"
+];
+
+describe("/admin/partner-registry gates on keys that really exist", () => {
+  test("every key the page names is DECLARED by a module", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const declared = new Set<string>();
+    for (const module of listModules()) {
+      for (const permission of module.permissions ?? []) {
+        declared.add(
+          `${module.key}.${permission.activityCode}.${permission.action}`
+        );
+      }
+    }
+
+    for (const key of EXPECTED) {
+      const [, activityCode, action] = key.split(".");
+      expect(page).toContain(`activityCode: "${activityCode}"`);
+      expect(page).toContain(`action: "${action}"`);
+      expect(declared.has(key)).toBe(true);
+    }
+  });
+
+  test("the page and its endpoint agree on the activity", async () => {
+    const route = await readFile(ROUTE, "utf8");
+    expect(route).toContain('activityCode: "partner_registry"');
+  });
+
+  test("both keys are PLATFORM-scoped, read from the live registry", () => {
+    resetPlatformScopeCacheForTests();
+
+    for (const key of EXPECTED) {
+      expect(isPlatformScopedPermissionKey(key)).toBe(true);
+    }
+  });
+
+  test("the nav link is gated on the platform key, not a tenant one", async () => {
+    const module = await readFile(
+      "src/modules/identity-access/module.ts",
+      "utf8"
+    );
+
+    // The reason `/admin/tenants` records: there is no tenant-readable half of
+    // this screen, so a link gated on anything a customer can hold would put an
+    // entry in their sidebar that always answers 403.
+    expect(module).toContain(
+      'requiredPermission: "identity_access.partner_registry.read"'
+    );
+    expect(module).toContain('path: "/admin/partner-registry"');
+  });
+});
+
+describe("the placement, which is the point of the issue", () => {
+  test("the CUSTOMER's page does not name the registry activity", async () => {
+    const customerPage = await readFile(CUSTOMER_PAGE, "utf8");
+
+    // `/admin/partners` gates on `partner_access`, the customer's own key.
+    // A `partner_registry` guard appearing there would mean the platform's list
+    // of every partnership had been rendered into a customer screen.
+    expect(customerPage).toContain('activityCode: "partner_access"');
+    expect(customerPage).not.toContain("partner_registry");
+  });
+
+  test("and the registry page does not name the customer activity", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).not.toContain('activityCode: "partner_access"');
+  });
+});
+
+describe("what the screen deliberately cannot do", () => {
+  test("there is no delete — the rows are FK targets that outlive engagements", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const route = await readFile(ROUTE, "utf8");
+
+    expect(page).not.toContain('"DELETE"');
+    expect(route).not.toContain("export const DELETE");
+  });
+
+  test("there is no tenant picker, and the page says why", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // A selectable list of every tenant is the directory ADR-0089 declines to
+    // hand out. `/admin/tenants` exists for a platform operator who needs to
+    // look one up, which is the permission boundary that should decide it.
+    expect(page).toContain("no picker on purpose");
+    expect(page).toContain('id="register-partner-tenant-id"');
+  });
+
+  test("`status` is never submitted — it is pinned until something reads it", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    const submitBlock = page.slice(page.indexOf('sendJson("POST"'));
+    expect(submitBlock).not.toContain("status");
+  });
+});
+
+describe("the ledger shrank, and stayed shrunk", () => {
+  test("no `partner_registry` key is left on NOT_YET_SCREENED", async () => {
+    const { NOT_YET_SCREENED } =
+      await import("../scripts/admin-screen-coverage-ledger");
+
+    expect(
+      NOT_YET_SCREENED.filter((key) => key.includes("partner_registry"))
+    ).toEqual([]);
+  });
+
+  test("and the two keys are exactly the ones this page claims", () => {
+    // Paired with the assertion above so neither passes vacuously.
+    expect(EXPECTED).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
Closes #540.

Registri mendapat penulis di #538 dan tidak punya halaman. Ini halamannya, dan hal terpenting tentangnya adalah **di mana ia tidak berada**.

## Penempatan adalah keseluruhan isu ini

`/admin/partners` adalah pandangan **pelanggan** atas siapa yang menjangkau tenant-nya sendiri. Menaruh registri di sana menaruh daftar setiap kemitraan platform di depan setiap pelanggan — direktori lintas-tenant yang ADR-0089 tolak sebagai tabel, dibangun ulang sebagai layar.

Test kontraknya menegakkan pemisahan itu dari **kedua arah**: halaman pelanggan tidak boleh menyebut `partner_registry`, dan halaman registri tidak boleh menyebut `partner_access`.

## Dua mekanisme menjaganya platform-only, dan keduanya menanggung beban

FORCE RLS menaruh setiap baris di tenant platform, jadi sesi pelanggan mana pun tidak bisa membacanya bahkan sambil memegang grant. Chokepoint menolak izin ber-scope platform kecuali tenant yang bertindak **memang** tenant platform. Tak satu pun cadangan bagi yang lain.

Link nav-nya digerbangi izin platform itu sendiri, dengan alasan yang `/admin/tenants` catat: tidak ada paruh layar ini yang bisa dibaca tenant biasa, jadi link ber-gerbang kunci pelanggan hanya akan menaruh entri sidebar yang selalu 403.

## Keputusan nav yang saya khawatirkan ternyata tidak ada

Issue-nya menandai "apakah permukaan platform butuh kelompok navigasi sendiri" sebagai hal yang harus diputuskan lebih dulu. Ternyata tidak: pengelompokan sidebar per-**modul**, bukan per-scope, dan platform-ness dinyatakan lewat `requiredPermission` — persis cara `/admin/tenants`. Layar platform kedua tidak menuntut mekanisme baru.

## Yang sengaja tidak bisa dilakukan

- **Tidak ada picker tenant.** Daftar tenant yang bisa dipilih adalah direktori yang desain ini menolak menyerahkannya. `/admin/tenants` ada untuk operator platform yang perlu mencarinya — batas **izin** yang seharusnya memutuskan, bukan sebuah `<select>`.
- **Tidak ada delete.** Barisnya target FK dari keterlibatan dan dari grant terdelegasi yang `sql/120` sengaja buat hidup lebih lama darinya.
- **`status` tidak pernah dikirim.** Ia dipatok `sql/116` sampai ada yang membaca suspensi (#543).

## Diverifikasi dengan menjalankan

- `DATABASE_URL="" bun run check` **hijau penuh**.
- **Lima mutasi memerahkan test yang tepat:** registri diselipkan ke layar pelanggan, izinnya dijadikan tenant-scoped, link nav digerbangi kunci pelanggan, form ikut mengirim `status`, dan satu kunci ditinggal di ledger.

`NOT_YET_SCREENED` **menyusut 51 → 49**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)