### PR TITLE
fix(blog-content): publishing an article from /admin/blog now purges the edge cache (#623)

### DIFF
--- a/.changeset/lifecycle-routes-purge-the-edge.md
+++ b/.changeset/lifecycle-routes-purge-the-edge.md
@@ -1,0 +1,44 @@
+---
+"awcms": patch
+---
+
+fix(blog-content): publishing an article from /admin/blog now purges the edge cache (#623)
+
+ADR-0042 §Rule 21 requires every handler that changes content to enqueue a purge
+inside the same transaction. For `blog_content`, five post lifecycle routes never
+called `enqueueModuleContentPurge` at all — including `publish.ts`, which is the
+endpoint the Publish button on `/admin/blog` calls.
+
+With `EDGE_CACHE_MODE` active — and it has been on in staging since 26 July 2026
+— publishing an article emitted no purge. `/blog/{code}` has a 120-second TTL and
+`blog-post` 300, so it healed itself and the symptom was "the new article takes a
+while to show up" rather than a hard failure. `archive` is the direction that
+matters: a withdrawn article kept being served from the edge until its TTL
+expired, which is the withdrawal not having happened.
+
+Purges added to `publish`, `archive`, `restore`, `purge`, and
+`revisions/{revisionId}/restore` — the last one was not in the issue's list (it
+lives a directory deeper) but rewrites the body of a post that may be published
+right now.
+
+`schedule.ts` deliberately did NOT get one, against the issue's enumeration:
+`ALLOWED_STATUS_TRANSITIONS` lets only `draft` and `review` become `scheduled`,
+so nothing it commits is ever visible publicly, and the sweep that does publish
+it already purges. Adding one would append a ban matching no cached object while
+the queue reported success — the "ceremony that reads as coverage" this repo
+already refuses for surfaceless module keys.
+
+### Why no gate caught it
+
+`edge-cache:surfaces:check` asks whether the MODULE purges somewhere, and
+`blog_content` did. `tests/edge-cache-content-purge.test.ts` pinned a per-file
+count for an enumerated list, and a list cannot report the file it does not
+contain — its own comment said so.
+
+The obligation is now derived: every mutating API route owned by a module that
+owns a cacheable surface must either purge or carry a checkable reason it cannot
+change what a reader sees. Six routes are exempt with reasons. Twenty-eight more
+are recorded on a shrink-only ledger — several of them, ads and homepage sections
+in particular, look like the same defect and are tracked for a follow-up rather
+than buried inside a five-route fix. A new mutating handler is on neither list,
+so it fails on arrival; proven by planting one, not merely observed green.

--- a/src/pages/api/v1/blog/posts/[id]/archive.ts
+++ b/src/pages/api/v1/blog/posts/[id]/archive.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -144,6 +145,17 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       postId,
       slug: updated.slug
     });
+
+    // ADR-0042 §Rule 21 (Issue #623) — the serious direction. Archiving is how a
+    // newsroom WITHDRAWS an article; an article still served from the edge is
+    // the withdrawal not having happened, and unlike a late publish that is not
+    // something a five-minute TTL makes acceptable.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.archived"
+    );
 
     const successResponse = ok(updated);
     const successBody = await successResponse.clone().json();

--- a/src/pages/api/v1/blog/posts/[id]/publish.ts
+++ b/src/pages/api/v1/blog/posts/[id]/publish.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -215,6 +216,19 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       postId,
       slug: updated.slug
     });
+
+    // ADR-0042 §Rule 21 (Issue #623) — this is the button `/admin/blog` calls,
+    // and the transition it performs is the one a stale cache hides. The PATCH
+    // path purged and this did not, so with the edge cache on, publishing an
+    // article emitted nothing and the newsroom waited out a 120-second TTL
+    // wondering whether the publish had worked. Same transaction as the status
+    // change, no-op when the cache is off.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.published"
+    );
 
     await socialPublishingPort.onArticlePublished(
       tx,

--- a/src/pages/api/v1/blog/posts/[id]/purge.ts
+++ b/src/pages/api/v1/blog/posts/[id]/purge.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -144,6 +145,19 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       moduleKey: "blog_content",
       postId
     });
+
+    // ADR-0042 §Rule 21 (Issue #623), same call the page purge route already
+    // makes. A purgeable post is archived or soft-deleted, so the transition
+    // that removed it from the public predicate has usually purged already —
+    // this is the last opportunity to evict anything derived from a row that is
+    // about to stop existing, and a hard delete is not the place to rely on
+    // "usually".
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.purged"
+    );
 
     const successResponse = ok({ id: postId, status: "purged" });
     const successBody = await successResponse.clone().json();

--- a/src/pages/api/v1/blog/posts/[id]/restore.ts
+++ b/src/pages/api/v1/blog/posts/[id]/restore.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import { enqueueModuleContentPurge } from "../../../../../../lib/edge-cache/content-purge";
 import {
   fail,
   jsonResponse,
@@ -142,6 +143,17 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       postId,
       slug: updated.slug
     });
+
+    // ADR-0042 §Rule 21 (Issue #623) — restoring clears `deleted_at`, and the
+    // public predicate excludes only on that column, not on status. So a post
+    // that was published when it was soft-deleted becomes publicly reachable
+    // again the moment this commits, which is a content change like any other.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.restored"
+    );
 
     const successResponse = ok(updated);
     const successBody = await successResponse.clone().json();

--- a/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
+++ b/src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts
@@ -1,5 +1,6 @@
 import type { APIRoute } from "astro";
 
+import { enqueueModuleContentPurge } from "../../../../../../../../lib/edge-cache/content-purge";
 import {
   contentBlocksToPortableText,
   readLegacyBlocks
@@ -280,6 +281,18 @@ export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
       attributes: { revisionId, revisionNumber: revision.revisionNumber },
       correlationId
     });
+
+    // ADR-0042 §Rule 21 (Issue #623). Not in that issue's enumeration — it
+    // listed the `[id]/` directory and this route lives one level down — but it
+    // is the same defect on the same resource, and a worse one: restoring a
+    // revision rewrites the BODY of a post that may be published right now, so
+    // the edge would keep serving the text an editor just replaced.
+    await enqueueModuleContentPurge(
+      tx,
+      tenantId,
+      "blog_content",
+      "blog.post.revision_restored"
+    );
 
     const successResponse = ok(updated);
     const successBody = await successResponse.clone().json();

--- a/src/pages/api/v1/blog/posts/[id]/schedule.ts
+++ b/src/pages/api/v1/blog/posts/[id]/schedule.ts
@@ -54,6 +54,18 @@ const IDEMPOTENCY_SCOPE = "blog_post_schedule";
  * the idempotency request hash alongside `scheduledAt`, so re-sending the same
  * key with a DIFFERENT withdrawal date is a 409 rather than a silent no-op —
  * two different windows are two different requests.
+ *
+ * ## No edge-cache purge here, deliberately (Issue #623)
+ *
+ * The other four lifecycle routes gained one; this one did not, and the reason
+ * is `ALLOWED_STATUS_TRANSITIONS`: only `draft` and `review` may become
+ * `scheduled`, and a published post cannot. So nothing this route commits is
+ * ever visible on a public surface — before or after — and the transition that
+ * DOES make it visible is `blog-scheduled-publish.ts`'s sweep, which purges.
+ *
+ * Adding one anyway would append a ban that matches no cached object while the
+ * queue reports success: the same "ceremony that reads as coverage" this repo
+ * already refuses for surfaceless module keys in `resolveDerivedSurfaceModuleKeys`.
  */
 export const POST: APIRoute = async ({ request, params, cookies, locals }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);

--- a/tests/edge-cache-content-purge.test.ts
+++ b/tests/edge-cache-content-purge.test.ts
@@ -13,6 +13,13 @@ import {
   resolveDerivedSurfaceModuleKeys
 } from "../src/lib/edge-cache/content-purge";
 import type { SqlExecutor } from "../src/lib/edge-cache/purge-queue";
+import { PUBLIC_CACHE_SURFACES } from "../src/lib/edge-cache/surface-registry";
+import { listModules } from "../src/modules";
+import {
+  collectClaims,
+  resolveOwner,
+  routeOf
+} from "../scripts/validate-module-routes";
 
 /** Records the parameter arrays passed to the tagged-template executor. */
 function recordingTx(): { tx: SqlExecutor; calls: unknown[][] } {
@@ -182,6 +189,22 @@ describe("content write paths emit a purge", () => {
   test.each([
     ["src/pages/api/v1/blog/posts/[id].ts", 2],
     ["src/pages/api/v1/blog/posts/index.ts", 1],
+    // Issue #623 — these five predate the page work below and were missed by
+    // it, because a list of files cannot report the file it does not contain.
+    // `publish` is the button `/admin/blog` calls: with the edge cache on, the
+    // whole newsroom publish path emitted no purge at all. `archive` is the
+    // direction that matters more — a withdrawn article still served from the
+    // edge is the withdrawal not having happened. `revisions/{id}/restore`
+    // rewrites the body of a post that may be published right now.
+    //
+    // `posts/[id]/schedule.ts` is deliberately ABSENT: only `draft` and
+    // `review` may become `scheduled`, so it changes nothing a reader can see,
+    // and the sweep that does publish it purges. See its own header.
+    ["src/pages/api/v1/blog/posts/[id]/publish.ts", 1],
+    ["src/pages/api/v1/blog/posts/[id]/archive.ts", 1],
+    ["src/pages/api/v1/blog/posts/[id]/restore.ts", 1],
+    ["src/pages/api/v1/blog/posts/[id]/purge.ts", 1],
+    ["src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts", 1],
     // Issue #594 gave `blog_content` the `blog-page` surface, so every handler
     // that changes a page now has the obligation posts already had. The four
     // lifecycle routes matter more than the two CRUD ones: `publish` is how a
@@ -226,4 +249,179 @@ describe("content write paths emit a purge", () => {
       expect(occurrences).toBe(expected);
     }
   );
+});
+
+/**
+ * The obligation, DERIVED rather than remembered (Issue #623).
+ *
+ * The list above pins how many times each enumerated file purges. Its weakness
+ * is structural and its own comment admitted it: a file that is not in the list
+ * is not checked, so a new mutating handler that forgets the enqueue turns
+ * nothing red. That is precisely how the five post lifecycle routes went a year
+ * without one while a gate named `edge-cache:surfaces:check` reported green —
+ * that gate asks whether the MODULE purges anywhere, and `blog_content` did.
+ *
+ * So the population is computed here instead: every mutating API route owned by
+ * a module that owns a cacheable surface. Each one either purges, or is named
+ * below with a reason it cannot change what a reader sees.
+ */
+const SURFACE_OWNING_MODULES = new Set(
+  PUBLIC_CACHE_SURFACES.map((surface) => surface.moduleKey).filter(
+    (key): key is string => Boolean(key)
+  )
+);
+
+/** `export const POST|PATCH|PUT|DELETE` — the handlers that can change content. */
+const MUTATING_HANDLER = /export const (?:POST|PATCH|PUT|DELETE)\b/;
+
+/**
+ * Verified exempt: the handler cannot change any cached public surface.
+ *
+ * A reason here must be checkable, not plausible. "Probably not public" is how
+ * an exemption list becomes the place obligations go to be forgotten.
+ */
+const PURGE_NOT_REQUIRED: Readonly<Record<string, string>> = {
+  "src/pages/api/v1/blog/posts/[id]/schedule.ts":
+    "Only `draft` and `review` may become `scheduled` (ALLOWED_STATUS_TRANSITIONS); a published post cannot. Nothing it commits is ever on a public surface, and the sweep that does publish it purges.",
+  "src/pages/api/v1/blog/posts/[id]/submit-review.ts":
+    "`review` is reachable from `draft` only — `published` transitions to `archived` or `draft`, never to `review`. So this never withdraws a live article.",
+  "src/pages/api/v1/theming/draft.ts":
+    "Writes a theme DRAFT. The live tokens change at `theming/publish.ts`, which purges.",
+  "src/pages/api/v1/theming/preview.ts":
+    "Creates a preview session, which is served to its holder rather than cached publicly.",
+  "src/pages/api/v1/theming/validate.ts":
+    "Validation only — no INSERT/UPDATE/DELETE anywhere in the file.",
+  "src/pages/api/v1/seo/redirects/validate.ts":
+    "Validation only — no INSERT/UPDATE/DELETE anywhere in the file."
+};
+
+/**
+ * Handlers whose purge obligation has NOT been decided yet — the ledger.
+ *
+ * Every one of these mutates something owned by a module that owns a cacheable
+ * surface, and several of them look like real staleness on inspection: ads and
+ * homepage sections are rendered onto `/blog/{code}` by Issue #594's work, blog
+ * settings gate whether `feed.xml` and `sitemap-blog.xml` answer at all, and
+ * terms are what the category and tag archives are built from.
+ *
+ * They are listed rather than fixed because deciding each one needs the same
+ * per-route reasoning the five above got, and doing twenty-eight of them inside
+ * a five-route bug fix would bury the fix. The list may only SHRINK: an entry
+ * removed from it must have gained a purge or a reason, and a NEW mutating
+ * handler is not in it, so it fails the test below on arrival.
+ */
+const PURGE_OBLIGATION_UNREVIEWED: readonly string[] = [
+  "src/pages/api/v1/blog/ads/[id].ts",
+  "src/pages/api/v1/blog/ads/index.ts",
+  "src/pages/api/v1/blog/institutions/[id].ts",
+  "src/pages/api/v1/blog/institutions/[id]/purge.ts",
+  "src/pages/api/v1/blog/institutions/[id]/restore.ts",
+  "src/pages/api/v1/blog/institutions/index.ts",
+  "src/pages/api/v1/blog/internal-tag-links/settings.ts",
+  "src/pages/api/v1/blog/menus/[id].ts",
+  "src/pages/api/v1/blog/menus/index.ts",
+  "src/pages/api/v1/blog/settings/index.ts",
+  "src/pages/api/v1/blog/templates/[id].ts",
+  "src/pages/api/v1/blog/templates/index.ts",
+  "src/pages/api/v1/blog/terms/[id].ts",
+  "src/pages/api/v1/blog/terms/index.ts",
+  "src/pages/api/v1/blog/theme/index.ts",
+  "src/pages/api/v1/blog/widgets/[id].ts",
+  "src/pages/api/v1/blog/widgets/index.ts",
+  "src/pages/api/v1/news-portal/ad-placements/[id].ts",
+  "src/pages/api/v1/news-portal/ad-placements/index.ts",
+  "src/pages/api/v1/news-portal/homepage-sections/[id].ts",
+  "src/pages/api/v1/news-portal/homepage-sections/index.ts",
+  "src/pages/api/v1/seo/not-found/[id].ts",
+  "src/pages/api/v1/seo/redirects/[id].ts",
+  "src/pages/api/v1/seo/redirects/[id]/lifecycle.ts",
+  "src/pages/api/v1/seo/redirects/capture-url-change.ts",
+  "src/pages/api/v1/seo/redirects/import.ts",
+  "src/pages/api/v1/seo/redirects/index.ts",
+  "src/pages/api/v1/seo/redirects/settings.ts"
+];
+
+type PurgeObligation = { file: string; owner: string; purges: boolean };
+
+async function collectPurgeObligations(): Promise<PurgeObligation[]> {
+  const { claims } = collectClaims(listModules());
+  const obligations: PurgeObligation[] = [];
+
+  for await (const file of new Bun.Glob("src/pages/api/**/*.ts").scan({
+    cwd: process.cwd()
+  })) {
+    const source = await Bun.file(file).text();
+
+    if (!MUTATING_HANDLER.test(source)) {
+      continue;
+    }
+
+    const owner = resolveOwner(routeOf(file), claims);
+
+    // An UNCLAIMED route resolves to no owner and is skipped here. That is not
+    // a hole: `modules:routes:check` already refuses a route no module declares,
+    // so a handler cannot reach main without an owner for this to read.
+    if (!owner || !SURFACE_OWNING_MODULES.has(owner)) {
+      continue;
+    }
+
+    obligations.push({
+      file,
+      owner,
+      purges: source.includes("enqueueModuleContentPurge(")
+    });
+  }
+
+  return obligations.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+describe("every mutating handler of a surface-owning module is accounted for", () => {
+  test("a handler either purges or carries a reason it need not", async () => {
+    const obligations = await collectPurgeObligations();
+
+    // Proves the population is real. An empty scan would make every assertion
+    // below pass while checking nothing — the failure mode a derived gate has
+    // and an enumerated list does not.
+    expect(obligations.length).toBeGreaterThan(40);
+
+    const unaccounted = obligations
+      .filter((entry) => !entry.purges)
+      .map((entry) => entry.file)
+      .filter((file) => !(file in PURGE_NOT_REQUIRED));
+
+    expect(unaccounted).toEqual([...PURGE_OBLIGATION_UNREVIEWED].sort());
+  });
+
+  test("no exemption or ledger entry names a route that no longer exists", async () => {
+    const population = new Set(
+      (await collectPurgeObligations()).map((entry) => entry.file)
+    );
+
+    // An entry pointing at a deleted or renamed file forgives nothing while
+    // reading as a decision — the shape that lets a ledger look shorter than
+    // the problem.
+    for (const file of [
+      ...Object.keys(PURGE_NOT_REQUIRED),
+      ...PURGE_OBLIGATION_UNREVIEWED
+    ]) {
+      expect(population.has(file)).toBe(true);
+    }
+  });
+
+  test("the five routes Issue #623 named are no longer among the unaccounted", async () => {
+    const obligations = await collectPurgeObligations();
+    const purging = new Set(
+      obligations.filter((entry) => entry.purges).map((entry) => entry.file)
+    );
+
+    for (const file of [
+      "src/pages/api/v1/blog/posts/[id]/publish.ts",
+      "src/pages/api/v1/blog/posts/[id]/archive.ts",
+      "src/pages/api/v1/blog/posts/[id]/restore.ts",
+      "src/pages/api/v1/blog/posts/[id]/purge.ts",
+      "src/pages/api/v1/blog/posts/[id]/revisions/[revisionId]/restore.ts"
+    ]) {
+      expect(purging.has(file)).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
Closes #623.

## The defect

ADR-0042 §Rule 21 requires every handler that changes content to enqueue a purge inside the same transaction. Five post lifecycle routes never called `enqueueModuleContentPurge` at all — including `publish.ts`, which is the endpoint the Publish button on `/admin/blog` calls.

`EDGE_CACHE_MODE` has been active in staging since 26 July 2026, so publishing an article emitted no purge. `/blog/{code}` has a 120-second TTL and `blog-post` 300, so it healed itself and the symptom was "the new article takes a while to appear" rather than a hard failure. **`archive` is the direction that matters**: a withdrawn article kept being served from the edge until its TTL expired, which is the withdrawal not having happened.

## What changed

Purges added to `publish`, `archive`, `restore`, `purge`, and `revisions/{revisionId}/restore`. Each carries the reason it needs one rather than a reference to the rule:

- **restore** clears `deleted_at`, and the public predicate excludes on that column and not on status — so a post that was published when it was soft-deleted becomes reachable again the moment it commits.
- **revisions/{revisionId}/restore** was **not** in the issue's list (it lives a directory deeper than the enumeration reached) but rewrites the body of a post that may be published right now.

### One deliberate deviation from the issue's DoD

`schedule.ts` did **not** get a purge, though the issue lists it. `ALLOWED_STATUS_TRANSITIONS` permits only `draft` and `review` to become `scheduled` — a published post cannot — so nothing it commits is ever visible on a public surface, and the transition that does make it visible is `blog-scheduled-publish.ts`'s sweep, which purges.

Adding one anyway would append a ban matching no cached object while the queue reported success: the same "ceremony that reads as coverage" this repo already refuses for surfaceless module keys in `resolveDerivedSurfaceModuleKeys`. The reasoning is recorded in the route's own header, so a future reader finds a decision rather than an omission. Happy to add it if you'd rather have the literal five.

## Why no gate caught this

`edge-cache:surfaces:check` asks whether the **module** purges somewhere, and `blog_content` did — green while five of its handlers were silent. `tests/edge-cache-content-purge.test.ts` pinned a per-file count for an enumerated list, and a list cannot report the file it does not contain; its own comment admitted exactly that.

The obligation is now **derived**: every mutating API route owned by a module that owns a cacheable surface must either purge or carry a checkable reason it cannot change what a reader sees.

- **6 exempt with reasons** — verified against the transition table or against the absence of any write in the file, not asserted as plausible.
- **28 on a shrink-only ledger.** Several look like the same defect on inspection — ads and homepage sections are rendered onto `/blog/{code}` by #594's work, blog settings gate whether `feed.xml` answers at all, terms are what the archives are built from. They are listed rather than fixed because deciding each needs the same per-route reasoning the five above got, and twenty-eight of those inside a five-route bug fix would bury the fix. I'll file a follow-up with this evidence.
- A **new** mutating handler is on neither list, so it fails on arrival. Proven by planting one, not merely observed green.

An unclaimed route resolves to no owner and is skipped — not a hole, since `modules:routes:check` already refuses a route no module declares.

## Verification

`DATABASE_URL="" bun run check` — full chain green, 0 fail. `edge-cache:surfaces:check` still reports 9 surfaces / 3 surface-owning modules emitting purges. App assets unchanged at 184,446 B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)