### PR TITLE
fix(security): the CSP blocked every direct-to-R2 upload before a byte left the browser

### DIFF
--- a/.changeset/csp-connect-src-for-media-upload.md
+++ b/.changeset/csp-connect-src-for-media-upload.md
@@ -1,0 +1,32 @@
+---
+"awcms": patch
+---
+
+fix(security): the CSP blocked every direct-to-R2 upload before a byte left the browser
+
+`media_library` has had the whole presigned upload flow for months — create a
+session, `PUT` the bytes straight to R2, finalize. The browser half could never
+have worked: the policy had **no `connect-src` directive at all**, so it fell
+through to `default-src 'self'` and the browser refused the cross-origin `PUT`.
+
+This is the **third** instance of one defect in this file. `img-src` was missed
+and every R2 image rendered as an empty box; `media-src` was missed the same way
+and every gallery video stayed blocked while the images beside it loaded. A
+directive that is never named does not announce its fall-through — the failure
+appears in a browser console, not in a response the server can see.
+
+### The origin is not the one already in the policy
+
+Reads come from `NEWS_MEDIA_R2_PUBLIC_BASE_URL`, usually a custom domain. Writes
+go to R2's S3 API endpoint, `https://{accountId}.r2.cloudflarestorage.com`.
+Reusing the public base for `connect-src` would emit a policy that reads as
+correctly configured and still blocks every upload, so
+`deriveMediaUploadOrigin` derives the write origin separately and a test pins
+that they differ.
+
+`connect-src` is emitted unconditionally — naming it is the entire point — and
+names the R2 origin only when uploads are configured. On a LAN/offline
+deployment the directive is exactly `connect-src 'self'` and no third-party
+origin appears anywhere in the policy, unchanged.
+
+Prerequisite for the upload UI in #595: without it there is nothing to build on.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 150   |
 | Tables with `FORCE` RLS             | 132   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 403   |
+| Test files                          | 404   |
 | Route files                         | 366   |
 | ADR                                 | 204   |
 
@@ -341,7 +341,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 347        |
+| `(root)`      | 348        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |

--- a/src/lib/security/security-headers.ts
+++ b/src/lib/security/security-headers.ts
@@ -91,6 +91,18 @@
  * deployment value can never reach the header — a rejected policy would take
  * every other directive down with it.
  *
+ * MEDIA UPLOADS — `connect-src`, the THIRD directive missed the same way. The
+ * direct-to-R2 flow has the browser `PUT` bytes to a presigned URL on R2's S3
+ * API endpoint, and `fetch`/`XHR` to a third-party origin is governed by
+ * `connect-src`. With no such directive it fell through to `default-src 'self'`
+ * and the browser refused every upload before a byte left the machine — which
+ * is why no upload UI existed to be broken (Issue #595).
+ *
+ * Note the origin is NOT the `img-src` one. Reads come from
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL` (usually a custom domain); writes go to
+ * `https://{accountId}.r2.cloudflarestorage.com`. Reusing the public base here
+ * would emit a policy that reads correctly and still blocks every upload.
+ *
  * When no public media is configured — the LAN/offline default — the directive
  * is `img-src 'self' data:` and NO third-party origin appears anywhere in the
  * policy. That guarantee is unchanged. `data:` is stated in both cases because
@@ -103,6 +115,7 @@
 import { TURNSTILE_ORIGIN } from "./turnstile";
 import { THEME_INIT_SCRIPT_HASH } from "./theme-init-script";
 import { deriveMediaPublicOrigin } from "../../modules/media-library/domain/media-public-origin";
+import { deriveMediaUploadOrigin } from "../../modules/media-library/domain/media-upload-origin";
 import { resolveNewsMediaR2Config } from "../../modules/media-library/domain/media-r2-config";
 
 const BASE_CSP_DIRECTIVES = [
@@ -180,15 +193,59 @@ function mediaSrcSources(mediaPublicBaseUrl: string): string {
   return sources.join(" ");
 }
 
+/**
+ * `connect-src` is the THIRD directive missed the same way `img-src` and
+ * `media-src` were, and the one that made a whole feature impossible rather
+ * than merely ugly.
+ *
+ * The direct-to-R2 upload flow (`r2-upload-sop.md` §2) has the browser `PUT`
+ * bytes straight to a presigned URL on R2's S3 API endpoint — a THIRD-PARTY
+ * origin, and `fetch`/`XHR` to it is governed by `connect-src`. With no such
+ * directive it fell through to `default-src 'self'` and the browser refused
+ * the request before a byte left the machine, so no upload UI could work at
+ * all.
+ *
+ * The origin is NOT re-derived here: `deriveMediaUploadOrigin` owns it, and it
+ * is deliberately a DIFFERENT origin from the `img-src` one — reads come from
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL` (usually a custom domain), writes go to
+ * `https://{accountId}.r2.cloudflarestorage.com`. Using the public base here
+ * would emit a policy that looks right and still blocks every upload.
+ *
+ * Unconditional, like its two siblings — naming the directive is the whole
+ * point. On a LAN/offline deployment R2 is off, `configured` is false, and the
+ * policy is exactly `connect-src 'self'` with no third-party origin anywhere.
+ */
+function connectSrcSources(
+  uploadAccountId: string,
+  uploadEndpointOverride: string
+): string {
+  const sources = ["'self'"];
+  const upload = deriveMediaUploadOrigin(
+    uploadAccountId,
+    uploadEndpointOverride
+  );
+
+  if (upload.configured && upload.origin !== null) {
+    sources.push(upload.origin);
+  }
+
+  return sources.join(" ");
+}
+
 function buildContentSecurityPolicy(
   turnstileEnabled: boolean,
-  mediaPublicBaseUrl: string
+  mediaPublicBaseUrl: string,
+  uploadAccountId: string,
+  uploadEndpointOverride: string
 ): string {
   const directives: string[] = [...BASE_CSP_DIRECTIVES];
 
   directives.push(`script-src ${scriptSrcSources(turnstileEnabled)}`);
   directives.push(`img-src ${imgSrcSources(mediaPublicBaseUrl)}`);
   directives.push(`media-src ${mediaSrcSources(mediaPublicBaseUrl)}`);
+  directives.push(
+    `connect-src ${connectSrcSources(uploadAccountId, uploadEndpointOverride)}`
+  );
 
   if (turnstileEnabled) {
     directives.push(`frame-src ${TURNSTILE_ORIGIN}`);
@@ -222,6 +279,26 @@ export type SecurityHeaderOptions = {
    * environment; `""` is the unconfigured state, not "use the default".
    */
   mediaPublicBaseUrl?: string;
+  /**
+   * The R2 account id whose S3 API endpoint the browser `PUT`s uploads to,
+   * and which therefore goes into `connect-src`.
+   *
+   * Separate from `mediaPublicBaseUrl` on purpose: reads and writes go to
+   * different origins (see `deriveMediaUploadOrigin`). Defaults to the
+   * deployment's own `NEWS_MEDIA_R2_ACCOUNT_ID` for the same reason
+   * `mediaPublicBaseUrl` defaults — a default of "unconfigured" would make the
+   * directive silently wrong on every deployment that accepts uploads.
+   *
+   * `""` is the unconfigured state, not "use the default".
+   */
+  mediaUploadAccountId?: string;
+  /**
+   * Test-only endpoint override, mirroring `media-r2-client.ts`'s own: when a
+   * local fake S3 server stands in for R2, the policy has to name IT or the
+   * fake is blocked exactly as the real endpoint would be — which would make
+   * an upload test pass or fail for a reason unrelated to what it tests.
+   */
+  mediaUploadEndpoint?: string;
 };
 
 export function buildSecurityHeaders(
@@ -232,7 +309,9 @@ export function buildSecurityHeaders(
       "Content-Security-Policy",
       buildContentSecurityPolicy(
         options.turnstileEnabled === true,
-        options.mediaPublicBaseUrl ?? resolveNewsMediaR2Config().publicBaseUrl
+        options.mediaPublicBaseUrl ?? resolveNewsMediaR2Config().publicBaseUrl,
+        options.mediaUploadAccountId ?? resolveNewsMediaR2Config().accountId,
+        options.mediaUploadEndpoint ?? ""
       )
     ],
     ["X-Content-Type-Options", "nosniff"],

--- a/src/modules/media-library/domain/media-upload-origin.ts
+++ b/src/modules/media-library/domain/media-upload-origin.ts
@@ -1,0 +1,97 @@
+/**
+ * The origin a BROWSER uploads bytes to, derived from deployment config so a
+ * Content-Security-Policy never has to hold a second copy of it.
+ *
+ * ## Why this is a different origin from the public one
+ *
+ * `deriveMediaPublicOrigin` answers "where are media objects READ from" —
+ * `NEWS_MEDIA_R2_PUBLIC_BASE_URL`, typically an R2 custom domain. This answers
+ * a different question: "where does the presigned `PUT` go", which is R2's
+ * S3-compatible API endpoint, `https://{accountId}.r2.cloudflarestorage.com`
+ * (`media-r2-client.ts` builds exactly that, with a test-only override).
+ *
+ * They are not interchangeable and are usually not even the same host. A
+ * deployment can serve reads from `media.example.com` while every upload still
+ * goes to the account endpoint.
+ *
+ * ## Why a CSP needs it at all, and why its absence was invisible
+ *
+ * The direct-to-R2 upload flow is `POST` a session here, then `PUT` the bytes
+ * from the browser straight to the presigned URL. That `PUT` is a
+ * `fetch`/`XMLHttpRequest` to a THIRD-PARTY origin, and `connect-src` governs
+ * it. Until this existed there was no `connect-src` directive at all, so it
+ * fell through to `default-src 'self'` and the browser refused the upload
+ * before a byte left the machine.
+ *
+ * This is the THIRD instance of one defect: `img-src` was missed and every R2
+ * image rendered as an empty box; `media-src` was missed the same way and every
+ * gallery video stayed blocked while the images beside it loaded. The shape
+ * repeats because a directive that is never named does not announce its
+ * fall-through — the failure appears in a console, not in a response.
+ *
+ * ## Unconfigured is a STATE, not an error
+ *
+ * On LAN/offline deployments R2 is switched off entirely and no upload origin
+ * exists. That reports `configured: false` so the caller adds no third-party
+ * source rather than a broken one — the same contract, and for the same
+ * reason, as `deriveMediaPublicOrigin`.
+ */
+
+export type MediaUploadOrigin = {
+  /** `false` when the deployment accepts no direct-to-R2 upload at all. */
+  configured: boolean;
+  /** Scheme + host + port, e.g. `https://abc123.r2.cloudflarestorage.com`. */
+  origin: string | null;
+};
+
+const UNCONFIGURED: MediaUploadOrigin = { configured: false, origin: null };
+
+/**
+ * Derives the browser-visible upload origin.
+ *
+ * `endpointOverride` mirrors `media-r2-client.ts`'s own test-only override (a
+ * local fake S3-compatible server): when it is set it IS the endpoint, so the
+ * policy must name it or the fake is blocked exactly as the real one would be.
+ *
+ * A value that is set but unparseable reports UNCONFIGURED rather than being
+ * echoed back, for the reason `deriveMediaPublicOrigin` states: handing a
+ * consumer a malformed origin to put in a CSP is worse than telling it there is
+ * none, because the whole policy can be rejected and take every other directive
+ * with it.
+ */
+export function deriveMediaUploadOrigin(
+  accountId: string,
+  endpointOverride?: string
+): MediaUploadOrigin {
+  const override = (endpointOverride ?? "").trim();
+
+  if (override !== "") {
+    return parseOrigin(override);
+  }
+
+  const account = accountId.trim();
+
+  if (account === "") return UNCONFIGURED;
+
+  // The account id lands in a host name. Anything outside the character set R2
+  // actually issues would either be a different host or an invalid one, and a
+  // CSP source is the wrong place to discover that.
+  if (!/^[A-Za-z0-9-]+$/.test(account)) return UNCONFIGURED;
+
+  return parseOrigin(`https://${account}.r2.cloudflarestorage.com`);
+}
+
+function parseOrigin(candidate: string): MediaUploadOrigin {
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return UNCONFIGURED;
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    return UNCONFIGURED;
+  }
+
+  return { configured: true, origin: parsed.origin };
+}

--- a/tests/media-upload-origin.test.ts
+++ b/tests/media-upload-origin.test.ts
@@ -1,0 +1,99 @@
+/**
+ * `deriveMediaUploadOrigin` (Issue #595) — the origin a browser `PUT`s upload
+ * bytes to, which a Content-Security-Policy has to name in `connect-src`.
+ *
+ * Pure function, no environment read: every case passes its inputs.
+ *
+ * The cases that matter are the degradations. A CSP source built from a
+ * malformed value is worse than none at all, because a rejected policy takes
+ * every other directive down with it — so anything that cannot be a host must
+ * report "unconfigured", never a guess.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { deriveMediaUploadOrigin } from "../src/modules/media-library/domain/media-upload-origin";
+
+describe("deriveMediaUploadOrigin", () => {
+  test("builds R2's S3 API endpoint from the account id", () => {
+    expect(deriveMediaUploadOrigin("abc123")).toEqual({
+      configured: true,
+      origin: "https://abc123.r2.cloudflarestorage.com"
+    });
+  });
+
+  test("reports unconfigured for an empty account id — the LAN/offline state", () => {
+    expect(deriveMediaUploadOrigin("")).toEqual({
+      configured: false,
+      origin: null
+    });
+    expect(deriveMediaUploadOrigin("   ")).toEqual({
+      configured: false,
+      origin: null
+    });
+  });
+
+  test("refuses an account id that could not be a host label", () => {
+    // These would each produce a DIFFERENT host than intended, or an invalid
+    // one — and a CSP source list is the wrong place to find that out.
+    for (const bad of [
+      "has space",
+      "has/slash",
+      "has.dot",
+      "has_underscore",
+      "has:colon",
+      "*"
+    ]) {
+      expect(deriveMediaUploadOrigin(bad)).toEqual({
+        configured: false,
+        origin: null
+      });
+    }
+  });
+
+  test("an endpoint override wins, so a local fake S3 server is not blocked", () => {
+    expect(deriveMediaUploadOrigin("abc123", "http://127.0.0.1:9000")).toEqual({
+      configured: true,
+      origin: "http://127.0.0.1:9000"
+    });
+  });
+
+  test("an override reduces to a bare ORIGIN — path, query and fragment are dropped", () => {
+    // A CSP host-source is scheme+host+port. Echoing a path back would emit a
+    // path-scoped source, which is a different (and redirect-fragile) policy
+    // than the caller asked for.
+    expect(
+      deriveMediaUploadOrigin("", "https://fake.test:8443/bucket?x=1#y").origin
+    ).toBe("https://fake.test:8443");
+  });
+
+  test("keeps a non-default port, which is part of the origin", () => {
+    expect(deriveMediaUploadOrigin("", "https://fake.test:8443").origin).toBe(
+      "https://fake.test:8443"
+    );
+  });
+
+  test("refuses a non-http(s) override rather than echoing it", () => {
+    // `file:`/`data:` mean something entirely different in a CSP source list.
+    for (const bad of ["file:///tmp/x", "data:text/plain,x", "ftp://h/x"]) {
+      expect(deriveMediaUploadOrigin("", bad)).toEqual({
+        configured: false,
+        origin: null
+      });
+    }
+  });
+
+  test("refuses an unparseable override rather than echoing it", () => {
+    expect(deriveMediaUploadOrigin("", "not a url")).toEqual({
+      configured: false,
+      origin: null
+    });
+  });
+
+  test("an override that is only whitespace falls back to the account id", () => {
+    // Otherwise a stray blank in config would silently disable uploads on a
+    // deployment whose account id is perfectly valid.
+    expect(deriveMediaUploadOrigin("abc123", "   ").origin).toBe(
+      "https://abc123.r2.cloudflarestorage.com"
+    );
+  });
+});

--- a/tests/security-headers-csp.test.ts
+++ b/tests/security-headers-csp.test.ts
@@ -37,12 +37,14 @@ import { THEME_INIT_SCRIPT_HASH } from "../src/lib/security/theme-init-script";
 function cspFor(
   isProduction: boolean,
   turnstileEnabled = false,
-  mediaPublicBaseUrl = ""
+  mediaPublicBaseUrl = "",
+  mediaUploadAccountId = ""
 ): string {
   const header = buildSecurityHeaders({
     isProduction,
     turnstileEnabled,
-    mediaPublicBaseUrl
+    mediaPublicBaseUrl,
+    mediaUploadAccountId
   }).find(([name]) => name === "Content-Security-Policy");
 
   if (!header) {
@@ -55,9 +57,15 @@ function cspFor(
 function directives(
   isProduction = false,
   turnstileEnabled = false,
-  mediaPublicBaseUrl = ""
+  mediaPublicBaseUrl = "",
+  mediaUploadAccountId = ""
 ): string[] {
-  return cspFor(isProduction, turnstileEnabled, mediaPublicBaseUrl)
+  return cspFor(
+    isProduction,
+    turnstileEnabled,
+    mediaPublicBaseUrl,
+    mediaUploadAccountId
+  )
     .split(";")
     .map((directive) => directive.trim());
 }
@@ -69,7 +77,7 @@ describe("buildSecurityHeaders — Content-Security-Policy (Issue #148)", () => 
     ).toContain("Content-Security-Policy");
   });
 
-  test("carries every directive ported from awcms-mini's own policy, plus the always-on script-src and img-src", () => {
+  test("carries every directive ported from awcms-mini's own policy, plus the always-on script-src, img-src, media-src and connect-src", () => {
     expect(directives()).toEqual([
       "default-src 'self'",
       "object-src 'none'",
@@ -78,7 +86,8 @@ describe("buildSecurityHeaders — Content-Security-Policy (Issue #148)", () => 
       "frame-ancestors 'none'",
       `script-src 'self' '${THEME_INIT_SCRIPT_HASH}'`,
       "img-src 'self' data:",
-      "media-src 'self'"
+      "media-src 'self'",
+      "connect-src 'self'"
     ]);
   });
 
@@ -410,6 +419,109 @@ describe("buildSecurityHeaders — media img-src", () => {
         delete process.env.NEWS_MEDIA_R2_PUBLIC_BASE_URL;
       } else {
         process.env.NEWS_MEDIA_R2_PUBLIC_BASE_URL = previous;
+      }
+    }
+  });
+});
+
+/**
+ * Issue #595 — `connect-src` and the direct-to-R2 upload.
+ *
+ * This is the third directive this policy needed and did not name; the first
+ * two (`img-src`, `media-src`) each made something render as nothing, and this
+ * one made a whole feature impossible: with `connect-src` falling through to
+ * `default-src 'self'`, the browser refuses the presigned `PUT` before a byte
+ * leaves the machine.
+ *
+ * The sharpest case here is `does NOT reuse the public media origin` — a policy
+ * built from the wrong R2 origin reads correctly and still blocks every upload.
+ */
+describe("buildSecurityHeaders — media upload connect-src (Issue #595)", () => {
+  const ACCOUNT = "abc123def456";
+  const UPLOAD_ORIGIN = `https://${ACCOUNT}.r2.cloudflarestorage.com`;
+  // Deliberately re-declared rather than shared with the img-src suite: the
+  // point of these cases is that the READ origin and the WRITE origin are
+  // different values, so they are written out separately here.
+  const READ_BASE = "https://media.example.com/news";
+  const READ_ORIGIN = "https://media.example.com";
+
+  test("names the R2 API origin, so the presigned PUT is not blocked by our own policy", () => {
+    expect(directives(false, false, "", ACCOUNT)).toContain(
+      `connect-src 'self' ${UPLOAD_ORIGIN}`
+    );
+  });
+
+  test("emits connect-src 'self' with NO origin when uploads are not configured — the LAN/offline guarantee", () => {
+    expect(directives()).toContain("connect-src 'self'");
+    expect(cspFor(true)).not.toContain("r2.cloudflarestorage.com");
+  });
+
+  test("does NOT reuse the public media origin — reads and writes go to different hosts", () => {
+    // The trap this test exists for: using `mediaPublicBaseUrl` for connect-src
+    // yields a policy that looks configured and still blocks every upload,
+    // because the presigned PUT never goes to the custom read domain.
+    const policy = cspFor(false, false, READ_BASE, ACCOUNT);
+    const connect = policy
+      .split(";")
+      .map((directive) => directive.trim())
+      .find((directive) => directive.startsWith("connect-src"));
+
+    expect(connect).toBe(`connect-src 'self' ${UPLOAD_ORIGIN}`);
+    expect(connect).not.toContain(READ_ORIGIN);
+  });
+
+  test("a malformed account id adds no origin at all, rather than a broken one", () => {
+    // A rejected policy takes every other directive down with it, so a value
+    // that cannot be a host must degrade to "no source", never to a guess.
+    expect(directives(false, false, "", "not a valid host!")).toContain(
+      "connect-src 'self'"
+    );
+  });
+
+  test("is additive: enabling uploads changes connect-src and nothing else", () => {
+    const off = directives(false, false, "", "");
+    const on = directives(false, false, "", ACCOUNT);
+
+    expect(on.length).toBe(off.length);
+    expect(on.filter((d) => !d.startsWith("connect-src"))).toEqual(
+      off.filter((d) => !d.startsWith("connect-src"))
+    );
+  });
+
+  test("an explicit empty string means unconfigured, not 'read the environment'", () => {
+    const previous = process.env.NEWS_MEDIA_R2_ACCOUNT_ID;
+    process.env.NEWS_MEDIA_R2_ACCOUNT_ID = ACCOUNT;
+
+    try {
+      expect(cspFor(true, false, "", "")).not.toContain(UPLOAD_ORIGIN);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NEWS_MEDIA_R2_ACCOUNT_ID;
+      } else {
+        process.env.NEWS_MEDIA_R2_ACCOUNT_ID = previous;
+      }
+    }
+  });
+
+  test("falls back to the deployment's own NEWS_MEDIA_R2_ACCOUNT_ID when no caller passes one — an inert fix is the failure mode here", () => {
+    // Both real call sites (`src/middleware.ts`, `standalone-entry.ts`) omit
+    // the option, so if the default did not read the environment the directive
+    // would be permanently `'self'` and every upload would stay blocked while
+    // this suite passed.
+    const previous = process.env.NEWS_MEDIA_R2_ACCOUNT_ID;
+    process.env.NEWS_MEDIA_R2_ACCOUNT_ID = ACCOUNT;
+
+    try {
+      const header = buildSecurityHeaders({ isProduction: false }).find(
+        ([name]) => name === "Content-Security-Policy"
+      );
+
+      expect(header?.[1]).toContain(`connect-src 'self' ${UPLOAD_ORIGIN}`);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.NEWS_MEDIA_R2_ACCOUNT_ID;
+      } else {
+        process.env.NEWS_MEDIA_R2_ACCOUNT_ID = previous;
       }
     }
   });


### PR DESCRIPTION
First PR toward #595. It does not add the upload UI — it removes the reason the upload UI could not have worked.

## The flow existed; the browser was never allowed to run it

`media_library` has had the whole presigned upload path for months: `POST` a session, `PUT` the bytes straight to R2, `POST` finalize. The middle step is a cross-origin `fetch`/`XHR` from the browser to R2's S3 API endpoint, and **`connect-src` governs it**.

There was no `connect-src` directive at all. It fell through to `default-src 'self'`, so the browser refused the `PUT` before a byte left the machine.

## This is the third instance of one defect in this file

The module header already documents two:

- **`img-src`** was missed — every R2 image rendered as an empty box, and `og:image` is a meta tag the page never fetches, so link previews kept working and made the pages look correct from the outside.
- **`media-src`** was missed the same way — every gallery video stayed blocked while the images beside it loaded from the same origin.

The shape repeats because *a directive that is never named does not announce its fall-through*. The failure lands in a browser console, not in a response the server can see. The header now records the third case in the same terms.

## The origin is not the one already in the policy

This is the trap the change is built around, and there is a test for it:

| direction | origin |
|---|---|
| read | `NEWS_MEDIA_R2_PUBLIC_BASE_URL` — usually a custom domain |
| write | `https://{accountId}.r2.cloudflarestorage.com` — R2's S3 API endpoint |

Reusing `mediaPublicBaseUrl` for `connect-src` would produce a policy that **reads as correctly configured and still blocks every upload**. So `deriveMediaUploadOrigin` derives the write origin separately, and `does NOT reuse the public media origin` asserts the emitted directive names the R2 endpoint and *not* the read domain.

## Degradation is toward "no source", never a guess

A rejected policy takes every other directive down with it, so anything that cannot be a host reports unconfigured: an account id containing a space, slash, dot, underscore, colon or `*`; a non-`http(s)` override; an unparseable override. An override that is only whitespace falls back to the account id rather than silently disabling uploads on a valid deployment.

## LAN/offline is unchanged

`connect-src` is emitted unconditionally — naming it is the whole point — and names the R2 origin only when uploads are configured. With R2 off, the directive is exactly `connect-src 'self'` and no third-party origin appears anywhere in the policy. A test asserts enabling uploads changes `connect-src` **and nothing else**.

## One test that exists because of how this fix could be inert

Both real call sites (`src/middleware.ts`, `standalone-entry.ts`) omit the new option, so the default has to read `NEWS_MEDIA_R2_ACCOUNT_ID`. If it did not, the directive would be permanently `'self'`, every upload would stay blocked, and the suite would pass anyway — so that path is tested directly.

The suite's helpers now pass the new option explicitly for the reason the file already documents: otherwise its exact-policy assertions would depend on the developer's `.env`.

## Verification

Full `bun run check` green at CI parity — **4,947 pass / 0 fail**, build clean. 34 CSP tests (7 new) plus 9 for the new deriver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
