### PR TITLE
fix(blog-content): one control character in one title made the whole feed unreadable; and LOG_LEVEL had no value that both validated and worked

### DIFF
--- a/.changeset/xml-escaping-and-log-level.md
+++ b/.changeset/xml-escaping-and-log-level.md
@@ -1,0 +1,48 @@
+---
+"awcms": patch
+---
+
+fix(blog-content): one control character in one title made the whole feed unreadable; and `LOG_LEVEL` had no value that both validated and worked
+
+Two findings from the 17 August 2026 audit round that share a shape — a control
+applied to the wrong copy, and a contract no value could satisfy.
+
+**A6 — `/blog/{tenantCode}/feed.xml` and `sitemap-blog.xml` escaped as HTML.**
+`escapeHtml` neutralises the five markup entities and passes C0 control
+characters through. XML 1.0 forbids most of them **anywhere** in a document,
+including as a numeric reference; HTML merely discourages them.
+`validateTitleField` checks a post title's length and nothing else, and there is
+no write-side stripping — so one stray control character in one title made the
+whole channel non-well-formed and every reader rejected it. Not that item: the
+feed.
+
+ADR-0038 named `escapeXmlText` for exactly this. It was applied to the
+`seo_distribution` serializers, which answer **404** in production, and not to
+these two routes, which answer **200**.
+
+The route's own docblock is why the wrong function looked right: *"escaped
+through the same `escapeHtml` used for HTML (XML and HTML share the same five
+entity escapes)"*. True, and not the whole difference. It has been corrected
+rather than deleted — a false comment beside correct code is the next author's
+instruction.
+
+**D3 — `LOG_LEVEL` had no working value.** `config:validate` accepted `warn`;
+the logger implements `warning`. `LOG_LEVEL=warn` therefore passed the validated
+contract, matched no level, fell back to `info`, and the firehose kept shipping
+while the operator believed they had quieted it — and `LOG_LEVEL=warning`, the
+value that would have worked, was rejected.
+
+Fixed on **both** sides and additively: the validator now accepts `warning`
+(and keeps `warn`), and the logger canonicalises `warn` → `warning` with a
+one-time notice naming the canonical spelling. Rejecting `warn` outright would
+have been tidier and would have turned a silent no-op into a failed
+`config:validate` on a deployment that is running right now, to punish a
+spelling. An unrecognised value still falls back to `info` — the safe direction,
+because the alternative is a deployment that logs nothing because somebody typed
+`infoo`.
+
+Also corrects `docs/PROJECT_STATE.md` §4: **A8 was already fixed** before this
+round wrote it up. Both site-search rate-limit settings already go through
+`parsePositiveIntSetting`, which handles the NaN half and the empty-string half.
+The entry is marked rather than deleted, because an audit item describing a
+defect that is not there sends the next reader looking for it.

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ APP_URL=http://localhost:4321
 # (`test` remains an accepted APP_ENV value for automated test runs, which is
 # not a deployment). Copying this file and setting `APP_ENV=staging` names an
 # environment that no longer exists anywhere in this repo.
+# debug | info | warning | error. `warn` is accepted as an alias for `warning`
+# and logs a one-time notice; before finding D3 it validated, matched no level,
+# and silently fell back to `info`.
 LOG_LEVEL=info
 AUDIT_LOG_RETENTION_DAYS=730
 

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:3ffc6f4ffd74d2f490bc281db837e690662b3095fe53f22127b8550c026afcae -->
+<!-- i18n-source-hash: sha256:c9dd334cae256163bd3e5e2ca23bde515a7ad5ef9a7f4eb46414766fe5d22ef7 -->
 
 # AWCMS — Project State & Continuation
 
@@ -536,11 +536,18 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
      tidak mencabut apa pun di B. "Keluarkan saya dari semua perangkat" punya batas yang
      sama, dan dua komentar dokumen menegaskan jaminan yang tidak lagi diberikan kodenya.
   6. **A6 — feed/sitemap blog meng-escape dengan `escapeHtml`, bukan `escapeXmlText`.**
+     **SELESAI (22 Agustus 2026).**
      `blog/[tenantCode]/feed.xml.ts:6,88,92,102`; `sitemap-blog.xml.ts:6,104,116`. Satu
      karakter kontrol C0 pada judul pos (`validateTitleField` hanya memeriksa panjang)
      membuat seluruh channel menjadi XML tidak well-formed dan setiap pembaca menolaknya.
      ADR-0038 menyebut `escapeXmlText`; itu diterapkan pada serializer `seo_distribution`
      yang 404 di produksi, dan tidak pada rute ini yang 200.
+     Kedua rute kini memakai `escapeXmlText` (16 titik panggil). Docblock rutenya sendiri
+     yang membuat fungsi salah itu terlihat benar — "escaped through the same `escapeHtml`
+     used for HTML (XML and HTML share the same five entity escapes)" — benar, dan bukan
+     seluruh perbedaannya. Ia DIKOREKSI alih-alih dihapus: komentar salah di samping kode
+     benar adalah instruksi bagi penulis berikutnya.
+
   7. **A7 — sync-storage memakai string dari node apa adanya sebagai jalur filesystem
      server dan sebagai kunci object-store.** `sync-storage/domain/object-queue.ts:40-58,91`;
      `object-storage-uploader.ts:110-129`. `localPath` tidak dikurung akar dan dispatcher
@@ -554,6 +561,18 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
      **limiter-nya mati** pada endpoint full-text anonim sementara metrik `rate_limited`
      tetap nol dan meneguhkannya sebagai "tidak ada penyalahgunaan". Nilai kosong
      menghasilkan `0` dan mem-429 setiap pengunjung.
+
+     **SUDAH DIPERBAIKI saat diperiksa, 22 Agustus 2026 — entri ini sudah basi pada hari ia
+     ditulis.** Kedua setelan sudah melewati `parsePositiveIntSetting`
+     (`src/lib/security/env-thresholds.ts`), yang mengembalikan fallback untuk nilai
+     kosong/undefined DAN untuk apa pun yang non-finite, non-integer, atau ≤ 0, sambil
+     memperingatkan sekali. `suggest.ts` bahkan membawa komentar "See `query.ts` — same
+     defect, same fix". Ditutup oleh #601 bersama #593.
+
+     **Dibiarkan terlihat alih-alih dihapus.** Entri audit yang menggambarkan cacat yang
+     TIDAK ADA mengirim pembaca berikutnya mencarinya — bentuk kegagalan yang sama dengan
+     banner skill basi, yang repo ini punya memorinya. Diverifikasi dengan membaca kedua
+     titik panggil dan helper-nya, bukan dengan mempercayai komentarnya.
 
   ### B. Performa (jalur request + pengiriman)
   9. **B1 — tiap probe afordans `can()` menjalankan ULANG SELURUH pipeline otorisasi.**
@@ -717,9 +736,18 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       mudah dan tidak informatif.
 
   24. **D3 — `LOG_LEVEL=warn` lolos `config:validate` dan diabaikan diam-diam; `warning`,
-      nilai yang diimplementasikan logger, ditolak.** `validate-env.ts:51-56`;
+      nilai yang diimplementasikan logger, ditolak.** **SELESAI (22 Agustus 2026).** `validate-env.ts:51-56`;
       `logger.ts:12,21-26`. Tidak ada nilai yang sekaligus lolos kontrak tervalidasi dan
       bekerja, jadi firehose terus mengirim sementara operator percaya sudah diredam.
+
+      Diperbaiki di KEDUA sisi dan bersifat aditif: validator menerima `warning` (dan tetap
+      menerima `warn`), dan logger mengkanonikalkan `warn` → `warning` sambil mencatat
+      pemberitahuan sekali yang menyebut ejaan kanoniknya. Menolak `warn` mentah-mentah akan
+      lebih rapi dan akan mengubah no-op senyap menjadi `config:validate` yang GAGAL di
+      deployment yang sedang berjalan, demi menghukum sebuah ejaan. Nilai yang tidak dikenali
+      tetap jatuh ke `info` — arah yang aman, karena alternatifnya adalah deployment yang
+      tidak mencatat apa pun karena seseorang mengetik `infoo`.
+
   25. **D4 — dua job analitik bercabang pada `result instanceof Response` setelah
       `withTenantOrThrow` — kode mati yang menyembunyikan abort nyata.**
       `visitor-analytics-rollup.ts:97-106`. `tenantsSkipped` permanen 0, peringatan

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -553,11 +553,19 @@ pioneered directly here after the ADR-0047 freeze.)
      hash, stamp it on sessions, reject stale-epoch sessions. Until then, correct the
      false comments.
   6. **A6 — blog feed/sitemap escape with `escapeHtml` instead of `escapeXmlText`.**
+     **DONE (22 August 2026).**
      `blog/[tenantCode]/feed.xml.ts:6,88,92,102`; `sitemap-blog.xml.ts:6,104,116`.
      One C0 control character in a post title (`validateTitleField` checks length only)
      makes the whole channel non-well-formed XML and every reader rejects it. ADR-0038
      named `escapeXmlText`; it was applied to the `seo_distribution` serializers, which
      are 404 in production, and not to these routes, which are 200.
+
+     Both routes now use `escapeXmlText` (16 call sites). The route's own docblock is why
+     the wrong function looked right — "escaped through the same `escapeHtml` used for HTML
+     (XML and HTML share the same five entity escapes)" — true, and not the whole
+     difference. It is CORRECTED rather than deleted: a false comment beside correct code
+     is the next author's instruction.
+
   7. **A7 — sync-storage uses node-supplied strings verbatim as a server filesystem path
      and as an object-store key.** `sync-storage/domain/object-queue.ts:40-58,91`;
      `object-storage-uploader.ts:110-129`. `localPath` gets no root confinement and the
@@ -567,10 +575,23 @@ pioneered directly here after the ADR-0047 freeze.)
      Requires a compromised legitimate node (`AWCMS_SYNC_ENABLED` + `R2_ENABLED` + the
      deployment HMAC secret), which is why it is not higher.
   8. **A8 — public site-search rate-limit config is neither validated nor NaN-guarded.**
+     **ALREADY FIXED when checked, 22 August 2026 — this entry was stale on the day it was
+     written.**
      `site-search/query.ts:34-37`; `suggest.ts:27-32`. A typo yields `NaN`, and both
      `count > NaN` and `now - windowStart >= NaN` are false — **the limiter is off** on an
      anonymous full-text endpoint while the `rate_limited` metric stays at zero and
      confirms it as "no abuse". An empty value yields `0` and 429s every visitor.
+
+     Both settings already go through `parsePositiveIntSetting`
+     (`src/lib/security/env-thresholds.ts`), which returns the fallback for an
+     empty/undefined value AND for anything non-finite, non-integer or ≤ 0, warning once.
+     `suggest.ts` even carries the comment "See `query.ts` — same defect, same fix". It was
+     closed by #601 alongside #593.
+
+     **Left visible rather than deleted.** An audit item describing a defect that is not
+     there sends the next reader looking for it — the same failure shape as a stale skill
+     banner, which this repository has a memory about. Verified by reading both call sites
+     and the helper, not by trusting the comment.
 
   ### B. Performance (request path + delivery)
   9. **B1 — every `can()` affordance probe re-runs the FULL authorization pipeline.**
@@ -734,9 +755,18 @@ pioneered directly here after the ADR-0047 freeze.)
       uninformative.
 
   24. **D3 — `LOG_LEVEL=warn` passes `config:validate` and is silently ignored; `warning`,
-      the value the logger implements, is rejected.** `validate-env.ts:51-56`;
+      the value the logger implements, is rejected.** **DONE (22 August 2026).** `validate-env.ts:51-56`;
       `logger.ts:12,21-26`. There is no value that both passes the validated contract and
       works, so the firehose keeps shipping while the operator believes it is quieted.
+
+      Fixed on BOTH sides and additively: the validator accepts `warning` (and keeps
+      `warn`), and the logger canonicalises `warn` → `warning` with a one-time notice
+      naming the canonical spelling. Rejecting `warn` outright would have been tidier and
+      would have turned a silent no-op into a FAILED `config:validate` on a deployment that
+      is running right now, to punish a spelling. An unrecognised value still falls back to
+      `info` — the safe direction, because the alternative is a deployment that logs nothing
+      because somebody typed `infoo`.
+
   25. **D4 — two analytics jobs branch on `result instanceof Response` after
       `withTenantOrThrow` — dead code hiding a real abort.** `visitor-analytics-rollup.ts:97-106`.
       `tenantsSkipped` is permanently 0, the `partial` warning can never fire, and

--- a/docs/awcms/18_configuration_env_reference.id.md
+++ b/docs/awcms/18_configuration_env_reference.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](18_configuration_env_reference.md)
 
-<!-- i18n-source-hash: sha256:95a54cc8a66d41b67358ea98036fc67ca83ec21cbf9ca8ad98fe363f9a1ed5fa -->
+<!-- i18n-source-hash: sha256:39cbaff6b9cf8994e83fe70a3aed17f8398494df67bb630c148f397f450a7ad3 -->
 
 # Bagian 18 — Configuration dan Environment Reference
 
@@ -87,13 +87,13 @@ Legenda: Wajib = perlu untuk boot; Sensitif = jangan bocor ke log/response.
 
 ### Inti aplikasi
 
-| Var                         | Wajib | Default                 | Sensitif | Fungsi                                                           |
-| --------------------------- | ----- | ----------------------- | -------- | ---------------------------------------------------------------- |
-| `APP_ENV`                   | Ya    | `development`           | –        | development/test/production (`staging` DIHAPUS — ADR-0083)       |
-| `APP_URL`                   | Ya    | `http://localhost:4321` | –        | Base URL aplikasi                                                |
-| `LOG_LEVEL`                 | –     | `info`                  | –        | debug/info/warn/error                                            |
-| `AUDIT_LOG_RETENTION_DAYS`  | –     | `730`                   | –        | Retensi `awcms_audit_events` (hari), dipakai job purge audit log |
-| `FORM_DRAFT_RETENTION_DAYS` | –     | `30`                    | –        | Retensi draft form `expired`/`abandoned` (hari)                  |
+| Var                         | Wajib | Default                 | Sensitif | Fungsi                                                                                                                                                                                                                  |
+| --------------------------- | ----- | ----------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `APP_ENV`                   | Ya    | `development`           | –        | development/test/production (`staging` DIHAPUS — ADR-0083)                                                                                                                                                              |
+| `APP_URL`                   | Ya    | `http://localhost:4321` | –        | Base URL aplikasi                                                                                                                                                                                                       |
+| `LOG_LEVEL`                 | –     | `info`                  | –        | `debug`/`info`/`warning`/`error`; `warn` diterima sebagai alias untuk `warning` dan mencatat pemberitahuan sekali (temuan D3 — sebelumnya ia lolos validasi, tidak cocok level mana pun, dan diam-diam jatuh ke `info`) |
+| `AUDIT_LOG_RETENTION_DAYS`  | –     | `730`                   | –        | Retensi `awcms_audit_events` (hari), dipakai job purge audit log                                                                                                                                                        |
+| `FORM_DRAFT_RETENTION_DAYS` | –     | `30`                    | –        | Retensi draft form `expired`/`abandoned` (hari)                                                                                                                                                                         |
 
 Timezone/locale default per tenant/entitas direncanakan dari data
 (`awcms_tenants`/`awcms_tenant_settings`), bukan env var — mengikuti pola

--- a/docs/awcms/18_configuration_env_reference.md
+++ b/docs/awcms/18_configuration_env_reference.md
@@ -87,13 +87,13 @@ logs/responses.
 
 ### Application core
 
-| Var                         | Required | Default                 | Sensitive | Purpose                                                                   |
-| --------------------------- | -------- | ----------------------- | --------- | ------------------------------------------------------------------------- |
-| `APP_ENV`                   | Yes      | `development`           | –         | development/test/production (`staging` REMOVED — ADR-0083)                |
-| `APP_URL`                   | Yes      | `http://localhost:4321` | –         | Application base URL                                                      |
-| `LOG_LEVEL`                 | –        | `info`                  | –         | debug/info/warn/error                                                     |
-| `AUDIT_LOG_RETENTION_DAYS`  | –        | `730`                   | –         | Retention of `awcms_audit_events` (days), used by the audit log purge job |
-| `FORM_DRAFT_RETENTION_DAYS` | –        | `30`                    | –         | Retention of `expired`/`abandoned` form drafts (days)                     |
+| Var                         | Required | Default                 | Sensitive | Purpose                                                                                                                                                                                        |
+| --------------------------- | -------- | ----------------------- | --------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `APP_ENV`                   | Yes      | `development`           | –         | development/test/production (`staging` REMOVED — ADR-0083)                                                                                                                                     |
+| `APP_URL`                   | Yes      | `http://localhost:4321` | –         | Application base URL                                                                                                                                                                           |
+| `LOG_LEVEL`                 | –        | `info`                  | –         | `debug`/`info`/`warning`/`error`; `warn` is accepted as an alias for `warning` and logs a one-time notice (finding D3 — it used to validate, match no level, and silently fall back to `info`) |
+| `AUDIT_LOG_RETENTION_DAYS`  | –        | `730`                   | –         | Retention of `awcms_audit_events` (days), used by the audit log purge job                                                                                                                      |
+| `FORM_DRAFT_RETENTION_DAYS` | –        | `30`                    | –         | Retention of `expired`/`abandoned` form drafts (days)                                                                                                                                          |
 
 The default timezone/locale per tenant/entity is planned to come from data
 (`awcms_tenants`/`awcms_tenant_settings`), not env vars — following the

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 444   |
+| Test files                          | 445   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -354,7 +354,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 378        |
+| `(root)`      | 379        |
 | `e2e`         | 12         |
 | `integration` | 53         |
 | `unit`        | 1          |

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -52,7 +52,12 @@ const RULES: readonly Rule[] = [
     name: "LOG_LEVEL",
     required: false,
     type: "enum",
-    values: ["debug", "info", "warn", "error"]
+    // `warning` is the level the logger implements; `warn` is accepted as an
+    // alias it canonicalises. Finding D3: this list used to hold `warn` and NOT
+    // `warning`, so the only spelling that validated was the one that matched
+    // no level and silently fell back to `info`, and the spelling that worked
+    // was rejected. There was no value that both passed and worked.
+    values: ["debug", "info", "warning", "warn", "error"]
   },
   { name: "AUDIT_LOG_RETENTION_DAYS", required: false, type: "int", min: 1 },
 

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -25,10 +25,70 @@ const LOG_LEVEL_SEVERITY: Record<LogLevel, number> = {
   error: 40
 };
 
-function currentThreshold(): number {
-  const configured = process.env.LOG_LEVEL as LogLevel | undefined;
+/**
+ * Spellings of a level that are accepted but are not the level's own name —
+ * finding D3 of the 17 August 2026 audit round.
+ *
+ * `config:validate` accepted `LOG_LEVEL=warn` and this logger implements
+ * `warning`, so `LOG_LEVEL_SEVERITY["warn"]` was `undefined`, the `?? info`
+ * fallback took over, and the firehose kept shipping while the operator
+ * believed they had quieted it. The value the logger DOES implement —
+ * `warning` — was rejected by the validator. There was no value that both
+ * passed the validated contract and worked.
+ *
+ * Fixed on both sides, and additively: the validator now accepts both, and this
+ * map makes `warn` mean what an operator writing it obviously meant. Rejecting
+ * `warn` outright would have been the tidier answer and would have turned a
+ * silent no-op into a failed `config:validate` on a deployment that is running
+ * right now, to punish a spelling.
+ */
+const LOG_LEVEL_ALIASES: Record<string, LogLevel> = {
+  warn: "warning"
+};
 
-  return LOG_LEVEL_SEVERITY[configured ?? "info"] ?? LOG_LEVEL_SEVERITY.info;
+let warnedAboutAlias = false;
+
+function currentThreshold(): number {
+  const configured = process.env.LOG_LEVEL?.trim();
+
+  if (configured === undefined || configured === "") {
+    return LOG_LEVEL_SEVERITY.info;
+  }
+
+  const alias = LOG_LEVEL_ALIASES[configured];
+
+  if (alias) {
+    if (!warnedAboutAlias) {
+      warnedAboutAlias = true;
+      // Written directly rather than through `log()`: this runs from inside the
+      // threshold check that `log()` itself calls, and routing it back through
+      // there is a recursion for a message about a spelling.
+      console.error(
+        JSON.stringify({
+          timestamp: new Date().toISOString(),
+          level: "warning",
+          message: "logging.log_level.deprecated_spelling",
+          moduleKey: "logging",
+          configured,
+          canonical: alias,
+          impact:
+            "accepted as an alias; write LOG_LEVEL=warning — before this it was accepted by config:validate, matched no level, and silently fell back to info"
+        })
+      );
+    }
+
+    return LOG_LEVEL_SEVERITY[alias];
+  }
+
+  // An unrecognised value still falls back to `info`, which is the safe
+  // direction: the alternative is a deployment that logs nothing because
+  // somebody typed `infoo`.
+  return LOG_LEVEL_SEVERITY[configured as LogLevel] ?? LOG_LEVEL_SEVERITY.info;
+}
+
+/** Test-only: clears the alias warn-once memory so tests do not bleed. */
+export function resetLogLevelAliasWarningForTests(): void {
+  warnedAboutAlias = false;
 }
 
 /**

--- a/src/pages/blog/[tenantCode]/feed.xml.ts
+++ b/src/pages/blog/[tenantCode]/feed.xml.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from "astro";
 import { getDatabaseClient } from "../../../lib/database/client";
 import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
-import { escapeHtml } from "../../../lib/html/escape";
+import { escapeXmlText } from "../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../lib/http/site-origin";
 import { DEFAULT_LOCALE } from "../../../lib/i18n/locales";
 import { coerceLocale } from "../../../lib/i18n/negotiate";
@@ -25,9 +25,19 @@ import { resolveMetaDescription } from "../../../modules/blog-content/domain/seo
  * `published`+`public` posts (same predicate as the index/sitemap, doc
  * issue #540 §RSS Requirements: excludes unlisted/private/archived/
  * scheduled-future/draft/review/deleted). Hand-built XML string (no RSS
- * library dependency — Bun-only, AGENTS.md rule 14), escaped through the
- * same `escapeHtml` used for HTML (XML and HTML share the same five
- * entity escapes). Issue #543 §Settings Page adds `rssEnabled` — a tenant
+ * library dependency — Bun-only, AGENTS.md rule 14), escaped through
+ * `escapeXmlText`.
+ *
+ * NOT `escapeHtml`, and the comment that used to sit here said otherwise: "XML
+ * and HTML share the same five entity escapes". They do — and that is not the
+ * whole difference. XML 1.0 forbids most C0 control characters ANYWHERE in a
+ * document, including as a numeric reference, while HTML merely discourages
+ * them. `validateTitleField` checks a post title's LENGTH and nothing else, and
+ * there is no write-side stripping, so one stray control character in a title
+ * made this entire channel non-well-formed and every reader rejected it — not
+ * the one item, the feed. ADR-0038 named `escapeXmlText` for exactly this; it
+ * was applied to the `seo_distribution` serializers, which answer 404 in
+ * production, and not to this route, which answers 200 (finding A6). Issue #543 §Settings Page adds `rssEnabled` — a tenant
  * that has turned the feed off gets the same 404 shape as an unknown
  * tenant/post (no distinguishable signal for a disabled vs. nonexistent
  * feed). Issue #564 adds the same generic 404 when the tenant's
@@ -81,15 +91,15 @@ export const GET: APIRoute = async ({ params, request, url }) => {
           post
         );
         const enclosure = previewImage
-          ? `<enclosure url="${escapeHtml(previewImage.url)}" length="${previewImage.sizeBytes ?? 0}" type="${escapeHtml(previewImage.mimeType)}" />`
+          ? `<enclosure url="${escapeXmlText(previewImage.url)}" length="${previewImage.sizeBytes ?? 0}" type="${escapeXmlText(previewImage.mimeType)}" />`
           : "";
 
         itemParts.push(`<item>
-<title>${escapeHtml(post.title)}</title>
-<link>${escapeHtml(link)}</link>
-<guid isPermaLink="true">${escapeHtml(link)}</guid>
+<title>${escapeXmlText(post.title)}</title>
+<link>${escapeXmlText(link)}</link>
+<guid isPermaLink="true">${escapeXmlText(link)}</guid>
 <pubDate>${post.publishedAt.toUTCString()}</pubDate>
-<description>${escapeHtml(description)}</description>
+<description>${escapeXmlText(description)}</description>
 ${enclosure}
 </item>`);
       }
@@ -99,10 +109,10 @@ ${enclosure}
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
 <channel>
-<title>${escapeHtml(tenant.tenantName)} Blog</title>
-<link>${escapeHtml(channelLink)}</link>
-<description>Latest posts from ${escapeHtml(tenant.tenantName)}.</description>
-<language>${escapeHtml(tenant.defaultLocale)}</language>
+<title>${escapeXmlText(tenant.tenantName)} Blog</title>
+<link>${escapeXmlText(channelLink)}</link>
+<description>Latest posts from ${escapeXmlText(tenant.tenantName)}.</description>
+<language>${escapeXmlText(tenant.defaultLocale)}</language>
 ${items}
 </channel>
 </rss>`;

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -3,7 +3,7 @@ import type { APIRoute } from "astro";
 import { getDatabaseClient } from "../../../lib/database/client";
 import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { resolvePublicTenantByCode } from "../../../lib/tenant/public-tenant-resolver";
-import { escapeHtml } from "../../../lib/html/escape";
+import { escapeXmlText } from "../../../lib/html/escape";
 import { resolveRequestOrigin } from "../../../lib/http/site-origin";
 import { DEFAULT_LOCALE } from "../../../lib/i18n/locales";
 import { coerceLocale } from "../../../lib/i18n/negotiate";
@@ -80,7 +80,7 @@ export const GET: APIRoute = async ({ params, request, url }) => {
         buildHreflangAlternates(barePath, tenantDefaultLocale)
           .map(
             (alternate) =>
-              `<xhtml:link rel="alternate" hreflang="${escapeHtml(alternate.hreflang)}" href="${escapeHtml(origin + alternate.pathname)}" />`
+              `<xhtml:link rel="alternate" hreflang="${escapeXmlText(alternate.hreflang)}" href="${escapeXmlText(origin + alternate.pathname)}" />`
           )
           .join("\n");
       const channelPath = `/blog/${tenantCode}`;
@@ -100,11 +100,11 @@ export const GET: APIRoute = async ({ params, request, url }) => {
           post
         );
         const imageTag = previewImage
-          ? `<image:image><image:loc>${escapeHtml(previewImage.url)}</image:loc></image:image>`
+          ? `<image:image><image:loc>${escapeXmlText(previewImage.url)}</image:loc></image:image>`
           : "";
 
         urlParts.push(`<url>
-<loc>${escapeHtml(link)}</loc>
+<loc>${escapeXmlText(link)}</loc>
 ${alternatesXml(postPath)}
 <lastmod>${post.publishedAt.toISOString()}</lastmod>
 ${imageTag}
@@ -124,7 +124,7 @@ ${imageTag}
         const pagePath = `${channelPath}/pages/${page.slug}`;
 
         urlParts.push(`<url>
-<loc>${escapeHtml(localisedUrl(pagePath))}</loc>
+<loc>${escapeXmlText(localisedUrl(pagePath))}</loc>
 ${alternatesXml(pagePath)}
 <lastmod>${page.updatedAt.toISOString()}</lastmod>
 </url>`);
@@ -135,7 +135,7 @@ ${alternatesXml(pagePath)}
       const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:xhtml="http://www.w3.org/1999/xhtml">
 <url>
-<loc>${escapeHtml(channelLink)}</loc>
+<loc>${escapeXmlText(channelLink)}</loc>
 ${alternatesXml(channelPath)}
 </url>
 ${urls}

--- a/tests/xml-escaping-and-log-level.test.ts
+++ b/tests/xml-escaping-and-log-level.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Two findings from the 17 August 2026 audit round that share a shape: a
+ * control that was applied to the wrong copy, and a contract that no value
+ * could satisfy.
+ *
+ * ## A6 — the feed and sitemap escaped as HTML, not as XML
+ *
+ * `escapeHtml` neutralises the five markup entities and passes C0 control
+ * characters through. XML 1.0 forbids most of them ANYWHERE in a document,
+ * including as a numeric reference (`&#x1;` is itself not well-formed). HTML
+ * merely discourages them.
+ *
+ * `validateTitleField` checks a post title's LENGTH and nothing else, and there
+ * is no write-side stripping, so one stray control character in one title made
+ * the whole channel non-well-formed and every reader rejected it — not that
+ * item, the feed.
+ *
+ * ADR-0038 named `escapeXmlText` for exactly this. It was applied to the
+ * `seo_distribution` serializers, which answer **404** in production, and not to
+ * `/blog/{tenantCode}/feed.xml` and `sitemap-blog.xml`, which answer **200**.
+ * The route's own docblock asserted the equivalence ("XML and HTML share the
+ * same five entity escapes") — true, and not the whole difference.
+ *
+ * ## D3 — no value of `LOG_LEVEL` both validated and worked
+ *
+ * `config:validate` accepted `warn`. The logger implements `warning`. So
+ * `LOG_LEVEL=warn` passed the validated contract, matched no level, fell back
+ * to `info`, and the firehose kept shipping while the operator believed it was
+ * quiet — and `LOG_LEVEL=warning`, the value that would have worked, was
+ * rejected.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { escapeHtml, escapeXmlText } from "../src/lib/html/escape";
+import { resetLogLevelAliasWarningForTests } from "../src/lib/logging/logger";
+
+const XML_ROUTES = [
+  "src/pages/blog/[tenantCode]/feed.xml.ts",
+  "src/pages/blog/[tenantCode]/sitemap-blog.xml.ts"
+];
+
+describe("A6 — the XML routes escape as XML", () => {
+  test("a C0 control character survives escapeHtml and does not survive escapeXmlText", () => {
+    // Written as an escape, not as a literal: a raw U+0001 in a source file is
+    // invisible in review and does not survive every editor that touches it —
+    // which is the same reason it reaches a post title in the first place.
+    const title = `Banjir\u0001 Kobar`;
+
+    expect(escapeHtml(title)).toContain("\u0001");
+    expect(escapeXmlText(title)).not.toContain("\u0001");
+    expect(escapeXmlText(title)).toBe("Banjir Kobar");
+  });
+
+  test("every XML-1.0-illegal C0 character is removed, not just the obvious one", () => {
+    // U+0000-U+0008, U+000B, U+000C, U+000E-U+001F. Enumerated because "strip
+    // control characters" is the kind of rule a regex gets 90% right.
+    const illegal = [
+      ...Array.from({ length: 9 }, (_, i) => String.fromCharCode(i)),
+      "\u000B",
+      "\u000C",
+      ...Array.from({ length: 18 }, (_, i) => String.fromCharCode(0x0e + i))
+    ];
+
+    for (const char of illegal) {
+      expect(escapeXmlText(`a${char}b`)).toBe("ab");
+    }
+  });
+
+  test("the three XML-legal control characters are kept", () => {
+    // TAB, LF and CR are legal XML 1.0 characters. Stripping them would corrupt
+    // multi-line text for no reason, which is the failure mode of a blunt
+    // "remove all control characters".
+    expect(escapeXmlText("a\tb\nc\rd")).toBe("a\tb\nc\rd");
+  });
+
+  test("entity escaping still happens", () => {
+    // NON-VACUOUS: a function that only stripped control characters would pass
+    // the assertions above and leave the markup injection it exists to stop.
+    expect(escapeXmlText('<a href="x">&</a>')).not.toContain("<a href");
+    expect(escapeXmlText("&")).toBe("&amp;");
+  });
+
+  test("neither XML route calls escapeHtml any more", async () => {
+    for (const route of XML_ROUTES) {
+      const source = await Bun.file(route).text();
+      const code = source
+        .split("\n")
+        .filter((line) => {
+          const trimmed = line.trim();
+          return (
+            !trimmed.startsWith("*") &&
+            !trimmed.startsWith("//") &&
+            !trimmed.startsWith("/*")
+          );
+        })
+        .join("\n");
+
+      expect(code).not.toContain("escapeHtml(");
+      expect(code).toContain("escapeXmlText(");
+    }
+  });
+
+  test("the docblock no longer claims the two are interchangeable", async () => {
+    // The sentence was the reason the wrong function looked right. A false
+    // comment beside correct code is the next author's instruction.
+    const source = await Bun.file(XML_ROUTES[0]!).text();
+
+    expect(source).not.toContain(
+      "same `escapeHtml` used for HTML (XML and HTML share the same five"
+    );
+  });
+});
+
+describe("D3 — LOG_LEVEL has a value that both validates and works", () => {
+  const previous = process.env.LOG_LEVEL;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.LOG_LEVEL;
+    else process.env.LOG_LEVEL = previous;
+    resetLogLevelAliasWarningForTests();
+  });
+
+  test("the validator accepts the level the logger implements", async () => {
+    const source = await Bun.file("scripts/validate-env.ts").text();
+    const block = source.slice(
+      source.indexOf('name: "LOG_LEVEL"'),
+      source.indexOf('name: "AUDIT_LOG_RETENTION_DAYS"')
+    );
+
+    // Before D3 this list held `warn` and NOT `warning`.
+    expect(block).toContain('"warning"');
+  });
+
+  test("`warn` is still accepted, so a running deployment does not start failing config:validate", async () => {
+    const source = await Bun.file("scripts/validate-env.ts").text();
+    const block = source.slice(
+      source.indexOf('name: "LOG_LEVEL"'),
+      source.indexOf('name: "AUDIT_LOG_RETENTION_DAYS"')
+    );
+
+    expect(block).toContain('"warn"');
+  });
+
+  test("`warn` now actually raises the threshold instead of falling back to info", async () => {
+    // The defect itself: an `info` line under LOG_LEVEL=warn used to be printed.
+    process.env.LOG_LEVEL = "warn";
+    resetLogLevelAliasWarningForTests();
+
+    const { log } = await import("../src/lib/logging/logger");
+    const lines = captureStdout(() => log("info", "should.be.suppressed"));
+
+    expect(lines.join("")).not.toContain("should.be.suppressed");
+  });
+
+  test("`warning` works too", async () => {
+    process.env.LOG_LEVEL = "warning";
+
+    const { log } = await import("../src/lib/logging/logger");
+    const lines = captureStdout(() => log("info", "should.be.suppressed"));
+
+    expect(lines.join("")).not.toContain("should.be.suppressed");
+  });
+
+  test("NON-VACUOUS: an info line IS printed at the default level", async () => {
+    // Without this, a logger that printed nothing at all would satisfy both
+    // assertions above.
+    delete process.env.LOG_LEVEL;
+
+    const { log } = await import("../src/lib/logging/logger");
+    const lines = captureStdout(() => log("info", "should.be.printed"));
+
+    expect(lines.join("")).toContain("should.be.printed");
+  });
+
+  test("an unrecognised value still falls back to info rather than silencing everything", async () => {
+    // The safe direction: the alternative is a deployment that logs nothing
+    // because somebody typed `infoo`.
+    process.env.LOG_LEVEL = "infoo";
+
+    const { log } = await import("../src/lib/logging/logger");
+    const lines = captureStdout(() => log("info", "still.printed"));
+
+    expect(lines.join("")).toContain("still.printed");
+  });
+});
+
+function captureStdout(run: () => void): string[] {
+  const lines: string[] = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+
+  console.log = (...args: unknown[]) => void lines.push(args.join(" "));
+  console.error = () => {};
+
+  try {
+    run();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+
+  return lines;
+}


### PR DESCRIPTION
Findings **A6** and **D3** of the 17 August 2026 audit round, plus a correction to **A8**. Two defects that share a shape: a control applied to the wrong copy, and a contract no value could satisfy.

## A6 — the feed and sitemap escaped as HTML

`escapeHtml` neutralises the five markup entities and passes C0 control characters through. **XML 1.0 forbids most of them anywhere in a document**, including as a numeric reference (`&#x1;` is itself not well-formed); HTML merely discourages them.

`validateTitleField` checks a post title's length and nothing else, and there is no write-side stripping — so one stray control character in one title made the whole channel non-well-formed and every reader rejected it. Not that item: **the feed**.

ADR-0038 named `escapeXmlText` for exactly this. It was applied to the `seo_distribution` serializers, which answer **404** in production, and not to `/blog/{tenantCode}/feed.xml` and `sitemap-blog.xml`, which answer **200**. Sixteen call sites across the two routes now use it.

**The route's own docblock is why the wrong function looked right:** *"escaped through the same `escapeHtml` used for HTML (XML and HTML share the same five entity escapes)"*. True, and not the whole difference. It is **corrected rather than deleted** — a false comment beside correct code is the next author's instruction.

## D3 — `LOG_LEVEL` had no working value

`config:validate` accepted `warn`. The logger implements `warning`. So:

- `LOG_LEVEL=warn` passed the validated contract, matched no level, and fell back to `info`. The firehose kept shipping while the operator believed they had quieted it.
- `LOG_LEVEL=warning`, the value that would have worked, was **rejected** by the validator.

Fixed on **both** sides, additively: the validator accepts `warning` and keeps `warn`; the logger canonicalises `warn` to `warning` with a one-time notice naming the canonical spelling.

Rejecting `warn` outright would have been tidier, and would have turned a silent no-op into a **failed `config:validate` on a deployment that is running right now**, to punish a spelling. An unrecognised value still falls back to `info` — the safe direction, because the alternative is a deployment that logs nothing because somebody typed `infoo`.

## A8 was already fixed — the entry was stale on the day it was written

Both site-search rate-limit settings already go through `parsePositiveIntSetting`, which returns the fallback for an empty/undefined value **and** for anything non-finite, non-integer or at most zero, warning once. `suggest.ts` even carries the comment *"See `query.ts` — same defect, same fix"*. Closed by #601 alongside #593.

Marked in section 4 **rather than deleted**: an audit item describing a defect that is not there sends the next reader looking for it — the same failure shape as a stale skill banner. Verified by reading both call sites and the helper, not by trusting the comment.

## Tests

`tests/xml-escaping-and-log-level.test.ts` — the escaping difference stated as the two functions rather than described; every XML-1.0-illegal C0 character enumerated (because "strip control characters" is the kind of rule a regex gets 90% right); the three legal ones kept; neither route calling `escapeHtml` any more; the false docblock gone. For D3: both spellings raise the threshold, an unrecognised value still prints, and an `info` line **is** printed at the default level so the suppression assertions cannot pass vacuously.

**Mutation-proven both ways**: dropping the `warn` alias turns one red; reverting the feed to `escapeHtml` turns another red.

*(The first draft of the control-character test wrote a literal U+0001 into the source. It did not survive being written, and left two assertions vacuously true — `toContain` against an empty string. They are explicit unicode escapes now, for the same reason the character reaches a post title in the first place: it is invisible.)*

`bun run check` full green (5436 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
