### PR TITLE
fix(docs): repo inventory went stale between two squash merges

### DIFF
--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 150   |
 | Tables with `FORCE` RLS             | 132   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 400   |
+| Test files                          | 401   |
 | Route files                         | 366   |
 | ADR                                 | 200   |
 
@@ -340,7 +340,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 344        |
+| `(root)`      | 345        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |


### PR DESCRIPTION
#601 and #602 each regenerated `docs/awcms/repo-inventory.md` against their own branch. Each was correct in isolation; their combination is not — the real test-file count is **401** and `main` records **400**.

`repo:inventory:check` is in the `check` chain, so **`main` is currently red** until this lands. Two numbers change, nothing else.

This is the ordinary cost of squash-merging two branches that both touch a generated artefact, and it is exactly what the gate exists to catch.