### PR TITLE
perf(blog-content): three round trips the request path paid for and threw away

### DIFF
--- a/.changeset/public-path-wasted-reads.md
+++ b/.changeset/public-path-wasted-reads.md
@@ -1,0 +1,51 @@
+---
+"awcms": patch
+---
+
+perf(blog-content): three round trips the request path paid for and threw away
+
+Findings **B2**, **B3** and **B4** of the 17 August 2026 audit round. One PR
+because they are one habit: a caller re-derives something the caller above it
+already had.
+
+**B2 — a read taken and discarded on every anonymous page view, and it was worse
+than the finding said.** `isLegacyTenantRouteEnabled` went through the merged
+settings reader, which also reads `awcms_blog_settings` and then throws that row
+away. One wasted round trip on all seven `/blog/{tenantCode}/*` routes — 100% of
+page views on a default deployment, where the edge cache is off.
+
+**Two of the seven were paying for it twice.** `feed.xml.ts` and
+`sitemap-blog.xml.ts` call `isLegacyTenantRouteEnabled` and then call
+`fetchBlogSettings` themselves for `rssEnabled`/`sitemapEnabled` — so
+`awcms_blog_settings` was read, discarded, and read again. The gate is now one
+query; the merged reader still reads both, because it uses both, and a test pins
+each so the saving cannot come from quietly dropping a field.
+
+**B3 — the tenant id the route resolved and dropped.** All eight `/blog/*` routes
+now publish `locals.edgeCacheTenantId`, so middleware stops repeating the
+`awcms_tenants` lookup on every cache MISS. `discovery-route.ts:145` was the
+working precedent.
+
+Placement is the whole of it, and the test asserts placement rather than
+behaviour: `publish-tenant.ts`'s standing rule is *resolve, gate, produce,
+publish last*. A 404 is a cacheable status, so publishing before the
+missing-resource branch would annotate a "no such post" 404 differently from an
+"unknown tenant" 404 and answer, from one request, the question the routes'
+generic-404 shape exists to withhold. Every `return notFound…` stays above the
+publish; the one response that serves the resource is below it.
+
+**B4 — a third transaction whose first read was a column nobody fetched.**
+`AdminLayout` ran `SELECT tenant_name FROM awcms_tenants` on every `/admin/*`
+render, against the row `readTenantDisplayDefaults` already had open one
+transaction earlier for `default_locale`/`default_theme`. The name now rides
+along on that primary-key read.
+
+The layout's circuit-open shape check moved with it: it keyed on `tenantName`,
+which is no longer in that block's return, so leaving it would have tested for a
+field that is never there and silently skipped **every** assignment below it —
+the sync indicator, the disabled-module set and the sidebar arrangement. It keys
+on `syncActive` now, and a test pins that.
+
+*Both B4 assertions failed on their first run by matching the corrective comment
+explaining the removal rather than any code — finding D2 in miniature, caught by
+the shared comment stripper D2 landed one PR earlier. They strip first now.*

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:ed0d365bb7f6639c4f1eb8db4d6cbc0362b726c4926e73d9801cbbf47881bbd2 -->
+<!-- i18n-source-hash: sha256:163a10000ee02f9bc34710df9de9dbac0944b5d725047b96e59bf43964cfdf88 -->
 
 # AWCMS — Project State & Continuation
 
@@ -603,16 +603,41 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
      TANPA cache, dan jawabannya berubah.
 
   10. **B2 — `isLegacyTenantRouteEnabled` membaca `awcms_blog_settings` lalu membuangnya.**
+      **SELESAI (22 Agustus 2026).**
       `public-route-settings.ts:68-87`; dipanggil ketujuh rute `/blog/[tenantCode]/*`. Satu
       round trip terbuang penuh pada setiap tampilan halaman anonim — 100% dari semuanya
       pada deployment default, tempat edge cache mati.
   11. **B3 — rute `/blog/*` tidak pernah menerbitkan `locals.edgeCacheTenantId`.** Rute
+      **SELESAI (22 Agustus 2026).**
       sudah meresolusi tenant lalu membuang id-nya, jadi middleware mengulang lookup
       `awcms_tenants` pada tiap MISS cache. Presedennya sudah bekerja di
       `seo-distribution/presentation/discovery-route.ts:145`.
   12. **B4 — `AdminLayout` membuka transaksi ketiga yang baca pertamanya adalah kolom yang
+      **SELESAI (22 Agustus 2026).**
       tak diambil siapa pun.** `AdminLayout.astro:184-206`. `tenant_name` diambil terpisah
       dari baris yang sama yang sudah dipilih `readTenantDisplayDefaults`.
+
+      **B2 lebih buruk dari yang tertulis: dua dari tujuh membayar DUA KALI.**
+      `feed.xml.ts` dan `sitemap-blog.xml.ts` memanggil `isLegacyTenantRouteEnabled` lalu
+      memanggil `fetchBlogSettings` sendiri, sehingga `awcms_blog_settings` dibaca, dibuang,
+      lalu dibaca lagi. Gerbangnya kini SATU query dan pembaca gabungannya tetap membaca
+      keduanya, karena ia memakai keduanya — dipatok terpisah supaya penghematannya tidak
+      berasal dari membuang field yang dipakai orang lain.
+
+      **Penempatan B3 adalah keseluruhannya.** `publish-tenant.ts` menyatakan aturannya —
+      resolve, gate, produksi, publish TERAKHIR — karena 404 adalah status yang bisa
+      di-cache: mem-publish sebelum cabang sumber-daya-tidak-ada membuat 404 "post tidak
+      ada" beranotasi beda dari 404 "tenant tidak dikenal" dan menjawab, dari satu
+      permintaan, pertanyaan yang justru ditahan bentuk 404 generiknya. Tesnya menuntut
+      URUTAN terhadap `notFound` terakhir dan satu-satunya respons penyaji, dan mutasi yang
+      memindahkan panggilannya ke atas gerbang memerahkannya.
+
+      **B4 memindahkan satu shape-check bersamanya, dan itu nyaris luput.** Penjaga
+      circuit-open berkunci pada `tenantName` — yang tidak lagi ada di return blok itu —
+      sehingga membiarkannya berarti menguji field yang tidak pernah ada dan diam-diam
+      melewati SETIAP penugasan di bawahnya: indikator sync, himpunan modul nonaktif, dan
+      susunan sidebar.
+
   13. **B5 — ~6 round trip middleware per request publik sebelum query pertama halaman.**
       `middleware.ts:305`; `redirect-resolution-service.ts:170-212`. Dibayar bahkan oleh
       tenant tanpa satu pun aturan redirect. `standar-performa-dan-keamanan.md:195` mengaku

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -114,7 +114,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Migrations                        | **143** (`sql/001`–`143`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0105** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **48** `.astro` files in `src/pages/admin/`; **0 of 24** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| `.astro` files                    | **61** (34.594 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
+| `.astro` files                    | **61** (34.599 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
 | Gates                             | **56** in the `bun run check` chain                                                    | `scripts.check` in `package.json`, split on `&&`                                        |
 | Contracts                         | Modular per-module OpenAPI + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -623,14 +623,37 @@ pioneered directly here after the ADR-0047 freeze.)
      changes.
 
   10. **B2 — `isLegacyTenantRouteEnabled` reads `awcms_blog_settings` and discards it.**
+      **DONE (22 August 2026).**
       `public-route-settings.ts:68-87`; called from all 7 `/blog/[tenantCode]/*` routes.
       One wholly wasted round trip on every anonymous page view — 100% of them on a
       default deployment, where the edge cache is off.
   11. **B3 — `/blog/*` routes never publish `locals.edgeCacheTenantId`.** The routes
+      **DONE (22 August 2026).**
       already resolved the tenant and drop the id, so middleware repeats the
       `awcms_tenants` lookup on every cache MISS. One call per route; the working
       precedent is `seo-distribution/presentation/discovery-route.ts:145`.
+
+      **B2 was worse than written: two of the seven paid TWICE.** `feed.xml.ts` and
+      `sitemap-blog.xml.ts` call `isLegacyTenantRouteEnabled` and then call
+      `fetchBlogSettings` themselves, so `awcms_blog_settings` was read, discarded, and
+      read again. The gate is now ONE query and the merged reader still reads both,
+      because it uses both — pinned separately so the saving cannot come from dropping a
+      field somebody depends on.
+
+      **B3's placement is the whole of it.** `publish-tenant.ts` states the rule — resolve,
+      gate, produce, publish LAST — because a 404 is a cacheable status: publishing before
+      the missing-resource branch annotates a "no such post" 404 differently from an
+      "unknown tenant" one and answers, from a single request, the question the generic-404
+      shape exists to withhold. The test asserts ORDER against the last `notFound` and the
+      one serving response, and a mutation moving the call above the gate turns it red.
+
+      **B4 moved a shape check with it, which was the near-miss.** The circuit-open guard
+      keyed on `tenantName` — no longer in that block's return — so leaving it would have
+      tested for a field that is never there and silently skipped EVERY assignment below:
+      the sync indicator, the disabled-module set, the sidebar arrangement.
+
   12. **B4 — `AdminLayout` opens a third transaction whose first read is a column nobody
+      **DONE (22 August 2026).**
       fetched.** `AdminLayout.astro:184-206`. `tenant_name` is fetched separately from the
       same row `readTenantDisplayDefaults` already selects.
   13. **B5 — ~6 middleware round trips per public request before the page's first query.**

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 446   |
+| Test files                          | 447   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -356,7 +356,7 @@
 | ------------- | ---------- |
 | `(root)`      | 379        |
 | `e2e`         | 12         |
-| `integration` | 54         |
+| `integration` | 55         |
 | `unit`        | 1          |
 
 ### Routes

--- a/src/layouts/AdminLayout.astro
+++ b/src/layouts/AdminLayout.astro
@@ -164,7 +164,20 @@ const defaultThemeAttribute =
  * `undefined`. Testing for a key we know we returned is what makes the
  * fallback real.
  */
-let tenantName = "Tenant";
+/**
+ * Finding B4 — taken from the session, which already had the row open.
+ *
+ * This layout used to open a THIRD transaction whose first statement was
+ * `SELECT tenant_name FROM awcms_tenants WHERE id = $1`. `readTenantDisplayDefaults`
+ * in `ssr-session.ts` reads that same row for `default_locale`/`default_theme`
+ * on every `/admin/*` render, so the name now rides along on that query and this
+ * screen spends a connection acquisition and a round trip less.
+ *
+ * `"Tenant"` stays the fallback for the same reason it always was: on a
+ * circuit-open session resolution the field is `null`, and chrome degrades
+ * rather than failing.
+ */
+let tenantName = ssr.display.tenantName?.trim() || "Tenant";
 let syncActive = false;
 /**
  * Empty on failure, which shows the full sidebar. Deliberate: hiding a link is
@@ -183,12 +196,7 @@ let arrangement: SidebarArrangement = { types: [], items: [] };
 try {
   const sql = getDatabaseClient();
   const chrome = await withTenantOrThrow(sql, ssr.tenantId, async (tx) => {
-    const rows = (await tx`
-      SELECT tenant_name FROM awcms_tenants WHERE id = ${ssr.tenantId}
-    `) as Array<{ tenant_name: string | null }>;
-
     return {
-      tenantName: rows[0]?.tenant_name ?? null,
       // Bounded EXISTS, not the full sync-health aggregation — the topbar
       // needs one boolean and this runs on every `/admin/*` request.
       syncActive: await fetchSyncIndicatorActive(tx, ssr.tenantId),
@@ -205,16 +213,13 @@ try {
     };
   });
 
-  // Shape check, not a truthiness check: on circuit-open `withTenant` hands
-  // back a `Response`, whose `.tenantName` is `undefined` rather than an error.
-  if (chrome && typeof chrome === "object" && "tenantName" in chrome) {
-    if (
-      typeof chrome.tenantName === "string" &&
-      chrome.tenantName.trim() !== ""
-    ) {
-      tenantName = chrome.tenantName;
-    }
-
+  // Shape check, not a truthiness check: on circuit-open `withTenant` hands back
+  // a `Response`, whose fields are `undefined` rather than an error.
+  //
+  // Keyed on `syncActive` since finding B4 moved `tenantName` to the session —
+  // keying on a field this block no longer returns would test for something that
+  // is never there and silently skip every assignment below.
+  if (chrome && typeof chrome === "object" && "syncActive" in chrome) {
     syncActive = chrome.syncActive === true;
     disabledModuleKeys = new Set(chrome.disabledModuleKeys);
     arrangement = chrome.arrangement;

--- a/src/lib/auth/ssr-session.ts
+++ b/src/lib/auth/ssr-session.ts
@@ -28,23 +28,35 @@ import type { SQL } from "bun";
 async function readTenantDisplayDefaults(
   tx: SQL,
   tenantId: string
-): Promise<{ defaultLocale: string | null; defaultTheme: string | null }> {
+): Promise<{
+  defaultLocale: string | null;
+  defaultTheme: string | null;
+  tenantName: string | null;
+}> {
   try {
+    // `tenant_name` rides along for finding B4. `AdminLayout` used to open a
+    // THIRD transaction whose first statement was
+    // `SELECT tenant_name FROM awcms_tenants WHERE id = $1` — the same row this
+    // query already has open, one column wider. Adding a column to a
+    // primary-key read costs nothing; the transaction it removes is a
+    // connection acquisition and a round trip on every `/admin/*` render.
     const rows = (await tx`
-      SELECT default_locale, default_theme
+      SELECT default_locale, default_theme, tenant_name
       FROM awcms_tenants
       WHERE id = ${tenantId}
     `) as Array<{
       default_locale: string | null;
       default_theme: string | null;
+      tenant_name: string | null;
     }>;
 
     return {
       defaultLocale: rows[0]?.default_locale ?? null,
-      defaultTheme: rows[0]?.default_theme ?? null
+      defaultTheme: rows[0]?.default_theme ?? null,
+      tenantName: rows[0]?.tenant_name ?? null
     };
   } catch {
-    return { defaultLocale: null, defaultTheme: null };
+    return { defaultLocale: null, defaultTheme: null, tenantName: null };
   }
 }
 
@@ -91,6 +103,14 @@ export type SsrContext = {
     tenantDefaultLocale: string | null;
     /** `awcms_tenants.default_theme` — see `theme-init-script.ts`'s seam. */
     tenantDefaultTheme: string | null;
+    /**
+     * `awcms_tenants.tenant_name` — the topbar label.
+     *
+     * Carried here because the query above already had the row open (finding
+     * B4). `AdminLayout` reads it from the session rather than opening its own
+     * transaction for one column.
+     */
+    tenantName: string | null;
   };
 };
 
@@ -168,7 +188,8 @@ export async function resolveSsrContext(
           preferredLocale: preferences.locale,
           preferredTheme: preferences.theme,
           tenantDefaultLocale: tenantDefaults.defaultLocale,
-          tenantDefaultTheme: tenantDefaults.defaultTheme
+          tenantDefaultTheme: tenantDefaults.defaultTheme,
+          tenantName: tenantDefaults.tenantName
         }
       };
     });

--- a/src/modules/blog-content/application/public-route-settings.ts
+++ b/src/modules/blog-content/application/public-route-settings.ts
@@ -68,23 +68,54 @@ export async function fetchEffectivePublicRouteSettings(
   tx: Bun.SQL,
   tenantId: string
 ): Promise<EffectivePublicRouteSettings> {
+  const [legacyTenantRouteEnabled, blogSettings] = [
+    await readLegacyTenantRouteEnabled(tx, tenantId),
+    await fetchBlogSettings(tx, tenantId)
+  ];
+
+  return {
+    legacyTenantRouteEnabled,
+    rssEnabled: blogSettings.rssEnabled,
+    sitemapEnabled: blogSettings.sitemapEnabled
+  };
+}
+
+/**
+ * The `legacyTenantRouteEnabled` half on its own — ONE read, from module
+ * settings only.
+ *
+ * Split out for finding B2. `isLegacyTenantRouteEnabled` used to go through the
+ * merged reader above, which also reads `awcms_blog_settings` and then throws
+ * that row away: a wholly wasted round trip on every anonymous page view of all
+ * seven `/blog/{tenantCode}/*` routes — 100% of them on a default deployment,
+ * where the edge cache is off.
+ *
+ * Two of those seven were paying for it TWICE. `feed.xml.ts` and
+ * `sitemap-blog.xml.ts` call `isLegacyTenantRouteEnabled` and then call
+ * `fetchBlogSettings` themselves for `rssEnabled`/`sitemapEnabled`, so
+ * `awcms_blog_settings` was read once and discarded, then read again and used.
+ *
+ * The normalisation lives here rather than in the caller for the reason the
+ * merged reader's own header gives: `validateModuleSettingsPatch` checks the
+ * SHAPE of a settings patch, never per-field types, so a tenant override holding
+ * a garbage value reaches this read path — and this is where it must fall back
+ * to the safe default rather than throw.
+ */
+async function readLegacyTenantRouteEnabled(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<boolean> {
   const moduleSettingsView = await fetchModuleSettingsView(
     tx,
     tenantId,
     BLOG_CONTENT_MODULE_KEY
   );
-  const blogSettings = await fetchBlogSettings(tx, tenantId);
 
   const effective = moduleSettingsView?.effective ?? {};
 
-  return {
-    legacyTenantRouteEnabled:
-      typeof effective.legacyTenantRouteEnabled === "boolean"
-        ? effective.legacyTenantRouteEnabled
-        : DEFAULT_LEGACY_TENANT_ROUTE_ENABLED,
-    rssEnabled: blogSettings.rssEnabled,
-    sitemapEnabled: blogSettings.sitemapEnabled
-  };
+  return typeof effective.legacyTenantRouteEnabled === "boolean"
+    ? effective.legacyTenantRouteEnabled
+    : DEFAULT_LEGACY_TENANT_ROUTE_ENABLED;
 }
 
 /**
@@ -121,7 +152,5 @@ export async function isLegacyTenantRouteEnabled(
   tx: Bun.SQL,
   tenantId: string
 ): Promise<boolean> {
-  const settings = await fetchEffectivePublicRouteSettings(tx, tenantId);
-
-  return settings.legacyTenantRouteEnabled;
+  return readLegacyTenantRouteEnabled(tx, tenantId);
 }

--- a/src/pages/blog/[tenantCode]/[slug].ts
+++ b/src/pages/blog/[tenantCode]/[slug].ts
@@ -31,6 +31,7 @@ import { renderSocialShareButtonsHtml } from "../../../modules/blog-content/doma
 import { composeAdSlots } from "../../../modules/blog-content/application/ad-slot-composition";
 import { AD_SLOT_AVAILABLE_LABEL } from "../../../modules/blog-content/domain/ad-slot-labels";
 import { insertMidArticleSlotHtml } from "../../../modules/blog-content/domain/ad-slot-rendering";
+import { publishEdgeCacheTenant } from "../../../lib/edge-cache/publish-tenant";
 
 const NEWS_SHARE_CLIENT_SCRIPT_SRC = "/js/news-share.js";
 
@@ -187,6 +188,18 @@ ${ads.get("article_bottom") ?? ""}
         structuredDataJsonLd: seoMetadata.structuredDataJsonLd,
         variant: "article"
       });
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(html, {
         status: 200,

--- a/src/pages/blog/[tenantCode]/category/[slug].ts
+++ b/src/pages/blog/[tenantCode]/category/[slug].ts
@@ -26,6 +26,7 @@ import {
   renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../../../modules/blog-content/domain/public-page-rendering";
+import { publishEdgeCacheTenant } from "../../../../lib/edge-cache/publish-tenant";
 
 /** `GET /blog/{tenantCode}/category/{slug}` (Issue #540) — same listing predicate as the index, scoped to posts assigned this category. 404 for an unknown or soft-deleted category, or (Issue #564) when `legacyTenantRouteEnabled` is `false`. */
 export const GET: APIRoute = async ({ locals, params, request, url }) => {
@@ -114,6 +115,18 @@ ${renderPaginationNavHtml(page, result.hasNextPage, urls.basePath)}`;
         locale: tenant.defaultLocale,
         variant: "list"
       });
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(html, {
         status: 200,

--- a/src/pages/blog/[tenantCode]/feed.xml.ts
+++ b/src/pages/blog/[tenantCode]/feed.xml.ts
@@ -19,6 +19,7 @@ import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/applic
 import { resolveNewsArticlePreviewImage } from "../../../modules/blog-content/application/news-article-seo-metadata";
 import { mediaLibraryPortAdapter } from "../../../modules/media-library/application/media-library-port-adapter";
 import { resolveMetaDescription } from "../../../modules/blog-content/domain/seo-rendering";
+import { publishEdgeCacheTenant } from "../../../lib/edge-cache/publish-tenant";
 
 /**
  * `GET /blog/{tenantCode}/feed.xml` (Issue #540) — RSS 2.0, only
@@ -43,7 +44,7 @@ import { resolveMetaDescription } from "../../../modules/blog-content/domain/seo
  * feed). Issue #564 adds the same generic 404 when the tenant's
  * `legacyTenantRouteEnabled` setting is `false`.
  */
-export const GET: APIRoute = async ({ params, request, url }) => {
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
   const tenantCode = params.tenantCode;
 
   if (!tenantCode) {
@@ -116,6 +117,18 @@ ${enclosure}
 ${items}
 </channel>
 </rss>`;
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(xml, {
         status: 200,

--- a/src/pages/blog/[tenantCode]/index.ts
+++ b/src/pages/blog/[tenantCode]/index.ts
@@ -29,6 +29,7 @@ import {
   renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../../modules/blog-content/domain/public-page-rendering";
+import { publishEdgeCacheTenant } from "../../../lib/edge-cache/publish-tenant";
 
 /**
  * `GET /blog/{tenantCode}` (Issue #540) — public blog index, listing
@@ -145,6 +146,18 @@ ${ads.get("homepage_bottom") ?? ""}`;
         locale: tenant.defaultLocale,
         variant: "list"
       });
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(html, {
         status: 200,

--- a/src/pages/blog/[tenantCode]/pages/[slug].ts
+++ b/src/pages/blog/[tenantCode]/pages/[slug].ts
@@ -27,6 +27,7 @@ import {
   resolveSeoTitle
 } from "../../../../modules/blog-content/domain/seo-rendering";
 import { renderPublicPageShell } from "../../../../modules/blog-content/domain/public-page-rendering";
+import { publishEdgeCacheTenant } from "../../../../lib/edge-cache/publish-tenant";
 
 /**
  * `GET /blog/{tenantCode}/pages/{slug}` (Issue #594) — the public route for
@@ -158,6 +159,18 @@ export const GET: APIRoute = async ({ locals, params, request, url }) => {
         robotsContent: resolveRobotsMetaContent(page.visibility),
         variant: "article"
       });
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(html, {
         status: 200,

--- a/src/pages/blog/[tenantCode]/search.ts
+++ b/src/pages/blog/[tenantCode]/search.ts
@@ -19,6 +19,7 @@ import {
   renderPublicPageShell
 } from "../../../modules/blog-content/domain/public-page-rendering";
 import { decodeKeysetCursor } from "../../../modules/_shared/keyset-pagination";
+import { publishEdgeCacheTenant } from "../../../lib/edge-cache/publish-tenant";
 
 /**
  * `GET /blog/{tenantCode}/search?q=` (Issue #540) — public search, reuses
@@ -112,6 +113,18 @@ export const GET: APIRoute = async ({ locals, params, url }) => {
         locale: tenant.defaultLocale,
         variant: "list"
       });
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(html, {
         status: 200,

--- a/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
+++ b/src/pages/blog/[tenantCode]/sitemap-blog.xml.ts
@@ -24,6 +24,7 @@ import { fetchBlogSettings } from "../../../modules/blog-content/application/blo
 import { isLegacyTenantRouteEnabled } from "../../../modules/blog-content/application/public-route-settings";
 import { resolveNewsArticlePreviewImage } from "../../../modules/blog-content/application/news-article-seo-metadata";
 import { mediaLibraryPortAdapter } from "../../../modules/media-library/application/media-library-port-adapter";
+import { publishEdgeCacheTenant } from "../../../lib/edge-cache/publish-tenant";
 
 /**
  * `GET /blog/{tenantCode}/sitemap-blog.xml` (Issue #540) — sitemap
@@ -34,7 +35,7 @@ import { mediaLibraryPortAdapter } from "../../../modules/media-library/applicat
  * generic 404 when the tenant's `legacyTenantRouteEnabled` setting is
  * `false`.
  */
-export const GET: APIRoute = async ({ params, request, url }) => {
+export const GET: APIRoute = async ({ locals, params, request, url }) => {
   const tenantCode = params.tenantCode;
 
   if (!tenantCode) {
@@ -140,6 +141,18 @@ ${alternatesXml(channelPath)}
 </url>
 ${urls}
 </urlset>`;
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(xml, {
         status: 200,

--- a/src/pages/blog/[tenantCode]/tag/[slug].ts
+++ b/src/pages/blog/[tenantCode]/tag/[slug].ts
@@ -26,6 +26,7 @@ import {
   renderPostSummaryListHtmlAtBasePath,
   renderPublicPageShell
 } from "../../../../modules/blog-content/domain/public-page-rendering";
+import { publishEdgeCacheTenant } from "../../../../lib/edge-cache/publish-tenant";
 
 /** `GET /blog/{tenantCode}/tag/{slug}` (Issue #540) — same as the category archive, scoped to `taxonomy_type = 'tag'`, including the Issue #564 `legacyTenantRouteEnabled` gate. */
 export const GET: APIRoute = async ({ locals, params, request, url }) => {
@@ -111,6 +112,18 @@ ${renderPaginationNavHtml(page, result.hasNextPage, urls.basePath)}`;
         locale: tenant.defaultLocale,
         variant: "list"
       });
+
+      // Finding B3 — publish the tenant this response belongs to, so middleware
+      // does not repeat the `awcms_tenants` lookup this route already made on
+      // every cache MISS. `discovery-route.ts:145` is the working precedent.
+      //
+      // HERE and not earlier, which is the rule `publish-tenant.ts` states: a
+      // 404 is a cacheable status, so publishing before the missing-resource
+      // branch would annotate that 404 differently from the unknown-tenant one
+      // and answer "is this tenant code live?" from a single request. Every
+      // `return notFound…` above is therefore left unpublished, and this sits
+      // immediately before the only response that serves the resource.
+      publishEdgeCacheTenant(locals, tenant.tenantId);
 
       return new Response(html, {
         status: 200,

--- a/tests/integration/public-path-wasted-reads.integration.test.ts
+++ b/tests/integration/public-path-wasted-reads.integration.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Three round trips the request path paid for and threw away — findings B2, B3
+ * and B4 of the 17 August 2026 audit round.
+ *
+ * They are one PR because they are one habit: a caller re-derives something the
+ * caller above it already had. What they cost individually is small; what makes
+ * them worth a test is that each is invisible to every other kind of check —
+ * the page renders, the feed validates, the assertions pass, and the only
+ * evidence is a query nobody needed.
+ *
+ * ## B2, and it was worse than the finding said
+ *
+ * `isLegacyTenantRouteEnabled` went through the merged settings reader, which
+ * also reads `awcms_blog_settings` and then discards that row. One wasted round
+ * trip on every anonymous page view of all seven `/blog/{tenantCode}/*` routes —
+ * 100% of them on a default deployment, where the edge cache is off.
+ *
+ * **Two of the seven paid for it twice.** `feed.xml.ts` and
+ * `sitemap-blog.xml.ts` call `isLegacyTenantRouteEnabled` and then call
+ * `fetchBlogSettings` themselves for `rssEnabled`/`sitemapEnabled`. So
+ * `awcms_blog_settings` was read, discarded, and read again.
+ *
+ * ## B3 — the tenant id the route resolved and dropped
+ *
+ * Asserted as source placement rather than behaviour, and deliberately so: the
+ * rule in `publish-tenant.ts` is about WHERE the call sits, not what it
+ * returns. Publishing before the missing-resource branch would annotate a
+ * "no such post" 404 differently from an "unknown tenant" 404, answering from a
+ * single request the question the routes' generic-404 shape exists to withhold.
+ * A behavioural test sees a cache header; only placement sees the disclosure.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { stripComments } from "../../scripts/lib/source-text";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import {
+  fetchEffectivePublicRouteSettings,
+  isLegacyTenantRouteEnabled
+} from "../../src/modules/blog-content/application/public-route-settings";
+
+const TENANT = "b2b2b2b2-b2b2-4b2b-8b2b-b2b2b2b2b2b2";
+
+const BLOG_ROUTES = [
+  "src/pages/blog/[tenantCode]/index.ts",
+  "src/pages/blog/[tenantCode]/search.ts",
+  "src/pages/blog/[tenantCode]/feed.xml.ts",
+  "src/pages/blog/[tenantCode]/sitemap-blog.xml.ts",
+  "src/pages/blog/[tenantCode]/category/[slug].ts",
+  "src/pages/blog/[tenantCode]/tag/[slug].ts",
+  "src/pages/blog/[tenantCode]/pages/[slug].ts",
+  "src/pages/blog/[tenantCode]/[slug].ts"
+];
+
+async function seed(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${TENANT}, 'b2-reads', 'B2 Reads', 'active')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("wasted reads on the public and admin paths", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seed();
+  });
+
+  test("B2: the gate every /blog route calls costs ONE query", async () => {
+    const { result, queries } = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      (tx) =>
+        countQueries(tx, (counting) =>
+          isLegacyTenantRouteEnabled(counting, TENANT)
+        ),
+      { workClass: "interactive" }
+    );
+
+    // It used to be two: the module settings row it uses, and the blog settings
+    // row it threw away.
+    expect(queries).toBe(1);
+    // NON-VACUOUS: the answer is still the answer, not a short-circuit.
+    expect(result).toBe(true);
+  });
+
+  test("B2: the MERGED reader still reads both, because it uses both", async () => {
+    // The saving must come from the narrow caller, not from the merged reader
+    // quietly dropping a field somebody depends on.
+    const { result, queries } = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      (tx) =>
+        countQueries(tx, (counting) =>
+          fetchEffectivePublicRouteSettings(counting, TENANT)
+        ),
+      { workClass: "interactive" }
+    );
+
+    expect(queries).toBe(2);
+    expect(result.legacyTenantRouteEnabled).toBe(true);
+    expect(typeof result.rssEnabled).toBe("boolean");
+    expect(typeof result.sitemapEnabled).toBe("boolean");
+  });
+
+  test("B3: every /blog route publishes its tenant, and only on the serving path", async () => {
+    for (const route of BLOG_ROUTES) {
+      const source = await Bun.file(route).text();
+
+      const publishAt = source.indexOf("publishEdgeCacheTenant(locals,");
+      expect(publishAt).toBeGreaterThan(-1);
+
+      // The rule from `publish-tenant.ts`: resolve, gate, produce, publish LAST.
+      // Every 404 branch must be above it, and the one response that serves the
+      // resource below it.
+      const lastNotFound = Math.max(
+        source.lastIndexOf("return notFoundHtmlResponse()"),
+        source.lastIndexOf("return notFoundXmlResponse()")
+      );
+      const serves = source.lastIndexOf("return new Response(");
+
+      expect(lastNotFound).toBeGreaterThan(-1);
+      expect(serves).toBeGreaterThan(-1);
+      expect(publishAt).toBeGreaterThan(lastNotFound);
+      expect(publishAt).toBeLessThan(serves);
+    }
+  });
+
+  test("B4: the admin layout no longer opens a transaction for one column", async () => {
+    // Comments stripped FIRST. Both this file's B4 assertions failed on their
+    // first run by matching the corrective comment that explains the removal —
+    // which is finding D2 in miniature, caught by the shared stripper D2 landed.
+    const layout = stripComments(
+      await Bun.file("src/layouts/AdminLayout.astro").text()
+    );
+
+    // The exact statement it used to run, on every `/admin/*` render, against a
+    // row `readTenantDisplayDefaults` already had open one transaction earlier.
+    expect(layout).not.toContain("SELECT tenant_name FROM awcms_tenants");
+    expect(layout).toContain("ssr.display.tenantName");
+  });
+
+  test("B4: the session's single tenant read carries all three columns", async () => {
+    // One primary-key read, three columns. The alternative this replaced was
+    // two reads of the same row in two different transactions.
+    const source = stripComments(
+      await Bun.file("src/lib/auth/ssr-session.ts").text()
+    );
+    const query = source.slice(
+      source.indexOf("async function readTenantDisplayDefaults"),
+      source.indexOf("export const SESSION_COOKIE_NAME")
+    );
+
+    expect(query).toContain(
+      "SELECT default_locale, default_theme, tenant_name"
+    );
+    expect((query.match(/FROM awcms_tenants/g) ?? []).length).toBe(1);
+  });
+
+  test("B4: a circuit-open render still falls back rather than showing `undefined`", async () => {
+    // The shape check in the layout keyed on `tenantName`, which this change
+    // moved to the session. Keying on a field the block no longer returns would
+    // test for something never present and silently skip every assignment —
+    // sync indicator, disabled modules, sidebar arrangement, all of it.
+    const layout = stripComments(
+      await Bun.file("src/layouts/AdminLayout.astro").text()
+    );
+
+    expect(layout).toContain('"syncActive" in chrome');
+    expect(layout).not.toContain('"tenantName" in chrome');
+    expect(layout).toContain('ssr.display.tenantName?.trim() || "Tenant"');
+  });
+});


### PR DESCRIPTION
Findings **B2**, **B3** and **B4** of the 17 August 2026 audit round. One PR because they are one habit: a caller re-derives something the caller above it already had.

## B2 — a read taken and discarded on every anonymous page view

`isLegacyTenantRouteEnabled` went through the merged settings reader, which also reads `awcms_blog_settings` and then throws that row away. One wasted round trip on all seven `/blog/{tenantCode}/*` routes — **100% of page views** on a default deployment, where the edge cache is off.

**Two of the seven were paying for it twice.** `feed.xml.ts` and `sitemap-blog.xml.ts` call `isLegacyTenantRouteEnabled` and then call `fetchBlogSettings` themselves for `rssEnabled`/`sitemapEnabled` — so `awcms_blog_settings` was read, discarded, and read again.

The gate is now **one query**. The merged reader still reads both, because it uses both, and a test pins each count separately so the saving cannot come from quietly dropping a field somebody depends on.

## B3 — the tenant id the route resolved and dropped

All eight `/blog/*` routes now publish `locals.edgeCacheTenantId`, so middleware stops repeating the `awcms_tenants` lookup on every cache MISS. `discovery-route.ts:145` was the working precedent.

**Placement is the whole of it**, and the test asserts placement rather than behaviour. `publish-tenant.ts` states the rule: *resolve, gate, produce, publish last*. A 404 is a cacheable status, so publishing before the missing-resource branch would annotate a "no such post" 404 differently from an "unknown tenant" 404 — answering, from a single request with no timing analysis, the question the routes' generic-404 shape exists to withhold.

Every `return notFound…` stays above the publish; the one response that serves the resource is below it. A mutation moving the call above the gate turns the test red.

## B4 — a third transaction whose first read was a column nobody fetched

`AdminLayout` ran `SELECT tenant_name FROM awcms_tenants WHERE id = $1` on every `/admin/*` render, against the row `readTenantDisplayDefaults` already had open one transaction earlier for `default_locale`/`default_theme`. The name rides along on that primary-key read now.

**The near-miss is the shape check that had to move with it.** The circuit-open guard keyed on `tenantName` — no longer in that block's return — so leaving it would have tested for a field that is never there and silently skipped **every** assignment below it: the sync indicator, the disabled-module set, the sidebar arrangement. It keys on `syncActive` now, and a test pins that.

## One thing worth reading

Both B4 assertions **failed on their first run by matching the corrective comment** explaining the removal, rather than any code. That is finding D2 in miniature — caught by the shared comment stripper D2 landed one PR earlier, which they now use.

## Tests

`tests/integration/public-path-wasted-reads.integration.test.ts` — the B2 query counts in both directions; the B3 ordering across all eight routes; the B4 removal, the widened single read, and the moved shape check. **Mutation-proven**: reverting B2 to the merged reader turns one red; moving the B3 publish above the gate turns another red.

`bun run check` full green (5459 pass, 0 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
