### PR TITLE
feat(blog-content): a build client can read the homepage, ad inventory and static pages

### DIFF
--- a/.changeset/blog-consumer-read-api.md
+++ b/.changeset/blog-consumer-read-api.md
@@ -1,0 +1,41 @@
+---
+"awcms": minor
+---
+
+feat(blog-content): a build client can read the homepage, the ad inventory and the static pages
+
+Four read endpoints close the last half of #594: `awcms-astro` renders its own
+templates, and until now it had no way to ask this repo what belongs on them.
+
+- `GET /api/v1/news-portal/homepage-sections/composed` — the RESOLVED homepage,
+  not its configuration. A consumer resolving the configuration itself would
+  re-implement the publication predicate in a second repository on a second
+  deploy cadence, and the first disagreement is a draft article on somebody's
+  front page.
+- `GET /api/v1/news-portal/ad-placements/active` — every slot's runnable
+  creatives, already rotated and capped. All twelve slots, including the three
+  this repo's own templates do not draw: the sidebar exists in the consuming
+  front end, and an endpoint shaped around what this repo renders would withhold
+  the inventory a consumer exists to show. An invalid or unpaired `targetType`
+  is refused rather than falling back to `global`, because silently widening an
+  ad query is how a placement booked against one article appears on all of them.
+- `GET /api/v1/blog/pages/public` and `/{slug}` — the pages a reader can
+  actually reach, sharing their predicates with `sitemap-blog.xml` and with
+  `/blog/{tenantCode}/pages/{slug}` respectively. Deliberately not
+  `/api/v1/blog/pages?status=published`: the admin list is an editor's view and
+  returns private and unlisted pages too, so a consumer reaching for it would
+  publish every private page the newsroom has with nothing reporting an error.
+  The detail ships the body as both `contentJson` and the canonical
+  `bodyPortableText`, which is what lets a consumer move to the canonical shape
+  on its own schedule.
+
+All four are **guarded, not anonymous** — the same decision ADR-0102 made for
+`GET /api/v1/site-profile/composed`: "public read" means the public site's
+builder can read it. A curated homepage names the articles an editor considers
+most important before they are on any page, and there is no reason to hand that
+to callers who are not building the site. A test pins that none of the four ever
+appears in `ALLOWED_PUBLIC_OPERATIONS`.
+
+No permission and no migration.
+
+Closes the awcms half of #594.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -6171,6 +6171,51 @@ Gated by blog_content.pages.restore (ADR-0057). High-risk, requires Idempotency-
 | 404    | Resource not found.                                            | [`ApiError`](#standard-error-envelope) |
 | 409    | The Idempotency-Key was already used with a different request. | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/blog/pages/public` — The static pages a reader can actually reach
+
+- **operationId**: `blogPagesPublicList`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.pages.read. NOT the same answer as `/api/v1/blog/pages?status=published`: the admin list is an editor's view and returns private and unlisted pages too, so a consumer reaching for it with a status filter would publish every private page the newsroom has and nothing would report an error. The predicate here is the one the public route enforces, shared with sitemap-blog.xml so the two cannot disagree. Metadata only — a body is fetched per page from /{slug}, because a tenant's legal pages are few but long.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                            | Schema                                 |
+| ------ | -------------------------------------- | -------------------------------------- |
+| 200    | Reachable static pages, in menu order. | object                                 |
+| 401    | Missing or invalid session.            | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.            | [`ApiError`](#standard-error-envelope) |
+
+### `GET /api/v1/blog/pages/public/{slug}` — One reachable static page, body included
+
+- **operationId**: `blogPagesPublicDetail`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.pages.read. The predicate is shared byte-for-byte with the public route /blog/{tenantCode}/pages/{slug}, so a draft cannot be read here for the same reason it cannot be read there. An unreachable slug answers 404 without distinguishing "no such page" from "that page is a draft" — not an information-disclosure boundary (the caller is authenticated) but consistency, so a consumer cannot depend on a distinction the browser-facing surface does not make. The body ships as BOTH `contentJson` (the projection this repo renders today) and `bodyPortableText` (the canonical column, ADR-0100), which is what lets a consumer move to the canonical shape on its own schedule.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+| `slug`             | path   | yes      | string |             |
+
+**Responses**
+
+| Status | Description                                                        | Schema                                 |
+| ------ | ------------------------------------------------------------------ | -------------------------------------- |
+| 200    | The page, with every referenced media object resolved in one call. | object                                 |
+| 400    | Validation error.                                                  | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.                                        | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.                                        | [`ApiError`](#standard-error-envelope) |
+| 404    | Resource not found.                                                | [`ApiError`](#standard-error-envelope) |
+
 ### `GET /api/v1/blog/posts` — List this tenant's non-deleted blog posts
 
 - **operationId**: `blogListPosts`
@@ -7084,6 +7129,27 @@ Gated by news_portal.homepage_sections.configure.
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
 
+### `GET /api/v1/news-portal/homepage-sections/composed` — The RESOLVED homepage, for a build client that renders its own templates
+
+- **operationId**: `newsPortalHomepageComposed`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.homepage_sections.read. Returns what the front page actually shows, not its configuration: every reference resolved against live public content, the deterministic fallback applied to a curated slot whose articles have all gone, and the render caps already enforced. A consumer must not resolve the configuration itself — that would re-implement the publication predicate in a second repository on a second deploy cadence, and the first disagreement is a draft article on somebody's front page. Media arrive as resolved public URLs here (unlike /api/v1/site-profile/composed, which returns ids) because a homepage is many short-lived images rather than one long-lived logo.
+
+**Parameters**
+
+| Name               | In     | Required | Type   | Description |
+| ------------------ | ------ | -------- | ------ | ----------- |
+| `X-Correlation-ID` | header | no       | string |             |
+
+**Responses**
+
+| Status | Description                 | Schema                                 |
+| ------ | --------------------------- | -------------------------------------- |
+| 200    | The composed homepage.      | object                                 |
+| 401    | Missing or invalid session. | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
+
 ## News Portal Ad Placements
 
 R2-only advertisement placement presets for the news portal (blog_content module — absorbed from the retired news_portal module by ADR-0044, which moved ownership without renaming the paths or this tag) — tenant-scoped, RLS-protected CRUD for ads assigned to a fixed set of placement keys. mediaObjectId must reference a verified R2 media object belonging to the same tenant — never a local path or arbitrary external image URL. linkUrl is optional and may be external, but is validated server-side as an absolute http(s) URL only.
@@ -7187,6 +7253,30 @@ Gated by news_portal.ad_placements.configure.
 | 401    | Missing or invalid session. | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
+
+### `GET /api/v1/news-portal/ad-placements/active` — Currently-runnable creatives per slot, already rotated and capped
+
+- **operationId**: `newsPortalAdPlacementsActive`
+- **Security**: bearerAuth + tenantHeader
+
+Gated by blog_content.ad_placements.read. Returns all twelve slots, including the three this repo's own templates do not render — the sidebar exists in the consuming front end, and an endpoint shaped around what this repo draws would withhold inventory the consumer exists to show. Rotation and the per-slot item cap are applied HERE so four rotation modes are not re-implemented elsewhere; random_safe and weighted make the response deliberately not byte-stable, so it is not cacheable and does not try to be. An invalid targetType is refused rather than falling back to global, because silently widening an ad query is how a placement booked against one article appears on all of them.
+
+**Parameters**
+
+| Name               | In     | Required | Type                                     | Description                                                     |
+| ------------------ | ------ | -------- | ---------------------------------------- | --------------------------------------------------------------- |
+| `X-Correlation-ID` | header | no       | string                                   |                                                                 |
+| `targetType`       | query  | no       | enum(`global`, `widget`, `post`, `page`) | The kind of page being rendered. Omit for the global inventory. |
+| `targetId`         | query  | no       | string (uuid)                            | Required when targetType is not global, and refused when it is. |
+
+**Responses**
+
+| Status | Description                           | Schema                                 |
+| ------ | ------------------------------------- | -------------------------------------- |
+| 200    | Selected creatives per placement key. | object                                 |
+| 400    | Validation error.                     | [`ApiError`](#standard-error-envelope) |
+| 401    | Missing or invalid session.           | [`ApiError`](#standard-error-envelope) |
+| 403    | Access denied by RBAC/ABAC.           | [`ApiError`](#standard-error-envelope) |
 
 ## Visitor Analytics
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | `awcms_*` tables                    | 151   |
 | Tables with `FORCE` RLS             | 133   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 413   |
-| Route files                         | 372   |
+| Test files                          | 414   |
+| Route files                         | 376   |
 | ADR                                 | 206   |
 
 ### Modules
@@ -344,7 +344,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 357        |
+| `(root)`      | 358        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |
@@ -353,7 +353,7 @@
 
 | Surface         | Files |
 | --------------- | ----- |
-| `/api/v1/**`    | 300   |
+| `/api/v1/**`    | 304   |
 | `/admin/**`     | 47    |
 | publik / anonim | 25    |
 

--- a/docs/awcms/work-class-registry.generated.json
+++ b/docs/awcms/work-class-registry.generated.json
@@ -307,6 +307,16 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/blog/pages/public.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
+      "path": "src/pages/api/v1/blog/pages/public/[slug].ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/blog/posts/[id].ts",
       "workClass": "interactive",
       "source": "default"
@@ -772,6 +782,11 @@
       "source": "default"
     },
     {
+      "path": "src/pages/api/v1/news-portal/ad-placements/active.ts",
+      "workClass": "interactive",
+      "source": "factory"
+    },
+    {
       "path": "src/pages/api/v1/news-portal/ad-placements/index.ts",
       "workClass": "interactive",
       "source": "default"
@@ -780,6 +795,11 @@
       "path": "src/pages/api/v1/news-portal/homepage-sections/[id].ts",
       "workClass": "interactive",
       "source": "default"
+    },
+    {
+      "path": "src/pages/api/v1/news-portal/homepage-sections/composed.ts",
+      "workClass": "interactive",
+      "source": "factory"
     },
     {
       "path": "src/pages/api/v1/news-portal/homepage-sections/index.ts",

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -4959,6 +4959,74 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/public:
+    get:
+      tags:
+        - Blog Content
+      summary: The static pages a reader can actually reach
+      description: "Gated by blog_content.pages.read. NOT the same answer as `/api/v1/blog/pages?status=published`: the admin list is an editor's view and returns private and unlisted pages too, so a consumer reaching for it with a status filter would publish every private page the newsroom has and nothing would report an error. The predicate here is the one the public route enforces, shared with sitemap-blog.xml so the two cannot disagree. Metadata only — a body is fetched per page from /{slug}, because a tenant's legal pages are few but long."
+      operationId: blogPagesPublicList
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Reachable static pages, in menu order.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      pages:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/PublicBlogPageSummary"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/pages/public/{slug}:
+    get:
+      tags:
+        - Blog Content
+      summary: One reachable static page, body included
+      description: Gated by blog_content.pages.read. The predicate is shared byte-for-byte with the public route /blog/{tenantCode}/pages/{slug}, so a draft cannot be read here for the same reason it cannot be read there. An unreachable slug answers 404 without distinguishing "no such page" from "that page is a draft" — not an information-disclosure boundary (the caller is authenticated) but consistency, so a consumer cannot depend on a distinction the browser-facing surface does not make. The body ships as BOTH `contentJson` (the projection this repo renders today) and `bodyPortableText` (the canonical column, ADR-0100), which is what lets a consumer move to the canonical shape on its own schedule.
+      operationId: blogPagesPublicDetail
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The page, with every referenced media object resolved in one call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/PublicBlogPageDetail"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/blog/posts:
     get:
       tags:
@@ -11177,6 +11245,60 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/news-portal/ad-placements/active:
+    get:
+      tags:
+        - News Portal Ad Placements
+      summary: Currently-runnable creatives per slot, already rotated and capped
+      description: Gated by blog_content.ad_placements.read. Returns all twelve slots, including the three this repo's own templates do not render — the sidebar exists in the consuming front end, and an endpoint shaped around what this repo draws would withhold inventory the consumer exists to show. Rotation and the per-slot item cap are applied HERE so four rotation modes are not re-implemented elsewhere; random_safe and weighted make the response deliberately not byte-stable, so it is not cacheable and does not try to be. An invalid targetType is refused rather than falling back to global, because silently widening an ad query is how a placement booked against one article appears on all of them.
+      operationId: newsPortalAdPlacementsActive
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: targetType
+          in: query
+          required: false
+          schema:
+            type: string
+            enum:
+              - global
+              - widget
+              - post
+              - page
+          description: The kind of page being rendered. Omit for the global inventory.
+        - name: targetId
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Required when targetType is not global, and refused when it is.
+      responses:
+        "200":
+          description: Selected creatives per placement key.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      slots:
+                        type: object
+                        additionalProperties:
+                          type: array
+                          items:
+                            $ref: "#/components/schemas/PublicAdPlacement"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/news-portal/homepage-sections:
     get:
       tags:
@@ -11359,6 +11481,41 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /api/v1/news-portal/homepage-sections/composed:
+    get:
+      tags:
+        - News Portal Homepage Sections
+      summary: The RESOLVED homepage, for a build client that renders its own templates
+      description: "Gated by blog_content.homepage_sections.read. Returns what the front page actually shows, not its configuration: every reference resolved against live public content, the deterministic fallback applied to a curated slot whose articles have all gone, and the render caps already enforced. A consumer must not resolve the configuration itself — that would re-implement the publication predicate in a second repository on a second deploy cadence, and the first disagreement is a draft article on somebody's front page. Media arrive as resolved public URLs here (unlike /api/v1/site-profile/composed, which returns ids) because a homepage is many short-lived images rather than one long-lived logo."
+      operationId: newsPortalHomepageComposed
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The composed homepage.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      isEmpty:
+                        type: boolean
+                        description: True when the tenant has composed nothing; the caller renders its own chronological listing.
+                      sections:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ComposedHomepageSection"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/offices:
     get:
       operationId: listOffices
@@ -20040,6 +20197,83 @@ components:
           type: boolean
         notifyOnReply:
           type: boolean
+    ComposedHomepageGroup:
+      type: object
+      properties:
+        heading:
+          type: string
+          nullable: true
+          description: Category name for a grid column; null for one ungrouped list.
+        slug:
+          type: string
+          nullable: true
+          description: Category slug, so the consumer can link the column to its archive.
+        posts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComposedHomepagePostCard"
+    ComposedHomepageImage:
+      type: object
+      properties:
+        url:
+          type: string
+        altText:
+          type: string
+          nullable: true
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+    ComposedHomepagePostCard:
+      type: object
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        publishedAt:
+          type: string
+          format: date-time
+        image:
+          allOf:
+            - $ref: "#/components/schemas/ComposedHomepageImage"
+          nullable: true
+    ComposedHomepageSection:
+      type: object
+      properties:
+        sectionKey:
+          type: string
+        sectionType:
+          type: string
+          enum:
+            - headline
+            - latest_posts
+            - featured_posts
+            - editor_picks
+            - category_grid
+            - gallery_block
+        title:
+          type: string
+          nullable: true
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComposedHomepageGroup"
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComposedHomepageImage"
+        caption:
+          type: string
+          nullable: true
+        fellBackToLatest:
+          type: boolean
+          description: True when curation resolved to nothing and the latest eligible articles were substituted.
     ComposedSiteIdentity:
       description: Both halves of site identity in one answer. The four SEO-owned fields are named exactly as seo_distribution names them, so this is visibly a passthrough rather than a second definition that could drift.
       allOf:
@@ -21933,6 +22167,103 @@ components:
           type: string
           format: date-time
           nullable: true
+    PublicAdPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          description: Internal label. A consumer renders it as alt text only when the media object carries none.
+        linkUrl:
+          type: string
+          nullable: true
+        mediaPublicUrl:
+          type: string
+          description: The media registry's own server-generated URL. There is no client-supplied URL column on this table.
+        mediaAltText:
+          type: string
+          nullable: true
+    PublicBlogPageDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          $ref: "#/components/schemas/BlogContentJson"
+          description: The derived block projection this repo's own renderer reads (ADR-0100).
+        bodyPortableText:
+          description: The canonical body. Empty until `bun run blog:portable-text:backfill` has run for this deployment.
+        contentText:
+          type: string
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        locale:
+          type: string
+        publishedAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        visibility:
+          type: string
+          enum:
+            - public
+            - unlisted
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        pageType:
+          type: string
+        resolvedMedia:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              publicUrl:
+                type: string
+              altText:
+                type: string
+                nullable: true
+              mimeType:
+                type: string
+              width:
+                type: integer
+                nullable: true
+              height:
+                type: integer
+                nullable: true
+          description: Every media object the body references, resolved in one call. An id that no longer resolves is simply absent.
+    PublicBlogPageSummary:
+      type: object
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        locale:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
     PublicComment:
       type: object
       description: A single publicly visible comment. Deliberately carries NO moderation metadata and no author contact data — `bodyHtml` is the escaped render of stored plain text, containing only `<br>` and safe http(s) `<a>` elements this server emitted.

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -830,6 +830,90 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/blog/pages/public:
+    get:
+      tags:
+        - Blog Content
+      summary: The static pages a reader can actually reach
+      description: >-
+        Gated by blog_content.pages.read. NOT the same answer as
+        `/api/v1/blog/pages?status=published`: the admin list is an editor's view
+        and returns private and unlisted pages too, so a consumer reaching for it
+        with a status filter would publish every private page the newsroom has and
+        nothing would report an error. The predicate here is the one the public
+        route enforces, shared with sitemap-blog.xml so the two cannot disagree.
+        Metadata only — a body is fetched per page from /{slug}, because a tenant's
+        legal pages are few but long.
+      operationId: blogPagesPublicList
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Reachable static pages, in menu order.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      pages:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/PublicBlogPageSummary"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/blog/pages/public/{slug}:
+    get:
+      tags:
+        - Blog Content
+      summary: One reachable static page, body included
+      description: >-
+        Gated by blog_content.pages.read. The predicate is shared byte-for-byte
+        with the public route /blog/{tenantCode}/pages/{slug}, so a draft cannot be
+        read here for the same reason it cannot be read there. An unreachable slug
+        answers 404 without distinguishing "no such page" from "that page is a
+        draft" — not an information-disclosure boundary (the caller is
+        authenticated) but consistency, so a consumer cannot depend on a
+        distinction the browser-facing surface does not make. The body ships as
+        BOTH `contentJson` (the projection this repo renders today) and
+        `bodyPortableText` (the canonical column, ADR-0100), which is what lets a
+        consumer move to the canonical shape on its own schedule.
+      operationId: blogPagesPublicDetail
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: The page, with every referenced media object resolved in one call.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    $ref: "#/components/schemas/PublicBlogPageDetail"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /api/v1/blog/pages:
     get:
       tags:
@@ -2597,6 +2681,109 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/news-portal/homepage-sections/composed:
+    get:
+      tags:
+        - News Portal Homepage Sections
+      summary: The RESOLVED homepage, for a build client that renders its own templates
+      description: >-
+        Gated by blog_content.homepage_sections.read. Returns what the front page
+        actually shows, not its configuration: every reference resolved against
+        live public content, the deterministic fallback applied to a curated slot
+        whose articles have all gone, and the render caps already enforced. A
+        consumer must not resolve the configuration itself — that would
+        re-implement the publication predicate in a second repository on a second
+        deploy cadence, and the first disagreement is a draft article on somebody's
+        front page. Media arrive as resolved public URLs here (unlike
+        /api/v1/site-profile/composed, which returns ids) because a homepage is
+        many short-lived images rather than one long-lived logo.
+      operationId: newsPortalHomepageComposed
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: The composed homepage.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      isEmpty:
+                        type: boolean
+                        description: True when the tenant has composed nothing; the caller renders its own chronological listing.
+                      sections:
+                        type: array
+                        items:
+                          $ref: "#/components/schemas/ComposedHomepageSection"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+  /api/v1/news-portal/ad-placements/active:
+    get:
+      tags:
+        - News Portal Ad Placements
+      summary: Currently-runnable creatives per slot, already rotated and capped
+      description: >-
+        Gated by blog_content.ad_placements.read. Returns all twelve slots,
+        including the three this repo's own templates do not render — the sidebar
+        exists in the consuming front end, and an endpoint shaped around what this
+        repo draws would withhold inventory the consumer exists to show. Rotation
+        and the per-slot item cap are applied HERE so four rotation modes are not
+        re-implemented elsewhere; random_safe and weighted make the response
+        deliberately not byte-stable, so it is not cacheable and does not try to
+        be. An invalid targetType is refused rather than falling back to global,
+        because silently widening an ad query is how a placement booked against one
+        article appears on all of them.
+      operationId: newsPortalAdPlacementsActive
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+        - name: targetType
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [global, widget, post, page]
+          description: The kind of page being rendered. Omit for the global inventory.
+        - name: targetId
+          in: query
+          required: false
+          schema:
+            type: string
+            format: uuid
+          description: Required when targetType is not global, and refused when it is.
+      responses:
+        "200":
+          description: Selected creatives per placement key.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum: [true]
+                  data:
+                    type: object
+                    properties:
+                      slots:
+                        type: object
+                        additionalProperties:
+                          type: array
+                          items:
+                            $ref: "#/components/schemas/PublicAdPlacement"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
   /api/v1/news-portal/homepage-sections:
     get:
       tags:
@@ -3865,6 +4052,178 @@ components:
           type: string
           format: date-time
           nullable: true
+    ComposedHomepageImage:
+      type: object
+      properties:
+        url:
+          type: string
+        altText:
+          type: string
+          nullable: true
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
+    ComposedHomepagePostCard:
+      type: object
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        publishedAt:
+          type: string
+          format: date-time
+        image:
+          allOf:
+            - $ref: "#/components/schemas/ComposedHomepageImage"
+          nullable: true
+    ComposedHomepageGroup:
+      type: object
+      properties:
+        heading:
+          type: string
+          nullable: true
+          description: Category name for a grid column; null for one ungrouped list.
+        slug:
+          type: string
+          nullable: true
+          description: Category slug, so the consumer can link the column to its archive.
+        posts:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComposedHomepagePostCard"
+    ComposedHomepageSection:
+      type: object
+      properties:
+        sectionKey:
+          type: string
+        sectionType:
+          type: string
+          enum:
+            - headline
+            - latest_posts
+            - featured_posts
+            - editor_picks
+            - category_grid
+            - gallery_block
+        title:
+          type: string
+          nullable: true
+        groups:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComposedHomepageGroup"
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComposedHomepageImage"
+        caption:
+          type: string
+          nullable: true
+        fellBackToLatest:
+          type: boolean
+          description: True when curation resolved to nothing and the latest eligible articles were substituted.
+    PublicAdPlacement:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+          description: Internal label. A consumer renders it as alt text only when the media object carries none.
+        linkUrl:
+          type: string
+          nullable: true
+        mediaPublicUrl:
+          type: string
+          description: The media registry's own server-generated URL. There is no client-supplied URL column on this table.
+        mediaAltText:
+          type: string
+          nullable: true
+    PublicBlogPageSummary:
+      type: object
+      properties:
+        title:
+          type: string
+        slug:
+          type: string
+        locale:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+    PublicBlogPageDetail:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        title:
+          type: string
+        slug:
+          type: string
+        excerpt:
+          type: string
+          nullable: true
+        contentJson:
+          $ref: "#/components/schemas/BlogContentJson"
+          description: The derived block projection this repo's own renderer reads (ADR-0100).
+        bodyPortableText:
+          description: The canonical body. Empty until `bun run blog:portable-text:backfill` has run for this deployment.
+        contentText:
+          type: string
+        seoTitle:
+          type: string
+          nullable: true
+        metaDescription:
+          type: string
+          nullable: true
+        canonicalUrl:
+          type: string
+          nullable: true
+        locale:
+          type: string
+        publishedAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        visibility:
+          type: string
+          enum: [public, unlisted]
+        featuredMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        pageType:
+          type: string
+        resolvedMedia:
+          type: object
+          additionalProperties:
+            type: object
+            properties:
+              publicUrl:
+                type: string
+              altText:
+                type: string
+                nullable: true
+              mimeType:
+                type: string
+              width:
+                type: integer
+                nullable: true
+              height:
+                type: integer
+                nullable: true
+          description: Every media object the body references, resolved in one call. An id that no longer resolves is simply absent.
     HomepageSectionItem:
       type: object
       required:

--- a/src/modules/blog-content/application/public-blog-directory.ts
+++ b/src/modules/blog-content/application/public-blog-directory.ts
@@ -440,6 +440,18 @@ export type PublicBlogPageDetail = {
   visibility: BlogContentVisibility;
   featuredMediaId: string | null;
   pageType: string;
+  /**
+   * The CANONICAL body (ADR-0100). Selected even though this repo's own public
+   * page route renders `contentJson` instead: `sql/134` defaults this column to
+   * `'[]'` until `bun run blog:portable-text:backfill` runs, so switching the
+   * HTML renderer to it would blank every page on a deployment that has not.
+   *
+   * A build client reading `GET /api/v1/blog/pages/public/{slug}` gets both and
+   * chooses — which is what lets `ahliweb/awcms-astro` move to the canonical
+   * column, and gain the marks the projection is lossy about, on its own
+   * schedule rather than on this repo's.
+   */
+  bodyPortableText: unknown;
 };
 
 type PublicBlogPageDetailRow = {
@@ -458,6 +470,7 @@ type PublicBlogPageDetailRow = {
   visibility: BlogContentVisibility;
   featured_media_id: string | null;
   page_type: string;
+  body_portable_text: unknown;
 };
 
 function toPageDetail(row: PublicBlogPageDetailRow): PublicBlogPageDetail {
@@ -476,7 +489,8 @@ function toPageDetail(row: PublicBlogPageDetailRow): PublicBlogPageDetail {
     updatedAt: row.updated_at,
     visibility: row.visibility,
     featuredMediaId: row.featured_media_id,
-    pageType: row.page_type
+    pageType: row.page_type,
+    bodyPortableText: row.body_portable_text
   };
 }
 
@@ -499,7 +513,7 @@ export async function fetchPublicBlogPageBySlug(
   const rows = (await tx`
     SELECT id, title, slug, excerpt, content_json, content_text, seo_title,
       meta_description, canonical_url, locale, published_at, updated_at,
-      visibility, featured_media_id, page_type
+      visibility, featured_media_id, page_type, body_portable_text
     FROM awcms_blog_pages
     WHERE tenant_id = ${tenantId} AND slug = ${slug}
       AND status = 'published' AND visibility IN ('public', 'unlisted')

--- a/src/pages/api/v1/blog/pages/public.ts
+++ b/src/pages/api/v1/blog/pages/public.ts
@@ -1,0 +1,43 @@
+import { ok } from "../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import { listPublicBlogPagesForSitemap } from "../../../../../modules/blog-content/application/public-blog-directory";
+
+/**
+ * `GET /api/v1/blog/pages/public` (Issue #594) — the static pages a reader can
+ * actually reach, for a build client that renders its own templates.
+ *
+ * ## Why this is not `GET /api/v1/blog/pages?status=published`
+ *
+ * Because that endpoint answers a different question and answers it correctly.
+ * The admin list is an EDITOR's view: it returns `private` and `unlisted` pages
+ * too, because an editor needs to see the page they marked private. A consumer
+ * that reached for it with a status filter would publish every private page the
+ * newsroom has, and nothing would report an error.
+ *
+ * The predicate here is the one the public route enforces —
+ * `listPublicBlogPagesForSitemap`, shared with `sitemap-blog.xml` so the two
+ * cannot disagree about what is public. One definition, three readers.
+ *
+ * ## Metadata only
+ *
+ * A body is fetched per page from `/{slug}` below, not inlined here. A tenant's
+ * legal and identity pages are few but long, and a consumer discovering the set
+ * should not have to download every disclaimer to find out there are four of
+ * them.
+ *
+ * Guarded on `blog_content.pages.read` — the same "the builder authenticates"
+ * decision as `GET /api/v1/site-profile/composed` (ADR-0102).
+ */
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "pages",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId }) => {
+    const pages = await listPublicBlogPagesForSitemap(tx, tenantId);
+
+    return ok({ pages });
+  }
+});

--- a/src/pages/api/v1/blog/pages/public/[slug].ts
+++ b/src/pages/api/v1/blog/pages/public/[slug].ts
@@ -1,0 +1,92 @@
+import { fail, ok } from "../../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../../modules/_shared/tenant-route";
+import { fetchPublicBlogPageBySlug } from "../../../../../../modules/blog-content/application/public-blog-directory";
+import { mediaLibraryPortAdapter } from "../../../../../../modules/media-library/application/media-library-port-adapter";
+import {
+  collectRenderableGalleryMediaObjectIds,
+  collectRenderableVideoNewsThumbnailMediaObjectIds
+} from "../../../../../../modules/blog-content/domain/content-block-rendering";
+
+/**
+ * `GET /api/v1/blog/pages/public/{slug}` (Issue #594) — one reachable static
+ * page, body included, for a build client.
+ *
+ * The predicate is `fetchPublicBlogPageBySlug`, shared byte-for-byte with the
+ * public route `/blog/{tenantCode}/pages/{slug}`: `published`, `visibility IN
+ * ('public', 'unlisted')`, not soft-deleted, `published_at` reached. A draft
+ * cannot be read here for the same reason it cannot be read there, and there is
+ * only one place that rule lives.
+ *
+ * An unreachable slug answers `404 RESOURCE_NOT_FOUND` rather than distinguishing
+ * "no such page" from "that page is a draft". The caller is authenticated and
+ * holds `pages.read`, so this is not an information-disclosure boundary — it is
+ * consistency with the public route, so a consumer cannot come to depend on a
+ * distinction the browser-facing surface does not make.
+ *
+ * ## Why the body ships as BOTH shapes
+ *
+ * `contentJson` is the projection this repo's own renderer reads today, and
+ * `bodyPortableText` is the canonical column (ADR-0100). A consumer that reads
+ * the projection keeps working; a consumer that reads Portable Text gets the
+ * marks — bold, italic, links — that the projection is lossy about. Shipping
+ * both is what lets `awcms-astro` move to the canonical column on its own
+ * schedule instead of on this repo's.
+ *
+ * Gallery and video media are resolved to URLs in one bulk call, so a consumer
+ * rendering a body does not have to walk it looking for ids and issue a request
+ * per image.
+ */
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "pages",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, params }) => {
+    const slug = params.slug;
+
+    if (!slug) {
+      return fail(400, "VALIDATION_ERROR", "Page slug is required.");
+    }
+
+    const page = await fetchPublicBlogPageBySlug(tx, tenantId, slug);
+
+    if (!page) {
+      return fail(404, "RESOURCE_NOT_FOUND", "Blog page not found.");
+    }
+
+    const mediaObjectIds = [
+      ...new Set([
+        ...collectRenderableGalleryMediaObjectIds(page.contentJson),
+        ...collectRenderableVideoNewsThumbnailMediaObjectIds(page.contentJson),
+        ...(page.featuredMediaId ? [page.featuredMediaId] : [])
+      ])
+    ];
+
+    const resolved = await mediaLibraryPortAdapter.resolveMediaReferences(
+      tx,
+      tenantId,
+      mediaObjectIds
+    );
+
+    return ok({
+      ...page,
+      // An id that no longer resolves is simply absent, the same "degrade,
+      // don't error" rule the renderers apply — a consumer sees the reference
+      // and no URL, and renders nothing for it.
+      resolvedMedia: Object.fromEntries(
+        [...resolved].map(([id, media]) => [
+          id,
+          {
+            publicUrl: media.publicUrl,
+            altText: media.altText,
+            mimeType: media.mimeType,
+            width: media.width,
+            height: media.height
+          }
+        ])
+      )
+    });
+  }
+});

--- a/src/pages/api/v1/news-portal/ad-placements/active.ts
+++ b/src/pages/api/v1/news-portal/ad-placements/active.ts
@@ -1,0 +1,156 @@
+import { fail, ok } from "../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import {
+  listActiveAdPlacementsForRendering,
+  type ActiveAdPlacementForRendering
+} from "../../../../../modules/blog-content/application/ad-placement-directory";
+import {
+  AD_PLACEMENT_KEYS,
+  AD_PLACEMENT_PRESETS,
+  isAdTargetType,
+  type AdPlacementKey,
+  type AdTarget
+} from "../../../../../modules/blog-content/domain/ad-placement-policy";
+import { selectAdsForRotation } from "../../../../../modules/blog-content/domain/ad-placement-rotation";
+import type { AdRotationCandidate } from "../../../../../modules/blog-content/domain/ad-placement-rotation";
+
+/**
+ * `GET /api/v1/news-portal/ad-placements/active` (Issue #594) — every slot's
+ * currently-runnable creatives, already rotated and capped, for a build client
+ * that renders its own markup.
+ *
+ * ## Why all twelve slots in one answer
+ *
+ * The alternative is a call per slot, and a consumer rendering a page has four
+ * to seven of them. More importantly, THREE of the twelve are ones this repo's
+ * own templates do not draw at all (`sidebar_*`, see
+ * `domain/ad-slot-rendering.ts`) — the sidebar exists in
+ * `ahliweb/awcms-astro`, not here. An endpoint shaped around what this repo
+ * renders would silently withhold the inventory a consumer exists to show.
+ *
+ * ## Rotation happens HERE, and that is the point
+ *
+ * A consumer receives the SELECTION, not the pool: `selectAdsForRotation`
+ * applies each slot's `rotationMode` and the preset's `maxItems` before the
+ * response is built. Leaving that to the caller would mean four rotation modes
+ * re-implemented in another repository, and the one that drifted would
+ * over-serve a slot an advertiser paid a fixed number of impressions for.
+ *
+ * `random_safe`/`weighted` make this response deliberately NOT byte-stable
+ * between calls. It is therefore not cacheable at the edge and does not try to
+ * be — `Cache-Control` is left to the standard headers, and a build client
+ * calls it once per build.
+ *
+ * ## `target` is a query parameter, and an invalid one is refused
+ *
+ * `?targetType=post&targetId=<uuid>` scopes the answer to one page: the
+ * placements booked against it UNIONED with every global placement for the same
+ * slot. Omitting both returns the global inventory, which is what a listing page
+ * carries. A `targetType` outside the four is a 400 rather than a silent
+ * fallback to `global`, because silently widening the scope of an ad query is
+ * how a placement books against one article and appears on all of them.
+ *
+ * Guarded on `blog_content.ad_placements.read` — same "the builder
+ * authenticates" decision as `GET /api/v1/site-profile/composed` (ADR-0102).
+ * Media URLs here are the registry's own server-generated ones, never client
+ * input; there is no free-URL column on this table at all.
+ */
+type PublicAdPlacement = {
+  id: string;
+  name: string;
+  linkUrl: string | null;
+  mediaPublicUrl: string;
+  mediaAltText: string | null;
+};
+
+function toPublic(ad: ActiveAdPlacementForRendering): PublicAdPlacement {
+  return {
+    id: ad.id,
+    name: ad.name,
+    linkUrl: ad.linkUrl,
+    mediaPublicUrl: ad.mediaPublicUrl,
+    mediaAltText: ad.mediaAltText
+  };
+}
+
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "ad_placements",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, url, now }) => {
+    const rawTargetType = url.searchParams.get("targetType");
+    const rawTargetId = url.searchParams.get("targetId");
+
+    let target: AdTarget | null = null;
+
+    if (rawTargetType !== null) {
+      if (!isAdTargetType(rawTargetType)) {
+        return fail(
+          400,
+          "VALIDATION_ERROR",
+          "targetType must be one of global, widget, post, page."
+        );
+      }
+
+      if (rawTargetType === "global") {
+        if (rawTargetId) {
+          return fail(
+            400,
+            "VALIDATION_ERROR",
+            "targetId must be omitted when targetType is global."
+          );
+        }
+      } else {
+        if (!rawTargetId) {
+          return fail(
+            400,
+            "VALIDATION_ERROR",
+            "targetId is required when targetType is not global."
+          );
+        }
+
+        target = { targetType: rawTargetType, targetId: rawTargetId };
+      }
+    } else if (rawTargetId) {
+      // A targetId with no targetType is a caller who thinks they scoped the
+      // query and did not. Answering the global inventory would look like it
+      // worked.
+      return fail(400, "VALIDATION_ERROR", "targetId requires targetType.");
+    }
+
+    const slots: Record<string, PublicAdPlacement[]> = {};
+
+    // Sequential, never concurrent: parallel queries on one transaction
+    // connection leak it. Twelve bounded queries, fixed by the key list rather
+    // than by anything the request controls.
+    for (const placementKey of AD_PLACEMENT_KEYS as readonly AdPlacementKey[]) {
+      const eligible = await listActiveAdPlacementsForRendering(
+        tx,
+        tenantId,
+        placementKey,
+        target,
+        now
+      );
+
+      if (eligible.length === 0) {
+        slots[placementKey] = [];
+        continue;
+      }
+
+      const selected = selectAdsForRotation<
+        ActiveAdPlacementForRendering & AdRotationCandidate
+      >(
+        eligible,
+        eligible[0]!.rotationMode,
+        AD_PLACEMENT_PRESETS[placementKey].maxItems
+      );
+
+      slots[placementKey] = selected.map(toPublic);
+    }
+
+    return ok({ slots });
+  }
+});

--- a/src/pages/api/v1/news-portal/homepage-sections/composed.ts
+++ b/src/pages/api/v1/news-portal/homepage-sections/composed.ts
@@ -1,0 +1,61 @@
+import { ok } from "../../../../../modules/_shared/api-response";
+import { defineTenantRoute } from "../../../../../modules/_shared/tenant-route";
+import { composeHomepage } from "../../../../../modules/blog-content/application/homepage-composition";
+import { mediaLibraryPortAdapter } from "../../../../../modules/media-library/application/media-library-port-adapter";
+
+/**
+ * `GET /api/v1/news-portal/homepage-sections/composed` (Issue #594) — the
+ * RESOLVED homepage, for a build client that renders its own templates.
+ *
+ * ## Resolved, not configured
+ *
+ * `GET /api/v1/news-portal/homepage-sections` already returns the configuration,
+ * and a consumer could in principle resolve it itself. It must not: doing so
+ * would mean re-implementing the publication predicate — published, `visibility
+ * = 'public'`, a reached `published_at`, not soft-deleted — in a second
+ * repository on a second deploy cadence. The first time those two disagree, the
+ * disagreement is a draft article on somebody's front page.
+ *
+ * So the same `composeHomepage` this repo's own `/blog/{tenantCode}` renders
+ * from answers here, including its deterministic fallback and its caps. One
+ * definition of "what is on the front page", two renderers.
+ *
+ * ## Guarded, not anonymous
+ *
+ * Same decision as `GET /api/v1/site-profile/composed` (ADR-0102) and
+ * `GET /api/v1/media/public-origin`: "public read" means the public site's
+ * BUILDER can read it, not that anyone can. The guard is this module's own
+ * `blog_content.homepage_sections.read`.
+ *
+ * That is not ceremony. A curated homepage names which articles an editor
+ * considers most important before they are on any page — an anonymous endpoint
+ * would publish the front page ahead of the front page, and there is no reason
+ * to hand that out to callers who are not building the site.
+ *
+ * ## Media arrives as URLs here, unlike everywhere else
+ *
+ * `composeHomepage` resolves media through `MediaLibraryPort` and yields public
+ * URLs, so that is what is returned. The `site-profile` composed endpoint
+ * deliberately returns media IDS instead, and the difference is real rather than
+ * an inconsistency: a logo is one long-lived reference a consumer resolves once,
+ * while a homepage is thirty cards whose images change every hour. Making a
+ * build client resolve those one by one would turn one request into thirty-one.
+ */
+export const GET = defineTenantRoute({
+  workClass: "interactive",
+  authorize: {
+    moduleKey: "blog_content",
+    activityCode: "homepage_sections",
+    action: "read"
+  },
+  handler: async ({ tx, tenantId, now }) => {
+    const composed = await composeHomepage(
+      tx,
+      tenantId,
+      mediaLibraryPortAdapter,
+      now
+    );
+
+    return ok(composed);
+  }
+});

--- a/tests/blog-content-consumer-read-api.test.ts
+++ b/tests/blog-content-consumer-read-api.test.ts
@@ -1,0 +1,182 @@
+/**
+ * The four consumer read endpoints (Issue #594) — the ones `ahliweb/awcms-astro`
+ * calls to render a homepage, an ad slot and a static page.
+ *
+ * ## What is actually at risk here
+ *
+ * Not the shape of the JSON. Two things:
+ *
+ * 1. **That none of them is anonymous.** ADR-0102 settled that "public read"
+ *    in this family means the public site's BUILDER authenticates, and
+ *    `api-spec-check`'s `ALLOWED_PUBLIC_OPERATIONS` is the list that would have
+ *    to name an operation for it to be otherwise. A route that acquired
+ *    `security: []` would publish a curated front page before it is a front
+ *    page, and an unpublished static page along with it.
+ * 2. **That each of them reads the PUBLIC predicate.** The admin list functions
+ *    return `private` and `unlisted` rows because an editor needs to see them.
+ *    A consumer endpoint reaching for one would publish every private page the
+ *    newsroom has, and nothing would report an error — the failure is silent on
+ *    both sides of the wire.
+ *
+ * Pure — no database, no network.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+
+const FRAGMENT_PATH = "openapi/modules/blog-content.openapi.yaml";
+const SPEC_CHECK_PATH = "scripts/api-spec-check.ts";
+
+const ROUTES: readonly {
+  path: string;
+  operationId: string;
+  guard: string;
+}[] = [
+  {
+    path: "src/pages/api/v1/news-portal/homepage-sections/composed.ts",
+    operationId: "newsPortalHomepageComposed",
+    guard: "homepage_sections"
+  },
+  {
+    path: "src/pages/api/v1/news-portal/ad-placements/active.ts",
+    operationId: "newsPortalAdPlacementsActive",
+    guard: "ad_placements"
+  },
+  {
+    path: "src/pages/api/v1/blog/pages/public.ts",
+    operationId: "blogPagesPublicList",
+    guard: "pages"
+  },
+  {
+    path: "src/pages/api/v1/blog/pages/public/[slug].ts",
+    operationId: "blogPagesPublicDetail",
+    guard: "pages"
+  }
+];
+
+describe("every consumer read endpoint is guarded, not anonymous", () => {
+  test("each declares its own module's read permission", async () => {
+    for (const route of ROUTES) {
+      const source = stripComments(await readFile(route.path, "utf8"));
+
+      expect(source).toContain("defineTenantRoute");
+      expect(source).toMatch(
+        new RegExp(
+          `moduleKey:\\s*"blog_content",\\s*activityCode:\\s*"${route.guard}",\\s*action:\\s*"read"`
+        )
+      );
+    }
+  });
+
+  test("none of them is on the anonymous allow-list", async () => {
+    const specCheck = await readFile(SPEC_CHECK_PATH, "utf8");
+
+    // Proves the corpus is the right file — otherwise the assertions below pass
+    // against any string that happens not to contain the ids.
+    expect(specCheck).toContain("ALLOWED_PUBLIC_OPERATIONS");
+
+    for (const route of ROUTES) {
+      expect(specCheck).not.toContain(route.operationId);
+    }
+  });
+
+  test("and none of them declares `security: []` in the contract", async () => {
+    const fragment = await readFile(FRAGMENT_PATH, "utf8");
+
+    for (const route of ROUTES) {
+      const start = fragment.indexOf(`operationId: ${route.operationId}`);
+
+      expect(start).toBeGreaterThan(-1);
+
+      // The operation's own block, up to the next `operationId` or the end.
+      const rest = fragment.slice(start + 1);
+      const nextOperation = rest.indexOf("operationId:");
+      const block = nextOperation === -1 ? rest : rest.slice(0, nextOperation);
+
+      expect(block).not.toContain("security: []");
+    }
+  });
+});
+
+describe("each endpoint reads the public predicate, never the editor's view", () => {
+  test("the page list shares its query with the sitemap", async () => {
+    const source = await readFile(
+      "src/pages/api/v1/blog/pages/public.ts",
+      "utf8"
+    );
+
+    expect(source).toContain("listPublicBlogPagesForSitemap");
+    // The admin list returns `private`/`unlisted` rows on purpose. Reaching for
+    // it here is the silent-publication bug this endpoint exists to avoid.
+    expect(source).not.toContain("listBlogPages");
+    expect(source).not.toContain("listBlogPagesForAdmin");
+  });
+
+  test("the page detail shares its query with the public route", async () => {
+    const source = await readFile(
+      "src/pages/api/v1/blog/pages/public/[slug].ts",
+      "utf8"
+    );
+    const publicRoute = await readFile(
+      "src/pages/blog/[tenantCode]/pages/[slug].ts",
+      "utf8"
+    );
+
+    expect(source).toContain("fetchPublicBlogPageBySlug");
+    expect(publicRoute).toContain("fetchPublicBlogPageBySlug");
+    expect(source).not.toContain("fetchBlogPageById");
+  });
+
+  test("the homepage endpoint resolves through the same composer the site renders", async () => {
+    const source = await readFile(
+      "src/pages/api/v1/news-portal/homepage-sections/composed.ts",
+      "utf8"
+    );
+    const publicIndex = await readFile(
+      "src/pages/blog/[tenantCode]/index.ts",
+      "utf8"
+    );
+
+    // Returning the CONFIGURATION instead would make the consumer re-implement
+    // the publication predicate in another repository.
+    expect(source).toContain("composeHomepage");
+    expect(publicIndex).toContain("composeHomepage");
+    expect(source).not.toContain("listHomepageSections");
+  });
+
+  test("the ad endpoint rotates and caps before answering", async () => {
+    const source = stripComments(
+      await readFile(
+        "src/pages/api/v1/news-portal/ad-placements/active.ts",
+        "utf8"
+      )
+    );
+
+    // Handing over the raw pool would put four rotation modes in a second
+    // repository, and the one that drifted would over-serve a slot an
+    // advertiser paid a fixed number of impressions for.
+    expect(source).toContain("selectAdsForRotation");
+    expect(source).toContain("AD_PLACEMENT_PRESETS[placementKey].maxItems");
+    // Every slot, including the three this repo's templates do not draw.
+    expect(source).toContain("AD_PLACEMENT_KEYS");
+  });
+
+  test("an unscoped targetId is refused rather than widened to global", async () => {
+    const source = stripComments(
+      await readFile(
+        "src/pages/api/v1/news-portal/ad-placements/active.ts",
+        "utf8"
+      )
+    );
+
+    // Silently widening the scope of an ad query is how a placement booked
+    // against one article ends up on all of them.
+    expect(source).toContain("targetId requires targetType.");
+    expect(source).toContain(
+      "targetId must be omitted when targetType is global."
+    );
+    expect(source).toContain("isAdTargetType");
+  });
+});


### PR DESCRIPTION
Four read endpoints close the awcms half of #594. `awcms-astro` renders its own templates and until now had no way to ask this repo what belongs on them.

Every one of them turns on the same decision: **resolve here, not there.**

## `GET /api/v1/news-portal/homepage-sections/composed`

The **resolved** homepage, not its configuration. `GET .../homepage-sections` already returns the configuration and a consumer could in principle resolve it — it must not, because that means re-implementing the publication predicate (published, `visibility = 'public'`, a reached `published_at`, not soft-deleted) in a second repository on a second deploy cadence. The first time those disagree, the disagreement is a draft article on somebody's front page.

Same `composeHomepage` this repo's own `/blog/{tenantCode}` renders from, deterministic fallback and caps included. One definition, two renderers.

Media arrive as resolved URLs here, unlike `site-profile/composed` which returns ids. That difference is deliberate: a logo is one long-lived reference resolved once, a homepage is thirty cards whose images change hourly — resolving those one by one would turn one request into thirty-one.

## `GET /api/v1/news-portal/ad-placements/active`

The **selection**, not the pool: rotation mode and the per-slot item cap are applied before the response is built. Leaving that to the caller would put four rotation modes in another repository, and the one that drifted would over-serve a slot an advertiser paid a fixed number of impressions for.

It answers **all twelve slots**, including the three this repo's templates do not draw — the sidebar exists in the consuming front end, and an endpoint shaped around what *this* repo renders would withhold the inventory a consumer exists to show.

An invalid or unpaired `targetType` is a `400`, never a fallback to `global`. Silently widening an ad query is how a placement booked against one article appears on all of them.

`random_safe`/`weighted` make this response deliberately not byte-stable, so it is not cacheable and does not pretend to be.

## `GET /api/v1/blog/pages/public` and `/public/{slug}`

They share their predicates with `sitemap-blog.xml` and with `/blog/{tenantCode}/pages/{slug}` respectively.

They exist instead of `GET /api/v1/blog/pages?status=published` because **the admin list is an editor's view** — it returns `private` and `unlisted` pages on purpose, since an editor needs to see the page they marked private. A consumer reaching for it with a status filter would publish every private page the newsroom has, and nothing would report an error.

The detail ships the body as **both** `contentJson` (the projection this repo renders today) and `bodyPortableText` (the canonical column, ADR-0100), which is what lets a consumer move to the canonical shape — and gain the marks the projection is lossy about — on its own schedule rather than on this repo's.

## Guarded, not anonymous

All four follow the decision ADR-0102 already made for `GET /api/v1/site-profile/composed`: *"public read" means the public site's builder can read it.* A curated homepage names the articles an editor considers most important **before they are on any page**, and there is no reason to hand that to callers who are not building the site.

A test pins that none of the four ever appears in `ALLOWED_PUBLIC_OPERATIONS` — checked in the routes, in `api-spec-check.ts`, and in the contract fragment, because `security: []` in any one of those three would be enough.

## Verification

`bun run check` green end to end — 5731 tests, 0 fail, clean build. No permission, no migration, no client asset cost.

## Scope

Part of #594 (6 of 6) — this closes the awcms half. The remaining half of the issue's Definition of Done, `awcms-astro` consuming these endpoints, lives in the other repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)