### PR TITLE
feat(blog): the legacy importer files its articles, instead of landing 23,906 of them under nothing

### DIFF
--- a/.changeset/legacy-import-carries-its-categories.md
+++ b/.changeset/legacy-import-carries-its-categories.md
@@ -1,0 +1,49 @@
+---
+"awcms": minor
+---
+
+feat(blog): the legacy importer files its articles, instead of landing 23,906 of them under nothing
+
+`LegacyPostImportInput` carried no taxonomy and `importLegacyBlogPost` wrote no
+join row, so a real import landed EVERY article with zero categories. The defect
+is not visible where you would look for it: each article renders correctly and
+reads correctly. The symptom appears somewhere else — `/{locale}/kategori/{slug}`,
+the page each legacy rubrik URL is redirected to, loads and lists nothing.
+
+A crawler reads that as a **soft 404**, which is worse than the hard 404 this
+issue exists to prevent: nothing reports it, and no test that looks at an
+article would ever see it.
+
+**The same handoff as the images, deliberately** — it is the same operator doing
+the same kind of work twice:
+
+- `--terms=<path>` writes the category work list (every legacy category the
+  archive files under, most-used first) and stops.
+- `--term-map=<path>` takes it back as `{ "<legacy name>": "<term uuid>" }`.
+
+Every id is checked against this tenant's **live** taxonomy before a single
+article is written, and one that is not aborts the whole run — a map is one
+artefact, so a wrong id in it is a wrong artefact, not a per-row problem.
+Soft-deleted terms count as unknown: filing an archive under a category an
+editor removed would resurrect it in every listing without anybody choosing to.
+
+**Names are never turned into terms.** An importer that creates a term because a
+row mentioned one converts a single typo in a 23,906-row export into a published
+category nobody chose, with no review step where anyone would notice. A
+newsroom's taxonomy is an editorial decision, not a side effect of an import. A
+row naming a category the map does not cover is refused, exactly as a row with
+an unmanaged `<img>` is, and for the same reason: an article that imported
+cleanly and lost its filing looks like a success.
+
+Two smaller decisions that are easy to get wrong and hard to see afterwards:
+
+- A `categories` value that is a bare string is REFUSED rather than read as one
+  name — an export that later grows a second category would otherwise file a
+  day's articles under one called `Politik,Daerah`.
+- Filing happens in the SAME transaction as the insert, and only for a row this
+  run actually inserted. `ON CONFLICT DO NOTHING` leaves no post id for an
+  article that was already present, and re-filing it would DELETE whatever an
+  editor has since corrected by hand.
+
+Also adds `findUnknownTermIds`, which names the missing ids rather than counting
+them: "3 of 40 are unknown" sends an operator to diff two lists by eye.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 479   |
+| Test files                          | 480   |
 | Route files                         | 382   |
 | ADR                                 | 226   |
 
@@ -358,7 +358,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 400        |
+| `(root)`      | 401        |
 | `e2e`         | 17         |
 | `integration` | 61         |
 | `unit`        | 1          |

--- a/scripts/blog-legacy-import.ts
+++ b/scripts/blog-legacy-import.ts
@@ -65,6 +65,31 @@
  * A mapped image becomes a one-item `gallery` node in the position it occupied
  * in the article; an unmapped one is refused exactly as before.
  *
+ * ## The categories, and why they are the same handoff again
+ *
+ * `LegacyPostImportInput` carried no taxonomy and this job wrote no join row,
+ * so a real import landed every article with ZERO categories. The redirect map
+ * would then have pointed the legacy rubrik URLs at
+ * `/{locale}/kategori/{slug}` pages that resolve, load, and list nothing — a
+ * SOFT 404, which is worse for the ranking than the hard 404 this issue exists
+ * to prevent, because nothing reports it.
+ *
+ *   `--terms=<path>`      writes the category work list (every legacy category
+ *                         the archive files under, most-used first) and stops.
+ *                         Create the terms you want in `/admin/blog-taxonomy`.
+ *   `--term-map=<path>`   takes the result back as `{ "<name>": "<term uuid>" }`.
+ *                         Every id is checked against this tenant's LIVE
+ *                         taxonomy before a single article is written, and one
+ *                         that is not aborts the run.
+ *
+ * Names are never created from a row. An importer that creates a term because
+ * an export mentioned one turns a single typo into a published category nobody
+ * chose, with no review step where anyone would notice; a newsroom's taxonomy
+ * is an editorial decision, not a side effect of an import. A row naming a
+ * category the map does not cover is refused, for the same reason a row with an
+ * unmanaged `<img>` is: an article that imported cleanly and lost its filing
+ * looks like a success.
+ *
  * ## Roles and transactions
  *
  * Runs as the APP role, not `awcms_worker`. This creates content, which is an
@@ -97,6 +122,16 @@ import {
   findTakenSlugs,
   importLegacyBlogPost
 } from "../src/modules/blog-content/application/legacy-import-directory";
+import {
+  findUnknownTermIds,
+  syncPostTermAssignments
+} from "../src/modules/blog-content/application/blog-taxonomy-directory";
+import {
+  parseLegacyTermMap,
+  summariseLegacyCategoryUsage,
+  termIdsIn
+} from "../src/modules/blog-content/domain/legacy-term-map";
+import type { LegacyCategoryUsage } from "../src/modules/blog-content/domain/legacy-term-map";
 
 /** One transaction per batch — small enough to retry, large enough to be worth a round trip. */
 const BATCH_SIZE = 200;
@@ -124,6 +159,10 @@ function usage(message: string): void {
       "                       references, most-used first — and stop there\n" +
       '  --media-map=<path>   JSON { "<img src>": "<media object uuid>" }; every id is\n' +
       "                       checked against this tenant's registry before anything is written\n" +
+      "  --terms=<path>       write the category work list — every legacy category the\n" +
+      "                       archive files under, most-used first — and stop there\n" +
+      '  --term-map=<path>    JSON { "<legacy category name>": "<term uuid>" }; every id is\n' +
+      "                       checked against this tenant's taxonomy before anything is written\n" +
       "  --commit             write. Without it, nothing is written and you get the report.\n"
   );
   process.exitCode = 1;
@@ -156,6 +195,31 @@ async function writeImageInventory(
   );
 }
 
+/**
+ * The category work list, the other half of the same handoff.
+ *
+ * Written for the operator, and ordered by demand so that mapping the first
+ * twenty covers most of the archive and the long tail is visible as exactly
+ * what it costs.
+ */
+async function writeCategoryInventory(
+  path: string,
+  usage_: readonly LegacyCategoryUsage[]
+): Promise<void> {
+  await Bun.write(path, `${JSON.stringify(usage_, null, 2)}\n`);
+
+  console.log(
+    `\nblog:legacy:import — wrote the category work list to ${path}\n` +
+      `  distinct categories  ${usage_.length}\n\n` +
+      "  Create the terms you want in `/admin/blog-taxonomy` — deliberately not\n" +
+      "  here. A term created because a row mentioned one turns a typo in the\n" +
+      "  export into a published category nobody chose, with no review step\n" +
+      "  where anyone would notice. The taxonomy of a newsroom is an editorial\n" +
+      "  decision, not a side effect of an import.\n\n" +
+      "  Then hand the result back as --term-map=<path>.\n"
+  );
+}
+
 async function main(): Promise<void> {
   const commit = process.argv.includes("--commit");
   const file = flag("file");
@@ -165,6 +229,8 @@ async function main(): Promise<void> {
   const defaultLocale = flag("locale") ?? "id";
   const imagesPath = flag("images");
   const mediaMapPath = flag("media-map");
+  const termsPath = flag("terms");
+  const termMapPath = flag("term-map");
 
   if (!file) return usage("`--file=<path>` is required.");
   if (!tenantId) return usage("`--tenant=<uuid>` is required.");
@@ -183,6 +249,8 @@ async function main(): Promise<void> {
   const seenLegacyIds = new Set<string>();
   /** One entry per article, so `summariseLegacyImageUsage` can count articles rather than tags. */
   const imageSrcsPerArticle: string[][] = [];
+  /** Same, for categories — collected from EVERY parsed row, importable or not. */
+  const categoriesPerArticle: string[][] = [];
 
   const sql = getDatabaseClient();
   let imported = 0;
@@ -258,6 +326,64 @@ async function main(): Promise<void> {
       ? (src: string): string | null => mediaMap.get(src) ?? null
       : undefined;
 
+    let termMap: ReadonlyMap<string, string> = new Map();
+
+    if (termMapPath) {
+      let rawMap: unknown;
+      try {
+        rawMap = JSON.parse(await Bun.file(termMapPath).text());
+      } catch (error) {
+        console.error(
+          `blog:legacy:import — ${termMapPath} is not valid JSON: ${safeErrorDetail(error)}`
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      const parsedMap = parseLegacyTermMap(rawMap);
+
+      if (!parsedMap.ok) {
+        console.error(
+          `blog:legacy:import — ${termMapPath} is not a usable term map:\n` +
+            parsedMap.errors.map((line) => `  - ${line}`).join("\n")
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      // Every id, against this tenant's taxonomy, BEFORE a single article is
+      // written — and one bad id stops the run rather than becoming a per-row
+      // refusal. A map is ONE artefact: a wrong id in it is a wrong artefact,
+      // and the failure it produces is silent in the worst way. `INSERT` into
+      // `awcms_blog_post_terms` with a term another tenant owns is refused by
+      // the composite foreign key, but a term id that is merely SOFT-DELETED
+      // here would file the whole archive under a category an editor removed
+      // and resurrect it in every listing.
+      const ids = termIdsIn(parsedMap.value);
+      const unknown = await withTenantOrThrow(sql, tenantId, (tx) =>
+        findUnknownTermIds(tx, tenantId, ids)
+      );
+
+      if (unknown.length > 0) {
+        console.error(
+          `blog:legacy:import — ${unknown.length} of ${ids.length} term id(s) in ` +
+            `${termMapPath} are not live terms of this tenant:\n` +
+            unknown.map((id) => `  - ${id}`).join("\n") +
+            "\n\n  Nothing was written. Create the terms in `/admin/blog-taxonomy`\n" +
+            "  first — this job will not create one from a name, because a typo\n" +
+            "  in the export would then become a published category nobody chose.\n"
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      console.log(
+        `blog:legacy:import — ${ids.length} term id(s) verified against this tenant's taxonomy.`
+      );
+
+      termMap = parsedMap.value;
+    }
+
     for (const [index, raw] of lines.entries()) {
       const lineNumber = index + 1;
       const trimmed = raw.trim();
@@ -303,6 +429,34 @@ async function main(): Promise<void> {
       }
       seenLegacyIds.add(record.value.legacyId);
 
+      // Collected before any refusal below, for the same reason the image set
+      // is: the work list belongs to the whole archive, and an article refused
+      // for a bad slug still names a category somebody has to map.
+      categoriesPerArticle.push([...record.value.categories]);
+
+      // A category this run cannot resolve is refused, not dropped. Importing
+      // past it produces an article that landed cleanly, reported nothing, and
+      // is filed under nothing — and `/{locale}/kategori/{slug}` then answers a
+      // crawler with a page that loads and lists nothing, which is read as a
+      // soft 404. That is the failure this whole issue exists to prevent,
+      // arriving through the door built to prevent it.
+      const unmapped = record.value.categories.filter(
+        (name) => !termMap.has(name)
+      );
+
+      if (unmapped.length > 0) {
+        refusals.push({
+          line: lineNumber,
+          legacyId: record.value.legacyId,
+          reasons: unmapped.map((name) =>
+            termMapPath
+              ? `category ${JSON.stringify(name)} is not in ${termMapPath}`
+              : `category ${JSON.stringify(name)} needs a --term-map (run --terms=<path> to get the work list)`
+          )
+        });
+        continue;
+      }
+
       const body = convertLegacyHtmlToPortableText(record.value.bodyHtml, {
         resolveImage
       });
@@ -333,6 +487,16 @@ async function main(): Promise<void> {
       acceptedBodies.set(record.value.legacyId, body);
     }
 
+    if (termsPath) {
+      // Before `--images`, because the two are independent and an operator who
+      // asked for both should get both files rather than discovering the order
+      // matters.
+      await writeCategoryInventory(
+        termsPath,
+        summariseLegacyCategoryUsage(categoriesPerArticle)
+      );
+    }
+
     if (imagesPath) {
       // A report, not a run. Writing the upload set and then importing would
       // invite reading the summary and skipping the list it just produced.
@@ -340,8 +504,9 @@ async function main(): Promise<void> {
         imagesPath,
         summariseLegacyImageUsage(imageSrcsPerArticle)
       );
-      return;
     }
+
+    if (termsPath || imagesPath) return;
 
     // One query for every slug in the file, before anything is written.
     const taken = await withTenantOrThrow(sql, tenantId, (tx) =>
@@ -393,8 +558,28 @@ async function main(): Promise<void> {
               }
             );
 
-            if (outcome.postId) imported += 1;
-            else alreadyPresent += 1;
+            if (outcome.postId) {
+              imported += 1;
+
+              // Same transaction as the INSERT. An article that committed and
+              // then failed to be filed is exactly the empty-category outcome
+              // this flag exists to prevent, and it would be invisible: the
+              // import reports success and the archive listing is short.
+              //
+              // Only for a row this run actually inserted — `ON CONFLICT DO
+              // NOTHING` means `postId` is null when the article was already
+              // present, and re-running would otherwise DELETE the filings an
+              // editor has since corrected by hand (`syncPostTermAssignments`
+              // replaces the set rather than adding to it).
+              if (record.categories.length > 0) {
+                await syncPostTermAssignments(
+                  tx,
+                  tenantId,
+                  outcome.postId,
+                  record.categories.map((name) => termMap.get(name)!)
+                );
+              }
+            } else alreadyPresent += 1;
           }
         });
 

--- a/src/modules/blog-content/application/blog-taxonomy-directory.ts
+++ b/src/modules/blog-content/application/blog-taxonomy-directory.ts
@@ -432,6 +432,36 @@ export async function fetchPostTermIdsForPosts(
 }
 
 /** Used before `syncPostTermAssignments` to reject a `termIds` list containing an id that doesn't exist (or belongs to another tenant, or is soft-deleted) — a bare FK violation would otherwise surface as a raw 500. */
+/**
+ * Which of these term ids this tenant does NOT have (Issue #599).
+ *
+ * `countExistingTerms` answers "how many", which is the right shape for a
+ * create/update guard rejecting one bad request. It is the wrong shape for an
+ * operator holding a hand-built `--term-map`: "3 of 40 are unknown" sends them
+ * to diff two lists by eye. This names them.
+ *
+ * Soft-deleted terms count as unknown, matching `countExistingTerms`: filing
+ * 23,906 articles under a category an editor deleted would resurrect it in
+ * every archive listing without anybody choosing to.
+ */
+export async function findUnknownTermIds(
+  tx: Bun.SQL,
+  tenantId: string,
+  termIds: readonly string[]
+): Promise<string[]> {
+  if (termIds.length === 0) {
+    return [];
+  }
+
+  const rows = (await tx`
+    SELECT id FROM awcms_blog_terms
+    WHERE tenant_id = ${tenantId} AND deleted_at IS NULL AND id = ANY(${tx.array([...termIds], "uuid")})
+  `) as { id: string }[];
+
+  const known = new Set(rows.map((row) => row.id));
+  return [...new Set(termIds)].filter((id) => !known.has(id));
+}
+
 export async function countExistingTerms(
   tx: Bun.SQL,
   tenantId: string,

--- a/src/modules/blog-content/domain/legacy-import-record.ts
+++ b/src/modules/blog-content/domain/legacy-import-record.ts
@@ -56,6 +56,15 @@ export type LegacyImportRecord = {
   publishedAt: Date | null;
   seoTitle: string | null;
   metaDescription: string | null;
+  /**
+   * Legacy category names, EXACTLY as the old system spelled them. Resolved to
+   * this tenant's terms through `--term-map`; never created from a name.
+   *
+   * Empty is legitimate — an archive may genuinely file nothing — which is why
+   * the importer refuses only a name it was given no mapping for, rather than
+   * demanding every row carry one.
+   */
+  categories: readonly string[];
 };
 
 export type LegacyImportRecordResult =
@@ -152,6 +161,28 @@ export function parseLegacyImportRecord(
     errors.push("publishedAt is required when status is 'published'");
   }
 
+  // Absent is fine and means "files under nothing". A PRESENT field that is not
+  // a list of names is refused rather than coerced: a single string here almost
+  // certainly means the export writes one category per row and someone will
+  // later add a second, and silently reading it as one name would file every
+  // article of that day under a category called `Politik,Daerah`.
+  const categories: string[] = [];
+  if (record.categories !== undefined && record.categories !== null) {
+    if (!Array.isArray(record.categories)) {
+      errors.push("categories must be an array of category names");
+    } else {
+      for (const entry of record.categories) {
+        if (typeof entry !== "string" || entry.trim().length === 0) {
+          errors.push(
+            `categories contains ${JSON.stringify(entry)}, which is not a category name`
+          );
+          continue;
+        }
+        categories.push(entry.trim());
+      }
+    }
+  }
+
   if (errors.length > 0) {
     return { ok: false, errors };
   }
@@ -169,7 +200,11 @@ export function parseLegacyImportRecord(
       visibility: visibilityRaw as BlogContentVisibility,
       publishedAt,
       seoTitle: optionalText(record.seoTitle, MAX_LEGACY_TITLE_LENGTH),
-      metaDescription: optionalText(record.metaDescription, 1000)
+      metaDescription: optionalText(record.metaDescription, 1000),
+      // Deduplicated here rather than at assignment time: a legacy row listing
+      // the same rubrik twice is one filing, and `syncPostTermAssignments`
+      // would otherwise try to insert the pair twice.
+      categories: [...new Set(categories)]
     }
   };
 }

--- a/src/modules/blog-content/domain/legacy-term-map.ts
+++ b/src/modules/blog-content/domain/legacy-term-map.ts
@@ -1,0 +1,126 @@
+/**
+ * The `--term-map` handoff for `blog:legacy:import` (Issue #599).
+ *
+ * ## Why an archive needs this at all
+ *
+ * `LegacyPostImportInput` carried no taxonomy, and `importLegacyBlogPost`
+ * touches no join table. So a real import landed every article with ZERO
+ * categories — 23,906 of them — and the category archives
+ * (`/{locale}/kategori/{slug}`, rendered by `ahliweb/awcms-astro`) came back
+ * empty. That is worse than the failure this issue exists to prevent: the
+ * legacy rubrik URLs would have been redirected onto pages that resolve, load,
+ * and list nothing, which a crawler reads as a soft 404 rather than as the
+ * moved-permanently it was promised.
+ *
+ * ## Why a map rather than ids in the rows, or names created on sight
+ *
+ * The same shape as `legacy-media-map.ts`, deliberately, because the operator
+ * is the same person doing the same kind of work twice:
+ *
+ * - **Not ids in each NDJSON row.** That pushes the name-to-uuid decision into
+ *   whatever script produced the export, where no gate here can see it, and
+ *   repeats it 23,906 times instead of stating it once.
+ * - **Not names created on sight.** An importer that creates a term because a
+ *   row mentioned one turns a single typo in an export into a category nobody
+ *   chose, published, with no review step where anyone would notice. The
+ *   taxonomy of a newsroom is an editorial decision, not a side effect of an
+ *   import.
+ *
+ * So: the rows carry the legacy category NAME exactly as the old system spelled
+ * it, and one map says what each name means here. `--terms=<path>` writes that
+ * work list; `--term-map=<path>` takes it back.
+ *
+ * Matching is literal, for the reason `legacy-media-map.ts` gives about `src`:
+ * normalising a name (case, spacing, an ampersand) would silently decide that
+ * two rubrics are the same one, and a WRONG match here files articles under a
+ * category the newsroom did not choose — which reads as correct.
+ */
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export type LegacyTermMapResult =
+  | { ok: true; value: ReadonlyMap<string, string> }
+  | { ok: false; errors: string[] };
+
+/** Every distinct term id the map names, for one round trip to the taxonomy. */
+export function termIdsIn(map: ReadonlyMap<string, string>): readonly string[] {
+  return [...new Set(map.values())];
+}
+
+/**
+ * Validates a parsed `--term-map` document.
+ *
+ * A flat `{ "<legacy category name>": "<term uuid>" }` object, because that is
+ * what an operator can produce from a spreadsheet without a schema.
+ *
+ * Every problem is reported, not just the first: an operator fixing a file one
+ * error per run is an operator who gives up.
+ */
+export function parseLegacyTermMap(raw: unknown): LegacyTermMapResult {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    return {
+      ok: false,
+      errors: [
+        'the term map must be a JSON object of { "<legacy category name>": "<term uuid>" }'
+      ]
+    };
+  }
+
+  const errors: string[] = [];
+  const value = new Map<string, string>();
+
+  for (const [name, termId] of Object.entries(raw as Record<string, unknown>)) {
+    if (name.trim().length === 0) {
+      errors.push("an entry has an empty category-name key");
+      continue;
+    }
+
+    if (typeof termId !== "string" || !UUID_PATTERN.test(termId)) {
+      errors.push(
+        `"${name}" maps to ${JSON.stringify(termId)}, which is not a term uuid`
+      );
+      continue;
+    }
+
+    value.set(name, termId);
+  }
+
+  if (errors.length > 0) {
+    return { ok: false, errors };
+  }
+
+  return { ok: true, value };
+}
+
+export type LegacyCategoryUsage = {
+  name: string;
+  /** How many articles in the file are filed under it. */
+  articles: number;
+};
+
+/**
+ * The work list: every category name the archive uses, most-used first.
+ *
+ * Ordering by demand is the point — it puts the categories that carry the
+ * archive at the top, so an operator who maps the first twenty has covered most
+ * of it and can see exactly what the long tail costs.
+ */
+export function summariseLegacyCategoryUsage(
+  namesPerArticle: readonly (readonly string[])[]
+): LegacyCategoryUsage[] {
+  const counts = new Map<string, number>();
+
+  for (const names of namesPerArticle) {
+    // One article filed under the same category twice is one article; the count
+    // exists to order the list, not to total the mentions.
+    for (const name of new Set(names)) {
+      if (name.trim().length === 0) continue;
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
+  }
+
+  return [...counts.entries()]
+    .map(([name, articles]) => ({ name, articles }))
+    .sort((a, b) => b.articles - a.articles || a.name.localeCompare(b.name));
+}

--- a/tests/blog-legacy-import.test.ts
+++ b/tests/blog-legacy-import.test.ts
@@ -313,3 +313,89 @@ describe("the redirect map lands in ONE hop", () => {
     expect(source).toContain("statusCode: 301");
   });
 });
+
+describe("categories: the archive is filed, or it is refused", () => {
+  test("absent categories parse as none — an archive may file nothing", () => {
+    const result = parseLegacyImportRecord(record(), DEFAULTS);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.categories).toEqual([]);
+  });
+
+  test("a category listed twice on one row is one filing", () => {
+    const result = parseLegacyImportRecord(
+      record({ categories: ["Daerah", "Daerah"] }),
+      DEFAULTS
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // `syncPostTermAssignments` would otherwise insert the same pair twice.
+    expect(result.value.categories).toEqual(["Daerah"]);
+  });
+
+  test("a bare string is REFUSED, not read as one name", () => {
+    const result = parseLegacyImportRecord(
+      record({ categories: "Politik,Daerah" }),
+      DEFAULTS
+    );
+
+    // Coercing this would file every article of that day under a category
+    // literally called `Politik,Daerah`.
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join(" ")).toContain("array of category names");
+  });
+
+  test("a non-name entry is named in the error", () => {
+    const result = parseLegacyImportRecord(
+      record({ categories: ["Daerah", 7] }),
+      DEFAULTS
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.join(" ")).toContain("7");
+  });
+});
+
+describe("the term map is verified as ONE artefact, before anything is written", () => {
+  test("a name is never turned into a term", async () => {
+    const source = stripComments(await readFile(IMPORT_SCRIPT, "utf8"));
+
+    // An importer that creates a term because a row mentioned one turns a typo
+    // in a 23,906-row export into a published category nobody chose.
+    expect(source).not.toContain("createBlogTerm");
+  });
+
+  test("every id is checked against the tenant's LIVE taxonomy, and a bad one stops the run", async () => {
+    const source = stripComments(await readFile(IMPORT_SCRIPT, "utf8"));
+
+    expect(source).toContain("findUnknownTermIds");
+    // Not a per-row refusal: a map is one artefact, and a wrong id in it is a
+    // wrong artefact.
+    const gate = source.slice(source.indexOf("findUnknownTermIds"));
+    expect(gate).toContain("process.exitCode = 1");
+  });
+
+  test("an unmapped category refuses the row rather than importing it unfiled", async () => {
+    const source = stripComments(await readFile(IMPORT_SCRIPT, "utf8"));
+
+    // An article that imported cleanly and lost its filing looks like a
+    // success, and the category archive it belongs in answers a crawler with a
+    // page that loads and lists nothing — a soft 404.
+    expect(source).toContain("(name) => !termMap.has(name)");
+  });
+
+  test("filing happens in the SAME transaction as the insert", async () => {
+    const source = stripComments(await readFile(IMPORT_SCRIPT, "utf8"));
+
+    const commitBlock = source.slice(source.indexOf("if (commit)"));
+    expect(commitBlock).toContain("syncPostTermAssignments");
+    // Only for a row this run inserted: `ON CONFLICT DO NOTHING` leaves
+    // `postId` null for an article already present, and re-filing it would
+    // DELETE whatever an editor has since corrected by hand.
+    expect(commitBlock).toContain("if (outcome.postId)");
+  });
+});

--- a/tests/legacy-term-map.test.ts
+++ b/tests/legacy-term-map.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The legacy category handoff (Issue #599).
+ *
+ * ## What is at risk
+ *
+ * An article that imports with no category is not a broken-looking article. It
+ * renders, it reads correctly, and the only visible symptom is somewhere else
+ * entirely: `/{locale}/kategori/{slug}`, the page the legacy rubrik URL is
+ * redirected to, loads and lists nothing. A crawler reads that as a SOFT 404 —
+ * worse than the hard 404 this issue exists to prevent, because nothing reports
+ * it and no test that looks at an article would ever see it.
+ *
+ * So the properties pinned here are about REFUSING and about NOT INVENTING:
+ *
+ * 1. A map that is not a flat `{ name: uuid }` object is refused as a whole.
+ * 2. Every problem in it is reported, not just the first.
+ * 3. Names are matched LITERALLY — no case folding, no trimming of interior
+ *    space — because a wrong match files articles under a category the newsroom
+ *    did not choose, and that reads as correct.
+ *
+ * The taxonomy check itself is not here: "is this a live term of this tenant"
+ * is `findUnknownTermIds`, which needs a database.
+ *
+ * Pure — no database.
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  parseLegacyTermMap,
+  summariseLegacyCategoryUsage,
+  termIdsIn
+} from "../src/modules/blog-content/domain/legacy-term-map";
+
+const TERM_A = "11111111-1111-4111-8111-111111111111";
+const TERM_B = "22222222-2222-4222-8222-222222222222";
+
+describe("parsing a term map", () => {
+  test("a flat name -> uuid object parses", () => {
+    const result = parseLegacyTermMap({ Daerah: TERM_A, Politik: TERM_B });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.get("Daerah")).toBe(TERM_A);
+    expect(result.value.size).toBe(2);
+  });
+
+  test("an array is refused as a whole", () => {
+    const result = parseLegacyTermMap([{ Daerah: TERM_A }]);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors[0]).toContain("must be a JSON object");
+  });
+
+  test("every bad entry is reported, not just the first", () => {
+    const result = parseLegacyTermMap({
+      Daerah: "not-a-uuid",
+      Politik: 7,
+      Olahraga: TERM_A
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    // An operator fixing a file one error per run is an operator who gives up.
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors.join(" ")).toContain("Daerah");
+    expect(result.errors.join(" ")).toContain("Politik");
+  });
+
+  test("an empty name key is refused", () => {
+    const result = parseLegacyTermMap({ "   ": TERM_A });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors[0]).toContain("empty category-name key");
+  });
+
+  test("names are matched LITERALLY — case and spacing are not normalised", () => {
+    const result = parseLegacyTermMap({ "Daerah ": TERM_A, daerah: TERM_B });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Three distinct legacy spellings are three distinct decisions for the
+    // operator to make. Folding them here would silently decide that two
+    // rubrics are the same one.
+    expect(result.value.get("Daerah ")).toBe(TERM_A);
+    expect(result.value.get("daerah")).toBe(TERM_B);
+    expect(result.value.get("Daerah")).toBeUndefined();
+  });
+
+  test("distinct ids are collapsed for one round trip", () => {
+    const result = parseLegacyTermMap({
+      Daerah: TERM_A,
+      Politik: TERM_A,
+      Olahraga: TERM_B
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect([...termIdsIn(result.value)].sort()).toEqual([TERM_A, TERM_B]);
+  });
+});
+
+describe("the category work list", () => {
+  test("counts ARTICLES, most-used first", () => {
+    const usage = summariseLegacyCategoryUsage([
+      ["Daerah", "Politik"],
+      ["Daerah"],
+      ["Daerah"],
+      ["Politik"]
+    ]);
+
+    expect(usage).toEqual([
+      { name: "Daerah", articles: 3 },
+      { name: "Politik", articles: 2 }
+    ]);
+  });
+
+  test("one article filed under the same category twice counts once", () => {
+    const usage = summariseLegacyCategoryUsage([["Daerah", "Daerah"]]);
+
+    // The count exists to ORDER the list, not to total the mentions.
+    expect(usage).toEqual([{ name: "Daerah", articles: 1 }]);
+  });
+
+  test("ties break by name, so the list is stable to diff", () => {
+    const usage = summariseLegacyCategoryUsage([["Zeta"], ["Alpha"]]);
+
+    expect(usage.map((entry) => entry.name)).toEqual(["Alpha", "Zeta"]);
+  });
+
+  test("blank names never reach the work list", () => {
+    const usage = summariseLegacyCategoryUsage([["   ", "Daerah"]]);
+
+    expect(usage).toEqual([{ name: "Daerah", articles: 1 }]);
+  });
+});


### PR DESCRIPTION
`LegacyPostImportInput` carried no taxonomy and `importLegacyBlogPost` wrote no join row, so a real import landed **every** article with zero categories.

## Why this would not have been caught

The defect is not visible where you would look for it. Each article renders correctly and reads correctly. The symptom appears somewhere else entirely: `/{locale}/kategori/{slug}` — the page each legacy rubrik URL is redirected to — loads and lists nothing.

A crawler reads that as a **soft 404**, which is worse than the hard 404 #599 exists to prevent: nothing reports it, and no test that looks at an article would ever see it.

## The same handoff as the images, deliberately

It is the same operator doing the same kind of work twice, so it is the same shape:

| Flag | What it does |
| --- | --- |
| `--terms=<path>` | Writes the category work list — every legacy category the archive files under, most-used first — and stops |
| `--term-map=<path>` | Takes it back as `{ "<legacy name>": "<term uuid>" }` |

Every id is checked against this tenant's **live** taxonomy before a single article is written, and one that is not aborts the whole run. A map is one artefact, so a wrong id in it is a wrong artefact — not a per-row problem. Soft-deleted terms count as unknown: filing an archive under a category an editor removed would resurrect it in every listing without anybody choosing to.

## Names are never turned into terms

An importer that creates a term because a row mentioned one converts a single typo in a 23,906-row export into a published category nobody chose, with no review step where anyone would notice. A newsroom's taxonomy is an editorial decision, not a side effect of an import.

A row naming a category the map does not cover is **refused**, exactly as a row with an unmanaged `<img>` is, and for the same reason: an article that imported cleanly and lost its filing looks like a success.

## Two smaller decisions that are hard to see afterwards

- A `categories` value that is a bare string is **refused** rather than read as one name. An export that later grows a second category would otherwise file a day's articles under one called `Politik,Daerah`.
- Filing happens in the **same transaction** as the insert, and only for a row this run actually inserted. `ON CONFLICT DO NOTHING` leaves no post id for an article that was already present, and re-filing it would `DELETE` whatever an editor has since corrected by hand — `syncPostTermAssignments` replaces the set rather than adding to it.

Also adds `findUnknownTermIds`, which **names** the missing ids rather than counting them: "3 of 40 are unknown" sends an operator to diff two lists by eye.

## Verification

Full `bun run check` green — every gate, **6542** tests (14 new, pure), the build. The taxonomy check itself needs a database and is exercised where that lives.