### PR TITLE
chore(api): the taxonomy endpoint is now CONSUMED, not merely promised (#597)

### DIFF
--- a/.changeset/terms-are-now-consumed.md
+++ b/.changeset/terms-are-now-consumed.md
@@ -1,0 +1,20 @@
+---
+"awcms": patch
+---
+
+chore(api): the taxonomy endpoint is now CONSUMED, not merely promised (#597)
+
+`ahliweb/awcms-astro#66` landed the category and tag archives, so
+`/api/v1/blog/terms` moves from `COMMITTED_PATHS` to `CONSUMED_PATHS` and the
+pinned count goes four to five — the same number that repo's own gate asserts,
+derived from its source with comments stripped.
+
+This is the third step of the sequence ADR-0104 records, and it is not
+bookkeeping. Breaking a consumed path breaks a build that exists today;
+breaking a committed one breaks a design that has been agreed and not yet
+built. The two deserve different care, and the distinction only survives if
+entries actually move — the state that once let three non-calls sit in
+`CONSUMED_PATHS` describing calls that never happened.
+
+The frozen fixture is unchanged in shape: the same seven paths were already
+frozen, only their justification moved.

--- a/scripts/api-consumer-contract.ts
+++ b/scripts/api-consumer-contract.ts
@@ -94,7 +94,9 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
   "/api/v1/media/public-origin":
     "the media origin the build must name in `img-src` BEFORE pulling a single object (#370). `scripts/asal-media.mjs`.",
   "/api/v1/site-profile/composed":
-    "who the site IS — masthead, favicon, footer, editorial address, contact details, social links, and the `Organization` node, plus the `seo_distribution` half this endpoint merges in (#596, ADR-0102). `src/lib/awcms/profil.ts` there. Promised as COMMITTED in #645 and moved here when `ahliweb/awcms-astro#61` made the call real."
+    "who the site IS — masthead, favicon, footer, editorial address, contact details, social links, and the `Organization` node, plus the `seo_distribution` half this endpoint merges in (#596, ADR-0102). `src/lib/awcms/profil.ts` there. Promised as COMMITTED in #645 and moved here when `ahliweb/awcms-astro#61` made the call real.",
+  "/api/v1/blog/terms":
+    "the tenant's vocabulary, read at build time so a category or tag archive can exist at all (#597 item 1, ADR-0104). `src/lib/awcms/taksonomi.ts` there. The consumer uses the `?order=created_at` TRAVERSAL and never the default alphabetical list — that list returns some of the terms and says nothing about the rest (#647), and a site built from it would generate a hundred archive pages out of thousands. Promised as COMMITTED in #650 and moved here when `ahliweb/awcms-astro#66` made the call real."
 };
 
 /**
@@ -112,8 +114,6 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
  * acquire the authority of a contract.
  */
 export const COMMITTED_PATHS: Readonly<Record<string, string>> = {
-  "/api/v1/blog/terms":
-    "ADR-0104 — the tenant's vocabulary, read at build time so a category or tag archive can exist at all (#597 item 1). The consumer uses the `?order=created_at` TRAVERSAL, never the default alphabetical list, which returns some of the terms and says nothing about the rest (#647). Frozen here first; it moves to CONSUMED when `ahliweb/awcms-astro` calls it.",
   "/api/v1/auth/session":
     "ADR-0049 — session introspection for the BFF of ADR-0050. The static build must NOT call it (it refuses machine credentials by design); the BFF that will is not built yet.",
   "/api/v1/access/machine-credentials":

--- a/tests/api-consumer-contract.test.ts
+++ b/tests/api-consumer-contract.test.ts
@@ -186,7 +186,7 @@ describe("the live contract", () => {
  * a fourth consumed surface here has to be a deliberate edit in both places.
  */
 describe("consumed vs committed", () => {
-  test("exactly four surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
+  test("exactly five surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
     // If this fails, one of two things happened, and they need opposite fixes:
     //   - awcms-astro started (or stopped) calling a surface -> update both
     //     this list and the marker block in that repo, in the same change;
@@ -199,11 +199,16 @@ describe("consumed vs committed", () => {
     // `ahliweb/awcms-astro#61` made the call real. A promise and a dependency
     // both deserve stability and fail differently, and the distinction only
     // survives if entries actually move.
+    //
+    // `/api/v1/blog/terms` is the fifth and took the identical path: COMMITTED
+    // in #650 with ADR-0104, moved here when `ahliweb/awcms-astro#66` built the
+    // category and tag archives on it.
     expect(Object.keys(CONSUMED_PATHS)).toEqual([
       "/api/v1/blog/posts",
       "/api/v1/media/objects",
       "/api/v1/media/public-origin",
-      "/api/v1/site-profile/composed"
+      "/api/v1/site-profile/composed",
+      "/api/v1/blog/terms"
     ]);
   });
 


### PR DESCRIPTION
Step three of the sequence ADR-0104 records. `ahliweb/awcms-astro#66` landed the category and tag archives, so `/api/v1/blog/terms` moves from `COMMITTED_PATHS` to `CONSUMED_PATHS` and the pinned count goes four → five — the same number that repo's own gate asserts, derived from its source with comments stripped first.

**This is not bookkeeping.** Breaking a consumed path breaks a build that exists today; breaking a committed one breaks a design that has been agreed and not yet built. The two deserve different care, and the distinction only survives if entries actually move — the state that once let three non-calls sit in `CONSUMED_PATHS` describing calls that never happened.

The frozen fixture keeps the same seven paths; only the justification moved.

`DATABASE_URL="" bun run check` green, `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)