### PR TITLE
docs(site-search): the reader's search box exists, so its two paths stop being a promise (#607, #597 item 3)

### DIFF
--- a/.changeset/search-consumer-contract-consumed.md
+++ b/.changeset/search-consumer-contract-consumed.md
@@ -1,0 +1,41 @@
+---
+"awcms": patch
+---
+
+docs(site-search): the reader's search box exists, so its two paths stop being a promise (#607, #597 item 3)
+
+`GET /api/v1/site-search/query` and `/suggest` were frozen as **COMMITTED** in
+#681 (ADR-0107) — a shape this repo had agreed to keep for a consumer that did
+not exist yet. `ahliweb/awcms-astro` now publishes the box (its ADR-0043), so
+both move to **CONSUMED**, which is the direction the cross-repo Definition of
+Done requires: freeze here first, call there second.
+
+### "Consumed" stopped meaning "the build calls it"
+
+The seven entries that were already there are called by `astro build` over
+there, from a machine holding a read-only credential. These two are called by
+the **reader's browser**, anonymously and cross-origin, and that difference is
+invisible from this side: both are `GET`s against this API, and the gate over
+there extracts string literals from `src/` without knowing who executes them.
+
+It is written into `CONSUMED_PATHS`' own docblock because it changes what
+breaking one costs. A shape change on a build-called path reddens a build
+somebody is watching. A shape change on these two fails **silently in a
+stranger's browser**, on a site that was published weeks ago and will not be
+rebuilt on account of it.
+
+### What the consumer actually relies on, beyond the result shape
+
+Recorded here so it is not discovered by breaking it:
+
+- **No `OPTIONS` handler is the contract, not an omission.** The box calls both
+  paths with `fetch` and no custom headers, which keeps them *simple requests*.
+  A header added on either side turns them into preflighted ones, and the
+  preflight has nothing to answer it.
+- **The facet payload is load-bearing.** The chips render from
+  `facets.resourceTypes` and `facets.terms`, and they rely on each facet being
+  counted WITHOUT its own filter — that is what keeps a reader who narrowed to
+  one channel able to click back out.
+- **`suggest`'s own limits still apply.** The consumer debounces and enforces a
+  minimum length client-side; both are courtesies, not controls, and this repo's
+  `min_query_length` and per-IP limit remain the only enforcement.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:5e146bdbd943b7e914947541d9d67bcf6215ec3f46b2420a6a9dd3418d02f45c -->
+<!-- i18n-source-hash: sha256:a4fa7f7b6cc32152c44ea3d80cc7158b28421cf095c3368ed26942e657de6a60 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,66 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN KONSUMEN — 23 Agustus 2026: dua butir menghadap-pembaca yang tersisa
+  sudah DIBANGUN, di `ahliweb/awcms-astro`. Tidak ada pekerjaan `awcms` yang
+  tersisa pada #597 maupun #607, dan satu-satunya perubahan `awcms` di putaran
+  ini adalah pemindahan kontrak.**
+
+  Dengan ADR-0107/0109/0110 ditulis di hari yang sama, kedua butir sisanya
+  menjadi pekerjaan biasa di repo sebelah. Yang mendarat di sana:
+
+  - **Kotak pencarian pembaca** (#607, #597 butir 3) — `/cari/` dan `/en/cari/`,
+    dengan hasil berperingkat, snippet tersorot, chip facet untuk jenis konten /
+    kanal / topik / instansi / wilayah, "muat lebih banyak" ber-cursor, dan
+    autocomplete. ADR-0043 di sana.
+  - **Byline** (#597 butir 4) — dirender di halaman artikel, di `author` JSON-LD
+    (sebuah `Person` bila ada), dan di entry Atom artikel itu. ADR-0042 di sana.
+
+  **Di sisi ini satu-satunya perubahan adalah `scripts/api-consumer-contract.ts`:**
+  `/api/v1/site-search/query` dan `/suggest` berpindah dari COMMITTED ke
+  CONSUMED, yaitu arah yang dituntut Definition of Done lintas-repo — bekukan di
+  sini dulu, panggil di sana kemudian. Byline tidak butuh pemindahan sama sekali:
+  `authorByline` menumpang `/api/v1/blog/posts`, yang sudah dikonsumsi.
+
+  **Tiga hal yang pantas dibawa maju, karena masing-masing sebuah KELAS dan bukan
+  satu insiden.**
+
+  **1. "CONSUMED" tidak lagi berarti "sebuah build memanggilnya".** Tujuh dari
+  sembilan jalur dipanggil `astro build` dari mesin yang memegang kredensial
+  baca-saja; dua jalur pencarian dipanggil PERAMBAN PEMBACA. Perbedaan itu tidak
+  terlihat dari sini — keduanya `GET`, dan gerbang di sana mengekstrak string
+  literal dari `src/` tanpa tahu siapa yang mengeksekusinya — dan ia menentukan
+  berapa mahal biaya merusaknya. Perubahan bentuk pada jalur yang dipanggil build
+  memerahkan build yang sedang dilihat seseorang. Perubahan bentuk pada dua yang
+  ini gagal **diam-diam di peramban seorang asing**, pada situs yang terbit
+  berminggu-minggu lalu dan tidak akan di-rebuild karenanya. Ditulis di docblock
+  berkas itu sendiri alih-alih dibiarkan ditemukan.
+
+  **2. Ketiadaan handler `OPTIONS` kini sebuah KONTRAK, bukan kelalaian.** Kotak
+  itu memanggil kedua jalur tanpa header tambahan, yang menjaga keduanya tetap
+  permintaan sederhana. Sebuah header yang ditambahkan di SALAH SATU sisi —
+  `accept`, id korelasi, petunjuk tenant — mengubahnya menjadi permintaan
+  ber-preflight dengan tidak ada yang menjawab preflight-nya. Kegagalan itu
+  terjadi di peramban pembaca dan tidak muncul di log mana pun di sini. Hal yang
+  sama berlaku bagi `Access-Control-Allow-Credentials`, yang ketiadaannya membuat
+  `credentials: "include"` tidak terbaca menurut konstruksi.
+
+  **3. Gerbang di sana tidak bisa melihat cacat yang penting, dan
+  MENJALANKANNYA menemukannya dalam satu menit.** Facet jenis konten
+  mengembalikan `resource_type` apa adanya — `blog_post`, `blog_page` — karena ia
+  pengenal registry modul repo ini dan tidak membawa label tulisan redaksi,
+  berbeda dari facet term. Jalannya yang pertama di peramban merender keduanya
+  sebagai chip, dalam kedua bahasa: kunci mesin di layar. Tidak ada yang bisa
+  merah — nilainya ada, tipenya benar, halamannya terbit. Ini kelas
+  `jalankan-jangan-dibaca` lagi, dan perbaikannya di sana adalah nilai facet
+  tanpa label yang bisa dibaca tidak merender chip sama sekali.
+
+  **Yang tersisa terbuka di #597, dan itu bukan pekerjaan:** butir 9, beacon
+  analytics, yang backend-nya sudah diverifikasi di #637/#638 dan yang terhalang
+  ADR privasi di `awcms-astro` — keputusan pemilik repo. #599 juga terhalang dua
+  artefak yang tidak ada di kedua repo (`.htaccess` legacy dan URL sitemap yang
+  hidup), bukan terhalang kode.
 
 - **PUTARAN KEPUTUSAN — 23 Agustus 2026: tiga butir #597 yang terhalang KEPUTUSAN
   TERTULIS, bukan pekerjaan.** **SELESAI — ADR-0107, ADR-0109, ADR-0110.**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,64 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **CONSUMER ROUND — 23 August 2026: the two reader-facing items that were left
+  are BUILT, in `ahliweb/awcms-astro`. There is no `awcms` work left on #597 or
+  #607, and the only `awcms` change in this round is a contract move.**
+
+  With ADR-0107/0109/0110 written the same day, both remaining items became
+  ordinary work in the neighbour repo. What landed there:
+
+  - **The reader's search box** (#607, #597 item 3) — `/cari/` and `/en/cari/`,
+    with ranked results, highlighted snippets, facet chips for content type /
+    channel / topic / institution / region, a cursor-paged "load more", and
+    autocomplete. Its ADR-0043 there.
+  - **The byline** (#597 item 4) — rendered on the article page, in the JSON-LD
+    `author` (a `Person` when there is one), and on the article's Atom entry. Its
+    ADR-0042 there.
+
+  **On this side the only change is `scripts/api-consumer-contract.ts`:**
+  `/api/v1/site-search/query` and `/suggest` move from COMMITTED to CONSUMED,
+  which is the direction the cross-repo Definition of Done requires — freeze
+  here first, call there second. The byline needed no move at all: `authorByline`
+  rides on `/api/v1/blog/posts`, which was already consumed.
+
+  **Three things worth carrying forward, because each is a class rather than an
+  incident.**
+
+  **1. "CONSUMED" no longer means "a build calls it".** Seven of the nine paths
+  are called by `astro build` from a machine holding a read-only credential; the
+  two search paths are called by the READER's BROWSER. That difference is
+  invisible from here — both are `GET`s, and the gate over there extracts string
+  literals from `src/` without knowing who executes them — and it changes what
+  breaking one costs. A shape change on a build-called path reddens a build
+  somebody is watching. A shape change on these two fails **silently in a
+  stranger's browser**, on a site published weeks ago that will not be rebuilt on
+  account of it. Written into that file's docblock rather than left to be
+  noticed.
+
+  **2. The absence of an `OPTIONS` handler is a CONTRACT now, not an omission.**
+  The box calls both paths with no custom headers, which keeps them simple
+  requests. A header added on EITHER side — an `accept`, a correlation id, a
+  tenant hint — turns them into preflighted requests with nothing to answer the
+  preflight. That failure happens in the reader's browser and appears in no log
+  here. The same holds for `Access-Control-Allow-Credentials`, whose absence is
+  what makes `credentials: "include"` unreadable by construction.
+
+  **3. The gate over there could not see the defect that mattered, and running it
+  found it in one minute.** The content-type facet returns `resource_type` as
+  stored — `blog_post`, `blog_page` — because it is this repo's module-registry
+  identifier and carries no editor-written label, unlike a term facet. The first
+  browser run rendered those as chips, in both languages: a machine key on
+  screen. Nothing could have gone red — the value was present, the type correct,
+  the page published. It is the `run-it-don't-read-it` class again, and the fix
+  over there is that a facet value with no readable label renders no chip at all.
+
+  **What this leaves open on #597, and it is not work:** item 9, the analytics
+  beacon, whose backend was verified in #637/#638 and which is blocked on a
+  privacy ADR in `awcms-astro` — the repo owner's decision. #599 is likewise
+  blocked on two artefacts that are not in either repo (the legacy `.htaccess`
+  and the live sitemap URL), not on code.
+
 - **DECISION ROUND — 23 August 2026: the three items of #597 that were blocked on
   a WRITTEN DECISION rather than on work.** **DONE — ADR-0107, ADR-0109,
   ADR-0110.** After that issue's items 1/2/5/6/7 shipped, its own status table

--- a/scripts/api-consumer-contract.ts
+++ b/scripts/api-consumer-contract.ts
@@ -51,6 +51,19 @@ const FIXTURE_PATH =
 /**
  * Surfaces `ahliweb/awcms-astro` CALLS today.
  *
+ * ## "Calls" stopped meaning "the build calls" on 23 August 2026
+ *
+ * Seven of these are called by `astro build` over there, from a machine holding
+ * a read-only credential. The two `site-search` entries are called by the
+ * READER's BROWSER, anonymously and cross-origin, and that difference is
+ * invisible from this side — both are `GET`s against this API, and the gate over
+ * there extracts string literals from `src/` without knowing who executes them.
+ *
+ * It is written here because it changes what breaking one costs. A shape change
+ * on a build-called path reddens a build somebody is watching. A shape change on
+ * these two fails silently in a stranger's browser, on a site that was published
+ * weeks ago and will not be rebuilt because of it.
+ *
  * The neighbour repo is the authority for this list, and it has a gate for it:
  * `tests/kontrak-awcms.test.mjs` there asserts an exact set of surfaces,
  * derived from `src/` **with comments stripped first**, and bound two-ways to a
@@ -100,7 +113,11 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
   "/api/v1/blog/menus":
     "the tenant's navigation menus, rendered as a SECONDARY footer region — the localised tab bar is NOT replaced, because a menu item carries one label and no per-locale variant (#597 item 6, ADR-0105). `src/lib/awcms/navigasi.ts` there. Only freezable after #652 gave the response a real schema; promised as COMMITTED in #653 and moved here when `ahliweb/awcms-astro#67` made the call real.",
   "/api/v1/blog/widgets":
-    "the tenant's widgets, rendered in their declared positions (#597 item 6, ADR-0105). `bodyText` is plain text and the consumer ESCAPES it, because the write path refuses markup rather than sanitizing it. Inactive widgets are returned on purpose and filtered there. Same #652/#653/#67 sequence as the menus above."
+    "the tenant's widgets, rendered in their declared positions (#597 item 6, ADR-0105). `bodyText` is plain text and the consumer ESCAPES it, because the write path refuses markup rather than sanitizing it. Inactive widgets are returned on purpose and filtered there. Same #652/#653/#67 sequence as the menus above.",
+  "/api/v1/site-search/query":
+    "the reader's search results (#597 item 3, #607, ADR-0107). `src/lib/pencarian.ts` there, and its ADR-0043. THE FIRST CONSUMED PATH THAT IS NOT CALLED BY A BUILD: it runs in a reader's browser, anonymously, cross-origin, so the tenant comes from the request's `Origin` matched against `awcms_tenant_domains` and never from a credential. That changes where a broken shape surfaces — in a stranger's browser rather than in a build somebody is watching — which is precisely why freezing it matters more here, not less. Frozen: the result shape AND the facet payload the filter chips render from. The CORS grant is a header, not a schema, and is documented on the path. Promised as COMMITTED in #681 and moved here when `ahliweb/awcms-astro` published the box.",
+  "/api/v1/site-search/suggest":
+    "the typeahead behind the same box, same origin rule, same anonymity (ADR-0107). Consumed through a `<datalist>` there, debounced client-side; this repo still enforces its own `min_query_length` and per-IP limit, because a consumer's debounce is a courtesy and not a control."
 };
 
 /**
@@ -121,11 +138,7 @@ export const COMMITTED_PATHS: Readonly<Record<string, string>> = {
   "/api/v1/auth/session":
     "ADR-0049 — session introspection for the BFF of ADR-0050. The static build must NOT call it (it refuses machine credentials by design); the BFF that will is not built yet.",
   "/api/v1/access/machine-credentials":
-    "ADR-0049 — how a human mints the read-only build credential. Never a build call, but the build cannot exist if this shape changes.",
-  "/api/v1/site-search/query":
-    "ADR-0107 — the reader's search results, called from the READER's browser at runtime rather than from the build (#597 item 3, #607). Unlike every other entry here it is anonymous: the tenant comes from the request's `Origin`, matched against `awcms_tenant_domains`. What is frozen is the result shape AND the facet payload the filter chips render from; the CORS grant itself is a header, not a schema, and is documented on the path.",
-  "/api/v1/site-search/suggest":
-    "ADR-0107 — the typeahead behind the same search box, same origin rule, same anonymity. Frozen alongside `/query` because a search box that lists suggestions and a search box that cannot are different products, and a consumer that has one will call both."
+    "ADR-0049 — how a human mints the read-only build credential. Never a build call, but the build cannot exist if this shape changes."
 };
 
 /** Every path frozen by the fixture: consumed today plus promised by ADR. */

--- a/tests/api-consumer-contract.test.ts
+++ b/tests/api-consumer-contract.test.ts
@@ -186,7 +186,7 @@ describe("the live contract", () => {
  * a fourth consumed surface here has to be a deliberate edit in both places.
  */
 describe("consumed vs committed", () => {
-  test("exactly seven surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
+  test("exactly nine surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
     // If this fails, one of two things happened, and they need opposite fixes:
     //   - awcms-astro started (or stopped) calling a surface -> update both
     //     this list and the marker block in that repo, in the same change;
@@ -209,6 +209,19 @@ describe("consumed vs committed", () => {
     // until #652 gave their responses an actual schema. Freezing an array of
     // bare `object` would have added a path to this list that no change could
     // ever break — a contract entry with no contract in it.
+    //
+    // The eighth and ninth, `/site-search/query` and `/suggest`, took the same
+    // path (COMMITTED in #681 with ADR-0107, moved here when that repo published
+    // its search box) and BROKE ITS PREMISE: they are not called by a build at
+    // all. They run in the READER's browser, anonymously and cross-origin.
+    //
+    // That is invisible from here — both are `GET`s against this API, and the
+    // neighbour's gate extracts string literals from `src/` without knowing who
+    // executes them — so it is written down rather than left to be inferred. It
+    // decides what breaking one costs: a shape change on the seven above reddens
+    // a build somebody is watching, while a shape change on these two fails in a
+    // stranger's browser, on a site published weeks ago that will not be rebuilt
+    // on account of it.
     expect(Object.keys(CONSUMED_PATHS)).toEqual([
       "/api/v1/blog/posts",
       "/api/v1/media/objects",
@@ -216,7 +229,9 @@ describe("consumed vs committed", () => {
       "/api/v1/site-profile/composed",
       "/api/v1/blog/terms",
       "/api/v1/blog/menus",
-      "/api/v1/blog/widgets"
+      "/api/v1/blog/widgets",
+      "/api/v1/site-search/query",
+      "/api/v1/site-search/suggest"
     ]);
   });
 


### PR DESCRIPTION
`GET /api/v1/site-search/query` and `/suggest` were frozen as **COMMITTED** in #681 (ADR-0107) — a shape this repo agreed to keep for a consumer that did not exist yet. `ahliweb/awcms-astro` now publishes the box ([its PR #69](https://github.com/ahliweb/awcms-astro/pull/69), its ADR-0043), so both move to **CONSUMED**, which is the direction the cross-repo Definition of Done requires: freeze here first, call there second.

## "Consumed" stopped meaning "the build calls it"

The seven entries already there are called by `astro build` over there, from a machine holding a read-only credential. **These two are called by the reader's browser**, anonymously and cross-origin.

That difference is invisible from this side — both are `GET`s against this API, and the neighbour's gate extracts string literals from `src/` without knowing who executes them. It is written into `CONSUMED_PATHS`' own docblock and into the gate's comment because it changes what breaking one costs: a shape change on a build-called path reddens a build somebody is watching, while a shape change on these two **fails silently in a stranger's browser**, on a site published weeks ago that will not be rebuilt on account of it.

## What the consumer actually relies on, recorded so it is not discovered by breaking it

- **The absence of an `OPTIONS` handler is the contract, not an omission.** The box calls both paths with no custom headers, which keeps them *simple requests*. A header added on either side turns them into preflighted ones with nothing to answer the preflight.
- **The facet payload is load-bearing** — the chips render from `facets.resourceTypes` and `facets.terms`, and rely on each facet being counted without its own filter.
- **`suggest`'s own limits still apply.** The consumer's debounce and minimum length are courtesies; `min_query_length` and the per-IP limit here remain the only enforcement.

## PROJECT_STATE §4

Records the round, including the defect no gate could see and one browser run found in a minute: the content-type facet returns `resource_type` as stored, so the box first rendered `blog_post` as a chip — a machine key on screen, in both languages. Nothing could have gone red; the value was present, the type correct, the page published. `run-it-don't-read-it`, again.

Also recorded: what stays open on #597 is item 9 (a privacy ADR over there, now accepted as Option B) and #599, blocked on the legacy `.htaccess` and sitemap URL — neither is code.

## Gates

`bun run test` (6,444 tests, 5,644 pass / 800 skip / 0 fail), `lint`, `typecheck`, `build`, `api:consumer-contract:check` (11 paths), `check:docs`, `check:docs:translation`, `project-state:inventory:check`, `skills:check`, `version:check` — all green.

> **Merge order:** this PR records a call that must already exist, so it merges **after** ahliweb/awcms-astro#69.

🤖 Generated with [Claude Code](https://claude.com/claude-code)