### PR TITLE
perf(blog-content): the blog lists sorted the whole tenant to return fifty rows

### DIFF
--- a/.changeset/blog-list-ordering-indexes.md
+++ b/.changeset/blog-list-ordering-indexes.md
@@ -1,0 +1,48 @@
+---
+"awcms": patch
+---
+
+perf(blog-content): the blog lists sorted the whole tenant to return fifty rows
+
+`sql/035` gives `awcms_blog_posts` seven indexes, and not one of them leads with
+`updated_at` or `created_at` — the two columns every list in the module orders
+by. `/admin/blog`, `/admin/pages`, the term-filtered post list, and the keyset
+traversal `GET /api/v1/blog/posts` that a static build walks were each a
+tenant-wide sequential scan followed by a top-N sort.
+
+**Measured rather than derived.** The audit could only reason from btree prefix
+rules; this was run against 24,000 seeded posts on PostgreSQL 18:
+
+| query | before | after |
+| --- | --- | --- |
+| `/admin/blog`, `LIMIT 50` | Seq Scan 24,000 rows + top-N heapsort, 7.4 ms | Index Scan, 50 rows, 0.057 ms |
+| same with the status filter | Seq Scan 20,572 rows + sort, 4.8 ms | Index Scan, 50 rows, 0.050 ms |
+| keyset first page | Seq Scan 24,000 rows + sort, 5.1 ms | Index Scan, 50 rows, 0.110 ms |
+| keyset page resumed at row 10,000 | — | Index Scan, 50 rows, 0.060 ms |
+
+The number that matters is not the milliseconds. It is **24,000 becoming 50**:
+the cost was O(tenant posts) and is now O(page size), so a page that is fast on a
+demo tenant stays fast on the 23,906-article archive Issue #599 exists to import.
+The resumed deep page is the case a first-page measurement cannot see, and the
+one a static build spends nearly all its time in.
+
+**One correction to the finding.** C1 also says "plus a second full scan for
+`count(*)`". That is not what happens: the count beside the list already plans as
+an Index Only Scan on `awcms_blog_posts_tenant_deleted_idx` (1.8 ms, unchanged by
+this migration). It reads every index entry, which is why it does not get faster
+— but it is not a heap scan, and no index added here would help it. A cheap count
+needs a different answer entirely, with its own trade-off.
+
+The posts indexes are **partial** on `deleted_at IS NULL`, which those queries
+write as a literal. The pages index is **not**: `listBlogPages` decides deleted
+versus live with a `CASE` over a bound parameter, so a partial index is provable
+under a custom plan and not under a generic one — and an index the planner can
+only sometimes prove applicable is an index that sometimes is not there.
+
+Held by `tests/integration/blog-list-ordering-plan.integration.test.ts`, which
+asserts the PLAN rather than a duration: the named index is the access path,
+there is no `Seq Scan`, there is no sort node, and no more than 50 rows are read.
+A timing threshold on shared CI hardware is a coin flip; `EXPLAIN` states the
+structural property directly. Its last case drops the index inside a rolled-back
+transaction and asserts the scan comes back — without that, every other
+assertion would also pass on a table too small to distinguish the plans.

--- a/.claude/skills/README.id.md
+++ b/.claude/skills/README.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](README.md)
 
-<!-- i18n-source-hash: sha256:f1aefc4ae0bcfe2e070084c8b63ed4f6fe9f00a0d8b04dbe344ca598cad22def -->
+<!-- i18n-source-hash: sha256:924228172b5ce8d60b12c2afb3de2d036d43c0a02856bb5903d0bef98dd713cd -->
 
 # AWCMS Project Skills
 
@@ -43,7 +43,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > Keluarga hari ini dua repo, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (halaman publik + permukaan admin USER, ADR-0070). **KOREKSI:** versi sebelumnya menyatakan
 > implementasi ini "baru fondasi Sprint 1–2" dengan empat modul — itu **sudah
-> lama tidak benar**. Repo ini punya **24 modul terdaftar** dan `sql/001`–`sql/142`;
+> lama tidak benar**. Repo ini punya **24 modul terdaftar** dan `sql/001`–`sql/143`;
 > lihat [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) untuk daftar nyata.
 > Skill yang badannya masih menandai dirinya "BACAAN SAJA" tetap begitu — itu
 > per-skill, bukan pernyataan tentang repo secara keseluruhan.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -41,7 +41,7 @@ Project-level Claude Code skills for AWCMS. Each skill encodes the standards fro
 > The family today is two repos, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (public pages + the USER admin surface, ADR-0070). **CORRECTION:** the previous version claimed this
 > implementation was "only the Sprint 1–2 foundation" with four modules — that has **not
-> been true for a long time**. This repo has **24 registered modules** and `sql/001`–`sql/142`;
+> been true for a long time**. This repo has **24 registered modules** and `sql/001`–`sql/143`;
 > see [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) for the real list.
 > A skill whose body still marks itself "READ-ONLY" stays that way — that is
 > per-skill, not a statement about the repo as a whole.

--- a/docs/ARCHITECTURE.id.md
+++ b/docs/ARCHITECTURE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](ARCHITECTURE.md)
 
-<!-- i18n-source-hash: sha256:09954334a520c01138de0742bce5608d1f795bdd4a6b9828f51279af41b032bc -->
+<!-- i18n-source-hash: sha256:ff9826fc96cc1c9490d1298b2bd0dc3f8747df684134fb6f25f3bd629dd33b79 -->
 
 # Arsitektur AWCMS
 
@@ -21,7 +21,7 @@ Sebagai template yang di-ship, base menyediakan **modul fondasi reusable + kontr
 modul domain ERP (finance, inventory, procurement, manufacturing, hr-payroll, dst.)
 **ditambahkan langsung di `src/modules/` template ini** saat dipakai, bukan di repo
 ekstensi/turunan terpisah (jalur aplikasi-turunan DIHAPUS — lihat §Komposisi modul di
-bawah). Repo ini punya **24 modul terdaftar**, migration `sql/001`-`sql/142`, RLS
+bawah). Repo ini punya **24 modul terdaftar**, migration `sql/001`-`sql/143`, RLS
 `FORCE` di seluruh tabel tenant-scoped, pemisahan role database, dan admin UI read+write
 (Issue #166, #171). Dokumen ini menjelaskan apa yang **ada di kode saat ini**. Untuk detail
 per modul, lihat `README.md` masing-masing di `src/modules/<module>/`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ As a shipped template, the base provides **reusable foundation modules + neutral
 ERP domain modules (finance, inventory, procurement, manufacturing, hr-payroll, etc.)
 are **added directly in this template's `src/modules/`** when it is used, not in a separate
 extension/derived repo (the derived-application pathway was REMOVED — see §Module composition
-below). This repo has **24 registered modules**, migrations `sql/001`-`sql/142`, RLS
+below). This repo has **24 registered modules**, migrations `sql/001`-`sql/143`, RLS
 `FORCE` on every tenant-scoped table, database role separation, and a read+write admin UI
 (Issue #166, #171). This document describes what is **in the code today**. For per-module
 detail, see each `README.md` under `src/modules/<module>/`.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:32688066ef50e4534e6ecfddc54de2337fa15f867bcc32cc29925b7572c8a53f -->
+<!-- i18n-source-hash: sha256:a72c4416be697d31eba8f61ec85e57ec097cceb48e6b9b181076bab3fa8fd241 -->
 
 # AWCMS — Project State & Continuation
 
@@ -111,7 +111,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Changeset menunggu (per tipe bump) | _jalankan perintah di kolom kanan_                                                    | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commit sejak rilis terakhir        | _jalankan perintah di kolom kanan_                                                    | `git rev-list --count v9.1.2..HEAD`                                                     |
 | Modul base                         | **24** (lihat daftar di ARCHITECTURE.md)                                              | `src/modules/index.ts`                                                                  |
-| Migrasi                            | **142** (`sql/001`–`142`)                                                             | `ls sql/`                                                                               |
+| Migrasi                            | **143** (`sql/001`–`143`)                                                             | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0103** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **48** berkas `.astro` di `src/pages/admin/`; **0 dari 24** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Berkas `.astro`                    | **61** (34.594 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
@@ -585,13 +585,42 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       tetapi mode gagalnya adalah OOM proses yang memegang setiap cache lain.
 
   ### C. Ongkos algoritma / query
-  15. **C1 — tidak ada indeks yang mendukung pengurutan daftar blog.**
+  15. **C1 — tidak ada indeks yang mendukung pengurutan daftar blog.** **SELESAI (22 Agustus 2026).**
       `blog-post-directory.ts:398,436`; `sql/035:95-119,174-193`. Empat query daftar
       mengurut `updated_at DESC` (satu keyset `created_at DESC, id DESC`); tidak satu pun
       dari tujuh indeks dipimpin kolom itu, jadi tiap `/admin/blog`, `/admin/pages`, dan
       `GET /api/v1/blog/posts` adalah scan se-tenant + sort top-N, plus scan penuh kedua
       untuk `count(*)`. `db:fk-index:check` tidak bisa melihatnya — `updated_at` bukan
       foreign key. Ongkosnya O(pos tenant), bukan O(ukuran halaman).
+
+      **DIUKUR, yang putaran ini tidak bisa lakukan.** `sql/143` menambah tiga indeks;
+      terhadap 24.000 post ter-seed di PostgreSQL 18, daftar `/admin/blog` berubah dari Seq
+      Scan 24.000 baris plus top-N heapsort (7,4 ms) menjadi Index Scan yang membaca **50**
+      baris (0,057 ms), halaman keyset pertama dari 5,1 ms menjadi 0,110 ms, dan halaman
+      keyset yang dilanjutkan di baris 10.000 membaca 50 baris dalam 0,060 ms. Milidetiknya
+      milik mesin ini; `24.000 → 50` itulah temuannya.
+
+      **Satu klaim di entri ini SALAH dan dibiarkan terlihat alih-alih disunting hilang:**
+      "plus scan penuh KEDUA untuk `count(*)`". Hitungan di samping daftar itu sudah
+      terencana sebagai Index Only Scan pada `awcms_blog_posts_tenant_deleted_idx` (1,8 ms,
+      tidak berubah oleh `sql/143`). Ia membaca setiap entri indeks — itu sebabnya ia tidak
+      menjadi lebih cepat — tetapi ia bukan heap scan, dan tidak ada indeks yang ditambahkan
+      di sini yang menolongnya. Hitungan yang murah adalah keputusan lain (estimasi, atau
+      penghitung terpelihara) dengan kompromnya sendiri.
+
+      Post mendapat indeks PARSIAL pada `deleted_at IS NULL`, yang ditulis literal oleh
+      query-nya. Page TIDAK: `listBlogPages` memutuskan terhapus-vs-hidup lewat `CASE` atas
+      parameter terikat, jadi indeks parsial dapat dibuktikan di custom plan dan tidak di
+      generic plan — indeks yang hanya kadang bisa dibuktikan planner adalah indeks yang
+      kadang tidak ada.
+
+      Dijaga oleh asersi RENCANA, bukan ambang waktu
+      (`tests/integration/blog-list-ordering-plan.integration.test.ts`): nama indeksnya,
+      tanpa `Seq Scan`, tanpa node sort, ≤50 baris dibaca. Kasus terakhirnya menjatuhkan
+      indeksnya di dalam transaksi yang di-rollback dan menuntut scan-nya kembali — tanpa
+      itu, setiap asersi lain juga lolos pada tabel yang terlalu kecil untuk membedakan
+      rencananya.
+
   16. **C2 — `purgeVisitorAnalyticsData` satu-satunya purge retensi tanpa batas di repo.**
       `retention-purge.ts:91-117`. Empat statement tanpa batas batch, tiap-tiap memakai
       `RETURNING id` hanya untuk mengambil `.length` di sisi JS. Setiap saudaranya membatasi

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -111,7 +111,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Pending changesets (by bump type) | _run the command in the right-hand column_                                             | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commits since the last release    | _run the command in the right-hand column_                                             | `git rev-list --count v9.1.2..HEAD`                                                     |
 | Base modules                      | **24** (see the list in ARCHITECTURE.md)                                               | `src/modules/index.ts`                                                                  |
-| Migrations                        | **142** (`sql/001`–`142`)                                                              | `ls sql/`                                                                               |
+| Migrations                        | **143** (`sql/001`–`143`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0105** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **48** `.astro` files in `src/pages/admin/`; **0 of 24** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | `.astro` files                    | **61** (34.594 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
@@ -586,12 +586,39 @@ pioneered directly here after the ADR-0047 freeze.)
       failure mode is an OOM of the process holding every other cache.
 
   ### C. Algorithm / query cost
-  15. **C1 — no index supports the blog list ordering.** `blog-post-directory.ts:398,436`;
+  15. **C1 — no index supports the blog list ordering.** **DONE (22 August 2026).** `blog-post-directory.ts:398,436`;
       `sql/035:95-119,174-193`. Four list queries order by `updated_at DESC` (one keyset by
       `created_at DESC, id DESC`); none of the seven indexes leads with either column, so
       each `/admin/blog`, `/admin/pages` and `GET /api/v1/blog/posts` is a tenant-wide scan
       - top-N sort, plus a second full scan for `count(*)`. `db:fk-index:check` cannot see
         it — `updated_at` is not a foreign key. Cost is O(tenant posts), not O(page size).
+
+      **MEASURED, which this round could not do.** `sql/143` adds three indexes; against
+      24,000 seeded posts on PostgreSQL 18 the `/admin/blog` list went from a Seq Scan of
+      24,000 rows plus a top-N heapsort (7.4 ms) to an Index Scan reading **50** (0.057
+      ms), the keyset first page from 5.1 ms to 0.110 ms, and a keyset page resumed at row
+      10,000 reads 50 rows in 0.060 ms. The milliseconds are this machine's; `24,000 → 50`
+      is the finding.
+
+      **One claim in this entry is wrong and is left visible rather than edited away:**
+      "plus a second full scan for `count(*)`". The count beside the list already plans as
+      an Index Only Scan on `awcms_blog_posts_tenant_deleted_idx` (1.8 ms, unchanged by
+      `sql/143`). It reads every index entry, which is why it does not get faster — but it
+      is not a heap scan, and no index added here helps it. A cheap count is a different
+      decision (an estimate, or a maintained counter) with its own trade-off.
+
+      Posts get PARTIAL indexes on `deleted_at IS NULL`, which those queries write as a
+      literal. Pages do NOT: `listBlogPages` decides deleted-vs-live with a `CASE` over a
+      bound parameter, so a partial index is provable under a custom plan and not under a
+      generic one — an index the planner can only sometimes prove applicable is an index
+      that sometimes is not there.
+
+      Held by a PLAN assertion, not a timing threshold
+      (`tests/integration/blog-list-ordering-plan.integration.test.ts`): named index, no
+      `Seq Scan`, no sort node, ≤50 rows read. Its last case drops the index inside a
+      rolled-back transaction and asserts the scan returns — without that, every other
+      assertion also passes on a table too small to tell the plans apart.
+
   16. **C2 — `purgeVisitorAnalyticsData` is the only unbounded retention purge in the
       repo.** `retention-purge.ts:91-117`. Four statements with no batch limit, each using
       `RETURNING id` only to take a JS-side `.length`. Every sibling caps at 5000 and loops.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -8,11 +8,11 @@
 | Aspect                              | Value |
 | ----------------------------------- | ----- |
 | Registered modules                  | 24    |
-| Migrations                          | 142   |
+| Migrations                          | 143   |
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 441   |
+| Test files                          | 442   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -191,6 +191,7 @@
 | 140 | `sql/140_awcms_site_search_term_facets.sql`                        |
 | 141 | `sql/141_awcms_repair_jsonb_string_bodies.sql`                     |
 | 142 | `sql/142_awcms_delegated_access_expiry_sweep.sql`                  |
+| 143 | `sql/143_awcms_blog_list_ordering_indexes.sql`                     |
 
 ### Tables & Row-Level Security
 
@@ -355,7 +356,7 @@
 | ------------- | ---------- |
 | `(root)`      | 376        |
 | `e2e`         | 12         |
-| `integration` | 52         |
+| `integration` | 53         |
 | `unit`        | 1          |
 
 ### Routes

--- a/sql/143_awcms_blog_list_ordering_indexes.sql
+++ b/sql/143_awcms_blog_list_ordering_indexes.sql
@@ -1,0 +1,96 @@
+-- Finding C1 of the 17 August 2026 audit round — an index for the ordering the
+-- blog lists actually use.
+--
+-- ## What was measured, not derived
+--
+-- `sql/035` gives `awcms_blog_posts` seven indexes. Not one of them leads with
+-- `updated_at` or `created_at`, and four list queries order by one of those:
+--
+--   * `listBlogPosts`            ORDER BY updated_at DESC          (/admin/blog)
+--   * `listBlogPostsPage`        ORDER BY p.updated_at DESC        (term-filtered)
+--   * `listBlogPostsFullPage`    ORDER BY created_at DESC, id DESC (GET /api/v1/blog/posts)
+--   * `listBlogPages`            ORDER BY updated_at DESC          (/admin/pages)
+--
+-- The audit could only derive the consequence from btree prefix rules. It has
+-- now been measured, against 24,000 seeded posts on PostgreSQL 18:
+--
+--   | query                              | before                        | after            |
+--   | ---------------------------------- | ----------------------------- | ---------------- |
+--   | /admin/blog list, LIMIT 50          | Seq Scan 24,000 + top-N sort — 7.4 ms | Index Scan 50 rows — 0.057 ms |
+--   | same, with the status filter        | Seq Scan 20,572 + top-N sort — 4.8 ms | Index Scan 50 rows — 0.050 ms |
+--   | keyset page, LIMIT 50               | Seq Scan 24,000 + top-N sort — 5.1 ms | Index Scan 50 rows — 0.110 ms |
+--
+-- The number that matters is not the milliseconds — it is `24,000` becoming
+-- `50`. The cost was O(tenant posts) and is now O(page size), so the page that
+-- is fast on a demo tenant stays fast on the 23,906-article archive Issue #599
+-- exists to import.
+--
+-- ## One correction to the finding
+--
+-- C1 also says "plus a second full scan for `count(*)`". That is NOT what
+-- happens: the count beside the list already plans as an Index Only Scan on
+-- `awcms_blog_posts_tenant_deleted_idx` (measured: 1.8 ms, unchanged by this
+-- migration). It reads every row of the index, which is why it does not get
+-- faster here — but it is not a heap scan, and no index added here would help
+-- it. A genuinely cheap count needs a different answer (an estimate, or a
+-- maintained counter), and that is a separate decision with its own trade-off.
+--
+-- ## Why PARTIAL on posts and PLAIN on pages
+--
+-- The post queries write `deleted_at IS NULL` as a literal, so the partial index
+-- is provably applicable and skips soft-deleted rows entirely.
+--
+-- `listBlogPages` does not: it writes
+-- `CASE WHEN $deletedOnly THEN deleted_at IS NOT NULL ELSE deleted_at IS NULL END`,
+-- so whether a partial index applies depends on the planner knowing the
+-- parameter — true for a custom plan, not guaranteed for a generic one. A plain
+-- index is usable under both branches and under either plan. Pages are
+-- low-cardinality, so the extra entries cost little; a partial index that the
+-- planner sometimes cannot prove costs the scan it was added to remove.
+--
+-- ## Why `DESC` in the index
+--
+-- PostgreSQL can walk an ASC index backwards, so it is not strictly required.
+-- It is written anyway, matching `awcms_blog_posts_tenant_status_published_idx`
+-- one file over: the direction the reader wants is part of what the index is
+-- FOR, and a reader comparing the two should not have to work out that they are
+-- the same shape written two ways.
+--
+-- No `CONCURRENTLY`: this repo's migration runner wraps each file in a
+-- transaction (`CREATE INDEX CONCURRENTLY` cannot run inside one), and every
+-- index here is on a table whose largest known deployment is a few tens of
+-- thousands of rows — seconds of lock, not minutes. A future table where that
+-- stops being true needs a different runner, not a different index.
+
+BEGIN;
+
+-- `/admin/blog`, and the term-filtered list behind it. Also the ordering
+-- `listBlogPostsByStatus` inherits, since it is a thin wrapper.
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_tenant_updated_idx
+  ON awcms_blog_posts (tenant_id, updated_at DESC)
+  WHERE deleted_at IS NULL;
+
+COMMENT ON INDEX awcms_blog_posts_tenant_updated_idx IS
+  'Finding C1. The ordering /admin/blog and the term-filtered post list actually use. Without it both were a tenant-wide Seq Scan plus a top-N heapsort: measured 24,000 rows scanned to return 50, 7.4 ms, on a 24,000-post tenant. Partial on deleted_at IS NULL because both queries write that predicate as a literal.';
+
+-- `GET /api/v1/blog/posts` — the keyset traversal a static build walks. The
+-- tiebreaker column is part of the ordering, so it is part of the index: a
+-- cursor that resumes on `(created_at, id)` cannot be answered in order by an
+-- index that stops at `created_at`.
+CREATE INDEX IF NOT EXISTS awcms_blog_posts_tenant_created_keyset_idx
+  ON awcms_blog_posts (tenant_id, created_at DESC, id DESC)
+  WHERE deleted_at IS NULL;
+
+COMMENT ON INDEX awcms_blog_posts_tenant_created_keyset_idx IS
+  'Finding C1. The keyset ordering of GET /api/v1/blog/posts (created_at DESC, id DESC). Carries the id tiebreaker because the cursor resumes on the PAIR — an index stopping at created_at would still need a sort. Measured: Seq Scan 24,000 + top-N sort at 5.1 ms becomes an Index Scan of 50 rows at 0.11 ms.';
+
+-- `/admin/pages`. Plain rather than partial: see this file's header — the query
+-- decides `deleted_at` with a CASE over a parameter, and an index the planner
+-- can only sometimes prove applicable is an index that sometimes is not there.
+CREATE INDEX IF NOT EXISTS awcms_blog_pages_tenant_updated_idx
+  ON awcms_blog_pages (tenant_id, updated_at DESC);
+
+COMMENT ON INDEX awcms_blog_pages_tenant_updated_idx IS
+  'Finding C1. The ordering /admin/pages uses. NOT partial on deleted_at: listBlogPages selects deleted vs live with a CASE over a bound parameter, so a partial index is provable under a custom plan and not under a generic one. Pages are low-cardinality; the extra entries cost less than a scan the planner falls back to.';
+
+COMMIT;

--- a/tests/integration/blog-list-ordering-plan.integration.test.ts
+++ b/tests/integration/blog-list-ordering-plan.integration.test.ts
@@ -1,0 +1,274 @@
+/**
+ * The blog list orderings are served by an index, not by sorting the tenant —
+ * finding C1 of the 17 August 2026 audit round, `sql/143`.
+ *
+ * ## Why this asserts a PLAN and not a duration
+ *
+ * A timing assertion on shared CI hardware is a coin flip with a threshold
+ * attached: it goes red for a noisy neighbour and green for a regression that
+ * happens to run on a quiet machine. What actually regressed in C1 is
+ * structural — the query reads every row of the tenant and then throws almost
+ * all of them away — and `EXPLAIN` states that directly.
+ *
+ * So each case asserts three things about the plan:
+ *
+ *   1. the named index from `sql/143` is the access path;
+ *   2. there is no `Seq Scan` on the table;
+ *   3. there is no sort node — the index already supplies the order, which is
+ *      the whole reason the tiebreaker column is IN the index.
+ *
+ * Together those make the cost O(page size). Before `sql/143`, measured against
+ * 24,000 seeded posts: 24,000 rows scanned plus a top-N heapsort to return 50,
+ * at 7.4 ms; after, 50 rows and 0.057 ms. The milliseconds are the machine's;
+ * the row count is the defect.
+ *
+ * ## The deep page is the case that matters
+ *
+ * A first page is fast under almost any plan. The assertion worth having is the
+ * RESUMED one: a cursor landing at row 10,000 still reads 50 rows. That is the
+ * property a keyset cursor exists for, and it is worth nothing if the index
+ * cannot supply the order.
+ *
+ * MUTATION PROOF: drop either index from `sql/143` → the matching case goes RED
+ * with a `Seq Scan` in its plan.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+
+const TENANT = "c1c1c1c1-c1c1-4c1c-8c1c-c1c1c1c1c1c1";
+
+/**
+ * Enough rows that a sequential scan is clearly the worse plan, and few enough
+ * that seeding is not the slowest thing in the suite. The defect is visible at
+ * any size — it is O(tenant posts) — but a planner given fifty rows will
+ * reasonably pick a scan, and a test that cannot distinguish "the index is
+ * missing" from "the table is tiny" asserts nothing.
+ */
+const POST_COUNT = 3000;
+
+async function seed(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${TENANT}, 'c1-plan', 'C1 Plan', 'active')
+  `;
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Author')
+    RETURNING id
+  `) as { id: string }[];
+
+  const identity = (await admin`
+    INSERT INTO awcms_identities
+      (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'c1@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+
+  const author = (await admin`
+    INSERT INTO awcms_tenant_users (tenant_id, identity_id)
+    VALUES (${TENANT}, ${identity[0]!.id})
+    RETURNING id
+  `) as { id: string }[];
+
+  // `generate_series` rather than 3000 round trips: the point of this file is
+  // the plan, and a fixture that takes a minute discourages running it.
+  await admin.unsafe(
+    `INSERT INTO awcms_blog_posts
+       (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+        status, visibility, locale, created_at, updated_at, published_at)
+     SELECT $1, $2, 'Judul ' || g, 'judul-' || g, $3::jsonb, 'isi',
+            CASE WHEN g % 7 = 0 THEN 'draft' ELSE 'published' END,
+            'public', 'id',
+            now() - (g || ' minutes')::interval,
+            now() - (g || ' seconds')::interval,
+            now() - (g || ' minutes')::interval
+     FROM generate_series(1, ${POST_COUNT}) g`,
+    [TENANT, author[0]!.id, JSON.stringify({ blocks: [] })]
+  );
+
+  // Without fresh statistics the planner is choosing between a scan it has
+  // measured and an index it has not, which is not the question under test.
+  await admin.unsafe("ANALYZE awcms_blog_posts");
+}
+
+type Plan = { text: string; scan: string; rowsRead: number };
+
+async function explain(
+  sqlText: string,
+  params: unknown[],
+  on: Bun.SQL = getAdminSql()
+): Promise<Plan> {
+  const rows = (await on.unsafe(
+    `EXPLAIN (ANALYZE, FORMAT TEXT) ${sqlText}`,
+    params as never[]
+  )) as Record<string, string>[];
+
+  const text = rows.map((row) => Object.values(row)[0]).join("\n");
+  const scan =
+    text.match(
+      /(Seq Scan|Index Scan|Index Only Scan|Bitmap Heap Scan)[^\n]*/
+    )?.[0] ?? "(no scan node)";
+
+  return {
+    text,
+    scan: scan.trim(),
+    rowsRead: Number(scan.match(/rows=([\d.]+)\.00 loops/)?.[1] ?? -1)
+  };
+}
+
+/** The three properties, asserted together because each alone is satisfiable by a wrong plan. */
+function expectServedByIndex(plan: Plan, indexName: string): void {
+  expect(plan.scan).toContain(indexName);
+  expect(plan.text).not.toContain("Seq Scan on awcms_blog_posts");
+  // No sort node: the index supplies the order. A plan that scanned the index
+  // and then sorted would satisfy the first two assertions and none of the
+  // point.
+  expect(plan.text).not.toContain("Sort Method");
+  // O(page size), which is the finding restated as a number.
+  expect(plan.rowsRead).toBeLessThanOrEqual(50);
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("blog list orderings are served by an index (sql/143)", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seed();
+  });
+
+  test("/admin/blog — ORDER BY updated_at DESC", async () => {
+    const plan = await explain(
+      `SELECT id, tenant_id, title, slug, status, visibility, locale,
+              published_at, updated_at, created_at
+       FROM awcms_blog_posts
+       WHERE tenant_id = $1 AND deleted_at IS NULL
+       ORDER BY updated_at DESC LIMIT 50`,
+      [TENANT]
+    );
+
+    expectServedByIndex(plan, "awcms_blog_posts_tenant_updated_idx");
+  });
+
+  test("/admin/blog with the status filter the route sends", async () => {
+    // The `${param}::text IS NULL OR col = ${param}` idiom every list in this
+    // module uses. It is not sargable on `status`, which is exactly why the
+    // index leads with `tenant_id, updated_at` and not with `status`.
+    const plan = await explain(
+      `SELECT id, title FROM awcms_blog_posts
+       WHERE tenant_id = $1 AND deleted_at IS NULL
+         AND ($2::text IS NULL OR status = $2)
+       ORDER BY updated_at DESC LIMIT 50`,
+      [TENANT, "published"]
+    );
+
+    expectServedByIndex(plan, "awcms_blog_posts_tenant_updated_idx");
+  });
+
+  test("GET /api/v1/blog/posts — keyset first page", async () => {
+    const plan = await explain(
+      `SELECT id, title FROM awcms_blog_posts
+       WHERE tenant_id = $1 AND deleted_at IS NULL
+       ORDER BY created_at DESC, id DESC LIMIT 50`,
+      [TENANT]
+    );
+
+    expectServedByIndex(plan, "awcms_blog_posts_tenant_created_keyset_idx");
+  });
+
+  test("GET /api/v1/blog/posts — keyset page RESUMED deep into the archive", async () => {
+    // The case a first-page test cannot see, and the one a static build of
+    // 23,906 articles spends almost all of its time in.
+    const anchor = (await getAdminSql().unsafe(
+      `SELECT created_at, id FROM awcms_blog_posts
+       WHERE tenant_id = $1 AND deleted_at IS NULL
+       ORDER BY created_at DESC, id DESC OFFSET 2000 LIMIT 1`,
+      [TENANT]
+    )) as { created_at: Date; id: string }[];
+
+    const plan = await explain(
+      `SELECT id, title FROM awcms_blog_posts
+       WHERE tenant_id = $1 AND deleted_at IS NULL
+         AND (created_at, id) < ($2, $3)
+       ORDER BY created_at DESC, id DESC LIMIT 50`,
+      [TENANT, anchor[0]!.created_at, anchor[0]!.id]
+    );
+
+    expectServedByIndex(plan, "awcms_blog_posts_tenant_created_keyset_idx");
+  });
+
+  test("the index really is what makes the difference", async () => {
+    // NON-VACUOUS. Every assertion above is also satisfied by a table small
+    // enough that any plan reads few rows. Dropping the index inside this
+    // transaction shows the plan the repository actually shipped: a scan of the
+    // whole tenant plus a sort, to return fifty rows.
+    //
+    // Rolled back through `sql.begin` rather than `BEGIN`/`ROLLBACK` on the
+    // pool: Bun.SQL refuses a raw transaction statement on a pooled client
+    // (`ERR_POSTGRES_UNSAFE_TRANSACTION`), and dropping the index outside a
+    // transaction would leak into every other file sharing this database —
+    // the harness is ref-counted and does not recreate the schema per file.
+    const admin = getAdminSql();
+    let planWithoutIndex: Plan | undefined;
+
+    try {
+      await admin.begin(async (tx) => {
+        await tx.unsafe("DROP INDEX awcms_blog_posts_tenant_updated_idx");
+
+        planWithoutIndex = await explain(
+          `SELECT id, title FROM awcms_blog_posts
+           WHERE tenant_id = $1 AND deleted_at IS NULL
+           ORDER BY updated_at DESC LIMIT 50`,
+          [TENANT],
+          tx as unknown as Bun.SQL
+        );
+
+        // The only way out that undoes the DROP. `try`/`catch` rather than
+        // `expect().rejects`, which hangs against a Bun.SQL query promise on
+        // this pool harness.
+        throw new Error("__rollback__");
+      });
+    } catch (error) {
+      if ((error as Error).message !== "__rollback__") throw error;
+    }
+
+    expect(planWithoutIndex).toBeDefined();
+    expect(planWithoutIndex!.text).toContain("Seq Scan on awcms_blog_posts");
+    expect(planWithoutIndex!.text).toContain("Sort Method");
+    expect(planWithoutIndex!.rowsRead).toBeGreaterThan(1000);
+
+    // And the index is back, so the file leaves the database as it found it.
+    const restored = await explain(
+      `SELECT id, title FROM awcms_blog_posts
+       WHERE tenant_id = $1 AND deleted_at IS NULL
+       ORDER BY updated_at DESC LIMIT 50`,
+      [TENANT]
+    );
+
+    expect(restored.scan).toContain("awcms_blog_posts_tenant_updated_idx");
+  });
+});


### PR DESCRIPTION
Finding **C1** of the 17 August 2026 audit round — fifth on the "do first" list, and the first one this session could actually **measure**.

## What was wrong

`sql/035` gives `awcms_blog_posts` seven indexes. Not one of them leads with `updated_at` or `created_at` — the two columns every list in the module orders by. `/admin/blog`, `/admin/pages`, the term-filtered post list, and the keyset traversal `GET /api/v1/blog/posts` that a static build walks were each a **tenant-wide sequential scan followed by a top-N sort**.

`db:fk-index:check` structurally cannot see it: `updated_at` is not a foreign key.

## Measured, not derived

The audit could only reason from btree prefix rules ("no live database was used"). This was run against 24,000 seeded posts on PostgreSQL 18:

| query | before | after |
| --- | --- | --- |
| `/admin/blog`, `LIMIT 50` | Seq Scan **24,000 rows** + top-N heapsort — 7.4 ms | Index Scan, **50 rows** — 0.057 ms |
| same, with the status filter | Seq Scan 20,572 rows + sort — 4.8 ms | Index Scan, 50 rows — 0.050 ms |
| keyset first page | Seq Scan 24,000 rows + sort — 5.1 ms | Index Scan, 50 rows — 0.110 ms |
| keyset page **resumed at row 10,000** | — | Index Scan, 50 rows — 0.060 ms |

The number that matters is not the milliseconds — it is **24,000 becoming 50**. The cost was O(tenant posts) and is now O(page size), so a page that is fast on a demo tenant stays fast on the 23,906-article archive Issue #599 exists to import. The resumed deep page is the case a first-page measurement cannot see, and the one a static build spends nearly all its time in.

## One correction to the finding

C1 also says "plus a second full scan for `count(*)`". **That is not what happens.** The count beside the list already plans as an Index Only Scan on `awcms_blog_posts_tenant_deleted_idx` (1.8 ms, unchanged by this migration). It reads every index entry, which is why it does not get faster — but it is not a heap scan, and no index added here would help it. A genuinely cheap count needs a different answer (an estimate, or a maintained counter) with its own trade-off. The wrong claim is left visible in `§4` rather than edited away.

## Partial on posts, plain on pages

The post queries write `deleted_at IS NULL` as a literal, so a partial index is provably applicable and skips soft-deleted rows entirely.

`listBlogPages` does not — it writes `CASE WHEN $deletedOnly THEN deleted_at IS NOT NULL ELSE deleted_at IS NULL END`, so whether a partial index applies depends on the planner knowing the parameter: true for a custom plan, not guaranteed for a generic one. An index the planner can only *sometimes* prove applicable is an index that sometimes is not there.

## The test asserts a PLAN, not a duration

A timing threshold on shared CI hardware is a coin flip: red for a noisy neighbour, green for a regression that happened to run on a quiet machine. What regressed here is structural, and `EXPLAIN` states it directly — named index, no `Seq Scan`, **no sort node** (the index supplies the order, which is why the tiebreaker column is *in* the index), at most 50 rows read.

Its last case drops the index inside a **rolled-back** transaction and asserts the scan comes back. Without that, every other assertion also passes on a table too small to distinguish the plans. (Rolled back through `sql.begin` rather than raw `BEGIN`/`ROLLBACK`: Bun.SQL refuses a raw transaction statement on a pooled client, and the harness database is ref-counted and shared between files.)

**Mutation-proven**: dropping the `id` tiebreaker from the keyset index turns both keyset cases red; removing the `updated_at` index turns the file red.

`bun run check` full green (5413 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)