### PR TITLE
docs(project-state): close the verify item ADR-0106 resolved

### DIFF
--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:b8eb296f4ffb75a7e41e314556954c5c8f76fedd35aefbd52c4e040f5a45565f -->
+<!-- i18n-source-hash: sha256:07657b43ed9a49d169c58b9254f5ba8f9b75a838cf4da92a22748e5ed20301d9 -->
 
 # AWCMS — Project State & Continuation
 
@@ -361,36 +361,39 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 ## 4. Backlog / langkah berikutnya
 
 - **DITEMUKAN SAAT BEKERJA, 22 Agustus 2026 (sambil menutup D7): `POST
-/api/v1/tenant/domains/{id}/verify` TIDAK MEMVERIFIKASI APA PUN.** Ia membaca barisnya,
-  memeriksa `verification_method IS NOT NULL`, lalu menyetel `status = 'active'`. Tidak
-  ada lookup DNS, tidak ada fetch berkas HTTP, tidak ada perbandingan token di mana pun
-  pada jalur rutenya — adapter Cloudflare ada
-  (`tenant-domain/infrastructure/cloudflare-dns-adapter.ts`), dipilih lewat
-  `TENANT_DOMAIN_DNS_PROVIDER`, dan tidak dipanggil siapa pun. Kolom yang menyebut sebuah
-  metode adalah keseluruhan pemeriksaannya.
+/api/v1/tenant/domains/{id}/verify` TIDAK MEMVERIFIKASI APA PUN.** **SELESAI (22 Agustus 2026) — [ADR-0106](adr/0106-domain-verification-proves-control-of-the-zone.id.md).** Ia
+  membaca baris, memeriksa `verification_method IS NOT NULL`, lalu menyetel
+  `status = 'active'`. Tanpa lookup DNS, tanpa pengambilan berkas HTTP, tanpa perbandingan
+  token di mana pun pada jalur rute itu. Domain `active` memberi makan
+  `resolvePublicTenantByHost`, daftar-izin redirect dan host kanonik, jadi admin tenant
+  yang memegang `domains.create` + `.update` + `.verify` bisa menambahkan hostname,
+  mem-PATCH `verificationMethod: "manual"`, memanggil verify, dan membuat deployment ini
+  menjawab untuk hostname itu sebagai tenant tersebut.
 
-  **Apa yang dibeli domain aktif.** `resolvePublicTenantByHost` memetakan `Host` sebuah
-  request ke tenant dari `awcms_tenant_domains`; `resolveTenantDomainSet`
-  memperlakukannya sebagai target redirect yang diizinkan; `resolveTenantPrimaryHost`
-  menaruhnya di URL kanonik, feed, dan sitemap. Jadi urutannya: tenant yang memegang
-  `tenant_domain.domains.create` + `.update` + `.verify` menambah sebuah hostname,
-  mem-PATCH `verificationMethod: "manual"`, memanggil verify, dan deployment itu kini akan
-  menjawab untuk hostname tersebut sebagai tenant itu.
+  **Membuat perbandingannya nyata baru setengah perbaikan.** API juga menerima NAMA dan
+  NILAI record dari pemanggil, dan pemeriksaan terhadap nama pilihan pemanggil dan nilai
+  pilihan pemanggil tidak membuktikan apa pun — keduanya bisa menunjuk record yang sudah
+  ada di zona yang tak dikuasai siapa pun. Kedua bagiannya kini dicetak server
+  (`_awcms-verify.<host>`, 32 bita acak per baris) dan mengirim salah satunya DITOLAK
+  dengan 400 yang menyebut nama field-nya, bukan diabaikan.
 
-  **Dua hal membatasinya, dan tak satu pun adalah kontrolnya.** Pembuatan dan verifikasi
-  digerbangi ABAC, jadi ini jangkauan seorang admin tenant dan bukan jangkauan anonim; dan
-  ia hanya penting untuk hostname yang DNS-nya benar-benar bisa diarahkan seseorang ke
-  deployment ini. Yang kedua bukan properti kode ini — ia properti DNS milik orang lain.
+  **`manual` dihapus, bukan diturunkan menjadi atestasi operator**, ke mana tebakan butir
+  ini sendiri mengarah. Permission ber-scope platform hanya boleh dijalankan tenant
+  platform (ADR-0053) dan RLS berarti ia tak bisa melihat baris tenant lain, jadi
+  mempertahankan jalur itu berarti membangun permukaan lintas-tenant — jenis paling
+  berbahaya yang dimiliki basis kode ini, dan reset MFA admin sengaja sendirian di sana.
+  `file` keluar karena berarti mengambil URL pilihan pemanggil; `dns_cname` karena butuh
+  target platform yang tidak ada. CHECK `sql/046` tidak disentuh.
 
-  **Tidak diperbaiki di sini, dengan sengaja.** Perbaikannya adalah langkah verifikasi
-  nyata (menerbitkan record `dns_txt` lalu memeriksanya, atau mengambil berkas well-known)
-  ditambah keputusan tentang apa yang boleh berarti `manual` — masuk akal bila "seorang
-  OPERATOR yang mengatestasi", yang akan menjadikannya aksi ber-scope platform, bukan
-  scope tenant. Itu perubahan keamanan yang mengandung ADR, bukan pembersihan settings,
-  dan melebur keduanya akan menjadi cara yang salah untuk mengambil keputusan itu.
-  Resolusi D7 sendiri dipilih supaya tidak MEMPERBURUK ini: `defaultVerificationMethod`
-  yang tak terbaca dihapus alih-alih diterapkan, karena menerapkannya akan menyerahkan ke
-  setiap domain yang baru dibuat satu-satunya prasyarat yang dimiliki `verify`.
+  Lookup-nya berjalan DI LUAR setiap transaksi (ADR-0006) di antara dua transaksi tenant;
+  yang kedua mengotorisasi ulang (ADR-0063) dan membawa nilai terbukti ke klausa
+  `WHERE`-nya. **Tidak ada bukan berarti tidak terjangkau** — NXDOMAIN fakta tentang
+  domain yang diklaim, SERVFAIL tentang resolver kita, dan hanya yang kedua memberi makan
+  breaker atau membiarkan statusnya utuh. Kegagalan mencatat `failed`, yang menjaga
+  keadaan itu tetap terjangkau. Baris pra-ADR dicetak tantangan secara malas pada verify
+  pertama alih-alih lewat migrasi ber-DML pada tabel FORCE RLS. Dibatasi laju per
+  PRINSIPAL, bukan per tenant — percobaan pertama mengunci pada header tenant dan
+  `tests/auth-source-rate-limit.test.ts` menolaknya, dengan benar (Issue #447).
 
 - **DITEMUKAN SAAT BEKERJA, 22 Agustus 2026: `docs:i18n:stamp` bisa MEMBUNGKAM
   `check:docs:translation` pada mirror yang kini SALAH.** **SELESAI (22 Agustus 2026).**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -361,33 +361,39 @@ pioneered directly here after the ADR-0047 freeze.)
 ## 4. Backlog / next steps
 
 - **FOUND WHILE WORKING, 22 August 2026 (while closing D7): `POST
-/api/v1/tenant/domains/{id}/verify` VERIFIES NOTHING.** It reads the row, checks
-  `verification_method IS NOT NULL`, and sets `status = 'active'`. There is no DNS
-  lookup, no HTTP file fetch, no token comparison anywhere on the route path — the
-  Cloudflare adapter exists (`tenant-domain/infrastructure/cloudflare-dns-adapter.ts`),
-  is selected by `TENANT_DOMAIN_DNS_PROVIDER`, and is called by nothing. The column that
-  names a method is the whole of the check.
+/api/v1/tenant/domains/{id}/verify` VERIFIES NOTHING.** **DONE (22 August 2026) —
+  [ADR-0106](adr/0106-domain-verification-proves-control-of-the-zone.md).** It read the
+  row, checked `verification_method IS NOT NULL`, and set `status = 'active'`. No DNS
+  lookup, no HTTP file fetch, no token comparison anywhere on the route path. An `active`
+  domain feeds `resolvePublicTenantByHost`, the redirect allow-list and the canonical
+  host, so a tenant admin holding `domains.create` + `.update` + `.verify` could add a
+  hostname, PATCH `verificationMethod: "manual"`, call verify, and have this deployment
+  answer for that hostname as that tenant.
 
-  **What an active domain buys.** `resolvePublicTenantByHost` maps a request `Host` to a
-  tenant from `awcms_tenant_domains`; `resolveTenantDomainSet` treats it as a permitted
-  redirect target; `resolveTenantPrimaryHost` puts it in canonical URLs, feeds and
-  sitemaps. So the sequence is: a tenant holding `tenant_domain.domains.create` +
-  `.update` + `.verify` adds a hostname, PATCHes `verificationMethod: "manual"`, calls
-  verify, and the deployment will now answer for that hostname as that tenant.
+  **Making the comparison real was only half the fix.** The API also accepted the record
+  NAME and VALUE from the caller, and a check against a caller-chosen name and a
+  caller-chosen value proves nothing — both can point at a record that already exists in
+  a zone nobody controls. Both halves are now server-minted
+  (`_awcms-verify.<host>`, 32 random bytes per row) and supplying either is REFUSED with
+  a 400 naming the field, not ignored.
 
-  **Two things bound it, and neither is the control.** Creation and verification are
-  ABAC-guarded, so this is a tenant admin's reach and not an anonymous one; and it only
-  matters for a hostname whose DNS someone can actually point at this deployment. The
-  second is not a property of this code — it is a property of somebody else's DNS.
+  **`manual` is removed rather than demoted to an operator attestation**, which is where
+  this item's own guess pointed. A platform-scoped permission may only be exercised by
+  the platform tenant (ADR-0053) and RLS means it cannot see another tenant's row, so
+  preserving that path would have meant building a cross-tenant surface — the most
+  dangerous kind this codebase has, and the MFA admin reset is deliberately alone in it.
+  `file` is out because it means fetching a caller-chosen URL; `dns_cname` because it
+  needs a platform target that does not exist. `sql/046`'s CHECK is untouched.
 
-  **Not fixed here, deliberately.** The fix is a real verification step (publish a
-  `dns_txt` record and check it, or fetch a well-known file) plus a decision about what
-  `manual` is allowed to mean — plausibly "an OPERATOR attests", which would make it a
-  platform-scoped action rather than a tenant one. That is a security change with an ADR
-  in it, not a settings cleanup, and bundling it into one would have been the wrong way
-  to make that decision. D7's own resolution was chosen to avoid making this WORSE: the
-  unread `defaultVerificationMethod` was deleted rather than applied, because applying it
-  would have handed every newly created domain the only precondition `verify` has.
+  The lookup runs OUTSIDE every transaction (ADR-0006) between two tenant transactions;
+  the second re-authorises (ADR-0063) and carries the proven value into its `WHERE`
+  clause. **Absent is not unavailable** — NXDOMAIN is a fact about the claimed domain,
+  SERVFAIL about our resolver, and only the second feeds the breaker or leaves the status
+  alone. A miss records `failed`, which keeps that state reachable. Pre-ADR rows are
+  minted a challenge lazily on first verify rather than by a DML migration against a
+  FORCE RLS table. Rate limited per PRINCIPAL, not per tenant — the first attempt keyed
+  it on the tenant header and `tests/auth-source-rate-limit.test.ts` refused it,
+  correctly (Issue #447).
 
 - **FOUND WHILE WORKING, 22 August 2026: `docs:i18n:stamp` can silence
   `check:docs:translation` on a mirror that is now WRONG.** **DONE (22 August 2026).**


### PR DESCRIPTION
§4's `POST /api/v1/tenant/domains/{id}/verify` VERIFIES NOTHING item was still written as open — including its "Not fixed here, deliberately" paragraph — after #678 closed it. A backlog entry that describes a live hole the repo no longer has sends the next reader to fix something already fixed, and it is the one document this project asks people to read first.

Both mirrors now carry the resolution, and it records where ADR-0106 went **against** this item's own guess: `manual` is removed rather than demoted to an operator attestation, because a platform-scoped permission cannot see another tenant's row and preserving that path would have meant building a cross-tenant surface.

Docs only. Full `bun run check` green; `DATABASE_URL="" bun run test` 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)