### PR TITLE
feat(i18n): the locale moves into the PATH — ADR-0098 implemented, and the public URL shape changes

### DIFF
--- a/.changeset/public-locale-path.md
+++ b/.changeset/public-locale-path.md
@@ -1,0 +1,81 @@
+---
+"awcms": minor
+---
+
+feat(i18n): the locale moves into the PATH — ADR-0098 implemented, and the public URL shape changes
+
+ADR-0095 gave every request a `locals.locale` and then localised **no** public
+surface, because `vcl_hash` hashes `(host, url)` and nothing else: one public URL
+whose body varied by cookie would serve the Indonesian page to an English reader,
+minutes later, from a cache neither could re-render. ADR-0098 decided the fix and
+this builds it.
+
+## What changed for a reader
+
+`/blog/{tenant}` and everything under it now answers **`307`** to `/en/…` or
+`/id/…`, chosen from ADR-0095's chain (cookie → tenant default → `Accept-Language`
+→ `en`). The prefixed URL is the canonical one; the bare path is a permanent
+alias that renders nothing.
+
+The redirect is `private, no-store` — it reads a cookie and must never be cached.
+Only its destination is cacheable, which is the property `Vary` cannot have.
+
+## The inversion that is the whole safety property
+
+On a prefixed URL the **PATH sets `locals.locale`, outranking the cookie.** If the
+cookie won there, two readers of `/en/blog/acme` would get different bodies under
+one cache key and whichever missed first would decide what the other saw — the
+exact misdelivery this ADR exists to make impossible. The URL is the key, so the
+URL chooses the body.
+
+`src/lib/i18n/public-locale-path.ts` is the decision made executable, and it is
+deliberately unable to read a header: a path goes in, a routing decision comes
+out.
+
+## The prefix is scoped to CACHEABLE HTML, and that is not a shortcut
+
+`CACHEABLE ⇒ prefixed`, and the converse is ADR-0098 decision 6's own reasoning:
+a `private, no-store` response never reaches a shared cache, so it can localise
+from a cookie with no possibility of misdelivery. `/admin` is the ADR's stated
+example; `/login`, `/register` and `/blog/{t}/search` are the same case for the
+same reason. Among cacheable surfaces only the HTML ones are prefixed —
+`robots.txt` sits at a protocol-fixed location a crawler will not follow a
+redirect to reach, and the feeds already carry `?locale=`, which is the same
+cache key in a different spelling.
+
+## Three things that would have been silent
+
+- **`matchPublicCacheSurface` needed a second matching attempt.** Without it
+  every `/en/…` and `/id/…` request would have missed the registry and been
+  stamped `private, no-store` — the ADR would have moved the locale into the key
+  while turning the entire public surface uncacheable, a regression that reads as
+  a caching bug rather than a routing one.
+- **The sitemap had to move with the canonical.** A `<loc>` naming the bare path
+  while the page's own `<link rel="canonical">` names the prefixed one is a
+  disagreement search engines resolve by trusting neither. `<loc>` now names the
+  tenant default's spelling, with `xhtml:link` alternates per locale.
+- **Every in-page link is built from the prefixed base path.** Building them bare
+  would drop each reader back onto the alias on their very next click.
+
+## Decision 2 is enforced twice, and both were proven by planting the defect
+
+`decideCacheability` REFUSES a response that varies on `Cookie` or
+`Accept-Language`. Refusing rather than stripping is the point: stripping would
+cache a body that its own author said varies, which is the misdelivery in its
+purest form. `edge-cache:surfaces:check` then fails the build on the same two
+names anywhere under `src/`, so the mistake is loud rather than merely safe.
+
+Mutation-proven, not assumed green: three spellings of a forbidden `Vary`
+(`{ Vary: "Cookie" }`, `headers.set("Vary", "Accept-Language")`, and
+`"Accept-Encoding, Cookie"` hidden in a list), a machine surface handed a
+prefixed alias, and a `localePrefixed` flag flipped out of agreement with the
+path patterns — each caught, each with the failure naming the consequence.
+
+## What is still open behind it
+
+Multi-language content fields for `blog_content`. The reader's interface language
+and the POST's own language are different axes, and `<html lang>` still comes
+from `post.locale`; the public chrome is not translated yet, so `/en/…` and
+`/id/…` differ today only in their `hreflang` and canonical. The mechanism is
+what had to land first — translating the chrome into a cache that could not tell
+the two apart was the failure ADR-0095 refused to ship.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:d4ae1e9af757a55872933fcf66162a832dd9edf58ee27950542399bc2ebeed06 -->
+<!-- i18n-source-hash: sha256:c17f38815554b6f323b9b98d6b886625ea44dce4281878302609d2e85dec518c -->
 
 # AWCMS — Project State & Continuation
 
@@ -688,18 +688,52 @@ Accept-Language` membatasi fan-out pada dua tetapi tak bisa melihat klik
   sesi lain dan setiap token reset yang beredar, dan keunikan diperiksa saat
   konfirmasi agar formulirnya bukan orakel keberadaan akun.
 
-  3. **Locale untuk permukaan PUBLIK — DIPUTUSKAN oleh ADR-0098; sebelumnya terblokir oleh pertanyaan kunci cache,
-     dan blokirnya nyata.** Varnish mem-key pada URL (ADR-0042). Satu URL publik
-     yang badannya berubah menurut cookie locale berarti pembaca Inggris
-     disajikan halaman Indonesia dari cache. ADR-0095 §"Keputusan 5" karena itu
-     TIDAK melokalkan satu pun surface publik dan mendaftarkannya sebagai
-     prasyarat: kunci cache harus membawa locale lebih dulu, dan itu ADR-nya
-     sendiri. Yang menunggu di belakangnya: `hreflang` yang benar
-     (`src/middleware.ts` masih meneruskan `locale: null` ke resolusi redirect
-     — dengan komentar yang menjelaskan bahwa ini kini PENOLAKAN yang disengaja,
-     bukan ketiadaan seam), dan field konten multi-bahasa untuk `blog_content`.
-     **Langkah 4 DITUTUP — `awcms_principal_preferences.time_zone`, sql/130.
+  3. **Langkah 3 DITUTUP — locale ada di PATH, ADR-0098 kini `Accepted`.
      15 Agustus 2026.**
+
+  `src/lib/i18n/public-locale-path.ts` adalah keputusan itu dijadikan eksekutabel:
+  sebuah path masuk, sebuah keputusan routing keluar, dan ia tidak bisa membaca
+  header apa pun. `/blog/…` menjawab `307 private, no-store` ke `/en/…` atau
+  `/id/…`; URL ber-prefiks di-rewrite kembali ke rute yang sudah ada, jadi tidak
+  ada pohon halaman `[locale]` yang diduplikasi. Pada URL ber-prefiks, PATH-lah
+  yang menetapkan `locals.locale` dan ia MENGALAHKAN cookie — inversi itulah
+  seluruh properti keamanannya, karena URL adalah kunci cache dan kuncilah yang
+  harus menentukan badannya.
+
+  Tiga hal layak dibawa ke depan. **Prefiks hanya untuk HTML yang CACHEABLE**,
+  bukan untuk setiap URL publik: `/admin`, `/login`, dan `/blog/{t}/search`
+  bersifat `private, no-store` dan melokalkan dari cookie persis seperti yang
+  diizinkan ADR-0098 keputusan 6 untuk `/admin`, jadi memberi mereka prefiks
+  hanya menambah satu redirect tanpa membeli apa pun; `robots.txt` terpaku pada
+  lokasi protokolnya dan feed sudah membawa `?locale=`, yang merupakan kunci yang
+  sama dengan ejaan berbeda. **`matchPublicCacheSurface` butuh percobaan
+  pencocokan KEDUA** atau setiap URL ber-prefiks akan meleset dari registry dan
+  distempel tidak-cacheable — ADR-nya akan memindahkan locale ke dalam kunci
+  sambil mematikan cacheability seluruh permukaan publik, regresi yang terbaca
+  sebagai bug caching alih-alih bug routing. Dan **sitemap harus ikut pindah
+  bersama canonical**: `<loc>` yang menyebut path telanjang sementara
+  `<link rel="canonical">` halamannya menyebut yang ber-prefiks adalah
+  ketidaksepakatan yang diselesaikan mesin pencari dengan tidak mempercayai
+  keduanya.
+
+  Keputusan 2 ditegakkan dua kali, bukan didokumentasikan sekali.
+  `decideCacheability` MENOLAK respons yang `Vary` pada `Cookie` atau
+  `Accept-Language` (menolak, bukan membuang — membuangnya berarti meng-cache
+  badan yang penulisnya sendiri bilang bervariasi), dan
+  `edge-cache:surfaces:check` menggagalkan build atas dua nama yang sama di mana
+  pun di bawah `src/`. Keduanya dibuktikan dengan MENANAM cacatnya: tiga ejaan
+  `Vary` terlarang, satu machine surface yang diberi alias ber-prefiks, dan satu
+  flag `localePrefixed` yang dibalik sehingga tidak lagi sepakat dengan pola
+  path-nya.
+
+  Yang masih terbuka di belakangnya: field konten multi-bahasa untuk
+  `blog_content` (bahasa antarmuka pembaca dan bahasa POST-nya adalah dua sumbu
+  berbeda — `<html lang>` masih berasal dari `post.locale`), dan chrome publiknya
+  sendiri belum diterjemahkan, jadi `/en/…` dan `/id/…` hari ini hanya berbeda
+  pada `hreflang` dan canonical-nya.
+
+  **Langkah 4 DITUTUP — `awcms_principal_preferences.time_zone`, sql/130.
+  15 Agustus 2026.**
 
   `/admin/account` merender setiap stempel waktu dalam zona pilihan pembacanya,
   dan fallback-nya tetap UTC alih-alih zona host — alasan aslinya ("menebak zona

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -683,17 +683,45 @@ Accept-Language` bounds the fan-out at two but cannot see an explicit click,
   outstanding reset token, and uniqueness is checked at confirmation so the form
   is not an account-existence oracle.
 
-  3. **Locale for the PUBLIC surface — DECIDED by ADR-0098; was blocked by the cache-key question,
-     and the block is real.** Varnish keys on the URL (ADR-0042). One public URL
-     whose body changes according to a locale cookie means an English reader is
-     served the Indonesian page from the cache. ADR-0095 §"Decision 5" therefore
-     localises NO public surface at all and registers this as a
-     prerequisite: the cache key must carry the locale first, and that is an ADR of its
-     own. What waits behind it: correct `hreflang`
-     (`src/middleware.ts` still passes `locale: null` into redirect resolution
-     — with a comment explaining that this is now a deliberate REFUSAL,
-     not a missing seam), and multi-language content fields for `blog_content`. 4. **Step 4 is CLOSED — `awcms_principal_preferences.time_zone`, sql/130.
+  3. **Step 3 is CLOSED — the locale is in the PATH, ADR-0098 is `Accepted`.
      15 August 2026.**
+
+  `src/lib/i18n/public-locale-path.ts` is the decision made executable: a path
+  goes in, a routing decision comes out, and it cannot read a header. `/blog/…`
+  answers `307 private, no-store` to `/en/…` or `/id/…`; the prefixed URL is
+  rewritten back onto the existing route, so there is no duplicated `[locale]`
+  page tree. On a prefixed URL the PATH sets `locals.locale` and outranks the
+  cookie — that inversion is the whole safety property, because the URL is the
+  cache key and the key must decide the body.
+
+  Three things are worth carrying forward. **The prefix is scoped to CACHEABLE
+  HTML**, not to every public URL: `/admin`, `/login` and `/blog/{t}/search` are
+  `private, no-store` and localise from the cookie exactly as ADR-0098 decision 6
+  says `/admin` may, so prefixing them would cost a redirect and buy nothing;
+  `robots.txt` is protocol-fixed and the feeds already carry `?locale=`, which is
+  the same key in a different spelling. **`matchPublicCacheSurface` needed a
+  second matching attempt** or every prefixed URL would have missed the registry
+  and been stamped uncacheable — the ADR would have moved the locale into the key
+  while turning the public surface uncacheable, a regression that reads as a
+  caching bug rather than a routing one. And **the sitemap had to move with the
+  canonical**: a `<loc>` naming the bare path while the page's own
+  `<link rel="canonical">` names the prefixed one is a disagreement search engines
+  resolve by trusting neither.
+
+  Decision 2 is enforced twice rather than documented once. `decideCacheability`
+  REFUSES a response that varies on `Cookie` or `Accept-Language` (refusing, not
+  stripping — stripping would cache a body its own author said varies), and
+  `edge-cache:surfaces:check` fails the build on the same two names anywhere
+  under `src/`. Both were proven by planting the defect: three spellings of a
+  forbidden `Vary`, a machine surface given a prefixed alias, and a `localePrefixed`
+  flag flipped out of agreement with the path patterns.
+
+  Still open behind it: multi-language content fields for `blog_content` (the
+  reader's interface language and the POST's own language are different axes —
+  `<html lang>` still comes from `post.locale`), and the public chrome itself is
+  not yet translated, so `/en/…` and `/id/…` differ today only in their
+  `hreflang` and canonical. 4. **Step 4 is CLOSED — `awcms_principal_preferences.time_zone`, sql/130.
+  15 August 2026.**
 
   `/admin/account` renders every timestamp in the reader's chosen zone, and the
   fallback stays UTC rather than the host's — the original reasoning ("guessing

--- a/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.id.md
+++ b/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.id.md
@@ -1,10 +1,10 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](0098-the-cache-key-carries-the-locale-in-the-path.md)
 
-<!-- i18n-source-hash: sha256:40f9a6024e84309db3f182cc0ac0a46d18fd56a8c0a93dd22c936cbc5599d5ef -->
+<!-- i18n-source-hash: sha256:3249dfe9efc7930a0aab5e42a825609ce8957c003c439d66d6712474cd92243c -->
 
 # ADR-0098 — Kunci cache membawa locale, dan ia membawanya di PATH
 
-- **Status:** Accepted (belum diimplementasikan)
+- **Status:** Accepted
 - **Tanggal:** 2026-08-15
 - **Pengambil keputusan:** @ahliweb
 - **Terkait:** [ADR-0042](0042-varnish-edge-cache-auto-activation.id.md) (URL adalah kunci cache), [ADR-0095](0095-the-interface-speaks-the-readers-language.id.md) §"Keputusan 5" (mencatat ini sebagai prasyarat), `infra/varnish/default.vcl`, `src/middleware.ts`

--- a/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.md
+++ b/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.md
@@ -2,7 +2,7 @@
 
 # ADR-0098 — The cache key carries the locale, and it carries it in the PATH
 
-- **Status:** Accepted (not yet implemented)
+- **Status:** Accepted
 - **Date:** 2026-08-15
 - **Decision maker:** @ahliweb
 - **Related:** [ADR-0042](0042-varnish-edge-cache-auto-activation.md) (the URL is the cache key), [ADR-0095](0095-the-interface-speaks-the-readers-language.md) §"Decision 5" (registered this as a prerequisite), `infra/varnish/default.vcl`, `src/middleware.ts`

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 148   |
 | Tables with `FORCE` RLS             | 130   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 395   |
+| Test files                          | 396   |
 | Route files                         | 361   |
 | ADR                                 | 200   |
 
@@ -335,7 +335,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 339        |
+| `(root)`      | 340        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |

--- a/scripts/edge-cache-surfaces-check.ts
+++ b/scripts/edge-cache-surfaces-check.ts
@@ -20,6 +20,7 @@ import {
   PUBLIC_CACHE_SURFACES,
   matchPublicCacheSurface
 } from "../src/lib/edge-cache/surface-registry";
+import { requiresPublicLocalePrefix } from "../src/lib/i18n/public-locale-path";
 import { listModules } from "../src/modules";
 
 /** Roots searched for `enqueueModuleContentPurge` call sites. */
@@ -152,8 +153,183 @@ export const MUST_NEVER_MATCH = [
   "/theming/preview/abc123",
   "/theming/preview-tokens/abc123.css",
   "/search",
-  "/blog/acme/search"
+  "/blog/acme/search",
+  // ADR-0098 gave `matchPublicCacheSurface` a SECOND matching attempt against
+  // the locale-stripped path, and a second attempt is a second chance to match
+  // something it must not. These probe that the retry inherits every guard the
+  // direct match has — traversal, the `/admin` and `/api` reserved segments,
+  // and the `localePrefixed` restriction that keeps machine surfaces from
+  // acquiring a prefixed alias nothing serves.
+  "/en/admin/users",
+  "/id/api/v1/health",
+  "/en/blog/../admin",
+  "/id/blog/%2e%2e/admin",
+  "/en/robots.txt",
+  "/id/sitemap.xml",
+  "/en/feed.xml",
+  "/id/theming/acme/tokens.css",
+  "/en/blog/acme/feed.xml",
+  "/id/blog/acme/search",
+  // Not a locale — `/es` has no catalogue, so it is a tenant code at most and
+  // must not be stripped into a prefixed match for a locale this build has
+  // never heard of.
+  "/es/blog/acme",
+  // Two prefixes is a second canonical name for one resource, which decision 4
+  // forbids outright.
+  "/en/id/blog/acme"
 ] as const;
+
+/**
+ * One representative path per declared surface, used to prove that the registry
+ * and `src/lib/i18n/public-locale-path.ts` still agree about which URLs carry a
+ * locale (ADR-0098).
+ *
+ * Two files decide this and they decide it with different machinery — a
+ * per-entry boolean here, path patterns there — because coupling them into one
+ * shared constant would make the edge cache import the i18n layer for its own
+ * matching, and cycles between those two are how a cache ends up unable to
+ * decide whether a path is cacheable. Independent definitions plus a gate that
+ * fails when they diverge is the trade this repo already makes for its ledgers.
+ *
+ * Drift here is silent in the worst way: a cacheable HTML surface added without
+ * `localePrefixed: true` serves one language to every reader of both URLs, and
+ * a machine surface marked `true` acquires a `/en/…` alias nothing renders.
+ */
+export const LOCALE_PREFIX_PROBES = [
+  "/blog/acme",
+  "/blog/acme/my-post",
+  "/blog/acme/category/news",
+  "/blog/acme/tag/launch",
+  "/blog/acme/feed.xml",
+  "/blog/acme/sitemap-blog.xml",
+  "/robots.txt",
+  "/sitemap.xml",
+  "/sitemap-2.xml",
+  "/feed.xml",
+  "/atom.xml",
+  "/feed.json",
+  "/theming/acme/tokens.css"
+] as const;
+
+/**
+ * Every surface must be reachable by at least one probe, or the agreement check
+ * above is only as complete as somebody remembered to make it.
+ */
+export function findSurfacesWithoutLocaleProbes(
+  surfaces: readonly { key: string }[],
+  probes: readonly string[],
+  match: (pathname: string) => { key: string } | null
+): string[] {
+  const covered = new Set(
+    probes.map((probe) => match(probe)?.key).filter(Boolean) as string[]
+  );
+
+  return surfaces
+    .filter((surface) => !covered.has(surface.key))
+    .map(
+      (surface) =>
+        `Surface "${surface.key}" is matched by no entry in LOCALE_PREFIX_PROBES, so nothing checks whether its locale decision (ADR-0098) is still right.`
+    );
+}
+
+/** Fails when the registry's `localePrefixed` and the path patterns disagree. */
+export function findLocalePrefixDrift(
+  probes: readonly string[],
+  match: (pathname: string) => { key: string; localePrefixed: boolean } | null,
+  requiresPrefix: (pathname: string) => boolean
+): string[] {
+  const failures: string[] = [];
+
+  for (const probe of probes) {
+    const surface = match(probe);
+
+    if (!surface) {
+      failures.push(
+        `LOCALE_PREFIX_PROBES contains "${probe}", which matches no declared surface — the probe is stale and proves nothing.`
+      );
+      continue;
+    }
+
+    const declared = surface.localePrefixed;
+    const derived = requiresPrefix(probe);
+
+    if (declared !== derived) {
+      failures.push(
+        `Surface "${surface.key}" declares localePrefixed=${declared} but src/lib/i18n/public-locale-path.ts ${
+          derived ? "prefixes" : "does not prefix"
+        } "${probe}". One of them is wrong, and the failure would be a cache serving one language to every reader.`
+      );
+    }
+  }
+
+  return failures;
+}
+
+/** Roots scanned for a response that varies on a header ADR-0098 forbids. */
+const VARY_SCAN_ROOTS = ["src"];
+
+/**
+ * ADR-0098 decision 2, enforced at BUILD time.
+ *
+ * `decideCacheability` already refuses such a response at run time, which makes
+ * the mistake safe; this makes it visible. A refusal alone would show up as an
+ * unexplained collapse in hit rate on one surface — a symptom nobody
+ * attributes to a header somebody added three weeks earlier.
+ *
+ * The scan is deliberately blunt: it looks for the two forbidden names appearing
+ * as a `Vary` value anywhere under `src/`, rather than trying to prove which
+ * responses are cacheable. A false positive costs one comment explaining why a
+ * `private, no-store` surface needs it; the false NEGATIVE this avoids costs a
+ * cross-reader disclosure.
+ */
+export async function findForbiddenVaryEmitters(
+  roots: readonly string[] = VARY_SCAN_ROOTS
+): Promise<string[]> {
+  const failures: string[] = [];
+  const pattern =
+    /["'`]\s*[Vv]ary\s*["'`]\s*[,:]\s*["'`]([^"'`]*)["'`]|[Vv]ary\s*:\s*["'`]([^"'`]*)["'`]/g;
+
+  async function walk(dir: string): Promise<void> {
+    let entries;
+
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        await walk(full);
+        continue;
+      }
+
+      if (!/\.(ts|tsx|astro|mts)$/.test(entry.name)) {
+        continue;
+      }
+
+      const source = await readFile(full, "utf8");
+
+      for (const match of source.matchAll(pattern)) {
+        const value = (match[1] ?? match[2] ?? "").toLowerCase();
+
+        if (/\bcookie\b|\baccept-language\b/.test(value)) {
+          failures.push(
+            `${full} sets \`Vary: ${match[1] ?? match[2]}\`. ADR-0098 §2 forbids both on a cacheable public response: Cookie multiplies cache objects by distinct cookie strings and puts a credential-bearing header in the key, and Accept-Language cannot see an explicit language click. The locale belongs in the PATH.`
+          );
+        }
+      }
+    }
+  }
+
+  for (const root of roots) {
+    await walk(root);
+  }
+
+  return failures;
+}
 
 /** Mirrors `sanitizeKeySegment` — a surface key becomes a surrogate-key segment. */
 const SAFE_SURFACE_KEY = /^[A-Za-z0-9._-]{1,128}$/;
@@ -435,7 +611,18 @@ async function main(): Promise<void> {
     ...validateSurfaces(PUBLIC_CACHE_SURFACES, moduleKeys),
     ...findCacheableForbiddenPaths(MUST_NEVER_MATCH, matchPublicCacheSurface),
     ...findOwnersWithoutPurges(PUBLIC_CACHE_SURFACES, purgedKeys),
-    ...findSurfacesWithoutServingRoutes(PUBLIC_CACHE_SURFACES, routesByModule)
+    ...findSurfacesWithoutServingRoutes(PUBLIC_CACHE_SURFACES, routesByModule),
+    ...findSurfacesWithoutLocaleProbes(
+      PUBLIC_CACHE_SURFACES,
+      LOCALE_PREFIX_PROBES,
+      matchPublicCacheSurface
+    ),
+    ...findLocalePrefixDrift(
+      LOCALE_PREFIX_PROBES,
+      matchPublicCacheSurface,
+      requiresPublicLocalePrefix
+    ),
+    ...(await findForbiddenVaryEmitters())
   ];
 
   if (failures.length > 0) {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -14,9 +14,12 @@ declare global {
        * route that the middleware ran for — and non-optional here precisely so
        * a new route cannot forget to consider it.
        *
-       * Public surfaces do not read this yet: a public page whose body varies by
-       * locale needs the edge-cache key to carry the locale first, which
-       * ADR-0095 §"Keputusan 5" defers rather than assumes.
+       * On a locale-prefixed public URL (ADR-0098) this is read from the PATH
+       * and outranks the cookie, because the path is the cache key: two readers
+       * of one cached URL must get one body, and the URL is what decides which.
+       * On every other surface — `/admin`, `/login`, anything `private,
+       * no-store` — it still comes from the ADR-0095 chain, which is safe there
+       * for the same reason: nothing shared is holding the response.
        */
       locale: Locale;
       /** Populated by `src/middleware.ts` for every request — echoes `X-Correlation-ID` or a fresh UUID. */

--- a/src/lib/edge-cache/cacheability.ts
+++ b/src/lib/edge-cache/cacheability.ts
@@ -71,6 +71,7 @@ export type CacheSkipReason =
   | "response_sets_cookie"
   | "response_declares_private"
   | "response_varies_on_everything"
+  | "response_varies_on_forbidden_header"
   | "tenant_unresolved"
   | "query_not_allowed";
 
@@ -102,6 +103,29 @@ export type CacheabilityInput = {
    */
   effectiveTtlSeconds: number;
 };
+
+/**
+ * Headers a cacheable public response may never `Vary` on (ADR-0098 §2).
+ *
+ * `Cookie` multiplies objects by distinct cookie STRINGS — session ids,
+ * analytics ids, CSRF tokens — so nearly every reader gets a private copy of a
+ * public page, and it puts a credential-bearing header into the cache key.
+ * `Accept-Language` bounds the fan-out but cannot see an explicit click, which
+ * is what would make the language switcher decorative on the public surface.
+ */
+const FORBIDDEN_VARY_HEADERS = new Set(["cookie", "accept-language"]);
+
+/** True when a `Vary` value names any header ADR-0098 forbids. */
+export function variesOnForbiddenHeader(vary: string | null): boolean {
+  if (!vary) {
+    return false;
+  }
+
+  return vary
+    .split(",")
+    .map((name) => name.trim().toLowerCase())
+    .some((name) => FORBIDDEN_VARY_HEADERS.has(name));
+}
 
 /** True when any request cookie is identity-bearing. */
 export function hasIdentityCookie(cookieHeader: string | null): boolean {
@@ -164,6 +188,26 @@ export function decideCacheability(input: CacheabilityInput): CacheDecision {
 
   if (input.responseHeaders.get("vary")?.trim() === "*") {
     return { cacheable: false, reason: "response_varies_on_everything" };
+  }
+
+  /**
+   * ADR-0098 decision 2, enforced at run time.
+   *
+   * `Vary: Cookie` and `Vary: Accept-Language` are the two mechanisms the ADR
+   * examined and rejected, and rejecting a design is worth nothing if the
+   * rejected design still works when somebody reaches for it. Both are refused
+   * here rather than merely absent, so the failure is "this response was not
+   * cached" instead of "this response was cached under a key that disagrees
+   * with its body".
+   *
+   * Refusing is deliberately not the same as stripping. Stripping the header
+   * would cache a body that its own author said varies — the misdelivery in its
+   * purest form. The author is taken at their word and the object is left
+   * uncached; `edge-cache:surfaces:check` then fails the build so the word gets
+   * corrected rather than silently costing hit rate.
+   */
+  if (variesOnForbiddenHeader(input.responseHeaders.get("vary"))) {
+    return { cacheable: false, reason: "response_varies_on_forbidden_header" };
   }
 
   // An object with no tenant key cannot be reached by any purge, so it would go

--- a/src/lib/edge-cache/surface-registry.ts
+++ b/src/lib/edge-cache/surface-registry.ts
@@ -91,6 +91,8 @@
  * on the ADR-0009 path-scoped surface keep the caching they already had.
  */
 
+import { splitPublicLocalePath } from "../i18n/public-locale-path";
+
 /** A declared cacheable public surface. */
 export type PublicCacheSurface = {
   /** Stable identifier; also the `s:` component of the surrogate key. */
@@ -121,6 +123,22 @@ export type PublicCacheSurface = {
    * into a small finite one.
    */
   allowedQueryParams: readonly string[];
+  /**
+   * Whether this surface's canonical URL carries a locale segment (ADR-0098).
+   *
+   * True for the surfaces that render interface chrome a human reads: their
+   * bodies differ by the reader's language, and since the edge keys on the URL
+   * alone, that difference MUST be in the URL or the cache misdelivers. False
+   * for the machine surfaces — a sitemap, a robots policy and a stylesheet
+   * contain no interface language, and `/feed.xml` already carries its locale
+   * as an allow-listed query parameter, which is the same key in a different
+   * spelling.
+   *
+   * `src/lib/i18n/public-locale-path.ts` owns the path patterns, and
+   * `edge-cache:surfaces:check` fails when the two disagree — so a new cacheable
+   * HTML surface cannot be added without deciding this.
+   */
+  localePrefixed: boolean;
   /** Why this surface is safe to cache — kept next to the declaration on purpose. */
   rationale: string;
 };
@@ -138,6 +156,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 120,
     requiresTenant: true,
     allowedQueryParams: ["page"],
+    localePrefixed: true,
     rationale:
       "Published-post listing for one tenant (ADR-0009 path-scoped). Shorter TTL than discovery because an editor expects a new post to appear promptly even if a purge is missed."
   },
@@ -148,6 +167,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 300,
     requiresTenant: true,
     allowedQueryParams: [],
+    localePrefixed: true,
     rationale:
       "A single published post. Purged by resource key on update/unpublish, so the TTL is only the fallback."
   },
@@ -158,6 +178,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 120,
     requiresTenant: true,
     allowedQueryParams: ["page"],
+    localePrefixed: true,
     rationale:
       "Published-post listing filtered by a taxonomy term; same reasoning as the index."
   },
@@ -168,6 +189,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 300,
     requiresTenant: true,
     allowedQueryParams: [],
+    localePrefixed: false,
     rationale:
       "Per-tenant blog feed and sitemap; content-derived, anonymous, identical for every reader."
   },
@@ -178,6 +200,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 600,
     requiresTenant: true,
     allowedQueryParams: [],
+    localePrefixed: false,
     rationale:
       "The tenant's crawl policy at its verified primary domain root. Derived from config rather than content — it changes only when an operator edits SEO settings, which enqueues the module purge — so it carries the longest TTL here alongside theming tokens."
   },
@@ -188,6 +211,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 300,
     requiresTenant: true,
     allowedQueryParams: [],
+    localePrefixed: false,
     rationale:
       "The sitemap index and its bounded child pages. Identical for every anonymous reader and rebuilt from a content roll-up on each request today, which is the single most repeated piece of database work on the public surface."
   },
@@ -198,6 +222,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 300,
     requiresTenant: true,
     allowedQueryParams: ["locale"],
+    localePrefixed: false,
     rationale:
       "RSS, Atom and JSON syndication of the latest published items. `locale` is the only permitted parameter and it is already validated to a short BCP-47-ish shape by `parseDiscoveryLocaleParam`, so the key space stays small and finite."
   },
@@ -208,6 +233,7 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
     ttlSeconds: 600,
     requiresTenant: true,
     allowedQueryParams: [],
+    localePrefixed: false,
     rationale:
       "Published design tokens for a tenant. Changes only on theme publish, which enqueues a module purge — the longest TTL here because it is the most stable and the most frequently re-fetched."
   }
@@ -234,9 +260,42 @@ export function matchPublicCacheSurface(
     (left, right) => right.pattern.source.length - left.pattern.source.length
   );
 
-  return (
-    specificFirst.find((surface) => surface.pattern.test(pathname)) ?? null
-  );
+  const direct =
+    specificFirst.find((surface) => surface.pattern.test(pathname)) ?? null;
+
+  if (direct) {
+    return direct;
+  }
+
+  /**
+   * ADR-0098: the canonical URL of an HTML surface carries a locale segment, so
+   * `/id/blog/acme` must resolve to `blog-index`. Patterns stay written against
+   * the BARE path — the prefix is a property of the URL, not of the surface —
+   * and are retried once against the stripped path.
+   *
+   * This retry is what makes the prefixed URL cacheable at all. Without it every
+   * `/en/…` and `/id/…` request would miss the registry, be stamped
+   * `private, no-store`, and the ADR would have moved the locale into the key
+   * while turning the entire public surface uncacheable — a regression that
+   * reads as a caching bug rather than a routing one.
+   *
+   * The `localePrefixed` guard is why `/en/robots.txt` and `/id/sitemap.xml` do
+   * NOT resolve here: those surfaces have no prefixed spelling and nothing
+   * serves one, so declaring a cacheable alias for them would let the edge store
+   * a 404 under a name the origin never blesses. Every guard above still applies
+   * — traversal and reserved segments are checked against the FULL path, before
+   * either attempt.
+   */
+  const { locale, pathname: bare } = splitPublicLocalePath(pathname);
+
+  if (!locale) {
+    return null;
+  }
+
+  const prefixed =
+    specificFirst.find((surface) => surface.pattern.test(bare)) ?? null;
+
+  return prefixed?.localePrefixed ? prefixed : null;
 }
 
 /**

--- a/src/lib/i18n/public-locale-path.ts
+++ b/src/lib/i18n/public-locale-path.ts
@@ -1,0 +1,307 @@
+/**
+ * ADR-0098 made executable: the cache key carries the locale, and it carries it
+ * in the PATH.
+ *
+ * This file is the whole mechanism. There is no `Vary` header anywhere in it,
+ * no cookie read, and nothing that inspects a request — a path goes in and a
+ * decision comes out. That is deliberate: ADR-0098's security argument is that
+ * NO request header enters the cache key, and the cheapest way to keep that
+ * true is for the function that decides the locale to be unable to see one.
+ *
+ * ## Which public paths carry a prefix, and why it is not "all of them"
+ *
+ * The rule is `CACHEABLE ⇒ prefixed`, and its converse is the reason ADR-0098
+ * decision 6 leaves `/admin` alone: a response that is `private, no-store`
+ * never reaches a shared cache, so it can localise from a cookie with no
+ * possibility of misdelivery. `/admin` is the ADR's stated example; `/login`,
+ * `/register`, `/reset-password` and `/blog/{tenant}/search` are the same case
+ * for the same reason, and prefixing them would cost a redirect and buy
+ * nothing.
+ *
+ * Among the CACHEABLE surfaces (`src/lib/edge-cache/surface-registry.ts`) only
+ * the ones that render chrome a human reads are prefixed. The others are
+ * machine surfaces whose bodies do not contain interface language at all:
+ *
+ * - `/robots.txt` is at a protocol-fixed location. A crawler will not follow a
+ *   redirect to find it, so prefixing it would break the surface outright.
+ * - `/sitemap*.xml` and `/blog/{tenant}/sitemap-blog.xml` are URL inventories.
+ *   They must LIST the prefixed URLs (they are the canonical ones), but the
+ *   inventory itself is one document per tenant, not one per language.
+ * - `/feed.xml`, `/atom.xml`, `/feed.json` already carry their locale as a
+ *   query parameter, which the surface registry allow-lists (`allowedQueryParams:
+ *   ["locale"]`). A query parameter IS part of the URL and therefore part of
+ *   the cache key, so those surfaces already satisfy ADR-0098 — by the same
+ *   principle, through a different spelling. Moving them to a path prefix would
+ *   break every existing subscription to buy nothing.
+ * - `/theming/{tenant}/tokens.css` is CSS.
+ *
+ * The list below is therefore NOT free-form: `edge-cache:surfaces:check` probes
+ * every declared surface through both files and fails when they disagree, and
+ * `tests/public-locale-path.test.ts` pins the consequence at run time. Adding a
+ * cacheable HTML surface without deciding its locale fails the gate, which is
+ * the point — the failure mode this ADR exists to prevent is silent, and a
+ * silent failure needs a loud gate.
+ */
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "./locales";
+
+/**
+ * The path patterns that must carry a locale prefix, matched against the
+ * UNPREFIXED pathname.
+ *
+ * Anchored, and `[^/]+` rather than `.*`, for the reason the surface registry
+ * gives: a path must not be able to smuggle itself into a more permissive
+ * pattern. These mirror `blog-index`, `blog-post` and `blog-taxonomy`.
+ *
+ * `blog-post` deliberately does NOT match `/blog/{tenant}/search`, `feed.xml`
+ * or `sitemap-blog.xml`; those are excluded explicitly below rather than left
+ * to pattern precedence, because relying on ordering here would mean a future
+ * two-segment surface silently changing which paths get prefixed.
+ */
+const LOCALE_PREFIXED_PATH_PATTERNS: readonly RegExp[] = [
+  /^\/blog\/[^/]+\/?$/,
+  /^\/blog\/[^/]+\/(category|tag)\/[^/]+$/,
+  /^\/blog\/[^/]+\/[^/]+$/
+];
+
+/**
+ * Paths that match a pattern above but are NOT interface documents. Checked
+ * first, so the broad `blog-post` shape cannot capture them.
+ */
+const NEVER_PREFIXED_PATHS: readonly RegExp[] = [
+  /^\/blog\/[^/]+\/(feed\.xml|sitemap-blog\.xml|search)$/
+];
+
+/** `/en`, `/id` — one segment per supported locale, derived from the one list. */
+const LOCALE_SEGMENT_PATTERN = new RegExp(
+  `^/(${SUPPORTED_LOCALES.join("|")})(?=/|$)`
+);
+
+export interface SplitLocalePath {
+  /** The locale the path names, or `null` when it names none. */
+  readonly locale: Locale | null;
+  /** The path with any locale segment removed. Always starts with `/`. */
+  readonly pathname: string;
+}
+
+/**
+ * Splits a leading locale segment off a pathname.
+ *
+ * `/id/blog/acme` → `{ locale: "id", pathname: "/blog/acme" }`
+ * `/blog/acme`    → `{ locale: null, pathname: "/blog/acme" }`
+ * `/id`           → `{ locale: "id", pathname: "/" }`
+ *
+ * Only a segment that is exactly a supported locale is stripped, so a tenant
+ * code of `indonesia` or a slug of `entrepreneurship` is untouched — the
+ * lookahead requires the segment to END at a `/` or at the end of the path.
+ */
+export function splitPublicLocalePath(pathname: string): SplitLocalePath {
+  const match = LOCALE_SEGMENT_PATTERN.exec(pathname);
+
+  if (!match) {
+    return { locale: null, pathname };
+  }
+
+  const rest = pathname.slice(match[0].length);
+
+  return {
+    locale: match[1] as Locale,
+    pathname: rest.length > 0 ? rest : "/"
+  };
+}
+
+/** `splitPublicLocalePath(...).pathname`, for callers that want only the path. */
+export function stripPublicLocalePrefix(pathname: string): string {
+  return splitPublicLocalePath(pathname).pathname;
+}
+
+/**
+ * Builds the prefixed form of a path. `/blog/acme` + `id` → `/id/blog/acme`.
+ *
+ * Idempotent by construction: the path is stripped before it is prefixed, so
+ * calling this on an already-prefixed path REPLACES the locale rather than
+ * nesting one inside another. A `/id/en/blog/...` URL would be a second
+ * canonical form for the same resource, which is precisely what ADR-0098
+ * decision 4 forbids.
+ */
+export function withPublicLocalePrefix(
+  pathname: string,
+  locale: Locale
+): string {
+  const bare = stripPublicLocalePrefix(pathname);
+
+  return bare === "/" ? `/${locale}` : `/${locale}${bare}`;
+}
+
+/**
+ * True when this UNPREFIXED path is one whose canonical URL carries a locale.
+ * Pass a prefixed path and you get the answer for the resource it names, since
+ * the prefix is stripped first.
+ */
+export function requiresPublicLocalePrefix(pathname: string): boolean {
+  const bare = stripPublicLocalePrefix(pathname);
+
+  if (NEVER_PREFIXED_PATHS.some((pattern) => pattern.test(bare))) {
+    return false;
+  }
+
+  return LOCALE_PREFIXED_PATH_PATTERNS.some((pattern) => pattern.test(bare));
+}
+
+export type PublicLocaleRoute =
+  | {
+      /** Path names a locale-prefixed resource and carries its prefix: serve it. */
+      readonly action: "serve";
+      /** Authoritative locale — it came from the cache key itself. */
+      readonly locale: Locale;
+      /** Path the request should be rewritten to, prefix removed. */
+      readonly servePathname: string;
+    }
+  | {
+      /** Path names a locale-prefixed resource WITHOUT a prefix: redirect. */
+      readonly action: "redirect";
+      /** Builds the target once the caller has resolved a locale. */
+      readonly target: (locale: Locale) => string;
+    }
+  | {
+      /** Nothing to do — not a locale-prefixed surface. */
+      readonly action: "ignore";
+    };
+
+/**
+ * The routing decision for one public pathname.
+ *
+ * Deliberately total and deliberately pure: every path gets an answer, and the
+ * answer never depends on a header, a cookie, a session or a clock. The caller
+ * (`src/middleware.ts`) supplies the locale only for the `redirect` case, which
+ * is the only case ADR-0098 allows a cookie to influence — and that response is
+ * `private, no-store`, so the cookie never reaches the cache.
+ *
+ * `/id/blog/acme/search` resolves to `ignore`, not `serve`: search is not a
+ * prefixed surface, so a prefixed spelling of it is simply not a URL this site
+ * has. It falls through to normal routing and 404s, rather than being quietly
+ * accepted as a second name for `/blog/acme/search`.
+ */
+export function resolvePublicLocaleRoute(pathname: string): PublicLocaleRoute {
+  const { locale, pathname: bare } = splitPublicLocalePath(pathname);
+
+  if (!requiresPublicLocalePrefix(bare)) {
+    return { action: "ignore" };
+  }
+
+  if (locale) {
+    return { action: "serve", locale, servePathname: bare };
+  }
+
+  return {
+    action: "redirect",
+    target: (chosen: Locale) => withPublicLocalePrefix(bare, chosen)
+  };
+}
+
+/**
+ * Carries a reader's locale through a `seo_distribution` redirect.
+ *
+ * Redirect RULES are authored against bare paths, because a slug change is not
+ * a language change and an editor should not have to write the same rule twice.
+ * That means matching happens on the stripped path — and it means the target
+ * comes back stripped too. Handing that target straight to a reader who arrived
+ * on `/id/…` would silently drop them into the default language, one hop after
+ * they chose otherwise.
+ *
+ * Only same-origin paths are touched. A rule pointing at another host is a
+ * deliberate exit from this site and its URL is not ours to rewrite; a target
+ * that is not itself a locale-prefixed surface (`/robots.txt`, an uploaded
+ * file) has no prefixed spelling to send anyone to.
+ */
+export function carryLocaleThroughRedirect(
+  location: string,
+  locale: Locale | null
+): string {
+  if (!locale || !location.startsWith("/") || location.startsWith("//")) {
+    return location;
+  }
+
+  const [pathname, ...rest] = location.split(/(?=[?#])/);
+
+  if (!pathname || !requiresPublicLocalePrefix(pathname)) {
+    return location;
+  }
+
+  return withPublicLocalePrefix(pathname, locale) + rest.join("");
+}
+
+/**
+ * The `hreflang` set for one resource — ADR-0098 decision 5.
+ *
+ * `x-default` points at the TENANT DEFAULT's prefixed URL, never at the bare
+ * alias. A crawler following `x-default` must land on the cacheable canonical
+ * document; landing it on the redirect would make the crawler's own
+ * `Accept-Language` decide which document it indexes as the default, which is
+ * option B's failure re-introduced through the back door.
+ */
+export function buildHreflangAlternates(
+  pathname: string,
+  tenantDefaultLocale: Locale = DEFAULT_LOCALE
+): readonly { readonly hreflang: string; readonly pathname: string }[] {
+  const bare = stripPublicLocalePrefix(pathname);
+
+  if (!requiresPublicLocalePrefix(bare)) {
+    return [];
+  }
+
+  return [
+    ...SUPPORTED_LOCALES.map((locale) => ({
+      hreflang: locale,
+      pathname: withPublicLocalePrefix(bare, locale)
+    })),
+    {
+      hreflang: "x-default",
+      pathname: withPublicLocalePrefix(bare, tenantDefaultLocale)
+    }
+  ];
+}
+
+export interface LocalisedPublicUrls {
+  /** Absolute canonical URL for THIS locale's spelling of the resource. */
+  readonly canonicalUrl: string;
+  /** Absolute `hreflang` set, ready for the page shell. */
+  readonly hreflangAlternates: readonly {
+    readonly hreflang: string;
+    readonly href: string;
+  }[];
+  /** Prefixed listing root, for building in-page links that keep the locale. */
+  readonly basePath: string;
+}
+
+/**
+ * Everything a public HTML route needs to name itself and its siblings.
+ *
+ * `barePathname` is what the route sees after the middleware rewrite
+ * (`Astro.url.pathname`), and it is deliberately the input rather than the
+ * prefixed URL: a route should not have to know whether it was reached through
+ * a prefix, only which locale it is rendering.
+ *
+ * The canonical URL is the PREFIXED one. That is the half of decision 4 that is
+ * easy to get wrong — leaving canonical pointing at the bare path would tell
+ * every crawler that the real document is the URL that answers `307`, and the
+ * two prefixed documents would be indexed as duplicates of a redirect.
+ */
+export function buildLocalisedPublicUrls(
+  origin: string,
+  barePathname: string,
+  locale: Locale,
+  tenantDefaultLocale: Locale = DEFAULT_LOCALE
+): LocalisedPublicUrls {
+  const bare = stripPublicLocalePrefix(barePathname);
+
+  return {
+    canonicalUrl: `${origin}${withPublicLocalePrefix(bare, locale)}`,
+    hreflangAlternates: buildHreflangAlternates(bare, tenantDefaultLocale).map(
+      (alternate) => ({
+        hreflang: alternate.hreflang,
+        href: `${origin}${alternate.pathname}`
+      })
+    ),
+    basePath: withPublicLocalePrefix(bare, locale)
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,11 +1,21 @@
+import type { APIContext } from "astro";
 import { defineMiddleware } from "astro:middleware";
 
 import { resolveSsrContext } from "./lib/auth/ssr-session";
+import { getDatabaseClient } from "./lib/database/client";
 import { annotateEdgeCache } from "./lib/edge-cache/runtime";
+import type { Locale } from "./lib/i18n/locales";
+import { coerceLocale } from "./lib/i18n/negotiate";
+import {
+  carryLocaleThroughRedirect,
+  resolvePublicLocaleRoute
+} from "./lib/i18n/public-locale-path";
 import {
   LOCALE_COOKIE_NAME,
   resolveRequestLocale
 } from "./lib/i18n/request-locale";
+import { log } from "./lib/logging/logger";
+import { resolvePublicTenantByCode } from "./lib/tenant/public-tenant-resolver";
 import { buildSecurityHeaders } from "./lib/security/security-headers";
 import { isTurnstileRequired } from "./lib/security/turnstile";
 import {
@@ -47,6 +57,116 @@ function applyResponseHeaders(
   }
 
   return response;
+}
+
+/**
+ * ADR-0098 decision 3 — the locale-selection redirect.
+ *
+ * `307`, not `301`/`308`: the choice is made from a cookie that a reader can
+ * change at any moment, so it must never be written into a browser's permanent
+ * redirect cache. A `301` here would pin the first-ever visitor's language onto
+ * that browser for the life of its cache, and the language switcher would look
+ * broken with nothing in any log to explain it.
+ *
+ * `private, no-store` is what keeps the cookie out of the shared cache. It is
+ * set here rather than left to `annotateEdgeCache`'s default because this
+ * response is the ONE place a cookie influences a public body, and a default is
+ * the wrong thing to rely on for that.
+ */
+function buildLocaleSelectionRedirect(target: URL): Response {
+  return new Response(null, {
+    status: 307,
+    headers: {
+      Location: target.pathname + target.search,
+      "Cache-Control": "private, no-store"
+    }
+  });
+}
+
+/**
+ * Rewrites a `seo_distribution` redirect's `Location` so a reader who arrived
+ * on `/id/…` stays on `/id/…`. Returns the response untouched when there is
+ * nothing to carry.
+ */
+function withLocaleCarriedThroughRedirect(
+  response: Response,
+  locale: Locale | null
+): Response {
+  const location = response.headers.get("Location");
+
+  if (!locale || !location) {
+    return response;
+  }
+
+  const carried = carryLocaleThroughRedirect(location, locale);
+
+  if (carried === location) {
+    return response;
+  }
+
+  const headers = new Headers(response.headers);
+  headers.set("Location", carried);
+
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers
+  });
+}
+
+/** `/blog/{tenantCode}/…` → `tenantCode`; `null` when the path names none. */
+function readTenantCodeFromPath(pathname: string): string | null {
+  return /^\/blog\/([^/]+)/.exec(pathname)?.[1] ?? null;
+}
+
+/**
+ * The locale for a bare public URL, following ADR-0095's chain as far as a
+ * request with no session can follow it: cookie → tenant default →
+ * `Accept-Language` → `en`. The stored principal preference is skipped because
+ * there is no principal — this is an anonymous public request, and the `/admin`
+ * branch below is where a session exists to read one from.
+ *
+ * The tenant default costs one query, and it is paid ONLY here — on a bare URL
+ * that is about to redirect, never on the prefixed URL that actually serves.
+ * That keeps the promise the provisional-locale block above makes (a served
+ * public request performs no extra query to know its language) while still
+ * honouring the tenant's own default, which is the step an Indonesian tenant's
+ * readers would notice missing.
+ *
+ * Fails OPEN, matching the redirect subsystem beside it: if the lookup throws,
+ * the reader is redirected using cookie and `Accept-Language` alone rather than
+ * being shown a 500 because a language preference could not be read.
+ */
+async function resolvePublicRedirectLocale(
+  context: APIContext
+): Promise<Locale> {
+  const cookieValue = context.cookies.get(LOCALE_COOKIE_NAME)?.value ?? null;
+  const acceptLanguage = context.request.headers.get("accept-language");
+  const tenantCode = readTenantCodeFromPath(context.url.pathname);
+
+  let tenantDefault: string | null = null;
+
+  if (tenantCode && !coerceLocale(cookieValue)) {
+    try {
+      const tenant = await resolvePublicTenantByCode(
+        getDatabaseClient(),
+        tenantCode
+      );
+
+      tenantDefault = tenant?.defaultLocale ?? null;
+    } catch (error) {
+      log("warning", "i18n.public_locale.tenant_default_unavailable", {
+        moduleKey: "i18n",
+        error: error instanceof Error ? error.message : String(error)
+      });
+    }
+  }
+
+  return resolveRequestLocale({
+    cookieValue,
+    tenantDefault,
+    acceptLanguage
+  });
 }
 
 /**
@@ -133,23 +253,68 @@ export const onRequest = defineMiddleware(async (context, next) => {
   // page), and the 404 capture runs AFTER the response is produced and never
   // throws. The `/admin` guard and the API body-ceiling above are untouched.
   //
-  // `locale` stays `null` here, and the reason has CHANGED: a locale seam now
-  // exists (ADR-0095 sets `locals.locale` above), so this is no longer "there is
-  // nothing to pass". It is a deliberate refusal to make a PUBLIC response vary
-  // by locale before the edge-cache key carries one. Varnish keys on the URL;
-  // handing a locale to redirect matching here would let the first reader's
-  // language decide which redirect every later reader gets. Passing the resolved
-  // locale is a one-line change that must wait for that key (ADR-0095
-  // §"Keputusan 5" lists it as the prerequisite).
+  // The locale is no longer withheld here. ADR-0098 put it in the PATH, which
+  // means it is part of the cache key, which is exactly the condition ADR-0095
+  // §"Keputusan 5" named as the prerequisite. Redirect RULES are still matched
+  // against the bare path (a slug change is not a language change), and the
+  // reader's locale is carried across the hop by rewriting `Location` — see
+  // `carryLocaleThroughRedirect`.
   if (!context.url.pathname.startsWith(PROTECTED_PREFIX)) {
+    const localeRoute = resolvePublicLocaleRoute(context.url.pathname);
+
+    /**
+     * ADR-0098 decision 3 — selection happens by REDIRECT, never by variation.
+     *
+     * This is the one response in the public branch that reads a cookie, and it
+     * is the one response that must never be cached: `buildLocaleSelectionRedirect`
+     * stamps it `private, no-store`, so the cookie decides where a reader goes
+     * without ever deciding what a shared cache holds. Only the prefixed
+     * destination is cacheable.
+     */
+    if (localeRoute.action === "redirect") {
+      const locale = await resolvePublicRedirectLocale(context);
+
+      return finalize(
+        buildLocaleSelectionRedirect(
+          new URL(localeRoute.target(locale) + context.url.search, context.url)
+        )
+      );
+    }
+
+    /**
+     * A prefixed URL: the PATH is authoritative, outranking the cookie that
+     * `resolveRequestLocale` consulted above.
+     *
+     * This inversion is the whole safety property. If the cookie won here, two
+     * readers of `/en/blog/acme` would get different bodies under one cache key
+     * and the first one to miss would decide what the second sees — the
+     * misdelivery ADR-0098 exists to make impossible. The URL is the key, so the
+     * URL chooses the body.
+     */
+    if (localeRoute.action === "serve") {
+      context.locals.locale = localeRoute.locale;
+    }
+
+    const barePathname =
+      localeRoute.action === "serve"
+        ? localeRoute.servePathname
+        : context.url.pathname;
+    const bareUrl = new URL(context.url);
+    bareUrl.pathname = barePathname;
+
     const redirectResult = await resolvePublicRedirectForRequest(
       context.request,
-      context.url,
-      null
+      bareUrl,
+      localeRoute.action === "serve" ? localeRoute.locale : null
     );
 
     if (redirectResult && "redirect" in redirectResult) {
-      return finalize(redirectResult.redirect);
+      return finalize(
+        withLocaleCarriedThroughRedirect(
+          redirectResult.redirect,
+          localeRoute.action === "serve" ? localeRoute.locale : null
+        )
+      );
     }
 
     const notFoundCapture =
@@ -157,7 +322,16 @@ export const onRequest = defineMiddleware(async (context, next) => {
         ? redirectResult.capture
         : null;
 
-    const response = await next();
+    // `next(path)` is a REWRITE, not a second request: the prefixed URL is what
+    // the reader sees and what the edge keys on, while the route file that
+    // serves it stays at `src/pages/blog/…` with no duplicated `[locale]` tree.
+    // Routes read the reader's language from `locals.locale`, set above, rather
+    // than from `Astro.url` — which a rewrite deliberately moves to the bare
+    // path (`Astro.originPathname` keeps the prefixed one).
+    const response =
+      localeRoute.action === "serve"
+        ? await next(barePathname + context.url.search)
+        : await next();
 
     if (notFoundCapture && response.status === 404) {
       await recordPublicNotFound(context.request, notFoundCapture);

--- a/src/modules/blog-content/domain/public-page-rendering.ts
+++ b/src/modules/blog-content/domain/public-page-rendering.ts
@@ -27,6 +27,21 @@ export type PublicPageShellOptions = {
   bodyHtml: string;
   locale: string;
   /**
+   * ADR-0098 decision 5 — the `hreflang` set for this resource, one entry per
+   * supported locale plus `x-default`.
+   *
+   * Expressible only now: before the locale lived in the path there was no
+   * second URL to point at, which is why ADR-0095 recorded `hreflang` as
+   * something waiting on this decision rather than something forgotten.
+   *
+   * `x-default` must name a PREFIXED URL, never the bare alias. The bare path
+   * answers `307` by choosing a locale from the request, so pointing
+   * `x-default` at it would hand the choice of which document is canonical to
+   * the crawler's own `Accept-Language` — reintroducing, at the crawler, exactly
+   * the header-driven variation this ADR removed at the cache.
+   */
+  hreflangAlternates?: readonly { hreflang: string; href: string }[];
+  /**
    * Issue #636 — an already-resolved, verified R2 media object public URL
    * (`seo-rendering.ts`'s `resolveOgImageUrl`), or `null` to omit
    * `og:image`/`twitter:image` entirely. Never a raw/unvalidated URL.
@@ -178,6 +193,13 @@ export function renderPublicPageShell(options: PublicPageShellOptions): string {
     ? `<link rel="canonical" href="${escapeHtml(options.canonicalUrl)}" />`
     : "";
 
+  const hreflangTags = (options.hreflangAlternates ?? [])
+    .map(
+      (alternate) =>
+        `<link rel="alternate" hreflang="${escapeHtml(alternate.hreflang)}" href="${escapeHtml(alternate.href)}" />`
+    )
+    .join("\n");
+
   const robotsTag = options.robotsContent
     ? `<meta name="robots" content="${escapeHtml(options.robotsContent)}" />`
     : "";
@@ -204,6 +226,7 @@ export function renderPublicPageShell(options: PublicPageShellOptions): string {
 <meta name="description" content="${escapeHtml(options.description)}" />
 <link rel="stylesheet" href="${PUBLIC_CONTENT_STYLESHEET_HREF}" />
 ${canonicalTag}
+${hreflangTags}
 ${robotsTag}
 ${ogTags}
 ${jsonLdTag}

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -5,6 +5,9 @@ import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../lib/http/site-origin";
+import { DEFAULT_LOCALE } from "../../../lib/i18n/locales";
+import { coerceLocale } from "../../../lib/i18n/negotiate";
+import { buildLocalisedPublicUrls } from "../../../lib/i18n/public-locale-path";
 import {
   notFoundHtmlResponse,
   serverErrorHtmlResponse
@@ -37,7 +40,7 @@ const NEWS_SHARE_CLIENT_SCRIPT_SRC = "/js/news-share.js";
  * 404s (same generic shape) when the tenant's `legacyTenantRouteEnabled`
  * setting is `false`.
  */
-export const GET: APIRoute = async ({ params, request, url }) => {
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
   const tenantCode = params.tenantCode;
   const slug = params.slug;
 
@@ -64,7 +67,23 @@ export const GET: APIRoute = async ({ params, request, url }) => {
         return notFoundHtmlResponse();
       }
 
-      const selfUrl = `${resolveRequestOrigin(url, request)}/blog/${tenantCode}/${post.slug}`;
+      // ADR-0098 — `selfUrl` is the PREFIXED spelling, because it becomes the
+      // canonical URL when the post declares no external one. Leaving it bare
+      // would point every crawler at the alias that answers `307`, and the two
+      // real documents would be indexed as duplicates of a redirect.
+      const urls = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}/${post.slug}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      );
+      const blogRootPath = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      ).basePath;
+      const selfUrl = urls.canonicalUrl;
       const seoTitle = resolveSeoTitle(post);
       const metaDescription = resolveMetaDescription(post);
       const canonicalUrl = resolveCanonicalUrl(post, selfUrl);
@@ -120,12 +139,13 @@ export const GET: APIRoute = async ({ params, request, url }) => {
   ${contentHtml}
 </article>
 ${shareButtonsHtml}
-<p><a href="/blog/${escapeHtml(tenantCode)}">Back to blog</a></p>`;
+<p><a href="${escapeHtml(blogRootPath)}">Back to blog</a></p>`;
 
       const html = renderPublicPageShell({
         title: seoTitle,
         description: metaDescription,
         canonicalUrl,
+        hreflangAlternates: urls.hreflangAlternates,
         bodyHtml,
         locale: post.locale,
         ogImageUrl: seoMetadata.ogImageUrl,

--- a/src/pages/blog/[tenantCode]/category/[slug].ts
+++ b/src/pages/blog/[tenantCode]/category/[slug].ts
@@ -5,6 +5,9 @@ import { withTenantOrThrow } from "../../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../../lib/http/site-origin";
+import { DEFAULT_LOCALE } from "../../../../lib/i18n/locales";
+import { coerceLocale } from "../../../../lib/i18n/negotiate";
+import { buildLocalisedPublicUrls } from "../../../../lib/i18n/public-locale-path";
 import {
   notFoundHtmlResponse,
   serverErrorHtmlResponse
@@ -18,12 +21,12 @@ import {
 import { isLegacyTenantRouteEnabled } from "../../../../modules/blog-content/application/public-route-settings";
 import {
   renderPaginationNavHtml,
-  renderPostSummaryListHtml,
+  renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../../../modules/blog-content/domain/public-page-rendering";
 
 /** `GET /blog/{tenantCode}/category/{slug}` (Issue #540) — same listing predicate as the index, scoped to posts assigned this category. 404 for an unknown or soft-deleted category, or (Issue #564) when `legacyTenantRouteEnabled` is `false`. */
-export const GET: APIRoute = async ({ params, request, url }) => {
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
   const tenantCode = params.tenantCode;
   const slug = params.slug;
 
@@ -66,15 +69,32 @@ export const GET: APIRoute = async ({ params, request, url }) => {
         }
       );
 
+      // ADR-0098 — canonical, hreflang and every in-page link are built from the
+      // PREFIXED path. `postsBasePath` is the listing root each post link hangs
+      // off, which is the tenant's blog root rather than this archive.
+      const urls = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}/category/${term.slug}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      );
+      const postsBasePath = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      ).basePath;
+
       const bodyHtml = `<h1>Category: ${escapeHtml(term.name)}</h1>
-<div class="posts">${renderPostSummaryListHtml(tenantCode, result.items, "No posts in this category yet.")}</div>
-${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}/category/${term.slug}`)}`;
+<div class="posts">${renderPostSummaryListHtmlAtBasePath(postsBasePath, result.items, "No posts in this category yet.")}</div>
+${renderPaginationNavHtml(page, result.hasNextPage, urls.basePath)}`;
 
       const html = renderPublicPageShell({
         title: `${term.name} — ${tenant.tenantName} Blog`,
         description:
           term.description ?? `Posts categorized under ${term.name}.`,
-        canonicalUrl: `${resolveRequestOrigin(url, request)}/blog/${tenantCode}/category/${term.slug}`,
+        canonicalUrl: urls.canonicalUrl,
+        hreflangAlternates: urls.hreflangAlternates,
         bodyHtml,
         locale: tenant.defaultLocale,
         variant: "list"

--- a/src/pages/blog/[tenantCode]/feed.xml.ts
+++ b/src/pages/blog/[tenantCode]/feed.xml.ts
@@ -5,6 +5,9 @@ import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../lib/http/site-origin";
+import { DEFAULT_LOCALE } from "../../../lib/i18n/locales";
+import { coerceLocale } from "../../../lib/i18n/negotiate";
+import { withPublicLocalePrefix } from "../../../lib/i18n/public-locale-path";
 import {
   notFoundXmlResponse,
   serverErrorXmlResponse
@@ -57,7 +60,12 @@ export const GET: APIRoute = async ({ params, request, url }) => {
       }
 
       const posts = await listPublicBlogPostsForFeed(tx, tenant.tenantId);
-      const channelLink = `${resolveRequestOrigin(url, request)}/blog/${tenantCode}`;
+      // ADR-0098 — feed item links point at the canonical (prefixed) document,
+      // for the same reason the sitemap does. The feed URL itself stays bare:
+      // it already carries its locale as an allow-listed `?locale=` parameter,
+      // and moving it would break every existing subscription.
+      const feedLocale = coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE;
+      const channelLink = `${resolveRequestOrigin(url, request)}${withPublicLocalePrefix(`/blog/${tenantCode}`, feedLocale)}`;
 
       // Issue #649 — see `/news/feed.xml.ts`'s identical comment: resolved
       // sequentially, one query at a time on the shared transaction.

--- a/src/pages/blog/[tenantCode]/index.ts
+++ b/src/pages/blog/[tenantCode]/index.ts
@@ -5,6 +5,9 @@ import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../lib/http/site-origin";
+import { DEFAULT_LOCALE } from "../../../lib/i18n/locales";
+import { coerceLocale } from "../../../lib/i18n/negotiate";
+import { buildLocalisedPublicUrls } from "../../../lib/i18n/public-locale-path";
 import {
   notFoundHtmlResponse,
   serverErrorHtmlResponse
@@ -18,7 +21,7 @@ import {
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import {
   renderPaginationNavHtml,
-  renderPostSummaryListHtml,
+  renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../../modules/blog-content/domain/public-page-rendering";
 
@@ -42,7 +45,7 @@ import {
  * routes — see `src/modules/blog-content/README.md` §Public route
  * settings.
  */
-export const GET: APIRoute = async ({ params, request, url }) => {
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
   const tenantCode = params.tenantCode;
 
   if (!tenantCode) {
@@ -70,16 +73,30 @@ export const GET: APIRoute = async ({ params, request, url }) => {
         pageSize: settings.postsPerPage
       });
 
+      // ADR-0098 — every in-page link is built from the PREFIXED base path, so
+      // a reader who arrived on `/id/…` stays there. Building them from
+      // `/blog/{code}` instead would drop each reader back onto the bare alias
+      // on their very next click, and the `307` would then re-derive a locale
+      // from their cookie — correct by luck, and wrong the moment the cookie
+      // disagrees with the URL they were reading.
+      const urls = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      );
+
       const bodyHtml = `<h1>${escapeHtml(tenant.tenantName)} Blog</h1>
-<div class="posts">${renderPostSummaryListHtml(tenantCode, result.items, "No posts yet.")}</div>
-${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}`)}`;
+<div class="posts">${renderPostSummaryListHtmlAtBasePath(urls.basePath, result.items, "No posts yet.")}</div>
+${renderPaginationNavHtml(page, result.hasNextPage, urls.basePath)}`;
 
       const html = renderPublicPageShell({
         title: settings.seoDefaultTitle ?? `${tenant.tenantName} Blog`,
         description:
           settings.seoDefaultDescription ??
           `Latest posts from ${tenant.tenantName}.`,
-        canonicalUrl: `${resolveRequestOrigin(url, request)}/blog/${tenantCode}`,
+        canonicalUrl: urls.canonicalUrl,
+        hreflangAlternates: urls.hreflangAlternates,
         bodyHtml,
         locale: tenant.defaultLocale,
         variant: "list"

--- a/src/pages/blog/[tenantCode]/search.ts
+++ b/src/pages/blog/[tenantCode]/search.ts
@@ -1,6 +1,7 @@
 import type { APIRoute } from "astro";
 
 import { getDatabaseClient } from "../../../lib/database/client";
+import { withPublicLocalePrefix } from "../../../lib/i18n/public-locale-path";
 import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
@@ -12,7 +13,7 @@ import { log } from "../../../lib/logging/logger";
 import { searchPublicBlogContent } from "../../../modules/blog-content/application/blog-search";
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import {
-  renderPostSummaryListHtml,
+  renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../../modules/blog-content/domain/public-page-rendering";
 import { decodeKeysetCursor } from "../../../modules/_shared/keyset-pagination";
@@ -26,7 +27,7 @@ import { decodeKeysetCursor } from "../../../modules/_shared/keyset-pagination";
  * a browsable public page, not a JSON API. Issue #564: 404s (same generic
  * shape) when `legacyTenantRouteEnabled` is `false`.
  */
-export const GET: APIRoute = async ({ params, url }) => {
+export const GET: APIRoute = async ({ locals, params, url }) => {
   const tenantCode = params.tenantCode;
 
   if (!tenantCode) {
@@ -64,6 +65,16 @@ export const GET: APIRoute = async ({ params, url }) => {
           ? `<a href="?q=${encodeURIComponent(query)}&cursor=${encodeURIComponent(result.nextCursor)}">Next</a>`
           : "";
 
+      // ADR-0098 — search itself is NOT locale-prefixed: it is `private,
+      // no-store` (an unbounded query key space, refused by the surface
+      // registry), so it localises from the cookie exactly as `/admin` does and
+      // needs no second URL. Its RESULTS, though, link into the prefixed blog,
+      // so the base path carries the reader's locale forward.
+      const postsBasePath = withPublicLocalePrefix(
+        `/blog/${tenantCode}`,
+        locals.locale
+      );
+
       const bodyHtml = `<h1>Search ${escapeHtml(tenant.tenantName)} Blog</h1>
 <form method="get" action="/blog/${escapeHtml(tenantCode)}/search">
   <input type="text" name="q" value="${escapeHtml(query)}" aria-label="Search" />
@@ -72,8 +83,8 @@ export const GET: APIRoute = async ({ params, url }) => {
 <div class="posts">${
         query.length === 0
           ? "<p>Enter a search term above.</p>"
-          : renderPostSummaryListHtml(
-              tenantCode,
+          : renderPostSummaryListHtmlAtBasePath(
+              postsBasePath,
               result.items,
               "No results found."
             )

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -5,6 +5,12 @@ import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../lib/http/site-origin";
+import { DEFAULT_LOCALE } from "../../../lib/i18n/locales";
+import { coerceLocale } from "../../../lib/i18n/negotiate";
+import {
+  buildHreflangAlternates,
+  withPublicLocalePrefix
+} from "../../../lib/i18n/public-locale-path";
 import {
   notFoundXmlResponse,
   serverErrorXmlResponse
@@ -52,13 +58,37 @@ export const GET: APIRoute = async ({ params, request, url }) => {
       }
 
       const posts = await listPublicBlogPostsForFeed(tx, tenant.tenantId);
-      const channelLink = `${resolveRequestOrigin(url, request)}/blog/${tenantCode}`;
+      // ADR-0098 — a sitemap must list the CANONICAL URL, and after this ADR the
+      // canonical URL of every blog page carries a locale. Listing the bare path
+      // would tell a crawler that the real document is the alias answering
+      // `307`, contradicting the `<link rel="canonical">` on the page it points
+      // at — the two would disagree, and search engines resolve that
+      // disagreement by trusting neither.
+      //
+      // `<loc>` names the tenant default's spelling and the `xhtml:link`
+      // alternates name every locale, which is the sitemap half of the same
+      // `hreflang` set the page emits in its head.
+      const origin = resolveRequestOrigin(url, request);
+      const tenantDefaultLocale =
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE;
+      const localisedUrl = (barePath: string): string =>
+        `${origin}${withPublicLocalePrefix(barePath, tenantDefaultLocale)}`;
+      const alternatesXml = (barePath: string): string =>
+        buildHreflangAlternates(barePath, tenantDefaultLocale)
+          .map(
+            (alternate) =>
+              `<xhtml:link rel="alternate" hreflang="${escapeHtml(alternate.hreflang)}" href="${escapeHtml(origin + alternate.pathname)}" />`
+          )
+          .join("\n");
+      const channelPath = `/blog/${tenantCode}`;
+      const channelLink = localisedUrl(channelPath);
 
       // Issue #649 — see `/news/sitemap-news.xml.ts`'s identical comment:
       // resolved sequentially, one query at a time on the shared transaction.
       const urlParts: string[] = [];
       for (const post of posts) {
-        const link = `${channelLink}/${post.slug}`;
+        const postPath = `${channelPath}/${post.slug}`;
+        const link = localisedUrl(postPath);
         const previewImage = await resolveNewsArticlePreviewImage(
           tx,
           tenant.tenantId,
@@ -72,6 +102,7 @@ export const GET: APIRoute = async ({ params, request, url }) => {
 
         urlParts.push(`<url>
 <loc>${escapeHtml(link)}</loc>
+${alternatesXml(postPath)}
 <lastmod>${post.publishedAt.toISOString()}</lastmod>
 ${imageTag}
 </url>`);
@@ -80,9 +111,10 @@ ${imageTag}
       const urls = urlParts.join("\n");
 
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 <url>
 <loc>${escapeHtml(channelLink)}</loc>
+${alternatesXml(channelPath)}
 </url>
 ${urls}
 </urlset>`;

--- a/src/pages/blog/[tenantCode]/tag/[slug].ts
+++ b/src/pages/blog/[tenantCode]/tag/[slug].ts
@@ -5,6 +5,9 @@ import { withTenantOrThrow } from "../../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
 import { escapeHtml } from "../../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../../lib/http/site-origin";
+import { DEFAULT_LOCALE } from "../../../../lib/i18n/locales";
+import { coerceLocale } from "../../../../lib/i18n/negotiate";
+import { buildLocalisedPublicUrls } from "../../../../lib/i18n/public-locale-path";
 import {
   notFoundHtmlResponse,
   serverErrorHtmlResponse
@@ -18,12 +21,12 @@ import {
 import { isLegacyTenantRouteEnabled } from "../../../../modules/blog-content/application/public-route-settings";
 import {
   renderPaginationNavHtml,
-  renderPostSummaryListHtml,
+  renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../../../modules/blog-content/domain/public-page-rendering";
 
 /** `GET /blog/{tenantCode}/tag/{slug}` (Issue #540) — same as the category archive, scoped to `taxonomy_type = 'tag'`, including the Issue #564 `legacyTenantRouteEnabled` gate. */
-export const GET: APIRoute = async ({ params, request, url }) => {
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
   const tenantCode = params.tenantCode;
   const slug = params.slug;
 
@@ -66,14 +69,31 @@ export const GET: APIRoute = async ({ params, request, url }) => {
         }
       );
 
+      // ADR-0098 — canonical, hreflang and every in-page link are built from the
+      // PREFIXED path. `postsBasePath` is the listing root each post link hangs
+      // off, which is the tenant's blog root rather than this archive.
+      const urls = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}/tag/${term.slug}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      );
+      const postsBasePath = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      ).basePath;
+
       const bodyHtml = `<h1>Tag: ${escapeHtml(term.name)}</h1>
-<div class="posts">${renderPostSummaryListHtml(tenantCode, result.items, "No posts with this tag yet.")}</div>
-${renderPaginationNavHtml(page, result.hasNextPage, `/blog/${tenantCode}/tag/${term.slug}`)}`;
+<div class="posts">${renderPostSummaryListHtmlAtBasePath(postsBasePath, result.items, "No posts with this tag yet.")}</div>
+${renderPaginationNavHtml(page, result.hasNextPage, urls.basePath)}`;
 
       const html = renderPublicPageShell({
         title: `${term.name} — ${tenant.tenantName} Blog`,
         description: term.description ?? `Posts tagged ${term.name}.`,
-        canonicalUrl: `${resolveRequestOrigin(url, request)}/blog/${tenantCode}/tag/${term.slug}`,
+        canonicalUrl: urls.canonicalUrl,
+        hreflangAlternates: urls.hreflangAlternates,
         bodyHtml,
         locale: tenant.defaultLocale,
         variant: "list"

--- a/tests/public-locale-path.test.ts
+++ b/tests/public-locale-path.test.ts
@@ -1,0 +1,387 @@
+/**
+ * ADR-0098 — the cache key carries the locale, and it carries it in the PATH.
+ *
+ * Pure: no database, no network, no filesystem. Every assertion here is about a
+ * string going in and a decision coming out, which is the property the ADR's
+ * security argument rests on — if this file ever needs a request to make its
+ * assertions, a header has entered the cache key.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  decideCacheability,
+  variesOnForbiddenHeader
+} from "../src/lib/edge-cache/cacheability";
+import { loadEdgeCacheConfig } from "../src/lib/edge-cache/config";
+import {
+  PUBLIC_CACHE_SURFACES,
+  matchPublicCacheSurface
+} from "../src/lib/edge-cache/surface-registry";
+import { SUPPORTED_LOCALES } from "../src/lib/i18n/locales";
+import {
+  buildHreflangAlternates,
+  buildLocalisedPublicUrls,
+  carryLocaleThroughRedirect,
+  requiresPublicLocalePrefix,
+  resolvePublicLocaleRoute,
+  splitPublicLocalePath,
+  stripPublicLocalePrefix,
+  withPublicLocalePrefix
+} from "../src/lib/i18n/public-locale-path";
+
+describe("splitPublicLocalePath", () => {
+  test("splits a supported locale segment off the front", () => {
+    expect(splitPublicLocalePath("/id/blog/acme")).toEqual({
+      locale: "id",
+      pathname: "/blog/acme"
+    });
+    expect(splitPublicLocalePath("/en/blog/acme/my-post")).toEqual({
+      locale: "en",
+      pathname: "/blog/acme/my-post"
+    });
+  });
+
+  test("a bare locale is the site root in that locale", () => {
+    expect(splitPublicLocalePath("/id")).toEqual({
+      locale: "id",
+      pathname: "/"
+    });
+  });
+
+  test("leaves a path with no locale segment untouched", () => {
+    expect(splitPublicLocalePath("/blog/acme")).toEqual({
+      locale: null,
+      pathname: "/blog/acme"
+    });
+  });
+
+  /**
+   * The failure this guards is a tenant code or slug that merely STARTS with a
+   * locale. Stripping `/entrepreneurship` down to `trepreneurship` would 404 a
+   * real page, and the 404 would look like missing content rather than a
+   * routing bug.
+   */
+  test("only strips a WHOLE segment, never a prefix of one", () => {
+    expect(splitPublicLocalePath("/entrepreneurship/blog")).toEqual({
+      locale: null,
+      pathname: "/entrepreneurship/blog"
+    });
+    expect(splitPublicLocalePath("/blog/indonesia/post")).toEqual({
+      locale: null,
+      pathname: "/blog/indonesia/post"
+    });
+    expect(splitPublicLocalePath("/ends")).toEqual({
+      locale: null,
+      pathname: "/ends"
+    });
+  });
+
+  test("an unsupported language segment is not a locale", () => {
+    expect(splitPublicLocalePath("/es/blog/acme").locale).toBeNull();
+    expect(splitPublicLocalePath("/fr/blog/acme").locale).toBeNull();
+  });
+});
+
+describe("withPublicLocalePrefix", () => {
+  test("prefixes a bare path", () => {
+    expect(withPublicLocalePrefix("/blog/acme", "id")).toBe("/id/blog/acme");
+  });
+
+  /**
+   * Decision 4 allows exactly one canonical URL per (resource, locale).
+   * `/id/en/blog/acme` would be a second name for one document, so prefixing is
+   * a REPLACE rather than a push.
+   */
+  test("replaces an existing prefix instead of nesting one", () => {
+    expect(withPublicLocalePrefix("/en/blog/acme", "id")).toBe("/id/blog/acme");
+    expect(
+      withPublicLocalePrefix(withPublicLocalePrefix("/blog/a", "en"), "en")
+    ).toBe("/en/blog/a");
+  });
+
+  test("round-trips with the splitter for every supported locale", () => {
+    for (const locale of SUPPORTED_LOCALES) {
+      const prefixed = withPublicLocalePrefix("/blog/acme/post", locale);
+
+      expect(splitPublicLocalePath(prefixed)).toEqual({
+        locale,
+        pathname: "/blog/acme/post"
+      });
+      expect(stripPublicLocalePrefix(prefixed)).toBe("/blog/acme/post");
+    }
+  });
+});
+
+describe("requiresPublicLocalePrefix", () => {
+  test("the HTML blog surfaces are prefixed", () => {
+    expect(requiresPublicLocalePrefix("/blog/acme")).toBe(true);
+    expect(requiresPublicLocalePrefix("/blog/acme/my-post")).toBe(true);
+    expect(requiresPublicLocalePrefix("/blog/acme/category/news")).toBe(true);
+    expect(requiresPublicLocalePrefix("/blog/acme/tag/launch")).toBe(true);
+  });
+
+  /**
+   * Machine surfaces and `private, no-store` surfaces are NOT prefixed, each
+   * for a reason stated in the module header. `robots.txt` is the sharpest: a
+   * crawler will not follow a redirect to find it.
+   */
+  test("machine and uncacheable surfaces are not", () => {
+    expect(requiresPublicLocalePrefix("/robots.txt")).toBe(false);
+    expect(requiresPublicLocalePrefix("/sitemap.xml")).toBe(false);
+    expect(requiresPublicLocalePrefix("/feed.xml")).toBe(false);
+    expect(requiresPublicLocalePrefix("/blog/acme/feed.xml")).toBe(false);
+    expect(requiresPublicLocalePrefix("/blog/acme/sitemap-blog.xml")).toBe(
+      false
+    );
+    expect(requiresPublicLocalePrefix("/blog/acme/search")).toBe(false);
+    expect(requiresPublicLocalePrefix("/admin/users")).toBe(false);
+    expect(requiresPublicLocalePrefix("/login")).toBe(false);
+  });
+
+  test("answers for the RESOURCE, so a prefixed spelling agrees", () => {
+    expect(requiresPublicLocalePrefix("/id/blog/acme")).toBe(true);
+    expect(requiresPublicLocalePrefix("/en/robots.txt")).toBe(false);
+  });
+});
+
+describe("resolvePublicLocaleRoute", () => {
+  test("a prefixed URL serves, and the PATH names the locale", () => {
+    const route = resolvePublicLocaleRoute("/id/blog/acme/my-post");
+
+    expect(route.action).toBe("serve");
+
+    if (route.action !== "serve") {
+      throw new Error("expected serve");
+    }
+
+    expect(route.locale).toBe("id");
+    expect(route.servePathname).toBe("/blog/acme/my-post");
+  });
+
+  test("a bare URL redirects, and the caller supplies the locale", () => {
+    const route = resolvePublicLocaleRoute("/blog/acme");
+
+    expect(route.action).toBe("redirect");
+
+    if (route.action !== "redirect") {
+      throw new Error("expected redirect");
+    }
+
+    expect(route.target("id")).toBe("/id/blog/acme");
+    expect(route.target("en")).toBe("/en/blog/acme");
+  });
+
+  test("everything else is ignored, prefixed or not", () => {
+    expect(resolvePublicLocaleRoute("/robots.txt").action).toBe("ignore");
+    expect(resolvePublicLocaleRoute("/admin/users").action).toBe("ignore");
+    expect(resolvePublicLocaleRoute("/api/v1/health").action).toBe("ignore");
+    // A prefixed spelling of a non-prefixed surface is simply not a URL this
+    // site has — it must not be quietly accepted as a second name for one.
+    expect(resolvePublicLocaleRoute("/en/robots.txt").action).toBe("ignore");
+    expect(resolvePublicLocaleRoute("/id/blog/acme/search").action).toBe(
+      "ignore"
+    );
+  });
+});
+
+describe("carryLocaleThroughRedirect", () => {
+  test("carries the reader's locale onto an internal prefixed target", () => {
+    expect(carryLocaleThroughRedirect("/blog/acme/new-slug", "id")).toBe(
+      "/id/blog/acme/new-slug"
+    );
+  });
+
+  test("preserves query and fragment", () => {
+    expect(carryLocaleThroughRedirect("/blog/acme?page=2", "id")).toBe(
+      "/id/blog/acme?page=2"
+    );
+    expect(carryLocaleThroughRedirect("/blog/acme#top", "en")).toBe(
+      "/en/blog/acme#top"
+    );
+  });
+
+  /**
+   * A rule pointing at another host is a deliberate exit from this site, and a
+   * protocol-relative `//evil.test/x` is an ABSOLUTE URL wearing a path's
+   * clothing — rewriting either would be this middleware inventing a URL on
+   * somebody else's origin.
+   */
+  test("never touches an off-site target", () => {
+    expect(carryLocaleThroughRedirect("https://elsewhere.test/x", "id")).toBe(
+      "https://elsewhere.test/x"
+    );
+    expect(carryLocaleThroughRedirect("//elsewhere.test/x", "id")).toBe(
+      "//elsewhere.test/x"
+    );
+  });
+
+  test("leaves a target with no prefixed spelling alone", () => {
+    expect(carryLocaleThroughRedirect("/robots.txt", "id")).toBe("/robots.txt");
+    expect(carryLocaleThroughRedirect("/blog/acme/search", "id")).toBe(
+      "/blog/acme/search"
+    );
+  });
+
+  test("no locale means no rewrite", () => {
+    expect(carryLocaleThroughRedirect("/blog/acme", null)).toBe("/blog/acme");
+  });
+});
+
+describe("buildHreflangAlternates", () => {
+  test("one entry per locale plus x-default", () => {
+    const alternates = buildHreflangAlternates("/blog/acme/post", "id");
+
+    expect(alternates.map((entry) => entry.hreflang)).toEqual([
+      ...SUPPORTED_LOCALES,
+      "x-default"
+    ]);
+  });
+
+  /**
+   * Decision 5. Pointing `x-default` at the bare alias would let the crawler's
+   * own `Accept-Language` decide which document it indexes as the default —
+   * header-driven variation reintroduced one layer up from the cache.
+   */
+  test("x-default names the tenant default's PREFIXED URL, not the alias", () => {
+    const alternates = buildHreflangAlternates("/blog/acme/post", "id");
+    const xDefault = alternates.find((entry) => entry.hreflang === "x-default");
+
+    expect(xDefault?.pathname).toBe("/id/blog/acme/post");
+    expect(
+      alternates.every(
+        (entry) =>
+          entry.pathname.startsWith("/en/") || entry.pathname.startsWith("/id/")
+      )
+    ).toBe(true);
+  });
+
+  test("a non-prefixed surface has no alternates at all", () => {
+    expect(buildHreflangAlternates("/robots.txt")).toEqual([]);
+  });
+});
+
+describe("buildLocalisedPublicUrls", () => {
+  test("canonical is the PREFIXED URL for the rendering locale", () => {
+    const urls = buildLocalisedPublicUrls(
+      "https://acme.test",
+      "/blog/acme/post",
+      "id",
+      "en"
+    );
+
+    expect(urls.canonicalUrl).toBe("https://acme.test/id/blog/acme/post");
+    expect(urls.basePath).toBe("/id/blog/acme/post");
+    expect(
+      urls.hreflangAlternates.find((entry) => entry.hreflang === "x-default")
+        ?.href
+    ).toBe("https://acme.test/en/blog/acme/post");
+  });
+});
+
+describe("the surface registry and the path patterns agree", () => {
+  /**
+   * The two files decide `localePrefixed` with different machinery on purpose
+   * (see `LOCALE_PREFIX_PROBES` in `scripts/edge-cache-surfaces-check.ts`).
+   * This asserts the consequence that matters at run time: a prefixed URL for a
+   * prefixed surface is CACHEABLE, and a prefixed URL for anything else is not
+   * a URL at all.
+   */
+  test("a prefixed HTML URL resolves to its surface", () => {
+    expect(matchPublicCacheSurface("/id/blog/acme")?.key).toBe("blog-index");
+    expect(matchPublicCacheSurface("/en/blog/acme/my-post")?.key).toBe(
+      "blog-post"
+    );
+    expect(matchPublicCacheSurface("/id/blog/acme/category/news")?.key).toBe(
+      "blog-taxonomy"
+    );
+  });
+
+  test("a prefixed MACHINE URL resolves to nothing", () => {
+    expect(matchPublicCacheSurface("/en/robots.txt")).toBeNull();
+    expect(matchPublicCacheSurface("/id/sitemap.xml")).toBeNull();
+    expect(matchPublicCacheSurface("/en/blog/acme/feed.xml")).toBeNull();
+  });
+
+  test("the bare spelling still resolves exactly as before", () => {
+    expect(matchPublicCacheSurface("/blog/acme")?.key).toBe("blog-index");
+    expect(matchPublicCacheSurface("/robots.txt")?.key).toBe("seo-robots");
+  });
+
+  test("every guard survives the second matching attempt", () => {
+    expect(matchPublicCacheSurface("/en/blog/../admin")).toBeNull();
+    expect(matchPublicCacheSurface("/id/blog/%2e%2e/admin")).toBeNull();
+    expect(matchPublicCacheSurface("/id/blog/acme/search")).toBeNull();
+    expect(matchPublicCacheSurface("/en/id/blog/acme")).toBeNull();
+  });
+
+  test("exactly the HTML surfaces declare localePrefixed", () => {
+    const prefixed = PUBLIC_CACHE_SURFACES.filter(
+      (surface) => surface.localePrefixed
+    ).map((surface) => surface.key);
+
+    expect(prefixed.sort()).toEqual([
+      "blog-index",
+      "blog-post",
+      "blog-taxonomy"
+    ]);
+  });
+});
+
+describe("decision 2 — a forbidden Vary is refused, not stripped", () => {
+  const cacheableInput = (vary: string | null) => ({
+    config: loadEdgeCacheConfig({ EDGE_CACHE_MODE: "on" }),
+    method: "GET",
+    requestHeaders: new Headers(),
+    responseStatus: 200,
+    responseHeaders: new Headers(
+      vary
+        ? { "content-type": "text/html", vary }
+        : { "content-type": "text/html" }
+    ),
+    surface: PUBLIC_CACHE_SURFACES.find(
+      (surface) => surface.key === "blog-post"
+    )!,
+    tenantId: "11111111-1111-1111-1111-111111111111",
+    searchParams: new URLSearchParams(),
+    effectiveTtlSeconds: 300
+  });
+
+  test("varies on nothing forbidden: cacheable", () => {
+    expect(decideCacheability(cacheableInput(null)).cacheable).toBe(true);
+    expect(
+      decideCacheability(cacheableInput("Accept-Encoding")).cacheable
+    ).toBe(true);
+  });
+
+  test("Vary: Cookie is refused", () => {
+    const decision = decideCacheability(cacheableInput("Cookie"));
+
+    expect(decision.cacheable).toBe(false);
+    expect(decision.cacheable === false && decision.reason).toBe(
+      "response_varies_on_forbidden_header"
+    );
+  });
+
+  test("Vary: Accept-Language is refused", () => {
+    const decision = decideCacheability(cacheableInput("accept-language"));
+
+    expect(decision.cacheable).toBe(false);
+    expect(decision.cacheable === false && decision.reason).toBe(
+      "response_varies_on_forbidden_header"
+    );
+  });
+
+  /**
+   * The realistic spelling: a forbidden name hidden in a list next to a
+   * legitimate one, in whatever casing the author happened to type.
+   */
+  test("a forbidden name inside a list, in any casing, is refused", () => {
+    expect(variesOnForbiddenHeader("Accept-Encoding, Cookie")).toBe(true);
+    expect(variesOnForbiddenHeader("ACCEPT-LANGUAGE")).toBe(true);
+    expect(variesOnForbiddenHeader("  cookie  ")).toBe(true);
+    expect(variesOnForbiddenHeader("Accept-Encoding")).toBe(false);
+    expect(variesOnForbiddenHeader(null)).toBe(false);
+    // Not a substring match: `Cookie-Policy` is a different header.
+    expect(variesOnForbiddenHeader("Cookie-Policy")).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements [ADR-0098](https://github.com/ahliweb/awcms/blob/main/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.md), accepted in #579, and flips its status to plain `Accepted` in the same PR — the artifact map in `tests/adr-implementation-status.test.ts` would fail otherwise, which is the point of binding them.

## The public URL shape changes

`/blog/{tenant}` and everything under it now answers **`307`** to `/en/…` or `/id/…`, chosen from ADR-0095's chain (cookie → tenant default → `Accept-Language` → `en`). The prefixed URL is canonical; the bare path is a permanent alias that renders nothing. Existing links keep working through the redirect but stop being canonical.

The redirect is `private, no-store` — it reads a cookie and must never be cached. Only its destination is cacheable, which is the property `Vary` cannot have.

## The inversion that IS the safety property

On a prefixed URL the **PATH sets `locals.locale`, outranking the cookie.** If the cookie won there, two readers of `/en/blog/acme` would get different bodies under one cache key and whichever missed first would decide what the other saw — the exact misdelivery the ADR exists to prevent. The URL is the key, so the URL chooses the body.

`src/lib/i18n/public-locale-path.ts` is deliberately unable to read a header: a path goes in, a routing decision comes out.

## Scope: `CACHEABLE ⇒ prefixed`

That is ADR-0098 decision 6's own reasoning generalised. A `private, no-store` response never reaches a shared cache, so it can localise from a cookie with no possibility of misdelivery — `/admin` is the ADR's example, and `/login`, `/register` and `/blog/{t}/search` are the same case. Among cacheable surfaces only the HTML ones are prefixed: `robots.txt` sits where a crawler will not follow a redirect to find it, and the feeds already carry `?locale=`, which is the same cache key in a different spelling.

## Three things that would have been silent

- **`matchPublicCacheSurface` needed a second matching attempt.** Without it every `/en/…` request would have missed the registry and been stamped `private, no-store` — the ADR would have moved the locale into the key while turning the public surface uncacheable, a regression that reads as a caching bug rather than a routing one.
- **The sitemap had to move with the canonical.** A `<loc>` naming the bare path while the page's `<link rel="canonical">` names the prefixed one is a disagreement search engines resolve by trusting neither. `<loc>` now names the tenant default's spelling with `xhtml:link` alternates per locale.
- **In-page links are built from the prefixed base path**, or every reader drops back onto the alias on their next click.

## Decision 2 enforced twice, both mutation-proven

`decideCacheability` **refuses** a response that varies on `Cookie` or `Accept-Language` — refusing rather than stripping, because stripping would cache a body its own author said varies. `edge-cache:surfaces:check` then fails the build on the same two names anywhere under `src/`.

Proven by planting the defect, not by reading green:

| Mutation | Caught by |
| --- | --- |
| `{ Vary: "Cookie" }` | `edge-cache:surfaces:check` |
| `headers.set("Vary", "Accept-Language")` | `edge-cache:surfaces:check` |
| `"Accept-Encoding, Cookie"` hidden in a list | `edge-cache:surfaces:check` |
| `localePrefixed` guard removed from the retry | 3 never-cacheable probes |
| `blog-post` flipped to `localePrefixed: false` | drift check |

15 new never-cacheable probes (41 total), 32 new tests, full `bun run check` green locally.

## Still open behind it

Multi-language content fields for `blog_content`. The reader's interface language and the post's own language are different axes — `<html lang>` still comes from `post.locale` — and the public chrome is not translated yet, so `/en/…` and `/id/…` differ today only in their `hreflang` and canonical. The mechanism had to land first: translating chrome into a cache that could not tell the two apart is the failure ADR-0095 refused to ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)