### PR TITLE
chore(api): the site-identity endpoint joins the frozen consumer contract (#596)

### DIFF
--- a/.changeset/consumer-contract-site-profile.md
+++ b/.changeset/consumer-contract-site-profile.md
@@ -1,0 +1,36 @@
+---
+"awcms": patch
+---
+
+chore(api): the site-identity endpoint joins the frozen consumer contract (#596)
+
+`GET /api/v1/site-profile/composed` shipped in #616 so a build client could ask
+who a site is without editing frontend source. Nothing froze its shape, so a
+field renamed here would have been green in this repo's CI and broken
+`ahliweb/awcms-astro`'s build — a failure surfacing where the person who caused
+it is not looking, which is the whole reason
+`tests/fixtures/awcms-astro-consumer-contract.openapi.yaml` exists.
+
+**The order is the point.** That repo's Definition of Done says a new call
+"reddens [its contract gate] until `awcms` freezes its response shape", so the
+entry lands here **first** and the neighbour starts calling it second. Reversing
+the two would put a live build on a shape this repo has not agreed to keep.
+
+Which is why it enters as `COMMITTED_PATHS`, not `CONSUMED_PATHS`. Today nothing
+calls it, and that file is explicit that blurring the two is what once let three
+non-calls sit in this list labelled as calls. It moves to CONSUMED — with the
+count in `tests/api-consumer-contract.test.ts` going to four, matching the
+literal the neighbour's own gate pins — in the change that makes the call real.
+The frozen fixture is identical either way, because it freezes the union.
+
+The freeze walks the transitive `$ref` closure, so `SiteProfile` and
+`ComposedSiteIdentity` are frozen with the path — which is where the interesting
+breakages live (a field renamed, a nullable dropped), not in the four-line path
+object.
+
+Regenerating also folded in `institutionIds` on `BlogPost`/`BlogPostSummary`.
+That field landed in #595 and the fixture predates it; the check is
+additive-superset, so a stale fixture stayed green while silently protecting
+less than it appeared to. It is now frozen too, which is the correct state and
+not a second change — the fixture is the shape at its last deliberate
+regeneration, and this is one.

--- a/scripts/api-consumer-contract.ts
+++ b/scripts/api-consumer-contract.ts
@@ -52,9 +52,18 @@ const FIXTURE_PATH =
  * Surfaces `ahliweb/awcms-astro` CALLS today.
  *
  * The neighbour repo is the authority for this list, and it has a gate for it:
- * `tests/kontrak-awcms.test.mjs` there asserts "the source calls exactly three
- * surfaces", derived from `src/` **with comments stripped first**, and bound
- * two-ways to a marker block in its own skill.
+ * `tests/kontrak-awcms.test.mjs` there asserts an exact set of surfaces,
+ * derived from `src/` **with comments stripped first**, and bound two-ways to a
+ * marker block in its own skill. That count is written as a literal there, so a
+ * new surface reddens it even when the author remembered the skill.
+ *
+ * ## The order this list is edited in is load-bearing
+ *
+ * That repo's Definition of Done says a new call "reddens it until `awcms`
+ * freezes its response shape" — so an entry lands HERE first, and the neighbour
+ * starts calling it second. Reversing the two would put a build in that repo on
+ * a shape this repo has not agreed to keep, which is precisely the failure this
+ * fixture exists to move back to where it can be fixed.
  *
  * ## Why this list used to hold six, and why that was wrong
  *
@@ -101,6 +110,8 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
  * acquire the authority of a contract.
  */
 export const COMMITTED_PATHS: Readonly<Record<string, string>> = {
+  "/api/v1/site-profile/composed":
+    "ADR-0102 — who the site IS: masthead, footer, editorial address, contact details, social links, plus the `seo_distribution` half this endpoint merges in (#596). The neighbour's Definition of Done requires this repo to freeze the shape BEFORE it starts calling, so the entry is a promise today and moves to CONSUMED the moment `awcms-astro` renders from it.",
   "/api/v1/auth/session":
     "ADR-0049 — session introspection for the BFF of ADR-0050. The static build must NOT call it (it refuses machine credentials by design); the BFF that will is not built yet.",
   "/api/v1/access/machine-credentials":

--- a/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
+++ b/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
@@ -372,6 +372,35 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+  /api/v1/site-profile/composed:
+    get:
+      operationId: siteProfileComposedRead
+      tags:
+        - Site Profile
+      summary: Site identity for a build client, both halves in one answer
+      description: "Gated by `site_profile.profile.read`. ADR-0102 splits OWNERSHIP — `awcms_seo_tenant_settings` keeps what crawlers see (og:site_name, the JSON-LD Organization node, the default og:image) and `awcms_site_profile` owns what people read. That boundary is right for ownership and wrong for consumers, so the composition happens here, once, rather than in every build template that would otherwise have to call two endpoints and merge them — and drift when one of them forgot. `logoMediaId`/`faviconMediaId` are media object IDS, not URLs: a consumer resolves them through media_library exactly as it resolves an article image, which is what keeps managed-media enforcement meaningful."
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      responses:
+        "200":
+          description: Composed site identity.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    $ref: "#/components/schemas/ComposedSiteIdentity"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
 components:
   parameters:
     CorrelationId:
@@ -680,6 +709,12 @@ components:
           items:
             type: string
             format: uuid
+        institutionIds:
+          description: "Issue #595 — the fourth classification dimension (sql/131). Institution is a TABLE rather than a taxonomy type because it carries a branch, a region code and its own landing SEO, but on this payload it is the same shape as `termIds`. Full-replace semantics: absent leaves the assignments alone, `[]` removes them."
+          type: array
+          items:
+            type: string
+            format: uuid
     BlogPostSummary:
       type: object
       description: |
@@ -781,6 +816,12 @@ components:
           items:
             type: string
             format: uuid
+        institutionIds:
+          description: "Issue #595 — the fourth classification dimension (sql/131). Institution is a TABLE rather than a taxonomy type because it carries a branch, a region code and its own landing SEO, but on this payload it is the same shape as `termIds`. Full-replace semantics: absent leaves the assignments alone, `[]` removes them."
+          type: array
+          items:
+            type: string
+            format: uuid
         translationGroupId:
           type: string
           format: uuid
@@ -788,6 +829,26 @@ components:
         autoInternalTagLinksDisabled:
           type: boolean
           description: Per-post opt-out of automatic internal tag linking.
+    ComposedSiteIdentity:
+      description: Both halves of site identity in one answer. The four SEO-owned fields are named exactly as seo_distribution names them, so this is visibly a passthrough rather than a second definition that could drift.
+      allOf:
+        - $ref: "#/components/schemas/SiteProfile"
+        - type: object
+          properties:
+            siteName:
+              type: string
+              nullable: true
+            organizationName:
+              type: string
+              nullable: true
+            organizationLogoMediaId:
+              type: string
+              format: uuid
+              nullable: true
+            defaultSocialMediaId:
+              type: string
+              format: uuid
+              nullable: true
     IssueMachineCredentialRequest:
       type: object
       required:
@@ -1045,3 +1106,64 @@ components:
               scopeId:
                 type: string
                 format: uuid
+    SiteProfile:
+      type: object
+      properties:
+        tagline:
+          type: string
+          nullable: true
+          maxLength: 200
+        copyrightNotice:
+          type: string
+          nullable: true
+          maxLength: 300
+        logoMediaId:
+          type: string
+          format: uuid
+          nullable: true
+        faviconMediaId:
+          description: "Separate from the logo on purpose: a favicon is square, tiny and usually a different crop, and one field for both would force every tenant to accept whichever compromise the renderer picked."
+          type: string
+          format: uuid
+          nullable: true
+        editorialAddress:
+          description: Free text and multi-line on purpose — Indonesian addresses do not decompose into street/city/postcode reliably, and forcing them to would produce a form nobody can fill in correctly.
+          type: string
+          nullable: true
+          maxLength: 1000
+        contactEmail:
+          type: string
+          nullable: true
+          maxLength: 320
+        contactPhone:
+          type: string
+          nullable: true
+          maxLength: 50
+        whatsappNumber:
+          description: "Kept separate from contactPhone: a newsroom's WhatsApp tip line is frequently not its switchboard number."
+          type: string
+          nullable: true
+          maxLength: 50
+        socialLinks:
+          type: array
+          maxItems: 20
+          items:
+            $ref: "#/components/schemas/SocialProfileLink"
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+    SocialProfileLink:
+      type: object
+      required:
+        - platform
+        - url
+      properties:
+        platform:
+          description: A label, deliberately NOT an enumeration. Closing the set would mean a migration every time a newsroom joins a new network, and unlike a content block type nothing renders differently per value — an unknown platform degrades to a plain link.
+          type: string
+          maxLength: 40
+        url:
+          description: "Absolute http(s) only. REFUSED rather than sanitized otherwise: this is rendered as an <a href> on every public page, so a javascript:/data: value would be stored XSS with a very long reach."
+          type: string
+          maxLength: 500


### PR DESCRIPTION
Advances #596 — the awcms half of its last open DoD line ("`awcms-astro` reads it at build time").

`GET /api/v1/site-profile/composed` shipped in #616 so a build client could ask who a site is without editing frontend source. **Nothing froze its shape.** A field renamed here would have been green in this repo's CI and broken `ahliweb/awcms-astro`'s build — a failure surfacing where the person who caused it is not looking, which is the entire reason `tests/fixtures/awcms-astro-consumer-contract.openapi.yaml` exists.

## Why COMMITTED and not CONSUMED

That repo's Definition of Done is explicit: a new call *"reddens [its contract gate] until `awcms` freezes its response shape"*. So the shape is agreed **here first**, and the neighbour starts calling it second. Reversing the two would put a live build on a shape this repo has not committed to keep.

Today nothing calls it, so it is a promise, not a dependency — and `api-consumer-contract.ts` is emphatic that blurring those two is what once let three non-calls sit in `CONSUMED_PATHS` labelled as calls (a type docblock, a comment explaining why the build deliberately does *not* call `/auth/session`, and an error message telling a human how to mint a token). `COMMITTED_PATHS` requires an ADR, and ADR-0102 is the one that makes this promise.

It moves to `CONSUMED_PATHS` — with the count in `tests/api-consumer-contract.test.ts` going to four, matching the literal the neighbour's own gate pins — in the change that makes the call real. The frozen fixture is byte-identical either way, because it freezes the union.

## What actually got frozen

The freeze walks the transitive `$ref` closure, so `SiteProfile` and `ComposedSiteIdentity` come with the path. That is where the interesting breakages live — a field renamed, a nullable dropped — not in the four-line path object.

Regenerating also folded in `institutionIds` on `BlogPost`/`BlogPostSummary`. That field landed in #595 and the fixture predates it; the check is additive-superset, so the stale fixture stayed green while silently protecting less than it appeared to. It is now frozen too — the fixture is the shape at its last deliberate regeneration, and this is one.

## Verification

`DATABASE_URL="" bun run check` — green end to end (5,367 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)