### PR TITLE
test(admin): nothing had ever watched an admin screen refuse a user holding no permissions

### DIFF
--- a/.changeset/admin-deny-path-verified.md
+++ b/.changeset/admin-deny-path-verified.md
@@ -1,0 +1,33 @@
+---
+"awcms": minor
+---
+
+test(admin): nothing had ever watched an admin screen refuse a user who holds no permissions
+
+The per-screen contract tests are source greps — they prove a page *mentions* a permission key, not that a control is hidden from someone lacking it. `admin-screens-render.e2e.ts` loads every screen as the seeded **owner**, who holds every permission. So the deny path — the half of authorization that actually matters — had never been executed by anything.
+
+A screen can name the right key, gate the right control, pass every static test, and still render its contents: because the gate was written on a variable that is `true` for the wrong reason, or because the deny branch was simply never exercised.
+
+### Four screens could not be checked at all
+
+`loadAdminScreen` never redirects, so a denied screen RENDERS, and the convention is an element carrying `id="<screen>-denied"`. Forty-three followed it. **`site-profile`, `blog-settings`, `sidebar-menu` and `comments` rendered a correct denial message with no id on it.**
+
+Nothing was broken for a user — they saw the right words. What was broken was verifiability: no mechanical check could tell those four apart from a screen that shows its contents to someone with no permission, because there was nothing to look for. A denial nobody can assert on is a denial nobody will notice losing.
+
+All four now carry the hook, and `tests/admin-deny-path-contract.test.ts` keeps every gated screen carrying one — including the assertion that each still routes through `loadAdminScreen`, since a page reading its data without that has no deny path at all.
+
+### `tests/e2e/admin-deny-path.e2e.ts`
+
+Logs in as a tenant user whose role holds **zero** permissions, and requires of all 46 static gated screens: status `200` (a denial is a rendered page — a 404 would mean the screen *threw*, the `/admin/seo` class, and a throw must never read as a refusal) and the screen's own `#…-denied` element present.
+
+The denial id is read **from each page's source**, not derived from its URL: several screens use a name that is not their route (`/admin/blog-ads` → `#ads-denied`, `/admin` → `#dashboard-denied`), and deriving would have produced confident failures against ids that never existed.
+
+The restricted user is seeded through the same primitives the owner bootstrap uses — `hashPassword`, `linkIdentityToPrincipal`, the same tables in the same order — because a user assembled by hand with a different hash, or with no principal link (ADR-0086), would be testing a shape the login path never produces.
+
+### Verified in both directions
+
+Green across all 46 screens. With `canRead` forced true on `/admin/site-profile` — a simulated authorization leak — the suite goes **red naming that screen**.
+
+One correction worth recording: the first run reported those same four screens as leaking, and they were not. The server was serving a build made before the hooks were added. The finding was a stale artefact, and re-running against a fresh build is the only reason it was not reported as a defect.
+
+**Not covered, deliberately:** a *partially*-permissioned user seeing the right subset of controls. Expected results differ per screen there, so it is per-screen knowledge rather than one mechanical rule, and it is a larger piece of work.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:6682b8223c17be1fdce5dedbe344356037a5c1bfd8e6fc6eef29b06f938e084f -->
+<!-- i18n-source-hash: sha256:3fd64e482687c9f6dc86a9e865f88fb1e74b3dbd5eddc3a5d2c20d90e19a5f73 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,43 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN DENY — 23 Agustus 2026: tidak pernah ada yang menyaksikan layar
+  admin MENOLAK pengguna tanpa permission, dan empat layar sama sekali tak bisa
+  diperiksa.**
+
+  Tes kontrak per-layar adalah grep sumber: ia membuktikan halaman MENYEBUT
+  sebuah permission key, bukan bahwa kontrolnya disembunyikan dari yang tidak
+  memilikinya. Uji asap render memuat setiap layar sebagai OWNER ter-seed, yang
+  memegang segalanya. Jadi jalur deny — separuh otorisasi yang justru penting —
+  tidak pernah dieksekusi.
+
+  `loadAdminScreen` tidak pernah redirect, jadi layar yang ditolak MERENDER,
+  secara konvensi lewat elemen ber-`id="<layar>-denied"`. Empat puluh tiga
+  mengikutinya. **`site-profile`, `blog-settings`, `sidebar-menu`, dan
+  `comments` merender pesan penolakan yang BENAR tanpa id padanya.** Tidak ada
+  yang rusak bagi pengguna; yang rusak adalah KETERVERIFIKASIAN — tak ada
+  pemeriksa yang bisa membedakan keempatnya dari layar yang menampilkan isinya
+  kepada orang tanpa permission. **Penolakan yang tak bisa di-assert siapa pun
+  adalah penolakan yang hilangnya tak akan disadari siapa pun.**
+
+  `tests/e2e/admin-deny-path.e2e.ts` kini login sebagai pengguna yang perannya
+  memegang NOL permission dan menuntut, untuk 46 layar ber-gerbang statis,
+  status `200` (penolakan adalah halaman terender; 404 berarti layarnya
+  MELEMPAR) serta hook penolakan milik layar itu. Id-nya dibaca DARI TIAP
+  HALAMAN, bukan diturunkan dari URL — beberapa layar memakai nama yang bukan
+  rutenya.
+
+  **Build basi nyaris menghasilkan laporan PALSU.** Jalan pertama menyebut
+  keempatnya bocor; servernya menyajikan bundel yang dibangun SEBELUM hook
+  ditambahkan. Menjalankan ulang di atas build segar adalah satu-satunya alasan
+  itu tidak dilaporkan sebagai cacat. Bangun ulang sebelum memercayai temuan
+  e2e.
+
+  **Masih belum tercakup, dengan sengaja:** pengguna ber-permission SEBAGIAN
+  yang melihat subset kontrol yang benar. Hasil yang diharapkan berbeda per
+  layar, jadi itu pengetahuan per-layar, bukan satu aturan mekanis — putarannya
+  sendiri.
 
 - **PUTARAN RENDER — 23 Agustus 2026: 41 dari 48 layar admin tidak pernah
   dimuat apa pun, dan gejala layar rusak adalah 404 — BUKAN 500.**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -114,7 +114,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Migrations                        | **146** (`sql/001`–`146`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0112** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **48** `.astro` files in `src/pages/admin/`; **0 of 24** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
-| `.astro` files                    | **61** (34.770 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
+| `.astro` files                    | **61** (34.774 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
 | Gates                             | **58** in the `bun run check` chain                                                    | `scripts.check` in `package.json`, split on `&&`                                        |
 | Contracts                         | Modular per-module OpenAPI + AsyncAPI; `MODULE_CONTRACT_VERSION` **4.1.0**             | `openapi/`, `asyncapi/`, `_shared/module-contract.ts`                                   |
 
@@ -359,6 +359,39 @@ pioneered directly here after the ADR-0047 freeze.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / next steps
+
+- **DENY ROUND — 23 August 2026: nothing had ever watched an admin screen
+  refuse a user holding no permissions, and four screens could not be checked
+  at all.**
+
+  The per-screen contract tests are source greps: they prove a page MENTIONS a
+  permission key, not that a control is hidden from someone lacking it. The
+  render smoke test loads every screen as the seeded OWNER, who holds
+  everything. So the deny path — the half of authorization that matters — had
+  never been executed.
+
+  `loadAdminScreen` never redirects, so a denied screen RENDERS, by convention
+  an element with `id="<screen>-denied"`. Forty-three followed it.
+  **`site-profile`, `blog-settings`, `sidebar-menu` and `comments` rendered a
+  correct denial message with no id on it.** Nothing was broken for a user; what
+  was broken was VERIFIABILITY — no checker could tell those four from a screen
+  showing its contents to someone with no permission. **A denial nobody can
+  assert on is a denial nobody will notice losing.**
+
+  `tests/e2e/admin-deny-path.e2e.ts` now logs in as a user whose role holds ZERO
+  permissions and requires, for all 46 static gated screens, status `200` (a
+  denial is a rendered page; a 404 would mean the screen THREW) and that
+  screen's own denial hook. The id is read FROM EACH PAGE, not derived from its
+  URL — several screens use a name that is not their route.
+
+  **A stale build nearly produced a false report.** The first run named those
+  four as leaking; the server was serving a bundle built before the hooks were
+  added. Re-running against a fresh build is the only reason it was not
+  reported as a defect. Rebuild before believing an e2e finding.
+
+  **Still uncovered, deliberately:** a PARTIALLY-permissioned user seeing the
+  right subset of controls. Expected results differ per screen, so it is
+  per-screen knowledge rather than one mechanical rule — its own round.
 
 - **RENDER ROUND — 23 August 2026: 41 of 48 admin screens were never loaded by
   anything, and the symptom of a broken one is a 404 — not a 500.**

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 472   |
+| Test files                          | 474   |
 | Route files                         | 382   |
 | ADR                                 | 226   |
 
@@ -357,8 +357,8 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 397        |
-| `e2e`         | 13         |
+| `(root)`      | 398        |
+| `e2e`         | 14         |
 | `integration` | 61         |
 | `unit`        | 1          |
 

--- a/src/pages/admin/blog-settings.astro
+++ b/src/pages/admin/blog-settings.astro
@@ -121,7 +121,7 @@ const VISIBILITY_OPTIONS = ["public", "private"] as const;
 
   {
     !canRead && (
-      <p class="admin-empty">
+      <p class="admin-empty" id="blog-settings-denied">
         {t("You do not have permission to view blog settings.")}
       </p>
     )

--- a/src/pages/admin/comments.astro
+++ b/src/pages/admin/comments.astro
@@ -138,7 +138,11 @@ function formatTimestamp(value: string): string {
 
   {
     !canRead && (
-      <div class="state-notice state-notice--denied" role="status">
+      <div
+        class="state-notice state-notice--denied"
+        role="status"
+        id="comments-denied"
+      >
         <p>
           <strong>{t("Access denied.")}</strong>
           {t("You do not have the")}

--- a/src/pages/admin/sidebar-menu.astro
+++ b/src/pages/admin/sidebar-menu.astro
@@ -118,7 +118,7 @@ const typeOptions = [
 
     {
       !canRead && (
-        <p class="admin-empty">
+        <p class="admin-empty" id="sidebar-menu-denied">
           {t("You do not have permission to view the sidebar configuration.")}
         </p>
       )

--- a/src/pages/admin/site-profile.astro
+++ b/src/pages/admin/site-profile.astro
@@ -86,7 +86,7 @@ const profile: SiteProfileView | null =
 
   {
     !canRead && (
-      <p class="admin-empty">
+      <p class="admin-empty" id="site-profile-denied">
         {t("You do not have permission to view the site profile.")}
       </p>
     )

--- a/tests/admin-deny-path-contract.test.ts
+++ b/tests/admin-deny-path-contract.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Every permission-gated admin screen must be able to SAY it denied.
+ *
+ * ## The contract, and why a hook rather than just a message
+ *
+ * `loadAdminScreen` never redirects — `src/lib/auth/admin-screen.ts` explains
+ * why — so a denied screen RENDERS, and the page decides what that looks like.
+ * The convention is an element carrying `id="<screen>-denied"`.
+ *
+ * Forty-three screens followed it. Four — `site-profile`, `blog-settings`,
+ * `sidebar-menu`, `comments` — rendered a correct denial message with no id on
+ * it. Nothing was broken for a user: they saw the right words. What was broken
+ * was **verifiability**. No mechanical check could tell those four apart from a
+ * screen that renders its content to someone with no permission at all, because
+ * there was nothing to look for.
+ *
+ * That is why this gate exists and why it is worth a test rather than a
+ * convention: a denial nobody can assert on is a denial nobody will notice
+ * losing.
+ *
+ * The companion is `tests/e2e/admin-deny-path.e2e.ts`, which logs in as a user
+ * holding no permissions and requires every one of these hooks to actually
+ * appear. This gate keeps the hooks present; that one keeps them honest.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+import { listFilesRecursive } from "../scripts/lib/repo-files";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+const ADMIN_ROOT = path.join(ROOT, "src/pages/admin");
+
+/**
+ * `/admin/account` loads through `loadSelfServiceScreen`, which has no
+ * permission to deny — every authenticated user owns their own account page.
+ * Identified by the loader it calls rather than by name, so the exemption
+ * cannot outlive the reason for it.
+ */
+function isSelfService(source: string): boolean {
+  return source.includes("loadSelfServiceScreen");
+}
+
+type Screen = { file: string; relative: string; source: string };
+
+const screens: Screen[] = listFilesRecursive(ADMIN_ROOT)
+  .filter((file) => file.endsWith(".astro"))
+  .map((file) => ({
+    file,
+    relative: path.relative(ROOT, file),
+    source: readFileSync(file, "utf8")
+  }));
+
+const gated = screens.filter((screen) => !isSelfService(screen.source));
+
+describe("admin deny path", () => {
+  test("the screen walk found them", () => {
+    // A walk that stops matching turns every assertion below into a loop over
+    // nothing, which passes. That failure mode has cost this repo real defects.
+    expect(screens.length).toBeGreaterThan(40);
+    expect(gated.length).toBeGreaterThan(40);
+  });
+
+  test("every gated screen loads through loadAdminScreen", () => {
+    // The authorization chokepoint for a SCREEN. A page that reads its data
+    // without it has no deny path at all, and no amount of markup would give
+    // it one.
+    for (const screen of gated) {
+      expect(
+        screen.source.includes("loadAdminScreen"),
+        `${screen.relative} does not call loadAdminScreen, so it has no deny path.`
+      ).toBe(true);
+    }
+  });
+
+  test("every gated screen carries a `-denied` hook", () => {
+    // Four screens rendered a correct denial with no id, which made them
+    // indistinguishable — to any checker — from a screen that shows its
+    // contents to a user with no permission.
+    for (const screen of gated) {
+      expect(
+        /id="[a-z0-9-]+-denied"/.test(screen.source),
+        `${screen.relative} renders no id="…-denied" element. ` +
+          "Deny RENDERS here (it never redirects), so the denied state needs a " +
+          "hook the e2e can require — otherwise nothing can tell a working " +
+          "denial from a screen that leaks its contents."
+      ).toBe(true);
+    }
+  });
+
+  test("the self-service exemption names a real screen and is not a pattern", () => {
+    // One screen, identified by the loader it calls. If this ever grows, the
+    // growth should be a decision somebody made rather than a filter widening
+    // quietly.
+    const selfService = screens.filter((screen) =>
+      isSelfService(screen.source)
+    );
+    expect(selfService.map((screen) => screen.relative)).toEqual([
+      "src/pages/admin/account.astro"
+    ]);
+  });
+});

--- a/tests/e2e/admin-deny-path.e2e.ts
+++ b/tests/e2e/admin-deny-path.e2e.ts
@@ -1,0 +1,163 @@
+/**
+ * Every permission-gated admin screen actually DENIES a user who holds nothing.
+ *
+ * ## The gap this closes
+ *
+ * The per-screen contract tests are source greps — they prove a page mentions
+ * a permission key, not that a control is hidden from someone lacking it. The
+ * render smoke test (`admin-screens-render.e2e.ts`) loads every screen as the
+ * seeded OWNER, who holds every permission. So nothing anywhere had ever
+ * watched an admin screen answer a user with no permissions at all.
+ *
+ * That is the half of authorization worth checking at runtime. A screen can
+ * name the right key, gate the right control, pass every static test, and still
+ * render its contents — because the gate was written on a variable that is
+ * `true` for the wrong reason, or because the deny branch was never exercised.
+ *
+ * ## What it asserts
+ *
+ * For all 47 gated screens, as a user whose role holds zero permissions:
+ *
+ * 1. **The denial renders.** `loadAdminScreen` never redirects (see
+ *    `src/lib/auth/admin-screen.ts`), so a denied screen renders an element
+ *    carrying `id="…-denied"`. `tests/admin-deny-path-contract.test.ts` keeps
+ *    that hook present in the source; this requires it to actually appear.
+ * 2. **The status is 200.** A denial is a rendered page, not an error. A 404
+ *    here would mean the screen THREW — the `/admin/seo` class — and a throw
+ *    must never be mistaken for a refusal.
+ *
+ * Soft assertions throughout: a run should report every screen that leaks, not
+ * stop at the first.
+ *
+ * ## What it deliberately does NOT assert
+ *
+ * That a PARTIALLY-permissioned user sees the right subset. Expected results
+ * differ per screen there, so it is per-screen knowledge rather than one
+ * mechanical rule, and it is a larger piece of work. This covers the case where
+ * one rule holds for every screen.
+ */
+import { test, expect } from "@playwright/test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { provideTenant } from "./support/e2e-auth";
+import { seedRestrictedUser } from "./support/e2e-restricted-user";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const databaseUrl = process.env.DATABASE_URL;
+
+const seeded = Boolean(tenantId && databaseUrl);
+
+const HERE = path.dirname(new URL(import.meta.url).pathname);
+const ADMIN_PAGES_ROOT = path.resolve(HERE, "../../src/pages/admin");
+
+type GatedScreen = { url: string; source: string; deniedId: string };
+
+/**
+ * Every permission-gated admin route, with the denial hook its own source
+ * declares.
+ *
+ * The hook is read FROM THE PAGE rather than derived from the URL: several
+ * screens use a name that is not their route (`/admin/blog-ads` →
+ * `#ads-denied`, `/admin` → `#dashboard-denied`). Deriving would produce
+ * confident failures against ids that never existed.
+ *
+ * `/admin/account` is excluded because it loads through
+ * `loadSelfServiceScreen` — there is no permission to deny; every
+ * authenticated user owns their own account page. Identified by the loader it
+ * calls, so the exemption cannot outlive its reason.
+ */
+function discoverGatedScreens(root: string, prefix = "/admin"): GatedScreen[] {
+  const screens: GatedScreen[] = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      screens.push(...discoverGatedScreens(full, `${prefix}/${entry.name}`));
+      continue;
+    }
+
+    if (!entry.name.endsWith(".astro")) continue;
+
+    const source = readFileSync(full, "utf8");
+    if (source.includes("loadSelfServiceScreen")) continue;
+
+    const match = /id="([a-z0-9-]+-denied)"/.exec(source);
+    if (!match?.[1]) continue;
+
+    const base = entry.name.slice(0, -".astro".length);
+    screens.push({
+      url: base === "index" ? prefix : `${prefix}/${base}`,
+      source: path.relative(process.cwd(), full),
+      deniedId: match[1]
+    });
+  }
+
+  return screens.sort((a, b) => a.url.localeCompare(b.url));
+}
+
+// Dynamic routes are excluded: a restricted user cannot reach the listing that
+// would supply a real id, so there is nothing honest to request. They are
+// covered as the OWNER by `admin-screens-render.e2e.ts`.
+const gatedScreens = discoverGatedScreens(ADMIN_PAGES_ROOT).filter(
+  (screen) => !screen.url.includes("[")
+);
+
+test.describe("admin screens deny a user holding no permissions", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant and DATABASE_URL — CI e2e-smoke provides both"
+  );
+
+  test("the screen walk found them", () => {
+    expect(
+      gatedScreens.length,
+      "no gated admin screens with a denial hook were discovered"
+    ).toBeGreaterThan(40);
+  });
+
+  test("every gated screen renders its denial, not its contents", async ({
+    page
+  }) => {
+    test.setTimeout(240_000);
+
+    const user = await seedRestrictedUser(databaseUrl!, tenantId!);
+
+    await page.goto("/login");
+    await provideTenant(page, tenantId!);
+    await page.locator("#login-identifier").fill(user.loginIdentifier);
+    await page.locator("#password").fill(user.password);
+    await page.locator("#login-submit").click();
+    await page.waitForURL("**/admin");
+
+    for (const screen of gatedScreens) {
+      const response = await page.goto(screen.url);
+      const status = response?.status() ?? 0;
+
+      // A denial is a RENDERED page. A 404 would mean the screen threw — the
+      // `/admin/seo` class — and a throw must never read as a refusal.
+      expect
+        .soft(
+          status,
+          `${screen.url} (${screen.source}) answered ${status} for a user with ` +
+            "no permissions. A denial renders with 200; a 404 here means the " +
+            "screen THREW, and the ReferenceError would be in the server log."
+        )
+        .toBe(200);
+
+      if (status !== 200) continue;
+
+      const denial = await page.locator(`#${screen.deniedId}`).count();
+      expect
+        .soft(
+          denial,
+          `${screen.url} (${screen.source}) did not render #${screen.deniedId} ` +
+            "for a user holding zero permissions. Either the screen is showing " +
+            "its contents to someone with no right to them, or its deny branch " +
+            "no longer renders the hook."
+        )
+        .toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/e2e/support/e2e-restricted-user.ts
+++ b/tests/e2e/support/e2e-restricted-user.ts
@@ -1,0 +1,129 @@
+/**
+ * Seed a tenant user holding a role with ZERO permissions.
+ *
+ * ## Why this is seeded rather than invited
+ *
+ * The product path for a second user is an invitation, and its token is stored
+ * hashed and delivered by email — a test cannot read it back. So the row is
+ * written directly, but through the SAME primitives the owner bootstrap uses
+ * (`hashPassword`, `linkIdentityToPrincipal`, the same tables in the same
+ * order). A user assembled by hand with a different password hash, or with no
+ * principal link, would be testing a shape the login path never produces.
+ *
+ * `linkIdentityToPrincipal` matters specifically: ADR-0086 moved the lockout
+ * counter onto the principal, and an identity with no principal counts no
+ * failed logins. Every identity writer links, so this one does too.
+ *
+ * ## The role holds nothing, deliberately
+ *
+ * Not "read-only" — empty. Every permission-gated admin screen then owes this
+ * user the same answer, so a single mechanical rule covers all 47: the denial
+ * renders and the contents do not. A partially-permissioned user is a more
+ * realistic operator and a much larger question, because the expected result
+ * differs per screen; that belongs in its own round.
+ */
+import { hashPassword } from "../../../src/lib/auth/password";
+import { linkIdentityToPrincipal } from "../../../src/modules/identity-access/application/principal-store";
+
+export type RestrictedUser = {
+  loginIdentifier: string;
+  password: string;
+  tenantUserId: string;
+};
+
+/**
+ * Create (or return, if it already exists) the restricted user for `tenantId`.
+ *
+ * Idempotent on `login_identifier` so a re-run against a database that already
+ * has one does not fail on the unique constraint — a local run of this suite
+ * twice is normal.
+ */
+export async function seedRestrictedUser(
+  databaseUrl: string,
+  tenantId: string,
+  loginIdentifier = "e2e-restricted@example.com",
+  password = "E2eRestricted!Passw0rd"
+): Promise<RestrictedUser> {
+  const sql = new Bun.SQL(databaseUrl, { max: 1 });
+
+  try {
+    return await sql.begin(async (tx: Bun.SQL) => {
+      await tx.unsafe(`SET LOCAL app.current_tenant_id = '${tenantId}'`);
+
+      const existing = (await tx`
+        SELECT tu.id
+        FROM awcms_tenant_users tu
+        JOIN awcms_identities i ON i.id = tu.identity_id
+        WHERE tu.tenant_id = ${tenantId}
+          AND i.login_identifier = ${loginIdentifier}
+        LIMIT 1
+      `) as { id: string }[];
+
+      if (existing[0]) {
+        return {
+          loginIdentifier,
+          password,
+          tenantUserId: existing[0].id
+        };
+      }
+
+      const profile = (await tx`
+        INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+        VALUES (${tenantId}, 'person', 'E2E Restricted')
+        RETURNING id
+      `) as { id: string }[];
+
+      const passwordHash = await hashPassword(password);
+      const identity = (await tx`
+        INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+        VALUES (${tenantId}, ${profile[0]!.id}, ${loginIdentifier}, ${passwordHash})
+        RETURNING id
+      `) as { id: string }[];
+
+      // ADR-0086 — the lockout counter lives on the principal; an identity with
+      // no principal counts no failed logins. Every identity writer links.
+      await linkIdentityToPrincipal(tx, identity[0]!.id, loginIdentifier);
+
+      const tenantUser = (await tx`
+        INSERT INTO awcms_tenant_users (tenant_id, identity_id)
+        VALUES (${tenantId}, ${identity[0]!.id})
+        RETURNING id
+      `) as { id: string }[];
+
+      // A real role, with NO rows in `awcms_role_permissions`. Giving the user
+      // no role at all would test a different thing — an unassigned user —
+      // and would not prove that an assigned role holding nothing denies.
+      const role = (await tx`
+        INSERT INTO awcms_roles (tenant_id, role_code, role_name, is_system)
+        VALUES (${tenantId}, 'e2e_restricted', 'E2E Restricted', false)
+        RETURNING id
+      `) as { id: string }[];
+
+      // ADR-0078 — the grant lands in `awcms_access_policies`, tenant-wide,
+      // exactly as the owner's does. Same shape, empty permission set.
+      const policy = (await tx`
+        INSERT INTO awcms_access_policies
+          (tenant_id, subject_type, tenant_user_id, role_id, scope_type, scope_id,
+           granted_by_tenant_user_id, reason)
+        VALUES
+          (${tenantId}, 'tenant_user', ${tenantUser[0]!.id}, ${role[0]!.id}, 'tenant', ${tenantId},
+           ${tenantUser[0]!.id}, 'e2e restricted-user fixture')
+        RETURNING id
+      `) as { id: string }[];
+
+      await tx`
+        INSERT INTO awcms_access_policy_events
+          (tenant_id, policy_id, event_type, actor_tenant_user_id, reason)
+        VALUES (${tenantId}, ${policy[0]!.id}, 'granted', ${tenantUser[0]!.id}, 'e2e restricted-user fixture')
+      `;
+
+      return {
+        loginIdentifier,
+        password,
+        tenantUserId: tenantUser[0]!.id
+      };
+    });
+  } finally {
+    await sql.end();
+  }
+}


### PR DESCRIPTION
The per-screen contract tests are **source greps** — they prove a page *mentions* a permission key, not that a control is hidden from someone lacking it. `admin-screens-render.e2e.ts` loads every screen as the seeded **owner**, who holds every permission.

So the deny path — the half of authorization that actually matters — had never been executed by anything. A screen can name the right key, gate the right control, pass every static test, and still render its contents: because the gate was written on a variable that is `true` for the wrong reason, or because the deny branch was simply never exercised.

## Four screens could not be checked at all

`loadAdminScreen` never redirects, so a denied screen **renders**, by convention an element carrying `id="<screen>-denied"`. Forty-three followed it. `site-profile`, `blog-settings`, `sidebar-menu` and `comments` rendered a correct denial message **with no id on it**.

Nothing was broken for a user — they saw the right words. What was broken was **verifiability**: no mechanical check could tell those four apart from a screen that shows its contents to someone with no permission, because there was nothing to look for.

> A denial nobody can assert on is a denial nobody will notice losing.

All four now carry the hook, and `tests/admin-deny-path-contract.test.ts` keeps every gated screen carrying one — plus the assertion that each still routes through `loadAdminScreen`, since a page reading its data without that has no deny path at all.

## `tests/e2e/admin-deny-path.e2e.ts`

Logs in as a tenant user whose role holds **zero** permissions and requires, for all 46 static gated screens:

- **status `200`** — a denial is a rendered page. A 404 would mean the screen *threw* (the `/admin/seo` class), and a throw must never read as a refusal.
- **the screen's own `#…-denied` element** — read **from each page's source**, not derived from its URL. Several screens use a name that is not their route (`/admin/blog-ads` → `#ads-denied`, `/admin` → `#dashboard-denied`), and deriving would have produced confident failures against ids that never existed.

The restricted user is seeded through the same primitives the owner bootstrap uses — `hashPassword`, `linkIdentityToPrincipal`, the same tables in the same order. A user assembled by hand with a different hash, or with no principal link (ADR-0086), would be testing a shape the login path never produces.

## Verified both directions

| Run | Result |
| --- | --- |
| all 46 gated screens, clean build | **green** |
| `canRead` forced `true` on `/admin/site-profile` (simulated leak) | **RED**, naming that screen |
| `bun run check` | exit 0, **5708 pass / 0 fail** |

**A correction worth recording:** the first run reported those same four screens as leaking, and they were not — the server was serving a build made *before* the hooks were added. The finding was a stale artefact, and re-running against a fresh build is the only reason it was not reported to you as a defect. Rebuild before believing an e2e finding.

## Not covered, deliberately

A **partially**-permissioned user seeing the right subset of controls. Expected results differ per screen there, so it is per-screen knowledge rather than one mechanical rule — a larger piece of work, and its own round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)