### PR TITLE
fix(family): the stack table said Astro `^7.0.7` while the repo ran `^7.2.2`

### DIFF
--- a/.changeset/family-doc-stack-table-drift.md
+++ b/.changeset/family-doc-stack-table-drift.md
@@ -1,0 +1,41 @@
+---
+"awcms": patch
+---
+
+docs(family): the stack table said Astro `^7.0.7` while the repo ran `^7.2.2`, and nothing was looking
+
+`docs/awcms/family-compatibility.md` is where a human goes to find out which
+Astro this repo is pinned to. It said `^7.0.7` and `@astrojs/node` `^11.0.2`.
+`package.json` and the manifest both said `^7.2.2` and `^11.1.2`, and
+`family:conformance:check` was green the whole time — it proves the manifest's
+`declared` values against their real `source`, and never reads the prose.
+
+### The drift has a direction, which is why it needed a gate and not a fix
+
+The Bun, TypeScript and PostgreSQL rows were correct. The two stale rows were
+exactly the two that **dependabot moves**: a bump edits `package.json`, the
+conformance gate forces the manifest to follow, and there the chain stops.
+
+So this table does not rot randomly. It ages in the direction dependency bumps
+push it, at the rate they land, and silently — which makes it worse than no
+table at all. An absent table sends the reader to `package.json`; a confident
+wrong one does not.
+
+Correcting the two rows without closing that would have bought a few weeks.
+
+### `tests/family-compatibility-doc-parity.test.ts`
+
+Every row of the stack table in **both** the English source and the `.id.md`
+mirror is now compared against the manifest, cell by cell. Em-dash cells are
+asserted as absent values, so a real number cannot be quietly added where the
+matrix says the repo declares none.
+
+Both files are read rather than just the source. The translation gates compare
+the mirror's `i18n-source-hash` against the English file, which catches "the
+source moved and the mirror did not" — it cannot catch "both were written
+wrong on the same day", which is what had happened here.
+
+Proved by mutation in five directions, each naming the offending file and row:
+the original defect restored; the mirror drifting alone; a row deleted; an
+em-dash cell gaining a value; and the real future case — the manifest bumped
+to `^7.2.4` with the docs untouched, which reddens both files by name.

--- a/docs/awcms/family-compatibility.id.md
+++ b/docs/awcms/family-compatibility.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](family-compatibility.md)
 
-<!-- i18n-source-hash: sha256:a5339d8ff0d7d237888d283ceb4300ad00c30854de4c02c3ac559db6a3185a58 -->
+<!-- i18n-source-hash: sha256:32e19fb9a3699c5351f74ac436380601fb877bb467076d16b1e29b34956d132b -->
 
 # Manifes kontrak keluarga AWCMS
 
@@ -53,8 +53,8 @@ Nilai `declared` di manifest WAJIB sama dengan nilai nyata di sumber yang ditunj
 | Bun (pin)        | `1.3.14`  | `>=1.3.0`         | `package.json` `packageManager` / `engines.bun`                |
 | Bun (CI current) | `1.3.14`  | —                 | `.github/workflows/ci.yml` job `quality` `setup-bun`           |
 | Bun (CI minimum) | —         | `1.3.0`           | `.github/workflows/ci.yml` job `minimum-supported` `setup-bun` |
-| Astro            | `^7.0.7`  | `^7.0.7`          | `package.json` `dependencies.astro`                            |
-| `@astrojs/node`  | `^11.0.2` | `^11.0.2`         | `package.json` `dependencies`                                  |
+| Astro            | `^7.2.2`  | `^7.2.2`          | `package.json` `dependencies.astro`                            |
+| `@astrojs/node`  | `^11.1.2` | `^11.1.2`         | `package.json` `dependencies`                                  |
 | TypeScript       | `^7.0.2`  | `^7.0.2`          | `package.json` `devDependencies`                               |
 | PostgreSQL       | `18.4`    | `18.4`            | `.github/workflows/ci.yml` `services.postgres`                 |
 

--- a/docs/awcms/family-compatibility.md
+++ b/docs/awcms/family-compatibility.md
@@ -51,8 +51,8 @@ A manifest `declared` value MUST equal the real value at the `source` it points 
 | Bun (pin)        | `1.3.14`  | `>=1.3.0`         | `package.json` `packageManager` / `engines.bun`                |
 | Bun (CI current) | `1.3.14`  | —                 | `.github/workflows/ci.yml` job `quality` `setup-bun`           |
 | Bun (CI minimum) | —         | `1.3.0`           | `.github/workflows/ci.yml` job `minimum-supported` `setup-bun` |
-| Astro            | `^7.0.7`  | `^7.0.7`          | `package.json` `dependencies.astro`                            |
-| `@astrojs/node`  | `^11.0.2` | `^11.0.2`         | `package.json` `dependencies`                                  |
+| Astro            | `^7.2.2`  | `^7.2.2`          | `package.json` `dependencies.astro`                            |
+| `@astrojs/node`  | `^11.1.2` | `^11.1.2`         | `package.json` `dependencies`                                  |
 | TypeScript       | `^7.0.2`  | `^7.0.2`          | `package.json` `devDependencies`                               |
 | PostgreSQL       | `18.4`    | `18.4`            | `.github/workflows/ci.yml` `services.postgres`                 |
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 467   |
+| Test files                          | 468   |
 | Route files                         | 382   |
 | ADR                                 | 222   |
 
@@ -357,7 +357,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 393        |
+| `(root)`      | 394        |
 | `e2e`         | 12         |
 | `integration` | 61         |
 | `unit`        | 1          |

--- a/tests/family-compatibility-doc-parity.test.ts
+++ b/tests/family-compatibility-doc-parity.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The stack table in `docs/awcms/family-compatibility.md` must say what the
+ * manifest says (Issue #183, epic #177, ADR-0032; ADR-0039 for the mirror).
+ *
+ * ## Why this gate exists at all
+ *
+ * `family:conformance:check` already proves the manifest's `declared` values
+ * equal the real ones at their `source`. What nothing proved is that the
+ * PROSE table — the thing a human actually reads when they want to know which
+ * Astro this repo is pinned to — agrees with either.
+ *
+ * It had already drifted, and the way it drifted is the point: on 23 August
+ * 2026 the table read Astro `^7.0.7` / `@astrojs/node` `^11.0.2` while the
+ * manifest and `package.json` both said `^7.2.2` / `^11.1.2`. The Bun,
+ * TypeScript and PostgreSQL rows were correct. Only the two rows **dependabot
+ * moves** were stale — because a bump updates `package.json` and the manifest
+ * (the gate forces that) and then stops, and no gate looks any further.
+ *
+ * So the failure is not random rot: this table ages in exactly the direction
+ * dependency bumps push it, at exactly the rate they land, and it does so
+ * silently. A reader consulting it gets a confident wrong answer, which is
+ * worse than no table — an absent table sends them to `package.json`.
+ *
+ * ## Both files, not just the source
+ *
+ * The `.id.md` mirror is a SEPARATE file that can drift on its own. The
+ * translation gates compare its `i18n-source-hash` against the English file,
+ * which catches "the source changed and the mirror did not" — it cannot catch
+ * "both were written wrong on the same day", which is precisely what happened
+ * here. So both files are read, and both are compared against the manifest.
+ *
+ * No DB, no network — plain file reads and one YAML parse.
+ */
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+import { parse as parseYaml } from "yaml";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+const DOCS = [
+  "docs/awcms/family-compatibility.md",
+  "docs/awcms/family-compatibility.id.md"
+] as const;
+
+type Manifest = {
+  stack: {
+    bun: {
+      packageManager: { declared: string };
+      engines: { declared: string };
+      ci: { declared: string };
+      ciMinimum: { declared: string };
+    };
+    astro: { declared: string };
+    astroNode: { declared: string };
+    typescript: { declared: string };
+    postgres: { declared: string };
+  };
+};
+
+function read(rel: string): string {
+  return readFileSync(path.join(ROOT, rel), "utf8");
+}
+
+function manifest(): Manifest {
+  return parseYaml(read("awcms-family-compatibility.yaml")) as Manifest;
+}
+
+/**
+ * The row label as it appears in the first column, and what the Current and
+ * Minimum-supported cells must contain.
+ *
+ * `null` means the cell is an em dash — the row deliberately declares only one
+ * of the two, and asserting that keeps a real value from being quietly added
+ * where the matrix says there is none.
+ */
+function expectedRows(
+  m: Manifest
+): Array<[string, string | null, string | null]> {
+  return [
+    [
+      "Bun (pin)",
+      m.stack.bun.packageManager.declared,
+      m.stack.bun.engines.declared
+    ],
+    ["Bun (CI current)", m.stack.bun.ci.declared, null],
+    ["Bun (CI minimum)", null, m.stack.bun.ciMinimum.declared],
+    ["Astro", m.stack.astro.declared, m.stack.astro.declared],
+    ["`@astrojs/node`", m.stack.astroNode.declared, m.stack.astroNode.declared],
+    ["TypeScript", m.stack.typescript.declared, m.stack.typescript.declared],
+    ["PostgreSQL", m.stack.postgres.declared, m.stack.postgres.declared]
+  ];
+}
+
+/** Every markdown table row in a document, as trimmed cell arrays. */
+function tableRows(doc: string): string[][] {
+  return doc
+    .split("\n")
+    .filter((line) => line.trimStart().startsWith("|"))
+    .map((line) =>
+      line
+        .trim()
+        .replace(/^\|/, "")
+        .replace(/\|$/, "")
+        .split("|")
+        .map((cell) => cell.trim())
+    );
+}
+
+/**
+ * `` `^7.2.2` `` -> `^7.2.2`; an em-dash cell -> `null`.
+ *
+ * A MISSING cell (the row has fewer columns than the header) also reads as
+ * `null` rather than throwing: a truncated row is drift too, and it should
+ * fail as a mismatched value naming its row, not as a crash in the harness.
+ */
+function cellValue(cell: string | undefined): string | null {
+  if (cell === undefined || cell === "—" || cell === "-" || cell === "") {
+    return null;
+  }
+  return cell.match(/^`(.+)`$/)?.[1] ?? cell;
+}
+
+describe("family-compatibility doc — stack table parity with the manifest", () => {
+  for (const rel of DOCS) {
+    describe(rel, () => {
+      const rows = tableRows(read(rel));
+
+      test("declares every stack row the manifest does", () => {
+        // A row DELETED from the table is the other way this drifts, and it
+        // reads as "this repo pins nothing there" rather than as an omission.
+        const labels = new Set(rows.map((cells) => cells[0]));
+        for (const [label] of expectedRows(manifest())) {
+          expect(labels.has(label)).toBe(true);
+        }
+      });
+
+      for (const [label, current, minimum] of expectedRows(manifest())) {
+        test(`row "${label}" matches the manifest`, () => {
+          const row = rows.find((cells) => cells[0] === label);
+          if (row === undefined) {
+            throw new Error(`${rel}: the stack table has no row "${label}"`);
+          }
+          expect(cellValue(row[1])).toBe(current);
+          expect(cellValue(row[2])).toBe(minimum);
+        });
+      }
+    });
+  }
+
+  test("the two documents agree with EACH OTHER cell for cell", () => {
+    // Redundant while both match the manifest, and deliberately kept: it is
+    // the assertion that still means something if the manifest shape changes
+    // and the loop above is loosened to follow it.
+    const en = tableRows(read(DOCS[0]));
+    const id = tableRows(read(DOCS[1]));
+    for (const [label] of expectedRows(manifest())) {
+      const a = en.find((cells) => cells[0] === label);
+      const b = id.find((cells) => cells[0] === label);
+      expect(a?.slice(1, 3)).toEqual(b?.slice(1, 3));
+    }
+  });
+});


### PR DESCRIPTION
`docs/awcms/family-compatibility.md` is where a human goes to find out which Astro this repo is pinned to. It said `^7.0.7` and `@astrojs/node` `^11.0.2`. `package.json` and the manifest both said `^7.2.2` and `^11.1.2` — and `family:conformance:check` was green the whole time, because it proves the manifest's `declared` values against their real `source` and never reads the prose.

Found while cleaning up branches after merging a dependabot bump in `ahliweb/awcms-astro`.

## The drift has a direction

The Bun, TypeScript and PostgreSQL rows were correct. The two stale rows were exactly the two that **dependabot moves**: a bump edits `package.json`, the conformance gate forces the manifest to follow, and there the chain stops.

So this table does not rot randomly. It ages in the direction dependency bumps push it, at the rate they land, and silently — which makes it worse than no table at all. An absent table sends the reader to `package.json`; a confident wrong one does not.

Correcting the two rows without closing that would have bought a few weeks.

## `tests/family-compatibility-doc-parity.test.ts`

Every row of the stack table, in **both** the English source and the `.id.md` mirror, is now compared against the manifest cell by cell. Em-dash cells are asserted as absent values, so a real number cannot be quietly added where the matrix says the repo declares none.

Both files are read rather than just the source. The translation gates compare the mirror's `i18n-source-hash` against the English file, which catches "the source moved and the mirror did not" — it cannot catch "both were written wrong on the same day", which is what had happened here.

## Verification

`DATABASE_URL="" bun run check` — exit 0, **5661 pass / 0 fail**, including `typecheck`, `build`, and `family:conformance:check` at 29/29.

The gate proved by mutation in five directions, each naming the offending file and row:

| Mutation | Result |
| --- | --- |
| the original defect restored (EN back to `^7.0.7`) | RED — names `family-compatibility.md`, row `Astro` |
| the `.id.md` mirror drifting alone | RED — names the mirror, row `` `@astrojs/node` `` |
| a row deleted | RED — `the stack table has no row "PostgreSQL"` |
| an em-dash cell gaining a value | RED — names row `Bun (CI current)` |
| **the real future case:** manifest bumped to `^7.2.4`, docs untouched | RED — reddens both files by name |

`docs/awcms/repo-inventory.md` is regenerated, not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)