### PR TITLE
feat(visitor-analytics): a static build on its own domain can finally reach the beacon (#637)

### DIFF
--- a/.changeset/beacon-cross-origin.md
+++ b/.changeset/beacon-cross-origin.md
@@ -1,0 +1,77 @@
+---
+"awcms": minor
+---
+
+feat(visitor-analytics): a static build on its own domain can finally reach the beacon (#637)
+
+`POST /api/v1/analytics/collect` is anonymous, rate-limited and always answers
+`202`. It was built to be called from a public page. When that public page is a
+static `awcms-astro` build on a **different** origin — the PRD §27.1 scenario —
+all three ways of calling it were blocked, and not one of the failures appeared
+in this repo's logs. The dashboards were right; nothing ever arrived.
+
+### The three paths, and what blocked each
+
+Astro's `security.checkOrigin` defaults to `true` and `astro.config.mjs` does
+not turn it off:
+
+1. `navigator.sendBeacon(url, blob)` sends `text/plain`, which IS in Astro's
+   `FORM_CONTENT_TYPES` — cross-origin, that is `403 Cross-site POST form
+   submissions are forbidden`.
+2. `fetch` with no `content-type` falls into the final `return !isSameOrigin`.
+   Also 403.
+3. `fetch` with `application/json` passes `checkOrigin` — and then the browser
+   sends a preflight `OPTIONS` that nothing answered.
+
+This opens **path 3 only**. Paths 1 and 2 stay closed on purpose:
+`checkOrigin` protects every other write in the repo, Astro installs it ahead of
+`src/middleware.ts` so it cannot be exempted per-route from inside the app, and
+disabling it globally would trade a repo-wide guarantee for one endpoint's
+convenience. The cost is a real constraint on the caller, written into the
+endpoint's docblock: the beacon must be sent as JSON, which means `fetch`, not
+`sendBeacon`.
+
+### CORS is not authorization
+
+A preflight carries **no body**, so the `OPTIONS` handler cannot know which
+`tenantCode` the POST will name. It answers the narrower question it can — is
+this `Origin` an active domain in `awcms_tenant_domains` — and the POST goes on
+validating `tenantCode` exactly as before. Neither replaces the other: one
+decides whether a browser may read our answer, the other decides whose analytics
+a row belongs to. An integration test pins them apart by posting tenant B's code
+from tenant A's domain and asserting the row lands under B.
+
+The allowed origin is always echoed verbatim from a value that resolved against
+the verified set. Never `*` — which would let any page on the internet write
+with a public tenant code, and is not even legal alongside the
+`Access-Control-Allow-Credentials` this endpoint needs. A domain that is merely
+`pending_verification` is refused: the allow-list is the proven set, not the
+claimed one.
+
+`Vary: Origin` goes out on **every** response, including refusals. A cached
+denial served to an allowed origin is the same defect as the reverse.
+
+### Two things that are easy to assume and are not true
+
+The anonymous visitor-key cookie is `SameSite=Lax`, and a Lax cookie is neither
+sent nor stored cross-site — so without a change every cross-origin page view
+would have looked like a first-ever visitor. It is now `SameSite=None` when the
+request is cross-origin **and** the cookie is `Secure`, falling back to `Lax`
+otherwise rather than emitting a cookie the browser will drop. A browser that
+blocks third-party cookies drops it regardless: cross-origin visitor keys are
+best-effort, page-view counts are not. Letting the client send its own
+identifier in the body would fix it and is refused — every identifier this
+endpoint stores is derived server-side.
+
+And CORS is enforced by the **browser, on the response**. A caller that is not a
+browser was never blocked by any of this and still is not; what bounds it is the
+per-IP rate limit, which now also fronts the new allow-list lookup — same key, so
+a preflight and the POST it precedes share one budget instead of doubling it.
+
+`security-headers.ts` rested its `Cross-Origin-Resource-Policy: same-origin` on
+the claim that `src/` contains **zero** occurrences of
+`Access-Control-Allow-Origin`. That claim stops being true with this change, so
+the comment is corrected in the same commit: CORP is unaffected either way,
+because it governs `no-cors` subresource embedding and a CORS-mode `fetch` is
+not one — but the reason is now "CORP does not apply to CORS" rather than "there
+is no CORS here".

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 422   |
+| Test files                          | 424   |
 | Route files                         | 382   |
 | ADR                                 | 208   |
 
@@ -350,9 +350,9 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 366        |
+| `(root)`      | 367        |
 | `e2e`         | 12         |
-| `integration` | 43         |
+| `integration` | 44         |
 | `unit`        | 1          |
 
 ### Routes

--- a/src/lib/security/security-headers.ts
+++ b/src/lib/security/security-headers.ts
@@ -335,10 +335,18 @@ export function buildSecurityHeaders(
     //
     // This repo serves a different surface, and it has no such resource:
     //   - HTML pages are NAVIGATIONS, which CORP does not govern at all;
-    //   - the JSON API is already unreachable cross-origin from a browser —
-    //     nothing here emits `Access-Control-Allow-Origin` (verified: zero
-    //     occurrences in `src/`), so `same-origin` removes no capability that
-    //     any browser client has today;
+    //   - the JSON API is unreachable cross-origin from a browser with ONE
+    //     deliberate exception. This bullet used to read "nothing here emits
+    //     `Access-Control-Allow-Origin` (verified: zero occurrences in
+    //     `src/`)", and Issue #637 ended that: the public visit-ingest beacon
+    //     (`api/v1/analytics/collect.ts`) now answers a preflight and echoes
+    //     the grant, for `Origin`s that are active tenant domains and never for
+    //     `*`. CORP is unaffected either way — it governs `no-cors` subresource
+    //     embedding, and a CORS-mode `fetch` is not a `no-cors` request — so
+    //     `same-origin` still removes no capability any browser client has;
+    //     what changed is that the reason is now "CORP does not apply to CORS"
+    //     rather than "there is no CORS here". If a SECOND endpoint ever opts
+    //     in, re-read this bullet before assuming it still holds;
     //   - `public/` holds `js/news-share.js`, `css/public-content.css` and
     //     `push-sw.js`, and `_astro/*` is hashed output — all of it loaded by
     //     this origin's own pages, and all of it now actually CARRYING these

--- a/src/modules/visitor-analytics/domain/beacon-cors.ts
+++ b/src/modules/visitor-analytics/domain/beacon-cors.ts
@@ -1,0 +1,236 @@
+/**
+ * Cross-origin policy for the PUBLIC visit-ingest beacon (Issue #637).
+ *
+ * ## What was actually broken
+ *
+ * `POST /api/v1/analytics/collect` is anonymous, rate-limited and always
+ * answers `202`. It was built to be called from a public page. When that public
+ * page is a static `awcms-astro` build on a DIFFERENT origin — the PRD §27.1
+ * scenario — all three ways of calling it were blocked, and none of the
+ * failures appeared in this repo's logs:
+ *
+ * 1. `navigator.sendBeacon(url, blob)` — the canonical beacon call. Its blob
+ *    carries `text/plain`, which IS in Astro's `FORM_CONTENT_TYPES`, so a
+ *    cross-origin call is answered `403 Cross-site POST form submissions are
+ *    forbidden` by `security.checkOrigin`.
+ * 2. `fetch` with NO `content-type` — falls into `return !isSameOrigin`. Also
+ *    403.
+ * 3. `fetch` with `application/json` — passes `checkOrigin` (not form-like),
+ *    but the browser sends a preflight `OPTIONS` first, and nothing here
+ *    answered it.
+ *
+ * This module closes **path 3**, deliberately and only path 3. Paths 1 and 2
+ * stay blocked: `security.checkOrigin` protects every other write in this repo,
+ * Astro installs it AHEAD of `src/middleware.ts`
+ * (`core/middleware/load.js` unshifts it), so it cannot be exempted per-route
+ * from inside the app, and turning it off globally to rescue `sendBeacon` would
+ * trade a repo-wide guarantee for one endpoint's convenience.
+ *
+ * The consequence is a real constraint on the caller and is stated in the
+ * endpoint's docblock: the beacon must be sent as JSON, which means `fetch`,
+ * not `sendBeacon`.
+ *
+ * ## CORS is not authorization
+ *
+ * A preflight carries NO BODY, so an `OPTIONS` handler cannot know which
+ * `tenantCode` the eventual POST will name. It therefore answers a narrower
+ * question — "is this `Origin` an active, verified domain of SOME tenant on
+ * this deployment" — and the POST goes on validating `tenantCode` exactly as it
+ * did before. Neither check substitutes for the other: this one decides whether
+ * a browser may read our answer, that one decides whose analytics a row belongs
+ * to.
+ *
+ * That distinction is easy to lose later, which is why it is written here
+ * rather than inferred from the code.
+ *
+ * ## Never `*`
+ *
+ * The allowed origin is always echoed verbatim from a value that resolved
+ * against `awcms_tenant_domains`. `*` would let any page on the internet write
+ * to the beacon with a public tenant code, and — because the beacon needs its
+ * anonymous visitor cookie — `*` is not even legal alongside
+ * `Access-Control-Allow-Credentials: true`.
+ *
+ * ## `Vary: Origin` on EVERY response
+ *
+ * Including the ones that carry no `Access-Control-Allow-Origin`. A cached
+ * denial served to an allowed origin is the same defect as a cached grant
+ * served to a denied one. This endpoint is not cached today; a header whose
+ * value depends on the request and does not say so is a defect waiting for the
+ * next cache change.
+ */
+
+/**
+ * How long a browser may reuse one preflight result. Ten minutes: long enough
+ * that a reader clicking through a news site pays for the preflight once, short
+ * enough that removing a domain from `awcms_tenant_domains` takes effect while
+ * somebody is still watching.
+ */
+export const BEACON_PREFLIGHT_MAX_AGE_SECONDS = 600;
+
+export type BeaconOrigin = {
+  /** The origin exactly as it will be echoed back, e.g. `https://news.example`. */
+  origin: string;
+  /** Its hostname, lowercased and port-free — the `awcms_tenant_domains` key. */
+  hostname: string;
+};
+
+/**
+ * Parses an `Origin` request header into something safe to look up and echo.
+ *
+ * Returns `null` — never a partially-trusted value — for everything that is not
+ * a plain `http(s)://host[:port]` origin. In particular:
+ *
+ * - **the literal string `null`**, which is what a sandboxed iframe, a
+ *   `file://` document and some redirect chains send. It is an opaque origin,
+ *   and echoing it back would hand a document with no origin the same access a
+ *   verified tenant domain has;
+ * - any non-`http(s)` scheme, so a `chrome-extension://` or `moz-extension://`
+ *   page cannot be granted access to a tenant's analytics endpoint;
+ * - anything carrying a path, query, fragment or userinfo. A real `Origin`
+ *   header has none of those, so rather than strip them, this requires the
+ *   header to be EQUAL to the parsed origin — one comparison that rejects every
+ *   such shape at once, including the ones nobody has thought of yet.
+ */
+export function parseBeaconOrigin(
+  originHeader: string | null | undefined
+): BeaconOrigin | null {
+  if (typeof originHeader !== "string") {
+    return null;
+  }
+
+  const trimmed = originHeader.trim();
+
+  if (trimmed.length === 0 || trimmed === "null") {
+    return null;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return null;
+  }
+
+  // A well-formed `Origin` serializes back to itself. Anything that does not —
+  // a trailing slash, a path, credentials, a query — is not an origin.
+  //
+  // The comparison is against the LOWERCASED header because scheme and host are
+  // case-insensitive and `new URL()` has already normalized them; a browser
+  // sends them lowercase anyway, and refusing `https://News.Example` would be
+  // strictness that protects nothing. What is echoed back is `url.origin`, the
+  // normalized form — which is also the form the browser compares against.
+  if (url.origin !== trimmed.toLowerCase()) {
+    return null;
+  }
+
+  if (url.hostname.length === 0) {
+    return null;
+  }
+
+  return { origin: url.origin, hostname: url.hostname.toLowerCase() };
+}
+
+/**
+ * True when this request came from a different origin than the one serving it.
+ *
+ * Same-origin callers — this repo's own `/blog/{tenantCode}` pages — take the
+ * unchanged path: no allow-list lookup, no CORS headers, not one extra query.
+ * The cost of the cross-origin surface lands only on the cross-origin surface.
+ */
+export function isCrossOriginBeacon(
+  parsedOrigin: BeaconOrigin | null,
+  requestUrl: string
+): boolean {
+  if (!parsedOrigin) {
+    return false;
+  }
+
+  try {
+    return parsedOrigin.origin !== new URL(requestUrl).origin;
+  } catch {
+    // An unparseable request URL cannot be shown to be same-origin, and the
+    // safe reading of "cannot be shown same-origin" is cross-origin: it leads
+    // to the allow-list check rather than around it.
+    return true;
+  }
+}
+
+/**
+ * Headers for a granted cross-origin ACTUAL request (the POST itself).
+ *
+ * `Access-Control-Allow-Credentials` is on because the beacon's anonymous
+ * visitor key is an `httpOnly` cookie: without credentials the browser would
+ * neither send the existing cookie nor store the new one, and every page view
+ * from every reader would look like a first-ever visit.
+ */
+export function beaconCorsResponseHeaders(
+  allowedOrigin: string
+): Record<string, string> {
+  return {
+    "access-control-allow-origin": allowedOrigin,
+    "access-control-allow-credentials": "true",
+    vary: "Origin"
+  };
+}
+
+/**
+ * Headers for a granted preflight, which is the same grant plus the three
+ * things a preflight is actually asking about.
+ *
+ * `access-control-allow-headers` lists `content-type` alone, and that is the
+ * whole point of the path this module opens: `content-type: application/json`
+ * is what keeps the request out of Astro's form-like branch. No other header is
+ * allowed, so this cannot quietly become a general-purpose cross-origin API.
+ */
+export function beaconPreflightHeaders(
+  allowedOrigin: string
+): Record<string, string> {
+  return {
+    ...beaconCorsResponseHeaders(allowedOrigin),
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+    "access-control-max-age": String(BEACON_PREFLIGHT_MAX_AGE_SECONDS)
+  };
+}
+
+/**
+ * Headers for a REFUSED cross-origin request, and for one that never asked.
+ *
+ * There is no `Access-Control-Allow-Origin` here — that is the refusal — but
+ * `Vary: Origin` still is, because the refusal is as origin-dependent as the
+ * grant.
+ */
+export function beaconCorsDeniedHeaders(): Record<string, string> {
+  return { vary: "Origin" };
+}
+
+/**
+ * `SameSite` for the anonymous visitor-key cookie.
+ *
+ * A `SameSite=Lax` cookie is neither sent nor stored on a cross-site request,
+ * so a cross-origin beacon would mint a fresh visitor key on every single page
+ * view and unique-visitor counts would climb with page views. `None` is what
+ * makes the key persist — and browsers refuse `SameSite=None` without `Secure`,
+ * so over plain `http` this falls back to `Lax` rather than emitting a cookie
+ * the browser will drop.
+ *
+ * What this does NOT promise: a browser that blocks third-party cookies
+ * outright (Safari's ITP, and Chrome by default for many users) will drop this
+ * cookie regardless. Cross-origin visitor keys are best-effort, page-view
+ * counts are not. The honest alternative — letting the client send its own
+ * identifier in the body — is deliberately refused: every identifier this
+ * endpoint stores is derived server-side, and a body-supplied one would be a
+ * value the reporter chooses.
+ */
+export function resolveVisitorCookieSameSite(input: {
+  crossOrigin: boolean;
+  secure: boolean;
+}): "lax" | "none" {
+  return input.crossOrigin && input.secure ? "none" : "lax";
+}

--- a/src/pages/api/v1/analytics/collect.ts
+++ b/src/pages/api/v1/analytics/collect.ts
@@ -11,7 +11,16 @@ import {
   readJsonBody
 } from "../../../../lib/security/request-body-limit";
 import { resolvePublicTenantByCode } from "../../../../lib/tenant/public-tenant-resolver";
+import { resolvePublicTenantByHost } from "../../../../lib/tenant/public-host-tenant-resolver";
 import { collectVisitorTelemetry } from "../../../../modules/visitor-analytics/application/collector";
+import {
+  beaconCorsDeniedHeaders,
+  beaconCorsResponseHeaders,
+  beaconPreflightHeaders,
+  isCrossOriginBeacon,
+  parseBeaconOrigin,
+  resolveVisitorCookieSameSite
+} from "../../../../modules/visitor-analytics/domain/beacon-cors";
 import { resolveVisitorAnalyticsConfig } from "../../../../modules/visitor-analytics/domain/visitor-analytics-config";
 import { resolveAnalyticsClientIp } from "../../../../modules/visitor-analytics/domain/client-ip";
 import { resolveGeoEnrichment } from "../../../../modules/visitor-analytics/domain/geo-enrichment";
@@ -82,6 +91,27 @@ const COLLECT_RATE_LIMIT_WINDOW_SEC = Number(
  * actually recorded (module disabled, unknown/inactive tenant, non-public or
  * non-trackable path) — fire-and-forget beacon semantics that never leak
  * tenant existence. `collectVisitorTelemetry` is itself fail-open.
+ *
+ * CROSS-ORIGIN (Issue #637): a static `awcms-astro` build on its own domain can
+ * call this, but ONLY as JSON — `security.checkOrigin` still answers 403 to a
+ * `text/plain` body, which is what `navigator.sendBeacon` sends. The supported
+ * call is therefore:
+ *
+ * ```js
+ * fetch("https://cms.example/api/v1/analytics/collect", {
+ *   method: "POST",
+ *   headers: { "content-type": "application/json" },
+ *   credentials: "include",           // the anonymous visitor-key cookie
+ *   keepalive: true,
+ *   body: JSON.stringify({ tenantCode, path: location.pathname })
+ * });
+ * ```
+ *
+ * `credentials: "include"` is what makes repeat visits from one reader count as
+ * one visitor; see `resolveVisitorCookieSameSite` for what it can and cannot
+ * promise. The `Origin` must be an active domain in `awcms_tenant_domains` —
+ * see `domain/beacon-cors.ts` for why that check is not, and does not replace,
+ * the `tenantCode` validation below.
  */
 export const POST: APIRoute = async ({
   request,
@@ -91,6 +121,81 @@ export const POST: APIRoute = async ({
 }) => {
   const config = resolveVisitorAnalyticsConfig();
   const existingVisitorKey = cookies.get(VISITOR_KEY_COOKIE_NAME)?.value;
+  const parsedOrigin = parseBeaconOrigin(request.headers.get("origin"));
+  const crossOrigin = isCrossOriginBeacon(parsedOrigin, request.url);
+
+  /**
+   * The per-IP limiter, consumed AT MOST ONCE per request no matter how many
+   * call sites reach for it.
+   *
+   * The binding rule this preserves is the one the constant above states: the
+   * limiter runs before ANY database work. Issue #637 added a second piece of
+   * database work (the cross-origin allow-list lookup) that happens earlier
+   * than the tenant lookup, so the check had to move ahead of it — without
+   * charging a cross-origin beacon twice for one request, and without charging
+   * a same-origin beacon that never reaches the database at all.
+   */
+  let rateLimitDecision: Awaited<
+    ReturnType<typeof checkSharedRateLimit>
+  > | null = null;
+  const consumeRateLimit = async () => {
+    rateLimitDecision ??= await checkSharedRateLimit(
+      `analytics-collect:${resolveClientIp(request, clientAddress)}`,
+      {
+        maxAttempts:
+          Number.isFinite(COLLECT_RATE_LIMIT_MAX) && COLLECT_RATE_LIMIT_MAX > 0
+            ? COLLECT_RATE_LIMIT_MAX
+            : 120,
+        windowMs:
+          (Number.isFinite(COLLECT_RATE_LIMIT_WINDOW_SEC) &&
+          COLLECT_RATE_LIMIT_WINDOW_SEC > 0
+            ? COLLECT_RATE_LIMIT_WINDOW_SEC
+            : 60) * 1000
+      }
+    );
+    return rateLimitDecision;
+  };
+
+  // Refused cross-origin, and every same-origin request, carry `Vary: Origin`
+  // and no grant. Only a verified tenant domain upgrades this.
+  let corsHeaders = beaconCorsDeniedHeaders();
+
+  /**
+   * Stamps the decision above onto a response that was built without knowing
+   * about it. EVERY exit from this handler goes through here — including the
+   * ones that refuse — because a response whose headers vary by `Origin` has to
+   * say so whichever way the decision went.
+   */
+  const withCors = (response: Response): Response => {
+    for (const [name, value] of Object.entries(corsHeaders)) {
+      response.headers.set(name, value);
+    }
+    return response;
+  };
+
+  if (crossOrigin && parsedOrigin) {
+    const preflightBudget = await consumeRateLimit();
+
+    if (!preflightBudget.allowed) {
+      return fail(
+        429,
+        "RATE_LIMITED",
+        "Too many analytics beacons from this source. Try again later.",
+        {},
+        undefined,
+        { ...corsHeaders, "retry-after": String(preflightBudget.retryAfterSec) }
+      );
+    }
+
+    const originTenant = await resolvePublicTenantByHost(
+      getDatabaseClient(),
+      parsedOrigin.hostname
+    );
+
+    if (originTenant) {
+      corsHeaders = beaconCorsResponseHeaders(parsedOrigin.origin);
+    }
+  }
 
   // Revoke a lingering anonymous identifier when the module is disabled —
   // before doing anything else, on every request, regardless of body shape.
@@ -103,7 +208,7 @@ export const POST: APIRoute = async ({
   const bodyRead = await readJsonBody(request);
 
   if (bodyRead.tooLarge) {
-    return bodyTooLargeResponse(bodyRead.limitBytes);
+    return withCors(bodyTooLargeResponse(bodyRead.limitBytes));
   }
 
   const body = bodyRead.value as Record<string, unknown> | null;
@@ -118,27 +223,32 @@ export const POST: APIRoute = async ({
     !path.startsWith("/") ||
     path.length > MAX_PATH_LENGTH
   ) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      "tenantCode (non-empty, <=128 chars) and path (must start with '/', <=2048 chars) are required."
+    return withCors(
+      fail(
+        400,
+        "VALIDATION_ERROR",
+        "tenantCode (non-empty, <=128 chars) and path (must start with '/', <=2048 chars) are required."
+      )
     );
   }
 
-  const accepted = jsonResponse(
-    { success: true, data: { accepted: true }, meta: {} },
-    { status: 202 }
-  );
+  const accepted = () =>
+    withCors(
+      jsonResponse(
+        { success: true, data: { accepted: true }, meta: {} },
+        { status: 202 }
+      )
+    );
 
   // Nothing to record: module off, non-public area, or a non-trackable path.
   // Still 202 (accepted) — never distinguish these cases to the caller.
   if (!config.enabled) {
-    return accepted;
+    return accepted();
   }
 
   const area = determineArea(path.split("?")[0] ?? path);
   if (area !== "public" || !config.collectPublic || !isTrackablePath(path)) {
-    return accepted;
+    return accepted();
   }
 
   // Per-IP rate-limit backstop — checked here, AFTER the free (no-DB) filters
@@ -146,30 +256,18 @@ export const POST: APIRoute = async ({
   // write below). Keyed on the client IP only, so it can never distinguish an
   // existing tenant from an unknown one (no enumeration oracle); a source that
   // exceeds the window is refused with 429 before it can touch the database.
-  const clientIp = resolveClientIp(request, clientAddress);
-  const rateLimit = await checkSharedRateLimit(
-    `analytics-collect:${clientIp}`,
-    {
-      maxAttempts:
-        Number.isFinite(COLLECT_RATE_LIMIT_MAX) && COLLECT_RATE_LIMIT_MAX > 0
-          ? COLLECT_RATE_LIMIT_MAX
-          : 120,
-      windowMs:
-        (Number.isFinite(COLLECT_RATE_LIMIT_WINDOW_SEC) &&
-        COLLECT_RATE_LIMIT_WINDOW_SEC > 0
-          ? COLLECT_RATE_LIMIT_WINDOW_SEC
-          : 60) * 1000
-    }
-  );
+  const rateLimit = await consumeRateLimit();
 
   if (!rateLimit.allowed) {
-    return fail(
-      429,
-      "RATE_LIMITED",
-      "Too many analytics beacons from this source. Try again later.",
-      {},
-      undefined,
-      { "retry-after": String(rateLimit.retryAfterSec) }
+    return withCors(
+      fail(
+        429,
+        "RATE_LIMITED",
+        "Too many analytics beacons from this source. Try again later.",
+        {},
+        undefined,
+        { "retry-after": String(rateLimit.retryAfterSec) }
+      )
     );
   }
 
@@ -177,11 +275,15 @@ export const POST: APIRoute = async ({
   const tenant = await resolvePublicTenantByCode(sql, tenantCode);
 
   if (!tenant) {
-    return accepted;
+    return accepted();
   }
 
   // Anonymous visitor key: reuse a valid existing cookie or mint a fresh one,
-  // and (re)set the cookie so it persists for dedup.
+  // and (re)set the cookie so it persists for dedup. A cross-origin beacon
+  // needs `SameSite=None` for the browser to keep it at all — and that is only
+  // legal alongside `Secure`, so a plain-http deployment keeps `Lax` and keeps
+  // minting fresh keys. `resolveVisitorCookieSameSite` carries the reasoning.
+  const cookieSecure = process.env.AUTH_COOKIE_SECURE === "true";
   const cookiePlan = planVisitorKeyCookie({
     config,
     existingValue: existingVisitorKey
@@ -190,8 +292,11 @@ export const POST: APIRoute = async ({
   if (cookiePlan.shouldSetCookie) {
     cookies.set(VISITOR_KEY_COOKIE_NAME, cookiePlan.value, {
       httpOnly: true,
-      sameSite: "lax",
-      secure: process.env.AUTH_COOKIE_SECURE === "true",
+      sameSite: resolveVisitorCookieSameSite({
+        crossOrigin,
+        secure: cookieSecure
+      }),
+      secure: cookieSecure,
       path: "/",
       maxAge: cookiePlan.maxAgeSeconds
     });
@@ -224,5 +329,79 @@ export const POST: APIRoute = async ({
     geo
   });
 
-  return accepted;
+  return accepted();
+};
+
+/**
+ * `OPTIONS /api/v1/analytics/collect` — the CORS preflight (Issue #637).
+ *
+ * A preflight carries NO BODY, so this handler cannot know which `tenantCode`
+ * the POST that follows will name. It answers the only question it can: is this
+ * `Origin` an active, verified domain of SOME tenant on this deployment
+ * (`awcms_tenant_domains`, via the same SECURITY DEFINER lookup the public host
+ * router uses)? The POST then validates `tenantCode` exactly as it always has.
+ * CORS is not authorization — see `domain/beacon-cors.ts`.
+ *
+ * Every outcome is `204`. What differs is whether the response carries the
+ * grant headers, because that is the one thing CORS cannot hide: a browser
+ * proceeds only when it sees `Access-Control-Allow-Origin`. That is not a new
+ * disclosure — visiting the hostname already serves that tenant's site, so
+ * "this host belongs to a tenant here" is public by construction.
+ *
+ * `OPTIONS` is in Astro's `SAFE_METHODS`, so `security.checkOrigin` lets the
+ * preflight through untouched; only the POST it authorizes is subject to the
+ * form-like content-type rule.
+ */
+export const OPTIONS: APIRoute = async ({ request, clientAddress }) => {
+  const parsedOrigin = parseBeaconOrigin(request.headers.get("origin"));
+
+  // No `Origin`, an opaque one, or our own: nothing to preflight. `Vary` still
+  // goes out — this response WOULD have differed for a different origin.
+  if (!isCrossOriginBeacon(parsedOrigin, request.url) || !parsedOrigin) {
+    return new Response(null, {
+      status: 204,
+      headers: beaconCorsDeniedHeaders()
+    });
+  }
+
+  // The allow-list lookup is a database read on an anonymous, unauthenticated
+  // request, so it sits behind the same per-IP limiter the POST uses — same
+  // key, so a preflight and the POST it precedes share one budget rather than
+  // doubling it. `Access-Control-Max-Age` keeps that from mattering in practice.
+  const preflightBudget = await checkSharedRateLimit(
+    `analytics-collect:${resolveClientIp(request, clientAddress)}`,
+    {
+      maxAttempts:
+        Number.isFinite(COLLECT_RATE_LIMIT_MAX) && COLLECT_RATE_LIMIT_MAX > 0
+          ? COLLECT_RATE_LIMIT_MAX
+          : 120,
+      windowMs:
+        (Number.isFinite(COLLECT_RATE_LIMIT_WINDOW_SEC) &&
+        COLLECT_RATE_LIMIT_WINDOW_SEC > 0
+          ? COLLECT_RATE_LIMIT_WINDOW_SEC
+          : 60) * 1000
+    }
+  );
+
+  if (!preflightBudget.allowed) {
+    return new Response(null, {
+      status: 429,
+      headers: {
+        ...beaconCorsDeniedHeaders(),
+        "retry-after": String(preflightBudget.retryAfterSec)
+      }
+    });
+  }
+
+  const originTenant = await resolvePublicTenantByHost(
+    getDatabaseClient(),
+    parsedOrigin.hostname
+  );
+
+  return new Response(null, {
+    status: 204,
+    headers: originTenant
+      ? beaconPreflightHeaders(parsedOrigin.origin)
+      : beaconCorsDeniedHeaders()
+  });
 };

--- a/tests/analytics-beacon-cors.test.ts
+++ b/tests/analytics-beacon-cors.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Issue #637 — the public visit-ingest beacon could not be called from a
+ * different origin by ANY of the three available paths, and none of the
+ * failures showed up in this repo's logs.
+ *
+ * Two layers are covered here:
+ *
+ *   1. the pure origin policy (`domain/beacon-cors.ts`) — what counts as an
+ *      origin at all, and what the grant/refusal headers are;
+ *   2. the ACTUAL route handlers, driven with a fake Astro context, on every
+ *      path that reaches a decision WITHOUT touching the database.
+ *
+ * The database-backed half — an `Origin` that really is a row in
+ * `awcms_tenant_domains` — is proven against real Postgres in
+ * `tests/integration/analytics-beacon-cors.integration.test.ts`. The split is
+ * deliberate: the allow-list is the one part a mock could get wrong in the
+ * direction that matters (granting), so it is never mocked.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { APIRoute } from "astro";
+
+import { OPTIONS as collectOPTIONS } from "../src/pages/api/v1/analytics/collect";
+import {
+  BEACON_PREFLIGHT_MAX_AGE_SECONDS,
+  beaconCorsDeniedHeaders,
+  beaconCorsResponseHeaders,
+  beaconPreflightHeaders,
+  isCrossOriginBeacon,
+  parseBeaconOrigin,
+  resolveVisitorCookieSameSite
+} from "../src/modules/visitor-analytics/domain/beacon-cors";
+import { resetRateLimitForTests } from "../src/lib/security/rate-limit";
+
+const ENDPOINT = "https://cms.example/api/v1/analytics/collect";
+
+describe("parseBeaconOrigin", () => {
+  test("accepts a plain https origin and lowercases the hostname", () => {
+    expect(parseBeaconOrigin("https://News.Example")).toEqual({
+      origin: "https://news.example",
+      hostname: "news.example"
+    });
+  });
+
+  test("keeps a non-default port in the echoed origin", () => {
+    // The echoed value must match the browser's `Origin` byte for byte or the
+    // grant does not apply; the hostname is the lookup key and carries no port.
+    expect(parseBeaconOrigin("http://localhost:4321")).toEqual({
+      origin: "http://localhost:4321",
+      hostname: "localhost"
+    });
+  });
+
+  test("rejects the literal `null` origin", () => {
+    // A sandboxed iframe, a `file://` document and some redirect chains all
+    // send this. Echoing it back would grant a document with NO origin the same
+    // access a verified tenant domain has.
+    expect(parseBeaconOrigin("null")).toBeNull();
+  });
+
+  test("rejects a missing or blank header", () => {
+    expect(parseBeaconOrigin(null)).toBeNull();
+    expect(parseBeaconOrigin(undefined)).toBeNull();
+    expect(parseBeaconOrigin("   ")).toBeNull();
+  });
+
+  test("rejects non-http(s) schemes", () => {
+    for (const value of [
+      "chrome-extension://abcdefghijklmnop",
+      "moz-extension://abcdefghijklmnop",
+      "file://",
+      "data:text/html,x",
+      "javascript:alert(1)"
+    ]) {
+      expect(parseBeaconOrigin(value)).toBeNull();
+    }
+  });
+
+  test("rejects anything that does not serialize back to itself", () => {
+    // A real `Origin` header is exactly `scheme://host[:port]`. Rather than
+    // strip a path/query/fragment/userinfo off, the parser demands equality —
+    // one comparison that also rejects the shapes nobody has thought of yet.
+    for (const value of [
+      "https://news.example/",
+      "https://news.example/path",
+      "https://news.example?a=1",
+      "https://news.example#frag",
+      "https://user:pass@news.example",
+      "https://news.example:443/x",
+      "not a url"
+    ]) {
+      expect(parseBeaconOrigin(value)).toBeNull();
+    }
+  });
+
+  test("rejects a URL with no hostname", () => {
+    expect(parseBeaconOrigin("http://")).toBeNull();
+  });
+});
+
+describe("isCrossOriginBeacon", () => {
+  test("a same-origin request is not cross-origin", () => {
+    expect(
+      isCrossOriginBeacon(parseBeaconOrigin("https://cms.example"), ENDPOINT)
+    ).toBe(false);
+  });
+
+  test("a different scheme, host or port is cross-origin", () => {
+    for (const origin of [
+      "http://cms.example",
+      "https://news.example",
+      "https://cms.example:8443"
+    ]) {
+      expect(isCrossOriginBeacon(parseBeaconOrigin(origin), ENDPOINT)).toBe(
+        true
+      );
+    }
+  });
+
+  test("no origin at all is not cross-origin", () => {
+    // Server-to-server callers and same-origin navigations send no `Origin`.
+    // They take the unchanged path: no allow-list lookup, no CORS headers.
+    expect(isCrossOriginBeacon(null, ENDPOINT)).toBe(false);
+  });
+
+  test("an unparseable request URL is treated as cross-origin", () => {
+    // "Cannot be shown same-origin" must lead INTO the allow-list check, not
+    // around it.
+    expect(
+      isCrossOriginBeacon(parseBeaconOrigin("https://news.example"), "::::")
+    ).toBe(true);
+  });
+});
+
+describe("CORS header sets", () => {
+  test("a grant echoes the origin verbatim and allows credentials", () => {
+    expect(beaconCorsResponseHeaders("https://news.example")).toEqual({
+      "access-control-allow-origin": "https://news.example",
+      "access-control-allow-credentials": "true",
+      vary: "Origin"
+    });
+  });
+
+  test("a preflight adds exactly the three preflight answers", () => {
+    const headers = beaconPreflightHeaders("https://news.example");
+
+    expect(headers["access-control-allow-methods"]).toBe("POST, OPTIONS");
+    // `content-type` alone. This is the whole point: `application/json` keeps
+    // the request out of Astro's form-like branch. Widening this list turns the
+    // beacon into a general-purpose cross-origin API.
+    expect(headers["access-control-allow-headers"]).toBe("content-type");
+    expect(headers["access-control-max-age"]).toBe(
+      String(BEACON_PREFLIGHT_MAX_AGE_SECONDS)
+    );
+  });
+
+  test("a refusal still carries Vary and never a grant", () => {
+    const headers = beaconCorsDeniedHeaders();
+
+    expect(headers.vary).toBe("Origin");
+    expect(headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  test("no header set can ever produce a wildcard origin", () => {
+    // `*` would let any page on the internet write to the beacon with a public
+    // tenant code, and is not even legal alongside allow-credentials.
+    const everything = {
+      ...beaconPreflightHeaders("https://news.example"),
+      ...beaconCorsResponseHeaders("https://news.example"),
+      ...beaconCorsDeniedHeaders()
+    };
+
+    expect(Object.values(everything)).not.toContain("*");
+  });
+});
+
+describe("resolveVisitorCookieSameSite", () => {
+  test("same-origin keeps Lax", () => {
+    expect(
+      resolveVisitorCookieSameSite({ crossOrigin: false, secure: true })
+    ).toBe("lax");
+  });
+
+  test("cross-origin over https uses None so the key survives", () => {
+    expect(
+      resolveVisitorCookieSameSite({ crossOrigin: true, secure: true })
+    ).toBe("none");
+  });
+
+  test("cross-origin without Secure falls back to Lax", () => {
+    // Browsers refuse `SameSite=None` without `Secure`. Emitting it anyway
+    // would set a cookie the browser drops — a beacon that looks like it works.
+    expect(
+      resolveVisitorCookieSameSite({ crossOrigin: true, secure: false })
+    ).toBe("lax");
+  });
+});
+
+/** Minimal AstroCookies stub — the preflight never touches it. */
+function fakeCookies() {
+  const store = new Map<string, string>();
+  return {
+    get: (name: string) =>
+      store.has(name) ? { value: store.get(name)! } : undefined,
+    set: (name: string, value: string) => store.set(name, value),
+    delete: (name: string) => store.delete(name),
+    has: (name: string) => store.has(name)
+  };
+}
+
+async function preflight(origin: string | null): Promise<Response> {
+  const request = new Request(ENDPOINT, {
+    method: "OPTIONS",
+    headers: origin === null ? {} : { origin }
+  });
+
+  return (await (collectOPTIONS as APIRoute)({
+    request,
+    cookies: fakeCookies(),
+    clientAddress: "203.0.113.9",
+    locals: { correlationId: "test-corr" }
+  } as never)) as Response;
+}
+
+describe("OPTIONS /api/v1/analytics/collect", () => {
+  beforeEach(() => {
+    resetRateLimitForTests();
+  });
+
+  afterEach(() => {
+    resetRateLimitForTests();
+  });
+
+  test("a request with no Origin gets 204, Vary, and no grant", async () => {
+    const response = await preflight(null);
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("vary")).toBe("Origin");
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("a same-origin preflight gets no grant", async () => {
+    const response = await preflight("https://cms.example");
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("an opaque `null` Origin gets no grant", async () => {
+    const response = await preflight("null");
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("an extension-scheme Origin gets no grant", async () => {
+    const response = await preflight("chrome-extension://abcdefghijklmnop");
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+});

--- a/tests/integration/analytics-beacon-cors.integration.test.ts
+++ b/tests/integration/analytics-beacon-cors.integration.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Issue #637 — a static build on a DIFFERENT origin can send the visit-ingest
+ * beacon, and the row is really written.
+ *
+ * The pure origin policy is covered in `tests/analytics-beacon-cors.test.ts`.
+ * What only a real database can prove is the half that decides who is let in:
+ * the `Origin` allow-list is `awcms_tenant_domains` read through the SECURITY
+ * DEFINER lookup, and the two ways to get that wrong — granting a host that is
+ * not an active tenant domain, and refusing one that is — are both invisible to
+ * a mock that returns whatever the test told it to.
+ *
+ * The four things asserted here, in the order they matter:
+ *
+ *   1. an `Origin` that IS an active tenant domain gets the grant;
+ *   2. an unknown host, and a domain that is merely `pending_verification`,
+ *      get no grant — the allow-list is the verified set, not the requested one;
+ *   3. a cross-origin POST from a granted origin actually WRITES a visitor
+ *      session — the whole point of the issue, which every earlier layer of
+ *      this feature could pass while still recording nothing;
+ *   4. the origin's tenant and the body's `tenantCode` are INDEPENDENT: the row
+ *      lands under the tenant the body names. CORS decided whether a browser
+ *      may read the answer; it did not decide whose analytics this is.
+ *
+ * WORLD 2 (harness.ts) — real route handlers reach for `getDatabaseClient()`
+ * internally, so this runs against the migrated `DATABASE_URL` database and
+ * seeds through `getHandlerAdminSql()`.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  ensureHandlerDatabaseReady,
+  getHandlerAdminSql,
+  integrationEnabled,
+  invoke,
+  resetHandlerDatabase,
+  teardownHandlerDatabase
+} from "./harness";
+import {
+  OPTIONS as collectOPTIONS,
+  POST as collectPOST
+} from "../../src/pages/api/v1/analytics/collect";
+
+const TENANT_A = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const TENANT_B = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+const ACTIVE_HOST = "news.example.test";
+const PENDING_HOST = "pending.example.test";
+const COLLECT_PATH = "/api/v1/analytics/collect";
+
+let handlerReady = false;
+let previousEnabled: string | undefined;
+
+async function seed(): Promise<void> {
+  const sql = getHandlerAdminSql();
+
+  await sql`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES
+      (${TENANT_A}, 'beacon-a', 'Beacon A', 'active'),
+      (${TENANT_B}, 'beacon-b', 'Beacon B', 'active')
+    ON CONFLICT (id) DO NOTHING
+  `;
+
+  await sql`
+    INSERT INTO awcms_tenant_domains
+      (tenant_id, hostname, normalized_hostname, status, verified_at)
+    VALUES
+      (${TENANT_A}, ${ACTIVE_HOST}, ${ACTIVE_HOST}, 'active', now()),
+      (${TENANT_A}, ${PENDING_HOST}, ${PENDING_HOST}, 'pending_verification', NULL)
+  `;
+}
+
+async function preflight(origin: string) {
+  return invoke(collectOPTIONS, {
+    method: "OPTIONS",
+    path: COLLECT_PATH,
+    headers: { origin }
+  });
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("analytics beacon cross-origin policy (integration)", () => {
+  beforeAll(async () => {
+    handlerReady = await ensureHandlerDatabaseReady();
+
+    // The module's master switch defaults to OFF, and an off module answers
+    // 202 without writing anything — which would make assertion 3 pass for the
+    // wrong reason. Turn it on for this file only, and put it back after.
+    previousEnabled = process.env.VISITOR_ANALYTICS_ENABLED;
+    process.env.VISITOR_ANALYTICS_ENABLED = "true";
+  });
+
+  afterAll(async () => {
+    if (previousEnabled === undefined) {
+      delete process.env.VISITOR_ANALYTICS_ENABLED;
+    } else {
+      process.env.VISITOR_ANALYTICS_ENABLED = previousEnabled;
+    }
+
+    if (handlerReady) {
+      await teardownHandlerDatabase();
+    }
+  });
+
+  beforeEach(async () => {
+    if (!handlerReady) {
+      return;
+    }
+    await resetHandlerDatabase();
+    await seed();
+  });
+
+  afterEach(async () => {
+    if (handlerReady) {
+      await resetHandlerDatabase();
+    }
+  });
+
+  test("an active tenant domain is granted, and the grant is never `*`", async () => {
+    if (!handlerReady) {
+      return;
+    }
+
+    const { status, response } = await preflight(`https://${ACTIVE_HOST}`);
+
+    expect(status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      `https://${ACTIVE_HOST}`
+    );
+    expect(response.headers.get("access-control-allow-origin")).not.toBe("*");
+    expect(response.headers.get("access-control-allow-credentials")).toBe(
+      "true"
+    );
+    expect(response.headers.get("access-control-allow-methods")).toBe(
+      "POST, OPTIONS"
+    );
+    expect(response.headers.get("access-control-allow-headers")).toBe(
+      "content-type"
+    );
+    expect(response.headers.get("vary")).toBe("Origin");
+  });
+
+  test("an unknown host is refused, and still says Vary", async () => {
+    if (!handlerReady) {
+      return;
+    }
+
+    const { status, response } = await preflight("https://nobody.example.test");
+
+    expect(status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    // A refusal is as origin-dependent as a grant. Without this, one cached
+    // object serves one origin's answer to another.
+    expect(response.headers.get("vary")).toBe("Origin");
+  });
+
+  test("a domain that is only pending_verification is refused", async () => {
+    if (!handlerReady) {
+      return;
+    }
+
+    // The allow-list is the VERIFIED set. A tenant claiming a hostname it has
+    // not proven it controls must not be able to grant itself cross-origin
+    // access by claiming it.
+    const { response } = await preflight(`https://${PENDING_HOST}`);
+
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+  });
+
+  test("a cross-origin POST from a granted origin actually records a visit", async () => {
+    if (!handlerReady) {
+      return;
+    }
+
+    const { status, response } = await invoke(collectPOST, {
+      method: "POST",
+      path: COLLECT_PATH,
+      headers: {
+        origin: `https://${ACTIVE_HOST}`,
+        "content-type": "application/json"
+      },
+      body: { tenantCode: "beacon-a", path: "/berita/contoh" }
+    });
+
+    expect(status).toBe(202);
+    expect(response.headers.get("access-control-allow-origin")).toBe(
+      `https://${ACTIVE_HOST}`
+    );
+
+    const rows = (await getHandlerAdminSql()`
+      SELECT tenant_id, area, current_path
+      FROM awcms_visitor_sessions
+      WHERE tenant_id = ${TENANT_A}
+    `) as { tenant_id: string; area: string; current_path: string | null }[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.area).toBe("public");
+  });
+
+  test("the origin's tenant and the body's tenantCode are independent", async () => {
+    if (!handlerReady) {
+      return;
+    }
+
+    // `news.example.test` belongs to tenant A; the body names tenant B. CORS
+    // answered "may this browser read our response", NOT "whose analytics is
+    // this" — so the row belongs to B, and A gets nothing. If these two ever
+    // become one decision, this test is what notices.
+    const { status } = await invoke(collectPOST, {
+      method: "POST",
+      path: COLLECT_PATH,
+      headers: {
+        origin: `https://${ACTIVE_HOST}`,
+        "content-type": "application/json"
+      },
+      body: { tenantCode: "beacon-b", path: "/berita/lain" }
+    });
+
+    expect(status).toBe(202);
+
+    const rows = (await getHandlerAdminSql()`
+      SELECT tenant_id FROM awcms_visitor_sessions
+    `) as { tenant_id: string }[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.tenant_id).toBe(TENANT_B);
+  });
+
+  test("a refused origin still records — CORS hides the answer, not the write", async () => {
+    if (!handlerReady) {
+      return;
+    }
+
+    // Worth pinning because it surprises people: CORS is enforced by the
+    // BROWSER on the response. A caller that is not a browser (curl, a server,
+    // a scraper) was never blocked by any of this and still is not. What
+    // actually bounds that caller is the per-IP rate limit and the fact that a
+    // public tenant code is all it could ever have.
+    const { status, response } = await invoke(collectPOST, {
+      method: "POST",
+      path: COLLECT_PATH,
+      headers: {
+        origin: "https://nobody.example.test",
+        "content-type": "application/json"
+      },
+      body: { tenantCode: "beacon-a", path: "/berita/contoh" }
+    });
+
+    expect(status).toBe(202);
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+
+    const rows = (await getHandlerAdminSql()`
+      SELECT tenant_id FROM awcms_visitor_sessions
+    `) as { tenant_id: string }[];
+
+    expect(rows).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #637.

`POST /api/v1/analytics/collect` is anonymous, rate-limited and always answers `202`. It was built to be called from a public page. When that page is a static `awcms-astro` build on a **different** origin — the PRD §27.1 scenario — all three ways of calling it were blocked, and not one of the failures appeared in this repo's logs. The dashboards were right; nothing ever arrived.

## The three paths, and what blocked each

`security.checkOrigin` defaults to `true` (`node_modules/astro/dist/core/config/schemas/defaults.js:44`) and `astro.config.mjs` does not turn it off:

1. `navigator.sendBeacon(url, blob)` sends `text/plain`, which IS in `FORM_CONTENT_TYPES` → `403 Cross-site POST form submissions are forbidden`.
2. `fetch` with no `content-type` → the final `return !isSameOrigin` → 403.
3. `fetch` with `application/json` passes `checkOrigin`, then dies on a preflight nothing answered.

**This opens path 3 only.** Paths 1 and 2 stay closed deliberately: `checkOrigin` protects every other write in the repo, and Astro *unshifts* it ahead of `src/middleware.ts` (`core/middleware/load.js`), so it cannot be exempted per-route from inside the app. Disabling it globally would trade a repo-wide guarantee for one endpoint's convenience. The cost is a real constraint on the caller, written into the endpoint's docblock: the beacon must be sent as JSON, which means `fetch`, not `sendBeacon`.

## CORS is not authorization

A preflight carries **no body**, so `OPTIONS` cannot know which `tenantCode` the POST will name. It answers the narrower question it can — is this `Origin` an active domain in `awcms_tenant_domains` (via the same SECURITY DEFINER lookup the public host router uses) — and the POST goes on validating `tenantCode` exactly as before.

One integration test exists specifically to keep those two from fusing later: it posts tenant B's code from tenant A's verified domain and asserts the row lands under **B**.

- The allowed origin is echoed verbatim from a value that resolved against the verified set. Never `*` — which would let any page on the internet write with a public tenant code, and is not legal alongside the `Access-Control-Allow-Credentials` this endpoint needs.
- A domain that is only `pending_verification` is **refused**: the allow-list is the proven set, not the claimed one.
- `Vary: Origin` on **every** response, including refusals — a cached denial served to an allowed origin is the same defect as the reverse.
- The `Origin` parser rejects the literal `null` origin (sandboxed iframe, `file://`), non-`http(s)` schemes, and anything that does not serialize back to itself.

## Two things easy to assume and not true

**The visitor cookie.** It is `SameSite=Lax`, and a Lax cookie is neither sent nor stored cross-site — so without a change every cross-origin page view would have looked like a first-ever visitor. It is now `SameSite=None` when the request is cross-origin **and** `Secure`, falling back to `Lax` rather than emitting a cookie the browser will drop. A browser that blocks third-party cookies drops it regardless: cross-origin visitor keys are best-effort, page-view counts are not. Letting the client send its own identifier in the body would fix it and is refused — every identifier this endpoint stores is derived server-side.

**CORS is enforced by the browser, on the response.** A non-browser caller was never blocked by any of this and still is not; what bounds it is the per-IP rate limit, which now also fronts the new allow-list lookup — same key, so a preflight and the POST it precedes share one budget rather than doubling it. A small memoized `consumeRateLimit()` keeps the "limiter before any database work" rule intact now that there are two DB reads at different depths.

## The corrected claim

`security-headers.ts` rested its `Cross-Origin-Resource-Policy: same-origin` on "nothing here emits `Access-Control-Allow-Origin` (verified: zero occurrences in `src/`)". That stops being true here, so the comment is corrected in the same commit. CORP is unaffected either way — it governs `no-cors` subresource embedding and a CORS-mode `fetch` is not one — but the reason is now "CORP does not apply to CORS" rather than "there is no CORS here".

## Verification

- `tests/analytics-beacon-cors.test.ts` — 22 tests: origin parsing, header sets, a no-wildcard-anywhere assertion, and the route's non-DB refusal paths.
- `tests/integration/analytics-beacon-cors.integration.test.ts` — against real Postgres: grant for an active domain, refusal for an unknown host and for `pending_verification`, a cross-origin POST that **actually writes a row**, and the origin/`tenantCode` independence test.
- `DATABASE_URL="" bun run check` — full chain green, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)