### PR TITLE
chore(db): drop the half of sql/138 that nothing ever wrote or read

### DIFF
--- a/.changeset/drop-dead-page-provenance-columns.md
+++ b/.changeset/drop-dead-page-provenance-columns.md
@@ -1,0 +1,34 @@
+---
+"awcms": patch
+---
+
+chore(db): drop the half of `sql/138` that nothing ever wrote or read
+
+`sql/138` gave BOTH `awcms_blog_posts` and `awcms_blog_pages` a
+`legacy_source_system`/`legacy_source_id` pair, reasoning that "a legacy archive
+has static pages too, and giving only posts provenance would make half the 301
+map underivable". The posts half was then built — `blog:legacy:import` writes it
+and `listLegacyRedirectMappings` derives the redirect map from it. The pages half
+never was: no importer writes those two columns and no query reads them,
+anywhere in `src/`, `scripts/` or `tests/`.
+
+Reading the legacy site's actual `.htaccess` settled the question they were
+speculating about. The static-page rewrite is
+`^([^/]*)\.html$ -> /data/?halaman=$1`, and `data/index.php` switches on a
+CLOSED SET OF THREE — `tentang_kami`, `pedoman_media_cyber`, `disclimer`. Three
+URLs is three exact-path rules in `awcms_seo_redirects`, supported since
+`sql/060`: admin data entry, not an importer and not a backfill.
+
+**Leaving them was not the cheap option, which is the part worth keeping.**
+`tests/legacy-redirect-map.test.ts` asserted that the MIGRATION FILE'S TEXT
+contained `ALTER TABLE awcms_blog_pages`, under the title "pages get the same
+treatment as posts". That reads as coverage and is not: a test over a
+migration's source proves a column exists, and cannot notice the column is dead.
+So the pair was not inert — it was answering "is the static-page half handled?"
+with "yes". That test is replaced by one that searches for a READER, which is
+the assertion the old one could not make.
+
+Safe by construction: nothing has ever written these columns, so every row's
+value is NULL in every deployment. There is no data to lose and no backfill to
+plan. The posts columns, their index and their CHECK are untouched — they are
+the live half, and the 301 map is derived from them.

--- a/.claude/skills/README.id.md
+++ b/.claude/skills/README.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](README.md)
 
-<!-- i18n-source-hash: sha256:a5e59ea6371afac9057f93086e4a32ec9a67b00300ef90197fa2936ce08d419b -->
+<!-- i18n-source-hash: sha256:9892144a27745b6c2a7e74fb3a452673884e43528483e4d1f213af3bb13993cb -->
 
 # AWCMS Project Skills
 
@@ -43,7 +43,7 @@ Skill Claude Code tingkat-proyek untuk AWCMS. Setiap skill meng-encode standar d
 > Keluarga hari ini dua repo, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (halaman publik + permukaan admin USER, ADR-0070). **KOREKSI:** versi sebelumnya menyatakan
 > implementasi ini "baru fondasi Sprint 1–2" dengan empat modul — itu **sudah
-> lama tidak benar**. Repo ini punya **24 modul terdaftar** dan `sql/001`–`sql/146`;
+> lama tidak benar**. Repo ini punya **24 modul terdaftar** dan `sql/001`–`sql/147`;
 > lihat [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) untuk daftar nyata.
 > Skill yang badannya masih menandai dirinya "BACAAN SAJA" tetap begitu — itu
 > per-skill, bukan pernyataan tentang repo secara keseluruhan.

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -41,7 +41,7 @@ Project-level Claude Code skills for AWCMS. Each skill encodes the standards fro
 > The family today is two repos, `awcms` + [`awcms-astro`](https://github.com/ahliweb/awcms-astro)
 > (public pages + the USER admin surface, ADR-0070). **CORRECTION:** the previous version claimed this
 > implementation was "only the Sprint 1–2 foundation" with four modules — that has **not
-> been true for a long time**. This repo has **24 registered modules** and `sql/001`–`sql/146`;
+> been true for a long time**. This repo has **24 registered modules** and `sql/001`–`sql/147`;
 > see [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md) for the real list.
 > A skill whose body still marks itself "READ-ONLY" stays that way — that is
 > per-skill, not a statement about the repo as a whole.

--- a/docs/ARCHITECTURE.id.md
+++ b/docs/ARCHITECTURE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](ARCHITECTURE.md)
 
-<!-- i18n-source-hash: sha256:22e01f9b45549c1c3e7f805e3ab848f9b9d2e09ecd43d200bdc7979ee687b594 -->
+<!-- i18n-source-hash: sha256:60809c8248fbf2c9649cd9b1a11690cd581436579c1108546a34e63a2883bcf2 -->
 
 # Arsitektur AWCMS
 
@@ -21,7 +21,7 @@ Sebagai template yang di-ship, base menyediakan **modul fondasi reusable + kontr
 modul domain ERP (finance, inventory, procurement, manufacturing, hr-payroll, dst.)
 **ditambahkan langsung di `src/modules/` template ini** saat dipakai, bukan di repo
 ekstensi/turunan terpisah (jalur aplikasi-turunan DIHAPUS — lihat §Komposisi modul di
-bawah). Repo ini punya **24 modul terdaftar**, migration `sql/001`-`sql/146`, RLS
+bawah). Repo ini punya **24 modul terdaftar**, migration `sql/001`-`sql/147`, RLS
 `FORCE` di seluruh tabel tenant-scoped, pemisahan role database, dan admin UI read+write
 (Issue #166, #171). Dokumen ini menjelaskan apa yang **ada di kode saat ini**. Untuk detail
 per modul, lihat `README.md` masing-masing di `src/modules/<module>/`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,7 +19,7 @@ As a shipped template, the base provides **reusable foundation modules + neutral
 ERP domain modules (finance, inventory, procurement, manufacturing, hr-payroll, etc.)
 are **added directly in this template's `src/modules/`** when it is used, not in a separate
 extension/derived repo (the derived-application pathway was REMOVED — see §Module composition
-below). This repo has **24 registered modules**, migrations `sql/001`-`sql/146`, RLS
+below). This repo has **24 registered modules**, migrations `sql/001`-`sql/147`, RLS
 `FORCE` on every tenant-scoped table, database role separation, and a read+write admin UI
 (Issue #166, #171). This document describes what is **in the code today**. For per-module
 detail, see each `README.md` under `src/modules/<module>/`.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:df3d80833c0c3f66ea86f26fc1da62c7bb2b771cb849e07c90fb2d79ab643d88 -->
+<!-- i18n-source-hash: sha256:d0d80cd9cd50843b048b769291da2f7782057a1c7567c63a011efea2e4113801 -->
 
 # AWCMS — Project State & Continuation
 
@@ -111,7 +111,7 @@ Model tata kelola dipakai-langsung/tanpa-repo-turunan (ADR-0034 §2/§3) **tidak
 | Changeset menunggu (per tipe bump) | _jalankan perintah di kolom kanan_                                                    | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commit sejak rilis terakhir        | _jalankan perintah di kolom kanan_                                                    | `git rev-list --count v9.1.2..HEAD`                                                     |
 | Modul base                         | **24** (lihat daftar di ARCHITECTURE.md)                                              | `src/modules/index.ts`                                                                  |
-| Migrasi                            | **146** (`sql/001`–`146`)                                                             | `ls sql/`                                                                               |
+| Migrasi                            | **147** (`sql/001`–`147`)                                                             | `ls sql/`                                                                               |
 | ADR                                | **0000**–**0111** (`0000` = template; status ADR tertinggi: **Accepted**)             | `ls docs/adr/`                                                                          |
 | Layar admin                        | **48** berkas `.astro` di `src/pages/admin/`; **0 dari 24** modul tanpa `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | Berkas `.astro`                    | **61** (34.760 baris) — soal typecheck lihat §6                                       | `find src -name '*.astro'`                                                              |
@@ -408,7 +408,9 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   dari URL). Tiga aturan exact-path, yang didukung `awcms_seo_redirects` sejak
   `sql/060` — entri data admin, bukan importer dan bukan backfill. Pasangan kolom
   itu harus dirangkai atau dihapus; membiarkannya adalah yang melahirkan RUPA
-  cakupan tadi.
+  cakupan tadi. **DIHAPUS di `sql/147`** — tak pernah ada yang menulisnya, jadi
+  nilai setiap baris NULL dan tak ada data yang hilang; tes yang meng-assert TEKS
+  migration diganti tes yang mencari PEMBACA.
 
   Satu bentuk yang tercakup terkonfirmasi benar: `berita/index.php:9` membaca
   `(int) $_GET['news']`, jadi id-nya adalah digit terdepan dan slug-nya dekoratif

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -111,7 +111,7 @@ The used-directly/no-derived-repo governance model (ADR-0034 §2/§3) is **uncha
 | Pending changesets (by bump type) | _run the command in the right-hand column_                                             | `grep -h '^"awcms":' .changeset/*.md \| sort \| uniq -c`                                |
 | Commits since the last release    | _run the command in the right-hand column_                                             | `git rev-list --count v9.1.2..HEAD`                                                     |
 | Base modules                      | **24** (see the list in ARCHITECTURE.md)                                               | `src/modules/index.ts`                                                                  |
-| Migrations                        | **146** (`sql/001`–`146`)                                                              | `ls sql/`                                                                               |
+| Migrations                        | **147** (`sql/001`–`147`)                                                              | `ls sql/`                                                                               |
 | ADR                               | **0000**–**0112** (`0000` = template; highest ADR status: **Accepted**)                | `ls docs/adr/`                                                                          |
 | Admin screens                     | **48** `.astro` files in `src/pages/admin/`; **0 of 24** modules without `navigation:` | `find src/pages/admin -name '*.astro'`, `grep -L 'navigation:' src/modules/*/module.ts` |
 | `.astro` files                    | **61** (34.774 lines) — on typechecking see §6                                         | `find src -name '*.astro'`                                                              |
@@ -405,7 +405,10 @@ pioneered directly here after the ADR-0047 freeze.)
   `/disclimer.html` (the legacy typo is part of the URL). Three exact-path
   rules, which `awcms_seo_redirects` has supported since `sql/060` — admin data
   entry, not an importer and not a backfill. The column pair should be wired or
-  dropped; leaving it is what produced the appearance of coverage.
+  dropped; leaving it is what produced the appearance of coverage. **Dropped in
+  `sql/147`** — nothing had ever written it, so every row's value was NULL and
+  there was no data to lose; the test that asserted the migration's TEXT is
+  replaced by one that searches for a READER.
 
   The one covered shape is confirmed right: `berita/index.php:9` reads
   `(int) $_GET['news']`, so the id is the leading digits and the slug is

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -8,7 +8,7 @@
 | Aspect                              | Value |
 | ----------------------------------- | ----- |
 | Registered modules                  | 24    |
-| Migrations                          | 146   |
+| Migrations                          | 147   |
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
@@ -195,6 +195,7 @@
 | 144 | `sql/144_awcms_credential_epoch.sql`                               |
 | 145 | `sql/145_awcms_subject_actor_indexes.sql`                          |
 | 146 | `sql/146_awcms_identity_public_byline.sql`                         |
+| 147 | `sql/147_awcms_blog_pages_drop_legacy_provenance.sql`              |
 
 ### Tables & Row-Level Security
 

--- a/sql/147_awcms_blog_pages_drop_legacy_provenance.sql
+++ b/sql/147_awcms_blog_pages_drop_legacy_provenance.sql
@@ -1,0 +1,50 @@
+-- Issue #599 — remove the half of `sql/138` that nothing ever wrote or read.
+--
+-- `sql/138` gave BOTH `awcms_blog_posts` and `awcms_blog_pages` a
+-- `legacy_source_system`/`legacy_source_id` pair, on the reasoning that "a
+-- legacy archive has static pages too, and giving only posts provenance would
+-- make half the 301 map underivable". The posts half was then built:
+-- `blog:legacy:import` writes it and `listLegacyRedirectMappings` derives the
+-- redirect map from it. The pages half never was. No importer writes these two
+-- columns, no query reads them, and no code path anywhere in `src/`, `scripts/`
+-- or `tests/` mentions them.
+--
+-- ## Why they are dropped rather than wired
+--
+-- Reading the legacy site's actual `.htaccess` (SHAPE ROUND, 24 August 2026)
+-- settled the question these columns were speculating about. Its static-page
+-- rewrite is `^([^/]*)\.html$ -> /data/?halaman=$1`, and `data/index.php`
+-- switches on a CLOSED SET OF THREE: `tentang_kami`, `pedoman_media_cyber`,
+-- `disclimer`. Three URLs is three exact-path rules in `awcms_seo_redirects`,
+-- which has supported them since `sql/060` — admin data entry, not an importer
+-- and not a backfill. There is no volume here for a derived map to solve.
+--
+-- ## Why leaving them was not the cheap option
+--
+-- `tests/legacy-redirect-map.test.ts` asserted that the MIGRATION FILE'S TEXT
+-- contained `ALTER TABLE awcms_blog_pages` and the dedup index name, under the
+-- title "pages get the same treatment as posts". That reads as coverage. A test
+-- over a migration's source proves a column EXISTS; it cannot notice the column
+-- is never used, and this one sat next to a comment stating the stakes. So the
+-- dead pair was not inert — it was actively answering "is the static-page half
+-- handled?" with "yes".
+--
+-- ## Safety
+--
+-- Nothing has ever written these columns, so every row's value is NULL in every
+-- deployment; there is no data to lose and no backfill to plan. The posts
+-- columns, its index, and its CHECK are deliberately untouched — they are the
+-- live half.
+--
+-- If a future legacy source really does bring thousands of static pages, this
+-- comes back as its own migration alongside the importer that fills it, which
+-- is the order that would have avoided the problem the first time.
+
+ALTER TABLE awcms_blog_pages
+  DROP CONSTRAINT IF EXISTS awcms_blog_pages_legacy_provenance_check;
+
+DROP INDEX IF EXISTS awcms_blog_pages_legacy_source_dedup;
+
+ALTER TABLE awcms_blog_pages
+  DROP COLUMN IF EXISTS legacy_source_system,
+  DROP COLUMN IF EXISTS legacy_source_id;

--- a/tests/legacy-redirect-map.test.ts
+++ b/tests/legacy-redirect-map.test.ts
@@ -23,6 +23,7 @@ import { describe, expect, test } from "bun:test";
 import { stripComments } from "../scripts/access-chokepoint-check";
 
 const MIGRATION = "sql/138_awcms_blog_legacy_provenance.sql";
+const DROP_MIGRATION = "sql/147_awcms_blog_pages_drop_legacy_provenance.sql";
 const DIRECTORY = "src/modules/blog-content/application/blog-post-directory.ts";
 const CREATE_VALIDATION =
   "src/modules/blog-content/domain/blog-post-validation.ts";
@@ -51,13 +52,41 @@ describe("the columns make a second import impossible", () => {
     );
   });
 
-  test("pages get the same treatment as posts", async () => {
-    const sql = await readFile(MIGRATION, "utf8");
+  test("the pages half is DROPPED, and nothing reads it", async () => {
+    // `sql/138` gave pages the same pair on the reasoning that "a legacy
+    // archive has static pages too". Nothing ever wrote or read it. This test
+    // used to assert that the migration's TEXT contained
+    // `ALTER TABLE awcms_blog_pages` — which reads as coverage, and is not:
+    // a test over a migration's source proves a column exists, and cannot
+    // notice the column is dead.
+    //
+    // The real legacy `.htaccess` settled it: the static-page rewrite covers a
+    // CLOSED SET OF THREE urls, which is three hand-authored rules in
+    // `awcms_seo_redirects`, not an importer. `sql/147` drops the pair.
+    const drop = await readFile(DROP_MIGRATION, "utf8");
 
-    // A legacy archive has static pages too, and giving only posts provenance
-    // would make half the 301 map underivable for the same reason.
-    expect(sql).toContain("ALTER TABLE awcms_blog_pages");
-    expect(sql).toContain("awcms_blog_pages_legacy_source_dedup");
+    expect(drop).toContain("ALTER TABLE awcms_blog_pages");
+    expect(drop).toContain("DROP COLUMN IF EXISTS legacy_source_system");
+    expect(drop).toContain("DROP COLUMN IF EXISTS legacy_source_id");
+    expect(drop).toContain(
+      "DROP INDEX IF EXISTS awcms_blog_pages_legacy_source_dedup"
+    );
+
+    // The live half is untouched: dropping both would take the 301 map with it.
+    expect(drop).not.toContain("ALTER TABLE awcms_blog_posts");
+  });
+
+  test("no code reads the dropped columns off a page", async () => {
+    // The assertion the old test could not make. A column with no reader is
+    // how the pages half looked covered for as long as it did, so the guard
+    // against re-adding one is a search for a READER, not for a migration line.
+    const sources = await Promise.all(
+      [DIRECTORY, CREATE_VALIDATION].map((f) => readFile(f, "utf8"))
+    );
+
+    for (const source of sources) {
+      expect(stripComments(source)).not.toContain("awcms_blog_pages");
+    }
   });
 
   test("the id is text, not an integer", async () => {


### PR DESCRIPTION
Closes the loose end the SHAPE ROUND left on #599, with the disposition chosen deliberately rather than by default.

`sql/138` gave BOTH `awcms_blog_posts` and `awcms_blog_pages` a `legacy_source_system`/`legacy_source_id` pair, reasoning that *"a legacy archive has static pages too, and giving only posts provenance would make half the 301 map underivable"*. The posts half was then built — `blog:legacy:import` writes it and `listLegacyRedirectMappings` derives the redirect map from it. **The pages half never was:** no importer writes those two columns and no query reads them, anywhere in `src/`, `scripts/` or `tests/`.

## Why dropped rather than wired

Reading the legacy site's actual `.htaccess` settled the question they were speculating about. The static-page rewrite is `^([^/]*)\.html$ → /data/?halaman=$1`, and `data/index.php` switches on a **closed set of three**: `tentang_kami`, `pedoman_media_cyber`, `disclimer`. Three URLs is three exact-path rules in `awcms_seo_redirects`, supported since `sql/060` — admin data entry, not an importer and not a backfill. There is no volume here for a derived map to solve.

## Leaving them was not the cheap option

`tests/legacy-redirect-map.test.ts` asserted that the **migration file's text** contained `ALTER TABLE awcms_blog_pages` and the dedup index name, under the title *"pages get the same treatment as posts"*. That reads as coverage and is not: a test over a migration's source proves a column exists, and cannot notice the column is dead. So the pair was not inert — it was answering "is the static-page half handled?" with "yes".

That test is replaced by two: one pinning the drop, and one that searches for a **reader** — the assertion the old one could not make.

## Safety

Nothing has ever written these columns, so every row's value is NULL in every deployment. There is no data to lose and no backfill to plan. The posts columns, their index and their CHECK are untouched — they are the live half.

If a future legacy source really does bring thousands of static pages, this comes back as its own migration alongside the importer that fills it, which is the order that would have avoided the problem the first time.

## Verification

Full `bun run check` green — every gate, 6524 tests, and the build. Both generated artifacts (`repo-inventory.md`, `PROJECT_STATE.md` §2) regenerated rather than hand-edited, and the four documents citing the `sql/001`–`sql/NNN` range moved with the new migration, mirrors included.