### PR TITLE
fix(tenant-domain,media-library,workflow-approval): three declarations nothing read

### DIFF
--- a/.changeset/declarations-with-no-reader.md
+++ b/.changeset/declarations-with-no-reader.md
@@ -1,0 +1,48 @@
+---
+"awcms": patch
+---
+
+fix(tenant-domain,media-library,workflow-approval): three declarations nothing read
+
+PROJECT_STATE §4 **D7**, **D8**, **D15**. One habit: a value is declared, it
+passes every shape check, and no runtime code reads it — so a gate that verifies
+STRUCTURE reports "present" for something that decides nothing, and the next
+reader takes the declaration as evidence of behaviour. The three resolved
+differently on purpose.
+
+**D7 — deleted, not wired.** `tenant_domain` declared
+`defaults: { defaultVerificationMethod: "manual" }` that nothing read, so every
+domain is created with `verification_method = NULL` and `verify` answers
+`missing_verification_method`. The repair that suggests itself — apply the
+default at creation — is the one that must not be made: `verifyTenantDomain`
+performs no verification of any kind. It checks the column is non-NULL and sets
+`status = 'active'`; there is no DNS lookup anywhere on the route path. A NULL
+`verification_method` is currently the only step between "a tenant created a
+hostname row" and "that hostname is active" in host→tenant resolution, the
+redirect allow-list and the canonical host. The settings block is gone with the
+reasoning in its place, and the test that asserted the default now asserts its
+absence plus the behaviour that must not change.
+
+**D8 — moved from judgement to ledger.** `media_library.enforcement.read`/
+`.enable` were filed as deliberate screening decisions reading "belongs with
+/admin/security, not an object console" — and `/admin/security` carries the MFA
+enforcement level and nothing about media. A relocation nobody performed is not
+a judgement, and filing it as one kept both surfaces off the shrink-only ledger,
+the one list that is supposed to say how much is unbuilt. Now 13 deliberate and
+36 awaiting a screen, where it was 15 and 34.
+
+**D15 — the comments, which is what the finding said the live defect was.** Two
+composition roots explained the missing notification port with "the `email`
+module has not been ported yet"; `email` is live and owns the adapter, whose own
+header says "only a composition root may import this file" while having zero
+importers. The two were each other's alibi. Both are corrected, and the port is
+deliberately still not injected: nothing can reach the path (`startWorkflowInstance`
+has no caller and no route creates an instance), so wiring it would add a second
+declared-and-never-run thing and put an announcement enqueue inside the decision
+transaction with no way to exercise its failure. A test pins the absence so the
+change that gives instance creation a caller has to remove the pin deliberately.
+
+Found while closing D7 and recorded as a new §4 item rather than fixed here:
+**`POST /api/v1/tenant/domains/{id}/verify` verifies nothing.** Closing it needs
+a real verification step plus a decision about what `manual` is allowed to mean,
+which is a security change with an ADR in it — not a settings cleanup.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:398eacb9dee40847b543fa82a46d46329b41b95e9c8e6f428c681fb3eb68151e -->
+<!-- i18n-source-hash: sha256:5fa03b4ade425d540f26dc81faa5b124d4832320b55e44e81ea5cf64db3c71d7 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,38 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **DITEMUKAN SAAT BEKERJA, 22 Agustus 2026 (sambil menutup D7): `POST
+/api/v1/tenant/domains/{id}/verify` TIDAK MEMVERIFIKASI APA PUN.** Ia membaca barisnya,
+  memeriksa `verification_method IS NOT NULL`, lalu menyetel `status = 'active'`. Tidak
+  ada lookup DNS, tidak ada fetch berkas HTTP, tidak ada perbandingan token di mana pun
+  pada jalur rutenya — adapter Cloudflare ada
+  (`tenant-domain/infrastructure/cloudflare-dns-adapter.ts`), dipilih lewat
+  `TENANT_DOMAIN_DNS_PROVIDER`, dan tidak dipanggil siapa pun. Kolom yang menyebut sebuah
+  metode adalah keseluruhan pemeriksaannya.
+
+  **Apa yang dibeli domain aktif.** `resolvePublicTenantByHost` memetakan `Host` sebuah
+  request ke tenant dari `awcms_tenant_domains`; `resolveTenantDomainSet`
+  memperlakukannya sebagai target redirect yang diizinkan; `resolveTenantPrimaryHost`
+  menaruhnya di URL kanonik, feed, dan sitemap. Jadi urutannya: tenant yang memegang
+  `tenant_domain.domains.create` + `.update` + `.verify` menambah sebuah hostname,
+  mem-PATCH `verificationMethod: "manual"`, memanggil verify, dan deployment itu kini akan
+  menjawab untuk hostname tersebut sebagai tenant itu.
+
+  **Dua hal membatasinya, dan tak satu pun adalah kontrolnya.** Pembuatan dan verifikasi
+  digerbangi ABAC, jadi ini jangkauan seorang admin tenant dan bukan jangkauan anonim; dan
+  ia hanya penting untuk hostname yang DNS-nya benar-benar bisa diarahkan seseorang ke
+  deployment ini. Yang kedua bukan properti kode ini — ia properti DNS milik orang lain.
+
+  **Tidak diperbaiki di sini, dengan sengaja.** Perbaikannya adalah langkah verifikasi
+  nyata (menerbitkan record `dns_txt` lalu memeriksanya, atau mengambil berkas well-known)
+  ditambah keputusan tentang apa yang boleh berarti `manual` — masuk akal bila "seorang
+  OPERATOR yang mengatestasi", yang akan menjadikannya aksi ber-scope platform, bukan
+  scope tenant. Itu perubahan keamanan yang mengandung ADR, bukan pembersihan settings,
+  dan melebur keduanya akan menjadi cara yang salah untuk mengambil keputusan itu.
+  Resolusi D7 sendiri dipilih supaya tidak MEMPERBURUK ini: `defaultVerificationMethod`
+  yang tak terbaca dihapus alih-alih diterapkan, karena menerapkannya akan menyerahkan ke
+  setiap domain yang baru dibuat satu-satunya prasyarat yang dimiliki `verify`.
 
 - **DITEMUKAN SAAT BEKERJA, 22 Agustus 2026: `docs:i18n:stamp` bisa MEMBUNGKAM
   `check:docs:translation` pada mirror yang justru sudah SALAH.** Skrip stamp menghitung
@@ -1103,13 +1135,53 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       breaker ia bisa memberi tahu operator masalahnya yang MANA.
 
   28. **D7 — `defaultVerificationMethod: "manual"` yang dideklarasikan `tenant_domain` tidak
-      punya pembaca runtime.** `tenant-domain/module.ts:163`. Validatornya default `null` dan
+      punya pembaca runtime.** **SELESAI (22 Agustus 2026) — diselesaikan dengan MENGHAPUSNYA,
+      bukan dengan menyambungnya.**
+      `tenant-domain/module.ts:163`. Validatornya default `null` dan
       verifikasi menjawab `missing_verification_method` — keadaan `pending_verification` yang
       sudah diamati item 6 §4 di produksi, tanpa menyebut sebab ini.
+
+      **Perbaikan yang tampak jelas justru akan MENGHAPUS sebuah kontrol, jadi tidak
+      dilakukan.** Menerapkan default itu saat pembuatan adalah yang disiratkan bingkai
+      temuan, dan itu salah di sini: `verifyTenantDomain` TIDAK melakukan verifikasi apa
+      pun. Ia memeriksa `verification_method` tidak NULL lalu menyetel `status = 'active'`
+      — tidak ada lookup DNS di mana pun pada jalur rutenya (adapter Cloudflare dipilih
+      lewat `TENANT_DOMAIN_DNS_PROVIDER` dan tidak dipanggil siapa pun). Jadi
+      `verification_method` yang NULL saat ini adalah satu-satunya langkah antara "sebuah
+      tenant membuat baris hostname" dan "hostname itu aktif", dan domain aktif memberi
+      makan resolusi host→tenant, allow-list redirect, dan canonical host.
+
+      Seluruh blok `settings` hilang, dengan penalarannya di tempatnya, dan uji yang dulu
+      mengasersi default itu kini mengasersi ketiadaannya DITAMBAH perilaku yang tidak
+      boleh berubah (pembuatan tetap meninggalkan kolomnya NULL).
+
+      **DITEMUKAN SAAT BEKERJA, dan inilah item yang sebenarnya: `verify` tidak
+      memverifikasi apa pun.** Friksi di atas hanya berjarak satu `PATCH` dari dihapus oleh
+      tenant mana pun yang memegang `domains.update` — setel `verificationMethod:
+"manual"`, panggil verify, dan hostname itu aktif. Apakah itu penting bergantung pada
+      DNS yang tidak dikendalikan siapa pun di sini, dan justru karena itu ia butuh
+      keputusan beralasan, bukan perbaikan diam-diam di dalam pembersihan settings. Dicatat
+      sebagai item BARU di §4, bukan ditutup di sini.
+
   29. **D8 — `media_library.enforcement.*` diarsipkan sebagai KEPUTUSAN penyaringan yang
-      menyebut layar yang tidak mengimplementasikannya.** `admin-screen-coverage-check.ts:91,93`.
+      menyebut layar yang tidak mengimplementasikannya.** **SELESAI (22 Agustus 2026).**
+      `admin-screen-coverage-check.ts:91,93`.
       Relokasi yang tak pernah terjadi tercatat sebagai penilaian, sehingga ledger yang hanya
       boleh menyusut tidak menghitungnya.
+
+      Diverifikasi sebelum dipindahkan: `/admin/security` membawa level enforcement MFA dan
+      sama sekali tidak membawa apa pun soal media. Kedua kunci berpindah dari
+      `DELIBERATELY_UNSCREENED` ke `NOT_YET_SCREENED`, sehingga hitungannya berubah dari "15
+      deliberate, 34 menunggu layar" menjadi "13 deliberate, 36 menunggu layar" — ledger itu
+      seharusnya adalah angka jujur tentang seberapa banyak yang belum dibangun, dan dua
+      permukaan dijauhkan darinya oleh sebuah kalimat. Penalaran tentang DI MANA switch itu
+      seharusnya berada bertahan sebagai catatan pada baris ledger; ia tak pernah salah, ia
+      hanya belum benar.
+
+      `DELIBERATELY_UNSCREENED` kini diekspor, sehingga sebuah uji bisa mengasersi kedua
+      daftar itu tak pernah berbagi kunci. Versi uji yang mentoleransi ekspor yang hilang
+      akan lulus tanpa melakukan apa pun — bentuk yang sama dengan temuan yang dijaganya.
+
   30. **D9 — `ship-logs.sh` menamai berkas keluarannya saat attach dan tidak pernah
       merotasi.** **SELESAI (22 Agustus 2026).**
       `ops/ship-logs.sh:53-57`. `$(date)` diekspansi sekali saat tailer
@@ -1221,9 +1293,27 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       di satu dari tiga salinan `parseInventoryRows`. `scripts/lib/repo-files.ts` kini ada
       dan enam skrip sudah dipindah — ini menyelesaikan pekerjaan yang sudah dimulai.
   36. **D15 — node `notify` workflow diam-diam tidak melakukan apa pun, dan kedua composition
-      root membenarkannya dengan klaim palsu.** `workflow-notification-port-adapter.ts:18`
+      root membenarkannya dengan klaim palsu.** **SELESAI (22 Agustus 2026) — komentarnya,
+      yang memang disebut temuan itu sebagai cacat hidupnya.**
+      `workflow-notification-port-adapter.ts:18`
       nol pengimpor; dua rute menyebut modul `email` "belum di-port" — ia hidup dan memiliki
       adapternya.
+
+      Adapter dan komentar itu saling menjadi alibi: rutenya menjelaskan wiring yang hilang
+      dengan modul yang ada, dan kepala adapternya menyatakan "hanya composition root yang
+      boleh mengimpor berkas ini", yang terbaca seolah ada yang mengimpornya. Keduanya
+      dikoreksi, dan adapternya kini menyatakan tak ada yang mengimpornya.
+
+      **Port-nya sengaja MASIH tidak disuntikkan.** Dipastikan sambil bekerja bahwa jalurnya
+      tak terjangkau — `startWorkflowInstance` tak punya pemanggil dan tak ada rute yang
+      membuat instance (`instances/[id].ts` hanya GET, plus cancel) — jadi menyuntikkannya
+      akan menambah satu lagi hal yang dideklarasikan-dan-tak-pernah-jalan, dan akan
+      menaruh enqueue announcement di dalam transaksi keputusan tanpa cara menguji
+      kegagalannya. Pemicunya dinamai sebagai gantinya: suntikkan pada perubahan yang
+      memberi pembuatan instance seorang pemanggil, tempat node `notify` benar-benar bisa
+      diuji ujung ke ujung. Sebuah uji memaku ketiadaannya supaya perubahan itu harus
+      melepas pakunya dengan sengaja.
+
   37. **D16 — keadaan siklus hidup orphan media tak terjangkau.**
       `media-object-directory.ts:592`. `markNewsMediaObjectOrphaned` satu-satunya penulis
       `status='orphaned'` di repo dan punya nol pemanggil, sehingga sapuan stale-orphan,

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,35 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **FOUND WHILE WORKING, 22 August 2026 (while closing D7): `POST
+/api/v1/tenant/domains/{id}/verify` VERIFIES NOTHING.** It reads the row, checks
+  `verification_method IS NOT NULL`, and sets `status = 'active'`. There is no DNS
+  lookup, no HTTP file fetch, no token comparison anywhere on the route path — the
+  Cloudflare adapter exists (`tenant-domain/infrastructure/cloudflare-dns-adapter.ts`),
+  is selected by `TENANT_DOMAIN_DNS_PROVIDER`, and is called by nothing. The column that
+  names a method is the whole of the check.
+
+  **What an active domain buys.** `resolvePublicTenantByHost` maps a request `Host` to a
+  tenant from `awcms_tenant_domains`; `resolveTenantDomainSet` treats it as a permitted
+  redirect target; `resolveTenantPrimaryHost` puts it in canonical URLs, feeds and
+  sitemaps. So the sequence is: a tenant holding `tenant_domain.domains.create` +
+  `.update` + `.verify` adds a hostname, PATCHes `verificationMethod: "manual"`, calls
+  verify, and the deployment will now answer for that hostname as that tenant.
+
+  **Two things bound it, and neither is the control.** Creation and verification are
+  ABAC-guarded, so this is a tenant admin's reach and not an anonymous one; and it only
+  matters for a hostname whose DNS someone can actually point at this deployment. The
+  second is not a property of this code — it is a property of somebody else's DNS.
+
+  **Not fixed here, deliberately.** The fix is a real verification step (publish a
+  `dns_txt` record and check it, or fetch a well-known file) plus a decision about what
+  `manual` is allowed to mean — plausibly "an OPERATOR attests", which would make it a
+  platform-scoped action rather than a tenant one. That is a security change with an ADR
+  in it, not a settings cleanup, and bundling it into one would have been the wrong way
+  to make that decision. D7's own resolution was chosen to avoid making this WORSE: the
+  unread `defaultVerificationMethod` was deleted rather than applied, because applying it
+  would have handed every newly created domain the only precondition `verify` has.
+
 - **FOUND WHILE WORKING, 22 August 2026: `docs:i18n:stamp` can silence
   `check:docs:translation` on a mirror that is now WRONG.** The stamp script re-hashes
   every English source into its mirror's `i18n-source-hash` marker. Its own output warns
@@ -1104,13 +1133,50 @@ busy)` clause, gated on the permanently-zero counter, could never print.
       operator WHICH problem it is.
 
   28. **D7 — `tenant_domain`'s declared `defaultVerificationMethod: "manual"` has no runtime
-      reader.** `tenant-domain/module.ts:163`. The validator defaults to `null` and
+      reader.** **DONE (22 August 2026) — resolved by DELETING it, not by wiring it.**
+      `tenant-domain/module.ts:163`. The validator defaults to `null` and
       verification answers `missing_verification_method` — the `pending_verification` state
       §4 item 6 already observes in production, without naming this cause.
+
+      **The obvious repair would have removed a control, so it was not made.**
+      Applying the default at creation is what the finding's framing suggests, and it is
+      wrong here: `verifyTenantDomain` performs NO verification of any kind. It checks
+      that `verification_method` is non-NULL and sets `status = 'active'` — no DNS lookup
+      exists anywhere on the route path (the Cloudflare adapter is selected by
+      `TENANT_DOMAIN_DNS_PROVIDER` and is called by nothing). So a NULL
+      `verification_method` is currently the only step between "a tenant created a
+      hostname row" and "that hostname is active", and an active domain feeds
+      host→tenant resolution, the redirect allow-list and the canonical host.
+
+      The whole `settings` block is gone, with the reasoning in its place, and the test
+      that used to assert the default now asserts its absence PLUS the behaviour that
+      must not change (creation still leaves the column NULL).
+
+      **FOUND WHILE WORKING, and it is the real item: `verify` verifies nothing.** The
+      friction above is one `PATCH` away from being removed by any tenant with
+      `domains.update` — set `verificationMethod: "manual"`, call verify, and the
+      hostname is active. Whether that matters depends on DNS nobody here controls, which
+      is exactly why it needs an argued decision rather than a quiet fix inside a
+      settings cleanup. Recorded as a NEW item below rather than closed here.
+
   29. **D8 — `media_library.enforcement.*` is filed as a screening DECISION naming a screen
-      that does not implement it.** `admin-screen-coverage-check.ts:91,93`. A relocation
+      that does not implement it.** **DONE (22 August 2026).**
+      `admin-screen-coverage-check.ts:91,93`. A relocation
       that never happened is recorded as judgement, so the shrink-only ledger does not
       count it.
+
+      Verified before moving: `/admin/security` carries the MFA enforcement level and
+      nothing about media at all. Both keys moved from `DELIBERATELY_UNSCREENED` to
+      `NOT_YET_SCREENED`, so the count went from "15 deliberate, 34 awaiting a screen" to
+      "13 deliberate, 36 awaiting a screen" — the ledger is supposed to be the honest
+      number for how much is unbuilt, and two surfaces were being kept off it by a
+      sentence. The reasoning about WHERE the switch belongs survives as a note on the
+      ledger line; it was never wrong, it was just not yet true.
+
+      `DELIBERATELY_UNSCREENED` is now exported, so a test can assert the two lists never
+      share a key. A version of that test which tolerated the missing export would have
+      passed by doing nothing — the same shape as the finding it guards.
+
   30. **D9 — `ship-logs.sh` names its output file at attach time and never rotates.**
       **DONE (22 August 2026).**
       `ops/ship-logs.sh:53-57`. `$(date)` is expanded once when the tailer is spawned and
@@ -1219,10 +1285,27 @@ busy)` clause, gated on the permanently-zero counter, could never print.
       one of six migration loaders. `scripts/lib/repo-files.ts` now exists and six scripts
       are migrated — this is finishing a started job.
   36. **D15 — workflow `notify` nodes silently do nothing, and both composition roots
-      justify it with a false claim.** `workflow-notification-port-adapter.ts:18` has zero
+      justify it with a false claim.** **DONE (22 August 2026) — the comments, which is
+      what the finding said the live defect was.**
+      `workflow-notification-port-adapter.ts:18` has zero
       importers; two routes say the `email` module "has not been ported yet" — it is live
       and owns the adapter. Unreachable today (`startWorkflowInstance` has no caller), so
       the live defect is the two misleading comments.
+
+      The adapter and the comments were each other's alibi: the routes explained the
+      missing wiring with a module that exists, and the adapter's header said "only a
+      composition root may import this file", which reads as though one does. Both are
+      corrected, and the adapter now states that nothing imports it.
+
+      **The port is deliberately still NOT injected.** Confirmed while working that
+      nothing can reach the path — `startWorkflowInstance` has no caller and no route
+      creates an instance (`instances/[id].ts` is GET, plus a cancel) — so injecting it
+      would add a second declared-and-never-run thing, and would put an announcement
+      enqueue inside the decision transaction with no way to exercise its failure. The
+      trigger is named instead: inject it in the change that gives instance creation a
+      caller, where a `notify` node can actually be tested end to end. A test pins the
+      absence so that change has to remove the pin deliberately.
+
   37. **D16 — the media orphan lifecycle state is unreachable.**
       `media-object-directory.ts:592`. `markNewsMediaObjectOrphaned` is the repo's only
       writer of `status='orphaned'` and has zero callers, so the stale-orphan sweep, its

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 458   |
+| Test files                          | 459   |
 | Route files                         | 382   |
 | ADR                                 | 212   |
 
@@ -356,7 +356,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 386        |
+| `(root)`      | 387        |
 | `e2e`         | 12         |
 | `integration` | 59         |
 | `unit`        | 1          |

--- a/scripts/admin-screen-coverage-check.ts
+++ b/scripts/admin-screen-coverage-check.ts
@@ -57,7 +57,7 @@ const SCREEN_GLOB = "src/pages/admin/**/*.astro";
  * not drive this from a page", and the next reader can disagree with a sentence
  * rather than with silence.
  */
-const DELIBERATELY_UNSCREENED: Readonly<Record<string, string>> = {
+export const DELIBERATELY_UNSCREENED: Readonly<Record<string, string>> = {
   // Six permissions, one decision: authoring a node/transition graph needs a
   // real editor, and a JSON textarea that accepts a malformed graph until
   // `publish` rejects it is a worse affordance than none.
@@ -92,13 +92,15 @@ const DELIBERATELY_UNSCREENED: Readonly<Record<string, string>> = {
   "media_library.media.cancel":
     "three-step upload; only the uploading client knows what to cancel",
 
-  // A ONE-WAY tenant policy switch, not an action on an object — it belongs
-  // with the other posture switches on `/admin/security`, not in an object
-  // console. Deliberately no `enforcement.disable` exists at all.
-  "media_library.enforcement.read":
-    "tenant posture switch; belongs with /admin/security, not an object console",
-  "media_library.enforcement.enable":
-    "tenant posture switch, one-way; belongs with /admin/security",
+  // `media_library.enforcement.read`/`.enable` USED to sit here, on the
+  // reasoning that a one-way tenant posture switch "belongs with the other
+  // posture switches on /admin/security, not in an object console". Finding D8:
+  // that sentence describes a RELOCATION THAT NEVER HAPPENED. `/admin/security`
+  // carries the MFA enforcement level and nothing about media at all, so the
+  // entry recorded a screen that does not implement it as a settled judgement —
+  // and a decision is exempt from the shrink-only ledger, so the surface stopped
+  // being counted as work not done. Moved to `NOT_YET_SCREENED`; the reasoning
+  // about WHERE it belongs survives there, as a note about the screen to build.
 
   // The admin post list has its own search, which tolerates an empty query;
   // the public search endpoint does not, and wiring the screen to it would make

--- a/scripts/admin-screen-coverage-ledger.ts
+++ b/scripts/admin-screen-coverage-ledger.ts
@@ -71,6 +71,18 @@ export const NOT_YET_SCREENED: readonly string[] = [
   "identity_access.sso_providers.delete",
   "identity_access.sso_providers.update",
 
+  // media_library (2) — finding D8. These were filed as DECISIONS
+  // ("belongs with /admin/security, not an object console") until 22 August
+  // 2026, and `/admin/security` implements the MFA enforcement level and
+  // nothing about media. A relocation nobody performed is not a judgement, and
+  // filing it as one kept the surface off this list — the one list that is
+  // supposed to say how much is unbuilt. The reasoning about WHERE it belongs
+  // still holds: a one-way tenant posture switch sits with the other posture
+  // switches, not in an object console. There is deliberately no
+  // `enforcement.disable` permission to screen at all.
+  "media_library.enforcement.enable",
+  "media_library.enforcement.read",
+
   // module_management (6)
   "module_management.health.check",
   "module_management.health.read",

--- a/src/modules/email/application/workflow-notification-port-adapter.ts
+++ b/src/modules/email/application/workflow-notification-port-adapter.ts
@@ -8,6 +8,20 @@
  * Only a composition root (a `src/pages/api/v1/workflows/**` route, or
  * `scripts/workflow-escalations-dispatch.ts`) may import this file —
  * never `workflow-approval/application/**`/`domain/**`.
+ *
+ * ## NOTHING IMPORTS IT TODAY (finding D15)
+ *
+ * Zero importers, and the two composition roots that would inject it carried a
+ * comment saying the `email` module "has not been ported yet" — so the adapter
+ * and the comment were each other's alibi, and `notify` nodes silently did
+ * nothing while every file involved appeared to explain why.
+ *
+ * The comments are corrected; the injection is deliberately still not done.
+ * Nothing can reach the path: `startWorkflowInstance` has no caller and no
+ * route creates a workflow instance, so no task exists to decide on. This file
+ * is kept rather than deleted because it is the correct wiring for the change
+ * that gives instance creation a caller — at which point injecting it, and
+ * testing that a `notify` node actually enqueues, belong together.
  */
 import { enqueueAnnouncement } from "./announcement-directory";
 import type {

--- a/src/modules/tenant-domain/module.ts
+++ b/src/modules/tenant-domain/module.ts
@@ -150,16 +150,29 @@ export const tenantDomainModule = defineModule({
       action: "set_primary",
       description: "Set a tenant domain as the active primary domain"
     }
-  ],
-  settings: {
-    schemaVersion: 1,
-    // Non-secret operational preference only: the default domain verification
-    // mode is manual DNS attestation, never an automatic provider. "manual"
-    // means no automated check at all is assumed until a tenant/operator
-    // explicitly picks one of the other `verification_method` values. The
-    // optional Cloudflare adapter is selected purely via the
-    // `TENANT_DOMAIN_DNS_PROVIDER` env var (not this settings object, and not
-    // wired into any route yet) — it never defaults this value away from manual.
-    defaults: { defaultVerificationMethod: "manual" }
-  }
+  ]
+  // NO `settings` BLOCK, and its absence is the decision — finding D7.
+  //
+  // This declared `defaults: { defaultVerificationMethod: "manual" }`, and
+  // NOTHING read it: `validateCreateTenantDomainInput` defaults the field to
+  // `null`, so every domain is created with `verification_method = NULL` and
+  // `POST …/domains/{id}/verify` answers `missing_verification_method`. That is
+  // the `pending_verification` state §4 item 6 observes in production, and the
+  // obvious repair is to have creation apply this default.
+  //
+  // **Do not do that.** `verifyTenantDomain` performs no verification of any
+  // kind — it checks that `verification_method` is non-NULL and then sets
+  // `status = 'active'`. There is no DNS lookup anywhere on the route path (the
+  // Cloudflare adapter is selected by `TENANT_DOMAIN_DNS_PROVIDER` and is
+  // called by nothing). So a NULL `verification_method` is currently the only
+  // thing standing between "a tenant created a hostname row" and "that hostname
+  // is active", and an active domain feeds host->tenant resolution, the
+  // redirect allow-list and the canonical host. Applying a default here would
+  // remove that step for every domain at creation.
+  //
+  // A setting whose only honest use would weaken a control does not belong in
+  // the descriptor pretending to be configuration. Deleted rather than left to
+  // read as a preference somebody had chosen. The real gap — that `verify`
+  // verifies nothing — is recorded as its own §4 item, because closing it is a
+  // security change and not a settings edit.
 });

--- a/src/pages/api/v1/workflows/tasks/[id]/decisions.ts
+++ b/src/pages/api/v1/workflows/tasks/[id]/decisions.ts
@@ -31,10 +31,23 @@ import {
 
 const GUARD_ACTIVITY = { moduleKey: "workflow", activityCode: "approval" };
 const IDEMPOTENCY_SCOPE = "workflow_task_decision";
-// No notification port is wired in this base — the `email` module (which
-// owns the concrete WorkflowNotificationPort adapter in awcms-mini) has not
-// been ported yet, so `notify` graph nodes silently no-op (they always
-// advance to `next` regardless). Inject an adapter here once `email` lands.
+// No notification port is injected here, so `notify` graph nodes advance to
+// `next` without sending anything.
+//
+// This comment used to say the reason was that "the `email` module has not been
+// ported yet". **That is false and has been for some time** (finding D15):
+// `email` is a live module in this repo and it OWNS the concrete adapter,
+// `src/modules/email/application/workflow-notification-port-adapter.ts` — which
+// has zero importers, so the adapter and the comment were each other's alibi.
+//
+// It is still not injected, and that is now a decision rather than an
+// oversight. Nothing can reach this path: `startWorkflowInstance` has no
+// caller and no route creates an instance, so no task exists to decide on.
+// Wiring a port into an unreachable path would add a second thing that is
+// declared and never runs — and it would put an announcement enqueue inside
+// the decision transaction with no way to exercise the failure. Inject it in
+// the same change that gives instance creation a caller, where the wiring can
+// actually be tested.
 
 /**
  * `POST /api/v1/workflows/tasks/{id}/decisions` (Issue 11.1, evolved by

--- a/src/pages/api/v1/workflows/tasks/[id]/force-decision.ts
+++ b/src/pages/api/v1/workflows/tasks/[id]/force-decision.ts
@@ -35,8 +35,9 @@ const FORCE_DECIDE_GUARD = {
   action: "force_decide" as const
 };
 const IDEMPOTENCY_SCOPE = "workflow_task_force_decision";
-// No notification port is wired in this base — see decisions.ts for why the
-// `email`-owned WorkflowNotificationPort adapter is not injected yet.
+// No notification port is injected here — see decisions.ts. (That note used to
+// say `email` "has not been ported yet"; it is live and owns the adapter. The
+// real reason is that nothing can reach this path yet — finding D15.)
 
 type ForceDecisionRequestBody = { decision?: unknown; reason?: unknown };
 

--- a/tests/declarations-with-no-reader.test.ts
+++ b/tests/declarations-with-no-reader.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Three declarations nothing read — findings D7, D8 and D15 of the 17 August
+ * 2026 audit round.
+ *
+ * They are one file because they are one habit, and this repository already
+ * keeps a memory of it: a field is declared, it passes every shape check, and
+ * no runtime code ever reads it. The shape check is what makes it durable — a
+ * registry gate that verifies STRUCTURE reports "present" for a value that
+ * decides nothing, and the next reader takes the declaration as evidence of
+ * behaviour.
+ *
+ * Each of the three resolved differently, and the difference is the point:
+ *
+ * - **D7** — the unread setting was DELETED, because the only way to make it
+ *   read would weaken a control. Asserted as an absence, plus the behaviour
+ *   that must not change.
+ * - **D8** — the unscreened permission was moved from a register of DECISIONS
+ *   to the shrink-only ledger of work not done. Asserted as membership, in
+ *   both directions.
+ * - **D15** — the port stays unwired, and the two comments that explained the
+ *   wiring with a false fact are corrected. Asserted as source, because the
+ *   defect WAS the prose.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/lib/source-text";
+import { DELIBERATELY_UNSCREENED } from "../scripts/admin-screen-coverage-check";
+import { NOT_YET_SCREENED } from "../scripts/admin-screen-coverage-ledger";
+import { tenantDomainModule } from "../src/modules/tenant-domain/module";
+
+const DECISIONS_ROUTE = "src/pages/api/v1/workflows/tasks/[id]/decisions.ts";
+const FORCE_DECISION_ROUTE =
+  "src/pages/api/v1/workflows/tasks/[id]/force-decision.ts";
+const COVERAGE_CHECK = "scripts/admin-screen-coverage-check.ts";
+const ADAPTER =
+  "src/modules/email/application/workflow-notification-port-adapter.ts";
+
+describe("D7 — tenant_domain declares no setting nothing reads", () => {
+  test("the descriptor carries no settings block at all", () => {
+    expect(tenantDomainModule.settings).toBeUndefined();
+  });
+
+  test("verifyTenantDomain still requires a verification_method to exist", async () => {
+    // The reason the default was deleted rather than applied. `verify` does no
+    // DNS lookup of any kind — it checks this column is non-NULL and sets
+    // `status = 'active'`, and an active domain feeds host->tenant resolution.
+    // A default applied at creation would hand every new row the only
+    // precondition there is.
+    const source = stripComments(
+      await Bun.file(
+        "src/modules/tenant-domain/application/tenant-domain-directory.ts"
+      ).text()
+    );
+
+    expect(source).toContain(
+      'return { outcome: "missing_verification_method" }'
+    );
+  });
+
+  test("no code path applies a default verification method", async () => {
+    const validation = stripComments(
+      await Bun.file(
+        "src/modules/tenant-domain/domain/tenant-domain-validation.ts"
+      ).text()
+    );
+    const directory = stripComments(
+      await Bun.file(
+        "src/modules/tenant-domain/application/tenant-domain-directory.ts"
+      ).text()
+    );
+
+    // Neither layer may reach for the module settings to fill the column in.
+    expect(validation).not.toContain("defaultVerificationMethod");
+    expect(directory).not.toContain("defaultVerificationMethod");
+    expect(directory).not.toContain("fetchModuleSettingsView");
+  });
+});
+
+describe("D8 — an unscreened permission is counted as unbuilt, not as a judgement", () => {
+  test("both enforcement keys are on the shrink-only ledger", () => {
+    expect(NOT_YET_SCREENED).toContain("media_library.enforcement.read");
+    expect(NOT_YET_SCREENED).toContain("media_library.enforcement.enable");
+  });
+
+  test("neither is still filed as a deliberate decision", async () => {
+    // Comment-stripped: the check file now EXPLAINS the move by quoting the old
+    // entries. Reading that explanation as a live entry is the mistake this
+    // assertion would otherwise make.
+    const source = stripComments(await Bun.file(COVERAGE_CHECK).text());
+
+    expect(source).not.toContain('"media_library.enforcement.read":');
+    expect(source).not.toContain('"media_library.enforcement.enable":');
+  });
+
+  test("no key is both a decision and a ledger line", () => {
+    // The two lists mean opposite things; an entry in both would let unfinished
+    // work keep the appearance of judgement, which is the failure D8 is. The
+    // register is exported for this — a version of this test that tolerated a
+    // missing export would pass by doing nothing, which is the same shape as
+    // the finding.
+    expect(Object.keys(DELIBERATELY_UNSCREENED).length).toBeGreaterThan(0);
+
+    for (const key of NOT_YET_SCREENED) {
+      expect(key in DELIBERATELY_UNSCREENED, `${key} is on both lists`).toBe(
+        false
+      );
+    }
+  });
+});
+
+describe("D15 — the workflow notification port, and two comments that were false", () => {
+  test("neither route still claims the email module is unported", async () => {
+    const decisions = await Bun.file(DECISIONS_ROUTE).text();
+    const force = await Bun.file(FORCE_DECISION_ROUTE).text();
+
+    // `email` is live and owns the adapter. The claim was true under the
+    // original port and stayed after it stopped being true.
+    expect(decisions).not.toContain("has not\n// been ported yet");
+    expect(decisions).toContain("`email` is a live module in this repo");
+    expect(force).toContain("it is live and owns the adapter");
+  });
+
+  test("the adapter's own docblock says it has no importers", async () => {
+    const adapter = await Bun.file(ADAPTER).text();
+
+    // Its header says "only a composition root may import this file", which
+    // reads as though one does. It now states that none does, and why.
+    expect(adapter).toContain("NOTHING IMPORTS IT TODAY");
+  });
+
+  test("the port is still not injected, and the path is still unreachable", async () => {
+    const decisions = stripComments(await Bun.file(DECISIONS_ROUTE).text());
+    const force = stripComments(await Bun.file(FORCE_DECISION_ROUTE).text());
+
+    // If a future change injects it, this test should fail and be deleted in
+    // the same commit that gives instance creation a caller — the two belong
+    // together, which is the whole argument for not doing it here.
+    expect(decisions).not.toContain("createEmailWorkflowNotificationAdapter");
+    expect(force).not.toContain("createEmailWorkflowNotificationAdapter");
+  });
+});

--- a/tests/tenant-domain-module.test.ts
+++ b/tests/tenant-domain-module.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 
 import { getModuleByKey, listModules } from "../src/modules";
 import { tenantDomainModule } from "../src/modules/tenant-domain/module";
+import { validateCreateTenantDomainInput } from "../src/modules/tenant-domain/domain/tenant-domain-validation";
 
 // The six permissions seeded by sql/047_awcms_tenant_domain_permissions.sql,
 // verbatim. The descriptor's `permissions` array must match this list exactly
@@ -94,29 +95,27 @@ describe("tenant_domain module descriptor (ported from awcms-micro)", () => {
     ]);
   });
 
-  test("settings.defaults only sets manual DNS verification mode", () => {
-    expect(tenantDomainModule.settings?.defaults).toEqual({
-      defaultVerificationMethod: "manual"
-    });
+  test("the module declares NO settings, and that is the decision (D7)", () => {
+    // It used to declare `defaults: { defaultVerificationMethod: "manual" }`
+    // that nothing read. The repair that suggests itself — apply it when a
+    // domain is created — is the one that must not be taken: `verify` performs
+    // no verification at all, so a NULL `verification_method` is currently the
+    // only step between "a tenant created a hostname row" and "that hostname is
+    // active" in host->tenant resolution. See the comment in `module.ts`.
+    expect(tenantDomainModule.settings).toBeUndefined();
   });
 
-  test("settings.defaults never contains a secret-shaped key or value", () => {
-    const defaults = tenantDomainModule.settings?.defaults ?? {};
-    const serialized = JSON.stringify(defaults).toLowerCase();
+  test("nothing applies a default verification method at creation", () => {
+    // The behavioural half of the above, and the half that would actually
+    // regress: a future edit that defaults the column on the create path leaves
+    // this test as the thing that says why not.
+    const validation = validateCreateTenantDomainInput({
+      hostname: "example.test",
+      domainType: "custom_domain"
+    });
 
-    for (const forbidden of [
-      "password",
-      "token",
-      "secret",
-      "credential",
-      "apikey",
-      "api_key"
-    ]) {
-      expect(serialized).not.toContain(forbidden);
-    }
-
-    expect(defaults).not.toHaveProperty("provider");
-    expect(defaults).not.toHaveProperty("cloudflareApiToken");
+    expect(validation.valid).toBe(true);
+    expect(validation.valid && validation.value.verificationMethod).toBeNull();
   });
 
   test("the DNS sync job is declared, with a schedule an operator can act on", () => {


### PR DESCRIPTION
PROJECT_STATE §4 **D7**, **D8**, **D15**. One habit: a value is declared, it passes every shape check, and no runtime code reads it — so a gate that verifies *structure* reports "present" for something that decides nothing, and the next reader takes the declaration as evidence of behaviour. The three resolved differently, and the difference is the substance.

## D7 — deleted, not wired

`tenant_domain` declared `defaults: { defaultVerificationMethod: "manual" }` and nothing read it, so every domain is created with `verification_method = NULL` and `POST …/verify` answers `missing_verification_method` — the `pending_verification` state §4 already observes in production.

The repair the finding's framing suggests — apply the default at creation — **is the one that must not be made.** `verifyTenantDomain` performs no verification of any kind: it checks the column is non-NULL and sets `status = 'active'`. There is no DNS lookup anywhere on the route path (the Cloudflare adapter is selected by `TENANT_DOMAIN_DNS_PROVIDER` and is called by nothing). So a NULL `verification_method` is currently the only step between "a tenant created a hostname row" and "that hostname is active", and an active domain feeds host→tenant resolution, the redirect allow-list and the canonical host.

The settings block is gone with the reasoning in its place. The test that asserted the default now asserts its absence **plus** the behaviour that must not change — creation still leaves the column NULL.

## D8 — moved from judgement to ledger

`media_library.enforcement.read`/`.enable` sat in `DELIBERATELY_UNSCREENED` reading *"belongs with /admin/security, not an object console"*. Verified before moving: `/admin/security` carries the MFA enforcement level and nothing about media at all. A relocation nobody performed is not a judgement, and filing it as one kept both surfaces off the shrink-only ledger — the one list that is supposed to be the honest number for how much is unbuilt.

Both keys moved to `NOT_YET_SCREENED`: **13 deliberate / 36 awaiting a screen**, where it was 15 / 34. The reasoning about *where* the switch belongs survives as a note on the ledger line; it was never wrong, it was just not yet true.

`DELIBERATELY_UNSCREENED` is now exported so a test can assert the two lists never share a key — a version of that test which tolerated a missing export would pass by doing nothing, which is the same shape as the finding.

## D15 — the comments, which is what the finding said the live defect was

Two composition roots explained the missing notification port with *"the `email` module … has not been ported yet"*. `email` is live and **owns** the adapter — whose own header says "only a composition root may import this file" while having zero importers. The adapter and the comments were each other's alibi.

Both are corrected, and the adapter now states that nothing imports it. **The port is deliberately still not injected.** Confirmed while working that nothing can reach the path: `startWorkflowInstance` has no caller and no route creates an instance (`instances/[id].ts` is GET, plus a cancel). Injecting it would add a second declared-and-never-run thing, and would put an announcement enqueue inside the decision transaction with no way to exercise its failure. The trigger is named instead — inject it in the change that gives instance creation a caller, where a `notify` node can be tested end to end. A test pins the absence so that change has to remove the pin deliberately.

## Found while working — recorded, not fixed

**`POST /api/v1/tenant/domains/{id}/verify` verifies nothing.** The sequence is: a tenant holding `domains.create` + `.update` + `.verify` adds a hostname, PATCHes `verificationMethod: "manual"`, calls verify, and the deployment answers for that hostname as that tenant. Two things bound it and neither is the control — the surface is ABAC-guarded so this is a tenant admin's reach and not an anonymous one, and it only matters for a hostname whose DNS someone can point here, which is a property of somebody else's DNS rather than of this code.

Not fixed in this PR on purpose: the fix is a real verification step plus a decision about what `manual` is allowed to mean (plausibly "an *operator* attests", which would make it platform-scoped rather than tenant-scoped). That is a security change with an ADR in it, and bundling it into a settings cleanup would be the wrong way to take that decision. D7's resolution was chosen specifically to avoid making it worse. Recorded as a new §4 item, in both mirrors.

## Verification

`bun run check` in full with the documented local splits: every gate green, `DATABASE_URL="" bun run test` **5556 pass / 0 fail**, `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)