### PR TITLE
chore(api): the menu and widget endpoints are now CONSUMED, not merely promised (#597)

### DIFF
--- a/.changeset/menus-and-widgets-are-now-consumed.md
+++ b/.changeset/menus-and-widgets-are-now-consumed.md
@@ -1,0 +1,20 @@
+---
+"awcms": patch
+---
+
+chore(api): the menu and widget endpoints are now CONSUMED, not merely promised (#597)
+
+`ahliweb/awcms-astro#67` renders the tenant's navigation menu and its widgets, so
+`/api/v1/blog/menus` and `/api/v1/blog/widgets` move from `COMMITTED_PATHS` to
+`CONSUMED_PATHS` and the pinned count goes five to seven — the same number that
+repo's own gate asserts.
+
+Their sequence had one step the others did not. `/api/v1/blog/terms` could be
+frozen the moment it was decided; these two could not be frozen **at all** until
+Issue #652 gave their responses an actual schema. Freezing an array of bare
+`object` would have added two paths to this list that no change could ever
+break — a contract entry with no contract in it, which is a more expensive kind
+of nothing than an empty list, because it reads as coverage.
+
+This closes Issue #597 item 6, and with it the last item on that issue that was
+not waiting on a written decision.

--- a/scripts/api-consumer-contract.ts
+++ b/scripts/api-consumer-contract.ts
@@ -96,7 +96,11 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
   "/api/v1/site-profile/composed":
     "who the site IS — masthead, favicon, footer, editorial address, contact details, social links, and the `Organization` node, plus the `seo_distribution` half this endpoint merges in (#596, ADR-0102). `src/lib/awcms/profil.ts` there. Promised as COMMITTED in #645 and moved here when `ahliweb/awcms-astro#61` made the call real.",
   "/api/v1/blog/terms":
-    "the tenant's vocabulary, read at build time so a category or tag archive can exist at all (#597 item 1, ADR-0104). `src/lib/awcms/taksonomi.ts` there. The consumer uses the `?order=created_at` TRAVERSAL and never the default alphabetical list — that list returns some of the terms and says nothing about the rest (#647), and a site built from it would generate a hundred archive pages out of thousands. Promised as COMMITTED in #650 and moved here when `ahliweb/awcms-astro#66` made the call real."
+    "the tenant's vocabulary, read at build time so a category or tag archive can exist at all (#597 item 1, ADR-0104). `src/lib/awcms/taksonomi.ts` there. The consumer uses the `?order=created_at` TRAVERSAL and never the default alphabetical list — that list returns some of the terms and says nothing about the rest (#647), and a site built from it would generate a hundred archive pages out of thousands. Promised as COMMITTED in #650 and moved here when `ahliweb/awcms-astro#66` made the call real.",
+  "/api/v1/blog/menus":
+    "the tenant's navigation menus, rendered as a SECONDARY footer region — the localised tab bar is NOT replaced, because a menu item carries one label and no per-locale variant (#597 item 6, ADR-0105). `src/lib/awcms/navigasi.ts` there. Only freezable after #652 gave the response a real schema; promised as COMMITTED in #653 and moved here when `ahliweb/awcms-astro#67` made the call real.",
+  "/api/v1/blog/widgets":
+    "the tenant's widgets, rendered in their declared positions (#597 item 6, ADR-0105). `bodyText` is plain text and the consumer ESCAPES it, because the write path refuses markup rather than sanitizing it. Inactive widgets are returned on purpose and filtered there. Same #652/#653/#67 sequence as the menus above."
 };
 
 /**
@@ -114,10 +118,6 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
  * acquire the authority of a contract.
  */
 export const COMMITTED_PATHS: Readonly<Record<string, string>> = {
-  "/api/v1/blog/menus":
-    "ADR-0105 — the tenant's navigation menus, rendered as a SECONDARY region so the localised tab bar is not replaced (#597 item 6). Frozen only after #652 gave the response a real schema: before that it was an array of bare `object`, and freezing it would have frozen a promise nothing could ever fail against.",
-  "/api/v1/blog/widgets":
-    "ADR-0105 — the tenant's widgets, rendered in their declared positions. `bodyText` is plain text and is escaped by the consumer, because the write path REFUSES markup rather than sanitizing it. Same #652 caveat as the menus above.",
   "/api/v1/auth/session":
     "ADR-0049 — session introspection for the BFF of ADR-0050. The static build must NOT call it (it refuses machine credentials by design); the BFF that will is not built yet.",
   "/api/v1/access/machine-credentials":

--- a/tests/api-consumer-contract.test.ts
+++ b/tests/api-consumer-contract.test.ts
@@ -186,7 +186,7 @@ describe("the live contract", () => {
  * a fourth consumed surface here has to be a deliberate edit in both places.
  */
 describe("consumed vs committed", () => {
-  test("exactly five surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
+  test("exactly seven surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
     // If this fails, one of two things happened, and they need opposite fixes:
     //   - awcms-astro started (or stopped) calling a surface -> update both
     //     this list and the marker block in that repo, in the same change;
@@ -203,12 +203,20 @@ describe("consumed vs committed", () => {
     // `/api/v1/blog/terms` is the fifth and took the identical path: COMMITTED
     // in #650 with ADR-0104, moved here when `ahliweb/awcms-astro#66` built the
     // category and tag archives on it.
+    //
+    // The sixth and seventh, `/blog/menus` and `/blog/widgets`, took the same
+    // path with one extra step in front of it: they could not be frozen at all
+    // until #652 gave their responses an actual schema. Freezing an array of
+    // bare `object` would have added a path to this list that no change could
+    // ever break — a contract entry with no contract in it.
     expect(Object.keys(CONSUMED_PATHS)).toEqual([
       "/api/v1/blog/posts",
       "/api/v1/media/objects",
       "/api/v1/media/public-origin",
       "/api/v1/site-profile/composed",
-      "/api/v1/blog/terms"
+      "/api/v1/blog/terms",
+      "/api/v1/blog/menus",
+      "/api/v1/blog/widgets"
     ]);
   });
 


### PR DESCRIPTION
Final step of #597 item 6. `ahliweb/awcms-astro#67` renders the tenant's navigation menu and its widgets, so `/api/v1/blog/menus` and `/api/v1/blog/widgets` move from `COMMITTED_PATHS` to `CONSUMED_PATHS` and the pinned count goes five → seven — the same number that repo's own gate asserts.

## One step the other surfaces did not have

`/api/v1/blog/terms` could be frozen the moment it was decided. These two **could not be frozen at all** until #652 gave their responses an actual schema.

Freezing an array of bare `object` would have added two paths to this list that **no change could ever break** — a contract entry with no contract in it. That is a more expensive kind of nothing than an empty list, because it reads as coverage: the gate would print a larger number and guard exactly as much as before.

That is why #652 came first and why it was a separate change rather than a paragraph in this one.

## Where #597 stands

This closes item 6 — and with it the last item on that issue that was **not** waiting on a written decision. What remains:

- **item 3 / #607** (reader search UI) — needs an ADR: the static site has never talked to `awcms` at runtime, and a search box means the *reader's browser* calling it. CORS, `connect-src`.
- **item 4** (byline) — needs a new surface *and* a decision: `structured-data-rendering.ts` deliberately emits the tenant name rather than a person's.
- **item 8** (video embeds) — the issue's own DoD requires an ADR for the CSP decision.
- **item 9** (analytics beacon) — `AGENTS.md` §Keamanan over there bans "analytics that bind an identity", with the `comments`/`form-drafts` precedent that such things are enabled "only through a new ADR".

`DATABASE_URL="" bun run check` green, `build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)