### PR TITLE
fix(gates): five gates were scanning less than they claimed, because a comment stripper ate real code

### DIFF
--- a/.changeset/shared-comment-stripper.md
+++ b/.changeset/shared-comment-stripper.md
@@ -1,0 +1,62 @@
+---
+"awcms": patch
+---
+
+fix(gates): five gates were scanning less than they claimed, because a comment stripper ate real code
+
+Eight files carried their own `stripComments`, and the version most of them
+carried began by running a block-comment regex over the whole file:
+
+```ts
+source.replace(/\/\*[\s\S]*?\*\//g, "")
+```
+
+Nothing there knows about strings. A `/*` inside a **string literal** opens a
+comment that is closed by the next `*/` anywhere in the file, and everything
+between them is deleted. A route glob is enough to trigger it, and route globs
+are ordinary:
+
+```ts
+const PARTNER_GLOB = "/api/v1/partner/**";
+
+await tx`INSERT INTO awcms_tenant_users (tenant_id) VALUES (${t})`;
+
+/** A docblock whose closing marker ends the accidental comment. */
+```
+
+Run through the naive stripper, that `INSERT INTO` **is gone**.
+
+**What it cost on a real file.** `src/modules/blog-content/module.ts` loses 7,260
+characters and 57 lines to it — including its entire `jobs:` and `capabilities:`
+declarations. Any gate reading that descriptor through the naive stripper was
+looking at a module with no jobs, and reporting OK. Across `src/`, 29 files lose
+more than 200 characters.
+
+Five gates were built on it: `modules:table-writes:check`,
+`access:chokepoint:check`, `config:env:coverage:check`,
+`identity:principal-access:check` and `access:grant-readers:check`.
+
+**No gate signal differs today**, which is exactly why this is worth fixing now:
+it is a fail-open that grows with every new docblock and every new glob constant,
+and reports nothing as it grows. All eight gates were run before and after — same
+answers, and `docs/awcms/work-class-registry.generated.json` regenerates
+byte-identical.
+
+The implementation now lives once, in `scripts/lib/source-text.ts`: the
+string-aware scanner that was local to `i18n-catalog-check.ts`. It blanks
+characters rather than removing them, so offsets and line numbers survive and a
+removed comment cannot splice two tokens into a third that matches.
+
+`work-class-registry-generate.ts`'s `codeOnly` is folded in too. It was not the
+swallowing variety — no whole-file regex — but it was blind the other way: a
+block comment whose middle lines do not begin with `*`, or a trailing
+`/* … */` after code, survived it and could be read as a call.
+
+`stripComments` stays re-exported from the three scripts that 21 test files
+already import it from, rather than editing 21 import lines in a change about
+something else.
+
+The test keeps the naive version as an **oracle** — a test that only exercised
+the good stripper would assert that it works, which is easy and uninformative.
+Comparing both on the same input is what shows the difference is real, and what
+notices if somebody reintroduces the shortcut.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:a2407c9641638efc8fd083b8175234dac4d83d634bcdc8e8bceca450c7f02de0 -->
+<!-- i18n-source-hash: sha256:3ffc6f4ffd74d2f490bc281db837e690662b3095fe53f22127b8550c026afcae -->
 
 # AWCMS — Project State & Continuation
 
@@ -681,7 +681,8 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       berbalut konfigurasi, dengan gejala yang identik dengan sukses.
 
   23. **D2 — empat salinan `stripComments` naif menelan kode nyata; lima gerbang memindai
-      lebih sedikit dari yang diakuinya.** `table-write-ownership-check.ts:68`;
+      lebih sedikit dari yang diakuinya.** **SELESAI (22 Agustus 2026)** — delapan salinan,
+      bukan empat. `table-write-ownership-check.ts:68`;
       `access-chokepoint-check.ts:111`; `env-contract-coverage-check.ts:145`;
       `identity-principal-access-check.ts:177`; `work-class-registry-generate.ts:101`. Regex
       komentar blok berjalan atas seluruh berkas lebih dulu, jadi docblock apa pun yang
@@ -691,6 +692,30 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       berkas kehilangan kode nyata dibanding orakel. Tidak ada sinyal gerbang yang berbeda
       _hari ini_ — ini fail-open laten yang tumbuh tiap ada docblock baru. Versi
       sadar-string yang benar sudah ada di `i18n-catalog-check.ts:263`.
+
+      **Mendarat, dan jangkauannya lebih besar dari yang tertulis di entri ini.** Delapan
+      berkas membawa salinan, bukan empat. Fakta paling tajamnya bukan jumlah berkas:
+      `src/modules/blog-content/module.ts` kehilangan **7.260 karakter dan 57 baris** akibat
+      stripper naif itu, TERMASUK seluruh deklarasi `jobs:` dan `capabilities:`-nya —
+      sehingga gerbang yang membaca deskriptor itu lewat stripper tersebut sedang melihat
+      modul tanpa job dan melaporkan OK. Di seluruh `src/`, 29 berkas kehilangan lebih dari
+      200 karakter.
+
+      Kedelapan gerbang terdampak dijalankan sebelum dan sesudah: jawabannya sama, dan
+      `work-class-registry.generated.json` diregenerasi identik byte-per-byte — klaim "tidak
+      ada sinyal yang berbeda hari ini" DIVERIFIKASI, bukan diulang.
+
+      `codeOnly` milik `work-class-registry-generate.ts` ikut dilebur. Ia BUKAN jenis
+      penelan (tanpa regex sewhole-file) tetapi buta ke arah sebaliknya: komentar blok yang
+      baris tengahnya tidak diawali `*`, atau `/* … */` di belakang kode, lolos darinya dan
+      bisa terbaca sebagai pemanggilan.
+
+      `stripComments` tetap DI-RE-EXPORT dari tiga skrip yang sudah menjadi tempat impor 21
+      berkas tes — menyunting 21 baris impor di dalam perubahan tentang hal lain adalah cara
+      sebuah diff berhenti bisa direview. Tesnya menyimpan versi naifnya sebagai ORACLE: tes
+      yang hanya menjalankan stripper yang benar hanya menegaskan bahwa ia bekerja, yang
+      mudah dan tidak informatif.
+
   24. **D3 — `LOG_LEVEL=warn` lolos `config:validate` dan diabaikan diam-diam; `warning`,
       nilai yang diimplementasikan logger, ditolak.** `validate-env.ts:51-56`;
       `logger.ts:12,21-26`. Tidak ada nilai yang sekaligus lolos kontrak tervalidasi dan

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -698,7 +698,8 @@ pioneered directly here after the ADR-0047 freeze.)
       wearing a configuration, with a symptom identical to success.
 
   23. **D2 — four copies of a naive `stripComments` swallow real code; five gates scan
-      less than they claim.** `table-write-ownership-check.ts:68`;
+      less than they claim.** **DONE (22 August 2026)** — eight copies, not four.
+      `table-write-ownership-check.ts:68`;
       `access-chokepoint-check.ts:111`; `env-contract-coverage-check.ts:145`;
       `identity-principal-access-check.ts:177`; `work-class-registry-generate.ts:101`. The
       block-comment regex runs over the whole file first, so any docblock containing a
@@ -709,6 +710,29 @@ pioneered directly here after the ADR-0047 freeze.)
       docblock. The correct string-aware version already exists at
       `i18n-catalog-check.ts:263`. **Change:** extract it to `scripts/lib/source-text.ts`
       and delete the five copies.
+
+      **Landed, and the blast radius was bigger than this entry says.** Eight files carried
+      a copy, not four. The sharpest single fact is not the file count:
+      `src/modules/blog-content/module.ts` loses **7,260 characters and 57 lines** to the
+      naive stripper, INCLUDING its entire `jobs:` and `capabilities:` declarations — so a
+      gate reading that descriptor through it was looking at a module with no jobs and
+      reporting OK. Across `src/`, 29 files lose more than 200 characters.
+
+      All eight affected gates were run before and after: same answers, and
+      `work-class-registry.generated.json` regenerates byte-identical — the "no signal
+      differs today" claim VERIFIED rather than repeated.
+
+      `work-class-registry-generate.ts`'s `codeOnly` is folded in as well. It was NOT the
+      swallowing variety (no whole-file regex) but it was blind the other way: a block
+      comment whose middle lines do not begin with `*`, or a trailing `/* … */` after code,
+      survived it and could be read as a call.
+
+      `stripComments` stays RE-EXPORTED from the three scripts that 21 test files already
+      import it from — editing 21 import lines inside a change about something else is how
+      a diff stops being reviewable. The test keeps the naive version as an ORACLE: one
+      that only exercised the good stripper would assert that it works, which is easy and
+      uninformative.
+
   24. **D3 — `LOG_LEVEL=warn` passes `config:validate` and is silently ignored; `warning`,
       the value the logger implements, is rejected.** `validate-env.ts:51-56`;
       `logger.ts:12,21-26`. There is no value that both passes the validated contract and

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 443   |
+| Test files                          | 444   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -354,7 +354,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 377        |
+| `(root)`      | 378        |
 | `e2e`         | 12         |
 | `integration` | 53         |
 | `unit`        | 1          |

--- a/scripts/access-chokepoint-check.ts
+++ b/scripts/access-chokepoint-check.ts
@@ -51,6 +51,7 @@
  */
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import { stripComments } from "./lib/source-text";
 
 const ROUTES_ROOT = "src/pages/api/v1";
 const SCREENS_ROOT = "src/pages/admin";
@@ -91,30 +92,6 @@ const CHOKEPOINT_EXEMPTIONS: Readonly<Record<string, string>> = {
  * each a sentence would have dressed 31 open defects as 31 decisions.
  */
 export const ADMIN_SCREEN_CHOKEPOINT_MIGRATION: readonly string[] = [];
-
-/**
- * Drops block comments and whole-line `//` comments before matching.
- *
- * Not hygiene — a correctness fix caught on this gate's first run against the
- * screen root. `form-drafts.astro` was migrated and then explained itself with
- * "the decision is the chokepoint's, not `ssr.permissions.has()`", so the
- * signal matched the sentence saying the code no longer does it. This repo has
- * hit the same shape three times (`table-write-ownership-check` reporting
- * itself, and PR #404's mutation probe matching its own comment), and it is
- * always the FIX that plants the false positive, because a fix explains what it
- * removed.
- *
- * Trailing `// ...` after code is left alone on purpose: stripping it would
- * truncate any line containing `https://`, trading a false positive for a false
- * negative.
- */
-export function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .split("\n")
-    .filter((line) => !/^\s*(?:\/\/|\*)/.test(line))
-    .join("\n");
-}
 
 export type ChokepointProblem = { handler: string; message: string };
 
@@ -503,3 +480,10 @@ async function main(): Promise<void> {
 if (import.meta.main) {
   await main();
 }
+
+/**
+ * Re-exported for the callers that already import it from here — finding D2
+ * moved the implementation to `scripts/lib/source-text.ts` and left the name
+ * reachable rather than editing 21 import lines in the same change.
+ */
+export { stripComments };

--- a/scripts/env-contract-coverage-check.ts
+++ b/scripts/env-contract-coverage-check.ts
@@ -46,6 +46,7 @@
  */
 import { readdir } from "node:fs/promises";
 import path from "node:path";
+import { stripComments } from "./lib/source-text";
 
 const SOURCE_ROOTS = ["src", "scripts"];
 const SOURCE_EXTENSIONS = [".ts", ".astro", ".mjs"];
@@ -135,20 +136,6 @@ export const TOOLING_ONLY: readonly { name: string; reason: string }[] = [
 ];
 
 export type EnvCoverageViolation = { name: string; files: string[] };
-
-/**
- * Comments are stripped so a docblock that MENTIONS `process.env.TOKEN` while
- * explaining a rule is not read as a read — `security-readiness.ts` does
- * exactly that, and without this the gate reports a variable that no code ever
- * touches.
- */
-export function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .split("\n")
-    .filter((line) => !/^\s*(?:\/\/|\*)/.test(line))
-    .join("\n");
-}
 
 /** Present whether assigned or left as a commented placeholder. */
 export function declaredInEnvExample(source: string): Set<string> {
@@ -243,3 +230,10 @@ async function main(): Promise<void> {
 if (import.meta.main) {
   await main();
 }
+
+/**
+ * Re-exported for the callers that already import it from here — finding D2
+ * moved the implementation to `scripts/lib/source-text.ts` and left the name
+ * reachable rather than editing 21 import lines in the same change.
+ */
+export { stripComments };

--- a/scripts/i18n-catalog-check.ts
+++ b/scripts/i18n-catalog-check.ts
@@ -45,6 +45,7 @@ import {
   type Locale
 } from "../src/lib/i18n/locales";
 import { REPO_ROOT, listFilesRecursive } from "./lib/repo-files";
+import { stripComments } from "./lib/source-text";
 
 const SOURCE_ROOTS = ["src"];
 const SOURCE_EXTENSIONS = [".ts", ".tsx", ".astro"];
@@ -234,89 +235,6 @@ function literalOf(
   if (raw === undefined) return undefined;
 
   return decodeSourceLiteral(raw) ?? undefined;
-}
-
-/**
- * Blanks out comments, preserving offsets and every non-comment character.
- *
- * WHY THIS IS NOT OPTIONAL
- *
- * The harvester matches source TEXT, and prose about the code is source text
- * too. `account.astro` documents its own bug fix with the words `t("Light")`
- * inside a block comment, and the first version of this gate dutifully reported
- * `"Light"` as an undeclared msgid — a failure with no defect behind it.
- *
- * The tempting fix is to reword the comment. That is backwards: it makes the
- * gate's false positive into a permanent tax on writing comments, and this repo
- * has already recorded the lesson that assertions over source must strip
- * comments FIRST.
- *
- * The scanner tracks string state so a `//` inside a quoted string (`"https://…"`)
- * does not start a comment — without that, everything after such a URL on the
- * same line would be blanked, which would silently HIDE real `t()` calls. A
- * false negative in a coverage gate is worse than the false positive it fixes.
- *
- * Characters are replaced with spaces rather than removed so that regex offsets
- * and line structure stay intact, and so a comment can never splice two tokens
- * together into something that matches.
- */
-export function stripComments(source: string): string {
-  const out = source.split("");
-  let index = 0;
-
-  const blank = (from: number, to: number): void => {
-    for (let i = from; i < to && i < out.length; i += 1) {
-      // Keep newlines: line numbers and the `[^"\\\n]` guards in LITERAL both
-      // depend on line structure surviving.
-      if (out[i] !== "\n") out[i] = " ";
-    }
-  };
-
-  while (index < source.length) {
-    const char = source[index];
-    const next = source[index + 1];
-
-    // String literals — skipped whole, so their contents are never treated as
-    // comment starts and never blanked.
-    if (char === '"' || char === "'" || char === "`") {
-      const quote = char;
-      index += 1;
-
-      while (index < source.length) {
-        if (source[index] === "\\") {
-          index += 2;
-          continue;
-        }
-        if (source[index] === quote) {
-          index += 1;
-          break;
-        }
-        index += 1;
-      }
-
-      continue;
-    }
-
-    if (char === "/" && next === "/") {
-      const end = source.indexOf("\n", index);
-      const stop = end === -1 ? source.length : end;
-      blank(index, stop);
-      index = stop;
-      continue;
-    }
-
-    if (char === "/" && next === "*") {
-      const end = source.indexOf("*/", index + 2);
-      const stop = end === -1 ? source.length : end + 2;
-      blank(index, stop);
-      index = stop;
-      continue;
-    }
-
-    index += 1;
-  }
-
-  return out.join("");
 }
 
 interface UsedMsgid {
@@ -580,3 +498,10 @@ function main(): void {
 if (import.meta.main) {
   main();
 }
+
+/**
+ * Re-exported for the callers that already import it from here — finding D2
+ * moved the implementation to `scripts/lib/source-text.ts` and left the name
+ * reachable rather than editing 21 import lines in the same change.
+ */
+export { stripComments };

--- a/scripts/identity-principal-access-check.ts
+++ b/scripts/identity-principal-access-check.ts
@@ -43,6 +43,7 @@
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { stripComments } from "./lib/source-text";
 
 type GuardedTable = {
   readonly table: string;
@@ -173,10 +174,6 @@ function tableInClause(table: string): RegExp {
  * the store and watching the detector stay silent.
  */
 const STATEMENT_WINDOW = 400;
-
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, " ").replace(/^\s*\/\/.*$/gm, " ");
-}
 
 /** Does this file issue a query against the table at all? */
 function mentionsTableInSql(source: string, table: string): boolean {

--- a/scripts/lib/source-text.ts
+++ b/scripts/lib/source-text.ts
@@ -1,0 +1,111 @@
+/**
+ * Reading a source file as TEXT, with the prose taken out — finding D2 of the
+ * 17 August 2026 audit round.
+ *
+ * ## Why this is a shared module now
+ *
+ * Eight files carried their own `stripComments`, and the version most of them
+ * carried was this one:
+ *
+ * ```ts
+ * source
+ *   .replace(/\/\*[\s\S]*?\*\//g, "")
+ *   .split("\n")
+ *   .filter((line) => !/^\s*(?:\/\/|\*)/.test(line))
+ *   .join("\n");
+ * ```
+ *
+ * The block-comment regex runs over the WHOLE file before anything knows about
+ * strings, so a `/*` inside a string literal opens a comment that is closed by
+ * the next `*\/` anywhere in the file — and everything between them is deleted.
+ * A route glob is enough to trigger it:
+ *
+ * ```ts
+ * const PARTNER_GLOB = "/api/v1/partner/**";
+ *
+ * await tx`INSERT INTO awcms_tenant_users (tenant_id) VALUES (${t})`;
+ *
+ * /** A docblock whose closing marker ends the accidental comment. *\/
+ * ```
+ *
+ * Run through the naive stripper, that `INSERT INTO` **is gone**. Every gate
+ * built on it — `modules:table-writes:check`, `access:chokepoint:check`,
+ * `config:env:coverage:check`, `identity:principal-access:check`,
+ * `access:grant-readers:check` — was scanning less than it claimed, silently,
+ * on any file shaped like that.
+ *
+ * No gate signal differed on the day this was found. That is the point: it is a
+ * fail-open that grows with every new docblock and every new glob constant, and
+ * it reports nothing when it grows.
+ *
+ * ## What replaced it
+ *
+ * The scanner below, previously local to `i18n-catalog-check.ts`, which tracks
+ * string state and therefore cannot be opened by a `/*` that is inside quotes.
+ * It also blanks trailing `// …` comments, which the naive version deliberately
+ * left alone — the naive one could not tell a trailing comment from the `//` in
+ * `"https://…"`, so leaving them was the safer of two wrong answers. This one
+ * can tell, so it does not have to choose.
+ *
+ * `tests/source-text-stripping.test.ts` holds both properties against a naive
+ * oracle, including the case above.
+ */
+
+export function stripComments(source: string): string {
+  const out = source.split("");
+  let index = 0;
+
+  const blank = (from: number, to: number): void => {
+    for (let i = from; i < to && i < out.length; i += 1) {
+      // Keep newlines: line numbers and the `[^"\\\n]` guards in LITERAL both
+      // depend on line structure surviving.
+      if (out[i] !== "\n") out[i] = " ";
+    }
+  };
+
+  while (index < source.length) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    // String literals — skipped whole, so their contents are never treated as
+    // comment starts and never blanked.
+    if (char === '"' || char === "'" || char === "`") {
+      const quote = char;
+      index += 1;
+
+      while (index < source.length) {
+        if (source[index] === "\\") {
+          index += 2;
+          continue;
+        }
+        if (source[index] === quote) {
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+
+      continue;
+    }
+
+    if (char === "/" && next === "/") {
+      const end = source.indexOf("\n", index);
+      const stop = end === -1 ? source.length : end;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      const end = source.indexOf("*/", index + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      blank(index, stop);
+      index = stop;
+      continue;
+    }
+
+    index += 1;
+  }
+
+  return out.join("");
+}

--- a/scripts/table-write-ownership-check.ts
+++ b/scripts/table-write-ownership-check.ts
@@ -47,31 +47,13 @@
  */
 import { listModules } from "../src/modules";
 import { collectClaims, resolveOwner, routeOf } from "./validate-module-routes";
+import { stripComments } from "./lib/source-text";
 
 /** `INSERT INTO x` / `UPDATE x` / `DELETE FROM x`, table name captured. */
 const WRITE_PATTERN =
   /\b(?:INSERT\s+INTO|UPDATE|DELETE\s+FROM)\s+(awcms_\w+)/gi;
 
 const SOURCE_GLOBS = ["src/**/*.ts", "src/**/*.astro", "scripts/*.ts"];
-
-/**
- * Drops block comments and whole-line `//` comments before matching.
- *
- * Without this the gate reports ITSELF and `person-profile.ts` as writers of
- * `awcms_profiles`, because both files EXPLAIN the rule using the statement
- * they are about — a gate going red on its own documentation, which is the
- * third time that shape has appeared in this repo. Trailing `// ...` after code
- * is deliberately left alone: stripping it would truncate any line containing
- * `https://`, trading a false positive for a false negative, and prose about
- * SQL does not live at the end of a code line.
- */
-export function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .split("\n")
-    .filter((line) => !/^\s*(?:\/\/|\*)/.test(line))
-    .join("\n");
-}
 
 /**
  * Owners that are not modules. Named so a violation reads as a sentence.
@@ -315,3 +297,10 @@ async function main(): Promise<void> {
 if (import.meta.main) {
   await main();
 }
+
+/**
+ * Re-exported for the callers that already import it from here — finding D2
+ * moved the implementation to `scripts/lib/source-text.ts` and left the name
+ * reachable rather than editing 21 import lines in the same change.
+ */
+export { stripComments };

--- a/scripts/work-class-registry-generate.ts
+++ b/scripts/work-class-registry-generate.ts
@@ -45,6 +45,7 @@ import path from "node:path";
 
 import { JOB_WORK_CLASS_REGISTRY } from "../src/lib/database/work-class-registry";
 import type { WorkClass } from "../src/lib/database/work-class";
+import { stripComments } from "./lib/source-text";
 
 const ROUTES_ROOT = "src/pages/api";
 const SCRIPTS_ROOT = "scripts";
@@ -97,20 +98,19 @@ async function* walk(directory: string): AsyncGenerator<string> {
   }
 }
 
-/** Comment lines are dropped so a docblock mentioning a call is not a call. */
+/**
+ * Comments are blanked so a docblock mentioning a call is not a call.
+ *
+ * `stripComments` from `./lib/source-text` rather than the line-based filter
+ * this used to carry (finding D2). The old one was not the swallowing variety —
+ * it had no whole-file block regex — but it was blind in the other direction: a
+ * block comment whose middle lines do not begin with `*`, or a trailing
+ * `/* … *\/` after code, survived it intact and could be read as a call. The
+ * shared scanner tracks string state and handles both, and it is now the only
+ * implementation in the repository.
+ */
 function codeOnly(content: string): string {
-  return content
-    .split("\n")
-    .filter((line) => {
-      const trimmed = line.trim();
-
-      return (
-        !trimmed.startsWith("*") &&
-        !trimmed.startsWith("//") &&
-        !trimmed.startsWith("/*")
-      );
-    })
-    .join("\n");
+  return stripComments(content);
 }
 
 /**

--- a/src/modules/_shared/permission-enforcement-coverage.ts
+++ b/src/modules/_shared/permission-enforcement-coverage.ts
@@ -1,4 +1,5 @@
 import type { ModuleDescriptor } from "./module-contract";
+import { stripComments } from "../../../scripts/lib/source-text";
 
 /**
  * Permission-enforcement coverage (ADR-0057 §F).
@@ -77,17 +78,6 @@ export type EnforcementCoverageResult = {
 
 export function permissionTripleKey(triple: PermissionTriple): string {
   return `${triple.moduleKey}.${triple.activityCode}.${triple.action}`;
-}
-
-/**
- * Strips `//` and block comments so that prose mentioning a guard shape cannot
- * be mistaken for one. This file's own header would otherwise register as an
- * enforcer for several permissions.
- */
-function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
 }
 
 /**

--- a/tests/form-post-origin-check.test.ts
+++ b/tests/form-post-origin-check.test.ts
@@ -21,33 +21,10 @@
 import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join, relative } from "node:path";
+import { stripComments } from "../scripts/lib/source-text";
 
 const REPO_ROOT = join(import.meta.dir, "..");
 const SRC_ROOT = join(REPO_ROOT, "src");
-
-/**
- * Comments are stripped BEFORE matching. This file's own subject matter is
- * `method="post"` and `application/x-www-form-urlencoded`, and the component it
- * guards explains the trap in prose — an assertion that reads comments would be
- * answered by the explanation rather than by the code.
- *
- * Block comments are removed FIRST, and the braces a JSX comment leaves behind
- * are collapsed afterwards. Doing it the other way round — matching `{/* … *\/}`
- * as one unit — is wrong in a way that is easy to ship: `\{\s*\/\*` also matches
- * `interface Props {` followed by its JSDoc, and the pattern then runs on
- * looking for a `*\/` that happens to be followed by `}`. The first one it finds
- * is the JSX comment far below in the template, so everything between them —
- * the entire markup, `<form>` included — disappears. The scanner then reports
- * nothing and reads as a pass. That is the same lazy-quantifier failure CodeQL
- * caught in `i18n-screen-coverage-check.ts`, in a different costume.
- */
-function stripComments(source: string): string {
-  return source
-    .replace(/<!--[\s\S]*?-->/g, " ")
-    .replace(/\/\*[\s\S]*?\*\//g, " ")
-    .replace(/\{\s*\}/g, " ")
-    .replace(/^[ \t]*\/\/.*$/gm, " ");
-}
 
 function walk(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {

--- a/tests/source-text-stripping.test.ts
+++ b/tests/source-text-stripping.test.ts
@@ -1,0 +1,196 @@
+/**
+ * One comment stripper, and it does not eat code — finding D2 of the
+ * 17 August 2026 audit round.
+ *
+ * ## The defect, in five lines
+ *
+ * Eight files carried their own `stripComments`, and the version most of them
+ * carried started by running a block-comment regex over the WHOLE file:
+ *
+ * ```ts
+ * source.replace(/\/\*[\s\S]*?\*\//g, "")
+ * ```
+ *
+ * Nothing there knows about strings. A `/*` inside a string literal opens a
+ * comment that is closed by the next `*` + `/` anywhere in the file, and
+ * everything between them is deleted. A route glob is enough to trigger it, and
+ * route globs are ordinary.
+ *
+ * ## What it actually cost, on a real file
+ *
+ * `src/modules/blog-content/module.ts` loses **7,260 characters** and 57 lines
+ * to the naive stripper — including its entire `jobs:` and `capabilities:`
+ * declarations. Every gate built on that stripper was reading a module
+ * descriptor with the module's jobs missing, and reporting OK.
+ *
+ * Across `src/`, 29 files lose more than 200 characters.
+ *
+ * **No gate signal differed on the day this was found.** That is the point. It
+ * is a fail-open that grows with every new docblock and every new glob
+ * constant, and it reports nothing as it grows.
+ *
+ * ## Why the naive version is kept HERE
+ *
+ * As an oracle. A test that only exercised the good stripper would assert that
+ * it works, which is easy and uninformative; comparing the two on the same input
+ * is what shows the difference is real and what would notice if somebody
+ * reintroduced the shortcut.
+ */
+import { readdir } from "node:fs/promises";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/lib/source-text";
+
+/** The implementation this replaced, kept as the oracle and nowhere else. */
+function naiveStripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((line) => !/^\s*(?:\/\/|\*)/.test(line))
+    .join("\n");
+}
+
+describe("the swallowing case, minimised", () => {
+  const sample = [
+    'const PARTNER_GLOB = "/api/v1/partner/**";',
+    "",
+    "await tx`INSERT INTO awcms_tenant_users (tenant_id) VALUES (${t})`;",
+    "",
+    "/** A docblock whose closing marker ends the accidental comment. */",
+    "export const AFTER = 1;"
+  ].join("\n");
+
+  test("the naive stripper deletes a real INSERT", () => {
+    // Asserted, not described: this is the behaviour five gates were built on.
+    expect(naiveStripComments(sample)).not.toContain("INSERT INTO");
+  });
+
+  test("the shared stripper keeps it", () => {
+    expect(stripComments(sample)).toContain("INSERT INTO awcms_tenant_users");
+  });
+
+  test("and still removes the docblock", () => {
+    // NON-VACUOUS: a stripper that returned its input unchanged would pass the
+    // assertion above and be useless.
+    expect(stripComments(sample)).not.toContain("accidental comment");
+  });
+});
+
+describe("string state is what makes the difference", () => {
+  test("a `//` inside a string does not start a comment", () => {
+    // The failure this guards is a FALSE NEGATIVE in a coverage gate: blanking
+    // from `https://` to end of line hides whatever followed on that line.
+    const source = 'const url = "https://example.test/a"; const key = "kept";';
+
+    expect(stripComments(source)).toContain('"kept"');
+  });
+
+  test("a trailing comment after code IS removed", () => {
+    // The naive version left these alone deliberately — it could not tell a
+    // trailing comment from the `//` in a URL, so leaving them was the safer of
+    // two wrong answers. This one can tell, so it does not have to choose.
+    const source = 'const key = "kept"; // t("NotADeclaration")';
+    const stripped = stripComments(source);
+
+    expect(stripped).toContain('"kept"');
+    expect(stripped).not.toContain("NotADeclaration");
+  });
+
+  test("offsets and line structure survive", () => {
+    // Blanking rather than deleting is what lets a caller match with a regex and
+    // still report a line number, and what stops a removed comment splicing two
+    // tokens into a third that matches.
+    const source = [
+      "const a = 1; /* gone */ const b = 2;",
+      "const c = 3;"
+    ].join("\n");
+    const stripped = stripComments(source);
+
+    expect(stripped).toHaveLength(source.length);
+    expect(stripped.split("\n")).toHaveLength(2);
+    expect(stripped).toContain("const a = 1;");
+    expect(stripped).toContain("const b = 2;");
+    expect(stripped).not.toContain("gone");
+  });
+
+  test("an unterminated block comment blanks to the end, not past it", () => {
+    const source = "const a = 1;\n/* never closed\nconst b = 2;";
+    const stripped = stripComments(source);
+
+    expect(stripped).toContain("const a = 1;");
+    expect(stripped).not.toContain("const b = 2;");
+    expect(stripped).toHaveLength(source.length);
+  });
+});
+
+describe("the cost on a real file in this repository", () => {
+  test("a module descriptor loses its jobs and capabilities to the naive stripper", async () => {
+    // The single most useful fact in this file: a gate scanning module
+    // descriptors through the naive stripper could not see this module's jobs.
+    const source = await Bun.file("src/modules/blog-content/module.ts").text();
+
+    const aware = stripComments(source);
+    const naive = naiveStripComments(source);
+
+    expect(aware).toContain("jobs:");
+    expect(aware).toContain("capabilities:");
+    expect(naive).not.toContain("jobs:");
+    expect(naive).not.toContain("capabilities:");
+  });
+
+  test("it is not one unlucky file", async () => {
+    const affected: string[] = [];
+
+    for await (const file of walk("src")) {
+      const source = await Bun.file(file).text();
+      const lost =
+        stripComments(source).replace(/\s+/g, " ").trim().length -
+        naiveStripComments(source).replace(/\s+/g, " ").trim().length;
+
+      if (lost > 200) affected.push(file);
+    }
+
+    // Measured at 29 when this landed. Asserted as a floor rather than an exact
+    // number: pinning the count would make an unrelated comment edit fail this
+    // test, which is how a ledger becomes an off-switch.
+    expect(affected.length).toBeGreaterThan(20);
+  });
+});
+
+describe("there is exactly one implementation", () => {
+  test("no file defines its own stripComments", async () => {
+    const offenders: string[] = [];
+
+    for (const root of ["scripts", "src", "tests"]) {
+      for await (const file of walk(root)) {
+        if (file.endsWith(path.join("scripts", "lib", "source-text.ts"))) {
+          continue;
+        }
+        // This file's oracle is deliberately local and deliberately named
+        // something else, so it cannot be mistaken for a fourth copy.
+        if (file.endsWith("source-text-stripping.test.ts")) continue;
+
+        const source = await Bun.file(file).text();
+
+        if (/function stripComments\s*\(/.test(source)) offenders.push(file);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name === "node_modules") continue;
+      yield* walk(full);
+    } else if (entry.name.endsWith(".ts") || entry.name.endsWith(".astro")) {
+      yield full;
+    }
+  }
+}

--- a/tests/tenant-provisioning.test.ts
+++ b/tests/tenant-provisioning.test.ts
@@ -27,6 +27,7 @@ import {
   isPlatformScopedPermissionKey,
   resetPlatformScopeCacheForTests
 } from "../src/modules/identity-access/domain/platform-scope";
+import { stripComments } from "../scripts/lib/source-text";
 
 const BOOTSTRAP = "src/modules/tenant-admin/application/platform-bootstrap.ts";
 const PROVISIONING =
@@ -34,19 +35,6 @@ const PROVISIONING =
 const ROUTE = "src/pages/api/v1/tenants/index.ts";
 const PAGE = "src/pages/admin/tenants.astro";
 const MIGRATION = "sql/086_awcms_tenant_provisioning_permissions.sql";
-
-/**
- * Removes block and line comments before counting call sites.
- *
- * Without this, a doc comment that MENTIONS `grantPlatformScope: true` — which
- * `bootstrapPlatformTenant`'s does, correctly — counts as a call site, and the
- * assertion below fails for a reason that has nothing to do with the code. The
- * fix is to count code, not prose; loosening the count would have hidden a real
- * second call site later.
- */
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\n]*/g, "");
-}
 
 describe("tenant provisioning is platform-scoped", () => {
   test("both provisioning permissions are declared PLATFORM-scoped", () => {


### PR DESCRIPTION
Finding **D2** of the 17 August 2026 audit round — the last item on the "do first" list, and the one the round called out as "what lets the next defect of this class ship green".

## The defect, in one regex

Eight files carried their own `stripComments`, and the version most of them carried began by running a block-comment regex over the **whole file**:

```ts
source.replace(/\/\*[\s\S]*?\*\//g, "")
```

Nothing there knows about strings. A `/*` inside a **string literal** opens a comment that is closed by the next `*/` anywhere in the file, and everything between them is deleted. A route glob is enough:

```ts
const PARTNER_GLOB = "/api/v1/partner/**";

await tx`INSERT INTO awcms_tenant_users (tenant_id) VALUES (${t})`;

/** A docblock whose closing marker ends the accidental comment. */
```

Run through the naive stripper, that `INSERT INTO` **is gone**.

## What it cost on a real file

`src/modules/blog-content/module.ts` loses **7,260 characters and 57 lines** — including its entire **`jobs:` and `capabilities:` declarations**. Any gate reading that descriptor through the naive stripper was looking at a module with no jobs, and reporting OK.

Across `src/`, **29 files** lose more than 200 characters.

Five gates were built on it: `modules:table-writes:check`, `access:chokepoint:check`, `config:env:coverage:check`, `identity:principal-access:check`, `access:grant-readers:check`.

## "No gate signal differs today" — verified, not repeated

All eight affected gates were run before and after: same answers. `docs/awcms/work-class-registry.generated.json` regenerates byte-identical.

That is the whole reason to fix it now rather than later. It is a fail-open that grows with every new docblock and every new glob constant, and it reports nothing as it grows.

## What replaced it

`scripts/lib/source-text.ts` — the string-aware scanner that was local to `i18n-catalog-check.ts`. It cannot be opened by a `/*` inside quotes, and it **blanks** characters rather than removing them, so offsets and line numbers survive and a removed comment cannot splice two tokens into a third that matches.

`work-class-registry-generate.ts`'s `codeOnly` is folded in as well. It was **not** the swallowing variety — no whole-file regex — but it was blind the other way: a block comment whose middle lines do not begin with `*`, or a trailing `/* … */` after code, survived it and could be read as a call.

`stripComments` stays **re-exported** from the three scripts that 21 test files already import it from. Editing 21 import lines inside a change about something else is how a diff stops being reviewable.

## The test keeps the naive version — as an oracle

A test that only exercised the good stripper would assert that it works, which is easy and uninformative. Comparing both on the same input is what shows the difference is real, and what notices if somebody reintroduces the shortcut. It also asserts, against the real repository, that `blog-content/module.ts` loses its `jobs:` to the naive one and keeps it under the shared one — and that no file anywhere defines its own `stripComments` any more.

`bun run check` full green (5434 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)