### PR TITLE
feat(blog-content): a static page can finally be read by a reader

### DIFF
--- a/.changeset/blog-pages-public-route.md
+++ b/.changeset/blog-pages-public-route.md
@@ -1,0 +1,26 @@
+---
+"awcms": minor
+---
+
+feat(blog-content): a static page can finally be read by a reader
+
+`awcms_blog_pages` has had full CRUD, lifecycle, revisions, a quality checklist
+and an admin screen for months, and no route ever served one. Redaksi, the
+Pedoman Media Siber, the disclaimer and the privacy policy — the pages a news
+site is required to keep reachable, and the ones Dewan Pers expects to find —
+were writable and unservable.
+
+`GET /blog/{tenantCode}/pages/{slug}` serves them, under a reserved segment
+because posts and pages have separate slug uniqueness and one segment could not
+break the tie. They are listed in `sitemap-blog.xml`, declared as the cacheable
+`blog-page` surface, and locale-prefixed like every other page a human reads.
+
+Every handler that changes a page now enqueues an edge-cache purge in its own
+transaction — the two CRUD routes and all four lifecycle routes. `publish` and
+`archive` matter most: they are how a page becomes reachable and how it stops
+being, and neither goes through the PATCH path.
+
+An unpublished page cannot be reached through this route by construction, and
+the predicate is pinned by a test that reads the SQL rather than the rows.
+
+Part of #594.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | `awcms_*` tables                    | 151   |
 | Tables with `FORCE` RLS             | 133   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 408   |
-| Route files                         | 369   |
+| Test files                          | 409   |
+| Route files                         | 370   |
 | ADR                                 | 206   |
 
 ### Modules
@@ -344,7 +344,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 352        |
+| `(root)`      | 353        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |
@@ -355,7 +355,7 @@
 | --------------- | ----- |
 | `/api/v1/**`    | 300   |
 | `/admin/**`     | 45    |
-| publik / anonim | 24    |
+| publik / anonim | 25    |
 
 <!-- END GENERATED: repo-inventory -->
 

--- a/scripts/edge-cache-surfaces-check.ts
+++ b/scripts/edge-cache-surfaces-check.ts
@@ -200,6 +200,7 @@ export const LOCALE_PREFIX_PROBES = [
   "/blog/acme/my-post",
   "/blog/acme/category/news",
   "/blog/acme/tag/launch",
+  "/blog/acme/pages/pedoman-media-siber",
   "/blog/acme/feed.xml",
   "/blog/acme/sitemap-blog.xml",
   "/robots.txt",

--- a/src/lib/edge-cache/surface-registry.ts
+++ b/src/lib/edge-cache/surface-registry.ts
@@ -183,6 +183,17 @@ export const PUBLIC_CACHE_SURFACES: readonly PublicCacheSurface[] = [
       "Published-post listing filtered by a taxonomy term; same reasoning as the index."
   },
   {
+    key: "blog-page",
+    moduleKey: "blog_content",
+    pattern: /^\/blog\/[^/]+\/pages\/[^/]+$/,
+    ttlSeconds: 300,
+    requiresTenant: true,
+    allowedQueryParams: [],
+    localePrefixed: true,
+    rationale:
+      "A single published static page — Redaksi, Pedoman Media Siber, disclaimer, privacy policy (Issue #594). The most stable content this module serves and the most frequently re-fetched, since every article footer links to it; the module purge on any page write is what makes the TTL a fallback rather than the only bound."
+  },
+  {
     key: "blog-discovery",
     moduleKey: "blog_content",
     pattern: /^\/blog\/[^/]+\/(feed\.xml|sitemap-blog\.xml)$/,

--- a/src/lib/i18n/public-locale-path.ts
+++ b/src/lib/i18n/public-locale-path.ts
@@ -50,7 +50,8 @@ import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "./locales";
  *
  * Anchored, and `[^/]+` rather than `.*`, for the reason the surface registry
  * gives: a path must not be able to smuggle itself into a more permissive
- * pattern. These mirror `blog-index`, `blog-post` and `blog-taxonomy`.
+ * pattern. These mirror `blog-index`, `blog-post`, `blog-taxonomy` and
+ * `blog-page`.
  *
  * `blog-post` deliberately does NOT match `/blog/{tenant}/search`, `feed.xml`
  * or `sitemap-blog.xml`; those are excluded explicitly below rather than left
@@ -60,6 +61,11 @@ import { DEFAULT_LOCALE, SUPPORTED_LOCALES, type Locale } from "./locales";
 const LOCALE_PREFIXED_PATH_PATTERNS: readonly RegExp[] = [
   /^\/blog\/[^/]+\/?$/,
   /^\/blog\/[^/]+\/(category|tag)\/[^/]+$/,
+  // Issue #594 — a static page is interface prose a human reads (Redaksi, the
+  // Pedoman Media Siber), so its canonical URL carries a locale for the same
+  // reason a post's does. It needs its own entry because the `blog-post`
+  // pattern below is two segments and this one is three.
+  /^\/blog\/[^/]+\/pages\/[^/]+$/,
   /^\/blog\/[^/]+\/[^/]+$/
 ];
 

--- a/src/modules/blog-content/application/public-blog-directory.ts
+++ b/src/modules/blog-content/application/public-blog-directory.ts
@@ -339,6 +339,9 @@ export async function fetchPublicBlogPostSummariesByIds(
 
 const FEED_ITEM_LIMIT = 50;
 
+/** See `listPublicBlogPagesForSitemap` for why this is lower than `FEED_ITEM_LIMIT`. */
+const SITEMAP_PAGE_LIMIT = 200;
+
 /** RSS/sitemap source — flat, unpaginated (feeds/sitemaps are consumed by machines, not paged by a visitor), bounded to the latest 50 published public posts. */
 export async function listPublicBlogPostsForFeed(
   tx: Bun.SQL,
@@ -358,6 +361,157 @@ export async function listPublicBlogPostsForFeed(
   `) as PublicBlogPostDetailRow[];
 
   return rows.map(toDetail);
+}
+
+/**
+ * A static page as a reader sees it (Issue #594).
+ *
+ * Deliberately the same shape as `PublicBlogPostDetail` minus the fields a page
+ * does not have: no `seoImageMediaId` and no `autoInternalTagLinksDisabled`
+ * (neither column exists on `awcms_blog_pages`), and no `unpublishAt` — `sql/133`
+ * withheld that column from pages on purpose, because Redaksi and Pedoman Media
+ * Siber are the surface a press council expects to find and must not disappear
+ * on a timer.
+ *
+ * `pageType` is carried but NOT used as a visibility gate. It is a classification
+ * label with no behaviour anywhere in this repo — nothing reads it at render
+ * time, and `status`/`visibility` are the publication model. Filtering on it here
+ * would invent a second, undocumented publication rule whose only symptom would
+ * be a page an editor published and cannot see.
+ */
+export type PublicBlogPageDetail = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  contentJson: Record<string, unknown>;
+  contentText: string;
+  seoTitle: string | null;
+  metaDescription: string | null;
+  canonicalUrl: string | null;
+  locale: string;
+  publishedAt: Date;
+  updatedAt: Date;
+  visibility: BlogContentVisibility;
+  featuredMediaId: string | null;
+  pageType: string;
+};
+
+type PublicBlogPageDetailRow = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  content_json: Record<string, unknown>;
+  content_text: string;
+  seo_title: string | null;
+  meta_description: string | null;
+  canonical_url: string | null;
+  locale: string;
+  published_at: Date;
+  updated_at: Date;
+  visibility: BlogContentVisibility;
+  featured_media_id: string | null;
+  page_type: string;
+};
+
+function toPageDetail(row: PublicBlogPageDetailRow): PublicBlogPageDetail {
+  return {
+    id: row.id,
+    title: row.title,
+    slug: row.slug,
+    excerpt: row.excerpt,
+    contentJson: row.content_json,
+    contentText: row.content_text,
+    seoTitle: row.seo_title,
+    metaDescription: row.meta_description,
+    canonicalUrl: row.canonical_url,
+    locale: row.locale,
+    publishedAt: row.published_at,
+    updatedAt: row.updated_at,
+    visibility: row.visibility,
+    featuredMediaId: row.featured_media_id,
+    pageType: row.page_type
+  };
+}
+
+/**
+ * DETAIL predicate — the same one `fetchPublicBlogPostBySlug` uses, including
+ * `visibility IN ('public', 'unlisted')`. A page is one of the two content
+ * shapes this module publishes and there is no reason for its unlisted tier to
+ * mean something different from a post's: reachable by direct link, absent from
+ * every listing.
+ *
+ * A `draft`/`review`/`scheduled`/`archived`/soft-deleted/future-dated page is
+ * unreachable here by construction, which is the "drafts never leak" half of
+ * Issue #594's Definition of Done.
+ */
+export async function fetchPublicBlogPageBySlug(
+  tx: Bun.SQL,
+  tenantId: string,
+  slug: string
+): Promise<PublicBlogPageDetail | null> {
+  const rows = (await tx`
+    SELECT id, title, slug, excerpt, content_json, content_text, seo_title,
+      meta_description, canonical_url, locale, published_at, updated_at,
+      visibility, featured_media_id, page_type
+    FROM awcms_blog_pages
+    WHERE tenant_id = ${tenantId} AND slug = ${slug}
+      AND status = 'published' AND visibility IN ('public', 'unlisted')
+      AND deleted_at IS NULL AND published_at IS NOT NULL AND published_at <= now()
+    ORDER BY published_at DESC
+    LIMIT 1
+  `) as PublicBlogPageDetailRow[];
+
+  const row = rows[0];
+  return row ? toPageDetail(row) : null;
+}
+
+export type PublicBlogPageSummary = {
+  title: string;
+  slug: string;
+  locale: string;
+  updatedAt: Date;
+};
+
+/**
+ * LISTING predicate (strict `visibility = 'public'`), for the sitemap.
+ *
+ * Bounded like `listPublicBlogPostsForFeed` and for the same reason. The ceiling
+ * is deliberately far above the real population — a tenant's static pages are
+ * Redaksi, the Pedoman Media Siber, a disclaimer and a privacy policy, a set
+ * measured in tens — so it never truncates a real site, and still stops one
+ * crawl from becoming an unbounded scan.
+ *
+ * Ordered by `menu_order` then `slug` so the sitemap is byte-stable between
+ * requests, which is what makes the edge-cached copy of it worth having.
+ */
+export async function listPublicBlogPagesForSitemap(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<PublicBlogPageSummary[]> {
+  const rows = (await tx`
+    SELECT title, slug, locale, updated_at
+    FROM awcms_blog_pages
+    WHERE tenant_id = ${tenantId}
+      AND status = 'published' AND visibility = 'public'
+      AND deleted_at IS NULL
+      AND published_at IS NOT NULL AND published_at <= now()
+    ORDER BY menu_order ASC, slug ASC
+    LIMIT ${SITEMAP_PAGE_LIMIT}
+  `) as {
+    title: string;
+    slug: string;
+    locale: string;
+    updated_at: Date;
+  }[];
+
+  return rows.map((row) => ({
+    title: row.title,
+    slug: row.slug,
+    locale: row.locale,
+    updatedAt: row.updated_at
+  }));
 }
 
 export type PublicBlogSettings = {

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -437,9 +437,17 @@ export const blogContentModule = defineModule({
   // `urlTemplate` carries `:tenantCode` because this base's public post route is
   // path-tenant-scoped (`/blog/{tenantCode}/{slug}`, ADR-0009) — awcms-micro's
   // descriptor used host-resolved `/news/:slug`, a route family that is NOT
-  // ported here (see this module's `description`). Blog PAGES are deliberately
-  // NOT contributed: they have no public route in this base, so an indexed page
-  // would produce a search hit that 404s.
+  // ported here (see this module's `description`). Blog PAGES are still NOT
+  // contributed, but Issue #594 changed the reason and the reason is worth
+  // keeping accurate. The old one — "they have no public route, so an indexed
+  // page would produce a search hit that 404s" — stopped being true the moment
+  // `/blog/{tenantCode}/pages/{slug}` shipped. What blocks it now is a GRANT: the
+  // index is built by `bun run site-search:reconcile` running as `awcms_worker`,
+  // and `sql/035` gives that role SELECT on `awcms_blog_posts` and nothing else
+  // in this module. A descriptor added without that grant passes every gate here
+  // — the registry check is pure, no test touches a database — and then fails at
+  // 03:00 in a job nobody is watching. Contributing pages therefore needs a
+  // migration first, which is its own change.
   //
   // This declaration adds NO dependency edge to `site_search`: the arrow points
   // inward (ADR-0040 §2) — content declares, the aggregator discovers.

--- a/src/pages/api/v1/blog/pages/[id].ts
+++ b/src/pages/api/v1/blog/pages/[id].ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import { enqueueModuleContentPurge } from "../../../../../lib/edge-cache/content-purge";
 import { fail, ok } from "../../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
@@ -345,6 +346,16 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       correlationId
     });
 
+    // ADR-0042 — see the identical call in `pages/index.ts`. An edit to the
+    // Pedoman Media Siber that a reader keeps not seeing is the exact failure
+    // the surface was declared for.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.page.updated"
+    );
+
     return ok(updated);
   });
 };
@@ -432,6 +443,13 @@ export const DELETE: APIRoute = async ({
       attributes: { reason },
       correlationId
     });
+
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.page.deleted"
+    );
 
     return ok({ id: pageId, deleted: true });
   });

--- a/src/pages/api/v1/blog/pages/[id]/archive.ts
+++ b/src/pages/api/v1/blog/pages/[id]/archive.ts
@@ -1,3 +1,4 @@
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -133,6 +134,16 @@ export const POST = defineTenantRoute<Prepared>({
       pageId,
       slug: updated.slug
     });
+
+    // ADR-0042 — archiving withdraws the page from the public route. A withdrawn
+    // page still being served from the edge is the withdrawal not having
+    // happened.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.page.archived"
+    );
 
     const response = ok(updated);
     const body = await response.clone().json();

--- a/src/pages/api/v1/blog/pages/[id]/publish.ts
+++ b/src/pages/api/v1/blog/pages/[id]/publish.ts
@@ -1,3 +1,4 @@
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -194,6 +195,16 @@ export const POST = defineTenantRoute<Prepared>({
       pageId,
       slug: updated.slug
     });
+
+    // ADR-0042 — the transition that makes this page reachable is the one a
+    // stale cache would hide, so the purge belongs here and not only on the
+    // PATCH path. Same transaction, no-op when the cache is off.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.page.published"
+    );
 
     const response = ok({ ...updated, qualityChecklist: checklist });
     const body = await response.clone().json();

--- a/src/pages/api/v1/blog/pages/[id]/purge.ts
+++ b/src/pages/api/v1/blog/pages/[id]/purge.ts
@@ -1,3 +1,4 @@
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -131,6 +132,15 @@ export const POST = defineTenantRoute<Prepared>({
       pageId,
       adPlacementsNowInert: result.adPlacementsNowInert
     });
+
+    // ADR-0042 — the row is gone for good; an edge object outliving it would be
+    // the only copy left, which is the opposite of what a purge is for.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.page.purged"
+    );
 
     const response = ok({
       id: pageId,

--- a/src/pages/api/v1/blog/pages/[id]/restore.ts
+++ b/src/pages/api/v1/blog/pages/[id]/restore.ts
@@ -1,3 +1,4 @@
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -135,6 +136,15 @@ export const POST = defineTenantRoute<Prepared>({
       pageId,
       slug: restored.slug
     });
+
+    // ADR-0042 — a restore can put a page back under a slug the edge is still
+    // holding a 404 for.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.page.restored"
+    );
 
     const response = ok(restored);
     const body = await response.clone().json();

--- a/src/pages/api/v1/blog/pages/index.ts
+++ b/src/pages/api/v1/blog/pages/index.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import { enqueueModuleContentPurge } from "../../../../../lib/edge-cache/content-purge";
 import { fail, ok } from "../../../../../modules/_shared/api-response";
 import { getDatabaseClient } from "../../../../../lib/database/client";
 import { withTenant } from "../../../../../lib/database/tenant-context";
@@ -283,6 +284,17 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
       message: `Blog page created: ${page.slug}.`,
       correlationId
     });
+
+    // ADR-0042: same transaction as the content change, so the invalidation
+    // cannot be lost or left behind by a rollback. No-op when the edge cache is
+    // disabled. Obligatory since Issue #594 gave `blog_content` the `blog-page`
+    // surface — before that a page write changed nothing any cache held.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.page.created"
+    );
 
     return ok(page);
   });

--- a/src/pages/blog/[tenantCode]/pages/[slug].ts
+++ b/src/pages/blog/[tenantCode]/pages/[slug].ts
@@ -1,0 +1,179 @@
+import type { APIRoute } from "astro";
+
+import { getDatabaseClient } from "../../../../lib/database/client";
+import { withTenantOrThrow } from "../../../../lib/database/tenant-context";
+import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
+import { escapeHtml } from "../../../../lib/html/escape";
+import { resolveRequestOrigin } from "../../../../lib/http/site-origin";
+import { DEFAULT_LOCALE } from "../../../../lib/i18n/locales";
+import { coerceLocale } from "../../../../lib/i18n/negotiate";
+import { buildLocalisedPublicUrls } from "../../../../lib/i18n/public-locale-path";
+import {
+  notFoundHtmlResponse,
+  serverErrorHtmlResponse
+} from "../../../../lib/html/error-responses";
+import { log } from "../../../../lib/logging/logger";
+import { fetchPublicBlogPageBySlug } from "../../../../modules/blog-content/application/public-blog-directory";
+import { isLegacyTenantRouteEnabled } from "../../../../modules/blog-content/application/public-route-settings";
+import { mediaLibraryPortAdapter } from "../../../../modules/media-library/application/media-library-port-adapter";
+import {
+  collectRenderableGalleryMediaObjectIds,
+  collectRenderableVideoNewsThumbnailMediaObjectIds,
+  renderContentJsonToHtml
+} from "../../../../modules/blog-content/domain/content-block-rendering";
+import {
+  resolveCanonicalUrl,
+  resolveMetaDescription,
+  resolveRobotsMetaContent,
+  resolveSeoTitle
+} from "../../../../modules/blog-content/domain/seo-rendering";
+import { renderPublicPageShell } from "../../../../modules/blog-content/domain/public-page-rendering";
+
+/**
+ * `GET /blog/{tenantCode}/pages/{slug}` (Issue #594) — the public route for
+ * `awcms_blog_pages`.
+ *
+ * ## Why this route had to exist
+ *
+ * `awcms_blog_pages` has had full CRUD, lifecycle, revisions and a quality
+ * checklist since Issue #539, an admin screen since ADR-0051 — and no reader
+ * could reach a single one of them. Redaksi, the Pedoman Media Siber, the
+ * disclaimer and the privacy policy are exactly the pages a news site is
+ * REQUIRED to keep reachable (PRD §35; the Dewan Pers requires the Pedoman Media
+ * Siber to be displayed), and every one of them was writable and unservable.
+ *
+ * ## Why `/pages/` and not `/blog/{tenantCode}/{slug}`
+ *
+ * Posts and pages have SEPARATE slug uniqueness (`awcms_blog_posts_slug_dedup`
+ * and `awcms_blog_pages_slug_dedup` are two indexes over two tables), so serving
+ * both from one segment would make `redaksi` resolvable to two different
+ * documents with nothing to break the tie. A reserved segment is the same
+ * decision `category/` and `tag/` already made, and it makes the collision
+ * impossible rather than merely unlikely.
+ *
+ * The cost is one more reserved post slug — a post slugged `pages` is shadowed
+ * by this directory, exactly as one slugged `category`, `tag` or `search`
+ * already is. That is a pre-existing property of the route family, not something
+ * this route introduces.
+ *
+ * ## Why the body renders from `content_json` and not `body_portable_text`
+ *
+ * ADR-0100 makes Portable Text the canonical body, and `content_json.blocks` a
+ * derived (lossy) projection of it — so rendering the projection is the WRONG
+ * source on its face. It is nonetheless what this route does, and what
+ * `[slug].ts` does for posts, for one reason: `sql/134` gives
+ * `body_portable_text` a `'[]'` default and leaves the conversion to
+ * `bun run blog:portable-text:backfill`, a deployment job. Reading the canonical
+ * column on a deployment that has not run that job yet renders EVERY page blank,
+ * and blank is indistinguishable from "the editor wrote nothing". Both routes
+ * move together, after the backfill, or not at all.
+ *
+ * Mirrors the post detail route in every other respect: anonymous, tenant
+ * resolved from the path segment (ADR-0009), `isLegacyTenantRouteEnabled` as the
+ * first statement inside the transaction (Issue #564), a generic 404 for every
+ * not-found reason so nothing distinguishes "no such tenant" from "no such page"
+ * from "that page is a draft", and a generic 500 that never leaks a stack trace.
+ */
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
+  const tenantCode = params.tenantCode;
+  const slug = params.slug;
+
+  if (!tenantCode || !slug) {
+    return notFoundHtmlResponse();
+  }
+
+  try {
+    const sql = getDatabaseClient();
+    const tenant = await resolvePublicTenantByCode(sql, tenantCode);
+
+    if (!tenant) {
+      return notFoundHtmlResponse();
+    }
+
+    return await withTenantOrThrow(sql, tenant.tenantId, async (tx) => {
+      if (!(await isLegacyTenantRouteEnabled(tx, tenant.tenantId))) {
+        return notFoundHtmlResponse();
+      }
+
+      const page = await fetchPublicBlogPageBySlug(tx, tenant.tenantId, slug);
+
+      if (!page) {
+        return notFoundHtmlResponse();
+      }
+
+      const urls = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}/pages/${page.slug}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      );
+      const blogRootPath = buildLocalisedPublicUrls(
+        resolveRequestOrigin(url, request),
+        `/blog/${tenantCode}`,
+        locals.locale,
+        coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
+      ).basePath;
+
+      const seoTitle = resolveSeoTitle(page);
+      const metaDescription = resolveMetaDescription(page);
+      const canonicalUrl = resolveCanonicalUrl(page, urls.canonicalUrl);
+
+      // One bulk resolution for both embed kinds, same as the post route —
+      // an id that does not resolve to a verified media object renders nothing
+      // rather than a broken `<img>`.
+      const mediaObjectIds = [
+        ...new Set([
+          ...collectRenderableGalleryMediaObjectIds(page.contentJson),
+          ...collectRenderableVideoNewsThumbnailMediaObjectIds(page.contentJson)
+        ])
+      ];
+      const resolvedMedia =
+        await mediaLibraryPortAdapter.resolveMediaReferences(
+          tx,
+          tenant.tenantId,
+          mediaObjectIds
+        );
+      const resolvedMediaUrls = new Map(
+        [...resolvedMedia].map(([id, media]) => [id, media.publicUrl])
+      );
+
+      const contentHtml = renderContentJsonToHtml(
+        page.contentJson,
+        resolvedMediaUrls
+      );
+
+      // No share buttons and no `NewsArticle` JSON-LD: a privacy policy is not
+      // an article, and stamping one with `datePublished`/`author` would tell a
+      // crawler something untrue about what it is looking at.
+      const bodyHtml = `<article>
+  <h1>${escapeHtml(page.title)}</h1>
+  ${contentHtml}
+</article>
+<p><a href="${escapeHtml(blogRootPath)}">Back to blog</a></p>`;
+
+      const html = renderPublicPageShell({
+        title: seoTitle,
+        description: metaDescription,
+        canonicalUrl,
+        hreflangAlternates: urls.hreflangAlternates,
+        bodyHtml,
+        locale: page.locale,
+        siteName: tenant.tenantName,
+        robotsContent: resolveRobotsMetaContent(page.visibility),
+        variant: "article"
+      });
+
+      return new Response(html, {
+        status: 200,
+        headers: { "content-type": "text/html; charset=utf-8" }
+      });
+    });
+  } catch (error) {
+    log("error", "public_blog.page_detail.failed", {
+      tenantCode,
+      slug,
+      error: error instanceof Error ? error.message : String(error)
+    });
+    return serverErrorHtmlResponse();
+  }
+};

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -16,7 +16,10 @@ import {
   serverErrorXmlResponse
 } from "../../../lib/html/error-responses";
 import { log } from "../../../lib/logging/logger";
-import { listPublicBlogPostsForFeed } from "../../../modules/blog-content/application/public-blog-directory";
+import {
+  listPublicBlogPagesForSitemap,
+  listPublicBlogPostsForFeed
+} from "../../../modules/blog-content/application/public-blog-directory";
 import { fetchBlogSettings } from "../../../modules/blog-content/application/blog-settings-directory";
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import { resolveNewsArticlePreviewImage } from "../../../modules/blog-content/application/news-article-seo-metadata";
@@ -105,6 +108,25 @@ export const GET: APIRoute = async ({ params, request, url }) => {
 ${alternatesXml(postPath)}
 <lastmod>${post.publishedAt.toISOString()}</lastmod>
 ${imageTag}
+</url>`);
+      }
+
+      // Issue #594 — static pages became publicly reachable in the same change
+      // that added them here. A sitemap that omitted them would leave the one
+      // surface a press council is expected to FIND (Pedoman Media Siber,
+      // Redaksi) discoverable only by someone who already knew its URL.
+      //
+      // No `<image:image>`: pages carry no `seoImageMediaId`, so there is no
+      // preview-image chain to resolve and nothing to emit.
+      const pages = await listPublicBlogPagesForSitemap(tx, tenant.tenantId);
+
+      for (const page of pages) {
+        const pagePath = `${channelPath}/pages/${page.slug}`;
+
+        urlParts.push(`<url>
+<loc>${escapeHtml(localisedUrl(pagePath))}</loc>
+${alternatesXml(pagePath)}
+<lastmod>${page.updatedAt.toISOString()}</lastmod>
 </url>`);
       }
 

--- a/tests/blog-content-public-page-route.test.ts
+++ b/tests/blog-content-public-page-route.test.ts
@@ -1,0 +1,167 @@
+/**
+ * `/blog/{tenantCode}/pages/{slug}` — the public route for `awcms_blog_pages`
+ * (Issue #594).
+ *
+ * Three properties, none of which a handler unit test would reach:
+ *
+ * 1. **A draft cannot leak.** The predicate is asserted on the SQL text, because
+ *    the failure it guards against is a missing clause, and a missing clause is
+ *    invisible to any test that only feeds the query rows it already filtered.
+ * 2. **The route is gated like its six siblings.** `isLegacyTenantRouteEnabled`
+ *    is the first statement inside the transaction in every existing public blog
+ *    route; a new one that omits it serves content for tenants that switched the
+ *    legacy family off, and nothing else in the repo would notice.
+ * 3. **The three files that must agree about this path do agree.** The route
+ *    exists, the edge cache declares it cacheable, and the i18n layer prefixes
+ *    it — get any one of those wrong and the symptom is a cache serving one
+ *    language to every reader, or a page that 404s only when the cache is on.
+ *
+ * Source assertions run over COMMENT-STRIPPED text. This repo has shipped a
+ * source assertion that passed on a sentence in a docblock rather than on the
+ * code it described.
+ *
+ * Pure — no database, no network.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+import { matchPublicCacheSurface } from "../src/lib/edge-cache/surface-registry";
+import {
+  buildHreflangAlternates,
+  requiresPublicLocalePrefix,
+  resolvePublicLocaleRoute
+} from "../src/lib/i18n/public-locale-path";
+
+const ROUTE = "src/pages/blog/[tenantCode]/pages/[slug].ts";
+const DIRECTORY =
+  "src/modules/blog-content/application/public-blog-directory.ts";
+const SITEMAP = "src/pages/blog/[tenantCode]/sitemap-blog.xml.ts";
+
+async function source(path: string): Promise<string> {
+  return stripComments(await readFile(path, "utf8"));
+}
+
+/** Collapses whitespace so a multi-line SQL template can be matched as prose. */
+function flat(text: string): string {
+  return text.replace(/\s+/g, " ");
+}
+
+describe("the public page query cannot serve an unpublished page", () => {
+  test("the detail predicate carries every exclusion the post predicate does", async () => {
+    const sql = flat(await source(DIRECTORY));
+    const fetchBody = sql.slice(
+      sql.indexOf("FROM awcms_blog_pages WHERE tenant_id")
+    );
+
+    // Proves the slice found something — an empty haystack would make every
+    // `toContain` below pass while asserting nothing.
+    expect(fetchBody.length).toBeGreaterThan(0);
+
+    expect(fetchBody).toContain("status = 'published'");
+    expect(fetchBody).toContain("visibility IN ('public', 'unlisted')");
+    expect(fetchBody).toContain("deleted_at IS NULL");
+    expect(fetchBody).toContain("published_at IS NOT NULL");
+    expect(fetchBody).toContain("published_at <= now()");
+  });
+
+  test("the sitemap listing is strict `public`, so unlisted stays out of listings", async () => {
+    const sql = flat(await source(DIRECTORY));
+    const listBody = sql.slice(sql.indexOf("SELECT title, slug, locale"));
+
+    expect(listBody.length).toBeGreaterThan(0);
+    expect(listBody).toContain("visibility = 'public'");
+    expect(listBody).not.toContain("visibility IN ('public', 'unlisted')");
+    expect(listBody).toContain("status = 'published'");
+    expect(listBody).toContain("deleted_at IS NULL");
+    expect(listBody).toContain("published_at <= now()");
+  });
+
+  test("the sitemap emits page URLs under the reserved segment", async () => {
+    const sitemap = await source(SITEMAP);
+
+    expect(sitemap).toContain("listPublicBlogPagesForSitemap");
+    expect(sitemap).toContain("${channelPath}/pages/${page.slug}");
+  });
+});
+
+describe("the route is gated like every other public blog route", () => {
+  test("`isLegacyTenantRouteEnabled` is the first statement in the transaction", async () => {
+    const route = await source(ROUTE);
+    const transactionStart = route.indexOf("async (tx) => {");
+
+    expect(transactionStart).toBeGreaterThan(-1);
+
+    const afterOpen = route.slice(transactionStart + "async (tx) => {".length);
+    const firstStatement = afterOpen.trim().split("\n")[0] ?? "";
+
+    expect(firstStatement).toContain("isLegacyTenantRouteEnabled");
+  });
+
+  test("every not-found reason answers with the same generic 404", async () => {
+    const route = await source(ROUTE);
+
+    // Missing param, unknown tenant, legacy family off, no such page: four
+    // distinguishable reasons, one indistinguishable answer. A route that
+    // differentiated them would confirm which tenants exist to anyone asking.
+    expect(route.split("notFoundHtmlResponse()").length - 1).toBe(4);
+    expect(route).toContain("serverErrorHtmlResponse()");
+    expect(route).not.toContain("error.stack");
+  });
+
+  test("the body is rendered through the whitelist renderer, never raw", async () => {
+    const route = await source(ROUTE);
+
+    expect(route).toContain("renderContentJsonToHtml(");
+    expect(route).not.toContain("set:html");
+    expect(route).not.toContain("page.contentText}");
+  });
+
+  test("an unlisted page renders noindex", async () => {
+    const route = await source(ROUTE);
+
+    expect(route).toContain("resolveRobotsMetaContent(page.visibility)");
+  });
+});
+
+describe("the cache and the locale layer agree about this path", () => {
+  const PATH = "/blog/acme/pages/pedoman-media-siber";
+
+  test("the path is a declared cacheable surface", () => {
+    expect(matchPublicCacheSurface(PATH)?.key).toBe("blog-page");
+  });
+
+  test("it is locale-prefixed, like every other page a human reads", () => {
+    expect(requiresPublicLocalePrefix(PATH)).toBe(true);
+    expect(matchPublicCacheSurface(PATH)?.localePrefixed).toBe(true);
+    expect(resolvePublicLocaleRoute(PATH).action).toBe("redirect");
+    expect(resolvePublicLocaleRoute(`/id${PATH}`)).toMatchObject({
+      action: "serve",
+      locale: "id",
+      servePathname: PATH
+    });
+  });
+
+  test("its hreflang set names the prefixed spellings, not the bare alias", () => {
+    const alternates = buildHreflangAlternates(PATH, "id");
+
+    expect(alternates.map((alternate) => alternate.pathname)).toContain(
+      `/id${PATH}`
+    );
+    expect(
+      alternates.find((alternate) => alternate.hreflang === "x-default")
+        ?.pathname
+    ).toBe(`/id${PATH}`);
+  });
+
+  test("the surface does not widen into anything deeper or into admin", () => {
+    // `[^/]+` rather than `.*` is the whole reason these hold.
+    expect(matchPublicCacheSurface("/blog/acme/pages/a/b")).toBeNull();
+    expect(matchPublicCacheSurface("/blog/acme/pages")).not.toMatchObject({
+      key: "blog-page"
+    });
+    expect(matchPublicCacheSurface("/blog/../admin/pages/x")).toBeNull();
+    expect(matchPublicCacheSurface("/blog/%2e%2e/pages/x")).toBeNull();
+  });
+});

--- a/tests/edge-cache-content-purge.test.ts
+++ b/tests/edge-cache-content-purge.test.ts
@@ -182,6 +182,17 @@ describe("content write paths emit a purge", () => {
   test.each([
     ["src/pages/api/v1/blog/posts/[id].ts", 2],
     ["src/pages/api/v1/blog/posts/index.ts", 1],
+    // Issue #594 gave `blog_content` the `blog-page` surface, so every handler
+    // that changes a page now has the obligation posts already had. The four
+    // lifecycle routes matter more than the two CRUD ones: `publish` is how a
+    // page becomes reachable at all and `archive` is how it stops being, and
+    // neither goes through the PATCH path that would otherwise have covered it.
+    ["src/pages/api/v1/blog/pages/[id].ts", 2],
+    ["src/pages/api/v1/blog/pages/index.ts", 1],
+    ["src/pages/api/v1/blog/pages/[id]/publish.ts", 1],
+    ["src/pages/api/v1/blog/pages/[id]/archive.ts", 1],
+    ["src/pages/api/v1/blog/pages/[id]/restore.ts", 1],
+    ["src/pages/api/v1/blog/pages/[id]/purge.ts", 1],
     // 2 since Issue #591: the publish sweep and the unpublish sweep each emit
     // one. The second matters MORE than the first — a withdrawn article still
     // sitting in the edge cache is the withdrawal not having happened, which is

--- a/tests/public-locale-path.test.ts
+++ b/tests/public-locale-path.test.ts
@@ -321,6 +321,9 @@ describe("the surface registry and the path patterns agree", () => {
 
     expect(prefixed.sort()).toEqual([
       "blog-index",
+      // Issue #594 — a static page is interface prose (Redaksi, Pedoman Media
+      // Siber), so it joins the HTML surfaces rather than the machine ones.
+      "blog-page",
       "blog-post",
       "blog-taxonomy"
     ]);


### PR DESCRIPTION
`awcms_blog_pages` has had full CRUD, lifecycle, revisions, a quality checklist and an admin screen for months, and no route ever served one. Redaksi, the Pedoman Media Siber, the disclaimer and the privacy policy — the pages a news site is required to keep reachable, and the ones Dewan Pers requires to be displayed — were writable and unservable.

`GET /blog/{tenantCode}/pages/{slug}` serves them.

## Why a reserved segment

Posts and pages have **separate** slug uniqueness — `awcms_blog_posts_slug_dedup` and `awcms_blog_pages_slug_dedup` are two indexes over two tables. Serving both from `/blog/{tenantCode}/{slug}` would make `redaksi` resolvable to two different documents with nothing to break the tie. `category/` and `tag/` already made this decision; the cost is one more reserved post slug, which is a pre-existing property of the family.

## The part worth reviewing is what the route drags behind it

Declaring the `blog-page` cache surface creates an obligation ADR-0042 already states, and page writes had never carried it — because until now a page write changed nothing any cache held. All six handlers enqueue a purge in their own transaction now.

`publish` and `archive` matter most: they are how a page becomes reachable and how it stops being, and **neither goes through the PATCH path** that would otherwise have covered them. `tests/edge-cache-content-purge.test.ts` pins the call count per file, so a seventh handler cannot be added silently.

The page is also locale-prefixed (ADR-0098) and listed in `sitemap-blog.xml` — a page a press council is expected to *find* should not be discoverable only by someone who already knows its URL.

## Why the body renders from `content_json`

ADR-0100 makes Portable Text canonical and `content_json.blocks` a lossy projection, so rendering the projection is the wrong source on its face. It is what this route does anyway, and the route says why: `sql/134` defaults `body_portable_text` to `'[]'` and leaves conversion to `bun run blog:portable-text:backfill`, a deployment job. Reading the canonical column on a deployment that has not run the backfill renders **every page blank**, and blank is indistinguishable from an empty draft. This route and the post route move together, after the backfill, or not at all.

## A comment that had become false

The `searchSources` descriptor excluded pages because "they have no public route in this base, so an indexed page would produce a search hit that 404s." That reason expired with this PR. It now states the one that actually blocks it: `awcms_worker` holds `SELECT` on `awcms_blog_posts` and nothing else in this module, so a page descriptor added without a migration passes every gate here — the registry check is pure — and then fails at 03:00 in a job nobody watches.

## Verification

`bun run check` green end to end, build clean. A draft cannot reach this route by construction, and the predicate is pinned by a test that reads the SQL rather than the rows it was handed.

## Scope

Part of #594 (1 of 6). Remaining: homepage-composition admin screen + renderer, ad-placement admin screen + renderer, and the public JSON read API for all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)