### PR TITLE
chore(api): the site-identity endpoint is now CONSUMED, not merely promised (#596)

### DIFF
--- a/.changeset/site-profile-now-consumed.md
+++ b/.changeset/site-profile-now-consumed.md
@@ -1,0 +1,21 @@
+---
+"awcms": patch
+---
+
+chore(api): the site-identity endpoint is now CONSUMED, not merely promised (#596)
+
+`ahliweb/awcms-astro#61` landed, so `GET /api/v1/site-profile/composed` is no
+longer a shape this repo promised to keep for a caller that did not exist — it
+is the shape a live build renders its masthead, favicon, footer, contact block,
+social links and `Organization` node from.
+
+The entry moves from `COMMITTED_PATHS` to `CONSUMED_PATHS` and the pinned count
+goes to four, matching the literal the neighbour's own gate asserts against its
+source. The frozen fixture does not change, because it freezes the union.
+
+That the move happens at all is the point. `api-consumer-contract.ts` keeps the
+two lists apart because a promise and a dependency deserve the same stability
+and fail differently — breaking a consumed path breaks a build that exists
+today. A distinction nothing ever acts on decays into a label, which is how
+three non-calls once sat in `CONSUMED_PATHS` describing calls that never
+happened.

--- a/scripts/api-consumer-contract.ts
+++ b/scripts/api-consumer-contract.ts
@@ -92,7 +92,9 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
   "/api/v1/media/objects":
     "batch image resolution for a built page (#318). `src/lib/awcms/media.ts`, `src/lib/article-images.ts`.",
   "/api/v1/media/public-origin":
-    "the media origin the build must name in `img-src` BEFORE pulling a single object (#370). `scripts/asal-media.mjs`."
+    "the media origin the build must name in `img-src` BEFORE pulling a single object (#370). `scripts/asal-media.mjs`.",
+  "/api/v1/site-profile/composed":
+    "who the site IS — masthead, favicon, footer, editorial address, contact details, social links, and the `Organization` node, plus the `seo_distribution` half this endpoint merges in (#596, ADR-0102). `src/lib/awcms/profil.ts` there. Promised as COMMITTED in #645 and moved here when `ahliweb/awcms-astro#61` made the call real."
 };
 
 /**
@@ -110,8 +112,6 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
  * acquire the authority of a contract.
  */
 export const COMMITTED_PATHS: Readonly<Record<string, string>> = {
-  "/api/v1/site-profile/composed":
-    "ADR-0102 — who the site IS: masthead, footer, editorial address, contact details, social links, plus the `seo_distribution` half this endpoint merges in (#596). The neighbour's Definition of Done requires this repo to freeze the shape BEFORE it starts calling, so the entry is a promise today and moves to CONSUMED the moment `awcms-astro` renders from it.",
   "/api/v1/auth/session":
     "ADR-0049 — session introspection for the BFF of ADR-0050. The static build must NOT call it (it refuses machine credentials by design); the BFF that will is not built yet.",
   "/api/v1/access/machine-credentials":

--- a/tests/api-consumer-contract.test.ts
+++ b/tests/api-consumer-contract.test.ts
@@ -186,16 +186,24 @@ describe("the live contract", () => {
  * a fourth consumed surface here has to be a deliberate edit in both places.
  */
 describe("consumed vs committed", () => {
-  test("exactly three surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
+  test("exactly four surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
     // If this fails, one of two things happened, and they need opposite fixes:
     //   - awcms-astro started (or stopped) calling a surface -> update both
     //     this list and the marker block in that repo, in the same change;
     //   - someone added a surface here that nobody calls -> it belongs in
     //     COMMITTED_PATHS with the ADR that promises it, or nowhere.
+    //
+    // The fourth arrived by exactly the route this split exists to make
+    // possible: `/api/v1/site-profile/composed` was frozen as COMMITTED in
+    // #645, BEFORE anything called it, and moved here once
+    // `ahliweb/awcms-astro#61` made the call real. A promise and a dependency
+    // both deserve stability and fail differently, and the distinction only
+    // survives if entries actually move.
     expect(Object.keys(CONSUMED_PATHS)).toEqual([
       "/api/v1/blog/posts",
       "/api/v1/media/objects",
-      "/api/v1/media/public-origin"
+      "/api/v1/media/public-origin",
+      "/api/v1/site-profile/composed"
     ]);
   });
 


### PR DESCRIPTION
Completes #596. Third and last step of the cross-repo landing.

[`ahliweb/awcms-astro#61`](https://github.com/ahliweb/awcms-astro/pull/61) merged, so `GET /api/v1/site-profile/composed` is no longer a shape this repo promised to keep for a caller that did not exist — it is what a live build renders its masthead, favicon, footer, contact block, social links and `Organization` node from.

The entry moves from `COMMITTED_PATHS` to `CONSUMED_PATHS`, and the pinned count goes to **four** — the same literal the neighbour's own gate asserts against its source, in both directions, against the marked table in its integration skill. The frozen fixture does not change: it freezes the union.

## Why the move is worth its own change

`api-consumer-contract.ts` keeps the two lists apart because a promise and a dependency deserve the same stability and fail differently — breaking a consumed path breaks a build that exists *today*; breaking a committed one breaks a design that has been agreed and not yet built.

A distinction nothing ever acts on decays into a label. That is not hypothetical here: three non-calls once sat in `CONSUMED_PATHS` describing calls that never happened (a type docblock, a comment explaining why the build deliberately does *not* call `/auth/session`, and an error message telling a human how to mint a token). Entries that never move are how a list gets back to that state.

## The full sequence, for the record

1. **#645** — freeze the shape as `COMMITTED`, citing ADR-0102. Nothing calls it.
2. **awcms-astro#61** — the template starts calling it; its own gate goes from three surfaces to four, and the marked skill tables follow in both languages.
3. **this PR** — `COMMITTED` → `CONSUMED`, count → four.

That order is what the neighbour's Definition of Done requires, and the reverse would have put a live build on a shape this repo had not agreed to keep.

## Verification

`DATABASE_URL="" bun run check` — green end to end (5,367 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)