### PR TITLE
docs(project-state): record the 23 August decision round (ADR-0107/0109/0110)

### DIFF
--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:1a5d4d641fc8d10a1b1bf0252d4946311b591bdce4887de6132f9d93c6b0ef0d -->
+<!-- i18n-source-hash: sha256:5e146bdbd943b7e914947541d9d67bcf6215ec3f46b2420a6a9dd3418d02f45c -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,42 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN KEPUTUSAN — 23 Agustus 2026: tiga butir #597 yang terhalang KEPUTUSAN
+  TERTULIS, bukan pekerjaan.** **SELESAI — ADR-0107, ADR-0109, ADR-0110.**
+  Setelah butir 1/2/5/6/7 issue itu mendarat, tabel statusnya sendiri membelah
+  sisanya menjadi "butuh permukaan `awcms` baru" dan "butuh keputusan lebih
+  dulu". Kelompok kedua kini kosong, dan di setiap kasus bagian yang menarik
+  bukanlah fiturnya.
+
+  - **Butir 3, kotak pencarian pembaca ([ADR-0107](adr/0107-a-readers-browser-may-search-and-the-origin-names-the-tenant.id.md)).**
+    Separuh CORS-nya masalah yang lebih kecil. `withSiteSearchTenant` meresolusi
+    tenant dari HOST, jadi pembaca di situs yang dibangun statis yang memanggil
+    CMS ini jatuh melalui rantai terdokumentasi (`PUBLIC_DEFAULT_TENANT_ID` ->
+    `PUBLIC_DEFAULT_TENANT_CODE` -> `awcms_setup_state`) dan mendarat di tenant
+    BAWAAN deployment — situs satu tenant menampilkan artikel tenant lain sebagai
+    hasilnya sendiri, dengan 200 dan tanpa apa pun yang melaporkan masalah.
+    Permintaan lintas-origin kini meresolusi tenant-nya dari `Origin` dan tidak
+    dari apa pun yang lain, yang menutupnya secara KONSTRUKSI: perbaikan
+    hanya-header akan meninggalkan konten itu di badan respons bagi `curl`,
+    perayap, atau proxy.
+  - **Butir 4, byline ([ADR-0109](adr/0109-a-byline-is-opted-into-and-it-is-not-your-account-name.id.md)).**
+    Menerbitkan `awcms_profiles.display_name` cukup satu baris tanpa migrasi, dan
+    ditolak: ia menjadikan setiap nama akun internal publik begitu sebuah artikel
+    terbit. `sql/146` menambahkan `public_byline_name` opt-in di mana NULL —
+    setiap baris yang sudah ada — mempertahankan atribusi organisasi, jadi tidak
+    ada artikel yang berubah.
+  - **Butir 8, embed video ([ADR-0110](adr/0110-a-video-embed-origin-is-an-operators-decision.id.md)).**
+    Renderer-nya sudah benar sejak #639 dan setiap iframe yang dipancarkannya
+    DIBLOKIR, karena CSP tidak memasukkan origin pihak ketiga mana pun.
+    `BLOG_VIDEO_EMBED_ENABLED` menambahkan tepat satu origin ke `frame-src`.
+    Menurunkannya dari data tenant ditolak: header CSP berlaku se-deployment,
+    jadi satu tenant akan membuka origin itu untuk setiap tenant yang berbagi
+    deployment.
+
+  **Sisa #597 dan #607 adalah pekerjaan `ahliweb/awcms-astro`**, ditambah butir 9
+  yang terhalang ADR privasi di repo itu — keputusan pemilik repo, bukan tugas.
+  TIDAK ADA pekerjaan sisi-`awcms` yang tersisa di kedua issue itu.
 
 - **DITEMUKAN SAAT BEKERJA, 23 Agustus 2026 (sambil merancang byline #597 butir
   4): PENGHAPUSAN yang dieksekusi meninggalkan nama, nama legal, dan alamat login

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,39 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **DECISION ROUND — 23 August 2026: the three items of #597 that were blocked on
+  a WRITTEN DECISION rather than on work.** **DONE — ADR-0107, ADR-0109,
+  ADR-0110.** After that issue's items 1/2/5/6/7 shipped, its own status table
+  split the remainder into "needs a new `awcms` surface" and "needs a decision
+  first". The second group is now empty, and in each case the interesting part
+  was not the feature.
+
+  - **Item 3, the reader's search box ([ADR-0107](adr/0107-a-readers-browser-may-search-and-the-origin-names-the-tenant.md)).**
+    The CORS half was the smaller problem. `withSiteSearchTenant` resolves the
+    tenant from the HOST, so a reader on a statically built site calling this CMS
+    falls through the documented chain (`PUBLIC_DEFAULT_TENANT_ID` ->
+    `PUBLIC_DEFAULT_TENANT_CODE` -> `awcms_setup_state`) and lands on the
+    deployment's DEFAULT tenant — one tenant's site displaying another's articles
+    as its own results, with a 200 and nothing reporting a problem. A
+    cross-origin request now resolves its tenant from the `Origin` and from
+    nothing else, which closes it by CONSTRUCTION: a header-only fix would have
+    left that content in the body for `curl`, a crawler or a proxy.
+  - **Item 4, the byline ([ADR-0109](adr/0109-a-byline-is-opted-into-and-it-is-not-your-account-name.md)).**
+    Publishing `awcms_profiles.display_name` was one line and no migration, and
+    is refused: it makes every internal account name public the moment an article
+    publishes. `sql/146` adds an opt-in `public_byline_name` where NULL — every
+    existing row — keeps the organisation attribution, so no article changes.
+  - **Item 8, video embeds ([ADR-0110](adr/0110-a-video-embed-origin-is-an-operators-decision.md)).**
+    The renderer has been correct since #639 and every iframe it emitted was
+    BLOCKED, because the CSP allow-lists no third-party origin.
+    `BLOG_VIDEO_EMBED_ENABLED` adds exactly one origin to `frame-src`. Deriving
+    it from tenant data was refused: a CSP header is deployment-wide, so one
+    tenant would open the origin for every tenant sharing the deployment.
+
+  **What remains of #597 and #607 is `ahliweb/awcms-astro` work**, plus item 9,
+  which is blocked on a privacy ADR in that repo — the repo owner's decision,
+  not a task. There is NO `awcms`-side work left on either issue.
+
 - **FOUND WHILE WORKING, 23 August 2026 (while designing the byline of #597 item
   4): an executed ERASURE left the person's name, legal name and login address in
   the database.** **DONE (23 August 2026) —


### PR DESCRIPTION
The continuation point for the next session.

#597's own status table split its remainder into "needs a new `awcms` surface" and "needs a written decision first". The second group is now empty — items 3, 4 and 8 landed as ADR-0107 (#681), ADR-0109 (#683) and ADR-0110 (#684) — and §4 records what each one actually turned on, which in every case was not the feature:

- **Item 3** — the CORS half was the smaller problem. Host-based tenant resolution would have handed a cross-origin reader the deployment's *default* tenant, with a 200 and a populated result list. Resolving from the `Origin` closes that by construction; a header-only fix leaves the content in the body for anything that is not a browser.
- **Item 4** — publishing `display_name` was one line and no migration, and it makes every internal account name public the moment an article publishes.
- **Item 8** — deriving a CSP origin from tenant data would let one tenant open it for every tenant sharing the deployment.

Also states plainly, so nobody re-derives it: **no `awcms`-side work remains on #597 or #607.** What is left is `awcms-astro`, plus item 9's privacy ADR there, which is the repo owner's decision rather than a task.

Full `bun run check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)