### PR TITLE
fix(ops,database): three operational signals that told an operator something untrue

### DIFF
--- a/.changeset/three-operational-signals-that-were-wrong.md
+++ b/.changeset/three-operational-signals-that-were-wrong.md
@@ -1,0 +1,61 @@
+---
+"awcms": patch
+---
+
+fix(ops,database): three operational signals that told an operator something untrue
+
+PROJECT_STATE §4 **D9**, **D10**, **D11**. Three unrelated mechanisms, one shape:
+each produced a signal an operator relies on, and each signal was wrong in a way
+nothing reported.
+
+**D9 — the log file named at attach time.** `ops/ship-logs.sh` redirected the
+tailer with `>> "${DEST}/app-$(date -u +%Y-%m-%d).log"`. A redirect names its
+file once, when the shell spawns the process, and the descriptor then lives
+until the container changes — weeks on a stable deployment. So today's lines
+landed in a file dated by the last DEPLOY, and the 30-day `-mtime` sweep could
+never reclaim it: the file it should have been bounding was the only one still
+growing. The redirect is now a `while read` loop that re-derives the date and
+reopens with `>>` per line (`printf -v day "%(...)T"`, a builtin — no `date`
+fork per line). The distinguishing property is testable without waiting for
+midnight: delete the file underneath a running writer and see whether the next
+line brings it back. The test executes exactly that, against the payload
+extracted from the script, and carries a control case driving the old shape
+through the same procedure.
+
+**D10 — nothing read the readiness endpoint.** `/api/v1/database/pool/health`
+reports `databaseReachable` and `circuitBreakerState`, is unauthenticated, and
+was consulted by nothing; Coolify, the container `HEALTHCHECK` and the Varnish
+probe all read the dependency-free liveness endpoint, so a release with an
+unreachable database is marked successful and cut over.
+
+The obvious fix is wrong and was not taken: those three RESTART or REROUTE, and
+restarting an app does not repair a database — pointing them at readiness turns a
+database outage into a container restart loop. Liveness is the right question
+for them, and that reasoning is now written at each site so it is not "fixed"
+later. What readiness needed was a reader on the path that pages a person:
+`ops/synthetic-check.sh` now probes it every 10 minutes from outside, asserting
+both fields, because the endpoint answers 200 while reporting the database is
+gone. Coolify's own Health Check Path is configuration outside this repo — the
+runbook states the split and says not to point it at readiness, and does not
+pretend that is enforced.
+
+**D11 — jobs ran as `interactive`, and it was seven scripts, not six.** The job
+work-class registry names a class for every worker script and feeds the capacity
+model, and seven scripts never passed it: their transactions took `withTenant`'s
+`"interactive"` default, so nightly purges queued in the bucket sized for live
+users. `site-search-reconcile.ts` had the drift running the other way, passing
+`maintenance` where the registry says `background_sync` — resolved toward the
+registry, whose entry carries an argued rationale where the script's literal
+carried none.
+
+The fix that matters is the gate: `db:work-class:generate` now refuses to run
+when a script does not open its transactions as its declared class, in both
+directions. It COUNTS rather than checking presence — a script with three calls
+and one literal reads as declared to any presence check while two of its
+transactions still run as `interactive`, and two of these scripts have exactly
+that shape. It reads one file, the script, and says so: a job whose transactions
+live in a module under `src/` is not covered by it.
+
+Both documents that asserted jobs "do not call `acquireWorkClassSlot`" are
+corrected. They were true when written and stayed after they stopped being
+true — jobs go through `withTenantOrThrow`, which is that call.

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -86,6 +86,16 @@ COPY --chown=bun:bun package.json ./
 USER bun
 EXPOSE 4321
 
+# LIVENESS, deliberately — `/api/v1/health` is dependency-free and answers 200
+# with the database on fire. That is the right question for a probe that
+# RESTARTS things: restarting an app does not repair a database, and a probe
+# that cycles containers through a database outage turns one incident into two.
+#
+# The other question — can this process actually serve content — is answered by
+# `/api/v1/database/pool/health` (`databaseReachable`, `circuitBreakerState`).
+# Finding D10 was that nothing read it; `ops/synthetic-check.sh` now does, from
+# outside, where it alerts a human instead of restarting a container. Do not
+# "fix" the probe below to point at it.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD bun -e "fetch('http://localhost:'+(process.env.PORT||4321)+'/api/v1/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:89dad0e2915ba1daed2dcc078dac6fac858d9e98b72e2354334f232b0d5f525a -->
+<!-- i18n-source-hash: sha256:398eacb9dee40847b543fa82a46d46329b41b95e9c8e6f428c681fb3eb68151e -->
 
 # AWCMS — Project State & Continuation
 
@@ -1111,20 +1111,99 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       Relokasi yang tak pernah terjadi tercatat sebagai penilaian, sehingga ledger yang hanya
       boleh menyusut tidak menghitungnya.
   30. **D9 — `ship-logs.sh` menamai berkas keluarannya saat attach dan tidak pernah
-      merotasi.** `ops/ship-logs.sh:53-57`. `$(date)` diekspansi sekali saat tailer
+      merotasi.** **SELESAI (22 Agustus 2026).**
+      `ops/ship-logs.sh:53-57`. `$(date)` diekspansi sekali saat tailer
       dijalankan dan fd-nya hidup sampai deploy berikutnya, jadi baris hari ini mendarat di
       berkas bertanggal deploy terakhir dan sapuan `-mtime` 30 hari tak pernah bisa
       menyentuh berkas yang terbuka itu.
+
+      Redirect itu kini menjadi loop `while read` yang menurunkan ulang tanggalnya dan
+      membuka ulang dengan `>>` per baris — `printf -v day "%(...)T"`, sebuah builtin
+      bash, sehingga tidak ada fork `date` per baris pada log yang justru menjadi alasan
+      skrip ini ada. `TZ=UTC` di dalam payload karena `%(...)T` memformat waktu LOKAL
+      sementara nama berkasnya selalu UTC.
+
+      **Sifatnya bisa diuji tanpa menunggu tengah malam, dan ujinya menjalankannya.**
+      Hapus berkasnya di bawah penulis yang sedang jalan: satu descriptor berumur panjang
+      terus menulis ke inode tak bertaut dan path-nya tak pernah kembali; `>>` per baris
+      membuatnya lagi pada baris berikutnya. `tests/ops-log-shipping-and-readiness.test.ts`
+      menjalankan itu terhadap payload yang DIEKSTRAK DARI SKRIPNYA (bukan salinan), dan
+      membawa kasus KONTROL yang menjalankan bentuk redirect lama lewat prosedur yang sama
+      untuk memperlihatkan berkasnya tetap hilang — tanpa itu suite tersebut hanya
+      membuktikan penulis baru bekerja, bukan bahwa ia berbeda.
+
   31. **D10 — tidak ada apa pun di jalur deploy atau load balancer yang membaca endpoint
-      readiness yang sudah ada.** `health.ts:8-14`; `infra/varnish/default.vcl:26-34`.
+      readiness yang sudah ada.** **SELESAI (22 Agustus 2026)** — dengan pemisahan yang
+      disengaja, bukan penukaran.
+      `health.ts:8-14`; `infra/varnish/default.vcl:26-34`.
       Coolify, HEALTHCHECK Docker, dan probe Varnish semuanya memakai endpoint liveness yang
       sengaja bebas dependensi, jadi rilis dengan database tak terjangkau ditandai sukses
       lalu dialihkan.
+
+      **Perbaikan yang tampak jelas justru salah dan tidak diambil.** Mengarahkan ketiga
+      probe itu ke readiness akan merestart atau mengeluarkan container dari rotasi saat
+      gangguan database, dan merestart aplikasi tidak memperbaiki database — ia mengubah
+      satu insiden menjadi dua. Ketiganya MERESTART atau MENGALIHKAN, jadi liveness adalah
+      pertanyaan yang benar bagi mereka, dan alasan itu kini tertulis di masing-masing
+      tempat agar pembaca berikutnya tidak "memperbaikinya".
+
+      **Yang kurang dari readiness adalah pembaca di jalur yang memanggil manusia.**
+      `ops/synthetic-check.sh` kini memeriksanya tiap 10 menit dari LUAR — berkas yang
+      kepalanya sendiri menyatakan tugasnya adalah pertanyaan yang dijawab healthcheck
+      container dari dalam, tempat "setiap cacat yang benar-benar dikirim proyek ini tak
+      terlihat". Ia mengasersi `databaseReachable` dan bahwa breaker tidak `open`, karena
+      endpoint itu menjawab 200 sambil melaporkan databasenya hilang: probe yang hanya
+      memeriksa kode status akan menjadi liveness lagi dengan URL lebih panjang.
+
+      **Yang BELUM tertutup, dan tak bisa ditutup dari sini.** Health Check Path Coolify
+      adalah konfigurasi di Coolify, bukan di repo ini. Runbook kini menyatakan
+      pemisahannya, memberikan asersi readiness sebagai langkah deploy bernomor, dan
+      menyatakan eksplisit untuk tidak mengarahkan Coolify ke sana — tetapi tak ada apa pun
+      di repositori ini yang bisa menegakkannya, dan menyebutnya ditegakkan akan menjadi
+      klaim sekelas "terukur" ≤3 query di B5.
+
   32. **D11 — enam skrip job memanggil `withTenantOrThrow` tanpa `workClass`, jadi berjalan
-      sebagai `interactive`.** Purge malam menisbatkan tekanan pool-nya ke ember yang
+      sebagai `interactive`.** **SELESAI (22 Agustus 2026) — dan jumlahnya TUJUH, bukan
+      enam.**
+      Purge malam menisbatkan tekanan pool-nya ke ember yang
       melayani pengguna hidup. Baik `work-class-registry.ts:11-17` maupun
       `database-capacity-runbook.md:268-282` menegaskan job tak pernah mencapai
       `acquireWorkClassSlot` — itu kini salah.
+
+      Himpunan lengkapnya, diperiksa alih-alih dihitung dari temuan:
+      `visitor-analytics-purge`, `visitor-analytics-rollup`, `blog-ads-drop-readiness`,
+      `blog-ads-ingest`, `comments-retention` (3 panggilan), `edge-cache-purge` (3
+      panggilan), dan `tenant-domain-dns-sync` — plus `site-search-reconcile` yang
+      bertentangan dengan peta. Masing-masing kini meneruskan kelas yang dinyatakan
+      registry untuknya. Driftnya diselesaikan KE ARAH REGISTRY (`background_sync` untuk
+      site-search): entri registry membawa rationale beralasan sementara literal skripnya
+      tidak membawa apa pun, dan bila `maintenance` yang benar, tempat mengubahnya adalah
+      rationale itu.
+
+      **Perbaikan yang penting adalah gerbangnya, karena tanpa itu ia menyimpang lagi.**
+      `db:work-class:generate` kini MENOLAK jalan bila sebuah skrip job tidak membuka
+      transaksinya sebagai kelas yang dinyatakannya — di kedua arah, opsi yang hilang
+      maupun yang bertentangan. Ia MENGHITUNG alih-alih memeriksa keberadaan: skrip dengan
+      tiga panggilan dan satu literal terbaca "sudah dinyatakan" oleh pemeriksaan
+      keberadaan mana pun sementara dua transaksinya tetap berjalan sebagai `interactive`,
+      dan dua skrip di sini persis berbentuk demikian. Dibuktikan dengan mengembalikan satu
+      opsi dan melihat gerbang menyebut nama berkas dan hitungannya.
+
+      **Gerbang itu membaca SATU berkas, yaitu skripnya, dan menyatakannya.** Beberapa
+      rationale registry mengklaim "setiap panggilan di dalam <modul> sudah meneruskannya
+      eksplisit"; panggilan itu ada di bawah `src/`, skripnya tidak punya `withTenant*(`
+      sendiri, dan tak ada yang memverifikasinya. Diam di sana berarti "tidak tercakup",
+      bukan "benar".
+
+      **Kedua klaim palsu dikoreksi.** `work-class-registry.ts` menyatakan job "tidak
+      memanggil `withTenant`/`acquireWorkClassSlot` sama sekali hari ini" dan bagian
+      "Keterbatasan yang diketahui" runbook kapasitas menyatakan hal yang sama. Keduanya
+      benar saat ditulis dan bertahan setelah berhenti benar — job melewati
+      `withTenantOrThrow`, yang MEMANG `acquireWorkClassSlot`. Bagian runbook itu diganti
+      namanya dari keterbatasan menjadi penjelasan bagaimana kedua mekanisme membagi tugas:
+      work class menentukan antrean terbatas mana yang ditunggu transaksi sebuah job,
+      advisory lock job-runner menentukan ada berapa job itu.
+
   33. **D12 — tiga inti fetch JSON nyaris identik di `src/lib/ui/`, plus `postJson` mati yang
       membawa komentar palsu.** `admin-form-client.ts:77-173`. Keduanya **sudah menyimpang**:
       `sendJson` mendukung `extraHeaders` (Idempotency-Key), request tanpa body, dan

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -1112,21 +1112,94 @@ busy)` clause, gated on the permanently-zero counter, could never print.
       that never happened is recorded as judgement, so the shrink-only ledger does not
       count it.
   30. **D9 — `ship-logs.sh` names its output file at attach time and never rotates.**
+      **DONE (22 August 2026).**
       `ops/ship-logs.sh:53-57`. `$(date)` is expanded once when the tailer is spawned and
       the fd lives until the next deploy, so today's lines land in a file dated by the last
       deploy and the 30-day `-mtime` sweep can never touch the open file.
+
+      The redirect is now a `while read` loop that re-derives the date and reopens with
+      `>>` per line — `printf -v day "%(...)T"`, a bash builtin, so there is no `date`
+      fork per line on a log this script exists to keep all of. `TZ=UTC` inside the
+      payload because `%(...)T` formats in LOCAL time while the filenames were always
+      UTC.
+
+      **The property is testable without waiting for midnight, and the test executes
+      it.** Delete the file underneath a running writer: a single long-lived descriptor
+      keeps writing into the unlinked inode and the path never returns; a per-line `>>`
+      recreates it on the next line. `tests/ops-log-shipping-and-readiness.test.ts` runs
+      that against the payload EXTRACTED FROM THE SCRIPT (not a copy), and carries a
+      CONTROL case driving the old redirect shape through the same procedure to show the
+      file staying gone — without it the suite would only prove the new writer works, not
+      that it differs.
+
   31. **D10 — nothing in the deploy or LB path consults the readiness endpoint that already
-      exists.** `health.ts:8-14`; `infra/varnish/default.vcl:26-34`. Coolify, the Docker
+      exists.** **DONE (22 August 2026)** — with a deliberate split, not a swap.
+      `health.ts:8-14`; `infra/varnish/default.vcl:26-34`. Coolify, the Docker
       HEALTHCHECK and the Varnish probe all use the deliberately dependency-free liveness
       endpoint, so a release with an unreachable database is marked successful and cut
       over. `/api/v1/database/pool/health` reports `databaseReachable` +
       `circuitBreakerState`, is equally unauthenticated, and is wired to nothing.
+
+      **The obvious fix is wrong and was not taken.** Pointing those three probes at
+      readiness would restart or de-route containers during a database outage, and
+      restarting an app does not repair a database — it turns one incident into two.
+      All three RESTART or REROUTE, so liveness is the correct question for them, and
+      that reasoning is now written at each site so the next reader does not "fix" it.
+
+      **What readiness was missing was a reader on the path that pages a person.**
+      `ops/synthetic-check.sh` now probes it every 10 minutes from OUTSIDE — the file
+      whose own header says its job is the question the container healthcheck answers
+      from inside, where "every defect this project has actually shipped was invisible".
+      It asserts `databaseReachable` and that the breaker is not `open`, because the
+      endpoint answers 200 while reporting the database is gone: a probe that only
+      checked the status code would be the liveness check again under a longer URL.
+
+      **What is NOT closed, and cannot be from here.** Coolify's Health Check Path is
+      configuration in Coolify, not in this repo. The runbook now states the split, gives
+      the readiness assertion as a numbered deploy step, and says explicitly not to point
+      Coolify at it — but nothing in this repository can enforce that, and calling it
+      enforced would be the same class of claim as the ≤3-query "measured" in B5.
+
   32. **D11 — six job scripts call `withTenantOrThrow` with no `workClass`, so they run as
-      `interactive`.** Nightly purges attribute their pool pressure to the bucket that
+      `interactive`.** **DONE (22 August 2026) — and it was SEVEN, not six.**
+      Nightly purges attribute their pool pressure to the bucket that
       serves live users. Both `work-class-registry.ts:11-17` and
       `database-capacity-runbook.md:268-282` assert jobs never reach
       `acquireWorkClassSlot` — that is now false, and `site-search-reconcile.ts:69` passes
       `maintenance` where the registry says `background_sync`, so the drift runs both ways.
+
+      The full set, checked rather than counted from the finding: `visitor-analytics-purge`,
+      `visitor-analytics-rollup`, `blog-ads-drop-readiness`, `blog-ads-ingest`,
+      `comments-retention` (3 calls), `edge-cache-purge` (3 calls) and
+      `tenant-domain-dns-sync` — plus `site-search-reconcile` contradicting the map. Each
+      now passes the class the registry declares for it. The drift was resolved TOWARD
+      THE REGISTRY (`background_sync` for site-search): the registry entry carries an
+      argued rationale and the script's literal carried none, and if `maintenance` is
+      right the place to change it is the rationale.
+
+      **The fix that matters is the gate, because otherwise it re-drifts.**
+      `db:work-class:generate` now REFUSES to run when a job script does not open its
+      transactions as its declared class — in both directions, a missing option and a
+      contradicting one. It COUNTS rather than checking presence: a script with three
+      calls and one literal reads as declared to any presence check while two of its
+      transactions still run as `interactive`, and two of these scripts have exactly that
+      shape. Proven by reverting one option and watching the gate name the file and the
+      count.
+
+      **The gate reads ONE file, the script, and says so.** Several registry rationales
+      claim "every call inside <module> already passes it explicitly"; those calls live
+      under `src/`, the script has no `withTenant*(` of its own, and nothing verifies
+      them. Silence there is "not covered", not "correct".
+
+      **Both false claims are corrected.** `work-class-registry.ts` said jobs "do not
+      call `withTenant`/`acquireWorkClassSlot` at all today" and the capacity runbook's
+      "Known limitation" said the same. Both were true when written and stayed after they
+      stopped being true — jobs go through `withTenantOrThrow`, which IS
+      `acquireWorkClassSlot`. The runbook section is renamed from a limitation to a
+      description of how the two mechanisms divide: work class decides which bounded
+      queue a job's transactions wait in, the job-runner advisory lock decides how many
+      of the job there are.
+
   33. **D12 — three near-identical JSON fetch cores in `src/lib/ui/`, plus dead `postJson`
       carrying a false comment.** `admin-form-client.ts:77-173`. They have **already
       drifted**: `sendJson` supports `extraHeaders` (Idempotency-Key), bodyless requests and

--- a/docs/awcms/database-capacity-runbook.id.md
+++ b/docs/awcms/database-capacity-runbook.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](database-capacity-runbook.md)
 
-<!-- i18n-source-hash: sha256:565290ea57679eab432f7524be0ef5e18818b594bd7f8782996b832a0029afb6 -->
+<!-- i18n-source-hash: sha256:21ae1faf11ff23d49e8442e5b70a8770654037592afe390f5b997cb21a452243 -->
 
 # Runbook Kapasitas Database — Anggaran Pool/Work-Class Sadar-Deployment
 
@@ -74,8 +74,8 @@ di `package.json` hari ini.
 **Default `DATABASE_CAPACITY_WORKER_INSTANCES_MAX` (1) lebih sempit
 daripada kelihatannya.** Ia hanya memperhitungkan satu instance dari NAMA
 job yang SAMA berjalan pada satu waktu — kasus yang sudah dimitigasi oleh
-advisory lock Postgres milik `job-runner.ts` (lihat §Keterbatasan yang
-diketahui di bawah). Ia TIDAK menganggarkan dua skrip worker BERBEDA yang
+advisory lock Postgres milik `job-runner.ts` (lihat §Job dan gerbang
+konkurensi di bawah). Ia TIDAK menganggarkan dua skrip worker BERBEDA yang
 dijadwalkan berjalan bersamaan di host yang sama (mis. job batch payroll
 dan purge audit-log sama-sama menyala di menit cron yang sama) —
 masing-masing adalah proses terpisah yang membuka pool role `worker`-nya
@@ -279,22 +279,39 @@ berkardinalitas-rendah/terdefinisi-di-kode, tanpa id tenant, tanpa DSN:
    lain — stempel waktu, kelas mana yang jenuh, jumlah instance saat itu,
    resolusinya (pulih sendiri vs. perubahan manual pool/jumlah instance).
 
-## Keterbatasan yang diketahui
+## Job dan gerbang konkurensi — dikoreksi 22 Agustus 2026
 
-Job latar (kelas proses `worker`) TIDAK digerbangi saat runtime lewat
-gerbang konkurensi milik `work-class.ts` — mereka diklasifikasikan di
-`src/lib/database/work-class-registry.ts` untuk ANGGARAN KONEKSI kapasitas
-(dihitung dalam rumus di atas) dan untuk gerbang drift CI yang dijelaskan
-di bawah (`bun run db:work-class:check`, target — belum ada di
-`package.json`, lihat §Gerbang drift CI), tapi panggilan DB nyata sebuah
-job saat ini tidak memanggil `acquireWorkClassSlot`. Konkurensi
-tingkat-job justru dibatasi oleh mekanisme lain yang sudah ada —
-advisory lock Postgres milik `src/lib/jobs/job-runner.ts` memastikan
-paling banyak SATU instance dari sebuah NAMA job berjalan se-cluster pada
-satu waktu, dan itulah risiko badai koneksi yang dominan untuk job
-terjadwal (re-run yang tumpang tindih dari job yang SAMA, mis. sebuah
-payroll run atau job purge). Memasang ulang seluruh skrip worker ke
-gerbang work-class itu sendiri adalah tindak lanjut yang masuk akal.
+Bagian ini dulu berjudul "Keterbatasan yang diketahui" dan menyatakan job latar
+**tidak** digerbangi saat runtime lewat `work-class.ts`, bahwa "panggilan DB
+nyata sebuah job saat ini tidak memanggil `acquireWorkClassSlot`", dan bahwa
+memasang ulang mereka adalah tindak lanjut yang masuk akal. **Itu benar saat
+ditulis dan sudah salah ketika ada yang membacanya.** Job membuka transaksi
+tenant lewat `withTenantOrThrow`, yang mengambil slot work-class persis seperti
+sebuah request — jadi mereka sudah melewati gerbang itu sejak lama, dan
+satu-satunya pertanyaan adalah bucket mana.
+
+Temuan D11 putaran 17 Agustus 2026 adalah harga dari kekaburan itu: **tujuh
+skrip tidak meneruskan `workClass` sama sekali**, sehingga transaksinya memakai
+default `"interactive"` yang didokumentasikan `withTenant` dan purge malam
+mengantre di bucket yang diukur untuk pengguna hidup. Driftnya juga berjalan
+arah sebaliknya — `site-search-reconcile.ts` meneruskan `maintenance` padahal
+registry menyatakan `background_sync`.
+
+**Posisinya sekarang.** Setiap skrip job yang membuka transaksinya sendiri
+meneruskan kelas yang dinyatakan `src/lib/database/work-class-registry.ts`
+untuknya, dan `bun run db:work-class:generate` MENOLAK jalan bila tidak — di
+kedua arah, opsi yang hilang maupun yang bertentangan. Penolakan itu membaca
+satu berkas, yaitu skripnya: job yang transaksinya berada di modul bawah `src/`
+tidak punya panggilan sendiri untuk diperiksa dan tidak tercakup olehnya.
+
+Konkurensi tingkat-job tetap dibatasi mekanisme kedua yang independen: advisory
+lock Postgres milik `src/lib/jobs/job-runner.ts` memastikan paling banyak SATU
+instance dari sebuah NAMA job berjalan se-cluster pada satu waktu, dan itulah
+risiko badai koneksi yang dominan untuk job terjadwal (re-run yang tumpang
+tindih dari job yang SAMA, mis. purge lambat yang masih jalan saat tik cron
+berikutnya menyala). Work class mengatur antrean terbatas mana yang ditunggu
+transaksi sebuah job; advisory lock mengatur ada berapa job itu. Keduanya tidak
+saling menggantikan.
 
 ## Gerbang drift CI — registry work-class (SUDAH DIBANGUN, Issue #263)
 

--- a/docs/awcms/database-capacity-runbook.md
+++ b/docs/awcms/database-capacity-runbook.md
@@ -71,7 +71,7 @@ that exist in `package.json` today.
 **`DATABASE_CAPACITY_WORKER_INSTANCES_MAX`'s default (1) is narrower than
 it looks.** It only accounts for one instance of the SAME job NAME running
 at a time — the case `job-runner.ts`'s Postgres advisory lock already
-mitigates (see §Known limitation below). It does NOT budget for two
+mitigates (see §Jobs and the concurrency gate below). It does NOT budget for two
 DIFFERENT worker scripts scheduled to run concurrently on the same host
 (e.g. a payroll batch job and an audit-log purge both firing in the same
 cron minute) — each is a separate process opening its own `worker`-role
@@ -265,21 +265,37 @@ labels only, no tenant ids, no DSNs:
    timestamp, which class saturated, instance count at the time, resolution
    (self-recovered vs. manual pool/instance-count change).
 
-## Known limitation
+## Jobs and the concurrency gate — corrected 22 August 2026
 
-Background jobs (the `worker` process class) are NOT runtime-gated through
-`work-class.ts`'s concurrency gate — they are classified in
-`src/lib/database/work-class-registry.ts` for the capacity CONNECTION
-BUDGET (counted in the formula above) and for the CI drift gate described
-below (`bun run db:work-class:check`, target — not yet in `package.json`,
-see §CI drift gate), but a job's actual DB calls do not
-currently call `acquireWorkClassSlot`. Job-level concurrency is instead
-bounded by a different, already-existing mechanism —
+This section used to be headed "Known limitation" and said background jobs are
+**not** runtime-gated through `work-class.ts`, that "a job's actual DB calls do
+not currently call `acquireWorkClassSlot`", and that retrofitting them was a
+reasonable follow-up. **That was true when written and false by the time anyone
+read it.** Jobs open their tenant transactions through `withTenantOrThrow`,
+which acquires a work-class slot exactly as a request does — so they have been
+going through the gate for some time, and the only question was which bucket.
+
+Finding D11 of the 17 August 2026 round is what that ambiguity cost: **seven
+scripts passed no `workClass` at all**, so their transactions took
+`withTenant`'s documented `"interactive"` default and nightly purges queued in
+the bucket sized for live users. The drift also ran the other way —
+`site-search-reconcile.ts` passed `maintenance` where the registry says
+`background_sync`.
+
+**Where it stands now.** Every job script that opens its own transaction passes
+the class `src/lib/database/work-class-registry.ts` declares for it, and
+`bun run db:work-class:generate` REFUSES to run when one does not — in both
+directions, a missing option and a contradicting one. The refusal reads one
+file, the script: a job whose transactions live in a module under `src/` has no
+call of its own to inspect and is not covered by it.
+
+Job-level concurrency is still bounded by a second, independent mechanism:
 `src/lib/jobs/job-runner.ts`'s Postgres advisory lock ensures at most ONE
-instance of a given job NAME runs cluster-wide at a time, which is the
-dominant connection-storm risk for scheduled jobs (an overlapping re-run of
-the SAME job, e.g. a payroll run or purge job). Retrofitting all worker
-scripts onto the work-class gate itself is a reasonable follow-up.
+instance of a given job NAME runs cluster-wide at a time, which is the dominant
+connection-storm risk for scheduled jobs (an overlapping re-run of the SAME job,
+e.g. a slow purge still running when the next cron tick fires). The work class
+governs which bounded queue a job's transactions wait in; the advisory lock
+governs how many of the job there are. Neither replaces the other.
 
 ## CI drift gate — work-class registry (BUILT, Issue #263)
 

--- a/docs/awcms/database-pooling.id.md
+++ b/docs/awcms/database-pooling.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](database-pooling.md)
 
-<!-- i18n-source-hash: sha256:f51d4fdde58f65ddd7f04fa301790e4123055956da102cd6c86f336ffbad9d7b -->
+<!-- i18n-source-hash: sha256:4f069960621f2a3f181edfc1bb4358e26f666a869c9a859a5749fea7587d2bff -->
 
 # Database Connection Pooling and Backpressure
 
@@ -343,9 +343,14 @@ implementasi CLI yang lebih rinci).
   (`tests/database-pooling.test.ts`), bukan skenario live.
 - Saturasi work-class di level HTTP sulit diamati secara deterministik
   karena request cenderung selesai lebih cepat daripada observasi manual.
-- Job worker (`scripts/*.ts`) belum runtime-gated lewat `work-class.ts`'s
-  concurrency gate — lihat `database-capacity-runbook.md` §Known
-  limitation untuk alasan dan status follow-up.
+- Job worker dulu terdaftar di sini sebagai "belum runtime-gated lewat
+  concurrency gate `work-class.ts`". Itu **salah, dan sudah salah sejak
+  beberapa waktu**: mereka membuka transaksinya lewat `withTenantOrThrow`,
+  yang mengambil slot work-class persis seperti sebuah request. Yang
+  benar-benar hilang — tujuh skrip tidak meneruskan kelas apa pun, sehingga
+  transaksinya mengantre sebagai `interactive` — adalah temuan D11, kini
+  tertutup dan digerbangi. Lihat `database-capacity-runbook.md` §Job dan
+  gerbang konkurensi.
 - Belum ada endpoint domain ERP nyata yang memanfaatkan klasifikasi
 work-class di atas — validasi ulang klasifikasi begitu modul finance/
 inventory/payroll pertama diimplementasikan.

--- a/docs/awcms/database-pooling.md
+++ b/docs/awcms/database-pooling.md
@@ -343,9 +343,13 @@ detailed CLI implementation status).
   test (`tests/database-pooling.test.ts`), not a live scenario.
 - Work-class saturation at the HTTP level is hard to observe deterministically
   because requests tend to finish faster than manual observation.
-- Job workers (`scripts/*.ts`) are not yet runtime-gated through
-  `work-class.ts`'s concurrency gate — see `database-capacity-runbook.md`
-  §Known limitation for the reason and follow-up status.
+- Job workers used to be listed here as "not yet runtime-gated through
+  `work-class.ts`'s concurrency gate". That is **wrong and was wrong for some
+  time**: they open their transactions through `withTenantOrThrow`, which
+  acquires a work-class slot exactly as a request does. What was genuinely
+  missing — seven scripts passing no class, so their transactions queued as
+  `interactive` — is finding D11, now closed and gated. See
+  `database-capacity-runbook.md` §Jobs and the concurrency gate.
 - There is no real ERP domain endpoint exploiting the work-class
   classification above yet — revalidate the classification once the first
   finance/inventory/payroll module is implemented.

--- a/docs/awcms/deploy-coolify.id.md
+++ b/docs/awcms/deploy-coolify.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](deploy-coolify.md)
 
-<!-- i18n-source-hash: sha256:b12082b7aaf4aaee3c566a5e4636e7ba9559193b7dc6a134369362534d84767c -->
+<!-- i18n-source-hash: sha256:0bfdfcc4d98b7c33658a97b718d005eabfab94aa4248156ce556b26e9a8bff6c -->
 
 # Deploy Coolify
 
@@ -206,7 +206,7 @@ Di Coolify, jalankan migrasi sebagai langkah terpisah **sebelum** deploy pertama
 
 Setiap aplikasi/database pada topologi multi-app punya migrasi one-shot sendiri — jangan menjalankan migrasi satu aplikasi terhadap database aplikasi lain.
 
-## Health check
+## Health check — dua endpoint, dua pertanyaan
 
 Endpoint: `GET /api/v1/health` — dipakai sebagai **Health Check Path** di konfigurasi Coolify application (lihat §Dua pola deploy di atas). Coolify memakai endpoint ini untuk menentukan container sehat sebelum menandai deploy sukses/sebelum mengarahkan traffic.
 
@@ -215,6 +215,26 @@ curl https://awcms.ahlikoding.com/api/v1/health
 ```
 
 Setiap aplikasi pada topologi multi-app dicek lewat endpoint health-nya masing-masing — tidak ada health check bersama lintas aplikasi. Perhatikan batas buktinya: endpoint ini membuktikan **container yang menjawab domain itu** sehat, bukan container mana yang menjawab. Untuk pertanyaan "apakah deployment X benar-benar hidup", jawabannya ada di `applications`/`standalone_postgresqls` Coolify — lihat catatan verifikasi di kepala dokumen ini.
+
+### Ini LIVENESS, dan ia menjawab 200 sementara database terbakar
+
+`/api/v1/health` sengaja tidak menyentuh satu pun dependensi. Coolify, `HEALTHCHECK` container, dan probe backend Varnish semuanya memakainya, dan ketiganya benar melakukannya: mereka MERESTART atau MENGALIHKAN, dan merestart aplikasi tidak memperbaiki database — probe yang menggilir container sepanjang gangguan database mengubah satu insiden menjadi dua.
+
+Konsekuensinya adalah yang disebut temuan **D10** putaran 17 Agustus 2026: **rilis yang databasenya tak terjangkau ditandai sukses lalu dialihkan.** Tidak ada apa pun di jalur deploy yang menanyakan apakah container baru benar-benar bisa melayani.
+
+### Endpoint readiness, dan di mana kini ia dibaca
+
+`GET /api/v1/database/pool/health` sama-sama tanpa autentikasi dan melaporkan `databaseReachable`, `circuitBreakerState`, saturasi per work class, serta kapasitas pool proses ini.
+
+```bash
+curl -s https://awcms.ahlikoding.com/api/v1/database/pool/health
+# {"status":"healthy","databaseReachable":true,"circuitBreakerState":"closed", …}
+```
+
+- **`ops/synthetic-check.sh` membacanya** (tiap 10 menit, dari luar, memberi alert sekali pada transisi) — itulah pembaca otomatis yang diminta D10, dan ia memanggil manusia alih-alih merestart container.
+- **Jalankan sendiri sebagai langkah terakhir deploy**, sebelum deploy dinyatakan selesai. `status` harus `healthy`; `databaseReachable` harus `true`; `circuitBreakerState` tidak boleh `open`. `200` dari domain bukan bukti rilisnya bekerja — container yang menjawabnya bisa jadi yang lama, dan ia menjawab `/api/v1/health` dalam kondisi apa pun.
+
+**JANGAN arahkan Health Check Path Coolify ke endpoint readiness.** Konfigurasi itu tidak ada di repo ini, jadi tidak ada yang bisa menegakkan pilihan tersebut dari sini — justru karena itu ia ditulis: ia menggerakkan restart, dan readiness adalah urusan jalur yang memanggil manusia.
 
 ## Backup — wajib, dan wajib SEBELUM migrasi
 

--- a/docs/awcms/deploy-coolify.md
+++ b/docs/awcms/deploy-coolify.md
@@ -203,7 +203,7 @@ On Coolify, run the migration as a separate step **before** the app's first depl
 
 Every application/database in a multi-app topology has its own one-shot migration — do not run one application's migration against another application's database.
 
-## Health check
+## Health check — two endpoints, two questions
 
 Endpoint: `GET /api/v1/health` — used as the **Health Check Path** in the Coolify application configuration (see §Two deploy patterns above). Coolify uses this endpoint to decide the container is healthy before marking the deploy successful/before routing traffic.
 
@@ -212,6 +212,26 @@ curl https://awcms.ahlikoding.com/api/v1/health
 ```
 
 Every application in a multi-app topology is checked via its own health endpoint — there is no shared cross-application health check. Note the limit of what it proves: this endpoint proves **the container answering that domain** is healthy, not which container is answering. For the question "is deployment X really alive", the answer is in Coolify's `applications`/`standalone_postgresqls` — see the verification note at the head of this document.
+
+### It is LIVENESS, and it answers 200 with the database on fire
+
+`/api/v1/health` touches no dependency by design. Coolify, the container `HEALTHCHECK` and the Varnish backend probe all use it, and all three are right to: they RESTART or REROUTE, and restarting an app does not repair a database — a probe that cycles containers through a database outage turns one incident into two.
+
+The consequence, and it is the one finding **D10** of the 17 August 2026 round names: **a release whose database is unreachable is marked successful and cut over.** Nothing in the deploy path asks whether the new container can actually serve.
+
+### The readiness endpoint, and where it is now read
+
+`GET /api/v1/database/pool/health` is equally unauthenticated and reports `databaseReachable`, `circuitBreakerState`, per-work-class saturation and this process's pool capacity.
+
+```bash
+curl -s https://awcms.ahlikoding.com/api/v1/database/pool/health
+# {"status":"healthy","databaseReachable":true,"circuitBreakerState":"closed", …}
+```
+
+- **`ops/synthetic-check.sh` reads it** (every 10 minutes, from outside, alerting once on the transition) — that is the automatic reader D10 asked for, and it alerts a human rather than restarting a container.
+- **Run it yourself as the last step of a deploy**, before you call the deploy done. `status` must be `healthy`; `databaseReachable` must be `true`; `circuitBreakerState` must not be `open`. A `200` from the domain is not evidence the release works — the container answering it may be the previous one, and it answers `/api/v1/health` either way.
+
+**Do NOT point Coolify's Health Check Path at the readiness endpoint.** That configuration is not in this repo, so nothing here can enforce the choice — which is exactly why it is written down: it drives restart, and readiness belongs on the path that pages a person.
 
 ## Backup — mandatory, and mandatory BEFORE a migration
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 456   |
+| Test files                          | 458   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -356,7 +356,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 384        |
+| `(root)`      | 386        |
 | `e2e`         | 12         |
 | `integration` | 59         |
 | `unit`        | 1          |

--- a/ops/ship-logs.sh
+++ b/ops/ship-logs.sh
@@ -65,12 +65,42 @@ fi
 # `--timestamps` so a line's time survives even when the app's own JSON is
 # truncated, and no `--since`: a new container's history starts at zero and we
 # want all of it. setsid + nohup so cron exiting does not take the tailer with it.
-setsid nohup docker logs -f --timestamps "$APP" \
-  >> "${DEST}/app-$(date -u +%Y-%m-%d).log" 2>&1 &
+#
+# WHY THE OUTPUT GOES THROUGH A LOOP AND NOT A REDIRECT
+#
+# This used to be `>> "${DEST}/app-$(date -u +%Y-%m-%d).log"`. A redirect names
+# its file ONCE, when the shell spawns the tailer, and the file descriptor then
+# lives until the container changes — which on a stable deployment is weeks. The
+# two consequences compound:
+#
+#   - Today's lines land in a file dated by the LAST DEPLOY. An operator reading
+#     `app-2026-08-01.log` to answer "what happened last night" is reading a
+#     file whose name is the one thing about it that is wrong.
+#   - The `-mtime` sweep below can never reclaim it: the file keeps being
+#     written, so its mtime is always today no matter how old its name is. The
+#     retention policy applied to every file except the one actually growing.
+#
+# The loop re-derives the date per line, so the writer follows midnight. `printf
+# -v ... %(...)T` is a bash builtin — no `date` fork per line, which matters on
+# a log this script exists to keep all of. `TZ=UTC` because `%(...)T` formats in
+# LOCAL time and the filenames are UTC (`date -u` above was explicit about it).
+# `>>` per line reopens the file, so a rotation or a delete underneath is
+# survivable rather than a silent write into an unlinked inode.
+setsid nohup bash -c '
+  set -uo pipefail
+  export TZ=UTC
+  docker logs -f --timestamps "$2" 2>&1 | while IFS= read -r line; do
+    printf -v day "%(%Y-%m-%d)T" -1
+    printf "%s\n" "$line" >> "$1/app-${day}.log"
+  done
+' _ "$DEST" "$APP" >/dev/null 2>&1 &
 
 echo "$APP" > "$MARKER"
 log "following ${APP}"
 
 # Retention. These files are the debugging record, not an archive — 30 days is
-# well past the window in which anyone asks "what happened last night".
+# well past the window in which anyone asks "what happened last night". This
+# only became a real policy with the loop above: while one descriptor stayed
+# open on one file forever, the file the operator most wanted bounded was the
+# single file this could never touch.
 find "$DEST" -maxdepth 1 -name 'app-*.log' -mtime "+${KEEP_DAYS}" -delete

--- a/ops/synthetic-check.sh
+++ b/ops/synthetic-check.sh
@@ -59,6 +59,39 @@ ok() { log "ok   $1"; }
 CODE=$($CURL -o /dev/null -w '%{http_code}' "${BASE}/api/v1/health" || echo 000)
 [ "$CODE" = "200" ] && ok "health 200" || fail "health returned ${CODE}"
 
+# --- 1b. READINESS, which is a different question ----------------------------
+#
+# Finding D10: `/api/v1/database/pool/health` reports `databaseReachable` and
+# `circuitBreakerState`, is equally unauthenticated, and until now was consulted
+# by NOTHING. Coolify, the Docker HEALTHCHECK and the Varnish probe all read
+# `/api/v1/health`, which is dependency-free ON PURPOSE — it answers "is this
+# process alive", and it answers `200` with the database on fire.
+#
+# Those three are right to use liveness: restarting an app does not repair a
+# database, and a probe that restarts containers during a database outage turns
+# one incident into two. What was missing is a reader for the OTHER question,
+# and this is the file whose job is exactly that — the header above says so:
+# "not 'is the box up' — the container healthcheck already answers that, and it
+# answers it from INSIDE, where every defect this project has actually shipped
+# was invisible."
+#
+# Matched as JSON text rather than through `jq`, which the rest of this script
+# does not require and the host may not have.
+READY=$($CURL "${BASE}/api/v1/database/pool/health" || echo "")
+if [ -z "$READY" ]; then
+  fail "readiness endpoint returned nothing — the process is not answering at all"
+else
+  case "$READY" in
+    *'"databaseReachable":true'*) ok "database reachable from the app" ;;
+    *) fail "app is up but reports databaseReachable=false — it can serve no content" ;;
+  esac
+  case "$READY" in
+    *'"circuitBreakerState":"open"'*)
+      fail "database circuit breaker is OPEN — the app is refusing its own queries" ;;
+    *) ok "database circuit breaker not open" ;;
+  esac
+fi
+
 # --- 2 & 3 & 4. the login page, its CSP, and its scripts ---------------------
 HEADERS=$(mktemp); BODY=$(mktemp)
 trap 'rm -f "$HEADERS" "$BODY"' EXIT

--- a/scripts/blog-ads-drop-readiness.ts
+++ b/scripts/blog-ads-drop-readiness.ts
@@ -49,8 +49,11 @@ async function main() {
 
     for (const tenant of tenants) {
       reports.push(
-        await withTenantOrThrow(sql, tenant.id, (tx) =>
-          assessLegacyAdDropReadiness(tx, tenant.id)
+        await withTenantOrThrow(
+          sql,
+          tenant.id,
+          (tx) => assessLegacyAdDropReadiness(tx, tenant.id),
+          { workClass: "maintenance" }
         )
       );
     }

--- a/scripts/blog-ads-ingest.ts
+++ b/scripts/blog-ads-ingest.ts
@@ -136,114 +136,123 @@ async function main() {
     `) as TenantRow[];
 
     for (const tenant of tenants) {
-      await withTenantOrThrow(sql, tenant.id, async (tx) => {
-        const ads = await listLegacyAdsForIngest(tx, tenant.id);
+      await withTenantOrThrow(
+        sql,
+        tenant.id,
+        async (tx) => {
+          const ads = await listLegacyAdsForIngest(tx, tenant.id);
 
-        for (const ad of ads) {
-          const classification = classifyLegacyAdImage({
-            tenantId: tenant.id,
-            imageUrl: ad.imageUrl,
-            publicBaseUrl
-          });
-
-          if (classification.kind === "residue") {
-            residue.push({
+          for (const ad of ads) {
+            const classification = classifyLegacyAdImage({
               tenantId: tenant.id,
-              adId: ad.id,
-              adName: ad.name,
-              reason: classification.reason,
-              detail: classification.detail
+              imageUrl: ad.imageUrl,
+              publicBaseUrl
             });
-            continue;
-          }
 
-          const media = await fetchNewsMediaObjectByObjectKey(
-            tx,
-            tenant.id,
-            classification.objectKey
-          );
-
-          // A registry row that is not safe to reference publicly (still
-          // pending, failed verification, orphaned) is treated exactly like a
-          // missing one. Carrying an ad onto it would produce a placement the
-          // render query filters out anyway — silently, which is the outcome
-          // this whole job exists to avoid.
-          if (
-            !media ||
-            !isNewsMediaObjectSafeForPublicReference(media.status)
-          ) {
-            residue.push({
-              tenantId: tenant.id,
-              adId: ad.id,
-              adName: ad.name,
-              reason: "unregistered_media_object",
-              detail: media
-                ? `${classification.objectKey} (status ${media.status})`
-                : classification.objectKey
-            });
-            continue;
-          }
-
-          const placements = await listLegacyAdPlacements(tx, tenant.id, ad.id);
-
-          if (placements.length === 0) {
-            residue.push({
-              tenantId: tenant.id,
-              adId: ad.id,
-              adName: ad.name,
-              reason: "unplaced_ad",
-              detail: UNPLACED_LEGACY_AD_DETAIL
-            });
-            continue;
-          }
-
-          for (const placement of placements) {
-            const mapping = mapLegacyPlacementToTarget(placement);
-
-            if (mapping.kind === "residue") {
+            if (classification.kind === "residue") {
               residue.push({
                 tenantId: tenant.id,
                 adId: ad.id,
                 adName: ad.name,
-                reason: mapping.reason,
-                detail: mapping.detail
+                reason: classification.reason,
+                detail: classification.detail
               });
               continue;
             }
 
-            ingestable += 1;
+            const media = await fetchNewsMediaObjectByObjectKey(
+              tx,
+              tenant.id,
+              classification.objectKey
+            );
 
-            if (!apply || !placementKey) {
+            // A registry row that is not safe to reference publicly (still
+            // pending, failed verification, orphaned) is treated exactly like a
+            // missing one. Carrying an ad onto it would produce a placement the
+            // render query filters out anyway — silently, which is the outcome
+            // this whole job exists to avoid.
+            if (
+              !media ||
+              !isNewsMediaObjectSafeForPublicReference(media.status)
+            ) {
+              residue.push({
+                tenantId: tenant.id,
+                adId: ad.id,
+                adName: ad.name,
+                reason: "unregistered_media_object",
+                detail: media
+                  ? `${classification.objectKey} (status ${media.status})`
+                  : classification.objectKey
+              });
               continue;
             }
 
-            const written = await insertIngestedAdPlacement(tx, tenant.id, {
-              placementKey,
-              name: ad.name,
-              mediaObjectId: media.id,
-              linkUrl: ad.linkUrl,
-              isActive: ad.isActive,
-              startsAt: ad.startsAt,
-              endsAt: ad.endsAt,
-              targetType: mapping.target.targetType,
-              targetId: mapping.target.targetId,
-              sourceLegacyAdId: ad.id
-            });
+            const placements = await listLegacyAdPlacements(
+              tx,
+              tenant.id,
+              ad.id
+            );
 
-            if (written) {
-              inserted += 1;
-              console.log(
-                `blog:ads:ingest INGESTED — tenant=${tenant.id} legacyAd=${ad.id} ` +
-                  `placementKey=${placementKey} target=${mapping.target.targetType}` +
-                  `${mapping.target.targetId ? `:${mapping.target.targetId}` : ""} ` +
-                  `mediaObject=${media.id}`
-              );
-            } else {
-              alreadyPresent += 1;
+            if (placements.length === 0) {
+              residue.push({
+                tenantId: tenant.id,
+                adId: ad.id,
+                adName: ad.name,
+                reason: "unplaced_ad",
+                detail: UNPLACED_LEGACY_AD_DETAIL
+              });
+              continue;
+            }
+
+            for (const placement of placements) {
+              const mapping = mapLegacyPlacementToTarget(placement);
+
+              if (mapping.kind === "residue") {
+                residue.push({
+                  tenantId: tenant.id,
+                  adId: ad.id,
+                  adName: ad.name,
+                  reason: mapping.reason,
+                  detail: mapping.detail
+                });
+                continue;
+              }
+
+              ingestable += 1;
+
+              if (!apply || !placementKey) {
+                continue;
+              }
+
+              const written = await insertIngestedAdPlacement(tx, tenant.id, {
+                placementKey,
+                name: ad.name,
+                mediaObjectId: media.id,
+                linkUrl: ad.linkUrl,
+                isActive: ad.isActive,
+                startsAt: ad.startsAt,
+                endsAt: ad.endsAt,
+                targetType: mapping.target.targetType,
+                targetId: mapping.target.targetId,
+                sourceLegacyAdId: ad.id
+              });
+
+              if (written) {
+                inserted += 1;
+                console.log(
+                  `blog:ads:ingest INGESTED — tenant=${tenant.id} legacyAd=${ad.id} ` +
+                    `placementKey=${placementKey} target=${mapping.target.targetType}` +
+                    `${mapping.target.targetId ? `:${mapping.target.targetId}` : ""} ` +
+                    `mediaObject=${media.id}`
+                );
+              } else {
+                alreadyPresent += 1;
+              }
             }
           }
-        }
-      });
+        },
+        { workClass: "maintenance" }
+      );
     }
 
     for (const row of residue) {

--- a/scripts/comments-retention.ts
+++ b/scripts/comments-retention.ts
@@ -104,11 +104,15 @@ async function main() {
       let anonymizeCutoffIso = "";
 
       for (const tenant of tenants) {
-        const preview = await withTenantOrThrow(sql, tenant.id, (tx) =>
-          previewCommentsRetention(tx, tenant.id, legalHoldGuardPortAdapter, {
-            retentionDays,
-            now
-          })
+        const preview = await withTenantOrThrow(
+          sql,
+          tenant.id,
+          (tx) =>
+            previewCommentsRetention(tx, tenant.id, legalHoldGuardPortAdapter, {
+              retentionDays,
+              now
+            }),
+          { workClass: "maintenance" }
         );
 
         wouldAnonymize += preview.wouldAnonymize;
@@ -135,11 +139,15 @@ async function main() {
 
     for (const tenant of tenants) {
       for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
-        const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
-          anonymizeAgedComments(tx, tenant.id, legalHoldGuardPortAdapter, {
-            retentionDays,
-            now
-          })
+        const result = await withTenantOrThrow(
+          sql,
+          tenant.id,
+          (tx) =>
+            anonymizeAgedComments(tx, tenant.id, legalHoldGuardPortAdapter, {
+              retentionDays,
+              now
+            }),
+          { workClass: "maintenance" }
         );
 
         cutoffIso = result.cutoff.toISOString();
@@ -157,8 +165,11 @@ async function main() {
       }
 
       for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
-        const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
-          purgeUnconfirmedReplySubscriptions(tx, tenant.id, { now })
+        const result = await withTenantOrThrow(
+          sql,
+          tenant.id,
+          (tx) => purgeUnconfirmedReplySubscriptions(tx, tenant.id, { now }),
+          { workClass: "maintenance" }
         );
 
         totalPurged += result.purgedCount;

--- a/scripts/edge-cache-purge.ts
+++ b/scripts/edge-cache-purge.ts
@@ -80,8 +80,17 @@ async function main(): Promise<void> {
 
     for (const tenant of tenants) {
       for (let pass = 0; pass < MAX_PASSES_PER_TENANT; pass += 1) {
-        const claimed = await withTenantOrThrow(sql, tenant.id, (tx) =>
-          claimEdgeCachePurges(tx, tenant.id, config.purgeBatchSize, new Date())
+        const claimed = await withTenantOrThrow(
+          sql,
+          tenant.id,
+          (tx) =>
+            claimEdgeCachePurges(
+              tx,
+              tenant.id,
+              config.purgeBatchSize,
+              new Date()
+            ),
+          { workClass: "background_sync" }
         );
 
         if (claimed.length === 0) {
@@ -95,16 +104,20 @@ async function main(): Promise<void> {
 
           // Each outcome is committed on its own so a crash mid-batch loses at
           // most one row's status, not the whole pass's progress.
-          await withTenantOrThrow(sql, tenant.id, (tx) =>
-            outcome.ok
-              ? markEdgeCachePurgeDone(tx, row.id, new Date())
-              : markEdgeCachePurgeFailed(
-                  tx,
-                  row.id,
-                  outcome.detail,
-                  new Date(),
-                  !outcome.retryable
-                )
+          await withTenantOrThrow(
+            sql,
+            tenant.id,
+            (tx) =>
+              outcome.ok
+                ? markEdgeCachePurgeDone(tx, row.id, new Date())
+                : markEdgeCachePurgeFailed(
+                    tx,
+                    row.id,
+                    outcome.detail,
+                    new Date(),
+                    !outcome.retryable
+                  ),
+            { workClass: "background_sync" }
           );
 
           if (outcome.ok) {
@@ -115,11 +128,17 @@ async function main(): Promise<void> {
         }
       }
 
-      const retention = await withTenantOrThrow(sql, tenant.id, (tx) =>
-        pruneTerminalEdgeCachePurges(tx, tenant.id, legalHoldGuardPortAdapter, {
-          now,
-          limit: config.purgeBatchSize
-        })
+      const retention = await withTenantOrThrow(
+        sql,
+        tenant.id,
+        (tx) =>
+          pruneTerminalEdgeCachePurges(
+            tx,
+            tenant.id,
+            legalHoldGuardPortAdapter,
+            { now, limit: config.purgeBatchSize }
+          ),
+        { workClass: "background_sync" }
       );
 
       prunedCompleted += retention.prunedCompleted;

--- a/scripts/site-search-reconcile.ts
+++ b/scripts/site-search-reconcile.ts
@@ -85,7 +85,12 @@ async function main(): Promise<void> {
               descriptors,
               { trigger: "scheduled" }
             ),
-          { workClass: "maintenance" }
+          // `background_sync`, matching the job registry's argued entry:
+          // this drives user-visible public search freshness, so it is a
+          // recurring dispatcher rather than a delay-tolerant sweep. The script
+          // used to pass `maintenance` with no reason given, and the drift ran
+          // in both directions (finding D11).
+          { workClass: "background_sync" }
         );
       } catch (error) {
         failedTenants.push(tenant.id);

--- a/scripts/tenant-domain-dns-sync.ts
+++ b/scripts/tenant-domain-dns-sync.ts
@@ -81,7 +81,8 @@ async function main(): Promise<void> {
               AND status = 'active'
               AND deleted_at IS NULL
             ORDER BY normalized_hostname
-          ` as Promise<ServingDomainRow[]>
+          ` as Promise<ServingDomainRow[]>,
+        { workClass: "background_sync" }
       );
 
       considered += rows.length;

--- a/scripts/visitor-analytics-purge.ts
+++ b/scripts/visitor-analytics-purge.ts
@@ -113,14 +113,18 @@ export async function runVisitorAnalyticsPurge(
       // by the next scheduled run.
       const outcome = await runBoundedBatches(
         async () => {
-          const pass = await withTenantOrThrow(sql, tenant.id, (tx) =>
-            purgeVisitorAnalyticsData(
-              tx,
-              tenant.id,
-              config,
-              now,
-              legalHoldGuardPortAdapter
-            )
+          const pass = await withTenantOrThrow(
+            sql,
+            tenant.id,
+            (tx) =>
+              purgeVisitorAnalyticsData(
+                tx,
+                tenant.id,
+                config,
+                now,
+                legalHoldGuardPortAdapter
+              ),
+            { workClass: "maintenance" }
           );
 
           totals.eventsDeleted += pass.eventsDeleted;

--- a/scripts/visitor-analytics-rollup.ts
+++ b/scripts/visitor-analytics-rollup.ts
@@ -112,8 +112,11 @@ export async function runVisitorAnalyticsRollup(
     // collected and printed rather than counted — `--date=` is the remedy and
     // an operator needs to know which tenants to name.
     try {
-      const result = await withTenantOrThrow(sql, tenant.id, (tx) =>
-        rollupVisitorAnalyticsForDate(tx, tenant.id, date)
+      const result = await withTenantOrThrow(
+        sql,
+        tenant.id,
+        (tx) => rollupVisitorAnalyticsForDate(tx, tenant.id, date),
+        { workClass: "background_sync" }
       );
 
       tenantsRolledUp += 1;

--- a/scripts/work-class-registry-generate.ts
+++ b/scripts/work-class-registry-generate.ts
@@ -167,6 +167,98 @@ export function compareJobRegistry(
   };
 }
 
+/** Global form of `WITH_TENANT_CALL`, for counting rather than testing. */
+const WITH_TENANT_CALL_GLOBAL = new RegExp(WITH_TENANT_CALL.source, "g");
+
+/**
+ * What a job script's own source says about the class its transactions run as.
+ *
+ * `undeclaredCalls` is the count of `withTenant*(` calls that no `workClass:`
+ * literal can account for; `conflicting` are literals that name a class other
+ * than the registry's.
+ */
+export type JobRuntimeDeclaration = {
+  path: string;
+  calls: number;
+  declared: WorkClass[];
+  undeclaredCalls: number;
+  conflicting: WorkClass[];
+};
+
+/**
+ * Finding D11 — the registry declared a class for every job, and seven scripts
+ * did not pass it, so they opened their transactions as the default
+ * `interactive`: a nightly purge attributing its pool pressure to the bucket
+ * that serves live users. The drift also ran the other way —
+ * `site-search-reconcile.ts` passed `maintenance` where the registry says
+ * `background_sync` — which is what makes this a two-sided check rather than a
+ * "did you remember an option" one.
+ *
+ * ## What this can and cannot see, stated because a gate that implies more is
+ * worse than one that implies less
+ *
+ * It reads ONE file: the script. A script whose transactions live in a job
+ * module under `src/` has no `withTenant*(` call of its own, so `calls` is 0
+ * and nothing here is asserted about it — several registry rationales say
+ * "every call inside <module> already passes it explicitly", and this gate is
+ * not the thing that verifies those. What it does cover exactly is the shape
+ * the finding had: a call in the script itself, with no class or with the
+ * wrong one.
+ *
+ * Counting is what catches the partial case. A script with three calls and one
+ * literal looks declared to any presence check, and two of its transactions
+ * still run as `interactive`.
+ */
+export function inspectJobRuntimeDeclaration(
+  filePath: string,
+  content: string,
+  registryClass: WorkClass
+): JobRuntimeDeclaration {
+  const code = codeOnly(content);
+  const calls = [...code.matchAll(WITH_TENANT_CALL_GLOBAL)].length;
+  const literals = [...code.matchAll(WORK_CLASS_LITERAL)].map(
+    (m) => m[1]! as WorkClass
+  );
+
+  return {
+    path: filePath,
+    calls,
+    declared: [...new Set(literals)].sort(),
+    undeclaredCalls: Math.max(0, calls - literals.length),
+    conflicting: [
+      ...new Set(literals.filter((c) => c !== registryClass))
+    ].sort()
+  };
+}
+
+/** The human-readable refusal for one script, or `null` when it is consistent. */
+export function describeJobRuntimeProblem(
+  declaration: JobRuntimeDeclaration,
+  registryClass: WorkClass
+): string | null {
+  if (declaration.calls === 0) {
+    return null;
+  }
+
+  const problems: string[] = [];
+
+  if (declaration.undeclaredCalls > 0) {
+    problems.push(
+      `${declaration.undeclaredCalls} of ${declaration.calls} withTenant call(s) declare no workClass, so they run as the default "interactive"`
+    );
+  }
+
+  if (declaration.conflicting.length > 0) {
+    problems.push(
+      `declares ${declaration.conflicting.map((c) => `"${c}"`).join(", ")} where the registry says "${registryClass}"`
+    );
+  }
+
+  return problems.length > 0
+    ? `  ${declaration.path} — ${problems.join("; ")}.`
+    : null;
+}
+
 export async function buildSnapshot(): Promise<WorkClassRegistrySnapshot> {
   const routes: RouteEntry[] = [];
 
@@ -215,6 +307,37 @@ export async function buildSnapshot(): Promise<WorkClassRegistrySnapshot> {
         `the scripts on disk. Fix src/lib/database/work-class-registry.ts first:\n${detail}\n` +
         "Refusing to GENERATE (not merely to check) is deliberate: a snapshot " +
         "written from a half-true map would look authoritative."
+    );
+  }
+
+  // The declared class must also be the one the script PASSES. Same refusal
+  // posture as the map/reality mismatch above and for the same reason: a
+  // snapshot that records `maintenance` for a job whose transactions open as
+  // `interactive` is a capacity model that reads as authoritative and is wrong.
+  const runtimeProblems: string[] = [];
+
+  for (const scriptPath of discovered.sort()) {
+    const registryClass = JOB_WORK_CLASS_REGISTRY[scriptPath]!.workClass;
+    const problem = describeJobRuntimeProblem(
+      inspectJobRuntimeDeclaration(
+        scriptPath,
+        await Bun.file(scriptPath).text(),
+        registryClass
+      ),
+      registryClass
+    );
+
+    if (problem) {
+      runtimeProblems.push(problem);
+    }
+  }
+
+  if (runtimeProblems.length > 0) {
+    throw new Error(
+      "db:work-class:generate REFUSES to run — a job script does not open its " +
+        "transactions as the class the registry declares for it. Pass " +
+        "`{ workClass: … }` to every withTenant call in the script, or change " +
+        `the registry entry deliberately:\n${runtimeProblems.join("\n")}`
     );
   }
 

--- a/src/lib/database/work-class-registry.ts
+++ b/src/lib/database/work-class-registry.ts
@@ -8,28 +8,39 @@
  * second hand-maintained copy).
  *
  * Background jobs (`scripts/*.ts` that call `getWorkerDatabaseClient()`/
- * `getSetupDatabaseClient()`) have no equivalent inline declaration — they
- * do not call `withTenant`/`acquireWorkClassSlot` at all today (see below),
- * so there is nothing to generate FROM. This is therefore a small,
- * hand-authored, DECLARATIVE map: which work-class "bucket" each job's
- * connection usage should be attributed to for the capacity model/registry
- * drift gate, not proof that the job runtime-enforces that class today.
+ * `getSetupDatabaseClient()`) have no equivalent inline declaration to
+ * generate FROM, so this is a small, hand-authored, DECLARATIVE map: which
+ * work-class "bucket" each job's connection usage is attributed to.
  *
- * ## Why jobs are not runtime-gated through work-class.ts (yet)
+ * ## What "declared" means here, corrected 22 August 2026
  *
- * Retrofitting all 9 worker scripts to call `acquireWorkClassSlot` around
- * their main loop is a real, separately-scoped follow-up (see
- * `docs/awcms/database-capacity-runbook.md` §Known limitation), not
- * done in Issue #743: job concurrency is already bounded by a DIFFERENT,
- * already-existing mechanism — `src/lib/jobs/job-runner.ts`'s Postgres
- * advisory lock ensures at most ONE instance of a given job NAME runs
- * cluster-wide at a time, which is the dominant connection-storm risk for
- * scheduled jobs (an overlapping re-run of the SAME job, e.g. a slow purge
- * still running when the next cron tick fires). This registry still
- * requires every worker script to be explicitly classified — closing the
- * "every database-using process is included in the capacity model, or
- * explicitly exempted with rationale" gap — without also taking on a
- * runtime behavior change to 9 already-shipped scripts in the same issue.
+ * This header used to say jobs "do not call `withTenant`/`acquireWorkClassSlot`
+ * at all today", and the capacity runbook said the same. **That was written
+ * when it was true and stayed after it stopped being true.** Jobs open tenant
+ * transactions through `withTenantOrThrow` — which is `acquireWorkClassSlot`,
+ * the same pool gate a request goes through — and finding D11 found seven
+ * scripts passing no class at all, so a nightly purge attributed its pool
+ * pressure to the bucket that serves live users, and one script passing
+ * `maintenance` where this map says `background_sync`.
+ *
+ * So the map is no longer only a capacity-planning label: for a script that
+ * opens its own transactions, the class here is the class the script must
+ * PASS, and `db:work-class:generate` refuses to run when it does not (in both
+ * directions — a missing option and a contradicting one). What the gate cannot
+ * see is a script whose transactions live in a job module under `src/`; those
+ * have no call of their own to inspect, and the rationales below that claim
+ * "every call inside <module> already passes it explicitly" are not verified
+ * by it.
+ *
+ * ## Job concurrency is still bounded by something else, and that is unchanged
+ *
+ * `src/lib/jobs/job-runner.ts`'s Postgres advisory lock ensures at most ONE
+ * instance of a given job NAME runs cluster-wide at a time, which is the
+ * dominant connection-storm risk for scheduled jobs (an overlapping re-run of
+ * the SAME job — a slow purge still running when the next cron tick fires).
+ * The work class governs which bounded queue the job's transactions wait in;
+ * the advisory lock governs how many of the job there are. Neither replaces
+ * the other.
  *
  * `scripts/work-class-registry-check.ts` discovers the CURRENT set of
  * worker scripts by grepping `scripts/*.ts` for `getWorkerDatabaseClient(`/

--- a/tests/job-work-class-declaration.test.ts
+++ b/tests/job-work-class-declaration.test.ts
@@ -1,0 +1,176 @@
+/**
+ * A job's declared work class must be the one it PASSES — finding D11 of the
+ * 17 August 2026 audit round.
+ *
+ * ## What was wrong, in both directions
+ *
+ * `src/lib/database/work-class-registry.ts` names a class for every worker
+ * script, and that map feeds the capacity model and the drift gate. Seven
+ * scripts never passed it: their `withTenantOrThrow` calls took the documented
+ * `"interactive"` default, so nightly purges queued in the bucket sized for
+ * live users while the registry recorded them as `maintenance`. And
+ * `site-search-reconcile.ts` passed `maintenance` where the registry says
+ * `background_sync` — the same drift running the other way.
+ *
+ * Neither could be seen by anything: the registry gate compared the map against
+ * which scripts EXIST, never against what they do.
+ *
+ * ## Why counting, and not "is there a literal"
+ *
+ * A presence check passes on a script with three transactions and one declared
+ * class, and two of them still run as `interactive`. `comments-retention.ts`
+ * and `edge-cache-purge.ts` are both three-call scripts, so this is the actual
+ * shape here rather than a hypothetical one.
+ *
+ * ## What this cannot see, stated rather than implied
+ *
+ * The inspection reads ONE file: the script. Several registry rationales say
+ * "every call inside <module> already passes it explicitly" — those calls live
+ * under `src/`, the script has no `withTenant*(` of its own, and nothing here
+ * verifies them. A gate that implied otherwise would be worse than one that
+ * says what it covers.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  describeJobRuntimeProblem,
+  inspectJobRuntimeDeclaration
+} from "../scripts/work-class-registry-generate";
+import { JOB_WORK_CLASS_REGISTRY } from "../src/lib/database/work-class-registry";
+
+describe("inspectJobRuntimeDeclaration", () => {
+  test("a call with no workClass is counted as undeclared", () => {
+    const declaration = inspectJobRuntimeDeclaration(
+      "scripts/example.ts",
+      "await withTenantOrThrow(sql, id, (tx) => work(tx));",
+      "maintenance"
+    );
+
+    expect(declaration.calls).toBe(1);
+    expect(declaration.undeclaredCalls).toBe(1);
+    expect(describeJobRuntimeProblem(declaration, "maintenance")).toContain(
+      'run as the default "interactive"'
+    );
+  });
+
+  test("three calls with one literal leave two undeclared", () => {
+    const declaration = inspectJobRuntimeDeclaration(
+      "scripts/example.ts",
+      `
+        await withTenantOrThrow(sql, id, a, { workClass: "maintenance" });
+        await withTenantOrThrow(sql, id, b);
+        await withTenantOrThrow(sql, id, c);
+      `,
+      "maintenance"
+    );
+
+    expect(declaration.calls).toBe(3);
+    expect(declaration.undeclaredCalls).toBe(2);
+    expect(describeJobRuntimeProblem(declaration, "maintenance")).toContain(
+      "2 of 3"
+    );
+  });
+
+  test("a literal that contradicts the registry is reported, not accepted", () => {
+    const declaration = inspectJobRuntimeDeclaration(
+      "scripts/example.ts",
+      'await withTenantOrThrow(sql, id, a, { workClass: "maintenance" });',
+      "background_sync"
+    );
+
+    expect(declaration.undeclaredCalls).toBe(0);
+    expect(declaration.conflicting).toEqual(["maintenance"]);
+    expect(describeJobRuntimeProblem(declaration, "background_sync")).toContain(
+      'declares "maintenance" where the registry says "background_sync"'
+    );
+  });
+
+  test("a consistent script reports no problem", () => {
+    const declaration = inspectJobRuntimeDeclaration(
+      "scripts/example.ts",
+      'await withTenantOrThrow(sql, id, a, { workClass: "maintenance" });',
+      "maintenance"
+    );
+
+    expect(describeJobRuntimeProblem(declaration, "maintenance")).toBeNull();
+  });
+
+  test("a script whose transactions live in a module is not judged", () => {
+    // No call of its own — the class is passed inside the job module it
+    // imports, which this cannot see. Silence here is "not covered", not "ok".
+    const declaration = inspectJobRuntimeDeclaration(
+      "scripts/example.ts",
+      "await runArchivePurgeJob(sql);",
+      "maintenance"
+    );
+
+    expect(declaration.calls).toBe(0);
+    expect(describeJobRuntimeProblem(declaration, "maintenance")).toBeNull();
+  });
+
+  test("a docblock naming a call is not a call", () => {
+    const declaration = inspectJobRuntimeDeclaration(
+      "scripts/example.ts",
+      `
+        /** Every pass is wrapped in withTenantOrThrow(...). */
+        await runJobModule(sql);
+      `,
+      "maintenance"
+    );
+
+    expect(declaration.calls).toBe(0);
+  });
+});
+
+describe("every registered job script agrees with the registry", () => {
+  test("no script opens a transaction as a class other than its declared one", async () => {
+    const problems: string[] = [];
+
+    for (const [scriptPath, entry] of Object.entries(JOB_WORK_CLASS_REGISTRY)) {
+      const source = await Bun.file(scriptPath).text();
+      const problem = describeJobRuntimeProblem(
+        inspectJobRuntimeDeclaration(scriptPath, source, entry.workClass),
+        entry.workClass
+      );
+
+      if (problem) problems.push(problem.trim());
+    }
+
+    expect(problems).toEqual([]);
+  });
+
+  test("the scripts the finding named do declare a class, and it is the registry's", async () => {
+    // Named rather than derived: a loop over "every script with a call" would
+    // pass vacuously if the discovery ever stopped finding them. These eight
+    // are the exact set D11 was about — seven undeclared plus the one that
+    // contradicted the map.
+    const named = [
+      "scripts/visitor-analytics-purge.ts",
+      "scripts/visitor-analytics-rollup.ts",
+      "scripts/blog-ads-drop-readiness.ts",
+      "scripts/blog-ads-ingest.ts",
+      "scripts/comments-retention.ts",
+      "scripts/edge-cache-purge.ts",
+      "scripts/tenant-domain-dns-sync.ts",
+      "scripts/site-search-reconcile.ts"
+    ];
+
+    for (const scriptPath of named) {
+      const entry = JOB_WORK_CLASS_REGISTRY[scriptPath];
+      expect(entry, `${scriptPath} is missing from the registry`).toBeDefined();
+
+      const declaration = inspectJobRuntimeDeclaration(
+        scriptPath,
+        await Bun.file(scriptPath).text(),
+        entry!.workClass
+      );
+
+      expect(
+        declaration.calls,
+        `${scriptPath} opens no transaction`
+      ).toBeGreaterThan(0);
+      expect(declaration.undeclaredCalls, scriptPath).toBe(0);
+      expect(declaration.declared, scriptPath).toEqual([entry!.workClass]);
+    }
+  });
+});

--- a/tests/ops-log-shipping-and-readiness.test.ts
+++ b/tests/ops-log-shipping-and-readiness.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Two operational signals that were wrong — findings D9 and D10 of the
+ * 17 August 2026 audit round.
+ *
+ * ## D9 — the log file named at attach time
+ *
+ * `ops/ship-logs.sh` redirected the tailer with
+ * `>> "${DEST}/app-$(date -u +%Y-%m-%d).log"`. A redirect names its file ONCE,
+ * when the shell spawns the process, and the descriptor then lives until the
+ * container changes — weeks, on a stable deployment. Two consequences that
+ * compound: today's lines land in a file dated by the last DEPLOY, and the
+ * `-mtime` retention sweep can never reclaim it, because the file it should be
+ * deleting is the one still being written.
+ *
+ * The distinguishing behaviour is **reopen per line**, and it is testable
+ * without waiting for midnight: delete the file underneath a running writer.
+ * A single long-lived descriptor keeps writing into an unlinked inode and the
+ * file never comes back; a per-line `>>` recreates it on the next line. That is
+ * what the first suite below actually executes, against the payload extracted
+ * from the script itself rather than a copy of it.
+ *
+ * ## D10 — nothing read the readiness endpoint
+ *
+ * `/api/v1/database/pool/health` reports `databaseReachable` and
+ * `circuitBreakerState`, is unauthenticated, and was consulted by nothing.
+ * Coolify, the container `HEALTHCHECK` and the Varnish probe all read the
+ * dependency-free liveness endpoint — correctly, because all three restart or
+ * reroute and restarting an app does not repair a database. What was missing
+ * was a reader on the path that pages a person. Asserted as source, because
+ * running it needs a live deployment; what is checked is that the probe exists,
+ * reads both fields, and that the three restart/reroute probes were NOT
+ * switched over.
+ */
+import { describe, expect, test } from "bun:test";
+
+/**
+ * `scripts/lib/source-text`'s `stripComments` understands `//` and block
+ * comments, not `#` — so on a shell file it leaves every comment intact. That
+ * matters here more than usual: the comments in both scripts QUOTE the defect
+ * they replaced, so a substring check that reads them answers about the
+ * documentation and not the code.
+ *
+ * A line whose first non-space character is `#` is a comment. `#` never opens
+ * one mid-line in either file, and the `bash -c` payload contains none at all.
+ */
+function shellCodeOnly(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => !/^\s*#/.test(line))
+    .join("\n");
+}
+
+const SHIP_LOGS = "ops/ship-logs.sh";
+const SYNTHETIC = "ops/synthetic-check.sh";
+const DOCKERFILE = "Dockerfile.production";
+const VCL = "infra/varnish/default.vcl";
+const READINESS_PATH = "/api/v1/database/pool/health";
+
+/**
+ * The `bash -c '…'` payload the script hands to `setsid nohup`, taken from the
+ * file so the test cannot drift from what actually ships.
+ */
+async function extractWriterPayload(): Promise<string> {
+  const source = await Bun.file(SHIP_LOGS).text();
+  const match = /setsid nohup bash -c '([\s\S]*?)'\s*_\s/.exec(source);
+
+  if (!match) {
+    throw new Error(
+      "could not find the `setsid nohup bash -c '…' _` writer in ops/ship-logs.sh"
+    );
+  }
+
+  return match[1]!;
+}
+
+/** Runs the payload with `docker` stubbed to emit `lines`, one per interval. */
+async function runWriter(
+  destination: string,
+  lines: readonly string[],
+  perLineDelayMs: number
+): Promise<{ stop: () => void; exited: Promise<number> }> {
+  const emitter = lines
+    .map(
+      (line) =>
+        `printf '%s\\n' ${JSON.stringify(line)}; sleep ${perLineDelayMs / 1000}`
+    )
+    .join("; ");
+
+  // The payload calls `docker logs -f --timestamps "$2"`. Shadowing `docker`
+  // with a shell function keeps the payload byte-identical to the shipped one.
+  const script = `
+docker() { ${emitter}; }
+export -f docker 2>/dev/null || true
+${await extractWriterPayload()}
+`;
+
+  const proc = Bun.spawn(["bash", "-c", script, "_", destination, "stub"], {
+    stdout: "pipe",
+    stderr: "pipe"
+  });
+
+  return { stop: () => proc.kill(), exited: proc.exited };
+}
+
+async function waitFor(
+  predicate: () => Promise<boolean>,
+  timeoutMs = 5000
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await Bun.sleep(25);
+  }
+
+  return false;
+}
+
+function todayUtc(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+describe("D9 — ship-logs writes through a per-line reopen, not one descriptor", () => {
+  test("the tailer's output is no longer a redirect naming the file once", async () => {
+    const source = shellCodeOnly(await Bun.file(SHIP_LOGS).text());
+
+    // The exact shape of the defect: a `$(date …)` evaluated by the SPAWNING
+    // shell, inside a redirect target.
+    expect(source).not.toMatch(/>>\s*"\$\{DEST\}\/app-\$\(date/);
+    expect(source).toContain('printf -v day "%(%Y-%m-%d)T" -1');
+  });
+
+  test("lines land in a file named for today, in UTC", async () => {
+    const dir = `${process.env.TMPDIR ?? "/tmp"}/awcms-shiplogs-${crypto.randomUUID()}`;
+    await Bun.$`mkdir -p ${dir}`.quiet();
+
+    const writer = await runWriter(dir, ["alpha", "beta"], 50);
+    const target = `${dir}/app-${todayUtc()}.log`;
+
+    const appeared = await waitFor(async () =>
+      (
+        await Bun.file(target)
+          .text()
+          .catch(() => "")
+      ).includes("beta")
+    );
+
+    writer.stop();
+    await writer.exited;
+
+    expect(appeared).toBe(true);
+    expect(await Bun.file(target).text()).toContain("alpha");
+
+    await Bun.$`rm -rf ${dir}`.quiet();
+  });
+
+  test("deleting the file underneath the writer does not lose the next line", async () => {
+    // This is the property a single long-lived descriptor cannot have: it would
+    // keep writing into the unlinked inode and the path would stay gone. It is
+    // also the same property that makes the `-mtime` retention sweep safe to
+    // run against a live tailer.
+    const dir = `${process.env.TMPDIR ?? "/tmp"}/awcms-shiplogs-${crypto.randomUUID()}`;
+    await Bun.$`mkdir -p ${dir}`.quiet();
+
+    const writer = await runWriter(dir, ["first", "second", "third"], 250);
+    const target = `${dir}/app-${todayUtc()}.log`;
+
+    const started = await waitFor(async () =>
+      (
+        await Bun.file(target)
+          .text()
+          .catch(() => "")
+      ).includes("first")
+    );
+    expect(started).toBe(true);
+
+    await Bun.$`rm -f ${target}`.quiet();
+
+    const recreated = await waitFor(async () =>
+      (
+        await Bun.file(target)
+          .text()
+          .catch(() => "")
+      ).includes("third")
+    );
+
+    writer.stop();
+    await writer.exited;
+
+    const finalText = await Bun.file(target)
+      .text()
+      .catch(() => "");
+
+    expect(recreated).toBe(true);
+    // Proof it is a NEW file rather than the original one still open: the line
+    // written before the delete is gone.
+    expect(finalText).not.toContain("first");
+
+    await Bun.$`rm -rf ${dir}`.quiet();
+  });
+
+  test("CONTROL: the redirect form this replaced loses the file", async () => {
+    // Without this, the test above only proves the new writer works — not that
+    // it differs from the old one. Same procedure, the shape that shipped: one
+    // `>>` evaluated by the spawning shell. The descriptor survives the delete;
+    // the path does not come back, and every line after it is written into an
+    // inode nothing can open.
+    const dir = `${process.env.TMPDIR ?? "/tmp"}/awcms-shiplogs-${crypto.randomUUID()}`;
+    await Bun.$`mkdir -p ${dir}`.quiet();
+
+    const target = `${dir}/app-${todayUtc()}.log`;
+
+    // The redirect is applied ONCE, to the whole group — the shape that
+    // shipped. `first` lands, the file is deleted, `third` is written into the
+    // descriptor that is still open on the unlinked inode.
+    const writer = Bun.spawn(
+      [
+        "bash",
+        "-c",
+        `{ printf '%s\\n' first; sleep 0.4; printf '%s\\n' third; } >> "$1"`,
+        "_",
+        target
+      ],
+      { stdout: "pipe", stderr: "pipe" }
+    );
+
+    const started = await waitFor(async () =>
+      (
+        await Bun.file(target)
+          .text()
+          .catch(() => "")
+      ).includes("first")
+    );
+    expect(started).toBe(true);
+
+    await Bun.$`rm -f ${target}`.quiet();
+    await writer.exited;
+
+    // `third` was written after the delete, into the unlinked inode.
+    expect(await Bun.file(target).exists()).toBe(false);
+
+    await Bun.$`rm -rf ${dir}`.quiet();
+  });
+});
+
+describe("D10 — the readiness endpoint has a reader", () => {
+  test("the synthetic check reads it, and checks BOTH fields", async () => {
+    const source = shellCodeOnly(await Bun.file(SYNTHETIC).text());
+
+    expect(source).toContain(READINESS_PATH);
+    // A probe that fetched it and only asserted a 200 would be the liveness
+    // check again under a different URL: this endpoint answers 200 while
+    // reporting the database is gone.
+    expect(source).toContain('"databaseReachable":true');
+    expect(source).toContain('"circuitBreakerState":"open"');
+  });
+
+  test("the three restart/reroute probes still use LIVENESS", async () => {
+    // Deliberate, and the reason is written at each site: they restart or
+    // reroute, and restarting an app does not repair a database. A future
+    // "fix" that points these at readiness turns a database outage into a
+    // container restart loop.
+    // Comment-stripped: both files now EXPLAIN the split, naming the readiness
+    // path in prose. Reading that prose as configuration is the mistake this
+    // assertion exists to avoid making itself.
+    const dockerfile = shellCodeOnly(await Bun.file(DOCKERFILE).text());
+    const vcl = await Bun.file(VCL).text();
+
+    expect(dockerfile).toContain("/api/v1/health");
+    expect(dockerfile).not.toContain(READINESS_PATH);
+    expect(vcl).toContain('.url = "/api/v1/health"');
+  });
+
+  test("the deploy runbook states which endpoint answers which question", async () => {
+    const runbook = await Bun.file("docs/awcms/deploy-coolify.md").text();
+
+    expect(runbook).toContain(READINESS_PATH);
+    expect(runbook).toContain("LIVENESS");
+    expect(runbook).toContain("Do NOT point Coolify's Health Check Path");
+  });
+});


### PR DESCRIPTION
PROJECT_STATE §4 **D9**, **D10**, **D11**. Three unrelated mechanisms, one shape: each produced a signal an operator relies on, and each was wrong in a way nothing reported.

## D9 — the log file was named at attach time

`ops/ship-logs.sh` redirected the tailer with `>> "${DEST}/app-$(date -u +%Y-%m-%d).log"`. A redirect names its file **once**, when the shell spawns the process, and the descriptor then lives until the container changes — weeks on a stable deployment. Two consequences that compound:

- today's lines landed in a file dated by the last **deploy**, so an operator opening `app-2026-08-01.log` to answer "what happened last night" read a file whose name was the one thing about it that was wrong;
- the 30-day `-mtime` sweep could never reclaim it — the file it should have been bounding is the only one still being written. Retention applied to every file except the growing one.

Now a `while read` loop that re-derives the date and reopens with `>>` per line. `printf -v day '%(...)T'` is a bash builtin, so there is no `date` fork per line on a log this script exists to keep all of; `TZ=UTC` inside the payload because `%(...)T` formats in *local* time while the filenames were always UTC.

**The distinguishing property is testable without waiting for midnight.** Delete the file underneath a running writer: one long-lived descriptor keeps writing into the unlinked inode and the path never returns; a per-line `>>` recreates it on the next line. The test executes exactly that, against the payload **extracted from the script** rather than a copy, and carries a CONTROL case driving the old redirect shape through the same procedure — without it the suite would only prove the new writer works, not that it differs.

## D10 — nothing read the readiness endpoint

`/api/v1/database/pool/health` reports `databaseReachable` and `circuitBreakerState`, is equally unauthenticated, and was consulted by nothing. Coolify, the container `HEALTHCHECK` and the Varnish backend probe all read the dependency-free liveness endpoint, so a release with an unreachable database is marked successful and cut over.

**The obvious fix is wrong and was not taken.** All three of those *restart or reroute*, and restarting an app does not repair a database — pointing them at readiness turns a database outage into a container restart loop. Liveness is the correct question for them, and the reasoning is now written at each site so it is not "fixed" later.

What readiness was missing is a reader on the path that pages a person. `ops/synthetic-check.sh` now probes it every 10 minutes from outside — the file whose own header says its job is the question the container healthcheck answers *from inside*, "where every defect this project has actually shipped was invisible". It asserts both fields, because the endpoint answers `200` while reporting the database is gone: a probe that only checked the status code would be the liveness check again under a longer URL.

**Not closed, and it cannot be from here:** Coolify's Health Check Path is configuration in Coolify. The runbook states the split, gives the readiness assertion as a numbered deploy step, and says explicitly not to point Coolify at it — but nothing in this repo can enforce that, and calling it enforced would be the same class of claim as the ≤3-query "measured" in B5.

## D11 — jobs ran as `interactive`, and it was seven scripts, not six

The registry names a work class for every job script and feeds the capacity model. Seven never passed it — `visitor-analytics-purge`, `visitor-analytics-rollup`, `blog-ads-drop-readiness`, `blog-ads-ingest`, `comments-retention` (3 calls), `edge-cache-purge` (3 calls), `tenant-domain-dns-sync` — so their transactions took `withTenant`'s `"interactive"` default and nightly purges queued in the bucket sized for live users. `site-search-reconcile` had the drift running the other way, passing `maintenance` where the registry says `background_sync`; resolved **toward the registry**, whose entry carries an argued rationale where the script's literal carried none.

**The fix that matters is the gate, because otherwise it re-drifts.** `db:work-class:generate` now refuses to run when a script does not open its transactions as its declared class — in both directions. It **counts** rather than checking presence: a script with three calls and one literal reads as declared to any presence check while two of its transactions still run as `interactive`, and two of these scripts have exactly that shape. Proven by reverting one option and watching the gate name the file and the count.

It reads **one file**, the script, and says so: a job whose transactions live in a module under `src/` has no call of its own to inspect, and several registry rationales claim things about those that nothing here verifies. Silence is "not covered", not "correct".

**Both documents asserting jobs never reach `acquireWorkClassSlot` are corrected** — `work-class-registry.ts`'s header and the capacity runbook's "Known limitation". Both were true when written and stayed after they stopped being true; jobs go through `withTenantOrThrow`, which *is* that call. The runbook section is now a description of how the two mechanisms divide (work class decides which queue a job's transactions wait in; the job-runner advisory lock decides how many of the job there are), and the two other documents that linked to it by its old name follow.

## Verification

`bun run check` in full with the documented local splits: every gate green, `DATABASE_URL="" bun run test` **5547 pass / 0 fail**, `bun run build` clean. The new gate and the D9 writer were each proven to FAIL on the pre-fix shape before being accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)