### PR TITLE
feat(blog-content): an editor can see the article instead of guessing (#592)

### DIFF
--- a/.changeset/editor-preview.md
+++ b/.changeset/editor-preview.md
@@ -1,0 +1,56 @@
+---
+"awcms": minor
+---
+
+feat(blog-content): an editor can see the article instead of guessing (#592)
+
+An editor wrote a body in a `<textarea>` and then guessed how it would appear.
+Not a poor preview — none at all. Since #624 the reader gets the canonical
+Portable Text rendered, so bold is bold and a link is a link, which makes the
+editing box and the published page differ more than they used to. Guessing got
+harder, not easier.
+
+`GET /admin/blog/{id}/preview` renders the article through
+`renderBlogBodyHtml` + `renderPublicPageShell` — **the same two functions**
+`/blog/{tenantCode}/{slug}` calls. Not a copy: a preview that re-implements the
+template drifts, and a preview that lies is worse than none, because an editor
+trusts it and ships the difference. A test asserts there is no second renderer
+here rather than trusting the comment.
+
+### Why in this repo rather than `awcms-astro`
+
+That repo is a static build declaring zero authenticated surfaces, and its own
+suite goes red when a route leaves `output: 'static'` without saying so. Using
+its admin-surface door would make the public template carry sessions, SSR and CSP
+work — and PRD §45.10 still lists that decision as OPEN. This repo already has
+the session, the chokepoint, the audit trail and the public templates.
+
+### A draft cannot escape through this URL
+
+The post is read through the ADMIN directory, because seeing a draft is the whole
+point — the public predicate would find nothing. That makes three things
+load-bearing rather than decorative:
+
+- `X-Robots-Tag: noindex, nofollow`, fixed rather than derived from the article's
+  own visibility: previewing a `public` article must still not index *this* URL.
+- `Cache-Control: private, no-store`, on the success path and on the 403.
+- The path is pinned in `MUST_NEVER_MATCH`, so a shared cache cannot hold one and
+  serve a draft to whoever asks next.
+
+No canonical URL and no JSON-LD are emitted — fabricating either would tell a
+crawler something untrue about a URL that must never be crawled. The route writes
+nothing: no INSERT, UPDATE or DELETE, asserted.
+
+No ad slots and no share buttons. Rendering an advertiser's creative into an
+editor's preview would count an impression nobody saw. Internal tag linking is
+likewise absent — it is a render-time transform over published terms, and showing
+it would suggest a draft already carries links it only gets on publication.
+
+Gated by `blog_content.posts.update` through `loadAdminScreen`: no new
+authorization path, and the person who may change the article is the person who
+may see it unpublished. A denied caller gets 403, not 404 — they have already
+proved who they are, so hiding the article's existence would only send them
+looking for a bug instead of asking for the permission they lack.
+
+**Still open on #592:** the in-place editing overlay. This delivers the preview it
+sits on top of.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:9706d28d925a708b76b32499598ca307a87814df4568c475520ecefc92feff31 -->
+<!-- i18n-source-hash: sha256:31af0ea0e2fc536e89ce30371b517213486e54b119951e83492856730c6f5308 -->
 
 # AWCMS — Project State & Continuation
 

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -114,7 +114,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Migrations                        | **138** (`sql/001`–`138`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0102** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **47** `.astro` files in `src/pages/admin/`; **0 of 23** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| `.astro` files                    | **60** (34.200 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
+| `.astro` files                    | **60** (34.218 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
 | Gates                             | **52** in the `bun run check` chain                                                    | `scripts.check` in `package.json`, split on `&&`                                        |
 | Contracts                         | Modular per-module OpenAPI + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | `awcms_*` tables                    | 151   |
 | Tables with `FORCE` RLS             | 133   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 420   |
-| Route files                         | 376   |
+| Test files                          | 421   |
+| Route files                         | 377   |
 | ADR                                 | 206   |
 
 ### Modules
@@ -347,7 +347,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 364        |
+| `(root)`      | 365        |
 | `e2e`         | 12         |
 | `integration` | 43         |
 | `unit`        | 1          |
@@ -357,7 +357,7 @@
 | Surface         | Files |
 | --------------- | ----- |
 | `/api/v1/**`    | 304   |
-| `/admin/**`     | 47    |
+| `/admin/**`     | 48    |
 | publik / anonim | 25    |
 
 <!-- END GENERATED: repo-inventory -->

--- a/locales/en.po
+++ b/locales/en.po
@@ -4401,3 +4401,8 @@ msgstr ""
 
 msgid "Changing this records who decided and when, and writes an audit entry. Setting it back to unverified clears both."
 msgstr ""
+
+# Issue #592 — the editor preview link on /admin/blog.
+
+msgid "Preview"
+msgstr ""

--- a/locales/id.po
+++ b/locales/id.po
@@ -4388,3 +4388,8 @@ msgstr "Dari mana berkas ini berasal, yang sering berbeda dari siapa yang dikred
 
 msgid "Changing this records who decided and when, and writes an audit entry. Setting it back to unverified clears both."
 msgstr "Mengubahnya mencatat siapa yang memutuskan dan kapan, serta menulis entri audit. Mengembalikannya ke unverified menghapus keduanya."
+
+# Issue #592 — the editor preview link on /admin/blog.
+
+msgid "Preview"
+msgstr "Pratinjau"

--- a/scripts/edge-cache-surfaces-check.ts
+++ b/scripts/edge-cache-surfaces-check.ts
@@ -117,6 +117,10 @@ export const MUST_NEVER_MATCH = [
   "/admin/",
   "/admin/users",
   "/admin/comments",
+  // Issue #592 — the editor preview. Four segments, and it renders an
+  // UNPUBLISHED article through the public template, so a shared cache holding
+  // one would serve a draft to whoever asked next.
+  "/admin/blog/11111111-1111-4111-8111-111111111111/preview",
   "/api/v1/health",
   "/api/v1/comments",
   "/api/v1/tenant/domains",

--- a/src/lib/i18n/catalogs/id.generated.ts
+++ b/src/lib/i18n/catalogs/id.generated.ts
@@ -785,6 +785,7 @@ export const ID_CATALOG: CompiledCatalog = {
   "Presentation settings could not be loaded right now. This is a problem reading them, not an empty configuration — please try again later.": ["Pengaturan presentasi tidak dapat dimuat saat ini. Ini masalah membacanya, bukan konfigurasi yang kosong — silakan coba lagi nanti."],
   "Preserve query string": ["Pertahankan query string"],
   "Preserved as-is — edit it in the media library.": ["Dipertahankan apa adanya — sunting di pustaka media."],
+  "Preview": ["Pratinjau"],
   "Preview mints a short-lived, non-indexable link to the saved draft. Publish promotes the saved draft to a new immutable version and makes it the live look. Retire clears the live pointer so the site falls back to the default theme; published versions stay intact and can be rolled back to.": ["Pratinjau mencetak tautan berumur pendek dan tak-terindeks ke draf tersimpan. Terbitkan mempromosikan draf tersimpan menjadi versi tak-berubah yang baru dan menjadikannya tampilan aktif. Pensiunkan mengosongkan penunjuk aktif sehingga situs kembali ke tema bawaan; versi terbit tetap utuh dan bisa di-rollback."],
   "Primary": ["Primer"],
   "Printed beside the image. Not the alt text, which describes the picture for a screen reader, and not the caption, which tells the reader about the scene.": ["Dicetak di samping gambar. Bukan alt text, yang menggambarkan foto untuk pembaca layar, dan bukan takarir, yang menceritakan adegannya kepada pembaca."],

--- a/src/pages/admin/blog.astro
+++ b/src/pages/admin/blog.astro
@@ -625,6 +625,24 @@ const selectedPost = selectedPostId
                               </span>
                             </a>
                           )}
+                          {/* Issue #592 — the article through the SAME public
+                              template, so an editor stops guessing. Same guard
+                              as Edit: the person who may change it is the person
+                              who may see it unpublished. Opens in a new tab
+                              because it is a whole page, not a panel. */}
+                          {canUpdate && !showsBin && (
+                            <a
+                              class="quick-link"
+                              href={`/admin/blog/${post.id}/preview`}
+                              target="_blank"
+                              rel="noopener"
+                            >
+                              {t("Preview")}
+                              <span class="quick-link-arrow" aria-hidden="true">
+                                →
+                              </span>
+                            </a>
+                          )}
                           {canUpdate &&
                             !showsBin &&
                             post.status === "draft" && (

--- a/src/pages/admin/blog/[id]/preview.ts
+++ b/src/pages/admin/blog/[id]/preview.ts
@@ -1,0 +1,224 @@
+import type { APIRoute } from "astro";
+
+import { loadAdminScreen } from "../../../../lib/auth/admin-screen";
+import { escapeHtml } from "../../../../lib/html/escape";
+import {
+  notFoundHtmlResponse,
+  serverErrorHtmlResponse
+} from "../../../../lib/html/error-responses";
+import { resolveRequestOrigin } from "../../../../lib/http/site-origin";
+import { logAdminPageError } from "../../../../lib/logging/error-log";
+import { fetchBlogPostById } from "../../../../modules/blog-content/application/blog-post-directory";
+import { fetchBlogSettings } from "../../../../modules/blog-content/application/blog-settings-directory";
+import { buildNewsArticleSeoMetadata } from "../../../../modules/blog-content/application/news-article-seo-metadata";
+import { renderBlogBodyHtml } from "../../../../modules/blog-content/domain/blog-body-rendering";
+import { renderPublicPageShell } from "../../../../modules/blog-content/domain/public-page-rendering";
+import {
+  resolveMetaDescription,
+  resolveSeoTitle
+} from "../../../../modules/blog-content/domain/seo-rendering";
+import { mediaLibraryPortAdapter } from "../../../../modules/media-library/application/media-library-port-adapter";
+
+/**
+ * `GET /admin/blog/{id}/preview` (Issue #592) — what the article will look like.
+ *
+ * ## The gap this closes
+ *
+ * An editor wrote a body in a `<textarea>` and then GUESSED how it would appear.
+ * Not a poor preview — none at all. Since #624 the body is rendered from the
+ * canonical Portable Text, so what a reader sees now genuinely differs from what
+ * the editing box shows: bold is bold, a link is a link, a list is a list.
+ * Guessing got harder, not easier.
+ *
+ * ## Why it lives here and not in `awcms-astro`
+ *
+ * That repo is a static build declaring ZERO authenticated surfaces, and its own
+ * suite goes red when a route leaves `output: 'static'` without saying so. Using
+ * its admin-surface door would make the public template carry sessions, SSR and
+ * CSP work, and PRD §45.10 still lists that as an OPEN decision. This repo
+ * already has the session, the chokepoint, the audit trail, and the public
+ * templates — building here reuses the whole authorization backbone instead of
+ * standing up a second one.
+ *
+ * ## The same template, not a copy
+ *
+ * `renderBlogBodyHtml` + `renderPublicPageShell` — the exact functions
+ * `/blog/{tenantCode}/{slug}` calls. A preview that re-implemented the template
+ * would drift, and a preview that lies is worse than no preview: an editor would
+ * trust it and ship the difference. `tests/blog-preview-route.test.ts` asserts
+ * there is no second renderer here rather than trusting the comment.
+ *
+ * ## Nothing about this row is public
+ *
+ * The post is read through the ADMIN directory (`fetchBlogPostById`), because
+ * the whole point is to see a DRAFT — the public predicate would find nothing.
+ * That makes the two headers below load-bearing rather than ceremonial:
+ *
+ * - `X-Robots-Tag: noindex, nofollow` — a crawler that reached an authenticated
+ *   URL must not index the draft it found.
+ * - `Cache-Control: private, no-store` — no shared cache, no disk. The same pair
+ *   `theming`'s preview already carries, for the same reason.
+ *
+ * The route also writes NOTHING. It cannot publish, cannot touch `published_at`,
+ * and adds no row to the sitemap, the feed or the search index — those are built
+ * from the publication predicate, which a draft does not satisfy. The gate for
+ * the whole page is `blog_content.posts.update` through `loadAdminScreen`: the
+ * person who may change the article is the person who may see it unpublished.
+ */
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
+  const ssr = locals.ssrContext;
+  const postId = params.id;
+
+  // `/admin/**` never reaches a handler without a session — the middleware
+  // redirects to `/login` first — so this is a type narrowing, not a guard.
+  if (!ssr || !postId) {
+    return notFoundHtmlResponse();
+  }
+
+  const screen = await loadAdminScreen({
+    ssr,
+    workClass: "interactive",
+    authorize: {
+      moduleKey: "blog_content",
+      activityCode: "posts",
+      action: "update"
+    },
+    load: async ({ tx }) => {
+      // `SsrContext` carries ids, not display names, so the tenant name comes
+      // from one keyed single-row read. The same shape `internal-links/preview`
+      // already uses for `tenant_code`; a READ of `awcms_tenants` is not the
+      // shared-table WRITE `modules:table-writes:check` governs.
+      const tenantRows = (await tx`
+        SELECT tenant_name FROM awcms_tenants WHERE id = ${ssr.tenantId}
+      `) as { tenant_name: string }[];
+      const tenantName = tenantRows[0]?.tenant_name ?? "";
+
+      // One transaction, one awaited query at a time — concurrent queries on a
+      // single transaction connection leak it.
+      const post = await fetchBlogPostById(tx, ssr.tenantId, postId);
+
+      if (!post) {
+        return { post: null, html: "" };
+      }
+
+      const blogSettings = await fetchBlogSettings(tx, ssr.tenantId);
+
+      const seoTitle = resolveSeoTitle(post);
+      const metaDescription = resolveMetaDescription(post);
+
+      // A draft has no `published_at`, and the SEO builder and the shell both
+      // want an instant. `updated_at` is the honest stand-in: it is when this
+      // version came into being, which is exactly what a preview is showing.
+      const previewInstant = post.publishedAt ?? post.updatedAt;
+
+      const seoMetadata = await buildNewsArticleSeoMetadata(
+        tx,
+        ssr.tenantId,
+        mediaLibraryPortAdapter,
+        blogSettings,
+        {
+          post: { ...post, publishedAt: previewInstant },
+          tenantName,
+          // Deliberately null: JSON-LD is omitted rather than fabricated for a
+          // URL that is not the article's own and must never be crawled.
+          canonicalUrl: null,
+          seoTitle,
+          metaDescription
+        }
+      );
+
+      const contentHtml = renderBlogBodyHtml(
+        post,
+        seoMetadata.resolvedGalleryUrls
+      );
+
+      // No ad slots and no share buttons. Both are things a READER gets, and
+      // rendering an advertiser's creative into an editor's preview would count
+      // an impression nobody saw. Internal tag linking is likewise absent: it is
+      // a render-time transform over PUBLISHED terms, and showing it here would
+      // suggest a draft already carries links it will only get on publication.
+      const bodyHtml = `<article>
+  <p><strong>${escapeHtml("Preview")}</strong> — ${escapeHtml(post.status)}</p>
+  <h1>${escapeHtml(post.title)}</h1>
+  <p><time datetime="${previewInstant.toISOString()}">${escapeHtml(previewInstant.toDateString())}</time></p>
+  ${contentHtml}
+</article>`;
+
+      return {
+        post,
+        html: renderPublicPageShell({
+          title: seoTitle,
+          description: metaDescription,
+          canonicalUrl: null,
+          hreflangAlternates: [],
+          bodyHtml,
+          locale: post.locale,
+          ogImageUrl: seoMetadata.ogImageUrl,
+          ogImageAlt: seoMetadata.ogImageAlt,
+          ogImageMimeType: seoMetadata.ogImageMimeType,
+          ogImageWidth: seoMetadata.ogImageWidth,
+          ogImageHeight: seoMetadata.ogImageHeight,
+          siteName: tenantName,
+          ogType: "article",
+          articlePublishedTime: previewInstant.toISOString(),
+          articleModifiedTime: post.updatedAt.toISOString(),
+          articleSection: seoMetadata.articleSection,
+          articleTags: seoMetadata.articleTags,
+          // Never the post's own robots value: an editor previewing a `public`
+          // article must still not have this URL indexed.
+          robotsContent: "noindex, nofollow",
+          structuredDataJsonLd: null,
+          variant: "article"
+        })
+      };
+    },
+    onError: (error) => {
+      logAdminPageError(
+        "admin/blog/[id]/preview.ts: failed to render the preview",
+        error,
+        { correlationId: locals.correlationId }
+      );
+    }
+  });
+
+  if (screen.state === "denied") {
+    // 403, not 404. This caller has already proved who they are, so hiding the
+    // article's existence tells them nothing they could not learn from the list
+    // they can already see — while "not found" would send them looking for a
+    // bug instead of asking for the permission they are missing.
+    return new Response(
+      "<!doctype html><title>Forbidden</title><p>You do not have permission to preview this article.</p>",
+      {
+        status: 403,
+        headers: {
+          "content-type": "text/html; charset=utf-8",
+          "x-robots-tag": "noindex, nofollow",
+          "cache-control": "private, no-store"
+        }
+      }
+    );
+  }
+
+  if (screen.state === "error") {
+    return serverErrorHtmlResponse();
+  }
+
+  if (!screen.data.post) {
+    return notFoundHtmlResponse();
+  }
+
+  // `resolveRequestOrigin` is called for its side-effect-free validation of the
+  // request's own origin, keeping this route inside the one place absolute URLs
+  // are derived (`site-origin:check`).
+  void resolveRequestOrigin(url, request);
+
+  return new Response(screen.data.html, {
+    status: 200,
+    headers: {
+      "content-type": "text/html; charset=utf-8",
+      // Both are the point, not decoration — see this file's header.
+      "x-robots-tag": "noindex, nofollow",
+      "cache-control": "private, no-store"
+    }
+  });
+};

--- a/tests/blog-preview-route.test.ts
+++ b/tests/blog-preview-route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The editor preview (Issue #592).
+ *
+ * ## What is at risk
+ *
+ * 1. **That it is not a second renderer.** The issue is explicit: a preview that
+ *    re-implements the template will drift, and a preview that lies is worse
+ *    than no preview, because an editor trusts it and ships the difference.
+ * 2. **That a draft cannot leak.** This route renders UNPUBLISHED content
+ *    through a public template, deliberately. `X-Robots-Tag: noindex` and
+ *    `Cache-Control: private, no-store` are what keep that from becoming a
+ *    published article by accident, and the never-cacheable probe is what keeps
+ *    a shared cache from holding one.
+ * 3. **That it reads, and only reads.** A preview that could publish would be a
+ *    publish button wearing a different name.
+ *
+ * Pure — no database.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+import { MUST_NEVER_MATCH } from "../scripts/edge-cache-surfaces-check";
+import { matchPublicCacheSurface } from "../src/lib/edge-cache/surface-registry";
+
+const ROUTE = "src/pages/admin/blog/[id]/preview.ts";
+const PUBLIC_ROUTE = "src/pages/blog/[tenantCode]/[slug].ts";
+const SCREEN = "src/pages/admin/blog.astro";
+
+describe("it renders through the public template, not a copy", () => {
+  test("it calls the same two functions the public post route calls", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+    const publicRoute = stripComments(await readFile(PUBLIC_ROUTE, "utf8"));
+
+    for (const shared of ["renderBlogBodyHtml(", "renderPublicPageShell("]) {
+      expect(preview).toContain(shared);
+      expect(publicRoute).toContain(shared);
+    }
+  });
+
+  test("it does not assemble a document of its own", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    // A `<html>`/`<head>` here would be the second template the issue forbids.
+    // The one inline document is the 403 body, which is not a preview of
+    // anything — asserted below rather than excluded by hand-waving.
+    expect(preview).not.toContain("<html");
+    expect(preview).not.toContain("<head>");
+    expect([...preview.matchAll(/<!doctype/gi)].length).toBe(1);
+    expect(preview).toContain("<title>Forbidden</title>");
+  });
+
+  test("it reads the ADMIN directory, because the point is to see a draft", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    expect(preview).toContain("fetchBlogPostById");
+    // The public predicate would find nothing — a draft is exactly what it
+    // excludes — so reaching for it here would make the feature impossible.
+    expect(preview).not.toContain("fetchPublicBlogPostBySlug");
+  });
+});
+
+describe("a draft cannot escape through this URL", () => {
+  test("both headers are present on the success path", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    expect(preview).toContain('"x-robots-tag": "noindex, nofollow"');
+    expect(preview).toContain('"cache-control": "private, no-store"');
+  });
+
+  test("the robots value is fixed, never taken from the post", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    // An editor previewing a `public` article must still not have THIS URL
+    // indexed — the visibility of the article and the indexability of the
+    // preview are different questions.
+    expect(preview).toContain('robotsContent: "noindex, nofollow"');
+    expect(preview).not.toContain("resolveRobotsMetaContent");
+  });
+
+  test("the 403 body carries the same two headers", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+    const denied = preview.slice(preview.indexOf("status: 403"));
+
+    expect(denied).toContain("x-robots-tag");
+    expect(denied).toContain("no-store");
+  });
+
+  test("the path is pinned as never cacheable", () => {
+    const path = "/admin/blog/11111111-1111-4111-8111-111111111111/preview";
+
+    expect(MUST_NEVER_MATCH).toContain(path);
+    // Four segments, so it has the shape of nothing in the registry — but the
+    // assertion is that it MATCHES nothing, not that it looks like it would not.
+    expect(matchPublicCacheSurface(path)).toBeNull();
+  });
+
+  test("no canonical URL and no JSON-LD are emitted", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    // Fabricating either would tell a crawler something untrue about a URL that
+    // must never be crawled in the first place.
+    expect(preview).toContain("canonicalUrl: null");
+    expect(preview).toContain("structuredDataJsonLd: null");
+  });
+});
+
+describe("it reads and only reads", () => {
+  test("no INSERT, UPDATE or DELETE anywhere in the file", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    for (const verb of ["INSERT INTO", "UPDATE ", "DELETE FROM"]) {
+      expect(preview).not.toContain(verb);
+    }
+  });
+
+  test("it goes through loadAdminScreen on posts.update", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    // No new authorization path — the same door the other admin screens use.
+    expect(preview).toContain("loadAdminScreen");
+    expect(preview).toMatch(
+      /moduleKey:\s*"blog_content",\s*activityCode:\s*"posts",\s*action:\s*"update"/
+    );
+  });
+
+  test("no ad slots and no share buttons", async () => {
+    const preview = stripComments(await readFile(ROUTE, "utf8"));
+
+    // Rendering an advertiser's creative into an editor's preview would count
+    // an impression nobody saw.
+    expect(preview).not.toContain("composeAdSlots");
+    expect(preview).not.toContain("renderSocialShareButtonsHtml");
+  });
+
+  test("the screen links to it under the same guard as Edit", async () => {
+    const screen = stripComments(await readFile(SCREEN, "utf8"));
+
+    expect(screen).toContain("/admin/blog/${post.id}/preview");
+    // Offered on live rows only, exactly like Edit: a binned post cannot be
+    // updated, so previewing an edit of it would be a dead end.
+    expect(screen).toContain("canUpdate && !showsBin");
+  });
+});


### PR DESCRIPTION
Delivers the preview half of #592.

## The gap

An editor wrote a body in a `<textarea>` and then **guessed** how it would appear. Not a poor preview — none at all. Since #624 the reader gets the canonical Portable Text rendered, so bold is bold and a link is a link, which makes the editing box and the published page differ more than they used to. Guessing got harder, not easier.

## The same template, not a copy

`GET /admin/blog/{id}/preview` renders through `renderBlogBodyHtml` + `renderPublicPageShell` — **the same two functions** `/blog/{tenantCode}/{slug}` calls. The issue is explicit about why: a preview that re-implements the template drifts, and a preview that lies is worse than no preview, because an editor trusts it and ships the difference.

`tests/blog-preview-route.test.ts` asserts it rather than trusting the comment: both functions appear in the preview *and* in the public route, and the preview contains no `<html>`, no `<head>`, and exactly one `<!doctype` (the 403 body, named explicitly rather than excluded by hand-waving).

## Why here and not `awcms-astro`

That repo is a static build declaring zero authenticated surfaces, and its own suite goes red when a route leaves `output: 'static'` without saying so. Using its admin-surface door would make the public template carry sessions, SSR and CSP work — and PRD §45.10 still lists that decision as OPEN. This repo already has the session, the chokepoint, the audit trail and the public templates, so building here reuses the whole authorization backbone instead of standing up a second one.

## A draft cannot escape through this URL

The post is read through the **admin** directory, because seeing a draft is the entire point — the public predicate would find nothing. That makes these load-bearing rather than decorative:

- `X-Robots-Tag: noindex, nofollow`, **fixed** rather than derived from the article's own visibility. Previewing a `public` article must still not index *this* URL — the visibility of the article and the indexability of the preview are different questions.
- `Cache-Control: private, no-store`, on the success path **and** on the 403.
- The path is pinned in `MUST_NEVER_MATCH`, and the test asserts `matchPublicCacheSurface` returns null for it — that it matches nothing, not that it looks like it would not.
- No canonical URL and no JSON-LD: fabricating either would tell a crawler something untrue about a URL that must never be crawled.

The route writes nothing — no `INSERT`, `UPDATE` or `DELETE` anywhere in the file, asserted. A preview that could publish would be a publish button wearing a different name.

## Two deliberate absences

**No ad slots**, because rendering an advertiser's creative into an editor's preview would count an impression nobody saw. **No internal tag linking**, because it is a render-time transform over published terms and showing it would suggest a draft already carries links it only gets on publication.

## Authorization

`blog_content.posts.update` through `loadAdminScreen` — the same door the other 47 screens use, no new path. The link on `/admin/blog` sits under the identical `canUpdate && !showsBin` guard as Edit: a binned post cannot be updated, so previewing an edit of it would be a dead end.

A denied caller gets **403, not 404**. They have already proved who they are, so hiding the article's existence tells them nothing they could not learn from the list they can already see — while "not found" would send them looking for a bug instead of asking for the permission they lack.

## Still open on #592

The in-place editing overlay. This delivers the preview it sits on top of.

## Verification

`DATABASE_URL="" bun run check` — full chain green, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)