### PR TITLE
fix(jobs): three scheduled jobs that reported success while doing nothing

### DIFF
--- a/.changeset/jobs-that-report-false-success.md
+++ b/.changeset/jobs-that-report-false-success.md
@@ -1,0 +1,68 @@
+---
+"awcms": patch
+---
+
+fix(jobs): three scheduled jobs that reported success while doing nothing
+
+Findings **D4**, **D5** and **D6** of the 17 August 2026 audit round. One PR
+because they are one failure mode, and it is the one that survives every other
+kind of check: the job runs, the exit code is 0, the summary prints a number,
+and the number is wrong in the direction that looks fine.
+
+**D4 — a dead branch, and a run that gave up on every remaining tenant.**
+`visitor-analytics-rollup.ts` tested `if (result instanceof Response)` to detect
+database backpressure. That shape only ever comes out of `withTenant`; this loop
+calls `withTenantOrThrow`, which **throws** `DatabaseBusyError` instead. So
+`tenantsSkipped` was permanently 0, the `partial` warning built on it could never
+fire, and — the part that actually cost something — a busy database abandoned
+every tenant after the first instead of skipping one. The rollup targets a single
+day, so an abandoned run is a permanent hole: tomorrow's pass rolls up tomorrow.
+Skipped tenants are now caught, **named** (`--date=` is the remedy and it needs
+the ids) and the loop continues. The catch is deliberately narrow — anything that
+is not `DatabaseBusyError` still reaches the job runner, or the fix would
+reintroduce the bug it is fixing.
+
+`visitor-analytics-purge.ts` carries the identical dead branch and is fixed the
+same way. It is the more serious of the two: it is what **enforces** retention,
+so an abandoned run means every tenant after the first keeps holding visitor data
+past its window — and the summary's own `(WARNING: … database busy)` clause,
+gated on the permanently-zero counter, could never print.
+
+**D5 — `failures=0` while a whole source had stopped indexing.**
+`failureCount` sums per-**document** failures across the sources that finished. A
+source whose reconcile threw never reached `results.push`, so it contributed
+nothing to that sum, and the `break` meant every source after it went
+unattempted. The engine returned `status: "failed"`;
+`scripts/site-search-reconcile.ts` summed the number and never looked at the
+status. `site-search:reconcile complete … failures=0`, exit 0, public search
+silently frozen.
+
+The engine now reports `failedSources` and `unattemptedSources` — named, and
+separate from `failureCount`, because collapsing a dead source into a document
+counter is how "0" came to mean "one whole source stopped". The script checks
+`status`, prints both lists, and exits **1**. The `break` stays: a source failing
+on a database error leaves the transaction aborted, so continuing would only
+produce a cascade of `25P02`s. That case now gets caught **per tenant** instead
+of rejecting out of the whole loop — the same lesson as D4.
+
+**D6 — a ledger that recorded contact that never happened, and a breaker one bad
+address could open.**
+
+`EmailDeliveryResult` gains `skipped`. When the Mailketing breaker opens
+*mid-pass*, `send` refuses without calling out; the dispatcher was writing a
+`failure` row into `awcms_email_delivery_attempts` and burning a `retry_count`
+for it, so a breaker that opened part-way through a batch could push the rest to
+terminal `failed` without one of them having been sent. Such a message now
+returns to `queued` untouched — no attempt row, no retry spent — counted as
+`deferred` and printed in the summary.
+
+Separately, the adapter was feeding the breaker for two **per-message business
+rejections**: a message with no recipient, and a `2xx` body carrying
+`status: "failed"`. Six invalid addresses in one batch was enough to open it and
+stop email for the whole deployment, including the password-reset messages that
+are the reason the module exists. Both now leave the breaker alone, and the
+HTTP-status branch adopts the split the sibling port already documents
+(`push-delivery/domain/fcm-error-mapping.ts`): 429 and 5xx are statements about
+the service, every other 4xx is about the message. A bad API token — the one
+shape that hides among those rejections — is `email:provider:health`'s job, and
+unlike the breaker it can tell an operator *which* problem it is.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:163a10000ee02f9bc34710df9de9dbac0944b5d725047b96e59bf43964cfdf88 -->
+<!-- i18n-source-hash: sha256:ab6615e97c418709f74d7d2934e24ead2b84689847eea94930833fa4af30ecec -->
 
 # AWCMS — Project State & Continuation
 
@@ -798,17 +798,66 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       `withTenantOrThrow` — kode mati yang menyembunyikan abort nyata.**
       `visitor-analytics-rollup.ts:97-106`. `tenantsSkipped` permanen 0, peringatan
       `partial` tak pernah bisa menyala, dan backpressure meninggalkan setiap tenant sisa
-      alih-alih melewati satu.
+      alih-alih melewati satu. Rollup hanya menyasar SATU hari, jadi
+      run yang ditinggalkan meninggalkan lubang permanen: pass besok me-rollup besok.
+
+      SELESAI (PR D4/D5/D6). Cabang mati diganti `catch` yang MELEMPAR ULANG apa pun yang
+      bukan `DatabaseBusyError` — sengaja sempit, karena mencuci query rusak menjadi
+      `tenantsSkipped` akan mengembalikan persis kelas bug yang jadi pokok temuan ini.
+      Tenant yang dilewati DISEBUT NAMANYA, bukan sekadar dihitung: `--date=` adalah
+      obatnya dan operator butuh id-nya.
+
+      Audit menyebut "dua job analitik" dan benar untuk keduanya:
+      `visitor-analytics-purge.ts:92` membawa cabang mati yang identik dan diperbaiki dengan
+      cara yang sama. Purge justru yang lebih serius. Job itulah yang MENEGAKKAN retensi,
+      jadi run yang ditinggalkan berarti setiap tenant sesudah yang pertama tetap menyimpan
+      data pengunjung melewati jendela retensinya — diam-diam, sementara ringkasannya
+      melaporkan sukses dan klausa `(WARNING: … database busy)` miliknya sendiri, yang
+      digerbangi penghitung yang permanen nol, tak pernah bisa tercetak.
+
   26. **D5 — `site-search:reconcile` keluar 0 dan mencetak `failures=0` saat satu sumber
       penuh gagal.** `site-search-reconcile.ts:57-83`. `break` di mesinnya terjadi sebelum
       `results.push`, jadi sumber yang gagal menyumbang nol ke `failureCount`. Pencarian
       publik berhenti diperbarui sementara setiap sinyal operator mengatakan sukses.
+
+      SELESAI (PR yang sama). Mesin kini melaporkan `failedSources` dan
+      `unattemptedSources`, dijaga TERPISAH dari `failureCount` — meleburkan sumber yang
+      mati ke dalam penghitung per-DOKUMEN justru itulah cara "0" berarti "satu sumber
+      penuh berhenti". Skripnya memeriksa `status`, mencetak kedua daftar, dan keluar 1.
+
+      Dua koreksi atas rekomendasinya. (a) `break` itu BENAR dan tetap: sumber yang gagal
+      karena error database meninggalkan transaksi dalam keadaan abort, jadi melanjutkan
+      hanya melahirkan rentetan `25P02` dan `finalizeRun` sendiri akan gagal. (b)
+      Sukses-palsu itu hanya terjangkau bila sumbernya melempar error **JS** (asersi
+      identifier di `buildExtractionQuery`, yang jalan sebelum SQL apa pun) — error DATABASE
+      meracuni transaksi, menyeret `finalizeRun`, lalu menolak keluar dari panggilan, dan
+      itu selalu berisik. Sampai PR ini ia berisik ke arah yang salah: ia meninggalkan
+      setiap tenant sisa. Skripnya kini menangkap PER TENANT lalu lanjut, bentuk yang sama
+      dengan D4.
+
   27. **D6 — circuit breaker email disuapi penolakan per-pesan, dan breaker terbuka dicatat
       sebagai percobaan nyata.** `mailketing-provider.ts:91-107`. Penolakan penerima tak
       sah — fakta tentang barisnya — mencatat kegagalan breaker, bertentangan dengan header
       berkas itu sendiri. Sekali terbuka, dispatcher menulis baris `failure` dan membakar
       `retry_count` untuk pesan yang tak pernah sampai ke provider: **buku besar pengiriman
       mencatat kontak yang tidak terjadi.**
+
+      SELESAI (PR yang sama). `EmailDeliveryResult` mendapat `skipped`, yang bukan percobaan
+      untuk dicatat maupun retry untuk dibelanjakan: pesan seperti itu kembali ke `queued`
+      tanpa disentuh, dihitung sebagai `deferred` dan dicetak di baris ringkasan. Angka yang
+      tidak dicetak ringkasan adalah angka yang tak dibaca siapa pun, jadi memisahkan
+      `deferred` tanpa mencetaknya justru akan membuat pass itu lebih senyap, bukan lebih
+      jelas.
+
+      Akuntansi breaker kini memakai pembagian yang sudah didokumentasikan
+      `push-delivery/domain/fcm-error-mapping.ts`: 429 dan 5xx adalah pernyataan tentang
+      LAYANAN, setiap 4xx lain tentang PESAN. Itu menutup kasus ketiga yang tak disebut
+      audit — cabang `!response.ok` juga menjatuhkan breaker pada 4xx biasa. Konkretnya:
+      ambangnya 5 kegagalan beruntun, jadi ENAM alamat tak sah dalam satu batch dulu cukup
+      untuk menghentikan email seluruh deployment, termasuk pesan reset kata sandi. Token
+      API yang benar-benar salah adalah urusan `email:provider:health`, dan tak seperti
+      breaker ia bisa memberi tahu operator masalahnya yang MANA.
+
   28. **D7 — `defaultVerificationMethod: "manual"` yang dideklarasikan `tenant_domain` tidak
       punya pembaca runtime.** `tenant-domain/module.ts:163`. Validatornya default `null` dan
       verifikasi menjawab `missing_verification_method` — keadaan `pending_verification` yang

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -815,16 +815,62 @@ pioneered directly here after the ADR-0047 freeze.)
       `tenantsSkipped` is permanently 0, the `partial` warning can never fire, and
       backpressure abandons every remaining tenant instead of skipping one. The rollup
       targets _yesterday_ only, so an aborted run leaves a permanent hole.
+
+      RESOLVED (PR for D4/D5/D6). The dead branch is a `catch` that re-throws anything that
+      is not a `DatabaseBusyError` — narrow on purpose, because laundering a broken query
+      into `tenantsSkipped` would reintroduce the exact class of bug the finding is about.
+      Skipped tenants are NAMED rather than counted: `--date=` is the remedy and an
+      operator needs the ids. The audit said "two analytics jobs" and it was right about
+      both: `visitor-analytics-purge.ts:92` carries the identical dead branch and is fixed
+      the same way.
+
+      The purge is the more serious of the two. It is what ENFORCES retention, so an
+      abandoned run means every tenant after the first keeps holding visitor data past its
+      window — silently, while the summary reports success and its `(WARNING: … database
+busy)` clause, gated on the permanently-zero counter, could never print.
+
   26. **D5 — `site-search:reconcile` exits 0 and prints `failures=0` when a whole source
       fails.** `site-search-reconcile.ts:57-83`. The engine's `break` happens before
       `results.push`, so a failed source contributes zero to `failureCount`. Public search
       stops updating while every operator signal says success.
+
+      RESOLVED (same PR). The engine now reports `failedSources` and `unattemptedSources`,
+      kept SEPARATE from `failureCount` — collapsing a dead source into a per-document
+      counter is precisely how "0" came to mean "one whole source stopped". The script
+      checks `status`, prints both lists and exits 1.
+
+      Two corrections to the recommendation. (a) The `break` is CORRECT and stays: a source
+      failing on a database error leaves the transaction aborted, so continuing would
+      produce a cascade of `25P02`s and `finalizeRun` itself would fail. (b) The
+      false-success is only reachable when the source throws a **JS** error (an identifier
+      assertion in `buildExtractionQuery`, which runs before any SQL) — a DATABASE error
+      poisons the transaction, takes `finalizeRun` down with it, and rejects out of the
+      call, which was always loud. It was also, until this PR, loud in the wrong way: it
+      abandoned every remaining tenant. The script now catches per tenant and continues,
+      the same shape as D4.
+
   27. **D6 — email circuit breaker is fed by per-message rejections, and an open breaker is
       recorded as a real attempt.** `mailketing-provider.ts:91-107`. An invalid-recipient
       rejection — a fact about the row — records a breaker failure, contrary to the file's
       own header and to the rule `push-delivery` states explicitly. Once open, the
       dispatcher writes a `failure` row and burns `retry_count` for messages that never
       reached the provider: **the delivery ledger records contacts that did not happen.**
+
+      RESOLVED (same PR). `EmailDeliveryResult` gains `skipped`, which is neither an attempt
+      to record nor a retry to spend: such a message returns to `queued` untouched, counted
+      as `deferred` and printed in the summary line. A number the summary does not print is
+      a number nobody reads, so splitting `deferred` out without printing it would have made
+      the pass quieter than before rather than clearer.
+
+      The breaker accounting is now the split `push-delivery/domain/fcm-error-mapping.ts`
+      already documents: 429 and 5xx are statements about the SERVICE, every other 4xx is
+      about the message. That removes a third case the audit did not name — the
+      `!response.ok` branch was tripping the breaker on ordinary 4xx too. Concretely: the
+      threshold is 5 consecutive failures, so SIX invalid addresses in one batch used to
+      stop email for the whole deployment, password-reset messages included. A genuinely bad
+      API token is `email:provider:health`'s job, and unlike the breaker it can tell an
+      operator WHICH problem it is.
+
   28. **D7 — `tenant_domain`'s declared `defaultVerificationMethod: "manual"` has no runtime
       reader.** `tenant-domain/module.ts:163`. The validator defaults to `null` and
       verification answers `missing_verification_method` — the `pending_verification` state

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 447   |
+| Test files                          | 448   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -354,7 +354,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 379        |
+| `(root)`      | 380        |
 | `e2e`         | 12         |
 | `integration` | 55         |
 | `unit`        | 1          |

--- a/scripts/email-dispatch.ts
+++ b/scripts/email-dispatch.ts
@@ -35,6 +35,14 @@ async function main() {
     let totalSent = 0;
     let totalRetried = 0;
     let totalFailed = 0;
+    // Finding D6 gave the dispatcher a fourth outcome, and a number the
+    // summary does not print is a number nobody reads. `deferred` rows were
+    // claimed and released without any contact; `suppressed` ones were never
+    // going to be sent. Both used to hide inside `claimed`, so a pass that
+    // sent nothing at all could still print `sent=0 failed=0` and look idle.
+    let totalDeferred = 0;
+    let totalSuppressed = 0;
+    let breakerSeenOpen = false;
 
     for (const tenant of tenants) {
       for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
@@ -46,6 +54,9 @@ async function main() {
         totalSent += result.sent;
         totalRetried += result.retried;
         totalFailed += result.failed;
+        totalDeferred += result.deferred;
+        totalSuppressed += result.suppressed;
+        breakerSeenOpen ||= result.breakerOpen;
 
         if (result.claimed === 0) {
           break;
@@ -56,8 +67,22 @@ async function main() {
     console.log(
       `email:dispatch complete — correlationId=${correlationId} ` +
         `tenants=${tenants.length} claimed=${totalClaimed} sent=${totalSent} ` +
-        `retried=${totalRetried} failed=${totalFailed}`
+        `retried=${totalRetried} failed=${totalFailed} ` +
+        `deferred=${totalDeferred} suppressed=${totalSuppressed} ` +
+        `breakerOpen=${breakerSeenOpen}`
     );
+
+    if (totalDeferred > 0 || breakerSeenOpen) {
+      // Deliberately not a non-zero exit, unlike `site-search:reconcile`. An
+      // open breaker is transient and self-healing, the deferred rows are back
+      // in `queued` with their retries intact, and the next scheduled pass
+      // sends them. Paging on it would page on the provider's weather.
+      console.warn(
+        `email:dispatch — the Mailketing circuit breaker was open; ` +
+          `${totalDeferred} claimed message(s) were released back to 'queued' ` +
+          "without an attempt. They go out on the next pass once the breaker closes."
+      );
+    }
   } catch (error) {
     logScriptFailure("email:dispatch FAILED", error);
   } finally {

--- a/scripts/site-search-reconcile.ts
+++ b/scripts/site-search-reconcile.ts
@@ -54,30 +54,80 @@ async function main(): Promise<void> {
     let totalIndexed = 0;
     let totalRemoved = 0;
     let totalFailures = 0;
+    // Finding D5 — this script summed `result.failureCount` and printed it, and
+    // never looked at `result.status`. `failureCount` counts DOCUMENTS that
+    // failed to map or upsert; a source whose reconcile threw contributes zero
+    // to it. So a run where a whole source stopped indexing printed
+    // `failures=0` and exited 0, while public search quietly stopped updating.
+    const failedTenants: string[] = [];
+    const failedSources = new Set<string>();
+    const unattemptedSources = new Set<string>();
+    let lastError: string | null = null;
 
     for (const tenant of tenants) {
-      const result = await withTenantOrThrow(
-        sql,
-        tenant.id,
-        (tx) =>
-          (rebuild ? rebuildTenantSearchIndex : reconcileTenantSearchIndex)(
-            tx,
-            tenant.id,
-            descriptors,
-            { trigger: "scheduled" }
-          ),
-        { workClass: "maintenance" }
-      );
+      // The other half of the same failure, and the one D4 names in
+      // `visitor-analytics-rollup.ts`: a source failing on a DATABASE error
+      // aborts the transaction, so `finalizeRun` cannot even write the run row
+      // and the whole call REJECTS. That was loud — it reached
+      // `logScriptFailure` and exited 1 — but it also abandoned every tenant
+      // after this one, on one tenant's bad row. Each tenant is an independent
+      // unit of work; one is now recorded and the loop continues.
+      let result;
+
+      try {
+        result = await withTenantOrThrow(
+          sql,
+          tenant.id,
+          (tx) =>
+            (rebuild ? rebuildTenantSearchIndex : reconcileTenantSearchIndex)(
+              tx,
+              tenant.id,
+              descriptors,
+              { trigger: "scheduled" }
+            ),
+          { workClass: "maintenance" }
+        );
+      } catch (error) {
+        failedTenants.push(tenant.id);
+        lastError = error instanceof Error ? error.message : String(error);
+        continue;
+      }
+
       totalIndexed += result.totalIndexed;
       totalRemoved += result.totalRemoved;
       totalFailures += result.failureCount;
+
+      if (result.status === "failed") {
+        failedTenants.push(tenant.id);
+        for (const key of result.failedSources) failedSources.add(key);
+        for (const key of result.unattemptedSources)
+          unattemptedSources.add(key);
+        lastError = result.lastError ?? lastError;
+      }
     }
 
     console.log(
       `site-search:reconcile complete — correlationId=${correlationId} ` +
         `mode=${rebuild ? "rebuild" : "reconcile"} tenants=${tenants.length} ` +
-        `indexed=${totalIndexed} removed=${totalRemoved} failures=${totalFailures}`
+        `indexed=${totalIndexed} removed=${totalRemoved} failures=${totalFailures} ` +
+        `tenantsFailed=${failedTenants.length}`
     );
+
+    if (failedTenants.length > 0) {
+      // Non-zero exit, because the whole point is that this used to be
+      // indistinguishable from success. `logScriptFailure` sets
+      // `process.exitCode = 1` only for an error that escapes the loop, and
+      // the loop no longer lets one escape — so it has to be said here.
+      console.error(
+        `site-search:reconcile INCOMPLETE — ${failedTenants.length} tenant(s) failed: ` +
+          `${failedTenants.join(", ")}\n` +
+          `  sources that failed:      ${[...failedSources].join(", ") || "(none named)"}\n` +
+          `  sources never attempted:  ${[...unattemptedSources].join(", ") || "(none)"}\n` +
+          `  last error:               ${lastError ?? "(none recorded)"}\n` +
+          "  Public search stops updating for the sources above until this is fixed."
+      );
+      process.exitCode = 1;
+    }
   } catch (error) {
     logScriptFailure("site-search:reconcile FAILED", error);
   } finally {

--- a/scripts/visitor-analytics-purge.ts
+++ b/scripts/visitor-analytics-purge.ts
@@ -25,7 +25,10 @@
  * deleting/clearing anything.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
-import { withTenantOrThrow } from "../src/lib/database/tenant-context";
+import {
+  DatabaseBusyError,
+  withTenantOrThrow
+} from "../src/lib/database/tenant-context";
 import {
   applyJobExitCode,
   formatJobOutcomeLine,
@@ -51,6 +54,8 @@ export type VisitorAnalyticsPurgeResult = {
   sessionsDeleted: number;
   rollupsDeleted: number;
   tenantsSkipped: number;
+  /** Named, not just counted — a re-run needs to know which tenants still hold data past retention. */
+  skippedTenantIds: string[];
 };
 
 export async function runVisitorAnalyticsPurge(
@@ -67,7 +72,8 @@ export async function runVisitorAnalyticsPurge(
     sessionsRawDetailCleared: 0,
     sessionsDeleted: 0,
     rollupsDeleted: 0,
-    tenantsSkipped: 0
+    tenantsSkipped: 0,
+    skippedTenantIds: []
   };
 
   if (ctx.dryRun) {
@@ -79,25 +85,41 @@ export async function runVisitorAnalyticsPurge(
       break;
     }
 
-    const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
-      purgeVisitorAnalyticsData(
-        tx,
-        tenant.id,
-        config,
-        now,
-        legalHoldGuardPortAdapter
-      )
-    );
+    // Finding D4, second occurrence — `if (result instanceof Response)` was
+    // DEAD here too. That shape only ever comes out of `withTenant`;
+    // `withTenantOrThrow` THROWS `DatabaseBusyError`. So `tenantsSkipped` was
+    // permanently 0, the summary's `(WARNING: … database busy)` clause could
+    // never print, and a busy database abandoned every remaining tenant.
+    //
+    // The stakes here are higher than the rollup's. This job is what ENFORCES
+    // retention: an abandoned run means every tenant after the first keeps
+    // holding visitor data past its retention window, silently, until someone
+    // notices the counts are too low — and the summary was reporting success.
+    try {
+      const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
+        purgeVisitorAnalyticsData(
+          tx,
+          tenant.id,
+          config,
+          now,
+          legalHoldGuardPortAdapter
+        )
+      );
 
-    if (result instanceof Response) {
+      totals.eventsDeleted += result.eventsDeleted;
+      totals.sessionsRawDetailCleared += result.sessionsRawDetailCleared;
+      totals.sessionsDeleted += result.sessionsDeleted;
+      totals.rollupsDeleted += result.rollupsDeleted;
+    } catch (error) {
+      // ONLY backpressure is a skip. A legal-hold refusal or a broken query is
+      // a real failure and must reach the job runner, which classifies a
+      // thrown error as a retryable failure — swallowing it would turn a
+      // retention job that cannot run into a quiet zero.
+      if (!(error instanceof DatabaseBusyError)) throw error;
+
       totals.tenantsSkipped += 1;
-      continue;
+      totals.skippedTenantIds.push(tenant.id);
     }
-
-    totals.eventsDeleted += result.eventsDeleted;
-    totals.sessionsRawDetailCleared += result.sessionsRawDetailCleared;
-    totals.sessionsDeleted += result.sessionsDeleted;
-    totals.rollupsDeleted += result.rollupsDeleted;
   }
 
   return totals;
@@ -125,7 +147,8 @@ async function main() {
               `sessionsDeleted=${purgeResult.sessionsDeleted} rollupsDeleted=${purgeResult.rollupsDeleted}` +
               (ctx.dryRun ? " (dry-run: nothing was deleted)" : "") +
               (skipped
-                ? ` (WARNING: ${purgeResult.tenantsSkipped} tenant(s) skipped — database busy)`
+                ? ` (WARNING: ${purgeResult.tenantsSkipped} tenant(s) skipped — database busy;` +
+                  ` data past retention is STILL HELD for: ${purgeResult.skippedTenantIds.join(", ")})`
                 : "")
           );
 

--- a/scripts/visitor-analytics-rollup.ts
+++ b/scripts/visitor-analytics-rollup.ts
@@ -33,6 +33,7 @@ import {
 } from "../src/lib/jobs/job-runner";
 import { fetchActiveTenants } from "../src/lib/jobs/batching";
 import { rollupVisitorAnalyticsForDate } from "../src/modules/visitor-analytics/application/rollup";
+import { DatabaseBusyError } from "../src/lib/database/tenant-context";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -66,6 +67,8 @@ export type VisitorAnalyticsRollupResult = {
   tenantsRolledUp: number;
   areasProcessed: number;
   tenantsSkipped: number;
+  /** Named, not just counted: `--date=` is the remedy and it needs the ids. */
+  skippedTenantIds: string[];
 };
 
 export async function runVisitorAnalyticsRollup(
@@ -81,32 +84,49 @@ export async function runVisitorAnalyticsRollup(
       tenantsChecked: tenants.length,
       tenantsRolledUp: 0,
       areasProcessed: 0,
-      tenantsSkipped: 0
+      tenantsSkipped: 0,
+      skippedTenantIds: []
     };
   }
 
   let tenantsRolledUp = 0;
   let areasProcessed = 0;
-  let tenantsSkipped = 0;
+  const skippedTenantIds: string[] = [];
 
   for (const tenant of tenants) {
     if (ctx.signal?.aborted) {
       break;
     }
 
-    const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
-      rollupVisitorAnalyticsForDate(tx, tenant.id, date)
-    );
+    // Finding D4 — this used to read
+    // `if (result instanceof Response) { tenantsSkipped += 1; continue; }`,
+    // and that branch was DEAD. `withTenant` returns a 503 `Response` on
+    // backpressure; `withTenantOrThrow`, which is what this loop calls,
+    // THROWS a `DatabaseBusyError` instead. So `tenantsSkipped` was
+    // permanently 0, the `partial` warning built on it could never fire, and
+    // — the part that actually cost something — a busy database abandoned
+    // every REMAINING tenant instead of skipping one.
+    //
+    // The rollup targets a single day, so an abandoned run is a permanent
+    // hole: tomorrow's pass rolls up tomorrow. That is why the ids are
+    // collected and printed rather than counted — `--date=` is the remedy and
+    // an operator needs to know which tenants to name.
+    try {
+      const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
+        rollupVisitorAnalyticsForDate(tx, tenant.id, date)
+      );
 
-    // `withTenant` returns a 503 `Response` when the circuit breaker is open /
-    // a work-class queue is saturated — count it as skipped, not processed.
-    if (result instanceof Response) {
-      tenantsSkipped += 1;
-      continue;
+      tenantsRolledUp += 1;
+      areasProcessed += result.areasProcessed;
+    } catch (error) {
+      // ONLY backpressure is a skip. Anything else is a defect in the rollup
+      // and must reach the job runner, which classifies a thrown error as a
+      // retryable failure — swallowing it would turn a broken query into a
+      // quiet zero.
+      if (!(error instanceof DatabaseBusyError)) throw error;
+
+      skippedTenantIds.push(tenant.id);
     }
-
-    tenantsRolledUp += 1;
-    areasProcessed += result.areasProcessed;
   }
 
   return {
@@ -114,7 +134,8 @@ export async function runVisitorAnalyticsRollup(
     tenantsChecked: tenants.length,
     tenantsRolledUp,
     areasProcessed,
-    tenantsSkipped
+    tenantsSkipped: skippedTenantIds.length,
+    skippedTenantIds
   };
 }
 
@@ -139,7 +160,7 @@ async function main() {
               `rolledUp=${rollupResult.tenantsRolledUp} areas=${rollupResult.areasProcessed}` +
               (ctx.dryRun ? " (dry-run: nothing was written)" : "") +
               (skipped
-                ? ` (WARNING: ${rollupResult.tenantsSkipped} tenant(s) skipped — database busy)`
+                ? ` (WARNING: ${rollupResult.tenantsSkipped} tenant(s) skipped — database busy; re-run with --date=${date} for: ${rollupResult.skippedTenantIds.join(", ")})`
                 : "")
           );
 

--- a/src/modules/email/application/email-dispatch.ts
+++ b/src/modules/email/application/email-dispatch.ts
@@ -84,6 +84,13 @@ export type DispatchEmailQueueResult = {
   retried: number;
   failed: number;
   suppressed: number;
+  /**
+   * Finding D6 — claimed messages the provider refused to even attempt (the
+   * breaker opening MID-pass). Returned to `queued` untouched: no
+   * `awcms_email_delivery_attempts` row, no `retry_count` increment. Counted
+   * separately from `failed`/`retried` precisely because it is neither.
+   */
+  deferred: number;
   breakerOpen: boolean;
 };
 
@@ -259,6 +266,44 @@ async function finalizeSuppressed(
   );
 }
 
+/**
+ * Finding D6 — the provider declined to attempt this message at all, so the
+ * claim is simply undone.
+ *
+ * `status = 'queued'` with `next_attempt_at = null` restores exactly the
+ * pre-claim state: the row was already due when `claimEligibleEntries` picked
+ * it up, so it is due again. No backoff is skipped, because no backoff was
+ * consumed — `retry_count` is deliberately not touched.
+ *
+ * What this replaced: `recordDeliveryAttempt(… 'failure' …)` followed by
+ * `finalizeFailure(…)`. That wrote a delivery-attempt row for a contact that
+ * never happened and spent one of the message's retries on it, so a breaker
+ * that opened part-way through a pass could push the rest of the batch to
+ * terminal `failed` without a single one of them having been sent.
+ *
+ * `last_error` carries the reason with an explicit non-attempt prefix, so the
+ * queue explains itself to an operator without the string being mistakable
+ * for a delivery failure.
+ */
+async function finalizeDeferred(
+  sql: Bun.SQL,
+  tenantId: string,
+  id: string,
+  reason: string
+): Promise<void> {
+  await withTenantOrThrow(
+    sql,
+    tenantId,
+    (tx) => tx`
+      UPDATE awcms_email_messages
+      SET status = 'queued', next_attempt_at = null,
+          last_error = ${`Deferred (no attempt made): ${reason}`}
+      WHERE tenant_id = ${tenantId} AND id = ${id} AND status = 'sending'
+    `,
+    { workClass: "background_sync" }
+  );
+}
+
 async function finalizeFailure(
   sql: Bun.SQL,
   tenantId: string,
@@ -367,6 +412,7 @@ export async function dispatchEmailQueue(
     retried: 0,
     failed: 0,
     suppressed: 0,
+    deferred: 0,
     breakerOpen
   };
 
@@ -515,6 +561,24 @@ export async function dispatchEmailQueue(
     const safeError = redactEmailAddressesInText(
       deliveryResult.error.slice(0, MAX_RESPONSE_SNIPPET_LENGTH)
     );
+
+    if (deliveryResult.skipped) {
+      // Nothing reached the provider. Undo the claim and move on — the loop
+      // deliberately does NOT break, because every remaining claimed row also
+      // needs releasing; breaking would leave them in `sending` until their
+      // lease expires. `provider.send` returns immediately once the breaker is
+      // open, so finishing the batch costs nothing outbound.
+      await finalizeDeferred(sql, tenantId, entry.id, safeError);
+      log("warning", "email.dispatch.deferred", {
+        correlationId: messageCorrelationId,
+        tenantId,
+        moduleKey: MODULE_KEY,
+        category: entry.category,
+        error: safeError
+      });
+      result.deferred += 1;
+      continue;
+    }
 
     await recordDeliveryAttempt(
       sql,

--- a/src/modules/email/domain/email-provider-contract.ts
+++ b/src/modules/email/domain/email-provider-contract.ts
@@ -47,7 +47,24 @@ export type EmailMessage = {
 
 export type EmailDeliveryResult =
   | { ok: true; providerMessageId?: string }
-  | { ok: false; error: string; retryable: boolean };
+  | {
+      ok: false;
+      error: string;
+      retryable: boolean;
+      /**
+       * Finding D6 — no attempt reached the provider AT ALL, and the
+       * dispatcher must not record one. Set when the adapter refuses to call
+       * out (the circuit breaker opening part-way through a pass is the only
+       * case today).
+       *
+       * Without this flag such a message was indistinguishable from a failed
+       * send: the dispatcher wrote a `failure` row into
+       * `awcms_email_delivery_attempts` and burned one of the message's
+       * retries for a contact that never happened. A skipped message returns
+       * to `queued` with its `retry_count` untouched and no ledger row.
+       */
+      skipped?: true;
+    };
 
 export type EmailHealthCheckResult =
   { ok: true } | { ok: false; error: string };
@@ -56,7 +73,20 @@ export type EmailHealthCheckResult =
  * The port. `retryable` on a failed send tells the dispatcher (Issue #495)
  * whether to schedule a retry (`queued → retry_wait`) or move straight to
  * a terminal `failed`/`suppressed` state — e.g. an invalid recipient
- * address is not retryable, a provider timeout is.
+ * address is not retryable, a provider timeout is. `skipped` is the third
+ * answer: not "it failed and may work later" but "it was never tried", which
+ * is neither an attempt to record nor a retry to spend.
+ *
+ * ## Who feeds the circuit breaker
+ *
+ * The ADAPTER, and only the adapter, as `push-delivery`'s
+ * `fcm-error-mapping.ts` states for the sibling port. The breaker exists to
+ * stop hammering a provider that is DOWN, so only statements about the
+ * SERVICE count toward it — a timeout, a 5xx, an unparseable body. A
+ * per-message business rejection (no recipient, a malformed address, a
+ * refused payload) says nothing about the provider's health and must not
+ * trip it, or one bad address in a batch takes email delivery down for
+ * everybody.
  */
 export type EmailProvider = {
   send(message: EmailMessage): Promise<EmailDeliveryResult>;

--- a/src/modules/email/infrastructure/mailketing-provider.ts
+++ b/src/modules/email/infrastructure/mailketing-provider.ts
@@ -60,6 +60,23 @@ function truncate(message: string): string {
  * `status: "failed"` is a provider-side validation/business rejection
  * (invalid recipient, bad token, etc.) — `retryable: false`, since retrying
  * an identical request cannot change the outcome.
+ *
+ * ## What counts toward the circuit breaker (finding D6)
+ *
+ * Only statements about the SERVICE: a network error, a timeout, a 5xx, a
+ * body that is not JSON. The breaker exists to stop hammering a provider that
+ * is down, and `push-delivery/domain/fcm-error-mapping.ts` states the same
+ * rule for the sibling port.
+ *
+ * Two branches used to trip it and no longer do — a message with no recipient,
+ * and a `2xx` body carrying `status: "failed"`. Both are per-message business
+ * rejections, which this file's own paragraph above already classifies as
+ * `retryable: false`. Counting them meant a handful of bad addresses in one
+ * batch could open the breaker and stop email for the whole deployment,
+ * including the password-reset messages that are the reason this module
+ * exists. A genuinely bad API token — the one shape that hides among those
+ * rejections — is `email:provider:health`'s job (`healthCheck` probes exactly
+ * that, and unlike the breaker it can tell an operator WHICH problem it is).
  */
 export function createMailketingEmailProvider(
   config: MailketingProviderConfig
@@ -90,17 +107,24 @@ export function createMailketingEmailProvider(
       const attemptedAt = new Date();
 
       if (!breaker.canAttempt(attemptedAt)) {
+        // `skipped` — nothing was sent, so there is no attempt to record and
+        // no retry to spend. `dispatchEmailQueue` short-circuits when the
+        // breaker is already open at the START of a pass; this branch is the
+        // one that opens MID-pass, and it used to bill the remaining claimed
+        // messages for a contact that never happened.
         return {
           ok: false,
-          error: "Mailketing circuit breaker is open; skipping attempt.",
-          retryable: true
+          error: "Mailketing circuit breaker is open; no attempt was made.",
+          retryable: true,
+          skipped: true
         };
       }
 
       const recipient = message.to[0]?.address;
 
       if (!recipient) {
-        breaker.recordFailure(attemptedAt);
+        // Deliberately does NOT feed the breaker: a message with no recipient
+        // is this deployment's own bad row, not a Mailketing outage.
         return {
           ok: false,
           error: "Email message has no recipient address.",
@@ -121,7 +145,13 @@ export function createMailketingEmailProvider(
         const { response, rawBody } = await callSend(formData);
 
         if (!response.ok) {
-          breaker.recordFailure(attemptedAt);
+          // Same split the sibling port draws (`fcm-error-mapping.ts`): 429 and
+          // 5xx are statements about the service; every other 4xx means the
+          // request was understood and refused, which is about this message.
+          if (response.status === 429 || response.status >= 500) {
+            breaker.recordFailure(attemptedAt);
+          }
+
           return {
             ok: false,
             error: truncate(
@@ -145,7 +175,8 @@ export function createMailketingEmailProvider(
         }
 
         if (parsed.status !== "success") {
-          breaker.recordFailure(attemptedAt);
+          // Also deliberately breaker-free. Mailketing answered, in time, with
+          // a well-formed body — it is up. It just refused THIS message.
           return {
             ok: false,
             error: truncate(parsed.response ?? "Unknown error from Mailketing"),

--- a/src/modules/site-search/application/search-index-engine.ts
+++ b/src/modules/site-search/application/search-index-engine.ts
@@ -68,6 +68,10 @@ export type IndexRunResult = {
   totalIndexed: number;
   totalRemoved: number;
   failureCount: number;
+  /** Sources whose reconcile THREW. Distinct from `failureCount`, which counts documents. */
+  failedSources: string[];
+  /** Sources never attempted because an earlier one failed and aborted the transaction. */
+  unattemptedSources: string[];
   lastError: string | null;
 };
 
@@ -396,7 +400,21 @@ async function runReconcile(
   let status: "succeeded" | "failed" = "succeeded";
   let lastError: string | null = null;
 
-  for (const descriptor of descriptors) {
+  // Finding D5 — a source that THROWS never reaches `results.push`, so it
+  // contributed zero to `failureCount` (which sums per-document failures across
+  // the results that succeeded) and the `break` meant every source after it was
+  // never attempted either. The run row said `failed`, and the operator-facing
+  // number said `failures=0`.
+  //
+  // The `break` STAYS. `reconcileSource` failing is almost always a database
+  // error, which leaves this transaction aborted — continuing would produce a
+  // cascade of `25P02`s and `finalizeRun` itself would fail. What changes is
+  // that the sources are now named: the one that failed, and the ones that were
+  // consequently never attempted.
+  const failedSources: string[] = [];
+  const unattemptedSources: string[] = [];
+
+  for (const [index, descriptor] of descriptors.entries()) {
     try {
       results.push(
         await reconcileSource(tx, tenantId, descriptor, {
@@ -407,6 +425,10 @@ async function runReconcile(
     } catch (error) {
       status = "failed";
       lastError = safeErrorDetail(error).slice(0, MAX_FAILURE_DETAIL_LENGTH);
+      failedSources.push(descriptor.key);
+      unattemptedSources.push(
+        ...descriptors.slice(index + 1).map((rest) => rest.key)
+      );
       break;
     }
   }
@@ -430,7 +452,13 @@ async function runReconcile(
       status,
       documentsIndexed: totalIndexed,
       documentsRemoved: totalRemoved,
-      failureCount
+      failureCount,
+      // Named separately from `failureCount`, which counts DOCUMENTS that
+      // failed to map or upsert. A source that died is a different fact and
+      // summing them into one number is how "failures=0" came to mean
+      // "one whole source stopped indexing".
+      failedSources,
+      unattemptedSources
     }
   );
 
@@ -442,6 +470,8 @@ async function runReconcile(
     totalIndexed,
     totalRemoved,
     failureCount,
+    failedSources,
+    unattemptedSources,
     lastError
   };
 }

--- a/tests/integration/site-search.integration.test.ts
+++ b/tests/integration/site-search.integration.test.ts
@@ -990,4 +990,109 @@ suite("site_search module (integration, ADR-0040)", () => {
       expect(facets.terms).toEqual({});
     });
   });
+  /**
+   * Finding D5 of the 17 August 2026 audit round — a reconcile that reported
+   * `failures=0` while a whole source had stopped indexing.
+   *
+   * `failureCount` sums the per-DOCUMENT failures recorded on each
+   * `SourceReconcileResult`. A source whose reconcile THREW never reached
+   * `results.push`, so it contributed nothing to that sum, and the `break`
+   * meant every source after it was never attempted either. The engine
+   * returned `status: "failed"`; the script summing the number never looked at
+   * it. `site-search:reconcile complete … failures=0`, exit 0, and public
+   * search silently frozen for that source.
+   *
+   * The source used here fails inside `buildExtractionQuery`'s identifier
+   * assertion, which runs BEFORE any SQL — so the transaction stays healthy and
+   * `finalizeRun` still commits the run row. That is the reachable half of the
+   * finding. The other half, a source that fails on a DATABASE error, aborts
+   * the transaction, takes `finalizeRun` down with it and rejects out of the
+   * call entirely; that was always loud, and `scripts/site-search-reconcile.ts`
+   * now catches it per tenant rather than abandoning the rest of the run.
+   */
+  describe("a source that dies is NAMED, not averaged into failures=0 (D5)", () => {
+    const BROKEN = {
+      key: "test_broken.source",
+      ownerModuleKey: "test_broken",
+      resourceType: "broken",
+      tableName: "awcms_blog_posts",
+      localeColumn: "locale",
+      updatedAtColumn: "updated_at",
+      // Rejected by `assertSafeIdentifier` — a plain JS throw, before a single
+      // statement is sent.
+      titleColumn: "title; DROP TABLE awcms_blog_posts",
+      bodyColumns: ["content_text"],
+      slugColumn: "slug",
+      urlTemplate: "/blog/:tenantCode/:slug",
+      publicPredicateSql: "status = 'published'"
+    } as unknown as (typeof SOURCES)[number];
+
+    test("the run reports WHICH source failed and which were never attempted", async () => {
+      await insertPost(TENANT_A, {
+        title: "Indexable one",
+        body: "indexable body",
+        slug: "indexable"
+      });
+
+      const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_A, [BROKEN, ...SOURCES])
+      );
+
+      expect(result.status).toBe("failed");
+      // The number the operator used to read. It is STILL zero — no document
+      // failed to map or upsert — which is exactly why it could never have
+      // carried this fact and why the fix is a separate field rather than a
+      // bigger count.
+      expect(result.failureCount).toBe(0);
+      expect(result.failedSources).toEqual([BROKEN.key]);
+      expect(result.unattemptedSources).toEqual(SOURCES.map((s) => s.key));
+      expect(result.lastError).toContain("unsafe titleColumn identifier");
+    });
+
+    test("sources that DID run are still reported, and their documents indexed", async () => {
+      // Ordering flipped: the real sources run first, the broken one last. The
+      // engine must report both halves — what succeeded and what did not — not
+      // collapse the run to a single verdict.
+      await insertPost(TENANT_A, {
+        title: "Alpha bright fox",
+        body: "fox body",
+        slug: "alpha"
+      });
+
+      const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_A, [...SOURCES, BROKEN])
+      );
+
+      expect(result.status).toBe("failed");
+      expect(result.results).toHaveLength(SOURCES.length);
+      expect(result.totalIndexed).toBe(1);
+      expect(result.failedSources).toEqual([BROKEN.key]);
+      // Nothing came after it, so nothing was abandoned.
+      expect(result.unattemptedSources).toEqual([]);
+
+      // The run row COMMITTED: this failure path leaves the transaction usable,
+      // which is what makes the misreported result observable at all.
+      const runs = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        fetchRecentRuns(tx, TENANT_A, 1)
+      );
+      expect(runs[0]!.status).toBe("failed");
+      expect(Number(runs[0]!.failureCount)).toBe(0);
+    });
+
+    test("a clean run names nothing — the fields are not always-populated noise", async () => {
+      await insertPost(TENANT_A, {
+        title: "Clean run",
+        body: "clean body",
+        slug: "clean"
+      });
+
+      const result = await withTenantOrThrow(getRuntimeSql(), TENANT_A, (tx) =>
+        reconcileTenantSearchIndex(tx, TENANT_A, SOURCES)
+      );
+
+      expect(result.status).toBe("succeeded");
+      expect(result.failedSources).toEqual([]);
+      expect(result.unattemptedSources).toEqual([]);
+    });
+  });
 });

--- a/tests/jobs-that-report-false-success.test.ts
+++ b/tests/jobs-that-report-false-success.test.ts
@@ -1,0 +1,525 @@
+/**
+ * Findings D4, D5 and D6 of the 17 August 2026 audit round — three jobs that
+ * reported success while doing nothing.
+ *
+ * They are one PR because they are one failure mode, and it is the one that
+ * survives every other kind of check: the code runs, the exit code is 0, the
+ * summary line prints a number, and the number is wrong in the direction that
+ * looks fine. Nothing is thrown, so no alert fires; nothing is logged as an
+ * error, so no dashboard reddens. The only way to catch it is to assert on the
+ * count itself.
+ *
+ * D5's engine half needs a live database and lives in
+ * `tests/integration/site-search.integration.test.ts`; what is here is
+ * everything provable without one.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  getDatabaseCircuitBreaker,
+  resetDatabaseCircuitBreakerForTests,
+  resetProviderCircuitBreakersForTests
+} from "../src/lib/database/circuit-breaker";
+import { dispatchEmailQueue } from "../src/modules/email/application/email-dispatch";
+import type {
+  EmailMessage,
+  EmailProvider
+} from "../src/modules/email/domain/email-provider-contract";
+import { createMailketingEmailProvider } from "../src/modules/email/infrastructure/mailketing-provider";
+import { stripComments } from "../scripts/lib/source-text";
+import { runVisitorAnalyticsPurge } from "../scripts/visitor-analytics-purge";
+import { runVisitorAnalyticsRollup } from "../scripts/visitor-analytics-rollup";
+import { VISITOR_ANALYTICS_DEFAULTS } from "../src/modules/visitor-analytics/domain/visitor-analytics-config";
+
+const TENANT_A = "11111111-1111-1111-1111-111111111111";
+const TENANT_B = "22222222-2222-2222-2222-222222222222";
+const MESSAGE_ID = "33333333-3333-3333-3333-333333333333";
+const NOW = new Date("2026-08-17T10:00:00.000Z");
+
+/** `createCircuitBreaker`'s `DEFAULT_FAILURE_THRESHOLD`. */
+const BREAKER_THRESHOLD = 5;
+
+type CapturedQuery = { text: string; values: unknown[] };
+
+/**
+ * The same "implement only the calls the code under test actually makes" fake
+ * `Bun.SQL` that `email-dispatch-lease.test.ts` established. `onQuery` lets a
+ * test make one specific statement fail.
+ */
+function createFakeSql(
+  reply: (text: string) => unknown[] | undefined,
+  onQuery?: (text: string) => void
+): { sql: Bun.SQL; queries: CapturedQuery[] } {
+  const queries: CapturedQuery[] = [];
+
+  const run = (strings: TemplateStringsArray, ...values: unknown[]) => {
+    const text = strings.join(" ? ").replace(/\s+/g, " ").trim();
+
+    queries.push({ text, values });
+    onQuery?.(text);
+
+    return Promise.resolve(reply(text) ?? []);
+  };
+
+  run.unsafe = (text: string, values: unknown[] = []) => {
+    queries.push({ text, values });
+    onQuery?.(text);
+
+    return Promise.resolve(reply(text) ?? []);
+  };
+  run.array = (values: unknown[], type: string) => ({ values, type });
+  run.begin = (callback: (tx: Bun.TransactionSQL) => Promise<unknown>) =>
+    callback(run as unknown as Bun.TransactionSQL);
+  run.savepoint = (callback: (sp: Bun.TransactionSQL) => Promise<unknown>) =>
+    callback(run as unknown as Bun.TransactionSQL);
+
+  return { sql: run as unknown as Bun.SQL, queries };
+}
+
+describe("D4 — two analytics jobs abandoned every remaining tenant", () => {
+  afterEach(() => {
+    resetDatabaseCircuitBreakerForTests();
+  });
+
+  function rollupSql(onQuery?: (text: string) => void) {
+    return createFakeSql((text) => {
+      if (text.includes("FROM awcms_tenants")) {
+        return [{ id: TENANT_A }, { id: TENANT_B }];
+      }
+
+      return [];
+    }, onQuery);
+  }
+
+  test("a busy database SKIPS the tenant and names it, instead of taking the run down", async () => {
+    const { sql } = rollupSql();
+
+    // `withTenantOrThrow` refuses with `DatabaseBusyError` while the database
+    // circuit breaker is open — the exact backpressure the dead
+    // `result instanceof Response` branch was written for and could never see,
+    // because that shape only ever comes out of `withTenant`.
+    //
+    // Recorded against the REAL clock, not `NOW`: the breaker's open window is
+    // 30 s, and `runTenantWork` asks `canAttempt(new Date())`. Tripping it with
+    // a fixed past timestamp opens it and then immediately elapses it to
+    // half-open, which lets the attempt through — the test would pass for the
+    // wrong reason and prove nothing.
+    const breaker = getDatabaseCircuitBreaker();
+    for (let i = 0; i < BREAKER_THRESHOLD; i += 1) {
+      breaker.recordFailure(new Date());
+    }
+
+    const result = await runVisitorAnalyticsRollup(
+      sql,
+      { dryRun: false },
+      "2026-08-16"
+    );
+
+    // Both tenants were CHECKED — the loop ran to the end rather than dying on
+    // the first one.
+    expect(result.tenantsChecked).toBe(2);
+    expect(result.tenantsSkipped).toBe(2);
+    // Named, not just counted. `--date=` is the remedy and it needs the ids.
+    expect(result.skippedTenantIds).toEqual([TENANT_A, TENANT_B]);
+    expect(result.tenantsRolledUp).toBe(0);
+  });
+
+  test("a rollup DEFECT is not swallowed as a skip — it reaches the job runner", async () => {
+    // The catch is deliberately narrow. A broken query must not be laundered
+    // into `tenantsSkipped`, or the class of bug this finding is about comes
+    // straight back in the fix for it.
+    const { sql } = rollupSql((text) => {
+      if (text.includes("FROM awcms_visit_events")) {
+        throw new Error("boom: relation does not exist");
+      }
+    });
+
+    let thrown: unknown = null;
+
+    try {
+      await runVisitorAnalyticsRollup(sql, { dryRun: false }, "2026-08-16");
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect((thrown as Error | null)?.message).toContain("boom");
+  });
+
+  test("the RETENTION purge had the identical dead branch, and it matters more", async () => {
+    // The audit said "two analytics jobs" and it was right about both. This one
+    // is what ENFORCES retention: an abandoned run means every tenant after the
+    // first keeps holding visitor data past its window, silently, while the
+    // summary reports success — and the summary's own
+    // `(WARNING: … database busy)` clause was gated on the permanently-zero
+    // counter, so it could never print.
+    const { sql } = createFakeSql((text) =>
+      text.includes("FROM awcms_tenants")
+        ? [{ id: TENANT_A }, { id: TENANT_B }]
+        : []
+    );
+
+    const breaker = getDatabaseCircuitBreaker();
+    for (let i = 0; i < BREAKER_THRESHOLD; i += 1) {
+      breaker.recordFailure(new Date());
+    }
+
+    const result = await runVisitorAnalyticsPurge(
+      sql,
+      { dryRun: false },
+      VISITOR_ANALYTICS_DEFAULTS
+    );
+
+    expect(result.tenantsChecked).toBe(2);
+    expect(result.tenantsSkipped).toBe(2);
+    expect(result.skippedTenantIds).toEqual([TENANT_A, TENANT_B]);
+  });
+
+  test("a purge DEFECT — a legal hold, a broken query — is not laundered into a skip", async () => {
+    const { sql } = createFakeSql(
+      (text) =>
+        text.includes("FROM awcms_tenants")
+          ? [{ id: TENANT_A }, { id: TENANT_B }]
+          : [],
+      (text) => {
+        if (text.includes("DELETE FROM awcms_visit_events")) {
+          throw new Error("boom: legal hold");
+        }
+      }
+    );
+
+    let thrown: unknown = null;
+
+    try {
+      await runVisitorAnalyticsPurge(
+        sql,
+        { dryRun: false },
+        VISITOR_ANALYTICS_DEFAULTS
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect((thrown as Error | null)?.message).toContain("boom");
+  });
+});
+
+describe("D6 — the email dispatcher billed messages for contact that never happened", () => {
+  const ENV = {
+    EMAIL_ENABLED: "true",
+    EMAIL_PROVIDER: "fake"
+  } as unknown as NodeJS.ProcessEnv;
+
+  const TEMPLATE_ROW = {
+    subject_template: { en: "Hello" },
+    text_body_template: { en: "Body" },
+    html_body_template: null
+  };
+
+  function dispatchSql() {
+    return createFakeSql((text) => {
+      if (text.includes("SELECT default_locale")) {
+        return [{ default_locale: "en" }];
+      }
+
+      if (text.includes("FROM awcms_email_templates")) {
+        return [TEMPLATE_ROW];
+      }
+
+      if (
+        text.includes("UPDATE awcms_email_messages") &&
+        text.includes("SET status = 'sending'")
+      ) {
+        return [
+          {
+            id: MESSAGE_ID,
+            correlation_id: null,
+            category: "system.announcement",
+            template_key: "system.announcement",
+            to_address: "user@example.com",
+            to_address_hash: "hash-user",
+            subject: "Hello",
+            variables: {},
+            retry_count: 2
+          }
+        ];
+      }
+
+      return [];
+    });
+  }
+
+  function skippingProvider(): EmailProvider {
+    return {
+      send: async (_message: EmailMessage) => ({
+        ok: false as const,
+        error: "Mailketing circuit breaker is open; no attempt was made.",
+        retryable: true,
+        skipped: true as const
+      }),
+      healthCheck: async () => ({ ok: true as const })
+    };
+  }
+
+  function failingProvider(): EmailProvider {
+    return {
+      send: async (_message: EmailMessage) => ({
+        ok: false as const,
+        error: "Mailketing rejected the recipient.",
+        retryable: false
+      }),
+      healthCheck: async () => ({ ok: true as const })
+    };
+  }
+
+  test("a skipped message writes NO delivery-attempt row and burns NO retry", async () => {
+    const { sql, queries } = dispatchSql();
+
+    const result = await dispatchEmailQueue(sql, TENANT_A, {
+      now: NOW,
+      env: ENV,
+      resolveProvider: () => skippingProvider()
+    });
+
+    expect(result.claimed).toBe(1);
+    expect(result.deferred).toBe(1);
+    // The three counters it used to land in. `retried`/`failed` both assert
+    // zero because which one it hit depended on `retry_count` vs the max — the
+    // message in this test is at 2, so on the old code it retried; at the cap
+    // it went terminally `failed` without ever having been sent.
+    expect(result.retried).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(result.sent).toBe(0);
+
+    // The ledger must not record a contact that did not happen.
+    const attempts = queries.filter((q) =>
+      q.text.includes("INSERT INTO awcms_email_delivery_attempts")
+    );
+    expect(attempts).toHaveLength(0);
+
+    // The claim is undone: back to `queued`, immediately due again, and
+    // `retry_count` is not in the statement at all.
+    const release = queries.find(
+      (q) =>
+        q.text.includes("UPDATE awcms_email_messages") &&
+        q.text.includes("SET status = 'queued'")
+    );
+    expect(release).toBeDefined();
+    expect(release!.text).not.toContain("retry_count");
+    // Guarded on `status = 'sending'`, like every other finalize — a message
+    // cancelled between CLAIM and here must not be resurrected.
+    expect(release!.text).toContain("status = 'sending'");
+  });
+
+  test("an ordinary rejection still records the attempt — the fix is narrow", async () => {
+    // NON-VACUOUS counterpart. If `skipped` were ignored, or if the new branch
+    // swallowed every failure, this test would not notice; if the new branch
+    // caught too much, this one goes red.
+    const { sql, queries } = dispatchSql();
+
+    const result = await dispatchEmailQueue(sql, TENANT_A, {
+      now: NOW,
+      env: ENV,
+      resolveProvider: () => failingProvider()
+    });
+
+    expect(result.deferred).toBe(0);
+    expect(result.failed).toBe(1);
+
+    const attempts = queries.filter((q) =>
+      q.text.includes("INSERT INTO awcms_email_delivery_attempts")
+    );
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]!.values).toContain("failure");
+  });
+});
+
+describe("D6 — one bad address must not open the breaker on everybody else", () => {
+  const realFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    resetProviderCircuitBreakersForTests();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    resetProviderCircuitBreakersForTests();
+  });
+
+  function provider() {
+    return createMailketingEmailProvider({
+      apiToken: "token",
+      baseUrl: "http://mailketing.invalid",
+      timeoutMs: 1_000
+    });
+  }
+
+  function message(address: string | null): EmailMessage {
+    return {
+      to: address === null ? [] : [{ address }],
+      from: { address: "sender@example.com" },
+      subject: "Subject",
+      textBody: "Body"
+    };
+  }
+
+  function respondWith(body: string, status = 200): void {
+    globalThis.fetch = (async () =>
+      new Response(body, { status })) as unknown as typeof fetch;
+  }
+
+  test("a 2xx `status: failed` body is a business rejection, not an outage", async () => {
+    respondWith(JSON.stringify({ status: "failed", response: "Bad address" }));
+
+    const mailketing = provider();
+
+    // Comfortably past the 5-failure threshold. Every one of these used to
+    // count, so six invalid addresses in one batch closed email delivery for
+    // the whole deployment — including the password-reset messages that are
+    // the reason this module exists.
+    for (let i = 0; i < BREAKER_THRESHOLD + 3; i += 1) {
+      const result = await mailketing.send(message(`bad-${i}@example.com`));
+
+      expect(result.ok).toBe(false);
+      expect(result).not.toHaveProperty("skipped", true);
+    }
+
+    // Still attempting: the breaker never opened.
+    respondWith(JSON.stringify({ status: "success", message_id: "abc" }));
+    const recovered = await mailketing.send(message("good@example.com"));
+
+    expect(recovered).toEqual({ ok: true, providerMessageId: "abc" });
+  });
+
+  test("a message with no recipient is this deployment's bad row, not Mailketing's", async () => {
+    respondWith(JSON.stringify({ status: "success", message_id: "abc" }));
+
+    const mailketing = provider();
+
+    for (let i = 0; i < BREAKER_THRESHOLD + 3; i += 1) {
+      const result = await mailketing.send(message(null));
+
+      expect(result).toEqual({
+        ok: false,
+        error: "Email message has no recipient address.",
+        retryable: false
+      });
+    }
+
+    const recovered = await mailketing.send(message("good@example.com"));
+
+    expect(recovered.ok).toBe(true);
+  });
+
+  test("a 5xx DOES open the breaker, and the refusal is marked `skipped`", async () => {
+    // The half that must keep working. A provider that is genuinely down is
+    // exactly what the breaker is for, and `skipped` is what tells the
+    // dispatcher the difference between "refused" and "never tried".
+    respondWith("upstream boom", 503);
+
+    const mailketing = provider();
+
+    for (let i = 0; i < BREAKER_THRESHOLD; i += 1) {
+      const result = await mailketing.send(message(`user-${i}@example.com`));
+
+      expect(result.ok).toBe(false);
+      expect(result).not.toHaveProperty("skipped", true);
+    }
+
+    const refused = await mailketing.send(message("user@example.com"));
+
+    expect(refused).toEqual({
+      ok: false,
+      error: "Mailketing circuit breaker is open; no attempt was made.",
+      retryable: true,
+      skipped: true
+    });
+  });
+
+  test("a 4xx that is not 429 is about the message, so it leaves the breaker closed", async () => {
+    respondWith("bad request", 400);
+
+    const mailketing = provider();
+
+    for (let i = 0; i < BREAKER_THRESHOLD + 3; i += 1) {
+      const result = await mailketing.send(message(`user-${i}@example.com`));
+
+      expect(result).not.toHaveProperty("skipped", true);
+    }
+
+    respondWith(JSON.stringify({ status: "success", message_id: "abc" }));
+
+    expect((await mailketing.send(message("good@example.com"))).ok).toBe(true);
+  });
+
+  test("a 429 IS about the service, so it counts", async () => {
+    respondWith("slow down", 429);
+
+    const mailketing = provider();
+
+    for (let i = 0; i < BREAKER_THRESHOLD; i += 1) {
+      await mailketing.send(message(`user-${i}@example.com`));
+    }
+
+    expect(await mailketing.send(message("user@example.com"))).toHaveProperty(
+      "skipped",
+      true
+    );
+  });
+});
+
+describe("D5 — the reconcile script that summed the wrong number and exited 0", () => {
+  // Source-level, and comments STRIPPED first (finding D2's lesson: an
+  // assertion that matches the prose explaining a change tests nothing). What
+  // makes these worth pinning is that the engine half is now correct — a
+  // caller that goes back to ignoring `status` would restore the whole defect
+  // while every engine test stayed green.
+  async function script(): Promise<string> {
+    return stripComments(
+      await Bun.file("scripts/site-search-reconcile.ts").text()
+    );
+  }
+
+  test("it reads `status`, not just `failureCount`", async () => {
+    const source = await script();
+
+    expect(source).toContain('result.status === "failed"');
+    expect(source).toContain("result.failedSources");
+    expect(source).toContain("result.unattemptedSources");
+  });
+
+  test("a failed source makes the process exit NON-zero", async () => {
+    const source = await script();
+
+    // `logScriptFailure` sets this only for an error that escapes the loop, and
+    // the loop no longer lets one escape.
+    expect(source).toContain("process.exitCode = 1");
+  });
+
+  test("one tenant's failure does not abandon the rest of the run", async () => {
+    const source = await script();
+    const loop = source.slice(
+      source.indexOf("for (const tenant of tenants)"),
+      source.indexOf("site-search:reconcile complete")
+    );
+
+    // A `catch` that `continue`s — the same shape D4 gave the rollup. Without
+    // it, a database error on tenant #1 rejected out of the whole loop and
+    // every later tenant went unindexed for that pass.
+    expect(loop).toContain("catch (error)");
+    expect(loop).toContain("continue;");
+  });
+});
+
+describe("D6 — the dispatch script must PRINT the outcome it just learned to tell apart", () => {
+  test("`deferred` reaches the summary line", async () => {
+    // A number the summary does not print is a number nobody reads, and
+    // splitting `deferred` out of `failed`/`retried` without printing it would
+    // have made the pass quieter than before rather than clearer.
+    const source = stripComments(
+      await Bun.file("scripts/email-dispatch.ts").text()
+    );
+
+    expect(source).toContain("result.deferred");
+    expect(source).toContain("deferred=${totalDeferred}");
+  });
+});


### PR DESCRIPTION
Findings **D4**, **D5** and **D6** of the 17 August 2026 audit round. One PR because they are one failure mode, and it is the one that survives every other kind of check: the job runs, the exit code is 0, the summary prints a number, and the number is wrong in the direction that looks fine. Nothing throws, so no alert fires; nothing logs as an error, so no dashboard reddens.

## D4 — a dead branch, and a run that gave up on every remaining tenant

Both analytics jobs tested `if (result instanceof Response)` to detect database backpressure. That shape only ever comes out of `withTenant`; these loops call `withTenantOrThrow`, which **throws** `DatabaseBusyError`. So `tenantsSkipped` was permanently 0, the warning built on it could never fire, and — the part that actually cost something — a busy database abandoned every tenant after the first instead of skipping one.

**The audit said "two analytics jobs" and it was right about both.** I initially wrote in §4 that only the rollup had it; `visitor-analytics-purge.ts:92` carries the identical branch and is fixed the same way. The purge is the more serious of the two: it is what **enforces** retention, so an abandoned run means every tenant after the first keeps holding visitor data past its window — silently, while the summary reports success and its own `(WARNING: … database busy)` clause, gated on the permanently-zero counter, could never print.

Skipped tenants are **named**, not counted — `--date=` is the remedy and an operator needs the ids. The catch is deliberately narrow: anything that is not `DatabaseBusyError` still reaches the job runner, or the fix reintroduces the exact class of bug it is fixing.

## D5 — `failures=0` while a whole source had stopped indexing

`failureCount` sums per-**document** failures across the sources that finished. A source whose reconcile threw never reached `results.push`, so it contributed nothing to that sum, and the `break` meant every source after it went unattempted. The engine returned `status: "failed"`; `scripts/site-search-reconcile.ts` summed the number and never looked at the status.

The engine now reports `failedSources` and `unattemptedSources`, kept **separate** from `failureCount` — collapsing a dead source into a per-document counter is precisely how "0" came to mean "one whole source stopped". The script checks `status`, prints both lists and exits **1**.

**Two corrections to the recommendation:**

1. **The `break` is correct and stays.** A source failing on a database error leaves the transaction aborted, so continuing would produce a cascade of `25P02`s and `finalizeRun` itself would fail.
2. **The false-success is only reachable for a JS throw** — an identifier assertion in `buildExtractionQuery`, which runs before any SQL, so the transaction stays healthy and the run row commits. A *database* error poisons the transaction, takes `finalizeRun` down with it and rejects out of the call, which was always loud. It was also, until this PR, loud in the wrong way: it abandoned every remaining tenant. The script now catches per tenant and continues — the same shape as D4.

## D6 — a ledger recording contact that never happened, and a breaker one bad address could open

`EmailDeliveryResult` gains `skipped`, which is neither an attempt to record nor a retry to spend. When the Mailketing breaker opens *mid-pass*, the dispatcher was writing a `failure` row into `awcms_email_delivery_attempts` and burning a `retry_count`, so a breaker that opened part-way through a batch could push the rest to terminal `failed` without one of them having been sent. Such a message now returns to `queued` untouched, counted as `deferred` — and **printed**, because a number the summary does not print is a number nobody reads, and splitting `deferred` out without printing it would have made the pass quieter than before rather than clearer.

The loop deliberately does **not** `break` on the first skip: every remaining claimed row needs releasing, or it sits in `sending` until its lease expires.

Separately, the adapter fed the breaker for two per-message business rejections — no recipient, and a `2xx` body carrying `status: "failed"` — contradicting its own header. The threshold is 5 consecutive failures, so **six invalid addresses in one batch** used to stop email for the whole deployment, password-reset messages included. The HTTP-status branch also adopts the split `push-delivery/domain/fcm-error-mapping.ts` already documents (429 and 5xx are about the service, every other 4xx is about the message), which closes a third case the audit did not name.

A genuinely bad API token — the one shape that hides among those rejections — is `email:provider:health`'s job, and unlike the breaker it can tell an operator *which* problem it is.

## Tests

`tests/jobs-that-report-false-success.test.ts` (15) — the two rollup/purge skip paths and their narrow-catch counterparts, driven by a fake `Bun.SQL` with the real database circuit breaker tripped; the dispatcher's deferred path (no attempt row, no `retry_count` in the statement, still guarded on `status = 'sending'`) plus a non-vacuous ordinary-rejection case; and the adapter's breaker accounting against a stubbed `fetch` across all five status classes.

*The breaker in that suite is tripped against the **real** clock, not the fixed `NOW`: the open window is 30 s and `runTenantWork` asks `canAttempt(new Date())`, so a fixed past timestamp opens the breaker and immediately elapses it to half-open — the test would have passed for the wrong reason.*

`tests/integration/site-search.integration.test.ts` (+3) — against real PostgreSQL: the run names the failed source and the unattempted ones while `failureCount` stays 0; the sources that *did* run are still reported and their run row commits; and a clean run names nothing, so the fields are not always-populated noise.

**Mutation-proven**, seven mutations, each turning exactly one test red: D4's catch removed (rollup and purge separately), the purge's id list left unpopulated, the dispatcher's `skipped` branch disabled, each of the two business-rejection `recordFailure` calls restored, the 429/5xx split removed, `failedSources` left unpopulated, and an off-by-one in the unattempted slice.

## Verification

`DATABASE_URL="" bun run check` — green (5474 pass, 0 fail, 56 gates).
`bun test tests/integration/` — 479 pass, 2 fail; both are the two pre-existing local `http`/`https` scheme failures verified on unmodified `main`.
Legacy DB-gated suite (17 files) — 147 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
