### PR TITLE
fix(seo-distribution): the middleware cost the performance gate could not see

### DIFF
--- a/.changeset/middleware-cost-the-gate-could-not-see.md
+++ b/.changeset/middleware-cost-the-gate-could-not-see.md
@@ -1,0 +1,48 @@
+---
+"awcms": patch
+---
+
+fix(seo-distribution): the middleware cost the performance gate could not see
+
+PROJECT_STATE §4 **B5**. The performance standard lists "queries per hot read
+request ≤ 3" as **measured**, citing two budget suites. Both hand a counting
+`tx` to a directory function — so everything a public request pays BEFORE the
+route (resolving the tenant from the host, opening the tenant transaction,
+asking `seo_distribution` whether the path redirects) was not merely unmeasured,
+it was outside what the tool could measure at all. `countQueries` can only be
+given a `tx`, which means it can only see code the test has already put inside a
+transaction.
+
+**Measured first.** `countPoolQueries` wraps the POOL and the transaction opened
+on it, and `tests/integration/middleware-query-budget.integration.test.ts` pins
+the real numbers against a real PostgreSQL: **5** statements for a passthrough,
+**7** when the request redirects, **0** for a path the redirect vocabulary does
+not cover. Exact rather than ceilings — a ceiling with slack cannot tell an
+improvement from a regression into the slack — and explicitly a floor, because
+`BEGIN` and `COMMIT` are two more round trips `sql.begin` issues itself that no
+Proxy can see. A budget that quietly under-counts is how "measured" came to mean
+something other than measured.
+
+**Then reduced, by one read rather than a short-circuit.**
+`resolveTenantAllowedHosts` and `resolveTenantPrimaryHost` read the same table
+under the same active/not-deleted filter, differing only by `is_primary`, and
+the redirect path called them one after the other on every eligible public
+request. `resolveTenantDomainSet` answers both from one round trip: 6 → 5, and
+8 → 7, proven by running the new budget against the pre-fix code and watching it
+report the old numbers. The "does this tenant have any live rule?" short-circuit
+the file's own perf note considered is still NOT applied, for the reason that
+note gives: the passthrough branch needs the server-derived host to attribute a
+404, and the legacy-blog auto-redirect fires from settings rather than a rule
+row.
+
+**The standard now states its scope.** The ≤ 3 ceiling was always a ROUTE budget
+and the table did not say so; the middleware budget is a separate row rather
+than folded into the same number, because the two are paid by different code and
+one sum would hide which half moved.
+
+**Also corrected: two comments that asserted a live code path was dead.** Both
+`redirect-resolution-service.ts` and `redirect-middleware.ts` said the middleware
+passes `locale = null` "all the way through", so locale-scoped redirect rules
+could never match. That was true under ADR-0039 and false since ADR-0098's
+locale routing landed and the middleware began passing the served locale for a
+prefixed URL.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:f1a13869b3fa723064588a3816cb62ccff87e0fb057570ec7416dc5ec201a8d1 -->
+<!-- i18n-source-hash: sha256:89dad0e2915ba1daed2dcc078dac6fac858d9e98b72e2354334f232b0d5f525a -->
 
 # AWCMS — Project State & Continuation
 
@@ -694,11 +694,55 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       susunan sidebar.
 
   13. **B5 — ~6 round trip middleware per request publik sebelum query pertama halaman.**
+      **SELESAI (22 Agustus 2026)** — diukur dulu, baru dikurangi.
       `middleware.ts:305`; `redirect-resolution-service.ts:170-212`. Dibayar bahkan oleh
       tenant tanpa satu pun aturan redirect. `standar-performa-dan-keamanan.md:195` mengaku
       plafon ≤3 query hot-read "terukur", tetapi **kedua suite budget memanggil fungsi
       directory langsung dan tidak pernah menggerakkan middleware**, jadi kelebihannya
       secara struktural tak terlihat oleh gerbang yang mengaku menegakkannya.
+
+      **Pengukurannya adalah paruh yang lebih sulit, dan itulah inti temuan ini.**
+      `countQueries` hanya bisa diberi `tx`, jadi ia hanya bisa melihat kode yang sudah
+      ditaruh uji di dalam transaksi — sebuah fungsi directory. Semua yang dibayar
+      request lebih dulu bukan sekadar tak terukur, melainkan tak TERUKURKAN oleh alat
+      itu. `countPoolQueries` membungkus POOL dan transaksi yang dibuka di atasnya, dan
+      `tests/integration/middleware-query-budget.integration.test.ts` kini memaku angka
+      sebenarnya di atas PostgreSQL nyata: **5 statement** untuk passthrough, **7**
+      untuk request yang redirect, **0** untuk path di luar kosakata redirect. Persis,
+      bukan plafon — plafon berkelonggaran tak bisa membedakan perbaikan dari regresi
+      ke dalam kelonggaran itu. Dan secara eksplisit BATAS BAWAH: `BEGIN` dan `COMMIT`
+      adalah dua round trip lagi yang dikirim `sql.begin` sendiri dan tak terlihat
+      Proxy mana pun. Anggaran yang diam-diam kurang menghitung adalah persis
+      bagaimana "terukur" bisa berarti sesuatu selain terukur.
+
+      **Pengurangannya satu pembacaan, bukan short-circuit.** `resolveTenantAllowedHosts`
+      dan `resolveTenantPrimaryHost` membaca tabel yang SAMA dengan filter
+      aktif/tak-terhapus yang sama, hanya beda `is_primary`, dan jalur redirect
+      memanggil keduanya berurutan — maka `resolveTenantDomainSet` menjawab keduanya
+      dari satu round trip (6 → 5, dan 8 → 7). Dibuktikan dengan menjalankan anggaran
+      baru itu terhadap kode SEBELUM perbaikan dan melihatnya melaporkan 6 dan 8.
+      Short-circuit yang dipertimbangkan catatan perf berkas itu sendiri ("apakah
+      tenant ini punya aturan hidup?") TETAP tidak diterapkan, dengan alasan yang
+      catatan itu berikan: cabang passthrough butuh host turunan-server untuk
+      mengatribusikan 404, dan auto-redirect legacy-blog menyala dari settings, bukan
+      dari baris aturan.
+
+      **Standar kini menyatakan cakupannya.** Plafon ≤ 3 selalu anggaran ROUTE; tabelnya
+      tidak mengatakan itu, dan "terukur" adalah kata yang ditangkap pembaca sebagai
+      batas atas sebuah REQUEST. Anggaran middleware menjadi baris terpisah alih-alih
+      dilebur ke angka yang sama, karena keduanya dibayar kode berbeda dan satu jumlah
+      akan menyembunyikan paruh mana yang bergerak.
+
+      **Ditemukan sambil bekerja: dua komentar menyatakan jalur kode HIDUP sebagai
+      mati.** Baik `redirect-resolution-service.ts` maupun `redirect-middleware.ts`
+      menyatakan middleware meneruskan `locale = null` "sepanjang jalan", sehingga
+      aturan redirect ber-scope locale tak pernah bisa cocok. Benar di bawah ADR-0039;
+      **salah sejak locale routing ADR-0098 mendarat** dan middleware mulai meneruskan
+      locale yang disajikan untuk URL berprefiks. Dikoreksi di kedua tempat. Bentuk
+      yang sama dengan hazard skill basi yang punya memori tersendiri di repo ini:
+      klaim yang menua menjadi kebalikan kebenaran, di berkas yang tak punya alasan
+      untuk dibaca ulang.
+
   14. **B6 — Map `buckets` rate-limit in-process tanpa eviction.** **SELESAI (22 Agustus
       2026).**
       `security/rate-limit.ts:57`. Satu entri permanen per IP klien berbeda; Redis mati

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -709,11 +709,53 @@ pioneered directly here after the ADR-0047 freeze.)
       fetched.** `AdminLayout.astro:184-206`. `tenant_name` is fetched separately from the
       same row `readTenantDisplayDefaults` already selects.
   13. **B5 — ~6 middleware round trips per public request before the page's first query.**
+      **DONE (22 August 2026)** — measured first, then reduced.
       `middleware.ts:305`; `redirect-resolution-service.ts:170-212`. Paid even by tenants
       with zero redirect rules. `standar-performa-dan-keamanan.md:195` claims the
       ≤3-query hot-read ceiling is "measured", but **both budget suites call directory
       functions directly and never drive middleware**, so the excess is structurally
       invisible to the gate that claims to enforce it.
+
+      **The measurement was the harder half, and it is what the finding was really
+      about.** `countQueries` can only be handed a `tx`, so it can only see code the
+      test has already placed inside a transaction — a directory function. Everything
+      the request pays first was not merely unmeasured but unmeasurable by that tool.
+      `countPoolQueries` wraps the POOL and the transaction opened on it, and
+      `tests/integration/middleware-query-budget.integration.test.ts` now pins the
+      real numbers against a real PostgreSQL: **5 statements** for a passthrough,
+      **7** for a request that redirects, **0** for a path the redirect vocabulary
+      does not cover. Exact, not ceilings — a ceiling with slack cannot tell an
+      improvement from a regression into the slack. And explicitly a FLOOR: `BEGIN`
+      and `COMMIT` are two more round trips that `sql.begin` issues itself and no
+      Proxy can see. A budget that quietly under-counts is how "measured" came to
+      mean something other than measured in the first place.
+
+      **The reduction is one read, not a short-circuit.** `resolveTenantAllowedHosts`
+      and `resolveTenantPrimaryHost` read the same table under the same
+      active/not-deleted filter, differing only by `is_primary`, and the redirect path
+      called them one after the other — so `resolveTenantDomainSet` answers both from
+      one round trip (6 → 5, and 8 → 7). Proven by running the new budget against the
+      PRE-fix code and watching it report 6 and 8. The short-circuit the file's own
+      perf note considered ("does this tenant have any live rule?") is still NOT
+      applied, for the reason that note gives: the passthrough branch needs the
+      server-derived host to attribute a 404, and the legacy-blog auto-redirect fires
+      from settings rather than a rule row.
+
+      **The standard now states its scope.** The ≤ 3 ceiling was always a ROUTE budget;
+      the table did not say so, and "measured" is a word a reader takes as a bound on
+      the REQUEST. The middleware budget is a separate row rather than folded into the
+      same number, because the two are paid by different code and one sum would hide
+      which half moved.
+
+      **Found while working: two comments asserted a live code path was dead.** Both
+      `redirect-resolution-service.ts` and `redirect-middleware.ts` said the middleware
+      passes `locale = null` "all the way through", so locale-scoped redirect rules
+      could never match. True under ADR-0039; **false since ADR-0098's locale routing
+      landed** and the middleware started passing the served locale for a prefixed
+      URL. Corrected in both places. Same shape as the stale-skill hazard this repo
+      keeps a memory about: a claim that ages into the opposite of the truth, in a
+      file nobody had reason to re-read.
+
   14. **B6 — in-process rate-limit `buckets` Map has no eviction.** **DONE (22 August
       2026).**
       `security/rate-limit.ts:57`. One permanent entry per distinct client IP; Redis is

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 455   |
+| Test files                          | 456   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -358,7 +358,7 @@
 | ------------- | ---------- |
 | `(root)`      | 384        |
 | `e2e`         | 12         |
-| `integration` | 58         |
+| `integration` | 59         |
 | `unit`        | 1          |
 
 ### Routes

--- a/docs/awcms/standar-performa-dan-keamanan.id.md
+++ b/docs/awcms/standar-performa-dan-keamanan.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](standar-performa-dan-keamanan.md)
 
-<!-- i18n-source-hash: sha256:6cf44a7fb8fcd59d4b3a3e81eb5fd52a0b79cc3da9f2812c37b1839522d2e6a8 -->
+<!-- i18n-source-hash: sha256:9539c183315a5a412de43d958ffa741ae9985abc729a5145a37766025883bec4 -->
 
 # awcms — Standar Performa dan Keamanan
 
@@ -191,16 +191,31 @@ boleh disalin bolak-balik.
 
 ### Target hasil, dan status pengukurannya
 
-| Metrik                          | Ambang "baik"   | Keadaan                                                                                                                                                                                                                     |
-| ------------------------------- | --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| LCP — Largest Contentful Paint  | ≤ 2,5 detik     | **diukur di LAB** — `tests/e2e/cwv-lab.e2e.ts` (Opsi D ADR-0067, 5 Agustus 2026); detektor regresi satu-mesin, **bukan** p75 lapangan                                                                                       |
-| INP — Interaction to Next Paint | ≤ 200 milidetik | **belum diukur, dan lab tidak mengklaimnya** — INP butuh interaksi pengunjung nyata; menunggu keputusan RUM (ADR-0067 Opsi B)                                                                                               |
-| CLS — Cumulative Layout Shift   | ≤ 0,1           | **diukur di LAB** — berkas yang sama, batas yang sama                                                                                                                                                                       |
-| Query per permintaan baca panas | ≤ 3             | **diukur** — `tests/integration/query-budget.integration.test.ts` (publik, fixture 40 post) + `tests/integration/query-budget-admin.integration.test.ts` (dashboard admin, daftar blog, sitemap — anggaran = aktual persis) |
+| Metrik                                                 | Ambang "baik"                 | Keadaan                                                                                                                                                                                                                                                     |
+| ------------------------------------------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LCP — Largest Contentful Paint                         | ≤ 2,5 detik                   | **diukur di LAB** — `tests/e2e/cwv-lab.e2e.ts` (Opsi D ADR-0067, 5 Agustus 2026); detektor regresi satu-mesin, **bukan** p75 lapangan                                                                                                                       |
+| INP — Interaction to Next Paint                        | ≤ 200 milidetik               | **belum diukur, dan lab tidak mengklaimnya** — INP butuh interaksi pengunjung nyata; menunggu keputusan RUM (ADR-0067 Opsi B)                                                                                                                               |
+| CLS — Cumulative Layout Shift                          | ≤ 0,1                         | **diukur di LAB** — berkas yang sama, batas yang sama                                                                                                                                                                                                       |
+| Query per permintaan baca panas                        | ≤ 3 di ROUTE-nya              | **diukur, dan cakupannya kini dinyatakan** — `tests/integration/query-budget.integration.test.ts` (publik, fixture 40 post) + `tests/integration/query-budget-admin.integration.test.ts` (dashboard admin, daftar blog, sitemap — anggaran = aktual persis) |
+| Query yang dibelanjakan MIDDLEWARE sebelum route jalan | 5 (passthrough), 7 (redirect) | **diukur** — `tests/integration/middleware-query-budget.integration.test.ts`; hitungan persis, dan merupakan BATAS BAWAH (`BEGIN`/`COMMIT` dua lagi yang tak bisa dilihat Proxy mana pun)                                                                   |
 
 Angka lab menjawab "apakah perubahan ini membuat halaman lebih lambat", bukan
 "apa yang dialami pengunjung" — menukar keduanya adalah kelas cacat yang ADR-0067
 tulis eksplisit. Bagian RUM tetap menunggu pemilik produk.
+
+**Plafon ≤ 3 selalu merupakan anggaran ROUTE, dan sampai 22 Agustus 2026 tabel
+ini tidak mengatakannya** (temuan B5 putaran 17 Agustus). Kedua suite yang
+dirujuknya menyerahkan `tx` penghitung ke sebuah fungsi directory, sehingga
+semua yang dibayar permintaan publik SEBELUM route — meresolusi tenant dari
+host, membuka transaksi tenant, menanyai `seo_distribution` apakah path itu
+redirect — berada di luar jangkauan hitungan keduanya. Kata "diukur" benar untuk
+apa yang diukur dan salah untuk apa yang akan ditangkap pembaca: batas atas
+sebuah permintaan.
+
+Baris middleware di atas menutup celah itu. Ia sengaja menjadi anggaran
+TERPISAH, bukan dilebur ke dalam ≤ 3: keduanya dibayar oleh kode berbeda dengan
+alasan berbeda, dan menjumlahkannya menjadi satu angka akan menyembunyikan
+paruh mana yang bergerak.
 
 ### Yang sudah benar
 

--- a/docs/awcms/standar-performa-dan-keamanan.md
+++ b/docs/awcms/standar-performa-dan-keamanan.md
@@ -187,16 +187,29 @@ not be copied back and forth.
 
 ### Outcome targets, and the state of their measurement
 
-| Metric                          | "Good" threshold | State                                                                                                                                                                                                                    |
-| ------------------------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| LCP — Largest Contentful Paint  | ≤ 2.5 seconds    | **measured in the LAB** — `tests/e2e/cwv-lab.e2e.ts` (ADR-0067 Option D, 5 August 2026); a single-machine regression detector, **not** field p75                                                                         |
-| INP — Interaction to Next Paint | ≤ 200 ms         | **not yet measured, and the lab does not claim it** — INP needs real visitor interaction; waiting on the RUM decision (ADR-0067 Option B)                                                                                |
-| CLS — Cumulative Layout Shift   | ≤ 0.1            | **measured in the LAB** — same file, same limits                                                                                                                                                                         |
-| Queries per hot read request    | ≤ 3              | **measured** — `tests/integration/query-budget.integration.test.ts` (public, 40-post fixture) + `tests/integration/query-budget-admin.integration.test.ts` (admin dashboard, blog list, sitemap — budget = exact actual) |
+| Metric                                              | "Good" threshold              | State                                                                                                                                                                                                                                                 |
+| --------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LCP — Largest Contentful Paint                      | ≤ 2.5 seconds                 | **measured in the LAB** — `tests/e2e/cwv-lab.e2e.ts` (ADR-0067 Option D, 5 August 2026); a single-machine regression detector, **not** field p75                                                                                                      |
+| INP — Interaction to Next Paint                     | ≤ 200 ms                      | **not yet measured, and the lab does not claim it** — INP needs real visitor interaction; waiting on the RUM decision (ADR-0067 Option B)                                                                                                             |
+| CLS — Cumulative Layout Shift                       | ≤ 0.1                         | **measured in the LAB** — same file, same limits                                                                                                                                                                                                      |
+| Queries per hot read request                        | ≤ 3 in the ROUTE              | **measured, and the scope is now stated** — `tests/integration/query-budget.integration.test.ts` (public, 40-post fixture) + `tests/integration/query-budget-admin.integration.test.ts` (admin dashboard, blog list, sitemap — budget = exact actual) |
+| Queries the MIDDLEWARE spends before the route runs | 5 (passthrough), 7 (redirect) | **measured** — `tests/integration/middleware-query-budget.integration.test.ts`; exact counts, and a FLOOR (`BEGIN`/`COMMIT` are two more that no Proxy can see)                                                                                       |
 
 The lab numbers answer "does this change make the page slower", not "what does a
 visitor experience" — swapping the two is the class of defect ADR-0067 writes out
 explicitly. The RUM part is still waiting on the product owner.
+
+**The ≤ 3 ceiling has always been a ROUTE budget, and until 22 August 2026 this
+table did not say so** (finding B5 of the 17 August round). Both suites it cites
+hand a counting `tx` to a directory function, so everything a public request
+pays BEFORE the route — resolving the tenant from the host, opening the tenant
+transaction, asking `seo_distribution` whether the path redirects — was outside
+what either could count. The word "measured" was true of what was measured and
+false of what a reader would take it to mean: a bound on the request.
+
+The middleware row above closes that. It is a separate budget on purpose rather
+than folded into the ≤ 3: the two are paid by different code for different
+reasons, and adding them into one number would hide which half moved.
 
 ### What is already right
 

--- a/src/modules/seo-distribution/application/redirect-resolution-service.ts
+++ b/src/modules/seo-distribution/application/redirect-resolution-service.ts
@@ -35,9 +35,15 @@
  *    to normal content resolution) — a redirect subsystem error must never take
  *    down public pages.
  *
- * awcms adaptation (ADR-0039): there is NO i18n/locale seam in this base, so the
- * middleware passes `locale = null` all the way through — locale-scoped rules simply
- * never match a locale, only the all-locales (`locale_scope IS NULL`) rules do.
+ * ## `locale` is no longer always `null` — corrected 22 August 2026
+ *
+ * ADR-0039 was written when this base had no i18n seam, and this header said the
+ * middleware "passes `locale = null` all the way through", so locale-scoped
+ * rules could never match. **ADR-0098's locale routing changed that and the
+ * claim went stale in place**: `src/middleware.ts` now passes the served locale
+ * for a prefixed URL (`/id/…`), and `null` only for a bare one. Locale-scoped
+ * rules DO fire, for prefixed URLs, and a reader who trusted this paragraph
+ * would have concluded a live code path was dead.
  */
 import { assertSafeRedirectTarget } from "../domain/redirect-target-classification";
 import { withTenantOrThrow } from "../../../lib/database/tenant-context";
@@ -65,8 +71,7 @@ import {
   findActiveRedirectByPath,
   incrementRedirectHit
 } from "./redirect-directory";
-import { resolveTenantAllowedHosts } from "./tenant-allowed-hosts";
-import { resolveTenantPrimaryHost } from "./resolve-canonical-host";
+import { resolveTenantDomainSet } from "./tenant-allowed-hosts";
 import { resolveSiteScheme } from "../../../lib/http/site-origin";
 
 /** Context the middleware needs to record a privacy-minimized 404 observation later. */
@@ -142,10 +147,14 @@ async function resolveRetiredNewsRedirect(
     // restates. Let the 404 it already chose stand.
     if (!routeSettings.legacyTenantRouteEnabled) return null;
 
-    const primaryHost = await resolveTenantPrimaryHost(tx, tenant.tenantId);
+    // One read for both: the allow-list and the canonical host are the same
+    // rows (B5).
+    const { hosts: allowedHosts, primaryHost } = await resolveTenantDomainSet(
+      tx,
+      tenant.tenantId
+    );
     if (!primaryHost) return null; // no canonical host — cannot safely redirect
 
-    const allowedHosts = await resolveTenantAllowedHosts(tx, tenant.tenantId);
     const target = `${resolveSiteScheme(request)}://${primaryHost}${buildLegacyBlogPath(tenant.tenantCode, rest)}${options.search}`;
 
     try {
@@ -192,11 +201,18 @@ async function resolveHostBasedRedirect(
       return { kind: "skip" };
     }
 
-    const allowedHosts = await resolveTenantAllowedHosts(tx, tenant.tenantId);
+    // One read for both. The allow-list is needed for the rule lookup itself
+    // (host-scoped rules) and for the frozen target guard; the canonical host
+    // is only the 404-attribution fallback — and it is the SAME rows, so
+    // asking twice was a round trip per eligible public request for a fact
+    // already in hand (B5).
+    const { hosts: allowedHosts, primaryHost } = await resolveTenantDomainSet(
+      tx,
+      tenant.tenantId
+    );
     const allowedLower = new Set(allowedHosts.map((h) => h.toLowerCase()));
     const scopeHost =
       requestHost && allowedLower.has(requestHost) ? requestHost : null;
-    const primaryHost = await resolveTenantPrimaryHost(tx, tenant.tenantId);
     const domainHost = scopeHost ?? primaryHost;
 
     const capture: NotFoundCaptureContext = {

--- a/src/modules/seo-distribution/application/resolve-canonical-host.ts
+++ b/src/modules/seo-distribution/application/resolve-canonical-host.ts
@@ -19,11 +19,35 @@ import { normalizePublicHost } from "../../../lib/tenant/public-host-tenant-reso
 type PrimaryHostRow = { normalized_hostname: string };
 
 /**
+ * Defense-in-depth: re-validate a stored hostname's DNS shape at the render
+ * boundary. The stored value is already `normalized_hostname` (migration 046
+ * rejects CR/LF/whitespace/underscores at write time), so a valid host
+ * round-trips to itself; if a future domain-write path ever relaxes that
+ * validation, this keeps `https://{host}/sitemap.xml` etc. (robots.txt /
+ * sitemap / feed) from being fed a header/response-splitting payload — an
+ * out-of-shape value degrades to `null` (discovery 404s), never emits a
+ * poisoned host.
+ *
+ * Exported so the batched reader in `tenant-allowed-hosts.ts` applies the SAME
+ * rule rather than a second copy of it: a defense that exists twice is a
+ * defense that can be relaxed in one place and still look present in the
+ * other.
+ */
+export function validateRenderableHost(host: string | null): string | null {
+  if (host === null) return null;
+
+  return normalizePublicHost(host) === host ? host : null;
+}
+
+/**
  * Resolve `tenantId`'s primary canonical host, or `null` when the tenant has no
  * verified primary domain (offline-lan / not-yet-configured deployments). The
  * returned value is the already-normalized hostname (lowercased, port-stripped —
  * migration 046's `normalized_hostname`), safe to place directly into
  * `https://{host}{path}`.
+ *
+ * For a caller that ALSO needs the tenant's full allowed-host set, use
+ * `resolveTenantDomainSet` instead — it answers both from one round trip.
  */
 export async function resolveTenantPrimaryHost(
   tx: Bun.SQL,
@@ -39,15 +63,5 @@ export async function resolveTenantPrimaryHost(
     LIMIT 1
   `) as PrimaryHostRow[];
 
-  const host = rows[0]?.normalized_hostname ?? null;
-  if (host === null) return null;
-
-  // Defense-in-depth: re-validate the DNS shape at the render boundary. The
-  // stored value is already `normalized_hostname` (migration 046 rejects
-  // CR/LF/whitespace/underscores at write time), so a valid host round-trips to
-  // itself; if a future domain-write path ever relaxes that validation, this
-  // keeps `https://{host}/sitemap.xml` etc. (robots.txt / sitemap / feed) from
-  // being fed a header/response-splitting payload — an out-of-shape value
-  // degrades to `null` (discovery 404s), never emits a poisoned host.
-  return normalizePublicHost(host) === host ? host : null;
+  return validateRenderableHost(rows[0]?.normalized_hostname ?? null);
 }

--- a/src/modules/seo-distribution/application/tenant-allowed-hosts.ts
+++ b/src/modules/seo-distribution/application/tenant-allowed-hosts.ts
@@ -12,14 +12,37 @@
  * tenant has since removed fails closed on the next resolve.
  */
 
-type HostRow = { normalized_hostname: string };
+import { validateRenderableHost } from "./resolve-canonical-host";
 
-export async function resolveTenantAllowedHosts(
+type HostRow = { normalized_hostname: string; is_primary: boolean };
+
+/** A tenant's verified active domains: the allow-list, plus which one is canonical. */
+export type TenantDomainSet = {
+  /** Every verified active host, ordered — the `allowedHosts` guard argument. */
+  hosts: string[];
+  /** The canonical host for absolute URLs, or `null` when the tenant has none. */
+  primaryHost: string | null;
+};
+
+/**
+ * Both facts about a tenant's domains in ONE round trip.
+ *
+ * `resolveTenantAllowedHosts` and `resolveTenantPrimaryHost` read the SAME
+ * table under the same `active`/not-deleted filter, differing only by
+ * `is_primary`. The public redirect path called them one after the other, on
+ * every eligible public request, so a fact already in the first result set was
+ * fetched a second time — finding B5 of the 17 August 2026 round, where the
+ * middleware's per-request round trips are the whole subject.
+ *
+ * `primaryHost` goes through the same `validateRenderableHost` as the dedicated
+ * reader, so a caller cannot get a laxer value by asking this way.
+ */
+export async function resolveTenantDomainSet(
   tx: Bun.SQL,
   tenantId: string
-): Promise<string[]> {
+): Promise<TenantDomainSet> {
   const rows = (await tx`
-    SELECT normalized_hostname
+    SELECT normalized_hostname, is_primary
     FROM awcms_tenant_domains
     WHERE tenant_id = ${tenantId}
       AND status = 'active'
@@ -27,5 +50,17 @@ export async function resolveTenantAllowedHosts(
     ORDER BY normalized_hostname
   `) as HostRow[];
 
-  return rows.map((r) => r.normalized_hostname);
+  return {
+    hosts: rows.map((r) => r.normalized_hostname),
+    primaryHost: validateRenderableHost(
+      rows.find((r) => r.is_primary)?.normalized_hostname ?? null
+    )
+  };
+}
+
+export async function resolveTenantAllowedHosts(
+  tx: Bun.SQL,
+  tenantId: string
+): Promise<string[]> {
+  return (await resolveTenantDomainSet(tx, tenantId)).hosts;
 }

--- a/src/modules/seo-distribution/presentation/redirect-middleware.ts
+++ b/src/modules/seo-distribution/presentation/redirect-middleware.ts
@@ -57,8 +57,11 @@ export function buildRedirectResponse(
  * `{ capture }` (tenant resolved, no redirect) so the caller can observe a
  * subsequent 404, or `null` (not eligible / no tenant / error). Never throws.
  *
- * awcms has NO i18n/locale seam (ADR-0039), so `locale` is always `null` here — the
- * parameter is kept for signature parity with awcms-micro and a future locale port.
+ * `locale` is the SERVED locale for a prefixed URL (`/id/…`) and `null` for a
+ * bare one. This used to say it was always `null` "for signature parity with a
+ * future locale port" — true under ADR-0039, false since ADR-0098's locale
+ * routing landed and made the middleware pass a real value. Corrected 22 August
+ * 2026; the parameter is live, not vestigial.
  */
 export async function resolvePublicRedirectForRequest(
   request: Request,

--- a/tests/integration/middleware-query-budget.integration.test.ts
+++ b/tests/integration/middleware-query-budget.integration.test.ts
@@ -1,0 +1,224 @@
+/**
+ * What the request pays BEFORE the page's first query — finding B5 of the
+ * 17 August 2026 round.
+ *
+ * ## The finding is about a measurement, not only about a cost
+ *
+ * `docs/awcms/standar-performa-dan-keamanan.md` lists "queries per hot read
+ * request ≤ 3" as **measured**, citing
+ * `query-budget.integration.test.ts` and `query-budget-admin.integration.test.ts`.
+ * Both of those hand a counting `tx` to a directory function. The middleware
+ * runs BEFORE any of that — it resolves the tenant from the host, opens its own
+ * tenant transaction and asks `seo_distribution` whether the path redirects —
+ * and none of it was inside anything either suite could count. The excess was
+ * not merely unmeasured; it was structurally invisible to the gate that claimed
+ * to enforce the ceiling.
+ *
+ * This file counts that prefix, through `countPoolQueries`, which wraps the
+ * POOL and the transaction opened on it. `src/middleware.ts` itself cannot be
+ * imported (it pulls in the `astro:middleware` virtual module), so the subject
+ * is `resolvePublicRedirect` — the one call the middleware makes on the public
+ * path, taking the same `sql`, `request` and options.
+ *
+ * ## The numbers are EXACT, and they are floors
+ *
+ * Exact, following `query-budget-admin.integration.test.ts`: a ceiling with
+ * slack hides the difference between "this improved" and "this regressed into
+ * the slack". Floors, because `BEGIN` and `COMMIT` are real round trips that
+ * `sql.begin` issues itself and no Proxy can see — so the true count is these
+ * numbers plus two. Saying so is the point of the finding.
+ *
+ * If one of these numbers changes, that is a real change in what every public
+ * request costs: update it deliberately, with the reason, rather than nudging
+ * it to green.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  appRoleActivated,
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countPoolQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { createRedirect } from "../../src/modules/seo-distribution/application/redirect-directory";
+import { resolvePublicRedirect } from "../../src/modules/seo-distribution/application/redirect-resolution-service";
+import { validateRedirectInput } from "../../src/modules/seo-distribution/domain/redirect-rule";
+
+const TENANT = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const ACTOR = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const HOST = "example.com";
+const NOW = new Date("2026-08-22T00:00:00.000Z");
+
+/** Host-based resolution — the mode a deployment with a custom domain runs. */
+const HOST_ENV = {
+  PUBLIC_TENANT_RESOLUTION_MODE: "host_default"
+} as NodeJS.ProcessEnv;
+
+/**
+ * Comfortably more rules than any budget below. A rule count that cannot change
+ * the query count is the whole claim; a one-rule fixture would prove nothing,
+ * exactly as a one-row fixture proves nothing about an N+1.
+ */
+const SEEDED_RULES = 40;
+
+function request(path: string): Request {
+  return new Request(`https://${HOST}${path}`, { headers: { host: HOST } });
+}
+
+function options(pathname: string) {
+  return { pathname, search: "", locale: null, now: NOW };
+}
+
+async function seedTenant(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${TENANT}, 'budget', 'Budget Tenant', 'active')
+  `;
+}
+
+async function seedPrimaryDomain(): Promise<void> {
+  await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+    await tx`
+      INSERT INTO awcms_tenant_domains
+        (tenant_id, hostname, normalized_hostname, domain_type, status, is_primary)
+      VALUES (${TENANT}, ${HOST}, ${HOST}, 'custom_domain', 'active', true)
+    `;
+  });
+}
+
+async function seedRules(count: number): Promise<void> {
+  await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+    for (let index = 0; index < count; index += 1) {
+      const validation = validateRedirectInput(
+        { sourcePath: `/legacy-${index}`, target: `/current-${index}` },
+        { allowedHosts: [] }
+      );
+
+      if (!validation.ok) {
+        throw new Error(`fixture rule ${index} invalid`);
+      }
+
+      await createRedirect(tx, TENANT, ACTOR, validation.value);
+    }
+  });
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("query budget — what the middleware spends before the page runs", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant();
+  });
+
+  test("a public path with NO redirect rule costs 5 statements", async () => {
+    if (!appRoleActivated) {
+      // Tenant resolution goes through the SECURITY DEFINER host lookup whose
+      // EXECUTE is granted to `awcms_app`; the count is not meaningful without
+      // the least-privilege role in play.
+      return;
+    }
+
+    await seedPrimaryDomain();
+
+    const { result, queries } = await countPoolQueries(getRuntimeSql(), (sql) =>
+      resolvePublicRedirect(sql, request("/about"), options("/about"), HOST_ENV)
+    );
+
+    // Assert the OUTCOME too. A resolution that skipped — disabled module,
+    // unresolved tenant — would issue fewer queries and pass a budget while
+    // proving nothing about the path the finding is about.
+    expect(result.kind).toBe("passthrough");
+
+    // host lookup, SET LOCAL, tenant module entry, tenant domains, rule lookup.
+    // The domain read used to be TWO — `resolveTenantAllowedHosts` and
+    // `resolveTenantPrimaryHost` asked the same table under the same filter.
+    expect(queries).toBe(5);
+  });
+
+  test("the cost does not grow with the number of rules the tenant has", async () => {
+    if (!appRoleActivated) {
+      return;
+    }
+
+    await seedPrimaryDomain();
+    await seedRules(SEEDED_RULES);
+
+    const { result, queries } = await countPoolQueries(getRuntimeSql(), (sql) =>
+      resolvePublicRedirect(sql, request("/about"), options("/about"), HOST_ENV)
+    );
+
+    expect(result.kind).toBe("passthrough");
+    expect(queries).toBe(5);
+  });
+
+  test("a request that DOES redirect costs 7", async () => {
+    if (!appRoleActivated) {
+      return;
+    }
+
+    await seedPrimaryDomain();
+    await seedRules(SEEDED_RULES);
+
+    const { result, queries } = await countPoolQueries(getRuntimeSql(), (sql) =>
+      resolvePublicRedirect(
+        sql,
+        request("/legacy-0"),
+        options("/legacy-0"),
+        HOST_ENV
+      )
+    );
+
+    expect(result).toMatchObject({ kind: "redirect", location: "/current-0" });
+
+    // The five above, plus the chain's second lookup (which is what proves the
+    // target is terminal) and the best-effort hit projection.
+    expect(queries).toBe(7);
+  });
+
+  test("a path outside the redirect vocabulary costs NOTHING", async () => {
+    if (!appRoleActivated) {
+      return;
+    }
+
+    await seedPrimaryDomain();
+
+    // `isRedirectEligiblePath` is applied in the middleware composition root,
+    // not here, so this asserts the other half: an ineligible path never even
+    // reaches this service. What it pins is that the service does no work of
+    // its own before deciding the retired-`/news` strategy does not apply —
+    // the strategy that DOES resolve a tenant from the host runs second.
+    const { queries } = await countPoolQueries(getRuntimeSql(), (sql) =>
+      resolvePublicRedirect(
+        sql,
+        new Request(`https://${HOST}/about`, { headers: {} }),
+        options("/about"),
+        {
+          PUBLIC_TENANT_RESOLUTION_MODE: "tenant_code_legacy"
+        } as NodeJS.ProcessEnv
+      )
+    );
+
+    expect(queries).toBe(0);
+  });
+});

--- a/tests/integration/query-budget.ts
+++ b/tests/integration/query-budget.ts
@@ -57,3 +57,100 @@ export async function countQueries<T>(
 
   return { result, queries };
 }
+
+/**
+ * Run `work` with a query-counting POOL handle, counting statements issued
+ * directly on it AND inside any `sql.begin(...)` transaction it opens.
+ *
+ * `countQueries` above can only be handed a `tx`, which means it can only
+ * measure code the test has already put inside a transaction — i.e. a directory
+ * function. That is why finding B5 could exist: the performance standard claims
+ * a "≤ 3 queries per hot read" ceiling as **measured**, and both budget suites
+ * call directory functions directly, so everything the request pays BEFORE the
+ * page's first query — tenant resolution, redirect resolution, the transaction
+ * they run in — was structurally outside what the measurement could see.
+ *
+ * ## What the number does and does not include
+ *
+ * Counted: every tagged-template statement, on the pool and inside the
+ * transaction, plus the `SET LOCAL` that `withTenantOrThrow` issues through
+ * `tx.unsafe`.
+ *
+ * NOT counted: the `BEGIN` and `COMMIT` that `sql.begin` sends itself. They are
+ * real round trips and a Proxy cannot see them, so a count from here is a
+ * **floor** on the true number, not the whole of it. Stating that is the point:
+ * a budget that quietly under-counts is how "measured" came to mean something
+ * other than measured.
+ */
+export async function countPoolQueries<T>(
+  sql: Bun.SQL,
+  work: (counting: Bun.SQL) => Promise<T>
+): Promise<{ result: T; queries: number }> {
+  let queries = 0;
+
+  const countTx = (tx: Bun.TransactionSQL): Bun.TransactionSQL =>
+    new Proxy(tx, {
+      apply(target, thisArg, args) {
+        queries += 1;
+
+        return Reflect.apply(
+          target as unknown as (...a: unknown[]) => unknown,
+          thisArg,
+          args
+        );
+      },
+      get(target, prop, receiver) {
+        if (prop === "unsafe") {
+          // `SET LOCAL app.current_tenant_id` comes through here on every
+          // tenant transaction — a round trip like any other.
+          return (...args: unknown[]) => {
+            queries += 1;
+
+            return (
+              target as unknown as {
+                unsafe: (...a: unknown[]) => unknown;
+              }
+            ).unsafe(...args);
+          };
+        }
+
+        return Reflect.get(target as object, prop, receiver);
+      }
+    }) as unknown as Bun.TransactionSQL;
+
+  const counting = new Proxy(sql, {
+    apply(target, thisArg, args) {
+      queries += 1;
+
+      return Reflect.apply(
+        target as unknown as (...a: unknown[]) => unknown,
+        thisArg,
+        args
+      );
+    },
+    get(target, prop, receiver) {
+      if (prop === "begin") {
+        // Called on the REAL pool, with the callback's `tx` wrapped — a proxy
+        // as `this` is not something Bun's transaction machinery has to
+        // tolerate, and the wrapping is what makes in-transaction work visible.
+        return (...args: unknown[]) => {
+          const fn = args[args.length - 1] as (
+            tx: Bun.TransactionSQL
+          ) => Promise<unknown>;
+
+          return (
+            target as unknown as { begin: (...a: unknown[]) => unknown }
+          ).begin(...args.slice(0, -1), (tx: Bun.TransactionSQL) =>
+            fn(countTx(tx))
+          );
+        };
+      }
+
+      return Reflect.get(target as object, prop, receiver);
+    }
+  }) as unknown as Bun.SQL;
+
+  const result = await work(counting);
+
+  return { result, queries };
+}


### PR DESCRIPTION
PROJECT_STATE §4 **B5** — measured first, then reduced.

## The finding is about a measurement, not only a cost

`docs/awcms/standar-performa-dan-keamanan.md` lists **"queries per hot read request ≤ 3"** as *measured*, citing `query-budget.integration.test.ts` and `query-budget-admin.integration.test.ts`. Both hand a counting `tx` to a directory function. `countQueries` can only be *given* a `tx` — so it can only see code the test has already placed inside a transaction. Everything a public request pays before the route runs (resolving the tenant from the host, opening the tenant transaction, asking `seo_distribution` whether the path redirects) was not merely unmeasured: it was outside what that tool could measure at all.

The word "measured" was true of what was measured and false of what a reader takes it to mean — a bound on the request.

## Measured

`countPoolQueries` wraps the **pool** and the transaction opened on it, and `tests/integration/middleware-query-budget.integration.test.ts` pins the real numbers against a real PostgreSQL:

| Case | Statements |
| --- | --- |
| Public path, no redirect rule | **5** |
| Same, with 40 rules seeded and none matching | **5** (cost is independent of rule count) |
| A request that does redirect | **7** |
| A path outside the redirect vocabulary | **0** |

Exact rather than ceilings, following `query-budget-admin`'s precedent: a ceiling with slack cannot tell an improvement from a regression *into* the slack. And explicitly a **floor** — `BEGIN` and `COMMIT` are two more round trips `sql.begin` issues itself that no Proxy can see. Stating that is the point; a budget that quietly under-counts is how "measured" came to mean something else in the first place.

Each case asserts the **outcome** as well as the count. A resolution that skipped (disabled module, unresolved tenant) would issue fewer queries and pass a budget while proving nothing.

## Reduced — by one read, not a short-circuit

`resolveTenantAllowedHosts` and `resolveTenantPrimaryHost` read the same table under the same active/not-deleted filter, differing only by `is_primary`, and the redirect path called them one after the other on every eligible public request. `resolveTenantDomainSet` answers both from one round trip: **6 → 5** and **8 → 7**, proven by running the new budget against the pre-fix code and watching it report the old numbers. `primaryHost` goes through the same `validateRenderableHost` as the dedicated reader — now exported rather than copied, so the defense-in-depth check has one definition.

The "does this tenant have any live rule?" short-circuit the file's own perf note considered is still **not** applied, for the reason that note gives: the passthrough branch needs the server-derived host to attribute a 404, and the legacy-blog auto-redirect fires from settings rather than a rule row.

## The standard now states its scope

The ≤ 3 ceiling was always a **route** budget and the table did not say so. The middleware budget is a separate row rather than folded into the same number, because the two are paid by different code for different reasons and one sum would hide which half moved.

## Found while working: two comments asserted a live code path was dead

Both `redirect-resolution-service.ts` and `redirect-middleware.ts` said the middleware passes `locale = null` "all the way through", so locale-scoped redirect rules could never match. True under ADR-0039; **false since ADR-0098's locale routing landed** and the middleware began passing the served locale for a prefixed URL. A reader trusting either paragraph would have concluded a live path was dead.

## Verification

- New budget run against a real PostgreSQL: 4 pass. Then run again with only the source fix reverted: **3 fail, reporting 6, 6 and 8** — the budget bites.
- Affected integration suites (`seo-redirect-governance`, `seo-distribution`, `query-budget`, `public-path-wasted-reads`) run locally: 19 pass, 1 fail — `seo-distribution`'s host-absolute sitemap case, which fails identically on `main` with these changes stashed (a local scheme-env artifact; it passes in CI).
- `bun run check` in full with the documented local splits: all gates green, `DATABASE_URL="" bun run test` 5532 pass / 0 fail, `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)