### PR TITLE
feat(blog-content)!: the write path stores Portable Text, and derives everything else from it

### DIFF
--- a/.changeset/portable-text-write-path.md
+++ b/.changeset/portable-text-write-path.md
@@ -1,0 +1,55 @@
+---
+"awcms": major
+---
+
+feat(blog-content)!: the write path stores Portable Text, and derives everything else from it
+
+The second half of ADR-0100. #604 landed the format, its validator, its renderer
+and the converter; this wires them to the endpoints, so an article's body is now
+Portable Text end to end.
+
+### Breaking
+
+`contentText` is **refused** on create and update, with a message naming its
+replacement. Refused rather than ignored: a field silently dropped is one a
+caller keeps sending for months while believing it does something, and the
+belief only surfaces when their search results disagree with their articles.
+
+`bodyPortableText` is **required** on create. An article with no body is not a
+draft — it is a row nothing can render, and accepting it moves the failure to
+whoever opens the page.
+
+`contentJson` becomes **optional** and is now the non-body envelope. It still
+carries `awcmsAstro`, the structured sidecar the sibling repo stores there; its
+`blocks` key is overwritten with the derived projection on every write.
+
+### The three body columns move together, or not at all
+
+A partial update that changed the envelope without the body, or the body
+without the derived search text, would leave a row internally inconsistent in a
+way nothing downstream could detect. So `content_json`, `content_text` and
+`body_portable_text` are written in one `CASE` keyed on whether a body arrived.
+
+### Restoring an old revision no longer blanks the post
+
+A revision written before the cutover carries an empty `bodyPortableText` and
+its real body in `contentJson.blocks`. Restoring it verbatim would blank the
+post — and **nothing would fail**: the row would be valid and the page would
+just be empty. The restore path converts from the revision's own envelope when
+the body is empty rather than trusting it.
+
+This is the "restore revision bypasses the new write path" defect class this
+epic has already hit once, closed at the one call site that can reintroduce a
+legacy body into a live post.
+
+### The frozen consumer contract was regenerated, deliberately
+
+`api:consumer-contract:check` correctly refused `BlogPostWriteInput` as a
+non-additive change (ADR-0065). Regenerating it is the sanctioned act, and it
+was taken only after verifying the premise: **`awcms-astro` never writes.** Its
+only call to this API is `awcmsGet("/api/v1/blog/posts")`, and it declares
+`contentText?: string` without reading it anywhere.
+
+`contentText` therefore stays in every RESPONSE schema, marked `readOnly` — the
+column still exists and is still what the full-text index is built from. Only
+the write inputs changed.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -9368,22 +9368,22 @@ Structured post/page body. `{ blocks: BlogContentBlock[] }` — never raw HTML, 
 
 Shared shape for POST /api/v1/blog/pages and PATCH /api/v1/blog/pages/{id} (all fields optional on update).
 
-| Field             | Type                                           | Required | Nullable | Description |
-| ----------------- | ---------------------------------------------- | -------- | -------- | ----------- |
-| `title`           | string                                         | no       | no       |             |
-| `slug`            | string                                         | no       | no       |             |
-| `excerpt`         | string                                         | no       | yes      |             |
-| `contentJson`     | [`BlogContentJson`](#schema-blogcontentjson)   | no       | no       |             |
-| `contentText`     | string                                         | no       | no       |             |
-| `locale`          | string                                         | no       | no       |             |
-| `visibility`      | enum(`public`, `private`, `unlisted`)          | no       | no       |             |
-| `featuredMediaId` | string (uuid)                                  | no       | yes      |             |
-| `seoTitle`        | string                                         | no       | yes      |             |
-| `metaDescription` | string                                         | no       | yes      |             |
-| `canonicalUrl`    | string                                         | no       | yes      |             |
-| `pageType`        | enum(`standard`, `landing`, `legal`, `system`) | no       | no       |             |
-| `parentPageId`    | string (uuid)                                  | no       | yes      |             |
-| `menuOrder`       | integer                                        | no       | no       |             |
+| Field              | Type                                           | Required | Nullable | Description                                                                                                                                                    |
+| ------------------ | ---------------------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`            | string                                         | no       | no       |                                                                                                                                                                |
+| `slug`             | string                                         | no       | no       |                                                                                                                                                                |
+| `excerpt`          | string                                         | no       | yes      |                                                                                                                                                                |
+| `contentJson`      | [`BlogContentJson`](#schema-blogcontentjson)   | no       | no       | ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved. |
+| `bodyPortableText` | [`PortableTextBody`](#schema-portabletextbody) | no       | no       |                                                                                                                                                                |
+| `locale`           | string                                         | no       | no       |                                                                                                                                                                |
+| `visibility`       | enum(`public`, `private`, `unlisted`)          | no       | no       |                                                                                                                                                                |
+| `featuredMediaId`  | string (uuid)                                  | no       | yes      |                                                                                                                                                                |
+| `seoTitle`         | string                                         | no       | yes      |                                                                                                                                                                |
+| `metaDescription`  | string                                         | no       | yes      |                                                                                                                                                                |
+| `canonicalUrl`     | string                                         | no       | yes      |                                                                                                                                                                |
+| `pageType`         | enum(`standard`, `landing`, `legal`, `system`) | no       | no       |                                                                                                                                                                |
+| `parentPageId`     | string (uuid)                                  | no       | yes      |                                                                                                                                                                |
+| `menuOrder`        | integer                                        | no       | no       |                                                                                                                                                                |
 
 **Example**
 
@@ -9400,7 +9400,20 @@ Shared shape for POST /api/v1/blog/pages and PATCH /api/v1/blog/pages/{id} (all 
       }
     ]
   },
-  "contentText": "string",
+  "bodyPortableText": [
+    {
+      "_type": "block",
+      "_key": "string",
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1,
+      "children": [],
+      "markDefs": [],
+      "items": [],
+      "provider": "string",
+      "videoId": "string"
+    }
+  ],
   "locale": "string",
   "visibility": "public",
   "featuredMediaId": "00000000-0000-0000-0000-000000000000",
@@ -9417,23 +9430,23 @@ Shared shape for POST /api/v1/blog/pages and PATCH /api/v1/blog/pages/{id} (all 
 
 Shared shape for POST /api/v1/blog/posts (all fields required) and PATCH /api/v1/blog/posts/{id} (all fields optional, only present fields change).
 
-| Field                          | Type                                         | Required | Nullable | Description                                                                                      |
-| ------------------------------ | -------------------------------------------- | -------- | -------- | ------------------------------------------------------------------------------------------------ |
-| `title`                        | string                                       | no       | no       |                                                                                                  |
-| `slug`                         | string                                       | no       | no       |                                                                                                  |
-| `excerpt`                      | string                                       | no       | yes      |                                                                                                  |
-| `contentJson`                  | [`BlogContentJson`](#schema-blogcontentjson) | no       | no       |                                                                                                  |
-| `contentText`                  | string                                       | no       | no       |                                                                                                  |
-| `locale`                       | string                                       | no       | no       |                                                                                                  |
-| `visibility`                   | enum(`public`, `private`, `unlisted`)        | no       | no       |                                                                                                  |
-| `featuredMediaId`              | string (uuid)                                | no       | yes      |                                                                                                  |
-| `seoImageMediaId`              | string (uuid)                                | no       | yes      | Explicit "use this image for social/SEO preview" override — takes priority over featuredMediaId. |
-| `seoTitle`                     | string                                       | no       | yes      |                                                                                                  |
-| `metaDescription`              | string                                       | no       | yes      |                                                                                                  |
-| `canonicalUrl`                 | string                                       | no       | yes      |                                                                                                  |
-| `termIds`                      | array of string (uuid)                       | no       | no       |                                                                                                  |
-| `translationGroupId`           | string (uuid)                                | no       | yes      |                                                                                                  |
-| `autoInternalTagLinksDisabled` | boolean                                      | no       | no       | Per-post opt-out of automatic internal tag linking.                                              |
+| Field                          | Type                                           | Required | Nullable | Description                                                                                                                                                    |
+| ------------------------------ | ---------------------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                        | string                                         | no       | no       |                                                                                                                                                                |
+| `slug`                         | string                                         | no       | no       |                                                                                                                                                                |
+| `excerpt`                      | string                                         | no       | yes      |                                                                                                                                                                |
+| `contentJson`                  | [`BlogContentJson`](#schema-blogcontentjson)   | no       | no       | ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved. |
+| `bodyPortableText`             | [`PortableTextBody`](#schema-portabletextbody) | no       | no       |                                                                                                                                                                |
+| `locale`                       | string                                         | no       | no       |                                                                                                                                                                |
+| `visibility`                   | enum(`public`, `private`, `unlisted`)          | no       | no       |                                                                                                                                                                |
+| `featuredMediaId`              | string (uuid)                                  | no       | yes      |                                                                                                                                                                |
+| `seoImageMediaId`              | string (uuid)                                  | no       | yes      | Explicit "use this image for social/SEO preview" override — takes priority over featuredMediaId.                                                               |
+| `seoTitle`                     | string                                         | no       | yes      |                                                                                                                                                                |
+| `metaDescription`              | string                                         | no       | yes      |                                                                                                                                                                |
+| `canonicalUrl`                 | string                                         | no       | yes      |                                                                                                                                                                |
+| `termIds`                      | array of string (uuid)                         | no       | no       |                                                                                                                                                                |
+| `translationGroupId`           | string (uuid)                                  | no       | yes      |                                                                                                                                                                |
+| `autoInternalTagLinksDisabled` | boolean                                        | no       | no       | Per-post opt-out of automatic internal tag linking.                                                                                                            |
 
 **Example**
 
@@ -9450,7 +9463,20 @@ Shared shape for POST /api/v1/blog/posts (all fields required) and PATCH /api/v1
       }
     ]
   },
-  "contentText": "string",
+  "bodyPortableText": [
+    {
+      "_type": "block",
+      "_key": "string",
+      "style": "normal",
+      "listItem": "bullet",
+      "level": 1,
+      "children": [],
+      "markDefs": [],
+      "items": [],
+      "provider": "string",
+      "videoId": "string"
+    }
+  ],
   "locale": "string",
   "visibility": "public",
   "featuredMediaId": "00000000-0000-0000-0000-000000000000",
@@ -9887,6 +9913,129 @@ Unparseable entries are refused at issuance. At request time an unreadable entry
 {
   "clientKey": "string",
   "redirectUri": "string"
+}
+```
+
+### Schema: PortableTextBody
+
+ADR-0100 — the canonical article body. contentJson.blocks is a derived, LOSSY projection of this, written only so ahliweb/awcms-astro keeps rendering until it reads this field directly.
+
+ADR-0100 — the canonical article body. contentJson.blocks is a derived, LOSSY projection of this, written only so ahliweb/awcms-astro keeps rendering until it reads this field directly.
+
+**Example**
+
+```json
+[
+  {
+    "_type": "block",
+    "_key": "string",
+    "style": "normal",
+    "listItem": "bullet",
+    "level": 1,
+    "children": [
+      {
+        "_type": "span",
+        "_key": "string",
+        "text": "string",
+        "marks": []
+      }
+    ],
+    "markDefs": [
+      {
+        "_type": "link",
+        "_key": "string",
+        "href": "string"
+      }
+    ],
+    "items": ["(operation-specific payload)"],
+    "provider": "string",
+    "videoId": "string"
+  }
+]
+```
+
+### Schema: PortableTextLinkAnnotation
+
+| Field   | Type         | Required | Nullable | Description                                                                                                                          |
+| ------- | ------------ | -------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `_type` | enum(`link`) | yes      | no       |                                                                                                                                      |
+| `_key`  | string       | yes      | no       |                                                                                                                                      |
+| `href`  | string       | yes      | no       | Relative, or http/https/mailto/tel. Checked by URL parsing rather than a pattern, so java\\nscript: and JaVaScRiPt: are refused too. |
+
+**Example**
+
+```json
+{
+  "_type": "link",
+  "_key": "string",
+  "href": "string"
+}
+```
+
+### Schema: PortableTextNode
+
+One node of a CLOSED Portable Text vocabulary (ADR-0100). _type is one of block, gallery, videoNews — anything else is refused at write time, which is what keeps "there is no field where arbitrary markup could live" true.
+
+| Field      | Type                                                                        | Required | Nullable | Description                                    |
+| ---------- | --------------------------------------------------------------------------- | -------- | -------- | ---------------------------------------------- |
+| `_type`    | enum(`block`, `gallery`, `videoNews`)                                       | yes      | no       |                                                |
+| `_key`     | string                                                                      | yes      | no       |                                                |
+| `style`    | enum(`normal`, `h1`, `h2`, `h3`, `h4`, `h5`, `h6`, `blockquote`)            | no       | no       |                                                |
+| `listItem` | enum(`bullet`, `number`)                                                    | no       | no       |                                                |
+| `level`    | integer                                                                     | no       | no       |                                                |
+| `children` | array of [`PortableTextSpan`](#schema-portabletextspan)                     | no       | no       |                                                |
+| `markDefs` | array of [`PortableTextLinkAnnotation`](#schema-portabletextlinkannotation) | no       | no       |                                                |
+| `items`    | array of object                                                             | no       | no       | Gallery items — present when _type is gallery. |
+| `provider` | string                                                                      | no       | no       | Present when _type is videoNews.               |
+| `videoId`  | string                                                                      | no       | no       | Present when _type is videoNews.               |
+
+**Example**
+
+```json
+{
+  "_type": "block",
+  "_key": "string",
+  "style": "normal",
+  "listItem": "bullet",
+  "level": 1,
+  "children": [
+    {
+      "_type": "span",
+      "_key": "string",
+      "text": "string",
+      "marks": []
+    }
+  ],
+  "markDefs": [
+    {
+      "_type": "link",
+      "_key": "string",
+      "href": "string"
+    }
+  ],
+  "items": ["(operation-specific payload)"],
+  "provider": "string",
+  "videoId": "string"
+}
+```
+
+### Schema: PortableTextSpan
+
+| Field   | Type            | Required | Nullable | Description                                                                                                                                                                        |
+| ------- | --------------- | -------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `_type` | enum(`span`)    | yes      | no       |                                                                                                                                                                                    |
+| `_key`  | string          | yes      | no       |                                                                                                                                                                                    |
+| `text`  | string          | yes      | no       | PLAIN text — never markup.                                                                                                                                                         |
+| `marks` | array of string | no       | no       | Decorator names (strong, em, code) and/or the _key of an annotation declared in this block's own markDefs. A mark naming neither is refused at write time as a dangling reference. |
+
+**Example**
+
+```json
+{
+  "_type": "span",
+  "_key": "string",
+  "text": "string",
+  "marks": ["string"]
 }
 ```
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -19280,8 +19280,13 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
+          description: ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved.
         contentText:
           type: string
+          description: ADR-0100 — DERIVED from bodyPortableText. Still returned (it is what the full-text index is built from) but no longer accepted on write.
+          readOnly: true
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         status:
           type: string
           enum:
@@ -19353,8 +19358,9 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
-        contentText:
-          type: string
+          description: ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved.
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         locale:
           type: string
         visibility:
@@ -19421,8 +19427,13 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
+          description: ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved.
         contentText:
           type: string
+          description: ADR-0100 — DERIVED from bodyPortableText. Still returned (it is what the full-text index is built from) but no longer accepted on write.
+          readOnly: true
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         status:
           type: string
           enum:
@@ -19555,8 +19566,9 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
-        contentText:
-          type: string
+          description: ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved.
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         locale:
           type: string
         visibility:
@@ -19627,8 +19639,13 @@ components:
           type: string
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
+          description: ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved.
         contentText:
           type: string
+          description: ADR-0100 — DERIVED from bodyPortableText. Still returned (it is what the full-text index is built from) but no longer accepted on write.
+          readOnly: true
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         excerpt:
           type: string
           nullable: true
@@ -21606,6 +21623,104 @@ components:
         engagedAt:
           type: string
           format: date-time
+    PortableTextBody:
+      type: array
+      maxItems: 2000
+      description: ADR-0100 — the canonical article body. contentJson.blocks is a derived, LOSSY projection of this, written only so ahliweb/awcms-astro keeps rendering until it reads this field directly.
+      items:
+        $ref: "#/components/schemas/PortableTextNode"
+    PortableTextLinkAnnotation:
+      type: object
+      required:
+        - _type
+        - _key
+        - href
+      properties:
+        _type:
+          type: string
+          enum:
+            - link
+        _key:
+          type: string
+        href:
+          type: string
+          maxLength: 2048
+          description: "Relative, or http/https/mailto/tel. Checked by URL parsing rather than a pattern, so java\\nscript: and JaVaScRiPt: are refused too."
+    PortableTextNode:
+      type: object
+      required:
+        - _type
+        - _key
+      description: One node of a CLOSED Portable Text vocabulary (ADR-0100). _type is one of block, gallery, videoNews — anything else is refused at write time, which is what keeps "there is no field where arbitrary markup could live" true.
+      properties:
+        _type:
+          type: string
+          enum:
+            - block
+            - gallery
+            - videoNews
+        _key:
+          type: string
+        style:
+          type: string
+          enum:
+            - normal
+            - h1
+            - h2
+            - h3
+            - h4
+            - h5
+            - h6
+            - blockquote
+        listItem:
+          type: string
+          enum:
+            - bullet
+            - number
+        level:
+          type: integer
+          minimum: 1
+          maximum: 6
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/PortableTextSpan"
+        markDefs:
+          type: array
+          items:
+            $ref: "#/components/schemas/PortableTextLinkAnnotation"
+        items:
+          type: array
+          description: Gallery items — present when _type is gallery.
+          items:
+            type: object
+        provider:
+          type: string
+          description: Present when _type is videoNews.
+        videoId:
+          type: string
+          description: Present when _type is videoNews.
+    PortableTextSpan:
+      type: object
+      required:
+        - _type
+        - _key
+        - text
+      properties:
+        _type:
+          type: string
+          enum:
+            - span
+        _key:
+          type: string
+        text:
+          type: string
+          description: PLAIN text — never markup.
+        marks:
+          type: array
+          items:
+            type: string
+          description: Decorator names (strong, em, code) and/or the _key of an annotation declared in this block's own markDefs. A mark naming neither is refused at write time as a dangling reference.
     ProfileEntityLink:
       type: object
       properties:

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -2962,8 +2962,12 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
-        contentText:
-          type: string
+          description: >-
+            ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key
+            is overwritten with the derived projection; other keys (notably
+            awcmsAstro) are preserved.
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         locale:
           type: string
         visibility:
@@ -3081,8 +3085,18 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
+          description: >-
+            ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key
+            is overwritten with the derived projection; other keys (notably
+            awcmsAstro) are preserved.
         contentText:
           type: string
+          description: >-
+            ADR-0100 — DERIVED from bodyPortableText. Still returned (it is what
+            the full-text index is built from) but no longer accepted on write.
+          readOnly: true
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         status:
           type: string
           enum: [draft, review, scheduled, published, archived]
@@ -3153,8 +3167,12 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
-        contentText:
-          type: string
+          description: >-
+            ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key
+            is overwritten with the derived projection; other keys (notably
+            awcmsAstro) are preserved.
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         locale:
           type: string
         visibility:
@@ -3217,8 +3235,18 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
+          description: >-
+            ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key
+            is overwritten with the derived projection; other keys (notably
+            awcmsAstro) are preserved.
         contentText:
           type: string
+          description: >-
+            ADR-0100 — DERIVED from bodyPortableText. Still returned (it is what
+            the full-text index is built from) but no longer accepted on write.
+          readOnly: true
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         status:
           type: string
           enum: [draft, review, scheduled, published, archived]
@@ -3306,6 +3334,93 @@ components:
         description:
           type: string
           nullable: true
+    PortableTextSpan:
+      type: object
+      required: [_type, _key, text]
+      properties:
+        _type:
+          type: string
+          enum: [span]
+        _key:
+          type: string
+        text:
+          type: string
+          description: PLAIN text — never markup.
+        marks:
+          type: array
+          items:
+            type: string
+          description: >-
+            Decorator names (strong, em, code) and/or the _key of an annotation
+            declared in this block's own markDefs. A mark naming neither is
+            refused at write time as a dangling reference.
+    PortableTextLinkAnnotation:
+      type: object
+      required: [_type, _key, href]
+      properties:
+        _type:
+          type: string
+          enum: [link]
+        _key:
+          type: string
+        href:
+          type: string
+          maxLength: 2048
+          description: >-
+            Relative, or http/https/mailto/tel. Checked by URL parsing rather
+            than a pattern, so java\nscript: and JaVaScRiPt: are refused too.
+    PortableTextNode:
+      type: object
+      required: [_type, _key]
+      description: >-
+        One node of a CLOSED Portable Text vocabulary (ADR-0100). _type is one
+        of block, gallery, videoNews — anything else is refused at write time,
+        which is what keeps "there is no field where arbitrary markup could
+        live" true.
+      properties:
+        _type:
+          type: string
+          enum: [block, gallery, videoNews]
+        _key:
+          type: string
+        style:
+          type: string
+          enum: [normal, h1, h2, h3, h4, h5, h6, blockquote]
+        listItem:
+          type: string
+          enum: [bullet, number]
+        level:
+          type: integer
+          minimum: 1
+          maximum: 6
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/PortableTextSpan"
+        markDefs:
+          type: array
+          items:
+            $ref: "#/components/schemas/PortableTextLinkAnnotation"
+        items:
+          type: array
+          description: Gallery items — present when _type is gallery.
+          items:
+            type: object
+        provider:
+          type: string
+          description: Present when _type is videoNews.
+        videoId:
+          type: string
+          description: Present when _type is videoNews.
+    PortableTextBody:
+      type: array
+      maxItems: 2000
+      description: >-
+        ADR-0100 — the canonical article body. contentJson.blocks is a derived,
+        LOSSY projection of this, written only so ahliweb/awcms-astro keeps
+        rendering until it reads this field directly.
+      items:
+        $ref: "#/components/schemas/PortableTextNode"
     BlogInstitution:
       type: object
       required: [id, tenantId, branch, name, slug]
@@ -3430,8 +3545,18 @@ components:
           type: string
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
+          description: >-
+            ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key
+            is overwritten with the derived projection; other keys (notably
+            awcmsAstro) are preserved.
         contentText:
           type: string
+          description: >-
+            ADR-0100 — DERIVED from bodyPortableText. Still returned (it is what
+            the full-text index is built from) but no longer accepted on write.
+          readOnly: true
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         excerpt:
           type: string
           nullable: true

--- a/src/modules/blog-content/application/blog-page-directory.ts
+++ b/src/modules/blog-content/application/blog-page-directory.ts
@@ -12,6 +12,11 @@ import {
   boundedPageNumber,
   boundedPageSize
 } from "../../_shared/offset-pagination";
+import {
+  portableTextToPlainText,
+  withProjectedBlocks
+} from "../domain/portable-text-conversion";
+import type { PortableTextDocument } from "../domain/portable-text";
 
 /**
  * Read/write query module for `awcms_blog_pages` (Issue #539) — same
@@ -87,6 +92,8 @@ export type BlogPageView = {
   excerpt: string | null;
   contentJson: Record<string, unknown>;
   contentText: string;
+  /** ADR-0100 — the canonical body. `contentJson.blocks` is a derived projection of it. */
+  bodyPortableText: PortableTextDocument;
   status: BlogContentStatus;
   visibility: BlogContentVisibility;
   featuredMediaId: string | null;
@@ -118,6 +125,7 @@ type BlogPageRow = {
   excerpt: string | null;
   content_json: Record<string, unknown>;
   content_text: string;
+  body_portable_text: PortableTextDocument;
   status: BlogContentStatus;
   visibility: BlogContentVisibility;
   featured_media_id: string | null;
@@ -150,6 +158,7 @@ function toView(row: BlogPageRow): BlogPageView {
     excerpt: row.excerpt,
     contentJson: row.content_json,
     contentText: row.content_text,
+    bodyPortableText: row.body_portable_text,
     status: row.status,
     visibility: row.visibility,
     featuredMediaId: row.featured_media_id,
@@ -182,18 +191,22 @@ export async function createBlogPage(
   const rows = (await tx`
     INSERT INTO awcms_blog_pages
       (tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-       content_text, status, visibility, featured_media_id, seo_title,
+       content_text, body_portable_text, status, visibility, featured_media_id,
+       seo_title,
        meta_description, canonical_url, locale, page_type, parent_page_id,
        menu_order)
     VALUES (
       ${tenantId}, ${authorTenantUserId}, ${input.title}, ${input.slug},
-      ${input.excerpt}, ${input.contentJson}, ${input.contentText}, 'draft',
+      ${input.excerpt},
+      ${withProjectedBlocks(input.contentJson, input.bodyPortableText)},
+      ${portableTextToPlainText(input.bodyPortableText)},
+      ${JSON.stringify(input.bodyPortableText)}::jsonb, 'draft',
       ${input.visibility}, ${input.featuredMediaId}, ${input.seoTitle},
       ${input.metaDescription}, ${input.canonicalUrl}, ${input.locale},
       ${input.pageType}, ${input.parentPageId}, ${input.menuOrder}
     )
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_title,
       meta_description, canonical_url, locale, page_type, parent_page_id,
       menu_order, published_at, scheduled_at, created_at, updated_at,
       deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
@@ -216,7 +229,7 @@ export async function fetchBlogPageById(
     options.includeDeleted
       ? await tx`
         SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_title,
       meta_description, canonical_url, locale, page_type, parent_page_id,
       menu_order, published_at, scheduled_at, created_at, updated_at,
       deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
@@ -225,7 +238,7 @@ export async function fetchBlogPageById(
       `
       : await tx`
         SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_title,
       meta_description, canonical_url, locale, page_type, parent_page_id,
       menu_order, published_at, scheduled_at, created_at, updated_at,
       deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
@@ -365,8 +378,25 @@ export async function updateBlogPage(
     SET title = COALESCE(${input.title ?? null}, title),
         slug = COALESCE(${input.slug ?? null}, slug),
         excerpt = CASE WHEN ${input.excerpt === undefined} THEN excerpt ELSE ${input.excerpt ?? null} END,
-        content_json = COALESCE(${input.contentJson ?? null}, content_json),
-        content_text = COALESCE(${input.contentText ?? null}, content_text),
+        -- ADR-0100 — the three body columns move TOGETHER or not at all. A
+        -- partial update that changed the envelope without the body, or the
+        -- body without the derived search text, would leave the row internally
+        -- inconsistent in a way nothing downstream could detect.
+        content_json = CASE
+          WHEN ${input.bodyPortableText !== undefined}
+            THEN ${input.bodyPortableText === undefined ? null : withProjectedBlocks(input.contentJson, input.bodyPortableText)}
+          ELSE COALESCE(${input.contentJson ?? null}, content_json)
+        END,
+        content_text = CASE
+          WHEN ${input.bodyPortableText !== undefined}
+            THEN ${input.bodyPortableText === undefined ? null : portableTextToPlainText(input.bodyPortableText)}
+          ELSE content_text
+        END,
+        body_portable_text = CASE
+          WHEN ${input.bodyPortableText !== undefined}
+            THEN ${input.bodyPortableText === undefined ? null : JSON.stringify(input.bodyPortableText)}::jsonb
+          ELSE body_portable_text
+        END,
         locale = COALESCE(${input.locale ?? null}, locale),
         visibility = COALESCE(${input.visibility ?? null}, visibility),
         featured_media_id = CASE
@@ -392,7 +422,7 @@ export async function updateBlogPage(
         updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_title,
       meta_description, canonical_url, locale, page_type, parent_page_id,
       menu_order, published_at, scheduled_at, created_at, updated_at,
       deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
@@ -453,7 +483,7 @@ export async function transitionBlogPageStatus(
         updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_title,
       meta_description, canonical_url, locale, page_type, parent_page_id,
       menu_order, published_at, scheduled_at, created_at, updated_at,
       deleted_at, deleted_by, delete_reason, restored_at, restored_by, version
@@ -475,7 +505,7 @@ export async function restoreBlogPage(
         restored_at = now(), restored_by = ${actorTenantUserId}, updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_title,
       meta_description, canonical_url, locale, page_type, parent_page_id,
       menu_order, published_at, scheduled_at, created_at, updated_at,
       deleted_at, deleted_by, delete_reason, restored_at, restored_by, version

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -14,6 +14,11 @@ import {
   encodeKeysetCursor,
   type KeysetCursor
 } from "../../_shared/keyset-pagination";
+import {
+  portableTextToPlainText,
+  withProjectedBlocks
+} from "../domain/portable-text-conversion";
+import type { PortableTextDocument } from "../domain/portable-text";
 
 /**
  * Read/write query module for `awcms_blog_posts` (Issue #537 scaffolded
@@ -72,6 +77,8 @@ export type BlogPostView = {
   excerpt: string | null;
   contentJson: Record<string, unknown>;
   contentText: string;
+  /** ADR-0100 — the canonical body. `contentJson.blocks` is a derived projection of it. */
+  bodyPortableText: PortableTextDocument;
   status: BlogContentStatus;
   visibility: BlogContentVisibility;
   featuredMediaId: string | null;
@@ -115,6 +122,7 @@ type BlogPostRow = {
   excerpt: string | null;
   content_json: Record<string, unknown>;
   content_text: string;
+  body_portable_text: PortableTextDocument;
   status: BlogContentStatus;
   visibility: BlogContentVisibility;
   featured_media_id: string | null;
@@ -148,6 +156,7 @@ function toView(row: BlogPostRow): BlogPostView {
     excerpt: row.excerpt,
     contentJson: row.content_json,
     contentText: row.content_text,
+    bodyPortableText: row.body_portable_text,
     status: row.status,
     visibility: row.visibility,
     featuredMediaId: row.featured_media_id,
@@ -181,18 +190,22 @@ export async function createBlogPost(
   const rows = (await tx`
     INSERT INTO awcms_blog_posts
       (tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-       content_text, status, visibility, featured_media_id, seo_image_media_id,
+       content_text, body_portable_text, status, visibility, featured_media_id,
+       seo_image_media_id,
        seo_title, meta_description, canonical_url, locale,
        auto_internal_tag_links_disabled)
     VALUES (
       ${tenantId}, ${authorTenantUserId}, ${input.title}, ${input.slug},
-      ${input.excerpt}, ${input.contentJson}, ${input.contentText}, 'draft',
+      ${input.excerpt},
+      ${withProjectedBlocks(input.contentJson, input.bodyPortableText)},
+      ${portableTextToPlainText(input.bodyPortableText)},
+      ${JSON.stringify(input.bodyPortableText)}::jsonb, 'draft',
       ${input.visibility}, ${input.featuredMediaId}, ${input.seoImageMediaId},
       ${input.seoTitle}, ${input.metaDescription}, ${input.canonicalUrl}, ${input.locale},
       ${input.autoInternalTagLinksDisabled}
     )
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       unpublish_at, created_at, updated_at, deleted_at, deleted_by, delete_reason,
       restored_at, restored_by, version, auto_internal_tag_links_disabled,
@@ -217,7 +230,7 @@ export async function fetchBlogPostById(
     options.includeDeleted
       ? await tx`
         SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       unpublish_at, created_at, updated_at, deleted_at, deleted_by, delete_reason,
       restored_at, restored_by, version, auto_internal_tag_links_disabled,
@@ -227,7 +240,7 @@ export async function fetchBlogPostById(
       `
       : await tx`
         SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       unpublish_at, created_at, updated_at, deleted_at, deleted_by, delete_reason,
       restored_at, restored_by, version, auto_internal_tag_links_disabled,
@@ -383,7 +396,7 @@ export async function listBlogPostsFullPage(
 
   const rows = (await tx`
     SELECT id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       unpublish_at, created_at, updated_at, deleted_at, deleted_by, delete_reason,
       restored_at, restored_by, version, auto_internal_tag_links_disabled,
@@ -465,8 +478,25 @@ export async function updateBlogPost(
     SET title = COALESCE(${input.title ?? null}, title),
         slug = COALESCE(${input.slug ?? null}, slug),
         excerpt = CASE WHEN ${input.excerpt === undefined} THEN excerpt ELSE ${input.excerpt ?? null} END,
-        content_json = COALESCE(${input.contentJson ?? null}, content_json),
-        content_text = COALESCE(${input.contentText ?? null}, content_text),
+        -- ADR-0100 — the three body columns move TOGETHER or not at all. A
+        -- partial update that changed the envelope without the body, or the
+        -- body without the derived search text, would leave the row internally
+        -- inconsistent in a way nothing downstream could detect.
+        content_json = CASE
+          WHEN ${input.bodyPortableText !== undefined}
+            THEN ${input.bodyPortableText === undefined ? null : withProjectedBlocks(input.contentJson, input.bodyPortableText)}
+          ELSE COALESCE(${input.contentJson ?? null}, content_json)
+        END,
+        content_text = CASE
+          WHEN ${input.bodyPortableText !== undefined}
+            THEN ${input.bodyPortableText === undefined ? null : portableTextToPlainText(input.bodyPortableText)}
+          ELSE content_text
+        END,
+        body_portable_text = CASE
+          WHEN ${input.bodyPortableText !== undefined}
+            THEN ${input.bodyPortableText === undefined ? null : JSON.stringify(input.bodyPortableText)}::jsonb
+          ELSE body_portable_text
+        END,
         locale = COALESCE(${input.locale ?? null}, locale),
         visibility = COALESCE(${input.visibility ?? null}, visibility),
         featured_media_id = CASE
@@ -494,7 +524,7 @@ export async function updateBlogPost(
         updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       unpublish_at, created_at, updated_at, deleted_at, deleted_by, delete_reason,
       restored_at, restored_by, version, auto_internal_tag_links_disabled,
@@ -567,7 +597,7 @@ export async function transitionBlogPostStatus(
         updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       unpublish_at, created_at, updated_at, deleted_at, deleted_by, delete_reason,
       restored_at, restored_by, version, auto_internal_tag_links_disabled,
@@ -589,7 +619,7 @@ export async function restoreBlogPost(
         restored_at = now(), restored_by = ${actorTenantUserId}, updated_at = now()
     WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NOT NULL
     RETURNING id, tenant_id, author_tenant_user_id, title, slug, excerpt, content_json,
-      content_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
+      content_text, body_portable_text, status, visibility, featured_media_id, seo_image_media_id, seo_title,
       meta_description, canonical_url, locale, published_at, scheduled_at,
       unpublish_at, created_at, updated_at, deleted_at, deleted_by, delete_reason,
       restored_at, restored_by, version, auto_internal_tag_links_disabled,

--- a/src/modules/blog-content/application/blog-revision-directory.ts
+++ b/src/modules/blog-content/application/blog-revision-directory.ts
@@ -1,4 +1,5 @@
 import { log } from "../../../lib/logging/logger";
+import type { PortableTextDocument } from "../domain/portable-text";
 
 /**
  * Read/write query module for `awcms_blog_revisions` (Issue #541).
@@ -13,6 +14,8 @@ export type BlogRevisionSnapshot = {
   title: string;
   contentJson: Record<string, unknown>;
   contentText: string;
+  /** ADR-0100 — the body as it stood at this revision. `[]` on a revision written before the cutover; the restore path converts from `contentJson.blocks` in that case. */
+  bodyPortableText: PortableTextDocument;
   excerpt: string | null;
   seoTitle: string | null;
   metaDescription: string | null;
@@ -64,6 +67,8 @@ function toSummary(row: BlogRevisionSummaryRow): BlogRevisionSummary {
 export type BlogRevisionDetail = BlogRevisionSummary & {
   contentJson: Record<string, unknown>;
   contentText: string;
+  /** ADR-0100 — the body as it stood at this revision. `[]` on a revision written before the cutover; the restore path converts from `contentJson.blocks` in that case. */
+  bodyPortableText: PortableTextDocument;
   excerpt: string | null;
   seoTitle: string | null;
   metaDescription: string | null;
@@ -73,6 +78,7 @@ export type BlogRevisionDetail = BlogRevisionSummary & {
 type BlogRevisionDetailRow = BlogRevisionSummaryRow & {
   content_json: Record<string, unknown>;
   content_text: string;
+  body_portable_text: PortableTextDocument;
   excerpt: string | null;
   seo_title: string | null;
   meta_description: string | null;
@@ -84,6 +90,7 @@ function toDetail(row: BlogRevisionDetailRow): BlogRevisionDetail {
     ...toSummary(row),
     contentJson: row.content_json,
     contentText: row.content_text,
+    bodyPortableText: row.body_portable_text,
     excerpt: row.excerpt,
     seoTitle: row.seo_title,
     metaDescription: row.meta_description,
@@ -112,7 +119,8 @@ export async function createBlogRevision(
   const rows = (await tx`
     INSERT INTO awcms_blog_revisions
       (tenant_id, resource_type, resource_id, revision_number, title,
-       content_json, content_text, excerpt, seo_title, meta_description,
+       content_json, content_text, body_portable_text, excerpt, seo_title,
+       meta_description,
        canonical_url, status, change_note, created_by_tenant_user_id)
     VALUES (
       ${tenantId}, ${resourceType}, ${resourceId},
@@ -123,12 +131,14 @@ export async function createBlogRevision(
         0
       ) + 1,
       ${snapshot.title}, ${snapshot.contentJson}, ${snapshot.contentText},
+      ${JSON.stringify(snapshot.bodyPortableText)}::jsonb,
       ${snapshot.excerpt}, ${snapshot.seoTitle}, ${snapshot.metaDescription},
       ${snapshot.canonicalUrl}, ${snapshot.status}, ${changeNote},
       ${createdByTenantUserId}
     )
     RETURNING id, tenant_id, resource_type, resource_id, revision_number, title,
-      content_json, content_text, excerpt, seo_title, meta_description,
+      content_json, content_text, body_portable_text, excerpt, seo_title,
+      meta_description,
       canonical_url, status, change_note, created_by_tenant_user_id, created_at
   `) as BlogRevisionDetailRow[];
 
@@ -186,7 +196,8 @@ export async function fetchBlogRevisionById(
 ): Promise<BlogRevisionDetail | null> {
   const rows = (await tx`
     SELECT id, tenant_id, resource_type, resource_id, revision_number, title,
-      content_json, content_text, excerpt, seo_title, meta_description,
+      content_json, content_text, body_portable_text, excerpt, seo_title,
+      meta_description,
       canonical_url, status, change_note, created_by_tenant_user_id, created_at
     FROM awcms_blog_revisions
     WHERE tenant_id = ${tenantId} AND resource_type = ${resourceType}

--- a/src/modules/blog-content/domain/blog-page-validation.ts
+++ b/src/modules/blog-content/domain/blog-page-validation.ts
@@ -1,7 +1,7 @@
 import {
   validateBlogContentCore,
   validateContentJsonField,
-  validateContentTextField,
+  rejectSuppliedContentText,
   validateDeleteReasonInput,
   validateExcerptField,
   validateLocaleField,
@@ -10,6 +10,8 @@ import {
   type DeleteReasonInput
 } from "./content-validation";
 import { validateSeoFields } from "./seo-validation";
+import { validatePortableTextDocument } from "./portable-text-validation";
+import type { PortableTextDocument } from "./portable-text";
 import {
   isBlogContentVisibility,
   type BlogContentVisibility
@@ -76,7 +78,8 @@ export type CreateBlogPageInput = {
   slug: string;
   excerpt: string | null;
   contentJson: Record<string, unknown>;
-  contentText: string;
+  /** ADR-0100 — the canonical body. `contentText` is derived from it, never supplied. */
+  bodyPortableText: PortableTextDocument;
   locale: string;
   visibility: BlogContentVisibility;
   featuredMediaId: string | null;
@@ -100,6 +103,14 @@ export function validateCreateBlogPageInput(
   const record = (body ?? {}) as Record<string, unknown>;
 
   const coreResult = validateBlogContentCore(record);
+
+  // ADR-0100 — the body is REQUIRED on create. An article with no body is not a
+  // draft, it is a row nothing can render, and accepting it would move the
+  // failure to whoever opens the page.
+  const bodyResult = validatePortableTextDocument(record.bodyPortableText);
+  if (!bodyResult.valid) {
+    errors.push(...bodyResult.errors);
+  }
   if (!coreResult.valid) {
     errors.push(...coreResult.errors);
   }
@@ -157,6 +168,7 @@ export function validateCreateBlogPageInput(
   if (
     errors.length > 0 ||
     !coreResult.valid ||
+    !bodyResult.valid ||
     !seoResult.valid ||
     !featuredMediaIdResult.valid ||
     !parentPageIdResult.valid ||
@@ -169,6 +181,7 @@ export function validateCreateBlogPageInput(
     valid: true,
     value: {
       ...coreResult.value,
+      bodyPortableText: bodyResult.valid ? bodyResult.value : [],
       visibility,
       featuredMediaId: featuredMediaIdResult.value,
       seoTitle: seoResult.value.seoTitle ?? null,
@@ -186,7 +199,7 @@ export type UpdateBlogPageInput = {
   slug?: string;
   excerpt?: string | null;
   contentJson?: Record<string, unknown>;
-  contentText?: string;
+  bodyPortableText?: PortableTextDocument;
   locale?: string;
   visibility?: BlogContentVisibility;
   featuredMediaId?: string | null;
@@ -248,12 +261,20 @@ export function validateUpdateBlogPageInput(
     }
   }
 
-  if (record.contentText !== undefined) {
-    const error = validateContentTextField(record.contentText);
-    if (error) {
-      errors.push(error);
+  // ADR-0100 — supplying `contentText` is refused rather than ignored.
+  const suppliedContentTextError = rejectSuppliedContentText(
+    record.contentText
+  );
+  if (suppliedContentTextError) {
+    errors.push(suppliedContentTextError);
+  }
+
+  if (record.bodyPortableText !== undefined) {
+    const result = validatePortableTextDocument(record.bodyPortableText);
+    if (!result.valid) {
+      errors.push(...result.errors);
     } else {
-      value.contentText = record.contentText as string;
+      value.bodyPortableText = result.value;
     }
   }
 

--- a/src/modules/blog-content/domain/blog-post-validation.ts
+++ b/src/modules/blog-content/domain/blog-post-validation.ts
@@ -1,7 +1,7 @@
 import {
   validateBlogContentCore,
   validateContentJsonField,
-  validateContentTextField,
+  rejectSuppliedContentText,
   validateDeleteReasonInput,
   validateExcerptField,
   validateLocaleField,
@@ -10,6 +10,8 @@ import {
   type DeleteReasonInput
 } from "./content-validation";
 import { validateSeoFields } from "./seo-validation";
+import { validatePortableTextDocument } from "./portable-text-validation";
+import type { PortableTextDocument } from "./portable-text";
 import {
   isBlogContentVisibility,
   type BlogContentVisibility
@@ -25,7 +27,8 @@ export type CreateBlogPostInput = {
   slug: string;
   excerpt: string | null;
   contentJson: Record<string, unknown>;
-  contentText: string;
+  /** ADR-0100 — the canonical body. `contentText` is derived from it, never supplied. */
+  bodyPortableText: PortableTextDocument;
   locale: string;
   visibility: BlogContentVisibility;
   featuredMediaId: string | null;
@@ -105,6 +108,14 @@ export function validateCreateBlogPostInput(
   const record = (body ?? {}) as Record<string, unknown>;
 
   const coreResult = validateBlogContentCore(record);
+
+  // ADR-0100 — the body is REQUIRED on create. An article with no body is not a
+  // draft, it is a row nothing can render, and accepting it would move the
+  // failure to whoever opens the page.
+  const bodyResult = validatePortableTextDocument(record.bodyPortableText);
+  if (!bodyResult.valid) {
+    errors.push(...bodyResult.errors);
+  }
   if (!coreResult.valid) {
     errors.push(...coreResult.errors);
   }
@@ -175,6 +186,7 @@ export function validateCreateBlogPostInput(
   if (
     errors.length > 0 ||
     !coreResult.valid ||
+    !bodyResult.valid ||
     !seoResult.valid ||
     !featuredMediaIdResult.valid ||
     !seoImageMediaIdResult.valid ||
@@ -188,6 +200,7 @@ export function validateCreateBlogPostInput(
     valid: true,
     value: {
       ...coreResult.value,
+      bodyPortableText: bodyResult.valid ? bodyResult.value : [],
       visibility,
       featuredMediaId: featuredMediaIdResult.value,
       seoImageMediaId: seoImageMediaIdResult.value,
@@ -206,7 +219,7 @@ export type UpdateBlogPostInput = {
   slug?: string;
   excerpt?: string | null;
   contentJson?: Record<string, unknown>;
-  contentText?: string;
+  bodyPortableText?: PortableTextDocument;
   locale?: string;
   visibility?: BlogContentVisibility;
   featuredMediaId?: string | null;
@@ -269,12 +282,20 @@ export function validateUpdateBlogPostInput(
     }
   }
 
-  if (record.contentText !== undefined) {
-    const error = validateContentTextField(record.contentText);
-    if (error) {
-      errors.push(error);
+  // ADR-0100 — supplying `contentText` is refused rather than ignored.
+  const suppliedContentTextError = rejectSuppliedContentText(
+    record.contentText
+  );
+  if (suppliedContentTextError) {
+    errors.push(suppliedContentTextError);
+  }
+
+  if (record.bodyPortableText !== undefined) {
+    const result = validatePortableTextDocument(record.bodyPortableText);
+    if (!result.valid) {
+      errors.push(...result.errors);
     } else {
-      value.contentText = record.contentText as string;
+      value.bodyPortableText = result.value;
     }
   }
 

--- a/src/modules/blog-content/domain/content-validation.ts
+++ b/src/modules/blog-content/domain/content-validation.ts
@@ -16,8 +16,12 @@ export type BlogContentCoreInput = {
   title: string;
   slug: string;
   excerpt: string | null;
+  /**
+   * ADR-0100 — the non-body ENVELOPE. The body lives in `bodyPortableText`;
+   * this carries whatever else a consumer stores here (notably `awcmsAstro`),
+   * and its `blocks` key is overwritten with the derived projection on write.
+   */
   contentJson: Record<string, unknown>;
-  contentText: string;
   locale: string;
 };
 
@@ -186,6 +190,28 @@ export function validateDeleteReasonInput(
   return { valid: true, value: { reason: record.reason.trim() } };
 }
 
+/**
+ * ADR-0100 — `contentText` is DERIVED and must not be supplied.
+ *
+ * Refused loudly rather than ignored. A field that is silently dropped is one a
+ * caller keeps sending for months while believing it does something, and the
+ * belief only surfaces when their search results disagree with their articles.
+ * The message names the replacement so the fix is obvious from the response.
+ */
+export function rejectSuppliedContentText(
+  value: unknown
+): ValidationError | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  return {
+    field: "contentText",
+    message:
+      "contentText is derived from bodyPortableText and must not be supplied (ADR-0100). Remove it from the request."
+  };
+}
+
 export function validateBlogContentCore(
   body: unknown
 ): BlogContentCoreValidationResult {
@@ -194,8 +220,14 @@ export function validateBlogContentCore(
     validateTitleField(record.title),
     validateSlugField(record.slug),
     validateExcerptField(record.excerpt),
-    validateContentJsonField(record.contentJson),
-    validateContentTextField(record.contentText),
+    // ADR-0100 — `contentJson` is now the non-body ENVELOPE and is optional. It
+    // still carries `awcmsAstro`, the structured sidecar the sibling repo
+    // stores there, so a caller may send it; its `blocks` key is overwritten
+    // with the derived projection either way.
+    record.contentJson === undefined
+      ? null
+      : validateContentJsonField(record.contentJson),
+    rejectSuppliedContentText(record.contentText),
     validateLocaleField(record.locale)
   ].filter((error): error is ValidationError => error !== null);
 
@@ -212,8 +244,7 @@ export function validateBlogContentCore(
         record.excerpt === undefined || record.excerpt === null
           ? null
           : (record.excerpt as string).trim(),
-      contentJson: record.contentJson as Record<string, unknown>,
-      contentText: record.contentText as string,
+      contentJson: (record.contentJson ?? {}) as Record<string, unknown>,
       locale: isNonEmptyString(record.locale) ? record.locale.trim() : "id"
     }
   };

--- a/src/pages/api/v1/blog/pages/[id].ts
+++ b/src/pages/api/v1/blog/pages/[id].ts
@@ -321,6 +321,7 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
           title: updated.title,
           contentJson: updated.contentJson,
           contentText: updated.contentText,
+          bodyPortableText: updated.bodyPortableText,
           excerpt: updated.excerpt,
           seoTitle: updated.seoTitle,
           metaDescription: updated.metaDescription,

--- a/src/pages/api/v1/blog/posts/[id].ts
+++ b/src/pages/api/v1/blog/posts/[id].ts
@@ -344,6 +344,7 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
           title: updated.title,
           contentJson: updated.contentJson,
           contentText: updated.contentText,
+          bodyPortableText: updated.bodyPortableText,
           excerpt: updated.excerpt,
           seoTitle: updated.seoTitle,
           metaDescription: updated.metaDescription,

--- a/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
+++ b/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
@@ -1,6 +1,11 @@
 import type { APIRoute } from "astro";
 
 import {
+  contentBlocksToPortableText,
+  readLegacyBlocks
+} from "../../../../../../../../modules/blog-content/domain/portable-text-conversion";
+
+import {
   fail,
   jsonResponse,
   ok
@@ -212,10 +217,26 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       );
     }
 
+    // ADR-0100 — a revision written BEFORE the cutover carries an empty
+    // `bodyPortableText` and its real body in `contentJson.blocks`. Restoring it
+    // verbatim would blank the post, and nothing would fail: the row would be
+    // valid and the page would just be empty. So an empty body is converted
+    // from the revision's own envelope rather than trusted.
+    //
+    // This is the "restore revision bypasses the new write path" defect class
+    // this epic has already hit once, closed at the one call site that can
+    // reintroduce a legacy body into a live post.
+    const restoredBody =
+      revision.bodyPortableText.length > 0
+        ? revision.bodyPortableText
+        : contentBlocksToPortableText(
+            readLegacyBlocks(normalizedContentJson) ?? []
+          );
+
     const updated = await updateBlogPost(tx, tenantId, postId, {
       title: revision.title,
       contentJson: normalizedContentJson,
-      contentText: revision.contentText,
+      bodyPortableText: restoredBody,
       excerpt: revision.excerpt,
       seoTitle: revision.seoTitle,
       metaDescription: revision.metaDescription,
@@ -236,6 +257,7 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
         title: updated.title,
         contentJson: updated.contentJson,
         contentText: updated.contentText,
+        bodyPortableText: updated.bodyPortableText,
         excerpt: updated.excerpt,
         seoTitle: updated.seoTitle,
         metaDescription: updated.metaDescription,

--- a/tests/blog-content-domain.test.ts
+++ b/tests/blog-content-domain.test.ts
@@ -30,7 +30,22 @@ describe("validateBlogContentCore", () => {
       slug: "hello-world",
       excerpt: null,
       contentJson: { blocks: [] },
-      contentText: "Hello world body."
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [
+            {
+              _type: "span",
+              _key: "b0s0",
+              text: "Hello world body.",
+              marks: []
+            }
+          ],
+          markDefs: []
+        }
+      ]
     });
 
     expect(result.valid).toBe(true);
@@ -40,7 +55,6 @@ describe("validateBlogContentCore", () => {
         slug: "hello-world",
         excerpt: null,
         contentJson: { blocks: [] },
-        contentText: "Hello world body.",
         locale: "id"
       });
     }
@@ -50,7 +64,15 @@ describe("validateBlogContentCore", () => {
     const result = validateBlogContentCore({
       slug: "Not A Valid Slug!",
       contentJson: {},
-      contentText: "body"
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+          markDefs: []
+        }
+      ]
     });
 
     expect(result.valid).toBe(false);
@@ -66,7 +88,15 @@ describe("validateBlogContentCore", () => {
       title: "Title",
       slug: "title",
       contentJson: "not-an-object",
-      contentText: "body"
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+          markDefs: []
+        }
+      ]
     });
 
     expect(result.valid).toBe(false);
@@ -77,12 +107,15 @@ describe("validateBlogContentCore", () => {
     }
   });
 
-  test("rejects a <script> tag in contentText", () => {
+  test("rejects contentText outright — it is derived now, not supplied (ADR-0100)", () => {
     const result = validateBlogContentCore({
       title: "Title",
       slug: "title",
       contentJson: {},
-      contentText: "<script>alert(1)</script>"
+      // Refused because it is SUPPLIED at all, not because of its content: a
+      // field silently dropped is one a caller keeps sending for months.
+      contentText: "<script>alert(1)</script>",
+      bodyPortableText: []
     });
 
     expect(result.valid).toBe(false);
@@ -98,7 +131,15 @@ describe("validateBlogContentCore", () => {
       title: "Title",
       slug: "title",
       contentJson: { html: '<img src=x onerror="alert(1)">' },
-      contentText: "body"
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+          markDefs: []
+        }
+      ]
     });
 
     expect(result.valid).toBe(false);
@@ -109,12 +150,20 @@ describe("validateBlogContentCore", () => {
     }
   });
 
-  test("accepts plain contentJson/contentText with no markup", () => {
+  test("accepts a plain contentJson envelope and body with no markup", () => {
     const result = validateBlogContentCore({
       title: "Title",
       slug: "title",
       contentJson: { blocks: [{ type: "paragraph", text: "Hello" }] },
-      contentText: "Hello"
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "Hello", marks: [] }],
+          markDefs: []
+        }
+      ]
     });
 
     expect(result.valid).toBe(true);

--- a/tests/blog-content-pages-terms-validation.test.ts
+++ b/tests/blog-content-pages-terms-validation.test.ts
@@ -31,7 +31,15 @@ describe("validateCreateBlogPageInput", () => {
     title: "About",
     slug: "about",
     contentJson: {},
-    contentText: "body"
+    bodyPortableText: [
+      {
+        _type: "block",
+        _key: "b0",
+        style: "normal",
+        children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+        markDefs: []
+      }
+    ]
   };
 
   test("accepts a minimal valid payload with defaults", () => {

--- a/tests/blog-content-posts-validation.test.ts
+++ b/tests/blog-content-posts-validation.test.ts
@@ -22,7 +22,15 @@ describe("validateCreateBlogPostInput", () => {
       title: "Hello",
       slug: "hello",
       contentJson: {},
-      contentText: "body"
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+          markDefs: []
+        }
+      ]
     });
 
     expect(result.valid).toBe(true);
@@ -38,7 +46,15 @@ describe("validateCreateBlogPostInput", () => {
       title: "Hello",
       slug: "hello",
       contentJson: {},
-      contentText: "body",
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+          markDefs: []
+        }
+      ],
       visibility: "bogus"
     });
 
@@ -53,7 +69,15 @@ describe("validateCreateBlogPostInput", () => {
       title: "Hello",
       slug: "hello",
       contentJson: {},
-      contentText: "body",
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+          markDefs: []
+        }
+      ],
       featuredMediaId: "not-a-uuid"
     });
 
@@ -69,7 +93,15 @@ describe("validateCreateBlogPostInput", () => {
     const result = validateCreateBlogPostInput({
       slug: "hello",
       contentJson: {},
-      contentText: "body"
+      bodyPortableText: [
+        {
+          _type: "block",
+          _key: "b0",
+          style: "normal",
+          children: [{ _type: "span", _key: "s0", text: "body", marks: [] }],
+          markDefs: []
+        }
+      ]
     });
 
     expect(result.valid).toBe(false);

--- a/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
+++ b/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
@@ -608,8 +608,13 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
+          description: ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved.
         contentText:
           type: string
+          description: ADR-0100 — DERIVED from bodyPortableText. Still returned (it is what the full-text index is built from) but no longer accepted on write.
+          readOnly: true
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         status:
           type: string
           enum:
@@ -657,6 +662,11 @@ components:
           type: string
           format: date-time
           nullable: true
+        unpublishAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Issue
         createdAt:
           type: string
           format: date-time
@@ -737,8 +747,9 @@ components:
           nullable: true
         contentJson:
           $ref: "#/components/schemas/BlogContentJson"
-        contentText:
-          type: string
+          description: ADR-0100 — the non-body ENVELOPE, optional on write. Its blocks key is overwritten with the derived projection; other keys (notably awcmsAstro) are preserved.
+        bodyPortableText:
+          $ref: "#/components/schemas/PortableTextBody"
         locale:
           type: string
         visibility:
@@ -878,6 +889,104 @@ components:
             - active
             - expired
             - revoked
+    PortableTextBody:
+      type: array
+      maxItems: 2000
+      description: ADR-0100 — the canonical article body. contentJson.blocks is a derived, LOSSY projection of this, written only so ahliweb/awcms-astro keeps rendering until it reads this field directly.
+      items:
+        $ref: "#/components/schemas/PortableTextNode"
+    PortableTextLinkAnnotation:
+      type: object
+      required:
+        - _type
+        - _key
+        - href
+      properties:
+        _type:
+          type: string
+          enum:
+            - link
+        _key:
+          type: string
+        href:
+          type: string
+          maxLength: 2048
+          description: "Relative, or http/https/mailto/tel. Checked by URL parsing rather than a pattern, so java\\nscript: and JaVaScRiPt: are refused too."
+    PortableTextNode:
+      type: object
+      required:
+        - _type
+        - _key
+      description: One node of a CLOSED Portable Text vocabulary (ADR-0100). _type is one of block, gallery, videoNews — anything else is refused at write time, which is what keeps "there is no field where arbitrary markup could live" true.
+      properties:
+        _type:
+          type: string
+          enum:
+            - block
+            - gallery
+            - videoNews
+        _key:
+          type: string
+        style:
+          type: string
+          enum:
+            - normal
+            - h1
+            - h2
+            - h3
+            - h4
+            - h5
+            - h6
+            - blockquote
+        listItem:
+          type: string
+          enum:
+            - bullet
+            - number
+        level:
+          type: integer
+          minimum: 1
+          maximum: 6
+        children:
+          type: array
+          items:
+            $ref: "#/components/schemas/PortableTextSpan"
+        markDefs:
+          type: array
+          items:
+            $ref: "#/components/schemas/PortableTextLinkAnnotation"
+        items:
+          type: array
+          description: Gallery items — present when _type is gallery.
+          items:
+            type: object
+        provider:
+          type: string
+          description: Present when _type is videoNews.
+        videoId:
+          type: string
+          description: Present when _type is videoNews.
+    PortableTextSpan:
+      type: object
+      required:
+        - _type
+        - _key
+        - text
+      properties:
+        _type:
+          type: string
+          enum:
+            - span
+        _key:
+          type: string
+        text:
+          type: string
+          description: PLAIN text — never markup.
+        marks:
+          type: array
+          items:
+            type: string
+          description: Decorator names (strong, em, code) and/or the _key of an annotation declared in this block's own markDefs. A mark naming neither is refused at write time as a dangling reference.
     ResolvedMediaReference:
       type: object
       description: A media object safe to reference publicly (verified/attached, same tenant, not deleted).


### PR DESCRIPTION
Completes #588's backend half. #604 landed the format, validator, renderer and converter; this wires them to the endpoints.

## Breaking

- **`contentText` is refused** on create and update, with a message naming its replacement. Refused rather than ignored — a field silently dropped is one a caller keeps sending for months while believing it does something, and the belief only surfaces when their search results disagree with their articles.
- **`bodyPortableText` is required** on create. An article with no body is not a draft; it is a row nothing can render, and accepting it moves the failure to whoever opens the page.
- **`contentJson` becomes optional**, and is now the non-body envelope. It still carries `awcmsAstro`, the sidecar the sibling repo stores there; its `blocks` key is overwritten with the derived projection on every write.

## The three body columns move together, or not at all

A partial update that changed the envelope without the body — or the body without the derived search text — would leave a row internally inconsistent in a way **nothing downstream could detect**. They are written in one `CASE` keyed on whether a body arrived.

## Restoring an old revision no longer blanks the post

A revision written before the cutover carries an empty `bodyPortableText` and its real body in `contentJson.blocks`. Restoring it verbatim would blank the post — and **nothing would fail**: the row would be valid, the page would just be empty.

The restore path now converts from the revision's own envelope when the body is empty. This is the *"restore revision bypasses the new write path"* defect class this epic has already hit once, closed at the one call site that can reintroduce a legacy body into a live post.

## The frozen consumer contract was regenerated — deliberately, and after checking

`api:consumer-contract:check` correctly refused `BlogPostWriteInput` as non-additive (ADR-0065). Regenerating is the sanctioned act, and it was taken **only after verifying the premise**:

> `awcms-astro` never writes. Its only call to this API is `awcmsGet("/api/v1/blog/posts")`, and it declares `contentText?: string` without reading it anywhere.

So `contentText` **stays in every response schema**, marked `readOnly` — the column still exists and is still what the full-text index is built from. Only the write inputs changed. Had that check gone the other way, this would have needed a coordinated release instead.

## Verification

Full `bun run check` green — 52 gates, 4,896 tests, build. The five existing validator tests that encoded the old contract were updated rather than deleted; they are the record of what changed.