### PR TITLE
fix(api): the menu and widget lists were documented as returning "object" (#597)

### DIFF
--- a/.changeset/menu-widget-responses-get-a-shape.md
+++ b/.changeset/menu-widget-responses-get-a-shape.md
@@ -1,0 +1,43 @@
+---
+"awcms": patch
+---
+
+fix(api): the menu and widget lists were documented as returning "object"
+
+`GET /api/v1/blog/menus` and `GET /api/v1/blog/widgets` each declared their
+payload as an array of bare `object`. That is not a wrong shape — it is **no
+shape**, and it is worse than a wrong one in a specific way: nothing can ever
+fail against it. Any field could be renamed or dropped and the frozen consumer
+contract would still pass, because everything is a subset of "object".
+
+Issue #597 item 6 says menus and widgets are configurable and nothing renders
+them. The reason no consumer could is that there was nothing to build against:
+`awcms-astro`'s contract gate freezes response shapes, and freezing this one
+would have frozen a promise with no content.
+
+So `BlogMenu` and `BlogWidget` are written out, and three things the code
+already does are now stated rather than left to be discovered:
+
+- **A menu carries its `items`**, already sorted by `sortOrder`. That is what
+  the schema exists for — a menu without items is a name, and navigation cannot
+  be rendered from a name.
+- **`key` is the identifier, `name` is the label.** A consumer that selects a
+  menu by `name` breaks the first time somebody fixes a typo.
+- **Inactive widgets ARE returned.** There is no `?activeOnly=`; `isActive` is
+  on every row and the consumer filters. An endpoint that hid them would make
+  "switched off" and "deleted" the same answer.
+- **`bodyText` is plain text, not markup.** The write path refuses unsafe HTML
+  rather than sanitizing it, so a consumer must escape before rendering.
+
+`BlogMenuItem` gains `tenantId` and `menuId` as `readOnly` — the read returns
+them and the write does not accept them, and the schema is shared by both.
+
+Writing a schema creates a new way to be wrong: naming a field the endpoint does
+not return. This repo shipped that once already — the post list documented as
+`BlogPost` while it returned a summary, which built an entire site of empty
+articles with nothing failing. So
+`tests/integration/menu-widget-response-shape.integration.test.ts` reads the
+`required` list out of the BUNDLED spec, seeds real rows, calls the same
+functions the routes call, and requires every one of those properties to be
+present on what comes back. The document cannot claim a field the code does not
+produce.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -5871,7 +5871,9 @@ Gated by blog_content.internal_links.configure. disabledTagIds are validated aga
 - **operationId**: `blogListMenus`
 - **Security**: bearerAuth + tenantHeader
 
-Gated by blog_content.menus.read.
+Gated by blog_content.menus.read. Bounded at 100 menus, name ascending — a site has a handful, and unlike the tag vocabulary this one does not grow with the archive.
+
+Each menu carries its own `items`, already sorted by `sortOrder`. That costs one query per menu rather than one for all of them, and the route says why in a comment: the queries run on one transaction, so they cannot be issued concurrently.
 
 **Parameters**
 
@@ -6980,13 +6982,16 @@ Gated by blog_content.theme.configure.
 - **operationId**: `blogListWidgets`
 - **Security**: bearerAuth + tenantHeader
 
-Gated by blog_content.widgets.read.
+Gated by blog_content.widgets.read. Optional `?position=` filter. Bounded at 100, ordered by `position` then `sortOrder`.
+
+**Inactive widgets are returned too.** There is no `?activeOnly=` parameter: `isActive` is on every row, and a consumer that wants only the live ones filters on it. An endpoint that hid them would make "this widget is switched off" and "this widget was deleted" the same answer.
 
 **Parameters**
 
-| Name               | In     | Required | Type   | Description |
-| ------------------ | ------ | -------- | ------ | ----------- |
-| `X-Correlation-ID` | header | no       | string |             |
+| Name               | In     | Required | Type                                                                   | Description |
+| ------------------ | ------ | -------- | ---------------------------------------------------------------------- | ----------- |
+| `position`         | query  | no       | enum(`header`, `sidebar`, `footer`, `content_before`, `content_after`) |             |
+| `X-Correlation-ID` | header | no       | string                                                                 |             |
 
 **Responses**
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 434   |
+| Test files                          | 435   |
 | Route files                         | 382   |
 | ADR                                 | 210   |
 
@@ -354,7 +354,7 @@
 | ------------- | ---------- |
 | `(root)`      | 373        |
 | `e2e`         | 12         |
-| `integration` | 48         |
+| `integration` | 49         |
 | `unit`        | 1          |
 
 ### Routes

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -4336,7 +4336,10 @@ paths:
         - Blog Content
       operationId: blogListMenus
       summary: List this tenant's navigation menus (with items)
-      description: Gated by blog_content.menus.read.
+      description: |
+        Gated by blog_content.menus.read. Bounded at 100 menus, name ascending — a site has a handful, and unlike the tag vocabulary this one does not grow with the archive.
+
+        Each menu carries its own `items`, already sorted by `sortOrder`. That costs one query per menu rather than one for all of them, and the route says why in a comment: the queries run on one transaction, so they cannot be issued concurrently.
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       responses:
@@ -4357,7 +4360,7 @@ paths:
                       menus:
                         type: array
                         items:
-                          type: object
+                          $ref: "#/components/schemas/BlogMenu"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -6428,8 +6431,21 @@ paths:
         - Blog Content
       operationId: blogListWidgets
       summary: List this tenant's widgets
-      description: Gated by blog_content.widgets.read.
+      description: |
+        Gated by blog_content.widgets.read. Optional `?position=` filter. Bounded at 100, ordered by `position` then `sortOrder`.
+
+        **Inactive widgets are returned too.** There is no `?activeOnly=` parameter: `isActive` is on every row, and a consumer that wants only the live ones filters on it. An endpoint that hid them would make "this widget is switched off" and "this widget was deleted" the same answer.
       parameters:
+        - name: position
+          in: query
+          schema:
+            type: string
+            enum:
+              - header
+              - sidebar
+              - footer
+              - content_before
+              - content_after
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -6449,7 +6465,7 @@ paths:
                       widgets:
                         type: array
                         items:
-                          type: object
+                          $ref: "#/components/schemas/BlogWidget"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -19762,6 +19778,58 @@ components:
           items:
             type: string
             format: uuid
+    BlogMenu:
+      type: object
+      description: |
+        One navigation menu, as `GET /api/v1/blog/menus` returns it.
+
+        It exists as a schema because that endpoint's response was documented as
+        an array of bare `object` — which promises a consumer nothing at all.
+        Any field could have been renamed or dropped and the frozen consumer
+        contract would still have passed, because everything is a subset of
+        "object". That is the same defect the list endpoint shipped once over
+        `BlogPostSummary`, one step further along: not a wrong shape, but no
+        shape.
+
+        `key` is the stable identifier a template selects a menu by (`main`,
+        `footer`); `name` is the editorial label and may be renamed at any time.
+        A consumer that keys off `name` breaks the first time somebody fixes a
+        typo.
+      required:
+        - id
+        - tenantId
+        - key
+        - name
+        - items
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        key:
+          type: string
+          description: Stable slug. What a consumer selects a menu by.
+        name:
+          type: string
+          description: Editorial label. NOT an identifier.
+        items:
+          type: array
+          description: Already sorted by `sortOrder`. One level of nesting at most — an item whose parent itself has a parent is refused at write time.
+          items:
+            $ref: "#/components/schemas/BlogMenuItem"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Always null on this list — it filters soft-deleted menus out. Present because the row carries it, and named here rather than left as a surprise field.
     BlogMenuItem:
       type: object
       required:
@@ -19773,6 +19841,16 @@ components:
         id:
           type: string
           format: uuid
+        tenantId:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Returned on a read, never accepted on a write — the tenant comes from the credential.
+        menuId:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Returned on a read, never accepted on a write — the item's menu is the one it was submitted with.
         parentItemId:
           type: string
           format: uuid
@@ -19789,9 +19867,11 @@ components:
           type: string
           format: uuid
           nullable: true
+          description: Required for `post`/`page`. Its existence is deliberately NOT checked against the posts/pages tables, because a menu may point at something not created yet — so a consumer must treat a target that resolves to nothing as a normal state, not an error.
         url:
           type: string
           nullable: true
+          description: Required for `url`. An absolute http(s) URL, validated at write time by the same check `canonicalUrl` uses.
         sortOrder:
           type: integer
     BlogPage:
@@ -20320,6 +20400,55 @@ components:
         description:
           type: string
           nullable: true
+    BlogWidget:
+      type: object
+      description: |
+        One widget, as `GET /api/v1/blog/widgets` returns it. Its response was
+        documented as an array of bare `object` too — see `BlogMenu` for why
+        that is worse than a wrong shape.
+
+        `bodyText` is PLAIN TEXT, not markup: the write path refuses unsafe HTML
+        rather than sanitizing it, so a consumer must escape this before
+        rendering and must not treat it as trusted HTML.
+      required:
+        - id
+        - tenantId
+        - position
+        - title
+        - bodyText
+        - isActive
+        - sortOrder
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        position:
+          type: string
+          enum:
+            - header
+            - sidebar
+            - footer
+            - content_before
+            - content_after
+        title:
+          type: string
+        bodyText:
+          type: string
+          description: Plain text. Escape before rendering.
+        isActive:
+          type: boolean
+          description: Inactive widgets ARE returned by the list — filter on this rather than expecting the endpoint to hide them.
+        sortOrder:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
     BulkModerationResult:
       type: object
       properties:

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -2144,7 +2144,10 @@ paths:
         - Blog Content
       operationId: blogListMenus
       summary: List this tenant's navigation menus (with items)
-      description: Gated by blog_content.menus.read.
+      description: |
+        Gated by blog_content.menus.read. Bounded at 100 menus, name ascending — a site has a handful, and unlike the tag vocabulary this one does not grow with the archive.
+
+        Each menu carries its own `items`, already sorted by `sortOrder`. That costs one query per menu rather than one for all of them, and the route says why in a comment: the queries run on one transaction, so they cannot be issued concurrently.
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       responses:
@@ -2164,7 +2167,7 @@ paths:
                       menus:
                         type: array
                         items:
-                          type: object
+                          $ref: "#/components/schemas/BlogMenu"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -2305,8 +2308,16 @@ paths:
         - Blog Content
       operationId: blogListWidgets
       summary: List this tenant's widgets
-      description: Gated by blog_content.widgets.read.
+      description: |
+        Gated by blog_content.widgets.read. Optional `?position=` filter. Bounded at 100, ordered by `position` then `sortOrder`.
+
+        **Inactive widgets are returned too.** There is no `?activeOnly=` parameter: `isActive` is on every row, and a consumer that wants only the live ones filters on it. An endpoint that hid them would make "this widget is switched off" and "this widget was deleted" the same answer.
       parameters:
+        - name: position
+          in: query
+          schema:
+            type: string
+            enum: [header, sidebar, footer, content_before, content_after]
         - $ref: "#/components/parameters/CorrelationId"
       responses:
         "200":
@@ -2325,7 +2336,7 @@ paths:
                       widgets:
                         type: array
                         items:
-                          type: object
+                          $ref: "#/components/schemas/BlogWidget"
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -3858,6 +3869,53 @@ components:
           nullable: true
         socialPreviewContentImageFallbackEnabled:
           type: boolean
+    BlogMenu:
+      type: object
+      description: |
+        One navigation menu, as `GET /api/v1/blog/menus` returns it.
+
+        It exists as a schema because that endpoint's response was documented as
+        an array of bare `object` — which promises a consumer nothing at all.
+        Any field could have been renamed or dropped and the frozen consumer
+        contract would still have passed, because everything is a subset of
+        "object". That is the same defect the list endpoint shipped once over
+        `BlogPostSummary`, one step further along: not a wrong shape, but no
+        shape.
+
+        `key` is the stable identifier a template selects a menu by (`main`,
+        `footer`); `name` is the editorial label and may be renamed at any time.
+        A consumer that keys off `name` breaks the first time somebody fixes a
+        typo.
+      required: [id, tenantId, key, name, items]
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        key:
+          type: string
+          description: Stable slug. What a consumer selects a menu by.
+        name:
+          type: string
+          description: Editorial label. NOT an identifier.
+        items:
+          type: array
+          description: Already sorted by `sortOrder`. One level of nesting at most — an item whose parent itself has a parent is refused at write time.
+          items:
+            $ref: "#/components/schemas/BlogMenuItem"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Always null on this list — it filters soft-deleted menus out. Present because the row carries it, and named here rather than left as a surprise field.
     BlogMenuItem:
       type: object
       required: [id, label, linkType, sortOrder]
@@ -3865,6 +3923,16 @@ components:
         id:
           type: string
           format: uuid
+        tenantId:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Returned on a read, never accepted on a write — the tenant comes from the credential.
+        menuId:
+          type: string
+          format: uuid
+          readOnly: true
+          description: Returned on a read, never accepted on a write — the item's menu is the one it was submitted with.
         parentItemId:
           type: string
           format: uuid
@@ -3878,11 +3946,50 @@ components:
           type: string
           format: uuid
           nullable: true
+          description: Required for `post`/`page`. Its existence is deliberately NOT checked against the posts/pages tables, because a menu may point at something not created yet — so a consumer must treat a target that resolves to nothing as a normal state, not an error.
         url:
           type: string
           nullable: true
+          description: Required for `url`. An absolute http(s) URL, validated at write time by the same check `canonicalUrl` uses.
         sortOrder:
           type: integer
+    BlogWidget:
+      type: object
+      description: |
+        One widget, as `GET /api/v1/blog/widgets` returns it. Its response was
+        documented as an array of bare `object` too — see `BlogMenu` for why
+        that is worse than a wrong shape.
+
+        `bodyText` is PLAIN TEXT, not markup: the write path refuses unsafe HTML
+        rather than sanitizing it, so a consumer must escape this before
+        rendering and must not treat it as trusted HTML.
+      required: [id, tenantId, position, title, bodyText, isActive, sortOrder]
+      properties:
+        id:
+          type: string
+          format: uuid
+        tenantId:
+          type: string
+          format: uuid
+        position:
+          type: string
+          enum: [header, sidebar, footer, content_before, content_after]
+        title:
+          type: string
+        bodyText:
+          type: string
+          description: Plain text. Escape before rendering.
+        isActive:
+          type: boolean
+          description: Inactive widgets ARE returned by the list — filter on this rather than expecting the endpoint to hide them.
+        sortOrder:
+          type: integer
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
     BlogContentBlock:
       description: |
         One block of `content_json`. The vocabulary is closed: a value outside

--- a/tests/integration/menu-widget-response-shape.integration.test.ts
+++ b/tests/integration/menu-widget-response-shape.integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * The `BlogMenu`/`BlogWidget` schemas held to the rows the code actually
+ * returns, against a real PostgreSQL (Issue #597 item 6).
+ *
+ * ## Why this exists
+ *
+ * `GET /api/v1/blog/menus` and `GET /api/v1/blog/widgets` were documented as
+ * returning an array of bare `object`. That is not a wrong shape — it is NO
+ * shape, and it promises a consumer nothing: any field could be renamed or
+ * dropped and the frozen consumer contract would still pass, because everything
+ * is a subset of "object".
+ *
+ * Writing the schemas out fixes the promise and creates a new way to be wrong:
+ * a document that names a field the endpoint does not return. This repo has
+ * shipped that one before — the post list was documented as `BlogPost` while it
+ * returned a summary, and a client that believed the document published a whole
+ * site of empty articles with nothing failing.
+ *
+ * So the assertion runs the other way from a normal test. It reads the SCHEMA
+ * out of the bundled spec, seeds real rows, calls the same functions the routes
+ * call, and requires every `required` property to be present on the object that
+ * comes back. The document cannot claim a field the code does not produce.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import { readFileSync } from "node:fs";
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+import { parse as parseYaml } from "yaml";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import {
+  fetchMenuItems,
+  listMenus
+} from "../../src/modules/blog-content/application/menu-directory";
+import { listWidgets } from "../../src/modules/blog-content/application/widget-directory";
+
+const TENANT = "f5555555-5555-4555-8555-555555555555";
+
+type AnyRecord = Record<string, unknown>;
+
+/** The `required` list of one component schema in the BUNDLED spec. */
+function requiredOf(schemaName: string): string[] {
+  const bundle = parseYaml(
+    readFileSync("openapi/awcms-public-api.openapi.yaml", "utf8")
+  ) as AnyRecord;
+
+  const components = bundle.components as AnyRecord;
+  const schemas = components.schemas as Record<string, AnyRecord>;
+  const schema = schemas[schemaName];
+
+  if (!schema) {
+    throw new Error(
+      `${schemaName} is not in the bundle — regenerate with \`bun run openapi:bundle\`.`
+    );
+  }
+
+  return (schema.required as string[] | undefined) ?? [];
+}
+
+async function seedTenant(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'menu-shape-tenant', 'Menu Shape Tenant')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("menu and widget response shapes match their schemas", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant();
+  });
+
+  test("every required BlogMenu property is on the row the route returns", async () => {
+    const admin = getAdminSql();
+    const menu = (await admin`
+      INSERT INTO awcms_blog_menus (tenant_id, key, name)
+      VALUES (${TENANT}, 'main', 'Menu Utama')
+      RETURNING id
+    `) as { id: string }[];
+
+    await admin`
+      INSERT INTO awcms_blog_menu_items
+        (tenant_id, menu_id, label, link_type, url, sort_order)
+      VALUES (${TENANT}, ${menu[0]!.id}, 'Beranda', 'url', 'https://example.test/', 1)
+    `;
+
+    const runtime = getRuntimeSql();
+    const assembled = await withTenantOrThrow(runtime, TENANT, async (tx) => {
+      // Exactly what `src/pages/api/v1/blog/menus/index.ts` assembles.
+      const menus = await listMenus(tx, TENANT);
+      const first = menus[0]!;
+
+      return { ...first, items: await fetchMenuItems(tx, TENANT, first.id) };
+    });
+
+    const row = assembled as unknown as AnyRecord;
+
+    for (const property of requiredOf("BlogMenu")) {
+      expect(
+        Object.hasOwn(row, property),
+        `BlogMenu declares "${property}" required, and the endpoint does not return it`
+      ).toBe(true);
+    }
+
+    // `items` is the field the whole schema exists for: a menu without it is a
+    // name, and a template cannot render navigation from a name.
+    expect(Array.isArray(row.items)).toBe(true);
+    expect((row.items as unknown[]).length).toBe(1);
+  });
+
+  test("every required BlogMenuItem property is on the item", async () => {
+    const admin = getAdminSql();
+    const menu = (await admin`
+      INSERT INTO awcms_blog_menus (tenant_id, key, name)
+      VALUES (${TENANT}, 'main', 'Menu Utama')
+      RETURNING id
+    `) as { id: string }[];
+
+    await admin`
+      INSERT INTO awcms_blog_menu_items
+        (tenant_id, menu_id, label, link_type, url, sort_order)
+      VALUES (${TENANT}, ${menu[0]!.id}, 'Beranda', 'url', 'https://example.test/', 1)
+    `;
+
+    const runtime = getRuntimeSql();
+    const items = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, menu[0]!.id)
+    );
+
+    const item = items[0]! as unknown as AnyRecord;
+
+    for (const property of requiredOf("BlogMenuItem")) {
+      expect(
+        Object.hasOwn(item, property),
+        `BlogMenuItem declares "${property}" required, and the endpoint does not return it`
+      ).toBe(true);
+    }
+  });
+
+  test("items come back in sortOrder, not insertion order", async () => {
+    // A menu rendered in the order rows happened to be written is navigation
+    // that reorders itself when an editor edits an unrelated item.
+    const admin = getAdminSql();
+    const menu = (await admin`
+      INSERT INTO awcms_blog_menus (tenant_id, key, name)
+      VALUES (${TENANT}, 'main', 'Menu Utama')
+      RETURNING id
+    `) as { id: string }[];
+
+    await admin`
+      INSERT INTO awcms_blog_menu_items
+        (tenant_id, menu_id, label, link_type, url, sort_order)
+      VALUES
+        (${TENANT}, ${menu[0]!.id}, 'Ketiga', 'url', 'https://example.test/c', 3),
+        (${TENANT}, ${menu[0]!.id}, 'Pertama', 'url', 'https://example.test/a', 1),
+        (${TENANT}, ${menu[0]!.id}, 'Kedua', 'url', 'https://example.test/b', 2)
+    `;
+
+    const runtime = getRuntimeSql();
+    const items = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, menu[0]!.id)
+    );
+
+    expect(items.map((item) => item.label)).toEqual([
+      "Pertama",
+      "Kedua",
+      "Ketiga"
+    ]);
+  });
+
+  test("every required BlogWidget property is on the row", async () => {
+    await getAdminSql()`
+      INSERT INTO awcms_blog_widgets (tenant_id, position, title, body_text, sort_order)
+      VALUES (${TENANT}, 'sidebar', 'Tentang Kami', 'Teks biasa.', 1)
+    `;
+
+    const runtime = getRuntimeSql();
+    const widgets = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listWidgets(tx, TENANT)
+    );
+
+    const row = widgets[0]! as unknown as AnyRecord;
+
+    for (const property of requiredOf("BlogWidget")) {
+      expect(
+        Object.hasOwn(row, property),
+        `BlogWidget declares "${property}" required, and the endpoint does not return it`
+      ).toBe(true);
+    }
+  });
+
+  test("an INACTIVE widget is still returned — the schema says so", async () => {
+    // The document states it, so a consumer will rely on it. If the endpoint
+    // ever starts hiding them, this fails here rather than in a build that
+    // quietly loses half a sidebar.
+    await getAdminSql()`
+      INSERT INTO awcms_blog_widgets (tenant_id, position, title, body_text, is_active)
+      VALUES (${TENANT}, 'sidebar', 'Dimatikan', '', false)
+    `;
+
+    const runtime = getRuntimeSql();
+    const widgets = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      listWidgets(tx, TENANT)
+    );
+
+    expect(widgets).toHaveLength(1);
+    expect(widgets[0]!.isActive).toBe(false);
+  });
+});


### PR DESCRIPTION
Groundwork for #597 item 6 — *"menus and widgets are configurable but nothing renders them"*.

## Why nothing could render them

`GET /api/v1/blog/menus` and `GET /api/v1/blog/widgets` each declared their payload as an array of bare `object`:

```yaml
menus:
  type: array
  items:
    type: object
```

That is not a wrong shape. It is **no shape**, and it is worse than a wrong one in one specific way: **nothing can ever fail against it.** Any field could be renamed or dropped and the frozen consumer contract would still pass, because everything is a subset of "object".

`awcms-astro` builds against frozen response shapes. Freezing this one would have frozen a promise with no content — which is exactly how the promised/consumed distinction decays into a label.

## What is now stated rather than discovered

- **A menu carries its `items`**, already sorted by `sortOrder`. That is the point of the schema: a menu without items is a name, and navigation cannot be rendered from a name.
- **`key` is the identifier, `name` is the label.** A consumer that selects a menu by `name` breaks the first time somebody fixes a typo.
- **Inactive widgets ARE returned.** There is deliberately no `?activeOnly=` — `isActive` is on every row and the consumer filters. An endpoint that hid them would make "switched off" and "deleted" the same answer.
- **`bodyText` is plain text, not markup.** The write path *refuses* unsafe HTML rather than sanitizing it, so a consumer must escape before rendering and must not treat it as trusted.
- **A menu item's `targetId` is not checked against the posts/pages tables** — deliberately, since a menu may point at something not created yet. So a consumer must treat an unresolvable target as a normal state, not an error.

`BlogMenuItem` gains `tenantId` and `menuId` as `readOnly`: the read returns them, the write does not accept them, and one schema serves both.

## The new way to be wrong, and the test for it

Writing a schema creates a fresh hazard — naming a field the endpoint does not return. This repo shipped that one already: the post list was documented as `BlogPost` while it returned a summary, and a client that believed the document published a whole site of empty articles with nothing failing.

So `tests/integration/menu-widget-response-shape.integration.test.ts` runs the assertion **backwards from a normal test**: it reads the `required` list out of the *bundled* spec, seeds real rows, calls the same functions the routes call, and requires every one of those properties to be present on what comes back. The document cannot claim a field the code does not produce.

It also pins two behaviours the schema now promises: items come back in `sortOrder` (not insertion order — navigation that reorders itself when an editor touches an unrelated item), and an inactive widget is still returned.

`DATABASE_URL="" bun run check` green, `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)