### PR TITLE
docs: koreksi — image job DIHAPUS tiap deploy, bukan basi diam-diam

### DIFF
--- a/.claude/skills/awcms-deploy/SKILL.md
+++ b/.claude/skills/awcms-deploy/SKILL.md
@@ -108,10 +108,13 @@ bun run db:pool:health    # pool sehat terhadap DB target
 > tidak ada penjadwal in-process sebagai jalur kedua. Deployment yang berjalan
 > memakai image kedua `awcms-jobs:<versi>` (dibangun dari `scripts/` + `src/` +
 > `sql/`) yang dipanggil `/home/admin1/awcms-jobs/run-job.sh <target>` dari
-> cron. **Image itu di-tag per versi dan tidak ikut ter-rebuild oleh deploy
-> app** — melewatkan langkah ini berarti cron menjalankan kode rilis LAMA
-> terhadap skema BARU, diam-diam. Detail + utang yang tersisa:
-> `docs/PROJECT_STATE.md` §4.
+> cron. **Coolify MENGHAPUS image itu tiap kali app di-deploy** (prune image
+> yang tak dipakai container mana pun) — karena itu `run-job.sh` membangunnya
+> ulang sendiri saat hilang (~55 detik). Yang TIDAK otomatis: konteks build
+> `/home/admin1/awcms-jobs/` adalah SNAPSHOT sumber, jadi **segarkan tiap
+> rilis** — auto-rebuild memperbaiki penghapusan, bukan keusangan, dan versi
+> job yang tertinggal akan menjalankan kode LAMA terhadap skema BARU tanpa
+> suara. Detail + utang yang tersisa: `docs/PROJECT_STATE.md` §4.
 
 **Setelah deploy rilis yang menambah modul/permission BARU, jalankan
 backfill permission:**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -388,13 +388,30 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   ia di-resolve bukan di-hardcode) dan menjalankan target apa pun di jaringan
   `coolify`. Cron pertama yang memakainya: `*/5` `email:dispatch`.
 
-  **Utang yang tersisa, dan ini milik REPO bukan host:** image job dibangun
-  tangan dan **di-tag per versi — ia akan basi diam-diam pada rilis berikutnya**
-  (cron akan menjalankan kode v9.0.0 terhadap skema v9.1.0). Perbaikan yang
-  benar adalah stage `jobs` di `Dockerfile.production` yang diterbitkan bersama
-  image runtime oleh `release.yml`, sehingga versi job dan versi app tidak bisa
-  menyimpang. Sampai itu ada, **rebuild `awcms-jobs` setiap kali deploy** —
-  langkah ini sekarang tertulis di skill `awcms-deploy`.
+  **KOREKSI beberapa jam kemudian — mode gagalnya lebih buruk dari dugaan
+  awal, dan lebih mudah dilihat.** Catatan ini semula memperingatkan image job
+  akan "basi diam-diam". Yang sebenarnya terjadi: **Coolify mem-prune image
+  yang tidak dipakai container mana pun setiap kali aplikasi di-deploy, dan
+  `awcms-jobs` persis seperti itu — jadi ia DIHAPUS pada tiap deploy.**
+  Terbukti pada redeploy pertama sesudahnya: `pull access denied for
+awcms-jobs, repository does not exist`. Jadi bukan hasil basi yang
+  menyesatkan, melainkan cron yang mati keras — lebih berisik, dan itu
+  keberuntungan.
+
+  Konteks build-nya (direktori biasa di `/home/admin1/awcms-jobs/`) selamat
+  dari prune, jadi `run-job.sh` kini **membangun ulang image sendiri saat
+  hilang** alih-alih bergantung pada seseorang yang ingat. Rebuild ~55 detik,
+  dan cron `*/5` menyerapnya tanpa terlihat.
+
+  **Utang yang tersisa, dan ini milik REPO bukan host:** konteks build itu
+  SNAPSHOT sumber — ia tidak mengikuti rilis. Auto-rebuild memperbaiki
+  penghapusan, BUKAN keusangan: setelah rilis berikutnya, cron akan
+  membangun ulang **kode versi lama** terhadap skema baru, dan kali ini
+  benar-benar diam-diam. Perbaikan yang benar adalah stage `jobs` di
+  `Dockerfile.production` yang diterbitkan `release.yml` bersama image
+  runtime, sehingga versi job dan versi app tidak BISA menyimpang. Sampai itu
+  ada, **segarkan konteks `/home/admin1/awcms-jobs/` setiap rilis** — langkah
+  ini tertulis di skill `awcms-deploy`.
 
 - **PUTARAN 14 Agustus 2026 (ketiga puluh) — rilis v9.0.0, dan empat dokumen
   yang menua ke arah yang SALAH.**


### PR DESCRIPTION
Koreksi terhadap [#561](https://github.com/ahliweb/awcms/pull/561), yang baru merged beberapa jam lalu.

## Apa yang salah di catatan sebelumnya

#561 memperingatkan image `awcms-jobs` akan **"basi diam-diam"** pada rilis berikutnya. Yang sebenarnya terjadi lebih buruk — dan, untungnya, jauh lebih berisik.

Coolify mem-prune image yang tidak direferensikan container mana pun setiap kali aplikasi di-deploy. `awcms-jobs` persis seperti itu: ia hanya dipakai sesaat oleh `docker run --rm` dari cron, jadi **ia DIHAPUS pada tiap deploy**.

Terbukti pada redeploy pertama sesudahnya (saat memasang env Mailketing):

```
run-job.sh: email:provider:health
Unable to find image 'awcms-jobs:latest' locally
docker: Error response from daemon: pull access denied for awcms-jobs,
        repository does not exist or may require 'docker login'
```

Jadi bukan hasil basi yang menyesatkan, melainkan **cron yang mati keras**. Itu keberuntungan: kegagalan yang berisik jauh lebih baik daripada dispatcher yang tampak jalan sambil memakai kode salah.

## Perbaikan

Konteks build-nya (`/home/admin1/awcms-jobs/`, direktori biasa) selamat dari prune. `run-job.sh` kini memeriksa `docker image inspect` dan **membangun ulang sendiri saat image hilang** — ~55 detik, terserap cron `*/5` tanpa terlihat — alih-alih bergantung pada seseorang yang ingat melakukannya tiap deploy.

## Utang yang tersisa berubah BENTUK, bukan hilang

Auto-rebuild memperbaiki **penghapusan**, bukan **keusangan**. Konteks build itu SNAPSHOT sumber dan tidak mengikuti rilis: setelah rilis berikutnya, cron akan membangun ulang **kode versi lama** terhadap skema baru — dan kali ini benar-benar diam-diam, karena rebuild-nya sukses.

Perbaikan yang benar tidak berubah: stage `jobs` di `Dockerfile.production` yang diterbitkan `release.yml` bersama image runtime, sehingga versi job dan versi app tidak BISA menyimpang. Sampai itu ada, "segarkan konteks tiap rilis" tercatat di skill `awcms-deploy`.

Tidak mengubah kode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)