### PR TITLE
fix(media-library,blog-content,docs): two surfaces that answered nobody

### DIFF
--- a/.changeset/three-duplications-with-a-real-cost.md
+++ b/.changeset/three-duplications-with-a-real-cost.md
@@ -29,7 +29,17 @@ deliberately not folded in — two are GET reads, and
 `data.subscription.endpointMasked`, which is exactly what the narrow shape
 exists to withhold.
 
-**Recovers 425 B of the client asset budget**, which had 161 B left.
+**It recovers no client bytes, and the claim that it would was wrong.** Both
+files were already shared chunks shipped once each, so "three copies of the
+bytes" was never true — three copies of the SOURCE shipped once. The 425 B
+"saving" measured during the work came from a `dist/` the build had not cleaned;
+clean builds either side of this change are byte-identical. `bun run build` now
+runs `rm -rf dist` first so the number cannot come from a tree the build did not
+produce — the budget script's own docblock had already recorded being misled
+this way twice.
+
+What the change is worth stands on the drift, the dead wrapper and the silent
+header disagreement, which is what the finding was actually about.
 
 **D13 — one timestamp expression, not twenty-one.** `KEYSET_CURSOR_CREATED_AT_SQL`
 hardcoded a bare `created_at` while its own docblock told callers to "wrap it in

--- a/.changeset/two-surfaces-that-answered-nobody.md
+++ b/.changeset/two-surfaces-that-answered-nobody.md
@@ -1,0 +1,79 @@
+---
+"awcms": minor
+---
+
+fix(media-library,blog-content,docs): two surfaces that answered nobody, and a gate that answered wrongly
+
+PROJECT_STATE §4 **D16**, **D17**, and the `docs:i18n:stamp` item found while
+working. The two media findings are opposites: one was a whole branch nothing
+could reach, the other a surface that answered with something unusable.
+
+**D16 — the orphan lifecycle is deleted, the schema is kept.**
+`markNewsMediaObjectOrphaned` was this repo's only writer of
+`status = 'orphaned'` and had zero callers, so the reconciliation job's
+stale-orphan sweep, its partial index and the grace-period comparison all gated
+a permanently empty set — and every run printed
+`staleOrphaned(total=0,deleted=0,deferred=0)`, which reads exactly like a clean
+bucket. It is a leftover of the pre-ADR-0036 model: `sql/087` removed the
+attach/detach relation, so no reference count exists to derive "orphaned" FROM.
+
+Gone: the writer, `markStaleOrphanedNewsMediaObjectDeleted`, the
+`cleanupStaleOrphaned` path (whose docblock reasoned carefully about a race that
+could not occur), the `staleOrphaned` category and the job's three counters.
+
+**`NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` is NOT deleted with them.** It looked dead
+and is not — `orphanInR2`, an R2 object with no DB row at all, genuinely uses it
+to decide when physical deletion is safe. Removing it would have taken out a
+live control.
+
+Kept, per the decision to delete the code and not the schema: the `'orphaned'`
+value in `sql/041`'s CHECK, `orphaned_at`, its partial index, and both status
+filters (the admin screen's and the API's — they are reads over a column that
+can still hold the value, and dropping one would leave two surfaces disagreeing).
+`isNewsMediaObjectSafeForPublicReference` still refuses the status, so a row that
+reached it by hand stays out of public references.
+
+**D17 — an ad row a renderer can actually use.** `GET /api/v1/news-portal/ad-placements`
+returned `mediaObjectId` and nothing else, so an external renderer could neither
+build an `<img src>` nor reproduce the media-safety filter. Three fields are
+added to `AdPlacementItem`, all required: `mediaPublicUrl`, `mediaAltText`, and
+`mediaPubliclyReferenceable`.
+
+The last is the point. It is the SERVER's verdict, not a status to interpret:
+`isNewsMediaObjectSafeForPublicReference` turns on which lifecycle states count
+as verified, and a consumer reimplementing it gets that wrong in the permissive
+direction — which publishes an unverified image. `false` also covers a
+soft-deleted object, so a consumer checking only this field cannot render one.
+
+Resolved in the same query on every path — a `LEFT JOIN` with the media
+predicate in the `ON` clause, so a placement whose object was soft-deleted still
+appears in the admin list rather than vanishing from the one screen that could
+repair it, and a data-modifying CTE on create/update so a freshly created ad is
+not reported as unreferenceable. No N+1, no second endpoint. `/admin/blog-ads`
+now says whether the attached image will actually be shown.
+
+**The client asset budget could be measured against a `dist/` the build had not
+cleaned, and it was.** `bun run build` now runs `rm -rf dist` first.
+`client-asset-budget.ts`'s own docblock already recorded being misled this way
+twice; it happened a third time on 22 August 2026, producing a phantom 425 B
+"saving" for D12 that sent a whole PR down the wrong road. The claim is
+corrected in the D12 changeset and in PROJECT_STATE §4. A gate that documents
+its own hazard will mislead somebody again, so the hazard is removed instead.
+
+**`docs:i18n:stamp` no longer declares a mirror current that nobody
+re-translated.** Re-writing the marker is a claim about the translation, and the
+tool made it unconditionally — so "edit the English, run the stamp" turned
+`check:docs:translation` green over a mirror that still said the old thing. That
+happened for real (a §2 count went 141 → 142 while the mirror still read 141) and
+was caught only by a test that checks `sql/NNN` ranges for a different reason.
+
+When a mirror's recorded hash is stale, re-stamping is now allowed only when the
+mirror itself is modified in the working tree, or the source changed only in
+whitespace since `HEAD` — the reflow case the tool exists for. Otherwise it
+refuses, names the file, and exits 1. `--force-restamp` is the deliberate
+override. Verified against all three cases.
+
+It immediately surfaced pre-existing drift it had been papering over: §2 of the
+Indonesian `PROJECT_STATE` said ADR `0000–0103` while the English source said
+`0000–0106`. §2 is generated into the English file ONLY, so its mirror is
+hand-maintained and had silently fallen three ADRs behind. Corrected here.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:f409ae4afc890ef28f4da83b2f1c1c313b60585cfcb7d6b127247d33d7605859 -->
+<!-- i18n-source-hash: sha256:b8eb296f4ffb75a7e41e314556954c5c8f76fedd35aefbd52c4e040f5a45565f -->
 
 # AWCMS — Project State & Continuation
 
@@ -114,7 +114,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Migrasi                            | **145** (`sql/001`–`145`)                                                             | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0106** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **48** berkas `.astro` di `src/pages/admin/`; **0 dari 24** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| Berkas `.astro`                    | **61** (34.712 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
+| Berkas `.astro`                    | **61** (34.728 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
 | Gerbang                            | **57** di rantai `bun run check`                                                      | `scripts.check` di `package.json`, dipisah pada `&&`                                    |
 | Kontrak                            | OpenAPI modular per-modul + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -393,27 +393,24 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   setiap domain yang baru dibuat satu-satunya prasyarat yang dimiliki `verify`.
 
 - **DITEMUKAN SAAT BEKERJA, 22 Agustus 2026: `docs:i18n:stamp` bisa MEMBUNGKAM
-  `check:docs:translation` pada mirror yang justru sudah SALAH.** Skrip stamp menghitung
-  ulang hash setiap sumber Inggris ke penanda `i18n-source-hash` mirrornya. Keluarannya
-  sendiri memperingatkan kasus yang menjadi alasan ia dibuat — `bun run format` menyentuh
-  sumber lalu hashnya basi tanpa alasan editorial — dan berkata "FORMAT DULU, BARU STAMP".
-  Yang TIDAK bisa ia bedakan adalah sumber yang ISINYA berubah. Menjalankannya setelah
-  menyunting dokumen Inggris menstempel ulang penandanya dan gerbang terjemahan menjadi
-  hijau padahal mirror Indonesianya masih mengatakan hal yang lama.
+  `check:docs:translation` pada mirror yang kini SALAH.** **SELESAI (22 Agustus 2026).**
+  Skrip stamp me-rehash setiap sumber Inggris ke penanda `i18n-source-hash` mirror-nya,
+  dan ia melakukannya tanpa syarat — sehingga "sunting bahasa Inggrisnya, jalankan stamp"
+  membuat gerbang terjemahan hijau sementara mirror Indonesia masih mengatakan hal yang
+  lama. Kena sungguhan: `project-state:inventory:generate` menggeser hitungan migrasi §2
+  dari 141 ke 142 dan stamp lalu menyatakan mirror-nya mutakhir sementara ia masih membaca
+  **141**. Ia tertangkap `tests/doc-inventory-counts.test.ts`, yang kebetulan memeriksa
+  rentang `sql/NNN` lintas dokumen — jaring pengaman yang ada untuk alasan lain dan
+  mencakup satu field.
 
-  Terjadi sungguhan di sesi ini: `project-state:inventory:generate` memperbarui hitungan
-  migrasi §2 di `PROJECT_STATE.md` (141 → 142) lalu `docs:i18n:stamp` menyatakan mirror
-  Indonesianya mutakhir padahal masih tertulis **141**. Yang menangkapnya
-  `tests/doc-inventory-counts.test.ts`, yang kebetulan memeriksa rentang `sql/NNN` di
-  dokumen — jaring pengaman yang ada untuk alasan lain dan hanya mencakup satu field.
-
-  **Tidak diperbaiki di sini, dan layak menjadi perubahannya sendiri.** Bentuk perbaikannya
-  adalah stamp yang MENOLAK menghitung ulang hash sumber yang isi non-spasinya berubah
-  (`--allow-formatting-only` sebagai bawaan, flag eksplisit untuk menstempel ulang setelah
-  terjemahan sungguhan), atau penanda di sisi mirror yang mencatat revisi MANA yang
-  diterjemahkan alih-alih sekadar bahwa ada yang diterjemahkan. Sampai itu ada, aturan
-  kerjanya: stempel ulang hanya setelah Anda benar-benar memperbarui mirrornya, dan jangan
-  pernah sebagai refleks supaya gerbangnya hijau.
+  Menulis ulang penanda itu adalah KLAIM tentang terjemahannya, jadi kini klaim itu hanya
+  dibuat bila ada yang menyatakan terjemahannya memang dilihat: mirror-nya termodifikasi
+  (atau untracked) di working tree ini, atau sumbernya hanya berubah SPASI sejak `HEAD` —
+  kasus reflow yang menjadi alasan tool ini dibuat, di mana tak ada penerjemah yang perlu
+  melakukan apa pun. Selain itu ia menolak, menyebut berkasnya, dan keluar 1;
+  `--force-restamp` adalah override yang disengaja untuk penulisan ulang yang tetap
+  dilewati terjemahannya. Versi `HEAD` yang tidak ada tidak diam-diam mengizinkannya.
+  Diverifikasi terhadap ketiga kasus.
 
 - **PUTARAN REKOMENDASI — 17 Agustus 2026, audit seluruh repo atas sepuluh dimensi.**
   **38 rekomendasi dari 48 temuan terverifikasi.** Metode: sepuluh pencari independen
@@ -1296,8 +1293,18 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
       sengaja TIDAK digabungkan: dua adalah baca GET, `language-switcher-client.ts` mem-POST
       secara ANONIM ke endpoint publik dan memutuskan lewat `response.ok` plus cookie, dan
       `push-subscription-client.ts` menampilkan `error.message` milik server — persis hal
-      yang ditahan bentuk sempit itu. **Memulihkan 425 B** dari anggaran aset klien yang
-      tersisa 161 B, dan itulah yang membuka jalan perubahan layar ADR-0106.
+      yang ditahan bentuk sempit itu.
+
+      **Ia TIDAK memulihkan bita klien satu pun, dan klaim bahwa ia akan memulihkannya
+      salah.** Kedua berkas sudah menjadi chunk bersama yang masing-masing dikirim sekali,
+      jadi "tiga salinan bita" tak pernah benar — tiga salinan SUMBER yang dikirim sekali.
+      "Penghematan" 425 B yang terukur saat bekerja berasal dari `dist/` yang belum
+      dibersihkan build, dan ia membawa seluruh batch ini ke jalan yang salah:
+      D12/D13/D14 diurutkan SEBELUM ADR-0106 demi membeli kelonggaran anggaran yang tidak
+      ada, dan cabang ADR-0106 ternyata sejak awal berada di dalam pagu (191.733 B pada
+      build bersih). `bun run build` kini menjalankan `rm -rf dist` lebih dulu, karena
+      docblock `client-asset-budget.ts` sendiri sudah mencatat tertipu dengan cara ini dua
+      kali dan memperingatkannya untuk ketiga kali pun tak akan berhasil.
 
   34. **D13 — `KEYSET_CURSOR_CREATED_AT_SQL` punya 3 pemakai dan 20 salinan inline tangan.**
       **SELESAI (22 Agustus 2026).** `_shared/keyset-pagination.ts:56-59`. Konstantanya
@@ -1367,17 +1374,52 @@ offsetSuffix)` bersama. **Salinannya dua puluh SATU, bukan dua puluh**: tiga lag
       diuji ujung ke ujung. Sebuah uji memaku ketiadaannya supaya perubahan itu harus
       melepas pakunya dengan sengaja.
 
-  37. **D16 — keadaan siklus hidup orphan media tak terjangkau.**
-      `media-object-directory.ts:592`. `markNewsMediaObjectOrphaned` satu-satunya penulis
-      `status='orphaned'` di repo dan punya nol pemanggil, sehingga sapuan stale-orphan,
-      indeks parsialnya, dan `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` menjaga himpunan yang
-      permanen kosong — dan penghitung nol terbaca identik dengan bucket bersih.
-      **Utamakan penghapusan** kecuali deteksi orphan memang sedang dibangun.
+  37. **D16 — keadaan siklus hidup orphan media tak terjangkau.** **SELESAI (22 Agustus 2026) — kode dihapus, skema dipertahankan.** `media-object-directory.ts:592`.
+      `markNewsMediaObjectOrphaned` satu-satunya penulis `status='orphaned'` di repo dan
+      punya nol pemanggil, sehingga sapuan stale-orphan, indeks parsialnya, dan
+      `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` menjaga himpunan yang permanen kosong — dan setiap
+      putaran mencetak `staleOrphaned(total=0,deleted=0,deferred=0)`, yang terbaca persis
+      seperti bucket bersih. Ia peninggalan model pra-ADR-0036: `sql/087` menghapus relasi
+      attach/detach, jadi tak ada hitungan rujukan untuk menurunkan "orphaned" DARINYA.
+
+      Yang hilang: penulisnya, `markStaleOrphanedNewsMediaObjectDeleted`, jalur
+      `cleanupStaleOrphaned` (yang docblock-nya menalar hati-hati tentang balapan yang tak
+      mungkin terjadi), kategori `staleOrphaned`, dan tiga penghitung job itu.
+
+      **Satu koreksi atas temuannya, dan ini penting:
+      `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` TIDAK mati** dan tidak dihapus. `orphanInR2` —
+      objek R2 yang sama sekali tak punya baris DB — benar-benar memakainya untuk
+      memutuskan kapan penghapusan fisik aman. Menghapusnya bersama sisanya akan mencabut
+      sebuah kontrol hidup.
+
+      Dipertahankan sesuai keputusan: nilai CHECK `'orphaned'`, `orphaned_at`, indeks
+      parsialnya, dan KEDUA filter status (layar admin dan API). Keduanya adalah baca atas
+      kolom yang masih bisa menampung nilai itu, dan membuang salah satunya akan membuat
+      dua permukaan berselisih tentang kolom yang sama.
+      `isNewsMediaObjectSafeForPublicReference` tetap menolak status itu, jadi baris yang
+      mencapainya secara manual tetap dijauhkan dari rujukan publik.
+
   38. **D17 — homepage section dan ad placement tidak punya permukaan baca yang sadar
-      kelayakan.** Ketiga helper rendering bernol pemanggil adalah **penangguhan
-      bertanda tangan** (ADR-0071). Yang benar-benar hilang sempit: daftar iklan
-      mengembalikan `media_object_id` tanpa `public_url` terresolusi dan tanpa join status
-      terverifikasi.
+      kelayakan.** **SELESAI (22 Agustus 2026) — bagian sempitnya, yang memang seluruh
+      isi kekurangannya.** Ketiga helper rendering bernol pemanggil adalah **penangguhan
+      bertanda tangan** (ADR-0071 memindahkan rendering berita publik ke `awcms-astro`)
+      dan tetap ditangguhkan.
+
+      Celah yang sebenarnya ditutup: `AdPlacementItem` kini membawa `mediaPublicUrl`,
+      `mediaAltText`, dan `mediaPubliclyReferenceable`, ketiganya wajib. Yang terakhir
+      itulah intinya — ia VONIS server, bukan status untuk ditafsirkan, karena
+      `isNewsMediaObjectSafeForPublicReference` bergantung pada keadaan siklus hidup mana
+      yang dihitung terverifikasi dan konsumen yang mengimplementasikannya ulang salah ke
+      arah PERMISIF, yang berarti menerbitkan gambar tak terverifikasi. `false` juga
+      mencakup objek yang di-soft-delete, jadi konsumen yang hanya memeriksa field ini pun
+      tak bisa merendernya.
+
+      Diresolusi dalam kueri yang sama di setiap jalur: `LEFT JOIN` dengan predikat media
+      di klausa `ON`, sehingga placement yang objeknya di-soft-delete tetap muncul di
+      daftar admin alih-alih lenyap dari satu-satunya layar yang bisa memperbaikinya, dan
+      CTE ber-DML pada create/update sehingga iklan yang baru dibuat tidak dilaporkan tak
+      dapat dirujuk. Tanpa N+1 dan tanpa endpoint kedua. `/admin/blog-ads` kini menyatakan
+      apakah gambar terlampirnya benar-benar akan ditampilkan.
 
   ### Sengaja TIDAK direkomendasikan (dicatat agar pertanyaannya tak dibuka ulang buta)
   - **Membuat `/api/v1/health` sadar dependensi.** Ia sengaja tidak memanggil DB dan tiga

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -114,7 +114,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Migrations                        | **145** (`sql/001`–`145`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0106** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **48** `.astro` files in `src/pages/admin/`; **0 of 24** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| `.astro` files                    | **61** (34.712 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
+| `.astro` files                    | **61** (34.728 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
 | Gates                             | **57** in the `bun run check` chain                                                    | `scripts.check` in `package.json`, split on `&&`                                        |
 | Contracts                         | Modular per-module OpenAPI + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.0.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -390,26 +390,22 @@ pioneered directly here after the ADR-0047 freeze.)
   would have handed every newly created domain the only precondition `verify` has.
 
 - **FOUND WHILE WORKING, 22 August 2026: `docs:i18n:stamp` can silence
-  `check:docs:translation` on a mirror that is now WRONG.** The stamp script re-hashes
-  every English source into its mirror's `i18n-source-hash` marker. Its own output warns
-  about the case it was built for — `bun run format` touching a source and going stale for
-  no editorial reason — and says "FORMAT FIRST, THEN STAMP". What it cannot distinguish is
-  a source whose CONTENT changed. Running it after editing an English document re-stamps
-  the marker and the translation gate goes green while the Indonesian mirror still says the
-  old thing.
-
-  Hit for real in this session: `project-state:inventory:generate` updated §2's migration
-  count in `PROJECT_STATE.md` (141 → 142) and `docs:i18n:stamp` then declared the
-  Indonesian mirror current while it still read **141**. It was caught by
+  `check:docs:translation` on a mirror that is now WRONG.** **DONE (22 August 2026).**
+  The stamp script re-hashes every English source into its mirror's `i18n-source-hash`
+  marker, and it did so unconditionally — so "edit the English, run the stamp" turned the
+  translation gate green while the Indonesian mirror still said the old thing. Hit for
+  real: `project-state:inventory:generate` moved §2's migration count 141 -> 142 and the
+  stamp then declared the mirror current while it still read **141**. It was caught by
   `tests/doc-inventory-counts.test.ts`, which happens to check `sql/NNN` ranges across
   docs — a backstop that exists for a different reason and covers one field.
 
-  **Not fixed here, and worth its own change.** The shape of a fix is a stamp that refuses
-  to re-hash a source whose non-whitespace content changed (`--allow-formatting-only` by
-  default, an explicit flag to re-stamp after a genuine re-translation), or a mirror-side
-  marker that records WHICH revision was translated rather than only that one was. Until
-  then the working rule is: re-stamp only after you have actually updated the mirror, and
-  never as a reflex to get a gate green.
+  Re-writing the marker is a CLAIM about the translation, so it is now made only when
+  something says the translation was actually looked at: the mirror is modified (or
+  untracked) in this working tree, or the source changed only in WHITESPACE since `HEAD`
+  — the reflow case the tool was built for, where no translator needs to do anything.
+  Otherwise it refuses, names the file and exits 1; `--force-restamp` is the deliberate
+  override for a reword the translation survives. A missing `HEAD` version does not
+  silently allow it. Verified against all three cases.
 
 - **RECOMMENDATION ROUND — 17 August 2026, whole-repo audit across ten dimensions.**
   **38 recommendations from 48 verified findings.** Method: ten independent finders
@@ -1286,8 +1282,18 @@ busy)` clause, gated on the permanently-zero counter, could never print.
       NOT folded in: two are GET reads, `language-switcher-client.ts` POSTs anonymously to a
       public endpoint and decides by `response.ok` plus a cookie, and
       `push-subscription-client.ts` surfaces the server's own `error.message` — the exact
-      thing the narrow shape exists to withhold. **Recovered 425 B** of a client asset
-      budget that had 161 B left, which is what unblocked ADR-0106's screen changes.
+      thing the narrow shape exists to withhold.
+
+      **It recovered NO client bytes, and the claim that it would was wrong.** Both files
+      were already shared chunks shipped once each, so "three copies of the bytes" was
+      never true — three copies of the SOURCE shipped once. The 425 B "saving" measured
+      while working came from a `dist/` the build had not cleaned, and it sent this whole
+      batch down the wrong road: D12/D13/D14 were sequenced BEFORE ADR-0106 to buy budget
+      headroom that did not exist, and the ADR-0106 branch turned out to be inside the
+      ceiling all along (191,733 B on a clean build). `bun run build` now runs
+      `rm -rf dist` first, because `client-asset-budget.ts`'s own docblock had already
+      recorded being misled this way twice and warning about it a third time would not
+      have worked either.
 
   34. **D13 — `KEYSET_CURSOR_CREATED_AT_SQL` has 3 users and 20 hand-inlined copies.**
       **DONE (22 August 2026).** `_shared/keyset-pagination.ts:56-59`. The constant
@@ -1355,20 +1361,49 @@ busy)` clause, gated on the permanently-zero counter, could never print.
       caller, where a `notify` node can actually be tested end to end. A test pins the
       absence so that change has to remove the pin deliberately.
 
-  37. **D16 — the media orphan lifecycle state is unreachable.**
-      `media-object-directory.ts:592`. `markNewsMediaObjectOrphaned` is the repo's only
-      writer of `status='orphaned'` and has zero callers, so the stale-orphan sweep, its
-      partial index and `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` gate a permanently empty set —
-      and a zero counter reads identically to a clean bucket. It is a leftover of the
-      pre-ADR-0036 model: `sql/087` deleted the attach/detach relation, so no reference
-      count exists to derive "orphaned" from. **Prefer deletion** unless orphan detection
-      is being built.
+  37. **D16 — the media orphan lifecycle state is unreachable.** **DONE (22 August 2026)
+      — code deleted, schema kept.** `media-object-directory.ts:592`.
+      `markNewsMediaObjectOrphaned` was the repo's only writer of `status='orphaned'`
+      and had zero callers, so the stale-orphan sweep, its partial index and
+      `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` gated a permanently empty set — and every run
+      printed `staleOrphaned(total=0,deleted=0,deferred=0)`, which reads exactly like a
+      clean bucket. A leftover of the pre-ADR-0036 model: `sql/087` deleted the
+      attach/detach relation, so no reference count exists to derive "orphaned" from.
+
+      Gone: the writer, `markStaleOrphanedNewsMediaObjectDeleted`, the
+      `cleanupStaleOrphaned` path (whose docblock reasoned carefully about a race that
+      could not occur), the `staleOrphaned` category and the job's three counters.
+
+      **One correction to the finding, and it matters:
+      `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` is NOT dead** and was not deleted. `orphanInR2` —
+      an R2 object with no DB row at all — genuinely uses it to decide when physical
+      deletion is safe. Removing it with the rest would have taken out a live control.
+
+      Kept per the decision: the `'orphaned'` CHECK value, `orphaned_at`, the partial
+      index, and BOTH status filters (admin screen and API). Those are reads over a column
+      that can still hold the value, and dropping one would leave two surfaces disagreeing
+      about the same column. `isNewsMediaObjectSafeForPublicReference` still refuses the
+      status, so a row that reached it by hand stays out of public references.
+
   38. **D17 — homepage sections and ad placements have no eligibility-aware read surface.**
+      **DONE (22 August 2026) — the narrow half, which is the whole of what was missing.**
       The three rendering helpers having zero callers is a **signed deferral** (ADR-0071
-      moved public news rendering to `awcms-astro`). The genuinely missing piece is narrow:
-      the ad list returns `media_object_id` with no resolved `public_url` and no
-      verified-status join, so an external renderer cannot reproduce the media safety
-      filter from the endpoint alone.
+      moved public news rendering to `awcms-astro`) and stays deferred.
+
+      The genuine gap is closed: `AdPlacementItem` now carries `mediaPublicUrl`,
+      `mediaAltText` and `mediaPubliclyReferenceable`, all three required. The last is the
+      point — it is the SERVER's verdict rather than a status to interpret, because
+      `isNewsMediaObjectSafeForPublicReference` turns on which lifecycle states count as
+      verified and a consumer reimplementing it gets that wrong in the PERMISSIVE
+      direction, which publishes an unverified image. `false` also covers a soft-deleted
+      object, so a consumer checking only this field cannot render one either.
+
+      Resolved in the same query on every path: a `LEFT JOIN` with the media predicate in
+      the `ON` clause, so a placement whose object was soft-deleted still appears in the
+      admin list instead of vanishing from the one screen that could repair it, and a
+      data-modifying CTE on create/update so a freshly created ad is not reported as
+      unreferenceable. No N+1 and no second endpoint. `/admin/blog-ads` now says whether
+      the attached image will actually be shown.
 
   ### Deliberately NOT recommended (recorded so the question is not reopened blind)
   - **Making `/api/v1/health` dependency-aware.** It does no DB call by design and three

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 462   |
+| Test files                          | 463   |
 | Route files                         | 382   |
 | ADR                                 | 214   |
 
@@ -356,7 +356,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 390        |
+| `(root)`      | 391        |
 | `e2e`         | 12         |
 | `integration` | 59         |
 | `unit`        | 1          |

--- a/locales/en.po
+++ b/locales/en.po
@@ -4043,6 +4043,9 @@ msgstr ""
 msgid "An image is attached."
 msgstr ""
 
+msgid "An image is attached, but it is not publicly referenceable — it is unverified or has been deleted, so this ad will render nothing."
+msgstr ""
+
 msgid "No image attached."
 msgstr ""
 

--- a/locales/id.po
+++ b/locales/id.po
@@ -4030,6 +4030,9 @@ msgstr "Gambar utama"
 msgid "An image is attached."
 msgstr "Sebuah gambar terpasang."
 
+msgid "An image is attached, but it is not publicly referenceable — it is unverified or has been deleted, so this ad will render nothing."
+msgstr "Sebuah gambar terlampir, tetapi tidak dapat dirujuk publik — ia belum terverifikasi atau sudah dihapus, jadi iklan ini tidak akan merender apa pun."
+
 msgid "No image attached."
 msgstr "Belum ada gambar terpasang."
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -19315,6 +19315,9 @@ components:
         - placementKey
         - name
         - mediaObjectId
+        - mediaPublicUrl
+        - mediaAltText
+        - mediaPubliclyReferenceable
         - rotationMode
         - priority
         - isActive
@@ -19349,6 +19352,16 @@ components:
           description: Must reference a verified (`verified`/`attached`) R2 media object belonging to this tenant (`awcms_news_media_objects`) — never a local path or arbitrary external URL.
           type: string
           format: uuid
+        mediaPublicUrl:
+          type: string
+          nullable: true
+          description: Resolved from the media registry (ADR-0036) so a renderer never has to fetch the object separately. `null` when the media object has been soft-deleted.
+        mediaAltText:
+          type: string
+          nullable: true
+        mediaPubliclyReferenceable:
+          type: boolean
+          description: Whether this ad's media object may appear on a public page — the server's own verdict, not a status to interpret. `false` also covers a soft-deleted object, so a consumer checking only this field cannot render one.
         linkUrl:
           description: Optional, possibly external, link — validated server-side as an absolute http(s) URL only.
           type: string

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -4468,6 +4468,9 @@ components:
         - placementKey
         - name
         - mediaObjectId
+        - mediaPublicUrl
+        - mediaAltText
+        - mediaPubliclyReferenceable
         - rotationMode
         - priority
         - isActive
@@ -4502,6 +4505,16 @@ components:
           description: Must reference a verified (`verified`/`attached`) R2 media object belonging to this tenant (`awcms_news_media_objects`) — never a local path or arbitrary external URL.
           type: string
           format: uuid
+        mediaPublicUrl:
+          type: string
+          nullable: true
+          description: "Resolved from the media registry (ADR-0036) so a renderer never has to fetch the object separately. `null` when the media object has been soft-deleted."
+        mediaAltText:
+          type: string
+          nullable: true
+        mediaPubliclyReferenceable:
+          type: boolean
+          description: "Whether this ad's media object may appear on a public page — the server's own verdict, not a status to interpret. `false` also covers a soft-deleted object, so a consumer checking only this field cannot render one."
         linkUrl:
           description: Optional, possibly external, link — validated server-side as an absolute http(s) URL only.
           type: string

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "scripts": {
     "dev": "bun --bun astro dev",
-    "build": "bun --bun astro build && bun run build:server-entry && bun run build:asset-budget:check && bun run build:inline-scripts:check",
+    "build": "bun run build:clean && bun --bun astro build && bun run build:server-entry && bun run build:asset-budget:check && bun run build:inline-scripts:check",
+    "build:clean": "rm -rf dist",
     "build:inline-scripts:check": "bun scripts/build-inline-script-check.ts",
     "build:server-entry": "bun build src/lib/server/standalone-entry.ts --target=bun --outfile=dist/standalone-entry.mjs",
     "build:asset-budget:check": "bun scripts/client-asset-budget.ts",

--- a/scripts/client-asset-budget.ts
+++ b/scripts/client-asset-budget.ts
@@ -135,8 +135,13 @@ export const READER_BUDGET_BYTES = 24_000;
  * August 2026 for the Portable Text block editor (ADR-0100, Issue #589), and
  * the measurement was the argument.**
  *
- * Measured on clean builds (`rm -rf dist && bun run build` — a stale `dist`
- * produced a wrong delta once already, so the clean step is not optional):
+ * Measured on clean builds. That used to be a manual `rm -rf dist &&` that this
+ * docblock told the reader not to skip — and the instruction was ignored twice,
+ * once here (a 2,493 B admin screen first reported as 82 B) and again on 22
+ * August 2026, when a phantom 425 B "saving" sent a whole PR down the wrong
+ * road. A gate that documents its own hazard is a gate that will mislead
+ * somebody a third time, so `bun run build` now runs `build:clean` first and
+ * the number cannot come from a tree the current build did not produce:
  *
  * ```
  * main                                     181,418 B

--- a/scripts/docs-i18n-stamp.mjs
+++ b/scripts/docs-i18n-stamp.mjs
@@ -18,9 +18,34 @@
  * moves the bookkeeping, which is why `--check` can be trusted to say whether a
  * tree is already correct.
  *
+ * ## It will REFUSE to declare a mirror current that nobody re-translated
+ *
+ * The marker says "this mirror was translated from a source with this hash".
+ * Re-writing it is a CLAIM about the translation, and until this guard existed
+ * the tool made that claim unconditionally — so the sequence "edit the English,
+ * run the stamp" turned `check:docs:translation` green over an Indonesian
+ * mirror that still said the old thing. That happened for real: a generated
+ * §2 count went 141 -> 142 in `PROJECT_STATE.md`, the stamp declared the mirror
+ * current, and the mirror still read 141. It was caught by a test that checks
+ * `sql/NNN` ranges across documents — a backstop that exists for a different
+ * reason and covers one field.
+ *
+ * So when a mirror's recorded hash is stale, re-stamping is allowed only when
+ * something says the translation was actually looked at:
+ *
+ *  1. **the mirror itself is modified** in this working tree (or untracked) —
+ *     somebody edited the translation, which is the whole signal; or
+ *  2. **the source changed only in whitespace** since `HEAD` — the case this
+ *     tool was built for, where `bun run format` reflows an English document
+ *     and no translator needs to do anything.
+ *
+ * Otherwise it refuses, names the file, and says what to do. `--force-restamp`
+ * is the deliberate override for a reword the translation genuinely survives.
+ *
  * Usage:
- *   bun run docs:i18n:stamp            # rewrite banners + markers in place
- *   bun run docs:i18n:stamp --check    # report what would change, exit 1 if any
+ *   bun run docs:i18n:stamp                   # rewrite banners + markers in place
+ *   bun run docs:i18n:stamp --check           # report what would change, exit 1 if any
+ *   bun run docs:i18n:stamp --force-restamp   # re-stamp even an untouched mirror
  */
 import { readFileSync, writeFileSync } from "node:fs";
 import { basename, join, resolve } from "node:path";
@@ -28,11 +53,13 @@ import { execFileSync } from "node:child_process";
 import {
   MARKER_REGEX,
   computeSourceHash,
-  deriveSourcePath
+  deriveSourcePath,
+  extractRecordedHash
 } from "./lib/docs-i18n-checks.mjs";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const CHECK_ONLY = process.argv.includes("--check");
+const FORCE_RESTAMP = process.argv.includes("--force-restamp");
 
 /** A line is a language banner when it opens with either flag. */
 const BANNER_REGEX = /^(?:🇬🇧|🇮🇩).*$/u;
@@ -176,6 +203,104 @@ function readFileIfPresent(path) {
   }
 }
 
+/**
+ * Paths git reports as modified, staged, or untracked in this working tree.
+ *
+ * Computed once: `git status --porcelain` over the whole repository is one
+ * process, where asking per file would be one per mirror.
+ *
+ * @returns {Set<string>}
+ */
+function workingTreeChanges() {
+  const output = execFileSync("git", ["status", "--porcelain", "-z"], {
+    cwd: ROOT,
+    encoding: "utf8"
+  });
+
+  const paths = new Set();
+
+  // NUL-separated so a path containing a space or a quote cannot be misparsed.
+  // A rename entry is `R  new\0old`, and both halves matter to us: the new path
+  // is the changed file, and the old one no longer exists.
+  for (const entry of output.split("\0")) {
+    if (entry.length < 4) continue;
+    paths.add(entry.slice(3));
+  }
+
+  return paths;
+}
+
+/**
+ * The committed content of `path`, or `null` when it is not in `HEAD` (a new
+ * file, or a repository with no commits yet).
+ *
+ * @param {string} path
+ * @returns {string | null}
+ */
+function committedContent(path) {
+  try {
+    return execFileSync("git", ["show", `HEAD:${path}`], {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"]
+    });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Every whitespace run to one space, so a reflow compares equal.
+ *
+ * @param {string} content
+ * @returns {string}
+ */
+function withoutWhitespace(content) {
+  return content.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * May this mirror's marker be re-written to claim the source's new hash?
+ *
+ * @param {string} mirrorPath
+ * @param {string} sourcePath
+ * @param {string} originalMirror
+ * @param {string} nextSource
+ * @param {Set<string>} touched
+ * @returns {boolean}
+ */
+function mayRestamp(
+  mirrorPath,
+  sourcePath,
+  originalMirror,
+  nextSource,
+  touched
+) {
+  if (FORCE_RESTAMP) return true;
+
+  const recorded = extractRecordedHash(originalMirror);
+
+  // No marker yet, or the marker already matches: nothing is being CLAIMED that
+  // was not already true, so there is nothing to refuse.
+  if (!recorded || recorded === computeSourceHash(nextSource)) return true;
+
+  // Somebody edited the translation in this working tree.
+  if (touched.has(mirrorPath)) return true;
+
+  // A formatting-only change to the source — the case this tool exists for.
+  const committed = committedContent(sourcePath);
+
+  return (
+    committed !== null &&
+    withoutWhitespace(committed) === withoutWhitespace(nextSource)
+  );
+}
+
+const touchedPaths = workingTreeChanges();
+
+/** @type {string[]} */
+const refused = [];
+
 /** @type {string[]} */
 const changed = [];
 
@@ -215,9 +340,39 @@ for (const mirrorPath of listMirrors()) {
     if (!CHECK_ONLY) writeFileSync(sourceFull, nextSource);
   }
   if (nextMirror !== originalMirror) {
+    if (
+      !mayRestamp(
+        mirrorPath,
+        sourcePath,
+        originalMirror,
+        nextSource,
+        touchedPaths
+      )
+    ) {
+      refused.push(mirrorPath);
+      continue;
+    }
+
     changed.push(mirrorPath);
     if (!CHECK_ONLY) writeFileSync(mirrorFull, nextMirror);
   }
+}
+
+if (refused.length > 0) {
+  console.error(
+    `docs:i18n:stamp REFUSES to re-stamp ${refused.length} mirror(s) nobody re-translated:`
+  );
+  for (const file of refused) console.error(`  - ${file}`);
+  console.error(
+    "\n  Their English source changed by more than whitespace and the mirror was\n" +
+      "  not touched in this working tree. Re-stamping would make\n" +
+      "  `check:docs:translation` green over a translation that still says the old\n" +
+      "  thing — which is the failure this guard exists for, and which has\n" +
+      "  happened.\n\n" +
+      "  Update the mirror, or pass --force-restamp if the translation genuinely\n" +
+      "  survives the reword."
+  );
+  process.exit(1);
 }
 
 if (CHECK_ONLY) {

--- a/scripts/news-media-r2-reconcile.ts
+++ b/scripts/news-media-r2-reconcile.ts
@@ -46,7 +46,7 @@
  * listing WITHOUT deleting or modifying anything — safe to run in
  * production to preview impact. See `news-media-reconciliation.ts`'s own
  * header for the exact categories (`healthy`/`orphanInDb`/`expiredPending`/
- * `staleOrphaned`/`orphanInR2`) and the ordering/race-safety guarantees the
+ * `orphanInR2`) and the ordering/race-safety guarantees the
  * REAL (non-dry-run) path applies.
  */
 import { getWorkerDatabaseClient } from "../src/lib/database/client";
@@ -108,7 +108,6 @@ async function main() {
           const hadFailures =
             totals.tenantsWithR2ListFailure > 0 ||
             totals.expiredPendingDeferred > 0 ||
-            totals.staleOrphanedDeferred > 0 ||
             totals.orphanInR2Deferred > 0;
 
           console.log(
@@ -116,7 +115,6 @@ async function main() {
               `tenants=${totals.tenantsChecked} healthy=${totals.healthy} ` +
               `orphanInDb=${totals.orphanInDb} ` +
               `expiredPending(total=${totals.expiredPendingTotal},deleted=${totals.expiredPendingDeleted},racedSkipped=${totals.expiredPendingRacedSkipped},deferred=${totals.expiredPendingDeferred}) ` +
-              `staleOrphaned(total=${totals.staleOrphanedTotal},deleted=${totals.staleOrphanedDeleted},deferred=${totals.staleOrphanedDeferred}) ` +
               `orphanInR2(total=${totals.orphanInR2Total},eligible=${totals.orphanInR2Eligible},deleted=${totals.orphanInR2Deleted},raceAverted=${totals.orphanInR2RaceAverted},deferred=${totals.orphanInR2Deferred})` +
               (ctx.dryRun ? " (dry-run: nothing was deleted/modified)" : "") +
               (totals.tenantsWithR2ListFailure > 0
@@ -137,7 +135,6 @@ async function main() {
               healthy: totals.healthy,
               orphanInDb: totals.orphanInDb,
               expiredPendingDeleted: totals.expiredPendingDeleted,
-              staleOrphanedDeleted: totals.staleOrphanedDeleted,
               orphanInR2Deleted: totals.orphanInR2Deleted
             },
             detail: summary.aborted

--- a/src/lib/i18n/catalogs/id.generated.ts
+++ b/src/lib/i18n/catalogs/id.generated.ts
@@ -86,6 +86,7 @@ export const ID_CATALOG: CompiledCatalog = {
   "Allowed email domains (comma separated; empty means any)": ["Domain email yang diizinkan (dipisah koma; kosong berarti apa pun)"],
   "Already archived": ["Sudah diarsipkan"],
   "An exception lets one person hold both halves of a conflict for a bounded window. Approving is the whole point of the checker half of this flow — and the person who asked for it, and the person it is for, are both refused.": ["Pengecualian membuat satu orang bisa memegang kedua sisi sebuah konflik untuk jangka waktu terbatas. Menyetujui adalah inti dari sisi pemeriksa pada alur ini — dan orang yang memintanya, serta orang yang dituju, sama-sama ditolak."],
+  "An image is attached, but it is not publicly referenceable — it is unverified or has been deleted, so this ad will render nothing.": ["Sebuah gambar terlampir, tetapi tidak dapat dirujuk publik — ia belum terverifikasi atau sudah dihapus, jadi iklan ini tidak akan merender apa pun."],
   "An image is attached.": ["Sebuah gambar terpasang."],
   "Analytics could not be loaded right now. Please try again later.": ["Analitik tidak dapat dimuat saat ini. Silakan coba lagi nanti."],
   "Any": ["Apa pun"],

--- a/src/modules/blog-content/application/ad-placement-directory.ts
+++ b/src/modules/blog-content/application/ad-placement-directory.ts
@@ -29,6 +29,30 @@ export type AdPlacementView = {
   placementKey: AdPlacementKey;
   name: string;
   mediaObjectId: string;
+  /**
+   * The media registry's own public URL for {@link mediaObjectId}, or `null`
+   * when the object has been soft-deleted (finding D17).
+   *
+   * Resolved server-side rather than left to the caller. The FK is `NOT NULL`,
+   * so every placement names an object — but an id alone is not something an
+   * external renderer can turn into an `<img src>`, and the one endpoint that
+   * hands these rows out was returning nothing else. The alternative, a second
+   * request per placement to the media resolver, is an N+1 across a list.
+   */
+  mediaPublicUrl: string | null;
+  mediaAltText: string | null;
+  /**
+   * Whether the media object may appear on a public page — the SERVER's
+   * verdict, not a status for the caller to interpret.
+   *
+   * `isNewsMediaObjectSafeForPublicReference` is the rule, and it is the kind
+   * of rule a consumer reimplementing it gets subtly wrong: it turns on which
+   * lifecycle states count as verified, and being wrong in the permissive
+   * direction publishes an unverified image. Returning the status string would
+   * have invited exactly that. `false` also covers the soft-deleted case, so a
+   * consumer that checks only this cannot show a deleted object either.
+   */
+  mediaPubliclyReferenceable: boolean;
   linkUrl: string | null;
   rotationMode: AdRotationMode;
   priority: number;
@@ -50,6 +74,9 @@ type AdPlacementRow = {
   placement_key: AdPlacementKey;
   name: string;
   media_object_id: string;
+  media_public_url: string | null;
+  media_alt_text: string | null;
+  media_status: string | null;
   link_url: string | null;
   rotation_mode: AdRotationMode;
   priority: number;
@@ -72,6 +99,15 @@ function toView(row: AdPlacementRow): AdPlacementView {
     placementKey: row.placement_key,
     name: row.name,
     mediaObjectId: row.media_object_id,
+    mediaPublicUrl: row.media_public_url,
+    mediaAltText: row.media_alt_text,
+    mediaPubliclyReferenceable:
+      row.media_status !== null &&
+      isNewsMediaObjectSafeForPublicReference(
+        row.media_status as Parameters<
+          typeof isNewsMediaObjectSafeForPublicReference
+        >[0]
+      ),
     linkUrl: row.link_url,
     rotationMode: row.rotation_mode,
     priority: row.priority,
@@ -99,6 +135,7 @@ export async function createAdPlacement(
   correlationId?: string
 ): Promise<AdPlacementView> {
   const rows = (await tx`
+    WITH written AS (
     INSERT INTO awcms_news_portal_ad_placements
       (tenant_id, placement_key, name, media_object_id, link_url, rotation_mode,
        priority, is_active, starts_at, ends_at, target_type, target_id)
@@ -110,6 +147,23 @@ export async function createAdPlacement(
     RETURNING id, tenant_id, placement_key, name, media_object_id, link_url,
       rotation_mode, priority, is_active, starts_at, ends_at, target_type,
       target_id, created_at, updated_at, deleted_at, deleted_by, delete_reason
+    )
+    -- The write and the media resolution in ONE statement (finding D17). A
+    -- data-modifying CTE keeps the resolved media fields consistent with every
+    -- read path without a second round trip, and without the alternative that
+    -- would actually be wrong: returning the written row with null media
+    -- fields, which reports a freshly created, perfectly valid ad as not
+    -- publicly referenceable.
+    SELECT p.id, p.tenant_id, p.placement_key, p.name, p.media_object_id,
+      m.public_url AS media_public_url, m.alt_text AS media_alt_text,
+      m.status AS media_status,
+      p.link_url, p.rotation_mode, p.priority, p.is_active, p.starts_at, p.ends_at,
+      p.target_type, p.target_id, p.created_at, p.updated_at, p.deleted_at,
+      p.deleted_by, p.delete_reason
+    FROM written p
+    LEFT JOIN awcms_news_media_objects m
+      ON m.id = p.media_object_id AND m.tenant_id = p.tenant_id
+      AND m.deleted_at IS NULL
   `) as AdPlacementRow[];
 
   const created = toView(rows[0]!);
@@ -136,11 +190,21 @@ export async function fetchAdPlacementById(
   id: string
 ): Promise<AdPlacementView | null> {
   const rows = (await tx`
-    SELECT id, tenant_id, placement_key, name, media_object_id, link_url,
-      rotation_mode, priority, is_active, starts_at, ends_at, target_type,
-      target_id, created_at, updated_at, deleted_at, deleted_by, delete_reason
-    FROM awcms_news_portal_ad_placements
-    WHERE tenant_id = ${tenantId} AND id = ${id} AND deleted_at IS NULL
+    SELECT p.id, p.tenant_id, p.placement_key, p.name, p.media_object_id,
+      m.public_url AS media_public_url, m.alt_text AS media_alt_text,
+      m.status AS media_status,
+      p.link_url, p.rotation_mode, p.priority, p.is_active, p.starts_at, p.ends_at,
+      p.target_type, p.target_id, p.created_at, p.updated_at, p.deleted_at,
+      p.deleted_by, p.delete_reason
+    FROM awcms_news_portal_ad_placements p
+    -- LEFT, and the media predicate is in the ON clause: a placement whose
+    -- object was soft-deleted must still appear in an ADMIN list, reported as
+    -- not publicly referenceable, rather than vanishing from the one screen
+    -- that could repair it.
+    LEFT JOIN awcms_news_media_objects m
+      ON m.id = p.media_object_id AND m.tenant_id = p.tenant_id
+      AND m.deleted_at IS NULL
+    WHERE p.tenant_id = ${tenantId} AND p.id = ${id} AND p.deleted_at IS NULL
   `) as AdPlacementRow[];
 
   const row = rows[0];
@@ -153,12 +217,22 @@ export async function listAdPlacements(
   tenantId: string
 ): Promise<AdPlacementView[]> {
   const rows = (await tx`
-    SELECT id, tenant_id, placement_key, name, media_object_id, link_url,
-      rotation_mode, priority, is_active, starts_at, ends_at, target_type,
-      target_id, created_at, updated_at, deleted_at, deleted_by, delete_reason
-    FROM awcms_news_portal_ad_placements
-    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL
-    ORDER BY placement_key ASC, priority DESC, created_at DESC
+    SELECT p.id, p.tenant_id, p.placement_key, p.name, p.media_object_id,
+      m.public_url AS media_public_url, m.alt_text AS media_alt_text,
+      m.status AS media_status,
+      p.link_url, p.rotation_mode, p.priority, p.is_active, p.starts_at, p.ends_at,
+      p.target_type, p.target_id, p.created_at, p.updated_at, p.deleted_at,
+      p.deleted_by, p.delete_reason
+    FROM awcms_news_portal_ad_placements p
+    -- LEFT, and the media predicate is in the ON clause: a placement whose
+    -- object was soft-deleted must still appear in an ADMIN list, reported as
+    -- not publicly referenceable, rather than vanishing from the one screen
+    -- that could repair it.
+    LEFT JOIN awcms_news_media_objects m
+      ON m.id = p.media_object_id AND m.tenant_id = p.tenant_id
+      AND m.deleted_at IS NULL
+    WHERE p.tenant_id = ${tenantId} AND p.deleted_at IS NULL
+    ORDER BY p.placement_key ASC, p.priority DESC, p.created_at DESC
     LIMIT 500
   `) as AdPlacementRow[];
 
@@ -181,6 +255,7 @@ export async function updateAdPlacement(
   correlationId?: string
 ): Promise<AdPlacementView | null> {
   const rows = (await tx`
+    WITH written AS (
     UPDATE awcms_news_portal_ad_placements
     SET placement_key = COALESCE(${input.placementKey ?? null}, placement_key),
         name = COALESCE(${input.name ?? null}, name),
@@ -198,6 +273,23 @@ export async function updateAdPlacement(
     RETURNING id, tenant_id, placement_key, name, media_object_id, link_url,
       rotation_mode, priority, is_active, starts_at, ends_at, target_type,
       target_id, created_at, updated_at, deleted_at, deleted_by, delete_reason
+    )
+    -- The write and the media resolution in ONE statement (finding D17). A
+    -- data-modifying CTE keeps the resolved media fields consistent with every
+    -- read path without a second round trip, and without the alternative that
+    -- would actually be wrong: returning the written row with null media
+    -- fields, which reports a freshly created, perfectly valid ad as not
+    -- publicly referenceable.
+    SELECT p.id, p.tenant_id, p.placement_key, p.name, p.media_object_id,
+      m.public_url AS media_public_url, m.alt_text AS media_alt_text,
+      m.status AS media_status,
+      p.link_url, p.rotation_mode, p.priority, p.is_active, p.starts_at, p.ends_at,
+      p.target_type, p.target_id, p.created_at, p.updated_at, p.deleted_at,
+      p.deleted_by, p.delete_reason
+    FROM written p
+    LEFT JOIN awcms_news_media_objects m
+      ON m.id = p.media_object_id AND m.tenant_id = p.tenant_id
+      AND m.deleted_at IS NULL
   `) as AdPlacementRow[];
 
   const updated = rows[0] ? toView(rows[0]) : null;

--- a/src/modules/media-library/application/media-object-directory.ts
+++ b/src/modules/media-library/application/media-object-directory.ts
@@ -37,7 +37,7 @@ import {
  * `pending_upload -> uploaded`
  * and any `-> orphaned`/`-> failed` transition are logged via the structured
  * logger only (`src/lib/logging/logger.ts`) — see `markNewsMediaObjectUploaded`/
- * `markNewsMediaObjectOrphaned`/`markNewsMediaObjectFailed` below for why
+ * `markNewsMediaObjectFailed` below for why
  * these are treated as routine lifecycle bookkeeping, not high-risk actions.
  */
 
@@ -625,42 +625,30 @@ export async function markNewsMediaObjectVerified(
  * flow produces, and it is equally referenceable.
  */
 
-/**
- * `pending_upload|uploaded|verified -> orphaned` — flags a never-attached
- * object as a cleanup candidate (doc `r2-backup-lifecycle.md` §2, e.g. a
- * pending TTL job). Deliberately excluded from the required audit-event
- * list (create/verify/attach/detach/delete/restore/purge) — this is routine
- * lifecycle bookkeeping performed by an automated job, not itself a
- * high-risk action; callers may still `log()` it structurally.
+/*
+ * `markNewsMediaObjectOrphaned` USED TO LIVE HERE, and is gone — finding D16.
  *
- * Sets `orphaned_at = now()` (migration 046, Issue #690) — the moment the
- * `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` grace period
- * (`scripts/news-media-r2-reconcile.ts`) starts counting from. Nothing else
- * in this file writes `orphaned_at` — it is set exactly once, here, and only
- * read afterward (by the reconciliation job's stale-orphan sweep), so the
- * grace period can never be silently reset/extended by an unrelated update.
+ * It was this repo's ONLY writer of `status = 'orphaned'`, and it had zero
+ * callers. So the reconciliation job's stale-orphan sweep, `sql/041`'s partial
+ * index and the `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` comparison all gated a
+ * permanently empty set — and a zero counter reads exactly like a clean bucket,
+ * which made the job's summary line a claim nobody could check.
+ *
+ * It is a leftover of the pre-ADR-0036 model, the same one that took
+ * `attachNewsMediaObject`/`detachNewsMediaObject` above: `sql/087` deleted the
+ * object->content relation, so there is no reference count left to derive
+ * "orphaned" FROM. Building the state a writer again would mean scanning every
+ * column in every module that can point at a media object, where one missed
+ * column silently deletes a live image after the grace period. That is a
+ * feature with a real design in it, not a repair, and it is not what the
+ * unreachable code was.
+ *
+ * The STATUS survives in `sql/041`'s CHECK, alongside `orphaned_at` and its
+ * partial index. An applied migration is immutable, the column stays honest
+ * about what the schema will hold, and it is where a future detector would
+ * write. `isNewsMediaObjectSafeForPublicReference` still refuses it, so a row
+ * that reached the state by hand is still kept out of public references.
  */
-export async function markNewsMediaObjectOrphaned(
-  tx: Bun.SQL,
-  tenantId: string,
-  id: string
-): Promise<NewsMediaObjectView | null> {
-  const rows = (await tx`
-    UPDATE awcms_news_media_objects
-    SET status = 'orphaned', orphaned_at = now(), updated_at = now()
-    WHERE tenant_id = ${tenantId} AND id = ${id}
-      AND status IN ('pending_upload', 'uploaded', 'verified') AND deleted_at IS NULL
-    RETURNING id, tenant_id, module_key, owner_resource_type, owner_resource_id,
-      storage_driver, bucket_name, object_key, original_filename, public_url,
-      mime_type, size_bytes, checksum_sha256, width, height, alt_text, caption,
-          credit_line, source_name, rights_notes, copyright_status,
-          rights_verification_status, rights_verified_by, rights_verified_at,
-      status, created_by_tenant_user_id, created_at, updated_at,
-      deleted_at, deleted_by, delete_reason, restored_at, restored_by
-  `) as NewsMediaObjectRow[];
-
-  return rows[0] ? toView(rows[0]) : null;
-}
 
 export type MarkNewsMediaObjectFailedOptions = {
   /**
@@ -686,7 +674,9 @@ export type MarkNewsMediaObjectFailedOptions = {
  * (checksum mismatch, R2 error, disallowed content sniffed, etc), OR (Issue
  * #690, `options.olderThan` set) the row expired past
  * `NEWS_MEDIA_R2_PENDING_TTL_MINUTES` without ever being finalized. Same
- * "not in the required audit list" reasoning as `markNewsMediaObjectOrphaned`.
+ * Deliberately excluded from the required audit-event list
+ * (create/verify/delete/restore/purge) — routine lifecycle bookkeeping
+ * performed by an automated job, not itself a high-risk action.
  */
 export async function markNewsMediaObjectFailed(
   tx: Bun.SQL,
@@ -773,49 +763,10 @@ export async function purgeExpiredPendingNewsMediaObject(
   return true;
 }
 
-/**
- * `orphaned -> ` soft-deleted (Issue #690,
- * `scripts/news-media-r2-reconcile.ts`) — physical R2 cleanup grace period
- * (`NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS`, `r2-backup-lifecycle.md` §3) has
- * elapsed for a row already flagged `orphaned`. Unlike
- * `purgeExpiredPendingNewsMediaObject`, this is a SOFT delete — the row WAS
- * a real, once-verified media object (§3's retention table: "Baris metadata
- * `deleted` (soft delete): baris tetap ada (audit trail)... objek fisik R2
- * dihapus setelah masa tenggang"). `status`/`orphaned_at` are left
- * unchanged (soft delete stays orthogonal to `status`, same convention as
- * every other transition in this file). No `actorTenantUserId` — this is a
- * system job, not a human action; `deleted_by` stays `NULL`.
+/*
+ * `markStaleOrphanedNewsMediaObjectDeleted` is gone with it (finding D16) —
+ * its only caller was the sweep over a category that could never be non-empty.
  */
-export async function markStaleOrphanedNewsMediaObjectDeleted(
-  tx: Bun.SQL,
-  tenantId: string,
-  id: string,
-  olderThan: Date
-): Promise<boolean> {
-  const rows = (await tx`
-    UPDATE awcms_news_media_objects
-    SET deleted_at = now(), delete_reason = 'r2_orphan_grace_period_expired',
-        updated_at = now()
-    WHERE tenant_id = ${tenantId} AND id = ${id}
-      AND status = 'orphaned' AND deleted_at IS NULL AND orphaned_at < ${olderThan}
-    RETURNING object_key
-  `) as { object_key: string }[];
-
-  if (rows.length === 0) return false;
-
-  await recordAuditEvent(tx, {
-    tenantId,
-    moduleKey: AUDIT_MODULE_KEY,
-    action: "news_media.object.orphan_expired_deleted",
-    resourceType: AUDIT_RESOURCE_TYPE,
-    resourceId: id,
-    severity: "warning",
-    message: `News media object soft deleted: orphan grace period expired (${rows[0]!.object_key}).`,
-    attributes: { objectKey: rows[0]!.object_key }
-  });
-
-  return true;
-}
 
 /**
  * Point lookup used as the FINAL, immediate-before-delete gate for

--- a/src/modules/media-library/application/media-reconciliation.ts
+++ b/src/modules/media-library/application/media-reconciliation.ts
@@ -37,25 +37,21 @@
  *   between this module's DB claim and its R2 delete therefore self-heals,
  *   just on the next scheduled run instead of instantly.
  *
- * **`staleOrphaned` (`cleanupStaleOrphaned`): R2 delete FIRST, DB soft-
- * delete SECOND** — the doc's original ordering, unmodified. This path has
- * no equivalent race to guard against: no other code path in
- * `news-media-object-directory.ts` ever transitions a row OUT of
- * `status = 'orphaned'` (there is no "un-orphan" operation), so there is no
- * concurrently-running flow that could be racing this cleanup the way
- * `finalize()` races `expiredPending`. R2-delete-first here matches the
- * doc's own crash-safety reasoning: a crash after the R2 delete but before
- * the DB soft-delete just leaves a row pointing at an already-gone object,
- * which the NEXT run's `orphanInDb`/retry naturally reconciles.
+ * There WAS a third path here, `cleanupStaleOrphaned`, and it is gone
+ * (finding D16). It cleaned up `status = 'orphaned'` rows past a grace period,
+ * and `markNewsMediaObjectOrphaned` was this repo's only writer of that status
+ * and had zero callers — so the path ran, found nothing, and printed
+ * `staleOrphaned(total=0,deleted=0,deferred=0)` on every run. A zero counter
+ * and a clean bucket read identically, which made the summary line a claim
+ * nobody could check. Its own docblock even reasoned carefully about a race
+ * that could not occur, because no row could be in the state it guarded.
  *
  * ## Idempotency across reruns
  *
  * Every mutation below is a guarded UPDATE/DELETE that only succeeds if the
  * row is STILL in the exact state that made it eligible. Once a row is
- * hard-deleted (`expiredPending`) or soft-deleted (`staleOrphaned`), it no
- * longer appears in the NEXT run's `fetchNewsMediaObjectsForReconciliation`
- * snapshot (hard-delete) or no longer satisfies the `deleted_at IS NULL`
- * guard (soft-delete) — so a rerun with nothing new to do performs zero
+ * hard-deleted (`expiredPending`), it no longer appears in the NEXT run's
+ * `fetchNewsMediaObjectsForReconciliation` snapshot — so a rerun with nothing new to do performs zero
  * mutations and reports the same `healthy` set, by construction, not by a
  * separate "already processed" bookkeeping mechanism.
  *
@@ -80,15 +76,13 @@ import {
   type NewsMediaExpiredPendingEntry,
   type NewsMediaOrphanInDbEntry,
   type NewsMediaOrphanInR2Entry,
-  type NewsMediaReconciliationDbRow,
-  type NewsMediaStaleOrphanedEntry
+  type NewsMediaReconciliationDbRow
 } from "../domain/media-reconciliation-categorization";
 import type { NewsMediaR2Config } from "../domain/media-r2-config";
 import type { NewsMediaR2Client } from "../infrastructure/media-r2-client";
 import {
   fetchNewsMediaObjectsForReconciliation,
   markNewsMediaObjectFailed,
-  markStaleOrphanedNewsMediaObjectDeleted,
   NEWS_MEDIA_RECONCILIATION_SNAPSHOT_LIMIT,
   objectKeyExistsForTenant,
   purgeExpiredPendingNewsMediaObject
@@ -123,11 +117,6 @@ export type NewsMediaTenantReconciliationResult = {
     total: number;
     deleted: number;
     racedSkipped: number;
-    deferred: number;
-  };
-  staleOrphaned: {
-    total: number;
-    deleted: number;
     deferred: number;
   };
   orphanInR2: {
@@ -283,48 +272,6 @@ async function cleanupExpiredPending(
   return { deleted, racedSkipped, deferred };
 }
 
-async function cleanupStaleOrphaned(
-  sql: Bun.SQL,
-  tenantId: string,
-  entries: NewsMediaStaleOrphanedEntry[],
-  orphanCutoff: Date,
-  r2Client: NewsMediaR2Client,
-  signal?: AbortSignal
-): Promise<{ deleted: number; deferred: number }> {
-  let deleted = 0;
-  let deferred = 0;
-
-  for (const entry of entries) {
-    if (signal?.aborted) break;
-
-    const deleteResult = await r2Client.deleteObject(entry.objectKey);
-
-    if (!deleteResult.ok) {
-      deferred += 1;
-      continue;
-    }
-
-    const softDeleted = await withTenantOrThrow(
-      sql,
-      tenantId,
-      (tx) =>
-        markStaleOrphanedNewsMediaObjectDeleted(
-          tx,
-          tenantId,
-          entry.id,
-          orphanCutoff
-        ),
-      { workClass: "maintenance" }
-    );
-
-    if (softDeleted) {
-      deleted += 1;
-    }
-  }
-
-  return { deleted, deferred };
-}
-
 async function cleanupOrphanInR2(
   sql: Bun.SQL,
   tenantId: string,
@@ -417,7 +364,6 @@ export async function reconcileNewsMediaForTenant(
       healthyCount: 0,
       orphanInDb: [],
       expiredPending: { total: 0, deleted: 0, racedSkipped: 0, deferred: 0 },
-      staleOrphaned: { total: 0, deleted: 0, deferred: 0 },
       orphanInR2: {
         total: 0,
         eligible: 0,
@@ -440,9 +386,6 @@ export async function reconcileNewsMediaForTenant(
   const pendingCutoff = new Date(
     now.getTime() - config.pendingTtlMinutes * 60_000
   );
-  const orphanCutoff = new Date(
-    now.getTime() - config.orphanGraceDays * 24 * 60 * 60 * 1000
-  );
 
   if (dryRun) {
     return {
@@ -457,11 +400,6 @@ export async function reconcileNewsMediaForTenant(
         total: categorized.expiredPending.length,
         deleted: 0,
         racedSkipped: 0,
-        deferred: 0
-      },
-      staleOrphaned: {
-        total: categorized.staleOrphaned.length,
-        deleted: 0,
         deferred: 0
       },
       orphanInR2: {
@@ -482,15 +420,6 @@ export async function reconcileNewsMediaForTenant(
     tenantId,
     categorized.expiredPending,
     pendingCutoff,
-    r2Client,
-    signal
-  );
-
-  const staleOrphanedResult = await cleanupStaleOrphaned(
-    sql,
-    tenantId,
-    categorized.staleOrphaned,
-    orphanCutoff,
     r2Client,
     signal
   );
@@ -516,10 +445,6 @@ export async function reconcileNewsMediaForTenant(
       total: categorized.expiredPending.length,
       ...expiredPendingResult
     },
-    staleOrphaned: {
-      total: categorized.staleOrphaned.length,
-      ...staleOrphanedResult
-    },
     orphanInR2: {
       total: categorized.orphanInR2.length,
       eligible: categorized.orphanInR2.filter((entry) =>
@@ -541,9 +466,6 @@ export type NewsMediaReconciliationTotals = {
   expiredPendingDeleted: number;
   expiredPendingRacedSkipped: number;
   expiredPendingDeferred: number;
-  staleOrphanedTotal: number;
-  staleOrphanedDeleted: number;
-  staleOrphanedDeferred: number;
   orphanInR2Total: number;
   orphanInR2Eligible: number;
   orphanInR2Deleted: number;
@@ -569,9 +491,6 @@ function emptyTotals(): NewsMediaReconciliationTotals {
     expiredPendingDeleted: 0,
     expiredPendingRacedSkipped: 0,
     expiredPendingDeferred: 0,
-    staleOrphanedTotal: 0,
-    staleOrphanedDeleted: 0,
-    staleOrphanedDeferred: 0,
     orphanInR2Total: 0,
     orphanInR2Eligible: 0,
     orphanInR2Deleted: 0,
@@ -624,9 +543,6 @@ export async function reconcileNewsMediaForAllTenants(
     totals.expiredPendingDeleted += result.expiredPending.deleted;
     totals.expiredPendingRacedSkipped += result.expiredPending.racedSkipped;
     totals.expiredPendingDeferred += result.expiredPending.deferred;
-    totals.staleOrphanedTotal += result.staleOrphaned.total;
-    totals.staleOrphanedDeleted += result.staleOrphaned.deleted;
-    totals.staleOrphanedDeferred += result.staleOrphaned.deferred;
     totals.orphanInR2Total += result.orphanInR2.total;
     totals.orphanInR2Eligible += result.orphanInR2.eligible;
     totals.orphanInR2Deleted += result.orphanInR2.deleted;

--- a/src/modules/media-library/domain/media-reconciliation-categorization.ts
+++ b/src/modules/media-library/domain/media-reconciliation-categorization.ts
@@ -36,10 +36,14 @@
  *   `pending_upload`/`uploaded` so a previous run's R2-delete failure
  *   (provider outage) is retried on the next run — see this module's own
  *   idempotency note below.
- * - **staleOrphaned** — a `status = 'orphaned'` row, not yet soft-deleted,
- *   whose `orphanedAt` is older than `orphanGraceDays`
- *   (`NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS`). Eligible for R2-object-delete +
- *   DB soft-delete (`r2-backup-lifecycle.md` §3's retention table).
+ * There is deliberately NO "stale orphaned" category (finding D16). One used
+ * to sit here, matching `status = 'orphaned'` rows past a grace period — and
+ * `markNewsMediaObjectOrphaned` was the repo's only writer of that status and
+ * had zero callers, so it matched a permanently empty set. A zero counter and
+ * a clean bucket printed the same line. The status itself is a leftover of the
+ * pre-ADR-0036 model: `sql/087` removed the attach/detach relation, so no
+ * reference count exists to derive "orphaned" FROM. `orphanGraceDays` survives
+ * because `orphanInR2` below genuinely uses it.
  * - **orphanInR2** — an R2 object whose key has NO matching DB row AT ALL
  *   (any status, any `deletedAt`) for this tenant. Eligible for physical R2
  *   deletion once its OWN age (R2's reported `lastModified`, the only
@@ -56,7 +60,7 @@
  *
  * ## Idempotency
  *
- * Categorizing the SAME snapshot twice always produces the SAME five lists
+ * Categorizing the SAME snapshot twice always produces the SAME four lists
  * — this function has no side effects and no hidden state. Real-world
  * idempotency across ACTUAL job runs (`bun run news-media:reconcile` twice
  * in a row doing nothing the second time) additionally depends on the
@@ -109,6 +113,13 @@ export type NewsMediaReconciliationInput = {
   r2Objects: NewsMediaReconciliationR2Object[];
   now: Date;
   pendingTtlMinutes: number;
+  /**
+   * NOT read by this function any more (finding D16) — the one category that
+   * used it, `staleOrphaned`, matched a permanently empty set. It stays on the
+   * INPUT because `isOrphanInR2EligibleForDeletion` below takes the same number
+   * and the application layer passes one config object to both; removing it
+   * here would only move the field, not delete it.
+   */
   orphanGraceDays: number;
 };
 
@@ -128,12 +139,6 @@ export type NewsMediaExpiredPendingEntry = {
   ageMinutes: number;
 };
 
-export type NewsMediaStaleOrphanedEntry = {
-  id: string;
-  objectKey: string;
-  ageDays: number;
-};
-
 export type NewsMediaOrphanInR2Entry = {
   objectKey: string;
   sizeBytes?: number;
@@ -145,7 +150,6 @@ export type NewsMediaReconciliationResult = {
   healthy: NewsMediaHealthyEntry[];
   orphanInDb: NewsMediaOrphanInDbEntry[];
   expiredPending: NewsMediaExpiredPendingEntry[];
-  staleOrphaned: NewsMediaStaleOrphanedEntry[];
   orphanInR2: NewsMediaOrphanInR2Entry[];
 };
 
@@ -186,20 +190,16 @@ function r2ObjectAgeInDays(
 export function categorizeNewsMediaReconciliation(
   input: NewsMediaReconciliationInput
 ): NewsMediaReconciliationResult {
-  const { dbRows, r2Objects, now, pendingTtlMinutes, orphanGraceDays } = input;
+  const { dbRows, r2Objects, now, pendingTtlMinutes } = input;
 
   const r2KeySet = new Set(r2Objects.map((object) => object.key));
   const dbKeySet = new Set(dbRows.map((row) => row.objectKey));
 
   const pendingCutoff = new Date(now.getTime() - pendingTtlMinutes * 60_000);
-  const orphanCutoff = new Date(
-    now.getTime() - orphanGraceDays * 24 * 60 * 60 * 1000
-  );
 
   const healthy: NewsMediaHealthyEntry[] = [];
   const orphanInDb: NewsMediaOrphanInDbEntry[] = [];
   const expiredPending: NewsMediaExpiredPendingEntry[] = [];
-  const staleOrphaned: NewsMediaStaleOrphanedEntry[] = [];
 
   for (const row of dbRows) {
     // Security-auditor Medium finding on PR #718: `"uploaded"` is a member
@@ -242,19 +242,6 @@ export function categorizeNewsMediaReconciliation(
         ageMinutes: ageInMinutes(row.createdAt, now)
       });
     }
-
-    if (
-      row.deletedAt === null &&
-      row.status === "orphaned" &&
-      row.orphanedAt !== null &&
-      row.orphanedAt < orphanCutoff
-    ) {
-      staleOrphaned.push({
-        id: row.id,
-        objectKey: row.objectKey,
-        ageDays: ageInDays(row.orphanedAt, now)
-      });
-    }
   }
 
   const orphanInR2: NewsMediaOrphanInR2Entry[] = r2Objects
@@ -265,7 +252,7 @@ export function categorizeNewsMediaReconciliation(
       ageDays: r2ObjectAgeInDays(object.lastModified, now)
     }));
 
-  return { healthy, orphanInDb, expiredPending, staleOrphaned, orphanInR2 };
+  return { healthy, orphanInDb, expiredPending, orphanInR2 };
 }
 
 /** `true` iff `entry.ageDays` is known AND at least `orphanGraceDays` — the deletion-eligibility gate for `orphanInR2` entries (application layer still re-verifies via `objectKeyExistsForTenant` immediately before acting). */

--- a/src/pages/admin/blog-ads.astro
+++ b/src/pages/admin/blog-ads.astro
@@ -375,10 +375,19 @@ function formatWindow(placement: AdPlacementView): string {
               value={editing?.mediaObjectId ?? ""}
             />
             <div class="media-choice" id="ad-media-choice">
+              {/* Finding D17 — the row now carries the media registry's own
+                  verdict, so this can say whether the image will actually be
+                  SHOWN rather than only that an id is set. An ad pointing at an
+                  unverified or soft-deleted object renders nothing publicly,
+                  and saying "an image is attached" is how that goes unnoticed. */}
               <p class="form-hint" id="ad-media-label">
-                {editing?.mediaObjectId
-                  ? t("An image is attached.")
-                  : t("No image attached.")}
+                {!editing?.mediaObjectId
+                  ? t("No image attached.")
+                  : editing.mediaPubliclyReferenceable
+                    ? t("An image is attached.")
+                    : t(
+                        "An image is attached, but it is not publicly referenceable — it is unverified or has been deleted, so this ad will render nothing."
+                      )}
               </p>
               <div class="media-choice-actions">
                 <button

--- a/src/pages/admin/media.astro
+++ b/src/pages/admin/media.astro
@@ -100,6 +100,13 @@ function readParam(name: string): string {
   return (Astro.url.searchParams.get(name) ?? "").trim();
 }
 
+// Two of these are statuses nothing WRITES any more, and both stay on purpose
+// (finding D16). `attached` was retired by ADR-0036's inversion (`sql/087`) and
+// rows already hold it. `orphaned` never had a reachable writer at all, and its
+// only one is now deleted — but `sql/041`'s CHECK still admits the value, so a
+// row could reach it by hand, and this list is a READ over that column. The
+// same is true of the API's own `status` filter; dropping the option here and
+// not there would leave two surfaces disagreeing about the same column.
 const STATUS_OPTIONS: readonly NewsMediaObjectStatus[] = [
   "pending_upload",
   "uploaded",

--- a/tests/admin-json-client-core.test.ts
+++ b/tests/admin-json-client-core.test.ts
@@ -5,8 +5,11 @@
  * `src/lib/ui/`, and they had ALREADY drifted: `sendJson` and `sendJsonForData`
  * supported `extraHeaders`, bodyless requests and `DELETE`;
  * `sendJsonWithFieldErrors` supported none of it until Issue #596 added the
- * first by hand. Three copies of a fetch is also three copies of the bytes, on
- * a client budget this repo measures and had 161 B left in.
+ * first by hand.
+ *
+ * It was ALSO argued as a byte saving, and that argument was wrong: both files
+ * were already shared chunks shipped once each, so consolidating them recovered
+ * nothing. The 425 B measured at the time came from an uncleaned `dist/`.
  *
  * What the consolidation must NOT do is merge the three public functions.
  * Their differing return shapes are a control, not an accident: `sendJson`'s

--- a/tests/media-reconciliation-categorization.test.ts
+++ b/tests/media-reconciliation-categorization.test.ts
@@ -199,33 +199,40 @@ describe("categorizeNewsMediaReconciliation (Issue #690)", () => {
     expect(result.expiredPending).toHaveLength(0);
   });
 
-  test("stale-orphaned: an orphaned row past the grace period is included, a fresh one is not", () => {
-    const staleOrphanedAt = new Date(
+  test("there is no orphaned category at all, and an orphaned row lands nowhere", () => {
+    // Finding D16. This test used to assert that an `orphaned` row past the
+    // grace period was picked up — over a status NOTHING could write:
+    // `markNewsMediaObjectOrphaned` was the repo's only writer of it and had
+    // zero callers, so the category matched a permanently empty set and the
+    // job printed `staleOrphaned(total=0,...)` on every run. A zero counter and
+    // a clean bucket read identically.
+    //
+    // The status value survives in `sql/041`'s CHECK — an applied migration is
+    // immutable and the column stays honest about what the schema will hold —
+    // so a row could still reach it by hand. It is categorised as nothing,
+    // which is the truthful answer: this job has no remediation for a state it
+    // cannot produce and cannot derive. `orphanGraceDays` is untouched; the
+    // `orphanInR2` category genuinely uses it.
+    const orphanedAt = new Date(
       NOW.getTime() - (ORPHAN_GRACE_DAYS + 1) * 24 * 60 * 60 * 1000
-    );
-    const freshOrphanedAt = new Date(
-      NOW.getTime() - (ORPHAN_GRACE_DAYS - 1) * 24 * 60 * 60 * 1000
     );
 
     const result = categorize(
       [
         row({
-          objectKey: "stale-orphan",
+          objectKey: "hand-written-orphan",
           status: "orphaned",
-          orphanedAt: staleOrphanedAt
-        }),
-        row({
-          objectKey: "fresh-orphan",
-          status: "orphaned",
-          orphanedAt: freshOrphanedAt
+          orphanedAt
         })
       ],
-      []
+      [{ key: "hand-written-orphan", lastModified: orphanedAt.toISOString() }]
     );
 
-    expect(result.staleOrphaned.map((entry) => entry.objectKey)).toEqual([
-      "stale-orphan"
-    ]);
+    expect(result).not.toHaveProperty("staleOrphaned");
+    expect(result.healthy).toHaveLength(0);
+    expect(result.orphanInDb).toHaveLength(0);
+    expect(result.expiredPending).toHaveLength(0);
+    expect(result.orphanInR2).toHaveLength(0);
   });
 
   test("orphan-in-r2: an R2 object with no matching DB row at all (any status) is flagged", () => {

--- a/tests/two-surfaces-that-answered-nobody.test.ts
+++ b/tests/two-surfaces-that-answered-nobody.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Findings D16 and D17 — two media surfaces that answered nobody, in opposite
+ * directions.
+ *
+ * **D16** was a whole lifecycle branch nothing could reach.
+ * `markNewsMediaObjectOrphaned` was this repo's only writer of
+ * `status = 'orphaned'` and had zero callers, so the reconciliation job's
+ * stale-orphan sweep, `sql/041`'s partial index and the grace-period comparison
+ * all gated a permanently empty set — and every run printed
+ * `staleOrphaned(total=0,deleted=0,deferred=0)`, which reads exactly like a
+ * clean bucket. The code is deleted; the SCHEMA is kept, and this file pins
+ * both halves of that split so a future reader does not "restore" one of them.
+ *
+ * **D17** was the reverse: a surface that answered, with something the answer
+ * could not be used for. The ad list handed out `mediaObjectId` and nothing
+ * else, so an external renderer could neither build an `<img src>` nor
+ * reproduce the media-safety filter — it would have had to reimplement
+ * `isNewsMediaObjectSafeForPublicReference` from a status string it was not
+ * given either.
+ */
+import { describe, expect, test } from "bun:test";
+
+import { stripComments } from "../scripts/lib/source-text";
+import { categorizeNewsMediaReconciliation } from "../src/modules/media-library/domain/media-reconciliation-categorization";
+import { isNewsMediaObjectSafeForPublicReference } from "../src/modules/media-library/application/media-object-directory";
+
+const DIRECTORY =
+  "src/modules/media-library/application/media-object-directory.ts";
+const RECONCILIATION =
+  "src/modules/media-library/application/media-reconciliation.ts";
+const AD_DIRECTORY =
+  "src/modules/blog-content/application/ad-placement-directory.ts";
+const MIGRATION = "sql/041_awcms_news_media_object_registry_schema.sql";
+
+describe("D16 — the unreachable orphan lifecycle is gone", () => {
+  test("nothing writes status = 'orphaned' any more", async () => {
+    const source = stripComments(await Bun.file(DIRECTORY).text());
+
+    expect(source).not.toContain("markNewsMediaObjectOrphaned");
+    expect(source).not.toContain("markStaleOrphanedNewsMediaObjectDeleted");
+    expect(source).not.toContain("orphaned_at = now()");
+    expect(source).not.toContain("status = 'orphaned'");
+  });
+
+  test("the reconciliation job no longer reports a category it cannot fill", async () => {
+    // The operator-facing half of the finding. A counter that is structurally
+    // always zero is worse than no counter: it reads as a measurement.
+    const source = stripComments(await Bun.file(RECONCILIATION).text());
+    const script = stripComments(
+      await Bun.file("scripts/news-media-r2-reconcile.ts").text()
+    );
+
+    expect(source).not.toContain("staleOrphaned");
+    expect(script).not.toContain("staleOrphaned");
+  });
+
+  test("an `orphaned` row is categorised as nothing, not as a sweep candidate", () => {
+    const now = new Date("2026-08-22T00:00:00.000Z");
+    const longAgo = new Date("2020-01-01T00:00:00.000Z");
+
+    const result = categorizeNewsMediaReconciliation({
+      dbRows: [
+        {
+          id: "11111111-1111-4111-8111-111111111111",
+          objectKey: "by-hand",
+          status: "orphaned",
+          createdAt: longAgo,
+          orphanedAt: longAgo,
+          deletedAt: null
+        }
+      ],
+      r2Objects: [{ key: "by-hand", lastModified: longAgo.toISOString() }],
+      now,
+      pendingTtlMinutes: 60,
+      orphanGraceDays: 30
+    });
+
+    expect(Object.keys(result).sort()).toEqual([
+      "expiredPending",
+      "healthy",
+      "orphanInDb",
+      "orphanInR2"
+    ]);
+    expect(result.healthy).toHaveLength(0);
+    expect(result.orphanInDb).toHaveLength(0);
+    expect(result.expiredPending).toHaveLength(0);
+  });
+
+  test("the SCHEMA is deliberately kept, and the status stays publicly unsafe", async () => {
+    // The decision was "delete the code, keep the schema". An applied migration
+    // is immutable in this repo, the column stays honest about what it will
+    // hold, and it is where a future detector would write. A row that reached
+    // the state by hand must still be refused a public reference.
+    const migration = await Bun.file(MIGRATION).text();
+
+    expect(migration).toContain("'orphaned'");
+    expect(migration).toContain("orphaned_at");
+    expect(isNewsMediaObjectSafeForPublicReference("orphaned")).toBe(false);
+  });
+
+  test("the grace-period setting is NOT deleted with it", async () => {
+    // It looked dead and is not: `orphanInR2` — an R2 object with no DB row at
+    // all — genuinely uses `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` to decide when
+    // physical deletion is safe. Deleting it with the rest of D16 would have
+    // removed a live control.
+    const config = await Bun.file(
+      "src/modules/media-library/domain/media-r2-config.ts"
+    ).text();
+
+    expect(config).toContain("NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS");
+
+    const reconciliation = stripComments(await Bun.file(RECONCILIATION).text());
+    expect(reconciliation).toContain("isOrphanInR2EligibleForDeletion");
+    expect(reconciliation).toContain("orphanGraceDays");
+  });
+});
+
+describe("D17 — an ad row a renderer can actually use", () => {
+  test("every read path resolves the media object in the same query", async () => {
+    // Not an N+1 across the list, and not a second endpoint. The join is what
+    // makes the resolved fields available at all, and it must be on every path
+    // that produces the view — including the two WRITES, which use a
+    // data-modifying CTE so a freshly created ad is not reported as
+    // unreferenceable.
+    const source = stripComments(await Bun.file(AD_DIRECTORY).text());
+    const joins = source.split("LEFT JOIN awcms_news_media_objects").length - 1;
+
+    // fetch by id, admin list, create, update.
+    expect(joins).toBe(4);
+    expect(source.split("WITH written AS").length - 1).toBe(2);
+  });
+
+  test("the verdict is computed server-side, never handed over as a status", async () => {
+    // The rule turns on which lifecycle states count as verified, and a
+    // consumer reimplementing it gets that wrong in the permissive direction —
+    // which publishes an unverified image. So the endpoint answers the
+    // QUESTION, not the input to it.
+    const source = stripComments(await Bun.file(AD_DIRECTORY).text());
+
+    expect(source).toContain("mediaPubliclyReferenceable");
+    expect(source).toContain("isNewsMediaObjectSafeForPublicReference");
+    // `media_status` is selected, but it must not reach the view.
+    expect(source).not.toContain("mediaStatus: row.media_status");
+  });
+
+  test("the contract requires the three fields, so a consumer can rely on them", async () => {
+    const spec = await Bun.file(
+      "openapi/modules/blog-content.openapi.yaml"
+    ).text();
+    const schema = spec.slice(
+      spec.indexOf("    AdPlacementItem:"),
+      spec.indexOf("    AdPlacementCreateRequest:")
+    );
+
+    for (const field of [
+      "mediaPublicUrl",
+      "mediaAltText",
+      "mediaPubliclyReferenceable"
+    ]) {
+      // Present as a property AND on `required` — an optional field is one a
+      // consumer has to defend against, which is the state D17 describes.
+      expect(schema, field).toContain(`        - ${field}`);
+      expect(schema, field).toContain(`        ${field}:`);
+    }
+  });
+
+  test("a soft-deleted media object leaves the placement visible and unsafe", async () => {
+    // The reason the join is LEFT and its media predicate sits in the ON
+    // clause. An INNER join would drop the broken placement from the one screen
+    // that could repair it, which is the same class of silence D16 was about.
+    const source = await Bun.file(AD_DIRECTORY).text();
+
+    expect(source).toContain("LEFT JOIN awcms_news_media_objects m");
+    expect(source).toContain("AND m.deleted_at IS NULL\n");
+    // Null media columns must produce `false`, never `undefined`/`true`.
+    expect(source).toContain("row.media_status !== null &&");
+  });
+});
+
+describe("docs:i18n:stamp refuses to declare a mirror nobody re-translated", () => {
+  // PROJECT_STATE §4, found while working. The marker says "this mirror was
+  // translated from a source with this hash", and re-writing it is a CLAIM
+  // about the translation. The tool used to make that claim unconditionally, so
+  // "edit the English, run the stamp" turned `check:docs:translation` green over
+  // an Indonesian mirror that still said the old thing — which happened, and was
+  // caught by a test that counts `sql/NNN` ranges for an unrelated reason.
+  const SCRIPT = "scripts/docs-i18n-stamp.mjs";
+
+  test("the refusal exists and is reachable", async () => {
+    const source = stripComments(await Bun.file(SCRIPT).text());
+
+    expect(source).toContain("mayRestamp");
+    expect(source).toContain("REFUSES to re-stamp");
+    expect(source).toContain("process.exit(1)");
+  });
+
+  test("both allow-paths are the ones that mean the translation was looked at", async () => {
+    const source = stripComments(await Bun.file(SCRIPT).text());
+
+    // 1. the mirror is modified/untracked in this working tree;
+    expect(source).toContain("touched.has(mirrorPath)");
+    // 2. the source changed only in whitespace since HEAD — the reflow case
+    //    the tool was built for, where no translator needs to do anything.
+    expect(source).toContain("withoutWhitespace(committed)");
+    // and the deliberate override, for a reword the translation survives.
+    expect(source).toContain("--force-restamp");
+  });
+
+  test("a missing HEAD version does not silently allow the re-stamp", async () => {
+    // `committedContent` returns null for a file not in HEAD. Reading that as
+    // "formatting-only" would reopen the hole for exactly the case where the
+    // source is brand new and the mirror is not.
+    const source = stripComments(await Bun.file(SCRIPT).text());
+
+    expect(source).toContain("committed !== null &&");
+  });
+});


### PR DESCRIPTION
PROJECT_STATE §4 **D16**, **D17**, the `docs:i18n:stamp` item found while working — and a correction to a claim I made in #677.

The two media findings are opposites: one was a whole branch nothing could reach, the other a surface that answered with something unusable.

## D16 — the orphan lifecycle is deleted, the schema is kept

`markNewsMediaObjectOrphaned` was this repo's only writer of `status = 'orphaned'` and had zero callers, so the reconciliation job's stale-orphan sweep, its partial index and the grace-period comparison all gated a permanently empty set — and every run printed `staleOrphaned(total=0,deleted=0,deferred=0)`, which reads exactly like a clean bucket.

It is a leftover of the pre-ADR-0036 model: `sql/087` removed the attach/detach relation, so no reference count exists to derive "orphaned" **from**.

Gone: the writer, `markStaleOrphanedNewsMediaObjectDeleted`, the `cleanupStaleOrphaned` path (whose docblock reasoned carefully about a race that could not occur), the `staleOrphaned` category and the job's three counters.

**One correction to the finding, and it matters: `NEWS_MEDIA_R2_ORPHAN_GRACE_DAYS` is NOT dead** and was not deleted. `orphanInR2` — an R2 object with no DB row at all — genuinely uses it to decide when physical deletion is safe. Removing it with the rest would have taken out a live control.

Kept per the decision to delete the code and not the schema: the `'orphaned'` CHECK value, `orphaned_at`, the partial index, and **both** status filters (admin screen and API). Those are reads over a column that can still hold the value, and dropping one would leave two surfaces disagreeing about the same column. `isNewsMediaObjectSafeForPublicReference` still refuses the status.

## D17 — an ad row a renderer can actually use

`GET /api/v1/news-portal/ad-placements` returned `mediaObjectId` and nothing else, so an external renderer could neither build an `<img src>` nor reproduce the media-safety filter.

Three fields added to `AdPlacementItem`, all **required**: `mediaPublicUrl`, `mediaAltText`, `mediaPubliclyReferenceable`.

The last is the point. It is the **server's verdict**, not a status to interpret: `isNewsMediaObjectSafeForPublicReference` turns on which lifecycle states count as verified, and a consumer reimplementing it gets that wrong in the *permissive* direction — which publishes an unverified image. `false` also covers a soft-deleted object, so a consumer checking only this field cannot render one.

Resolved in the same query on every path: a `LEFT JOIN` with the media predicate in the `ON` clause, so a placement whose object was soft-deleted still appears in the admin list rather than vanishing from the one screen that could repair it; and a data-modifying CTE on create/update so a freshly created ad is not reported as unreferenceable. No N+1, no second endpoint. `/admin/blog-ads` now says whether the attached image will actually be shown.

## `docs:i18n:stamp` no longer declares a mirror current that nobody re-translated

Re-writing the `i18n-source-hash` marker is a **claim** about the translation, and the tool made it unconditionally — so "edit the English, run the stamp" turned `check:docs:translation` green over a mirror that still said the old thing. That happened for real (a §2 count went 141 → 142 while the mirror still read 141) and was caught only by a test that checks `sql/NNN` ranges for a different reason.

Re-stamping a stale mirror is now allowed only when the mirror itself is modified in the working tree, or the source changed only in whitespace since `HEAD` — the reflow case the tool exists for. Otherwise it refuses, names the file, exits 1. `--force-restamp` is the deliberate override. Verified against all three cases.

It immediately surfaced drift it had been papering over: §2 of the Indonesian `PROJECT_STATE` said ADR `0000–0103` while the English said `0000–0106`. §2 is generated into the English file **only**, so its mirror is hand-maintained and had silently fallen three ADRs behind. Corrected.

## Correction to #677: the 425 B saving was not real

I claimed in #677 that the D12 consolidation recovered 425 B of client budget. **It recovered nothing.** Both files were already shared chunks shipped once each, so "three copies of the bytes" was never true — three copies of the *source* shipped once. Clean builds of `a65f05b9` (pre-#677) and `ce82c1d1` (post-#677) are byte-identical at 191,839 B.

The 425 B came from a `dist/` the build had not cleaned, and it did real damage: D12/D13/D14 were sequenced **before** ADR-0106 to buy headroom that did not exist, and #678 turned out to be inside the ceiling all along.

`client-asset-budget.ts`'s own docblock already recorded being misled this way twice. Warning a third time would not have worked either, so `bun run build` now runs `rm -rf dist` first. The claim is corrected in the D12 changeset (unreleased, so no CHANGELOG carries it), in PROJECT_STATE §4, and in the test file's header.

D12 still stands on what the finding was actually about: the drift, the dead `postJson`, and the silent header-precedence disagreement.

## Verification

Full `bun run check` green; `DATABASE_URL="" bun run test` 5595 pass / 0 fail; clean build 191,537 B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
