### PR TITLE
docs(skill): `awcms-workflow-approval` menyatakan `awcms_worker` TIDAK ADA — ia ada, dan salah arahnya berbahaya

### DIFF
--- a/.changeset/workflow-approval-skill-worker-role.md
+++ b/.changeset/workflow-approval-skill-worker-role.md
@@ -1,0 +1,34 @@
+---
+"awcms": patch
+---
+
+docs(skill): `awcms-workflow-approval` menyatakan role `awcms_worker` TIDAK ADA — ia ada, dan salah arahnya berbahaya
+
+Empat klaim di `.claude/skills/awcms-workflow-approval/SKILL.md` keliru, dan
+semuanya ke arah yang sama: menyuruh pembacanya MEMBATALKAN pemisahan privilege
+yang sudah terpasang.
+
+- "Repo ini tidak punya role `awcms_worker`" — ia DIBUAT di
+  `sql/022_awcms_db_worker_setup_roles.sql`.
+- "`WORKER_DATABASE_URL` fallback ke `DATABASE_URL` … pemisahan privilege BELUM
+  ada di sini" — produksi terverifikasi memakai `awcms_worker` untuk worker dan
+  `awcms_app` untuk aplikasi.
+- "Jangan tulis `GRANT … TO awcms_worker` — akan gagal jalan" — migrasi repo ini
+  memuat **78** GRANT semacam itu yang sudah lama berjalan.
+- "Temuan over-grant PR #778 vacuous di repo ini" — justru sebaliknya:
+  `sql/022:145` sudah memberi `awcms_workflow_instances` `SELECT` SAJA, yakni
+  persis bentuk perbaikannya, dan `WORKER_ROLE_GRANTS` di
+  `scripts/security-readiness.ts` menjaganya.
+
+**Kenapa arah salahnya yang penting.** Dokumen basi biasanya membuat orang
+melakukan pekerjaan yang sudah tak perlu. Yang ini sebaliknya: agen yang
+mempercayainya akan MENOLAK menulis GRANT worker untuk job baru dan
+menjalankannya sebagai role pemilik — menghapus pemisahan privilege yang nyata.
+Itu regresi keamanan yang lahir dari dokumentasi. Skill `awcms-deploy` sudah
+dikoreksi untuk klaim kembar ini; berkas ini terlewat, dan `skills:check`
+tidak bisa melihatnya karena ia memverifikasi bahwa path yang DIKUTIP ada,
+bukan bahwa kalimat di sekitarnya benar.
+
+Ditemukan saat menjadwalkan job yang selama ini tidak pernah berjalan:
+`workflow:escalations:dispatch` termasuk 31 dari 32 job yang tak ter-cron, dan
+pertanyaan "role apa yang dipakainya" langsung menabrak klaim ini.

--- a/.claude/skills/awcms-workflow-approval/SKILL.md
+++ b/.claude/skills/awcms-workflow-approval/SKILL.md
@@ -99,14 +99,36 @@ bounded batch, advisory lock, `--dry-run`. **Idempotency guard**: `UPDATE`
 escalation dikondisikan `WHERE status = 'pending' AND escalation_step =
 <value dibaca pass ini>` — race yang kalah (run konkuren, atau pass yang
 di-retry) mempengaruhi nol baris dan diam-diam di-skip, tidak pernah
-escalate dobel. **Role DB-nya**: di mini job ini berjalan sebagai role
-least-privilege `awcms_worker` (`SELECT`-only sejak fix PR #778, lihat
-§Security finding). **Repo ini tidak punya role `awcms_worker`** —
-`WORKER_DATABASE_URL` fallback ke `DATABASE_URL` (owner migrasi), jadi job
-ini hari ini berjalan dengan hak penuh dan pemisahan privilege itu BELUM
-ada di sini. Role yang ada baru `awcms_app` (`sql/019`, Issue #141).
-Jangan tulis `GRANT ... TO awcms_worker` di migration repo ini — akan gagal
-jalan.
+escalate dobel. **Role DB-nya**: job ini berjalan sebagai role
+least-privilege `awcms_worker`.
+
+> **KOREKSI 15 Agustus 2026 — versi sebelumnya SALAH, dan salahnya ke arah
+> yang berbahaya.** Ia menyatakan repo ini "tidak punya role `awcms_worker`",
+> bahwa `WORKER_DATABASE_URL` jatuh kembali ke `DATABASE_URL` sehingga
+> "pemisahan privilege BELUM ada di sini", dan melarang menulis
+> `GRANT ... TO awcms_worker` karena "akan gagal jalan". Keempatnya keliru:
+>
+> - `awcms_worker` DIBUAT di `sql/022_awcms_db_worker_setup_roles.sql`
+>   (Issue #163), bukan tidak ada.
+> - Migrasi repo ini memuat **78** pernyataan `GRANT ... TO awcms_worker`
+>   yang sudah lama berjalan — larangan itu akan menolak pekerjaan yang benar.
+> - Produksi terverifikasi memakai pemisahan itu: `WORKER_DATABASE_URL`
+>   menunjuk `awcms_worker`, `DATABASE_URL` menunjuk `awcms_app`.
+> - `sql/022` sudah memberi `awcms_workflow_instances` **`SELECT` saja** —
+>   yakni persis perbaikan finding #4 PR #778, sudah terpasang di sini.
+>
+> Arah kesalahannya yang membuatnya mahal: agen yang mempercayainya akan
+> MENOLAK menulis GRANT worker dan menjalankan job sebagai role pemilik,
+> sehingga menghapus pemisahan privilege yang sudah ada — regresi keamanan
+> yang lahir dari dokumentasi, bukan dari kode. Skill `awcms-deploy` sudah
+> dikoreksi untuk klaim yang sama; berkas ini terlewat.
+
+Grant worker untuk modul ini hidup di `sql/022` dan `sql/127`, dan
+**dijaga gerbang**: `WORKER_ROLE_GRANTS` di `scripts/security-readiness.ts`
+menyatakan set yang diharapkan (`awcms_workflow_tasks` `SELECT,UPDATE`;
+`awcms_workflow_instances` `SELECT`; `awcms_workflow_definitions` `SELECT`;
+`awcms_workflow_task_assignments` `INSERT,SELECT`). Menambah grant tanpa
+menambahkannya ke daftar itu akan memerahkan `security:readiness`.
 
 ## Administrative recovery (`application/workflow-recovery.ts`)
 
@@ -145,10 +167,17 @@ baru atau transisi status ter-guard.
 4. **Worker role escalation-job over-grant (Low)** — di mini, migrasi 060
    memberi `SELECT, UPDATE` di `awcms_workflow_instances` ke
    `awcms_worker`, padahal escalation job hanya pernah `SELECT` dari
-   tabel itu. Dipangkas jadi `SELECT`-only. **Temuan ini vacuous di repo
-   ini**: tidak ada role `awcms_worker` maupun migrasi 060 di sini — GRANT
-   yang over-scope itu tidak pernah ada untuk dipangkas. Relevan hanya
-   sebagai pelajaran saat pemisahan worker role akhirnya di-port.
+   tabel itu. Dipangkas jadi `SELECT`-only.
+
+   **KOREKSI 15 Agustus 2026:** versi sebelumnya menyebut temuan ini
+   "vacuous di repo ini" karena katanya role dan migrasinya tidak ada.
+   Justru sebaliknya — dan itu kabar baik: `sql/022:145` sudah memberi
+   `awcms_workflow_instances` **`SELECT` saja**, jadi bentuk yang benar
+   SUDAH terpasang, dan `WORKER_ROLE_GRANTS` di `security-readiness.ts`
+   MENJAGANYA tetap begitu. Pelajarannya karena itu berlaku penuh di sini,
+   bukan menunggu port: tiap grant worker baru wajib sebesar query yang
+   benar-benar dijalankan, dan gerbangnya akan menuntut daftar itu ikut
+   diperbarui.
 
 **Pelajaran generik dari keempatnya**: endpoint action baru pada resource
 yang punya konsep "pemilik/requester" WAJIB (a) lookup requester SEBELUM


### PR DESCRIPTION
Empat klaim keliru di satu skill, semuanya ke arah yang sama: **menyuruh pembacanya membatalkan pemisahan privilege yang sudah terpasang.**

| Skill menyatakan | Kenyataan terverifikasi |
| --- | --- |
| "Repo ini tidak punya role `awcms_worker`" | dibuat di `sql/022_awcms_db_worker_setup_roles.sql:79` |
| "`WORKER_DATABASE_URL` fallback ke `DATABASE_URL`, pemisahan BELUM ada" | produksi: worker=`awcms_worker`, app=`awcms_app` |
| "Jangan tulis `GRANT … TO awcms_worker` — akan gagal jalan" | **78** GRANT semacam itu sudah berjalan |
| "Temuan over-grant #778 vacuous di sini" | `sql/022:145` sudah `SELECT`-only; `WORKER_ROLE_GRANTS` menjaganya |

Dokumen basi biasanya membuat orang mengerjakan yang sudah tak perlu. Yang ini sebaliknya — ia menyuruh MENGHAPUS kontrol yang nyata, jadi ia regresi keamanan yang menunggu pembaca.

`skills:check` hijau sepanjang waktu itu dan memang seharusnya: ia memverifikasi bahwa path yang DIKUTIP ada, bukan bahwa kalimat di sekitarnya benar.

Ditemukan saat menyiapkan penjadwalan 31 job yang tak pernah berjalan — `workflow:escalations:dispatch` salah satunya, dan pertanyaan "ia jalan sebagai role apa" langsung menabrak klaim ini.

`DATABASE_URL="" bun run check` — **exit 0**, **4.382 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)