### PR TITLE
perf(blog): filing a post costs two queries instead of one per term, and a write path finally has a budget

### DIFF
--- a/.changeset/post-term-assignment-is-one-round-trip.md
+++ b/.changeset/post-term-assignment-is-one-round-trip.md
@@ -1,0 +1,42 @@
+---
+"awcms": patch
+---
+
+perf(blog): filing a post costs two queries instead of one per term, and a write path finally has a budget
+
+`syncPostTermAssignments` issued one `INSERT` PER TERM. Per save that is a small
+constant — an article carries a handful of terms — which is why it stood for as
+long as it did. It stopped being a small constant when a bulk importer became
+the caller: `blog:legacy:import` now files every article it inserts, so a
+23,906-row archive turned this into roughly 24,000 `DELETE`s and 48,000
+`INSERT`s inside batched transactions, where two statements per article will do.
+
+Now one `DELETE` and one `INSERT ... unnest`, the shape `comment-retention.ts`
+and `announcement-directory.ts` already use.
+
+**Deliberately NOT deduplicated on the way in.** `awcms_blog_post_terms_unique`
+refused a repeated `(post, term)` pair before this change and still does. A
+caller passing the same term twice has a bug, and swallowing it here would turn
+a loud constraint error into a silent difference between what was asked for and
+what was stored.
+
+**The finding behind it is worth more than the fix.** This repo has four query
+budget suites — public reads, admin reads, the sitemap builder, the middleware —
+and all four measure READS. Every N+1 a full scan of `src/` turns up is on a
+write path or in a job. That is not an oversight so much as where attention
+goes: a read path is hit constantly so its cost is felt, and a write path is hit
+once per save so a per-item query inside it looks like nothing.
+
+So this adds `tests/integration/post-term-assignment-budget.integration.test.ts`
+— the first query budget on a write path. The budget is EXACT (2), not a
+ceiling, because the property being pinned is that the number does not move with
+the number of terms; a `toBeLessThanOrEqual` would pass a per-term regression as
+long as the fixture stayed small. The fixture assigns twelve, so the old shape
+cannot pass by accident, and every case asserts the rows that actually landed
+beside the count — a budget on its own is satisfied by a function that writes
+nothing.
+
+The remaining findings from the same scan (nine lower-amplification write paths,
+a per-post fetch inside the scheduled-publish sweep, and a low-cardinality index
+on `awcms_blog_post_terms`) are recorded in `PROJECT_STATE.md` §4 rather than
+changed here, so they do not have to be re-derived.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:d0d80cd9cd50843b048b769291da2f7782057a1c7567c63a011efea2e4113801 -->
+<!-- i18n-source-hash: sha256:3ea30d883dca13d217a9db596dfe8b488bfe5be0256808d24573aa7400e01a55 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,62 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN PERFORMA — 24 Agustus 2026: seluruh anggaran query mengukur
+  PEMBACAAN. Setiap N+1 di repo ada di jalur TULIS atau di job — paruh yang
+  tak dihitung siapa pun.**
+
+  Metode: pemindaian setiap berkas `src/` untuk query yang diterbitkan DI DALAM
+  loop, lalu disilangkan dengan apa yang benar-benar dicakup keempat suite
+  anggaran (`query-budget`, `query-budget-admin`, `middleware-query-budget`, dan
+  pembangun sitemap). Keempatnya mengukur pembacaan. Itu bukan kelalaian
+  melainkan ke mana perhatian tertuju: jalur baca dipukul terus-menerus sehingga
+  biayanya terasa; jalur tulis dipukul sekali per penyimpanan, jadi query
+  per-item di dalamnya tampak bukan apa-apa.
+
+  Ia berhenti tampak bukan apa-apa begitu importer massal menjadi pemanggilnya.
+
+  **DIPERBAIKI — `syncPostTermAssignments` menerbitkan satu `INSERT` per term.**
+  Segelintir statement saat editor menyimpan artikel; sekitar 24rb `DELETE` dan
+  48rb `INSERT` saat `blog:legacy:import` mengarsipkan 23.906 artikel — pemanggil
+  nyata yang baru dibuat #708. Kini satu `DELETE` + satu `INSERT ... unnest`,
+  bentuk yang sudah dipakai `comment-retention.ts` dan
+  `announcement-directory.ts`. TIDAK dideduplikasi di jalan masuk:
+  `awcms_blog_post_terms_unique` menolak pasangan berulang dulu dan sekarang,
+  dan menelannya di sini akan mengubah error constraint yang NYARING menjadi
+  selisih SENYAP antara yang diminta dan yang tersimpan.
+
+  Dipatok `tests/integration/post-term-assignment-budget.integration.test.ts` —
+  **anggaran query PERTAMA pada jalur tulis**. Anggarannya PERSIS (2), bukan
+  plafon: propertinya adalah angkanya TIDAK bergerak mengikuti jumlah term, dan
+  `toBeLessThanOrEqual` akan meloloskan regresi per-term selama fixture-nya tetap
+  kecil. Fixture memasang 12, jadi bentuk lama tak bisa lolos kebetulan.
+  Kebenaran di-assert BERSEBELAHAN dengan tiap hitungan, karena anggaran sendirian
+  dipuaskan oleh fungsi yang tidak menulis apa pun.
+
+  **TIDAK diperbaiki, dicatat agar tak diturunkan ulang:**
+
+  - **Sembilan jalur tulis lain menyisipkan satu baris per item di dalam loop** —
+    item menu, penempatan iklan, institusi, template email, penulis kebijakan
+    ABAC, undangan, konfigurasi sidebar, push enqueue, `sync/push`. Masing-masing
+    dibatasi oleh apa yang dikirim SATU permintaan, jadi konstanta kecil, bukan
+    risiko penskalaan. Layak di-batch bila himpunannya dikendalikan pengguna;
+    tidak mendesak.
+  - **`blog-scheduled-publish` memanggil `fetchPostTermIds` per-post di dalam loop
+    sapuannya.** Dibatasi berapa post jatuh tempo dalam satu sapuan — yang saat
+    cutover tidak kecil. Kembaran ter-batch `fetchPostTermIdsForPosts` sudah ada.
+  - **`awcms_blog_post_terms_tenant_idx` adalah satu kolom berkardinalitas rendah.**
+    Arsip kategori — permukaan yang dinyatakan nyata oleh #708 — memfilter
+    `term_id` di bawah predikat `tenant_id` milik RLS; `(term_id)` melayaninya dan
+    komposit `(tenant_id, term_id)` akan melayani keduanya, membuat index
+    satu-kolom itu mubazir. Butuh `EXPLAIN` terhadap data nyata untuk membenarkan
+    biaya tulisnya, jadi ini tugas PENGUKURAN, bukan perubahan.
+
+  **Yang TIDAK ditemukan pemindaian, dan itulah paruh berguna dari hasil bersih:**
+  tak ada pembacaan publik tanpa batas, dan tak ada N+1 di jalur daftar publik.
+  Sisi baca dari relasi yang sama ini SUDAH diperbaiki dengan sengaja —
+  `fetchPostTermIdsForPosts` membawa komentar "tiga round trip per halaman, bukan
+  lima puluh satu". Sisi tulisnya sekadar tak ada yang menghitung.
 
 - **PUTARAN BENTUK — 24 Agustus 2026: `.htaccess` legacy yang ditunggu #599 ADA
   di mesin pengembangan, dan ia MEMBANTAH rencana yang disusun tanpanya. Lima

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,62 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **PERFORMANCE ROUND — 24 August 2026: the query budgets all measure READS.
+  Every N+1 in the repo is on a WRITE path or in a job — the half nothing
+  counts.**
+
+  Method: a scan of every `src/` file for a query issued inside a loop, then
+  cross-referenced against what the four budget suites actually cover
+  (`query-budget`, `query-budget-admin`, `middleware-query-budget`, and the
+  sitemap builder). All four measure reads. That is not an oversight so much as
+  where the attention went: a read path is hit constantly, so its cost is felt;
+  a write path is hit once per save, so a per-item query inside it looks like
+  nothing.
+
+  It stops looking like nothing the moment a bulk importer becomes the caller.
+
+  **FIXED — `syncPostTermAssignments` issued one `INSERT` per term.** A handful
+  of statements when an editor saves an article; roughly 24k `DELETE`s and 48k
+  `INSERT`s when `blog:legacy:import` files a 23,906-article archive, which
+  #708 made a real caller. Now one `DELETE` + one `INSERT ... unnest`, the shape
+  `comment-retention.ts` and `announcement-directory.ts` already use. NOT
+  deduplicated on the way in: `awcms_blog_post_terms_unique` refused a repeated
+  pair before and still does, and swallowing it here would turn a loud
+  constraint error into a silent difference between what was asked for and what
+  was stored.
+
+  Pinned by `tests/integration/post-term-assignment-budget.integration.test.ts`
+  — **the first query budget on a write path**. The budget is EXACT (2), not a
+  ceiling: the property is that the number does not move with the number of
+  terms, and a `toBeLessThanOrEqual` would pass a per-term regression as long as
+  the fixture stayed small. The fixture assigns 12, so the old shape cannot pass
+  by accident. Correctness is asserted beside every count, because a budget on
+  its own is satisfied by a function that writes nothing.
+
+  **NOT fixed, recorded so they are not re-derived:**
+
+  - **Nine more write paths insert one row per item in a loop** — menu items,
+    ad placements, institutions, email templates, the ABAC policy writer,
+    invitations, sidebar config, push enqueue, `sync/push`. Each is bounded by
+    what ONE request submits, so each is a small constant rather than a scaling
+    risk. Worth batching where the set is user-controlled; not urgent.
+  - **`blog-scheduled-publish` calls the per-post `fetchPostTermIds` inside its
+    sweep loop.** Bounded by how many posts are due in one sweep — which at a
+    cutover is not small. `fetchPostTermIdsForPosts` is the batched twin and
+    already exists.
+  - **`awcms_blog_post_terms_tenant_idx` is a single low-cardinality column.**
+    The category archive — the surface #708 makes real — filters `term_id`
+    under RLS's `tenant_id` predicate; `(term_id)` serves it and a composite
+    `(tenant_id, term_id)` would serve both, making the single-column index
+    redundant. Needs `EXPLAIN` against real data to justify the write cost, so
+    it is a measurement task, not a change.
+
+  **What the scan did NOT find, which is the useful half of a clean result:** no
+  unbounded public read, and no N+1 in the public list path. The read side of
+  this very relationship was fixed deliberately — `fetchPostTermIdsForPosts`
+  carries the comment "three round trips per page, not fifty-one". The write
+  side simply had nobody counting.
+
 - **SHAPE ROUND — 24 August 2026: the legacy `.htaccess` #599 was waiting for
   exists on the development machine, and it contradicts the plan built without
   it. Five URL shapes, not two; one of them was never listed; and the static-page

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 480   |
+| Test files                          | 481   |
 | Route files                         | 382   |
 | ADR                                 | 226   |
 
@@ -360,7 +360,7 @@
 | ------------- | ---------- |
 | `(root)`      | 401        |
 | `e2e`         | 17         |
-| `integration` | 61         |
+| `integration` | 62         |
 | `unit`        | 1          |
 
 ### Routes

--- a/src/modules/blog-content/application/blog-taxonomy-directory.ts
+++ b/src/modules/blog-content/application/blog-taxonomy-directory.ts
@@ -361,12 +361,28 @@ export async function syncPostTermAssignments(
     WHERE tenant_id = ${tenantId} AND post_id = ${postId}
   `;
 
-  for (const termId of termIds) {
-    await tx`
-      INSERT INTO awcms_blog_post_terms (tenant_id, post_id, term_id)
-      VALUES (${tenantId}, ${postId}, ${termId})
-    `;
+  if (termIds.length === 0) {
+    return;
   }
+
+  // ONE round trip, not one per term (`unnest`, the same shape
+  // `comment-retention.ts` and `announcement-directory.ts` use).
+  //
+  // Per save this was a small constant — a post carries a handful of terms —
+  // which is why it stood for as long as it did. What changed is the caller:
+  // `blog:legacy:import` now files every article it inserts, so a 23,906-row
+  // archive turned this into ~24k DELETEs and ~48k INSERTs inside batched
+  // transactions, where two statements per article will do.
+  //
+  // Deliberately NOT deduplicated: `awcms_blog_post_terms_unique` refuses a
+  // repeated (post, term) pair, and it refused one before this change too. A
+  // caller passing the same term twice has a bug, and swallowing it here would
+  // turn a loud constraint error into a silent difference between what was
+  // asked for and what was stored.
+  await tx`
+    INSERT INTO awcms_blog_post_terms (tenant_id, post_id, term_id)
+    SELECT ${tenantId}, ${postId}, unnest(${tx.array([...termIds], "uuid")}::uuid[])
+  `;
 }
 
 export async function fetchPostTermIds(

--- a/tests/integration/post-term-assignment-budget.integration.test.ts
+++ b/tests/integration/post-term-assignment-budget.integration.test.ts
@@ -1,0 +1,206 @@
+/**
+ * A query budget on a WRITE path (Issue #599, performance round).
+ *
+ * ## Why this file exists at all
+ *
+ * The four budget suites this repo already has — public reads, admin reads, the
+ * sitemap builder, the middleware — all measure READS. That is not an oversight
+ * so much as where the attention went: a read path is hit constantly, so its
+ * cost is felt. A write path is hit once per save, so a per-item query inside it
+ * looks like nothing.
+ *
+ * It stops looking like nothing the moment a bulk importer becomes the caller.
+ * `syncPostTermAssignments` issued one `INSERT` PER TERM, which is a handful of
+ * statements when an editor saves an article and roughly 48,000 of them when
+ * `blog:legacy:import` files a 23,906-article archive. The read side of exactly
+ * this relationship was already fixed for the same reason — see
+ * `fetchPostTermIdsForPosts`, "three round trips per page, not fifty-one" — and
+ * the write side simply had nobody counting.
+ *
+ * ## The budget is EXACT, and the fixture is deliberately larger than it
+ *
+ * Two statements: one `DELETE` for the previous set, one `INSERT ... unnest`
+ * for the new one. Exact rather than a ceiling, because the whole point is that
+ * the number does not move with the number of terms — a `toBeLessThanOrEqual`
+ * would pass a regression that added one query per term as long as the fixture
+ * stayed small.
+ *
+ * The fixture assigns 12 terms. With a per-term `INSERT` that is 13 queries
+ * against a budget of 2, so the old shape cannot pass by accident.
+ *
+ * ## Correctness is asserted alongside the count
+ *
+ * A budget on its own is satisfied by a function that writes nothing. Every
+ * case below checks the rows that actually landed, because "fast" and "wrote
+ * the right thing" are different claims and this change is only allowed to make
+ * one of them different.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { syncPostTermAssignments } from "../../src/modules/blog-content/application/blog-taxonomy-directory";
+
+const TENANT = "f7777777-7777-4777-8777-777777777777";
+const AUTHOR = "f7000000-0000-4000-8000-000000000001";
+
+/** More than the budget by an order of magnitude, so a per-item query cannot hide. */
+const TERM_COUNT = 12;
+
+/** One `DELETE` for the old set, one `INSERT ... unnest` for the new one. */
+const ASSIGNMENT_QUERY_BUDGET = 2;
+
+async function seedFixtures(): Promise<string[]> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'term-budget', 'Term Budget Tenant')
+  `;
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Author')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'term-budget@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${AUTHOR}, ${TENANT}, ${identity[0]!.id})
+  `;
+
+  await admin`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+       status, visibility, locale)
+    VALUES (${TENANT}, ${AUTHOR}, 'Filed', 'filed', '{}'::jsonb, '',
+            'published', 'public', 'id')
+  `;
+
+  const terms = (await admin`
+    INSERT INTO awcms_blog_terms (tenant_id, taxonomy_type, name, slug)
+    SELECT ${TENANT}, 'category', 'Kategori ' || n, 'kategori-' || n
+    FROM generate_series(1, ${TERM_COUNT}) AS n
+    RETURNING id
+  `) as { id: string }[];
+
+  return terms.map((row) => row.id);
+}
+
+async function postId(): Promise<string> {
+  const rows = (await getAdminSql()`
+    SELECT id FROM awcms_blog_posts WHERE tenant_id = ${TENANT} AND slug = 'filed'
+  `) as { id: string }[];
+
+  return rows[0]!.id;
+}
+
+async function assignedTermIds(id: string): Promise<string[]> {
+  const rows = (await getAdminSql()`
+    SELECT term_id FROM awcms_blog_post_terms
+    WHERE tenant_id = ${TENANT} AND post_id = ${id}
+    ORDER BY term_id
+  `) as { term_id: string }[];
+
+  return rows.map((row) => row.term_id);
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("filing a post costs the same whether it has one term or twelve", () => {
+  let termIds: string[] = [];
+
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    termIds = await seedFixtures();
+  });
+
+  test("twelve terms cost two queries, and all twelve land", async () => {
+    const id = await postId();
+    const runtime = getRuntimeSql();
+
+    const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        syncPostTermAssignments(counting, TENANT, id, termIds)
+      )
+    );
+
+    expect(queries).toBe(ASSIGNMENT_QUERY_BUDGET);
+    expect(await assignedTermIds(id)).toEqual([...termIds].sort());
+  });
+
+  test("one term costs the same two queries", async () => {
+    const id = await postId();
+    const runtime = getRuntimeSql();
+
+    const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        syncPostTermAssignments(counting, TENANT, id, [termIds[0]!])
+      )
+    );
+
+    // The number does not move with the input. That is the whole property.
+    expect(queries).toBe(ASSIGNMENT_QUERY_BUDGET);
+    expect(await assignedTermIds(id)).toEqual([termIds[0]!]);
+  });
+
+  test("filing nothing skips the INSERT entirely", async () => {
+    const id = await postId();
+    const runtime = getRuntimeSql();
+
+    const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        syncPostTermAssignments(counting, TENANT, id, [])
+      )
+    );
+
+    // An empty `unnest` would be a legal statement and a wasted round trip.
+    expect(queries).toBe(1);
+    expect(await assignedTermIds(id)).toEqual([]);
+  });
+
+  test("it REPLACES the set rather than adding to it", async () => {
+    const id = await postId();
+    const runtime = getRuntimeSql();
+
+    await withTenantOrThrow(runtime, TENANT, (tx) =>
+      syncPostTermAssignments(tx, TENANT, id, termIds.slice(0, 4))
+    );
+    await withTenantOrThrow(runtime, TENANT, (tx) =>
+      syncPostTermAssignments(tx, TENANT, id, termIds.slice(8))
+    );
+
+    // The batched INSERT must not turn a replace into an append: the second
+    // call's terms are the only ones that should remain.
+    expect(await assignedTermIds(id)).toEqual([...termIds.slice(8)].sort());
+  });
+});


### PR DESCRIPTION
The first result of the performance discovery round.

## The fix

`syncPostTermAssignments` issued one `INSERT` **per term**. Per save that is a small constant — an article carries a handful of terms — which is why it stood for as long as it did.

It stopped being a small constant when a bulk importer became the caller. #708 made `blog:legacy:import` file every article it inserts, so a 23,906-row archive turns this into roughly **24,000 `DELETE`s and 48,000 `INSERT`s** inside batched transactions, where two statements per article will do.

Now one `DELETE` and one `INSERT ... unnest` — the shape `comment-retention.ts` and `announcement-directory.ts` already use.

**Deliberately not deduplicated on the way in.** `awcms_blog_post_terms_unique` refused a repeated `(post, term)` pair before this change and still does. A caller passing the same term twice has a bug, and swallowing it here would turn a loud constraint error into a silent difference between what was asked for and what was stored.

## The finding behind it is worth more than the fix

This repo has four query-budget suites — public reads, admin reads, the sitemap builder, the middleware. **All four measure reads.** Every N+1 a full scan of `src/` turns up is on a write path or in a job.

That is not an oversight so much as where attention goes: a read path is hit constantly so its cost is felt; a write path is hit once per save, so a per-item query inside it looks like nothing — until a bulk caller arrives.

Worth noting the read side of *this very relationship* was already fixed deliberately: `fetchPostTermIdsForPosts` carries the comment *"three round trips per page, not fifty-one."* The write side simply had nobody counting.

## So this adds the first write-path budget

`tests/integration/post-term-assignment-budget.integration.test.ts`.

The budget is **exact (2), not a ceiling** — the property being pinned is that the number does not move with the number of terms, and a `toBeLessThanOrEqual` would happily pass a per-term regression as long as the fixture stayed small. The fixture assigns twelve, so the old shape cannot pass by accident.

Every case asserts the rows that actually landed beside the count, because a budget on its own is satisfied by a function that writes nothing — including one case that proves the batched `INSERT` still **replaces** the set rather than appending to it.

## What is deliberately not in this PR

The rest of the scan's findings are recorded in `PROJECT_STATE.md` §4 rather than changed here, so they need not be re-derived: nine lower-amplification write paths (each bounded by one request's payload), a per-post fetch inside the scheduled-publish sweep, and a low-cardinality index on `awcms_blog_post_terms` that needs `EXPLAIN` against real data before it is worth the write cost.

## Verification

Full `bun run check` green — every gate, 6548 tests, the build. The budget itself is DB-gated and runs in CI's integration job.