### PR TITLE
docs(visitor-analytics): the beacon has a caller now, and it is the third reader-browser path (#597 item 9)

### DIFF
--- a/.changeset/beacon-consumer-contract-consumed.md
+++ b/.changeset/beacon-consumer-contract-consumed.md
@@ -1,0 +1,41 @@
+---
+"awcms": patch
+---
+
+docs(visitor-analytics): the beacon has a caller now, and it is the third reader-browser path (#597 item 9)
+
+`POST /api/v1/analytics/collect` had its cross-origin path opened in #637/#638
+so a statically built site on its own domain could reach it. Nothing called it.
+`ahliweb/awcms-astro` now does — its ADR-0044 decided **whether**, and the answer
+came with a constraint this repo should know about — so the path joins
+`CONSUMER_PATHS` and its shape is frozen with the rest.
+
+### Three reader-browser paths, and they do NOT share one rule
+
+Ten paths are consumed. Seven are called by `astro build` from a machine holding
+a read-only credential. Three run in a reader's browser: the two `site-search`
+paths and this one. That much was already recorded when search landed.
+
+What is new is that the three disagree, and the disagreement is load-bearing:
+
+- **the search paths must carry NO custom header** — nothing answers a preflight
+  for them, deliberately;
+- **the beacon MUST carry `content-type: application/json`** — `checkOrigin`
+  refuses the alternatives, and the `OPTIONS` handler exists for the preflight
+  that follows. `navigator.sendBeacon` is unusable there for the same reason.
+
+Making them consistent, in either direction, kills one of them in a reader's
+browser and in no log here.
+
+### The consumer calls it WITHOUT credentials, by decision
+
+Its ADR-0044 chose that deliberately: a cross-origin `fetch` that does not ask
+for credentials neither sends nor stores cookies, so the `awcms_visitor_key`
+cookie this endpoint sets is **discarded by the browser**. Every page view
+arrives as a first visit.
+
+Recorded here because it is an assumption this repo could otherwise make and be
+wrong about: for that consumer, page-view counts are real and unique-visitor
+counts are not. Nothing on this side should be changed on the premise that a
+repeat visitor is recognisable — and the `SameSite=None` work in #637 is not
+wasted, it simply serves consumers that make the other choice.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:a4fa7f7b6cc32152c44ea3d80cc7158b28421cf095c3368ed26942e657de6a60 -->
+<!-- i18n-source-hash: sha256:5397fb3b0200d1d2cefe285a6bbc3e59b7ca713dc27f209b0c0ca31d2337d7c3 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,46 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN BEACON — 23 Agustus 2026: #597 butir 9 sudah DIBANGUN, dan keputusan
+  yang menghalanginya ternyata lebih kecil daripada "analitik: ya atau tidak".**
+
+  Penghalang butir itu adalah ADR privasi di `ahliweb/awcms-astro` — keputusan
+  pemilik repo, bukan sebuah tugas. Keputusannya dibuat, dan fakta yang
+  membukanya dibaca dari collector repo INI alih-alih ditebak: **`fetch`
+  lintas-origin tanpa `credentials` tidak mengirim maupun menyimpan cookie.**
+  Jadi konsumennya sudah memegang sakelarnya, tanpa perubahan apa pun di sini.
+
+  ADR-0044 di sana mengambil **Opsi B**: sebuah situs boleh memanggil beacon,
+  hanya bila ia menyatakannya, dan selalu tanpa kredensial. Cookie
+  `awcms_visitor_key` yang dipasang endpoint ini karena itu dibuang peramban, dan
+  **setiap kunjungan halaman tiba sebagai kunjungan pertama** — hitungan
+  kunjungan nyata bagi konsumen itu, hitungan pengunjung unik tidak. Tidak ada
+  apa pun di sini yang boleh diubah dengan premis bahwa pengunjung berulang bisa
+  dikenali, dan pekerjaan `SameSite=None` di #637 tidak terbuang: ia melayani
+  konsumen yang mengambil pilihan sebaliknya.
+
+  **Di sisi ini perubahannya sekali lagi satu pemindahan kontrak**, dan ia
+  menjadikan kelas peramban-pembaca selebar tiga jalur.
+
+  **Konsekuensi yang pantas dibawa maju: ketiganya TIDAK berbagi satu aturan.**
+  Kedua jalur `site-search` tidak boleh membawa header tambahan, karena tidak ada
+  yang menjawab preflight untuk keduanya — dan itu disengaja. Beacon HARUS
+  membawa `content-type: application/json`, karena `security.checkOrigin` menolak
+  POST lintas-origin yang tipe isinya mirip form, dan handler `OPTIONS` yang
+  ditambahkan #637 ada justru untuk preflight yang menyusul.
+  `navigator.sendBeacon` tidak bisa dipakai di sana sama sekali: ia mengirim
+  `text/plain`, salah satu tipe yang ditolak.
+
+  Menyeragamkan ketiganya — ke arah mana pun, dan itu adalah kerapian yang cepat
+  atau lambat akan diusulkan seseorang — mematikan salah satunya di peramban
+  pembaca dan tidak di log mana pun di sini. Karena itu ia ditulis di docblock
+  `CONSUMED_PATHS` dan di komentar gerbangnya sendiri.
+
+  **Dengan ini #597 selesai di kesembilan butirnya dan #607 di ketiganya.** Yang
+  masih terbuka di keluarga ini adalah #599, dan ia terhalang dua artefak yang
+  tidak ada di kedua repo — `.htaccess` legacy dan URL sitemap yang hidup —
+  alih-alih terhalang kode.
 
 - **PUTARAN KONSUMEN — 23 Agustus 2026: dua butir menghadap-pembaca yang tersisa
   sudah DIBANGUN, di `ahliweb/awcms-astro`. Tidak ada pekerjaan `awcms` yang

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,44 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **BEACON ROUND — 23 August 2026: #597 item 9 is BUILT, and the decision it was
+  blocked on turned out to be smaller than "analytics: yes or no".**
+
+  That item's blocker was a privacy ADR in `ahliweb/awcms-astro` — the repo
+  owner's decision, not a task. It was made, and the fact that unlocked it was
+  read out of this repo's own collector rather than guessed: **a cross-origin
+  `fetch` without `credentials` neither sends nor stores cookies.** So the
+  consumer already held the switch, with no change needed here.
+
+  Its ADR-0044 takes **Option B**: a site may call the beacon, only when it
+  declares it, and always without credentials. The `awcms_visitor_key` cookie
+  this endpoint sets is therefore discarded by the browser, and **every page
+  view arrives as a first visit** — page-view counts are real for that consumer,
+  unique-visitor counts are not. Nothing here should be changed on the premise
+  that a repeat visitor is recognisable, and the `SameSite=None` work in #637 is
+  not wasted: it serves consumers that make the other choice.
+
+  **On this side the change is again one contract move**, and it makes the
+  reader-browser class three paths wide.
+
+  **The consequence worth carrying forward: the three do NOT share one rule.**
+  The two `site-search` paths must carry no custom header, because nothing
+  answers a preflight for them — deliberately. The beacon MUST carry
+  `content-type: application/json`, because `security.checkOrigin` refuses a
+  cross-origin POST whose content type is form-like, and the `OPTIONS` handler
+  added in #637 exists for the preflight that follows. `navigator.sendBeacon`
+  cannot be used there at all: it sends `text/plain`, one of the refused types.
+
+  Making the three consistent — in either direction, and it is the tidying
+  somebody will eventually propose — kills one of them in a reader's browser and
+  in no log here. It is written into `CONSUMED_PATHS`' docblock and the gate's
+  own comment for that reason.
+
+  **With this, #597 is finished across all nine items and #607 across all
+  three.** What remains open in the family is #599, and it is blocked on two
+  artefacts that exist in neither repo — the legacy `.htaccess` and a live
+  sitemap URL — rather than on code.
+
 - **CONSUMER ROUND — 23 August 2026: the two reader-facing items that were left
   are BUILT, in `ahliweb/awcms-astro`. There is no `awcms` work left on #597 or
   #607, and the only `awcms` change in this round is a contract move.**

--- a/scripts/api-consumer-contract.ts
+++ b/scripts/api-consumer-contract.ts
@@ -54,10 +54,17 @@ const FIXTURE_PATH =
  * ## "Calls" stopped meaning "the build calls" on 23 August 2026
  *
  * Seven of these are called by `astro build` over there, from a machine holding
- * a read-only credential. The two `site-search` entries are called by the
- * READER's BROWSER, anonymously and cross-origin, and that difference is
- * invisible from this side — both are `GET`s against this API, and the gate over
- * there extracts string literals from `src/` without knowing who executes them.
+ * a read-only credential. THREE are called by the READER's BROWSER, anonymously
+ * and cross-origin — the two `site-search` entries and the analytics beacon —
+ * and that difference is invisible from this side, because the gate over there
+ * extracts string literals from `src/` without knowing who executes them.
+ *
+ * The three do not even share one rule. The two search paths must carry NO
+ * custom header, because nothing answers a preflight for them. The beacon MUST
+ * carry `content-type: application/json`, because `checkOrigin` refuses the
+ * alternatives — and its `OPTIONS` handler exists for the preflight that
+ * follows. Making them consistent, in either direction, kills one of them in a
+ * reader's browser.
  *
  * It is written here because it changes what breaking one costs. A shape change
  * on a build-called path reddens a build somebody is watching. A shape change on
@@ -117,7 +124,9 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
   "/api/v1/site-search/query":
     "the reader's search results (#597 item 3, #607, ADR-0107). `src/lib/pencarian.ts` there, and its ADR-0043. THE FIRST CONSUMED PATH THAT IS NOT CALLED BY A BUILD: it runs in a reader's browser, anonymously, cross-origin, so the tenant comes from the request's `Origin` matched against `awcms_tenant_domains` and never from a credential. That changes where a broken shape surfaces — in a stranger's browser rather than in a build somebody is watching — which is precisely why freezing it matters more here, not less. Frozen: the result shape AND the facet payload the filter chips render from. The CORS grant is a header, not a schema, and is documented on the path. Promised as COMMITTED in #681 and moved here when `ahliweb/awcms-astro` published the box.",
   "/api/v1/site-search/suggest":
-    "the typeahead behind the same box, same origin rule, same anonymity (ADR-0107). Consumed through a `<datalist>` there, debounced client-side; this repo still enforces its own `min_query_length` and per-IP limit, because a consumer's debounce is a courtesy and not a control."
+    "the typeahead behind the same box, same origin rule, same anonymity (ADR-0107). Consumed through a `<datalist>` there, debounced client-side; this repo still enforces its own `min_query_length` and per-IP limit, because a consumer's debounce is a courtesy and not a control.",
+  "/api/v1/analytics/collect":
+    "one page view, posted from the READER's browser (#597 item 9; `awcms-astro` ADR-0044 decided WHETHER, and its `src/lib/beacon.ts` is the caller). Third of the reader-browser class and the only one that must carry a HEADER: `security.checkOrigin` refuses a cross-origin POST whose content type is form-like, so only `application/json` gets through — which is what the `OPTIONS` handler added in #637 exists for, and why `navigator.sendBeacon` cannot be used there. The consumer calls it WITHOUT credentials by decision, so the `awcms_visitor_key` cookie this endpoint sets is discarded by the browser and every view arrives as a first visit; nothing here should be changed on the assumption that a repeat visitor is recognisable. Frozen: the request body (`tenantCode`, `path`, optional `referrer`), its bounds, and the always-`202` answer."
 };
 
 /**

--- a/tests/api-consumer-contract.test.ts
+++ b/tests/api-consumer-contract.test.ts
@@ -186,7 +186,7 @@ describe("the live contract", () => {
  * a fourth consumed surface here has to be a deliberate edit in both places.
  */
 describe("consumed vs committed", () => {
-  test("exactly nine surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
+  test("exactly ten surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
     // If this fails, one of two things happened, and they need opposite fixes:
     //   - awcms-astro started (or stopped) calling a surface -> update both
     //     this list and the marker block in that repo, in the same change;
@@ -222,6 +222,13 @@ describe("consumed vs committed", () => {
     // a build somebody is watching, while a shape change on these two fails in a
     // stranger's browser, on a site published weeks ago that will not be rebuilt
     // on account of it.
+    //
+    // The tenth, `/analytics/collect`, is in that same reader-browser class and
+    // breaks its rule again: it is the only consumed path that must carry a
+    // HEADER. `security.checkOrigin` refuses a cross-origin POST whose content
+    // type is form-like, so only `application/json` gets through — which is what
+    // the `OPTIONS` handler from #637 exists for. Three reader-browser paths,
+    // two opposite header rules, and no way to tell them apart from this side.
     expect(Object.keys(CONSUMED_PATHS)).toEqual([
       "/api/v1/blog/posts",
       "/api/v1/media/objects",
@@ -231,7 +238,8 @@ describe("consumed vs committed", () => {
       "/api/v1/blog/menus",
       "/api/v1/blog/widgets",
       "/api/v1/site-search/query",
-      "/api/v1/site-search/suggest"
+      "/api/v1/site-search/suggest",
+      "/api/v1/analytics/collect"
     ]);
   });
 

--- a/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
+++ b/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
@@ -99,6 +99,49 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ApiError"
+  /api/v1/analytics/collect:
+    post:
+      tags:
+        - Visitor Analytics
+      summary: Public visitor page-view beacon (anonymous)
+      description: "PUBLIC, unauthenticated visit-ingest beacon. Resolves the tenant from the request body's `tenantCode` (the RLS-free tenant root), records a privacy-preserving page-view for `public`-area paths only (IP/user-agent stored as salted hashes; anonymous — no identity). Fire-and-forget: always 202 for a well-formed request whether or not anything was recorded (module disabled, unknown tenant, non-public/non-trackable path all still return 202 without leaking tenant existence). Requires no auth."
+      operationId: analyticsCollect
+      security: []
+      parameters:
+        - $ref: "#/components/parameters/CorrelationId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CollectVisitBeaconRequest"
+      responses:
+        "202":
+          description: Beacon accepted (recorded or intentionally ignored — never distinguished).
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                    enum:
+                      - true
+                  data:
+                    type: object
+                    properties:
+                      accepted:
+                        type: boolean
+                        enum:
+                          - true
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "413":
+          description: Request body exceeds the size limit (BODY_TOO_LARGE).
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiError"
   /api/v1/auth/session:
     get:
       operationId: introspectAuthSession
@@ -1495,6 +1538,22 @@ components:
         updatedAt:
           type: string
           format: date-time
+    CollectVisitBeaconRequest:
+      type: object
+      required:
+        - tenantCode
+        - path
+      properties:
+        tenantCode:
+          type: string
+          description: Public tenant code the beacon is reporting for.
+        path:
+          type: string
+          description: The page path being reported (must start with '/'). Sanitized server-side; sensitive query params are stripped.
+        referrer:
+          type: string
+          nullable: true
+          description: Optional referrer URL; only its bare hostname is ever stored.
     ComposedSiteIdentity:
       description: Both halves of site identity in one answer. The four SEO-owned fields are named exactly as seo_distribution names them, so this is visibly a passthrough rather than a second definition that could drift.
       allOf:


### PR DESCRIPTION
`POST /api/v1/analytics/collect` had its cross-origin path opened in #637/#638 so a statically built site on its own domain could reach it. **Nothing called it.** `ahliweb/awcms-astro` now does — its ADR-0044 decided *whether*, and the answer came with a constraint this repo should know about — so the path joins `CONSUMER_PATHS` and its shape is frozen with the rest.

## Three reader-browser paths, and they do NOT share one rule

Ten paths are consumed. Seven are called by `astro build` from a machine holding a read-only credential. Three run in a reader's browser: the two `site-search` paths and this one. That much was recorded when search landed in #686.

What is new is that the three **disagree**, and the disagreement is load-bearing:

- the search paths must carry **no custom header** — nothing answers a preflight for them, deliberately;
- the beacon **must** carry `content-type: application/json` — `checkOrigin` refuses the alternatives, and the `OPTIONS` handler exists for the preflight that follows. `navigator.sendBeacon` is unusable there for the same reason.

Making them consistent, in either direction, kills one of them in a reader's browser and in no log here.

## The consumer calls it WITHOUT credentials, by decision

Its ADR-0044 chose that deliberately: a cross-origin `fetch` that does not ask for credentials neither sends nor stores cookies, so the `awcms_visitor_key` cookie this endpoint sets is **discarded by the browser**. Every page view arrives as a first visit.

Recorded because it is an assumption this repo could otherwise make and be wrong about: for that consumer, page-view counts are real and unique-visitor counts are not. Nothing here should be changed on the premise that a repeat visitor is recognisable — and the `SameSite=None` work in #637 is not wasted, it simply serves consumers that make the other choice.

## Gates

`api:consumer-contract:generate` re-froze the fixture (12 paths, 36 components); `lint`, `typecheck`, `check:docs`, and `bun run test` (6,444 tests, 0 fail) are green.

> **Merge order:** this freezes a shape before the consumer PR calls it, so it merges **before** the awcms-astro beacon PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)