### PR TITLE
test(e2e): the sweeps were accidentally immune, and the harness had to be fixed first

### DIFF
--- a/.changeset/e2e-read-write-waves.md
+++ b/.changeset/e2e-read-write-waves.md
@@ -1,0 +1,44 @@
+---
+"awcms": minor
+---
+
+test(e2e): the sweeps were accidentally immune, and the fix had to come first
+
+Every e2e spec shares one seeded tenant. Some of them change it tenant-wide, and under `fullyParallel: true` a reader could observe that change mid-flight. The previous round fixed one symptom of this; this one fixes the cause, and then fixes what the cause had been hiding.
+
+### Two waves, ordered
+
+`playwright.config.ts` now runs `setup` → `read` → `write`. Read-wave specs see the tenant as the bootstrap left it; writers run afterwards. Within each wave everything is still parallel, so the cost is one barrier, not serialization — the suite still finishes in ~19s.
+
+Reads run first rather than last on purpose. Running them last would depend on every mutator reverting cleanly, which is true today but is an invariant nobody could enforce: a mutator that fails halfway leaves residue by definition, and the reader would then be asserting against the wreckage of a different failure.
+
+### The classification is checked, not trusted
+
+A list of filenames is normally the wrong answer in this repo — a gate that checks its own matrix rather than what exists is the recurring failure here. So it is held from both ends:
+
+- `tests/e2e-wave-classification.test.ts` requires every `*.e2e.ts` on disk to appear in exactly one wave. A new spec fails CI until its author decides which it is, and an unclassified spec would not run at all.
+- Membership of the read wave is enforced **at run time**: read-wave specs import `test` from `tests/e2e/support/e2e-read-wave.ts`, which fails any test that issues a mutating `/api/` request. Verified by mutation — adding one `fetch(…, {method: "POST"})` to a read-wave spec turns that spec red, naming the request.
+
+Session endpoints are the only allowed exception, because three specs must authenticate as somebody other than the shared owner.
+
+### What the ordering unlocked: the sweeps were not actually checking anything
+
+This is the part worth reading. `admin-screens-render.e2e.ts` asserted `200`, and **a denied screen also returns `200`** — denial renders here, it never redirects. So the sweep would have stayed green if a screen started refusing the owner: a module switched off, a grant dropped from the bootstrap, a tenant-wide `deny` authored. It was accidentally immune rather than correct, and it could not be tightened while a mutator might be running concurrently.
+
+It now asserts the screen rendered its **contents** — no denial hook anywhere in the page. Verified by mutation: disabling the `reporting` module makes it fail on `/admin` **and** `/admin/reporting` together, which is exactly the interference that used to be indistinguishable from a defect. Under the old assertion that scenario was green.
+
+### A read-only operator is now covered, and it is where ADR-0053 gets its runtime check
+
+`tests/e2e/admin-read-only-access.e2e.ts` — written a round ago, held back because it failed roughly one run in three through no fault of its own — lands unchanged. It drives a user granted every tenant-scoped `read` and nothing else: the grant comes from the permission catalogue, the expectation from each page's own `authorize` block, so the two halves come from different sources.
+
+`/admin/tenants` and `/admin/partner-registry` must refuse that user. This is the only runtime check on ADR-0053 anywhere in the repo, and verified by mutation: granting the read-only role the two platform reads makes both screens serve their contents and the spec reports cross-tenant disclosure.
+
+**It belongs here rather than in the owner sweep, and finding that out cost a failed run.** The first attempt asserted the owner is refused by those two screens. It failed — against an environment where the seeded tenant *is* the platform tenant, whose owner legitimately holds those permissions. What the owner is owed there depends on which tenant was seeded, which the sweep has no independent way to know, so those two screens are now exempt from the contents-vs-refusal question there and held to `200` + shell. For the read-only user it is unconditional: a `scope = 'tenant'` grant can never include a platform permission, whichever tenant they belong to.
+
+### Corrected: the browser-test skill described a different repo
+
+`.claude/skills/awcms-browser-test/SKILL.md` claimed specs for `/admin/analytics` and `/admin/security`, an `admin-responsive-nav.e2e.ts`, an `admin-a11y-smoke.e2e.ts`, and a `@axe-core/playwright` devDependency. **None exists here** — all of it was inherited from `awcms-mini` when the skill was ported.
+
+It also described the CI job as running in **two phases** with `--grep-invert "@full-online-gate"`, restarting the server under `AUTH_ONLINE_SECURITY_ENABLED=true` for `admin-security-enabled.e2e.ts`. `ci.yml` has no second phase and neither spec exists. Both corrections are stated in place rather than silently overwritten, because the failure mode of a stale skill is that an agent follows it instead of looking — and a confident false description of CI is worse than none.
+
+The Status section now lists the 15 specs that are actually present, and a new mandatory convention covers wave classification, so the next author is told about it by the skill rather than by a failing gate.

--- a/.claude/skills/awcms-browser-test/SKILL.id.md
+++ b/.claude/skills/awcms-browser-test/SKILL.id.md
@@ -5,7 +5,7 @@ description: Tulis/jalankan browser E2E test AWCMS dengan Playwright di atas Bun
 
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](SKILL.md)
 
-<!-- i18n-source-hash: sha256:ddd8f05d80839dac2c927767714ae8d49fe77b74c6cc56d204688f8ef9140ce8 -->
+<!-- i18n-source-hash: sha256:db7c289569f139fe8bc281367eb30bd586d54a9b112a27b8823688114a91002c -->
 
 # AWCMS — Browser E2E Test (Playwright + Bun)
 
@@ -78,20 +78,21 @@ service terisolasi, `db:migrate`, `bun run build`, `bun run start`, health
 check, lalu `bun run test:e2e` sungguhan (bukan skip-jika-server-tidak-
 jalan, karena CI memang menyediakan server+DB hidup). **Tetap belum**
 bagian dari `bun run check` lokal (`check` tidak boot server/DB sendiri) —
-lokal tetap manual seperti di atas. Job CI-nya berjalan **dua fase**
-(lifecycle server terpisah): fase 1 dengan config default menjalankan
-semua spec KECUALI `admin-security-enabled.e2e.ts` (yang di-tag
-`@full-online-gate` di `test.describe`-nya sendiri, bukan dicocokkan lewat
-judul prosa — `--grep-invert "@full-online-gate"`, tahan terhadap rename
-judul di masa depan), fase 2 me-restart server
-dengan `AUTH_ONLINE_SECURITY_ENABLED=true`/`AUTH_ONLINE_SECURITY_PROFILE=full_online`
-lalu menjalankan hanya spec itu — ditemukan empiris saat mewire job ini
-bahwa `admin-security-disabled.e2e.ts` dan `admin-security-enabled.e2e.ts`
-menguji render YANG BERTENTANGAN dari halaman yang sama digerbangi env var
-boot-time, jadi tidak bisa jalan terhadap satu instance server yang sama.
-Spec baru yang butuh config server non-default lain (var env baru, dsb.)
-kemungkinan butuh fase ketiga serupa — lihat `ci.yml`'s `e2e-smoke` job
-untuk pola lengkapnya sebelum menambah.
+lokal tetap manual seperti di atas.
+
+Job-nya **satu fase**: start server, tunggu catch-all 404 menjawab, seed satu
+tenant + owner + head office lewat `POST /api/v1/setup/initialize` sungguhan,
+ekspor `E2E_TENANT_ID` yang dikembalikan, lalu `bun run test:e2e` sekali.
+(Versi sebelumnya bagian ini menggambarkan job DUA fase dengan
+`--grep-invert "@full-online-gate"` dan `admin-security-enabled.e2e.ts` /
+`admin-security-disabled.e2e.ts`. **Itu `awcms-mini`, bukan repo ini** — spec
+seperti itu tidak ada di sini dan `ci.yml` tidak punya fase kedua. Dikoreksi
+24 Agu 2026.) Spec yang butuh env var boot-time non-default akan butuh fase
+kedua ditambahkan — baca job `e2e-smoke` di `ci.yml` sebelum menulisnya, dan
+catat bahwa project gelombang (`setup` → `read` → `write`) juga harus
+dijalankan ulang di fase itu.
+
+Urutan di dalam satu run BUKAN sekadar `fullyParallel` — lihat konvensi 7.
 
 ## Konvensi wajib
 
@@ -163,28 +164,60 @@ test:e2e` (atau `bunx playwright test`) diam-diam menjalankan proses
    inline. Jalankan E2E terhadap build produksi (`build && start`), bukan
    `dev` (dev server menyuntik HMR inline yang diblokir CSP ini).
 
+7. **Setiap spec baru WAJIB diklasifikasikan ke sebuah GELOMBANG, dan
+   gelombang baca ditegakkan saat RUNTIME.** Semua spec berbagi SATU tenant
+   ter-seed, jadi spec yang menulis mengubah apa yang dilihat spec yang
+   membaca. `playwright.config.ts` menjalankan `setup` → `read` → `write`, dan
+   `tests/e2e/support/e2e-waves.ts` menentukan spec mana yang mana. Berkas baru
+   yang tidak ada di kedua daftar **tidak berjalan sama sekali**, dan
+   `tests/e2e-wave-classification.test.ts` merah sampai ia ditambahkan — jadi
+   keputusannya tak bisa dilewati, hanya bisa diambil. Tanyakan: apakah spec ini
+   mengubah keadaan se-tenant (peran, enablement modul, kebijakan ABAC,
+   penugasan)? Kalau ya → `WRITE_WAVE`. Kalau tidak → `READ_WAVE`, dan ia WAJIB
+   mengimpor `test` dari `./support/e2e-read-wave`, bukan dari
+   `@playwright/test` — fixture itu menggagalkan tes yang mengirim request
+   `/api/` yang memutasi, jadi label gelombangnya DIPERIKSA, bukan dipercaya.
+   Ini bukan birokrasi: tumpang tindihnya berharga TIGA diagnosis (dua di
+   antaranya salah) dan menahan satu spec yang sudah bekerja di luar `main`
+   selama satu putaran penuh.
+
 ## File referensi
 
 - `playwright.config.ts` — config utama (testDir, testMatch, baseURL,
-  launchOptions dengan escape hatch `PLAYWRIGHT_CHROMIUM_EXECUTABLE`).
+  launchOptions dengan escape hatch `PLAYWRIGHT_CHROMIUM_EXECUTABLE`), dan
+  rantai project `setup` → `read` → `write`.
+- `tests/e2e/support/e2e-waves.ts` — klasifikasi gelombang dan alasannya,
+  termasuk dua kasus tumpang tindih yang nyata.
 - `tests/e2e/login.e2e.ts` — contoh kerja nyata (bukan placeholder),
   sudah dijalankan dan lulus terhadap dev server + Postgres sungguhan
   sebagai bagian dari penambahan skill ini.
 
 ## Status
 
-Selain `login.e2e.ts`, sudah ada spec untuk `/admin/analytics`,
-`/admin/security` (kedua profil gate), dan — sejak Issue #693 (epic #679
-platform-hardening) — `admin-responsive-nav.e2e.ts` (sidebar/drawer
-responsif: toggle, scrim, Escape, focus management, skip link),
-`admin-access-users-migrated.e2e.ts`/`admin-tenant-domains-migrated.e2e.ts`
-(migrasi ke primitive `DataTable`/`StatusBadge`/`ConfirmDialog`), dan
-`admin-a11y-smoke.e2e.ts` (smoke test aksesibilitas otomatis berbasis
-`@axe-core/playwright`, ditambahkan sebagai devDependency khusus untuk
-issue ini — lihat docblock file itu untuk kenapa ini bukan pelanggaran
-"Bun-only", AGENTS.md #14: itu soal runtime/tooling build, bukan dependency
-yang dipakai dari dalam proses `bun --bun playwright test` yang sudah
-berjalan di Bun). Belum ada spec untuk admin page lain (`blog/*`, dst) —
-tambahkan sesuai kebutuhan issue, jangan retrofit semua admin page
-sekaligus tanpa alasan konkret (lihat prinsip repo ini: jangan bangun
-cakupan di luar scope issue yang sedang dikerjakan).
+**Bagian ini dulu menyebut spec yang TIDAK ADA di repo ini**
+(`admin-responsive-nav.e2e.ts`, `admin-a11y-smoke.e2e.ts`, devDependency
+`@axe-core/playwright`, profil gate `/admin/analytics` dan `/admin/security`).
+Semuanya warisan `awcms-mini` saat skill ini di-port. Tak satu pun ada di sini,
+dan `@axe-core/playwright` bukan dependency repo ini. Dikoreksi 24 Agu 2026 —
+skill yang menggambarkan repo LAIN lebih buruk daripada tak ada skill, karena
+agen MENGIKUTINYA alih-alih melihat sendiri.
+
+Yang benar-benar ada (15 berkas spec di `tests/e2e/`):
+
+- **Gelombang baca** — `login.e2e.ts` (alur login itu sendiri),
+  `not-found.e2e.ts`, `cwv-lab.e2e.ts` (ber-env-gate `E2E_CWV_LAB`),
+  `admin-offices.e2e.ts`, dan tiga sapuan se-armada yang menemukan sendiri
+  targetnya dari `src/pages/admin/**.astro`: `admin-screens-render.e2e.ts`
+  (setiap layar merender untuk owner), `admin-deny-path.e2e.ts` (setiap layar
+  ber-gate MENOLAK pengguna tanpa permission), `admin-read-only-access.e2e.ts`
+  (operator read-only tenant — pemeriksaan platform-scope ADR-0053 saat
+  runtime).
+- **Gelombang tulis** — `admin-roles.e2e.ts`, `admin-users.e2e.ts`,
+  `admin-abac-policies.e2e.ts`, `admin-modules-toggle.e2e.ts`, serta spec CRUD
+  `admin-*-create` / `admin-offices-edit`.
+
+Ketiga sapuan sudah mencakup SETIAP layar admin, jadi layar baru tidak butuh
+spec baru untuk sekadar DIMUAT — hanya butuh spec sendiri bila ada perilaku
+yang layak diasersi. Jangan retrofit spec per-halaman tanpa alasan konkret
+(prinsip repo ini: jangan bangun cakupan di luar scope issue yang sedang
+dikerjakan).

--- a/.claude/skills/awcms-browser-test/SKILL.md
+++ b/.claude/skills/awcms-browser-test/SKILL.md
@@ -76,20 +76,21 @@ service, `db:migrate`, `bun run build`, `bun run start`, a health
 check, then a real `bun run test:e2e` (not skip-if-the-server-is-not-
 running, because CI does provide a live server+DB). It is **still not**
 part of the local `bun run check` (`check` does not boot a server/DB itself) —
-locally it stays manual as above. Its CI job runs in **two phases**
-(separate server lifecycles): phase 1 with the default config runs
-every spec EXCEPT `admin-security-enabled.e2e.ts` (which is tagged
-`@full-online-gate` on its own `test.describe`, not matched through a
-prose title — `--grep-invert "@full-online-gate"`, resilient to future title
-renames), phase 2 restarts the server
-with `AUTH_ONLINE_SECURITY_ENABLED=true`/`AUTH_ONLINE_SECURITY_PROFILE=full_online`
-then runs only that spec — it was found empirically while wiring this job
-that `admin-security-disabled.e2e.ts` and `admin-security-enabled.e2e.ts`
-test CONTRADICTORY renders of the same page gated by a boot-time env
-var, so they cannot run against one and the same server instance.
-A new spec that needs some other non-default server config (a new env var, etc.)
-will likely need a similar third phase — see `ci.yml`'s `e2e-smoke` job
-for the full pattern before adding one.
+locally it stays manual as above.
+
+The job is **one phase**: start the server, wait for the catch-all 404 to
+answer, seed one tenant + owner + head office through the real
+`POST /api/v1/setup/initialize`, export the returned `E2E_TENANT_ID`, then
+`bun run test:e2e` once. (A previous version of this section described a
+two-phase job with `--grep-invert "@full-online-gate"` and
+`admin-security-enabled.e2e.ts` / `admin-security-disabled.e2e.ts`. **That is
+`awcms-mini`, not this repo** — no such specs exist here and `ci.yml` has no
+second phase. Corrected 2026-08-24.) A spec needing a non-default boot-time
+env var would need a second phase adding — read `ci.yml`'s `e2e-smoke` job
+before writing one, and note that the wave projects
+(`setup` → `read` → `write`) would have to be re-run in that phase too.
+
+Ordering inside the run is not `fullyParallel` alone — see convention 7.
 
 ## Mandatory conventions
 
@@ -160,28 +161,57 @@ for the full pattern before adding one.
    `<style>`. Run E2E against the production build (`build && start`), not
    `dev` (the dev server injects inline HMR which this CSP blocks).
 
+7. **Every new spec must be classified into a WAVE, and the read wave is
+   enforced at run time.** All specs share ONE seeded tenant, so a spec that
+   writes changes what a spec that reads observes. `playwright.config.ts` runs
+   `setup` → `read` → `write`, and `tests/e2e/support/e2e-waves.ts` says which
+   spec is which. A new file that is in neither list **does not run at all**,
+   and `tests/e2e-wave-classification.test.ts` fails until it is added — so the
+   decision cannot be skipped, only made. Ask: does this spec change tenant-wide
+   state (roles, module enablement, ABAC policies, assignments)? Then
+   `WRITE_WAVE`. Otherwise `READ_WAVE`, and it must import `test` from
+   `./support/e2e-read-wave` rather than from `@playwright/test` — that fixture
+   fails the test if it issues any mutating `/api/` request, so the wave label
+   is checked rather than trusted. This is not bureaucracy: interleaving cost
+   three diagnoses (two of them wrong) and kept a working spec off `main` for a
+   full round.
+
 ## Reference files
 
 - `playwright.config.ts` — the main config (testDir, testMatch, baseURL,
-  launchOptions with the `PLAYWRIGHT_CHROMIUM_EXECUTABLE` escape hatch).
+  launchOptions with the `PLAYWRIGHT_CHROMIUM_EXECUTABLE` escape hatch), and
+  the `setup` → `read` → `write` project chain.
+- `tests/e2e/support/e2e-waves.ts` — the wave classification and the reasoning
+  behind it, including the two concrete interference cases.
 - `tests/e2e/login.e2e.ts` — a real working example (not a placeholder),
   already run and passing against a dev server + a real Postgres
   as part of adding this skill.
 
 ## Status
 
-Besides `login.e2e.ts`, there are already specs for `/admin/analytics`,
-`/admin/security` (both gate profiles), and — since Issue #693 (epic #679
-platform-hardening) — `admin-responsive-nav.e2e.ts` (responsive
-sidebar/drawer: toggle, scrim, Escape, focus management, skip link),
-`admin-access-users-migrated.e2e.ts`/`admin-tenant-domains-migrated.e2e.ts`
-(migration to the `DataTable`/`StatusBadge`/`ConfirmDialog` primitives), and
-`admin-a11y-smoke.e2e.ts` (an automated accessibility smoke test based on
-`@axe-core/playwright`, added as a devDependency specifically for
-this issue — see that file's docblock for why this is not a violation of
-"Bun-only", AGENTS.md #14: that rule is about the runtime/build tooling, not about a dependency
-used from inside the `bun --bun playwright test` process that is already
-running on Bun). There is no spec yet for the other admin pages (`blog/*`, etc.) —
-add them as the issue at hand requires, do not retrofit every admin page
-at once without a concrete reason (see this repo's principle: do not build
-coverage outside the scope of the issue being worked on).
+**This section previously described specs that do not exist in this repo**
+(`admin-responsive-nav.e2e.ts`, `admin-a11y-smoke.e2e.ts`, a
+`@axe-core/playwright` devDependency, `/admin/analytics` and `/admin/security`
+gate profiles). They were inherited from `awcms-mini` when the skill was ported.
+None of them is here, and `@axe-core/playwright` is not a dependency of this
+repo. Corrected on 2026-08-24 — a skill that describes the wrong repo is worse
+than no skill, because an agent follows it instead of looking.
+
+What actually exists (15 spec files under `tests/e2e/`):
+
+- **Read wave** — `login.e2e.ts` (the login flow itself), `not-found.e2e.ts`,
+  `cwv-lab.e2e.ts` (env-gated on `E2E_CWV_LAB`), `admin-offices.e2e.ts`, and
+  three whole-fleet sweeps that discover their own targets from
+  `src/pages/admin/**.astro`: `admin-screens-render.e2e.ts` (every screen
+  renders for the owner), `admin-deny-path.e2e.ts` (every gated screen refuses
+  a user holding nothing), `admin-read-only-access.e2e.ts` (a tenant read-only
+  operator — the ADR-0053 platform-scope check at run time).
+- **Write wave** — `admin-roles.e2e.ts`, `admin-users.e2e.ts`,
+  `admin-abac-policies.e2e.ts`, `admin-modules-toggle.e2e.ts`, and the
+  `admin-*-create` / `admin-offices-edit` CRUD specs.
+
+The three sweeps cover every admin screen already, so a new screen needs no new
+spec to be _loaded_ — only a spec of its own if it has behaviour worth
+asserting. Do not retrofit per-page specs without a concrete reason (this
+repo's principle: do not build coverage outside the scope of the issue being
+worked on).

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:b0e32c0de5a233137606a63dedc540022a769a966268e648f5313cb710f66b04 -->
+<!-- i18n-source-hash: sha256:1583eb80a49db54fa0416ee150dd408c23fbcc6a0486b23b8f1ac3ade4d64c1f -->
 
 # AWCMS — Project State & Continuation
 
@@ -360,6 +360,77 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 ## 4. Backlog / langkah berikutnya
 
+- **PUTARAN GELOMBANG — 24 Agustus 2026: dua sapuan admin itu KEBETULAN KEBAL,
+  dan harness-nya harus dibereskan DULU sebelum keduanya boleh berkata jujur.**
+
+  Ini menutup masalah harness yang ditinggalkan terbuka oleh PUTARAN SESI di
+  bawah, lalu membereskan apa yang selama ini DISEMBUNYIKAN oleh masalah itu.
+
+  **Pengurutannya.** `playwright.config.ts` kini menjalankan
+  `setup` → `read` → `write` (`tests/e2e/support/e2e-waves.ts`). Spec gelombang
+  baca melihat tenant sebagaimana ditinggalkan bootstrap; penulis berjalan
+  sesudahnya. Di DALAM tiap gelombang semuanya tetap paralel — biayanya satu
+  barrier, dan suite tetap selesai ~19 detik. Baca berjalan DULUAN, bukan
+  terakhir, dan itu disengaja: menjalankannya terakhir akan bergantung pada
+  setiap mutator yang membereskan dirinya dengan rapi, sedangkan mutator yang
+  gagal separuh jalan meninggalkan residu menurut definisinya.
+
+  **Klasifikasinya DIPERIKSA, bukan dipercaya.** Daftar nama berkas biasanya
+  jawaban yang SALAH di repo ini — gerbang yang memeriksa matriksnya sendiri
+  alih-alih apa yang ADA adalah kegagalan yang berulang di sini. Jadi ia
+  dipegang dari dua arah: `tests/e2e-wave-classification.test.ts` menuntut
+  setiap `*.e2e.ts` di disk ada di TEPAT SATU gelombang (spec tak terklasifikasi
+  malah tidak berjalan sama sekali), dan keanggotaan gelombang baca ditegakkan
+  SAAT RUNTIME — spec gelombang baca mengimpor `test` dari
+  `tests/e2e/support/e2e-read-wave.ts`, yang menggagalkan tes mana pun yang
+  mengirim request `/api/` yang memutasi. Terbukti lewat mutasi: satu
+  `fetch(…, {method:"POST"})` membuat spec itu merah dan menyebut request-nya.
+
+  **Apa yang dibuka oleh pengurutan itu — bagian yang paling layak dibaca.**
+  `admin-screens-render.e2e.ts` meng-assert `200` — dan **layar yang MENOLAK
+  juga menjawab `200`**, karena penolakan di sini DIRENDER, tidak pernah
+  redirect. Sapuan itu akan tetap hijau seandainya sebuah layar mulai menolak
+  owner: modul dimatikan, sebuah grant hilang dari bootstrap, kebijakan `deny`
+  se-tenant ditulis. Kini ia meng-assert layar merender ISINYA — tanpa hook
+  penolakan di mana pun di halaman. Terbukti lewat mutasi: mematikan modul
+  `reporting` membuatnya gagal di `/admin` DAN `/admin/reporting` sekaligus. Di
+  bawah asersi lama skenario itu HIJAU — persis alasan kenapa ia tak bisa
+  diperketat selagi mutator mungkin berjalan bersamaan.
+
+  **Sapuan read-only mendarat TANPA perubahan.** `admin-read-only-access.e2e.ts`
+  menjalankan pengguna yang diberi SETIAP permission `read` ber-scope tenant dan
+  tidak lebih — grantnya dari KATALOG permission, ekspektasinya dari blok
+  `authorize` milik tiap halaman, jadi kedua paruhnya berasal dari sumber
+  BERBEDA. `/admin/tenants` dan `/admin/partner-registry` WAJIB menolaknya.
+  **Ini satu-satunya pemeriksaan ADR-0053 saat runtime di seluruh repo.**
+  Terbukti lewat mutasi: memberi peran itu dua platform read membuat kedua layar
+  menyajikan isinya dan spec melaporkan pengungkapan lintas-tenant.
+
+  **Percobaan pertama yang SALAH, dicatat karena ia temuan nyata.** Asersi
+  ADR-0053 mula-mula ditulis di sapuan OWNER — "kedua layar ini menolak owner" —
+  dan GAGAL di lingkungan yang tenant ter-seed-nya ADALAH platform tenant, yang
+  owner-nya memang sah memegang permission itu. Apa yang menjadi hak owner di
+  sana bergantung pada tenant mana yang di-seed, yang tak bisa diketahui sapuan
+  itu secara mandiri — jadi kedua layar itu kini dikecualikan dari pertanyaan
+  isi-vs-penolakan di sana dan hanya dipegang pada `200` + shell. Untuk pengguna
+  read-only sifatnya TANPA SYARAT: grant `scope = 'tenant'` tak pernah bisa
+  memuat permission platform, di tenant mana pun ia berada.
+
+  **Ditemukan sambil bekerja: skill browser-test menggambarkan REPO LAIN.**
+  `.claude/skills/awcms-browser-test/SKILL.md` mengklaim ada spec untuk
+  `/admin/analytics` dan `/admin/security`, `admin-responsive-nav.e2e.ts`,
+  `admin-a11y-smoke.e2e.ts`, serta devDependency `@axe-core/playwright`. Tak
+  satu pun ada di sini — semuanya warisan `awcms-mini` saat skill itu di-port.
+  Ia juga menggambarkan job CI berjalan DUA FASE dengan
+  `--grep-invert "@full-online-gate"`; `ci.yml` hanya satu fase dan kedua spec
+  security itu tidak ada. Bagian Status kini mendaftar 15 spec yang
+  benar-benar ada, dan satu konvensi wajib baru mencakup klasifikasi gelombang.
+
+  **Masih terbuka, dan DISEBUT alih-alih dianggap tertutup:** kontrol TULIS mana
+  yang boleh dilihat pengguna ber-permission separuh. Ekspektasinya berbeda
+  per-layar — tak ada selector yang dipakai bersama oleh 76 kontrol terdelegasi
+  — jadi itu pekerjaan per-layar, bukan satu aturan mekanis.
+
 - **PUTARAN SESI — 23 Agustus 2026: DUA kegagalan e2e intermiten yang berbeda,
   dan yang di CI ternyata KEADAAN TENANT BERSAMA. Dua diagnosis sebelumnya salah.**
 
@@ -399,7 +470,8 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   **Pola di balik semuanya: spec memutasi keadaan tenant BERSAMA yang dibaca spec
   lain.** Peran yang dibuat satu spec mengubah dropdown spec lain; toggle modul
   mematikan `reporting`, yang justru menjadi otorisasi `/admin`. Itulah masalah
-  harness yang sebenarnya, dan ia MASIH TERBUKA.
+  harness yang sebenarnya. **DITUTUP oleh PUTARAN GELOMBANG di atas (24
+  Agustus 2026).**
 
   `tests/e2e/auth.setup.ts` me-login owner SEKALI lalu menyimpan `storageState`;
   tiga belas login menjadi empat. Enam kali jalan berturut-turut ~18 detik,
@@ -419,7 +491,9 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   dengan sengaja. Dua sapuan yang sudah ada di `main` KEBETULAN kebal, bukan
   benar: sapuan render hanya meng-assert `200` dan layar yang menolak tetap
   mengembalikan `200`; sapuan deny justru mengharapkan penolakan, yang juga
-  dihasilkan modul yang dimatikan.
+  dihasilkan modul yang dimatikan. **Keduanya SELESAI di PUTARAN GELOMBANG di
+  atas — sapuan kini meng-assert isi, dan spec read-only mendarat tanpa
+  perubahan.**
 
 - **PUTARAN DENY — 23 Agustus 2026: tidak pernah ada yang menyaksikan layar
   admin MENOLAK pengguna tanpa permission, dan empat layar sama sekali tak bisa

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,75 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **WAVE ROUND — 24 August 2026: the two admin sweeps were ACCIDENTALLY IMMUNE,
+  and the harness had to be fixed before they could be told the truth.**
+
+  This closes the harness problem the SESSION ROUND below left open, and then
+  fixes what that problem had been hiding.
+
+  **The ordering.** `playwright.config.ts` now runs `setup` → `read` → `write`
+  (`tests/e2e/support/e2e-waves.ts`). Read-wave specs see the tenant as the
+  bootstrap left it; writers run after. Within each wave everything is still
+  parallel — the cost is one barrier, and the suite still finishes in ~19s.
+  Reads run FIRST rather than last deliberately: running them last would depend
+  on every mutator reverting cleanly, and a mutator that fails halfway leaves
+  residue by definition.
+
+  **The classification is checked, not trusted.** A list of filenames is
+  normally the wrong answer here — a gate that checks its own matrix rather than
+  what exists is this repo's recurring failure. So it is held from both ends:
+  `tests/e2e-wave-classification.test.ts` requires every `*.e2e.ts` on disk to
+  be in exactly one wave (an unclassified spec would not run at all), and read
+  membership is enforced AT RUN TIME — read-wave specs import `test` from
+  `tests/e2e/support/e2e-read-wave.ts`, which fails any test issuing a mutating
+  `/api/` request. Mutation-proven: one added `fetch(…, {method:"POST"})` turns
+  that spec red and names the request.
+
+  **What the ordering unlocked, and this is the part worth reading.**
+  `admin-screens-render.e2e.ts` asserted `200` — and **a denied screen also
+  returns `200`**, because denial renders here and never redirects. The sweep
+  would have stayed green if a screen started refusing the owner: a module
+  switched off, a grant dropped from the bootstrap, a tenant-wide `deny`
+  authored. It now asserts the screen rendered its CONTENTS — no denial hook
+  anywhere in the page. Mutation-proven: disabling `reporting` fails on
+  `/admin` AND `/admin/reporting` together. Under the old assertion that
+  scenario was green, which is exactly why it could not be tightened while a
+  mutator might run concurrently.
+
+  **The read-only sweep landed unchanged.** `admin-read-only-access.e2e.ts`
+  drives a user granted every tenant-scoped `read` and nothing else — the grant
+  from the permission catalogue, the expectation from each page's own
+  `authorize` block, so the two halves come from different sources.
+  `/admin/tenants` and `/admin/partner-registry` must refuse it. **This is the
+  only runtime check on ADR-0053 anywhere in the repo.** Mutation-proven:
+  granting that role the two platform reads makes both screens serve their
+  contents and the spec reports cross-tenant disclosure.
+
+  **A wrong first attempt, recorded because it was a real finding.** The
+  ADR-0053 assertion was first written into the OWNER sweep — "these two screens
+  refuse the owner" — and it FAILED against an environment where the seeded
+  tenant IS the platform tenant, whose owner legitimately holds those
+  permissions. What the owner is owed there depends on which tenant was seeded,
+  which the sweep cannot know independently, so those two screens are exempt
+  from the contents-vs-refusal question there and held to `200` + shell. For the
+  read-only user it is unconditional: a `scope = 'tenant'` grant can never
+  include a platform permission, whichever tenant they belong to.
+
+  **Found while working: the browser-test skill described a DIFFERENT REPO.**
+  `.claude/skills/awcms-browser-test/SKILL.md` claimed specs for
+  `/admin/analytics` and `/admin/security`, an `admin-responsive-nav.e2e.ts`, an
+  `admin-a11y-smoke.e2e.ts`, and a `@axe-core/playwright` devDependency. None
+  exists here — all inherited from `awcms-mini` when the skill was ported. It
+  also described the CI job as running in TWO PHASES with
+  `--grep-invert "@full-online-gate"`; `ci.yml` has one phase and neither
+  security spec exists. The Status section now lists the 15 specs that are
+  actually present, and a new mandatory convention covers wave classification.
+
+  **Still open, and named rather than assumed closed:** which individual WRITE
+  controls a partially-permissioned user should see. Those expectations differ
+  per screen — there is no selector all 76 delegated controls share — so it is
+  per-screen work, not one mechanical rule.
+
 - **SESSION ROUND — 23 August 2026: TWO different intermittent e2e failures,
   and the CI one was SHARED TENANT STATE. Two diagnoses before it were wrong.**
 
@@ -396,7 +465,7 @@ pioneered directly here after the ADR-0047 freeze.)
   **The pattern under all of it: specs mutate shared tenant state that other
   specs read.** Roles created by one spec change another's dropdown; the module
   toggle disables `reporting`, which `/admin` authorizes on. That is the real
-  harness problem, and it is still open.
+  harness problem. **CLOSED by the WAVE ROUND above (24 August 2026).**
 
   `tests/e2e/auth.setup.ts` logs the owner in once and saves `storageState`;
   thirteen logins became four. Six consecutive runs at ~18s, zero variance.
@@ -413,7 +482,8 @@ pioneered directly here after the ADR-0047 freeze.)
   harness change worth doing deliberately. The two sweeps already on `main` are
   ACCIDENTALLY immune, not correct: the render sweep asserts only `200` and a
   denied screen still returns `200`; the deny sweep expects denial, which a
-  disabled module also produces.
+  disabled module also produces. **Both DONE in the WAVE ROUND above — the
+  sweep now asserts contents, and the read-only spec landed unchanged.**
 
 - **DENY ROUND — 23 August 2026: nothing had ever watched an admin screen
   refuse a user holding no permissions, and four screens could not be checked

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 474   |
+| Test files                          | 476   |
 | Route files                         | 382   |
 | ADR                                 | 226   |
 
@@ -357,8 +357,8 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 398        |
-| `e2e`         | 14         |
+| `(root)`      | 399        |
+| `e2e`         | 15         |
 | `integration` | 61         |
 | `unit`        | 1          |
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,11 @@
 import { defineConfig, devices } from "@playwright/test";
 
+import {
+  READ_WAVE,
+  WRITE_WAVE,
+  waveTestMatch
+} from "./tests/e2e/support/e2e-waves";
+
 /**
  * E2E browser test config (Playwright + Bun). See skill
  * `.claude/skills/awcms-browser-test/SKILL.md` for the full setup rationale,
@@ -52,14 +58,33 @@ export default defineConfig({
       testMatch: /auth\.setup\.ts/,
       use: { ...devices["Desktop Chrome"] }
     },
+    // Two waves, ordered — see `tests/e2e/support/e2e-waves.ts` for why. Reads
+    // run against the tenant as the bootstrap left it; writers run afterwards
+    // and may change it. Within each wave everything is still parallel, so the
+    // cost is one barrier rather than serialization.
+    //
+    // This is what lets the sweeps assert something real: while a mutator could
+    // be running, "the owner sees this screen" and "a module was switched off
+    // mid-run" are indistinguishable, so the sweeps could only assert what is
+    // true either way — which is how they ended up accidentally immune.
     {
-      name: "chromium",
+      name: "read",
       dependencies: ["setup"],
+      testMatch: waveTestMatch(READ_WAVE),
       use: {
         ...devices["Desktop Chrome"],
         // Specs that authenticate as somebody else — or as nobody, which is
         // `login.e2e.ts`'s whole subject — override this per file with
         // `test.use({ storageState: ... })`.
+        storageState: "playwright/.auth/owner.json"
+      }
+    },
+    {
+      name: "write",
+      dependencies: ["read"],
+      testMatch: waveTestMatch(WRITE_WAVE),
+      use: {
+        ...devices["Desktop Chrome"],
         storageState: "playwright/.auth/owner.json"
       }
     }

--- a/tests/e2e-wave-classification.test.ts
+++ b/tests/e2e-wave-classification.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Every e2e spec is classified into a wave, and the read wave is guarded.
+ *
+ * ## What went wrong without this
+ *
+ * All e2e specs share ONE seeded tenant. Two of them change it tenant-wide —
+ * `admin-roles.e2e.ts` adds a role that the `/admin/users` assign picker lists,
+ * `admin-modules-toggle.e2e.ts` switches off `reporting`, which `/admin`
+ * authorizes on. Under `fullyParallel: true` a reader could observe either
+ * change mid-flight and fail describing a tenant nobody set up. That cost three
+ * diagnoses, two of them wrong, and it kept a working read-only sweep off
+ * `main`.
+ *
+ * The ordering fix lives in `playwright.config.ts`. This is what stops the
+ * ordering from quietly becoming a lie.
+ *
+ * ## Two different things are checked, and only one is bookkeeping
+ *
+ * A new spec must be classified — that is bookkeeping, and it fails here rather
+ * than in whichever unrelated file it eventually breaks.
+ *
+ * The claim that a read-wave spec only reads is NOT checked here, because it
+ * cannot be: a spec's behaviour is not visible in its text. It is checked at run
+ * time by the fixture in `tests/e2e/support/e2e-read-wave.ts`, which fails any
+ * test that issues a mutating request to the app. What this file enforces is
+ * that read-wave specs actually IMPORT that fixture — without which the label
+ * would be a comment and the guard would never run.
+ *
+ * Pure — no database, no browser. Runs in `quality` on every PR, which is where
+ * it is useful: the e2e suite itself is env-gated and skips wherever no tenant
+ * is seeded.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { describe, expect, test } from "bun:test";
+
+import { READ_WAVE, WRITE_WAVE, waveTestMatch } from "./e2e/support/e2e-waves";
+
+const E2E_ROOT = path.resolve(import.meta.dir, "e2e");
+const CONFIG = path.resolve(import.meta.dir, "../playwright.config.ts");
+
+const GUARDED_IMPORT = './support/e2e-read-wave"';
+
+function specFilesOnDisk(): string[] {
+  return readdirSync(E2E_ROOT)
+    .filter((name) => name.endsWith(".e2e.ts"))
+    .sort();
+}
+
+function read(spec: string): string {
+  return readFileSync(path.join(E2E_ROOT, spec), "utf8");
+}
+
+describe("e2e wave classification", () => {
+  test("every spec on disk is in exactly one wave", () => {
+    const onDisk = specFilesOnDisk();
+    const classified = [...READ_WAVE, ...WRITE_WAVE].sort();
+
+    // Not a set comparison in either direction alone: a duplicate would survive
+    // one and a missing file would survive the other.
+    expect(
+      classified,
+      "tests/e2e/support/e2e-waves.ts does not account for exactly the specs " +
+        "that exist. A new spec must be classified: does it change tenant-wide " +
+        "state (WRITE_WAVE), or only observe it (READ_WAVE)? Leaving it out is " +
+        "not an option, because an unclassified spec would never run at all — " +
+        "the projects match on these lists."
+    ).toEqual(onDisk);
+
+    expect(
+      new Set(classified).size,
+      "a spec appears in both waves, or twice in one"
+    ).toBe(classified.length);
+  });
+
+  test("read-wave specs import the guarded test, write-wave specs do not", () => {
+    for (const spec of READ_WAVE) {
+      expect(
+        read(spec).includes(GUARDED_IMPORT),
+        `${spec} is in READ_WAVE but imports \`test\` from somewhere other ` +
+          "than ./support/e2e-read-wave. The wave label is only a claim; that " +
+          "fixture is what checks it at run time by failing on any mutating " +
+          "request. Without the import the claim is unverified, and a spec that " +
+          "starts writing would break OTHER files instead of this one."
+      ).toBe(true);
+    }
+
+    for (const spec of WRITE_WAVE) {
+      expect(
+        read(spec).includes(GUARDED_IMPORT),
+        `${spec} is in WRITE_WAVE but imports the read-wave guard, which fails ` +
+          "on any mutating request. Either it belongs in READ_WAVE, or it " +
+          "should import `test` from @playwright/test."
+      ).toBe(false);
+    }
+  });
+
+  test("the setup → read → write chain is what the config actually declares", () => {
+    const config = readFileSync(CONFIG, "utf8");
+
+    // The ordering is the whole mechanism. A config that stopped depending
+    // `write` on `read` would run them concurrently again, and the symptom
+    // would be an intermittent failure in a third file weeks later.
+    expect(
+      config,
+      "playwright.config.ts no longer orders the waves. `write` must depend on " +
+        "`read`, and `read` on `setup`."
+    ).toContain('name: "read"');
+    expect(config).toContain('dependencies: ["setup"]');
+    expect(config).toContain('name: "write"');
+    expect(config).toContain('dependencies: ["read"]');
+
+    // And it must select the specs from the lists rather than from a glob that
+    // silently picks up whatever is there — which would make the classification
+    // decorative.
+    expect(config).toContain("waveTestMatch(READ_WAVE)");
+    expect(config).toContain("waveTestMatch(WRITE_WAVE)");
+  });
+
+  test("waveTestMatch produces globs Playwright can match a filename against", () => {
+    expect(waveTestMatch(["a.e2e.ts", "b.e2e.ts"])).toEqual([
+      "**/a.e2e.ts",
+      "**/b.e2e.ts"
+    ]);
+  });
+
+  test("auth.setup.ts is in neither wave — it is its own project", () => {
+    // It does not end in `.e2e.ts`, so it cannot appear on disk in the list
+    // above; asserting it explicitly documents that the setup project is
+    // deliberately outside the classification rather than an oversight.
+    expect([...READ_WAVE, ...WRITE_WAVE]).not.toContain("auth.setup.ts");
+  });
+});

--- a/tests/e2e/admin-deny-path.e2e.ts
+++ b/tests/e2e/admin-deny-path.e2e.ts
@@ -36,7 +36,7 @@
  * mechanical rule, and it is a larger piece of work. This covers the case where
  * one rule holds for every screen.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./support/e2e-read-wave";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
@@ -105,7 +105,7 @@ const gatedScreens = discoverGatedScreens(ADMIN_PAGES_ROOT).filter(
 );
 
 // This spec authenticates as somebody other than the owner, so it must NOT
-// inherit the shared owner session the `chromium` project supplies.
+// inherit the shared owner session the `read` project supplies.
 test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe("admin screens deny a user holding no permissions", () => {

--- a/tests/e2e/admin-offices.e2e.ts
+++ b/tests/e2e/admin-offices.e2e.ts
@@ -12,7 +12,7 @@
  * `office_management.read` gate on the page passes and the bootstrap's
  * `head_office` row is what the table must show.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./support/e2e-read-wave";
 import { provideTenant } from "./support/e2e-auth";
 
 const tenantId = process.env.E2E_TENANT_ID;

--- a/tests/e2e/admin-read-only-access.e2e.ts
+++ b/tests/e2e/admin-read-only-access.e2e.ts
@@ -1,0 +1,214 @@
+/**
+ * The operator between "owner" and "nobody": every tenant-scoped READ, and
+ * nothing else.
+ *
+ * ## The gap
+ *
+ * Two sweeps already watch the extremes. `admin-screens-render.e2e.ts` loads
+ * every screen as the seeded owner, who holds everything; `admin-deny-path.e2e.ts`
+ * loads every screen as a user holding nothing. Neither says anything about the
+ * only user shape a real deployment actually has — someone granted a job's worth
+ * of permissions.
+ *
+ * That matters most for the screens nobody would think to check. An entry gate
+ * written on a variable that happens to be `true` for the owner passes both
+ * existing sweeps: the owner sees contents (expected), the empty user sees a
+ * refusal (also expected). It takes a user in between for the gate's actual
+ * condition to be observable.
+ *
+ * ## The expectation is COMPUTED, and it is two-directional
+ *
+ * The grant comes from the permission CATALOGUE — `scope = 'tenant' AND
+ * action = 'read'` — not from any page. The expectation comes from each page's
+ * own `authorize` block. So the two halves are derived from different sources
+ * and the test is whether the running app agrees with both.
+ *
+ * `loadAdminScreen` denies an empty list and otherwise admits on ANY entry
+ * request (`selectEntryOutcome`, `Array.prototype.some`), so a screen admits
+ * this user exactly when at least one of its entry requests is a tenant-scoped
+ * read.
+ *
+ * As it happens that is **every screen but two** — `/admin/tenants` and
+ * `/admin/partner-registry`, which are platform-scoped (ADR-0053). That is
+ * asserted explicitly rather than left implied: entering any other admin screen
+ * currently costs exactly one `read`, and a screen that starts demanding
+ * `configure` to be *entered* is a product decision that should turn a test red
+ * and be written down, not slide in.
+ *
+ * ## This is where the ADR-0053 runtime check belongs, and why not the owner sweep
+ *
+ * `admin-screens-render.e2e.ts` cannot make this assertion. What the seeded
+ * OWNER is owed by those two screens depends on whether the seeded tenant is
+ * the platform tenant — its owner holds the platform permissions and sees them,
+ * anyone else's owner does not. A first attempt to assert refusal there failed
+ * against exactly that case.
+ *
+ * Here it is unconditional. The grant is filtered `scope = 'tenant'`, so this
+ * user can never hold a platform permission no matter which tenant they belong
+ * to, and both screens must refuse them either way. Nothing else in the repo
+ * watches ADR-0053 at run time.
+ *
+ * ## What this does NOT prove, stated plainly
+ *
+ * Two things, and the first has already fooled me once in this suite:
+ *
+ * 1. If a screen named the WRONG permission in its `authorize` block, the
+ *    expectation would be computed from that same wrong key and the test would
+ *    pass. It checks that the app enforces what the screen declares; it cannot
+ *    check that the declaration is right. `admin:screen-coverage:check` watches
+ *    the declaration.
+ * 2. It says nothing about which individual WRITE controls this user should
+ *    see. Those expectations differ per screen — there is no selector all 76
+ *    delegated controls share — so that is per-screen work, not one rule.
+ *    Naming it here keeps the gap visible instead of assumed closed.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { test, expect } from "./support/e2e-read-wave";
+import { provideTenant } from "./support/e2e-auth";
+import { seedRestrictedUser } from "./support/e2e-restricted-user";
+import { extractScreenAuthorizeKeys } from "./support/admin-screen-authorize";
+import { platformScopedPermissionKeys } from "../../src/modules/identity-access/domain/platform-scope";
+
+const tenantId = process.env.E2E_TENANT_ID;
+const databaseUrl = process.env.DATABASE_URL;
+
+const seeded = Boolean(tenantId && databaseUrl);
+
+const HERE = path.dirname(new URL(import.meta.url).pathname);
+const ADMIN_PAGES_ROOT = path.resolve(HERE, "../../src/pages/admin");
+
+type Screen = { url: string; source: string; admits: boolean };
+
+/**
+ * Every static admin screen, with what a tenant-read-only user is owed by it.
+ *
+ * Screens with no `authorize:` block at all are skipped: `/admin/account` loads
+ * through `loadSelfServiceScreen`, where there is no permission to hold and
+ * every authenticated user owns their own page.
+ *
+ * Dynamic routes are excluded for the same reason `admin-deny-path` excludes
+ * them — a real id has to come from somewhere, and deriving one here would only
+ * re-test the listing screen this file already loads.
+ */
+function discoverScreens(root: string, prefix = "/admin"): Screen[] {
+  const platform = platformScopedPermissionKeys();
+  const screens: Screen[] = [];
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const full = path.join(root, entry.name);
+
+    if (entry.isDirectory()) {
+      screens.push(...discoverScreens(full, `${prefix}/${entry.name}`));
+      continue;
+    }
+
+    if (!entry.name.endsWith(".astro")) continue;
+
+    const keys = extractScreenAuthorizeKeys(readFileSync(full, "utf8"));
+    if (keys.length === 0) continue;
+
+    const base = entry.name.slice(0, -".astro".length);
+    const url = base === "index" ? prefix : `${prefix}/${base}`;
+    if (url.includes("[")) continue;
+
+    screens.push({
+      url,
+      source: path.relative(process.cwd(), full),
+      // ANY entry request suffices, so one tenant-scoped read is enough.
+      admits: keys.some((key) => !platform.has(key) && key.endsWith(".read"))
+    });
+  }
+
+  return screens.sort((a, b) => a.url.localeCompare(b.url));
+}
+
+const screens = discoverScreens(ADMIN_PAGES_ROOT);
+
+// Authenticates as somebody other than the shared owner, so it must not
+// inherit the session the `read` project supplies.
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe("admin screens for a tenant read-only operator", () => {
+  test.skip(
+    !seeded,
+    "requires a seeded tenant and DATABASE_URL — CI e2e-smoke provides both"
+  );
+
+  test("the screen walk found them, and the refusals are the platform two", () => {
+    expect(
+      screens.length,
+      "no admin screens with an authorize block were discovered"
+    ).toBeGreaterThan(40);
+
+    expect(
+      screens.filter((screen) => !screen.admits).map((screen) => screen.url),
+      "the set of screens a tenant read-only operator may NOT enter changed. " +
+        "Today that is exactly the two platform-scoped screens (ADR-0053). A " +
+        "new entry here means some screen now demands more than a read to be " +
+        "OPENED — which may be right, but it is a product decision and it " +
+        "belongs in an ADR rather than in a diff nobody reads."
+    ).toEqual(["/admin/partner-registry", "/admin/tenants"]);
+  });
+
+  test("each screen either serves this user or refuses them, per its own gate", async ({
+    page
+  }) => {
+    test.setTimeout(240_000);
+
+    const user = await seedRestrictedUser(databaseUrl!, tenantId!, "read");
+
+    await page.goto("/login");
+    await provideTenant(page, tenantId!);
+    await page.locator("#login-identifier").fill(user.loginIdentifier);
+    await page.locator("#password").fill(user.password);
+    await page.locator("#login-submit").click();
+    await page.waitForURL("**/admin");
+
+    for (const screen of screens) {
+      const response = await page.goto(screen.url);
+      const status = response?.status() ?? 0;
+
+      // Both outcomes are rendered pages. A 404 means the screen THREW — the
+      // `/admin/seo` class — and for this user specifically that is the
+      // interesting failure: a `load` written against data only an owner has.
+      expect
+        .soft(
+          status,
+          `${screen.url} (${screen.source}) answered ${status} for a read-only ` +
+            "operator. Both a refusal and a rendered screen are 200 here, so a " +
+            "404 means it threw — and the ReferenceError is in the SERVER log, " +
+            "not in this status."
+        )
+        .toBe(200);
+
+      if (status !== 200) continue;
+
+      const denials = await page.locator('[id$="-denied"]').count();
+
+      if (screen.admits) {
+        expect
+          .soft(
+            denials,
+            `${screen.url} (${screen.source}) refused a user holding every ` +
+              "tenant-scoped read, though its entry gate asks only for one. " +
+              "Either the gate is checking something other than the permission " +
+              "it names, or a panel inside the page is gated on a write the " +
+              "screen never declared."
+          )
+          .toBe(0);
+        continue;
+      }
+
+      expect
+        .soft(
+          denials,
+          `${screen.url} (${screen.source}) served its contents to an ordinary ` +
+            "tenant user. It is platform-scoped (ADR-0053) and enumerates data " +
+            "belonging to the whole platform — this is cross-tenant disclosure."
+        )
+        .toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/e2e/admin-screens-render.e2e.ts
+++ b/tests/e2e/admin-screens-render.e2e.ts
@@ -50,14 +50,52 @@
  * that was never built.
  *
  * So the assertion is **`200` exactly, plus the admin shell in the body**. The
- * seeded owner holds every permission, so every admin screen owes it a rendered
- * page — there is no legitimate 403 or 404 for this user. The shell check
- * remains alongside the status because a rendered error page can carry a
- * cheerful status, and a blank 200 is not a working screen either.
+ * shell check remains alongside the status because a rendered error page can
+ * carry a cheerful status, and a blank 200 is not a working screen either.
+ *
+ * ## `200` alone was not enough, and that was a real weakness
+ *
+ * A DENIED screen also answers `200` — denial renders here, it never redirects
+ * (`src/lib/auth/admin-screen.ts`). So the original version of this sweep would
+ * have stayed green if a screen started refusing the owner: if a module were
+ * switched off, if a grant were dropped from the blanket bootstrap, if a `deny`
+ * policy were authored tenant-wide. It was accidentally immune rather than
+ * correct.
+ *
+ * It now asserts the screen rendered its CONTENTS — no denial hook anywhere in
+ * the page — for every screen the owner is owed one. That could not be done
+ * while `admin-modules-toggle.e2e.ts` might be running concurrently: it
+ * disables `reporting`, `/admin` authorizes on `reporting.dashboard.read`, and
+ * a correct denial would have read as a defect. The read/write waves
+ * (`tests/e2e/support/e2e-waves.ts`) are what make this assertion possible.
+ *
+ * ## Two screens are exempt, and the reason is not a shrug
+ *
+ * `/admin/tenants` and `/admin/partner-registry` are platform-scoped
+ * (ADR-0053): they enumerate every tenant and every partnership on the
+ * platform. What the seeded owner is owed by them depends on WHICH tenant was
+ * seeded — the platform tenant's owner holds those permissions and sees the
+ * screens; any other tenant's owner is refused. This spec has no independent
+ * way to know which it is looking at, and a first attempt that assumed "ordinary
+ * tenant" failed against a local environment where the seeded tenant IS the
+ * platform tenant. Asserting either outcome would encode an assumption about
+ * the fixture rather than a property of the product.
+ *
+ * So they are held to `200` + shell here, and the real ADR-0053 runtime check
+ * lives in `admin-read-only-access.e2e.ts`, where it is unconditional: a user
+ * granted every TENANT-scoped read can never hold a platform permission, so
+ * both screens must refuse them whichever tenant they are in.
+ *
+ * Which screens those are is not written down; it is computed from each page's
+ * own `authorize` block against the module registry's platform set
+ * (`support/admin-screen-authorize.ts`), and the resulting set is asserted so a
+ * third one appearing is a decision rather than a surprise.
  */
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page } from "./support/e2e-read-wave";
 import { readdirSync } from "node:fs";
 import path from "node:path";
+
+import { requiresPlatformScope } from "./support/admin-screen-authorize";
 
 const tenantId = process.env.E2E_TENANT_ID;
 const loginIdentifier = process.env.E2E_LOGIN_IDENTIFIER;
@@ -68,8 +106,25 @@ const seeded = Boolean(tenantId && loginIdentifier && password);
 const HERE = path.dirname(new URL(import.meta.url).pathname);
 const ADMIN_PAGES_ROOT = path.resolve(HERE, "../../src/pages/admin");
 
-/** A route the filesystem yielded: its URL, and the source file it came from. */
-type AdminRoute = { url: string; source: string; dynamic: boolean };
+/**
+ * A route the filesystem yielded: its URL, the source file it came from, and
+ * whether entering it needs a permission no tenant owner can hold.
+ */
+type AdminRoute = {
+  url: string;
+  source: string;
+  dynamic: boolean;
+  platformScoped: boolean;
+};
+
+/**
+ * What the seeded owner is owed by a screen.
+ *
+ * `either` is for the platform-scoped pair, where the answer depends on whether
+ * the seeded tenant is the platform tenant — see the header. They still get the
+ * status and shell checks; only the contents-vs-refusal question is left open.
+ */
+type Expectation = "contents" | "either";
 
 /**
  * Every `/admin` route, derived from the pages directory.
@@ -99,7 +154,8 @@ export function discoverAdminRoutes(
     routes.push({
       url,
       source: path.relative(process.cwd(), full),
-      dynamic: url.includes("[")
+      dynamic: url.includes("["),
+      platformScoped: requiresPlatformScope(full)
     });
   }
 
@@ -111,7 +167,8 @@ const staticRoutes = routes.filter((route) => !route.dynamic);
 const dynamicRoutes = routes.filter((route) => route.dynamic);
 
 /**
- * Load one admin URL and assert it rendered, SOFTLY.
+ * Load one admin URL and assert the owner got what that screen owes them,
+ * SOFTLY.
  *
  * The status comes from the navigation response rather than from the DOM,
  * because a rendered error page can be served with any status the framework
@@ -120,21 +177,26 @@ const dynamicRoutes = routes.filter((route) => route.dynamic);
 async function checkRenders(
   page: Page,
   url: string,
-  source: string
+  source: string,
+  expected: Expectation = "contents"
 ): Promise<void> {
   const response = await page.goto(url);
   const status = response?.status() ?? 0;
 
+  // Both outcomes are `200`: a refusal is a rendered page here, not an error.
+  // So the status separates "the screen produced something" from "the screen
+  // threw", and the DOM below separates contents from refusal.
   expect
     .soft(
       status,
-      `${url} (${source}) answered ${status}, expected 200. The seeded owner ` +
-        "holds every permission, so this screen owes it a rendered page. " +
+      `${url} (${source}) answered ${status}, expected 200. ` +
         "A 404 here is far more likely to be a THROW during render than a " +
         "missing route: that is exactly how /admin/seo failed, and the " +
         "ReferenceError is in the SERVER log, not in this status."
     )
     .toBe(200);
+
+  if (status !== 200) return;
 
   // Kept alongside the status because a rendered error page can carry a
   // cheerful status, and a blank 200 is not a working screen either. Every
@@ -147,6 +209,26 @@ async function checkRenders(
       `${url} (${source}) returned ${status} but rendered no .admin-shell.`
     )
     .toBeGreaterThan(0);
+
+  if (expected === "either") return;
+
+  // Denial renders an element carrying `id="…-denied"` — never a redirect, so
+  // the DOM is the only place the outcome shows. Counting ANY such hook rather
+  // than one known id also covers the sub-panel gates (`/admin/seo` has four),
+  // so a screen that renders while quietly refusing half of itself to the owner
+  // is caught too.
+  const denials = await page.locator('[id$="-denied"]').count();
+
+  expect
+    .soft(
+      denials,
+      `${url} (${source}) refused the seeded owner, who holds every ` +
+        "tenant-scoped permission. Something removed a grant, disabled the " +
+        "module behind this screen, or authored a tenant-wide deny policy. " +
+        "(If this screen is meant to be platform-only, it must say so in its " +
+        "own `authorize` block — that is where the expectation comes from.)"
+    )
+    .toBe(0);
 }
 
 test.describe("every admin screen renders", () => {
@@ -163,6 +245,26 @@ test.describe("every admin screen renders", () => {
       staticRoutes.length,
       "no admin screens were discovered under src/pages/admin"
     ).toBeGreaterThan(40);
+
+    // The same hazard one level down: if the `authorize` extractor stopped
+    // matching, every screen would be classed "tenant-scoped" and the sweep
+    // would demand contents from the two platform screens — loudly wrong, so
+    // that direction is self-announcing. The quiet direction is the opposite,
+    // and this is what watches it. A THIRD platform screen appearing should be
+    // a decision, not a surprise.
+    const platform = staticRoutes
+      .filter((route) => route.platformScoped)
+      .map((route) => route.url)
+      .sort();
+
+    expect(
+      platform,
+      "the set of platform-scoped admin screens changed. ADR-0053 screens " +
+        "enumerate data belonging to the whole platform, and a tenant owner " +
+        "must be refused by them. If this is intended, update the list here " +
+        "deliberately; if it is not, a screen just claimed — or stopped " +
+        "claiming — cross-tenant authority."
+    ).toEqual(["/admin/partner-registry", "/admin/tenants"]);
   });
 
   test("every static admin screen renders", async ({ page }) => {
@@ -171,7 +273,12 @@ test.describe("every admin screen renders", () => {
     // and this project reuses that session. See `tests/e2e/auth.setup.ts`.
 
     for (const route of staticRoutes) {
-      await checkRenders(page, route.url, route.source);
+      await checkRenders(
+        page,
+        route.url,
+        route.source,
+        route.platformScoped ? "either" : "contents"
+      );
     }
   });
 

--- a/tests/e2e/cwv-lab.e2e.ts
+++ b/tests/e2e/cwv-lab.e2e.ts
@@ -32,7 +32,7 @@
  * `E2E_CWV_LAB=1 bun run perf:cwv:lab` di terminal lain. Job CI `e2e-smoke`
  * men-set env-nya dan menjalankan spec ini sebagai bagian `bun run test:e2e`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./support/e2e-read-wave";
 
 /**
  * Ambang "baik" Core Web Vitals (https://web.dev/articles/vitals):

--- a/tests/e2e/login.e2e.ts
+++ b/tests/e2e/login.e2e.ts
@@ -21,10 +21,10 @@
  * the tenant read then fails closed to the manual field), then
  * `bun run test:e2e`.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./support/e2e-read-wave";
 
 // The login flow IS this spec's subject, so it must start logged OUT rather
-// than inherit the shared owner session the `chromium` project supplies.
+// than inherit the shared owner session the `read` project supplies.
 test.use({ storageState: { cookies: [], origins: [] } });
 
 test.describe("login page", () => {

--- a/tests/e2e/not-found.e2e.ts
+++ b/tests/e2e/not-found.e2e.ts
@@ -13,7 +13,7 @@
  * Run: `bun run dev` (or `bun run build && bun run start`) in one terminal with
  * `DATABASE_URL` set, then `bun run test:e2e` in another.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from "./support/e2e-read-wave";
 
 test.describe("catch-all 404 page", () => {
   test("an unknown browser path renders a clean 404 HTML page", async ({

--- a/tests/e2e/support/admin-screen-authorize.ts
+++ b/tests/e2e/support/admin-screen-authorize.ts
@@ -1,0 +1,67 @@
+/**
+ * Which permission an admin screen demands of whoever loads it.
+ *
+ * ## What this is for
+ *
+ * The render sweep needs to know what the seeded OWNER is owed by each screen,
+ * and "a rendered page" is not the answer everywhere. Two screens are
+ * platform-scoped (ADR-0053): `/admin/tenants` lists every tenant on the
+ * platform, `/admin/partner-registry` lists every partnership. The blanket
+ * grant a tenant owner receives filters on `scope = 'tenant'`, so an ordinary
+ * owner is refused there — and that refusal is the product working.
+ *
+ * Without this, the sweep can only assert what is true of both cases, which is
+ * `200` — and `200` is exactly what a broken screen returns too. Knowing which
+ * screens owe a refusal is what lets the other 46 be held to rendering.
+ *
+ * ## Read from the page, cross-checked against the code registry
+ *
+ * The triple is parsed out of the page's own `authorize:` block, then looked up
+ * in `platformScopedPermissionKeys()` — which is built from the module
+ * descriptors, not from the page. So the page says WHICH permission it wants
+ * and the registry says what that permission IS; neither one alone decides.
+ *
+ * The honest limit, stated because the same shape has already fooled me once in
+ * this suite: if a screen named the wrong permission, this would compute the
+ * wrong expectation and pass. It defends against a screen breaking, not against
+ * a screen being mis-declared. `admin:screen-coverage:check` is what watches the
+ * declaration.
+ */
+import { readFileSync } from "node:fs";
+
+import { permissionKey } from "../../../src/modules/identity-access/domain/access-control";
+import { platformScopedPermissionKeys } from "../../../src/modules/identity-access/domain/platform-scope";
+
+/**
+ * The `moduleKey` / `activityCode` / `action` triples in a screen's
+ * SCREEN-LEVEL `authorize` — one object, or an array of them.
+ *
+ * Bounded to the slice between `authorize:` and the `load:` that follows it.
+ * Admin pages are full of further triples (`can({ … })` guards deciding whether
+ * a create button renders); those govern controls, not entry, and folding them
+ * in would claim a screen needs a permission it only needs for one button.
+ */
+export function extractScreenAuthorizeKeys(source: string): string[] {
+  const start = source.indexOf("authorize:");
+  if (start === -1) return [];
+
+  const rest = source.slice(start);
+  const end = rest.indexOf("\n  load:");
+  const slice = end === -1 ? rest.slice(0, 1_000) : rest.slice(0, end);
+
+  const triple =
+    /moduleKey:\s*"([a-z0-9_]+)"[\s\S]{0,200}?activityCode:\s*"([a-z0-9_]+)"[\s\S]{0,200}?action:\s*"([a-z0-9_]+)"/g;
+
+  const keys: string[] = [];
+  for (const match of slice.matchAll(triple)) {
+    keys.push(permissionKey(match[1]!, match[2]!, match[3]!));
+  }
+  return keys;
+}
+
+/** Does loading this screen require a permission no tenant owner can hold? */
+export function requiresPlatformScope(sourceFile: string): boolean {
+  const keys = extractScreenAuthorizeKeys(readFileSync(sourceFile, "utf8"));
+  const platform = platformScopedPermissionKeys();
+  return keys.some((key) => platform.has(key));
+}

--- a/tests/e2e/support/e2e-read-wave.ts
+++ b/tests/e2e/support/e2e-read-wave.ts
@@ -1,0 +1,84 @@
+/**
+ * The `test` a READ-wave spec must import — it fails the test if the spec
+ * mutates anything through the app.
+ *
+ * ## Why a fixture rather than a promise
+ *
+ * `e2e-waves.ts` classifies each spec, and `tests/e2e-wave-classification.test.ts`
+ * makes the classification impossible to skip. Neither can tell whether the
+ * classification is TRUE. A spec sitting in the read wave that grows a click on
+ * a submit button is still labelled "read", and the label is what the ordering
+ * trusts — so the label would be quietly wrong and the symptom would surface in
+ * a different file, which is exactly the class of bug this whole change exists
+ * to end.
+ *
+ * So membership is checked by observation. Every non-GET request the browser
+ * context makes to `/api/` is recorded, and the test fails if any survived the
+ * allow-list. The spec that broke the rule is the spec that turns red.
+ *
+ * ## What is allowed, and why each one is
+ *
+ * `POST /api/v1/auth/login` and `/logout` mint and drop a SESSION. That is the
+ * only write a read-wave spec legitimately makes: no other spec's expectation
+ * reads it, and three specs here authenticate as somebody other than the shared
+ * owner and therefore must drive the real form.
+ *
+ * Direct database seeding by a fixture is not visible here at all, and that is
+ * intentional rather than an oversight — see the note on `READ_WAVE`. The rule
+ * is about mutations made through the app, because those are the ones that
+ * change what another spec's screen renders.
+ */
+import { test as base, expect } from "@playwright/test";
+
+export { expect };
+export type { Page, Locator, Response } from "@playwright/test";
+
+/**
+ * Session endpoints. Anchored, so a future `/api/v1/auth/login-as` — which
+ * would be a very different thing — is not silently covered by a prefix match.
+ */
+const ALLOWED_MUTATIONS = [
+  "/api/v1/auth/login",
+  "/api/v1/auth/logout"
+] as const;
+
+function isAllowed(pathname: string): boolean {
+  return ALLOWED_MUTATIONS.some((allowed) => pathname === allowed);
+}
+
+export const test = base.extend<{ noAppMutation: void }>({
+  noAppMutation: [
+    async ({ context }, use) => {
+      const violations = new Set<string>();
+
+      context.on("request", (request) => {
+        const method = request.method();
+        if (method === "GET" || method === "HEAD") return;
+
+        // Only the API is inspected. Every admin write in this app goes through
+        // `/api/v1/...` via the delegated form client, so that is where a
+        // mutation actually appears; watching every origin would catch browser
+        // chatter and report it as a test defect.
+        const pathname = new URL(request.url()).pathname;
+        if (!pathname.startsWith("/api/")) return;
+        if (isAllowed(pathname)) return;
+
+        violations.add(`${method} ${pathname}`);
+      });
+
+      await use();
+
+      expect(
+        [...violations].sort(),
+        "This spec is classified in the READ wave (tests/e2e/support/e2e-waves.ts) " +
+          "but it mutated tenant state through the app. Read-wave specs run " +
+          "FIRST, against a pristine tenant, precisely so the sweeps can assert " +
+          "what a screen owes an untouched tenant — a write here changes what " +
+          "the OTHER read specs see, and the failure lands in their file rather " +
+          "than in this one. Either drop the mutation, or move this spec to " +
+          "WRITE_WAVE and stop importing `test` from `./support/e2e-read-wave`."
+      ).toEqual([]);
+    },
+    { auto: true }
+  ]
+});

--- a/tests/e2e/support/e2e-restricted-user.ts
+++ b/tests/e2e/support/e2e-restricted-user.ts
@@ -20,14 +20,14 @@
  * permission-gated screen owes the same answer and one rule covers all of them:
  * the denial renders and the contents do not.
  *
- * `read` gives every tenant-scoped read, a real minimum-privilege operator.
- * NOTHING USES IT YET: the spec written against it proved flaky for a reason
- * that is not its own — `admin-modules-toggle.e2e.ts` deliberately DISABLES the
- * `reporting` module, and `/admin` authorizes on `reporting.dashboard.read`, so
- * a read-only sweep overlapping that toggle sees the dashboard correctly deny.
- * The fixture is kept because the interference is a harness problem worth
- * solving properly (read sweeps must not overlap global-state mutators), not a
- * reason to throw the grant away.
+ * `read` gives every tenant-scoped read, a real minimum-privilege operator, and
+ * `admin-read-only-access.e2e.ts` is what uses it. That spec was written first
+ * and held back for a full round: it failed roughly one run in three for a
+ * reason that was not its own — `admin-modules-toggle.e2e.ts` deliberately
+ * DISABLES the `reporting` module, and `/admin` authorizes on
+ * `reporting.dashboard.read`, so a read sweep overlapping that toggle saw the
+ * dashboard correctly deny. The read/write waves (`e2e-waves.ts`) fixed the
+ * harness, and the spec landed unchanged.
  *
  * What neither covers is which individual WRITE controls a partially-
  * permissioned user should see. Those expectations differ per screen, so they

--- a/tests/e2e/support/e2e-waves.ts
+++ b/tests/e2e/support/e2e-waves.ts
@@ -1,0 +1,103 @@
+/**
+ * Which e2e specs may run while the tenant is pristine, and which are allowed
+ * to change it underneath everyone else.
+ *
+ * ## The failure this exists to prevent
+ *
+ * Every spec shares ONE seeded tenant. With `fullyParallel: true` a spec that
+ * writes runs interleaved with specs that read, and the reader sees a tenant
+ * that nobody described. Two real instances, both diagnosed the hard way:
+ *
+ * - `admin-roles.e2e.ts` creates a role. The "Assign" picker on `/admin/users`
+ *   lists EVERY role in the tenant, so its default option was sometimes a role
+ *   the owner did not hold — the assignment then legitimately succeeded and the
+ *   spec expecting `409` failed with `200`. Nothing was broken; the expectation
+ *   depended on state another file mutates.
+ * - `admin-modules-toggle.e2e.ts` deliberately DISABLES `reporting`, and
+ *   `/admin` authorizes on `reporting.dashboard.read`. Any read sweep
+ *   overlapping that window sees the dashboard deny — correctly. That is what
+ *   kept a working read-only sweep off `main`.
+ *
+ * The second one matters more than it looks. It is not only a flake: it is why
+ * the two sweeps already shipped are **accidentally immune rather than
+ * correct**. `admin-screens-render` asserted only `200`, and a denied screen
+ * returns `200`; `admin-deny-path` expects denial, which a disabled module also
+ * produces. Both would have stayed green while a module toggle broke a screen
+ * for real. Neither could be tightened while a mutator might be running.
+ *
+ * ## Two waves, ordered by Playwright's own dependency graph
+ *
+ * `setup` → `read` → `write`. The read wave gets the tenant as the bootstrap
+ * left it; the write wave runs afterwards and may do as it likes. Within each
+ * wave everything is still parallel, so the cost is one barrier, not
+ * serialization.
+ *
+ * Reads run FIRST rather than last on purpose. Running them last would depend
+ * on every mutator reverting cleanly, which is true today (the module toggle is
+ * self-reversing) but is an invariant nobody could enforce — a mutator that
+ * fails halfway leaves residue by definition, and the reader would then be
+ * asserting against the wreckage of a different failure.
+ *
+ * ## Why a list, and what stops the list from rotting
+ *
+ * A list is normally the wrong answer in this repo — a gate that checks its own
+ * matrix rather than what exists is the recurring failure here. So this list is
+ * held to what exists from both directions:
+ *
+ * 1. `tests/e2e-wave-classification.test.ts` requires every `*.e2e.ts` on disk
+ *    to appear in exactly one wave. A new spec fails CI until its author
+ *    decides which it is — the decision cannot be skipped, only made.
+ * 2. Membership of the read wave is enforced at RUN TIME, not by trusting the
+ *    label: read-wave specs import `test` from `./e2e-read-wave`, which fails
+ *    any test that issues a mutating request to the app. A spec that quietly
+ *    starts writing turns red in its own file rather than in somebody else's.
+ *
+ * (2) is the part that makes this more than bookkeeping. The classification
+ * below is a claim; the fixture is what checks it.
+ */
+
+/**
+ * Specs that only READ tenant state — they may log in, and they may seed their
+ * own fixture rows directly through the database, but they must not drive the
+ * app into changing anything.
+ *
+ * Direct fixture seeding is deliberately still allowed here: `seedRestrictedUser`
+ * writes a role holding nothing, which no other spec's expectation depends on.
+ * The rule these specs are held to is about mutations made THROUGH the app,
+ * because those are the ones that change what another spec's screen renders.
+ */
+export const READ_WAVE: readonly string[] = [
+  "admin-deny-path.e2e.ts",
+  "admin-offices.e2e.ts",
+  "admin-read-only-access.e2e.ts",
+  "admin-screens-render.e2e.ts",
+  "cwv-lab.e2e.ts",
+  "login.e2e.ts",
+  "not-found.e2e.ts"
+];
+
+/**
+ * Specs that change tenant-wide state through the app.
+ *
+ * `admin-abac-policies.e2e.ts` is the sharpest of them — it authors a **deny**
+ * policy and toggles it, and ABAC deny is evaluated for every request in the
+ * tenant. `admin-modules-toggle.e2e.ts` and `admin-roles.e2e.ts` are the two
+ * that have actually broken other specs. The `*-create` / `*-edit` pair only
+ * append rows, which no reader here counts, but they belong to the same wave
+ * because "appends only" is a property that quietly stops being true.
+ */
+export const WRITE_WAVE: readonly string[] = [
+  "admin-abac-policies.e2e.ts",
+  "admin-email-templates-create.e2e.ts",
+  "admin-modules-toggle.e2e.ts",
+  "admin-offices-create.e2e.ts",
+  "admin-offices-edit.e2e.ts",
+  "admin-profiles-create.e2e.ts",
+  "admin-roles.e2e.ts",
+  "admin-users.e2e.ts"
+];
+
+/** Glob form, for a Playwright project's `testMatch`. */
+export function waveTestMatch(wave: readonly string[]): string[] {
+  return wave.map((file) => `**/${file}`);
+}


### PR DESCRIPTION
Closes the harness problem the previous round left open — and then fixes what that problem had been hiding.

## Two waves, ordered

`playwright.config.ts` runs `setup` → `read` → `write`. Read-wave specs see the tenant as the bootstrap left it; writers run after. Within each wave everything is still parallel, so the cost is one barrier — the suite still finishes in ~19s.

Reads run **first** rather than last on purpose. Running them last would depend on every mutator reverting cleanly, which is true today but is an invariant nobody could enforce: a mutator that fails halfway leaves residue by definition, and the reader would then be asserting against the wreckage of a different failure.

## The classification is checked, not trusted

A list of filenames is normally the wrong answer in this repo — a gate that checks its own matrix rather than what exists is the recurring failure here. So it is held from both ends:

- `tests/e2e-wave-classification.test.ts` requires every `*.e2e.ts` on disk to be in exactly one wave. An unclassified spec would not run at all, so the decision cannot be skipped, only made.
- Read membership is enforced **at run time**: read-wave specs import `test` from `tests/e2e/support/e2e-read-wave.ts`, which fails any test that issues a mutating `/api/` request.

Session endpoints are the only exception, because three specs must authenticate as somebody other than the shared owner.

## What the ordering unlocked — the sweeps were not checking much

`admin-screens-render.e2e.ts` asserted `200`, and **a denied screen also returns `200`**: denial renders here, it never redirects. So the sweep would have stayed green if a screen started refusing the owner — a module switched off, a grant dropped from the bootstrap, a tenant-wide `deny` authored. It was accidentally immune rather than correct, and it could not be tightened while a mutator might run concurrently.

It now asserts the screen rendered its **contents** — no denial hook anywhere in the page.

## The read-only sweep lands unchanged

`tests/e2e/admin-read-only-access.e2e.ts` — written a round ago, held back because it failed roughly one run in three through no fault of its own — drives a user granted every tenant-scoped `read` and nothing else. The grant comes from the permission catalogue, the expectation from each page's own `authorize` block, so the two halves come from different sources.

`/admin/tenants` and `/admin/partner-registry` must refuse that user. **This is the only runtime check on ADR-0053 anywhere in the repo.**

### A wrong first attempt, recorded because it was a real finding

That check was first written into the OWNER sweep — "these two screens refuse the owner" — and it **failed**, against an environment where the seeded tenant *is* the platform tenant, whose owner legitimately holds those permissions. What the owner is owed there depends on which tenant was seeded, which the sweep cannot know independently. Those two screens are now exempt from the contents-vs-refusal question there and held to `200` + shell; for the read-only user it is unconditional, because a `scope = 'tenant'` grant can never include a platform permission.

## Every mechanism proven to fail on a real defect

| Mutation | Result |
|---|---|
| Remove a spec from both wave lists | classification gate red |
| Read-wave spec imports `@playwright/test` | classification gate red |
| Add one `fetch(…, {method:"POST"})` to a read-wave spec | that spec red, naming `POST /api/v1/offices` |
| Disable the `reporting` module | render sweep red on `/admin` **and** `/admin/reporting` — green under the old assertion |
| Grant the read-only role the two platform reads | read-only sweep red, reporting cross-tenant disclosure |

Full local run against a real Postgres + production build: **24 passed, 1 skipped** (`cwv-lab`, env-gated), read wave completing entirely before the write wave starts. `bun run check` green (5713 pass, 0 fail, 465 files).

## Found while working: the browser-test skill described a different repo

`.claude/skills/awcms-browser-test/SKILL.md` claimed specs for `/admin/analytics` and `/admin/security`, an `admin-responsive-nav.e2e.ts`, an `admin-a11y-smoke.e2e.ts`, and a `@axe-core/playwright` devDependency. It also described the CI job as running in **two phases** with `--grep-invert "@full-online-gate"`.

**None of that exists here** — all inherited from `awcms-mini` when the skill was ported; `ci.yml` has one phase. Both corrections are stated in place rather than silently overwritten, because the failure mode of a stale skill is that an agent follows it instead of looking.

## Still open, named rather than assumed closed

Which individual **write** controls a partially-permissioned user should see. Those expectations differ per screen — there is no selector all 76 delegated controls share — so it is per-screen work, not one mechanical rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)