### PR TITLE
fix(security): a typo in a rate-limit env var switched the limiter off entirely

### DIFF
--- a/.changeset/public-rate-limits-fail-open-on-a-typo.md
+++ b/.changeset/public-rate-limits-fail-open-on-a-typo.md
@@ -1,0 +1,46 @@
+---
+"awcms": patch
+---
+
+fix(security): a typo in a rate-limit env var switched the limiter off entirely
+
+Three PUBLIC, unauthenticated endpoints read their rate-limit thresholds as
+`Number(process.env.X ?? 60)`. That expression is wrong in two directions, and
+both failures are silent:
+
+- `??` falls back only on `undefined`/`null`. A **non-numeric** value —
+  `SITE_SEARCH_RATE_LIMIT_MAX=6O` with a letter O — yields `NaN`. Every
+  comparison against `NaN` is `false`, so `count > NaN` never trips and **the
+  limiter is off**. Worse than merely off: the `rate_limited` metric stays at
+  zero, which an operator reads as evidence of no abuse.
+- An **empty** value is not `undefined`, so `??` does not fire either;
+  `Number("")` is `0`, and a ceiling of zero 429s every visitor on their first
+  request.
+
+The three: `/api/v1/site-search/query` (anonymous full-text search),
+`/api/v1/site-search/suggest` (runs on every keystroke), and
+`/api/v1/setup/initialize` — the last being the highest-value of them, because
+it bootstraps a tenant, office and owner for an unauthenticated caller and that
+limit is the only bound on how many Cloudflare siteverify round-trips and
+multi-row bootstrap attempts one caller can drive.
+
+`resolveLoginPolicyConfig` learned this in Issue #147 and grew its own parser.
+The lesson never travelled; this moves it to
+`src/lib/security/env-thresholds.ts` where the next public endpoint will find
+it.
+
+### Why the helper takes the VALUE and not the variable name
+
+The obvious shape — `parsePositiveIntEnv("SITE_SEARCH_RATE_LIMIT_MAX", 60)` —
+would have been a quiet regression. `config:env:coverage:check` resolves literal
+`process.env.NAME` spellings and says in its own header that computed reads
+"need a human". A variable read only through a name-taking helper therefore
+stops being checked against `.env.example`, and an operator loses the one
+artefact telling them the knob exists. So the call site keeps the literal read
+and passes the value; the name is used for the warning and nothing else. A test
+asserts that literal spelling survives, so a future "tidy-up" cannot undo it
+silently.
+
+Bad values now fall back to the documented default and warn once — deduplicated
+per `name=value`, because a per-request warning on a public endpoint is a free
+log-volume amplifier.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 150   |
 | Tables with `FORCE` RLS             | 132   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 399   |
+| Test files                          | 400   |
 | Route files                         | 366   |
 | ADR                                 | 200   |
 
@@ -339,7 +339,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 343        |
+| `(root)`      | 344        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |

--- a/src/lib/security/env-thresholds.ts
+++ b/src/lib/security/env-thresholds.ts
@@ -1,0 +1,109 @@
+import { log } from "../logging/logger";
+
+/**
+ * Parsing for operator-set NUMERIC SECURITY THRESHOLDS read from the
+ * environment — rate-limit ceilings, windows, lockout counts.
+ *
+ * ## The defect this exists to make unrepeatable
+ *
+ * `Number(process.env.X ?? 60)` is wrong in two directions at once, and both
+ * failures are silent:
+ *
+ * - `??` falls back only on `undefined`/`null`. A **non-numeric** value —
+ *   `SITE_SEARCH_RATE_LIMIT_MAX=6O` with a letter O, or `sixty` — yields
+ *   `NaN`. Every comparison against `NaN` is `false`, so `count > NaN` never
+ *   trips and **the limiter is switched off entirely**. Worse than merely off:
+ *   the `rate_limited` metric stays at zero, which an operator reads as
+ *   evidence of no abuse.
+ * - An **empty** value (`SITE_SEARCH_RATE_LIMIT_MAX=`) is not `undefined`, so
+ *   `??` does not fire either; `Number("")` is `0`, and a ceiling of zero 429s
+ *   every visitor on the first request.
+ *
+ * `resolveLoginPolicyConfig` learned this in Issue #147 and grew its own
+ * `parsePositiveIntEnv`. The lesson did not travel: the three public,
+ * UNAUTHENTICATED rate limits — site search, search suggestions, and the setup
+ * bootstrap — each kept the raw `Number(process.env…)` form.
+ *
+ * ## Why this takes the VALUE and not the NAME
+ *
+ * `parsePositiveIntEnv(name, fallback)` reads `process.env[name]`, and a
+ * computed read is INVISIBLE to `config:env:coverage:check` — that gate resolves
+ * literal `process.env.NAME` spellings (and `env.NAME` aliases) and says so in
+ * its own header: computed reads "need a human". A variable read only through a
+ * name-taking helper therefore stops being checked against `.env.example`, and
+ * an operator loses the one artefact that tells them the knob exists.
+ *
+ * So the call site keeps the literal read and passes the VALUE:
+ *
+ * ```ts
+ * const MAX = parsePositiveIntSetting(
+ *   process.env.SITE_SEARCH_RATE_LIMIT_MAX, // literal — the gate still sees it
+ *   60,
+ *   "SITE_SEARCH_RATE_LIMIT_MAX"           // for the warning only
+ * );
+ * ```
+ *
+ * The name argument is used for the log message and nothing else. It is
+ * deliberately NOT used to read the environment.
+ */
+
+/**
+ * Deduplicated per `name=value`, because these constants are evaluated by
+ * modules serving public, unauthenticated endpoints. A per-request warning
+ * would be a free log-volume amplifier for an attacker, and repeating a message
+ * about a value that cannot change mid-process adds nothing.
+ */
+const warnedValues = new Set<string>();
+
+function warnOnce(name: string, raw: string, fallback: number): void {
+  const dedupeKey = `${name}=${raw}`;
+
+  if (warnedValues.has(dedupeKey)) {
+    return;
+  }
+
+  warnedValues.add(dedupeKey);
+
+  // `value` is echoed deliberately: these are operator-set numeric thresholds,
+  // never secrets, and the malformed value is the whole point of the message.
+  log("warning", "security.env_threshold.invalid_value", {
+    envVar: name,
+    value: raw,
+    fallback,
+    reason: "not a positive integer — falling back to the default"
+  });
+}
+
+/**
+ * Returns `fallback` for anything that is not a usable positive integer:
+ * absent, empty, whitespace, non-numeric, fractional, zero, or negative.
+ *
+ * Zero and negatives are rejected as firmly as `NaN`. A ceiling of `0` refuses
+ * every request; a window of `0` divides the limiter's arithmetic by nothing.
+ * Neither is a value an operator can have meant, and treating them as absent is
+ * the only reading that fails CLOSED — back to the documented default — rather
+ * than open.
+ */
+export function parsePositiveIntSetting(
+  raw: string | undefined,
+  fallback: number,
+  name: string
+): number {
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = Number(raw);
+
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    warnOnce(name, raw, fallback);
+    return fallback;
+  }
+
+  return parsed;
+}
+
+/** Test-only: clears the warn-once memory so tests do not bleed into each other. */
+export function resetEnvThresholdWarningsForTests(): void {
+  warnedValues.clear();
+}

--- a/src/pages/api/v1/setup/initialize.ts
+++ b/src/pages/api/v1/setup/initialize.ts
@@ -6,6 +6,7 @@ import {
   checkSharedRateLimit,
   resolveClientIp
 } from "../../../../lib/security/rate-limit";
+import { parsePositiveIntSetting } from "../../../../lib/security/env-thresholds";
 import {
   bodyTooLargeResponse,
   readJsonBody
@@ -26,9 +27,19 @@ import { bootstrapPlatformTenant } from "../../../../modules/tenant-admin/applic
  * Cloudflare siteverify round-trips (and multi-row bootstrap attempts) an
  * unauthenticated caller can drive on a full-online deployment.
  */
-const SETUP_RATE_LIMIT_MAX = Number(process.env.SETUP_RATE_LIMIT_MAX ?? 10);
-const SETUP_RATE_LIMIT_WINDOW_SEC = Number(
-  process.env.SETUP_RATE_LIMIT_WINDOW_SEC ?? 60
+// The highest-value of the three: this endpoint bootstraps a tenant, office and
+// owner for an UNAUTHENTICATED caller, and the rate limit is the only thing
+// bounding how many Cloudflare siteverify round-trips and multi-row bootstrap
+// attempts one caller can drive. A `NaN` ceiling removes that bound entirely.
+const SETUP_RATE_LIMIT_MAX = parsePositiveIntSetting(
+  process.env.SETUP_RATE_LIMIT_MAX,
+  10,
+  "SETUP_RATE_LIMIT_MAX"
+);
+const SETUP_RATE_LIMIT_WINDOW_SEC = parsePositiveIntSetting(
+  process.env.SETUP_RATE_LIMIT_WINDOW_SEC,
+  60,
+  "SETUP_RATE_LIMIT_WINDOW_SEC"
 );
 
 /**

--- a/src/pages/api/v1/site-search/query.ts
+++ b/src/pages/api/v1/site-search/query.ts
@@ -9,6 +9,7 @@ import {
   checkSharedRateLimit,
   resolveClientIp
 } from "../../../../lib/security/rate-limit";
+import { parsePositiveIntSetting } from "../../../../lib/security/env-thresholds";
 import { ok, fail } from "../../../../modules/_shared/api-response";
 import { withSiteSearchTenant } from "../../../../modules/site-search/application/public-search-tenant-resolution";
 import { recordSearchQuery } from "../../../../modules/site-search/application/search-query-log";
@@ -31,9 +32,20 @@ import {
  * query-length-bounded, and result-capped. Every non-resolving/disabled/short
  * outcome returns the same neutral empty payload — never leak WHY.
  */
-const RATE_LIMIT_MAX = Number(process.env.SITE_SEARCH_RATE_LIMIT_MAX ?? 60);
-const RATE_LIMIT_WINDOW_SEC = Number(
-  process.env.SITE_SEARCH_RATE_LIMIT_WINDOW_SEC ?? 60
+// Parsed rather than coerced: `Number(process.env.X ?? 60)` yields `NaN` for a
+// non-numeric value, and `count > NaN` is false — which switches this limiter
+// OFF on an anonymous full-text endpoint while the `rate_limited` metric stays
+// at zero and reads as "no abuse". The literal `process.env.NAME` spelling is
+// kept because `config:env:coverage:check` cannot see a computed read.
+const RATE_LIMIT_MAX = parsePositiveIntSetting(
+  process.env.SITE_SEARCH_RATE_LIMIT_MAX,
+  60,
+  "SITE_SEARCH_RATE_LIMIT_MAX"
+);
+const RATE_LIMIT_WINDOW_SEC = parsePositiveIntSetting(
+  process.env.SITE_SEARCH_RATE_LIMIT_WINDOW_SEC,
+  60,
+  "SITE_SEARCH_RATE_LIMIT_WINDOW_SEC"
 );
 
 export const GET: APIRoute = async ({ request, url, clientAddress }) => {

--- a/src/pages/api/v1/site-search/suggest.ts
+++ b/src/pages/api/v1/site-search/suggest.ts
@@ -9,6 +9,7 @@ import {
   checkSharedRateLimit,
   resolveClientIp
 } from "../../../../lib/security/rate-limit";
+import { parsePositiveIntSetting } from "../../../../lib/security/env-thresholds";
 import { ok, fail } from "../../../../modules/_shared/api-response";
 import { withSiteSearchTenant } from "../../../../modules/site-search/application/public-search-tenant-resolution";
 import { suggestSiteContent } from "../../../../modules/site-search/application/search-service";
@@ -24,11 +25,17 @@ import {
  * at most `suggestion_limit` title suggestions; disabled when the tenant turns
  * suggestions off.
  */
-const RATE_LIMIT_MAX = Number(
-  process.env.SITE_SEARCH_SUGGEST_RATE_LIMIT_MAX ?? 120
+// See `query.ts` — same defect, same fix. Suggestions run on every keystroke,
+// so an off-by-NaN limiter here is the cheaper of the two endpoints to abuse.
+const RATE_LIMIT_MAX = parsePositiveIntSetting(
+  process.env.SITE_SEARCH_SUGGEST_RATE_LIMIT_MAX,
+  120,
+  "SITE_SEARCH_SUGGEST_RATE_LIMIT_MAX"
 );
-const RATE_LIMIT_WINDOW_SEC = Number(
-  process.env.SITE_SEARCH_SUGGEST_RATE_LIMIT_WINDOW_SEC ?? 60
+const RATE_LIMIT_WINDOW_SEC = parsePositiveIntSetting(
+  process.env.SITE_SEARCH_SUGGEST_RATE_LIMIT_WINDOW_SEC,
+  60,
+  "SITE_SEARCH_SUGGEST_RATE_LIMIT_WINDOW_SEC"
 );
 
 export const GET: APIRoute = async ({ request, url, clientAddress }) => {

--- a/tests/security-env-thresholds.test.ts
+++ b/tests/security-env-thresholds.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  parsePositiveIntSetting,
+  resetEnvThresholdWarningsForTests
+} from "../src/lib/security/env-thresholds";
+
+/**
+ * The defect these lock down (issue #593).
+ *
+ * `Number(process.env.X ?? 60)` guarded the three PUBLIC, UNAUTHENTICATED rate
+ * limits in this repo — site search, search suggestions, and the setup
+ * bootstrap. It fails open in one direction and closed in the other, and both
+ * silently:
+ *
+ * - a non-numeric value yields `NaN`, every comparison against `NaN` is false,
+ *   so the limiter never trips — while the `rate_limited` metric stays at zero
+ *   and reads to an operator as evidence of no abuse;
+ * - an EMPTY value is not `undefined`, so `??` does not fire; `Number("")` is
+ *   `0`, and a ceiling of zero 429s every visitor on their first request.
+ *
+ * Each assertion below is written against the RAW expression as well, so the
+ * test states what the old code actually did rather than only what the new code
+ * does.
+ */
+
+afterEach(() => {
+  resetEnvThresholdWarningsForTests();
+});
+
+describe("parsePositiveIntSetting", () => {
+  test("absent falls back", () => {
+    expect(parsePositiveIntSetting(undefined, 60, "X")).toBe(60);
+  });
+
+  test("a non-numeric value falls back instead of yielding NaN", () => {
+    // The exact shape of the bug: a letter O for a zero.
+    expect(Number("6O" as unknown as string)).toBeNaN();
+    expect(parsePositiveIntSetting("6O", 60, "X")).toBe(60);
+
+    // ...and the consequence the old code had, stated directly.
+    const oldBehaviour = Number("6O");
+    expect(5 > oldBehaviour).toBe(false);
+    expect(5 > parsePositiveIntSetting("6O", 60, "X")).toBe(false);
+    expect(500 > parsePositiveIntSetting("6O", 60, "X")).toBe(true);
+  });
+
+  test("an EMPTY value falls back rather than becoming zero", () => {
+    // `??` never fires for "" because "" is not nullish, so the old expression
+    // reached `Number("")`, which is 0 — a ceiling of zero, refusing everyone.
+    // Typed as the env shape rather than the literal "", because `"" ?? 60` is
+    // a compile error TypeScript is right to raise.
+    const raw: string | undefined = "";
+    expect(raw ?? 60).toBe("");
+    expect(Number(raw ?? 60)).toBe(0);
+    expect(parsePositiveIntSetting(raw, 60, "X")).toBe(60);
+  });
+
+  test("whitespace is treated as absent", () => {
+    expect(parsePositiveIntSetting("   ", 60, "X")).toBe(60);
+  });
+
+  test("zero and negatives fall back — neither is a value an operator can mean", () => {
+    // A ceiling of 0 refuses every request; a window of 0 divides by nothing.
+    expect(parsePositiveIntSetting("0", 60, "X")).toBe(60);
+    expect(parsePositiveIntSetting("-5", 60, "X")).toBe(60);
+  });
+
+  test("fractional values fall back", () => {
+    expect(parsePositiveIntSetting("1.5", 60, "X")).toBe(60);
+  });
+
+  test("Infinity falls back — Number('Infinity') is finite-looking but useless as a ceiling", () => {
+    expect(parsePositiveIntSetting("Infinity", 60, "X")).toBe(60);
+  });
+
+  test("a usable positive integer is returned unchanged", () => {
+    expect(parsePositiveIntSetting("120", 60, "X")).toBe(120);
+    expect(parsePositiveIntSetting(" 120 ", 60, "X")).toBe(120);
+  });
+});
+
+describe("the call sites keep the literal process.env spelling", () => {
+  /**
+   * `config:env:coverage:check` resolves literal `process.env.NAME` reads and
+   * `env.NAME` aliases; a COMPUTED read (`process.env[name]`) is invisible to
+   * it, and its own header says such reads "need a human".
+   *
+   * So the helper takes the VALUE, never the name. If a future refactor
+   * "tidies" these into `parsePositiveIntEnv("SITE_SEARCH_RATE_LIMIT_MAX", 60)`,
+   * the variable silently stops being checked against `.env.example` and an
+   * operator loses the only artefact telling them the knob exists. This test is
+   * what makes that regression loud.
+   */
+  const FILES = [
+    "src/pages/api/v1/site-search/query.ts",
+    "src/pages/api/v1/site-search/suggest.ts",
+    "src/pages/api/v1/setup/initialize.ts"
+  ];
+
+  const EXPECTED_LITERALS: Record<string, readonly string[]> = {
+    "src/pages/api/v1/site-search/query.ts": [
+      "process.env.SITE_SEARCH_RATE_LIMIT_MAX",
+      "process.env.SITE_SEARCH_RATE_LIMIT_WINDOW_SEC"
+    ],
+    "src/pages/api/v1/site-search/suggest.ts": [
+      "process.env.SITE_SEARCH_SUGGEST_RATE_LIMIT_MAX",
+      "process.env.SITE_SEARCH_SUGGEST_RATE_LIMIT_WINDOW_SEC"
+    ],
+    "src/pages/api/v1/setup/initialize.ts": [
+      "process.env.SETUP_RATE_LIMIT_MAX",
+      "process.env.SETUP_RATE_LIMIT_WINDOW_SEC"
+    ]
+  };
+
+  for (const file of FILES) {
+    test(`${file} reads its thresholds literally and parses them safely`, async () => {
+      const source = await Bun.file(file).text();
+
+      for (const literal of EXPECTED_LITERALS[file]!) {
+        expect(source).toContain(literal);
+      }
+
+      expect(source).toContain("parsePositiveIntSetting");
+
+      // The raw coercion must be gone from these files entirely — a single
+      // survivor is a limiter that can still be switched off by a typo.
+      const withoutComments = source.replace(/\/\*[\s\S]*?\*\/|\/\/.*$/gm, "");
+      expect(withoutComments).not.toContain("Number(process.env");
+    });
+  }
+});


### PR DESCRIPTION
Part of #593.

Three **public, unauthenticated** endpoints read their rate-limit thresholds as `Number(process.env.X ?? 60)`. That expression is wrong in two directions, and both fail silently:

- `??` falls back only on `undefined`/`null`. A **non-numeric** value — `SITE_SEARCH_RATE_LIMIT_MAX=6O` with a letter O — yields `NaN`. Every comparison against `NaN` is `false`, so `count > NaN` never trips and **the limiter is off**. Worse than merely off: the `rate_limited` metric stays at zero, which an operator reads as evidence of no abuse.
- An **empty** value is not `undefined`, so `??` does not fire either; `Number("")` is `0`, and a ceiling of zero 429s every visitor on their first request.

The three endpoints:

| Route | Why it matters |
|---|---|
| `/api/v1/site-search/query` | anonymous full-text search |
| `/api/v1/site-search/suggest` | runs on every keystroke — the cheaper one to abuse |
| `/api/v1/setup/initialize` | **bootstraps a tenant, office and owner for an unauthenticated caller.** This limit is the only bound on how many Cloudflare siteverify round-trips and multi-row bootstrap attempts one caller can drive. |

`resolveLoginPolicyConfig` learned this in Issue #147 and grew its own parser. The lesson never travelled. It now lives in `src/lib/security/env-thresholds.ts`, where the next public endpoint will find it.

## Why the helper takes the VALUE, not the variable name

The obvious shape — `parsePositiveIntEnv("SITE_SEARCH_RATE_LIMIT_MAX", 60)` — would have been a quiet regression. `config:env:coverage:check` resolves literal `process.env.NAME` spellings and states in its own header that computed reads "need a human". A variable read only through a name-taking helper stops being checked against `.env.example`, and an operator loses the one artefact telling them the knob exists.

So the call site keeps the literal read and passes the value; the name is used for the warning and nothing else. **A test asserts that literal spelling survives**, so a future "tidy-up" cannot undo it silently.

## Verification

The test was run against the pre-fix code and **fails** there, then passes on the fix — not merely asserted green. Full `bun run check` green: 52 gates, tests, build.