### PR TITLE
feat(blog-content): the tag vocabulary can finally be read past its hundredth entry (#597)

### DIFF
--- a/.changeset/terms-list-becomes-traversable.md
+++ b/.changeset/terms-list-becomes-traversable.md
@@ -1,0 +1,40 @@
+---
+"awcms": patch
+---
+
+feat(blog-content): the tag vocabulary can finally be read past its hundredth entry
+
+`GET /api/v1/blog/terms` ended in a bounded `LIMIT`, ordered by name, and
+returned a bare array. Nothing in that answer distinguishes "this tenant has
+ninety tags" from "this tenant has three thousand tags and you are holding the
+alphabetically-first hundred". There was no cursor, no total, no flag — the
+only honest reading of a full page was "there may or may not be more, ask
+somebody".
+
+For `category` and `channel` the bound was right and stays right: a newsroom
+has a dozen of each, and the endpoint's own comment called terms
+"low-cardinality config". For `tag` it was never right. A tag vocabulary grown
+over the 23,906-article archive of Issue #599 runs to thousands of entries, and
+a static build generating one archive page per tag would build a hundred pages,
+green, with every article filed under a later tag linking into a page nobody
+generated. The failure is invisible from both ends: the server answered every
+question it was asked, and the client got well-formed data.
+
+`?order=created_at` now selects a stable keyset traversal and the response
+carries `nextCursor`; follow it until it is null. `?limit=` is accepted (default
+100, max 200). `?cursor=` without `?order=created_at` is refused with `400`
+rather than quietly honoured, because `name` is editable: renaming a term moves
+it across a page boundary, so a cursor over the alphabetical ordering skips or
+repeats terms and neither side can tell. That is the same refusal, for the same
+reason, that `GET /api/v1/blog/posts` already makes about `updated_at`.
+
+The default list is deliberately unchanged — the admin taxonomy screen wants
+names in alphabetical order, and a screen showing a page is not lying about
+anything. What changed is that a caller which needs the whole vocabulary now has
+a way to say so, and a way to know when it has it.
+
+`tests/integration/blog-term-cursor.integration.test.ts` asserts the traversal
+against a real PostgreSQL over rows inserted by a single statement — sharing a
+`created_at` to the microsecond, the shape that reduced page two to zero rows
+before Issue #158 — and also asserts the default list's truncation head-on,
+because that behaviour is still there and is the reason any of this was needed.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -6829,14 +6829,21 @@ Gated by blog_content.templates.configure.
 - **operationId**: `blogListTerms`
 - **Security**: bearerAuth + tenantHeader
 
-Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter.
+Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter, ?limit= bounded (default 100, max 200).
+
+Ordering defaults to `name ASC` — right for the admin taxonomy screen, and unsound as a keyset key because renaming a term moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY term passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
+
+**The default list is bounded and says nothing about what it left out.** For `category` or `channel` that is harmless — a newsroom has a dozen of each. For `tag` it is not: a vocabulary grown over tens of thousands of articles runs to thousands of entries, and a caller that generated one archive page per tag from the default list would build a hundred pages, `200 OK`, with every article filed under a later tag pointing at a page nobody generated. That is what `order=created_at` exists for.
 
 **Parameters**
 
-| Name               | In     | Required | Type                                        | Description |
-| ------------------ | ------ | -------- | ------------------------------------------- | ----------- |
-| `taxonomyType`     | query  | no       | enum(`category`, `tag`, `channel`, `topic`) |             |
-| `X-Correlation-ID` | header | no       | string                                      |             |
+| Name               | In     | Required | Type                                        | Description                                                                                                                                          |
+| ------------------ | ------ | -------- | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `taxonomyType`     | query  | no       | enum(`category`, `tag`, `channel`, `topic`) |                                                                                                                                                      |
+| `limit`            | query  | no       | integer                                     |                                                                                                                                                      |
+| `order`            | query  | no       | enum(`created_at`, `name`)                  | Sort key. `created_at` selects the STABLE, cursor-capable traversal; `name` (default) is the admin ordering and rejects `cursor`.                    |
+| `cursor`           | query  | no       | string                                      | Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor". |
+| `X-Correlation-ID` | header | no       | string                                      |                                                                                                                                                      |
 
 **Responses**
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 431   |
+| Test files                          | 433   |
 | Route files                         | 382   |
 | ADR                                 | 208   |
 
@@ -352,9 +352,9 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 372        |
+| `(root)`      | 373        |
 | `e2e`         | 12         |
-| `integration` | 46         |
+| `integration` | 47         |
 | `unit`        | 1          |
 
 ### Routes

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -6155,7 +6155,12 @@ paths:
         - Blog Content
       operationId: blogListTerms
       summary: List this tenant's categories/tags
-      description: Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter.
+      description: |
+        Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter, ?limit= bounded (default 100, max 200).
+
+        Ordering defaults to `name ASC` — right for the admin taxonomy screen, and unsound as a keyset key because renaming a term moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY term passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
+
+        **The default list is bounded and says nothing about what it left out.** For `category` or `channel` that is harmless — a newsroom has a dozen of each. For `tag` it is not: a vocabulary grown over tens of thousands of articles runs to thousands of entries, and a caller that generated one archive page per tag from the default list would build a hundred pages, `200 OK`, with every article filed under a later tag pointing at a page nobody generated. That is what `order=created_at` exists for.
       parameters:
         - name: taxonomyType
           in: query
@@ -6166,6 +6171,25 @@ paths:
               - tag
               - channel
               - topic
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - name: order
+          in: query
+          description: Sort key. `created_at` selects the STABLE, cursor-capable traversal; `name` (default) is the admin ordering and rejects `cursor`.
+          schema:
+            type: string
+            enum:
+              - created_at
+              - name
+        - name: cursor
+          in: query
+          description: Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor".
+          schema:
+            type: string
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -6186,6 +6210,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/BlogTerm"
+                      nextCursor:
+                        type: string
+                        nullable: true
+                        description: Present only with `order=created_at`. Null once the traversal is complete.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -1368,13 +1368,35 @@ paths:
         - Blog Content
       operationId: blogListTerms
       summary: List this tenant's categories/tags
-      description: Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter.
+      description: |
+        Gated by blog_content.taxonomies.read. Optional ?taxonomyType= filter, ?limit= bounded (default 100, max 200).
+
+        Ordering defaults to `name ASC` — right for the admin taxonomy screen, and unsound as a keyset key because renaming a term moves it, so a row can cross a page boundary between requests and be skipped or repeated. A caller that needs EVERY term passes `?order=created_at`, which is immutable, and follows `nextCursor` until it is null. `?cursor=` without `?order=created_at` is refused with 400 rather than quietly honoured.
+
+        **The default list is bounded and says nothing about what it left out.** For `category` or `channel` that is harmless — a newsroom has a dozen of each. For `tag` it is not: a vocabulary grown over tens of thousands of articles runs to thousands of entries, and a caller that generated one archive page per tag from the default list would build a hundred pages, `200 OK`, with every article filed under a later tag pointing at a page nobody generated. That is what `order=created_at` exists for.
       parameters:
         - name: taxonomyType
           in: query
           schema:
             type: string
             enum: [category, tag, channel, topic]
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - name: order
+          in: query
+          description: Sort key. `created_at` selects the STABLE, cursor-capable traversal; `name` (default) is the admin ordering and rejects `cursor`.
+          schema:
+            type: string
+            enum: [created_at, name]
+        - name: cursor
+          in: query
+          description: Opaque keyset cursor from a previous response's `nextCursor`. Requires `order=created_at`. A malformed value is a 400, never treated as "no cursor".
+          schema:
+            type: string
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -1394,6 +1416,10 @@ paths:
                         type: array
                         items:
                           $ref: "#/components/schemas/BlogTerm"
+                      nextCursor:
+                        type: string
+                        nullable: true
+                        description: Present only with `order=created_at`. Null once the traversal is complete.
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":

--- a/src/modules/blog-content/README.id.md
+++ b/src/modules/blog-content/README.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](README.md)
 
-<!-- i18n-source-hash: sha256:103b468786721f3b27d5d9863ea7a8cae52d4fc9b622051b63119c074d753812 -->
+<!-- i18n-source-hash: sha256:433ad79d259b1ac49e5bffde87cd6b63de489bd869af9518468fdafbca7252a2 -->
 
 # Blog Content
 
@@ -173,6 +173,12 @@ DELETE /api/v1/blog/terms/{id}     -> blog_content.taxonomies.configure
 ```
 
 Satu permission (`configure`) menggerbangi create/update/delete sekaligus — sama seperti `sync_storage.conflict_resolution.approve` menggerbangi seluruh `POST /sync/conflicts/{id}/resolve` apa pun hasilnya (permission = kapabilitas "mengelola taksonomi", bukan per-aksi terpisah). Tidak ada restore/purge — doc issue #537's permission seed tidak punya `taxonomies.restore`/`.purge`, jadi soft-delete term bersifat satu arah lewat kode ini (baris tetap ada di DB untuk audit, tapi tidak ada jalur API mengembalikannya).
+
+### `?order=created_at` — membaca SELURUH kosakata (Issue #597)
+
+List default-nya `name ASC` dengan `LIMIT` berbatas (100, maks 200 lewat `?limit=`) — persis yang diinginkan layar taksonomi admin, dan persis yang membuat endpoint ini tak terpakai untuk hal lain. Sebuah array telanjang tidak membawa field apa pun yang bisa berkata "masih ada lagi", jadi pemanggil yang butuh setiap term menerima seratus pertama menurut abjad dan tidak punya cara mengetahuinya. Untuk `category` atau `channel` itu tak berbahaya — sebuah redaksi punya belasan. Untuk `tag` pada arsip 23.906 artikel di Issue #599 artinya build statis membangkitkan seratus halaman tag dari ribuan, `200 OK`, dan setiap artikel yang berada di tag berabjad belakang menaut ke halaman yang tak pernah dibangkitkan siapa pun.
+
+`?order=created_at` memilih traversal stabil dan responsnya mendapat `nextCursor`; ikuti sampai `null`. `?cursor=` tanpa `?order=created_at` adalah `400`, karena `name` dapat disunting dan penggantian nama memindahkan term melintasi batas halaman — penalaran yang sama persis dicatat `GET /api/v1/blog/posts` untuk `updated_at`. `listBlogTermsPage` (`application/blog-taxonomy-directory.ts`) adalah query-nya; `domain/blog-term-list-query.ts` permukaan penolakannya, dan `tests/integration/blog-term-cursor.integration.test.ts` menegakkan traversal MAUPUN pemotongan senyap list default terhadap PostgreSQL nyata.
 
 `PATCH` yang mengubah `taxonomyType` ke `tag` sambil `parentId` lama masih ada (tidak ikut dikosongkan di request yang sama) ditolak `400` — endpoint menggabungkan field yang dikirim dengan baris existing sebelum memanggil ulang `validateTermParent`, persis dicatat di `blog-term-validation.ts`'s docblock.
 

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -172,6 +172,12 @@ DELETE /api/v1/blog/terms/{id}     -> blog_content.taxonomies.configure
 
 One permission (`configure`) gates create/update/delete at once — just as `sync_storage.conflict_resolution.approve` gates the whole of `POST /sync/conflicts/{id}/resolve` whatever the outcome (the permission is the capability "manage taxonomies", not a separate per-action one). There is no restore/purge — the issue #537 doc's permission seed has no `taxonomies.restore`/`.purge`, so a term soft-delete is one-way through this code (the row stays in the DB for audit, but no API path brings it back).
 
+### `?order=created_at` — reading the WHOLE vocabulary (Issue #597)
+
+The list defaults to `name ASC` with a bounded `LIMIT` (100, max 200 via `?limit=`), which is what the admin taxonomy screen wants and what made the endpoint unusable for anything else. A bare array carries no field that could say "there are more", so a caller that needed every term received the alphabetically-first hundred and had no way to find out. For `category` or `channel` that is harmless — a newsroom has a dozen of each. For `tag` on the 23,906-article archive of Issue #599 it means a static build generating a hundred tag pages out of thousands, `200 OK`, with every article filed under a later tag linking into a page nobody generated.
+
+`?order=created_at` selects the stable traversal and the response gains `nextCursor`; follow it until it is null. `?cursor=` without `?order=created_at` is a `400`, because `name` is editable and a rename moves a term across a page boundary — the identical reasoning `GET /api/v1/blog/posts` records for `updated_at`. `listBlogTermsPage` (`application/blog-taxonomy-directory.ts`) is the query; `domain/blog-term-list-query.ts` is the refusal surface, and `tests/integration/blog-term-cursor.integration.test.ts` asserts both the traversal and the default list's silent truncation against a real PostgreSQL.
+
 A `PATCH` that changes `taxonomyType` to `tag` while the old `parentId` is still there (not cleared in the same request) is rejected with `400` — the endpoint merges the submitted fields with the existing row before calling `validateTermParent` again, exactly as recorded in `blog-term-validation.ts`'s docblock.
 
 ## Post-term relation handling (Issue #539)

--- a/src/modules/blog-content/application/blog-taxonomy-directory.ts
+++ b/src/modules/blog-content/application/blog-taxonomy-directory.ts
@@ -3,6 +3,11 @@ import type {
   CreateBlogTermInput,
   UpdateBlogTermInput
 } from "../domain/blog-term-validation";
+import { boundedPageSize } from "../../_shared/offset-pagination";
+import {
+  encodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
 
 /**
  * Read/write query module for `awcms_blog_terms` and
@@ -95,14 +100,32 @@ export async function fetchBlogTermById(
 
 export type ListBlogTermsFilter = {
   taxonomyType?: TaxonomyType;
+  limit?: number;
 };
 
-/** `LIMIT 100`, name ascending — terms are low-cardinality config, same bounded-list convention as email templates. */
+export const DEFAULT_TERM_LIST_LIMIT = 100;
+export const MAX_TERM_LIST_LIMIT = 200;
+
+/**
+ * The admin taxonomy screen's list: name ascending, bounded, no cursor.
+ *
+ * Alphabetical order is what a human scanning a table wants, and it is
+ * precisely what makes this unsuitable for a caller that needs EVERY term —
+ * a name is editable, so it cannot key a cursor, and the bound then truncates
+ * in the one direction nobody notices. {@link listBlogTermsPage} is the
+ * traversal; this stays as it was for the screens that only ever want a page.
+ */
 export async function listBlogTerms(
   tx: Bun.SQL,
   tenantId: string,
   filter: ListBlogTermsFilter = {}
 ): Promise<BlogTermView[]> {
+  const limit = boundedPageSize(
+    filter.limit,
+    DEFAULT_TERM_LIST_LIMIT,
+    MAX_TERM_LIST_LIMIT
+  );
+
   const rows = (await tx`
     SELECT id, tenant_id, taxonomy_type, parent_id, name, slug, description,
       created_at, updated_at, deleted_at, deleted_by, delete_reason
@@ -110,10 +133,72 @@ export async function listBlogTerms(
     WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
       AND (${filter.taxonomyType ?? null}::text IS NULL OR taxonomy_type = ${filter.taxonomyType ?? null})
     ORDER BY name ASC
-    LIMIT 100
+    LIMIT ${limit}
   `) as BlogTermRow[];
 
   return rows.map(toView);
+}
+
+/**
+ * The same list as a stable traversal — `created_at DESC, id DESC`, with a
+ * cursor, so a caller can walk to the end and know it got there.
+ *
+ * ## Why the alphabetical list was not enough
+ *
+ * `listBlogTerms` answers a tenant with three thousand tags by returning the
+ * alphabetically-first hundred and saying nothing about the rest. Nothing
+ * fails: the caller gets `200`, a well-formed array, and a vocabulary that is
+ * silently missing everything past roughly the letter B. A static build that
+ * generates one archive page per tag then generates a hundred pages, and every
+ * article filed under a later tag links to a page that was never built.
+ *
+ * Ordering by `created_at` rather than `name` is not a preference. A term can
+ * be renamed at any time, and a rename moves it across a page boundary — so a
+ * cursor over `name` skips or repeats terms and neither side can tell.
+ * `created_at` is immutable, which is the whole reason it is the key here and
+ * in `listBlogPostsPage`.
+ */
+export async function listBlogTermsPage(
+  tx: Bun.SQL,
+  tenantId: string,
+  options: {
+    taxonomyType?: TaxonomyType;
+    limit?: number;
+    cursor?: KeysetCursor | null;
+  } = {}
+): Promise<{ items: BlogTermView[]; nextCursor: string | null }> {
+  const limit = boundedPageSize(
+    options.limit,
+    DEFAULT_TERM_LIST_LIMIT,
+    MAX_TERM_LIST_LIMIT
+  );
+
+  const cursorCreatedAt = options.cursor?.createdAt ?? null;
+  const cursorId = options.cursor?.id ?? null;
+  const taxonomyType = options.taxonomyType ?? null;
+
+  const rows = (await tx`
+    SELECT id, tenant_id, taxonomy_type, parent_id, name, slug, description,
+      created_at, updated_at, deleted_at, deleted_by, delete_reason,
+      to_char(created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"+00:00"') AS created_at_cursor
+    FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
+      AND (${taxonomyType}::text IS NULL OR taxonomy_type = ${taxonomyType})
+      AND (
+        ${cursorCreatedAt}::timestamptz IS NULL
+        OR (created_at, id) < (${cursorCreatedAt}::timestamptz, ${cursorId}::uuid)
+      )
+    ORDER BY created_at DESC, id DESC
+    LIMIT ${limit}
+  `) as (BlogTermRow & { created_at_cursor: string })[];
+
+  const last = rows[rows.length - 1];
+  const nextCursor =
+    rows.length === limit && last
+      ? encodeKeysetCursor(last.created_at_cursor, last.id)
+      : null;
+
+  return { items: rows.map(toView), nextCursor };
 }
 
 /** Thin convenience wrapper kept for the pre-#539 call shape (Issue #537). */

--- a/src/modules/blog-content/domain/blog-term-list-query.ts
+++ b/src/modules/blog-content/domain/blog-term-list-query.ts
@@ -1,0 +1,115 @@
+/**
+ * Parses and validates the query string of `GET /api/v1/blog/terms`.
+ *
+ * ## Why this endpoint grew a traversal
+ *
+ * `listBlogTerms` has always ended in `LIMIT 100`, ordered by name, and its
+ * own comment justified that as "terms are low-cardinality config, same
+ * bounded-list convention as email templates". For `category` and `channel`
+ * that is true — a newsroom has a dozen of each, and always will.
+ *
+ * For `tag` it is not true and never was. The archive this repo is being made
+ * ready for is 23,906 articles (Issue #599), and a tag vocabulary grown over
+ * that many articles runs to thousands of entries. The endpoint answered such
+ * a tenant with the alphabetically-first hundred, `200 OK`, and no indication
+ * that anything had been left out — so a caller building a page per tag builds
+ * a hundred pages, and every article filed under a tag later in the alphabet
+ * points at a page nobody generated.
+ *
+ * That is the shape of failure this module exists to end, and the fix is the
+ * one `GET /api/v1/blog/posts` already established: an explicit
+ * `?order=created_at` traversal with an opaque cursor, so a caller that needs
+ * EVERY term can walk to the end and know when it has arrived.
+ *
+ * ## Why the default ordering is still by name, and why a cursor is refused there
+ *
+ * The admin taxonomy screen wants names in alphabetical order; a build wants
+ * completeness. Those are different requests and this endpoint now serves
+ * both, but only one of them can carry a cursor: `name` is editable, so a term
+ * renamed between two requests moves across the page boundary and is either
+ * skipped or returned twice, with nothing able to detect it. `created_at` is
+ * immutable, which is what makes it the only sound key — the identical
+ * reasoning `blog-post-list-query.ts` records for `updated_at`.
+ *
+ * Passing `?cursor=` without `?order=created_at` is therefore refused outright
+ * rather than quietly honoured. A caller that silently paginates over a
+ * mutable ordering does not find out; it just publishes a site that is missing
+ * some tags.
+ */
+import {
+  decodeKeysetCursor,
+  type KeysetCursor
+} from "../../_shared/keyset-pagination";
+import {
+  isTaxonomyType,
+  TAXONOMY_TYPE_LIST,
+  type TaxonomyType
+} from "./taxonomy-policy";
+
+export type BlogTermListQuery = {
+  taxonomyType?: TaxonomyType;
+  limit?: number;
+  /** True only for `order=created_at` — the sole ordering a cursor is sound over. */
+  stableOrder: boolean;
+  cursor: KeysetCursor | null;
+};
+
+export type BlogTermListQueryResult =
+  { valid: true; value: BlogTermListQuery } | { valid: false; message: string };
+
+export function parseBlogTermListQuery(
+  params: URLSearchParams
+): BlogTermListQueryResult {
+  const taxonomyTypeParam = params.get("taxonomyType");
+  let taxonomyType: TaxonomyType | undefined;
+
+  if (taxonomyTypeParam !== null) {
+    if (!isTaxonomyType(taxonomyTypeParam)) {
+      return {
+        valid: false,
+        message: `taxonomyType must be one of ${TAXONOMY_TYPE_LIST}.`
+      };
+    }
+
+    taxonomyType = taxonomyTypeParam;
+  }
+
+  const limitParam = params.get("limit");
+  const limit = limitParam ? Number(limitParam) : undefined;
+
+  if (
+    limitParam !== null &&
+    (!Number.isFinite(limit) || (limit as number) < 1)
+  ) {
+    return { valid: false, message: "limit must be a positive number." };
+  }
+
+  const orderParam = params.get("order");
+
+  if (
+    orderParam !== null &&
+    orderParam !== "created_at" &&
+    orderParam !== "name"
+  ) {
+    return { valid: false, message: "order must be one of created_at, name." };
+  }
+
+  const stableOrder = orderParam === "created_at";
+  const cursorParam = params.get("cursor");
+
+  if (cursorParam !== null && !stableOrder) {
+    return {
+      valid: false,
+      message:
+        "cursor requires order=created_at — a term can be renamed, so a cursor over the name ordering can skip or repeat terms."
+    };
+  }
+
+  const cursor = cursorParam ? decodeKeysetCursor(cursorParam) : null;
+
+  if (cursorParam !== null && cursor === null) {
+    return { valid: false, message: "cursor is malformed." };
+  }
+
+  return { valid: true, value: { taxonomyType, limit, stableOrder, cursor } };
+}

--- a/src/pages/api/v1/blog/terms/index.ts
+++ b/src/pages/api/v1/blog/terms/index.ts
@@ -17,13 +17,11 @@ import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   createBlogTerm,
-  listBlogTerms
+  listBlogTerms,
+  listBlogTermsPage
 } from "../../../../../modules/blog-content/application/blog-taxonomy-directory";
 import { validateCreateBlogTermInput } from "../../../../../modules/blog-content/domain/blog-term-validation";
-import {
-  isTaxonomyType,
-  TAXONOMY_TYPE_LIST
-} from "../../../../../modules/blog-content/domain/taxonomy-policy";
+import { parseBlogTermListQuery } from "../../../../../modules/blog-content/domain/blog-term-list-query";
 
 const READ_GUARD = {
   moduleKey: "blog_content",
@@ -37,7 +35,28 @@ const CONFIGURE_GUARD = {
   action: "configure" as const
 };
 
-/** `GET /api/v1/blog/terms` (Issue #539) — list this tenant's non-deleted categories/tags, `?taxonomyType=` optional filter. */
+/**
+ * `GET /api/v1/blog/terms` (Issue #539) — list this tenant's non-deleted
+ * vocabularies. `?taxonomyType=` optional filter, `?limit=` bounded
+ * (default 100, max 200).
+ *
+ * ## `?order=created_at` and `?cursor=` — a stable traversal (Issue #597)
+ *
+ * The default ordering is `name ASC`: right for the admin taxonomy screen,
+ * and unsound as a keyset key, because renaming a term moves it and a row can
+ * cross the page boundary between two requests — skipped, or returned twice,
+ * with nothing able to detect it.
+ *
+ * Until this existed there was no second option, so a caller that needed EVERY
+ * term got the alphabetically-first hundred and no signal that more existed.
+ * For `category` that is harmless; for `tag` on the 23,906-article archive of
+ * Issue #599 it means a site that builds a hundred tag pages out of thousands,
+ * green, with every article filed under a later tag linking into a 404.
+ *
+ * So a caller that needs the whole vocabulary asks for `?order=created_at`,
+ * which is immutable, and follows `nextCursor`. Passing `?cursor=` without it
+ * is refused rather than quietly honoured — see `blog-term-list-query.ts`.
+ */
 export const GET: APIRoute = async ({ request, cookies, url }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
 
@@ -49,15 +68,13 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
     return fail(401, "AUTH_REQUIRED", "Authentication required.");
   }
 
-  const taxonomyTypeParam = url.searchParams.get("taxonomyType");
+  const query = parseBlogTermListQuery(url.searchParams);
 
-  if (taxonomyTypeParam !== null && !isTaxonomyType(taxonomyTypeParam)) {
-    return fail(
-      400,
-      "VALIDATION_ERROR",
-      `taxonomyType must be one of ${TAXONOMY_TYPE_LIST}.`
-    );
+  if (!query.valid) {
+    return fail(400, "VALIDATION_ERROR", query.message);
   }
+
+  const { taxonomyType, limit, stableOrder, cursor } = query.value;
 
   const sql = getDatabaseClient();
   const tokenHash = hashSessionToken(token);
@@ -76,9 +93,17 @@ export const GET: APIRoute = async ({ request, cookies, url }) => {
       return auth.denied;
     }
 
-    const terms = await listBlogTerms(tx, tenantId, {
-      taxonomyType: taxonomyTypeParam ?? undefined
-    });
+    if (stableOrder) {
+      const page = await listBlogTermsPage(tx, tenantId, {
+        taxonomyType,
+        limit,
+        cursor
+      });
+
+      return ok({ terms: page.items, nextCursor: page.nextCursor });
+    }
+
+    const terms = await listBlogTerms(tx, tenantId, { taxonomyType, limit });
 
     return ok({ terms });
   });

--- a/tests/blog-content-terms-list-query.test.ts
+++ b/tests/blog-content-terms-list-query.test.ts
@@ -1,0 +1,156 @@
+/**
+ * `GET /api/v1/blog/terms` query contract (Issue #597 item 1).
+ *
+ * The endpoint gained a traversal because the list it had could not be walked
+ * to the end, and did not say so. Every refusal pinned below exists because
+ * the ACCEPTING version of it returns `200` with a vocabulary that is missing
+ * entries:
+ *
+ *   - a cursor over the `name` ordering skips or repeats terms as they are
+ *     renamed, and neither side can tell;
+ *   - a malformed cursor read as "no cursor" restarts the traversal at page
+ *     one, so a build re-reads what it already has and never terminates;
+ *   - an unknown `order` silently falling back to the alphabetical list hands
+ *     a caller that asked for the whole vocabulary the first page of it.
+ *
+ * The last one is the reason this endpoint was worth changing at all. A tag
+ * vocabulary grown over the 23,906-article archive of Issue #599 runs to
+ * thousands of entries; the old answer was the alphabetically-first hundred,
+ * with no field anywhere indicating that more existed.
+ *
+ * Pure over `URLSearchParams`: no database, no session, so these run in the
+ * `quality` job rather than only where a Postgres is available.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { encodeKeysetCursor } from "../src/modules/_shared/keyset-pagination";
+import { parseBlogTermListQuery } from "../src/modules/blog-content/domain/blog-term-list-query";
+
+function parse(qs: string) {
+  return parseBlogTermListQuery(new URLSearchParams(qs));
+}
+
+const CURSOR = encodeKeysetCursor(
+  "2026-07-17T10:00:00.029058+00:00",
+  "11111111-2222-4333-8444-555555555555"
+);
+
+describe("defaults", () => {
+  test("an empty query is the admin screen's alphabetical list", () => {
+    const result = parse("");
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+
+    expect(result.value.stableOrder).toBe(false);
+    expect(result.value.cursor).toBeNull();
+    expect(result.value.taxonomyType).toBeUndefined();
+    expect(result.value.limit).toBeUndefined();
+  });
+
+  test("order=created_at selects the cursor-capable traversal", () => {
+    const result = parse("order=created_at");
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.stableOrder).toBe(true);
+  });
+
+  test("order=name is accepted and is NOT the traversal", () => {
+    // Spelling the default out loud must not quietly buy a cursor.
+    const result = parse("order=name");
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.stableOrder).toBe(false);
+  });
+});
+
+describe("taxonomyType", () => {
+  test("every vocabulary the module has is accepted", () => {
+    for (const type of ["category", "tag", "channel", "topic"]) {
+      const result = parse(`taxonomyType=${type}`);
+      expect(result.valid).toBe(true);
+      if (!result.valid) return;
+      expect(result.value.taxonomyType).toBe(type as never);
+    }
+  });
+
+  test("an unknown vocabulary is refused, not ignored", () => {
+    // Ignoring it returns EVERY term to a caller that asked for one kind —
+    // a tag archive built from that list would also generate a page per
+    // category, at the tag URL.
+    const result = parse("taxonomyType=institution");
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.message).toContain("category, tag, channel, topic");
+  });
+});
+
+describe("cursor is refused over the mutable ordering", () => {
+  test("a cursor without order=created_at is a 400", () => {
+    const result = parse(`cursor=${CURSOR}`);
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.message).toContain("order=created_at");
+  });
+
+  test("a cursor with the explicit name ordering is refused too", () => {
+    const result = parse(`order=name&cursor=${CURSOR}`);
+    expect(result.valid).toBe(false);
+  });
+
+  test("a cursor with order=created_at decodes to its two parts", () => {
+    const result = parse(`order=created_at&cursor=${CURSOR}`);
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+
+    expect(result.value.cursor).toEqual({
+      createdAt: "2026-07-17T10:00:00.029058+00:00",
+      id: "11111111-2222-4333-8444-555555555555"
+    });
+  });
+
+  test("the cursor keeps its MICROSECONDS", () => {
+    // A cursor routed through a JS `Date` denotes an instant strictly earlier
+    // than the row it came from, so the traversal skips every row sharing that
+    // millisecond — the Issue #158 defect, re-pinned here because a term
+    // catalogue is exactly the kind of table that gets seeded in one batch
+    // insert sharing a single millisecond.
+    const result = parse(`order=created_at&cursor=${CURSOR}`);
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.cursor?.createdAt).toContain(".029058");
+  });
+
+  test("a malformed cursor is a 400, never treated as page one", () => {
+    const result = parse("order=created_at&cursor=not-a-cursor");
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.message).toContain("malformed");
+  });
+});
+
+describe("limit", () => {
+  test("a positive limit is carried through", () => {
+    const result = parse("limit=25");
+    expect(result.valid).toBe(true);
+    if (!result.valid) return;
+    expect(result.value.limit).toBe(25);
+  });
+
+  test("zero, negative and non-numeric limits are refused", () => {
+    for (const value of ["0", "-1", "abc"]) {
+      expect(parse(`limit=${value}`).valid).toBe(false);
+    }
+  });
+});
+
+describe("order", () => {
+  test("an unknown order is refused, never a silent fallback", () => {
+    // Falling back would hand the alphabetical FIRST PAGE to a caller that
+    // asked for a traversal, which is the whole failure this endpoint change
+    // exists to end.
+    const result = parse("order=updated_at");
+    expect(result.valid).toBe(false);
+    if (result.valid) return;
+    expect(result.message).toContain("created_at, name");
+  });
+});

--- a/tests/integration/blog-term-cursor.integration.test.ts
+++ b/tests/integration/blog-term-cursor.integration.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Cursor traversal over `awcms_blog_terms` against a real PostgreSQL
+ * (Issue #597 item 1).
+ *
+ * ## Why a vocabulary needed its own traversal
+ *
+ * `listBlogTerms` ends in a bounded `LIMIT`, ordered by name, and returns an
+ * array. Nothing in that answer distinguishes "this tenant has ninety tags"
+ * from "this tenant has three thousand tags and you are holding the first
+ * hundred". A caller generating one archive page per tag therefore builds a
+ * hundred pages, green, and every article filed under a tag later in the
+ * alphabet links to a page nobody generated.
+ *
+ * The first test below asserts that truncation deliberately, because it is
+ * still the behaviour of the default list and the reason the traversal exists;
+ * the rest assert the traversal actually reaches the end.
+ *
+ * ## Why one batch insert
+ *
+ * Every term is inserted by a single statement, so the rows share a
+ * `created_at` down to the microsecond — the shape that reduced page two to
+ * ZERO rows before Issue #158 was fixed. A term catalogue is exactly the kind
+ * of table that arrives that way (a migration import, a seed), so if the
+ * cursor ever loses precision again this suite loses rows and says so.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { decodeKeysetCursor } from "../../src/modules/_shared/keyset-pagination";
+import {
+  DEFAULT_TERM_LIST_LIMIT,
+  listBlogTerms,
+  listBlogTermsPage
+} from "../../src/modules/blog-content/application/blog-taxonomy-directory";
+
+const TENANT = "f2222222-2222-4222-8222-222222222222";
+
+/** Comfortably past the default bound, so the truncation is unambiguous. */
+const TOTAL_TAGS = 250;
+const PAGE_SIZE = 40;
+
+async function seedTenant(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'term-cursor-tenant', 'Term Cursor Tenant')
+  `;
+}
+
+/**
+ * `lpad` keeps the generated names in a stable alphabetical order, which is
+ * what lets the truncation test name exactly which terms survive the default
+ * list and which are dropped.
+ */
+async function seedTags(count: number): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_blog_terms (tenant_id, taxonomy_type, name, slug)
+    SELECT ${TENANT}, 'tag', 'Tag ' || lpad(n::text, 4, '0'), 'tag-' || lpad(n::text, 4, '0')
+    FROM generate_series(1, ${count}) AS n
+  `;
+}
+
+async function collectAllPages(
+  taxonomyType?: "category" | "tag" | "channel" | "topic"
+): Promise<string[]> {
+  const runtime = getRuntimeSql();
+  const seen: string[] = [];
+  let cursor: string | null = null;
+
+  for (let guard = 0; guard < 100; guard += 1) {
+    const page: { items: { id: string }[]; nextCursor: string | null } =
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        listBlogTermsPage(tx, TENANT, {
+          taxonomyType,
+          limit: PAGE_SIZE,
+          cursor: cursor ? decodeKeysetCursor(cursor) : null
+        })
+      );
+
+    seen.push(...page.items.map((item) => item.id));
+
+    if (!page.nextCursor) return seen;
+    cursor = page.nextCursor;
+  }
+
+  throw new Error("cursor traversal did not terminate");
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("blog term cursor traversal", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant();
+  });
+
+  test("the DEFAULT list truncates silently — this is what the traversal is for", async () => {
+    await seedTags(TOTAL_TAGS);
+
+    const runtime = getRuntimeSql();
+    const terms = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogTerms(tx, TENANT, { taxonomyType: "tag" })
+    );
+
+    // A hundred of two hundred and fifty, and the shape of the answer — a bare
+    // array — carries no field that could have told the caller so.
+    expect(terms).toHaveLength(DEFAULT_TERM_LIST_LIMIT);
+    expect(terms[0]!.name).toBe("Tag 0001");
+    expect(terms.at(-1)!.name).toBe("Tag 0100");
+    expect(terms.some((term) => term.name === "Tag 0250")).toBe(false);
+  });
+
+  test("a batch sharing one instant is traversed WITHOUT losing terms", async () => {
+    await seedTags(TOTAL_TAGS);
+
+    const seen = await collectAllPages();
+
+    expect(seen).toHaveLength(TOTAL_TAGS);
+    expect(new Set(seen).size).toBe(TOTAL_TAGS);
+  });
+
+  test("page two is not empty (the exact Issue #158 symptom)", async () => {
+    await seedTags(TOTAL_TAGS);
+    const runtime = getRuntimeSql();
+
+    const first = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogTermsPage(tx, TENANT, { limit: PAGE_SIZE })
+    );
+    expect(first.items).toHaveLength(PAGE_SIZE);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogTermsPage(tx, TENANT, {
+        limit: PAGE_SIZE,
+        cursor: decodeKeysetCursor(first.nextCursor!)
+      })
+    );
+
+    expect(second.items).toHaveLength(PAGE_SIZE);
+
+    const firstIds = new Set(first.items.map((item) => item.id));
+    expect(second.items.some((item) => firstIds.has(item.id))).toBe(false);
+  });
+
+  test("the taxonomyType filter survives the cursor", async () => {
+    await seedTags(PAGE_SIZE * 2);
+    await getAdminSql()`
+      INSERT INTO awcms_blog_terms (tenant_id, taxonomy_type, name, slug)
+      SELECT ${TENANT}, 'category', 'Kategori ' || n, 'kategori-' || n
+      FROM generate_series(1, 5) AS n
+    `;
+
+    const tags = await collectAllPages("tag");
+    const categories = await collectAllPages("category");
+
+    expect(tags).toHaveLength(PAGE_SIZE * 2);
+    expect(categories).toHaveLength(5);
+    // Two disjoint vocabularies: a filtered traversal that leaked across them
+    // would put category pages at tag URLs.
+    const tagIds = new Set(tags);
+    expect(categories.some((id) => tagIds.has(id))).toBe(false);
+  });
+
+  test("soft-deleted terms never appear", async () => {
+    await seedTags(PAGE_SIZE);
+    await getAdminSql()`
+      UPDATE awcms_blog_terms SET deleted_at = now()
+      WHERE tenant_id = ${TENANT} AND slug = 'tag-0001'
+    `;
+
+    const seen = await collectAllPages();
+
+    expect(seen).toHaveLength(PAGE_SIZE - 1);
+  });
+
+  test("the last page reports no next cursor", async () => {
+    await seedTags(PAGE_SIZE - 1);
+
+    const runtime = getRuntimeSql();
+    const only = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listBlogTermsPage(tx, TENANT, { limit: PAGE_SIZE })
+    );
+
+    expect(only.items).toHaveLength(PAGE_SIZE - 1);
+    expect(only.nextCursor).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes nothing on its own — this is the `awcms` half that #597 item 1 (category/tag archives on `awcms-astro`) cannot be built without.

## The defect

`GET /api/v1/blog/terms` ended in a bounded `LIMIT`, ordered by name, and returned a bare array. Nothing in that answer distinguishes *"this tenant has ninety tags"* from *"this tenant has three thousand tags and you are holding the alphabetically-first hundred"*. No cursor, no total, no flag.

The endpoint's own comment justified the bound as *"terms are low-cardinality config"*. For `category` and `channel` that is true and stays true — a newsroom has a dozen of each. For `tag` it was never true: a vocabulary grown over the 23,906-article archive of #599 runs to thousands of entries.

So a static build generating one archive page per tag would build a hundred pages, `200 OK`, with every article filed under a tag later in the alphabet linking into a page nobody generated. **The failure is invisible from both ends** — the server answered every question it was asked, and the client received well-formed data.

## The fix

`?order=created_at` selects a stable keyset traversal and the response gains `nextCursor`; follow it until null. `?limit=` is accepted (default 100, max 200).

`?cursor=` without `?order=created_at` is refused with `400` rather than quietly honoured: `name` is editable, so renaming a term moves it across a page boundary and a cursor over the alphabetical ordering skips or repeats terms with nothing able to detect it. That is the same refusal, for the same reason, that this endpoint's sibling already makes about `updated_at`.

**The default list is deliberately unchanged.** The admin taxonomy screen wants names in alphabetical order, and a screen showing a page is not lying about anything. What changed is that a caller which needs the whole vocabulary now has a way to say so — and a way to know when it has it.

## Tests

- `tests/blog-content-terms-list-query.test.ts` — 13 pure tests over the refusal surface.
- `tests/integration/blog-term-cursor.integration.test.ts` — the traversal against real PostgreSQL, over 250 rows inserted by **one statement** so they share a `created_at` to the microsecond (the shape that reduced page two to zero rows before #158). It also asserts the default list's truncation head-on, because that behaviour is still there and is the reason any of this was needed.

`DATABASE_URL="" bun run check` green, `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)