### PR TITLE
fix(security,identity-access,blog-content): three costs that grew with something nobody was watching

### DIFF
--- a/.changeset/costs-that-grow-with-the-tenant.md
+++ b/.changeset/costs-that-grow-with-the-tenant.md
@@ -1,0 +1,51 @@
+---
+"awcms": patch
+---
+
+fix(security,identity-access,blog-content): three costs that grew with something nobody was watching
+
+Three PROJECT_STATE §4 items whose common shape is a cost that is invisible at
+the size everything was tested at, and that grows with something the code never
+looks at: how many clients have ever connected, how many roles a tenant has
+defined, how many tags an article could match.
+
+**B6 — the in-process rate-limit map had no eviction.** One entry per distinct
+client IP, created on first contact and never removed. Redis is off by default,
+so this map is the live path for the topology this base documents as its
+default, and the end state is an OOM of the process that also holds every other
+cache. Two mechanisms now, because a sweep alone is not a bound: an amortised
+sweep drops entries whose window has elapsed (`checkRateLimit` already treats
+that as a fresh start, so they hold no information), and a hard cap of 50,000
+evicts — in one batch, down to 45,000 — the entries CLOSEST TO EXPIRING, which
+is the least harmful choice available when nothing has expired to reclaim. The
+bucket now stores its own `windowMs`: eviction happens outside any call for that
+key, and the map is shared by callers with windows in seconds and in minutes, so
+sweeping by the triggering caller's window would expire the other family's
+counters early. Forgetting a LIVE counter hands its owner a fresh allowance,
+which is the one failure a memory fix must not introduce, and it is asserted
+alongside the size.
+
+**C6 — `/admin/roles` was an N+1 plus a payload that grew as roles × catalogue.**
+`listRolePermissions` was awaited once per role, sequentially (concurrent
+queries on one transaction connection leak it), so a 40-role tenant paid 40
+summed round trips to render one screen; `listRolePermissionsForRoles` answers
+the set in one, with an entry for every requested id so no caller has to tell
+"no grants" from "not in the result". The single-role reader is deleted rather
+than left unused — a zero-caller export is how the next screen quietly
+reintroduces the N+1. The ~230-row permission catalogue was also rendered as
+`<option>`s once per role — ~23,000 options in one document, of which at most
+one is ever chosen. It is now emitted once in a `<template>` and cloned into a
+role's picker on first open, minus what that panel already lists as granted. The
+server still decides whether a picker exists at all, and the endpoint's
+`configure` guard remains the only authority on the grant itself.
+
+**C7 — `prepareCandidates` re-escaped every tag name inside the sort
+comparator.** A comparator runs O(n log n) times: 1090 `escapeHtml` calls per
+sort at the 100-candidate cap instead of 100, on by default on every public
+article render. Decorate-sort-undecorate, with the escaped name carried on the
+row the dedupe loop and the caller both already need.
+
+One thing worth knowing before the next screen: C6's client-side picker costs
+~540 B and leaves **161 B** of headroom under `build:asset-budget:check`'s
+192,000 B app ceiling. The trade is good in itself, but the next client script
+to land will fail that gate for reasons unrelated to whatever it did.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:a605ad70c9f559b56d18940d2356f79ad7e367c84de28b6daee479abacf6b6dc -->
+<!-- i18n-source-hash: sha256:f1a13869b3fa723064588a3816cb62ccff87e0fb057570ec7416dc5ec201a8d1 -->
 
 # AWCMS — Project State & Continuation
 
@@ -114,7 +114,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **145** (`sql/001`–`145`)                                                             | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0103** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **48** berkas `.astro` di `src/pages/admin/`; **0 dari 24** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **61** (34.594 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **61** (34.697 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **57** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -699,10 +699,31 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       plafon ≤3 query hot-read "terukur", tetapi **kedua suite budget memanggil fungsi
       directory langsung dan tidak pernah menggerakkan middleware**, jadi kelebihannya
       secara struktural tak terlihat oleh gerbang yang mengaku menegakkannya.
-  14. **B6 — Map `buckets` rate-limit in-process tanpa eviction.**
+  14. **B6 — Map `buckets` rate-limit in-process tanpa eviction.** **SELESAI (22 Agustus
+      2026).**
       `security/rate-limit.ts:57`. Satu entri permanen per IP klien berbeda; Redis mati
       secara default sehingga inilah jalur hidupnya. Kebocoran lambat, bukan risiko akut —
       tetapi mode gagalnya adalah OOM proses yang memegang setiap cache lain.
+
+      **Dua mekanisme, karena sapuan saja bukan batas.** Sapuan ter-amortisasi (paling
+      sering sekali per menit, dan saat melewati cap) membuang setiap entri yang
+      jendelanya sudah lewat — `checkRateLimit` memang sudah memperlakukan jendela lewat
+      sebagai awal baru, jadi entri seperti itu tidak menyimpan informasi apa pun. Itu
+      membatasi map ke "klien berbeda yang terlihat dalam satu jendela", yaitu working
+      set yang benar dan, saat banjir terdistribusi, dikendalikan penyerang. Maka ada
+      juga cap keras 50.000, dan ketika tercapai korbannya dipilih yang paling tidak
+      merugikan: entri yang PALING DEKAT KEDALUWARSA, dibuang satu batch sampai 45.000
+      supaya sort yang memilihnya jalan sekali per 10% pertumbuhan, bukan tiap request.
+
+      **Rekomendasi tidak menyebut dari mana `windowMs` datang, dan justru itulah inti
+      desainnya.** Bucket kini menyimpannya. Eviction terjadi DI LUAR panggilan untuk
+      kunci itu, jadi sapuan harus tahu kapan entri yang tidak ditanyakan berhenti
+      menghitung, dan map itu dipakai bersama oleh pemanggil dengan jendela berbeda
+      (login menit, site-search detik) — mengambil jendela dari pemanggil yang kebetulan
+      memicu sapuan akan mengedaluwarsakan penghitung keluarga lain lebih awal.
+      Kedaluwarsa dini adalah satu-satunya kegagalan yang tidak boleh diperkenalkan
+      perbaikan memori: melupakan penghitung HIDUP memberi pemiliknya jatah baru —
+      itulah yang diasersi `tests/rate-limit-bucket-eviction.test.ts` bersama ukurannya.
 
   ### C. Ongkos algoritma / query
   15. **C1 — tidak ada indeks yang mendukung pengurutan daftar blog.** **SELESAI (22 Agustus 2026).**
@@ -842,12 +863,54 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       identik dan hanya BIAYA-nya yang berbeda. Itu persis bentuk temuannya sendiri, jadi
       suite-nya kini membawa asersi eksplisit bahwa statement-nya benar-benar memuat LIMIT.
 
-  20. **C6 — `/admin/roles` adalah N+1 plus payload O(peran × katalog).**
+  20. **C6 — `/admin/roles` adalah N+1 plus payload O(peran × katalog).** **SELESAI (22
+      Agustus 2026).**
       `roles.astro:88-94`. `listRolePermissions` di-await sekali per peran (sampai 100,
       berurutan); katalog ~230 baris dirender sebagai `<option>` sekali per peran.
+
+      **Paruh N+1:** `listRolePermissionsForRoles` menjawab seluruh himpunan dalam satu
+      round trip `role_id = ANY(...)` dan mengembalikan entri untuk SETIAP id yang
+      diminta, termasuk array kosong — pemanggil yang harus membedakan "tanpa grant" dari
+      "tidak ada di hasil" akan kembali bertanya per peran. Pembaca satu-peran DIHAPUS,
+      bukan dibiarkan tak terpakai: ekspor tanpa pemanggil adalah cara layar berikutnya
+      diam-diam menghidupkan lagi N+1 (lihat D12/D15/D16 untuk bentuk yang sama sebagai
+      temuan hidup).
+
+      **Paruh payload memindahkan satu keputusan ke klien, jadi perlu tegas soal apa yang
+      TIDAK ikut pindah.** Katalog kini dikirim sekali di dalam `<template>` — konten
+      inert, tidak dirender dan tidak ikut submit — dan klien mengklonnya ke picker satu
+      peran saat panel itu pertama dibuka, dikurangi apa yang sudah didaftar panel itu
+      sebagai granted. Id yang granted diambil dari tombol revoke panel itu sendiri,
+      karena salinan kedua hanya bisa berbeda dari daftar yang sudah di layar. SERVER
+      tetap memutuskan apakah picker ada sama sekali (`availableCount > 0`, dihitung
+      terhadap katalog dan bukan lewat pengurangan — sebuah peran bisa memegang izin yang
+      tidak ada di katalog), dan guard `configure` endpoint tetap satu-satunya otoritas
+      atas grant-nya. Picker kosong tanpa JavaScript; itu bukan regresi, formulirnya
+      memang selalu submit lewat `sendJson`.
+
+      **Satu hal untuk dibawa ke depan: ini menghabiskan hampir seluruh anggaran aset
+      klien.** `build:asset-budget:check` mengizinkan 192.000 B untuk bundel app; pengisi
+      picker memakan ~540 B dan menyisakan **161 B**. Tukar-tambahnya bagus (beberapa
+      ratus byte JS ter-cache melawan ~23.000 `<option>` di tiap render halaman) tetapi
+      layar BERIKUTNYA yang menambah skrip klien akan memerahkan gerbang itu, dan
+      memerahkannya karena sebab yang tak ada hubungannya dengan layar tersebut.
+      Menaikkan plafon adalah keputusan, bukan formalitas — tidak diambil di sini.
+
   21. **C7 — `prepareCandidates` meng-escape ulang tiap nama tag di dalam komparator sort.**
+      **SELESAI (22 Agustus 2026).**
       `internal-tag-linking.ts:155-158`. Terukur 1090 panggilan/sort vs 100 untuk
       decorate-sort-undecorate. Hemat absolutnya kecil (~0,14 ms), itulah sebabnya terakhir.
+
+      Decorate-sort-undecorate, dengan nama ter-escape dibawa di baris yang memang sudah
+      dibutuhkan loop dedupe dan pemanggilnya — sehingga versi yang lebih murah juga
+      lebih pendek. Tidak ada uji perilaku yang bisa memisahkan kedua implementasi:
+      escaping monoton atas prefiks, jadi "lebih panjang mentah" dan "lebih panjang
+      ter-escape" hanya bisa berbeda untuk kandidat yang tak pernah bersaing di posisi
+      teks yang sama. Yang diasersi sebagai gantinya: komparator tidak memuat panggilan
+      `escapeHtml(`, plus dua properti yang menjadi alasan sort itu ada (terpanjang-
+      ter-escape lebih dulu untuk istilah yang tumpang tindih; `minTermLength` tetap
+      diukur pada nama MENTAH, sehingga escaping tak bisa menyelundupkan kembali tag yang
+      sudah tersaring).
 
   ### D. Perbaikan fungsional & kemudahan pemeliharaan
   22. **D1 — job terjadwal berjalan di container tanpa volume dan dengan allow-list env yang

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -114,7 +114,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Migrations                        | **145** (`sql/001`–`145`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0105** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **48** `.astro` files in `src/pages/admin/`; **0 of 24** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| `.astro` files                    | **61** (34.599 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
+| `.astro` files                    | **61** (34.697 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
 | Gates                             | **57** in the `bun run check` chain                                                    | `scripts.check` in `package.json`, split on `&&`                                        |
 | Contracts                         | Modular per-module OpenAPI + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -714,10 +714,31 @@ pioneered directly here after the ADR-0047 freeze.)
       ≤3-query hot-read ceiling is "measured", but **both budget suites call directory
       functions directly and never drive middleware**, so the excess is structurally
       invisible to the gate that claims to enforce it.
-  14. **B6 — in-process rate-limit `buckets` Map has no eviction.**
+  14. **B6 — in-process rate-limit `buckets` Map has no eviction.** **DONE (22 August
+      2026).**
       `security/rate-limit.ts:57`. One permanent entry per distinct client IP; Redis is
       off by default so this is the live path. A slow leak, not an acute risk — but the
       failure mode is an OOM of the process holding every other cache.
+
+      **Two mechanisms, because a sweep alone is not a bound.** An amortised sweep (at
+      most once a minute, and on the way past the cap) drops every entry whose window has
+      elapsed — `checkRateLimit` already treats an elapsed window as a fresh start, so
+      such an entry holds no information. That bounds the map to "distinct clients seen
+      within one window", which is the correct working set and, under a distributed
+      flood, is itself attacker-controlled. So there is also a hard cap of 50,000, and
+      when it is reached the victims are chosen to be the least harmful ones available:
+      the entries CLOSEST TO EXPIRING, evicted in one batch down to 45,000 so the sort
+      that picks them runs once per 10% of growth rather than once per request.
+
+      **The recommendation did not say where `windowMs` comes from, and that is the
+      whole design.** The bucket now stores it. Eviction happens OUTSIDE any call for
+      that key, so a sweep has to know when an entry it was not asked about stopped
+      counting, and the map is shared by callers with different windows (login is
+      minutes, site-search is seconds) — taking the window from whichever caller happens
+      to trigger the sweep would expire the other family's counters early. Early
+      expiry is the one failure a memory fix must not introduce: forgetting a LIVE
+      counter hands its owner a fresh allowance, so that is what
+      `tests/rate-limit-bucket-eviction.test.ts` asserts alongside the size.
 
   ### C. Algorithm / query cost
   15. **C1 — no index supports the blog list ordering.** **DONE (22 August 2026).** `blog-post-directory.ts:398,436`;
@@ -851,13 +872,52 @@ pioneered directly here after the ADR-0047 freeze.)
       identical and only the COST differs. That is the finding's own shape, so the suite
       now carries an explicit assertion that the statement really contains the LIMIT.
 
-  20. **C6 — `/admin/roles` is an N+1 plus an O(roles × catalogue) payload.**
+  20. **C6 — `/admin/roles` is an N+1 plus an O(roles × catalogue) payload.** **DONE (22
+      August 2026).**
       `roles.astro:88-94`. `listRolePermissions` awaited once per role (up to 100,
       sequential); the ~230-row catalogue rendered as `<option>` once per role.
+
+      **The N+1 half:** `listRolePermissionsForRoles` answers the whole set in one
+      `role_id = ANY(...)` round trip and returns an entry for EVERY requested id, empty
+      array included — a caller that had to tell "no grants" from "not in the result"
+      would be back to asking per role. The single-role reader was DELETED rather than
+      left unused: a zero-caller export is how the next screen quietly reintroduces the
+      N+1 (see D12/D15/D16 for the same shape as a live finding).
+
+      **The payload half moved a decision to the client, so it is worth being explicit
+      about what did not move.** The catalogue is now emitted once inside a `<template>`
+      — inert content, not rendered and not submitted — and the client clones it into a
+      role's picker on the first open, minus what that panel already lists as granted.
+      The granted ids come from the panel's own revoke buttons, because a second copy
+      could only disagree with the list already on screen. The SERVER still decides
+      whether a picker exists at all (`availableCount > 0`, counted against the
+      catalogue rather than by subtraction — a role can hold a permission the catalogue
+      omits), and the endpoint's `configure` guard remains the only authority on the
+      grant itself. The picker is empty without JavaScript; that is not a regression,
+      the form has always submitted through `sendJson`.
+
+      **One thing to carry forward: this consumed nearly all of the client asset
+      budget.** `build:asset-budget:check` allows 192,000 B for the app bundle; the
+      picker filler costs ~540 B and leaves **161 B** of headroom. The trade is good in
+      itself (a few hundred bytes of cached JS against ~23,000 `<option>`s in every
+      render of the page) but the NEXT screen that adds a client script will fail that
+      gate, and it will fail it for reasons unrelated to whatever that screen did.
+      Raising the ceiling is a decision, not a formality — it is not taken here.
+
   21. **C7 — `prepareCandidates` re-escapes every tag name inside the sort comparator.**
+      **DONE (22 August 2026).**
       `internal-tag-linking.ts:155-158`. Measured 1090 calls/sort vs 100 for
       decorate-sort-undecorate. On by default on every public article render; absolute
       saving is small (~0.14 ms), which is why it is last.
+
+      Decorate-sort-undecorate, with the escaped name carried on the row the dedupe loop
+      and the caller both already need — so the cheaper version is also the shorter one.
+      No behavioural test can separate the two implementations: escaping is monotone
+      over a prefix, so raw-longer and escaped-longer can only disagree for candidates
+      that never compete at the same text position. What is asserted instead is that the
+      comparator contains no `escapeHtml(` call, plus the two properties the sort exists
+      to provide (longest-escaped-first for overlapping terms; `minTermLength` still
+      measured on the RAW name, so escaping cannot smuggle a filtered-out tag back in).
 
   ### D. Functional improvements & maintainability
   22. **D1 — scheduled jobs run in a container with no volume and a lossy env

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 452   |
+| Test files                          | 455   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -356,7 +356,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 381        |
+| `(root)`      | 384        |
 | `e2e`         | 12         |
 | `integration` | 58         |
 | `unit`        | 1          |

--- a/src/lib/security/rate-limit.ts
+++ b/src/lib/security/rate-limit.ts
@@ -1,3 +1,4 @@
+import { log } from "../logging/logger";
 import { getRedisClient, withRedisCommandTimeout } from "../redis/client";
 import { buildRedisKey } from "../redis/config";
 
@@ -52,9 +53,102 @@ export type RateLimitConfig = {
 export type RateLimitResult =
   { allowed: true } | { allowed: false; retryAfterSec: number };
 
-type Bucket = { count: number; windowStart: number };
+/**
+ * `windowMs` is stored per bucket, not read from the caller's config, because
+ * eviction happens outside any call for that key: the sweep below has to know
+ * when an entry it was not asked about stopped counting, and the same map is
+ * shared by callers with different windows (login: minutes; site-search:
+ * seconds).
+ */
+type Bucket = { count: number; windowStart: number; windowMs: number };
 
 const buckets = new Map<string, Bucket>();
+
+/**
+ * ## Why this map is swept, and why it is also capped
+ *
+ * An entry is created per distinct key — in practice per client IP — and
+ * before this it was never removed. A live entry is only meaningful until its
+ * window ends: `checkRateLimit` already treats an elapsed window as a fresh
+ * start, so an entry past `windowStart + windowMs` holds no information and
+ * only occupies memory. Redis is off by default, so the in-process map is the
+ * live path for the default topology, and the leak is one permanent entry per
+ * IP that has ever touched a rate-limited endpoint — a slow leak whose end
+ * state is an OOM of the process holding every other cache.
+ *
+ * The sweep alone bounds the map to "distinct clients seen within one window",
+ * which is the correct working set. That set is itself attacker-controlled
+ * during a distributed flood, so there is also a hard cap. Evicting a LIVE
+ * bucket forgets a counter and hands its owner a fresh allowance, so the cap
+ * is deliberately high and the victims are chosen as the least harmful ones
+ * available: the entries CLOSEST TO EXPIRING, which would have been forgotten
+ * within milliseconds anyway. Eviction is in one batch down to
+ * `BUCKET_EVICTION_TARGET` rather than one entry per insert, so the sort it
+ * needs runs once per 10% growth instead of once per request while the cap is
+ * pinned.
+ *
+ * This is a memory bound, not a second limiter: nothing here can make a
+ * request MORE limited than the configured ceiling.
+ */
+const BUCKET_SWEEP_INTERVAL_MS = 60_000;
+const BUCKET_HARD_CAP = 50_000;
+const BUCKET_EVICTION_TARGET = Math.floor(BUCKET_HARD_CAP * 0.9);
+
+let lastSweepAt = 0;
+let warnedAboutCap = false;
+
+/** Drops every entry whose window has already elapsed. */
+function sweepExpiredBuckets(now: number): void {
+  for (const [key, bucket] of buckets) {
+    if (now - bucket.windowStart >= bucket.windowMs) {
+      buckets.delete(key);
+    }
+  }
+}
+
+function boundBuckets(now: number): void {
+  if (
+    buckets.size < BUCKET_HARD_CAP &&
+    now - lastSweepAt < BUCKET_SWEEP_INTERVAL_MS
+  ) {
+    return;
+  }
+
+  lastSweepAt = now;
+  sweepExpiredBuckets(now);
+
+  // `<` rather than `<=`: this runs BEFORE the caller's own insert, so leaving
+  // the map exactly AT the cap is leaving it one entry over.
+  if (buckets.size < BUCKET_HARD_CAP) {
+    return;
+  }
+
+  // Still over the cap with nothing expired to reclaim: every remaining entry
+  // is live. Take the ones with the least window left.
+  const byExpiry = [...buckets.entries()].sort(
+    (a, b) =>
+      a[1].windowStart + a[1].windowMs - (b[1].windowStart + b[1].windowMs)
+  );
+
+  const evictCount = buckets.size - BUCKET_EVICTION_TARGET;
+
+  for (let index = 0; index < evictCount; index += 1) {
+    buckets.delete(byExpiry[index]![0]);
+  }
+
+  if (!warnedAboutCap) {
+    warnedAboutCap = true;
+
+    // Once per process: this fires under exactly the traffic that makes a
+    // per-event log a free amplifier for whoever caused it.
+    log("warning", "security.rate_limit.bucket_cap_reached", {
+      cap: BUCKET_HARD_CAP,
+      evicted: evictCount,
+      reason:
+        "in-process rate-limit map hit its size cap — soonest-to-expire counters were dropped; configure Redis (REDIS_URL) for a shared limiter"
+    });
+  }
+}
 
 /**
  * Clear all in-process rate-limit buckets. Test-only: the integration harness
@@ -66,6 +160,13 @@ const buckets = new Map<string, Bucket>();
  */
 export function resetRateLimitForTests(): void {
   buckets.clear();
+  lastSweepAt = 0;
+  warnedAboutCap = false;
+}
+
+/** Test-only: the number of live in-process buckets. */
+export function rateLimitBucketCountForTests(): number {
+  return buckets.size;
 }
 
 export function checkRateLimit(
@@ -73,10 +174,16 @@ export function checkRateLimit(
   config: RateLimitConfig,
   now: number = Date.now()
 ): RateLimitResult {
+  boundBuckets(now);
+
   const existing = buckets.get(key);
 
   if (!existing || now - existing.windowStart >= config.windowMs) {
-    buckets.set(key, { count: 1, windowStart: now });
+    buckets.set(key, {
+      count: 1,
+      windowStart: now,
+      windowMs: config.windowMs
+    });
     return { allowed: true };
   }
 

--- a/src/modules/blog-content/domain/internal-tag-linking.ts
+++ b/src/modules/blog-content/domain/internal-tag-linking.ts
@@ -143,35 +143,48 @@ type PreparedCandidate = InternalTagLinkCandidate & { escapedName: string };
  * match wins" true here), and de-duplicates by matching key (case rules
  * per `policy.caseInsensitive`), keeping the first (i.e. longest, then
  * alphabetically first) survivor on a collision.
+ *
+ * `escapeHtml` runs ONCE per candidate, before the sort, rather than twice
+ * per comparison inside it (decorate-sort-undecorate). This runs on every
+ * public article render with internal tag linking on — the default — and a
+ * comparator is called O(n log n) times, so the escaped name is computed here
+ * and carried on the row that the dedupe loop and the caller both already
+ * need. Measured on the 100-candidate cap: 1090 `escapeHtml` calls per sort
+ * before, 100 after.
  */
 function prepareCandidates(
   candidates: readonly InternalTagLinkCandidate[],
   policy: InternalTagLinkingPolicy
 ): PreparedCandidate[] {
-  const filtered = candidates.filter(
-    (candidate) => candidate.name.trim().length >= policy.minTermLength
-  );
+  const decorated: PreparedCandidate[] = [];
 
-  const sorted = [...filtered].sort((a, b) => {
-    const lengthDiff = escapeHtml(b.name).length - escapeHtml(a.name).length;
+  for (const candidate of candidates) {
+    if (candidate.name.trim().length < policy.minTermLength) {
+      continue;
+    }
+
+    decorated.push({ ...candidate, escapedName: escapeHtml(candidate.name) });
+  }
+
+  decorated.sort((a, b) => {
+    const lengthDiff = b.escapedName.length - a.escapedName.length;
     return lengthDiff !== 0 ? lengthDiff : a.name.localeCompare(b.name);
   });
 
   const seenKeys = new Set<string>();
   const prepared: PreparedCandidate[] = [];
 
-  for (const candidate of sorted) {
-    const escapedName = escapeHtml(candidate.name);
+  for (const candidate of decorated) {
     const key = policy.caseInsensitive
-      ? escapedName.toLowerCase()
-      : escapedName;
+      ? candidate.escapedName.toLowerCase()
+      : candidate.escapedName;
 
     if (seenKeys.has(key)) {
       continue;
     }
 
     seenKeys.add(key);
-    prepared.push({ ...candidate, escapedName });
+    prepared.push(candidate);
   }
 
   return prepared;

--- a/src/modules/identity-access/application/role-admin.ts
+++ b/src/modules/identity-access/application/role-admin.ts
@@ -221,27 +221,63 @@ export async function listPermissionCatalog(
   }));
 }
 
-/** The permissions currently granted to `roleId`, joined to the catalog. */
-export async function listRolePermissions(
+/**
+ * The permissions currently granted to each role, joined to the catalog — in
+ * ONE round trip for the whole set.
+ *
+ * `/admin/roles` renders one grant panel per role, and awaiting
+ * `listRolePermissions` inside that loop is an N+1 whose N is the tenant's
+ * role count — sequential, because concurrent queries on a single transaction
+ * connection leak it, so the latency is the sum rather than the max. A tenant
+ * with 40 roles paid 40 round trips to render one screen.
+ *
+ * Every requested id gets an entry, empty array included. A caller that has to
+ * tell "this role has no grants" from "this role was not in the result" would
+ * reintroduce the per-role question this exists to remove.
+ */
+export async function listRolePermissionsForRoles(
   tx: Bun.SQL,
   tenantId: string,
-  roleId: string
-): Promise<PermissionCatalogEntry[]> {
+  roleIds: readonly string[]
+): Promise<Map<string, PermissionCatalogEntry[]>> {
+  const byRole = new Map<string, PermissionCatalogEntry[]>();
+
+  for (const roleId of roleIds) {
+    byRole.set(roleId, []);
+  }
+
+  if (byRole.size === 0) {
+    return byRole;
+  }
+
+  // `= ANY(tx.array(...))` rather than `IN ${…}`: a bare `${array}` binding
+  // arrives at PostgreSQL as comma-joined TEXT (22P02), not as a list.
   const rows = (await tx`
-    SELECT p.id, p.module_key, p.activity_code, p.action, p.description
+    SELECT rp.role_id, p.id, p.module_key, p.activity_code, p.action, p.description
     FROM awcms_role_permissions rp
     JOIN awcms_permissions p ON p.id = rp.permission_id
-    WHERE rp.tenant_id = ${tenantId} AND rp.role_id = ${roleId}
-    ORDER BY p.module_key, p.activity_code, p.action
-  `) as PermissionRow[];
+    WHERE rp.tenant_id = ${tenantId}
+      AND rp.role_id = ANY(${tx.array([...byRole.keys()], "uuid")})
+    ORDER BY rp.role_id, p.module_key, p.activity_code, p.action
+  `) as (PermissionRow & { role_id: string })[];
 
-  return rows.map((row) => ({
-    id: row.id,
-    moduleKey: row.module_key,
-    activityCode: row.activity_code,
-    action: row.action,
-    description: row.description
-  }));
+  for (const row of rows) {
+    // Present by construction above; a row for an unrequested role cannot
+    // occur, but dropping one silently would be worse than not creating it.
+    const entries = byRole.get(row.role_id) ?? [];
+
+    entries.push({
+      id: row.id,
+      moduleKey: row.module_key,
+      activityCode: row.activity_code,
+      action: row.action,
+      description: row.description
+    });
+
+    byRole.set(row.role_id, entries);
+  }
+
+  return byRole;
 }
 
 // --- Writes ---

--- a/src/pages/admin/roles.astro
+++ b/src/pages/admin/roles.astro
@@ -30,7 +30,7 @@ import { getTranslatorFor } from "../../lib/i18n";
 import {
   listDeletedRoles,
   listPermissionCatalog,
-  listRolePermissions,
+  listRolePermissionsForRoles,
   type DeletedRoleView,
   type PermissionCatalogEntry
 } from "../../modules/identity-access/application/role-admin";
@@ -38,10 +38,20 @@ import {
 const ssr = Astro.locals.ssrContext!;
 const { t, tn } = getTranslatorFor(Astro.locals.locale);
 
+/**
+ * `availableCount` rather than the available ENTRIES: the catalogue is ~230
+ * rows and it used to be rendered as `<option>`s once per role, so the
+ * document grew as roles x catalogue — ~23,000 options on a 100-role tenant,
+ * of which at most one is ever chosen. The catalogue is now emitted once, in a
+ * `<template>`, and the client clones it into a role's `<select>` the first
+ * time that role's panel is opened, minus what the panel already lists as
+ * granted. The count is still needed here because a role holding EVERYTHING
+ * must not be offered an empty grant form.
+ */
 type RolePermRow = {
   role: RoleView;
   granted: PermissionCatalogEntry[];
-  available: PermissionCatalogEntry[];
+  availableCount: number;
 };
 
 function permLabel(p: PermissionCatalogEntry): string {
@@ -71,6 +81,7 @@ const screen = await loadAdminScreen({
     if (!canConfigure) {
       return {
         liveRoles,
+        catalog: [] as PermissionCatalogEntry[],
         rolePerms: [] as RolePermRow[],
         deletedRoles: [] as DeletedRoleView[],
         canConfigure
@@ -85,16 +96,30 @@ const screen = await loadAdminScreen({
       includePlatformScoped:
         platformTenant !== null && platformTenant.tenantId === ssr.tenantId
     });
-    const perms: RolePermRow[] = [];
-    for (const role of liveRoles) {
-      const granted = await listRolePermissions(tx, ssr.tenantId, role.id);
+    // One query for every role's grants, not one per role.
+    const grantsByRole = await listRolePermissionsForRoles(
+      tx,
+      ssr.tenantId,
+      liveRoles.map((role) => role.id)
+    );
+    const perms: RolePermRow[] = liveRoles.map((role) => {
+      const granted = grantsByRole.get(role.id) ?? [];
       const grantedIds = new Set(granted.map((p) => p.id));
-      const available = catalog.filter((p) => !grantedIds.has(p.id));
-      perms.push({ role, granted, available });
-    }
+
+      // Counted against the catalogue rather than `catalog.length -
+      // granted.length`: a role can hold a permission the catalogue omits (a
+      // platform-scoped grant seen from a non-platform tenant), and the
+      // subtraction would then under-count and hide the grant form.
+      return {
+        role,
+        granted,
+        availableCount: catalog.filter((p) => !grantedIds.has(p.id)).length
+      };
+    });
 
     return {
       liveRoles,
+      catalog,
       rolePerms: perms,
       deletedRoles: await listDeletedRoles(tx, ssr.tenantId),
       canConfigure
@@ -115,15 +140,18 @@ const roles: RoleView[] =
   screen.state === "allowed" ? screen.data.liveRoles : [];
 const rolePerms: RolePermRow[] =
   screen.state === "allowed" ? screen.data.rolePerms : [];
+const catalog: PermissionCatalogEntry[] =
+  screen.state === "allowed" ? screen.data.catalog : [];
 const deletedRoles: DeletedRoleView[] =
   screen.state === "allowed" ? screen.data.deletedRoles : [];
 const canConfigure = screen.state === "allowed" && screen.data.canConfigure;
 
 // A uniform row list so the table renders the same whether or not the viewer
-// can configure (a read-only viewer gets empty grant/available lists).
+// can configure (a read-only viewer gets empty grant lists and nothing on
+// offer).
 const rows: RolePermRow[] = canConfigure
   ? rolePerms
-  : roles.map((role) => ({ role, granted: [], available: [] }));
+  : roles.map((role) => ({ role, granted: [], availableCount: 0 }));
 const colCount = canConfigure ? 5 : 4;
 ---
 
@@ -239,7 +267,7 @@ const colCount = canConfigure ? 5 : 4;
                 </td>
               </tr>
             ) : (
-              rows.map(({ role, granted, available }) => (
+              rows.map(({ role, granted, availableCount }) => (
                 <tr>
                   <td data-label="Code">
                     <span class="cell-code">{role.roleCode}</span>
@@ -280,7 +308,7 @@ const colCount = canConfigure ? 5 : 4;
                           </button>
                         )}
                       </div>
-                      <details class="role-permissions">
+                      <details class="role-permissions" data-role-panel>
                         <summary>
                           {t("Permissions ({count})", {
                             count: granted.length
@@ -310,7 +338,7 @@ const colCount = canConfigure ? 5 : 4;
                             ))
                           )}
                         </ul>
-                        {available.length > 0 && (
+                        {availableCount > 0 && (
                           <form
                             class="admin-create-form"
                             data-role-grant-form
@@ -319,11 +347,13 @@ const colCount = canConfigure ? 5 : 4;
                             <label for={`grant-${role.id}`}>
                               {t("Add permission")}
                             </label>
-                            <select id={`grant-${role.id}`} name="permissionId">
-                              {available.map((p) => (
-                                <option value={p.id}>{permLabel(p)}</option>
-                              ))}
-                            </select>
+                            {/* Filled from the one catalogue `<template>` below
+                                the first time this panel is opened. */}
+                            <select
+                              id={`grant-${role.id}`}
+                              name="permissionId"
+                              data-role-grant-select
+                            />
                             <button type="submit">{t("Add")}</button>
                           </form>
                         )}
@@ -336,6 +366,23 @@ const colCount = canConfigure ? 5 : 4;
           </tbody>
         </table>
       </div>
+    )
+  }
+
+  {
+    /*
+     * The permission catalogue, ONCE for the whole page. `<template>` content
+     * is inert — not rendered, not submitted, not focusable — so this costs
+     * one copy of the catalogue instead of one per role, and the client clones
+     * from it on demand. Options carry no per-role state, so one copy is all
+     * there is to share.
+     */
+    canConfigure && !loadError && catalog.length > 0 && (
+      <template id="permission-catalog-options">
+        {catalog.map((p) => (
+          <option value={p.id}>{permLabel(p)}</option>
+        ))}
+      </template>
     )
   }
 
@@ -412,6 +459,57 @@ const colCount = canConfigure ? 5 : 4;
 
   const actionError = messageBox("roles-action-error");
   const createError = messageBox("role-create-error");
+
+  /*
+   * Fills a role's permission picker from the single catalogue `<template>`,
+   * the first time that role's panel is opened.
+   *
+   * The server sends the catalogue once and each role's GRANTS; the options a
+   * role may still be given are the difference, computed here rather than
+   * shipped per role (see `RolePermRow`). The granted ids come from the
+   * panel's own revoke buttons — the list is already in the DOM, so a second
+   * copy could only disagree with it.
+   *
+   * The picker is empty until this runs. That is not a regression in
+   * no-JavaScript behaviour: the grant form submits through `sendJson` and has
+   * never worked without the bundle. The server still decides whether the form
+   * exists at all (`availableCount > 0`), and the endpoint's `configure` guard
+   * remains the only authority on the grant itself.
+   */
+  function fillGrantPicker(panel: HTMLDetailsElement): void {
+    const select = panel.querySelector<HTMLSelectElement>(
+      "select[data-role-grant-select]"
+    );
+    if (!select || select.options.length > 0) return;
+
+    const template = document.getElementById("permission-catalog-options");
+    if (!(template instanceof HTMLTemplateElement)) return;
+
+    const granted = new Set<string | undefined>();
+
+    for (const element of panel.querySelectorAll<HTMLElement>(
+      "[data-permission-id]"
+    )) {
+      granted.add(element.dataset.permissionId);
+    }
+
+    const options = template.content.cloneNode(true) as DocumentFragment;
+
+    // `querySelectorAll` returns a STATIC list, so removing as we go is safe.
+    for (const option of options.querySelectorAll("option")) {
+      if (granted.has(option.value)) option.remove();
+    }
+
+    select.appendChild(options);
+  }
+
+  for (const panel of document.querySelectorAll<HTMLDetailsElement>(
+    "details[data-role-panel]"
+  )) {
+    panel.addEventListener("toggle", () => {
+      if (panel.open) fillGrantPicker(panel);
+    });
+  }
 
   onSubmit("role-create-form", async ({ data, submit }) => {
     await mutateAndReload(

--- a/tests/admin-roles-page-payload.test.ts
+++ b/tests/admin-roles-page-payload.test.ts
@@ -1,0 +1,91 @@
+/**
+ * PROJECT_STATE §4 **C6** — `/admin/roles` used to render the whole permission
+ * catalogue as `<option>`s once per role.
+ *
+ * ~230 catalogue rows x up to 100 roles is ~23,000 options in one document, of
+ * which at most one is ever chosen, and the growth is silent: the screen looks
+ * identical, it just gets heavier with every role the tenant adds. The
+ * catalogue is now emitted ONCE inside a `<template>` — inert content, not
+ * rendered and not submitted — and the client clones it into a role's picker
+ * the first time that role's panel is opened.
+ *
+ * Asserted from the source rather than from a rendered page because the defect
+ * is structural: it is the per-role LOOP over the catalogue that has to be
+ * gone, and a rendered snapshot of a two-role fixture would look fine either
+ * way.
+ *
+ * Comments are stripped first — the prose above the code names the very
+ * constructs being asserted absent, and a substring check that reads comments
+ * answers about the documentation instead of the code.
+ */
+import { readFile } from "node:fs/promises";
+
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/lib/source-text";
+
+const PAGE = "src/pages/admin/roles.astro";
+const ROLE_ADMIN = "src/modules/identity-access/application/role-admin.ts";
+
+describe("the catalogue is sent once, not once per role", () => {
+  test("it is rendered inside a single template element", async () => {
+    const page = stripComments(await readFile(PAGE, "utf8"));
+
+    expect(page).toContain('<template id="permission-catalog-options">');
+    expect(page.split('id="permission-catalog-options"')).toHaveLength(2);
+  });
+
+  test("no per-role option loop remains", async () => {
+    const page = stripComments(await readFile(PAGE, "utf8"));
+
+    // The row renderer must not carry the catalogue at all — the surviving
+    // `catalog.map` is the template's, outside the `rows.map`.
+    const rowsAt = page.indexOf("rows.map(");
+    const rowBody = page.slice(rowsAt, page.indexOf("<template", rowsAt));
+
+    expect(rowsAt).toBeGreaterThan(-1);
+    expect(rowBody).not.toContain("available.map(");
+    expect(rowBody).not.toContain("catalog.map(");
+  });
+
+  test("the row still decides whether a picker is offered at all", async () => {
+    const page = stripComments(await readFile(PAGE, "utf8"));
+
+    // Without this the server would render an empty picker for a role that
+    // already holds everything, and the client would have nothing to put in
+    // it — a control that cannot succeed.
+    expect(page).toContain("availableCount > 0");
+    expect(page).toContain("availableCount:");
+  });
+
+  test("the picker is filled from the template, minus what the panel lists as granted", async () => {
+    const page = stripComments(await readFile(PAGE, "utf8"));
+
+    expect(page).toContain("select[data-role-grant-select]");
+    expect(page).toContain("permission-catalog-options");
+    expect(page).toContain("[data-permission-id]");
+    // First open, not page load: cloning ~230 options per role up front would
+    // move the cost rather than remove it.
+    expect(page).toContain('addEventListener("toggle"');
+  });
+});
+
+describe("the grants are read in one round trip", () => {
+  test("the screen uses the batched reader", async () => {
+    const page = stripComments(await readFile(PAGE, "utf8"));
+
+    expect(page).toContain("listRolePermissionsForRoles(");
+  });
+
+  test("no per-role grant query survives anywhere", async () => {
+    const page = stripComments(await readFile(PAGE, "utf8"));
+    const roleAdmin = stripComments(await readFile(ROLE_ADMIN, "utf8"));
+
+    // The single-role reader is GONE rather than merely unused: an export with
+    // no callers is how the next screen quietly reintroduces the N+1.
+    expect(page).not.toContain("listRolePermissions(");
+    expect(roleAdmin).not.toContain(
+      "export async function listRolePermissions("
+    );
+  });
+});

--- a/tests/e2e/admin-roles.e2e.ts
+++ b/tests/e2e/admin-roles.e2e.ts
@@ -71,4 +71,85 @@ test.describe("admin roles CRUD (authenticated)", () => {
     ).toBeVisible();
     await expect(row.locator("details.role-permissions")).toBeVisible();
   });
+
+  /**
+   * PROJECT_STATE §4 **C6** — the permission catalogue is sent ONCE, in a
+   * `<template>`, and cloned into a role's picker when that role's panel is
+   * opened. The exclusion of already-granted permissions moved from the server
+   * to that clone, so it needs cross-layer proof: source assertions
+   * (`admin-roles-page-payload.test.ts`) can show the template exists and the
+   * per-role loop is gone, but only a browser can show that the picker ends up
+   * holding the right options — and, after a grant, one fewer.
+   */
+  test("the grant picker fills from the shared catalogue and drops what is granted", async ({
+    page
+  }) => {
+    await page.goto("/login");
+    await provideTenant(page, tenantId!);
+    await page.locator("#login-identifier").fill(loginIdentifier!);
+    await page.locator("#password").fill(password!);
+    await page.locator("#login-submit").click();
+    await page.waitForURL("**/admin");
+
+    await page.goto("/admin/roles");
+
+    const newCode = `qa-e2e-grant-${Date.now()}`;
+    await page.locator("#role-code").fill(newCode);
+    await page.locator("#role-name").fill("E2E Grant Role");
+    await page.locator("#role-create-submit").click();
+
+    const table = page.locator("#roles-table");
+    await expect(table).toContainText(newCode);
+
+    // The catalogue is in the document exactly once, whatever the role count.
+    await expect(page.locator("#permission-catalog-options")).toHaveCount(1);
+
+    const openPanel = async () => {
+      const row = table.locator("tr", { hasText: newCode });
+      const panel = row.locator("details.role-permissions");
+      await panel.locator("summary").click();
+      return panel;
+    };
+
+    let panel = await openPanel();
+    const select = panel.locator("select[data-role-grant-select]");
+
+    // Empty until the panel is opened; filled from the template on open.
+    await expect(select.locator("option").first()).toBeAttached();
+    const optionsBefore = await select.locator("option").count();
+    expect(optionsBefore).toBeGreaterThan(0);
+
+    const grantedId = await select
+      .locator("option")
+      .first()
+      .getAttribute("value");
+    expect(grantedId).toBeTruthy();
+
+    await select.selectOption(grantedId!);
+    await panel
+      .locator("form[data-role-grant-form] button[type='submit']")
+      .click();
+
+    // The client reloads on success. Wait on the GRANT itself rather than on
+    // the row — the row is already on screen, so waiting for it would pass
+    // against the pre-reload DOM and race the navigation. The revoke button
+    // exists only in the re-rendered page (attached, though its panel starts
+    // collapsed).
+    await expect(
+      page.locator(`button[data-permission-id="${grantedId}"]`)
+    ).toBeAttached();
+
+    panel = await openPanel();
+    await expect(
+      panel.locator(`button[data-permission-id="${grantedId}"]`)
+    ).toBeVisible();
+
+    // ...and the picker no longer offers it.
+    const selectAfter = panel.locator("select[data-role-grant-select]");
+    await expect(selectAfter.locator("option").first()).toBeAttached();
+    await expect(
+      selectAfter.locator(`option[value="${grantedId}"]`)
+    ).toHaveCount(0);
+    expect(await selectAfter.locator("option").count()).toBe(optionsBefore - 1);
+  });
 });

--- a/tests/e2e/admin-roles.e2e.ts
+++ b/tests/e2e/admin-roles.e2e.ts
@@ -104,9 +104,14 @@ test.describe("admin roles CRUD (authenticated)", () => {
     // The catalogue is in the document exactly once, whatever the role count.
     await expect(page.locator("#permission-catalog-options")).toHaveCount(1);
 
+    // Everything below is scoped to THIS role's row. The seeded tenant has
+    // several roles, and the permission granted here is one the owner role
+    // already holds — a page-wide `[data-permission-id=…]` matches all of
+    // them, which is a strict-mode violation rather than a useful assertion.
+    const roleRow = () => table.locator("tr", { hasText: newCode });
+
     const openPanel = async () => {
-      const row = table.locator("tr", { hasText: newCode });
-      const panel = row.locator("details.role-permissions");
+      const panel = roleRow().locator("details.role-permissions");
       await panel.locator("summary").click();
       return panel;
     };
@@ -130,13 +135,13 @@ test.describe("admin roles CRUD (authenticated)", () => {
       .locator("form[data-role-grant-form] button[type='submit']")
       .click();
 
-    // The client reloads on success. Wait on the GRANT itself rather than on
-    // the row — the row is already on screen, so waiting for it would pass
-    // against the pre-reload DOM and race the navigation. The revoke button
-    // exists only in the re-rendered page (attached, though its panel starts
-    // collapsed).
+    // The client reloads on success. Wait on THIS ROW's grant rather than on
+    // the row itself — the row is already on screen, so waiting for it would
+    // pass against the pre-reload DOM and race the navigation. The revoke
+    // button exists only in the re-rendered page (attached, though its panel
+    // starts collapsed).
     await expect(
-      page.locator(`button[data-permission-id="${grantedId}"]`)
+      roleRow().locator(`button[data-permission-id="${grantedId}"]`)
     ).toBeAttached();
 
     panel = await openPanel();

--- a/tests/internal-tag-linking.test.ts
+++ b/tests/internal-tag-linking.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
+import { stripComments } from "../scripts/lib/source-text";
 import {
   applyInternalTagLinksToHtml,
   createInternalTagLinkEngine,
@@ -403,5 +404,65 @@ describe("createInternalTagLinkEngine", () => {
       { ...BASE_POLICY, minTermLength: 5 }
     );
     expect(engine).toBeNull();
+  });
+});
+
+/**
+ * PROJECT_STATE §4 **C7** — `prepareCandidates` re-escaped every tag name
+ * inside the sort comparator.
+ *
+ * A comparator runs O(n log n) times, so escaping inside it cost 1090
+ * `escapeHtml` calls per sort at the 100-candidate cap instead of 100. This is
+ * on by default on every public article render.
+ *
+ * The saving is small in absolute terms; what makes it worth locking is that
+ * the comparator is the wrong place for it either way — the escaped name is
+ * needed by the dedupe loop and by the caller, so computing it once and
+ * carrying it is also the simpler code.
+ */
+describe("candidate preparation escapes once, not once per comparison", () => {
+  test("the sort comparator does not call escapeHtml", async () => {
+    const source = stripComments(
+      await Bun.file(
+        "src/modules/blog-content/domain/internal-tag-linking.ts"
+      ).text()
+    );
+    const sortAt = source.indexOf("decorated.sort(");
+    const comparator = source.slice(sortAt, source.indexOf("});", sortAt));
+
+    expect(sortAt).toBeGreaterThan(-1);
+    expect(comparator).not.toContain("escapeHtml(");
+    // The escaped form is carried on the row rather than recomputed.
+    expect(comparator).toContain("escapedName.length");
+  });
+
+  test("longest-escaped-first ordering still decides overlapping terms", async () => {
+    // The property the comparator exists for: JS alternation takes the FIRST
+    // alternative that matches, so "Jakarta Selatan" must precede "Jakarta".
+    const html = "<p>Reporting from Jakarta Selatan this week.</p>";
+    const result = await applyInternalTagLinksToHtml(
+      html,
+      [
+        candidate("t1", "Jakarta", "/news/tag/jakarta"),
+        candidate("t2", "Jakarta Selatan", "/news/tag/jakarta-selatan")
+      ],
+      BASE_POLICY
+    );
+
+    expect(result.matches[0]?.tagId).toBe("t2");
+    expect(result.html).toContain(">Jakarta Selatan</a>");
+  });
+
+  test("the raw name still decides eligibility and the alphabetical tie", async () => {
+    // `minTermLength` is measured on the RAW name — a short tag is noisy
+    // regardless of how it happens to escape — and escaping must not smuggle a
+    // filtered-out candidate back in by inflating its length.
+    const result = await applyInternalTagLinksToHtml(
+      "<p>Trading as R&amp;D today.</p>",
+      [candidate("t1", "R&D", "/news/tag/rd")],
+      { ...BASE_POLICY, minTermLength: 4 }
+    );
+
+    expect(result.matches).toHaveLength(0);
   });
 });

--- a/tests/rate-limit-bucket-eviction.test.ts
+++ b/tests/rate-limit-bucket-eviction.test.ts
@@ -1,0 +1,127 @@
+/**
+ * PROJECT_STATE §4 **B6** — the in-process rate-limit `Map` had no eviction.
+ *
+ * One entry per distinct client IP, created on first contact and never
+ * removed. Redis is off by default, so this map is the live path for the
+ * topology this base documents as its default, and the end state of the leak
+ * is an OOM of the process that also holds every other cache.
+ *
+ * What is asserted here is the pair of properties that make an eviction safe
+ * rather than merely small: an entry is only dropped once it can no longer
+ * say anything (its window has elapsed — `checkRateLimit` already treats that
+ * as a fresh start), and a LIVE counter survives the sweep. A limiter that
+ * forgets a live counter hands its owner a fresh allowance, which is the one
+ * failure mode a memory fix must not introduce.
+ */
+import { describe, expect, test, beforeEach } from "bun:test";
+
+import {
+  checkRateLimit,
+  rateLimitBucketCountForTests,
+  resetRateLimitForTests
+} from "../src/lib/security/rate-limit";
+
+const CONFIG = { maxAttempts: 5, windowMs: 60_000 };
+
+beforeEach(() => {
+  resetRateLimitForTests();
+});
+
+describe("expired buckets are reclaimed", () => {
+  test("entries whose window has elapsed are dropped", () => {
+    const start = 1_000_000;
+
+    for (let index = 0; index < 500; index += 1) {
+      checkRateLimit(`ip-${index}`, CONFIG, start);
+    }
+
+    expect(rateLimitBucketCountForTests()).toBe(500);
+
+    // Past both the window and the sweep interval: nothing here still counts.
+    checkRateLimit("late-arrival", CONFIG, start + CONFIG.windowMs + 1);
+
+    // Only the caller that triggered the sweep is left.
+    expect(rateLimitBucketCountForTests()).toBe(1);
+  });
+
+  test("a counter still inside its window survives the sweep", () => {
+    const start = 2_000_000;
+
+    // A long-window key, then enough sweep-interval time to trigger a sweep
+    // while that key is still live.
+    const longWindow = { maxAttempts: 3, windowMs: 3_600_000 };
+
+    checkRateLimit("attacker", longWindow, start);
+    checkRateLimit("attacker", longWindow, start + 1);
+    checkRateLimit("attacker", longWindow, start + 2);
+
+    // Some other client, an hour of sweep intervals later but still inside
+    // `attacker`'s window.
+    checkRateLimit("bystander", longWindow, start + 120_000);
+
+    // The fourth attempt must still be over the ceiling — i.e. the counter was
+    // not reset by the sweep that ran in between.
+    const result = checkRateLimit("attacker", longWindow, start + 120_001);
+
+    expect(result.allowed).toBe(false);
+  });
+
+  test("the sweep does not run on every call", () => {
+    const start = 3_000_000;
+
+    // Two keys created together; the first is left to expire.
+    checkRateLimit("short", { maxAttempts: 5, windowMs: 1_000 }, start);
+
+    // A call one second later: `short` has expired, but the sweep interval has
+    // not elapsed, so the map is not walked. This asserts the amortisation —
+    // walking the map on every request would trade a leak for a cost paid by
+    // every authentication attempt.
+    checkRateLimit("other", CONFIG, start + 1_001);
+
+    expect(rateLimitBucketCountForTests()).toBe(2);
+  });
+});
+
+describe("the map is capped even when nothing has expired", () => {
+  test("a flood of distinct live keys cannot grow the map without bound", () => {
+    const start = 4_000_000;
+    const cap = 50_000;
+
+    // Every key inside its window, so there is nothing for the sweep to
+    // reclaim — the cap is the only thing standing between this and the OOM.
+    for (let index = 0; index <= cap; index += 1) {
+      checkRateLimit(`flood-${index}`, CONFIG, start + index);
+    }
+
+    expect(rateLimitBucketCountForTests()).toBeLessThanOrEqual(cap);
+
+    // And the eviction is a batch, not one-per-insert: the map is taken well
+    // under the cap so the sort it needs is rare rather than per-request.
+    expect(rateLimitBucketCountForTests()).toBeLessThan(cap);
+  });
+
+  test("eviction takes the entries closest to expiring", () => {
+    const start = 5_000_000;
+    const cap = 50_000;
+
+    // `oldest` is created first, so it expires first and is the intended
+    // victim; `newest` is created last and must survive.
+    checkRateLimit("oldest", CONFIG, start);
+
+    for (let index = 1; index <= cap; index += 1) {
+      checkRateLimit(`flood-${index}`, CONFIG, start + index);
+    }
+
+    // Its counter is gone, so this is a first attempt again.
+    const oldest = checkRateLimit("oldest", CONFIG, start + cap + 1);
+    expect(oldest.allowed).toBe(true);
+
+    // The most recent key kept its counter through the eviction.
+    for (let attempt = 0; attempt < CONFIG.maxAttempts; attempt += 1) {
+      checkRateLimit(`flood-${cap}`, CONFIG, start + cap + 2);
+    }
+
+    const newest = checkRateLimit(`flood-${cap}`, CONFIG, start + cap + 3);
+    expect(newest.allowed).toBe(false);
+  });
+});

--- a/tests/role-permissions-batch-read.test.ts
+++ b/tests/role-permissions-batch-read.test.ts
@@ -1,0 +1,157 @@
+/**
+ * PROJECT_STATE §4 **C6** — `/admin/roles` awaited `listRolePermissions` once
+ * per role.
+ *
+ * Sequential, because concurrent queries on one transaction connection leak
+ * it: a tenant with 40 roles paid 40 round trips, summed rather than
+ * overlapped, to render one screen. `listRolePermissionsForRoles` answers the
+ * whole set in one.
+ *
+ * These are unit-level proofs against a fake `tx` — the point is the SHAPE of
+ * the access (one query, every id answered, list bound as an array), which is
+ * exactly what a real-database test cannot show you without counting round
+ * trips. The rows themselves are covered by the screen's own integration
+ * coverage.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { listRolePermissionsForRoles } from "../src/modules/identity-access/application/role-admin";
+
+const TENANT_ID = "11111111-1111-4111-8111-111111111111";
+const ROLE_A = "22222222-2222-4222-8222-222222222222";
+const ROLE_B = "33333333-3333-4333-8333-333333333333";
+const ROLE_C = "44444444-4444-4444-8444-444444444444";
+
+type Capture = { text: string; values: unknown[] };
+
+type PermissionRow = {
+  role_id: string;
+  id: string;
+  module_key: string;
+  activity_code: string;
+  action: string;
+  description: string | null;
+};
+
+function permissionRow(roleId: string, id: string): PermissionRow {
+  return {
+    role_id: roleId,
+    id,
+    module_key: "identity_access",
+    activity_code: "access_control",
+    action: "read",
+    description: null
+  };
+}
+
+/**
+ * A `tx` that records each tagged-template call and answers with `rows`.
+ * `array` returns a marker rather than the bare list so a test can tell the
+ * two bindings apart: a bare `${ids}` reaches PostgreSQL as comma-joined TEXT
+ * and fails with 22P02, which is a defect this repo has hit before.
+ */
+function recordingTx(rows: PermissionRow[], captured: Capture[]): Bun.SQL {
+  const tx = ((strings: TemplateStringsArray, ...values: unknown[]) => {
+    captured.push({ text: strings.join("?"), values });
+    return Promise.resolve(rows);
+  }) as unknown as Bun.SQL;
+
+  (
+    tx as unknown as { array: (value: unknown[], type: string) => unknown }
+  ).array = (value: unknown[], type: string) => ({ boundArray: value, type });
+
+  return tx;
+}
+
+/** A `tx` that throws the moment it is used — proves no query was issued. */
+const THROWING_TX = ((..._args: unknown[]) => {
+  throw new Error("the database must not be queried for an empty role list");
+}) as unknown as Bun.SQL;
+
+describe("listRolePermissionsForRoles", () => {
+  test("issues ONE query for the whole set of roles", async () => {
+    const captured: Capture[] = [];
+    const tx = recordingTx(
+      [permissionRow(ROLE_A, "perm-1"), permissionRow(ROLE_B, "perm-2")],
+      captured
+    );
+
+    await listRolePermissionsForRoles(tx, TENANT_ID, [ROLE_A, ROLE_B, ROLE_C]);
+
+    expect(captured).toHaveLength(1);
+  });
+
+  test("answers every requested role, including the ones with no grants", async () => {
+    const captured: Capture[] = [];
+    const tx = recordingTx([permissionRow(ROLE_A, "perm-1")], captured);
+
+    const result = await listRolePermissionsForRoles(tx, TENANT_ID, [
+      ROLE_A,
+      ROLE_B,
+      ROLE_C
+    ]);
+
+    // A caller that had to tell "no grants" from "not in the result" would be
+    // back to asking per role.
+    expect([...result.keys()].sort()).toEqual([ROLE_A, ROLE_B, ROLE_C].sort());
+    expect(result.get(ROLE_B)).toEqual([]);
+    expect(result.get(ROLE_C)).toEqual([]);
+  });
+
+  test("groups rows under the role that holds them", async () => {
+    const captured: Capture[] = [];
+    const tx = recordingTx(
+      [
+        permissionRow(ROLE_A, "perm-1"),
+        permissionRow(ROLE_A, "perm-2"),
+        permissionRow(ROLE_B, "perm-3")
+      ],
+      captured
+    );
+
+    const result = await listRolePermissionsForRoles(tx, TENANT_ID, [
+      ROLE_A,
+      ROLE_B
+    ]);
+
+    expect(result.get(ROLE_A)?.map((p) => p.id)).toEqual(["perm-1", "perm-2"]);
+    expect(result.get(ROLE_B)?.map((p) => p.id)).toEqual(["perm-3"]);
+  });
+
+  test("binds the ids as a uuid array, and scopes the read to the tenant", async () => {
+    const captured: Capture[] = [];
+    const tx = recordingTx([], captured);
+
+    await listRolePermissionsForRoles(tx, TENANT_ID, [ROLE_A, ROLE_B]);
+
+    const query = captured[0]!;
+    expect(query.text).toContain("= ANY(");
+    expect(query.values).toContainEqual({
+      boundArray: [ROLE_A, ROLE_B],
+      type: "uuid"
+    });
+    expect(query.values).toContain(TENANT_ID);
+  });
+
+  test("does not query at all when there are no roles", async () => {
+    const result = await listRolePermissionsForRoles(
+      THROWING_TX,
+      TENANT_ID,
+      []
+    );
+
+    expect(result.size).toBe(0);
+  });
+
+  test("a repeated id is asked for once", async () => {
+    const captured: Capture[] = [];
+    const tx = recordingTx([], captured);
+
+    await listRolePermissionsForRoles(tx, TENANT_ID, [ROLE_A, ROLE_A, ROLE_B]);
+
+    expect(captured[0]!.values).toContainEqual({
+      boundArray: [ROLE_A, ROLE_B],
+      type: "uuid"
+    });
+  });
+});


### PR DESCRIPTION
Three §4 items (**B6**, **C6**, **C7**) whose common shape is a cost that is invisible at the size everything was tested at, and that grows with something the code never looks at: how many clients have ever connected, how many roles a tenant has defined, how many tags an article could match.

## B6 — the in-process rate-limit map had no eviction

One entry per distinct client IP, created on first contact and never removed. Redis is off by default, so this map is the live path for the topology this base documents as its default, and the end state of the leak is an OOM of the process that also holds every other cache.

Two mechanisms, because a sweep alone is not a bound:

- An **amortised sweep** (at most once a minute, and on the way past the cap) drops every entry whose window has elapsed. `checkRateLimit` already treats an elapsed window as a fresh start, so such an entry holds no information.
- That bounds the map to "distinct clients seen within one window" — the correct working set, and itself attacker-controlled during a distributed flood. So there is also a **hard cap of 50,000**, and the victims are the entries **closest to expiring**, evicted in one batch down to 45,000 so the sort that picks them runs once per 10% of growth rather than once per request.

The bucket now stores its own `windowMs`. Eviction happens *outside* any call for that key, and the map is shared by callers with different windows (login: minutes; site-search: seconds) — sweeping by the triggering caller's window would expire the other family's counters early. Early expiry is the one failure a memory fix must not introduce, so `tests/rate-limit-bucket-eviction.test.ts` asserts a live counter survives, not only that the map shrinks.

## C6 — `/admin/roles` was an N+1 plus a payload that grew as roles × catalogue

**The N+1:** `listRolePermissions` was awaited once per role, sequentially (concurrent queries on one transaction connection leak it), so a 40-role tenant paid 40 *summed* round trips to render one screen. `listRolePermissionsForRoles` answers the set in one `role_id = ANY(...)` and returns an entry for **every** requested id, empty array included — a caller that had to tell "no grants" from "not in the result" would be back to asking per role. The single-role reader is **deleted**, not left unused: a zero-caller export is how the next screen quietly reintroduces the N+1.

**The payload:** the ~230-row catalogue was rendered as `<option>`s once per role — ~23,000 options in one document, of which at most one is ever chosen. It is now emitted once in a `<template>` (inert content: not rendered, not submitted) and cloned into a role's picker the first time that panel is opened, minus what the panel already lists as granted. The granted ids come from the panel's own revoke buttons, because a second copy could only disagree with the list already on screen.

What did **not** move to the client: the server still decides whether a picker exists at all (`availableCount > 0`, counted against the catalogue rather than by subtraction — a role can hold a permission the catalogue omits), and the endpoint's `configure` guard remains the only authority on the grant itself. The picker is empty without JavaScript; not a regression, the form has always submitted through `sendJson`. `tests/e2e/admin-roles.e2e.ts` grants a permission through the real browser and asserts the picker comes back one option shorter.

## C7 — `prepareCandidates` re-escaped every tag name inside the sort comparator

A comparator runs O(n log n) times: 1090 `escapeHtml` calls per sort at the 100-candidate cap instead of 100, on by default on every public article render. Decorate-sort-undecorate, with the escaped name carried on the row the dedupe loop and the caller both already need.

## One thing to know before the next screen

C6's client-side picker costs ~540 B and leaves **161 B** of headroom under `build:asset-budget:check`'s 192,000 B app ceiling. The trade is good in itself (a few hundred bytes of cached JS against ~23,000 `<option>`s in every render) but the next client script to land will fail that gate for reasons unrelated to whatever it did. Raising the ceiling is a decision, not a formality — it is not taken here, and it is recorded in §4.

## Verification

`bun run check` in full, with the two documented local splits (`DATABASE_URL="" bun run test`, then `bun run build`): all gates green, 5532 pass / 0 fail. Regenerated `PROJECT_STATE.md` §2 and `repo-inventory.md`; the Indonesian mirror was re-translated (all three §4 entries plus the drifted `.astro` line count) before the marker was re-stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
