### PR TITLE
fix(security): a suspended tenant could still rewrite its profile, change its password and mint new sessions

### DIFF
--- a/.changeset/suspension-reaches-the-factories.md
+++ b/.changeset/suspension-reaches-the-factories.md
@@ -1,0 +1,45 @@
+---
+"awcms": patch
+---
+
+fix(security): a suspended tenant could still rewrite its profile, change its password and mint new sessions
+
+ADR-0073 made suspension a SERVICE status rather than a login status, and put the
+refusal in the two places that decide access: `authorizeInTransaction` and
+`ssr-session.ts`. Neither of those is on the path of
+`defineSelfServiceTenantRoute` or `defineClientCredentialTenantRoute` — the two
+factories that deliberately have no `AccessRequest` to consult — so twelve routes
+kept serving a suspended tenant's live session.
+
+Verified against a real database before the fix: `PATCH /api/v1/auth/profile`
+answered **200** for a suspended tenant.
+
+The one that matters most is the pair `POST /api/v1/auth/session-handoff/issue`
+and `.../redeem`: they MINT a session. A session that would have expired renews
+itself, so the foothold outlives the TTL suspension exists to drain — the
+suspension never finishes.
+
+`push/subscriptions/index.ts` did carry the check, by hand, on `POST` only. Its
+`DELETE` sibling did not, and that asymmetry is what shows the omission was
+accidental rather than a decision: a per-route copy is enforced by whoever
+remembers, and eleven other routes in the class did not.
+
+**The refusal now belongs to both factories**, one `awcms_tenants` primary-key
+read on an RLS-free table, with the platform-tenant resolution behind the `&&` so
+it runs only for a tenant that is already refused. A missing row reads as
+stopped.
+
+**Omitting the declaration REFUSES.** A route that must stay reachable states
+`allowedWhileTenantSuspended: "<reason>"` — a reason rather than a boolean, for
+the same discipline `SUSPENDED_TENANT_ALLOWED_PERMISSION_KEYS` carries: `true`
+can be added in a diff without anybody saying what it buys. Four routes declare
+one, and they follow one rule: **a suspended tenant may still SEE its own
+security state and may still do things that only ever REMOVE its own access.**
+Listing your sessions, ending one, ending all of them, and unregistering a push
+device. A suspension that stops a customer from ending a stolen session is
+protecting the attacker.
+
+`api:tenant-route:check` now also fails any file under `src/pages/api` or
+`src/pages/admin` that calls `isTenantServiceStopped` itself, so the copy cannot
+come back. Comment lines are skipped, so a docblock explaining that the factory
+owns the refusal is not read as a route deciding it.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:b40ae00dfd60694e88244573f1c6e20e0a08bbfcd4156026f8aada80e5ad8574 -->
+<!-- i18n-source-hash: sha256:171a1010c7d986d7865954c45189e76e6989d900e5d6bcd9e172c5433d76c38f -->
 
 # AWCMS — Project State & Continuation
 
@@ -443,7 +443,21 @@ DEFINER` sempit mengikuti preseden `sql/048`/`sql/119`/`sql/124`, hanya arah-tol
      keluar dari model kapasitas.
 
   2. **A2 — penangguhan ADR-0073 tidak menjangkau factory rute self-service maupun
-     client-credential.** `_shared/tenant-route.ts:247-301` dan `:342-379`;
+     client-credential.** **SELESAI (22 Agustus 2026).** Kedua factory kini menolak
+     sebelum handler-nya jalan, dan klausa ketiga rencananya ikut mendarat:
+     `api:tenant-route:check` menggagalkan berkas mana pun di
+     `src/pages/api`/`src/pages/admin` yang memanggil `isTenantServiceStopped` sendiri.
+     Diverifikasi terhadap basis data nyata: `PATCH /api/v1/auth/profile` menjawab **200**
+     untuk tenant yang ditangguhkan sebelum perbaikan, dan `403 TENANT_SUSPENDED` sesudah.
+
+     Satu penyimpangan dari "resolve statusnya sekali di dalam kedua factory": MENGHILANGKAN
+     deklarasinya berarti MENOLAK, dan rute yang harus tetap terjangkau menyatakan
+     `allowedWhileTenantSuspended: "<alasan>"`. Empat rute melakukannya, dengan satu aturan
+     — tenant yang ditangguhkan masih boleh MELIHAT keadaan keamanannya sendiri dan masih
+     boleh melakukan hal yang hanya MENGHAPUS aksesnya sendiri (melihat daftar sesi,
+     mengakhiri satu, mengakhiri semua, mencabut pendaftaran perangkat push). Penangguhan
+     yang menghalangi pelanggan mengakhiri sesi curian justru melindungi penyerangnya.
+     `_shared/tenant-route.ts:247-301` dan `:342-379`;
      `auth/profile.ts:125`; `session-handoff/{issue,redeem}.ts`; `auth/password/change.ts:118`.
      Pemeriksaannya hanya ada di `authorizeInTransaction` dan `ssr-session.ts`, dan tidak
      satu pun factory memanggilnya, jadi sesi hidup milik tenant yang ditangguhkan masih
@@ -451,6 +465,7 @@ DEFINER` sempit mengikuti preseden `sql/048`/`sql/119`/`sql/124`, hanya arah-tol
      batas — pijakan itu hidup lebih lama daripada TTL yang seharusnya dikuras penangguhan.
      `push/subscriptions/index.ts:154` memeriksa dengan tangan; saudara `DELETE`-nya tidak,
      dan asimetri itulah yang membuktikan kelalaian ini tidak disengaja.
+
   3. **A3 — admin SSO tenant bisa menyebut env var APA PUN sebagai client secret OIDC dan
      mengirimkannya ke host pilihannya.** `tenant-sso.ts:180-184`;
      `tenant-sso-policy.ts:229-239,333-348`. `client_secret_env_var` hanya divalidasi

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -438,7 +438,19 @@ pioneered directly here after the ADR-0047 freeze.)
      `getWorkerDatabaseClient(`, so the job would fall out of the capacity model.
 
   2. **A2 — ADR-0073 suspension does not reach the self-service or client-credential
-     route factories.** `_shared/tenant-route.ts:247-301` and `:342-379`;
+     route factories.** **DONE (22 August 2026).** Both factories now refuse before the
+     handler runs, and the plan's third clause landed too: `api:tenant-route:check` fails
+     any file under `src/pages/api`/`src/pages/admin` that calls `isTenantServiceStopped`
+     itself. Verified against a real database that `PATCH /api/v1/auth/profile` answered
+     **200** for a suspended tenant beforehand and `403 TENANT_SUSPENDED` after.
+
+     One departure from "resolve the status once inside both factories": omitting the
+     declaration REFUSES, and a route that must stay reachable states
+     `allowedWhileTenantSuspended: "<reason>"`. Four do, under one rule — a suspended
+     tenant may still SEE its own security state and may still do things that only ever
+     REMOVE its own access (list sessions, end one, end all, unregister a push device). A
+     suspension that stops a customer ending a stolen session is protecting the attacker.
+     `_shared/tenant-route.ts:247-301` and `:342-379`;
      `auth/profile.ts:125`; `session-handoff/{issue,redeem}.ts`; `auth/password/change.ts:118`.
      The check lives only in `authorizeInTransaction` and `ssr-session.ts`, and neither
      factory calls it, so a suspended tenant's live session can still write profiles,
@@ -447,6 +459,7 @@ pioneered directly here after the ADR-0047 freeze.)
      checks by hand; its sibling `DELETE` does not, which is the asymmetry proving the
      omission is accidental. **Change:** resolve `awcms_tenants.status` once inside both
      factories; delete the hand-rolled copy; extend `api:tenant-route:check` to assert it.
+
   3. **A3 — a tenant SSO admin can name ANY env var as the OIDC client secret and POST
      it to a host they choose.** `tenant-sso.ts:180-184`;
      `tenant-sso-policy.ts:229-239,333-348`; `generic-oidc-client.ts:268-277`.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 437   |
+| Test files                          | 438   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -354,7 +354,7 @@
 | ------------- | ---------- |
 | `(root)`      | 374        |
 | `e2e`         | 12         |
-| `integration` | 50         |
+| `integration` | 51         |
 | `unit`        | 1          |
 
 ### Routes

--- a/scripts/tenant-route-factory-check.ts
+++ b/scripts/tenant-route-factory-check.ts
@@ -342,8 +342,8 @@ async function* walk(
   }
 }
 
-/** Comment lines are skipped so a docblock MENTIONING `withTenant(` is not a call. */
-function callsWithTenantDirectly(content: string): boolean {
+/** Comment lines are skipped so a docblock MENTIONING a call is not a call. */
+function matchesOutsideComments(content: string, pattern: RegExp): boolean {
   return content.split("\n").some((line) => {
     const trimmed = line.trim();
 
@@ -355,15 +355,35 @@ function callsWithTenantDirectly(content: string): boolean {
       return false;
     }
 
-    return WITH_TENANT_CALL_PATTERN.test(line);
+    return pattern.test(line);
   });
 }
+
+function callsWithTenantDirectly(content: string): boolean {
+  return matchesOutsideComments(content, WITH_TENANT_CALL_PATTERN);
+}
+
+/**
+ * The ADR-0073 refusal, named once so a file that re-implements it is visible.
+ *
+ * `push/subscriptions/index.ts` used to carry this call by hand, on `POST`
+ * only. Its `DELETE` sibling did not, and neither did the other eleven routes
+ * in the self-service class — so a suspended tenant could still write its
+ * profile, rewrite its credential, and mint new sessions. The check now belongs
+ * to `defineSelfServiceTenantRoute` and
+ * `defineClientCredentialTenantRoute`; a route that decides it again is a route
+ * that can decide it differently, which is how the asymmetry appeared the first
+ * time.
+ */
+const SUSPENSION_CALL_PATTERN = /\bisTenantServiceStopped\s*\(/;
 
 export type TenantRouteMigrationResult = {
   /** Calls `withTenant` directly and is NOT on the allowlist — a newly hand-rolled opening. */
   unlisted: string[];
   /** Allowlist entries that no longer call `withTenant` directly — the list must only shrink. */
   stale: string[];
+  /** Decides ADR-0073 suspension itself instead of letting its factory do it. */
+  handRolledSuspension: string[];
 };
 
 /** Pure over already-read contents, so both failure directions are unit-testable without a synthetic file tree. */
@@ -373,9 +393,17 @@ export function evaluateTenantRouteMigration(
 ): TenantRouteMigrationResult {
   const allowed = new Set(allowlist);
   const unlisted: string[] = [];
+  const handRolledSuspension: string[] = [];
   const stillDirect = new Set<string>();
 
   for (const file of files) {
+    // Comment-skipping for the same reason `callsWithTenantDirectly` does it: a
+    // docblock EXPLAINING that the factory owns this refusal must not read as a
+    // route deciding it.
+    if (matchesOutsideComments(file.content, SUSPENSION_CALL_PATTERN)) {
+      handRolledSuspension.push(file.path);
+    }
+
     if (!callsWithTenantDirectly(file.content)) {
       continue;
     }
@@ -390,7 +418,8 @@ export function evaluateTenantRouteMigration(
 
   return {
     unlisted,
-    stale: allowlist.filter((entry) => !stillDirect.has(entry))
+    stale: allowlist.filter((entry) => !stillDirect.has(entry)),
+    handRolledSuspension
   };
 }
 
@@ -432,17 +461,20 @@ async function main(): Promise<void> {
     }
   }
 
-  const { unlisted, stale } = evaluateTenantRouteMigration(
-    files,
-    NOT_YET_MIGRATED
-  );
+  const { unlisted, stale, handRolledSuspension } =
+    evaluateTenantRouteMigration(files, NOT_YET_MIGRATED);
 
-  if (unlisted.length === 0 && stale.length === 0) {
+  if (
+    unlisted.length === 0 &&
+    stale.length === 0 &&
+    handRolledSuspension.length === 0
+  ) {
     console.log(
       `api:tenant-route:check OK — ${files.length} berkas di ` +
         `${SCAN_ROOTS.map((scan) => scan.root).join(" + ")}: memakai defineTenantRoute, ` +
         `atau salah satu dari ${NOT_YET_MIGRATED.length} berkas yang masih antre migrasi ` +
-        "(rute API: Issue #255; layar admin: R3 / Issue #424)."
+        "(rute API: Issue #255; layar admin: R3 / Issue #424); " +
+        "0 berkas memutuskan penangguhan ADR-0073 sendiri."
     );
     process.exit(0);
   }
@@ -460,9 +492,20 @@ async function main(): Promise<void> {
     );
   }
 
+  for (const file of handRolledSuspension) {
+    console.error(
+      `${file} — memutuskan penangguhan ADR-0073 sendiri lewat isTenantServiceStopped(). ` +
+        "Refusal itu milik defineSelfServiceTenantRoute/defineClientCredentialTenantRoute " +
+        "(src/modules/_shared/tenant-route.ts). Sebuah rute yang tetap harus terjangkau saat " +
+        "tenant ditangguhkan menyatakan ALASANNYA lewat `allowedWhileTenantSuspended`, bukan " +
+        "dengan menyalin pemeriksaannya — salinan per-rute ditegakkan oleh siapa pun yang ingat."
+    );
+  }
+
   console.error(
     `\napi:tenant-route:check GAGAL — ${unlisted.length} berkas membuka transaksinya sendiri tanpa terdaftar, ` +
-      `${stale.length} entri allowlist basi.`
+      `${stale.length} entri allowlist basi, ` +
+      `${handRolledSuspension.length} berkas menyalin penangguhan ADR-0073.`
   );
 
   process.exit(1);

--- a/src/modules/_shared/tenant-route.ts
+++ b/src/modules/_shared/tenant-route.ts
@@ -15,6 +15,11 @@ import {
   type AuthorizeResult
 } from "../identity-access/application/access-guard";
 import type { AccessRequest } from "../identity-access/domain/access-control";
+import {
+  isSuspensionExemptTenant,
+  isTenantServiceStopped
+} from "../identity-access/domain/suspended-tenant-allowlist";
+import { resolvePlatformTenantIdIgnoringStatus } from "../../lib/tenant/platform-tenant";
 import { runSseLoop, type SseTickOutcome } from "./sse-stream";
 
 /**
@@ -197,6 +202,21 @@ export type TenantRouteConfig<TPrepared> = {
  * shared default would quietly flatten.
  */
 export type SelfServiceTenantRouteConfig<TPrepared = undefined> = {
+  /**
+   * ADR-0073 — WHY this route stays reachable while the tenant is suspended.
+   *
+   * Omitting it refuses, which is the default a new route inherits and the
+   * whole reason the field is shaped this way round. A REASON rather than a
+   * boolean, for the reason `SUSPENDED_TENANT_ALLOWED_PERMISSION_KEYS` is a
+   * code declaration: `true` can be added in a diff without anybody having to
+   * say what it buys, and this list only stays short if each entry argues for
+   * itself.
+   *
+   * The rule the current entries follow: a suspended tenant may still SEE its
+   * own security state and may still do things that only ever REMOVE its own
+   * access. Everything else is service, and suspension stops service.
+   */
+  allowedWhileTenantSuspended?: string;
   /** REQUIRED, same reasoning as `defineTenantRoute`. */
   workClass: WorkClass;
   queueTimeoutMs?: number;
@@ -244,6 +264,55 @@ export type SelfServiceTenantRouteConfig<TPrepared = undefined> = {
   ) => Response | Promise<Response>;
 };
 
+/**
+ * ADR-0073 for the two factories that have no `AccessRequest` to consult.
+ *
+ * `authorizeInTransaction` refuses a suspended tenant before it looks up a
+ * permission, and `ssr-session.ts` refuses one before it hands an admin screen a
+ * session. Neither of those is on the path of a self-service or
+ * client-credential route, so until this existed a suspended tenant's live
+ * session could still write its profile, rewrite its credential, and — through
+ * the handoff pair — mint NEW sessions indefinitely. The foothold outlived the
+ * TTL that suspension was meant to drain, which is the one thing suspension is
+ * for.
+ *
+ * ## One read, and only for the tenant that is already suspended
+ *
+ * `awcms_tenants` is the deliberately RLS-free root table (ADR-0003), so this is
+ * a primary-key lookup with no policy work. The platform-tenant resolution —
+ * which can cost a chain — sits behind the `&&`, so it runs only for a tenant
+ * that is ALREADY refused. A healthy request pays one PK read.
+ *
+ * A missing row reads as stopped. That is unreachable behind a resolved tenant
+ * id, and it is because it is unreachable that fail-closed costs nothing.
+ */
+async function refuseIfTenantSuspended(
+  tx: Bun.SQL,
+  tenantId: string,
+  allowedWhileTenantSuspended: string | undefined
+): Promise<Response | undefined> {
+  if (allowedWhileTenantSuspended) return undefined;
+
+  const rows = (await tx`
+    SELECT status FROM awcms_tenants WHERE id = ${tenantId}
+  `) as { status: string }[];
+
+  const status = rows[0]?.status ?? "suspended";
+
+  if (!isTenantServiceStopped(status)) return undefined;
+
+  if (
+    isSuspensionExemptTenant(
+      tenantId,
+      await resolvePlatformTenantIdIgnoringStatus(tx)
+    )
+  ) {
+    return undefined;
+  }
+
+  return fail(403, "TENANT_SUSPENDED", "Tenant is suspended.");
+}
+
 export function defineSelfServiceTenantRoute<TPrepared = undefined>(
   config: SelfServiceTenantRouteConfig<TPrepared>
 ): APIRoute {
@@ -286,14 +355,23 @@ export function defineSelfServiceTenantRoute<TPrepared = undefined>(
     return withTenant<Response>(
       sqlClientForRoute(),
       tenantId,
-      async (tx) =>
-        config.handler({
+      async (tx) => {
+        const suspended = await refuseIfTenantSuspended(
+          tx,
+          tenantId,
+          config.allowedWhileTenantSuspended
+        );
+
+        if (suspended) return suspended;
+
+        return config.handler({
           ...requestContext,
           tx,
           token,
           tokenHash: hashSessionToken(token),
           prepared
-        }),
+        });
+      },
       {
         workClass: config.workClass,
         queueTimeoutMs: config.queueTimeoutMs
@@ -327,6 +405,13 @@ export function defineSelfServiceTenantRoute<TPrepared = undefined>(
  * it is authenticating, not in a shared default that would flatten it.
  */
 export type ClientCredentialTenantRouteConfig = {
+  /**
+   * ADR-0073 — see `SelfServiceTenantRouteConfig`. Omitting it refuses.
+   *
+   * The one route in this class today MINTS a session, which is precisely the
+   * loop suspension has to close, so nothing here opts out.
+   */
+  allowedWhileTenantSuspended?: string;
   /** REQUIRED, same reasoning as `defineTenantRoute`. */
   workClass: WorkClass;
   queueTimeoutMs?: number;
@@ -370,7 +455,17 @@ export function defineClientCredentialTenantRoute(
     return withTenant<Response>(
       sqlClientForRoute(),
       tenantId,
-      async (tx) => config.handler({ ...requestContext, tx }),
+      async (tx) => {
+        const suspended = await refuseIfTenantSuspended(
+          tx,
+          tenantId,
+          config.allowedWhileTenantSuspended
+        );
+
+        if (suspended) return suspended;
+
+        return config.handler({ ...requestContext, tx });
+      },
       {
         workClass: config.workClass,
         queueTimeoutMs: config.queueTimeoutMs

--- a/src/pages/api/v1/auth/sessions/[id].ts
+++ b/src/pages/api/v1/auth/sessions/[id].ts
@@ -49,6 +49,10 @@ function authRequired(): Response {
 }
 
 export const DELETE = defineSelfServiceTenantRoute({
+  // ADR-0073 — see `revoke-all.ts`: ending a session can only take access
+  // away, and the suspended tenant is exactly the one that may need to.
+  allowedWhileTenantSuspended:
+    "Revocation only ever removes access; refusing it would protect a stolen session.",
   workClass: "interactive",
   onUnauthenticated: (reason) =>
     reason === "tenant"

--- a/src/pages/api/v1/auth/sessions/index.ts
+++ b/src/pages/api/v1/auth/sessions/index.ts
@@ -54,6 +54,12 @@ function authRequired(): Response {
 }
 
 export const GET = defineSelfServiceTenantRoute({
+  // ADR-0073 — "where am I signed in" is the customer's own security view, and
+  // it is what a person needs in order to notice and end a session they do not
+  // recognise. Refusing it while a tenant is cut off would take away the only
+  // list the DELETE beside it operates on.
+  allowedWhileTenantSuspended:
+    "Seeing one's own live sessions is a security view, not service.",
   workClass: "interactive",
   onUnauthenticated: (reason) =>
     reason === "tenant"

--- a/src/pages/api/v1/auth/sessions/revoke-all.ts
+++ b/src/pages/api/v1/auth/sessions/revoke-all.ts
@@ -55,6 +55,11 @@ function authRequired(): Response {
 }
 
 export const POST = defineSelfServiceTenantRoute({
+  // ADR-0073 — sign-out only ever REMOVES access. A suspended tenant that
+  // cannot sign itself out everywhere is a suspension that protects a stolen
+  // session, which is the opposite of what suspension is for.
+  allowedWhileTenantSuspended:
+    "Revocation only ever removes access; refusing it would protect a stolen session.",
   workClass: "interactive",
   onUnauthenticated: (reason) =>
     reason === "tenant"

--- a/src/pages/api/v1/push/subscriptions/[id].ts
+++ b/src/pages/api/v1/push/subscriptions/[id].ts
@@ -40,6 +40,10 @@ function authRequired(): Response {
 }
 
 export const DELETE = defineSelfServiceTenantRoute({
+  // ADR-0073 — unregistering a device removes a delivery target and grants
+  // nothing. Its POST sibling, which ADDS one, is refused.
+  allowedWhileTenantSuspended:
+    "Unregistering a device only ever removes a delivery target.",
   workClass: "interactive",
   onUnauthenticated: (reason) =>
     reason === "tenant"

--- a/src/pages/api/v1/push/subscriptions/index.ts
+++ b/src/pages/api/v1/push/subscriptions/index.ts
@@ -10,7 +10,6 @@ import {
 } from "../../../../../lib/security/request-body-limit";
 import { isMachineCredentialToken } from "../../../../../lib/auth/machine-credential-token";
 import { resolveTenantPrincipal } from "../../../../../modules/identity-access/application/auth-context";
-import { isTenantServiceStopped } from "../../../../../modules/identity-access/domain/suspended-tenant-allowlist";
 import {
   listPushSubscriptions,
   registerPushSubscription
@@ -47,9 +46,14 @@ import { summarizeUserAgent } from "../../../../../lib/security/client-fingerpri
  *
  * ADR-0073 made suspension a SERVICE status rather than a login status, and the
  * chokepoint enforces it for every guarded route. A self-service route has no
- * chokepoint, so it does the same check by hand — otherwise the one class of
- * endpoint that skips the guard would become the one place a suspended tenant
- * can still add outbound capacity.
+ * chokepoint — so `defineSelfServiceTenantRoute` now carries the refusal for
+ * the whole class, and neither verb here opts out.
+ *
+ * This file used to do it by hand, on `POST` only. The `DELETE` sibling never
+ * had it, and that asymmetry is what showed the omission was accidental: a
+ * per-route copy is enforced by whoever remembers, and eleven other routes in
+ * this class did not. Unregistering a device DOES stay reachable, because it
+ * removes a delivery target and grants nothing.
  */
 const NO_STORE_HEADERS = { "cache-control": "private, no-store" };
 
@@ -151,14 +155,11 @@ export const POST = defineSelfServiceTenantRoute({
 
     if (!principal) return authRequired();
 
-    if (isTenantServiceStopped(principal.tenantStatus)) {
-      return fail(
-        403,
-        "TENANT_SUSPENDED",
-        "This tenant is suspended; new device registrations are not accepted."
-      );
-    }
-
+    // The ADR-0073 refusal that used to sit here by hand now belongs to
+    // `defineSelfServiceTenantRoute`, which applies it to every route in this
+    // class instead of the one that remembered. The DELETE sibling never had
+    // this check, and that asymmetry is what showed the omission was accidental
+    // rather than a decision.
     const body = await readJsonBody(request);
 
     if (body.tooLarge) return bodyTooLargeResponse(body.limitBytes);

--- a/tests/integration/suspended-tenant-self-service.integration.test.ts
+++ b/tests/integration/suspended-tenant-self-service.integration.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Finding A2 of the 17 August 2026 audit round — ADR-0073 suspension now reaches
+ * the self-service and client-credential route factories.
+ *
+ * The chokepoint refused a suspended tenant, and `ssr-session.ts` refused one an
+ * admin screen. Neither is on the path of `defineSelfServiceTenantRoute` or
+ * `defineClientCredentialTenantRoute`, so a suspended tenant's LIVE session
+ * could still write its profile, rewrite its credential, and — through the
+ * handoff pair — mint NEW sessions for as long as it liked. The foothold
+ * outlived the TTL suspension exists to drain.
+ *
+ * ## Why this needs a real database rather than a mock
+ *
+ * The refusal reads `awcms_tenants.status` inside the route's own transaction.
+ * A mocked `Bun.SQL` would return whatever the test told it to, which is the
+ * same thing as asserting the code the test just read. The two failure
+ * directions that matter here — a suspended tenant still being served, and an
+ * ACTIVE tenant being refused by an over-eager gate — are both invisible to it.
+ *
+ * MUTATION PROOFS:
+ * - Delete the `refuseIfTenantSuspended` call from the self-service factory →
+ *   "a suspended tenant cannot rewrite its profile" goes RED.
+ * - Make `allowedWhileTenantSuspended` default to allowing (drop the `if` and
+ *   always return `undefined`) → the same test goes RED.
+ * - Remove `allowedWhileTenantSuspended` from `sessions/index.ts` → "a suspended
+ *   tenant can still see and end its own sessions" goes RED, which is the
+ *   over-eager direction a fail-closed default makes easy to ship.
+ *
+ * WORLD 2 (harness.ts) — real route handlers reach for `getDatabaseClient()`
+ * internally, so this runs against the migrated `DATABASE_URL` database.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  ensureHandlerDatabaseReady,
+  getHandlerAdminSql,
+  integrationEnabled,
+  invoke,
+  resetHandlerDatabase,
+  teardownHandlerDatabase
+} from "./harness";
+import { PATCH as profilePATCH } from "../../src/pages/api/v1/auth/profile";
+import { GET as sessionsGET } from "../../src/pages/api/v1/auth/sessions/index";
+import { POST as revokeAllPOST } from "../../src/pages/api/v1/auth/sessions/revoke-all";
+import { POST as handoffIssuePOST } from "../../src/pages/api/v1/auth/session-handoff/issue";
+import {
+  generateSessionToken,
+  hashSessionToken
+} from "../../src/lib/auth/session-token";
+
+const TENANT = "a2a2a2a2-a2a2-4a2a-8a2a-a2a2a2a2a2a2";
+const PROFILE = "a2a2a2a2-0000-4a2a-8a2a-a2a2a2a2a201";
+const IDENTITY = "a2a2a2a2-0000-4a2a-8a2a-a2a2a2a2a202";
+const TENANT_USER = "a2a2a2a2-0000-4a2a-8a2a-a2a2a2a2a203";
+
+let handlerReady = false;
+let sessionToken = "";
+
+async function seed(): Promise<void> {
+  const sql = getHandlerAdminSql();
+
+  await sql`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${TENANT}, 'a2-suspend', 'Suspension A2', 'active')
+    ON CONFLICT (id) DO NOTHING
+  `;
+
+  await sql`
+    INSERT INTO awcms_profiles (id, tenant_id, profile_type, display_name)
+    VALUES (${PROFILE}, ${TENANT}, 'person', 'A2 Person')
+  `;
+
+  await sql`
+    INSERT INTO awcms_identities
+      (id, tenant_id, profile_id, login_identifier, password_hash, status)
+    VALUES (${IDENTITY}, ${TENANT}, ${PROFILE}, 'a2@example.test',
+            'not-a-real-hash', 'active')
+  `;
+
+  await sql`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id, status)
+    VALUES (${TENANT_USER}, ${TENANT}, ${IDENTITY}, 'active')
+  `;
+
+  sessionToken = generateSessionToken();
+
+  await sql`
+    INSERT INTO awcms_sessions (tenant_id, identity_id, token_hash, expires_at)
+    VALUES (${TENANT}, ${IDENTITY}, ${hashSessionToken(sessionToken)},
+            now() + interval '1 hour')
+  `;
+}
+
+async function setTenantStatus(status: string): Promise<void> {
+  await getHandlerAdminSql()`
+    UPDATE awcms_tenants SET status = ${status} WHERE id = ${TENANT}
+  `;
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-tenant-id": TENANT,
+    authorization: `Bearer ${sessionToken}`
+  };
+}
+
+const describeOrSkip = integrationEnabled ? describe : describe.skip;
+
+describeOrSkip("ADR-0073 reaches the factories that have no chokepoint", () => {
+  beforeAll(async () => {
+    handlerReady = await ensureHandlerDatabaseReady();
+  });
+
+  afterAll(async () => {
+    if (handlerReady) await teardownHandlerDatabase();
+  });
+
+  beforeEach(async () => {
+    if (!handlerReady) return;
+    await resetHandlerDatabase();
+    await seed();
+  });
+
+  afterEach(async () => {
+    if (handlerReady) await resetHandlerDatabase();
+  });
+
+  test("an ACTIVE tenant is served — the gate is not simply refusing everything", async () => {
+    if (!handlerReady) return;
+    // NON-VACUOUS. Without this, every assertion below would also pass against
+    // a factory that refused unconditionally, which is the failure direction a
+    // fail-closed default makes easiest to ship.
+    const res = await invoke(profilePATCH, {
+      method: "PATCH",
+      path: "/api/v1/auth/profile",
+      headers: authHeaders(),
+      body: { displayName: "Renamed While Active" }
+    });
+
+    expect(res.status).not.toBe(403);
+  });
+
+  test("a suspended tenant cannot rewrite its profile", async () => {
+    if (!handlerReady) return;
+    await setTenantStatus("suspended");
+
+    const res = await invoke<{ error: { code: string } }>(profilePATCH, {
+      method: "PATCH",
+      path: "/api/v1/auth/profile",
+      headers: authHeaders(),
+      body: { displayName: "Renamed While Suspended" }
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("TENANT_SUSPENDED");
+
+    // And the write really did not happen. A 403 returned from INSIDE
+    // `withTenant` is a COMMIT, not a rollback, so "it answered 403" and "it
+    // changed nothing" are different claims in this codebase.
+    const rows = (await getHandlerAdminSql()`
+      SELECT display_name FROM awcms_profiles WHERE id = ${PROFILE}
+    `) as { display_name: string }[];
+
+    expect(rows[0]!.display_name).toBe("A2 Person");
+  });
+
+  test("a suspended tenant cannot mint a new session through the handoff", async () => {
+    if (!handlerReady) return;
+    // The loop this finding is really about: a session that would have expired
+    // renews itself indefinitely, so suspension never drains anything.
+    await setTenantStatus("suspended");
+
+    const res = await invoke<{ error: { code: string } }>(handoffIssuePOST, {
+      method: "POST",
+      path: "/api/v1/auth/session-handoff/issue",
+      headers: authHeaders(),
+      body: { clientKey: "bff", redirectUri: "https://example.test/cb" }
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("TENANT_SUSPENDED");
+  });
+
+  test("`inactive` stops service too, not only `suspended`", async () => {
+    if (!handlerReady) return;
+    await setTenantStatus("inactive");
+
+    const res = await invoke<{ error: { code: string } }>(profilePATCH, {
+      method: "PATCH",
+      path: "/api/v1/auth/profile",
+      headers: authHeaders(),
+      body: { displayName: "Renamed While Inactive" }
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("TENANT_SUSPENDED");
+  });
+
+  test("a suspended tenant can still SEE and END its own sessions", async () => {
+    if (!handlerReady) return;
+    await setTenantStatus("suspended");
+
+    const listed = await invoke(sessionsGET, {
+      method: "GET",
+      path: "/api/v1/auth/sessions",
+      headers: authHeaders()
+    });
+
+    expect(listed.status).toBe(200);
+
+    // Sign-out only ever removes access. A suspension that protects a stolen
+    // session is the opposite of what suspension is for.
+    const revoked = await invoke(revokeAllPOST, {
+      method: "POST",
+      path: "/api/v1/auth/sessions/revoke-all",
+      headers: authHeaders(),
+      body: {}
+    });
+
+    expect(revoked.status).toBe(200);
+  });
+});

--- a/tests/push-http-surface.test.ts
+++ b/tests/push-http-surface.test.ts
@@ -279,18 +279,44 @@ describe("a machine credential is refused before any database work", () => {
 });
 
 describe("the self-service routes carry the suspension check the chokepoint would have", () => {
-  test("registration refuses a suspended tenant", () => {
+  test("neither verb on the collection opts out of it", () => {
     // ADR-0073 made suspension a SERVICE status. Guarded routes get it from
     // `authorizeInTransaction`; these three do not go through it, so the one
     // class of endpoint that skips the guard must not become the one place a
     // suspended tenant can still add outbound capacity.
+    //
+    // This file used to assert the check INLINE here, and that is exactly what
+    // went wrong: the copy sat on `POST` only, `DELETE` never had it, and
+    // eleven other self-service routes never had it either. The refusal now
+    // belongs to `defineSelfServiceTenantRoute`, so what is left to assert here
+    // is that this file does not opt OUT of it — and that it no longer decides
+    // the question itself, which `api:tenant-route:check` also enforces.
     const source = readFileSync(
       "src/pages/api/v1/push/subscriptions/index.ts",
       "utf8"
     );
 
-    expect(source).toContain("isTenantServiceStopped(principal.tenantStatus)");
-    expect(source).toContain("TENANT_SUSPENDED");
+    expect(source).not.toContain("allowedWhileTenantSuspended");
+    expect(source).not.toContain("isTenantServiceStopped(");
+    expect(source).toContain("defineSelfServiceTenantRoute({");
+  });
+
+  test("unregistering a device DOES stay reachable, with a stated reason", () => {
+    // The one deliberate exception in this module, and the rule behind it: a
+    // suspended tenant may still do things that only ever REMOVE its own
+    // access. Removing a delivery target grants nothing.
+    const source = readFileSync(
+      "src/pages/api/v1/push/subscriptions/[id].ts",
+      "utf8"
+    );
+
+    const match = source.match(
+      /allowedWhileTenantSuspended:\s*\n?\s*"([^"]+)"/
+    );
+
+    expect(match).not.toBeNull();
+    // A REASON, not a boolean — the whole point of the field's shape.
+    expect(match![1]!.length).toBeGreaterThan(20);
   });
 });
 

--- a/tests/tenant-route-factory-check.test.ts
+++ b/tests/tenant-route-factory-check.test.ts
@@ -79,7 +79,67 @@ describe("tenant-route migration ledger", () => {
       []
     );
 
-    expect(result).toEqual({ unlisted: [], stale: [] });
+    expect(result).toEqual({
+      unlisted: [],
+      stale: [],
+      handRolledSuspension: []
+    });
+  });
+});
+
+describe("a route may not decide ADR-0073 suspension itself (finding A2)", () => {
+  test("a hand-rolled isTenantServiceStopped() call is reported", () => {
+    const content = `
+${MIGRATED}
+    if (isTenantServiceStopped(principal.tenantStatus)) {
+      return fail(403, "TENANT_SUSPENDED", "no");
+    }
+`;
+
+    const result = evaluateTenantRouteMigration(
+      [{ path: "src/pages/api/v1/thing/index.ts", content }],
+      []
+    );
+
+    // The state this repository actually shipped in: ONE route in the
+    // self-service class carried the check, on one of its two verbs, and the
+    // eleven others did not.
+    expect(result.handRolledSuspension).toEqual([
+      "src/pages/api/v1/thing/index.ts"
+    ]);
+  });
+
+  test("a docblock EXPLAINING that the factory owns the refusal is not a call", () => {
+    const content = `
+/**
+ * The isTenantServiceStopped() refusal belongs to the factory now.
+ * // isTenantServiceStopped(status) — also not a call
+ */
+${MIGRATED}
+`;
+
+    const result = evaluateTenantRouteMigration(
+      [{ path: "src/pages/api/v1/thing/index.ts", content }],
+      []
+    );
+
+    expect(result.handRolledSuspension).toEqual([]);
+  });
+
+  test("declaring a REASON is not deciding it", () => {
+    const content = `
+export const GET = defineSelfServiceTenantRoute({
+  allowedWhileTenantSuspended: "Revocation only ever removes access.",
+  workClass: "interactive"
+});
+`;
+
+    const result = evaluateTenantRouteMigration(
+      [{ path: "src/pages/api/v1/thing/index.ts", content }],
+      []
+    );
+
+    expect(result.handRolledSuspension).toEqual([]);
   });
 });
 
@@ -150,7 +210,11 @@ const rows = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => load(tx));
       ["src/pages/admin/thing.astro"]
     );
 
-    expect(listed).toEqual({ unlisted: [], stale: [] });
+    expect(listed).toEqual({
+      unlisted: [],
+      stale: [],
+      handRolledSuspension: []
+    });
   });
 
   test("`src/pages/admin` is actually walked, with `.astro` among its extensions", () => {

--- a/tests/tenant-suspension-enforcement.test.ts
+++ b/tests/tenant-suspension-enforcement.test.ts
@@ -25,6 +25,7 @@ const GUARD_SOURCE = "src/modules/identity-access/application/access-guard.ts";
 const SSR_SOURCE = "src/lib/auth/ssr-session.ts";
 const LIFECYCLE_SOURCE =
   "src/modules/tenant-admin/application/tenant-lifecycle.ts";
+const FACTORY_SOURCE = "src/modules/_shared/tenant-route.ts";
 
 describe("which tenant states stop service", () => {
   test("suspended and inactive both stop it; active does not", () => {
@@ -187,5 +188,110 @@ describe("the admin shell", () => {
 
     expect(source).toContain("isTenantServiceStopped(");
     expect(source).toContain("resolveTenantPrincipal(");
+  });
+});
+
+/**
+ * Finding A2 — the two factories that have no `AccessRequest` to consult.
+ *
+ * The behavioural half is
+ * `tests/integration/suspended-tenant-self-service.integration.test.ts`. What is
+ * asserted here is the shape that decides which way an omission fails, and every
+ * one of these was FALSE before the fix.
+ */
+describe("the factories with no chokepoint", () => {
+  test("both open their transaction and refuse BEFORE the handler runs", async () => {
+    const source = await Bun.file(FACTORY_SOURCE).text();
+
+    // Two call sites, one per factory. One would mean a route class was left
+    // out, which is exactly how this finding came to exist.
+    expect(
+      (source.match(/await refuseIfTenantSuspended\(/g) ?? []).length
+    ).toBe(2);
+
+    // Sliced by factory rather than matched on a formatted call expression: an
+    // assertion keyed to exact indentation is one `bun run format` away from
+    // passing for a reason nobody chose.
+    const factories: [string, string][] = [
+      [
+        "export function defineSelfServiceTenantRoute",
+        "export type ClientCredentialTenantRouteConfig"
+      ],
+      ["export function defineClientCredentialTenantRoute", "\n/**\n * SSE"]
+    ];
+
+    for (const [start, end] of factories) {
+      const from = source.indexOf(start);
+      const to = source.indexOf(end, from);
+
+      expect(from).toBeGreaterThan(-1);
+      expect(to).toBeGreaterThan(from);
+
+      const body = source.slice(from, to);
+      const refusal = body.indexOf("refuseIfTenantSuspended(");
+      const handler = body.indexOf("config.handler(");
+
+      expect(refusal).toBeGreaterThan(-1);
+      expect(handler).toBeGreaterThan(-1);
+      expect(refusal).toBeLessThan(handler);
+    }
+  });
+
+  test("omitting the declaration REFUSES — the default is the safe one", async () => {
+    const source = await Bun.file(FACTORY_SOURCE).text();
+
+    // A truthy reason opts out; anything else falls through to the read. The
+    // inverse shape (`if (!allowed) return undefined`) would make every route
+    // that never heard of this field served while suspended, which is the state
+    // this finding describes.
+    expect(source).toContain(
+      "if (allowedWhileTenantSuspended) return undefined;"
+    );
+  });
+
+  test("a missing tenant row reads as stopped", async () => {
+    const source = await Bun.file(FACTORY_SOURCE).text();
+
+    expect(source).toContain('const status = rows[0]?.status ?? "suspended";');
+  });
+
+  test("the platform exemption is consulted, and only for a tenant already refused", async () => {
+    const source = await Bun.file(FACTORY_SOURCE).text();
+
+    const stopped = source.indexOf("if (!isTenantServiceStopped(status))");
+    const exempt = source.indexOf("isSuspensionExemptTenant(");
+
+    expect(stopped).toBeGreaterThan(-1);
+    expect(exempt).toBeGreaterThan(stopped);
+    // The status-IGNORING resolver, for the reason the guard uses it: a
+    // platform tenant that has been suspended must still be able to lift it.
+    expect(source).toContain("resolvePlatformTenantIdIgnoringStatus(");
+  });
+
+  test("every opt-out states a REASON, and the set is the four that only remove access", async () => {
+    const declared: Record<string, string> = {};
+
+    for await (const entry of new Bun.Glob("src/pages/api/**/*.ts").scan(".")) {
+      const source = await Bun.file(entry).text();
+      const match = source.match(
+        /allowedWhileTenantSuspended:\s*\n?\s*"([^"]+)"/
+      );
+
+      if (match) declared[entry.split("\\").join("/")] = match[1]!;
+    }
+
+    // Widening this set is widening what a cut-off customer may still do, and
+    // it should be as visible in a diff as an entry in
+    // SUSPENDED_TENANT_ALLOWED_PERMISSION_KEYS is.
+    expect(Object.keys(declared).sort()).toEqual([
+      "src/pages/api/v1/auth/sessions/[id].ts",
+      "src/pages/api/v1/auth/sessions/index.ts",
+      "src/pages/api/v1/auth/sessions/revoke-all.ts",
+      "src/pages/api/v1/push/subscriptions/[id].ts"
+    ]);
+
+    for (const reason of Object.values(declared)) {
+      expect(reason.length).toBeGreaterThan(20);
+    }
   });
 });


### PR DESCRIPTION
Finding **A2** of the 17 August 2026 audit round (`docs/PROJECT_STATE.md` §4) — second on the "do first" list.

## What was wrong

ADR-0073 made suspension a SERVICE status rather than a login status, and put the refusal in the two places that decide access: `authorizeInTransaction` and `ssr-session.ts`.

Neither is on the path of `defineSelfServiceTenantRoute` or `defineClientCredentialTenantRoute` — the two factories that deliberately have **no `AccessRequest` to consult** — so twelve routes kept serving a suspended tenant's live session.

**Verified against a real database before the fix: `PATCH /api/v1/auth/profile` answered `200` for a suspended tenant.**

The one that matters most is the pair `POST /api/v1/auth/session-handoff/issue` and `.../redeem`: they **mint a session**. A session that would have expired renews itself, so the foothold outlives the TTL that suspension exists to drain — the suspension never finishes.

`push/subscriptions/index.ts` did carry the check, by hand, on `POST` only. Its `DELETE` sibling did not, and that asymmetry is what shows the omission was accidental rather than a decision: a per-route copy is enforced by whoever remembers, and eleven other routes in the class did not.

## The refusal now belongs to both factories

One `awcms_tenants` primary-key read on the RLS-free root table, with the platform-tenant resolution behind the `&&` so it runs **only for a tenant that is already refused**. A healthy request pays one PK read. A missing row reads as stopped.

## Omitting the declaration REFUSES

A route that must stay reachable states `allowedWhileTenantSuspended: "<reason>"` — a **reason** rather than a boolean, for the same discipline `SUSPENDED_TENANT_ALLOWED_PERMISSION_KEYS` carries: `true` can be added in a diff without anybody saying what it buys.

Four routes declare one, under a single rule:

> A suspended tenant may still **SEE** its own security state, and may still do things that only ever **REMOVE** its own access.

Listing your sessions, ending one, ending all of them, unregistering a push device. A suspension that stops a customer from ending a stolen session is protecting the attacker.

Everything else — profile writes, preference writes, the password change (which under ADR-0086 rewrites a **global** credential), session introspection, push registration, and both halves of the handoff — is service, and suspension stops service.

## The gate

`api:tenant-route:check` now also fails any file under `src/pages/api` or `src/pages/admin` that calls `isTenantServiceStopped` itself. Comment lines are skipped, so a docblock explaining that the factory owns the refusal is not read as a route deciding it.

## Tests

- `tests/tenant-suspension-enforcement.test.ts` (pure): both factories refuse before the handler; the default is refuse; a missing row reads as stopped; the platform exemption is consulted and only for a tenant already refused; and the opt-out **inventory** is pinned to those four files with a non-empty reason each. Mutation-proven — flipping the default and deleting the client-credential call each turn one red.
- `tests/tenant-route-factory-check.test.ts`: the new gate rule, in both directions (a real call is caught; a docblock and a `allowedWhileTenantSuspended` declaration are not).
- `tests/integration/suspended-tenant-self-service.integration.test.ts` (new, real PostgreSQL): active tenant still served (non-vacuous), suspended tenant refused on profile **and the row really is unchanged** — a 4xx returned from inside `withTenant` is a COMMIT in this codebase — handoff refused, `inactive` refused, and sessions still listable and revocable. **Run locally against a migrated database: 5/5 pass, and 3 of the 5 go red when the gate is removed.**

`bun run check` full green; `bun test tests/integration/` green apart from two pre-existing `http`/`https` scheme failures that also fail on `main` unmodified (the `url.origin` P1 already recorded in §4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)