### PR TITLE
docs(project-state): the legacy .htaccess exists, and it says five URL shapes not two

### DIFF
--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:e6cf46128545c346d88fed45ce77ec683a80a3f8b8a6325bfca10748fba34459 -->
+<!-- i18n-source-hash: sha256:df3d80833c0c3f66ea86f26fc1da62c7bb2b771cb849e07c90fb2d79ab643d88 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,73 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN BENTUK — 24 Agustus 2026: `.htaccess` legacy yang ditunggu #599 ADA
+  di mesin pengembangan, dan ia MEMBANTAH rencana yang disusun tanpanya. Lima
+  bentuk URL, bukan dua; salah satunya tak pernah didaftar; dan separuh
+  halaman-statis `sql/138` adalah sepasang kolom yang TAK ADA penulis maupun
+  pembacanya.**
+
+  PUTARAN CUTOVER di bawah ditutup dengan "yang tersisa pada #599 bukan kode —
+  menjalankan job-nya butuh `.htaccess` legacy dan ekspor sitemap, yang tidak
+  ada di kedua repo". Paruh pertamanya kini TIDAK berlaku lagi. Berkasnya ada di
+  `/home/data/dev_php/seputarborneo.com/.htaccess`, salinan kerja situs legacy
+  yang duduk BERSEBELAHAN dengan repo ini, dan membacanya menggerakkan #599
+  tanpa menggerakkan satu baris kode aplikasi pun.
+
+  **Lima bentuk rewrite.** Artikel `^news/([^/]*)\.html$`; rubrik
+  `^rubrik/([^/]*)\.html$`; **`^([^/]*)/([^/]*)\.html$`**, catch-all dua-segmen
+  telanjang yang memetakan ke `/rubriks/?news=$1&kt=$2`; pencarian
+  `^cari_berita/([^/]*)\.html$`; dan halaman statis `^([^/]*)\.html$`. Hanya
+  yang pertama tercakup. Yang ketiga TIDAK muncul di versi rencana mana pun pada
+  issue itu — dan karena ia catch-all, justru keluarga itulah yang akan dijatuhkan
+  DIAM-DIAM dalam jumlah terbesar oleh peta yang dibangun dari bentuk-bentuk yang
+  terdaftar: persis keluaran yang hendak dicegah catatan "enumerasi setiap bentuk".
+
+  **"Menutupinya cukup satu run lagi, bukan perubahan kode" SALAH untuk tiga dari
+  lima.** `blog:legacy:redirects:import` MENOLAK `--path-template` yang tidak
+  memuat `{legacyId}` dan menurunkan petanya dari
+  `awcms_blog_posts.legacy_source_id`. Daftar rubrik dan halaman statis BUKAN
+  artikel, jadi tak ada template yang bisa menyatakannya; tak ada yang bisa
+  dijalankan. Term bahkan tak punya kolom provenance sama sekali.
+
+  **`awcms_blog_pages.legacy_source_system`/`legacy_source_id` TANPA penulis dan
+  TANPA pembaca.** `blog:legacy:import` hanya mengimpor post, dan
+  `listLegacyRedirectMappings` mengambil `FROM awcms_blog_posts`. Pasangan itu
+  mati sejak `sql/138` mendarat. Yang membuatnya TERBACA tercakup adalah bentuk
+  yang wajib dibawa ke depan: `tests/legacy-redirect-map.test.ts:54-61`, "pages
+  get the same treatment as posts", meng-assert bahwa TEKS BERKAS MIGRATION
+  memuat `ALTER TABLE awcms_blog_pages` dan nama index dedup-nya. Tes atas sumber
+  sebuah migration membuktikan kolomnya ADA; ia tak bisa melihat kolom itu tak
+  pernah dipakai. Komentarnya sendiri menyebut taruhannya — _"memberi provenance
+  hanya pada post akan membuat separuh peta 301 tak dapat diturunkan"_ — dan
+  separuh itu lalu tak pernah dirangkai. Sekeluarga dengan gerbang registry yang
+  memeriksa BENTUK, bukan MAKNA.
+
+  **Kolom mati itu pun bukan obatnya.** `data/index.php:195-212` melakukan switch
+  atas himpunan TERTUTUP berisi tiga: `/tentang_kami.html`,
+  `/pedoman_media_cyber.html`, `/disclimer.html` (salah ketik legacy itu BAGIAN
+  dari URL). Tiga aturan exact-path, yang didukung `awcms_seo_redirects` sejak
+  `sql/060` — entri data admin, bukan importer dan bukan backfill. Pasangan kolom
+  itu harus dirangkai atau dihapus; membiarkannya adalah yang melahirkan RUPA
+  cakupan tadi.
+
+  Satu bentuk yang tercakup terkonfirmasi benar: `berita/index.php:9` membaca
+  `(int) $_GET['news']`, jadi id-nya adalah digit terdepan dan slug-nya dekoratif
+  — `/news/{legacyId}_{slug}.html` memang template yang tepat.
+
+  **Yang MASIH terhalang lebih sempit daripada "artefaknya".** Bentuk rubrik butuh
+  daftar rubrik, yang butuh data yang tak dimiliki salinan kerja itu (dump-nya,
+  `seputa58_sbb.sql`, berukuran 0 byte), DAN rute target yang dirender
+  `ahliweb/awcms-astro`, bukan di sini (ADR-0045/ADR-0070) — pertanyaan kontrak
+  lintas-repo sebelum menjadi pertanyaan impor. Crawl pra-cutover tak berubah:
+  `blog:legacy:cutover:verify` sudah ada dan butuh URL sitemap hidup, pada level
+  halaman karena ia menolak index. URL hasil pencarian TIDAK boleh di-301 ke
+  konten; query sembarang tak punya satu tujuan yang benar.
+
+  Direkomendasikan: PECAH #599 alih-alih menahan satu issue pada artefak
+  terlambatnya. Bentuk 1 plus tiga aturan statis sudah menjadi peta siap-cutover
+  hari ini.
 
 - **PUTARAN LEDGER — 24 Agustus 2026: 121 endpoint MENOLAK pengguna tenant
   TANPA MENCATAT bahwa mereka melakukannya.**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,69 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **SHAPE ROUND — 24 August 2026: the legacy `.htaccess` #599 was waiting for
+  exists on the development machine, and it contradicts the plan built without
+  it. Five URL shapes, not two; one of them was never listed; and the static-page
+  half of `sql/138` is a column pair nothing writes and nothing reads.**
+
+  The CUTOVER ROUND below closed with "what remains on #599 is not code —
+  running the jobs needs the legacy `.htaccess` and a sitemap export, which
+  exist in neither repo". The first half of that is no longer true. The file is
+  at `/home/data/dev_php/seputarborneo.com/.htaccess`, a working copy of the
+  legacy site sitting beside this repo, and reading it moves #599 without
+  moving a line of application code.
+
+  **Five rewrite shapes.** Articles `^news/([^/]*)\.html$`; rubrik
+  `^rubrik/([^/]*)\.html$`; **`^([^/]*)/([^/]*)\.html$`**, a bare two-segment
+  catch-all mapping to `/rubriks/?news=$1&kt=$2`; search
+  `^cari_berita/([^/]*)\.html$`; and static pages `^([^/]*)\.html$`. Only the
+  first is covered. The third appears in no version of this issue's plan — and
+  being a catch-all, it is the family a map built from the listed shapes would
+  have dropped in the largest number, silently, which is the exact outcome the
+  "enumerate every shape" note existed to prevent.
+
+  **"Covering them is a second run, not a code change" is wrong for three of the
+  five.** `blog:legacy:redirects:import` rejects a `--path-template` that does
+  not contain `{legacyId}` and derives its map from
+  `awcms_blog_posts.legacy_source_id`. Rubrik listings and static pages are not
+  articles, so no template can express them; there is nothing to run. Terms have
+  no provenance column at all.
+
+  **`awcms_blog_pages.legacy_source_system`/`legacy_source_id` have no writer
+  and no reader.** `blog:legacy:import` imports posts only, and
+  `listLegacyRedirectMappings` selects `FROM awcms_blog_posts`. The pair has
+  been dead since `sql/138` landed. What made it read as covered is the shape to
+  carry forward: `tests/legacy-redirect-map.test.ts:54-61`, "pages get the same
+  treatment as posts", asserts that the MIGRATION FILE'S TEXT contains
+  `ALTER TABLE awcms_blog_pages` and the dedup index name. A test over a
+  migration's source proves a column exists; it cannot notice the column is
+  never used. Its own comment names the stakes — _"giving only posts provenance
+  would make half the 301 map underivable"_ — and that half was then never
+  wired. Same family as the registry gates that check SHAPE rather than MEANING.
+
+  **The dead column is not the fix anyway.** `data/index.php:195-212` switches
+  on a closed set of three: `/tentang_kami.html`, `/pedoman_media_cyber.html`,
+  `/disclimer.html` (the legacy typo is part of the URL). Three exact-path
+  rules, which `awcms_seo_redirects` has supported since `sql/060` — admin data
+  entry, not an importer and not a backfill. The column pair should be wired or
+  dropped; leaving it is what produced the appearance of coverage.
+
+  The one covered shape is confirmed right: `berita/index.php:9` reads
+  `(int) $_GET['news']`, so the id is the leading digits and the slug is
+  decorative — `/news/{legacyId}_{slug}.html` is the correct template.
+
+  **What is still blocked is narrower than "the artifacts".** The rubrik shapes
+  need the rubrik list, which needs data the working copy does not have (its
+  dump, `seputa58_sbb.sql`, is 0 bytes), AND a target route rendered by
+  `ahliweb/awcms-astro`, not here (ADR-0045/ADR-0070) — a cross-repo contract
+  question before it is an import question. The pre-cutover crawl is unchanged:
+  `blog:legacy:cutover:verify` is built and needs the live sitemap URL, at page
+  level because it refuses an index. Search-result URLs should NOT 301 onto
+  content; an arbitrary query has no single correct destination.
+
+  Recommended: split #599 rather than keep one issue blocked on its slowest
+  artifact. Shape 1 plus the three static rules is a cutover-ready map today.
+
 - **LEDGER ROUND — 24 August 2026: 121 endpoints refuse a tenant user WITHOUT
   RECORDING that they did.**
 


### PR DESCRIPTION
Records a SHAPE ROUND in `PROJECT_STATE.md` §4 (and its Indonesian mirror), because the round changes what is true about a blocked issue rather than adding work.

#599 has said since 21 August that it "unblocks the moment somebody drops the `.htaccess` and the sitemap URL in here", and the CUTOVER ROUND below this entry closed with "what remains on #599 is not code — running the jobs needs the legacy `.htaccess` and a sitemap export, **which exist in neither repo**".

The `.htaccess` is on the development machine, beside this repo. Reading it moves the issue without moving application code, and contradicts the plan built without it:

- **Five rewrite shapes, not two.** One of them — `^([^/]*)/([^/]*)\.html$`, a bare two-segment catch-all — appears in no version of the plan. Being a catch-all, it is the family a map built from the listed shapes drops in the largest number, silently.
- **"Covering them is a second run, not a code change" is wrong for three of the five.** `blog:legacy:redirects:import` rejects a `--path-template` without `{legacyId}` and derives its map from `awcms_blog_posts.legacy_source_id`; rubrik listings and static pages are not articles, so no template can express them. Terms have no provenance column at all.
- **`awcms_blog_pages.legacy_source_system`/`legacy_source_id` have no writer and no reader** anywhere in `src/`, `scripts/` or `tests/`. What kept it looking covered is worth carrying forward: `tests/legacy-redirect-map.test.ts:54-61` asserts the MIGRATION FILE'S TEXT contains `ALTER TABLE awcms_blog_pages`. A test over a migration's source proves a column exists; it cannot notice the column is dead. Its own comment names the stakes and that half was then never wired.
- **The dead column is not the fix anyway** — the legacy static pages are a closed set of three, which `awcms_seo_redirects` has handled since `sql/060`.

The findings are posted on #599 as well (#599 comment). Recommended there and here: split the issue rather than keep it blocked on its slowest artifact.

Docs only — no code, no schema, no contract change. `changesets:policy:check` reports docs-only, so no changeset. Full `bun run check` green (all gates, 6523 tests, build).