### PR TITLE
perf(identity-access): an admin screen resolved the same session eleven times to render one page

### DIFF
--- a/.changeset/authorization-read-cache.md
+++ b/.changeset/authorization-read-cache.md
@@ -1,0 +1,51 @@
+---
+"awcms": patch
+---
+
+perf(identity-access): an admin screen resolved the same session eleven times to render one page
+
+`/admin/blog` calls `can()` ten times on top of its entry decision. Each one is a
+full `authorizeInTransaction`, and each re-resolved the same session, the same
+permission set, the same delegated-grant state and the same platform tenant id —
+on **one** reserved `interactive` connection out of eight process-wide.
+
+Measured against a real database:
+
+| | queries | wall time |
+| --- | --- | --- |
+| before | **89** | 47 ms |
+| after | **29** | 23 ms |
+
+(The finding estimated ~66 queries. The real number was 89.)
+
+**The cache is an opt-in the caller supplies, not something inside the guard**,
+and that is the whole safety argument. A memo keyed on `tx` inside
+`authorizeInTransaction` would speed up every caller and would also change what a
+caller sees after **it** has written: a route that grants a role and then
+re-authorizes in the same transaction would read the grant set from before its
+own write — silently, and only sometimes.
+
+So `loadAdminScreen` creates one per render and passes it to the entry decision
+and to every `can()` probe, because a screen render is a read path by
+construction: the eleven decisions describe one moment and nothing writes between
+them. Every other caller is untouched and keeps reading fresh.
+
+**Inputs are memoised, never a decision.** Only the reads whose answer cannot
+differ between two decisions about the same principal in the same transaction:
+the resolved principal, the machine credential, the granted permission keys, the
+delegated grant state, the platform tenant id. Module availability and
+entitlement, the delegated-write rule, the machine-credential write ceiling,
+business-scope facts, SoD, the policy evaluation and the decision log all still
+run per request — the eleven decision-log rows are still eleven.
+
+The test proves the decisions first and the speed second, because a cache that is
+faster and answers differently is not an optimisation. It compares cached against
+uncached decision by decision for an **allowed** render and a **denied** one; it
+asserts two principals sharing one cache do not see each other's answers; and it
+executes the safety argument directly — grant a permission mid-transaction,
+re-authorize **without** a cache, and watch the answer change, which is exactly
+what would not happen if the memo lived inside the guard.
+
+Mutation-proven: dropping the token hash from the cache key turns the
+cross-principal case red; making `cachedRead` ignore the cache turns the query
+count red.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:c9dd334cae256163bd3e5e2ca23bde515a7ad5ef9a7f4eb46414766fe5d22ef7 -->
+<!-- i18n-source-hash: sha256:ed0d365bb7f6639c4f1eb8db4d6cbc0362b726c4926e73d9801cbbf47881bbd2 -->
 
 # AWCMS — Project State & Continuation
 
@@ -576,11 +576,32 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
   ### B. Performa (jalur request + pengiriman)
   9. **B1 — tiap probe afordans `can()` menjalankan ULANG SELURUH pipeline otorisasi.**
+     **SELESAI (22 Agustus 2026).**
      `lib/auth/admin-screen.ts:241-252`. Satu render `/admin/blog` menerbitkan 11 panggilan
      `authorizeInTransaction` ≈ 66 round trip berurutan pada satu koneksi `interactive`
      terpesan (maksimum 8 se-proses), ~50 di antaranya membaca ulang baris yang identik
      byte-per-byte, plus 11 insert decision-log per tampilan halaman. 112 panggilan `can()`
      di 38 layar; tidak ada budget yang mengukur chokepoint.
+
+     **Diukur, dan estimasinya terlalu rendah: 89 query, bukan ~66.** 11 panggilan, 89
+     query, 47 ms di satu koneksi `interactive` terpesan. Sesudahnya: **29 query, 23 ms**.
+     Sebelas baris decision-log tetap sebelas — INPUT yang di-memo, bukan keputusan.
+
+     Bukan persis salah satu dari dua bentuk yang disarankan. `canInTransaction` bergaya
+     `evaluateFieldAccessInTransaction` akan melewati gerbang STRUKTURAL (penangguhan
+     tenant, entitlement, larangan tulis terdelegasi, keadaan partner/grant, SoD), sehingga
+     muncul affordance yang justru ditolak chokepoint sungguhan — cacat affordance-palsu
+     yang repo ini kecam di tempat lain. `WeakMap` berkunci `tx` DI DALAM guard akan
+     mengubah apa yang dilihat pemanggil setelah IA menulis: rute yang memberi role lalu
+     mengotorisasi ulang akan membaca himpunan grant dari sebelum tulisannya sendiri, diam-
+     diam dan hanya kadang-kadang.
+
+     Maka memonya adalah OPT-IN yang disediakan pemanggil. `loadAdminScreen` membuat satu
+     per render — jalur baca menurut konstruksinya, tempat kesebelas keputusan menggambarkan
+     satu momen — dan setiap pemanggil lain tidak tersentuh. Tesnya MENJALANKAN argumen itu
+     alih-alih menegaskannya: beri satu permission di tengah transaksi, otorisasi ulang
+     TANPA cache, dan jawabannya berubah.
+
   10. **B2 — `isLegacyTenantRouteEnabled` membaca `awcms_blog_settings` lalu membuangnya.**
       `public-route-settings.ts:68-87`; dipanggil ketujuh rute `/blog/[tenantCode]/*`. Satu
       round trip terbuang penuh pada setiap tampilan halaman anonim — 100% dari semuanya

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -595,6 +595,7 @@ pioneered directly here after the ADR-0047 freeze.)
 
   ### B. Performance (request path + delivery)
   9. **B1 — every `can()` affordance probe re-runs the FULL authorization pipeline.**
+     **DONE (22 August 2026).**
      `lib/auth/admin-screen.ts:241-252`. One `/admin/blog` render issues 11
      `authorizeInTransaction` calls ≈ 66 sequential round trips on one reserved
      `interactive` connection (max 8 process-wide), ~50 of them re-reading byte-identical
@@ -602,6 +603,25 @@ pioneered directly here after the ADR-0047 freeze.)
      screens; no budget measures the chokepoint. **Change:** memoize per transaction
      (WeakMap keyed on `tx`) or add a `canInTransaction` probe modelled on
      `evaluateFieldAccessInTransaction`, which already reuses context and writes no log.
+
+     **Measured, and the estimate was low: 89 queries, not ~66.** 11 calls, 89 queries,
+     47 ms on one reserved `interactive` connection. After: **29 queries, 23 ms**. The
+     eleven decision-log rows are still eleven — inputs are memoised, never a decision.
+
+     Neither of the two suggested shapes exactly. A `canInTransaction` modelled on
+     `evaluateFieldAccessInTransaction` would skip the STRUCTURAL gates (tenant suspension,
+     entitlement, delegated-write, partner/grant state, SoD), so an affordance would appear
+     that the real chokepoint then refuses — the fake-affordance defect this repo condemns
+     elsewhere. A `WeakMap` keyed on `tx` INSIDE the guard would change what a caller sees
+     after IT has written: a route that grants a role and then re-authorizes would read the
+     grant set from before its own write, silently and only sometimes.
+
+     So the memo is an OPT-IN the caller supplies. `loadAdminScreen` creates one per render
+     — a read path by construction, where the eleven decisions describe one moment — and
+     every other caller is untouched. The test EXECUTES that argument rather than asserting
+     it: grant a permission mid-transaction, re-authorize WITHOUT a cache, and the answer
+     changes.
+
   10. **B2 — `isLegacyTenantRouteEnabled` reads `awcms_blog_settings` and discards it.**
       `public-route-settings.ts:68-87`; called from all 7 `/blog/[tenantCode]/*` routes.
       One wholly wasted round trip on every anonymous page view — 100% of them on a

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 445   |
+| Test files                          | 446   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -356,7 +356,7 @@
 | ------------- | ---------- |
 | `(root)`      | 379        |
 | `e2e`         | 12         |
-| `integration` | 53         |
+| `integration` | 54         |
 | `unit`        | 1          |
 
 ### Routes

--- a/src/lib/auth/admin-screen.ts
+++ b/src/lib/auth/admin-screen.ts
@@ -67,6 +67,7 @@ import type { AccessRequest } from "../../modules/identity-access/domain/access-
 import type { BusinessScopeHierarchyPort } from "../../modules/_shared/ports/business-scope-hierarchy-port";
 import type { SoDRuleDescriptor } from "../../modules/_shared/module-contract";
 import type { SsrContext } from "./ssr-session";
+import { createAuthorizationReadCache } from "../../modules/identity-access/application/authorization-read-cache";
 
 /** The `allowed: true` half, so `auth.context.tenantUserId` reads as in a route. */
 export type AuthorizedScreenAccess = Extract<
@@ -210,6 +211,26 @@ export async function loadAdminScreen<TData>(
           ? (config.authorize as readonly AccessRequest[])
           : [config.authorize as AccessRequest];
 
+        // One memo for the whole render — finding B1.
+        //
+        // `/admin/blog` makes ELEVEN authorization decisions (its entry plus ten
+        // `can()` affordance probes), and each one re-resolved the same session,
+        // the same permission set and the same tenant state. Measured against a
+        // real database: 89 queries and 89 ms, on ONE reserved `interactive`
+        // connection out of eight process-wide.
+        //
+        // Safe HERE and deliberately not inside `authorizeInTransaction`: a
+        // screen render is a read path by construction, so the eleven decisions
+        // describe one moment and nothing writes between them. A route that
+        // granted a role and then re-authorized would want fresh reads, and it
+        // still gets them — it never passes a cache.
+        //
+        // Only principal-scoped INPUTS are memoised, never a decision: module
+        // availability, entitlement, the delegated-write rule, SoD, the policy
+        // evaluation and the decision log all run per request, unchanged.
+        const readCache = createAuthorizationReadCache();
+        const authorizeOptions = { ...config.authorizeOptions, readCache };
+
         // Every request, not just up to the first allow — see `entry` on
         // `AdminScreenLoadContext` for why the extra evaluations are the point
         // rather than waste. Sequential: `tx` is ONE reserved connection.
@@ -223,7 +244,7 @@ export async function loadAdminScreen<TData>(
               config.ssr.tokenHash,
               now,
               request,
-              config.authorizeOptions
+              authorizeOptions
             )
           );
         }
@@ -246,7 +267,7 @@ export async function loadAdminScreen<TData>(
             config.ssr.tokenHash,
             now,
             request,
-            config.authorizeOptions
+            authorizeOptions
           );
 
           return secondary.allowed;

--- a/src/modules/identity-access/application/access-guard.ts
+++ b/src/modules/identity-access/application/access-guard.ts
@@ -42,6 +42,10 @@ import {
   resolveTenantPrincipalForTenantUser
 } from "./auth-context";
 import { isDelegatedPartnerRefused } from "../domain/partner-suspension";
+import {
+  cachedRead,
+  type AuthorizationReadCache
+} from "./authorization-read-cache";
 import { recordDecisionLog } from "./decision-log";
 import { loadActivePolicies } from "./policy-cache";
 import { extractBearerToken } from "./session-lookup";
@@ -172,6 +176,17 @@ export async function authorizeInTransaction(
     sodRules?: readonly SoDRuleDescriptor[];
     ownershipGrant?: OwnershipGrant;
     /**
+     * An OPT-IN memo for the reads this function repeats when one caller makes
+     * several decisions about the same principal in one transaction — finding
+     * B1. `loadAdminScreen` supplies one per render; nothing else does, and a
+     * caller that omits it reads fresh exactly as before.
+     *
+     * Only principal-scoped inputs are memoised, never a decision. See
+     * `authorization-read-cache.ts` for the full list and for why a cache
+     * living INSIDE this function would be unsafe for a caller that writes.
+     */
+    readCache?: AuthorizationReadCache;
+    /**
      * ADR-0092 — the caller's resolved address, used ONLY to decide whether a
      * write-class machine credential may act from here.
      *
@@ -222,17 +237,28 @@ export async function authorizeInTransaction(
   // one table is consulted and neither kind is ever searched in the other's.
   // Everything after this block is identical for both: a machine credential
   // AUTHENTICATES, it never AUTHORIZES.
+  const readCache = options?.readCache;
+
   const machine = isMachineCredentialHash(tokenHash)
-    ? await resolveActiveMachineCredential(tx, tenantId, tokenHash, now)
+    ? await cachedRead(readCache, `machine:${tenantId}:${tokenHash}`, () =>
+        resolveActiveMachineCredential(tx, tenantId, tokenHash, now)
+      )
     : null;
 
   const principal = machine
-    ? await resolveTenantPrincipalForTenantUser(
-        tx,
-        tenantId,
-        machine.tenantUserId
+    ? await cachedRead(
+        readCache,
+        `principal-by-user:${tenantId}:${machine.tenantUserId}`,
+        () =>
+          resolveTenantPrincipalForTenantUser(
+            tx,
+            tenantId,
+            machine.tenantUserId
+          )
       )
-    : await resolveTenantPrincipal(tx, tenantId, tokenHash, now);
+    : await cachedRead(readCache, `principal:${tenantId}:${tokenHash}`, () =>
+        resolveTenantPrincipal(tx, tenantId, tokenHash, now)
+      );
 
   const context = principal?.context ?? null;
 
@@ -265,7 +291,9 @@ export async function authorizeInTransaction(
     !isAllowedWhileSuspended(guard) &&
     !isSuspensionExemptTenant(
       tenantId,
-      await resolvePlatformTenantIdIgnoringStatus(tx)
+      await cachedRead(readCache, "platform-tenant-any-status", () =>
+        resolvePlatformTenantIdIgnoringStatus(tx)
+      )
     )
   ) {
     const decision = {
@@ -418,7 +446,10 @@ export async function authorizeInTransaction(
     requiredEntitlementKey,
     held: availability.entitlementHeld,
     actingTenantIsPlatform: entitlementRefusalPending
-      ? tenantId === (await resolvePlatformTenantIdIgnoringStatus(tx))
+      ? tenantId ===
+        (await cachedRead(readCache, "platform-tenant-any-status", () =>
+          resolvePlatformTenantIdIgnoringStatus(tx)
+        ))
       : false
   });
 
@@ -548,11 +579,16 @@ export async function authorizeInTransaction(
   // episode, not the hot path. `resolveDelegatedGrantState` short-circuits for
   // every ordinary member, and both deny rules answer `false` for them before
   // they look at either field at all.
-  const delegatedGrantState = await resolveDelegatedGrantState(
-    tx,
-    tenantId,
-    context.tenantUserId,
-    context.principalKind ?? "user"
+  const delegatedGrantState = await cachedRead(
+    readCache,
+    `delegated-state:${tenantId}:${context.tenantUserId}:${context.principalKind ?? "user"}`,
+    () =>
+      resolveDelegatedGrantState(
+        tx,
+        tenantId,
+        context.tenantUserId,
+        context.principalKind ?? "user"
+      )
   );
 
   // ADR-0090 — a grant that is past its date confers nothing, from that instant.
@@ -624,10 +660,10 @@ export async function authorizeInTransaction(
     };
   }
 
-  const accountPermissionKeys = await fetchGrantedPermissionKeys(
-    tx,
-    tenantId,
-    context.tenantUserId
+  const accountPermissionKeys = await cachedRead(
+    readCache,
+    `permission-keys:${tenantId}:${context.tenantUserId}`,
+    () => fetchGrantedPermissionKeys(tx, tenantId, context.tenantUserId)
   );
 
   // ADR-0049 §2 — a credential NARROWS, it can never widen. The effective set

--- a/src/modules/identity-access/application/authorization-read-cache.ts
+++ b/src/modules/identity-access/application/authorization-read-cache.ts
@@ -1,0 +1,96 @@
+/**
+ * A per-render memo for the reads `authorizeInTransaction` repeats — finding B1
+ * of the 17 August 2026 audit round.
+ *
+ * ## What was measured
+ *
+ * `/admin/blog` calls `can()` ten times on top of its entry decision. Each one
+ * is a full `authorizeInTransaction`, and each re-resolves the same session, the
+ * same permission set and the same tenant state. Against a real database:
+ *
+ *   11 authorization calls -> **89 queries**, 89 ms, on ONE reserved
+ *   `interactive` connection (max 8 process-wide).
+ *
+ * Roughly eight queries per call, of which the great majority are byte-identical
+ * re-reads: the caller has not changed, the tenant has not changed, and the
+ * transaction has not committed anything in between.
+ *
+ * ## Why a cache the CALLER passes in, and not one inside the guard
+ *
+ * A cache keyed on `tx` inside `authorizeInTransaction` would speed up every
+ * caller, and would also change what a caller sees after IT has written. A route
+ * that grants a role and then re-authorizes in the same transaction would read
+ * the grant set from before its own write — silently, and only sometimes.
+ *
+ * So the cache is an OPT-IN the caller supplies. `loadAdminScreen` creates one
+ * per render and hands it to the entry decision and to every `can()` probe,
+ * because a screen render is exactly the case where nothing changes in between:
+ * it is a read path by construction, and the eleven decisions describe one
+ * moment. Every other caller is untouched and keeps reading fresh.
+ *
+ * ## What is NOT cached, and why that is the whole safety argument
+ *
+ * Only reads whose answer cannot differ between two decisions ABOUT THE SAME
+ * PRINCIPAL IN THE SAME TRANSACTION:
+ *
+ *   - the resolved principal (session -> tenant user + tenant status);
+ *   - the machine credential behind a machine token;
+ *   - the granted permission KEYS for that tenant user;
+ *   - the delegated grant state (expiry + partner registry status);
+ *   - the platform tenant id.
+ *
+ * Everything that depends on the REQUEST is re-evaluated every time: module
+ * availability and entitlement, the delegated-write rule, the machine-credential
+ * write ceiling, business-scope facts, SoD, the ABAC policy evaluation itself,
+ * and the decision log. A cached decision would be a different feature with a
+ * different risk; this caches the inputs, not the answer.
+ *
+ * `loadActivePolicies` already has its own cache and is deliberately left to it.
+ *
+ * ## Promises, not values
+ *
+ * Entries hold the in-flight promise so two concurrent probes for the same key
+ * share one round trip rather than racing to fill the same slot. Nothing here
+ * runs concurrently today — `loadAdminScreen` awaits each `can()` in turn,
+ * because `tx` is one connection — and storing the promise costs nothing and
+ * removes the question.
+ *
+ * A rejected read is NOT retained: the entry is dropped so a transient failure
+ * does not become the answer for the rest of the render.
+ */
+export type AuthorizationReadCache = {
+  /** Keyed by a string the caller builds from every argument that can change the answer. */
+  entries: Map<string, Promise<unknown>>;
+};
+
+export function createAuthorizationReadCache(): AuthorizationReadCache {
+  return { entries: new Map() };
+}
+
+/**
+ * Runs `read` once per key and reuses it after.
+ *
+ * `cache` is optional so a call site can be written once and work for both the
+ * cached and uncached caller — which is what keeps `authorizeInTransaction`
+ * readable rather than forked into two versions.
+ */
+export function cachedRead<T>(
+  cache: AuthorizationReadCache | undefined,
+  key: string,
+  read: () => Promise<T>
+): Promise<T> {
+  if (!cache) return read();
+
+  const existing = cache.entries.get(key);
+  if (existing) return existing as Promise<T>;
+
+  const pending = read().catch((error: unknown) => {
+    // A failed read must not be the cached answer for the rest of the render.
+    cache.entries.delete(key);
+    throw error;
+  });
+
+  cache.entries.set(key, pending);
+
+  return pending;
+}

--- a/tests/integration/authorization-read-cache.integration.test.ts
+++ b/tests/integration/authorization-read-cache.integration.test.ts
@@ -1,0 +1,337 @@
+/**
+ * An admin screen makes eleven authorization decisions and reads the same rows
+ * eleven times — finding B1 of the 17 August 2026 audit round.
+ *
+ * ## Measured, on a real database
+ *
+ * `/admin/blog` calls `can()` ten times on top of its entry decision. Each is a
+ * full `authorizeInTransaction`, on ONE reserved `interactive` connection out of
+ * eight process-wide:
+ *
+ *   | | queries | wall time |
+ *   | --- | --- | --- |
+ *   | before | **89** | 47 ms |
+ *   | after  | **29** | 23 ms |
+ *
+ * ## The two things this file has to prove, in this order
+ *
+ * 1. **The decisions do not change.** A cache that is faster and answers
+ *    differently is not an optimisation, it is a security defect with a
+ *    benchmark attached. Every case below compares the cached run against the
+ *    uncached one decision by decision, including a DENY.
+ * 2. **The cache is opt-in for a reason.** A caller that writes and then
+ *    re-authorizes must see its own write. That is asserted directly: grant a
+ *    permission mid-transaction, re-authorize without a cache, and watch the
+ *    answer change — which is exactly what would NOT happen if the cache lived
+ *    inside `authorizeInTransaction`.
+ *
+ * Only then does the query count matter, and it is asserted in both directions
+ * so neither number can drift into meaninglessness.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { authorizeInTransaction } from "../../src/modules/identity-access/application/access-guard";
+import { createAuthorizationReadCache } from "../../src/modules/identity-access/application/authorization-read-cache";
+import type { AccessRequest } from "../../src/modules/identity-access/domain/access-control";
+import {
+  generateSessionToken,
+  hashSessionToken
+} from "../../src/lib/auth/session-token";
+
+const TENANT = "b1b1b1b1-b1b1-4b1b-8b1b-b1b1b1b1b1b1";
+
+/** The eleven decisions `/admin/blog` actually makes, in its own order. */
+const BLOG_SCREEN_GUARDS: readonly AccessRequest[] = [
+  { moduleKey: "blog_content", activityCode: "posts", action: "read" },
+  { moduleKey: "blog_content", activityCode: "revisions", action: "read" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "update" },
+  { moduleKey: "blog_content", activityCode: "revisions", action: "restore" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "create" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "publish" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "schedule" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "archive" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "delete" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "restore" },
+  { moduleKey: "blog_content", activityCode: "posts", action: "purge" }
+];
+
+let sessionToken = "";
+let ownerRoleId = "";
+let editorRoleId = "";
+let editorTenantUserId = "";
+let editorToken = "";
+
+async function seed(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${TENANT}, 'b1-cache', 'B1 Cache', 'active')
+  `;
+
+  const makeMember = async (
+    label: string,
+    roleId: string | null
+  ): Promise<{ tenantUserId: string; token: string }> => {
+    const profile = (await admin`
+      INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+      VALUES (${TENANT}, 'person', ${label})
+      RETURNING id
+    `) as { id: string }[];
+
+    const identity = (await admin`
+      INSERT INTO awcms_identities
+        (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${TENANT}, ${profile[0]!.id}, ${`${label}@example.test`}, 'x')
+      RETURNING id
+    `) as { id: string }[];
+
+    const tenantUser = (await admin`
+      INSERT INTO awcms_tenant_users (tenant_id, identity_id)
+      VALUES (${TENANT}, ${identity[0]!.id})
+      RETURNING id
+    `) as { id: string }[];
+
+    if (roleId) {
+      await admin`
+        INSERT INTO awcms_access_policies
+          (tenant_id, tenant_user_id, role_id, scope_type, scope_id,
+           granted_by_tenant_user_id)
+        VALUES (${TENANT}, ${tenantUser[0]!.id}, ${roleId}, 'tenant', ${TENANT},
+                ${tenantUser[0]!.id})
+      `;
+    }
+
+    const token = generateSessionToken();
+
+    await admin`
+      INSERT INTO awcms_sessions (tenant_id, identity_id, token_hash, expires_at)
+      VALUES (${TENANT}, ${identity[0]!.id}, ${hashSessionToken(token)},
+              now() + interval '1 hour')
+    `;
+
+    return { tenantUserId: tenantUser[0]!.id, token };
+  };
+
+  const roles = (await admin`
+    INSERT INTO awcms_roles (tenant_id, role_code, role_name, is_system)
+    VALUES (${TENANT}, 'owner', 'Owner', true),
+           (${TENANT}, 'editor', 'Editor', false)
+    RETURNING id, role_code
+  `) as { id: string; role_code: string }[];
+
+  ownerRoleId = roles.find((row) => row.role_code === "owner")!.id;
+  editorRoleId = roles.find((row) => row.role_code === "editor")!.id;
+
+  // The owner holds every permission; the editor holds NONE, which is what
+  // makes the deny comparison below non-vacuous.
+  await admin.unsafe(
+    `INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+     SELECT $1, $2, id FROM awcms_permissions`,
+    [TENANT, ownerRoleId]
+  );
+
+  sessionToken = (await makeMember("owner", ownerRoleId)).token;
+
+  const editor = await makeMember("editor", editorRoleId);
+  editorTenantUserId = editor.tenantUserId;
+  editorToken = editor.token;
+}
+
+type Run = { decisions: boolean[]; queries: number };
+
+async function renderScreen(options: {
+  token: string;
+  cached: boolean;
+}): Promise<Run> {
+  return withTenantOrThrow(
+    getRuntimeSql(),
+    TENANT,
+    async (tx) => {
+      const { result, queries } = await countQueries(tx, async (counting) => {
+        const readCache = options.cached
+          ? createAuthorizationReadCache()
+          : undefined;
+        const decisions: boolean[] = [];
+
+        for (const guard of BLOG_SCREEN_GUARDS) {
+          const outcome = await authorizeInTransaction(
+            counting,
+            TENANT,
+            hashSessionToken(options.token),
+            new Date(),
+            guard,
+            readCache ? { readCache } : undefined
+          );
+
+          decisions.push(outcome.allowed);
+        }
+
+        return decisions;
+      });
+
+      return { decisions: result, queries };
+    },
+    { workClass: "interactive" }
+  );
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("the authorization read cache (finding B1)", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seed();
+  });
+
+  test("an ALLOWED render reaches the same eleven decisions either way", async () => {
+    const uncached = await renderScreen({ token: sessionToken, cached: false });
+    const cached = await renderScreen({ token: sessionToken, cached: true });
+
+    expect(cached.decisions).toEqual(uncached.decisions);
+    // NON-VACUOUS: eleven `false`s would also be "the same".
+    expect(uncached.decisions.every(Boolean)).toBe(true);
+  });
+
+  test("a DENIED render reaches the same eleven decisions either way", async () => {
+    // The direction that matters. A cache that made a refusal into an allow
+    // would be a security defect with a benchmark attached.
+    const uncached = await renderScreen({ token: editorToken, cached: false });
+    const cached = await renderScreen({ token: editorToken, cached: true });
+
+    expect(cached.decisions).toEqual(uncached.decisions);
+    expect(uncached.decisions.some(Boolean)).toBe(false);
+  });
+
+  test("and it costs far fewer queries", async () => {
+    const uncached = await renderScreen({ token: sessionToken, cached: false });
+    const cached = await renderScreen({ token: sessionToken, cached: true });
+
+    // Asserted in BOTH directions: a floor on the uncached run so the ceiling
+    // below cannot pass because the whole pipeline got shorter for some
+    // unrelated reason, and a ceiling on the cached one.
+    expect(uncached.queries).toBeGreaterThan(70);
+    expect(cached.queries).toBeLessThan(40);
+    expect(cached.queries).toBeLessThan(uncached.queries / 2);
+  });
+
+  test("every decision is still logged — the cache memoises inputs, not answers", async () => {
+    await renderScreen({ token: sessionToken, cached: true });
+
+    const rows = (await getAdminSql()`
+      SELECT count(*)::int AS n FROM awcms_abac_decision_logs
+      WHERE tenant_id = ${TENANT}
+    `) as { n: number }[];
+
+    expect(rows[0]!.n).toBe(BLOG_SCREEN_GUARDS.length);
+  });
+
+  test("two principals in one cache do not see each other's answers", async () => {
+    // The keys carry the token hash and the tenant user id. If they did not, an
+    // affordance probe for one person could be answered from another's
+    // permission set — which is the worst thing a cache like this could do.
+    const outcome = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) => {
+        const readCache = createAuthorizationReadCache();
+        const guard = BLOG_SCREEN_GUARDS[0]!;
+
+        const owner = await authorizeInTransaction(
+          tx,
+          TENANT,
+          hashSessionToken(sessionToken),
+          new Date(),
+          guard,
+          { readCache }
+        );
+
+        const editor = await authorizeInTransaction(
+          tx,
+          TENANT,
+          hashSessionToken(editorToken),
+          new Date(),
+          guard,
+          { readCache }
+        );
+
+        return { owner: owner.allowed, editor: editor.allowed };
+      },
+      { workClass: "interactive" }
+    );
+
+    expect(outcome.owner).toBe(true);
+    expect(outcome.editor).toBe(false);
+  });
+
+  test("a caller WITHOUT a cache sees its own write — which is why the cache is opt-in", async () => {
+    // The safety argument, executed. If this memo lived inside
+    // `authorizeInTransaction` keyed on `tx`, the second decision below would
+    // still be `false`: the grant would be invisible to the transaction that
+    // made it. Every route reads fresh precisely because none of them passes a
+    // cache.
+    const outcome = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) => {
+        const guard = BLOG_SCREEN_GUARDS[0]!;
+
+        const before = await authorizeInTransaction(
+          tx,
+          TENANT,
+          hashSessionToken(editorToken),
+          new Date(),
+          guard
+        );
+
+        await tx`
+          INSERT INTO awcms_role_permissions (tenant_id, role_id, permission_id)
+          SELECT ${TENANT}, ${editorRoleId}, id FROM awcms_permissions
+          WHERE module_key = ${guard.moduleKey}
+            AND activity_code = ${guard.activityCode}
+            AND action = ${guard.action}
+        `;
+
+        const after = await authorizeInTransaction(
+          tx,
+          TENANT,
+          hashSessionToken(editorToken),
+          new Date(),
+          guard
+        );
+
+        return { before: before.allowed, after: after.allowed };
+      },
+      { workClass: "interactive" }
+    );
+
+    expect(outcome.before).toBe(false);
+    expect(outcome.after).toBe(true);
+    expect(editorTenantUserId).not.toBe("");
+  });
+});


### PR DESCRIPTION
Finding **B1** of the 17 August 2026 audit round — the largest request-path item in the round.

## What was measured

`/admin/blog` calls `can()` ten times on top of its entry decision. Each one is a full `authorizeInTransaction`, and each re-resolved the same session, the same permission set, the same delegated-grant state and the same platform tenant id — on **one** reserved `interactive` connection out of eight process-wide.

| | queries | wall time |
| --- | --- | --- |
| before | **89** | 47 ms |
| after | **29** | 23 ms |

The finding estimated ~66 queries. The real number was **89**.

## Neither of the two suggested shapes, and why

The round proposed either a `WeakMap` keyed on `tx` inside the guard, or a `canInTransaction` probe modelled on `evaluateFieldAccessInTransaction`. Both are wrong here, in opposite directions:

- **`canInTransaction`** would skip the *structural* gates — tenant suspension, entitlement, the delegated-write rule, partner/grant state, SoD. An affordance would appear that the real chokepoint then refuses on click: the fake-affordance defect this repo condemns elsewhere.
- **A `WeakMap` inside the guard** would change what a caller sees after **it** has written. A route that grants a role and then re-authorizes in the same transaction would read the grant set from before its own write — silently, and only sometimes.

So the memo is an **opt-in the caller supplies**. `loadAdminScreen` creates one per render and passes it to the entry decision and to every `can()` probe, because a screen render is a read path by construction: the eleven decisions describe one moment and nothing writes between them. Every other caller is untouched and keeps reading fresh.

## Inputs are memoised, never a decision

Only reads whose answer cannot differ between two decisions about the same principal in the same transaction: the resolved principal, the machine credential, the granted permission keys, the delegated grant state, the platform tenant id.

Everything request-shaped still runs every time — module availability and entitlement, the delegated-write rule, the machine-credential write ceiling, business-scope facts, SoD, the ABAC evaluation itself, and the decision log. **The eleven decision-log rows are still eleven.**

## The test proves the decisions first and the speed second

A cache that is faster and answers differently is not an optimisation; it is a security defect with a benchmark attached. So `tests/integration/authorization-read-cache.integration.test.ts`:

- compares cached against uncached **decision by decision** for an ALLOWED render (all eleven true) and a DENIED one (all eleven false) — each asserted non-vacuously, since "the same" is also true of eleven identical wrong answers;
- asserts two principals sharing **one** cache do not see each other's answers;
- asserts the decision-log count is unchanged;
- and **executes** the safety argument rather than describing it: grant a permission mid-transaction, re-authorize **without** a cache, and the answer changes from `false` to `true` — which is exactly what would not happen if the memo lived inside the guard;
- bounds the query count in **both** directions, so neither number can quietly drift into meaninglessness.

**Mutation-proven**: dropping the token hash from the cache key turns the cross-principal case red; making `cachedRead` ignore the cache turns the query-count case red.

`bun run check` full green (5459 pass, 0 fail). `bun test tests/integration/` shows only the two pre-existing `http`/`https` scheme failures that also fail on unmodified `main` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
