### PR TITLE
fix(visitor-analytics,data-lifecycle): two reads with no ceiling

### DIFF
--- a/.changeset/reads-with-no-ceiling.md
+++ b/.changeset/reads-with-no-ceiling.md
@@ -1,0 +1,57 @@
+---
+"awcms": minor
+---
+
+fix(visitor-analytics,data-lifecycle): two reads with no ceiling
+
+Findings **C2** and **C5** of the 17 August 2026 audit round. `sql/145`. One PR
+because they are one habit: a statement whose real cost is O(everything this
+tenant has ever accumulated), written where the author was thinking about one
+subject or one cutoff.
+
+**C2 — the only unbounded retention purge in the repo.** Four statements with no
+batch limit, each using `RETURNING id` purely to take a JS-side `.length`. A
+tenant with a year of unpurged analytics deleted every row in one transaction:
+one lock set held for the duration, one WAL burst, and a `statement_timeout` that
+turns the whole pass into a rollback rather than partial progress. Every sibling
+already caps at 5000 and loops.
+
+All four statements are now `WHERE <pk> IN (SELECT … ORDER BY … LIMIT n)` — the
+shape `audit-purge.ts` established — and the function returns `hasMore`. The
+scheduled job loops with a **fresh transaction per pass** (looping inside one
+would hold every lock and dead tuple for the duration, which is the thing the
+batching exists to avoid) and reports any tenant that hits the pass cap. The
+on-demand endpoint does **one** bounded pass and returns `hasMore`, because the
+size of the work is unknown when the caller presses the button.
+
+*What the ORDER BY buys is stated precisely rather than assumed.* Termination
+does not depend on it — a DELETE removes what it took. It buys oldest-first,
+which matches the index the predicate already uses and means an interrupted purge
+has removed the data furthest past retention rather than an arbitrary slice. On a
+retention control, "which half got deleted" is not a detail. This correction came
+from a mutation: removing the ORDER BY left every test green, and the code comment
+claiming it gave monotonic progress was wrong.
+
+**C5 — a subject-access export with 49 unbounded reads, two over unindexed
+columns.** `awcms_audit_events.actor_tenant_user_id` and the `awcms_domain_events`
+twin have no index and are **not foreign keys**, deliberately (an audit row must
+survive the deletion of the actor it names), so `db:fk-index:check` structurally
+cannot see them. The near-miss makes it worse:
+`awcms_audit_events_actor_tenant_idx` covers `actor_tenant_id` — the delegated
+actor's *tenant*, a different column one character apart in reading.
+
+`sql/145` adds three partial indexes. **Measured** on 60,000 rows: the actor read
+went from a Seq Scan touching 858 buffers (2.5 ms) to an Index Scan touching 33
+(0.039 ms).
+
+The reads are also row-capped, with the cap reported. A cap on a subject-access
+export is only acceptable because it is **flagged**: an export that quietly
+returned the first N rows would answer a legal obligation with a number dressed
+as an answer — strictly worse than the unbounded read it replaced, which was at
+least honest. `truncated` is per table, `truncatedTables` rides in the response
+beside the existing `unanswered` coverage statement, and the `critical` audit
+event says INCOMPLETE in its message. The cap is a safety valve against a
+pathological subject (an automation account named as actor on a million rows),
+not a page size; there is deliberately no cursor, because a "complete answer"
+assembled across pages has a boundary at every request where a partial answer can
+be mistaken for the whole one.

--- a/.claude/skills/README.id.md
+++ b/.claude/skills/README.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](README.md)
 
-<!-- i18n-source-hash: sha256:16db617b05816cff119b542beb17d080a464c6d3a4c220b89bb6ce9868470add -->
+<!-- i18n-source-hash: sha256:7f4b8de4c05cda6aedc01eaf733ddb621ad777806c22675221028be63f73956d -->
 
 # AWCMS Project Skills
 
@@ -43,7 +43,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > Keluarga hari ini dua repo, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (halaman publik + permukaan admin USER, ADR-0070). **KOREKSI:** versi sebelumnya menyatakan
 > implementasi ini "baru fondasi Sprint 1–2" dengan empat modul — itu **sudah
-> lama tidak benar**. Repo ini punya **24 modul terdaftar** dan `sql/001`–`sql/144`;
+> lama tidak benar**. Repo ini punya **24 modul terdaftar** dan `sql/001`–`sql/145`;
 > lihat [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) untuk daftar nyata.
 > Skill yang badannya masih menandai dirinya "BACAAN SAJA" tetap begitu — itu
 > per-skill, bukan pernyataan tentang repo secara keseluruhan.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -41,7 +41,7 @@ Project-level Claude Code skills for AWCMS. Each skill encodes the standards fro
 > The family today is two repos, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (public pages + the USER admin surface, ADR-0070). **CORRECTION:** the previous version claimed this
 > implementation was "only the Sprint 1–2 foundation" with four modules — that has **not
-> been true for a long time**. This repo has **24 registered modules** and `sql/001`–`sql/144`;
+> been true for a long time**. This repo has **24 registered modules** and `sql/001`–`sql/145`;
 > see [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) for the real list.
 > A skill whose body still marks itself "READ-ONLY" stays that way — that is
 > per-skill, not a statement about the repo as a whole.

--- a/docs/ARCHITECTURE.id.md
+++ b/docs/ARCHITECTURE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](ARCHITECTURE.md)
 
-<!-- i18n-source-hash: sha256:0e19ec8ff28bdee785ad20b45e5ee9d808d5af16dfcf807318d0cda2544517a1 -->
+<!-- i18n-source-hash: sha256:7b702226fd4d1e614101225a78a03b3e21db51c977e6f8bb505151761ce4e96c -->
 
 # Arsitektur AWCMS
 
@@ -21,7 +21,7 @@ Sebagai template yang di-ship, base menyediakan **modul fondasi reusable + kontr
 modul domain ERP (finance, inventory, procurement, manufacturing, hr-payroll, dst.)
 **ditambahkan langsung di `src/modules/` template ini** saat dipakai, bukan di repo
 ekstensi/turunan terpisah (jalur aplikasi-turunan DIHAPUS — lihat §Komposisi modul di
-bawah). Repo ini punya **24 modul terdaftar**, migration `sql/001`-`sql/144`, RLS
+bawah). Repo ini punya **24 modul terdaftar**, migration `sql/001`-`sql/145`, RLS
 `FORCE` di seluruh tabel tenant-scoped, pemisahan role database, dan admin UI read+write
 (Issue #166, #171). Dokumen ini menjelaskan apa yang **ada di kode saat ini**. Untuk detail
 per modul, lihat `README.md` masing-masing di `src/modules/<module>/`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ As a shipped template, the base provides **reusable foundation modules + neutral
 ERP domain modules (finance, inventory, procurement, manufacturing, hr-payroll, etc.)
 are **added directly in this template's `src/modules/`** when it is used, not in a separate
 extension/derived repo (the derived-application pathway was REMOVED — see §Module composition
-below). This repo has **24 registered modules**, migrations `sql/001`-`sql/144`, RLS
+below). This repo has **24 registered modules**, migrations `sql/001`-`sql/145`, RLS
 `FORCE` on every tenant-scoped table, database role separation, and a read+write admin UI
 (Issue #166, #171). This document describes what is **in the code today**. For per-module
 detail, see each `README.md` under `src/modules/<module>/`.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:ab261b9aa8ad7c3e352d3c6cded3e08094ec6ef59e507c1a25410f192e735f64 -->
+<!-- i18n-source-hash: sha256:a605ad70c9f559b56d18940d2356f79ad7e367c84de28b6daee479abacf6b6dc -->
 
 # AWCMS — Project State & Continuation
 
@@ -111,7 +111,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Changeset menunggu (per tipe bump) | _jalankan perintah di kolom kanan_                                                    | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commit sejak rilis terakhir        | _jalankan perintah di kolom kanan_                                                    | `git rev-list --count v9.1.2..HEAD`                                                     |
 | Modul base                         | **24** (lihat daftar di ARCHITECTURE.md)                                              | `src/modules/index.ts`                                                                  |
-| Migrasi                            | **144** (`sql/001`–`144`)                                                             | `ls sql/`                                                                               |
+| Migrasi                            | **145** (`sql/001`–`145`)                                                             | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0103** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **48** berkas `.astro` di `src/pages/admin/`; **0 dari 24** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Berkas `.astro`                    | **61** (34.594 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
@@ -538,7 +538,7 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
      `credential_epoch` pada `awcms_principals`, naikkan di statement yang mengganti hash,
      stempelkan pada sesi, tolak sesi ber-epoch basi. Sebelum itu, perbaiki komentar palsunya.
 
-     SELESAI (22 Agustus 2026), `sql/144`. Rekomendasi diterapkan apa adanya, ditambah dua
+     SELESAI (22 Agustus 2026), `sql/145`. Rekomendasi diterapkan apa adanya, ditambah dua
      hal yang tidak disebutkannya.
 
      Pertama, MENGAPA epoch dan bukan pencabutan yang diperlebar — ditulis ke dalam migration
@@ -713,7 +713,7 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       untuk `count(*)`. `db:fk-index:check` tidak bisa melihatnya — `updated_at` bukan
       foreign key. Ongkosnya O(pos tenant), bukan O(ukuran halaman).
 
-      **DIUKUR, yang putaran ini tidak bisa lakukan.** `sql/144` menambah tiga indeks;
+      **DIUKUR, yang putaran ini tidak bisa lakukan.** `sql/145` menambah tiga indeks;
       terhadap 24.000 post ter-seed di PostgreSQL 18, daftar `/admin/blog` berubah dari Seq
       Scan 24.000 baris plus top-N heapsort (7,4 ms) menjadi Index Scan yang membaca **50**
       baris (0,057 ms), halaman keyset pertama dari 5,1 ms menjadi 0,110 ms, dan halaman
@@ -723,7 +723,7 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       **Satu klaim di entri ini SALAH dan dibiarkan terlihat alih-alih disunting hilang:**
       "plus scan penuh KEDUA untuk `count(*)`". Hitungan di samping daftar itu sudah
       terencana sebagai Index Only Scan pada `awcms_blog_posts_tenant_deleted_idx` (1,8 ms,
-      tidak berubah oleh `sql/144`). Ia membaca setiap entri indeks — itu sebabnya ia tidak
+      tidak berubah oleh `sql/145`). Ia membaca setiap entri indeks — itu sebabnya ia tidak
       menjadi lebih cepat — tetapi ia bukan heap scan, dan tidak ada indeks yang ditambahkan
       di sini yang menolongnya. Hitungan yang murah adalah keputusan lain (estimasi, atau
       penghitung terpelihara) dengan kompromnya sendiri.
@@ -745,6 +745,27 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       `retention-purge.ts:91-117`. Empat statement tanpa batas batch, tiap-tiap memakai
       `RETURNING id` hanya untuk mengambil `.length` di sisi JS. Setiap saudaranya membatasi
       di 5000 dan mengulang.
+
+      SELESAI (22 Agustus 2026). Keempat statement kini
+      `WHERE <pk> IN (SELECT … ORDER BY … LIMIT n)` dan fungsinya mengembalikan `hasMore`.
+      Job terjadwal mengulang dengan transaksi BARU tiap pass — mengulang di dalam satu
+      transaksi akan menahan setiap lock dan tuple mati selama durasinya, persis hal yang
+      hendak dihindari batching itu — dan menyebut nama tenant yang mentok di batas pass.
+      Endpoint on-demand melakukan SATU pass terbatas lalu mengembalikan `hasMore`, karena
+      besarnya pekerjaan tidak diketahui saat pemanggil menekan tombolnya.
+
+      Satu KOREKSI yang ditemukan lewat mutasi, bukan lewat membaca: komentar kodenya
+      mengklaim ORDER BY memberi kemajuan monotonik. Tidak — DELETE menghapus apa yang
+      diambilnya, jadi terminasi tetap berlaku tanpa itu. Yang dibelinya adalah
+      TERTUA-DULU, yang cocok dengan indeks yang sudah dipakai predikatnya dan berarti purge
+      yang terputus telah menghapus data yang paling jauh melewati retensinya, bukan
+      potongan sembarang. Menghapus ORDER BY membuat semua test tetap hijau sampai ditulis
+      test untuk properti yang memang benar.
+
+      `awcms_visitor_daily_rollups` dibatasi lewat `ctid`, bukan id surrogate: ia berkunci
+      `(tenant_id, date, area)` dan tak punya kolom id. `ctid` tidak stabil melintasi UPDATE
+      — justru itulah sebabnya ia hanya dipakai di dalam satu statement yang memilihnya.
+
   17. **C3 — sync push melakukan read-modify-write pada `current_version` tanpa row lock.**
       `sync/push.ts:132-137`. Dua batch bersamaan sama-sama membaca 5, sama-sama lolos
       pemeriksaan konflik, sama-sama menulis literal `6`: dua event berkonflik diterima, nol
@@ -800,6 +821,27 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       Tanpa LIMIT, tanpa cursor, semua baris di-buffer; `awcms_audit_events.actor_tenant_user_id`
       dan kembarannya di `awcms_domain_events` tidak berindeks dan **bukan kolom FK sehingga
       `db:fk-index:check` secara struktural tidak bisa melihatnya**.
+
+      SELESAI (22 Agustus 2026), `sql/145`. Tiga indeks parsial, dan DIUKUR pada 60.000
+      baris: baca aktor beralih dari Seq Scan menyentuh 858 buffer (2,5 ms) menjadi Index
+      Scan menyentuh 33 (0,039 ms). Nyaris-lolosnya layak dicatat — `awcms_audit_events`
+      MEMANG punya `awcms_audit_events_actor_tenant_idx`, pada `actor_tenant_id`: TENANT si
+      aktor terdelegasi, kolom berbeda yang hanya berjarak satu huruf saat dibaca.
+
+      Bacanya juga dibatasi 10.000 baris dengan batas itu DILAPORKAN (`truncated` per tabel,
+      `truncatedTables` di respons bersebelahan dengan pernyataan cakupan `unanswered` yang
+      sudah ada, dan kata INCOMPLETE di pesan audit event `critical`-nya). Batas pada ekspor
+      hak subjek hanya bisa diterima KARENA ditandai: ekspor yang diam-diam mengembalikan N
+      baris pertama akan menjawab kewajiban hukum dengan angka yang berpakaian jawaban —
+      lebih buruk daripada baca tak terbatas yang digantikannya. Tanpa cursor, dengan
+      sengaja — "jawaban lengkap" yang dirakit lintas halaman punya batas di setiap request,
+      tempat jawaban parsial bisa disalahartikan sebagai keseluruhannya.
+
+      Satu mutasi mengajarkan hal yang layak disimpan: menghapus LIMIT sepenuhnya TIDAK
+      memerahkan apa pun, karena dengan 12 baris dan batas 10 flag serta potongannya keluar
+      identik dan hanya BIAYA-nya yang berbeda. Itu persis bentuk temuannya sendiri, jadi
+      suite-nya kini membawa asersi eksplisit bahwa statement-nya benar-benar memuat LIMIT.
+
   20. **C6 — `/admin/roles` adalah N+1 plus payload O(peran × katalog).**
       `roles.astro:88-94`. `listRolePermissions` di-await sekali per peran (sampai 100,
       berurutan); katalog ~230 baris dirender sebagai `<option>` sekali per peran.

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -111,7 +111,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Pending changesets (by bump type) | _run the command in the right-hand column_                                             | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commits since the last release    | _run the command in the right-hand column_                                             | `git rev-list --count v9.1.2..HEAD`                                                     |
 | Base modules                      | **24** (see the list in ARCHITECTURE.md)                                               | `src/modules/index.ts`                                                                  |
-| Migrations                        | **144** (`sql/001`–`144`)                                                              | `ls sql/`                                                                               |
+| Migrations                        | **145** (`sql/001`–`145`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0105** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **48** `.astro` files in `src/pages/admin/`; **0 of 24** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | `.astro` files                    | **61** (34.599 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
@@ -553,7 +553,7 @@ pioneered directly here after the ADR-0047 freeze.)
      hash, stamp it on sessions, reject stale-epoch sessions. Until then, correct the
      false comments.
 
-     DONE (22 August 2026), `sql/144`. The recommendation is implemented as written, plus
+     DONE (22 August 2026), `sql/145`. The recommendation is implemented as written, plus
      two things it did not say.
 
      First, WHY an epoch and not a wider revoke, written into the migration so the next
@@ -727,7 +727,7 @@ pioneered directly here after the ADR-0047 freeze.)
       - top-N sort, plus a second full scan for `count(*)`. `db:fk-index:check` cannot see
         it — `updated_at` is not a foreign key. Cost is O(tenant posts), not O(page size).
 
-      **MEASURED, which this round could not do.** `sql/144` adds three indexes; against
+      **MEASURED, which this round could not do.** `sql/145` adds three indexes; against
       24,000 seeded posts on PostgreSQL 18 the `/admin/blog` list went from a Seq Scan of
       24,000 rows plus a top-N heapsort (7.4 ms) to an Index Scan reading **50** (0.057
       ms), the keyset first page from 5.1 ms to 0.110 ms, and a keyset page resumed at row
@@ -737,7 +737,7 @@ pioneered directly here after the ADR-0047 freeze.)
       **One claim in this entry is wrong and is left visible rather than edited away:**
       "plus a second full scan for `count(*)`". The count beside the list already plans as
       an Index Only Scan on `awcms_blog_posts_tenant_deleted_idx` (1.8 ms, unchanged by
-      `sql/144`). It reads every index entry, which is why it does not get faster — but it
+      `sql/145`). It reads every index entry, which is why it does not get faster — but it
       is not a heap scan, and no index added here helps it. A cheap count is a different
       decision (an estimate, or a maintained counter) with its own trade-off.
 
@@ -756,6 +756,27 @@ pioneered directly here after the ADR-0047 freeze.)
   16. **C2 — `purgeVisitorAnalyticsData` is the only unbounded retention purge in the
       repo.** `retention-purge.ts:91-117`. Four statements with no batch limit, each using
       `RETURNING id` only to take a JS-side `.length`. Every sibling caps at 5000 and loops.
+
+      DONE (22 August 2026). All four statements are
+      `WHERE <pk> IN (SELECT … ORDER BY … LIMIT n)` and the function returns `hasMore`. The
+      scheduled job loops with a FRESH transaction per pass — looping inside one would hold
+      every lock and dead tuple for the duration, which is the thing the batching exists to
+      avoid — and names any tenant that hits the pass cap. The on-demand endpoint does ONE
+      bounded pass and returns `hasMore`, because the size of the work is unknown when the
+      caller presses the button.
+
+      A CORRECTION found by mutation, not by reading: the code comment claimed the ORDER BY
+      gave monotonic progress. It does not — a DELETE removes what it took, so termination
+      holds regardless. What it buys is OLDEST-FIRST, which matches the index the predicate
+      already uses and means an interrupted purge has removed the data furthest past
+      retention rather than an arbitrary slice. Removing the ORDER BY left every test green
+      until a test was written for the property that is actually true.
+
+      `awcms_visitor_daily_rollups` is bounded on `ctid` rather than a surrogate id: it is
+      keyed `(tenant_id, date, area)` and has no id column. `ctid` is not stable across an
+      UPDATE, which is exactly why it is only ever used inside the one statement that
+      selected it.
+
   17. **C3 — sync push does read-modify-write on `current_version` with no row lock.**
       `sync/push.ts:132-137`. Two concurrent batches both read 5, both pass the conflict
       check, both write the literal `6`: two conflicting events accepted, zero conflict
@@ -809,6 +830,27 @@ pioneered directly here after the ADR-0047 freeze.)
       `awcms_domain_events` twin have no index and are **not FK columns, so
       `db:fk-index:check` structurally cannot see them**. The route's own comment claims
       "a bounded set of rows".
+
+      DONE (22 August 2026), `sql/145`. Three partial indexes, and MEASURED on 60,000 rows:
+      the actor read went from a Seq Scan touching 858 buffers (2.5 ms) to an Index Scan
+      touching 33 (0.039 ms). The near-miss is worth recording — `awcms_audit_events` DOES
+      have `awcms_audit_events_actor_tenant_idx`, on `actor_tenant_id`: the delegated
+      actor's TENANT, a different column one character apart in reading.
+
+      The reads are row-capped at 10,000 with the cap REPORTED (`truncated` per table,
+      `truncatedTables` in the response beside the existing `unanswered` coverage
+      statement, and INCOMPLETE in the `critical` audit event's message). A cap on a
+      subject-access export is only acceptable because it is flagged: an export that
+      quietly returned the first N rows would answer a legal obligation with a number
+      dressed as an answer, which is worse than the unbounded read it replaced. No cursor,
+      deliberately — a "complete answer" assembled across pages has a boundary at every
+      request where a partial answer can be mistaken for the whole one.
+
+      One mutation taught something worth keeping: deleting the LIMIT entirely turned
+      NOTHING red, because with 12 rows and a cap of 10 the flag and the slice come out
+      identical and only the COST differs. That is the finding's own shape, so the suite
+      now carries an explicit assertion that the statement really contains the LIMIT.
+
   20. **C6 — `/admin/roles` is an N+1 plus an O(roles × catalogue) payload.**
       `roles.astro:88-94`. `listRolePermissions` awaited once per role (up to 100,
       sequential); the ~230-row catalogue rendered as `<option>` once per role.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -8,11 +8,11 @@
 | Aspect                              | Value |
 | ----------------------------------- | ----- |
 | Registered modules                  | 24    |
-| Migrations                          | 144   |
+| Migrations                          | 145   |
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 451   |
+| Test files                          | 452   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -193,6 +193,7 @@
 | 142 | `sql/142_awcms_delegated_access_expiry_sweep.sql`                  |
 | 143 | `sql/143_awcms_blog_list_ordering_indexes.sql`                     |
 | 144 | `sql/144_awcms_credential_epoch.sql`                               |
+| 145 | `sql/145_awcms_subject_actor_indexes.sql`                          |
 
 ### Tables & Row-Level Security
 
@@ -357,7 +358,7 @@
 | ------------- | ---------- |
 | `(root)`      | 381        |
 | `e2e`         | 12         |
-| `integration` | 57         |
+| `integration` | 58         |
 | `unit`        | 1          |
 
 ### Routes

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -7844,6 +7844,11 @@ paths:
                         description: What this answer does NOT cover, and why.
                         items:
                           $ref: "#/components/schemas/DataLifecycleSubjectUnanswered"
+                      truncatedTables:
+                        type: array
+                        description: Keys of tables that hit the per-table row cap, so the report is INCOMPLETE for them. Empty means complete — a claim worth being able to make explicitly rather than by the absence of a warning. The cap is a safety valve against a pathological subject (an automation account named as actor on a million audit rows), not a page size; there is deliberately no cursor, because a "complete answer" assembled across pages has a boundary at every request where a partial answer can be mistaken for the whole one.
+                        items:
+                          type: string
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -21275,6 +21280,9 @@ components:
           items:
             type: object
             additionalProperties: true
+        truncated:
+          type: boolean
+          description: "True when this table filled the per-table row cap, so the export is incomplete for it. Reported rather than swallowed: a subject-access export that quietly returned the first N rows would answer a legal obligation with a number dressed as an answer."
     DataLifecycleSubjectUnanswered:
       type: object
       properties:
@@ -23165,6 +23173,9 @@ components:
           type: integer
         rollupsDeleted:
           type: integer
+        hasMore:
+          type: boolean
+          description: True when at least one step filled its batch, so data past retention remains. This endpoint performs ONE bounded pass on purpose — the size of the work is unknown when the caller presses the button, and an interactive request must not hold a purge of unbounded size open. Call it again, or let the scheduled `analytics:purge` job (which loops) finish the tenant.
     Role:
       type: object
       properties:

--- a/openapi/modules/data-lifecycle.openapi.yaml
+++ b/openapi/modules/data-lifecycle.openapi.yaml
@@ -375,6 +375,21 @@ paths:
                         description: What this answer does NOT cover, and why.
                         items:
                           $ref: "#/components/schemas/DataLifecycleSubjectUnanswered"
+                      truncatedTables:
+                        type: array
+                        description: >-
+                          Keys of tables that hit the per-table row cap, so the
+                          report is INCOMPLETE for them. Empty means complete —
+                          a claim worth being able to make explicitly rather
+                          than by the absence of a warning. The cap is a safety
+                          valve against a pathological subject (an automation
+                          account named as actor on a million audit rows), not a
+                          page size; there is deliberately no cursor, because a
+                          "complete answer" assembled across pages has a
+                          boundary at every request where a partial answer can
+                          be mistaken for the whole one.
+                        items:
+                          type: string
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -613,6 +628,13 @@ components:
           items:
             type: object
             additionalProperties: true
+        truncated:
+          type: boolean
+          description: >-
+            True when this table filled the per-table row cap, so the export is
+            incomplete for it. Reported rather than swallowed: a subject-access
+            export that quietly returned the first N rows would answer a legal
+            obligation with a number dressed as an answer.
     DataLifecycleSubjectErasureTarget:
       type: object
       properties:

--- a/openapi/modules/visitor-analytics.openapi.yaml
+++ b/openapi/modules/visitor-analytics.openapi.yaml
@@ -705,3 +705,12 @@ components:
           type: integer
         rollupsDeleted:
           type: integer
+        hasMore:
+          type: boolean
+          description: >-
+            True when at least one step filled its batch, so data past retention
+            remains. This endpoint performs ONE bounded pass on purpose — the
+            size of the work is unknown when the caller presses the button, and
+            an interactive request must not hold a purge of unbounded size open.
+            Call it again, or let the scheduled `analytics:purge` job (which
+            loops) finish the tenant.

--- a/scripts/visitor-analytics-purge.ts
+++ b/scripts/visitor-analytics-purge.ts
@@ -39,7 +39,10 @@ import {
   writeJobTelemetry,
   type JobContext
 } from "../src/lib/jobs/job-runner";
-import { fetchActiveTenants } from "../src/lib/jobs/batching";
+import {
+  fetchActiveTenants,
+  runBoundedBatches
+} from "../src/lib/jobs/batching";
 import { purgeVisitorAnalyticsData } from "../src/modules/visitor-analytics/application/retention-purge";
 import {
   resolveVisitorAnalyticsConfig,
@@ -56,6 +59,8 @@ export type VisitorAnalyticsPurgeResult = {
   tenantsSkipped: number;
   /** Named, not just counted — a re-run needs to know which tenants still hold data past retention. */
   skippedTenantIds: string[];
+  /** Finding C2 — tenants that hit the pass cap with work still to do. The next run continues them; silence here would read as "finished". */
+  tenantsWithBacklog: string[];
 };
 
 export async function runVisitorAnalyticsPurge(
@@ -73,7 +78,8 @@ export async function runVisitorAnalyticsPurge(
     sessionsDeleted: 0,
     rollupsDeleted: 0,
     tenantsSkipped: 0,
-    skippedTenantIds: []
+    skippedTenantIds: [],
+    tenantsWithBacklog: []
   };
 
   if (ctx.dryRun) {
@@ -96,20 +102,44 @@ export async function runVisitorAnalyticsPurge(
     // holding visitor data past its retention window, silently, until someone
     // notices the counts are too low — and the summary was reporting success.
     try {
-      const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
-        purgeVisitorAnalyticsData(
-          tx,
-          tenant.id,
-          config,
-          now,
-          legalHoldGuardPortAdapter
-        )
+      // Finding C2 — the purge is BATCHED now, so one pass is one bounded bite
+      // and the loop is what finishes the job. A fresh transaction per pass is
+      // the whole point: looping inside one transaction would hold every lock
+      // and every dead tuple for the duration, which is the thing the batching
+      // exists to avoid.
+      //
+      // `runBoundedBatches` caps the passes, so a tenant with a pathological
+      // backlog cannot make this job run forever; whatever is left is picked up
+      // by the next scheduled run.
+      const outcome = await runBoundedBatches(
+        async () => {
+          const pass = await withTenantOrThrow(sql, tenant.id, (tx) =>
+            purgeVisitorAnalyticsData(
+              tx,
+              tenant.id,
+              config,
+              now,
+              legalHoldGuardPortAdapter
+            )
+          );
+
+          totals.eventsDeleted += pass.eventsDeleted;
+          totals.sessionsRawDetailCleared += pass.sessionsRawDetailCleared;
+          totals.sessionsDeleted += pass.sessionsDeleted;
+          totals.rollupsDeleted += pass.rollupsDeleted;
+
+          // `count` drives the loop: zero ends it. `hasMore` alone would not,
+          // because a pass that deletes nothing but is `hasMore` cannot exist —
+          // and a pass that deletes something without being `hasMore` should
+          // still stop.
+          return { count: pass.hasMore ? 1 : 0 };
+        },
+        { signal: ctx.signal }
       );
 
-      totals.eventsDeleted += result.eventsDeleted;
-      totals.sessionsRawDetailCleared += result.sessionsRawDetailCleared;
-      totals.sessionsDeleted += result.sessionsDeleted;
-      totals.rollupsDeleted += result.rollupsDeleted;
+      if (outcome.hitPassLimit) {
+        totals.tenantsWithBacklog.push(tenant.id);
+      }
     } catch (error) {
       // ONLY backpressure is a skip. A legal-hold refusal or a broken query is
       // a real failure and must reach the job runner, which classifies a
@@ -139,6 +169,11 @@ async function main() {
         handler: async (ctx) => {
           const purgeResult = await runVisitorAnalyticsPurge(sql, ctx, config);
           const skipped = purgeResult.tenantsSkipped > 0;
+          // Finding C2 — the batching means "finished this pass" and "finished"
+          // are now different states, and a run that stops with work left must
+          // say so. A summary that reads identically either way is the same
+          // false-success the D4/D5/D6 round was about.
+          const backlog = purgeResult.tenantsWithBacklog.length > 0;
 
           console.log(
             `analytics:purge complete — correlationId=${ctx.correlationId} ` +
@@ -149,22 +184,29 @@ async function main() {
               (skipped
                 ? ` (WARNING: ${purgeResult.tenantsSkipped} tenant(s) skipped — database busy;` +
                   ` data past retention is STILL HELD for: ${purgeResult.skippedTenantIds.join(", ")})`
+                : "") +
+              (backlog
+                ? ` (${purgeResult.tenantsWithBacklog.length} tenant(s) hit the pass cap with work remaining;` +
+                  ` the next run continues them: ${purgeResult.tenantsWithBacklog.join(", ")})`
                 : "")
           );
 
           return {
-            status: skipped ? "partial" : "success",
+            status: skipped || backlog ? "partial" : "success",
             itemCounts: {
               tenantsChecked: purgeResult.tenantsChecked,
               eventsDeleted: purgeResult.eventsDeleted,
               sessionsRawDetailCleared: purgeResult.sessionsRawDetailCleared,
               sessionsDeleted: purgeResult.sessionsDeleted,
               rollupsDeleted: purgeResult.rollupsDeleted,
-              tenantsSkipped: purgeResult.tenantsSkipped
+              tenantsSkipped: purgeResult.tenantsSkipped,
+              tenantsWithBacklog: purgeResult.tenantsWithBacklog.length
             },
             detail: skipped
               ? `${purgeResult.tenantsSkipped} tenant(s) skipped due to database backpressure`
-              : undefined
+              : backlog
+                ? `${purgeResult.tenantsWithBacklog.length} tenant(s) hit the pass cap with work remaining`
+                : undefined
           };
         }
       },

--- a/sql/145_awcms_subject_actor_indexes.sql
+++ b/sql/145_awcms_subject_actor_indexes.sql
@@ -1,0 +1,51 @@
+-- 145_awcms_subject_actor_indexes.sql
+--
+-- Finding C5 of the 17 August 2026 audit round — the subject-data export reads
+-- two of the largest append-only tables in the schema over columns nothing
+-- indexes.
+--
+-- `readSubjectExport` answers "everything this repository holds about this
+-- person" by reading every registered exportable table with a predicate on the
+-- subject's own columns. For `awcms_audit_events` and `awcms_domain_events`
+-- those columns are `actor_tenant_user_id` (plus `actor_profile_id` on the
+-- second), and neither has an index — so a data-subject-access request is two
+-- sequential scans of the tables that grow fastest and are never pruned below
+-- their retention window.
+--
+-- ## Why no gate saw it
+--
+-- `db:fk-index:check` enforces "an FK column must be index-reachable"
+-- (ADR-0064). These columns are NOT foreign keys, deliberately: an audit row
+-- must survive the deletion of the actor it names, and an FK would either block
+-- that deletion or cascade the evidence away. So the one gate that looks at
+-- index coverage structurally cannot see them, and the near-miss makes it
+-- worse: `awcms_audit_events_actor_tenant_idx` covers `actor_tenant_id` — the
+-- delegated actor's TENANT, a different column one character apart in reading.
+--
+-- ## Shape
+--
+-- Partial on `IS NOT NULL`, because most rows have no actor at all (system
+-- writes, scheduled jobs, anonymous public events) and an index entry for every
+-- one of them is bytes on the write path bought for nothing. `tenant_id` leads,
+-- matching the export's own predicate and every other index on these tables.
+--
+-- No `created_at` tail: the export takes the whole set for one subject and does
+-- not order it, so a third column would only widen the entry. That is a
+-- deliberate difference from `awcms_audit_events_actor_tenant_idx`, which
+-- serves a time-ordered admin listing.
+
+CREATE INDEX IF NOT EXISTS awcms_audit_events_actor_tenant_user_idx
+  ON awcms_audit_events (tenant_id, actor_tenant_user_id)
+  WHERE actor_tenant_user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS awcms_domain_events_actor_tenant_user_idx
+  ON awcms_domain_events (tenant_id, actor_tenant_user_id)
+  WHERE actor_tenant_user_id IS NOT NULL;
+
+-- `awcms_domain_events` matches the subject on a SECOND column, and the export
+-- ORs them. Postgres can use two partial indexes for an OR through a BitmapOr,
+-- which is why this is two narrow indexes rather than one composite that would
+-- serve neither branch alone.
+CREATE INDEX IF NOT EXISTS awcms_domain_events_actor_profile_idx
+  ON awcms_domain_events (tenant_id, actor_profile_id)
+  WHERE actor_profile_id IS NOT NULL;

--- a/src/modules/data-lifecycle/application/subject-data-executor.ts
+++ b/src/modules/data-lifecycle/application/subject-data-executor.ts
@@ -127,6 +127,40 @@ export type SubjectTableExport = {
   /** Columns held back — carried so the report can SAY what it withheld. */
   redactedColumns: readonly string[];
   rows: readonly Record<string, unknown>[];
+  /**
+   * Finding C5 — this table filled the row cap, so the export is INCOMPLETE for
+   * it.
+   *
+   * Reported, never swallowed, and that is the whole reason a cap is acceptable
+   * here at all. A subject-access export that quietly returned the first N rows
+   * would answer a legal obligation with a number dressed as an answer —
+   * strictly worse than the unbounded read it replaced, which was at least
+   * honest. `redactedColumns` already establishes the shape: the report says
+   * what it held back.
+   */
+  truncated: boolean;
+};
+
+/**
+ * Finding C5 — the export ran 49 reads with no LIMIT, buffering every row of
+ * every registered table into one interactive HTTP response, inside one
+ * transaction.
+ *
+ * The cap is a SAFETY VALVE, not a page size. It sits far above any real
+ * subject's footprint; the point is that a pathological case — an automation
+ * account named as actor on a million audit rows — degrades into a flagged,
+ * incomplete report rather than a transaction that buffers a million rows and
+ * then times out with nothing to show for it.
+ *
+ * There is deliberately no cursor. Paging a subject-access export would mean
+ * the "complete answer" is assembled by a client across requests, and every
+ * page boundary is a place where a partial answer can be mistaken for the whole
+ * one. A flagged truncation says the true thing in one response.
+ */
+export const SUBJECT_EXPORT_ROW_LIMIT = 10_000;
+
+export type SubjectExportOptions = {
+  rowLimit?: number;
 };
 
 /**
@@ -171,8 +205,10 @@ export async function readSubjectExport(
   tx: Bun.SQL,
   tenantId: string,
   plan: SubjectPlan,
-  columnTypes: ReadonlyMap<string, ColumnType[]>
+  columnTypes: ReadonlyMap<string, ColumnType[]>,
+  options: SubjectExportOptions = {}
 ): Promise<SubjectTableExport[]> {
+  const rowLimit = options.rowLimit ?? SUBJECT_EXPORT_ROW_LIMIT;
   const results: SubjectTableExport[] = [];
 
   for (const entry of plan.exportEntries) {
@@ -192,24 +228,35 @@ export async function readSubjectExport(
         tableName: entry.tableName,
         ownerModuleKey: entry.ownerModuleKey,
         redactedColumns: entry.redactedColumns,
-        rows: []
+        rows: [],
+        // Nothing was read, so nothing was cut short. `false` here is a fact,
+        // not a default.
+        truncated: false
       });
       continue;
     }
 
     const predicate = subjectPredicate(entry, 2);
+    // `rowLimit + 1` is what makes `truncated` truthful rather than a guess:
+    // reading exactly the limit cannot distinguish "there were exactly N" from
+    // "there were more". One extra row answers it, and is discarded.
+    const limitPlaceholder = `$${2 + predicate.values.length}`;
     const rows = (await tx.unsafe(
       `SELECT ${selected.join(", ")} FROM ${table} ` +
-        `WHERE ${tenantColumn} = $1::uuid AND ${predicate.sql}`,
-      [tenantId, ...predicate.values]
+        `WHERE ${tenantColumn} = $1::uuid AND ${predicate.sql} ` +
+        `LIMIT ${limitPlaceholder}`,
+      [tenantId, ...predicate.values, rowLimit + 1]
     )) as Record<string, unknown>[];
+
+    const truncated = rows.length > rowLimit;
 
     results.push({
       key: entry.key,
       tableName: entry.tableName,
       ownerModuleKey: entry.ownerModuleKey,
       redactedColumns: entry.redactedColumns,
-      rows
+      rows: truncated ? rows.slice(0, rowLimit) : rows,
+      truncated
     });
   }
 

--- a/src/modules/visitor-analytics/application/retention-purge.ts
+++ b/src/modules/visitor-analytics/application/retention-purge.ts
@@ -51,6 +51,33 @@ export type RetentionPurgeResult = {
   sessionsRawDetailCleared: number;
   sessionsDeleted: number;
   rollupsDeleted: number;
+  /**
+   * Finding C2 — at least one of the four statements filled its batch, so there
+   * is more to purge. The caller decides what to do with that: the scheduled
+   * job loops in a FRESH transaction per pass; the on-demand endpoint returns
+   * it, because an interactive request must not hold a purge of unknown size
+   * open.
+   */
+  hasMore: boolean;
+};
+
+/**
+ * Finding C2 — this was the only unbounded retention purge in the repo. Four
+ * statements with no limit, each using `RETURNING id` purely to take a JS-side
+ * `.length`, so a tenant with a year of unpurged analytics deleted every row in
+ * ONE transaction: one lock set held for the duration, one WAL burst, and a
+ * `statement_timeout` that turns the whole pass into a rollback rather than
+ * partial progress.
+ *
+ * 5000 is the number every sibling already uses
+ * (`AUDIT_EVENT_PURGE_BATCH_LIMIT`), and matching it matters more than the
+ * value: a purge cadence that differs per table for no stated reason is a
+ * cadence nobody can reason about.
+ */
+export const VISITOR_ANALYTICS_PURGE_BATCH_LIMIT = 5000;
+
+export type PurgeVisitorAnalyticsOptions = {
+  batchLimit?: number;
 };
 
 function daysAgo(now: Date, days: number): Date {
@@ -62,8 +89,10 @@ export async function purgeVisitorAnalyticsData(
   tenantId: string,
   config: VisitorAnalyticsConfig,
   now: Date,
-  legalHoldGuard: LegalHoldGuardPort
+  legalHoldGuard: LegalHoldGuardPort,
+  options: PurgeVisitorAnalyticsOptions = {}
 ): Promise<RetentionPurgeResult> {
+  const batchLimit = options.batchLimit ?? VISITOR_ANALYTICS_PURGE_BATCH_LIMIT;
   const eventCutoff = daysAgo(now, config.eventRetentionDays);
   const rawDetailCutoff = daysAgo(now, config.rawDetailRetentionDays);
   const rollupCutoff = daysAgo(now, config.rollupRetentionDays)
@@ -84,38 +113,82 @@ export async function purgeVisitorAnalyticsData(
       eventsDeleted: 0,
       sessionsRawDetailCleared: 0,
       sessionsDeleted: 0,
-      rollupsDeleted: 0
+      rollupsDeleted: 0,
+      // A hold is not "more to purge": looping would spin forever against a
+      // control whose whole purpose is to stop the purge.
+      hasMore: false
     };
   }
 
+  // Every statement is `WHERE <pk> IN (SELECT … ORDER BY … LIMIT n)` — the shape
+  // `audit-purge.ts` already established.
+  //
+  // What the ORDER BY buys, stated precisely: termination does NOT depend on it
+  // (a DELETE removes what it took, so any bounded slice shrinks the set and the
+  // loop ends regardless). It buys OLDEST-FIRST, which is worth having for two
+  // reasons — the ordering matches the index the predicate already uses, and a
+  // purge interrupted half way has removed the data furthest past retention
+  // rather than an arbitrary slice of it. On a retention control, "which half
+  // got deleted" is not a detail.
+  //
+  // `tenant_id` stays in the inner predicate even though FORCE RLS already
+  // scopes the table: it keeps the index usable.
   const deletedEvents = await tx`
     DELETE FROM awcms_visit_events
-    WHERE tenant_id = ${tenantId} AND occurred_at < ${eventCutoff}
+    WHERE id IN (
+      SELECT id FROM awcms_visit_events
+      WHERE tenant_id = ${tenantId} AND occurred_at < ${eventCutoff}
+      ORDER BY occurred_at ASC
+      LIMIT ${batchLimit}
+    )
     RETURNING id
   `;
 
   const clearedSessions = await tx`
     UPDATE awcms_visitor_sessions
     SET ip_address = NULL, login_identifier_snapshot = NULL, updated_at = now()
-    WHERE tenant_id = ${tenantId}
-      AND last_seen_at < ${rawDetailCutoff}
-      AND (ip_address IS NOT NULL OR login_identifier_snapshot IS NOT NULL)
+    WHERE id IN (
+      SELECT id FROM awcms_visitor_sessions
+      WHERE tenant_id = ${tenantId}
+        AND last_seen_at < ${rawDetailCutoff}
+        AND (ip_address IS NOT NULL OR login_identifier_snapshot IS NOT NULL)
+      ORDER BY last_seen_at ASC
+      LIMIT ${batchLimit}
+    )
     RETURNING id
   `;
 
+  // The `NOT EXISTS` guard stays exactly where it was and is why this statement
+  // is ordered by `last_seen_at` rather than deleted outright: a session whose
+  // events have not been purged yet is skipped THIS pass and caught by a later
+  // one, once step 1 has removed them.
   const deletedSessions = await tx`
-    DELETE FROM awcms_visitor_sessions s
-    WHERE s.tenant_id = ${tenantId} AND s.last_seen_at < ${eventCutoff}
-      AND NOT EXISTS (
-        SELECT 1 FROM awcms_visit_events e
-        WHERE e.visitor_session_id = s.id
-      )
+    DELETE FROM awcms_visitor_sessions
+    WHERE id IN (
+      SELECT s.id FROM awcms_visitor_sessions s
+      WHERE s.tenant_id = ${tenantId} AND s.last_seen_at < ${eventCutoff}
+        AND NOT EXISTS (
+          SELECT 1 FROM awcms_visit_events e
+          WHERE e.visitor_session_id = s.id
+        )
+      ORDER BY s.last_seen_at ASC
+      LIMIT ${batchLimit}
+    )
     RETURNING id
   `;
 
+  // `awcms_visitor_daily_rollups` is keyed on `(tenant_id, date, area)`, not a
+  // surrogate id, so the bound is `ctid` — the one identifier every Postgres
+  // row has. It is not stable across an UPDATE, which is exactly why it is
+  // only ever used inside the single statement that selected it.
   const deletedRollups = await tx`
     DELETE FROM awcms_visitor_daily_rollups
-    WHERE tenant_id = ${tenantId} AND date < ${rollupCutoff}
+    WHERE ctid IN (
+      SELECT ctid FROM awcms_visitor_daily_rollups
+      WHERE tenant_id = ${tenantId} AND date < ${rollupCutoff}
+      ORDER BY date ASC
+      LIMIT ${batchLimit}
+    )
     RETURNING tenant_id
   `;
 
@@ -123,6 +196,12 @@ export async function purgeVisitorAnalyticsData(
     eventsDeleted: deletedEvents.length,
     sessionsRawDetailCleared: clearedSessions.length,
     sessionsDeleted: deletedSessions.length,
-    rollupsDeleted: deletedRollups.length
+    rollupsDeleted: deletedRollups.length,
+    // Any statement that filled its batch means there is more behind it.
+    hasMore:
+      deletedEvents.length === batchLimit ||
+      clearedSessions.length === batchLimit ||
+      deletedSessions.length === batchLimit ||
+      deletedRollups.length === batchLimit
   };
 }

--- a/src/pages/api/v1/analytics/retention/purge.ts
+++ b/src/pages/api/v1/analytics/retention/purge.ts
@@ -99,6 +99,12 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
       });
     }
 
+    // Finding C2 — ONE bounded pass, deliberately. The scheduled job loops until
+    // a tenant is drained; an interactive request must not, because the size of
+    // the work is unknown at the moment the caller presses the button and a
+    // request that holds a purge of unbounded size open is the problem the
+    // batching was added to remove. `hasMore` travels back in the response body
+    // so the operator knows to run it again rather than assuming it finished.
     const result = await purgeVisitorAnalyticsData(
       tx,
       tenantId,

--- a/src/pages/api/v1/data-lifecycle/subject-requests/export.ts
+++ b/src/pages/api/v1/data-lifecycle/subject-requests/export.ts
@@ -168,6 +168,15 @@ export const POST = defineTenantRoute<Prepared>({
     );
     const tables = await readSubjectExport(tx, tenantId, plan, columnTypes);
     const rowCount = tables.reduce((sum, table) => sum + table.rows.length, 0);
+    // Finding C5 — the export is row-capped now, so "incomplete" is a state
+    // that can occur and must never be silent. It rides in the response
+    // alongside `unanswered` (this file's own coverage statement) and into the
+    // audit event, because a disclosure record that says "we gave them
+    // everything" when a table was cut short is the record being wrong about
+    // the one thing it exists to establish.
+    const truncatedTables = tables
+      .filter((table) => table.truncated)
+      .map((table) => table.key);
 
     const record = await recordExportDisclosure(tx, tenantId, {
       subjectTenantUserId: prepared.subjectTenantUserId,
@@ -189,13 +198,17 @@ export const POST = defineTenantRoute<Prepared>({
       resourceType: "subject_request",
       resourceId: record.id,
       severity: "critical",
-      message: `Subject-access export disclosed for tenant user ${prepared.subjectTenantUserId}`,
+      message:
+        truncatedTables.length > 0
+          ? `Subject-access export disclosed for tenant user ${prepared.subjectTenantUserId} — INCOMPLETE, ${truncatedTables.length} table(s) hit the row cap`
+          : `Subject-access export disclosed for tenant user ${prepared.subjectTenantUserId}`,
       attributes: {
         subjectTenantUserId: prepared.subjectTenantUserId,
         reason: prepared.reason,
         tablesRead: tables.length,
         rowCount,
-        tablesUnanswered: plan.unansweredEntries.length
+        tablesUnanswered: plan.unansweredEntries.length,
+        tablesTruncated: truncatedTables
       },
       correlationId: locals.correlationId ?? undefined
     });
@@ -205,7 +218,11 @@ export const POST = defineTenantRoute<Prepared>({
       subject: { tenantUserId: prepared.subjectTenantUserId },
       tables,
       // The report's own coverage statement — see this file's header.
-      unanswered: plan.unansweredEntries
+      unanswered: plan.unansweredEntries,
+      // The second half of that statement (finding C5): which tables were cut
+      // short. Empty means the report is complete, which is a claim worth being
+      // able to make explicitly rather than by the absence of a warning.
+      truncatedTables
     });
     const successBody = await successResponse.clone().json();
 

--- a/tests/integration/data-lifecycle-tenant-state.integration.test.ts
+++ b/tests/integration/data-lifecycle-tenant-state.integration.test.ts
@@ -269,7 +269,10 @@ suite("data_lifecycle module (integration)", () => {
       eventsDeleted: 0,
       sessionsRawDetailCleared: 0,
       sessionsDeleted: 0,
-      rollupsDeleted: 0
+      rollupsDeleted: 0,
+      // Finding C2 — a hold is not "more to purge". Looping on it would spin
+      // forever against a control whose whole purpose is to stop the purge.
+      hasMore: false
     });
 
     // The PII column is physically untouched, and both rows still exist.

--- a/tests/integration/unbounded-reads.integration.test.ts
+++ b/tests/integration/unbounded-reads.integration.test.ts
@@ -1,0 +1,412 @@
+/**
+ * Findings C2 and C5 of the 17 August 2026 audit round — two reads with no
+ * ceiling.
+ *
+ * They are one PR because they are one habit: a statement whose cost is
+ * O(everything this tenant has ever accumulated), written where the author was
+ * thinking about one subject or one cutoff. Neither is wrong on a small table
+ * and neither has a size at which it starts being wrong loudly.
+ *
+ * Against a real PostgreSQL, and it has to be. C2's fix is only meaningful if
+ * repeated passes make monotonic progress, which is a property of what the
+ * previous pass actually deleted; C5's is a claim about which PLAN the planner
+ * chooses, and a fake driver has no planner.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { purgeVisitorAnalyticsData } from "../../src/modules/visitor-analytics/application/retention-purge";
+import {
+  loadColumnTypes,
+  readSubjectExport
+} from "../../src/modules/data-lifecycle/application/subject-data-executor";
+import { buildSubjectPlan } from "../../src/modules/data-lifecycle/domain/subject-data-plan";
+import { collectSubjectDataDescriptors } from "../../src/modules/data-lifecycle/domain/subject-data-registry";
+import { listModules } from "../../src/modules";
+import { stripComments } from "../../scripts/lib/source-text";
+import { VISITOR_ANALYTICS_DEFAULTS } from "../../src/modules/visitor-analytics/domain/visitor-analytics-config";
+import type { LegalHoldGuardPort } from "../../src/modules/_shared/ports/legal-hold-guard-port";
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+const TENANT = "c2c2c2c2-c2c2-4c2c-8c2c-c2c2c2c2c2c2";
+const SUBJECT = "c5c5c5c5-c5c5-4c5c-8c5c-c5c5c5c5c5c5";
+// Distinct ids, never reused: `buildSubjectPlan` ORs the three, so sharing one
+// value would make a match on the wrong column look like a match on the right
+// one and the truncation assertions would be about the wrong row set.
+const SUBJECT_IDENTITY = "c5c5c5c5-c5c5-4c5c-8c5c-c5c5c5c5c5c6";
+const SUBJECT_PROFILE = "c5c5c5c5-c5c5-4c5c-8c5c-c5c5c5c5c5c7";
+const NOW = new Date("2026-08-22T12:00:00.000Z");
+
+/** No hold. The held path has its own test in `data-lifecycle-tenant-state`. */
+const NO_HOLD: LegalHoldGuardPort = {
+  async isDescriptorHeld() {
+    return false;
+  }
+};
+
+async function seedTenant(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${TENANT}, 'c2-bounds', 'C2 Bounds', 'active')
+  `;
+}
+
+/** `count` visit events, all comfortably past the retention cutoff. */
+async function seedOldEvents(count: number): Promise<void> {
+  const old = new Date(
+    NOW.getTime() -
+      (VISITOR_ANALYTICS_DEFAULTS.eventRetentionDays + 30) * 86_400_000
+  );
+
+  await getAdminSql()`
+    INSERT INTO awcms_visit_events
+      (tenant_id, occurred_at, method, area, path_sanitized, human_status)
+    SELECT ${TENANT}, ${old}::timestamptz + (g || ' seconds')::interval,
+           'GET', 'public', '/x', 'human'
+    FROM generate_series(1, ${count}) g
+  `;
+}
+
+function purge(batchLimit: number) {
+  return withTenantOrThrow(
+    getRuntimeSql(),
+    TENANT,
+    (tx) =>
+      purgeVisitorAnalyticsData(
+        tx,
+        TENANT,
+        VISITOR_ANALYTICS_DEFAULTS,
+        NOW,
+        NO_HOLD,
+        { batchLimit }
+      ),
+    { workClass: "maintenance" }
+  );
+}
+
+async function remainingEvents(): Promise<number> {
+  const rows = (await getAdminSql()`
+    SELECT count(*)::int AS n FROM awcms_visit_events WHERE tenant_id = ${TENANT}
+  `) as { n: number }[];
+
+  return rows[0]!.n;
+}
+
+suite("reads that used to have no ceiling (C2, C5)", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant();
+  });
+
+  test("C2: a pass deletes at most its batch, and says there is more", async () => {
+    await seedOldEvents(25);
+
+    const first = await purge(10);
+
+    expect(first.eventsDeleted).toBe(10);
+    expect(first.hasMore).toBe(true);
+    expect(await remainingEvents()).toBe(15);
+  });
+
+  test("C2: repeated passes converge and then stop", async () => {
+    // Termination does not depend on the ORDER BY — a DELETE removes what it
+    // took — so this asserts convergence, which is what is actually true. What
+    // the ordering buys has its own test below.
+    await seedOldEvents(25);
+
+    const counts: number[] = [];
+    let passes = 0;
+
+    for (;;) {
+      const pass = await purge(10);
+      counts.push(pass.eventsDeleted);
+      passes += 1;
+
+      if (!pass.hasMore) break;
+      if (passes > 10) throw new Error("purge did not converge");
+    }
+
+    expect(counts).toEqual([10, 10, 5]);
+    expect(await remainingEvents()).toBe(0);
+  });
+
+  test("C2: a pass that exactly empties the table still reports hasMore, and the next one is a no-op", async () => {
+    // `hasMore` is "the batch filled", not "rows remain" — it cannot be the
+    // latter without a second count. The honest consequence is one extra empty
+    // pass, which the loop terminates on, and this test exists so that extra
+    // pass is a documented behaviour rather than a surprise.
+    await seedOldEvents(10);
+
+    const first = await purge(10);
+    expect(first.eventsDeleted).toBe(10);
+    expect(first.hasMore).toBe(true);
+
+    const second = await purge(10);
+    expect(second.eventsDeleted).toBe(0);
+    expect(second.hasMore).toBe(false);
+  });
+
+  test("C2: a partial purge removes the OLDEST rows, not an arbitrary slice", async () => {
+    // What the ORDER BY actually buys, pinned. Dropping it left every other
+    // test in this file green — Postgres returned rows in physical order on a
+    // small table and the ordering looked redundant. On a retention control,
+    // "which half got deleted when the pass ran out of budget" is not a detail:
+    // an interrupted purge must have removed the data furthest past its window.
+    await seedOldEvents(20);
+
+    await purge(5);
+
+    const rows = (await getAdminSql()`
+      SELECT occurred_at FROM awcms_visit_events
+      WHERE tenant_id = ${TENANT} ORDER BY occurred_at ASC LIMIT 1
+    `) as { occurred_at: Date }[];
+
+    const oldest = new Date(
+      NOW.getTime() -
+        (VISITOR_ANALYTICS_DEFAULTS.eventRetentionDays + 30) * 86_400_000
+    );
+
+    // The five oldest are gone, so the survivor's timestamp is at least five
+    // one-second steps past the seed's start.
+    expect(rows[0]!.occurred_at.getTime()).toBeGreaterThanOrEqual(
+      oldest.getTime() + 5_000
+    );
+  });
+
+  test("C2: nothing past the cutoff is touched", async () => {
+    // NON-VACUOUS. A purge that deleted everything would satisfy every count
+    // above.
+    await seedOldEvents(5);
+    await getAdminSql()`
+      INSERT INTO awcms_visit_events
+        (tenant_id, occurred_at, method, area, path_sanitized, human_status)
+      VALUES (${TENANT}, ${NOW}, 'GET', 'public', '/fresh', 'human')
+    `;
+
+    await purge(100);
+
+    expect(await remainingEvents()).toBe(1);
+  });
+
+  test("C5: the subject-actor read uses the new index instead of scanning", async () => {
+    // `db:fk-index:check` structurally cannot see these columns — they are not
+    // foreign keys, deliberately, because an audit row must survive the deletion
+    // of the actor it names. So the coverage is asserted here or nowhere.
+    const admin = getAdminSql();
+
+    await admin`
+      INSERT INTO awcms_audit_events
+        (tenant_id, actor_tenant_user_id, module_key, action, resource_type, severity, message)
+      SELECT ${TENANT},
+             CASE WHEN g % 200 = 0 THEN ${SUBJECT}::uuid ELSE gen_random_uuid() END,
+             'logging', 'x', 'y', 'info', 'm'
+      FROM generate_series(1, 4000) g
+    `;
+    await admin.unsafe("ANALYZE awcms_audit_events");
+
+    const plan = (await admin.unsafe(
+      `EXPLAIN (FORMAT JSON)
+       SELECT id FROM awcms_audit_events
+       WHERE tenant_id = $1::uuid AND actor_tenant_user_id = $2::uuid`,
+      [TENANT, SUBJECT]
+    )) as { "QUERY PLAN": unknown }[];
+
+    const text = JSON.stringify(plan);
+
+    expect(text).toContain("awcms_audit_events_actor_tenant_user_idx");
+    expect(text).not.toContain("Seq Scan");
+  });
+
+  test("C5: dropping the index brings the scan back — the assertion above is not free", async () => {
+    // Without this, every claim in the previous test also passes on a table too
+    // small for the planner to care, which is the failure mode
+    // `blog-list-ordering-plan` documents for the same kind of assertion. The
+    // drop is inside a transaction that is rolled back, so the schema is
+    // untouched.
+    const admin = getAdminSql();
+
+    await admin`
+      INSERT INTO awcms_audit_events
+        (tenant_id, actor_tenant_user_id, module_key, action, resource_type, severity, message)
+      SELECT ${TENANT},
+             CASE WHEN g % 200 = 0 THEN ${SUBJECT}::uuid ELSE gen_random_uuid() END,
+             'logging', 'x', 'y', 'info', 'm'
+      FROM generate_series(1, 4000) g
+    `;
+    await admin.unsafe("ANALYZE awcms_audit_events");
+
+    let planWithout = "";
+
+    try {
+      await admin.begin(async (tx) => {
+        await tx.unsafe("DROP INDEX awcms_audit_events_actor_tenant_user_idx");
+        await tx.unsafe("ANALYZE awcms_audit_events");
+
+        const plan = (await tx.unsafe(
+          `EXPLAIN (FORMAT JSON)
+           SELECT id FROM awcms_audit_events
+           WHERE tenant_id = $1::uuid AND actor_tenant_user_id = $2::uuid`,
+          [TENANT, SUBJECT]
+        )) as { "QUERY PLAN": unknown }[];
+
+        planWithout = JSON.stringify(plan);
+
+        // `expect().rejects` hangs on this pool harness, so the rollback is a
+        // thrown sentinel caught outside.
+        throw new Error("__rollback__");
+      });
+    } catch (error) {
+      if ((error as Error).message !== "__rollback__") throw error;
+    }
+
+    expect(planWithout).toContain("Seq Scan");
+  });
+  test("C5: a table over the cap is CUT and SAYS SO, and one under it is not", async () => {
+    // The two halves have to be asserted together. `truncated: true` on
+    // everything would satisfy the first assertion alone, and a report that
+    // over-claims incompleteness is its own kind of wrong on a legal
+    // obligation.
+    const admin = getAdminSql();
+
+    await admin`
+      INSERT INTO awcms_audit_events
+        (tenant_id, actor_tenant_user_id, module_key, action, resource_type, severity, message)
+      SELECT ${TENANT}, ${SUBJECT}::uuid, 'logging', 'x', 'y', 'info', 'm'
+      FROM generate_series(1, 12) g
+    `;
+
+    const plan = buildSubjectPlan(
+      collectSubjectDataDescriptors(listModules()),
+      {
+        tenantId: TENANT,
+        tenantUserId: SUBJECT,
+        identityId: SUBJECT_IDENTITY,
+        profileId: SUBJECT_PROFILE
+      }
+    );
+    const tableNames = plan.exportEntries.map((entry) => entry.tableName);
+
+    const tables = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) =>
+        readSubjectExport(
+          tx,
+          TENANT,
+          plan,
+          await loadColumnTypes(tx, tableNames),
+          { rowLimit: 10 }
+        ),
+      { workClass: "interactive" }
+    );
+
+    const audit = tables.find(
+      (table) => table.tableName === "awcms_audit_events"
+    );
+
+    expect(audit).toBeDefined();
+    // Exactly the cap, not the cap plus the probe row.
+    expect(audit!.rows).toHaveLength(10);
+    expect(audit!.truncated).toBe(true);
+
+    // Every other table has nothing for this subject and must not claim to have
+    // been cut short.
+    for (const table of tables) {
+      if (table.tableName === "awcms_audit_events") continue;
+      expect(table.truncated).toBe(false);
+    }
+  });
+
+  test("C5: a table exactly AT the cap is not reported as truncated", async () => {
+    // The off-by-one the `+1` probe row exists to get right. Reading exactly the
+    // limit cannot distinguish "there were exactly N" from "there were more",
+    // and guessing either way is wrong on a report that is signed.
+    const admin = getAdminSql();
+
+    await admin`
+      INSERT INTO awcms_audit_events
+        (tenant_id, actor_tenant_user_id, module_key, action, resource_type, severity, message)
+      SELECT ${TENANT}, ${SUBJECT}::uuid, 'logging', 'x', 'y', 'info', 'm'
+      FROM generate_series(1, 10) g
+    `;
+
+    const plan = buildSubjectPlan(
+      collectSubjectDataDescriptors(listModules()),
+      {
+        tenantId: TENANT,
+        tenantUserId: SUBJECT,
+        identityId: SUBJECT_IDENTITY,
+        profileId: SUBJECT_PROFILE
+      }
+    );
+
+    const tables = await withTenantOrThrow(
+      getRuntimeSql(),
+      TENANT,
+      async (tx) =>
+        readSubjectExport(
+          tx,
+          TENANT,
+          plan,
+          await loadColumnTypes(
+            tx,
+            plan.exportEntries.map((entry) => entry.tableName)
+          ),
+          { rowLimit: 10 }
+        ),
+      { workClass: "interactive" }
+    );
+
+    const audit = tables.find(
+      (table) => table.tableName === "awcms_audit_events"
+    )!;
+
+    expect(audit.rows).toHaveLength(10);
+    expect(audit.truncated).toBe(false);
+  });
+  test("C5: the LIMIT is actually in the statement, not just in the result shape", async () => {
+    // This assertion exists because removing the LIMIT entirely turned NOTHING
+    // red. With 12 rows and a cap of 10, an unbounded read still yields
+    // `rows.length = 12 > 10`, so `truncated` is still true and the slice is
+    // still 10 — the behaviour is identical and only the COST differs. That is
+    // precisely the shape of the finding: an unbounded read that looks fine
+    // from the outside.
+    //
+    // Comments stripped first: the paragraph above this one in the executor
+    // discusses the LIMIT at length, and an assertion that matched prose rather
+    // than code would be finding D2 all over again.
+    const source = stripComments(
+      await Bun.file(
+        "src/modules/data-lifecycle/application/subject-data-executor.ts"
+      ).text()
+    );
+
+    expect(source).toContain("LIMIT ${limitPlaceholder}");
+    // And the probe row that makes `truncated` a fact rather than a guess.
+    expect(source).toContain("rowLimit + 1");
+  });
+});


### PR DESCRIPTION
Findings **C2** and **C5** of the 17 August 2026 audit round. `sql/145`. One PR because they are one habit: a statement whose real cost is O(everything this tenant has ever accumulated), written where the author was thinking about one subject or one cutoff.

## C2 — the only unbounded retention purge in the repo

Four statements with no batch limit, each using `RETURNING id` purely to take a JS-side `.length`. A tenant with a year of unpurged analytics deleted every row in one transaction: one lock set held for the duration, one WAL burst, and a `statement_timeout` that turns the whole pass into a rollback rather than partial progress. Every sibling already caps at 5000 and loops.

All four are now `WHERE <pk> IN (SELECT … ORDER BY … LIMIT n)` and the function returns `hasMore`. The scheduled job loops with a **fresh transaction per pass** — looping inside one would hold every lock and dead tuple for the duration, which is the thing the batching exists to avoid — and names any tenant that hits the pass cap. The on-demand endpoint does **one** bounded pass and returns `hasMore`, because the size of the work is unknown when the caller presses the button.

**A correction found by mutation, not by reading.** The code comment I first wrote claimed the `ORDER BY` gave monotonic progress. It does not — a DELETE removes what it took, so termination holds without it. What it buys is *oldest-first*: it matches the index the predicate already uses, and an interrupted purge has then removed the data furthest past retention rather than an arbitrary slice. On a retention control, "which half got deleted" is not a detail. Removing the `ORDER BY` left every test green until a test was written for the property that is actually true.

`awcms_visitor_daily_rollups` is bounded on `ctid` rather than a surrogate id — it is keyed `(tenant_id, date, area)` and has no id column. `ctid` is not stable across an UPDATE, which is exactly why it is only ever used inside the single statement that selected it.

## C5 — 49 unbounded reads, two over columns no gate can see

`awcms_audit_events.actor_tenant_user_id` and the `awcms_domain_events` twin have no index, and they are **not foreign keys** — deliberately, because an audit row must survive the deletion of the actor it names. So `db:fk-index:check` (ADR-0064) structurally cannot see them. The near-miss makes it worse: `awcms_audit_events_actor_tenant_idx` covers `actor_tenant_id`, the delegated actor's *tenant* — a different column, one character apart in reading.

`sql/145` adds three partial indexes (partial on `IS NOT NULL`, because most rows have no actor at all). **Measured** on 60,000 rows:

| | Buffers | Time |
|---|---|---|
| Seq Scan (before) | 858 | 2.511 ms |
| Index Scan (after) | 33 | 0.039 ms |

`awcms_domain_events` matches the subject on two columns which the export ORs, so it gets two narrow indexes rather than one composite that would serve neither branch alone — Postgres reaches them through a BitmapOr.

The reads are also row-capped, **with the cap reported**. That is the only reason a cap is acceptable here: an export that quietly returned the first N rows would answer a legal obligation with a number dressed as an answer — strictly worse than the unbounded read it replaced, which was at least honest. `truncated` is per table, `truncatedTables` rides beside the existing `unanswered` coverage statement, and the `critical` audit event says INCOMPLETE in its message.

The cap is a safety valve against a pathological subject (an automation account named as actor on a million rows), not a page size. There is deliberately **no cursor**: a "complete answer" assembled by a client across pages has a boundary at every request where a partial answer can be mistaken for the whole one.

## Tests

`tests/integration/unbounded-reads.integration.test.ts` (10) against real PostgreSQL — C2's bounded pass, convergence, the exactly-empties edge (`hasMore` means "the batch filled", not "rows remain", and the honest consequence is one extra empty pass), oldest-first, and the non-vacuous "nothing past the cutoff is touched". For C5: the plan assertion, a **drop-the-index-and-roll-back** counterpart so the plan claim is not free on a small table, the truncation flag in both directions, and the exactly-at-the-cap off-by-one.

**Mutation-proven**, and two mutations changed the work rather than just confirming it:

- Removing the `ORDER BY` turned **nothing** red → the code comment was wrong and a test for the true property was added.
- Removing the `LIMIT` **entirely** turned nothing red → with 12 rows and a cap of 10, the flag and the slice come out identical and only the *cost* differs, which is the finding's own shape. The suite now carries an explicit assertion that the statement really contains the LIMIT (comments stripped first — D2's lesson).

The other five all turn exactly one test red: unbounded events delete, `hasMore` forced false, `ORDER BY` reversed, the probe row kept, and the `+1` probe removed.

## Verification

`DATABASE_URL="" bun run check` — green (5512 pass, 0 fail, 57 gates).
`bun test tests/integration/` — 505 pass, 2 fail; both are the pre-existing local `http`/`https` scheme failures verified on unmodified `main`.
Legacy DB-gated suite (17 files) — 148 pass, 0 fail.
`bun run db:migrate` applied `sql/145` against a real database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
