### PR TITLE
fix(blog-content): a phrase an editor bolded now reaches the reader bold (#624)

### DIFF
--- a/.changeset/canonical-body-reaches-the-reader.md
+++ b/.changeset/canonical-body-reaches-the-reader.md
@@ -1,0 +1,56 @@
+---
+"awcms": patch
+---
+
+fix(blog-content): a phrase an editor bolded now reaches the reader bold (#624)
+
+ADR-0100 made Portable Text the canonical body, and #605/#606 gave editors an
+editor that produces **bold**, _italic_, code and inline links.
+`domain/portable-text-rendering.ts` renders every one of them correctly, and had
+**zero production callers** — `grep` found only its own definition.
+
+What the public routes rendered was `content_json.blocks`, the projection that
+`portable-text-conversion.ts` itself calls lossy by construction: "ContentBlock
+has no marks. So bold, italic, code and links flatten to their plain text on the
+way back." A journalist bolded a phrase, saved, opened the article, and read it
+plain. No error, no log, no red gate — the failure was silent on both sides.
+
+### Why this is a fallback and not a swap
+
+`sql/134` gives `body_portable_text` a `'[]'::jsonb` DEFAULT and leaves the
+conversion to `bun run blog:portable-text:backfill`, a deployment job that
+deliberately does not run from the migration. On a deployment that has not run
+it, the canonical column is empty for every pre-existing row, so switching the
+renderer unconditionally would render **every article blank** — and blank is
+indistinguishable from "the editor wrote nothing".
+
+`renderBlogBodyHtml` renders the canonical body when it holds content and the
+projection when it does not. That is byte-identical to the previous output on a
+deployment that has not backfilled, needs no release coordination, and heals per
+row as the backfill progresses. Every write since #605 populates both columns in
+one statement, so the two shapes are consistent by construction and an empty
+canonical body means either "predates the backfill" or "the editor cleared it" —
+both served correctly by falling back.
+
+Applied to the public post route, the public static-page route (which had
+documented that the two must move together or not at all) and the internal-link
+preview, so an editor previews what a reader will actually get.
+
+### Media follows the body that renders
+
+Gallery and video-thumbnail ids are now collected from **both** stored shapes and
+ordered by the one that renders, because the social-preview fallback takes the
+first image in the content and "first" must mean first as the reader sees it.
+`fetchPublicBlogPostBySlug` and `listPublicBlogPostsForFeed` select the canonical
+column, without which the fallback would be permanent and look correct.
+
+### The gate
+
+A renderer with no callers is invisible to every gate that checks shape rather
+than reach, and this repo has recorded that defect class before. A test now fails
+when any production file outside `blog-body-rendering.ts` names either low-level
+renderer, and when the reader-facing routes stop calling the deciding one.
+
+RSS, the sitemap, `seo_facts` and the `site_search` index were checked and are
+unaffected: all four read `content_text`, the derived plain-text column, which
+carries no marks either way.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 151   |
 | Tables with `FORCE` RLS             | 133   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 414   |
+| Test files                          | 415   |
 | Route files                         | 376   |
 | ADR                                 | 206   |
 
@@ -344,7 +344,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 358        |
+| `(root)`      | 359        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |

--- a/src/lib/ui/blog-body-editor.ts
+++ b/src/lib/ui/blog-body-editor.ts
@@ -66,7 +66,7 @@ export function splitBodyTextIntoParagraphs(bodyText: string): string[] {
     .filter((paragraph) => paragraph.length > 0);
 }
 
-/** The `contentJson` half of the payload: `{ blocks: [...] }`, the shape `renderContentJsonToHtml` reads and everything downstream of it expects. */
+/** The `contentJson` half of the payload: `{ blocks: [...] }`, the lossy projection kept for consumers of the old vocabulary. Since Issue #624 a reader is served the canonical Portable Text half whenever it holds content — see `blog-body-rendering.ts`. */
 export function buildContentJsonFromBodyText(
   bodyText: string
 ): ParagraphBodyDocument {

--- a/src/modules/blog-content/application/news-article-seo-metadata.ts
+++ b/src/modules/blog-content/application/news-article-seo-metadata.ts
@@ -17,10 +17,7 @@ import type { MediaLibraryPort } from "../../_shared/ports/media-library-port";
 import type { PublicBlogPostDetail } from "./public-blog-directory";
 import { fetchPublicPostTaxonomyTerms } from "./public-blog-directory";
 import type { BlogSettingsView } from "./blog-settings-directory";
-import {
-  collectRenderableGalleryMediaObjectIds,
-  collectRenderableVideoNewsThumbnailMediaObjectIds
-} from "../domain/content-block-rendering";
+import { collectBlogBodyMediaObjectIds } from "../domain/blog-body-rendering";
 import {
   resolveSocialPreviewImageSourceId,
   type SocialPreviewImageCandidates
@@ -44,7 +41,7 @@ export type NewsArticleSeoMetadataInput = {
 };
 
 export type NewsArticleSeoMetadata = {
-  /** `mediaObjectId -> publicUrl`, for `renderContentJsonToHtml`'s gallery/video-thumbnail rendering — same map shape every existing caller already builds, now built once here instead of per-route. */
+  /** `mediaObjectId -> publicUrl`, for `renderBlogBodyHtml`'s gallery/video-thumbnail rendering — same map shape every existing caller already builds, now built once here instead of per-route. */
   resolvedGalleryUrls: ReadonlyMap<string, string>;
   ogImageUrl: string | null;
   ogImageAlt: string | null;
@@ -65,11 +62,14 @@ export async function buildNewsArticleSeoMetadata(
   blogSettings: BlogSettingsView,
   input: NewsArticleSeoMetadataInput
 ): Promise<NewsArticleSeoMetadata> {
-  const galleryMediaObjectIds = collectRenderableGalleryMediaObjectIds(
-    input.post.contentJson
-  );
-  const videoThumbnailMediaObjectIds =
-    collectRenderableVideoNewsThumbnailMediaObjectIds(input.post.contentJson);
+  // Issue #624 — collected from BOTH body shapes, ordered by the one that will
+  // actually render. Reading `contentJson` alone would drop an image that exists
+  // only in the canonical Portable Text body, and would order the social-preview
+  // "first image in content" fallback by a body the reader never sees.
+  const {
+    galleryImageMediaObjectIds: galleryMediaObjectIds,
+    videoThumbnailMediaObjectIds
+  } = collectBlogBodyMediaObjectIds(input.post);
 
   const candidateIds = new Set<string>();
   if (input.post.featuredMediaId) {
@@ -207,9 +207,8 @@ export async function resolveNewsArticlePreviewImage(
   blogSettings: BlogSettingsView,
   post: PublicBlogPostDetail
 ): Promise<ResolvedNewsArticlePreviewImage | null> {
-  const galleryMediaObjectIds = collectRenderableGalleryMediaObjectIds(
-    post.contentJson
-  );
+  const { galleryImageMediaObjectIds: galleryMediaObjectIds } =
+    collectBlogBodyMediaObjectIds(post);
 
   const candidateIds = new Set<string>();
   if (post.featuredMediaId) {

--- a/src/modules/blog-content/application/public-blog-directory.ts
+++ b/src/modules/blog-content/application/public-blog-directory.ts
@@ -46,6 +46,17 @@ export type PublicBlogPostDetail = {
   autoInternalTagLinksDisabled: boolean;
   /** Issue #649 — explicit "use this image for social/SEO preview" override; highest priority source in `social-preview-image-resolution.ts`'s chain, ahead of `featuredMediaId`. */
   seoImageMediaId: string | null;
+  /**
+   * The CANONICAL body (ADR-0100), and since Issue #624 the one the public post
+   * route actually renders — through `renderBlogBodyHtml`, which falls back to
+   * `contentJson` when this is empty because `sql/134` leaves the column `'[]'`
+   * until `bun run blog:portable-text:backfill` runs.
+   *
+   * `unknown` rather than `PortableTextDocument`: a row written before that
+   * backfill can hold anything, and the renderer's job is to degrade rather than
+   * to trust the type.
+   */
+  bodyPortableText: unknown;
 };
 
 type PublicBlogPostDetailRow = {
@@ -65,6 +76,7 @@ type PublicBlogPostDetailRow = {
   featured_media_id: string | null;
   auto_internal_tag_links_disabled: boolean;
   seo_image_media_id: string | null;
+  body_portable_text: unknown;
 };
 
 function toDetail(row: PublicBlogPostDetailRow): PublicBlogPostDetail {
@@ -84,7 +96,8 @@ function toDetail(row: PublicBlogPostDetailRow): PublicBlogPostDetail {
     visibility: row.visibility,
     featuredMediaId: row.featured_media_id,
     autoInternalTagLinksDisabled: row.auto_internal_tag_links_disabled,
-    seoImageMediaId: row.seo_image_media_id
+    seoImageMediaId: row.seo_image_media_id,
+    bodyPortableText: row.body_portable_text
   };
 }
 
@@ -97,7 +110,7 @@ export async function fetchPublicBlogPostBySlug(
     SELECT id, title, slug, excerpt, content_json, content_text, seo_title,
       meta_description, canonical_url, locale, published_at, updated_at,
       visibility, featured_media_id, auto_internal_tag_links_disabled,
-      seo_image_media_id
+      seo_image_media_id, body_portable_text
     FROM awcms_blog_posts
     WHERE tenant_id = ${tenantId} AND slug = ${slug}
       AND status = 'published' AND visibility IN ('public', 'unlisted')
@@ -387,7 +400,18 @@ const FEED_ITEM_LIMIT = 50;
 /** See `listPublicBlogPagesForSitemap` for why this is lower than `FEED_ITEM_LIMIT`. */
 const SITEMAP_PAGE_LIMIT = 200;
 
-/** RSS/sitemap source — flat, unpaginated (feeds/sitemaps are consumed by machines, not paged by a visitor), bounded to the latest 50 published public posts. */
+/**
+ * RSS/sitemap source — flat, unpaginated (feeds/sitemaps are consumed by
+ * machines, not paged by a visitor), bounded to the latest 50 published public
+ * posts.
+ *
+ * `body_portable_text` is selected even though no feed element renders a body:
+ * `resolveNewsArticlePreviewImage` collects the enclosure image from whichever
+ * body shape is live (Issue #624), and omitting the column here would leave the
+ * detail shape half-populated — a trap for the next caller, which would silently
+ * read the lossy projection instead. Fifty rows already carry `content_json`;
+ * this is the same order of bytes, once, for a bounded query.
+ */
 export async function listPublicBlogPostsForFeed(
   tx: Bun.SQL,
   tenantId: string
@@ -395,7 +419,7 @@ export async function listPublicBlogPostsForFeed(
   const rows = (await tx`
     SELECT id, title, slug, excerpt, content_json, content_text, seo_title,
       meta_description, canonical_url, locale, published_at, updated_at,
-      visibility, featured_media_id, seo_image_media_id
+      visibility, featured_media_id, seo_image_media_id, body_portable_text
     FROM awcms_blog_posts
     WHERE tenant_id = ${tenantId}
       AND status = 'published' AND visibility = 'public'

--- a/src/modules/blog-content/domain/blog-body-rendering.ts
+++ b/src/modules/blog-content/domain/blog-body-rendering.ts
@@ -1,0 +1,190 @@
+import type { ResolvedGalleryMediaUrls } from "../../_shared/rendering/gallery-block-renderer";
+import {
+  collectRenderableGalleryMediaObjectIds,
+  collectRenderableVideoNewsThumbnailMediaObjectIds,
+  renderContentJsonToHtml
+} from "./content-block-rendering";
+import { renderPortableTextToHtml } from "./portable-text-rendering";
+
+/**
+ * The ONE place that decides which stored body a reader actually sees
+ * (Issue #624).
+ *
+ * ## The defect this closes
+ *
+ * ADR-0100 made Portable Text the canonical body, and #605/#606 gave editors an
+ * editor that produces bold, italic, code and inline links. `renderPortableTextToHtml`
+ * renders all of it correctly — and had ZERO production callers. Every public
+ * surface rendered `content_json.blocks` instead, the projection that
+ * `portable-text-conversion.ts` itself calls lossy by construction: "ContentBlock
+ * has no marks. So bold, italic, code and links flatten to their plain text on the
+ * way back."
+ *
+ * So a journalist bolded a phrase, saved, opened the public page, and read it
+ * plain. No error, no log, no red gate.
+ *
+ * ## Why this is a fallback and not a swap
+ *
+ * `sql/134` gives `body_portable_text` a `'[]'::jsonb` DEFAULT and leaves the
+ * conversion to `bun run blog:portable-text:backfill`, a deployment job that
+ * deliberately does not run from the migration (the tables are FORCE RLS; DML in a
+ * migration is green on an empty CI database and breaks in production).
+ *
+ * On a deployment that has not run that job, the canonical column is empty for
+ * every pre-existing row. An unconditional switch would render EVERY article blank
+ * — and blank is indistinguishable from "the editor wrote nothing", which is the
+ * worst possible failure shape for a news site.
+ *
+ * So: render the canonical body when it holds something, fall back to the
+ * projection when it does not. That is byte-identical to today's output on a
+ * deployment that has not backfilled, needs no release coordination, and heals
+ * PER ROW as the backfill progresses.
+ *
+ * ## Why "empty canonical" is a safe signal
+ *
+ * Every write since #605 populates both columns in the same statement
+ * (`blog-post-directory.ts` / `blog-page-directory.ts` derive `content_json` from
+ * the Portable Text via `withProjectedBlocks`), so the two are consistent by
+ * construction for anything written since. An empty canonical body therefore means
+ * exactly one of two things — the row predates the backfill, or the editor really
+ * did clear the body — and both are served correctly by falling back, because in
+ * the second case the projection is empty too and both renderers return `""`.
+ *
+ * Pure module: no database, no I/O.
+ */
+
+export type BlogBodySource = {
+  /** The canonical body (ADR-0100). `unknown` because it arrives as jsonb and a pre-backfill row can hold anything a caller must not trust. */
+  bodyPortableText: unknown;
+  /** The lossy derived projection, still the fallback for un-backfilled rows. */
+  contentJson: Record<string, unknown>;
+};
+
+/**
+ * Whether the canonical body carries content.
+ *
+ * A non-array is not "malformed" here — it is what `undefined` looks like when a
+ * query did not select the column. Both answer `false` and fall back, which is
+ * the same "degrade, never throw" rule both renderers already follow.
+ */
+export function hasCanonicalPortableTextBody(body: BlogBodySource): boolean {
+  return (
+    Array.isArray(body.bodyPortableText) && body.bodyPortableText.length > 0
+  );
+}
+
+/**
+ * Renders a post or page body to safe HTML from whichever source is live for
+ * this row.
+ *
+ * Both branches escape every character of author-supplied content and emit tags
+ * only from closed mappings — the safety property does not depend on which one
+ * runs.
+ */
+export function renderBlogBodyHtml(
+  body: BlogBodySource,
+  resolvedMediaUrls?: ResolvedGalleryMediaUrls
+): string {
+  return hasCanonicalPortableTextBody(body)
+    ? renderPortableTextToHtml(body.bodyPortableText, resolvedMediaUrls)
+    : renderContentJsonToHtml(body.contentJson, resolvedMediaUrls);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Projects a Portable Text document into the `{ blocks: [...] }` shape the
+ * existing reference collectors read.
+ *
+ * Deliberately a shape adapter rather than a second extractor: "which gallery
+ * item references a media object" is a rule with a write-time half
+ * (`collectGalleryImageReferences` decides what must be verified before a post is
+ * stored) and a render-time half. Re-implementing the UUID check, the
+ * image-only filter and the missing-vs-malformed distinction here would give the
+ * two halves two chances to drift, and the symptom of that drift is an image an
+ * editor placed that silently renders nothing.
+ *
+ * Only the two media-bearing node types are projected — prose blocks reference
+ * no media, and `portableTextToContentBlocks` cannot be reused for this because
+ * it assumes a well-formed document and this input comes straight from jsonb.
+ */
+function portableTextMediaProjection(
+  document: unknown
+): Record<string, unknown> {
+  if (!Array.isArray(document)) {
+    return {};
+  }
+
+  const blocks: Record<string, unknown>[] = [];
+
+  for (const node of document) {
+    if (!isRecord(node)) {
+      continue;
+    }
+
+    if (node._type === "gallery") {
+      blocks.push({ type: "gallery", items: node.items });
+      continue;
+    }
+
+    if (node._type === "videoNews") {
+      blocks.push({
+        type: "video_news",
+        thumbnailMediaObjectId: node.thumbnailMediaObjectId
+      });
+    }
+  }
+
+  return { blocks };
+}
+
+function unionInOrder(...lists: readonly string[][]): string[] {
+  return [...new Set(lists.flat())];
+}
+
+export type BlogBodyMediaReferences = {
+  /** Gallery IMAGE ids, in the order they appear in the body that will actually be rendered. */
+  galleryImageMediaObjectIds: string[];
+  /** `video_news` / `videoNews` thumbnail ids. */
+  videoThumbnailMediaObjectIds: string[];
+};
+
+/**
+ * Every media object id a rendered body can reference, collected from BOTH
+ * stored shapes.
+ *
+ * The union is belt-and-braces: the write path derives one shape from the other,
+ * so the id sets are identical today. Collecting from only the rendered source
+ * would make that an unstated invariant whose first violation shows up as a
+ * missing photo on a live article, and the union costs one extra traversal of a
+ * body already in memory.
+ *
+ * ORDER follows the rendered source, because the caller's "first image in the
+ * content" social-preview fallback (`social-preview-image-resolution.ts`) means
+ * the first image a READER sees, not the first one in whichever shape happened
+ * to be traversed first.
+ */
+export function collectBlogBodyMediaObjectIds(
+  body: BlogBodySource
+): BlogBodyMediaReferences {
+  const canonicalProjection = portableTextMediaProjection(
+    body.bodyPortableText
+  );
+  const rendersCanonical = hasCanonicalPortableTextBody(body);
+
+  const first = rendersCanonical ? canonicalProjection : body.contentJson;
+  const second = rendersCanonical ? body.contentJson : canonicalProjection;
+
+  return {
+    galleryImageMediaObjectIds: unionInOrder(
+      collectRenderableGalleryMediaObjectIds(first),
+      collectRenderableGalleryMediaObjectIds(second)
+    ),
+    videoThumbnailMediaObjectIds: unionInOrder(
+      collectRenderableVideoNewsThumbnailMediaObjectIds(first),
+      collectRenderableVideoNewsThumbnailMediaObjectIds(second)
+    )
+  };
+}

--- a/src/pages/api/v1/blog/posts/[id]/internal-links/preview.ts
+++ b/src/pages/api/v1/blog/posts/[id]/internal-links/preview.ts
@@ -9,7 +9,7 @@ import {
 } from "../../../../../../../modules/identity-access/application/access-guard";
 import { hashSessionToken } from "../../../../../../../lib/auth/session-token";
 import { fetchBlogPostById } from "../../../../../../../modules/blog-content/application/blog-post-directory";
-import { renderContentJsonToHtml } from "../../../../../../../modules/blog-content/domain/content-block-rendering";
+import { renderBlogBodyHtml } from "../../../../../../../modules/blog-content/domain/blog-body-rendering";
 import { previewInternalTagLinksForContent } from "../../../../../../../modules/blog-content/application/internal-tag-link-rendering";
 import { resolveBlogAutoInternalTagLinksConfig } from "../../../../../../../modules/blog-content/domain/internal-tag-linking-config";
 
@@ -26,8 +26,9 @@ const PREVIEW_GUARD = {
  * endpoint/UI shows which terms will be linked before publish"). Runs the
  * exact same `applyInternalTagLinksToHtml` engine the public `/news`/
  * `/blog/{tenantCode}` routes use at render time (via
- * `previewInternalTagLinksForContent`), against the post's CURRENT
- * `content_json` regardless of its `status` (draft/review/scheduled all
+ * `previewInternalTagLinksForContent`), against the post's CURRENT body —
+ * whichever of the two stored shapes the public route would render (Issue
+ * #624) — regardless of its `status` (draft/review/scheduled all
  * previewable — that's the point) — gallery/video media is rendered
  * without R2 resolution (media verification is `content-quality-checklist`'s
  * concern, Issue #640; this endpoint only cares about which text terms
@@ -88,7 +89,11 @@ export const GET: APIRoute = async ({ request, cookies, params }) => {
       SELECT tenant_code FROM awcms_tenants WHERE id = ${tenantId}
     `) as TenantCodeRow[];
     const basePath = `/blog/${tenantRows[0]?.tenant_code ?? ""}`;
-    const contentHtml = renderContentJsonToHtml(post.contentJson);
+    // Issue #624 — the same body-source decision the public route makes. A
+    // preview rendered from the other shape would answer a question the editor
+    // did not ask: the projection flattens inline links, and an already-linked
+    // phrase is exactly what the linking engine skips.
+    const contentHtml = renderBlogBodyHtml(post);
 
     const preview = await previewInternalTagLinksForContent(
       tx,

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -19,7 +19,7 @@ import { fetchBlogSettings } from "../../../modules/blog-content/application/blo
 import { buildNewsArticleSeoMetadata } from "../../../modules/blog-content/application/news-article-seo-metadata";
 import { mediaLibraryPortAdapter } from "../../../modules/media-library/application/media-library-port-adapter";
 import { resolveBlogShareConfig } from "../../../modules/blog-content/domain/social-share-config";
-import { renderContentJsonToHtml } from "../../../modules/blog-content/domain/content-block-rendering";
+import { renderBlogBodyHtml } from "../../../modules/blog-content/domain/blog-body-rendering";
 import { renderContentHtmlWithInternalTagLinks } from "../../../modules/blog-content/application/internal-tag-link-rendering";
 import {
   resolveCanonicalUrl,
@@ -110,8 +110,12 @@ export const GET: APIRoute = async ({ locals, params, request, url }) => {
         }
       );
 
-      const renderedContentHtml = renderContentJsonToHtml(
-        post.contentJson,
+      // Issue #624 — the CANONICAL body (ADR-0100) when it holds something,
+      // the lossy `content_json` projection when it does not. Before this, a
+      // phrase an editor bolded reached the reader plain, because nothing in
+      // production called the Portable Text renderer at all.
+      const renderedContentHtml = renderBlogBodyHtml(
+        post,
         seoMetadata.resolvedGalleryUrls
       );
 

--- a/src/pages/blog/[tenantCode]/pages/[slug].ts
+++ b/src/pages/blog/[tenantCode]/pages/[slug].ts
@@ -17,10 +17,9 @@ import { fetchPublicBlogPageBySlug } from "../../../../modules/blog-content/appl
 import { isLegacyTenantRouteEnabled } from "../../../../modules/blog-content/application/public-route-settings";
 import { mediaLibraryPortAdapter } from "../../../../modules/media-library/application/media-library-port-adapter";
 import {
-  collectRenderableGalleryMediaObjectIds,
-  collectRenderableVideoNewsThumbnailMediaObjectIds,
-  renderContentJsonToHtml
-} from "../../../../modules/blog-content/domain/content-block-rendering";
+  collectBlogBodyMediaObjectIds,
+  renderBlogBodyHtml
+} from "../../../../modules/blog-content/domain/blog-body-rendering";
 import {
   resolveCanonicalUrl,
   resolveMetaDescription,
@@ -56,17 +55,15 @@ import { renderPublicPageShell } from "../../../../modules/blog-content/domain/p
  * already is. That is a pre-existing property of the route family, not something
  * this route introduces.
  *
- * ## Why the body renders from `content_json` and not `body_portable_text`
+ * ## Which stored body renders (Issue #624)
  *
- * ADR-0100 makes Portable Text the canonical body, and `content_json.blocks` a
- * derived (lossy) projection of it — so rendering the projection is the WRONG
- * source on its face. It is nonetheless what this route does, and what
- * `[slug].ts` does for posts, for one reason: `sql/134` gives
- * `body_portable_text` a `'[]'` default and leaves the conversion to
- * `bun run blog:portable-text:backfill`, a deployment job. Reading the canonical
- * column on a deployment that has not run that job yet renders EVERY page blank,
- * and blank is indistinguishable from "the editor wrote nothing". Both routes
- * move together, after the backfill, or not at all.
+ * Neither column unconditionally: `renderBlogBodyHtml` reads the canonical
+ * Portable Text body (ADR-0100) when it holds something and the lossy
+ * `content_json` projection when it does not, because `sql/134` leaves the
+ * canonical column `'[]'` until `bun run blog:portable-text:backfill` runs and
+ * an unconditional switch would blank every page on a deployment that has not.
+ * The decision lives in that one function, and this route and the post route
+ * moved together — as the earlier version of this comment said they had to.
  *
  * Mirrors the post detail route in every other respect: anonymous, tenant
  * resolved from the path segment (ADR-0009), `isLegacyTenantRouteEnabled` as the
@@ -120,11 +117,13 @@ export const GET: APIRoute = async ({ locals, params, request, url }) => {
 
       // One bulk resolution for both embed kinds, same as the post route —
       // an id that does not resolve to a verified media object renders nothing
-      // rather than a broken `<img>`.
+      // rather than a broken `<img>`. Issue #624: collected from both stored
+      // body shapes, so the ids follow whichever one renders below.
+      const bodyMedia = collectBlogBodyMediaObjectIds(page);
       const mediaObjectIds = [
         ...new Set([
-          ...collectRenderableGalleryMediaObjectIds(page.contentJson),
-          ...collectRenderableVideoNewsThumbnailMediaObjectIds(page.contentJson)
+          ...bodyMedia.galleryImageMediaObjectIds,
+          ...bodyMedia.videoThumbnailMediaObjectIds
         ])
       ];
       const resolvedMedia =
@@ -137,10 +136,7 @@ export const GET: APIRoute = async ({ locals, params, request, url }) => {
         [...resolvedMedia].map(([id, media]) => [id, media.publicUrl])
       );
 
-      const contentHtml = renderContentJsonToHtml(
-        page.contentJson,
-        resolvedMediaUrls
-      );
+      const contentHtml = renderBlogBodyHtml(page, resolvedMediaUrls);
 
       // No share buttons and no `NewsArticle` JSON-LD: a privacy policy is not
       // an article, and stamping one with `datePublished`/`author` would tell a

--- a/tests/blog-content-canonical-body-rendering.test.ts
+++ b/tests/blog-content-canonical-body-rendering.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Which stored body a reader actually sees (Issue #624).
+ *
+ * ## The defect
+ *
+ * ADR-0100 made Portable Text canonical and #605/#606 gave editors marks — bold,
+ * italic, code, inline links. `renderPortableTextToHtml` rendered every one of
+ * them correctly and had ZERO production callers. The public post route rendered
+ * `content_json.blocks`, the projection its own converter calls lossy by
+ * construction, so a bolded phrase reached the reader plain with no error, no log
+ * and no red gate.
+ *
+ * ## What is pinned here
+ *
+ * 1. **The fallback is a fallback.** Canonical when non-empty, projection when
+ *    empty. Unconditional either way is a bug: reading the canonical column on a
+ *    deployment that has not run `bun run blog:portable-text:backfill` blanks
+ *    every article, and reading the projection is the defect itself.
+ * 2. **Media survives the switch.** Ids are collected from both stored shapes and
+ *    ordered by the one that renders, because "first image in the content" feeds
+ *    the social-preview fallback.
+ * 3. **The canonical renderer cannot lose its callers again.** This repo has
+ *    recorded this defect class before ("the writer moved, its readers did not"):
+ *    a renderer with no callers is invisible to every gate that checks shape
+ *    rather than reach. So the two low-level renderers are reachable from exactly
+ *    one production module, and that module is called by the routes that serve
+ *    readers.
+ *
+ * Pure — no database, no network.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+import {
+  collectBlogBodyMediaObjectIds,
+  hasCanonicalPortableTextBody,
+  renderBlogBodyHtml
+} from "../src/modules/blog-content/domain/blog-body-rendering";
+
+const MEDIA_A = "11111111-1111-4111-8111-111111111111";
+const MEDIA_B = "22222222-2222-4222-8222-222222222222";
+const MEDIA_C = "33333333-3333-4333-8333-333333333333";
+
+/** A body with a mark — the exact thing the projection flattens. */
+const CANONICAL_WITH_MARK = [
+  {
+    _type: "block",
+    _key: "a",
+    style: "normal",
+    markDefs: [{ _key: "l1", _type: "link", href: "https://example.org/x" }],
+    children: [
+      { _type: "span", _key: "s1", text: "Menteri ", marks: [] },
+      { _type: "span", _key: "s2", text: "menegaskan", marks: ["strong"] },
+      { _type: "span", _key: "s3", text: " ", marks: [] },
+      { _type: "span", _key: "s4", text: "hal itu", marks: ["l1"] }
+    ]
+  }
+];
+
+/** The projection of the body above, as `portableTextToContentBlocks` produces it. */
+const FLATTENED_PROJECTION = {
+  blocks: [{ type: "paragraph", text: "Menteri menegaskan hal itu" }]
+};
+
+describe("renderBlogBodyHtml picks the body a reader should see", () => {
+  test("renders the canonical body, marks included, when it holds content", () => {
+    const html = renderBlogBodyHtml({
+      bodyPortableText: CANONICAL_WITH_MARK,
+      contentJson: FLATTENED_PROJECTION
+    });
+
+    // The whole point of the issue: this is what an editor typed.
+    expect(html).toContain("<strong>menegaskan</strong>");
+    expect(html).toContain(
+      '<a href="https://example.org/x" rel="noopener noreferrer">hal itu</a>'
+    );
+  });
+
+  test("falls back to the projection when the canonical column is still `[]`", () => {
+    // `sql/134`'s DEFAULT, on a deployment that has not run the backfill. If this
+    // ever renders "" instead, every pre-backfill article on that deployment is
+    // a blank page — and blank is indistinguishable from "nothing was written".
+    const html = renderBlogBodyHtml({
+      bodyPortableText: [],
+      contentJson: FLATTENED_PROJECTION
+    });
+
+    expect(html).toBe("<p>Menteri menegaskan hal itu</p>");
+  });
+
+  test("falls back when the column was not selected at all", () => {
+    const html = renderBlogBodyHtml({
+      bodyPortableText: undefined,
+      contentJson: FLATTENED_PROJECTION
+    });
+
+    expect(html).toBe("<p>Menteri menegaskan hal itu</p>");
+  });
+
+  test("a genuinely empty body renders empty, from either shape", () => {
+    expect(
+      renderBlogBodyHtml({ bodyPortableText: [], contentJson: { blocks: [] } })
+    ).toBe("");
+    expect(renderBlogBodyHtml({ bodyPortableText: [], contentJson: {} })).toBe(
+      ""
+    );
+  });
+
+  test("a corrupt canonical body degrades rather than throwing", () => {
+    expect(() =>
+      renderBlogBodyHtml({
+        bodyPortableText: [null, 42, { _type: "unknown" }],
+        contentJson: FLATTENED_PROJECTION
+      })
+    ).not.toThrow();
+  });
+
+  test("resolved media urls reach whichever renderer runs", () => {
+    const gallery = {
+      _type: "gallery",
+      _key: "g",
+      items: [{ mediaType: "image", mediaObjectId: MEDIA_A }]
+    };
+
+    const html = renderBlogBodyHtml(
+      { bodyPortableText: [gallery], contentJson: {} },
+      new Map([[MEDIA_A, "https://cdn.example.org/a.jpg"]])
+    );
+
+    expect(html).toContain("https://cdn.example.org/a.jpg");
+  });
+
+  test("hasCanonicalPortableTextBody is the single predicate", () => {
+    expect(
+      hasCanonicalPortableTextBody({
+        bodyPortableText: CANONICAL_WITH_MARK,
+        contentJson: {}
+      })
+    ).toBe(true);
+    expect(
+      hasCanonicalPortableTextBody({ bodyPortableText: [], contentJson: {} })
+    ).toBe(false);
+    expect(
+      hasCanonicalPortableTextBody({ bodyPortableText: null, contentJson: {} })
+    ).toBe(false);
+  });
+});
+
+describe("media references are collected from both stored shapes", () => {
+  test("an image present only in the canonical body is still resolved", () => {
+    const refs = collectBlogBodyMediaObjectIds({
+      bodyPortableText: [
+        {
+          _type: "gallery",
+          _key: "g",
+          items: [{ mediaType: "image", mediaObjectId: MEDIA_A }]
+        }
+      ],
+      contentJson: { blocks: [] }
+    });
+
+    expect(refs.galleryImageMediaObjectIds).toEqual([MEDIA_A]);
+  });
+
+  test("an image present only in the projection is still resolved", () => {
+    const refs = collectBlogBodyMediaObjectIds({
+      bodyPortableText: [],
+      contentJson: {
+        blocks: [
+          {
+            type: "gallery",
+            items: [{ mediaType: "image", mediaObjectId: MEDIA_B }]
+          }
+        ]
+      }
+    });
+
+    expect(refs.galleryImageMediaObjectIds).toEqual([MEDIA_B]);
+  });
+
+  test("ids are deduplicated and ordered by the body that renders", () => {
+    // The social-preview fallback takes the FIRST content image. When the
+    // canonical body renders, "first" must mean first as the reader sees it.
+    const refs = collectBlogBodyMediaObjectIds({
+      bodyPortableText: [
+        {
+          _type: "gallery",
+          _key: "g",
+          items: [
+            { mediaType: "image", mediaObjectId: MEDIA_C },
+            { mediaType: "image", mediaObjectId: MEDIA_A }
+          ]
+        }
+      ],
+      contentJson: {
+        blocks: [
+          {
+            type: "gallery",
+            items: [
+              { mediaType: "image", mediaObjectId: MEDIA_A },
+              { mediaType: "image", mediaObjectId: MEDIA_B }
+            ]
+          }
+        ]
+      }
+    });
+
+    expect(refs.galleryImageMediaObjectIds).toEqual([
+      MEDIA_C,
+      MEDIA_A,
+      MEDIA_B
+    ]);
+  });
+
+  test("video thumbnails are collected from both node spellings", () => {
+    const refs = collectBlogBodyMediaObjectIds({
+      bodyPortableText: [
+        {
+          _type: "videoNews",
+          _key: "v",
+          provider: "youtube",
+          thumbnailMediaObjectId: MEDIA_A
+        }
+      ],
+      contentJson: {
+        blocks: [{ type: "video_news", thumbnailMediaObjectId: MEDIA_B }]
+      }
+    });
+
+    expect(refs.videoThumbnailMediaObjectIds).toEqual([MEDIA_A, MEDIA_B]);
+  });
+});
+
+const BODY_RENDERING_MODULE =
+  "src/modules/blog-content/domain/blog-body-rendering.ts";
+
+/**
+ * The files allowed to name the two low-level renderers: their own definitions,
+ * and the one module that decides between them.
+ */
+const RENDERER_OWNERS: readonly string[] = [
+  "src/modules/blog-content/domain/content-block-rendering.ts",
+  "src/modules/blog-content/domain/portable-text-rendering.ts",
+  BODY_RENDERING_MODULE
+];
+
+async function productionSources(): Promise<string[]> {
+  const files: string[] = [];
+
+  for (const pattern of ["**/*.ts", "**/*.astro"]) {
+    for await (const file of new Bun.Glob(pattern).scan({ cwd: "src" })) {
+      files.push(`src/${file}`);
+    }
+  }
+
+  return files.sort();
+}
+
+describe("the canonical renderer cannot lose its callers again", () => {
+  test("no production file picks a body renderer for itself", async () => {
+    const offenders: string[] = [];
+
+    for (const file of await productionSources()) {
+      if (RENDERER_OWNERS.includes(file)) {
+        continue;
+      }
+
+      // Comments stripped first: several files legitimately EXPLAIN these
+      // functions, and a docblock must not be able to satisfy — or violate — a
+      // reachability assertion.
+      const source = stripComments(await readFile(file, "utf8"));
+
+      if (
+        source.includes("renderContentJsonToHtml") ||
+        source.includes("renderPortableTextToHtml")
+      ) {
+        offenders.push(file);
+      }
+    }
+
+    // A route that reaches past `renderBlogBodyHtml` picks one stored body
+    // unconditionally, which is either "marks never reach a reader" (Issue #624)
+    // or "every pre-backfill article is blank". Route through the decision.
+    expect(offenders).toEqual([]);
+  });
+
+  test("both renderers are actually reachable from the deciding module", async () => {
+    const source = stripComments(await readFile(BODY_RENDERING_MODULE, "utf8"));
+
+    expect(source).toContain("renderPortableTextToHtml(");
+    expect(source).toContain("renderContentJsonToHtml(");
+  });
+
+  test("and that module is called by the surfaces that serve readers", async () => {
+    const readerSurfaces = [
+      "src/pages/blog/[tenantCode]/[slug].ts",
+      "src/pages/blog/[tenantCode]/pages/[slug].ts"
+    ];
+
+    for (const file of readerSurfaces) {
+      const source = stripComments(await readFile(file, "utf8"));
+
+      expect(source).toContain("renderBlogBodyHtml(");
+    }
+  });
+
+  test("the public post query selects the canonical column", async () => {
+    const source = stripComments(
+      await readFile(
+        "src/modules/blog-content/application/public-blog-directory.ts",
+        "utf8"
+      )
+    );
+
+    // Without this the fallback is unconditional and silently correct-looking:
+    // an unselected column is `undefined`, which is not an array, which renders
+    // the projection forever.
+    expect(source).toContain("FROM awcms_blog_posts");
+    expect(source).toContain("seo_image_media_id, body_portable_text");
+    expect(source).toContain("bodyPortableText: row.body_portable_text");
+  });
+});

--- a/tests/blog-content-public-page-route.test.ts
+++ b/tests/blog-content-public-page-route.test.ts
@@ -113,7 +113,10 @@ describe("the route is gated like every other public blog route", () => {
   test("the body is rendered through the whitelist renderer, never raw", async () => {
     const route = await source(ROUTE);
 
-    expect(route).toContain("renderContentJsonToHtml(");
+    // Issue #624 — `renderBlogBodyHtml` chooses between the canonical Portable
+    // Text body and the `content_json` projection; both branches escape every
+    // character and emit tags only from closed mappings.
+    expect(route).toContain("renderBlogBodyHtml(");
     expect(route).not.toContain("set:html");
     expect(route).not.toContain("page.contentText}");
   });


### PR DESCRIPTION
Closes #624.

## The defect

ADR-0100 made Portable Text the canonical body, and #605/#606 gave editors an editor that produces **bold**, _italic_, code and inline links. `src/modules/blog-content/domain/portable-text-rendering.ts` renders every one of them correctly, and had **zero production callers** — `grep` found only its own definition.

What the public routes rendered was `content_json.blocks`, the projection that `portable-text-conversion.ts` itself calls lossy by construction: *"ContentBlock has no marks. So bold, italic, code and links flatten to their plain text on the way back."*

A journalist bolded a phrase, saved, opened the article, and read it plain. No error, no log, no red gate — silent on both sides.

## Why a fallback and not a swap

`sql/134` gives `body_portable_text` a `'[]'::jsonb` DEFAULT and leaves the conversion to `bun run blog:portable-text:backfill`, a deployment job that deliberately does not run from the migration (the tables are FORCE RLS; DML in a migration is green on an empty CI database and breaks in production).

On a deployment that has not run it, the canonical column is empty for every pre-existing row, so an unconditional switch would render **every article blank** — and blank is indistinguishable from "the editor wrote nothing".

`renderBlogBodyHtml` renders the canonical body when it holds content and the projection when it does not. Byte-identical to the previous output before the backfill, no release coordination, self-healing per row as the backfill progresses. Every write since #605 populates both columns in one statement, so an empty canonical body means either "predates the backfill" or "the editor cleared it" — both served correctly by falling back, because in the second case the projection is empty too.

Applied to the public post route, the public static-page route — whose docblock had recorded that the two must move together or not at all — and the internal-link preview, so an editor previews what a reader will actually get.

## Media follows the body that renders

Gallery and video-thumbnail ids are collected from **both** stored shapes and ordered by the one that renders: the social-preview fallback takes the first image in the content, and "first" must mean first as the reader sees it. `fetchPublicBlogPostBySlug` and `listPublicBlogPostsForFeed` now select the canonical column — without it the fallback would be permanent and look correct.

The collector is a shape adapter feeding the existing `collectGalleryImageReferences`, not a second extractor, so the write-time and render-time halves of "which item references a media object" cannot drift.

## The gate

A renderer with no callers is invisible to every gate that checks shape rather than reach, and this repo has recorded that defect class before. `tests/blog-content-canonical-body-rendering.test.ts` fails when any production file outside `blog-body-rendering.ts` names either low-level renderer, and when the reader-facing routes stop calling the deciding one. Proven to fail on a deliberately introduced violation, not merely observed green.

## Checked, unaffected

RSS, the sitemap, `seo_facts` and the `site_search` index all read `content_text`, the derived plain-text column, which carries no marks either way.

## Verification

`DATABASE_URL="" bun run check` — full chain green. 5,131 pass, 0 fail, 407 files. App assets 184,446 B of 185,000 (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)