### PR TITLE
feat(admin): layar Business scope — dan izin checker yang selama ini tak pernah dibaca (#545)

### DIFF
--- a/.changeset/admin-business-scope-screen.md
+++ b/.changeset/admin-business-scope-screen.md
@@ -1,0 +1,63 @@
+---
+"awcms": minor
+---
+
+feat(admin): layar Business scope — dan izin checker yang selama ini dideklarasikan tanpa pernah dibaca (#545)
+
+Sembilan izin punya endpoint dan tidak punya halaman. Ledger menamai celahnya dengan
+tepat: "penugasan plus alur maker/checker untuk pengecualian **tanpa inbox bagi
+checker-nya**". Alur maker/checker tanpa tempat bagi checker melihat apa yang menunggu
+bukan alur; ia dua endpoint yang kebetulan berpasangan, dan sampai hari ini siapa pun
+yang harus menyetujui pengecualian SoD harus diberi tahu lewat jalur di luar sistem.
+
+**INBOX-NYA DI SINI, BUKAN DI `/admin/approvals`, dan itulah keputusannya.**
+`/admin/approvals` adalah permukaan keputusan MILIK `workflow_approval`, dan
+pengecualian SoD sama sekali tidak berjalan di mesin itu: tabelnya sendiri, mesin
+statusnya sendiri (`pending/approved/rejected/expired/revoked`), izinnya sendiri,
+nama field alasannya sendiri. Merender keduanya di sana akan menaruh sumber data kedua
+yang tak berhubungan pada halaman yang seluruh kosakatanya — task, instance, quorum,
+delegation — tidak menggambarkan satu pun darinya, dan menggerbangi dua keluarga izin
+yang tak berkaitan pada satu layar. Alternatif yang MEMANG membenarkan penyatuan adalah
+mem-port pengecualian SoD ke mesin workflow: itu perubahan fondasi dengan ADR-nya
+sendiri, dan akan membuat `identity_access` bergantung pada `workflow` — sisi yang tidak
+dimiliki DAG modul hari ini. Sementara itu baris pending adalah baris yang layar ini
+sudah daftarkan: inbox-nya adalah partisi dari daftar itu plus dua tombol.
+
+**IZIN CHECKER YANG DIDEKLARASIKAN DAN TIDAK PERNAH DIBACA.**
+`SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission` disebut kontrak modul
+sebagai "kunci izin yang harus dipegang tenant user BERBEDA untuk menyetujui pengecualian
+atas aturan INI". Gerbang registry menolak aturan yang tidak menyertakannya.
+`sod-exception-service.ts` menulis dalam prosa bahwa ia "digerbangi di route".
+
+Tidak ada kode yang membacanya. Route approve menanyakan chokepoint untuk
+`identity_access.business_scope_exceptions.approve` yang tetap, lalu berhenti — dan satu
+aturan yang dikirim base ini kebetulan menamai persis kunci itu, sehingga keduanya
+berimpit dan celahnya tak terlihat. Modul pertama yang mendeklarasikan aturan yang hanya
+boleh disetujui, katakanlah, seorang controller keuangan akan mendapati syarat itu
+diabaikan diam-diam sementara TIGA artefak menyatakan sebaliknya. Route kini
+menegakkannya lewat `resolveSoDApprovalAuthority` yang murni, dengan urutan yang satu-
+satunya aman: gerbang tetap DULU (penelepon tanpa hak tidak boleh belajar aturan mana
+yang dimiliki sebuah id), baru rule dibaca dan kunci miliknya ditanyakan bila berbeda.
+Aturan yang tidak dikenal registry **MENOLAK** — pengecualian yang tak bisa dijelaskan
+tak bisa direview, dan ia toh sudah inert karena evaluator mencari pengecualian lewat
+rule key. Menolak dan mencabut tetap tersedia. Nol perubahan perilaku hari ini: satu
+aturan yang ada menamai kunci yang sama.
+
+**APPROVE DISEMBUNYIKAN DI DUA SUMBU, BUKAN SATU.** `approveSoDConflictException` menolak
+saat approver adalah requester DAN saat approver adalah SUBJEK. Layar yang memeriksa satu
+sumbu akan merender tombol Approve yang selalu menjawab 403 bagi orang yang paling
+termotivasi menekannya.
+
+**PICKER ATURAN DITURUNKAN dari registry hidup**, dan hanya dari aturan yang
+`exceptionPolicy.allowed`-nya true — daftar tulis-tangan akan terlihat lengkap di base
+dengan satu aturan lalu diam-diam melewatkan apa pun yang disumbang modul domain. Plafon
+`maxDurationDays` per-aturan menyempitkan field tanggal saat aturan dipilih, pola yang
+sama dengan plafon aksi tulis di `/admin/machine-credentials`.
+
+DIVERIFIKASI DENGAN MENJALANKAN. `bun run check` penuh hijau. Empat mutasi memerahkan
+test yang tepat: mengembalikan cacat aslinya (gerbang kedua dihapus) memerahkan 3 test,
+aturan tak dikenal yang jatuh ke `base_only` memerahkan 1, layar yang hanya memeriksa
+sumbu requester memerahkan 1, dan rule key yang ditulis tangan di picker memerahkan 2.
+
+`NOT_YET_SCREENED` **menyusut 47 → 38**. Aset klien 154,0 → 157,5 kB dari plafon 180 kB —
+layar terbesar sejauh ini, dan ia muat karena #552 mendarat lebih dulu.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -109,8 +109,8 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Modul base                         | **22** (lihat daftar di ARCHITECTURE.md)                                                | `src/modules/index.ts`                                                                  |
 | Migrasi                            | **123** (`sql/001`–`123`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0092** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-13).**) | `ls docs/adr/`                                                                          |
-| Layar admin                        | **40** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **53** (27.029 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Layar admin                        | **41** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
+| Berkas `.astro`                    | **54** (28.114 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **42** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **3.1.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -2039,7 +2039,11 @@ Requests a bounded-lifetime, scope-bound exception to a registered SoD rule (`st
 - **operationId**: `approveSoDConflictException`
 - **Security**: bearerAuth + tenantHeader
 
-Approves a pending exception (the sanctioned administrative override). Self-approval is denied (re-checked from the DB row). Gated on the dedicated `identity_access.business_scope_exceptions.approve` permission. Requires `Idempotency-Key`; audited at `critical` severity.
+Approves a pending exception (the sanctioned administrative override). Self-approval is denied on BOTH independence axes, re-checked from the DB row: the approver may be neither the requester nor the subject.
+
+TWO permissions are checked. Every approval needs the dedicated `identity_access.business_scope_exceptions.approve`. A rule may also name its own checker in `SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission`, and when that differs from the dedicated key the caller must hold it too (403 `ACCESS_DENIED`). An exception whose rule no installed module declares any more cannot be approved at all (403 `SOD_RULE_UNKNOWN`); rejecting and revoking it stay available.
+
+Requires `Idempotency-Key`; audited at `critical` severity.
 
 **Parameters**
 

--- a/docs/awcms/module-composition-inventory.json
+++ b/docs/awcms/module-composition-inventory.json
@@ -142,7 +142,7 @@
         }
       ],
       "permissionCount": 42,
-      "navigationCount": 10,
+      "navigationCount": 11,
       "jobCount": 3,
       "hasHealthCheck": false,
       "hasReadinessCheck": false,

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | Tabel `awcms_*`                    | 146   |
 | Tabel dengan `FORCE` RLS           | 129   |
 | Tabel RLS-free (global, by design) | 17    |
-| Berkas test                        | 374   |
-| Berkas route                       | 350   |
+| Berkas test                        | 376   |
+| Berkas route                       | 351   |
 | ADR                                | 93    |
 
 ### Modul
@@ -326,7 +326,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 320        |
+| `(root)`      | 322        |
 | `e2e`         | 12         |
 | `integration` | 41         |
 | `unit`        | 1          |
@@ -336,7 +336,7 @@
 | Permukaan       | Berkas |
 | --------------- | ------ |
 | `/api/v1/**`    | 286    |
-| `/admin/**`     | 40     |
+| `/admin/**`     | 41     |
 | publik / anonim | 24     |
 
 <!-- END GENERATED: repo-inventory -->

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -8543,7 +8543,12 @@ paths:
       tags:
         - Identity & Access
       summary: Approve a pending SoD conflict exception (high-risk, audited, idempotent).
-      description: Approves a pending exception (the sanctioned administrative override). Self-approval is denied (re-checked from the DB row). Gated on the dedicated `identity_access.business_scope_exceptions.approve` permission. Requires `Idempotency-Key`; audited at `critical` severity.
+      description: |-
+        Approves a pending exception (the sanctioned administrative override). Self-approval is denied on BOTH independence axes, re-checked from the DB row: the approver may be neither the requester nor the subject.
+
+        TWO permissions are checked. Every approval needs the dedicated `identity_access.business_scope_exceptions.approve`. A rule may also name its own checker in `SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission`, and when that differs from the dedicated key the caller must hold it too (403 `ACCESS_DENIED`). An exception whose rule no installed module declares any more cannot be approved at all (403 `SOD_RULE_UNKNOWN`); rejecting and revoking it stay available.
+
+        Requires `Idempotency-Key`; audited at `critical` severity.
       parameters:
         - name: id
           in: path

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -2325,8 +2325,20 @@ paths:
       summary: Approve a pending SoD conflict exception (high-risk, audited, idempotent).
       description: >-
         Approves a pending exception (the sanctioned administrative override).
-        Self-approval is denied (re-checked from the DB row). Gated on the
-        dedicated `identity_access.business_scope_exceptions.approve` permission.
+        Self-approval is denied on BOTH independence axes, re-checked from the
+        DB row: the approver may be neither the requester nor the subject.
+
+
+        TWO permissions are checked. Every approval needs the dedicated
+        `identity_access.business_scope_exceptions.approve`. A rule may also
+        name its own checker in
+        `SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission`, and
+        when that differs from the dedicated key the caller must hold it too
+        (403 `ACCESS_DENIED`). An exception whose rule no installed module
+        declares any more cannot be approved at all (403 `SOD_RULE_UNKNOWN`);
+        rejecting and revoking it stay available.
+
+
         Requires `Idempotency-Key`; audited at `critical` severity.
       parameters:
         - name: id

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -19,11 +19,13 @@
  * but it is an edit somebody makes on purpose, in a file whose only content is
  * work not done.
  *
- * Nine modules, and the two largest groups are worth naming because they are not
- * cosmetic: every `email` suppression key (a suppressed address silently stops
- * receiving mail, including password resets, and nothing can list or clear it
- * from a page), and every `identity_access.business_scope_*` key (assignment
- * plus a maker/checker exception flow with no inbox for the checker).
+ * Nine modules. Two groups here were named as NOT cosmetic, and both have since
+ * been built: every `email` suppression key (a suppressed address silently
+ * stops receiving mail, including password resets, and nothing could list or
+ * clear it from a page), and every `identity_access.business_scope_*` key
+ * (assignment plus a maker/checker exception flow with no inbox for the
+ * checker — #545 built the inbox, and found that the checker permission each
+ * rule declares for itself was never enforced either).
  * `module_management.settings.*` was the one with a false alibi: three
  * documents claimed a generic `/admin/modules/{key}` settings panel existed,
  * and one used that claim to justify not building an editor. It never did —
@@ -65,17 +67,7 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "form_drafts.draft.create",
   "form_drafts.draft.update",
 
-  // identity_access (12)
-  //
-  "identity_access.business_scope_assignments.create",
-  "identity_access.business_scope_assignments.read",
-  "identity_access.business_scope_assignments.revoke",
-  "identity_access.business_scope_conflicts.read",
-  "identity_access.business_scope_exceptions.approve",
-  "identity_access.business_scope_exceptions.create",
-  "identity_access.business_scope_exceptions.read",
-  "identity_access.business_scope_exceptions.reject",
-  "identity_access.business_scope_exceptions.revoke",
+  // identity_access (3)
   "identity_access.sso_providers.create",
   "identity_access.sso_providers.delete",
   "identity_access.sso_providers.update",

--- a/src/modules/identity-access/application/sod-exception-service.ts
+++ b/src/modules/identity-access/application/sod-exception-service.ts
@@ -11,11 +11,22 @@
  * describe: a bounded-lifetime, scope-bound, audited, revocable authorization
  * to proceed despite a detected conflict. Approve requires a DEDICATED
  * permission (`rule.exceptionPolicy.requiresApprovalPermission`, gated at the
- * route) AND a DIFFERENT approver than the requester — re-checked from the DB
- * row itself, NEVER trusted from the request body (issue #181: "Exception
- * tidak boleh self-approved"; "Creator tidak dapat menjadi approver pada
- * resource yang sama kecuali override tersanksi"). Approve/revoke are audited
- * `critical` (high audit severity).
+ * route) AND an approver who is neither the requester NOR the subject —
+ * re-checked from the DB row itself, NEVER trusted from the request body
+ * (issue #181: "Exception tidak boleh self-approved"; "Creator tidak dapat
+ * menjadi approver pada resource yang sama kecuali override tersanksi").
+ * Approve/revoke are audited `critical` (high audit severity).
+ *
+ * ## The first half of that sentence was FALSE until #545
+ *
+ * "gated at the route" described a gate that did not exist. The approve route
+ * asked the chokepoint for the fixed `business_scope_exceptions.approve` and
+ * nothing ever read `requiresApprovalPermission` — the registry validated the
+ * field's SHAPE and no code its MEANING. Today's single rule happens to name
+ * exactly the fixed key, so the two coincided and nothing looked wrong; the
+ * first module to declare a rule approvable only by, say, a finance controller
+ * would have had that requirement silently ignored. The route now enforces it,
+ * and this comment describes what the code does.
  */
 import { recordAuditEvent } from "../../logging/application/audit-log";
 import { recordCounter } from "../../../lib/observability/metrics-port";
@@ -489,4 +500,30 @@ export async function findValidSoDConflictException(
   );
 
   return validByRuleKey.get(ruleKey) ?? null;
+}
+
+/**
+ * The `rule_key` of one exception, for a caller that must decide something
+ * about the RULE before acting on the row — today, the approve route, which
+ * has to know which rule an exception belongs to in order to ask the
+ * chokepoint about that rule's `requiresApprovalPermission`.
+ *
+ * `null` for a row this tenant does not have. The caller must not turn that
+ * into its own 404: the decide functions below already answer `not_found` for
+ * the same condition, and a second, earlier not-found answer on a different
+ * code path is how two callers end up disagreeing about what a missing row
+ * means.
+ */
+export async function findSoDConflictExceptionRuleKey(
+  tx: Bun.SQL,
+  tenantId: string,
+  exceptionId: string
+): Promise<string | null> {
+  const rows = (await tx`
+    SELECT rule_key
+    FROM awcms_sod_conflict_exceptions
+    WHERE tenant_id = ${tenantId} AND id = ${exceptionId}
+  `) as { rule_key: string }[];
+
+  return rows[0]?.rule_key ?? null;
 }

--- a/src/modules/identity-access/domain/access-control.ts
+++ b/src/modules/identity-access/domain/access-control.ts
@@ -289,6 +289,34 @@ export function permissionKey(
   return `${moduleKey}.${activityCode}.${action}`;
 }
 
+/**
+ * The inverse of {@link permissionKey}: turns a stored `module.activity.action`
+ * string back into the request shape the chokepoint takes. `null` when the
+ * string is not three non-empty dot-separated segments.
+ *
+ * Exists because some permission keys are DATA rather than code —
+ * `SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission` names the
+ * permission a checker must hold to approve an exception to that particular
+ * rule, and a module declares it as a string. Enforcing it means asking the
+ * chokepoint about a key nobody wrote as a literal.
+ *
+ * `action` is cast rather than checked against the `AccessAction` union: there
+ * is no runtime list of the union's members, and inventing one here would be a
+ * second place to forget when an action is added. The cast is safe in the only
+ * direction that matters — an action nobody declared matches no row in the
+ * permission catalogue, so the chokepoint denies it. A parser that threw would
+ * turn a typo in a descriptor into a 500 instead of a refusal.
+ */
+export function parsePermissionKey(key: string): AccessRequest | null {
+  const parts = key.split(".");
+  if (parts.length !== 3) return null;
+
+  const [moduleKey, activityCode, action] = parts;
+  if (!moduleKey || !activityCode || !action) return null;
+
+  return { moduleKey, activityCode, action: action as AccessAction };
+}
+
 function scopeListContains(
   list: readonly BusinessScopeReference[],
   scopeType: string,

--- a/src/modules/identity-access/domain/sod-approval-authority.ts
+++ b/src/modules/identity-access/domain/sod-approval-authority.ts
@@ -1,0 +1,100 @@
+/**
+ * Who may approve an exception to a PARTICULAR SoD rule (Issue #545).
+ *
+ * ## The field that was declared and never read
+ *
+ * `SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission` is described
+ * by the module contract as "the permission key a DIFFERENT tenant user must
+ * hold to approve an exception to THIS rule, never the same permission the
+ * rule itself conflicts over". `sod-rule-registry.ts` refuses a rule that
+ * omits it or misspells it. `sod-exception-service.ts` said in prose that it
+ * was "gated at the route".
+ *
+ * Nothing read it. The approve route asked the chokepoint for the fixed
+ * `identity_access.business_scope_exceptions.approve` and stopped there, and
+ * the one rule this base ships names exactly that key — so the two coincided
+ * and the omission was invisible. The first module to declare a rule
+ * approvable only by, say, a finance controller would have had that
+ * requirement silently ignored while three artefacts said otherwise: a
+ * control that reads as enforced and is not.
+ *
+ * ## Why this is a pure function and not four lines in the route
+ *
+ * The interesting part is not "does the route call the chokepoint" — the
+ * chokepoint gate proves that — but WHICH request it should ask about, and
+ * what it should do when the rule cannot be found. Those are three branches
+ * with a fail-closed default, and a branch that leans the wrong way here
+ * approves a segregation-of-duties bypass. Pure, they are testable without a
+ * database; in the route, they would only be reachable through an HTTP test
+ * that needs one.
+ */
+import type { SoDRuleDescriptor } from "../../_shared/module-contract";
+import { parsePermissionKey, type AccessRequest } from "./access-control";
+
+export type SoDApprovalAuthority =
+  /** The rule asks for nothing beyond the fixed approve permission. */
+  | { outcome: "base_only" }
+  /** The rule names its own checker permission; the caller must hold it TOO. */
+  | { outcome: "additional"; request: AccessRequest }
+  /** Nobody may approve this one. */
+  | {
+      outcome: "refused";
+      code: "SOD_RULE_UNKNOWN" | "SOD_RULE_APPROVAL_PERMISSION_INVALID";
+      message: string;
+    };
+
+/**
+ * `baseApprovalKey` is passed in rather than hard-coded so the caller and this
+ * function cannot disagree about which gate already ran — the whole point of
+ * the `additional` outcome is that it is the SECOND one.
+ */
+export function resolveSoDApprovalAuthority(
+  ruleKey: string,
+  rules: readonly SoDRuleDescriptor[],
+  baseApprovalKey: string
+): SoDApprovalAuthority {
+  const rule = rules.find((candidate) => candidate.ruleKey === ruleKey);
+
+  // An exception's whole meaning is "proceed despite THIS rule", so an
+  // override nobody can describe is one nobody can review. It is also already
+  // inert — the evaluator resolves exceptions by rule key, and no decision
+  // consults a rule that is gone — which is why refusing costs nothing that
+  // was working. Rejecting and revoking stay available, so an operator can
+  // still clean the row up.
+  if (!rule) {
+    return {
+      outcome: "refused",
+      code: "SOD_RULE_UNKNOWN",
+      message:
+        "No installed module declares that SoD rule, so an exception to it cannot be approved. It can still be rejected or revoked."
+    };
+  }
+
+  const required = rule.exceptionPolicy.requiresApprovalPermission;
+
+  // Absent is legitimate: the registry only requires the field when
+  // `allowed` is true, and a rule that forbids exceptions has no pending row
+  // to approve in the first place (the create path refuses it). Treating
+  // absent as "base only" therefore changes nothing that can occur, while
+  // treating it as a refusal would break the one case that can.
+  if (!required || required === baseApprovalKey) {
+    return { outcome: "base_only" };
+  }
+
+  const request = parsePermissionKey(required);
+
+  // Unparseable DENIES rather than falling through to the base gate. The
+  // registry check makes this unreachable for a rule that shipped through CI,
+  // and "the declared checker permission is malformed" must never be the
+  // reason a bypass is approved by someone the rule did not name.
+  if (!request) {
+    return {
+      outcome: "refused",
+      code: "SOD_RULE_APPROVAL_PERMISSION_INVALID",
+      message:
+        "That rule declares an approval permission this deployment cannot parse."
+    };
+  }
+
+  return { outcome: "additional", request };
+}

--- a/src/modules/identity-access/module.ts
+++ b/src/modules/identity-access/module.ts
@@ -178,6 +178,19 @@ export const identityAccessModule = defineModule({
       order: 28,
       requiredPermission: "identity_access.invitations.read"
     },
+    // ADR-0060/ADR-0081, #545. Gated on `business_scope_assignments.read`, the
+    // first of the page's three any-of entry keys — a link needs ONE key that
+    // implies something to see, and the assignment register is the panel an
+    // operator reaching this screen almost always wants. A holder of only
+    // `business_scope_conflicts.read` still reaches the page by URL and sees
+    // its own panel; the link is the coarser gate, the same shape
+    // `/admin/security` records for `mfa_admin`.
+    {
+      labelKey: "admin.layout.nav_business_scope",
+      path: "/admin/business-scope",
+      order: 29,
+      requiredPermission: "identity_access.business_scope_assignments.read"
+    },
     // ADR-0089, #540. PLATFORM-scoped, and the link is gated on the platform
     // permission ITSELF for the reason `/admin/tenants` records: unlike
     // `/admin/idn-regions` there is no tenant-readable half of this screen, so

--- a/src/modules/module-management/domain/sidebar-menu.ts
+++ b/src/modules/module-management/domain/sidebar-menu.ts
@@ -210,6 +210,7 @@ export const SIDEBAR_LABELS: Readonly<Record<string, string>> = {
   "admin.layout.nav_partner_registry": "Partner registry",
   "admin.layout.nav_machine_credentials": "Machine credentials",
   "admin.layout.nav_invitations": "Invitations",
+  "admin.layout.nav_business_scope": "Business scope",
   "admin.layout.nav_seo": "SEO & distribution"
 };
 

--- a/src/pages/admin/business-scope.astro
+++ b/src/pages/admin/business-scope.astro
@@ -1,0 +1,1085 @@
+---
+/**
+ * Business scope — assignments, SoD conflict history, and the exception
+ * maker/checker flow. Issue #545, ADR-0060/ADR-0081.
+ *
+ * Nine permissions had endpoints and no page. The ledger named the gap
+ * precisely: "assignment plus a maker/checker exception flow with NO INBOX for
+ * the checker". A maker/checker flow with nowhere for the checker to see what
+ * is waiting is not a flow; it is two endpoints that happen to pair, and today
+ * whoever must approve an SoD exception has to be told out-of-band that one
+ * exists.
+ *
+ * ## The inbox lives HERE, not on /admin/approvals — and that was the decision
+ *
+ * `/admin/approvals` is the decision surface OF `workflow_approval`, and SoD
+ * exceptions do not run on that engine at all: their own table, their own
+ * state machine (`pending/approved/rejected/expired/revoked`), their own
+ * permissions, their own reason fields. Rendering them there would put a
+ * second, unrelated data source on a page whose entire vocabulary — task,
+ * instance, quorum, delegation — describes none of it, and would gate two
+ * unrelated permission families on one screen.
+ *
+ * The alternative that WOULD justify merging is porting SoD exceptions onto
+ * the workflow engine. That is a foundation change with its own ADR, and it
+ * would make `identity_access` depend on `workflow`, which the module DAG does
+ * not have today. Meanwhile the pending rows are rows this screen already
+ * lists: the inbox is a partition of that list plus two buttons, not a new
+ * surface.
+ *
+ * ## Approve is hidden on BOTH independence axes, not one
+ *
+ * `approveSoDConflictException` refuses when the approver is the requester AND
+ * when the approver is the SUBJECT — the beneficiary of a bypass may not
+ * approve it even when a third party filed the request. A screen that checked
+ * only the requester axis would render an Approve button that always answers
+ * 403 for exactly the person most motivated to press it.
+ *
+ * ## The rule list is DERIVED, and on this base it is nearly empty
+ *
+ * `collectSoDRuleDescriptors(listModules())` is the live registry. The base
+ * declares ONE rule today (`data_lifecycle.legal_hold_maker_checker`), so a
+ * hand-written picker would look complete and silently omit whatever a domain
+ * module contributes. The same descriptor carries `maxDurationDays`, which the
+ * service enforces — so the form derives the ceiling per rule rather than
+ * letting an operator compose a window the endpoint will reject.
+ *
+ * ## Reads
+ *
+ * Any-of entry across the three independently-readable panels, then one
+ * transaction, awaited in sequence — concurrent queries on a single
+ * transaction connection leak it.
+ */
+import AdminLayout from "../../layouts/AdminLayout.astro";
+import "../../styles/admin-screens.css";
+import { loadAdminScreen } from "../../lib/auth/admin-screen";
+import { logAdminPageError } from "../../lib/logging/error-log";
+import {
+  decodeKeysetCursor,
+  encodeKeysetCursor
+} from "../../modules/_shared/keyset-pagination";
+import { listModules } from "../../modules";
+import { collectSoDRuleDescriptors } from "../../modules/identity-access/domain/sod-rule-registry";
+import {
+  listBusinessScopeAssignments,
+  type BusinessScopeAssignmentRow
+} from "../../modules/identity-access/application/business-scope-assignment-service";
+import {
+  listSoDConflictExceptions,
+  type SoDConflictExceptionRow
+} from "../../modules/identity-access/application/sod-exception-service";
+import {
+  listSoDConflictEvaluations,
+  type SoDConflictEvaluationRow
+} from "../../modules/identity-access/application/sod-conflict-evaluation-log";
+
+const ssr = Astro.locals.ssrContext!;
+
+const CONFLICT_PAGE_SIZE = 50;
+
+/** Mirrors the endpoint's own `status` whitelist — a hand-edited query string must not 400 the page. */
+const ASSIGNMENT_STATUSES = ["active", "expired", "revoked"] as const;
+type AssignmentStatus = (typeof ASSIGNMENT_STATUSES)[number];
+
+/**
+ * Only rules that ALLOW exceptions can be excepted, and the create endpoint
+ * refuses the rest. Offering them would compose a request that fails after the
+ * operator has written the justification.
+ */
+const EXCEPTABLE_RULES = collectSoDRuleDescriptors(listModules()).filter(
+  (rule) => rule.exceptionPolicy.allowed
+);
+
+function readParam(name: string): string {
+  return (Astro.url.searchParams.get(name) ?? "").trim();
+}
+
+const statusRaw = readParam("status");
+const assignmentStatus: AssignmentStatus | null = (
+  ASSIGNMENT_STATUSES as readonly string[]
+).includes(statusRaw)
+  ? (statusRaw as AssignmentStatus)
+  : statusRaw === "all"
+    ? null
+    : "active";
+
+const conflictCursorParam = readParam("conflictCursor");
+// A malformed cursor is dropped rather than forwarded: the endpoint answers a
+// bad value with a 400, and a hand-edited query string must not turn a console
+// into an error page.
+const conflictCursor = conflictCursorParam
+  ? decodeKeysetCursor(conflictCursorParam)
+  : null;
+
+const now = new Date();
+
+const screen = await loadAdminScreen({
+  ssr,
+  workClass: "interactive",
+  now,
+  // ANY-OF: the three panels are independently readable, and an operator who
+  // holds only the conflict history should not be refused the page for lacking
+  // the assignment register.
+  authorize: [
+    {
+      moduleKey: "identity_access",
+      activityCode: "business_scope_assignments",
+      action: "read"
+    },
+    {
+      moduleKey: "identity_access",
+      activityCode: "business_scope_exceptions",
+      action: "read"
+    },
+    {
+      moduleKey: "identity_access",
+      activityCode: "business_scope_conflicts",
+      action: "read"
+    }
+  ],
+  load: async ({ tx, can, entry }) => {
+    const [
+      readAssignments = false,
+      readExceptions = false,
+      readConflicts = false
+    ] = entry;
+
+    return {
+      readAssignments,
+      readExceptions,
+      readConflicts,
+      assignments: readAssignments
+        ? await listBusinessScopeAssignments(tx, ssr.tenantId, {
+            status: assignmentStatus ?? undefined
+          })
+        : [],
+      // ONE query for both the inbox and the register: they are the same table
+      // partitioned by status, and a second query would be a second chance for
+      // the two halves to disagree about what is pending.
+      exceptions: readExceptions
+        ? await listSoDConflictExceptions(tx, ssr.tenantId, {})
+        : [],
+      conflicts: readConflicts
+        ? await listSoDConflictEvaluations(tx, ssr.tenantId, {
+            limit: CONFLICT_PAGE_SIZE + 1,
+            cursor: conflictCursor
+          })
+        : [],
+      canCreateAssignment: await can({
+        moduleKey: "identity_access",
+        activityCode: "business_scope_assignments",
+        action: "create"
+      }),
+      canRevokeAssignment: await can({
+        moduleKey: "identity_access",
+        activityCode: "business_scope_assignments",
+        action: "revoke"
+      }),
+      canCreateException: await can({
+        moduleKey: "identity_access",
+        activityCode: "business_scope_exceptions",
+        action: "create"
+      }),
+      canApproveException: await can({
+        moduleKey: "identity_access",
+        activityCode: "business_scope_exceptions",
+        action: "approve"
+      }),
+      canRejectException: await can({
+        moduleKey: "identity_access",
+        activityCode: "business_scope_exceptions",
+        action: "reject"
+      }),
+      canRevokeException: await can({
+        moduleKey: "identity_access",
+        activityCode: "business_scope_exceptions",
+        action: "revoke"
+      })
+    };
+  },
+  onError: (error) => {
+    logAdminPageError(
+      "admin/business-scope.astro: failed to load the business-scope console",
+      error,
+      { correlationId: Astro.locals.correlationId }
+    );
+  }
+});
+
+const canRead = screen.state !== "denied";
+const loadError = screen.state === "error";
+const allowed = screen.state === "allowed";
+
+const readAssignments = allowed && screen.data.readAssignments;
+const readExceptions = allowed && screen.data.readExceptions;
+const readConflicts = allowed && screen.data.readConflicts;
+
+const assignments: BusinessScopeAssignmentRow[] = allowed
+  ? screen.data.assignments
+  : [];
+const allExceptions: SoDConflictExceptionRow[] = allowed
+  ? screen.data.exceptions
+  : [];
+const conflictPage: SoDConflictEvaluationRow[] = allowed
+  ? screen.data.conflicts
+  : [];
+
+const canCreateAssignment = allowed && screen.data.canCreateAssignment;
+const canRevokeAssignment = allowed && screen.data.canRevokeAssignment;
+const canCreateException = allowed && screen.data.canCreateException;
+const canApproveException = allowed && screen.data.canApproveException;
+const canRejectException = allowed && screen.data.canRejectException;
+const canRevokeException = allowed && screen.data.canRevokeException;
+
+const pending = allExceptions.filter(
+  (exception) => exception.status === "pending"
+);
+const decided = allExceptions.filter(
+  (exception) => exception.status !== "pending"
+);
+
+// One row over the page size was fetched purely to answer "is there more?" —
+// it is dropped before rendering so the page never shows 51 of 50.
+const conflicts = conflictPage.slice(0, CONFLICT_PAGE_SIZE);
+const nextConflictCursor =
+  conflictPage.length > CONFLICT_PAGE_SIZE
+    ? // Full-precision text, never a JS `Date`: `occurred_at` is microsecond
+      // precision and a millisecond-truncated cursor skips rows.
+      encodeKeysetCursor(
+        conflicts[conflicts.length - 1]!.occurredAtCursor,
+        conflicts[conflicts.length - 1]!.id
+      )
+    : null;
+
+function linkWith(overrides: Record<string, string | null>): string {
+  const params = new URLSearchParams(Astro.url.search);
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === null) params.delete(key);
+    else params.set(key, value);
+  }
+  const query = params.toString();
+  return query ? `/admin/business-scope?${query}` : "/admin/business-scope";
+}
+
+function day(value: Date): string {
+  return value.toISOString().slice(0, 10);
+}
+
+function scopeLabel(scopeType: string | null, scopeId: string | null): string {
+  if (!scopeType) return "tenant-wide";
+  return scopeId ? `${scopeType} · ${scopeId}` : scopeType;
+}
+
+/**
+ * Whether THIS caller could ever approve THIS row. Both axes, because the
+ * service refuses both: approver ≠ requester and approver ≠ subject.
+ */
+function callerMayApprove(exception: SoDConflictExceptionRow): boolean {
+  return (
+    canApproveException &&
+    exception.requestedByTenantUserId !== ssr.tenantUserId &&
+    exception.subjectTenantUserId !== ssr.tenantUserId
+  );
+}
+
+const assignmentColumns = canRevokeAssignment ? 7 : 6;
+const decidedColumns = canRevokeException ? 7 : 6;
+---
+
+<AdminLayout title="Business scope">
+  <header class="page-header fade-in-up">
+    <h1 id="business-scope-heading">Business scope</h1>
+    <p class="page-description">
+      Which part of the organisation a person's authority covers, the
+      segregation-of-duties conflicts that produced, and the time-bounded
+      exceptions someone approved to work past one.
+    </p>
+  </header>
+
+  {
+    !canRead && (
+      <p class="state-notice fade-in-up" id="business-scope-denied">
+        You do not have permission to view business scope.
+      </p>
+    )
+  }
+
+  {
+    canRead && loadError && (
+      <p class="state-notice fade-in-up" id="business-scope-load-error">
+        Could not load the business-scope console. Please try again.
+      </p>
+    )
+  }
+
+  {
+    canRead && !loadError && (
+      <>
+        <p
+          id="business-scope-action-error"
+          class="state-notice"
+          role="alert"
+          hidden
+        />
+
+        {readExceptions && (
+          <section
+            class="fade-in-up"
+            aria-labelledby="business-scope-inbox-heading"
+          >
+            <h2 id="business-scope-inbox-heading">
+              Waiting for a decision ({pending.length})
+            </h2>
+            <p class="page-description">
+              An exception lets one person hold both halves of a conflict for a
+              bounded window. Approving is the whole point of the checker half
+              of this flow — and the person who asked for it, and the person it
+              is for, are both refused.
+            </p>
+
+            {pending.length === 0 ? (
+              <div class="empty-state">
+                <p id="business-scope-inbox-empty">
+                  Nothing is waiting. Requests appear here the moment someone
+                  files one.
+                </p>
+              </div>
+            ) : (
+              <div class="data-table-scroll">
+                <table class="data-table data-table--stack">
+                  <thead>
+                    <tr>
+                      <th scope="col">Rule</th>
+                      <th scope="col">Subject</th>
+                      <th scope="col">Scope</th>
+                      <th scope="col">Justification</th>
+                      <th scope="col">Requested by</th>
+                      <th scope="col">Window</th>
+                      <th scope="col">Decision</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pending.map((exception) => (
+                      <tr>
+                        <th scope="row" data-label="Rule">
+                          <span class="cell-code">{exception.ruleKey}</span>
+                        </th>
+                        <td data-label="Subject">
+                          <span class="cell-code">
+                            {exception.subjectTenantUserId}
+                          </span>
+                        </td>
+                        <td data-label="Scope">
+                          {scopeLabel(exception.scopeType, exception.scopeId)}
+                        </td>
+                        <td data-label="Justification">
+                          {exception.justification}
+                        </td>
+                        <td data-label="Requested by">
+                          <span class="cell-code">
+                            {exception.requestedByTenantUserId}
+                          </span>
+                        </td>
+                        <td data-label="Window">
+                          {day(exception.effectiveFrom)} →{" "}
+                          {day(exception.effectiveTo)}
+                        </td>
+                        <td data-label="Decision">
+                          <div class="row-actions">
+                            {callerMayApprove(exception) && (
+                              <button
+                                type="button"
+                                class="module-toggle js-approve-exception"
+                                data-exception-id={exception.id}
+                              >
+                                Approve
+                              </button>
+                            )}
+                            {canApproveException &&
+                              !callerMayApprove(exception) && (
+                                <span class="cell-muted">
+                                  You filed this or it is about you — a
+                                  different checker must decide it.
+                                </span>
+                              )}
+                            {canRejectException && (
+                              <button
+                                type="button"
+                                class="btn-inline js-reject-exception"
+                                data-exception-id={exception.id}
+                              >
+                                Reject
+                              </button>
+                            )}
+                          </div>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </section>
+        )}
+
+        {readAssignments && (
+          <section
+            class="fade-in-up"
+            aria-labelledby="business-scope-assignments-heading"
+          >
+            <h2 id="business-scope-assignments-heading">Scope assignments</h2>
+
+            <div class="admin-toolbar">
+              {[...ASSIGNMENT_STATUSES, "all"].map((option) => (
+                <a
+                  class="quick-link"
+                  href={linkWith({ status: option, conflictCursor: null })}
+                >
+                  {option}
+                </a>
+              ))}
+            </div>
+
+            {assignments.length === 0 ? (
+              <div class="empty-state">
+                <p id="business-scope-assignments-empty">
+                  No assignment matches this filter. Without one, a person's
+                  authority is not narrowed to any part of the organisation.
+                </p>
+              </div>
+            ) : (
+              <div class="data-table-scroll">
+                <table class="data-table data-table--stack">
+                  <thead>
+                    <tr>
+                      <th scope="col">Subject</th>
+                      <th scope="col">Role</th>
+                      <th scope="col">Scope</th>
+                      <th scope="col">Window</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">Granted by</th>
+                      {canRevokeAssignment && <th scope="col">Actions</th>}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {assignments.map((assignment) => (
+                      <tr>
+                        <th scope="row" data-label="Subject">
+                          <span class="cell-code">
+                            {assignment.tenantUserId}
+                          </span>
+                        </th>
+                        <td data-label="Role">
+                          <span class="cell-code">
+                            {assignment.roleId ?? "every role"}
+                          </span>
+                        </td>
+                        <td data-label="Scope">
+                          {scopeLabel(assignment.scopeType, assignment.scopeId)}
+                        </td>
+                        <td data-label="Window">
+                          {day(assignment.effectiveFrom)} →{" "}
+                          {assignment.effectiveTo
+                            ? day(assignment.effectiveTo)
+                            : "open-ended"}
+                        </td>
+                        <td data-label="Status">{assignment.status}</td>
+                        <td data-label="Granted by">
+                          <span class="cell-code">
+                            {assignment.grantedByTenantUserId ?? "—"}
+                          </span>
+                        </td>
+                        {canRevokeAssignment && (
+                          <td data-label="Actions">
+                            {assignment.status === "active" && (
+                              <button
+                                type="button"
+                                class="btn-inline btn-inline--danger js-revoke-assignment"
+                                data-assignment-id={assignment.id}
+                              >
+                                Revoke
+                              </button>
+                            )}
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {canCreateAssignment && (
+              <>
+                <h3>Assign a scope</h3>
+                <form id="assign-scope-form" class="admin-form">
+                  <p class="page-description">
+                    Ids, not pickers: a selectable list of every tenant user is
+                    a directory this module gates separately, and
+                    <a href="/admin/users"> the Users screen</a> is where that
+                    lookup already belongs. Assigning to yourself is refused by
+                    the endpoint.
+                  </p>
+
+                  <label for="assign-scope-user">Tenant user id</label>
+                  <input
+                    id="assign-scope-user"
+                    name="tenantUserId"
+                    type="text"
+                    required
+                    autocomplete="off"
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                  />
+
+                  <label for="assign-scope-role">
+                    Role id (blank = every role this person holds)
+                  </label>
+                  <input
+                    id="assign-scope-role"
+                    name="roleId"
+                    type="text"
+                    autocomplete="off"
+                  />
+
+                  <label for="assign-scope-type">Scope type</label>
+                  <input
+                    id="assign-scope-type"
+                    name="scopeType"
+                    type="text"
+                    required
+                    autocomplete="off"
+                    placeholder="office"
+                  />
+                  <p class="page-description">
+                    Only a scope type some module can RESOLVE is accepted — this
+                    base resolves <code>office</code> against the office tree.
+                    Anything else is refused rather than assumed, which is what
+                    keeps an unresolvable scope from reading as unrestricted
+                    access.
+                  </p>
+
+                  <label for="assign-scope-id">Scope id</label>
+                  <input
+                    id="assign-scope-id"
+                    name="scopeId"
+                    type="text"
+                    required
+                    autocomplete="off"
+                  />
+
+                  <label for="assign-scope-until">
+                    Effective until (blank = open-ended)
+                  </label>
+                  <input
+                    id="assign-scope-until"
+                    name="effectiveTo"
+                    type="date"
+                  />
+
+                  <label for="assign-scope-reason">Reason</label>
+                  <input
+                    id="assign-scope-reason"
+                    name="reason"
+                    type="text"
+                    maxlength="500"
+                  />
+
+                  <button id="assign-scope-submit" type="submit">
+                    Assign scope
+                  </button>
+                </form>
+              </>
+            )}
+          </section>
+        )}
+
+        {readExceptions && (
+          <section
+            class="fade-in-up"
+            aria-labelledby="business-scope-exceptions-heading"
+          >
+            <h2 id="business-scope-exceptions-heading">Decided exceptions</h2>
+
+            {decided.length === 0 ? (
+              <div class="empty-state">
+                <p id="business-scope-exceptions-empty">
+                  No exception has been decided yet.
+                </p>
+              </div>
+            ) : (
+              <div class="data-table-scroll">
+                <table class="data-table data-table--stack">
+                  <thead>
+                    <tr>
+                      <th scope="col">Rule</th>
+                      <th scope="col">Subject</th>
+                      <th scope="col">Scope</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">Window</th>
+                      <th scope="col">Approved by</th>
+                      {canRevokeException && <th scope="col">Actions</th>}
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {decided.map((exception) => (
+                      <tr>
+                        <th scope="row" data-label="Rule">
+                          <span class="cell-code">{exception.ruleKey}</span>
+                        </th>
+                        <td data-label="Subject">
+                          <span class="cell-code">
+                            {exception.subjectTenantUserId}
+                          </span>
+                        </td>
+                        <td data-label="Scope">
+                          {scopeLabel(exception.scopeType, exception.scopeId)}
+                        </td>
+                        <td data-label="Status">{exception.status}</td>
+                        <td data-label="Window">
+                          {day(exception.effectiveFrom)} →{" "}
+                          {day(exception.effectiveTo)}
+                        </td>
+                        <td data-label="Approved by">
+                          <span class="cell-code">
+                            {exception.approvedByTenantUserId ?? "—"}
+                          </span>
+                        </td>
+                        {canRevokeException && (
+                          <td data-label="Actions">
+                            {exception.status === "approved" && (
+                              <button
+                                type="button"
+                                class="btn-inline btn-inline--danger js-revoke-exception"
+                                data-exception-id={exception.id}
+                              >
+                                Revoke
+                              </button>
+                            )}
+                          </td>
+                        )}
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+
+            {canCreateException &&
+              (EXCEPTABLE_RULES.length === 0 ? (
+                <p class="page-description" id="business-scope-no-rules">
+                  No installed module declares a segregation-of-duties rule that
+                  allows exceptions, so there is nothing here to except. Rules
+                  arrive with the module that owns them.
+                </p>
+              ) : (
+                <>
+                  <h3>Request an exception</h3>
+                  <form id="request-exception-form" class="admin-form">
+                    <p class="page-description">
+                      Filing one grants nothing: it is `pending` until a
+                      DIFFERENT person approves it, and it expires on its own.
+                    </p>
+
+                    <label for="request-exception-rule">Rule</label>
+                    <select id="request-exception-rule" name="ruleKey" required>
+                      {EXCEPTABLE_RULES.map((rule) => (
+                        <option
+                          value={rule.ruleKey}
+                          data-max-days={String(
+                            rule.exceptionPolicy.maxDurationDays ?? ""
+                          )}
+                        >
+                          {rule.ruleKey} ({rule.severity})
+                        </option>
+                      ))}
+                    </select>
+                    <div id="request-exception-rule-notes">
+                      {EXCEPTABLE_RULES.map((rule) => (
+                        <p class="page-description">
+                          <span class="cell-code">{rule.ruleKey}</span> —{" "}
+                          {rule.description} Exceptions run at most{" "}
+                          {rule.exceptionPolicy.maxDurationDays} days, and are
+                          approved by whoever holds{" "}
+                          <span class="cell-code">
+                            {rule.exceptionPolicy.requiresApprovalPermission}
+                          </span>
+                          .
+                        </p>
+                      ))}
+                    </div>
+
+                    <label for="request-exception-subject">
+                      Subject tenant user id
+                    </label>
+                    <input
+                      id="request-exception-subject"
+                      name="subjectTenantUserId"
+                      type="text"
+                      required
+                      autocomplete="off"
+                      placeholder="00000000-0000-0000-0000-000000000000"
+                    />
+
+                    <label for="request-exception-scope-type">
+                      Scope type (blank = tenant-wide)
+                    </label>
+                    <input
+                      id="request-exception-scope-type"
+                      name="scopeType"
+                      type="text"
+                      autocomplete="off"
+                    />
+
+                    <label for="request-exception-scope-id">Scope id</label>
+                    <input
+                      id="request-exception-scope-id"
+                      name="scopeId"
+                      type="text"
+                      autocomplete="off"
+                    />
+
+                    <label for="request-exception-until">Effective until</label>
+                    <input
+                      id="request-exception-until"
+                      name="effectiveTo"
+                      type="date"
+                      required
+                    />
+                    <p class="page-description">
+                      Every exception is time-bounded — there is no indefinite
+                      override. The ceiling comes from the rule itself and the
+                      field above narrows to it as you choose one.
+                    </p>
+
+                    <label for="request-exception-justification">
+                      Justification
+                    </label>
+                    <textarea
+                      id="request-exception-justification"
+                      name="justification"
+                      rows="3"
+                      required
+                    />
+
+                    <button id="request-exception-submit" type="submit">
+                      File the request
+                    </button>
+                  </form>
+                </>
+              ))}
+          </section>
+        )}
+
+        {readConflicts && (
+          <section
+            class="fade-in-up"
+            aria-labelledby="business-scope-conflicts-heading"
+          >
+            <h2 id="business-scope-conflicts-heading">Conflict history</h2>
+            <p class="page-description">
+              Every time a rule was evaluated — at assignment time and at every
+              high-risk decision — and what it decided. Read-only: this is the
+              evidence, not a control.
+            </p>
+
+            {conflicts.length === 0 ? (
+              <div class="empty-state">
+                <p id="business-scope-conflicts-empty">
+                  No rule has been evaluated yet.
+                </p>
+              </div>
+            ) : (
+              <>
+                <div class="data-table-scroll">
+                  <table class="data-table data-table--stack">
+                    <thead>
+                      <tr>
+                        <th scope="col">When</th>
+                        <th scope="col">Rule</th>
+                        <th scope="col">Subject</th>
+                        <th scope="col">Trigger</th>
+                        <th scope="col">Conflict</th>
+                        <th scope="col">Resolved via</th>
+                        <th scope="col">Reason</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {conflicts.map((evaluation) => (
+                        <tr>
+                          <th scope="row" data-label="When">
+                            {evaluation.occurredAt
+                              .toISOString()
+                              .replace("T", " ")
+                              .slice(0, 16)}
+                          </th>
+                          <td data-label="Rule">
+                            <span class="cell-code">{evaluation.ruleKey}</span>
+                          </td>
+                          <td data-label="Subject">
+                            <span class="cell-code">
+                              {evaluation.subjectTenantUserId ?? "—"}
+                            </span>
+                          </td>
+                          <td data-label="Trigger">
+                            {evaluation.triggerContext}
+                          </td>
+                          <td data-label="Conflict">
+                            {evaluation.conflictDetected ? "yes" : "no"}
+                          </td>
+                          <td data-label="Resolved via">
+                            {evaluation.resolvedVia}
+                          </td>
+                          <td data-label="Reason">
+                            {evaluation.decisionReason}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+
+                {nextConflictCursor && (
+                  <div class="admin-toolbar">
+                    {/* Keyset, not offset: the cursor carries full-precision
+                        `occurred_at` text, so a page boundary cannot skip or
+                        repeat a row the way a millisecond-truncated timestamp
+                        would. */}
+                    <a
+                      class="quick-link"
+                      href={linkWith({ conflictCursor: nextConflictCursor })}
+                    >
+                      Older
+                      <span class="quick-link-arrow" aria-hidden="true">
+                        →
+                      </span>
+                    </a>
+                  </div>
+                )}
+              </>
+            )}
+          </section>
+        )}
+      </>
+    )
+  }
+</AdminLayout>
+
+<script>
+  // Bundled unconditionally (Astro hoists every `<script>` at build time). The
+  // import forces Astro to emit this EXTERNAL, where the app's
+  // `default-src 'self'` CSP allows it.
+  import {
+    blankToNull,
+    field,
+    messageBox,
+    mutateAndReload,
+    onAction,
+    onSubmit,
+    sendJson
+  } from "../../lib/ui/admin-form-client";
+
+  const actionError = messageBox("business-scope-action-error");
+
+  /**
+   * EVERY mutation on this screen requires the header — assignment create and
+   * revoke, and all four exception transitions. A fresh value per click is
+   * also what makes a deliberate second action run instead of replaying the
+   * first one's stored response.
+   */
+  function idempotency(): Record<string, string> {
+    return { "Idempotency-Key": crypto.randomUUID() };
+  }
+
+  /** A `date` input gives midnight LOCAL; send the end of that day in UTC. */
+  function endOfDay(day: string): string | null {
+    return day ? `${day}T23:59:00.000Z` : null;
+  }
+
+  // The ceiling is per-RULE (`exceptionPolicy.maxDurationDays`) and the service
+  // enforces it, so the picker narrows the date field as the rule changes —
+  // the same reasoning as the write-action ceiling on /admin/machine-credentials.
+  const ruleSelect = document.getElementById(
+    "request-exception-rule"
+  ) as HTMLSelectElement | null;
+  const untilInput = document.getElementById(
+    "request-exception-until"
+  ) as HTMLInputElement | null;
+
+  function syncExceptionCeiling(): void {
+    if (!ruleSelect || !untilInput) return;
+
+    const days = Number(ruleSelect.selectedOptions[0]?.dataset.maxDays ?? "");
+    if (!Number.isFinite(days) || days <= 0) return;
+
+    const max = new Date(Date.now() + days * 86_400_000)
+      .toISOString()
+      .slice(0, 10);
+    untilInput.max = max;
+    if (untilInput.value > max) untilInput.value = max;
+  }
+
+  ruleSelect?.addEventListener("change", syncExceptionCeiling);
+  syncExceptionCeiling();
+
+  onSubmit("assign-scope-form", async ({ data, submit }) => {
+    await mutateAndReload(
+      submit,
+      actionError,
+      () =>
+        sendJson(
+          "POST",
+          "/api/v1/identity/business-scope/assignments",
+          {
+            tenantUserId: field(data, "tenantUserId"),
+            roleId: blankToNull(field(data, "roleId")),
+            scopeType: field(data, "scopeType"),
+            scopeId: field(data, "scopeId"),
+            effectiveTo: endOfDay(field(data, "effectiveTo")),
+            reason: blankToNull(field(data, "reason"))
+          },
+          idempotency()
+        ),
+      (errorCode) =>
+        errorCode === "SOD_CONFLICT"
+          ? "That assignment would give one person both halves of a segregation-of-duties rule. File an exception first, or assign a narrower scope."
+          : errorCode === "SCOPE_UNRESOLVED"
+            ? "No installed module can resolve that scope type, so the assignment would not restrict anything."
+            : errorCode === "SELF_GRANT_DENIED"
+              ? "You cannot assign a scope to yourself."
+              : "Could not create the assignment. Check the ids and try again.",
+      "Assigning…"
+    );
+  });
+
+  onAction(".js-revoke-assignment", async (button) => {
+    const id = button.dataset.assignmentId;
+    if (!id) return;
+
+    const reason = window.prompt(
+      "Why is this assignment being revoked? (recorded in the audit trail)"
+    );
+    if (reason === null || reason.trim() === "") return;
+
+    await mutateAndReload(
+      button,
+      actionError,
+      () =>
+        sendJson(
+          "POST",
+          `/api/v1/identity/business-scope/assignments/${id}/revoke`,
+          { revokeReason: reason.trim() },
+          idempotency()
+        ),
+      "Could not revoke the assignment. Please try again.",
+      "Revoking…"
+    );
+  });
+
+  onSubmit("request-exception-form", async ({ data, submit }) => {
+    const until = endOfDay(field(data, "effectiveTo"));
+    if (!until) return;
+
+    await mutateAndReload(
+      submit,
+      actionError,
+      () =>
+        sendJson(
+          "POST",
+          "/api/v1/identity/business-scope/exceptions",
+          {
+            ruleKey: field(data, "ruleKey"),
+            subjectTenantUserId: field(data, "subjectTenantUserId"),
+            scopeType: blankToNull(field(data, "scopeType")),
+            scopeId: blankToNull(field(data, "scopeId")),
+            justification: field(data, "justification"),
+            effectiveTo: until
+          },
+          idempotency()
+        ),
+      (errorCode) =>
+        errorCode === "VALIDATION_ERROR"
+          ? "Check the justification and the window — an exception cannot run longer than the rule allows."
+          : "Could not file the request. Please try again.",
+      "Filing…"
+    );
+  });
+
+  /** Approve and reject differ only in the URL and what the reason is called. */
+  function decideException(
+    action: "approve" | "reject",
+    prompt: string,
+    failure: string
+  ): void {
+    onAction(`.js-${action}-exception`, async (button) => {
+      const id = button.dataset.exceptionId;
+      if (!id) return;
+
+      const reason = window.prompt(prompt);
+      if (reason === null) return;
+
+      await mutateAndReload(
+        button,
+        actionError,
+        () =>
+          sendJson(
+            "POST",
+            `/api/v1/identity/business-scope/exceptions/${id}/${action}`,
+            { decisionReason: reason.trim() || null },
+            idempotency()
+          ),
+        (errorCode) =>
+          errorCode === "SELF_APPROVAL_DENIED"
+            ? "You filed this request or it is about you. A different checker must decide it."
+            : errorCode === "SOD_RULE_UNKNOWN"
+              ? "No installed module declares that rule any more, so this cannot be approved. Reject or revoke it instead."
+              : errorCode === "ACCESS_DENIED"
+                ? "That rule names a checker permission you do not hold."
+                : failure,
+        action === "approve" ? "Approving…" : "Rejecting…"
+      );
+    });
+  }
+
+  decideException(
+    "approve",
+    "Reason for approving this override (optional — recorded with it):",
+    "Could not approve the exception. Please try again."
+  );
+  decideException(
+    "reject",
+    "Reason for rejecting this request (optional — recorded with it):",
+    "Could not reject the request. Please try again."
+  );
+
+  onAction(".js-revoke-exception", async (button) => {
+    const id = button.dataset.exceptionId;
+    if (!id) return;
+
+    if (
+      !window.confirm(
+        "Revoke this exception? The override stops applying at the next decision."
+      )
+    ) {
+      return;
+    }
+
+    const reason = window.prompt(
+      "Why is this override being ended early? (recorded in the audit trail)"
+    );
+    if (reason === null || reason.trim() === "") return;
+
+    await mutateAndReload(
+      button,
+      actionError,
+      () =>
+        sendJson(
+          "POST",
+          `/api/v1/identity/business-scope/exceptions/${id}/revoke`,
+          { revokeReason: reason.trim() },
+          idempotency()
+        ),
+      "Could not revoke the exception. Please try again.",
+      "Revoking…"
+    );
+  });
+</script>

--- a/src/pages/api/v1/identity/business-scope/exceptions/[id]/approve.ts
+++ b/src/pages/api/v1/identity/business-scope/exceptions/[id]/approve.ts
@@ -17,9 +17,24 @@ import {
   findIdempotencyRecord,
   saveIdempotencyRecord
 } from "../../../../../../../modules/_shared/idempotency";
-import { approveSoDConflictException } from "../../../../../../../modules/identity-access/application/sod-exception-service";
+import {
+  approveSoDConflictException,
+  findSoDConflictExceptionRuleKey
+} from "../../../../../../../modules/identity-access/application/sod-exception-service";
+import { resolveSoDApprovalAuthority } from "../../../../../../../modules/identity-access/domain/sod-approval-authority";
+import { collectSoDRuleDescriptors } from "../../../../../../../modules/identity-access/domain/sod-rule-registry";
+import { listModules } from "../../../../../../../modules";
 
 const IDEMPOTENCY_SCOPE = "identity_access_sod_conflict_exception_approve";
+
+/**
+ * The composed registry's SoD rules, read here for the SECOND gate below — the
+ * one each rule declares for itself.
+ */
+const SOD_RULES = collectSoDRuleDescriptors(listModules());
+
+/** The fixed permission every approval needs, whatever the rule adds. */
+const BASE_APPROVE_KEY = "identity_access.business_scope_exceptions.approve";
 
 type DecideExceptionBody = {
   decisionReason?: unknown;
@@ -32,6 +47,28 @@ type DecideExceptionBody = {
  * permission and denies self-approval (re-checked from the DB row, never
  * trusted from the request body). High-risk: `Idempotency-Key` required,
  * audited `critical`.
+ *
+ * ## TWO gates, because the rule gets to name its own checker (#545)
+ *
+ * `SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission` is described
+ * by the contract as "the permission key a DIFFERENT tenant user must hold to
+ * approve an exception to THIS rule", the registry gate refuses a rule that
+ * omits it, and until #545 nothing on any code path ever read it. The single
+ * rule this base ships names exactly the fixed key above, so the omission was
+ * invisible: the first module to declare a rule approvable only by a finance
+ * controller would have had that requirement silently ignored, and the
+ * descriptor would have kept saying otherwise.
+ *
+ * So the fixed gate runs first — an unauthorized caller learns nothing about
+ * which rule an id belongs to — and only then is the rule looked up and its
+ * own key asked for, when it differs.
+ *
+ * A rule the registry does not know REFUSES. An exception's whole meaning is
+ * "proceed despite THIS rule", so an override nobody can describe is one
+ * nobody can review; it is also already inert, because the evaluator resolves
+ * exceptions by rule key and no decision consults a rule that is gone.
+ * Rejecting and revoking stay available, which is the direction that lets an
+ * operator clean up.
  */
 export const POST: APIRoute = async ({ request, cookies, locals, params }) => {
   const exceptionId = params.id;
@@ -85,6 +122,42 @@ export const POST: APIRoute = async ({ request, cookies, locals, params }) => {
 
     if (!auth.allowed) {
       return auth.denied;
+    }
+
+    // Read AFTER the fixed gate: the rule key is information about the row,
+    // and a caller who may not approve anything must not learn it. `null` is
+    // left to `approveSoDConflictException` to answer as `not_found`, so the
+    // missing-row response has exactly one author.
+    const ruleKey = await findSoDConflictExceptionRuleKey(
+      tx,
+      tenantId,
+      exceptionId
+    );
+
+    if (ruleKey !== null) {
+      const authority = resolveSoDApprovalAuthority(
+        ruleKey,
+        SOD_RULES,
+        BASE_APPROVE_KEY
+      );
+
+      if (authority.outcome === "refused") {
+        return fail(403, authority.code, authority.message);
+      }
+
+      if (authority.outcome === "additional") {
+        const ruleAuth = await authorizeInTransaction(
+          tx,
+          tenantId,
+          tokenHash,
+          now,
+          authority.request
+        );
+
+        if (!ruleAuth.allowed) {
+          return ruleAuth.denied;
+        }
+      }
     }
 
     const existingIdempotency = await findIdempotencyRecord(

--- a/tests/admin-business-scope-page-contract.test.ts
+++ b/tests/admin-business-scope-page-contract.test.ts
@@ -1,0 +1,239 @@
+/**
+ * `/admin/business-scope` gates against the endpoints it drives — #545.
+ *
+ * Sibling of the other page-contract tests, for the same silent failure: a page
+ * gating on a permission key no migration seeds hides the control from EVERYONE
+ * — including the owner — while still looking like a working screen.
+ *
+ * Four properties are specific to this surface, and three of them are the
+ * reason the issue existed:
+ *
+ * - **The inbox is HERE, not on `/admin/approvals`.** SoD exceptions do not run
+ *   on the `workflow` engine: own table, own state machine, own permissions.
+ *   Putting them on the approvals page would gate two unrelated permission
+ *   families on one screen and make `identity_access` depend on `workflow`.
+ * - **Approve is hidden on BOTH independence axes.** The service refuses when
+ *   the approver is the requester AND when the approver is the SUBJECT. A
+ *   screen that checked one axis would render a button that always 403s for
+ *   the beneficiary.
+ * - **The rule picker is DERIVED from the live registry**, and only from rules
+ *   whose `exceptionPolicy.allowed` is true. A hand-written list would look
+ *   complete on a base with one rule and omit whatever a module contributes.
+ * - **Every mutation carries a fresh `Idempotency-Key`.** All six endpoints
+ *   answer `IDEMPOTENCY_REQUIRED` without one, so a screen that omitted it
+ *   would render six controls that always fail.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+import { listModules } from "../src/modules";
+import { collectSoDRuleDescriptors } from "../src/modules/identity-access/domain/sod-rule-registry";
+
+const PAGE = "src/pages/admin/business-scope.astro";
+const APPROVALS_PAGE = "src/pages/admin/approvals.astro";
+const ROUTES = [
+  "src/pages/api/v1/identity/business-scope/assignments/index.ts",
+  "src/pages/api/v1/identity/business-scope/assignments/[id]/revoke.ts",
+  "src/pages/api/v1/identity/business-scope/conflicts/index.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/index.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/[id]/approve.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/[id]/reject.ts",
+  "src/pages/api/v1/identity/business-scope/exceptions/[id]/revoke.ts"
+];
+
+const EXPECTED = [
+  "identity_access.business_scope_assignments.create",
+  "identity_access.business_scope_assignments.read",
+  "identity_access.business_scope_assignments.revoke",
+  "identity_access.business_scope_conflicts.read",
+  "identity_access.business_scope_exceptions.approve",
+  "identity_access.business_scope_exceptions.create",
+  "identity_access.business_scope_exceptions.read",
+  "identity_access.business_scope_exceptions.reject",
+  "identity_access.business_scope_exceptions.revoke"
+];
+
+type Triple = `${string}.${string}.${string}`;
+
+function guardTriplesFrom(source: string): Set<Triple> {
+  const found = new Set<Triple>();
+  const pattern =
+    /moduleKey:\s*"([a-z_]+)",\s*activityCode:\s*"([a-z_]+)",\s*action:\s*"([a-z_]+)"/g;
+
+  for (const match of source.matchAll(pattern)) {
+    found.add(`${match[1]}.${match[2]}.${match[3]}` as Triple);
+  }
+
+  return found;
+}
+
+describe("/admin/business-scope gates on keys that really exist", () => {
+  test("every key the page claims is DECLARED by a module", async () => {
+    const page = await readFile(PAGE, "utf8");
+    const claimed = guardTriplesFrom(page);
+
+    const declared = new Set<string>();
+    for (const module of listModules()) {
+      for (const permission of module.permissions ?? []) {
+        declared.add(
+          `${module.key}.${permission.activityCode}.${permission.action}`
+        );
+      }
+    }
+
+    // Paired with the subset check so neither can pass on an empty parse.
+    expect(claimed.size).toBe(EXPECTED.length);
+    for (const key of EXPECTED) {
+      expect(claimed.has(key as Triple)).toBe(true);
+      expect(declared.has(key)).toBe(true);
+    }
+  });
+
+  test("and every one of them is ENFORCED by an endpoint this page calls", async () => {
+    const enforced = new Set<Triple>();
+    for (const route of ROUTES) {
+      for (const triple of guardTriplesFrom(await readFile(route, "utf8"))) {
+        enforced.add(triple);
+      }
+    }
+
+    expect(enforced.size).toBeGreaterThan(0);
+    expect(EXPECTED.filter((key) => !enforced.has(key as Triple))).toEqual([]);
+  });
+
+  test("the page calls each of the six mutating endpoints", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain('"/api/v1/identity/business-scope/assignments"');
+    expect(page).toContain(
+      "/api/v1/identity/business-scope/assignments/${id}/revoke`"
+    );
+    expect(page).toContain('"/api/v1/identity/business-scope/exceptions"');
+    expect(page).toContain(
+      "/api/v1/identity/business-scope/exceptions/${id}/${action}`"
+    );
+    expect(page).toContain(
+      "/api/v1/identity/business-scope/exceptions/${id}/revoke`"
+    );
+  });
+
+  test("every mutation carries a fresh Idempotency-Key", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // All six endpoints answer `IDEMPOTENCY_REQUIRED` without the header. The
+    // helper is counted at its CALL SITES, and the freshness property is held
+    // by the assertion above it — a helper that hoisted one key into a
+    // constant would turn this red.
+    expect(page).toContain(
+      'return { "Idempotency-Key": crypto.randomUUID() };'
+    );
+    // One definition + five call sites: assign, revoke assignment, request an
+    // exception, decide one (approve and reject share a wiring function), and
+    // revoke one.
+    expect(page.match(/idempotency\(\)/g)).toHaveLength(6);
+  });
+});
+
+describe("the placement decision, which is the point of the issue", () => {
+  test("the approvals page does NOT claim any business-scope key", async () => {
+    const approvals = await readFile(APPROVALS_PAGE, "utf8");
+
+    // `/admin/approvals` is the decision surface of `workflow_approval`. A
+    // business-scope guard appearing there would mean the SoD exception flow
+    // had been folded into a page whose vocabulary describes none of it.
+    expect(approvals).not.toContain("business_scope");
+    expect(approvals).toContain('moduleKey: "workflow"');
+  });
+
+  test("and this page does not reach into the workflow module", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // Merging the two surfaces would make `identity_access` depend on
+    // `workflow`, an edge the module DAG does not have.
+    expect(page).not.toContain('moduleKey: "workflow"');
+    expect(page).not.toContain("workflow-approval");
+  });
+});
+
+describe("the two independence axes, both of them", () => {
+  test("Approve is withheld when the caller is the requester OR the subject", async () => {
+    const page = stripComments(await readFile(PAGE, "utf8"));
+
+    // `approveSoDConflictException` refuses both. Checking only the requester
+    // axis would render a button that always 403s for the beneficiary — the
+    // person most motivated to press it.
+    expect(page).toContain(
+      "exception.requestedByTenantUserId !== ssr.tenantUserId"
+    );
+    expect(page).toContain(
+      "exception.subjectTenantUserId !== ssr.tenantUserId"
+    );
+  });
+
+  test("and the service really does refuse both, so the screen is not inventing a rule", async () => {
+    const service = stripComments(
+      await readFile(
+        "src/modules/identity-access/application/sod-exception-service.ts",
+        "utf8"
+      )
+    );
+
+    expect(service).toContain(
+      "existing.requested_by_tenant_user_id === actorTenantUserId"
+    );
+    expect(service).toContain(
+      "existing.subject_tenant_user_id === actorTenantUserId"
+    );
+  });
+});
+
+describe("the rule picker is derived, not written down", () => {
+  test("no rule key is hard-coded in the page", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    expect(page).toContain("collectSoDRuleDescriptors(listModules())");
+    for (const rule of collectSoDRuleDescriptors(listModules())) {
+      expect(page).not.toContain(`"${rule.ruleKey}"`);
+    }
+  });
+
+  test("only rules that ALLOW exceptions reach the picker", async () => {
+    const page = await readFile(PAGE, "utf8");
+
+    // The create endpoint refuses a rule whose policy forbids exceptions, so
+    // offering one composes a request that fails after the justification is
+    // written.
+    expect(page).toContain("rule.exceptionPolicy.allowed");
+  });
+
+  test("and there is a real rule to derive from, so the assertions above are not vacuous", () => {
+    const exceptable = collectSoDRuleDescriptors(listModules()).filter(
+      (rule) => rule.exceptionPolicy.allowed
+    );
+
+    expect(exceptable.length).toBeGreaterThan(0);
+    for (const rule of exceptable) {
+      expect(rule.exceptionPolicy.maxDurationDays).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("the ledger shrank, and stayed shrunk", () => {
+  test("no `business_scope` key is left on NOT_YET_SCREENED", async () => {
+    const { NOT_YET_SCREENED } =
+      await import("../scripts/admin-screen-coverage-ledger");
+
+    expect(
+      NOT_YET_SCREENED.filter((key) => key.includes("business_scope"))
+    ).toEqual([]);
+  });
+
+  test("and the nine keys are exactly the ones this page claims", () => {
+    // Paired with the assertion above so neither passes vacuously.
+    expect(EXPECTED).toHaveLength(9);
+  });
+});

--- a/tests/sod-approval-authority.test.ts
+++ b/tests/sod-approval-authority.test.ts
@@ -1,0 +1,215 @@
+/**
+ * The checker permission each SoD rule declares for itself — #545.
+ *
+ * `SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission` is described
+ * by the module contract as "the permission key a DIFFERENT tenant user must
+ * hold to approve an exception to THIS rule". `sod-rule-registry.ts` refuses a
+ * rule that omits it or misspells it. `sod-exception-service.ts` said in prose
+ * that it was "gated at the route".
+ *
+ * Nothing read it. The approve route asked the chokepoint for the fixed
+ * `identity_access.business_scope_exceptions.approve` and stopped, and the one
+ * rule this base ships names exactly that key — so the two coincided and the
+ * gap was invisible. Three artefacts asserted a control that did not exist.
+ *
+ * These tests pin the resolver that closes it, and the two places the wiring
+ * could still go wrong: the ORDER of the two gates (a rule key read before the
+ * first gate would tell an unauthorized caller which rule an id belongs to),
+ * and the fail-closed defaults.
+ *
+ * Pure — no database, no network. Runs in `quality` on every PR.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+import { listModules } from "../src/modules";
+import type { SoDRuleDescriptor } from "../src/modules/_shared/module-contract";
+import {
+  parsePermissionKey,
+  permissionKey
+} from "../src/modules/identity-access/domain/access-control";
+import { resolveSoDApprovalAuthority } from "../src/modules/identity-access/domain/sod-approval-authority";
+import { collectSoDRuleDescriptors } from "../src/modules/identity-access/domain/sod-rule-registry";
+
+const BASE_KEY = "identity_access.business_scope_exceptions.approve";
+const ROUTE =
+  "src/pages/api/v1/identity/business-scope/exceptions/[id]/approve.ts";
+
+function rule(
+  ruleKey: string,
+  requiresApprovalPermission: string | undefined
+): SoDRuleDescriptor {
+  return {
+    ruleKey,
+    ownerModuleKey: ruleKey.split(".")[0]!,
+    description: "test rule",
+    conflictingPermissionKeys: ["a.b.create", "a.b.release"],
+    scopeApplicability: "global_within_tenant",
+    severity: "critical",
+    exceptionPolicy:
+      requiresApprovalPermission === undefined
+        ? { allowed: false }
+        : {
+            allowed: true,
+            requiresApprovalPermission,
+            maxDurationDays: 14
+          }
+  };
+}
+
+describe("parsePermissionKey is the exact inverse of permissionKey", () => {
+  test("round-trips a real key", () => {
+    const parsed = parsePermissionKey(
+      permissionKey("identity_access", "business_scope_exceptions", "approve")
+    );
+
+    expect(parsed).toEqual({
+      moduleKey: "identity_access",
+      activityCode: "business_scope_exceptions",
+      action: "approve"
+    });
+  });
+
+  test("refuses anything that is not three non-empty segments", () => {
+    for (const bad of ["", "a", "a.b", "a.b.c.d", ".b.c", "a..c", "a.b."]) {
+      expect(parsePermissionKey(bad)).toBeNull();
+    }
+  });
+
+  test("an unknown ACTION parses rather than throwing", () => {
+    // Deliberate: there is no runtime list of the `AccessAction` union, and a
+    // parser that threw would turn a typo in a descriptor into a 500. An
+    // action nobody declared matches no row in the permission catalogue, so
+    // the chokepoint denies it — the failure lands as a refusal.
+    expect(parsePermissionKey("a.b.not_a_real_action")).toEqual({
+      moduleKey: "a",
+      activityCode: "b",
+      action: "not_a_real_action" as never
+    });
+  });
+});
+
+describe("resolveSoDApprovalAuthority", () => {
+  test("a rule naming the base key asks for nothing extra", () => {
+    expect(
+      resolveSoDApprovalAuthority("m.r", [rule("m.r", BASE_KEY)], BASE_KEY)
+    ).toEqual({ outcome: "base_only" });
+  });
+
+  test("a rule naming a DIFFERENT key demands it as a second request", () => {
+    // The whole point of the issue: before #545 this key was declared,
+    // validated, documented — and never asked about.
+    expect(
+      resolveSoDApprovalAuthority(
+        "m.r",
+        [rule("m.r", "finance.controls.approve")],
+        BASE_KEY
+      )
+    ).toEqual({
+      outcome: "additional",
+      request: {
+        moduleKey: "finance",
+        activityCode: "controls",
+        action: "approve"
+      }
+    });
+  });
+
+  test("an unknown rule REFUSES rather than falling through", () => {
+    const resolved = resolveSoDApprovalAuthority("m.gone", [], BASE_KEY);
+
+    expect(resolved.outcome).toBe("refused");
+    expect(resolved).toMatchObject({ code: "SOD_RULE_UNKNOWN" });
+  });
+
+  test("an unparseable declared key REFUSES rather than falling back to the base gate", () => {
+    // "the declared checker permission is malformed" must never be the reason
+    // a bypass is approved by someone the rule did not name.
+    const resolved = resolveSoDApprovalAuthority(
+      "m.r",
+      [rule("m.r", "not-a-key")],
+      BASE_KEY
+    );
+
+    expect(resolved.outcome).toBe("refused");
+    expect(resolved).toMatchObject({
+      code: "SOD_RULE_APPROVAL_PERMISSION_INVALID"
+    });
+  });
+
+  test("a rule that forbids exceptions asks for nothing extra", () => {
+    // Reachable only in theory — the create path refuses such a rule, so there
+    // is no pending row to approve. Treating the absent field as a refusal
+    // would break the one case that CAN occur while protecting none.
+    expect(
+      resolveSoDApprovalAuthority("m.r", [rule("m.r", undefined)], BASE_KEY)
+    ).toEqual({ outcome: "base_only" });
+  });
+});
+
+describe("the route wires it in the only safe order", () => {
+  test("the rule key is read AFTER the fixed gate, never before", async () => {
+    const source = stripComments(await readFile(ROUTE, "utf8"));
+
+    const fixedGate = source.indexOf(
+      'activityCode: "business_scope_exceptions"'
+    );
+    const ruleKeyRead = source.indexOf("findSoDConflictExceptionRuleKey(");
+    const secondGate = source.indexOf("resolveSoDApprovalAuthority(");
+
+    // All three present — an absent marker would make the ordering assertions
+    // compare -1 and pass by accident.
+    expect(fixedGate).toBeGreaterThan(-1);
+    expect(ruleKeyRead).toBeGreaterThan(-1);
+    expect(secondGate).toBeGreaterThan(-1);
+
+    // Which rule an id belongs to is information about the row. A caller who
+    // may not approve anything must not learn it.
+    expect(fixedGate).toBeLessThan(ruleKeyRead);
+    expect(ruleKeyRead).toBeLessThan(secondGate);
+  });
+
+  test("a missing row is left to the service, so not-found has ONE author", async () => {
+    const source = stripComments(await readFile(ROUTE, "utf8"));
+
+    // The route must not answer 404 itself when the rule-key read comes back
+    // null: `approveSoDConflictException` already answers `not_found` for the
+    // same condition, and two authors of one response is how they drift.
+    expect(source).toContain("if (ruleKey !== null) {");
+  });
+
+  test("the second gate goes through the chokepoint, not a grant-set peek", async () => {
+    const source = stripComments(await readFile(ROUTE, "utf8"));
+
+    expect(source.match(/authorizeInTransaction\(/g)?.length).toBe(2);
+  });
+});
+
+describe("the installed registry stays consistent with the gate", () => {
+  test("every rule that allows exceptions declares a PARSEABLE checker permission", () => {
+    const exceptable = collectSoDRuleDescriptors(listModules()).filter(
+      (candidate) => candidate.exceptionPolicy.allowed
+    );
+
+    // Paired with the loop so an empty registry cannot pass this vacuously.
+    expect(exceptable.length).toBeGreaterThan(0);
+
+    for (const candidate of exceptable) {
+      const declared = candidate.exceptionPolicy.requiresApprovalPermission;
+      expect(declared).toBeTruthy();
+      expect(parsePermissionKey(declared!)).not.toBeNull();
+
+      // And the resolver reaches a decision for it — never `refused`, which on
+      // an installed rule would mean nobody can approve its exceptions.
+      expect(
+        resolveSoDApprovalAuthority(
+          candidate.ruleKey,
+          collectSoDRuleDescriptors(listModules()),
+          BASE_KEY
+        ).outcome
+      ).not.toBe("refused");
+    }
+  });
+});


### PR DESCRIPTION
Menutup #545.

Sembilan izin punya endpoint dan tidak punya halaman. Ledger menamai celahnya dengan tepat: *"penugasan plus alur maker/checker untuk pengecualian **tanpa inbox bagi checker-nya**"*. Alur maker/checker tanpa tempat bagi checker melihat apa yang menunggu bukan alur — ia dua endpoint yang kebetulan berpasangan.

## Keputusan yang issue ini minta: inbox-nya di sini, bukan di `/admin/approvals`

`/admin/approvals` adalah permukaan keputusan **milik** `workflow_approval`, dan pengecualian SoD sama sekali tidak berjalan di mesin itu: tabelnya sendiri, mesin statusnya sendiri (`pending/approved/rejected/expired/revoked`), izinnya sendiri, nama field alasannya sendiri. Merendernya di sana akan menaruh sumber data kedua yang tak berhubungan pada halaman yang seluruh kosakatanya — task, instance, quorum, delegation — tidak menggambarkan satu pun darinya, dan menggerbangi dua keluarga izin yang tak berkaitan pada satu layar.

Alternatif yang **memang** membenarkan penyatuan adalah mem-port pengecualian SoD ke mesin workflow. Itu perubahan fondasi dengan ADR-nya sendiri, dan akan membuat `identity_access` bergantung pada `workflow` — sisi yang tidak dimiliki DAG modul hari ini. Sementara itu baris pending adalah baris yang layar ini sudah daftarkan: inbox-nya adalah partisi dari daftar itu plus dua tombol, bukan permukaan baru. Dua test memakukan keputusan itu di kedua arah.

## Temuan: izin checker yang dideklarasikan dan tidak pernah dibaca

`SoDRuleDescriptor.exceptionPolicy.requiresApprovalPermission` disebut kontrak modul sebagai *"kunci izin yang harus dipegang tenant user BERBEDA untuk menyetujui pengecualian atas aturan INI"*. Gerbang registry menolak aturan yang tidak menyertakannya atau salah menuliskannya. `sod-exception-service.ts` menulis dalam prosa bahwa ia *"digerbangi di route"*.

**Tidak ada kode yang membacanya.** Route approve menanyakan chokepoint untuk `identity_access.business_scope_exceptions.approve` yang tetap lalu berhenti — dan satu aturan yang dikirim base ini kebetulan menamai persis kunci itu, sehingga keduanya berimpit dan celahnya tak terlihat. Modul pertama yang mendeklarasikan aturan yang hanya boleh disetujui seorang controller keuangan akan mendapati syarat itu diabaikan diam-diam, sementara tiga artefak menyatakan sebaliknya.

Ditutup lewat `resolveSoDApprovalAuthority` yang murni, dengan urutan yang satu-satunya aman:

1. gerbang tetap **dulu** — penelepon tanpa hak tidak boleh belajar aturan mana yang dimiliki sebuah id;
2. baru rule key dibaca, dan kunci milik aturan itu ditanyakan bila berbeda;
3. aturan yang tidak dikenal registry **menolak** — pengecualian yang tak bisa dijelaskan tak bisa direview, dan ia toh sudah inert karena evaluator mencari pengecualian lewat rule key. Menolak dan mencabut tetap tersedia.

Nol perubahan perilaku hari ini: satu aturan yang ada menamai kunci yang sama. OpenAPI-nya ikut dikoreksi — deskripsinya menyebut satu gerbang.

## Yang layar ini tolak lakukan

- **Approve disembunyikan di DUA sumbu.** `approveSoDConflictException` menolak saat approver adalah requester **dan** saat approver adalah subjek. Memeriksa satu sumbu merender tombol yang selalu 403 bagi orang yang paling termotivasi menekannya.
- **Picker aturan diturunkan** dari registry hidup, hanya aturan yang `exceptionPolicy.allowed` — daftar tulis-tangan terlihat lengkap di base dengan satu aturan lalu diam-diam melewatkan sumbangan modul domain. Plafon `maxDurationDays` per-aturan menyempitkan field tanggal saat aturan dipilih.
- **Tidak ada picker pengguna**, id saja — daftar setiap tenant user adalah direktori yang modul ini gerbangi terpisah, dan `/admin/users` sudah tempatnya.

## Bukti mutasi

| mutasi | test yang memerah |
|---|---|
| kembalikan cacat aslinya — gerbang kedua dihapus seluruhnya | 3 |
| aturan tak dikenal jatuh ke `base_only` alih-alih menolak | 1 |
| layar hanya memeriksa sumbu requester | 1 |
| rule key ditulis tangan di picker | 2 |

`bun run check` penuh hijau. `NOT_YET_SCREENED` **menyusut 47 → 38**. Aset klien 154,0 → 157,5 kB dari plafon 180 kB — layar terbesar sejauh ini, dan ia muat karena #552 mendarat lebih dulu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)