### PR TITLE
fix(identity-access): a delegated access grant that had run out kept conferring its role

### DIFF
--- a/.changeset/delegated-grant-expiry-is-a-gate.md
+++ b/.changeset/delegated-grant-expiry-is-a-gate.md
@@ -1,0 +1,54 @@
+---
+"awcms": patch
+---
+
+fix(identity-access): a delegated access grant that had run out kept conferring its role
+
+`sql/117` gave every partner grant an `expires_at`, ADR-0090 wrote that
+revocation **and expiry** deactivate the membership in the same transaction, and
+`expireDelegatedAccessGrants` exists to do it. Nothing has ever called it — no
+job descriptor, no script, no `package.json` target — and both request-time
+resolvers filtered on `revoked_at IS NULL` alone. A partner engagement approved
+"until 30 September" therefore conferred its role for as long as nobody revoked
+it by hand, and the 31-day `CHECK` that caps the date was enforcing a ceiling on
+a value nothing read. `sql/117` even ships a `(tenant_id, expires_at)` index
+built for the sweep that was never wired.
+
+**Expiry is now a gate, not a sweep.** `resolveDelegatedGrantState` carries
+`expires_at > now()` in the same statement that reads the partner's registry
+status, and the chokepoint refuses `403 DELEGATED_GRANT_EXPIRED` above
+`fetchGrantedPermissionKeys`, so no grant row can influence it. That is the shape
+this module already uses twice — `isBusinessScopeAssignmentCurrentlyActive` and
+`isSoDConflictExceptionCurrentlyValid` both refuse an elapsed row at decision
+time and leave `status` to a job. A sweep alone would leave a window between the
+second on the row and the second the timer next fires, which is precisely when
+the access was supposed to have stopped.
+
+`now()` rather than a parameter, because it is the transaction-start instant from
+the same clock that wrote the column; comparing against a JavaScript `Date` would
+make the gate depend on two clocks agreeing.
+
+**The refusal is named accurately, and that is not cosmetic.** An expired grant
+also reads as "no live row" to the partner-registry resolver, so it would have
+fallen through the existing `partner_suspended` branch and written a decision-log
+row asserting a suspension that never happened — sending a customer to ask a
+vendor about it. The new branch runs first and files under
+`delegated_grant_expired`. The attribution resolver is deliberately left
+unfiltered: a refusal that cannot name the engagement is where an investigation
+stops, and the id reaches audit rows only, never a decision.
+
+Redemption now also stamps the grant's own `expires_at` onto the role it writes
+(`effective_to`), so `activeRoleGrants` — whose `effective_to IS NULL` branch
+means "in force forever" — stops answering yes on its own. Both timestamps are
+written together: `sql/102` constrains `effective_to > effective_from`, and
+`effective_from` DEFAULTs to `now()`, so supplying only the end date would
+compare this process's clock against PostgreSQL's and could refuse a legitimate
+redemption whenever the two disagree.
+
+Still outstanding, and deliberately a separate change: the sweep that ends the
+membership row and its sessions. Until it lands an expired actor is refused every
+authorization but keeps an `active` row in the customer's user list — bookkeeping,
+not access. It is separate because giving `awcms_worker` blanket `UPDATE` on
+`awcms_tenant_users` and `awcms_sessions` would hand a scheduled job the ability
+to re-activate a deactivated member and un-revoke a session, which is a wider
+privilege than the sweep needs and warrants its own decision.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:1ae99f2a24cb338cd378b46e6b40e4139ae4323ef55e37236bb4c272a956b515 -->
+<!-- i18n-source-hash: sha256:b40ae00dfd60694e88244573f1c6e20e0a08bbfcd4156026f8aada80e5ad8574 -->
 
 # AWCMS — Project State & Continuation
 
@@ -392,6 +392,8 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
   ### A. Keamanan
   1. **A1 — grant delegated-access yang sudah ditebus TIDAK PERNAH kedaluwarsa.**
+     **SEBAGIAN BESAR SELESAI (22 Agustus 2026)** — gerbangnya mendarat; sapuannya tidak,
+     lihat paragraf penutup.
      _(ditemukan independen oleh dua dimensi, dari sisi job dan dari sisi chokepoint)_
      `identity-access/application/auth-context.ts:63-70` dan `:101-108`;
      `delegated-access-store.ts:283`; `access-policy-writer.ts:65`; `grant-source.ts:113`;
@@ -408,6 +410,38 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
      `isDelegatedPartnerRefused` yang sudah ada — tanpa jalur kode baru); teruskan
      `expiresAt` grant sebagai `effective_to`; lalu tambahkan job-nya supaya sesi
      benar-benar dicabut.
+
+     **Yang mendarat, dan dua tempat rencananya TIDAK diikuti.** Predikatnya kini ada di
+     `resolveDelegatedGrantState` (resolver yang diganti nama, menjawab kedaluwarsa dan
+     status partner dari SATU baris), dan penebusan menstempel `effective_to` **berpasangan
+     dengan `effective_from` eksplisit** — `sql/102` membandingkan kedua kolom itu dan
+     `effective_from` ber-DEFAULT `now()`, jadi mengirim hanya tanggal akhir berarti
+     membandingkan jam proses ini dengan jam PostgreSQL dan bisa menolak penebusan yang
+     sah. Kedaluwarsa TIDAK jatuh ke cabang `partner_suspended` seperti rencana: itu akan
+     menulis baris decision-log yang menyatakan penangguhan yang tidak pernah terjadi, jadi
+     ia mendapat cabangnya sendiri di atasnya (`403 DELEGATED_GRANT_EXPIRED`,
+     `matchedPolicy: "delegated_grant_expired"`). Resolver ATRIBUSI
+     (`resolveDelegatedGrantId`) sengaja dibiarkan tanpa saringan — pembacanya hanya
+     `awcms_abac_decision_logs` dan `awcms_audit_events` (terverifikasi), jadi id basi tak
+     bisa melebarkan keputusan apa pun dan justru itulah yang membuat penolakannya menyebut
+     keterlibatan mana.
+
+     **Masih terbuka: sapuannya.** Aktor yang kedaluwarsa ditolak setiap otorisasi tetapi
+     tetap memegang baris `active` di daftar pengguna pelanggan dan baris sesi hidup —
+     pembukuan, bukan akses. `expireDelegatedAccessGrants` masih nol pemanggil.
+     Penghalangnya keputusan HAK AKSES, bukan pekerjaan: sapuan itu mematikan keanggotaan
+     dan mencabut sesinya, sedangkan `awcms_worker` tidak memegang `UPDATE` pada
+     `awcms_tenant_users` maupun apa pun pada `awcms_sessions`. Memberikannya polos akan
+     membuat sebuah job terjadwal bisa mengembalikan anggota nonaktif menjadi `active` dan
+     mengembalikan `revoked_at` menjadi `NULL` pada sesi curian — lebih lebar dari yang
+     dibutuhkan sapuan, dan ke arah eskalasi. Tiga kandidatnya: (a) fungsi `SECURITY
+DEFINER` sempit mengikuti preseden `sql/048`/`sql/119`/`sql/124`, hanya arah-tolak;
+     (b) grant ber-kolom plus risiko sisa yang diterima dan DITULIS; (c) menjalankan job
+     yang satu ini di koneksi `awcms_app`, yang sudah memegang persis hak ini karena
+     pencabutan jalur-request melakukan hal yang sama — dengan ongkos `db:work-class:check`
+     menemukan skrip worker lewat grep `getWorkerDatabaseClient(`, sehingga job itu jatuh
+     keluar dari model kapasitas.
+
   2. **A2 — penangguhan ADR-0073 tidak menjangkau factory rute self-service maupun
      client-credential.** `_shared/tenant-route.ts:247-301` dan `:342-379`;
      `auth/profile.ts:125`; `session-handoff/{issue,redeem}.ts`; `auth/password/change.ts:118`.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -391,8 +391,8 @@ pioneered directly here after the ADR-0047 freeze.)
   defect of this class ship green).
 
   ### A. Security
-  1. **A1 — a redeemed delegated-access grant never expires.** _(found independently by
-     two dimensions, from the job side and the chokepoint side)_
+  1. **A1 — a redeemed delegated-access grant never expires.** **MOSTLY DONE (22 August 2026)** — the gate landed; the sweep did not, see the closing paragraph.
+     _(found independently by two dimensions, from the job side and the chokepoint side)_
      `identity-access/application/auth-context.ts:63-70` and `:101-108`;
      `delegated-access-store.ts:283`; `access-policy-writer.ts:65`; `grant-source.ts:113`;
      `sql/117:105,165`. `expireDelegatedAccessGrants` has **zero callers** — no job
@@ -407,6 +407,36 @@ pioneered directly here after the ADR-0047 freeze.)
      through the existing `isDelegatedPartnerRefused` null-is-refuse branch — no new code
      path); pass the grant's `expiresAt` as `effective_to`; then add the job so sessions
      are actually revoked.
+
+     **What landed, and the two places the plan was not followed.** The predicate is now
+     in `resolveDelegatedGrantState` (the renamed resolver, which answers expiry and
+     partner status off ONE row), and redemption stamps `effective_to` **paired with an
+     explicit `effective_from`** — `sql/102` compares the two columns and `effective_from`
+     DEFAULTs to `now()`, so supplying only the end date would compare this process's
+     clock against PostgreSQL's and could refuse a legitimate redemption. Expiry does NOT
+     fall through the `partner_suspended` branch as planned: that would have written a
+     decision-log row asserting a suspension that never happened, so it gets its own
+     branch above it (`403 DELEGATED_GRANT_EXPIRED`, `matchedPolicy:
+"delegated_grant_expired"`). The ATTRIBUTION resolver (`resolveDelegatedGrantId`) is
+     deliberately left unfiltered — its only readers are `awcms_abac_decision_logs` and
+     `awcms_audit_events` (verified), so a stale id can widen no decision and it is what
+     makes the refusal name the engagement.
+
+     **Still open: the sweep.** An expired actor is refused every authorization but keeps
+     an `active` row in the customer's user list and a live session row — bookkeeping, not
+     access. `expireDelegatedAccessGrants` still has zero callers. The blocker is a
+     PRIVILEGE decision, not work: the sweep ends a membership and revokes its sessions,
+     and `awcms_worker` holds neither `UPDATE` on `awcms_tenant_users` nor anything on
+     `awcms_sessions`. Granting them plainly would let a scheduled job set a deactivated
+     member back to `active` and set `revoked_at` back to `NULL` on a stolen session —
+     wider than the sweep needs, and in the escalation direction. The three candidates:
+     (a) a narrow `SECURITY DEFINER` function per the `sql/048`/`sql/119`/`sql/124`
+     precedent, deny-direction only; (b) column-scoped grants plus an accepted residual
+     risk, written down; (c) run this one job on the `awcms_app` connection, which already
+     holds exactly these privileges because the request-path revocation does the identical
+     thing — at the cost that `db:work-class:check` discovers worker scripts by grepping
+     `getWorkerDatabaseClient(`, so the job would fall out of the capacity model.
+
   2. **A2 — ADR-0073 suspension does not reach the self-service or client-credential
      route factories.** `_shared/tenant-route.ts:247-301` and `:342-379`;
      `auth/profile.ts:125`; `session-handoff/{issue,redeem}.ts`; `auth/password/change.ts:118`.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 436   |
+| Test files                          | 437   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -352,7 +352,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 373        |
+| `(root)`      | 374        |
 | `e2e`         | 12         |
 | `integration` | 50         |
 | `unit`        | 1          |

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -36,7 +36,7 @@ import {
 import { listModules } from "../../index";
 import {
   fetchGrantedPermissionKeys,
-  resolveDelegatedPartnerRegistryStatus,
+  resolveDelegatedGrantState,
   resolveModuleAvailability,
   resolveTenantPrincipal,
   resolveTenantPrincipalForTenantUser
@@ -57,7 +57,10 @@ import {
 } from "../../../lib/auth/machine-credential-token";
 import { isPrincipalSelectionHash } from "../../../lib/auth/principal-selection-token";
 import { isDelegatedAccessCodeHash } from "../../../lib/auth/delegated-access-code";
-import { isDelegatedWriteForbidden } from "../domain/delegated-access";
+import {
+  isDelegatedGrantNotInForce,
+  isDelegatedWriteForbidden
+} from "../domain/delegated-access";
 
 /**
  * Resolves the tenant id + bearer token an endpoint should authenticate with,
@@ -542,20 +545,61 @@ export async function authorizeInTransaction(
   // anybody rewriting anything.
   //
   // The read costs one query, and only for a delegated actor — a support
-  // episode, not the hot path. `resolveDelegatedPartnerRegistryStatus` returns
-  // `null` for every ordinary member, and `isDelegatedPartnerRefused` answers
-  // `false` for them before it looks at the status at all.
-  const partnerRegistryStatus = await resolveDelegatedPartnerRegistryStatus(
+  // episode, not the hot path. `resolveDelegatedGrantState` short-circuits for
+  // every ordinary member, and both deny rules answer `false` for them before
+  // they look at either field at all.
+  const delegatedGrantState = await resolveDelegatedGrantState(
     tx,
     tenantId,
     context.tenantUserId,
     context.principalKind ?? "user"
   );
 
+  // ADR-0090 — a grant that is past its date confers nothing, from that instant.
+  //
+  // Above the partner check, and the ORDER is the point rather than an accident:
+  // an expired grant also reads as "no live row" to the partner resolver, so
+  // whichever branch runs first is the one that names the refusal. Recording an
+  // expiry as `partner_suspended` would put a false fact in the decision log and
+  // send a customer to ask a vendor about a suspension that never happened.
+  //
+  // Structural, and above `fetchGrantedPermissionKeys`, so no grant row can
+  // influence it — the redemption path also stamps `effective_to` on the role
+  // grant it writes, but that only covers grants redeemed since, and this covers
+  // every one of them.
+  if (
+    isDelegatedGrantNotInForce({
+      principalKind: context.principalKind ?? "user",
+      grantLive: delegatedGrantState.grantLive
+    })
+  ) {
+    const decision = {
+      allowed: false,
+      reason:
+        "The delegated access grant behind this session is no longer in force.",
+      matchedPolicy: "delegated_grant_expired"
+    };
+
+    await recordDecisionLog(
+      tx,
+      tenantId,
+      context.tenantUserId,
+      guard,
+      decision,
+      machine?.id,
+      context.delegatedGrantId
+    );
+
+    return {
+      allowed: false,
+      denied: fail(403, "DELEGATED_GRANT_EXPIRED", decision.reason)
+    };
+  }
+
   if (
     isDelegatedPartnerRefused({
       principalKind: context.principalKind ?? "user",
-      partnerRegistryStatus
+      partnerRegistryStatus: delegatedGrantState.partnerRegistryStatus
     })
   ) {
     const decision = {

--- a/src/modules/identity-access/application/access-policy-writer.ts
+++ b/src/modules/identity-access/application/access-policy-writer.ts
@@ -33,6 +33,24 @@ export type GrantRolePolicyInput = {
   /** `null` for bootstrap, where no session exists yet to attribute it to. */
   grantedByTenantUserId: string | null;
   reason?: string;
+  /**
+   * An END DATE for the grant, for the callers that have one — today only the
+   * delegated-access redemption, whose grant carries `expires_at` (ADR-0090).
+   * Omitted means open-ended, which is what every other grant is.
+   *
+   * ## Pass BOTH or NEITHER
+   *
+   * `sql/102` constrains `effective_to > effective_from`, and `effective_from`
+   * DEFAULTs to `now()` — the TRANSACTION START instant, not the application's
+   * clock. Supplying only `effectiveTo` would compare a `Date` this process
+   * produced against an instant PostgreSQL produced, so a grant whose end date
+   * is genuinely in the future can still trip the CHECK whenever the two clocks
+   * disagree by more than the remaining life of the grant. Supplying both makes
+   * the constraint compare two values from the SAME clock — the one the caller
+   * already validated the pair against.
+   */
+  effectiveFrom?: Date;
+  effectiveTo?: Date;
 };
 
 export type GrantGroupRolePolicyInput = {
@@ -65,11 +83,13 @@ export async function grantRolePolicy(
   const rows = (await tx`
     INSERT INTO awcms_access_policies
       (tenant_id, subject_type, tenant_user_id, role_id, scope_type, scope_id,
-       granted_by_tenant_user_id, reason)
+       granted_by_tenant_user_id, reason, effective_from, effective_to)
     VALUES
       (${tenantId}, 'tenant_user', ${input.tenantUserId}, ${input.roleId},
        ${TENANT_WIDE_SCOPE_TYPE}, ${tenantId},
-       ${input.grantedByTenantUserId}, ${input.reason ?? null})
+       ${input.grantedByTenantUserId}, ${input.reason ?? null},
+       COALESCE(${input.effectiveFrom ?? null}::timestamptz, now()),
+       ${input.effectiveTo ?? null}::timestamptz)
     RETURNING id
   `) as { id: string }[];
 

--- a/src/modules/identity-access/application/auth-context.ts
+++ b/src/modules/identity-access/application/auth-context.ts
@@ -51,6 +51,16 @@ export type ResolvedTenantPrincipal = {
  * fail-quiet by design: the id is an ATTRIBUTION, not an authorization input.
  * Nothing is permitted or refused because of it, so a missing one costs a
  * column in an audit row and never a decision.
+ *
+ * ## Deliberately NOT filtered on `expires_at`
+ *
+ * `resolveDelegatedGrantState` is; this is not, and the asymmetry is the point.
+ * A request refused BECAUSE the grant expired is exactly the row an
+ * investigation starts from, and dropping the id there would leave the decision
+ * log saying "some delegated actor was refused" without naming which engagement.
+ * The only readers are `awcms_abac_decision_logs` and `awcms_audit_events`
+ * (verified: no other caller), so a stale id can widen no decision — it can only
+ * make the refusal legible.
  */
 async function resolveDelegatedGrantId(
   tx: Bun.SQL,
@@ -71,12 +81,35 @@ async function resolveDelegatedGrantId(
 }
 
 /**
- * The registry status of the partner behind a delegated actor — ADR-0093.
+ * The two authorization facts about the grant behind a delegated actor: is the
+ * grant still IN FORCE, and is the partner it belongs to still registered —
+ * ADR-0090 (expiry) and ADR-0093 (suspension).
  *
  * A SEPARATE call from `resolveDelegatedGrantId`, and deliberately so: that one
  * resolves an ATTRIBUTION and is documented as fail-quiet, because nothing is
  * permitted or refused because of it. This one IS an authorization input, and
  * mixing the two would give a fail-quiet resolver a decision to make.
+ *
+ * ## `expires_at > now()` is the gate ADR-0090 promised
+ *
+ * ADR-0090 says revocation **and expiry** deactivate the membership in the same
+ * transaction. Revocation had an executor; expiry never did, so until this
+ * predicate existed a grant scoped "until 30 September" kept conferring its role
+ * for as long as nobody revoked it by hand. The sweep
+ * (`identity-access:delegated-access:expiry`) is CLEANUP — it ends the session
+ * and the membership — and this predicate is the gate: expiry takes effect at
+ * the instant on the row, not at the instant a timer next fires.
+ *
+ * `now()` is the transaction start instant, so every decision inside one request
+ * reads the same clock, and it is the DATABASE's clock — the same one that wrote
+ * `expires_at`. Comparing it against an application `Date` would make the gate
+ * depend on two clocks agreeing.
+ *
+ * ## Why one query for two facts
+ *
+ * They come off the same row. A second round trip would buy nothing, and the
+ * caller needs both before it can name the refusal correctly — an expired grant
+ * recorded as `partner_suspended` puts a false fact in the decision log.
  *
  * `awcms_partners` belongs to the PLATFORM tenant and is `FORCE ROW LEVEL
  * SECURITY`; this runs in the CUSTOMER's transaction and cannot read it. The
@@ -84,32 +117,50 @@ async function resolveDelegatedGrantId(
  * a `text`, never a row — with the four `sql/048` safeguards and the same
  * memberless NOLOGIN owner `sql/119` created.
  *
- * Returns `null` for a non-delegated actor (nothing to ask about) and for a
- * partner with no registry row. The caller must treat the SECOND `null` as
- * suspended; `isDelegatedPartnerRefused` does, and only ever looks at the
- * status for a delegated principal, so the two `null`s cannot be confused into
- * refusing an ordinary member.
+ * For a NON-delegated actor this returns `{ grantLive: true, status: null }`:
+ * there is no grant to be past its date and no partner to ask about, and the
+ * two deny rules both look at `principalKind` before they look at either field,
+ * so an ordinary member's decision is exactly where it was.
+ *
+ * For a delegated actor with no matching row BOTH fields say refuse. That is
+ * unreachable (`sql/120`'s foreign key keeps the partner registered, and
+ * `sql/117`'s pairing constraint keeps a redeemed grant's tenant user set), and
+ * it is because it is unreachable that fail-closed costs nothing.
  */
-export async function resolveDelegatedPartnerRegistryStatus(
+export type DelegatedGrantState = {
+  /** `false` once `expires_at` has passed, or when no live grant row matches. */
+  grantLive: boolean;
+  partnerRegistryStatus: PartnerRegistryStatus;
+};
+
+export async function resolveDelegatedGrantState(
   tx: Bun.SQL,
   tenantId: string,
   tenantUserId: string,
   principalKind: PrincipalKind
-): Promise<PartnerRegistryStatus> {
-  if (principalKind !== "delegated") return null;
+): Promise<DelegatedGrantState> {
+  if (principalKind !== "delegated") {
+    return { grantLive: true, partnerRegistryStatus: null };
+  }
 
   const rows = (await tx`
-    SELECT awcms_partner_registry_status(g.partner_tenant_id) AS status
+    SELECT awcms_partner_registry_status(g.partner_tenant_id) AS status,
+           (g.expires_at > now()) AS grant_live
     FROM awcms_delegated_access_grants g
     WHERE g.tenant_id = ${tenantId}
       AND g.granted_tenant_user_id = ${tenantUserId}
       AND g.revoked_at IS NULL
     LIMIT 1
-  `) as { status: string | null }[];
+  `) as { status: string | null; grant_live: boolean }[];
 
-  const status = rows[0]?.status ?? null;
+  const row = rows[0];
+  const status = row?.status ?? null;
 
-  return status === "active" || status === "suspended" ? status : null;
+  return {
+    grantLive: row?.grant_live === true,
+    partnerRegistryStatus:
+      status === "active" || status === "suspended" ? status : null
+  };
 }
 
 export async function resolveTenantContextForTenantUser(

--- a/src/modules/identity-access/application/delegated-access-store.ts
+++ b/src/modules/identity-access/application/delegated-access-store.ts
@@ -198,7 +198,20 @@ export async function redeemDelegatedAccess(
     // dibuktikan lebih lanjut oleh email konfirmasi kedua.
     emailVerified: true,
     roleIds: [grant.role_id],
-    reason: `delegated_access:${grant.id}`
+    reason: `delegated_access:${grant.id}`,
+    // ADR-0090 — the role ends when the ENGAGEMENT does. Without this the grant
+    // row carried a date and the thing it granted did not, so `activeRoleGrants`
+    // (whose `effective_to IS NULL` branch means "in force forever") kept
+    // answering yes long after the partner was supposed to be gone.
+    //
+    // Both instants come from the pair this function has ALREADY compared four
+    // lines above: `now` is the caller's clock and `expires_at` was read on this
+    // row, so the `sql/102` CHECK re-checks exactly the assertion that let
+    // execution reach here. Re-parsing `expires_at` truncates PostgreSQL's
+    // microseconds to JavaScript milliseconds — up to 999µs EARLIER, which is
+    // the direction that can only end the grant sooner.
+    roleEffectiveFrom: now,
+    roleEffectiveTo: new Date(grant.expires_at)
   });
 
   if (membership.outcome !== "created") {

--- a/src/modules/identity-access/application/membership-materialization.ts
+++ b/src/modules/identity-access/application/membership-materialization.ts
@@ -72,6 +72,17 @@ export type MaterializeMembershipInput = {
   roleIds: readonly string[];
   /** Recorded on each grant, so `awcms_access_policy_events` says WHY the role was held. */
   reason: string;
+  /**
+   * ADR-0090 — the instant the granted roles stop being in force, for the one
+   * caller whose offer carries an end date (delegated-access redemption).
+   * Omitted means open-ended: an invitation grants a membership, not an episode.
+   *
+   * Paired with `roleEffectiveFrom` for the reason `GrantRolePolicyInput`
+   * records — the two are compared by a CHECK, and only the caller knows which
+   * clock produced the end date.
+   */
+  roleEffectiveFrom?: Date;
+  roleEffectiveTo?: Date;
 };
 
 export type MaterializeMembershipResult =
@@ -185,7 +196,9 @@ export async function materializeMembership(
       // No actor: the invitee granted themselves nothing. The administrator who
       // decided this is named by the invitation, and by its audit row.
       grantedByTenantUserId: null,
-      reason: input.reason
+      reason: input.reason,
+      effectiveFrom: input.roleEffectiveFrom,
+      effectiveTo: input.roleEffectiveTo
     });
   }
 

--- a/src/modules/identity-access/domain/delegated-access.ts
+++ b/src/modules/identity-access/domain/delegated-access.ts
@@ -60,6 +60,43 @@ export function isDelegatedWriteForbidden(input: {
   return input.action !== DELEGATED_ALLOWED_ACTION_IN_FORBIDDEN_MODULE;
 }
 
+/**
+ * Deny-only. `true` HANYA untuk aktor terdelegasi yang grantnya sudah lewat
+ * tanggalnya — atau yang tidak punya baris grant hidup sama sekali.
+ *
+ * ## Kenapa aturan ini ada di sini dan bukan di jobnya
+ *
+ * ADR-0090 menjanjikan pencabutan **dan kedaluwarsa** mematikan keanggotaan di
+ * transaksi yang sama. Pencabutan punya pelaksana; kedaluwarsa tidak pernah
+ * punya. Sebuah sapuan terjadwal — sebaik apa pun jadwalnya — meninggalkan
+ * jendela antara detik `expires_at` dan detik timer berikutnya, dan jendela itu
+ * PERSIS saat aksesnya seharusnya sudah berhenti. Preseden yang sama sudah
+ * tertulis dua kali di repo ini: `isBusinessScopeAssignmentCurrentlyActive` dan
+ * `isSoDConflictExceptionCurrentlyValid` keduanya menolak baris yang lewat
+ * `effective_to` pada waktu keputusan, dan jobnya cuma membereskan `status`.
+ *
+ * ## Kenapa `grantLive` dan bukan `expiresAt`
+ *
+ * Perbandingannya dikerjakan basis data terhadap jamnya sendiri — jam yang sama
+ * yang menulis `expires_at`. Membawa `Date` aplikasi ke sini akan membuat
+ * gerbangnya bergantung pada dua jam yang sepakat, dan `now()` Postgres adalah
+ * instant MULAI TRANSAKSI sehingga setiap keputusan dalam satu permintaan
+ * membaca jam yang sama.
+ *
+ * Aktor biasa (`principalKind` absen atau `"user"`) mendapat `false` sebelum
+ * `grantLive` dilihat sama sekali, jadi keputusannya tidak berubah.
+ */
+export function isDelegatedGrantNotInForce(input: {
+  /** `undefined` dibaca sebagai `"user"` — lihat `TenantContext.principalKind`. */
+  principalKind?: PrincipalKind;
+  /** Dari `resolveDelegatedGrantState`: `expires_at > now()` di baris grantnya. */
+  grantLive: boolean;
+}): boolean {
+  if (input.principalKind !== "delegated") return false;
+
+  return !input.grantLive;
+}
+
 export type DelegatedGrantTtlProblem =
   | { ok: true }
   | { ok: false; reason: "expires_in_the_past" | "exceeds_max_ttl" };

--- a/tests/delegated-grant-expiry.test.ts
+++ b/tests/delegated-grant-expiry.test.ts
@@ -1,0 +1,218 @@
+/**
+ * An expired delegated grant confers nothing — ADR-0090, finding A1 of the
+ * 17 August 2026 audit round.
+ *
+ * `sql/117` gave every grant an `expires_at` and a 31-day CHECK, ADR-0090 wrote
+ * that revocation **and expiry** deactivate the membership, and
+ * `expireDelegatedAccessGrants` was written to do it. Nothing ever called it,
+ * and both request-time resolvers filtered on `revoked_at IS NULL` alone — so a
+ * partner engagement scoped "until 30 September" kept conferring its role until
+ * somebody revoked it by hand. The date was decoration.
+ *
+ * The repair is deliberately NOT "schedule the sweep". A sweep leaves a window
+ * between the second on the row and the second the timer next fires, and that
+ * window is exactly when the access should already have stopped. So expiry is a
+ * DECISION-TIME gate, the shape `isBusinessScopeAssignmentCurrentlyActive` and
+ * `isSoDConflictExceptionCurrentlyValid` already use twice over in this module,
+ * and the sweep — when it lands — is bookkeeping on top of a gate that has
+ * already refused.
+ *
+ * These tests hold three properties, and the third is the one a behavioural
+ * test cannot see:
+ *
+ * - **deny-only.** An ordinary member's decision is untouched, whatever the
+ *   dates say.
+ * - **fail-closed.** No live grant row reads as "not in force".
+ * - **the comparison happens in the DATABASE, against the clock that wrote the
+ *   column.** A resolver that pulled `expires_at` out and compared it to a
+ *   JavaScript `Date` would pass every behavioural test and make the gate
+ *   depend on two clocks agreeing.
+ *
+ * Pure — no database, no network. The SQL assertions read the statements as
+ * source, which is the only way to pin "the predicate is INSIDE the statement".
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/access-chokepoint-check";
+import { isDelegatedGrantNotInForce } from "../src/modules/identity-access/domain/delegated-access";
+
+const GUARD = "src/modules/identity-access/application/access-guard.ts";
+const AUTH_CONTEXT = "src/modules/identity-access/application/auth-context.ts";
+const GRANT_STORE =
+  "src/modules/identity-access/application/delegated-access-store.ts";
+const POLICY_WRITER =
+  "src/modules/identity-access/application/access-policy-writer.ts";
+
+describe("the decision rule is deny-only and fail-closed", () => {
+  test("an ordinary member is never refused, whatever `grantLive` says", () => {
+    for (const grantLive of [true, false]) {
+      expect(
+        isDelegatedGrantNotInForce({ principalKind: "user", grantLive })
+      ).toBe(false);
+      // `undefined` reads as "user" — the field is optional on TenantContext.
+      expect(isDelegatedGrantNotInForce({ grantLive })).toBe(false);
+    }
+  });
+
+  test("a delegated actor is refused exactly when the grant is not live", () => {
+    expect(
+      isDelegatedGrantNotInForce({
+        principalKind: "delegated",
+        grantLive: true
+      })
+    ).toBe(false);
+    expect(
+      isDelegatedGrantNotInForce({
+        principalKind: "delegated",
+        grantLive: false
+      })
+    ).toBe(true);
+  });
+});
+
+describe("the resolver asks the database, not the process clock", () => {
+  test("the predicate is `expires_at > now()`, inside the statement", async () => {
+    const source = stripComments(await readFile(AUTH_CONTEXT, "utf8"));
+
+    const statement = source.slice(
+      source.indexOf("export async function resolveDelegatedGrantState"),
+      source.indexOf("`) as { status: string | null; grant_live: boolean }[]")
+    );
+
+    expect(statement.length).toBeGreaterThan(200);
+    expect(statement).toContain("g.expires_at > now()");
+    // The whole point of `now()`: it is the transaction-start instant, from the
+    // same clock that wrote `expires_at`. A `${now}` parameter here would carry
+    // this process's clock into a comparison the database is answering.
+    expect(statement).not.toMatch(/expires_at\s*>\s*\$\{/);
+  });
+
+  test("both facts come off one row, so the refusal can be named correctly", async () => {
+    const source = stripComments(await readFile(AUTH_CONTEXT, "utf8"));
+
+    const statement = source.slice(
+      source.indexOf("export async function resolveDelegatedGrantState"),
+      source.indexOf("`) as { status: string | null; grant_live: boolean }[]")
+    );
+
+    expect(statement).toContain("awcms_partner_registry_status(");
+    expect(statement).toContain("grant_live");
+    expect(
+      (statement.match(/FROM awcms_delegated_access_grants/g) ?? []).length
+    ).toBe(1);
+  });
+
+  test("no live row means BOTH fields refuse", async () => {
+    const source = stripComments(await readFile(AUTH_CONTEXT, "utf8"));
+
+    // `row?.grant_live === true` rather than `!== false`: a missing row, a NULL
+    // and an undefined column all have to land on "not in force", and only an
+    // explicit positive test does that for all three.
+    expect(source).toContain("grantLive: row?.grant_live === true");
+  });
+
+  test("the attribution resolver is deliberately NOT filtered on expiry", async () => {
+    const source = stripComments(await readFile(AUTH_CONTEXT, "utf8"));
+
+    const attribution = source.slice(
+      source.indexOf("async function resolveDelegatedGrantId"),
+      source.indexOf("export type DelegatedGrantState")
+    );
+
+    expect(attribution.length).toBeGreaterThan(200);
+    expect(attribution).not.toContain("expires_at");
+    // Because that id is what makes the refusal legible: a decision log that
+    // cannot name the engagement is where an investigation stops.
+    expect(attribution).toContain(
+      "SELECT id FROM awcms_delegated_access_grants"
+    );
+  });
+});
+
+describe("the chokepoint refuses before anything can widen the decision", () => {
+  test("the expiry gate runs BEFORE any permission is fetched", async () => {
+    const source = stripComments(await readFile(GUARD, "utf8"));
+
+    const gate = source.indexOf("isDelegatedGrantNotInForce(");
+    const grants = source.indexOf("fetchGrantedPermissionKeys(");
+
+    expect(gate).toBeGreaterThan(-1);
+    expect(grants).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(grants);
+  });
+
+  test("it runs BEFORE the partner-suspension gate, so the reason is the true one", async () => {
+    const source = stripComments(await readFile(GUARD, "utf8"));
+
+    const expiry = source.indexOf("isDelegatedGrantNotInForce(");
+    const suspended = source.indexOf("isDelegatedPartnerRefused(");
+
+    expect(expiry).toBeGreaterThan(-1);
+    expect(suspended).toBeGreaterThan(-1);
+    // An expired grant also reads as "no live row" to the partner resolver, so
+    // whichever branch runs first names the refusal. Recording an expiry as
+    // `partner_suspended` would send a customer to ask a vendor about a
+    // suspension that never happened.
+    expect(expiry).toBeLessThan(suspended);
+  });
+
+  test("it refuses with its own code, and writes its own decision log", async () => {
+    const source = await readFile(GUARD, "utf8");
+
+    expect(source).toContain('"DELEGATED_GRANT_EXPIRED"');
+    expect(source).toContain('matchedPolicy: "delegated_grant_expired"');
+
+    const stripped = stripComments(source);
+    const gate = stripped.indexOf("isDelegatedGrantNotInForce(");
+    const log = stripped.indexOf("recordDecisionLog(", gate);
+    const refusal = stripped.indexOf("DELEGATED_GRANT_EXPIRED", gate);
+
+    expect(log).toBeGreaterThan(gate);
+    expect(log).toBeLessThan(refusal);
+  });
+});
+
+describe("redemption dates the role it grants", () => {
+  test("the redemption passes the grant's own expiry as the role's end date", async () => {
+    const source = stripComments(await readFile(GRANT_STORE, "utf8"));
+
+    const redeem = source.slice(
+      source.indexOf("export async function redeemDelegatedAccess"),
+      source.indexOf("UPDATE awcms_delegated_access_grants")
+    );
+
+    expect(redeem.length).toBeGreaterThan(200);
+    expect(redeem).toContain("roleEffectiveTo: new Date(grant.expires_at)");
+    // Paired, never alone: `sql/102` compares the two columns, and the default
+    // for `effective_from` is `now()` — the transaction clock, not this one.
+    expect(redeem).toContain("roleEffectiveFrom: now");
+    // And the pair is only safe because the function already refused a grant
+    // whose date has passed, against that same `now`.
+    expect(redeem).toContain('return { ok: false, code: "GRANT_EXPIRED" };');
+  });
+
+  test("the policy writer writes both columns, and defaults only the start", async () => {
+    const source = stripComments(await readFile(POLICY_WRITER, "utf8"));
+
+    const insert = source.slice(
+      source.indexOf("INSERT INTO awcms_access_policies"),
+      source.indexOf("RETURNING id")
+    );
+
+    expect(insert).toContain("effective_from, effective_to");
+    expect(insert).toContain("COALESCE(");
+    expect(insert).toContain("::timestamptz, now())");
+  });
+
+  test("every other grant stays open-ended", async () => {
+    const source = stripComments(await readFile(POLICY_WRITER, "utf8"));
+
+    // Optional, not required: an invitation grants a membership, not an
+    // episode, and a required end date would make every caller invent one.
+    expect(source).toContain("effectiveFrom?: Date;");
+    expect(source).toContain("effectiveTo?: Date;");
+    expect(source).toContain("${input.effectiveTo ?? null}::timestamptz");
+  });
+});

--- a/tests/partner-delegated-access-e2e.test.ts
+++ b/tests/partner-delegated-access-e2e.test.ts
@@ -26,10 +26,13 @@
  * - Point `listManagedTenants` at the table instead of the function → "the
  *   partner sees its book" goes RED with zero rows, which is exactly the
  *   failure `sql/119` exists to prevent.
- * - Point `resolveDelegatedPartnerRegistryStatus` at `awcms_partners` directly
- *   instead of `awcms_partner_registry_status()` → the suspension tests go RED
- *   with `null`, which is the SAME cross-tenant-read failure one table over
+ * - Point `resolveDelegatedGrantState` at `awcms_partners` directly instead of
+ *   `awcms_partner_registry_status()` → the suspension tests go RED with
+ *   `null`, which is the SAME cross-tenant-read failure one table over
  *   (ADR-0093).
+ * - Drop `AND (g.expires_at > now())` from `resolveDelegatedGrantState` → "the
+ *   chokepoint refuses the instant the grant's date passes" goes RED, which is
+ *   the state the repository actually shipped in until finding A1 (ADR-0090).
  */
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import type { APIRoute } from "astro";
@@ -499,6 +502,42 @@ describeOrSkip("partnership and delegated access (real PostgreSQL)", () => {
     expect(rows[0]!.status).toBe("active");
   });
 
+  test("ADR-0090: the role it grants carries the grant's OWN end date", async () => {
+    // Before this, the grant row had a date and the thing it granted did not:
+    // `activeRoleGrants` reads `effective_to IS NULL` as "in force forever", so
+    // an engagement scoped "until 30 September" conferred its role until
+    // somebody revoked it by hand.
+    await sql`SELECT set_config('app.current_tenant_id', ${customerTenantId}, false)`;
+    const rows = (await sql`
+      SELECT ap.effective_from, ap.effective_to, g.expires_at
+      FROM awcms_access_policies ap
+      JOIN awcms_delegated_access_grants g
+        ON g.tenant_id = ap.tenant_id AND g.id = ${grantId}
+      WHERE ap.tenant_id = ${customerTenantId}
+        AND ap.tenant_user_id = ${delegatedTenantUserId}
+    `) as {
+      effective_from: Date;
+      effective_to: Date | null;
+      expires_at: Date;
+    }[];
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.effective_to).not.toBeNull();
+
+    // Equal to the grant's own expiry, to the millisecond JavaScript can carry.
+    // PostgreSQL stores microseconds, so the round trip can only land EARLIER —
+    // the direction that ends the grant sooner, never later.
+    const stamped = new Date(rows[0]!.effective_to!).getTime();
+    const expires = new Date(rows[0]!.expires_at).getTime();
+    expect(expires - stamped).toBeGreaterThanOrEqual(0);
+    expect(expires - stamped).toBeLessThan(1000);
+
+    // And the CHECK it has to satisfy really is comparing these two columns.
+    expect(stamped).toBeGreaterThan(
+      new Date(rows[0]!.effective_from).getTime()
+    );
+  });
+
   test("the same code cannot be redeemed twice", async () => {
     const res = await callRoute(redeemPOST, {
       tenantId: partnerTenantId,
@@ -553,6 +592,99 @@ describeOrSkip("partnership and delegated access (real PostgreSQL)", () => {
     // The gate reads this field, and it comes from the row both resolvers read.
     expect(kinds).toBe("delegated");
     expect(typeof authorizeInTransaction).toBe("function");
+  });
+
+  test("ADR-0090: the chokepoint refuses the instant the grant's date passes", async () => {
+    const { authorizeInTransaction } =
+      await import("../src/modules/identity-access/application/access-guard");
+
+    // A live session for the delegated member — the chokepoint authenticates
+    // from a token hash, so "expired" has to be provable through the same door
+    // a real request comes in by.
+    await sql`SELECT set_config('app.current_tenant_id', ${customerTenantId}, false)`;
+    const identity = (await sql`
+      SELECT identity_id FROM awcms_tenant_users
+      WHERE tenant_id = ${customerTenantId} AND id = ${delegatedTenantUserId}
+    `) as { identity_id: string }[];
+
+    const token = generateSessionToken();
+    const tokenHash = hashSessionToken(token);
+    await sql`
+      INSERT INTO awcms_sessions (tenant_id, identity_id, token_hash, expires_at, origin_auth)
+      VALUES (${customerTenantId}, ${identity[0]!.identity_id},
+              ${tokenHash}, ${new Date(Date.now() + 3600_000)}, 'delegated')
+    `;
+
+    const guard = {
+      moduleKey: "blog_content",
+      activityCode: "posts",
+      action: "read" as const
+    };
+
+    const codeFor = async () => {
+      const result = await withTenantOrThrow(
+        sql,
+        customerTenantId,
+        (tx) =>
+          authorizeInTransaction(
+            tx,
+            customerTenantId,
+            tokenHash,
+            new Date(),
+            guard
+          ),
+        { workClass: "interactive" }
+      );
+
+      if (result.allowed) return "ALLOWED";
+      return ((await result.denied.json()) as { error: { code: string } }).error
+        .code;
+    };
+
+    // NON-VACUOUS: while the grant is live the refusal is the ordinary
+    // permission one. Without this half, a test asserting the expiry code would
+    // also pass against a chokepoint that refused delegated actors outright.
+    const before = await codeFor();
+    expect(before).not.toBe("DELEGATED_GRANT_EXPIRED");
+
+    // Age the grant past its date. `created_at` moves with it because `sql/117`
+    // constrains the PAIR (`expires_at > created_at` and within 31 days) — an
+    // UPDATE that moved only the end date would be refused by the database,
+    // which is itself the proof that the ceiling is enforced there and not only
+    // in `validateDelegatedGrantTtl`.
+    await sql`
+      UPDATE awcms_delegated_access_grants
+      SET created_at = now() - interval '40 days',
+          expires_at = now() - interval '10 days'
+      WHERE tenant_id = ${customerTenantId} AND id = ${grantId}
+    `;
+
+    expect(await codeFor()).toBe("DELEGATED_GRANT_EXPIRED");
+
+    // And the refusal is EXPLAINED, by its own name — not filed under the
+    // suspension the partner never had.
+    const logged = (await sql`
+      SELECT matched_policy FROM awcms_abac_decision_logs
+      WHERE tenant_id = ${customerTenantId}
+        AND tenant_user_id = ${delegatedTenantUserId}
+        AND matched_policy = 'delegated_grant_expired'
+    `) as { matched_policy: string }[];
+
+    expect(logged.length).toBeGreaterThan(0);
+
+    // Put the dates back: the arc continues with a grant that is revoked by a
+    // human, which is a different story from one that ran out.
+    await sql`
+      UPDATE awcms_delegated_access_grants
+      SET created_at = now() - interval '1 hour',
+          expires_at = now() + interval '7 days'
+      WHERE tenant_id = ${customerTenantId} AND id = ${grantId}
+    `;
+
+    await sql`
+      UPDATE awcms_sessions SET revoked_at = now()
+      WHERE tenant_id = ${customerTenantId} AND token_hash = ${tokenHash}
+    `;
   });
 
   test("revoking the grant deactivates the membership and kills its sessions", async () => {


### PR DESCRIPTION
Finding **A1** of the 17 August 2026 audit round (`docs/PROJECT_STATE.md` §4) — found independently from the job side and the chokepoint side, and the highest-payoff item on the "do first" list.

## What was wrong

`sql/117` gave every partner grant an `expires_at` and a 31-day `CHECK`. ADR-0090 wrote that revocation **and expiry** deactivate the membership in the same transaction. `expireDelegatedAccessGrants` exists to do it — and has **zero callers**: no job descriptor, no script, no `package.json` target. Both request-time resolvers filtered on `revoked_at IS NULL` alone, and the role grant written at redemption omitted `effective_to`, which `activeRoleGrants` reads as in force forever.

So an engagement approved "until 30 September" conferred its role indefinitely, the 31-day ceiling capped a value nothing read, and `sql/117:165` shipped a `(tenant_id, expires_at)` index built for a sweep that was never wired.

## The repair: a gate, not a sweep

`resolveDelegatedGrantState` (renamed from `resolveDelegatedPartnerRegistryStatus`) now answers **two** facts off one row — `expires_at > now()` and the partner's registry status — and the chokepoint refuses `403 DELEGATED_GRANT_EXPIRED` **above** `fetchGrantedPermissionKeys`, so no grant row can influence it.

A sweep alone leaves a window between the second on the row and the second the timer next fires, which is precisely when the access should already have stopped. This is the shape the module already uses twice: `isBusinessScopeAssignmentCurrentlyActive` and `isSoDConflictExceptionCurrentlyValid` both refuse an elapsed row at decision time and leave `status` to a job.

`now()` rather than a parameter: it is the transaction-start instant, from the same clock that wrote the column.

## Two places the recommendation was not followed, on purpose

- **The refusal does not fall through `partner_suspended`.** An expired grant also reads as "no live row" to the registry resolver, so it would have written a decision-log row asserting a suspension that never happened — and sent a customer to ask a vendor about it. It gets its own branch above, with `matchedPolicy: "delegated_grant_expired"`.
- **The ATTRIBUTION resolver stays unfiltered.** `resolveDelegatedGrantId`'s only readers are `awcms_abac_decision_logs` and `awcms_audit_events` (verified — no other caller), so a stale id can widen no decision, and it is what makes a refusal name the engagement instead of saying "some delegated actor".

## Redemption dates the role it grants

`effective_to` is stamped from the grant's own `expires_at`, **paired with an explicit `effective_from`**. `sql/102` constrains `effective_to > effective_from` and `effective_from` DEFAULTs to `now()`; supplying only the end date would compare this process's clock against PostgreSQL's and could refuse a legitimate redemption at the boundary.

## Deliberately not in this PR

The sweep that ends the membership row and its sessions. Until it lands, an expired actor is refused every authorization but keeps an `active` row in the customer's user list — bookkeeping, not access.

It is separate because it is a **privilege decision**, not more work: `awcms_worker` holds neither `UPDATE` on `awcms_tenant_users` nor anything on `awcms_sessions`, and granting them plainly would let a scheduled job set a deactivated member back to `active` and set `revoked_at` back to `NULL` on a stolen session. The three candidates are written into `docs/PROJECT_STATE.md` §4 under A1.

## Tests

- `tests/delegated-grant-expiry.test.ts` (new, pure): deny-only, fail-closed, the predicate is inside the statement, the gate ordering, and the redemption pairing. **Mutation-proven** — rewriting `now()` as a `${new Date()}` parameter turns it red.
- `tests/partner-delegated-access-e2e.test.ts` (real PostgreSQL): the role carries the grant's own end date; and the chokepoint refusal, made **non-vacuous** by asserting the code is *not* `DELEGATED_GRANT_EXPIRED` while the grant is still live, then ageing the row past its date and asserting it is — plus the decision-log row that names it.

`bun run check` full green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)