### PR TITLE
fix(i18n): script pengalih bahasa DI-INLINE, jadi CSP menolaknya — cacat kedua di kontrol yang sama

### DIFF
--- a/.changeset/switcher-script-must-be-external.md
+++ b/.changeset/switcher-script-must-be-external.md
@@ -1,0 +1,42 @@
+---
+"awcms": patch
+---
+
+fix(i18n): script pengalih bahasa DI-INLINE, jadi CSP menolaknya — cacat KEDUA di kontrol yang sama
+
+v9.1.1 memperbaiki 403-nya dan pengalih bahasa **tetap mati**. Ada dua cacat
+independen di kontrol ini, dan yang kedua ini bahkan tak pernah sampai ke
+jaringan: script-nya tak pernah dieksekusi.
+
+Astro me-render script komponen **INLINE** bila setelah bundling ia tak lagi
+punya import LINTAS-CHUNK. CSP repo ini `script-src 'self' 'sha256-…'` dengan
+TEPAT SATU hash — script theme-init. Script inline yang hash-nya tak dikenal
+tidak pernah jalan.
+
+Versi lama menahan import-nya dengan
+`if (typeof LOCALE_COOKIE_NAME !== "string") throw …`. Konstanta itu string,
+jadi minifier membuktikan tesnya salah, menghapus cabangnya, menemukan import-nya
+tak terpakai, lalu meng-elide-nya. Script jadi bebas-import dan di-inline —
+persis yang dicegah oleh penjaga itu, sementara komentarnya terus menyatakan hal
+itu mustahil.
+
+**"Punya import" adalah cara yang SALAH untuk menyatakan aturannya**, dan
+menyatakannya keliru memakan satu rilis. `admin-form-client` selamat karena
+dipakai banyak layar sehingga menjadi chunk tersendiri; modul privat
+satu-pemanggil dilipat ke dalam script pemanggilnya, dan script itu lalu
+di-inline. Perbaikan pertama saya — `import "…"` telanjang ke modul baru —
+gagal karena alasan yang sama, dan build MEMBUKTIKANNYA sebelum apa pun dikirim.
+
+Perilakunya kini dimuat dari script `AdminLayout`, satu-satunya script yang sudah
+terbukti eksternal (ia mengimpor chunk bersama itu), dan `AdminLayout` memang
+satu-satunya yang me-render komponen ini. Komponennya sendiri tak lagi punya
+`<script>`.
+
+**Dibuktikan pada artefak build, bukan pada niat:** `dist/client/_astro/
+AdminLayout.astro_astro_type_script_index_0_lang.*.js` memuat logika pengalih,
+dan `dist/server/entry.mjs` memuatnya **NOL kali** — sebelum perbaikan ini
+kebalikannya yang benar.
+
+Digerbangi `tests/form-post-origin-check.test.ts`: komponennya tak boleh punya
+`<script>` sendiri lagi, dan `AdminLayout` wajib tetap mengimpor keduanya —
+modul pengalih DAN chunk bersama yang membuat script itu eksternal.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -110,7 +110,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **128** (`sql/001`–`128`)                                                               | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0096** (`0000` = template; status ADR tertinggi: **Diterima (2026-08-14).**) | `ls docs/adr/`                                                                          |
 | Layar admin                        | **43** berkas `.astro` di `src/pages/admin/`; **0 dari 22** modul tanpa `navigation:`   | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **56** (30.083 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **56** (30.044 baris) — soal typecheck lihat §6                                         | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **46** di rantai `bun run check`                                                        | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**               | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -35,9 +35,23 @@
  * on any page it appears on: `/login` submits its credentials with `fetch`, so a
  * reader without script cannot sign in to reach the admin at all.
  *
- * The `<script>` is import-bearing so Astro bundles it to an external module — an
- * inline script would be blocked by this repo's `default-src 'self'` CSP, which
- * admits exactly one inline script (the theme-init hash) and no others.
+ * ## Why the behaviour lives in a module rather than in the `<script>`
+ *
+ * Because "import-bearing, therefore bundled externally" was ASSUMED here and
+ * was false. Astro inlines a component script that has no imports left after
+ * bundling, and this repo's CSP is `script-src 'self' 'sha256-…'` with exactly
+ * one hash — the theme-init script. An inline script it has no hash for never
+ * runs.
+ *
+ * The earlier version held its import in place with
+ * `if (typeof LOCALE_COOKIE_NAME !== "string") throw …`. That constant is a
+ * string, so the minifier proved the test false, deleted the branch, found the
+ * import unused, and elided it. The script became import-free and was inlined —
+ * precisely what the guard existed to prevent, while its comment went on saying
+ * it could not happen.
+ *
+ * A bare side-effect `import "…"` cannot be elided, because dropping it would
+ * drop observable behaviour. See `src/lib/ui/language-switcher-client.ts`.
  *
  * ## Why it posts to an API route instead of setting the cookie in script
  *
@@ -175,70 +189,3 @@ const returnPath = `${Astro.url.pathname}${Astro.url.search}`;
     }
   }
 </style>
-
-<script>
-  // Import-bearing so Astro emits an EXTERNAL module (CSP `script-src 'self'`).
-  import { LOCALE_COOKIE_NAME } from "../lib/i18n/request-locale";
-
-  const form = document.querySelector<HTMLFormElement>(".locale-switcher");
-  const select = form?.querySelector<HTMLSelectElement>(
-    ".locale-switcher-select"
-  );
-
-  if (form && select) {
-    select.addEventListener("change", () => {
-      // `form.requestSubmit()` rather than `submit()`: the latter does not fire
-      // `submit` handlers, so it would bypass the listener below and fall back
-      // to the native form POST that this deployment answers with 403.
-      form.requestSubmit();
-    });
-
-    form.addEventListener("submit", (event) => {
-      // The native POST would be form-encoded, and Astro's `checkOrigin` refuses
-      // form-encoded writes whenever `url.origin` disagrees with the `Origin`
-      // header — which it always does behind TLS termination. JSON is exempt.
-      event.preventDefault();
-      void applyLocale();
-    });
-  }
-
-  async function applyLocale(): Promise<void> {
-    if (!form || !select) return;
-
-    const returnTo = form.querySelector<HTMLInputElement>(
-      'input[name="return_to"]'
-    )?.value;
-
-    select.disabled = true;
-
-    try {
-      const response = await fetch(form.action, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        // The anonymous endpoint needs no session, but the persisting one is
-        // bearer-gated — without this it would answer 401 for a signed-in reader.
-        credentials: "same-origin",
-        body: JSON.stringify({ locale: select.value, return_to: returnTo })
-      });
-
-      if (!response.ok) {
-        select.disabled = false;
-        return;
-      }
-
-      // Re-request the page rather than swapping text in place: the locale
-      // decides the server-rendered document, `<html lang>` included.
-      window.location.reload();
-    } catch {
-      // Offline or blocked — leave the control usable rather than stuck.
-      select.disabled = false;
-    }
-  }
-
-  // Referenced so the import is not elided by the bundler, and so this file
-  // fails to build if the cookie name is ever renamed out from under it — the
-  // endpoint and this component must agree on it.
-  if (typeof LOCALE_COOKIE_NAME !== "string") {
-    throw new Error("LOCALE_COOKIE_NAME must be a string");
-  }
-</script>

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -444,7 +444,21 @@ const ICON_USER =
       // The import forces Astro to bundle this to an EXTERNAL file — an
       // import-free script would be inlined, and inline scripts are blocked by
       // the middleware CSP (`default-src 'self'`). See admin-form-client.ts.
+      //
+      // "Has an import" turns out to be the wrong way to state that rule, and
+      // stating it wrongly cost a release. What Astro actually inlines is a
+      // script left with no CROSS-CHUNK import after bundling. `lockElement`
+      // survives because `admin-form-client` is shared by many screens and so
+      // becomes its own chunk; a private one-caller module is folded into the
+      // script itself and the script is then inlined.
+      //
+      // `LanguageSwitcher` learned that the expensive way: its own `<script>`
+      // imported a module nothing else used, was inlined, and never ran under
+      // the CSP. Its behaviour is loaded HERE instead, from the one script
+      // already proven external, because `AdminLayout` is the only thing that
+      // renders that component.
       import { lockElement } from "../lib/ui/admin-form-client";
+      import "../lib/ui/language-switcher-client";
 
       const logoutButton = document.getElementById(
         "admin-logout"

--- a/src/lib/ui/language-switcher-client.ts
+++ b/src/lib/ui/language-switcher-client.ts
@@ -1,0 +1,95 @@
+/**
+ * Client behaviour for `LanguageSwitcher.astro`.
+ *
+ * ## Why this is a MODULE and not a `<script>` body
+ *
+ * Two reasons, and the second one is why the switcher was dead in production.
+ *
+ * 1. A `<script>` inside an `.astro` file is not typechecked by `tsc` — the
+ *    blind spot `check:astro-scripts:check` exists to cover.
+ * 2. Astro decides where a component script goes by whether it still has
+ *    imports AFTER bundling. A script with none is written into the SSR
+ *    manifest's `inlinedScripts` and rendered INLINE — and this repo's CSP is
+ *    `script-src 'self' 'sha256-…'` with exactly one hash, the theme-init
+ *    script. An inline script it does not know the hash of never executes.
+ *
+ * The previous version tried to hold its import in place with a guard:
+ *
+ *     if (typeof LOCALE_COOKIE_NAME !== "string") throw new Error(…)
+ *
+ * `LOCALE_COOKIE_NAME` is a `const` string, so the minifier proved the test
+ * false, deleted the branch, found the import unused, and elided it. The script
+ * became import-free and was inlined — exactly the outcome the guard was written
+ * to prevent, with the comment still there claiming it could not happen.
+ *
+ * A bare side-effect `import "…"` in the `.astro` cannot be elided, because
+ * dropping it would drop observable behaviour. That is what makes this file the
+ * mechanism rather than a decoration.
+ */
+import { LOCALE_COOKIE_NAME } from "../i18n/request-locale";
+
+const form = document.querySelector<HTMLFormElement>(".locale-switcher");
+const select = form?.querySelector<HTMLSelectElement>(
+  ".locale-switcher-select"
+);
+
+/** True when the server actually set the cookie we are about to reload for. */
+function localeCookieIsSet(): boolean {
+  return document.cookie
+    .split("; ")
+    .some((entry) => entry.startsWith(`${LOCALE_COOKIE_NAME}=`));
+}
+
+async function applyLocale(): Promise<void> {
+  if (!form || !select) return;
+
+  const returnTo = form.querySelector<HTMLInputElement>(
+    'input[name="return_to"]'
+  )?.value;
+
+  select.disabled = true;
+
+  try {
+    const response = await fetch(form.action, {
+      method: "POST",
+      // JSON, not the form encoding a native submit would use. Astro's
+      // `checkOrigin` refuses form-like content types unless the `Origin` header
+      // equals `url.origin`, and behind TLS termination those never match: the
+      // app listens on plain HTTP, so its `url.origin` is `http://…` while the
+      // browser sends `https://…`. JSON is exempt because a cross-site
+      // `application/json` POST is already stopped by CORS preflight.
+      headers: { "Content-Type": "application/json" },
+      // The anonymous endpoint needs no session; the persisting one is
+      // bearer-gated and would answer 401 without this.
+      credentials: "same-origin",
+      body: JSON.stringify({ locale: select.value, return_to: returnTo })
+    });
+
+    if (!response.ok || !localeCookieIsSet()) {
+      // Reloading after a refusal would just re-render the same language and
+      // look like the control silently did nothing.
+      select.disabled = false;
+      return;
+    }
+
+    // Re-request the page rather than swapping text in place: the locale decides
+    // the server-rendered document, `<html lang>` included.
+    window.location.reload();
+  } catch {
+    select.disabled = false;
+  }
+}
+
+if (form && select) {
+  select.addEventListener("change", () => {
+    // `requestSubmit()` rather than `submit()`: the latter does not fire submit
+    // handlers, so it would bypass the listener below and fall through to the
+    // native form POST this deployment answers with 403.
+    form.requestSubmit();
+  });
+
+  form.addEventListener("submit", (event) => {
+    event.preventDefault();
+    void applyLocale();
+  });
+}

--- a/tests/form-post-origin-check.test.ts
+++ b/tests/form-post-origin-check.test.ts
@@ -105,7 +105,11 @@ describe("no native form POST survives Astro's origin check", () => {
       "utf8"
     );
 
-    expect(component).not.toMatch(/^<script>/m);
+    // Case-insensitive, and tolerant of attributes: `<SCRIPT>` and
+    // `<script type="module">` are both scripts, and a guard that only knows
+    // one spelling is a guard the next edit walks straight past. CodeQL
+    // `js/bad-tag-filter` flagged the narrower version of this line.
+    expect(component).not.toMatch(/^<script[\s/>]/im);
   });
 
   test("AdminLayout loads the switcher's behaviour", () => {

--- a/tests/form-post-origin-check.test.ts
+++ b/tests/form-post-origin-check.test.ts
@@ -61,45 +61,81 @@ function walk(dir: string, out: string[] = []): string[] {
 const POSTING_FORM = /<form\b[^>]*\bmethod\s*=\s*["']post["']/i;
 
 describe("no native form POST survives Astro's origin check", () => {
-  const offenders: string[] = [];
   const posting: string[] = [];
 
   for (const file of walk(SRC_ROOT)) {
     const body = stripComments(readFileSync(file, "utf8"));
-    if (!POSTING_FORM.test(body)) continue;
-
-    const relativePath = relative(REPO_ROOT, file);
-    posting.push(relativePath);
-
-    // The interception must be in the same file as the form — a handler living
-    // somewhere else is not something this assertion can honestly verify.
-    if (!body.includes("preventDefault")) offenders.push(relativePath);
+    if (POSTING_FORM.test(body)) posting.push(relative(REPO_ROOT, file));
   }
 
-  test("every posting form cancels the native submit", () => {
-    expect(offenders).toEqual([]);
-  });
-
   /**
-   * Not a style rule — a bound. Each posting form is a place this trap can
-   * reappear, so their number is worth noticing when it grows.
+   * Not a style rule — a bound. Every posting form is a place this trap can
+   * reappear, and the interception that saves it is checked below by name. A new
+   * entry here is a new thing to verify, not a formatting question.
    */
   test("the set of posting forms is still the one known form", () => {
     expect(posting).toEqual(["src/components/LanguageSwitcher.astro"]);
   });
+
+  test("its native submit is cancelled, in the module that carries it", () => {
+    const client = stripComments(
+      readFileSync(
+        join(SRC_ROOT, "lib", "ui", "language-switcher-client.ts"),
+        "utf8"
+      )
+    );
+
+    expect(client).toContain("preventDefault");
+  });
+
+  /**
+   * The component must own NO `<script>` of its own.
+   *
+   * A private one-caller module is folded into the script that imports it, which
+   * leaves that script with no cross-chunk import — and Astro inlines exactly
+   * those, into a page whose CSP is `script-src 'self' 'sha256-…'` with a single
+   * hash for the theme-init script. So the switcher's behaviour is loaded from
+   * `AdminLayout`'s script, which is external because it also imports the shared
+   * `admin-form-client` chunk. Giving this component a `<script>` again would
+   * quietly reproduce the inlining.
+   */
+  test("the component ships no script of its own", () => {
+    const component = readFileSync(
+      join(SRC_ROOT, "components", "LanguageSwitcher.astro"),
+      "utf8"
+    );
+
+    expect(component).not.toMatch(/^<script>/m);
+  });
+
+  test("AdminLayout loads the switcher's behaviour", () => {
+    const layout = stripComments(
+      readFileSync(join(SRC_ROOT, "layouts", "AdminLayout.astro"), "utf8")
+    );
+
+    expect(layout).toContain('import "../lib/ui/language-switcher-client"');
+    // Its externality depends on this shared chunk staying in the same script.
+    expect(layout).toContain('from "../lib/ui/admin-form-client"');
+  });
 });
 
 describe("the language switcher sends JSON", () => {
-  const source = stripComments(
+  const client = stripComments(
+    readFileSync(
+      join(SRC_ROOT, "lib", "ui", "language-switcher-client.ts"),
+      "utf8"
+    )
+  );
+  const component = stripComments(
     readFileSync(join(SRC_ROOT, "components", "LanguageSwitcher.astro"), "utf8")
   );
 
   test("it posts application/json, which checkOrigin exempts", () => {
-    expect(source).toContain('"Content-Type": "application/json"');
+    expect(client).toContain('"Content-Type": "application/json"');
   });
 
   test("it sends credentials, or the persisting endpoint answers 401", () => {
-    expect(source).toContain('credentials: "same-origin"');
+    expect(client).toContain('credentials: "same-origin"');
   });
 
   /**
@@ -107,7 +143,7 @@ describe("the language switcher sends JSON", () => {
    * would show a broken control to precisely the readers who cannot use it.
    */
   test("the no-script submit button ships hidden", () => {
-    expect(source).toMatch(
+    expect(component).toMatch(
       /<button[^>]*class="locale-switcher-submit"[^>]*hidden/
     );
   });


### PR DESCRIPTION
fix(i18n): script pengalih bahasa DI-INLINE, jadi CSP menolaknya — cacat KEDUA di kontrol yang sama

v9.1.1 memperbaiki 403-nya dan pengalih bahasa **tetap mati**. Ada dua cacat
independen di kontrol ini, dan yang kedua ini bahkan tak pernah sampai ke
jaringan: script-nya tak pernah dieksekusi.

Astro me-render script komponen **INLINE** bila setelah bundling ia tak lagi
punya import LINTAS-CHUNK. CSP repo ini `script-src 'self' 'sha256-…'` dengan
TEPAT SATU hash — script theme-init. Script inline yang hash-nya tak dikenal
tidak pernah jalan.

Versi lama menahan import-nya dengan
`if (typeof LOCALE_COOKIE_NAME !== "string") throw …`. Konstanta itu string,
jadi minifier membuktikan tesnya salah, menghapus cabangnya, menemukan import-nya
tak terpakai, lalu meng-elide-nya. Script jadi bebas-import dan di-inline —
persis yang dicegah oleh penjaga itu, sementara komentarnya terus menyatakan hal
itu mustahil.

**"Punya import" adalah cara yang SALAH untuk menyatakan aturannya**, dan
menyatakannya keliru memakan satu rilis. `admin-form-client` selamat karena
dipakai banyak layar sehingga menjadi chunk tersendiri; modul privat
satu-pemanggil dilipat ke dalam script pemanggilnya, dan script itu lalu
di-inline. Perbaikan pertama saya — `import "…"` telanjang ke modul baru —
gagal karena alasan yang sama, dan build MEMBUKTIKANNYA sebelum apa pun dikirim.

Perilakunya kini dimuat dari script `AdminLayout`, satu-satunya script yang sudah
terbukti eksternal (ia mengimpor chunk bersama itu), dan `AdminLayout` memang
satu-satunya yang me-render komponen ini. Komponennya sendiri tak lagi punya
`<script>`.

**Dibuktikan pada artefak build, bukan pada niat:** `dist/client/_astro/
AdminLayout.astro_astro_type_script_index_0_lang.*.js` memuat logika pengalih,
dan `dist/server/entry.mjs` memuatnya **NOL kali** — sebelum perbaikan ini
kebalikannya yang benar.

Digerbangi `tests/form-post-origin-check.test.ts`: komponennya tak boleh punya
`<script>` sendiri lagi, dan `AdminLayout` wajib tetap mengimpor keduanya —
modul pengalih DAN chunk bersama yang membuat script itu eksternal.

---

`DATABASE_URL="" bun run check` — **exit 0**, **4.382 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)