### PR TITLE
fix(i18n): pengalih bahasa 403 di produksi — form POST asli tak bisa lolos checkOrigin di belakang TLS

### DIFF
--- a/.changeset/language-switcher-posts-json.md
+++ b/.changeset/language-switcher-posts-json.md
@@ -1,0 +1,55 @@
+---
+"awcms": patch
+---
+
+fix(i18n): pengalih bahasa 403 di produksi — satu-satunya form POST asli di repo ini
+
+v9.1.0 mengirim pengalih bahasa yang **tidak pernah bekerja di produksi**. Ia
+mengembalikan `403 Cross-site POST form submissions are forbidden` untuk semua
+orang, dan karena ia SATU-SATUNYA jalan menuju bahasa Indonesia, fitur utama
+rilis itu inert di lingkungan yang sesungguhnya.
+
+**Sebabnya.** `checkOrigin` Astro (`core/app/origin-check.js`) menolak tiap
+request ber-content-type mirip-form kecuali
+`request.headers.get("origin") === url.origin`. Deployment ini mengakhiri TLS di
+Traefik sementara app-nya sendiri mendengarkan HTTP polos, jadi `url.origin`
+adalah `http://…` sedangkan tiap browser mengirim `https://…`. Dua string itu
+tak pernah sama.
+
+**Kenapa NOL gerbang melihatnya.** Ia hanya salah di belakang proxy yang
+mengakhiri TLS. Dev, `bun run build`, dan smoke test Playwright semuanya bicara
+HTTP polos ke app, dan di sana `origin` DAN `url.origin` memang cocok. 47
+gerbang hijau, 4.375 test hijau, dan permukaannya tetap mati saat menghadapi
+pembaca sungguhan. Ini penegasan lain dari "jalankan, jangan dibaca" — kali ini
+"jalankan DI TOPOLOGI YANG SEBENARNYA".
+
+**Perbaikannya** mengirim `application/json` lewat `fetch`, yang `checkOrigin`
+kecualikan dengan alasan yang benar: POST `application/json` lintas-situs sudah
+dihentikan preflight CORS. Itu juga yang dilakukan SETIAP tulisan lain di
+aplikasi ini — komponen ini satu-satunya form POST asli di seluruh repo, dan
+itulah kenapa tak ada yang pernah menabrak dinding ini sebelumnya.
+
+Ongkosnya: pengalih kini MEMBUTUHKAN script. Itu bukan batasan baru di halaman
+mana pun yang memuatnya — `/login` mengirim kredensialnya dengan `fetch`, jadi
+pembaca tanpa script tak bisa masuk sama sekali. Tombol fallback karena itu
+dikirim `hidden` DI MARKUP, bukan disembunyikan belakangan oleh script: tombol
+yang terlihat sampai script jalan adalah kontrol yang rusak persis bagi pembaca
+yang tak bisa memakainya.
+
+**Digerbangi** `tests/form-post-origin-check.test.ts`: tiap `<form method="post">`
+di `src/` wajib membatalkan submit aslinya, dan daftar form yang mem-POST
+dibatasi pada satu berkas yang diketahui. Dibuktikan GAGAL lebih dulu dengan
+menghapus `preventDefault`.
+
+Penulisan gerbang itu sendiri mengulang cacat yang baru saja ditutup CodeQL:
+versi pertama pemotong komentarnya mencocokkan `{/* … */}` sebagai satu kesatuan,
+tetapi `\{\s*\/\*` juga cocok dengan `interface Props {` beserta JSDoc-nya, lalu
+BERLARI mencari `*/` yang kebetulan diikuti `}` — menelan seluruh markup di
+antaranya. Pemindainya lalu melaporkan NOL form dan terbaca sebagai lulus.
+Kuantifier malas yang meleset tidak gagal setempat; ia menelan.
+
+**Utang yang dinyatakan, bukan ditutup:** `url.origin` app SALAH di produksi
+(skema `http` untuk situs `https`). Tak ada satu pun tempat di repo ini yang
+membaca `X-Forwarded-Proto`, dan adapter Node menurunkan protokol dari
+listener-nya sendiri. PR ini menghindari akibatnya di satu titik; akarnya —
+dan apa pun lain yang bersandar pada origin absolut — masih menunggu.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **128** (`sql/001`–`128`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0096** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-14).**) | `ls docs/adr/`                                                                          |
 | Layar admin                        | **43** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **56** (30.030 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **56** (30.083 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **46** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | Tabel `awcms_*`                    | 148   |
 | Tabel dengan `FORCE` RLS           | 130   |
 | Tabel RLS-free (global, by design) | 18    |
-| Berkas test                        | 387   |
+| Berkas test                        | 388   |
 | Berkas route                       | 361   |
 | ADR                                | 97    |
 
@@ -333,7 +333,7 @@
 
 | Direktori     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 332        |
+| `(root)`      | 333        |
 | `e2e`         | 12         |
 | `integration` | 42         |
 | `unit`        | 1          |

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -9,18 +9,35 @@
  * props it already took (a locale rather than an assumption) are why this is a
  * replacement rather than a rewrite.
  *
- * ## Why a form that submits, rather than a `<select>` driven by script
+ * ## Why the form is submitted by SCRIPT, not natively
  *
- * The switch has to work on `/login` and on ADR-0088's tenant-selection screen —
- * pages where there is no session, so no preference can be stored, and the
- * cookie is the only place the choice can live. A plain form POST works there,
- * works with script disabled, and needs no client bundle at all.
+ * The first version of this component posted the form natively and claimed to
+ * work with script disabled. **In production it did not work at all**, and the
+ * reason is worth writing down because no gate in this repo could have caught it.
  *
- * The `<script>` below is a progressive ENHANCEMENT (submit on change, so the
- * reader does not have to find a button), not the mechanism. It is
- * import-bearing so Astro bundles it to an external module — an inline script
- * would be blocked by this repo's `default-src 'self'` CSP, which admits exactly
- * one inline script (the theme-init hash) and no others.
+ * Astro's `checkOrigin` (`core/app/origin-check.js`) refuses any request whose
+ * content-type is form-like unless `request.headers.get("origin") === url.origin`.
+ * This deployment terminates TLS at Traefik and the app itself listens on plain
+ * HTTP, so `url.origin` is `http://…` while every browser sends `https://…`.
+ * Those two strings are never equal, so a native form POST is answered
+ * `403 Cross-site POST form submissions are forbidden` — always, for everyone.
+ *
+ * It passed every gate because it is only wrong behind a TLS-terminating proxy:
+ * dev, `bun run build`, and the Playwright smoke test all speak plain HTTP to
+ * the app, where origin and `url.origin` DO match.
+ *
+ * Posting JSON avoids it honestly rather than by evasion: `checkOrigin` exempts
+ * non-form content-types because a cross-site `application/json` POST is already
+ * blocked by CORS preflight. That is also what every other write in this
+ * application does — this component was the only native form POST in the repo.
+ *
+ * The cost is that the switch now REQUIRES script. That is not a new constraint
+ * on any page it appears on: `/login` submits its credentials with `fetch`, so a
+ * reader without script cannot sign in to reach the admin at all.
+ *
+ * The `<script>` is import-bearing so Astro bundles it to an external module — an
+ * inline script would be blocked by this repo's `default-src 'self'` CSP, which
+ * admits exactly one inline script (the theme-init hash) and no others.
  *
  * ## Why it posts to an API route instead of setting the cookie in script
  *
@@ -93,11 +110,12 @@ const returnPath = `${Astro.url.pathname}${Astro.url.search}`;
     }
   </select>
   {
-    /* Shown only when script is unavailable — the enhancement below hides it.
-      A form with no visible submit and no script is a control that cannot be
-      operated, which is the very failure this component replaced. */
+    /* `hidden` in the MARKUP, not hidden later by script. The switch cannot work
+      without script (see the header), so a button that is visible until script
+      runs is a control that is broken for exactly the readers who cannot use it.
+      The script unhides nothing; it simply takes over the `submit` event. */
   }
-  <button type="submit" class="locale-switcher-submit"
+  <button type="submit" class="locale-switcher-submit" hidden
     >{t("Change language")}</button
   >
 </form>
@@ -166,20 +184,55 @@ const returnPath = `${Astro.url.pathname}${Astro.url.search}`;
   const select = form?.querySelector<HTMLSelectElement>(
     ".locale-switcher-select"
   );
-  const submit = form?.querySelector<HTMLButtonElement>(
-    ".locale-switcher-submit"
-  );
 
   if (form && select) {
-    // Script is available, so the explicit button is redundant.
-    submit?.setAttribute("hidden", "hidden");
-
     select.addEventListener("change", () => {
-      // `form.requestSubmit()` rather than `submit()`: the latter skips
-      // validation and, more importantly here, does not fire `submit` handlers —
-      // so anything added later would be silently bypassed.
+      // `form.requestSubmit()` rather than `submit()`: the latter does not fire
+      // `submit` handlers, so it would bypass the listener below and fall back
+      // to the native form POST that this deployment answers with 403.
       form.requestSubmit();
     });
+
+    form.addEventListener("submit", (event) => {
+      // The native POST would be form-encoded, and Astro's `checkOrigin` refuses
+      // form-encoded writes whenever `url.origin` disagrees with the `Origin`
+      // header — which it always does behind TLS termination. JSON is exempt.
+      event.preventDefault();
+      void applyLocale();
+    });
+  }
+
+  async function applyLocale(): Promise<void> {
+    if (!form || !select) return;
+
+    const returnTo = form.querySelector<HTMLInputElement>(
+      'input[name="return_to"]'
+    )?.value;
+
+    select.disabled = true;
+
+    try {
+      const response = await fetch(form.action, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // The anonymous endpoint needs no session, but the persisting one is
+        // bearer-gated — without this it would answer 401 for a signed-in reader.
+        credentials: "same-origin",
+        body: JSON.stringify({ locale: select.value, return_to: returnTo })
+      });
+
+      if (!response.ok) {
+        select.disabled = false;
+        return;
+      }
+
+      // Re-request the page rather than swapping text in place: the locale
+      // decides the server-rendered document, `<html lang>` included.
+      window.location.reload();
+    } catch {
+      // Offline or blocked — leave the control usable rather than stuck.
+      select.disabled = false;
+    }
   }
 
   // Referenced so the import is not elided by the bundler, and so this file

--- a/tests/form-post-origin-check.test.ts
+++ b/tests/form-post-origin-check.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Native form POSTs are unusable in this deployment, and nothing else says so.
+ *
+ * Astro's `checkOrigin` (`astro/dist/core/app/origin-check.js`) refuses any
+ * request whose content-type is form-like unless
+ * `request.headers.get("origin") === url.origin`. This deployment terminates TLS
+ * at Traefik while the app listens on plain HTTP, so `url.origin` is `http://…`
+ * and the browser's `Origin` is `https://…`. Those strings never match, so every
+ * native `<form method="post">` is answered
+ * `403 Cross-site POST form submissions are forbidden`.
+ *
+ * It shipped to production in v9.1.0 because the failure needs a TLS-terminating
+ * proxy to appear: dev, `bun run build`, and the Playwright smoke test all speak
+ * plain HTTP to the app, where the two origins DO match. No gate could see it,
+ * and the feature it broke — the only route to Indonesian — looked fine locally.
+ *
+ * So the rule is asserted here instead: a form that POSTs must be intercepted by
+ * script and re-sent as JSON, which `checkOrigin` exempts because a cross-site
+ * `application/json` POST is already stopped by CORS preflight.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const REPO_ROOT = join(import.meta.dir, "..");
+const SRC_ROOT = join(REPO_ROOT, "src");
+
+/**
+ * Comments are stripped BEFORE matching. This file's own subject matter is
+ * `method="post"` and `application/x-www-form-urlencoded`, and the component it
+ * guards explains the trap in prose — an assertion that reads comments would be
+ * answered by the explanation rather than by the code.
+ *
+ * Block comments are removed FIRST, and the braces a JSX comment leaves behind
+ * are collapsed afterwards. Doing it the other way round — matching `{/* … *\/}`
+ * as one unit — is wrong in a way that is easy to ship: `\{\s*\/\*` also matches
+ * `interface Props {` followed by its JSDoc, and the pattern then runs on
+ * looking for a `*\/` that happens to be followed by `}`. The first one it finds
+ * is the JSX comment far below in the template, so everything between them —
+ * the entire markup, `<form>` included — disappears. The scanner then reports
+ * nothing and reads as a pass. That is the same lazy-quantifier failure CodeQL
+ * caught in `i18n-screen-coverage-check.ts`, in a different costume.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/\{\s*\}/g, " ")
+    .replace(/^[ \t]*\/\/.*$/gm, " ");
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) walk(full, out);
+    else if (/\.(astro|ts|tsx)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+const POSTING_FORM = /<form\b[^>]*\bmethod\s*=\s*["']post["']/i;
+
+describe("no native form POST survives Astro's origin check", () => {
+  const offenders: string[] = [];
+  const posting: string[] = [];
+
+  for (const file of walk(SRC_ROOT)) {
+    const body = stripComments(readFileSync(file, "utf8"));
+    if (!POSTING_FORM.test(body)) continue;
+
+    const relativePath = relative(REPO_ROOT, file);
+    posting.push(relativePath);
+
+    // The interception must be in the same file as the form — a handler living
+    // somewhere else is not something this assertion can honestly verify.
+    if (!body.includes("preventDefault")) offenders.push(relativePath);
+  }
+
+  test("every posting form cancels the native submit", () => {
+    expect(offenders).toEqual([]);
+  });
+
+  /**
+   * Not a style rule — a bound. Each posting form is a place this trap can
+   * reappear, so their number is worth noticing when it grows.
+   */
+  test("the set of posting forms is still the one known form", () => {
+    expect(posting).toEqual(["src/components/LanguageSwitcher.astro"]);
+  });
+});
+
+describe("the language switcher sends JSON", () => {
+  const source = stripComments(
+    readFileSync(join(SRC_ROOT, "components", "LanguageSwitcher.astro"), "utf8")
+  );
+
+  test("it posts application/json, which checkOrigin exempts", () => {
+    expect(source).toContain('"Content-Type": "application/json"');
+  });
+
+  test("it sends credentials, or the persisting endpoint answers 401", () => {
+    expect(source).toContain('credentials: "same-origin"');
+  });
+
+  /**
+   * The fallback button is `hidden` in the MARKUP. Hiding it from script instead
+   * would show a broken control to precisely the readers who cannot use it.
+   */
+  test("the no-script submit button ships hidden", () => {
+    expect(source).toMatch(
+      /<button[^>]*class="locale-switcher-submit"[^>]*hidden/
+    );
+  });
+});


### PR DESCRIPTION
fix(i18n): pengalih bahasa 403 di produksi — satu-satunya form POST asli di repo ini

v9.1.0 mengirim pengalih bahasa yang **tidak pernah bekerja di produksi**. Ia
mengembalikan `403 Cross-site POST form submissions are forbidden` untuk semua
orang, dan karena ia SATU-SATUNYA jalan menuju bahasa Indonesia, fitur utama
rilis itu inert di lingkungan yang sesungguhnya.

**Sebabnya.** `checkOrigin` Astro (`core/app/origin-check.js`) menolak tiap
request ber-content-type mirip-form kecuali
`request.headers.get("origin") === url.origin`. Deployment ini mengakhiri TLS di
Traefik sementara app-nya sendiri mendengarkan HTTP polos, jadi `url.origin`
adalah `http://…` sedangkan tiap browser mengirim `https://…`. Dua string itu
tak pernah sama.

**Kenapa NOL gerbang melihatnya.** Ia hanya salah di belakang proxy yang
mengakhiri TLS. Dev, `bun run build`, dan smoke test Playwright semuanya bicara
HTTP polos ke app, dan di sana `origin` DAN `url.origin` memang cocok. 47
gerbang hijau, 4.375 test hijau, dan permukaannya tetap mati saat menghadapi
pembaca sungguhan. Ini penegasan lain dari "jalankan, jangan dibaca" — kali ini
"jalankan DI TOPOLOGI YANG SEBENARNYA".

**Perbaikannya** mengirim `application/json` lewat `fetch`, yang `checkOrigin`
kecualikan dengan alasan yang benar: POST `application/json` lintas-situs sudah
dihentikan preflight CORS. Itu juga yang dilakukan SETIAP tulisan lain di
aplikasi ini — komponen ini satu-satunya form POST asli di seluruh repo, dan
itulah kenapa tak ada yang pernah menabrak dinding ini sebelumnya.

Ongkosnya: pengalih kini MEMBUTUHKAN script. Itu bukan batasan baru di halaman
mana pun yang memuatnya — `/login` mengirim kredensialnya dengan `fetch`, jadi
pembaca tanpa script tak bisa masuk sama sekali. Tombol fallback karena itu
dikirim `hidden` DI MARKUP, bukan disembunyikan belakangan oleh script: tombol
yang terlihat sampai script jalan adalah kontrol yang rusak persis bagi pembaca
yang tak bisa memakainya.

**Digerbangi** `tests/form-post-origin-check.test.ts`: tiap `<form method="post">`
di `src/` wajib membatalkan submit aslinya, dan daftar form yang mem-POST
dibatasi pada satu berkas yang diketahui. Dibuktikan GAGAL lebih dulu dengan
menghapus `preventDefault`.

Penulisan gerbang itu sendiri mengulang cacat yang baru saja ditutup CodeQL:
versi pertama pemotong komentarnya mencocokkan `{/* … */}` sebagai satu kesatuan,
tetapi `\{\s*\/\*` juga cocok dengan `interface Props {` beserta JSDoc-nya, lalu
BERLARI mencari `*/` yang kebetulan diikuti `}` — menelan seluruh markup di
antaranya. Pemindainya lalu melaporkan NOL form dan terbaca sebagai lulus.
Kuantifier malas yang meleset tidak gagal setempat; ia menelan.

**Utang yang dinyatakan, bukan ditutup:** `url.origin` app SALAH di produksi
(skema `http` untuk situs `https`). Tak ada satu pun tempat di repo ini yang
membaca `X-Forwarded-Proto`, dan adapter Node menurunkan protokol dari
listener-nya sendiri. PR ini menghindari akibatnya di satu titik; akarnya —
dan apa pun lain yang bersandar pada origin absolut — masih menunggu.

---

Diverifikasi terhadap produksi yang sedang berjalan: `curl -X POST` ke `/api/v1/auth/preferences/locale` menjawab **403** dengan `Cross-site POST form submissions are forbidden`, baik lewat edge maupun langsung ke container app — jadi ini bukan artefak Cloudflare/Varnish.

`DATABASE_URL="" bun run check` — **exit 0**, **4.380 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)