### PR TITLE
feat(blog-content): the composed homepage is finally rendered to a reader

### DIFF
--- a/.changeset/blog-homepage-renderer.md
+++ b/.changeset/blog-homepage-renderer.md
@@ -1,0 +1,34 @@
+---
+"awcms": minor
+---
+
+feat(blog-content): the composed homepage is finally rendered to a reader
+
+`listActiveHomepageSectionsForRendering` has existed since `sql/044` with zero
+callers. A tenant could compose a homepage and no reader would ever see it.
+
+`/blog/{tenantCode}` now renders that composition above its chronological
+listing, on page 1 only — pages 2..n are the archive, and repeating a curated
+front page above each of them would put the same articles on every page.
+
+**The deterministic fallback (PRD §10).** A curated slot whose articles have all
+been unpublished would render a heading over nothing, which reads as a broken
+site rather than an editorial gap. Such a slot is filled from the most recent
+eligible articles instead — from one shared pool, consumed in order, excluding
+every article already placed above it, so a fallback can never duplicate an
+article the editor curated three sections up. `latest_posts` and `category_grid`
+are deliberately NOT rescued: they already query live content, and substituting
+unrelated articles would answer a different question than the editor asked.
+
+**A section that resolves to nothing is dropped, heading included** — and if
+every section drops out, the page is exactly what a tenant who never opened the
+composer sees. A front page cannot come out blank.
+
+**The query count is a constant.** This is an anonymous page, so an unbounded
+query count is an expense a stranger chooses. Curated post ids, category slugs
+and images are each resolved in ONE bulk query for the whole page; only
+per-section list queries remain, capped by `MAX_RENDERED_SECTIONS` and
+`MAX_CATEGORY_GROUPS`, both of which log what they dropped rather than
+truncating silently.
+
+Part of #594.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 151   |
 | Tables with `FORCE` RLS             | 133   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 410   |
+| Test files                          | 411   |
 | Route files                         | 371   |
 | ADR                                 | 206   |
 
@@ -344,7 +344,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 354        |
+| `(root)`      | 355        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |

--- a/src/modules/blog-content/application/homepage-composition.ts
+++ b/src/modules/blog-content/application/homepage-composition.ts
@@ -1,0 +1,446 @@
+/**
+ * Resolves the editorial homepage sections into something a renderer can draw
+ * (Issue #594).
+ *
+ * `listActiveHomepageSectionsForRendering` has existed since `sql/044` and has
+ * never had a caller. Its own docblock says why this file has to exist: a
+ * section being active does not mean everything it REFERENCES is still public.
+ * A curated post can be unpublished, a category archived, a media object
+ * deleted — the section survives all three, and resolving it is where that gets
+ * noticed.
+ *
+ * ## The deterministic fallback (PRD LenteraKalteng §10)
+ *
+ * A curated slot whose articles have all gone is the failure case that matters:
+ * the homepage would otherwise render a heading with nothing under it, which
+ * reads as a broken site rather than as an editorial gap. So a curated slot that
+ * resolves to nothing is filled from the most recent eligible articles, and
+ * `fellBackToLatest` records that it happened.
+ *
+ * Deterministic means two things here, both load-bearing:
+ *
+ * 1. **No randomness and no clock beyond the one passed in.** Same rows, same
+ *    `now`, same page — which is what makes the result safe to put in a shared
+ *    edge cache.
+ * 2. **One fallback pool, consumed in order, with nothing repeated.** Every
+ *    article already placed by an earlier section is excluded, so a fallback can
+ *    never duplicate an article the editor deliberately curated three sections
+ *    above. That makes a section's content depend on the sections before it,
+ *    which is still a pure function of the same inputs.
+ *
+ * ## Why the query count is bounded, and where it is bounded
+ *
+ * This runs on an anonymous public page, so an unbounded query count is a
+ * request anybody can make expensive. `listActiveHomepageSectionsForRendering`
+ * already caps at 50 sections, but 50 `category_grid` sections at 8 categories
+ * each would be 400 queries for one page view.
+ *
+ * Two caps close that, and both REPORT rather than truncate silently:
+ * `MAX_RENDERED_SECTIONS` and `MAX_CATEGORY_GROUPS`. Everything else is bulk —
+ * one query for every curated post id on the page, one for every category slug,
+ * one media resolution for every image — so the total is a small constant plus
+ * those two caps.
+ */
+import type { MediaLibraryPort } from "../../_shared/ports/media-library-port";
+import type { HomepageSectionType } from "../domain/homepage-section-policy";
+// The RENDER MODEL is declared in `domain/`, and consumed in both directions
+// from there: this file produces it, `domain/homepage-section-rendering.ts`
+// draws it. Declaring it here instead would make the renderer import the
+// application layer, which is the wrong way round and the only import of that
+// shape anywhere in this module.
+import type {
+  ComposedHomepage,
+  ComposedHomepageImage
+} from "../domain/homepage-section-rendering";
+import {
+  listActiveHomepageSectionsForRendering,
+  type HomepageSectionView
+} from "./homepage-section-directory";
+import {
+  fetchPublicBlogPostSummariesByIds,
+  fetchPublicTermsBySlugs,
+  listPublicBlogPosts,
+  listPublicBlogPostsByTermId,
+  type PublicBlogPostSummary,
+  type PublicTermSummary
+} from "./public-blog-directory";
+import { log } from "../../../lib/logging/logger";
+
+/**
+ * A homepage with more than a dozen sections is a different problem than this
+ * composer solves, and the public index needs a query count somebody can state.
+ */
+export const MAX_RENDERED_SECTIONS = 12;
+
+/** Across the WHOLE page, not per section — one grid of 8 plus another of 8 is 12 groups drawn and 4 reported. */
+export const MAX_CATEGORY_GROUPS = 12;
+
+/** How deep the shared fallback pool goes. Twelve sections cannot exhaust it. */
+const FALLBACK_POOL_SIZE = 50;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function configStrings(config: Record<string, unknown>, key: string): string[] {
+  const value = config[key];
+
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : [];
+}
+
+function configString(
+  config: Record<string, unknown>,
+  key: string
+): string | null {
+  const value = config[key];
+
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function configNumber(
+  config: Record<string, unknown>,
+  key: string,
+  fallback: number
+): number {
+  const value = config[key];
+
+  return typeof value === "number" && Number.isInteger(value) && value > 0
+    ? value
+    : fallback;
+}
+
+/** Which section types curate an explicit list of articles — the ones a fallback rescues. */
+function isCurated(sectionType: HomepageSectionType): boolean {
+  return (
+    sectionType === "headline" ||
+    sectionType === "featured_posts" ||
+    sectionType === "editor_picks"
+  );
+}
+
+/** How many articles a curated slot should end up with when its curation is empty. */
+function fallbackSize(sectionType: HomepageSectionType): number {
+  return sectionType === "headline" ? 1 : 3;
+}
+
+export async function composeHomepage(
+  tx: Bun.SQL,
+  tenantId: string,
+  mediaPort: MediaLibraryPort,
+  now: Date = new Date()
+): Promise<ComposedHomepage> {
+  const active = await listActiveHomepageSectionsForRendering(
+    tx,
+    tenantId,
+    now
+  );
+
+  if (active.length === 0) {
+    return { sections: [], isEmpty: true };
+  }
+
+  const sections = active.slice(0, MAX_RENDERED_SECTIONS);
+
+  if (active.length > sections.length) {
+    // Reported, not silent: a section an editor enabled and cannot see on the
+    // page is indistinguishable from a bug unless something says otherwise.
+    log("warning", "blog-content.homepage.sections_truncated", {
+      tenantId,
+      moduleKey: "blog_content",
+      active: active.length,
+      rendered: sections.length
+    });
+  }
+
+  // --- bulk pass 1: every curated post id on the page, in one query ----------
+  const curatedIds = new Set<string>();
+
+  for (const section of sections) {
+    const config = isRecord(section.config) ? section.config : {};
+
+    if (section.sectionType === "headline") {
+      const postId = configString(config, "postId");
+      if (postId) curatedIds.add(postId);
+      continue;
+    }
+
+    if (
+      section.sectionType === "featured_posts" ||
+      section.sectionType === "editor_picks"
+    ) {
+      for (const id of configStrings(config, "postIds")) curatedIds.add(id);
+    }
+  }
+
+  const curatedById = new Map<string, PublicBlogPostSummary>(
+    (
+      await fetchPublicBlogPostSummariesByIds(tx, tenantId, [...curatedIds])
+    ).map((post) => [post.id, post])
+  );
+
+  // --- bulk pass 2: every category slug on the page, in one query ------------
+  const slugs = new Set<string>();
+
+  for (const section of sections) {
+    const config = isRecord(section.config) ? section.config : {};
+
+    if (section.sectionType === "latest_posts") {
+      const slug = configString(config, "categorySlug");
+      if (slug) slugs.add(slug);
+      continue;
+    }
+
+    if (section.sectionType === "category_grid") {
+      for (const slug of configStrings(config, "categorySlugs")) {
+        slugs.add(slug);
+      }
+    }
+  }
+
+  const termBySlug = new Map<string, PublicTermSummary>(
+    (await fetchPublicTermsBySlugs(tx, tenantId, "category", [...slugs])).map(
+      (term) => [term.slug, term]
+    )
+  );
+
+  // --- resolution -----------------------------------------------------------
+  const placedPostIds = new Set<string>();
+  let fallbackPool: PublicBlogPostSummary[] | null = null;
+  let groupBudget = MAX_CATEGORY_GROUPS;
+  let droppedGroups = 0;
+
+  /** Fetched at most once per request, and only if some slot actually needs it. */
+  async function takeFromFallback(
+    count: number
+  ): Promise<PublicBlogPostSummary[]> {
+    if (fallbackPool === null) {
+      fallbackPool = (
+        await listPublicBlogPosts(tx, tenantId, {
+          page: 1,
+          pageSize: FALLBACK_POOL_SIZE
+        })
+      ).items;
+    }
+
+    const taken: PublicBlogPostSummary[] = [];
+
+    for (const post of fallbackPool) {
+      if (taken.length >= count) break;
+      if (placedPostIds.has(post.id)) continue;
+      taken.push(post);
+      placedPostIds.add(post.id);
+    }
+
+    return taken;
+  }
+
+  function place(posts: PublicBlogPostSummary[]): PublicBlogPostSummary[] {
+    for (const post of posts) placedPostIds.add(post.id);
+
+    return posts;
+  }
+
+  type Resolved = {
+    section: HomepageSectionView;
+    groups: {
+      heading: string | null;
+      slug: string | null;
+      posts: PublicBlogPostSummary[];
+    }[];
+    mediaObjectIds: string[];
+    caption: string | null;
+    fellBackToLatest: boolean;
+  };
+
+  const resolved: Resolved[] = [];
+
+  for (const section of sections) {
+    const config = isRecord(section.config) ? section.config : {};
+    const entry: Resolved = {
+      section,
+      groups: [],
+      mediaObjectIds: [],
+      caption: null,
+      fellBackToLatest: false
+    };
+
+    switch (section.sectionType) {
+      case "headline":
+      case "featured_posts":
+      case "editor_picks": {
+        const ids =
+          section.sectionType === "headline"
+            ? [configString(config, "postId")].filter(
+                (id): id is string => id !== null
+              )
+            : configStrings(config, "postIds");
+
+        // Curation ORDER is preserved, and an id that no longer resolves is
+        // dropped rather than rendered as a gap — the same "degrade, don't 500"
+        // convention `fetchPublicBlogPostSummariesByIds` already applies.
+        const posts = place(
+          ids
+            .map((id) => curatedById.get(id))
+            .filter((post): post is PublicBlogPostSummary => post !== undefined)
+        );
+
+        entry.groups = [{ heading: null, slug: null, posts }];
+        break;
+      }
+
+      case "latest_posts": {
+        const limit = configNumber(config, "limit", 5);
+        const slug = configString(config, "categorySlug");
+        const term = slug ? (termBySlug.get(slug) ?? null) : null;
+
+        // A configured category that no longer exists means the section's whole
+        // premise is gone, so it renders empty rather than silently widening to
+        // every category — an editor asking for "Politik" must not get "all".
+        const posts =
+          slug && !term
+            ? []
+            : term
+              ? (
+                  await listPublicBlogPostsByTermId(tx, tenantId, term.id, {
+                    page: 1,
+                    pageSize: limit
+                  })
+                ).items
+              : (
+                  await listPublicBlogPosts(tx, tenantId, {
+                    page: 1,
+                    pageSize: limit
+                  })
+                ).items;
+
+        entry.groups = [
+          {
+            heading: term?.name ?? null,
+            slug: term?.slug ?? null,
+            posts: place(posts)
+          }
+        ];
+        break;
+      }
+
+      case "category_grid": {
+        const perCategory = configNumber(config, "postsPerCategory", 3);
+
+        for (const slug of configStrings(config, "categorySlugs")) {
+          const term = termBySlug.get(slug);
+          if (!term) continue;
+
+          if (groupBudget <= 0) {
+            droppedGroups += 1;
+            continue;
+          }
+
+          groupBudget -= 1;
+
+          const posts = (
+            await listPublicBlogPostsByTermId(tx, tenantId, term.id, {
+              page: 1,
+              pageSize: perCategory
+            })
+          ).items;
+
+          entry.groups.push({
+            heading: term.name,
+            slug: term.slug,
+            posts: place(posts)
+          });
+        }
+        break;
+      }
+
+      case "gallery_block": {
+        entry.mediaObjectIds = configStrings(config, "mediaObjectIds");
+        entry.caption = configString(config, "caption");
+        break;
+      }
+    }
+
+    // The fallback rescues curated slots only. `latest_posts` and
+    // `category_grid` are already queries against live content: if they come
+    // back empty the tenant genuinely has nothing to show there, and
+    // substituting unrelated articles would misrepresent the category.
+    if (isCurated(section.sectionType) && entry.groups[0]?.posts.length === 0) {
+      entry.groups[0].posts = await takeFromFallback(
+        fallbackSize(section.sectionType)
+      );
+      entry.fellBackToLatest = entry.groups[0].posts.length > 0;
+    }
+
+    resolved.push(entry);
+  }
+
+  if (droppedGroups > 0) {
+    log("warning", "blog-content.homepage.category_groups_truncated", {
+      tenantId,
+      moduleKey: "blog_content",
+      dropped: droppedGroups,
+      cap: MAX_CATEGORY_GROUPS
+    });
+  }
+
+  // --- bulk pass 3: one media resolution for every image on the page --------
+  const mediaIds = new Set<string>();
+
+  for (const entry of resolved) {
+    for (const id of entry.mediaObjectIds) mediaIds.add(id);
+
+    for (const group of entry.groups) {
+      for (const post of group.posts) {
+        if (post.featuredMediaId) mediaIds.add(post.featuredMediaId);
+      }
+    }
+  }
+
+  const media = await mediaPort.resolveMediaReferences(tx, tenantId, [
+    ...mediaIds
+  ]);
+
+  function toImage(id: string | null): ComposedHomepageImage | null {
+    if (!id) return null;
+
+    const resolvedMedia = media.get(id);
+
+    return resolvedMedia
+      ? {
+          url: resolvedMedia.publicUrl,
+          altText: resolvedMedia.altText,
+          width: resolvedMedia.width,
+          height: resolvedMedia.height
+        }
+      : null;
+  }
+
+  return {
+    isEmpty: false,
+    sections: resolved.map((entry) => ({
+      sectionKey: entry.section.sectionKey,
+      sectionType: entry.section.sectionType,
+      title: entry.section.title,
+      groups: entry.groups.map((group) => ({
+        heading: group.heading,
+        slug: group.slug,
+        posts: group.posts.map((post) => ({
+          title: post.title,
+          slug: post.slug,
+          excerpt: post.excerpt,
+          publishedAt: post.publishedAt,
+          image: toImage(post.featuredMediaId)
+        }))
+      })),
+      // An unresolved id renders nothing rather than a broken `<img>`, the same
+      // rule `renderContentJsonToHtml` applies to a gallery block in an article.
+      images: entry.mediaObjectIds
+        .map((id) => toImage(id))
+        .filter((image): image is ComposedHomepageImage => image !== null),
+      caption: entry.caption,
+      fellBackToLatest: entry.fellBackToLatest
+    }))
+  };
+}

--- a/src/modules/blog-content/application/public-blog-directory.ts
+++ b/src/modules/blog-content/application/public-blog-directory.ts
@@ -231,6 +231,51 @@ export async function fetchPublicTermBySlug(
   };
 }
 
+/**
+ * The bulk form of `fetchPublicTermBySlug` (Issue #594).
+ *
+ * The homepage composer needs every category slug named anywhere on the page,
+ * and resolving them one at a time would make the query count a function of how
+ * many sections an editor happened to configure — on an anonymous page, that is
+ * a cost a stranger chooses. A slug that resolves to nothing is simply absent
+ * from the result; the caller decides what an unresolvable reference means, and
+ * for a homepage section it means the section renders empty rather than
+ * silently widening to every category.
+ */
+export async function fetchPublicTermsBySlugs(
+  tx: Bun.SQL,
+  tenantId: string,
+  taxonomyType: string,
+  slugs: readonly string[]
+): Promise<PublicTermSummary[]> {
+  if (slugs.length === 0) {
+    return [];
+  }
+
+  const rows = (await tx`
+    SELECT id, taxonomy_type, name, slug, description
+    FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND taxonomy_type = ${taxonomyType}
+      AND slug = ANY(${tx.array([...new Set(slugs)], "text")})
+      AND deleted_at IS NULL
+    ORDER BY name ASC
+  `) as {
+    id: string;
+    taxonomy_type: string;
+    name: string;
+    slug: string;
+    description: string | null;
+  }[];
+
+  return rows.map((row) => ({
+    id: row.id,
+    taxonomyType: row.taxonomy_type,
+    name: row.name,
+    slug: row.slug,
+    description: row.description
+  }));
+}
+
 export type PublicPostTaxonomyTerm = {
   taxonomyType: string;
   name: string;

--- a/src/modules/blog-content/domain/homepage-section-rendering.ts
+++ b/src/modules/blog-content/domain/homepage-section-rendering.ts
@@ -1,0 +1,188 @@
+/**
+ * Draws a composed homepage (Issue #594).
+ *
+ * Pure: a resolved model goes in, an HTML string comes out. Every reference has
+ * already been checked against live, public content by
+ * `application/homepage-composition.ts`, so nothing here decides visibility —
+ * which is deliberate, because a renderer that could also hide things would be a
+ * second place for the publication rule to live.
+ *
+ * Every text value passes through `escapeHtml`, and every URL is either built
+ * from a base path this application controls or is a media URL the media library
+ * already vouched for. There is no path by which section configuration reaches
+ * the output as markup: the config vocabulary is uuids, slugs and integers, and
+ * the only free text on the page — the section title and the gallery caption —
+ * is escaped like any other.
+ *
+ * Section headings are `<h2>` and category-column headings `<h3>`, under the
+ * page's single `<h1>`. That is the whole accessibility contract this file has,
+ * and it is why the heading level is not a parameter: a caller free to pick
+ * would eventually pick one that skips a level.
+ */
+import { escapeHtml } from "../../../lib/html/escape";
+import type { HomepageSectionType } from "./homepage-section-policy";
+
+export type ComposedHomepageImage = {
+  url: string;
+  altText: string | null;
+  width: number | null;
+  height: number | null;
+};
+
+export type ComposedHomepagePostCard = {
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  publishedAt: Date;
+  image: ComposedHomepageImage | null;
+};
+
+export type ComposedHomepageGroup = {
+  /** Category name for a grid column; `null` for a section with one ungrouped list. */
+  heading: string | null;
+  /** Category slug, so the renderer can link the column to its archive. `null` when ungrouped. */
+  slug: string | null;
+  posts: ComposedHomepagePostCard[];
+};
+
+export type ComposedHomepageSection = {
+  sectionKey: string;
+  sectionType: HomepageSectionType;
+  title: string | null;
+  groups: ComposedHomepageGroup[];
+  images: ComposedHomepageImage[];
+  caption: string | null;
+  /** True when curation resolved to nothing and the latest eligible articles were substituted. */
+  fellBackToLatest: boolean;
+};
+
+export type ComposedHomepage = {
+  sections: ComposedHomepageSection[];
+  /**
+   * True when the tenant has composed nothing at all. The caller renders its
+   * ordinary chronological index in that case — a tenant that has never opened
+   * the composer must not get a blank front page.
+   */
+  isEmpty: boolean;
+};
+
+function renderImage(image: ComposedHomepageImage | null): string {
+  if (!image) {
+    return "";
+  }
+
+  // `loading="lazy"` on every homepage image: this page can carry dozens, and
+  // they are below the fold the moment there is more than one section.
+  const dimensions = [
+    image.width === null ? "" : ` width="${image.width}"`,
+    image.height === null ? "" : ` height="${image.height}"`
+  ].join("");
+
+  return `<img src="${escapeHtml(image.url)}" alt="${escapeHtml(image.altText ?? "")}" loading="lazy"${dimensions} />`;
+}
+
+function renderCard(
+  basePath: string,
+  post: ComposedHomepagePostCard,
+  headingTag: "h2" | "h3"
+): string {
+  const href = `${escapeHtml(basePath)}/${escapeHtml(post.slug)}`;
+
+  return `<article class="hp-card">
+  <a href="${href}">${renderImage(post.image)}</a>
+  <${headingTag}><a href="${href}">${escapeHtml(post.title)}</a></${headingTag}>
+  <p><time datetime="${post.publishedAt.toISOString()}">${escapeHtml(post.publishedAt.toDateString())}</time></p>
+  ${post.excerpt ? `<p>${escapeHtml(post.excerpt)}</p>` : ""}
+</article>`;
+}
+
+function renderGroup(
+  basePath: string,
+  group: ComposedHomepageGroup,
+  cardHeadingTag: "h2" | "h3"
+): string {
+  const heading =
+    group.heading === null
+      ? ""
+      : group.slug === null
+        ? `<h3>${escapeHtml(group.heading)}</h3>`
+        : `<h3><a href="${escapeHtml(basePath)}/category/${escapeHtml(group.slug)}">${escapeHtml(group.heading)}</a></h3>`;
+
+  const cards = group.posts
+    .map((post) => renderCard(basePath, post, cardHeadingTag))
+    .join("\n");
+
+  return `<div class="hp-group">${heading}${cards}</div>`;
+}
+
+export function renderHomepageSectionHtml(
+  basePath: string,
+  section: ComposedHomepageSection
+): string {
+  const title = section.title ? `<h2>${escapeHtml(section.title)}</h2>` : "";
+
+  if (section.sectionType === "gallery_block") {
+    // A gallery whose every image failed to resolve renders nothing at all,
+    // heading included: a caption with no pictures under it is worse than an
+    // absent section, because it tells a reader something is missing without
+    // telling them what.
+    if (section.images.length === 0) {
+      return "";
+    }
+
+    const figures = section.images
+      .map((image) => `<figure>${renderImage(image)}</figure>`)
+      .join("\n");
+    const caption = section.caption
+      ? `<p class="hp-caption">${escapeHtml(section.caption)}</p>`
+      : "";
+
+    return `<section class="hp-section hp-section--gallery" data-section-key="${escapeHtml(section.sectionKey)}">
+${title}
+<div class="hp-gallery">${figures}</div>
+${caption}
+</section>`;
+  }
+
+  const hasPosts = section.groups.some((group) => group.posts.length > 0);
+
+  // Same argument as the gallery: an empty section is dropped rather than drawn
+  // as a heading over nothing. A CURATED slot can only reach this point when the
+  // fallback also came back empty, which means the tenant has no eligible
+  // articles at all.
+  if (!hasPosts) {
+    return "";
+  }
+
+  // A grid names its columns, so the card headings drop a level to sit under
+  // them. Every other type has one ungrouped list directly under the section.
+  const cardHeadingTag =
+    section.sectionType === "category_grid" ? "h3" : ("h2" as const);
+  const groups = section.groups
+    .filter((group) => group.posts.length > 0)
+    .map((group) => renderGroup(basePath, group, cardHeadingTag))
+    .join("\n");
+
+  return `<section class="hp-section hp-section--${escapeHtml(section.sectionType)}" data-section-key="${escapeHtml(section.sectionKey)}">
+${title}
+${groups}
+</section>`;
+}
+
+/**
+ * The whole composed homepage.
+ *
+ * Returns an empty string when nothing survived resolution — the caller falls
+ * back to its ordinary chronological index, which is the same answer a tenant
+ * that never opened the composer gets. A front page that renders as a blank
+ * because every curated reference expired is the outcome this exists to avoid.
+ */
+export function renderComposedHomepageHtml(
+  basePath: string,
+  composed: ComposedHomepage
+): string {
+  return composed.sections
+    .map((section) => renderHomepageSectionHtml(basePath, section))
+    .filter((html) => html.length > 0)
+    .join("\n");
+}

--- a/src/pages/blog/[tenantCode]/index.ts
+++ b/src/pages/blog/[tenantCode]/index.ts
@@ -19,6 +19,9 @@ import {
   listPublicBlogPosts
 } from "../../../modules/blog-content/application/public-blog-directory";
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
+import { composeHomepage } from "../../../modules/blog-content/application/homepage-composition";
+import { renderComposedHomepageHtml } from "../../../modules/blog-content/domain/homepage-section-rendering";
+import { mediaLibraryPortAdapter } from "../../../modules/media-library/application/media-library-port-adapter";
 import {
   renderPaginationNavHtml,
   renderPostSummaryListHtmlAtBasePath,
@@ -68,6 +71,16 @@ export const GET: APIRoute = async ({ locals, params, request, url }) => {
       }
 
       const settings = await fetchPublicBlogSettings(tx, tenant.tenantId);
+
+      // Issue #594 — the editorial composition, if the tenant has one. Only on
+      // page 1: pages 2..n are the chronological archive, and repeating a
+      // curated front page above every one of them would make the same articles
+      // appear on every page of the archive.
+      const composed =
+        page === 1
+          ? await composeHomepage(tx, tenant.tenantId, mediaLibraryPortAdapter)
+          : null;
+
       const result = await listPublicBlogPosts(tx, tenant.tenantId, {
         page,
         pageSize: settings.postsPerPage
@@ -86,7 +99,16 @@ export const GET: APIRoute = async ({ locals, params, request, url }) => {
         coerceLocale(tenant.defaultLocale) ?? DEFAULT_LOCALE
       );
 
+      // An empty string here means one of two things and the answer is the same
+      // for both: the tenant has composed nothing, or everything it composed
+      // resolved to nothing. Either way the chronological listing below is what
+      // a reader gets, so a front page can never come out blank.
+      const composedHtml = composed
+        ? renderComposedHomepageHtml(urls.basePath, composed)
+        : "";
+
       const bodyHtml = `<h1>${escapeHtml(tenant.tenantName)} Blog</h1>
+${composedHtml}
 <div class="posts">${renderPostSummaryListHtmlAtBasePath(urls.basePath, result.items, "No posts yet.")}</div>
 ${renderPaginationNavHtml(page, result.hasNextPage, urls.basePath)}`;
 

--- a/tests/blog-content-homepage-composition.test.ts
+++ b/tests/blog-content-homepage-composition.test.ts
@@ -1,0 +1,583 @@
+/**
+ * The composed homepage (Issue #594) — resolution, the deterministic fallback,
+ * the caps, and the renderer.
+ *
+ * The composer is exercised against a FAKE tagged-template executor that
+ * dispatches on the SQL text, not against a database. That is a deliberate
+ * trade: it cannot prove the SQL is valid (the integration suite and
+ * `db:fk-index:check` cover that), and it CAN prove the behaviour every
+ * reviewer of this change actually worries about — that a curated slot pointing
+ * at an unpublished article does not render a heading over nothing, that the
+ * fallback never repeats an article a human curated, and that the query count on
+ * an anonymous public page is bounded by a constant rather than by how many
+ * sections somebody configured.
+ *
+ * Pure — no database, no network.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  MAX_CATEGORY_GROUPS,
+  MAX_RENDERED_SECTIONS,
+  composeHomepage
+} from "../src/modules/blog-content/application/homepage-composition";
+import {
+  renderComposedHomepageHtml,
+  renderHomepageSectionHtml
+} from "../src/modules/blog-content/domain/homepage-section-rendering";
+import type { MediaLibraryPort } from "../src/modules/_shared/ports/media-library-port";
+
+const TENANT = "11111111-1111-4111-8111-111111111111";
+const NOW = new Date("2026-08-21T00:00:00.000Z");
+
+type SectionSeed = {
+  id: string;
+  section_key: string;
+  section_type: string;
+  title: string | null;
+  config_json: Record<string, unknown>;
+};
+
+type PostSeed = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string | null;
+  published_at: Date;
+  featured_media_id: string | null;
+};
+
+function post(n: number, overrides: Partial<PostSeed> = {}): PostSeed {
+  return {
+    id: `p${n}`,
+    title: `Post ${n}`,
+    slug: `post-${n}`,
+    excerpt: null,
+    published_at: new Date("2026-08-01T00:00:00.000Z"),
+    featured_media_id: null,
+    ...overrides
+  };
+}
+
+function section(seed: Partial<SectionSeed> & { section_type: string }) {
+  return {
+    id: seed.id ?? `s-${seed.section_type}`,
+    tenant_id: TENANT,
+    section_key: seed.section_key ?? seed.section_type,
+    section_type: seed.section_type,
+    title: seed.title ?? null,
+    config_json: seed.config_json ?? {},
+    sort_order: 0,
+    is_enabled: true,
+    starts_at: null,
+    ends_at: null,
+    created_at: NOW,
+    updated_at: NOW,
+    deleted_at: null,
+    deleted_by: null,
+    delete_reason: null
+  };
+}
+
+type World = {
+  sections: ReturnType<typeof section>[];
+  /** Every publicly-eligible post, newest first — the shape both post queries read. */
+  posts: PostSeed[];
+  terms: {
+    id: string;
+    taxonomy_type: string;
+    name: string;
+    slug: string;
+    description: null;
+  }[];
+  /** term id -> ordered post ids */
+  postsByTerm: Record<string, string[]>;
+};
+
+/** Records the SQL each call issued, so the query COUNT can be asserted directly. */
+function fakeTx(world: World): { tx: Bun.SQL; queries: string[] } {
+  const queries: string[] = [];
+
+  const run = (strings: TemplateStringsArray, values: unknown[]): unknown[] => {
+    const sql = strings.join(" ? ");
+    queries.push(sql);
+
+    if (sql.includes("awcms_news_portal_homepage_sections")) {
+      return world.sections;
+    }
+
+    if (sql.includes("awcms_blog_terms")) {
+      const wanted = values.find((value) => Array.isArray(value)) as
+        string[] | undefined;
+
+      return world.terms.filter((term) => (wanted ?? []).includes(term.slug));
+    }
+
+    if (sql.includes("awcms_blog_post_terms")) {
+      // `listPublicBlogPostsByTermId` — the term id is the second bound value,
+      // and the limit is `pageSize + 1`.
+      const termId = values[1] as string;
+      const limit = values[2] as number;
+      const ids = world.postsByTerm[termId] ?? [];
+
+      return world.posts
+        .filter((entry) => ids.includes(entry.id))
+        .slice(0, limit);
+    }
+
+    if (sql.includes("id = ANY")) {
+      const wanted = values.find((value) => Array.isArray(value)) as
+        string[] | undefined;
+
+      return world.posts.filter((entry) => (wanted ?? []).includes(entry.id));
+    }
+
+    if (sql.includes("awcms_blog_posts")) {
+      const limit = values[1] as number;
+      return world.posts.slice(0, limit);
+    }
+
+    return [];
+  };
+
+  const tx = ((strings: TemplateStringsArray, ...values: unknown[]) =>
+    Promise.resolve(run(strings, values))) as unknown as Bun.SQL;
+
+  (tx as unknown as { array: (input: unknown[]) => unknown[] }).array = (
+    input
+  ) => input;
+
+  return { tx, queries };
+}
+
+const emptyMediaPort: MediaLibraryPort = {
+  isMediaReferenceSafe: async () => false,
+  resolveMediaReferences: async () => new Map()
+} as unknown as MediaLibraryPort;
+
+function mediaPortWith(
+  ids: readonly string[],
+  altText: string | null = "alt"
+): MediaLibraryPort {
+  return {
+    isMediaReferenceSafe: async () => true,
+    resolveMediaReferences: async (
+      _tx: unknown,
+      _tenantId: string,
+      requested: string[]
+    ) =>
+      new Map(
+        requested
+          .filter((id) => ids.includes(id))
+          .map((id) => [
+            id,
+            {
+              publicUrl: `https://cdn.example/${id}.jpg`,
+              altText,
+              mimeType: "image/jpeg",
+              width: 800,
+              height: 600
+            }
+          ])
+      )
+  } as unknown as MediaLibraryPort;
+}
+
+const EMPTY_WORLD: World = {
+  sections: [],
+  posts: [],
+  terms: [],
+  postsByTerm: {}
+};
+
+describe("a tenant that has composed nothing", () => {
+  test("reports empty, so the caller keeps its chronological index", async () => {
+    const { tx, queries } = fakeTx(EMPTY_WORLD);
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+
+    expect(composed).toEqual({ sections: [], isEmpty: true });
+    // And it costs exactly one query. A composer that kept going would make
+    // every tenant pay for a feature none of them had switched on.
+    expect(queries).toHaveLength(1);
+  });
+});
+
+describe("curated slots", () => {
+  test("preserve the editor's order and drop references that are gone", async () => {
+    const { tx } = fakeTx({
+      ...EMPTY_WORLD,
+      sections: [
+        section({
+          section_type: "featured_posts",
+          config_json: { postIds: ["p3", "p-gone", "p1"] }
+        })
+      ],
+      posts: [post(1), post(3)]
+    });
+
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+    const slugs = composed.sections[0]!.groups[0]!.posts.map(
+      (entry) => entry.slug
+    );
+
+    // Curation order, NOT `published_at DESC`, and the missing id simply absent.
+    expect(slugs).toEqual(["post-3", "post-1"]);
+    expect(composed.sections[0]!.fellBackToLatest).toBe(false);
+  });
+
+  test("fall back to the latest eligible articles when everything curated is gone", async () => {
+    const { tx } = fakeTx({
+      ...EMPTY_WORLD,
+      sections: [
+        section({
+          section_type: "editor_picks",
+          config_json: { postIds: ["p-gone", "p-also-gone"] }
+        })
+      ],
+      posts: [post(9), post(8), post(7), post(6)]
+    });
+
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+
+    expect(composed.sections[0]!.fellBackToLatest).toBe(true);
+    expect(
+      composed.sections[0]!.groups[0]!.posts.map((entry) => entry.slug)
+    ).toEqual(["post-9", "post-8", "post-7"]);
+  });
+
+  test("a headline falls back to exactly one article", async () => {
+    const { tx } = fakeTx({
+      ...EMPTY_WORLD,
+      sections: [
+        section({ section_type: "headline", config_json: { postId: "p-gone" } })
+      ],
+      posts: [post(9), post(8)]
+    });
+
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+
+    expect(composed.sections[0]!.groups[0]!.posts).toHaveLength(1);
+    expect(composed.sections[0]!.groups[0]!.posts[0]!.slug).toBe("post-9");
+  });
+
+  test("a fallback never repeats an article a human curated above it", async () => {
+    // The property that makes the fallback safe to ship: without it, the
+    // editor's chosen headline would appear a second time three rows down,
+    // which reads as a duplicate-content bug rather than as a fallback.
+    const { tx } = fakeTx({
+      ...EMPTY_WORLD,
+      sections: [
+        section({
+          id: "s1",
+          section_key: "hero",
+          section_type: "headline",
+          config_json: { postId: "p9" }
+        }),
+        section({
+          id: "s2",
+          section_key: "picks",
+          section_type: "editor_picks",
+          config_json: { postIds: ["p-gone"] }
+        })
+      ],
+      posts: [post(9), post(8), post(7), post(6)]
+    });
+
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+
+    expect(composed.sections[0]!.groups[0]!.posts[0]!.slug).toBe("post-9");
+    expect(
+      composed.sections[1]!.groups[0]!.posts.map((entry) => entry.slug)
+    ).toEqual(["post-8", "post-7", "post-6"]);
+  });
+
+  test("the same inputs produce the same output twice", async () => {
+    const world: World = {
+      ...EMPTY_WORLD,
+      sections: [
+        section({ section_type: "editor_picks", config_json: { postIds: [] } })
+      ],
+      posts: [post(9), post(8), post(7), post(6), post(5)]
+    };
+
+    const first = await composeHomepage(
+      fakeTx(world).tx,
+      TENANT,
+      emptyMediaPort,
+      NOW
+    );
+    const second = await composeHomepage(
+      fakeTx(world).tx,
+      TENANT,
+      emptyMediaPort,
+      NOW
+    );
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+});
+
+describe("live-content slots are not rescued by the fallback", () => {
+  test("a `latest_posts` section pointing at a vanished category renders empty, not everything", async () => {
+    // Widening to "all categories" would silently answer a different question
+    // than the editor asked, and the page would look correct while being wrong.
+    const { tx } = fakeTx({
+      ...EMPTY_WORLD,
+      sections: [
+        section({
+          section_type: "latest_posts",
+          config_json: { limit: 3, categorySlug: "politik" }
+        })
+      ],
+      posts: [post(9), post(8)]
+    });
+
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+
+    expect(composed.sections[0]!.groups[0]!.posts).toEqual([]);
+    expect(composed.sections[0]!.fellBackToLatest).toBe(false);
+  });
+});
+
+describe("the query count is bounded by constants, not by configuration", () => {
+  test("more sections than the cap are rendered up to it", async () => {
+    const many = Array.from({ length: MAX_RENDERED_SECTIONS + 4 }, (_, index) =>
+      section({
+        id: `s${index}`,
+        section_key: `k${index}`,
+        section_type: "featured_posts",
+        config_json: { postIds: ["p1"] }
+      })
+    );
+
+    const { tx } = fakeTx({ ...EMPTY_WORLD, sections: many, posts: [post(1)] });
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+
+    expect(composed.sections).toHaveLength(MAX_RENDERED_SECTIONS);
+  });
+
+  test("category groups are capped across the whole page, and every grid query is one query", async () => {
+    const slugs = Array.from({ length: 8 }, (_, index) => `c${index}`);
+    const terms = slugs.map((slug, index) => ({
+      id: `t${index}`,
+      taxonomy_type: "category",
+      name: `Category ${index}`,
+      slug,
+      description: null
+    }));
+
+    const { tx, queries } = fakeTx({
+      sections: [
+        section({
+          id: "g1",
+          section_key: "grid-1",
+          section_type: "category_grid",
+          config_json: { categorySlugs: slugs, postsPerCategory: 2 }
+        }),
+        section({
+          id: "g2",
+          section_key: "grid-2",
+          section_type: "category_grid",
+          config_json: { categorySlugs: slugs, postsPerCategory: 2 }
+        })
+      ],
+      posts: [post(1), post(2)],
+      terms,
+      postsByTerm: Object.fromEntries(terms.map((term) => [term.id, ["p1"]]))
+    });
+
+    const composed = await composeHomepage(tx, TENANT, emptyMediaPort, NOW);
+    const drawn = composed.sections.reduce(
+      (total, entry) => total + entry.groups.length,
+      0
+    );
+
+    expect(drawn).toBe(MAX_CATEGORY_GROUPS);
+
+    // Sixteen configured groups, twelve drawn, and the slug lookup was ONE
+    // query rather than sixteen. That difference is the whole point of the bulk
+    // passes.
+    const termQueries = queries.filter((sql) =>
+      sql.includes("awcms_blog_terms")
+    );
+    expect(termQueries).toHaveLength(1);
+    expect(queries.length).toBeLessThanOrEqual(MAX_CATEGORY_GROUPS + 6);
+  });
+});
+
+describe("images", () => {
+  test("an id that does not resolve renders no image rather than a broken one", async () => {
+    const { tx } = fakeTx({
+      ...EMPTY_WORLD,
+      sections: [
+        section({
+          section_type: "gallery_block",
+          config_json: { mediaObjectIds: ["m1", "m-gone"], caption: "Kalteng" }
+        })
+      ]
+    });
+
+    const composed = await composeHomepage(
+      tx,
+      TENANT,
+      mediaPortWith(["m1"]),
+      NOW
+    );
+
+    expect(composed.sections[0]!.images).toHaveLength(1);
+    expect(composed.sections[0]!.images[0]!.url).toBe(
+      "https://cdn.example/m1.jpg"
+    );
+    expect(composed.sections[0]!.caption).toBe("Kalteng");
+  });
+
+  test("every image on the page is resolved in ONE port call", async () => {
+    let calls = 0;
+    const port = {
+      isMediaReferenceSafe: async () => true,
+      resolveMediaReferences: async () => {
+        calls += 1;
+        return new Map();
+      }
+    } as unknown as MediaLibraryPort;
+
+    const { tx } = fakeTx({
+      ...EMPTY_WORLD,
+      sections: [
+        section({
+          id: "a",
+          section_key: "a",
+          section_type: "gallery_block",
+          config_json: { mediaObjectIds: ["m1"] }
+        }),
+        section({
+          id: "b",
+          section_key: "b",
+          section_type: "gallery_block",
+          config_json: { mediaObjectIds: ["m2"] }
+        })
+      ]
+    });
+
+    await composeHomepage(tx, TENANT, port, NOW);
+
+    expect(calls).toBe(1);
+  });
+});
+
+describe("renderComposedHomepageHtml", () => {
+  const base = "/id/blog/acme";
+
+  test("escapes every text value it is handed", () => {
+    const html = renderHomepageSectionHtml(base, {
+      sectionKey: 'k"><script>',
+      sectionType: "featured_posts",
+      title: "<script>alert(1)</script>",
+      groups: [
+        {
+          heading: null,
+          slug: null,
+          posts: [
+            {
+              title: "<b>bold</b>",
+              slug: 'a"b',
+              excerpt: "<i>x</i>",
+              publishedAt: NOW,
+              image: null
+            }
+          ]
+        }
+      ],
+      images: [],
+      caption: null,
+      fellBackToLatest: false
+    });
+
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;");
+    expect(html).toContain("&lt;b&gt;bold&lt;/b&gt;");
+    expect(html).toContain("&quot;");
+  });
+
+  test("a section with nothing in it is dropped, heading included", () => {
+    const html = renderHomepageSectionHtml(base, {
+      sectionKey: "empty",
+      sectionType: "latest_posts",
+      title: "Terbaru",
+      groups: [{ heading: null, slug: null, posts: [] }],
+      images: [],
+      caption: null,
+      fellBackToLatest: false
+    });
+
+    expect(html).toBe("");
+  });
+
+  test("a gallery with no resolvable image is dropped, caption included", () => {
+    const html = renderHomepageSectionHtml(base, {
+      sectionKey: "gal",
+      sectionType: "gallery_block",
+      title: "Galeri",
+      groups: [],
+      images: [],
+      caption: "A caption with no pictures",
+      fellBackToLatest: false
+    });
+
+    expect(html).toBe("");
+    expect(html).not.toContain("A caption with no pictures");
+  });
+
+  test("links are built from the locale-prefixed base path", () => {
+    const html = renderHomepageSectionHtml(base, {
+      sectionKey: "grid",
+      sectionType: "category_grid",
+      title: null,
+      groups: [
+        {
+          heading: "Politik",
+          slug: "politik",
+          posts: [
+            {
+              title: "Satu",
+              slug: "satu",
+              excerpt: null,
+              publishedAt: NOW,
+              image: null
+            }
+          ]
+        }
+      ],
+      images: [],
+      caption: null,
+      fellBackToLatest: false
+    });
+
+    // ADR-0098 — an in-page link that dropped the prefix would send the reader
+    // through a redirect to the other language.
+    expect(html).toContain('href="/id/blog/acme/category/politik"');
+    expect(html).toContain('href="/id/blog/acme/satu"');
+    // A grid names its columns, so its cards sit a heading level below them.
+    expect(html).toContain('<h3><a href="/id/blog/acme/category/politik"');
+    expect(html).toContain('<h3><a href="/id/blog/acme/satu"');
+  });
+
+  test("the whole page is the empty string when every section drops out", () => {
+    expect(
+      renderComposedHomepageHtml(base, {
+        isEmpty: false,
+        sections: [
+          {
+            sectionKey: "a",
+            sectionType: "headline",
+            title: "Utama",
+            groups: [{ heading: null, slug: null, posts: [] }],
+            images: [],
+            caption: null,
+            fellBackToLatest: false
+          }
+        ]
+      })
+    ).toBe("");
+  });
+});


### PR DESCRIPTION
`listActiveHomepageSectionsForRendering` has existed since `sql/044` with **zero callers**. A tenant could compose a homepage and no reader would ever see it.

`/blog/{tenantCode}` now renders that composition above its chronological listing — **on page 1 only**, because pages 2..n are the archive and repeating a curated front page above each of them would put the same articles on every page of it.

## The deterministic fallback (PRD LenteraKalteng §10)

A curated slot whose articles have all been unpublished would render a heading over nothing, which reads as a broken site rather than an editorial gap. Such a slot is filled from the most recent eligible articles instead.

Deterministic means two specific things:

- no randomness, and no clock beyond the one passed in — which is what makes the result safe to sit in a shared edge cache;
- **one pool, consumed in order, excluding every article already placed above it.** Without that exclusion the editor's chosen headline reappears three rows down, which reads as a duplicate-content bug rather than as a fallback. A test pins exactly this.

`latest_posts` and `category_grid` are deliberately **not** rescued. They already query live content; substituting unrelated articles would answer a different question than the editor asked, and the page would look correct while being wrong. A `latest_posts` section whose category has been archived renders empty rather than silently widening to "all categories".

## Nothing renders as a hole

A section that resolves to nothing is dropped — heading and caption included, because a caption with no pictures under it tells a reader something is missing without telling them what. If every section drops out, the page is exactly what a tenant who never opened the composer sees. **A front page cannot come out blank.**

## The query count is a constant

This is an anonymous page, so an unbounded query count is an expense a stranger chooses. `listActiveHomepageSectionsForRendering` caps at 50 sections, but 50 grids of 8 categories would be 400 queries for one page view.

Curated post ids, category slugs and images are each resolved in **one** bulk query for the whole page. Only the per-section list queries remain, capped by `MAX_RENDERED_SECTIONS` (12) and `MAX_CATEGORY_GROUPS` (12 across the page, not per section) — and both caps `log()` what they dropped, because a section an editor enabled and cannot see is indistinguishable from a bug unless something says otherwise.

A tenant that has composed nothing costs exactly **one** query, asserted by a test: nobody pays for a feature they have not switched on.

## On the tests

The composer runs against a fake tagged-template executor that dispatches on SQL text. Stated plainly in the file header: that cannot prove the SQL is valid, and it can prove the things a reviewer of this change actually worries about — curation order preserved, vanished references dropped, the fallback not repeating a curated article, the caps holding, and every image on the page resolved in one port call.

## Verification

`bun run check` green end to end — 5700 tests, 0 fail, build clean. No client asset cost: the composed homepage is server-rendered HTML.

## Scope

Part of #594 (3 of 6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)