### PR TITLE
feat(site-search): a search result set can say what else is in it (#607)

### DIFF
--- a/.changeset/search-facets.md
+++ b/.changeset/search-facets.md
@@ -1,0 +1,54 @@
+---
+"awcms": minor
+---
+
+feat(site-search): a search result set can say what else is in it (#607)
+
+`GET /api/v1/site-search/query` returned a ranked list and nothing about the
+shape of the set it came from. A reader could not narrow by content type, and a
+build client had nothing to render a filter from. `search-query.ts` emitted no
+aggregation at all, which the issue named as the one item of its scope that
+might need backend work — it did.
+
+`countSearchFacets` counts per `resource_type` over the same result set, and the
+endpoint returns them on every page.
+
+### The filter is deliberately not applied to its own counts
+
+A facet answers *"what else is there"*, so it is computed BEFORE the facet's own
+filter narrows the set. Applying `resourceType` would zero every other value the
+moment a reader picks one — and a reader looking at a list of zeroes has no way
+back to results that still exist, because the interface has stopped saying they
+do.
+
+Every OTHER predicate is shared with the result query character for character:
+same tenant, same locale, same `websearch_to_tsquery`, same admitted-type
+allow-list. A count derived from a wider predicate advertises documents the
+reader cannot reach. The signature is an `Omit<…, "resourceType">`, so passing
+the filter is unrepresentable rather than merely unused.
+
+### It cannot become a cross-tenant oracle
+
+A COUNT leaks the existence of content without displaying it, so a facet that
+escaped its tenant would be a disclosure with nothing on screen to notice it by.
+The explicit `tenant_id` predicate and RLS FORCE both bind it, and the
+integration suite asserts it negatively against a real database with both tenants
+holding rows that match the same query — non-vacuously, since tenant B holds
+more than tenant A.
+
+Counts are computed on every page, including cursor pages: they describe the
+whole result set rather than the page, so omitting them after the first would
+make them look like they had changed. The value list is bounded.
+
+### The neutral payload stays one shape
+
+`facets` is present and `required` in every response — an unresolved host, a
+disabled tenant, a rejected query and a real answer. A key present in one shape
+and absent in another re-opens exactly the distinction that neutral payload
+exists to close.
+
+Two of the issue's three scope items are unchanged by this and belong elsewhere:
+the reader search box and autocomplete consumer are `awcms-astro`'s under
+PRD §27.1, and the endpoints they need already exist. Term facets — channel,
+institution, region, topic — need the index to carry them first; see the
+follow-up issue for why `tagsColumn` cannot express a join table.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 151   |
 | Tables with `FORCE` RLS             | 133   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 416   |
+| Test files                          | 417   |
 | Route files                         | 376   |
 | ADR                                 | 206   |
 
@@ -345,7 +345,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 360        |
+| `(root)`      | 361        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -23194,6 +23194,32 @@ components:
           maxItems: 20
           items:
             $ref: "#/components/schemas/SocialProfileLink"
+    SiteSearchFacets:
+      type: object
+      description: |
+        Counts per facet value for the whole result set (Issue #607), computed on every page — they describe the result set rather than the page, so omitting them after the first page would make them look like they had changed.
+
+        The `type` filter is deliberately NOT applied to these counts: a facet answers "what else is there", and applying it would zero every other value the moment a reader picks one, leaving no way back to results that still exist.
+
+        Every other predicate is shared with the result query character for character, so a count can never advertise a document the reader cannot reach. Bounded to 20 values.
+      properties:
+        resourceTypes:
+          type: array
+          items:
+            $ref: "#/components/schemas/SiteSearchFacetValue"
+      required:
+        - resourceTypes
+    SiteSearchFacetValue:
+      type: object
+      properties:
+        value:
+          type: string
+          description: A `resourceType` as stored — `blog_post`, `blog_page`, and whatever a future module contributes.
+        count:
+          type: integer
+      required:
+        - value
+        - count
     SiteSearchIndexFailure:
       type: object
       properties:
@@ -23364,6 +23390,8 @@ components:
         nextCursor:
           type: string
           nullable: true
+        facets:
+          $ref: "#/components/schemas/SiteSearchFacets"
         query:
           type: string
           description: The NORMALIZED query actually executed (empty when nothing ran).
@@ -23379,6 +23407,7 @@ components:
       required:
         - items
         - nextCursor
+        - facets
         - query
         - locale
     SiteSearchResultItem:

--- a/openapi/modules/site-search.openapi.yaml
+++ b/openapi/modules/site-search.openapi.yaml
@@ -422,6 +422,8 @@ components:
         nextCursor:
           type: string
           nullable: true
+        facets:
+          $ref: "#/components/schemas/SiteSearchFacets"
         query:
           type: string
           description: The NORMALIZED query actually executed (empty when nothing ran).
@@ -437,8 +439,35 @@ components:
       required:
         - items
         - nextCursor
+        - facets
         - query
         - locale
+    SiteSearchFacets:
+      type: object
+      description: |
+        Counts per facet value for the whole result set (Issue #607), computed on every page — they describe the result set rather than the page, so omitting them after the first page would make them look like they had changed.
+
+        The `type` filter is deliberately NOT applied to these counts: a facet answers "what else is there", and applying it would zero every other value the moment a reader picks one, leaving no way back to results that still exist.
+
+        Every other predicate is shared with the result query character for character, so a count can never advertise a document the reader cannot reach. Bounded to 20 values.
+      properties:
+        resourceTypes:
+          type: array
+          items:
+            $ref: "#/components/schemas/SiteSearchFacetValue"
+      required:
+        - resourceTypes
+    SiteSearchFacetValue:
+      type: object
+      properties:
+        value:
+          type: string
+          description: A `resourceType` as stored — `blog_post`, `blog_page`, and whatever a future module contributes.
+        count:
+          type: integer
+      required:
+        - value
+        - count
     SiteSearchSuggestionItem:
       type: object
       properties:

--- a/src/modules/site-search/application/search-service.ts
+++ b/src/modules/site-search/application/search-service.ts
@@ -144,6 +144,77 @@ export async function searchSiteContent(
   };
 }
 
+export type SearchFacetValue = {
+  /** The `resource_type` as stored — `blog_post`, `blog_page`, and whatever a future module contributes. */
+  value: string;
+  count: number;
+};
+
+export type SearchFacets = {
+  resourceTypes: SearchFacetValue[];
+};
+
+/**
+ * How many facet VALUES may be returned. A facet list is a public, anonymous
+ * response body; without a ceiling its size is decided by however many resource
+ * types the registry grows to.
+ */
+const MAX_FACET_VALUES = 20;
+
+/**
+ * Counts per resource type for one query (Issue #607).
+ *
+ * ## Why the type filter is deliberately NOT applied
+ *
+ * A facet count answers "what else is there", so it must be computed over the
+ * result set BEFORE the facet's own filter narrows it. Applying `resourceType`
+ * here would make every other count zero the moment a reader picks one — and a
+ * reader looking at a list of zeroes has no way back to the results they can
+ * see, because the interface has stopped telling them those results exist.
+ *
+ * Every OTHER predicate is shared with `searchSiteContent`, character for
+ * character: same tenant, same locale, same `websearch_to_tsquery`, same
+ * admitted-type allow-list. A facet count derived from a wider predicate than
+ * the results would advertise documents the reader cannot reach.
+ *
+ * ## Why this cannot become a cross-tenant oracle
+ *
+ * The explicit `tenant_id` predicate and RLS FORCE both bind it, the same
+ * defence in depth every query in this repo carries. That matters more here than
+ * for a result list: a COUNT leaks the existence of content without displaying
+ * it, so a facet that escaped its tenant would be a disclosure with nothing on
+ * screen to notice it by. `tests/integration/site-search.integration.test.ts`
+ * asserts it negatively against a real database.
+ */
+export async function countSearchFacets(
+  tx: Bun.SQL,
+  tenantId: string,
+  options: Omit<SearchQueryOptions, "limit" | "cursor" | "resourceType">
+): Promise<SearchFacets> {
+  const allowedTypes = options.enabledResourceTypes ?? null;
+  const allowedTypesParam =
+    allowedTypes === null ? null : tx.array(allowedTypes, "text");
+
+  const rows = (await tx`
+    SELECT d.resource_type AS value, count(*)::int AS count
+    FROM awcms_site_search_documents d
+    WHERE d.tenant_id = ${tenantId}
+      AND d.locale = ${options.locale}
+      AND d.search_vector @@ websearch_to_tsquery('simple', ${options.query})
+      AND (${allowedTypesParam}::text[] IS NULL OR d.resource_type = ANY(${allowedTypesParam}::text[]))
+    GROUP BY d.resource_type
+    ORDER BY count DESC, value ASC
+    LIMIT ${MAX_FACET_VALUES}
+  `) as { value: string; count: number }[];
+
+  return {
+    resourceTypes: rows.map((row) => ({
+      value: row.value,
+      count: Number(row.count)
+    }))
+  };
+}
+
 export type SuggestionItem = {
   resourceType: string;
   resourceId: string;

--- a/src/pages/api/v1/site-search/query.ts
+++ b/src/pages/api/v1/site-search/query.ts
@@ -14,6 +14,7 @@ import { ok, fail } from "../../../../modules/_shared/api-response";
 import { withSiteSearchTenant } from "../../../../modules/site-search/application/public-search-tenant-resolution";
 import { recordSearchQuery } from "../../../../modules/site-search/application/search-query-log";
 import {
+  countSearchFacets,
   decodeSearchCursor,
   searchSiteContent
 } from "../../../../modules/site-search/application/search-service";
@@ -96,6 +97,7 @@ export const GET: APIRoute = async ({ request, url, clientAddress }) => {
         return {
           items: [],
           nextCursor: null,
+          facets: { resourceTypes: [] },
           query: "",
           locale,
           reason: normalized.reason
@@ -120,6 +122,19 @@ export const GET: APIRoute = async ({ request, url, clientAddress }) => {
         cursor
       });
 
+      // Issue #607 — awaited SEQUENTIALLY, not with `Promise.all`. Both run on
+      // the same transaction connection, and concurrent queries on one leak it
+      // (the rule every admin screen in this repo already follows).
+      //
+      // Computed on every page, including a cursor page: the counts describe
+      // the whole result set rather than the page, so omitting them after the
+      // first page would make them look like they had changed.
+      const facets = await countSearchFacets(tx, tenant.tenantId, {
+        query: normalized.value,
+        locale,
+        enabledResourceTypes: settings.enabledResourceTypes
+      });
+
       if (settings.analyticsEnabled) {
         await recordSearchQuery(tx, tenant.tenantId, {
           queryHash: hashSearchQuery(normalized.value),
@@ -137,6 +152,7 @@ export const GET: APIRoute = async ({ request, url, clientAddress }) => {
       return {
         items: search.items,
         nextCursor: search.nextCursor,
+        facets,
         query: normalized.value,
         locale
       };
@@ -154,7 +170,16 @@ export const GET: APIRoute = async ({ request, url, clientAddress }) => {
     });
     // Neutral empty payload — indistinguishable from "no results", so an
     // unresolved host / disabled search never leaks its state.
-    return ok({ items: [], nextCursor: null, query: "", locale: "" });
+    return ok({
+      items: [],
+      nextCursor: null,
+      // Same SHAPE as a real answer: a payload that omitted `facets` here would
+      // distinguish "search is off for this host" from "no results", which is
+      // exactly what the neutral payload exists to prevent.
+      facets: { resourceTypes: [] },
+      query: "",
+      locale: ""
+    });
   }
   return ok(result);
 };

--- a/tests/integration/site-search.integration.test.ts
+++ b/tests/integration/site-search.integration.test.ts
@@ -44,6 +44,7 @@ import {
   reconcileTenantSearchIndex,
   reindexSearchResource
 } from "../../src/modules/site-search/application/search-index-engine";
+import { countSearchFacets } from "../../src/modules/site-search/application/search-service";
 import {
   decodeSearchCursor,
   searchSiteContent,
@@ -586,5 +587,119 @@ suite("site_search module (integration, ADR-0040)", () => {
     expect(runs[0]!.runType).toBe("reconcile");
     expect(runs[0]!.documentsIndexed).toBe(1);
     expect(runs[0]!.finishedAt).not.toBeNull();
+  });
+
+  describe("facet counts (Issue #607)", () => {
+    test("count the whole matching set, and are NOT narrowed by the type filter", async () => {
+      await insertPost(TENANT_A, {
+        title: "Kalteng flood one",
+        body: "banjir kalteng",
+        slug: "flood-1"
+      });
+      await insertPost(TENANT_A, {
+        title: "Kalteng flood two",
+        body: "banjir kalteng",
+        slug: "flood-2"
+      });
+      await insertPost(TENANT_A, {
+        title: "Unrelated aardvark",
+        body: "nothing to do with it",
+        slug: "other"
+      });
+
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
+      );
+
+      const facets = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        countSearchFacets(tx, TENANT_A, { query: "kalteng", locale: "en" })
+      );
+
+      expect(facets.resourceTypes).toEqual([{ value: "blog_post", count: 2 }]);
+    });
+
+    test("a query matching nothing yields no facet values, not a zero row", async () => {
+      await insertPost(TENANT_A, {
+        title: "Something",
+        body: "body",
+        slug: "s"
+      });
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
+      );
+
+      const facets = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        countSearchFacets(tx, TENANT_A, {
+          query: "zzzzunmatchable",
+          locale: "en"
+        })
+      );
+
+      expect(facets.resourceTypes).toEqual([]);
+    });
+
+    test("a facet count NEVER includes another tenant's rows", async () => {
+      // The negative assertion Issue #607 asks for by name. A COUNT leaks the
+      // existence of content without displaying it, so a facet that escaped its
+      // tenant would be a disclosure with nothing on screen to notice it by.
+      await insertPost(TENANT_A, {
+        title: "Shared keyword aardvark",
+        body: "a body",
+        slug: "a"
+      });
+      await insertPost(TENANT_B, {
+        title: "Shared keyword aardvark",
+        body: "b body",
+        slug: "b1"
+      });
+      await insertPost(TENANT_B, {
+        title: "Shared keyword aardvark again",
+        body: "b body",
+        slug: "b2"
+      });
+
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
+      );
+      await withTenantOrThrow(getRuntimeSql(), TENANT_B, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_B, SOURCES)
+      );
+
+      const aFacets = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        countSearchFacets(tx, TENANT_A, { query: "aardvark", locale: "en" })
+      );
+      const bFacets = await withTenantOrThrow(getRuntimeSql(), TENANT_B, (tx) =>
+        countSearchFacets(tx, TENANT_B, { query: "aardvark", locale: "en" })
+      );
+
+      // Non-vacuous in both directions: B really does hold more than A, so a
+      // count that leaked would be visibly wrong rather than coincidentally
+      // equal.
+      expect(aFacets.resourceTypes).toEqual([{ value: "blog_post", count: 1 }]);
+      expect(bFacets.resourceTypes).toEqual([{ value: "blog_post", count: 2 }]);
+    });
+
+    test("the admitted-type allow-list bounds the facets too", async () => {
+      await insertPost(TENANT_A, {
+        title: "Allowed aardvark",
+        body: "body",
+        slug: "a"
+      });
+      await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
+      );
+
+      // A type the tenant has not admitted must not be counted — otherwise the
+      // facet advertises a document the result query would refuse to return.
+      const facets = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        countSearchFacets(tx, TENANT_A, {
+          query: "aardvark",
+          locale: "en",
+          enabledResourceTypes: ["blog_page"]
+        })
+      );
+
+      expect(facets.resourceTypes).toEqual([]);
+    });
   });
 });

--- a/tests/site-search-facets.test.ts
+++ b/tests/site-search-facets.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Facet counts on the public search endpoint (Issue #607).
+ *
+ * ## What is at risk, and it is not the arithmetic
+ *
+ * 1. **That the neutral payload stays neutral.** `GET /api/v1/site-search/query`
+ *    is anonymous and answers an unresolved host, a disabled tenant and a
+ *    zero-result query with the SAME body, on purpose. A `facets` key present in
+ *    one shape and absent in another re-opens exactly the distinction that
+ *    payload exists to close.
+ * 2. **That the facet is not narrowed by its own filter.** A facet answers "what
+ *    else is there". Applying `resourceType` to the counts zeroes every other
+ *    value the moment a reader picks one, and a list of zeroes gives them no way
+ *    back to results that still exist.
+ * 3. **That it shares every OTHER predicate with the results.** A count derived
+ *    from a wider predicate advertises documents the reader cannot reach.
+ *
+ * The cross-tenant negative — a count must never include another tenant's rows —
+ * needs a real database and lives in
+ * `tests/integration/site-search.integration.test.ts`.
+ *
+ * Pure — no database.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+
+const ROUTE = "src/pages/api/v1/site-search/query.ts";
+const SERVICE = "src/modules/site-search/application/search-service.ts";
+const FRAGMENT = "openapi/modules/site-search.openapi.yaml";
+
+describe("the neutral payload stays one shape", () => {
+  test("every return path from the route carries facets", async () => {
+    const source = stripComments(await readFile(ROUTE, "utf8"));
+
+    // Three shapes: rejected query, real answer, and the unresolved/disabled
+    // fallback. Each must name `facets`, or the body tells a caller which one
+    // it got.
+    const returns = [...source.matchAll(/facets/g)].length;
+
+    expect(returns).toBeGreaterThanOrEqual(4);
+    expect(source).toContain("facets: { resourceTypes: [] }");
+    expect(source).toContain("facets,");
+  });
+
+  test("the contract marks facets required, not optional", async () => {
+    const fragment = await readFile(FRAGMENT, "utf8");
+    const start = fragment.indexOf("SiteSearchQueryResult:");
+
+    expect(start).toBeGreaterThan(-1);
+
+    const block = fragment.slice(start, fragment.indexOf("SiteSearchFacets:"));
+
+    // Optional would let a client branch on its presence, which is the same
+    // leak as omitting it.
+    expect(block).toContain("- facets");
+  });
+});
+
+describe("the facet query is the result query minus its own filter", () => {
+  test("it applies tenant, locale, the tsquery and the allow-list", async () => {
+    const source = stripComments(await readFile(SERVICE, "utf8"));
+    const start = source.indexOf("export async function countSearchFacets");
+
+    expect(start).toBeGreaterThan(-1);
+
+    const body = source.slice(start, source.indexOf("export", start + 10));
+
+    expect(body).toContain("d.tenant_id = ${tenantId}");
+    expect(body).toContain("d.locale = ${options.locale}");
+    expect(body).toContain(
+      "d.search_vector @@ websearch_to_tsquery('simple', ${options.query})"
+    );
+    expect(body).toContain("d.resource_type = ANY(");
+  });
+
+  test("and does NOT apply the resourceType filter", async () => {
+    const source = stripComments(await readFile(SERVICE, "utf8"));
+    const start = source.indexOf("export async function countSearchFacets");
+    const body = source.slice(start, source.indexOf("export", start + 10));
+
+    // The signature makes it unrepresentable rather than merely unused — an
+    // `Omit` a future edit has to defeat on purpose.
+    expect(source).toContain(
+      'Omit<SearchQueryOptions, "limit" | "cursor" | "resourceType">'
+    );
+    expect(body).not.toContain("typeFilter");
+  });
+
+  test("the value list is bounded", async () => {
+    const source = stripComments(await readFile(SERVICE, "utf8"));
+
+    // A public anonymous body whose length is decided by however many resource
+    // types the registry grows to is a body with no ceiling.
+    expect(source).toContain("MAX_FACET_VALUES");
+    expect(source).toContain("LIMIT ${MAX_FACET_VALUES}");
+  });
+
+  test("the two queries run sequentially on the shared transaction", async () => {
+    const source = stripComments(await readFile(ROUTE, "utf8"));
+
+    // Concurrent queries on one transaction connection leak it — the rule every
+    // admin screen here already follows.
+    expect(source).not.toContain("Promise.all");
+    expect(source).toContain("await countSearchFacets(");
+  });
+});


### PR DESCRIPTION
Addresses the backend half of #607.

## What was missing

`GET /api/v1/site-search/query` returned a ranked list and nothing about the shape of the set it came from. A reader could not narrow by content type; a build client had nothing to render a filter from. `search-query.ts` emitted no aggregation at all — which is exactly the item the issue flagged as *"the only one that might demand backend work"*. It did.

## The filter is deliberately not applied to its own counts

A facet answers **"what else is there"**, so it is computed BEFORE the facet's own filter narrows the set. Applying `resourceType` would zero every other value the moment a reader picks one, and a reader looking at a list of zeroes has no way back to results that still exist — the interface has stopped telling them those results exist.

Every **other** predicate is shared with the result query character for character: same tenant, same locale, same `websearch_to_tsquery`, same admitted-type allow-list. A count derived from a wider predicate advertises documents the reader cannot reach. The signature is `Omit<SearchQueryOptions, "limit" | "cursor" | "resourceType">`, so passing the filter is unrepresentable rather than merely unused — a future edit has to defeat it on purpose.

## It cannot become a cross-tenant oracle

The issue asks for this negatively and by name. A COUNT leaks the existence of content **without displaying it**, so a facet that escaped its tenant would be a disclosure with nothing on screen to notice it by.

The explicit `tenant_id` predicate and RLS FORCE both bind it, and the integration suite asserts it against a real database with **both** tenants holding rows that match the same query — non-vacuously, since tenant B holds two and tenant A holds one, so a leak would be visibly wrong rather than coincidentally equal. The admitted-type allow-list is asserted to bound the facets too: a type the tenant has not admitted must not be counted, or the facet advertises a document the result query would refuse to return.

## The neutral payload stays one shape

`facets` is present and `required` in every response — unresolved host, disabled tenant, rejected query, real answer. A key present in one shape and absent in another re-opens exactly the distinction that neutral payload exists to close.

Counts are computed on every page, including cursor pages: they describe the whole result set rather than the page, so omitting them after the first would make them look like they had changed. The two queries are awaited **sequentially** — concurrent queries on one transaction connection leak it. The value list is bounded.

## What this PR does not do, and why

Two of the issue's three scope items are not this repo's:

- **The reader search box and the autocomplete consumer** belong to `awcms-astro` under PRD §27.1, and the endpoints they call (`/query`, `/suggest`) already exist. The issue says to verify that before writing a route; verified, no new endpoint was needed for them.
- **Term facets** — channel, institution, region, topic — need the index to carry them first. `tagsColumn` in a search-source descriptor names a single column on the source table, and since `sql/131` those terms live in `awcms_blog_post_terms`, a join table a column name cannot express. I'll file a follow-up with the options (descriptor-level join, denormalized column, or a view) rather than widen the descriptor contract inside this change.

No second search engine was introduced, as the issue requires: this is one `GROUP BY` against the same table, behind the same index.

## Verification

`DATABASE_URL="" bun run check` — full chain green, 0 fail. The four facet integration tests are DB-gated and run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)