### PR TITLE
docs: 29 job terdaftar, NOL yang bisa jalan di image produksi

### DIFF
--- a/.claude/skills/awcms-deploy/SKILL.md
+++ b/.claude/skills/awcms-deploy/SKILL.md
@@ -101,6 +101,18 @@ bun run db:pool:health    # pool sehat terhadap DB target
 > di `scripts/README.md` §Ditunda — jalankan langkah-langkahnya sendiri
 > (perintah di atas, plus `bun run check` yang sudah memuat test + build).
 
+> **Image runtime TIDAK BISA menjalankan job apa pun — rebuild image job tiap
+> deploy.** `Dockerfile.production`'s stage `runtime` hanya menyalin `dist/`,
+> `node_modules/`, `package.json`. Ke-29 job yang didaftarkan modul berbentuk
+> `bun run <target>` dan **semuanya** keluar `error: Script not found` di sana;
+> tidak ada penjadwal in-process sebagai jalur kedua. Deployment yang berjalan
+> memakai image kedua `awcms-jobs:<versi>` (dibangun dari `scripts/` + `src/` +
+> `sql/`) yang dipanggil `/home/admin1/awcms-jobs/run-job.sh <target>` dari
+> cron. **Image itu di-tag per versi dan tidak ikut ter-rebuild oleh deploy
+> app** — melewatkan langkah ini berarti cron menjalankan kode rilis LAMA
+> terhadap skema BARU, diam-diam. Detail + utang yang tersisa:
+> `docs/PROJECT_STATE.md` §4.
+
 **Setelah deploy rilis yang menambah modul/permission BARU, jalankan
 backfill permission:**
 

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -356,6 +356,46 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 ## 4. Backlog / langkah berikutnya
 
+- **PEMBLOKIR OPERASIONAL — image produksi TIDAK BISA menjalankan satu pun dari
+  29 job terdaftar. Ditemukan 14 Agustus 2026 saat men-deploy v9.0.0.**
+
+  `Dockerfile.production`'s stage `runtime` hanya menyalin `dist/`,
+  `node_modules/`, dan `package.json`. Tidak ada `scripts/`, tidak ada `src/`.
+  Setiap job yang didaftarkan modul lewat `ModuleDescriptor.jobs` berbentuk
+  `bun run <target>`, dan **tiap satu dari 29 target itu keluar dengan
+  `error: Script not found` di dalam container produksi** — `email:dispatch`,
+  `logs:audit:purge`, `blog:publish:scheduled`, `domain-events:dispatch`,
+  `push:dispatch`, `data-lifecycle:archive-purge`, semuanya.
+
+  Aplikasi juga TIDAK punya penjadwal in-process (nol `setInterval`/cron di
+  `standalone-entry.ts` maupun `middleware.ts`), jadi tidak ada jalur kedua.
+
+  **Kenapa ini tidak pernah terlihat:** registry job hanya memverifikasi bahwa
+  `command` menunjuk target yang ada di `package.json` — sebuah fakta tentang
+  REPO, bukan tentang image yang berjalan. Gerbangnya benar dan hijau; yang
+  tidak ada adalah pertanyaan "apakah target itu bisa dieksekusi di tempat ia
+  seharusnya berjalan". Registry yang lengkap membuat 29 job terlihat
+  terpasang, sementara nol di antaranya bisa jalan.
+
+  **Konsekuensi yang sudah terjadi:** retensi audit tidak pernah dieksekusi,
+  outbox domain-event tidak pernah dikirim, post terjadwal tidak pernah terbit
+  — semuanya diam, tanpa error, karena tidak ada yang memanggilnya.
+
+  **Mitigasi yang dipasang hari ini (host, BUKAN di repo):** image kedua
+  `awcms-jobs:<versi>` dibangun dari sumber yang sama (`scripts/` + `src/` +
+  `sql/`), plus `/home/admin1/awcms-jobs/run-job.sh` yang membaca env dari
+  container app yang SEDANG berjalan (nama container berubah tiap deploy, jadi
+  ia di-resolve bukan di-hardcode) dan menjalankan target apa pun di jaringan
+  `coolify`. Cron pertama yang memakainya: `*/5` `email:dispatch`.
+
+  **Utang yang tersisa, dan ini milik REPO bukan host:** image job dibangun
+  tangan dan **di-tag per versi — ia akan basi diam-diam pada rilis berikutnya**
+  (cron akan menjalankan kode v9.0.0 terhadap skema v9.1.0). Perbaikan yang
+  benar adalah stage `jobs` di `Dockerfile.production` yang diterbitkan bersama
+  image runtime oleh `release.yml`, sehingga versi job dan versi app tidak bisa
+  menyimpang. Sampai itu ada, **rebuild `awcms-jobs` setiap kali deploy** —
+  langkah ini sekarang tertulis di skill `awcms-deploy`.
+
 - **PUTARAN 14 Agustus 2026 (ketiga puluh) — rilis v9.0.0, dan empat dokumen
   yang menua ke arah yang SALAH.**
 


### PR DESCRIPTION
Ditemukan saat men-deploy v9.0.0 ke produksi dan mencoba memasang dispatcher email untuk reset password.

## Temuan

`Dockerfile.production`'s stage `runtime` hanya menyalin `dist/`, `node_modules/`, dan `package.json`. Tidak ada `scripts/`, tidak ada `src/`.

Setiap job yang didaftarkan modul lewat `ModuleDescriptor.jobs` berbentuk `bun run <target>`, dan **tiap satu dari 29 target itu keluar dengan `error: Script not found`** di dalam container produksi — `email:dispatch`, `logs:audit:purge`, `blog:publish:scheduled`, `domain-events:dispatch`, `push:dispatch`, `data-lifecycle:archive-purge`, semuanya. Aplikasi juga tidak punya penjadwal in-process (nol `setInterval`/cron di `standalone-entry.ts` maupun `middleware.ts`), jadi tidak ada jalur kedua.

Diverifikasi langsung di container yang sedang berjalan:

```
$ docker exec <app> sh -c 'pwd; ls'
/home/bun/app
dist  node_modules  package.json
```

## Kenapa tak pernah terlihat

`modules:jobs:check` memverifikasi bahwa `command` menunjuk target yang ADA di `package.json` — sebuah fakta tentang **repo**, bukan tentang **image yang berjalan**. Gerbangnya benar dan hijau. Yang tidak ditanyakan siapa pun adalah apakah target itu bisa DIEKSEKUSI di tempat ia seharusnya berjalan.

Ini bentuk kegagalan yang sama dengan yang sudah tercatat berkali-kali di §4: registry yang lengkap membuat 29 job **tampak** terpasang, sementara nol di antaranya bisa jalan. Konsekuensinya sudah berjalan diam-diam sejak lama — retensi audit tidak pernah dieksekusi, outbox domain-event tidak pernah dikirim, post terjadwal tidak pernah terbit, tanpa satu pun error, karena tidak ada yang memanggilnya.

## Mitigasi (sudah terpasang di host, BUKAN di repo)

Image kedua `awcms-jobs:<versi>` dibangun dari sumber yang sama (`scripts/` + `src/` + `sql/`), dipanggil `/home/admin1/awcms-jobs/run-job.sh <target>` yang membaca env dari container app yang SEDANG berjalan (nama container berubah tiap deploy, jadi di-resolve bukan di-hardcode) dan menjalankannya di jaringan `coolify`. Cron pertama yang memakainya: `*/5 email:dispatch` — terverifikasi menyala.

## Utang yang tersisa — dan ini milik REPO

Image job dibangun tangan dan di-tag per versi, sehingga **ia akan basi diam-diam pada rilis berikutnya**: cron akan menjalankan kode v9.0.0 terhadap skema v9.1.0. Perbaikan yang benar adalah stage `jobs` di `Dockerfile.production` yang diterbitkan `release.yml` bersama image runtime, sehingga versi job dan versi app tidak BISA menyimpang. Sampai itu ada, rebuild manual dicatat sebagai langkah wajib di skill `awcms-deploy`.

PR ini mendokumentasikan temuan + utangnya; tidak mengubah kode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)