### PR TITLE
feat(blog-content): a legacy archive can keep its photographs (#599)

### DIFF
--- a/.changeset/legacy-import-image-handoff.md
+++ b/.changeset/legacy-import-image-handoff.md
@@ -1,0 +1,66 @@
+---
+"awcms": minor
+---
+
+feat(blog-content): a legacy archive can keep its photographs (#599)
+
+`bun run blog:legacy:import` landed in #640 and, on a real CKEditor archive,
+would have refused very nearly every row.
+
+`convertLegacyHtmlToPortableText` rejects `<img>` — correctly, because a
+managed-media deployment stores images as registry references and an import that
+kept the raw `src` would smuggle unmanaged media past the enforcement
+`media_library` exists to apply. The rejection names the `src` "so the importer
+can resolve it to an uploaded object first". Nothing implemented *first*. For
+23,906 articles that meant a refusal log with ~24,000 entries and zero imported
+posts.
+
+### What was NOT built, and why that is the same answer as last time
+
+Not a fetcher. Turning a legacy URL into a managed object means pulling
+third-party bytes from the server at an address somebody else chose — a
+server-side request forgery primitive — and then minting a `verified` registry
+row for bytes no upload pipeline ever inspected. `legacy-ad-ingest.ts` faced
+exactly this question for `awcms_blog_ads.image_url` and wrote the answer down
+at length: bytes are vouched for by the upload pipeline or not at all. That
+reasoning is unchanged by the volume.
+
+### What was built: the other half of the handoff
+
+- **`--images=<path>`** writes the upload set — every distinct `<img src>` the
+  archive references, counted by ARTICLE and ordered by demand — and stops
+  there. It is built from the converter's own findings rather than a second scan
+  of the HTML, so there is one definition of "what counts as an image
+  reference".
+- **`--media-map=<path>`** takes the result back as `{ "<src>": "<uuid>" }`
+  after the operator has uploaded the files through `/admin/media`. A mapped
+  image becomes a one-item `gallery` node **in the position it occupied in the
+  article**; consecutive images join one gallery, which is the common CKEditor
+  photo-row shape.
+
+Without `--media-map` nothing changes: `<img>` is residue exactly as before, and
+an image the map does not cover still refuses its article rather than importing
+it with a hole.
+
+### The check that has to happen before anything is written
+
+Every id in the map is put to the registry — `isMediaReferenceSafe`, so
+"exists, belongs to this tenant, and is verified/attached" — and one that fails
+aborts the whole run.
+
+That is deliberate rather than defensive. `renderGalleryBlockHtml` silently
+drops a gallery item whose media object does not resolve, because a public page
+must degrade rather than 500. So a wrong id produces an article that imported
+cleanly, reported no error, and has lost its photographs — visible only to a
+reader, on a page nobody re-checks. It cannot be a per-row refusal either: a map
+is one artefact, and a wrong id in it is a wrong artefact. The cross-tenant and
+not-yet-verified cases are tested against real Postgres, because "is this a
+uuid" and "is this our verified media" are different questions and only the
+second one is the right one.
+
+### One thing deliberately not carried across
+
+No `caption`. The renderer prints `caption` as a visible `<figcaption>` (and
+reuses it as the `alt`), while a legacy `alt` is very often the file name.
+Carrying it would print a filename under 23,906 photographs — a silent edit to
+every article in the archive, made by an import script.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 430   |
+| Test files                          | 431   |
 | Route files                         | 382   |
 | ADR                                 | 208   |
 
@@ -352,7 +352,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 371        |
+| `(root)`      | 372        |
 | `e2e`         | 12         |
 | `integration` | 46         |
 | `unit`        | 1          |

--- a/scripts/blog-legacy-import.ts
+++ b/scripts/blog-legacy-import.ts
@@ -42,6 +42,29 @@
  *    in one query, so a collision is a line in the report rather than a
  *    constraint error 12,000 rows into a run.
  *
+ * ## The images, and the two flags that make the archive importable at all
+ *
+ * Gate 2 above meant that in practice EVERY row of a real CKEditor archive was
+ * residue: `<img>` is refused because a managed-media deployment stores images
+ * as registry references, and nothing here can turn a legacy URL into one.
+ * That is not a gap to close by fetching the file — see
+ * `legacy-media-map.ts` and `legacy-ad-ingest.ts` for why the server must not.
+ * It is a handoff, and it now has both halves:
+ *
+ *   `--images=<path>`     writes the upload set (every distinct `<img src>` in
+ *                         the archive, most-used first) and stops. Upload those
+ *                         through `/admin/media`.
+ *   `--media-map=<path>`  takes the result back as `{ "<src>": "<uuid>" }`.
+ *                         Every id is checked against THIS tenant's registry
+ *                         before a single article is converted, and one that is
+ *                         not verified media aborts the run — an unresolvable
+ *                         media reference renders as nothing, so importing past
+ *                         it would produce articles that look fine and have
+ *                         lost their photographs.
+ *
+ * A mapped image becomes a one-item `gallery` node in the position it occupied
+ * in the article; an unmapped one is refused exactly as before.
+ *
  * ## Roles and transactions
  *
  * Runs as the APP role, not `awcms_worker`. This creates content, which is an
@@ -59,9 +82,17 @@
 import { getDatabaseClient } from "../src/lib/database/client";
 import { withTenantOrThrow } from "../src/lib/database/tenant-context";
 import { logScriptFailure } from "../src/lib/logging/error-log";
+import { safeErrorDetail } from "../src/lib/logging/error-sanitizer";
 import { convertLegacyHtmlToPortableText } from "../src/modules/blog-content/domain/legacy-html-conversion";
 import { parseLegacyImportRecord } from "../src/modules/blog-content/domain/legacy-import-record";
 import type { LegacyImportRecord } from "../src/modules/blog-content/domain/legacy-import-record";
+import {
+  mediaObjectIdsIn,
+  parseLegacyMediaMap,
+  summariseLegacyImageUsage
+} from "../src/modules/blog-content/domain/legacy-media-map";
+import type { LegacyImageUsage } from "../src/modules/blog-content/domain/legacy-media-map";
+import { mediaLibraryPortAdapter } from "../src/modules/media-library/application/media-library-port-adapter";
 import {
   findTakenSlugs,
   importLegacyBlogPost
@@ -89,9 +120,40 @@ function usage(message: string): void {
       "  --author=<uuid>      awcms_tenant_users.id recorded as the author (required)\n" +
       "  --system=<name>      legacy_source_system value, e.g. seputarborneo (required)\n" +
       "  --locale=<tag>       default locale for lines that carry none (default: id)\n" +
+      "  --images=<path>      write the upload set — every <img src> the archive\n" +
+      "                       references, most-used first — and stop there\n" +
+      '  --media-map=<path>   JSON { "<img src>": "<media object uuid>" }; every id is\n' +
+      "                       checked against this tenant's registry before anything is written\n" +
       "  --commit             write. Without it, nothing is written and you get the report.\n"
   );
   process.exitCode = 1;
+}
+
+/**
+ * The upload set, written for the operator and nothing else.
+ *
+ * This is the first half of the handoff `legacy-media-map.ts` describes: the
+ * converter refuses a raw `<img>` and names its `src`, and an archive of 23,906
+ * articles turns that into a refusal log nobody can act on. The same
+ * information, deduplicated and ordered, is a work list.
+ */
+async function writeImageInventory(
+  path: string,
+  usage_: readonly LegacyImageUsage[]
+): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(usage_, null, 2)}\n`);
+
+  console.log(
+    `\nblog:legacy:import — wrote the upload set to ${path}\n` +
+      `  distinct images  ${usage_.length}\n\n` +
+      "  Upload these through the media library (`/admin/media`), which is the\n" +
+      "  one path with upload validation, MIME sniffing and size caps. This job\n" +
+      "  deliberately does not fetch them: pulling third-party bytes from the\n" +
+      "  server at an address somebody else chose is a request-forgery\n" +
+      "  primitive, and minting a `verified` registry row for bytes nothing\n" +
+      "  inspected is the assertion the upload pipeline exists to make.\n\n" +
+      "  Then hand the result back as --media-map=<path>.\n"
+  );
 }
 
 async function main(): Promise<void> {
@@ -101,6 +163,8 @@ async function main(): Promise<void> {
   const authorId = flag("author");
   const system = flag("system");
   const defaultLocale = flag("locale") ?? "id";
+  const imagesPath = flag("images");
+  const mediaMapPath = flag("media-map");
 
   if (!file) return usage("`--file=<path>` is required.");
   if (!tenantId) return usage("`--tenant=<uuid>` is required.");
@@ -117,76 +181,168 @@ async function main(): Promise<void> {
   >();
   const refusals: Refusal[] = [];
   const seenLegacyIds = new Set<string>();
-
-  for (const [index, raw] of lines.entries()) {
-    const lineNumber = index + 1;
-    const trimmed = raw.trim();
-
-    if (trimmed.length === 0) continue;
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(trimmed);
-    } catch {
-      refusals.push({
-        line: lineNumber,
-        legacyId: "(unparseable)",
-        reasons: ["line is not valid JSON"]
-      });
-      continue;
-    }
-
-    const record = parseLegacyImportRecord(parsed, { locale: defaultLocale });
-
-    if (!record.ok) {
-      refusals.push({
-        line: lineNumber,
-        legacyId:
-          typeof (parsed as { legacyId?: unknown })?.legacyId === "string"
-            ? String((parsed as { legacyId: string }).legacyId)
-            : "(missing)",
-        reasons: record.errors
-      });
-      continue;
-    }
-
-    // A duplicate inside ONE file is the export script's bug, and the database
-    // would answer it with a silent `DO NOTHING` — which reads in the report as
-    // "already imported" and hides the real problem.
-    if (seenLegacyIds.has(record.value.legacyId)) {
-      refusals.push({
-        line: lineNumber,
-        legacyId: record.value.legacyId,
-        reasons: ["legacyId appears more than once in this file"]
-      });
-      continue;
-    }
-    seenLegacyIds.add(record.value.legacyId);
-
-    const body = convertLegacyHtmlToPortableText(record.value.bodyHtml);
-
-    if (!body.ok) {
-      refusals.push({
-        line: lineNumber,
-        legacyId: record.value.legacyId,
-        reasons: body.rejections.map(
-          (rejection) =>
-            `${rejection.reason} at offset ${rejection.offset}: ${rejection.found}` +
-            (rejection.detail ? ` (${rejection.detail})` : "")
-        )
-      });
-      continue;
-    }
-
-    accepted.push(record.value);
-    acceptedBodies.set(record.value.legacyId, body);
-  }
+  /** One entry per article, so `summariseLegacyImageUsage` can count articles rather than tags. */
+  const imageSrcsPerArticle: string[][] = [];
 
   const sql = getDatabaseClient();
   let imported = 0;
   let alreadyPresent = 0;
 
   try {
+    let mediaMap: ReadonlyMap<string, string> = new Map();
+
+    if (mediaMapPath) {
+      let rawMap: unknown;
+      try {
+        rawMap = JSON.parse(await Bun.file(mediaMapPath).text());
+      } catch (error) {
+        console.error(
+          `blog:legacy:import — ${mediaMapPath} is not valid JSON: ${safeErrorDetail(error)}`
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const parsedMap = parseLegacyMediaMap(rawMap);
+
+      if (!parsedMap.ok) {
+        console.error(
+          `blog:legacy:import — ${mediaMapPath} is not a usable media map:\n` +
+            parsedMap.errors.map((line) => `  - ${line}`).join("\n")
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      // Every id, against the registry, BEFORE a single article is converted.
+      // `renderGalleryBlockHtml` silently drops an item whose media object does
+      // not resolve, so an id this tenant does not own produces an article that
+      // imported cleanly and has lost its photographs — visible only to a
+      // reader. That cannot be a per-row refusal either: a map is one artefact,
+      // and a wrong id in it is a wrong artefact.
+      const ids = mediaObjectIdsIn(parsedMap.value);
+      const unsafe = await withTenantOrThrow(sql, tenantId, async (tx) => {
+        const found: string[] = [];
+        for (const id of ids) {
+          const safe = await mediaLibraryPortAdapter.isMediaReferenceSafe(
+            tx,
+            tenantId,
+            id
+          );
+          if (!safe) found.push(id);
+        }
+        return found;
+      });
+
+      if (unsafe.length > 0) {
+        console.error(
+          `blog:legacy:import — ${unsafe.length} of ${ids.length} media object id(s) in ` +
+            `${mediaMapPath} are not verified media of this tenant:\n` +
+            unsafe.map((id) => `  - ${id}`).join("\n") +
+            "\n\n  Nothing was written. An id the registry does not vouch for renders\n" +
+            "  as NOTHING, so importing past this would produce articles that look\n" +
+            "  fine and have lost their photographs.\n"
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      console.log(
+        `blog:legacy:import — ${ids.length} media object id(s) verified against this tenant's registry.`
+      );
+
+      mediaMap = parsedMap.value;
+    }
+
+    const resolveImage = mediaMapPath
+      ? (src: string): string | null => mediaMap.get(src) ?? null
+      : undefined;
+
+    for (const [index, raw] of lines.entries()) {
+      const lineNumber = index + 1;
+      const trimmed = raw.trim();
+
+      if (trimmed.length === 0) continue;
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        refusals.push({
+          line: lineNumber,
+          legacyId: "(unparseable)",
+          reasons: ["line is not valid JSON"]
+        });
+        continue;
+      }
+
+      const record = parseLegacyImportRecord(parsed, { locale: defaultLocale });
+
+      if (!record.ok) {
+        refusals.push({
+          line: lineNumber,
+          legacyId:
+            typeof (parsed as { legacyId?: unknown })?.legacyId === "string"
+              ? String((parsed as { legacyId: string }).legacyId)
+              : "(missing)",
+          reasons: record.errors
+        });
+        continue;
+      }
+
+      // A duplicate inside ONE file is the export script's bug, and the database
+      // would answer it with a silent `DO NOTHING` — which reads in the report as
+      // "already imported" and hides the real problem.
+      if (seenLegacyIds.has(record.value.legacyId)) {
+        refusals.push({
+          line: lineNumber,
+          legacyId: record.value.legacyId,
+          reasons: ["legacyId appears more than once in this file"]
+        });
+        continue;
+      }
+      seenLegacyIds.add(record.value.legacyId);
+
+      const body = convertLegacyHtmlToPortableText(record.value.bodyHtml, {
+        resolveImage
+      });
+
+      // Collected from the converter's own findings, for every article, whether
+      // or not it is importable — the upload set is the whole archive's, and an
+      // article refused for a bad slug still needs its photographs uploaded.
+      imageSrcsPerArticle.push(
+        body.rejections
+          .filter((rejection) => rejection.reason === "unmanaged_image")
+          .map((rejection) => rejection.detail ?? "")
+      );
+
+      if (!body.ok) {
+        refusals.push({
+          line: lineNumber,
+          legacyId: record.value.legacyId,
+          reasons: body.rejections.map(
+            (rejection) =>
+              `${rejection.reason} at offset ${rejection.offset}: ${rejection.found}` +
+              (rejection.detail ? ` (${rejection.detail})` : "")
+          )
+        });
+        continue;
+      }
+
+      accepted.push(record.value);
+      acceptedBodies.set(record.value.legacyId, body);
+    }
+
+    if (imagesPath) {
+      // A report, not a run. Writing the upload set and then importing would
+      // invite reading the summary and skipping the list it just produced.
+      await writeImageInventory(
+        imagesPath,
+        summariseLegacyImageUsage(imageSrcsPerArticle)
+      );
+      return;
+    }
+
     // One query for every slug in the file, before anything is written.
     const taken = await withTenantOrThrow(sql, tenantId, (tx) =>
       findTakenSlugs(

--- a/src/modules/blog-content/domain/legacy-html-conversion.ts
+++ b/src/modules/blog-content/domain/legacy-html-conversion.ts
@@ -48,6 +48,19 @@ import {
  * enforcement `media_library` exists to apply. The report names each one with
  * its `src` so the importer can resolve it to an uploaded object first.
  *
+ * That "first" now has a second half. Pass `resolveImage` and a `src` the
+ * caller has ALREADY resolved to a verified media object becomes a real image
+ * in the body — a one-item `gallery` node — instead of residue. Everything else
+ * is unchanged: no resolver, or a `src` the resolver does not know, and the
+ * image is refused exactly as before.
+ *
+ * What this module still refuses to do is resolve one itself. Turning an
+ * arbitrary legacy URL into a managed object means fetching third-party bytes
+ * from the server at an address somebody else chose, which is a server-side
+ * request forgery primitive; `legacy-ad-ingest.ts` faced the same question for
+ * `awcms_blog_ads.image_url` and answered it the same way, at length. Bytes get
+ * vouched for by the upload pipeline or not at all.
+ *
  * Pure module: no database, no network, no DOM. The parser is deliberately
  * small and total — it never throws, because a converter that throws on article
  * 14,002 of 23,906 tells the operator nothing about the other 9,904.
@@ -78,9 +91,12 @@ const BLOCK_STYLE_TAGS: Readonly<Record<string, PortableTextBlockStyle>> = {
 /**
  * Tags whose presence makes an article unconvertible.
  *
- * `img` is here for a different reason than the rest — see the header. Keeping
- * it in one list would blur "this can execute" with "this needs resolving
- * first", so the reason travels with the finding rather than with the list.
+ * `img` is NO LONGER one of them: it is handled before this list is consulted,
+ * because whether it makes the article unconvertible now depends on the
+ * caller's resolver. Everything left here is unconditional — it can execute,
+ * embed or fetch, and no option makes it acceptable. That is the distinction
+ * the old comment here was making in prose and the code can now make
+ * structurally.
  */
 const REJECTED_TAGS: readonly string[] = [
   "script",
@@ -93,8 +109,7 @@ const REJECTED_TAGS: readonly string[] = [
   "style",
   "link",
   "meta",
-  "base",
-  "img"
+  "base"
 ];
 
 /**
@@ -123,6 +138,29 @@ export type LegacyConversionRejection = {
   offset: number;
   /** Present for `unmanaged_image`: the `src` an importer must resolve to a media object. */
   detail?: string;
+};
+
+/**
+ * Answers "which managed media object is this legacy `src`?", or `null`.
+ *
+ * The converter never decides this itself, and cannot: the answer needs the
+ * media registry, and this module is pure. What it CAN do is refuse to guess —
+ * a resolver that returns an id the registry does not vouch for produces a
+ * gallery item `renderGalleryBlockHtml` silently drops, i.e. an article that
+ * looks imported and has lost its photographs. So the caller's contract is that
+ * a returned id has already been checked (`isMediaReferenceSafe`), and
+ * `blog:legacy:import` refuses the whole run rather than pass one through
+ * unverified.
+ */
+export type LegacyImageResolver = (src: string) => string | null;
+
+export type LegacyConversionOptions = {
+  /**
+   * Turns `<img src=…>` into a managed media reference instead of a rejection
+   * (Issue #599). Absent — the default — keeps the original behaviour: every
+   * image is `unmanaged_image` residue with its `src` named.
+   */
+  resolveImage?: LegacyImageResolver;
 };
 
 export type LegacyConversionResult = {
@@ -286,7 +324,8 @@ type OpenBlock = {
  * per article rather than a stack trace on one of them.
  */
 export function convertLegacyHtmlToPortableText(
-  html: unknown
+  html: unknown,
+  options: LegacyConversionOptions = {}
 ): LegacyConversionResult {
   if (typeof html !== "string" || html.trim().length === 0) {
     return { ok: true, document: [], rejections: [], plainText: "" };
@@ -332,6 +371,48 @@ export function convertLegacyHtmlToPortableText(
     }
 
     current = null;
+  };
+
+  /**
+   * Places a resolved image in the document, in the position it occupied in the
+   * article (Issue #599).
+   *
+   * `gallery` is the ONLY node in ADR-0100's closed vocabulary that carries an
+   * image, so a lone photograph is a one-item gallery. That is not a workaround:
+   * the alternative is a new `_type`, and the vocabulary is closed precisely so
+   * that adding one is a deliberate act with its own validation, not something
+   * an import script invents.
+   *
+   * CONSECUTIVE images join the gallery already at the end of the document
+   * rather than each starting one, which is the common CKEditor photo-row shape.
+   * `flush()` first is what makes that test correct: it pushes any pending text,
+   * so a gallery can only still be last when nothing was written between the two
+   * images.
+   *
+   * No `caption`, and that is a decision rather than an omission.
+   * `renderGalleryBlockHtml` prints `caption` as a VISIBLE `<figcaption>` (and
+   * reuses it as the `alt`), while a legacy `alt` is very often the file name.
+   * Carrying it across would print a filename under 23,906 photographs — a
+   * silent edit to every article in the archive, made by an import script. An
+   * uncaptioned image is the honest result; a caption is something an editor
+   * adds on purpose.
+   */
+  const appendGalleryImage = (mediaObjectId: string): void => {
+    flush();
+
+    const last = document[document.length - 1];
+
+    if (last && last._type === "gallery") {
+      last.items.push({ mediaType: "image", mediaObjectId });
+      return;
+    }
+
+    const index = document.length;
+    document.push({
+      _type: "gallery",
+      _key: nodeKey(index),
+      items: [{ mediaType: "image", mediaObjectId }]
+    });
   };
 
   const open = (style: PortableTextBlockStyle): void => {
@@ -392,22 +473,30 @@ export function convertLegacyHtmlToPortableText(
       }
     }
 
+    if (name === "img" && token.kind !== "close") {
+      const src = token.attrs.src ?? "";
+      const mediaObjectId = src ? (options.resolveImage?.(src) ?? null) : null;
+
+      if (mediaObjectId) {
+        appendGalleryImage(mediaObjectId);
+      } else {
+        rejections.push({
+          reason: "unmanaged_image",
+          found: "img",
+          offset: token.offset,
+          detail: src
+        });
+      }
+      continue;
+    }
+
     if (REJECTED_TAGS.includes(name)) {
       if (token.kind !== "close") {
-        rejections.push(
-          name === "img"
-            ? {
-                reason: "unmanaged_image",
-                found: "img",
-                offset: token.offset,
-                detail: token.attrs.src ?? ""
-              }
-            : {
-                reason: "executable_markup",
-                found: name,
-                offset: token.offset
-              }
-        );
+        rejections.push({
+          reason: "executable_markup",
+          found: name,
+          offset: token.offset
+        });
       }
       continue;
     }

--- a/src/modules/blog-content/domain/legacy-media-map.ts
+++ b/src/modules/blog-content/domain/legacy-media-map.ts
@@ -1,0 +1,139 @@
+/**
+ * The legacy image map: `<img src>` -> managed media object id (Issue #599).
+ *
+ * ## Why an operator has to supply this, rather than the import deriving it
+ *
+ * `legacy-html-conversion.ts` refuses a raw `<img>` because a managed-media
+ * deployment stores images as registry references, and an import that kept the
+ * `src` would smuggle unmanaged media past the enforcement `media_library`
+ * exists to apply. That refusal names the `src` — and until now that was where
+ * the trail ended, which for an archive of 23,906 CKEditor articles meant
+ * essentially every row was residue and nothing could be imported at all.
+ *
+ * The missing half is NOT "fetch the image and register it". That would mean
+ * the server pulling third-party bytes from an address somebody else chose — a
+ * server-side request forgery primitive — and then minting a `verified`
+ * registry row for bytes no upload pipeline ever inspected.
+ * `legacy-ad-ingest.ts` faced exactly this question for
+ * `awcms_blog_ads.image_url` and answered it at length: bytes are vouched for
+ * by the upload pipeline or not at all.
+ *
+ * So the missing half is a HANDOFF. `blog:legacy:import --images` reports the
+ * complete set of `src` values the archive references; the operator uploads
+ * them through the media library, which is the one path with validation, MIME
+ * sniffing and size caps; and this map hands the result back. Nothing here
+ * creates a media object, and nothing here decides one is safe — the importer
+ * asks the registry about every id before a single article is written.
+ *
+ * ## Why an unknown id must abort the run rather than be skipped
+ *
+ * `renderGalleryBlockHtml` silently drops a gallery item whose `mediaObjectId`
+ * resolves to nothing. A wrong id therefore produces an article that imported
+ * cleanly, reports no error, and has lost its photographs — visible only to a
+ * reader, on a page nobody re-checks. Refusing the whole run is the only
+ * outcome that cannot end there.
+ *
+ * Pure module: no database, no network.
+ */
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type LegacyMediaMapResult =
+  | { ok: true; value: ReadonlyMap<string, string> }
+  | { ok: false; errors: string[] };
+
+/** Every distinct media object id the map names, for one round trip to the registry. */
+export function mediaObjectIdsIn(
+  map: ReadonlyMap<string, string>
+): readonly string[] {
+  return [...new Set(map.values())];
+}
+
+/**
+ * Validates a parsed `--media-map` document.
+ *
+ * A flat `{ "<src>": "<uuid>" }` object, because that is what an operator can
+ * produce from a spreadsheet of uploads without a schema, and because the key
+ * is the exact string the archive's HTML contains — matching is literal on
+ * purpose. Normalising it (trimming a trailing slash, lower-casing a host,
+ * resolving a relative path) would silently rewrite what a `src` means, and the
+ * failure mode of a WRONG match here is the same as a missing one: photographs
+ * gone from a published article.
+ *
+ * Every problem is reported, not just the first: an operator fixing a
+ * 24,000-entry file one error per run is an operator who gives up.
+ */
+export function parseLegacyMediaMap(raw: unknown): LegacyMediaMapResult {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return {
+      ok: false,
+      errors: [
+        'the media map must be a JSON object of { "<img src>": "<media object uuid>" }'
+      ]
+    };
+  }
+
+  const errors: string[] = [];
+  const value = new Map<string, string>();
+
+  for (const [src, mediaObjectId] of Object.entries(
+    raw as Record<string, unknown>
+  )) {
+    if (src.trim().length === 0) {
+      errors.push("an entry has an empty `src` key");
+      continue;
+    }
+
+    if (
+      typeof mediaObjectId !== "string" ||
+      !UUID_PATTERN.test(mediaObjectId)
+    ) {
+      errors.push(
+        `"${src}" maps to ${JSON.stringify(mediaObjectId)}, which is not a media object uuid`
+      );
+      continue;
+    }
+
+    value.set(src, mediaObjectId);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, value };
+}
+
+export type LegacyImageUsage = {
+  src: string;
+  /** How many articles in the file reference it. */
+  articles: number;
+};
+
+/**
+ * The upload set: every `src` the archive references, most-used first.
+ *
+ * Built from the converter's own `unmanaged_image` rejections rather than by
+ * scanning the HTML again — a second scanner would be a second answer to "what
+ * counts as an image reference", and the two would drift exactly where it
+ * matters least visibly.
+ */
+export function summariseLegacyImageUsage(
+  srcsPerArticle: readonly (readonly string[])[]
+): LegacyImageUsage[] {
+  const counts = new Map<string, number>();
+
+  for (const srcs of srcsPerArticle) {
+    // One article referencing the same file twice is one article, not two —
+    // this is an upload list, and the count exists to order it.
+    for (const src of new Set(srcs)) {
+      if (src.trim().length === 0) continue;
+      counts.set(src, (counts.get(src) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([src, articles]) => ({ src, articles }))
+    .sort((a, b) => b.articles - a.articles || a.src.localeCompare(b.src));
+}

--- a/tests/blog-legacy-import.test.ts
+++ b/tests/blog-legacy-import.test.ts
@@ -189,10 +189,19 @@ describe("the importer preserves what makes the archive worth moving", () => {
 describe("the import script refuses rather than repairs", () => {
   test("a body with rejections is skipped, not stored sanitized", async () => {
     const source = stripComments(await readFile(IMPORT_SCRIPT, "utf8"));
-    const block = source.slice(
-      source.indexOf("convertLegacyHtmlToPortableText(record.value.bodyHtml)"),
-      source.indexOf("accepted.push(")
+    // No closing paren in the anchor: the call now carries a second argument
+    // (`resolveImage`, Issue #599). The `not.toBe(-1)` is the lesson from that
+    // — a missing anchor makes `slice` return something a `toContain` can still
+    // be run against, so the assertion has to prove it found the code first.
+    const start = source.indexOf(
+      "convertLegacyHtmlToPortableText(record.value.bodyHtml"
     );
+    const end = source.indexOf("accepted.push(");
+
+    expect(start).not.toBe(-1);
+    expect(end).toBeGreaterThan(start);
+
+    const block = source.slice(start, end);
 
     // The `continue` is the whole assertion: a rejected body never reaches
     // `accepted`, so it is never written with its images dropped.

--- a/tests/integration/legacy-import.integration.test.ts
+++ b/tests/integration/legacy-import.integration.test.ts
@@ -16,6 +16,8 @@
  *      and an import that re-dated the archive would look completely normal.
  *   3. The redirect map comes back LOCALE-PREFIXED (ADR-0098) and covers only
  *      published, non-deleted rows.
+ *   4. A mapped image is a REGISTRY question, not a uuid-shape one — see the
+ *      second suite at the bottom of this file.
  *
  * WORLD 1 (harness.ts) — the ephemeral migrated database, driven through the
  * application layer inside `withTenantOrThrow`.
@@ -43,6 +45,8 @@ import {
   importLegacyBlogPost
 } from "../../src/modules/blog-content/application/legacy-import-directory";
 import { listLegacyRedirectMappings } from "../../src/modules/blog-content/application/blog-post-directory";
+import { convertLegacyHtmlToPortableText } from "../../src/modules/blog-content/domain/legacy-html-conversion";
+import { mediaLibraryPortAdapter } from "../../src/modules/media-library/application/media-library-port-adapter";
 import type { LegacyPostImportInput } from "../../src/modules/blog-content/application/legacy-import-directory";
 
 const TENANT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
@@ -306,5 +310,160 @@ suite("legacy article import (integration, Issue #599)", () => {
 
     expect(map).toHaveLength(1);
     expect(map[0]!.targetPath).toBe("/id/blog/seputar/banjir-melanda-kobar");
+  });
+});
+
+/**
+ * The image handoff (Issue #599) — the half only a real database can answer.
+ *
+ * The pure half is in `tests/legacy-media-map.test.ts`. What matters here is
+ * that "verified media of THIS tenant" is decided by the registry and not by
+ * the map: an id that exists but belongs to somebody else, or exists and was
+ * never verified, must fail the same way a made-up one does. The consequence of
+ * getting that wrong is an article that imports cleanly and renders without its
+ * photographs, because `renderGalleryBlockHtml` drops what it cannot resolve.
+ */
+suite("legacy image mapping (integration, Issue #599)", () => {
+  const UPLOADER = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+  const OTHER_UPLOADER = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenants();
+  });
+
+  async function seedUploader(
+    tenantId: string,
+    userId: string,
+    label: string
+  ): Promise<void> {
+    const admin = getAdminSql();
+    const profile = (await admin`
+      INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+      VALUES (${tenantId}, 'person', 'Uploader')
+      RETURNING id
+    `) as { id: string }[];
+    const identity = (await admin`
+      INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${tenantId}, ${profile[0]!.id}, ${`${label}@example.test`}, 'x')
+      RETURNING id
+    `) as { id: string }[];
+    await admin`
+      INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+      VALUES (${userId}, ${tenantId}, ${identity[0]!.id})
+    `;
+  }
+
+  /**
+   * `module_key='news_portal'` and `storage_driver='cloudflare_r2'` are CHECK
+   * constraints (`sql/041`), and `object_key` is CHECK-constrained to
+   * `news-media/<tenant_id>/YYYY/MM/<uuid>.<ext>` against the row's OWN
+   * tenant_id — so a fixture cannot take a shortcut here, and a cross-tenant
+   * key is refused by the database rather than by application code.
+   */
+  async function seedMedia(
+    tenantId: string,
+    userId: string,
+    status: string
+  ): Promise<string> {
+    const objectKey = `news-media/${tenantId}/2026/08/${crypto.randomUUID()}.png`;
+    const rows = (await getAdminSql()`
+      INSERT INTO awcms_news_media_objects
+        (tenant_id, module_key, storage_driver, bucket_name, object_key,
+         public_url, mime_type, status, created_by_tenant_user_id)
+      VALUES (
+        ${tenantId}, 'news_portal', 'cloudflare_r2', 'bucket', ${objectKey},
+        'https://cdn.example.test/photo.png', 'image/png', ${status}, ${userId}
+      )
+      RETURNING id
+    `) as { id: string }[];
+
+    return rows[0]!.id;
+  }
+
+  test("a mapped image is stored as a gallery node the reader can resolve", async () => {
+    await seedUploader(TENANT, UPLOADER, "lentera");
+    const mediaId = await seedMedia(TENANT, UPLOADER, "verified");
+
+    const converted = convertLegacyHtmlToPortableText(
+      '<p>Air naik.</p><img src="http://legacy.example/banjir.jpg">',
+      { resolveImage: (src) => (src.endsWith("banjir.jpg") ? mediaId : null) }
+    );
+    expect(converted.ok).toBe(true);
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      importLegacyBlogPost(tx, TENANT, AUTHOR, SYSTEM, {
+        ...input(),
+        bodyPortableText: converted.document
+      })
+    );
+
+    const rows = (await getAdminSql()`
+      SELECT body_portable_text FROM awcms_blog_posts WHERE tenant_id = ${TENANT}
+    `) as { body_portable_text: unknown }[];
+
+    // An ARRAY, not the jsonb string Issue #641 was about — a gallery node that
+    // came back as text would make `hasCanonicalPortableTextBody` false and the
+    // article would render from the lossy projection, without the image.
+    const stored = rows[0]!.body_portable_text as unknown[];
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored[1]).toEqual({
+      _type: "gallery",
+      _key: "n1",
+      items: [{ mediaType: "image", mediaObjectId: mediaId }]
+    });
+
+    const safe = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      mediaLibraryPortAdapter.isMediaReferenceSafe(tx, TENANT, mediaId)
+    );
+    expect(safe).toBe(true);
+  });
+
+  test("the registry refuses another tenant's media, and unverified media", async () => {
+    await seedUploader(TENANT, UPLOADER, "lentera");
+    await seedUploader(OTHER_TENANT, OTHER_UPLOADER, "seputar");
+
+    const foreign = await seedMedia(OTHER_TENANT, OTHER_UPLOADER, "verified");
+    const unverified = await seedMedia(TENANT, UPLOADER, "uploaded");
+
+    const verdicts = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) => ({
+        // Exists, is verified, and belongs to somebody else. This is the check
+        // the importer makes before writing anything, and the reason it is a
+        // registry question rather than a "is it a uuid" question.
+        foreign: await mediaLibraryPortAdapter.isMediaReferenceSafe(
+          tx,
+          TENANT,
+          foreign
+        ),
+        // Exists, is ours, and stopped at `uploaded` — the bytes arrived and
+        // nothing has vouched for them, which is exactly the state
+        // `isMediaReferenceSafe` exists to distinguish from `verified`.
+        unverified: await mediaLibraryPortAdapter.isMediaReferenceSafe(
+          tx,
+          TENANT,
+          unverified
+        ),
+        invented: await mediaLibraryPortAdapter.isMediaReferenceSafe(
+          tx,
+          TENANT,
+          "ffffffff-ffff-4fff-8fff-ffffffffffff"
+        )
+      })
+    );
+
+    expect(verdicts).toEqual({
+      foreign: false,
+      unverified: false,
+      invented: false
+    });
   });
 });

--- a/tests/legacy-html-conversion.test.ts
+++ b/tests/legacy-html-conversion.test.ts
@@ -290,3 +290,124 @@ describe("entities decode exactly once", () => {
     expect(text).not.toContain("<script>");
   });
 });
+
+describe("a resolved image becomes a real image (Issue #599)", () => {
+  const MEDIA_ID = "11111111-1111-4111-8111-111111111111";
+  const OTHER_ID = "22222222-2222-4222-8222-222222222222";
+
+  const resolveImage = (src: string): string | null =>
+    src === "http://legacy.example/a.jpg"
+      ? MEDIA_ID
+      : src === "http://legacy.example/b.jpg"
+        ? OTHER_ID
+        : null;
+
+  test("without a resolver, nothing about `<img>` changed", () => {
+    // The default is the whole existing contract: an import that predates
+    // managed-media enforcement must not be able to walk past it.
+    const result = convertLegacyHtmlToPortableText(
+      '<p>Teks</p><img src="http://legacy.example/a.jpg">'
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.rejections[0]!.reason).toBe("unmanaged_image");
+    expect(result.rejections[0]!.detail).toBe("http://legacy.example/a.jpg");
+  });
+
+  test("a mapped `src` lands as a gallery node, in position", () => {
+    const result = convertLegacyHtmlToPortableText(
+      '<p>Sebelum</p><img src="http://legacy.example/a.jpg"><p>Sesudah</p>',
+      { resolveImage }
+    );
+
+    expect(result.ok).toBe(true);
+    expect(result.rejections).toEqual([]);
+    expect(result.document).toHaveLength(3);
+    expect(result.document[1]).toEqual({
+      _type: "gallery",
+      _key: "n1",
+      items: [{ mediaType: "image", mediaObjectId: MEDIA_ID }]
+    });
+    // The order is the article's order. A gallery collected at the end would
+    // read as a photo dump under an article that had photographs in it.
+    expect(textOf(result.document[0])).toContain("Sebelum");
+    expect(textOf(result.document[2])).toContain("Sesudah");
+  });
+
+  test("no caption is invented from `alt`", () => {
+    // `caption` renders as a VISIBLE `<figcaption>`, and a legacy alt is very
+    // often the file name — carrying it across would edit every article.
+    const result = convertLegacyHtmlToPortableText(
+      '<img src="http://legacy.example/a.jpg" alt="a.jpg">',
+      { resolveImage }
+    );
+
+    expect(result.document[0]).toEqual({
+      _type: "gallery",
+      _key: "n0",
+      items: [{ mediaType: "image", mediaObjectId: MEDIA_ID }]
+    });
+  });
+
+  test("consecutive images join ONE gallery, separated ones do not", () => {
+    const together = convertLegacyHtmlToPortableText(
+      '<img src="http://legacy.example/a.jpg"><img src="http://legacy.example/b.jpg">',
+      { resolveImage }
+    );
+
+    expect(together.document).toHaveLength(1);
+    expect((together.document[0] as { items: unknown[] }).items).toHaveLength(
+      2
+    );
+
+    const apart = convertLegacyHtmlToPortableText(
+      '<img src="http://legacy.example/a.jpg"><p>Antara</p><img src="http://legacy.example/b.jpg">',
+      { resolveImage }
+    );
+
+    expect(apart.document).toHaveLength(3);
+  });
+
+  test("an UNMAPPED image is still refused, alongside mapped ones", () => {
+    // Partial coverage must not import the article with a hole in it — that is
+    // the "looks imported, lost its photographs" outcome, arrived at from the
+    // other direction.
+    const result = convertLegacyHtmlToPortableText(
+      '<img src="http://legacy.example/a.jpg"><img src="http://legacy.example/missing.jpg">',
+      { resolveImage }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.rejections).toHaveLength(1);
+    expect(result.rejections[0]!.detail).toBe(
+      "http://legacy.example/missing.jpg"
+    );
+  });
+
+  test("a resolver cannot smuggle anything else past the gates", () => {
+    // The resolver answers ONE question. A `<script>` next to a mapped image is
+    // still a refusal, and the image is still converted for the preview.
+    const result = convertLegacyHtmlToPortableText(
+      '<img src="http://legacy.example/a.jpg"><script>steal()</script>',
+      { resolveImage }
+    );
+
+    expect(result.ok).toBe(false);
+    expect(result.rejections.map((r) => r.reason)).toContain(
+      "executable_markup"
+    );
+    expect(textOf(result.document)).not.toContain("steal");
+  });
+
+  test("the result is a VALID Portable Text document", () => {
+    // A gallery node this converter invents has to satisfy the same write-time
+    // validator the API applies, or the import fails one row at a time in a
+    // batch that already reported itself importable.
+    const result = convertLegacyHtmlToPortableText(
+      '<p>Teks</p><img src="http://legacy.example/a.jpg">',
+      { resolveImage }
+    );
+
+    expect(validatePortableTextDocument(result.document).valid).toBe(true);
+  });
+});

--- a/tests/legacy-media-map.test.ts
+++ b/tests/legacy-media-map.test.ts
@@ -1,0 +1,132 @@
+/**
+ * The legacy image handoff (Issue #599).
+ *
+ * ## What is at risk
+ *
+ * `renderGalleryBlockHtml` DROPS a gallery item whose media object does not
+ * resolve — silently, by design, because a public page must degrade rather than
+ * 500. That makes a wrong media object id the worst possible input to a bulk
+ * import: the run reports success, the article looks imported, and its
+ * photographs are gone. Nobody re-reads 23,906 articles.
+ *
+ * So the properties pinned here are about REFUSING, not about mapping:
+ *
+ * 1. A map that is not a flat `{ src: uuid }` object is refused as a whole.
+ * 2. Every problem in it is reported, not just the first.
+ * 3. `src` keys are matched LITERALLY — no trimming, no normalising — because
+ *    a wrong match and a missing one have the same consequence, and only one of
+ *    them is visible in a report.
+ *
+ * The registry check itself is not here: "is this a verified media object of
+ * this tenant" is `isMediaReferenceSafe`, which needs a database, and
+ * `tests/integration/legacy-import.integration.test.ts` is where that lives.
+ *
+ * Pure — no database.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  mediaObjectIdsIn,
+  parseLegacyMediaMap,
+  summariseLegacyImageUsage
+} from "../src/modules/blog-content/domain/legacy-media-map";
+
+const ID_A = "11111111-1111-4111-8111-111111111111";
+const ID_B = "22222222-2222-4222-8222-222222222222";
+
+describe("the map is refused as a whole, or accepted as a whole", () => {
+  test("a usable map parses", () => {
+    const result = parseLegacyMediaMap({
+      "http://legacy.example/a.jpg": ID_A,
+      "/uploads/b.png": ID_B
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.get("http://legacy.example/a.jpg")).toBe(ID_A);
+    expect(result.value.get("/uploads/b.png")).toBe(ID_B);
+  });
+
+  test("anything that is not a flat object is refused", () => {
+    for (const raw of [null, [], "x", 5, undefined]) {
+      expect(parseLegacyMediaMap(raw).ok).toBe(false);
+    }
+  });
+
+  test("a value that is not a media object uuid is refused, by name", () => {
+    const result = parseLegacyMediaMap({
+      "a.jpg": ID_A,
+      "b.jpg": "https://cdn.example/b.jpg",
+      "c.jpg": 42
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // BOTH, not just the first — an operator fixing a 24,000-entry file one
+    // error per run is an operator who gives up.
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors.join("\n")).toContain("b.jpg");
+    expect(result.errors.join("\n")).toContain("c.jpg");
+  });
+
+  test("one bad entry refuses the map even though the others are fine", () => {
+    // Partial acceptance would import the good rows and leave the rest as a
+    // second, forgotten run — with a live site half-migrated in between.
+    const result = parseLegacyMediaMap({ "a.jpg": ID_A, "b.jpg": "nope" });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("keys are matched literally", () => {
+    // Normalising a `src` — trimming a slash, lower-casing a host — would
+    // silently change which file an article points at. A miss is reported; a
+    // wrong match is not.
+    const result = parseLegacyMediaMap({ " a.jpg ": ID_A });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.has(" a.jpg ")).toBe(true);
+    expect(result.value.has("a.jpg")).toBe(false);
+  });
+
+  test("distinct ids are collected once, for one registry round trip", () => {
+    const result = parseLegacyMediaMap({
+      "a.jpg": ID_A,
+      "a-copy.jpg": ID_A,
+      "b.jpg": ID_B
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(mediaObjectIdsIn(result.value)).toEqual([ID_A, ID_B]);
+  });
+});
+
+describe("the upload set", () => {
+  test("counts ARTICLES, not tags, and orders by demand", () => {
+    const usage = summariseLegacyImageUsage([
+      ["a.jpg", "a.jpg", "b.jpg"],
+      ["a.jpg"],
+      ["c.jpg"]
+    ]);
+
+    // `a.jpg` twice in one article is one article: this is an upload list, and
+    // the count exists only to order it.
+    expect(usage).toEqual([
+      { src: "a.jpg", articles: 2 },
+      { src: "b.jpg", articles: 1 },
+      { src: "c.jpg", articles: 1 }
+    ]);
+  });
+
+  test("an `<img>` with no `src` contributes nothing", () => {
+    expect(summariseLegacyImageUsage([["", "  ", "a.jpg"]])).toEqual([
+      { src: "a.jpg", articles: 1 }
+    ]);
+  });
+
+  test("an archive with no images produces an empty set, not an error", () => {
+    expect(summariseLegacyImageUsage([])).toEqual([]);
+    expect(summariseLegacyImageUsage([[], []])).toEqual([]);
+  });
+});


### PR DESCRIPTION
Advances #599 (does not close it — see the bottom).

`bun run blog:legacy:import` landed in #640 and, run against a real CKEditor
archive, would have refused very nearly every row.

`convertLegacyHtmlToPortableText` rejects `<img>` — correctly, because a
managed-media deployment stores images as registry references and an import that
kept the raw `src` would smuggle unmanaged media past the enforcement
`media_library` exists to apply. The rejection names the `src` *"so the importer
can resolve it to an uploaded object first"*. Nothing implemented **first**. For
23,906 articles that meant a refusal log with ~24,000 entries and zero imported
posts.

## What was NOT built, and why that is the same answer as last time

Not a fetcher. Turning a legacy URL into a managed object means pulling
third-party bytes from the server at an address somebody else chose — a
server-side request forgery primitive — and then minting a `verified` registry
row for bytes no upload pipeline ever inspected. `legacy-ad-ingest.ts` faced
exactly this question for `awcms_blog_ads.image_url` and wrote the answer down
at length. The volume does not change it.

## What was built: the other half of the handoff

- **`--images=<path>`** writes the upload set — every distinct `<img src>` the
  archive references, counted by **article** and ordered by demand — and stops.
  Built from the converter's own findings rather than a second scan of the HTML,
  so there is one definition of "what counts as an image reference".
- **`--media-map=<path>`** takes the result back as `{ "<src>": "<uuid>" }`
  after the operator has uploaded through `/admin/media`. A mapped image becomes
  a one-item `gallery` node **in the position it occupied in the article**;
  consecutive images join one gallery, which is the common CKEditor photo-row
  shape.

Without `--media-map` nothing changes: `<img>` is residue exactly as before, and
an image the map does not cover still refuses its article rather than importing
it with a hole.

## The check that happens before anything is written

Every id in the map goes to the registry — `isMediaReferenceSafe`, so *exists,
belongs to this tenant, and is verified/attached* — and one that fails aborts the
whole run.

That is deliberate rather than defensive. `renderGalleryBlockHtml` silently drops
a gallery item whose media object does not resolve, because a public page must
degrade rather than 500. So a wrong id produces an article that imported cleanly,
reported no error, and has lost its photographs — visible only to a reader, on a
page nobody re-checks. It cannot be a per-row refusal either: a map is one
artefact, and a wrong id in it is a wrong artefact.

The cross-tenant and not-yet-verified cases are tested against real Postgres,
because "is this a uuid" and "is this our verified media" are different questions
and only the second is the right one. The integration test also asserts the
stored body comes back as an **array** rather than the jsonb string of #641 — a
gallery node that round-tripped as text would make `hasCanonicalPortableTextBody`
false and render the article from the lossy projection, without the image.

## One thing deliberately not carried across

No `caption`. The renderer prints `caption` as a visible `<figcaption>` (and
reuses it as the `alt`), while a legacy `alt` is very often the file name.
Carrying it would print a filename under 23,906 photographs — a silent edit to
every article in the archive, made by an import script.

## Why #599 stays open

Unchanged from #640: the remaining two scope items need artefacts that are not
in this repo — the real `.htaccess` (to enumerate the other legacy URL shapes,
which is a second `--path-template` **run**, not more code) and the live legacy
sitemap for the pre-cutover crawl.

## Verification

`DATABASE_URL="" bun run check` — green end to end (5,367 pass, 0 fail).
Integration suite run against a real PostgreSQL 18: the two new tests pass, and
the two unrelated failures that appear when the whole suite runs together on
this machine are present on `main` too (a `http:` vs `https:` origin difference
in the local environment, not code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)