### PR TITLE
perf(blog): the scheduled sweeps cost a constant, not a constant per post

### DIFF
--- a/.changeset/scheduled-sweeps-cost-a-constant.md
+++ b/.changeset/scheduled-sweeps-cost-a-constant.md
@@ -39,6 +39,16 @@ Reusing the first pass's verdicts would have removed the mitigation entirely
 while looking like a tidy-up, so the second pass is still a second pass — it
 just costs two queries for the whole batch instead of two per post.
 
+**And it is now the first thing holding that mitigation.** It was a comment with
+nothing behind it: a budget would be HAPPIER if the second pass were deleted,
+and a correctness test over a stable fixture cannot tell the two passes apart.
+`tests/integration/scheduled-publish-toctou.integration.test.ts` drives a
+`MediaLibraryPort` stub that resolves the featured media on the FIRST call and
+stops on the second — the detachment, made deterministic — and requires the post
+to stay `scheduled`. The control case (media that never goes away) must publish,
+so a test that passed because the checklist never passed at all cannot hide.
+Mutation-proven: reusing the first verdict turns two of its three cases red.
+
 **`recordAuditEvents`** is the reusable half: N audit rows in one statement,
 built from a single `jsonb` parameter rather than one array per column. Bun's
 array binding cannot carry a NULL — it writes the literal string `null` without

--- a/.changeset/scheduled-sweeps-cost-a-constant.md
+++ b/.changeset/scheduled-sweeps-cost-a-constant.md
@@ -1,0 +1,75 @@
+---
+"awcms": patch
+---
+
+perf(blog): the scheduled publish/unpublish sweeps cost a constant, not a constant per post
+
+The previous round left this named rather than fixed: "`blog-scheduled-publish`
+calls the per-post `fetchPostTermIds` inside its sweep loop. Bounded by how many
+posts are due in one sweep — which at a cutover is not small."
+
+It was worse than a term fetch. Per due post the sweep issued a term fetch, a
+managed-media enforcement read PER checklist evaluation (and it evaluates
+twice), a media resolve per evaluation, an `UPDATE`, an edge-cache purge enqueue
+and an audit `INSERT`. Measured against the previous implementation with twelve
+due posts:
+
+| Sweep (12 due posts)     | Before | After |
+| ------------------------ | ------ | ----- |
+| publish, enforcement off |     40 |     6 |
+| publish, enforcement on  |     52 |     7 |
+| unpublish                |     27 |     4 |
+
+The slope is what matters: `4 + 3N`, `4 + 4N` and `3 + 2N` against a flat 6, 7
+and 4. At the batch bound of 200 due posts that is 604, 804 and 403 round trips
+— per tenant, on the ONE reserved `maintenance` connection the job holds, in a
+job that visits every active tenant in sequence.
+
+**Nothing in the sweep was per-post except the verdict.** Two of the three reads
+are not per-post facts at all: managed-media enforcement is a property of the
+tenant, and media resolution is keyed by media object id, which is tenant-wide.
+Resolving the union of a batch's references in one `id = ANY(...)` returns
+byte-identical rows to resolving each post's separately.
+
+**The TOCTOU re-check got smaller, not weaker.** The sweep re-evaluates the
+checklist immediately before it writes, because the referenced media objects are
+not locked by the batch's `FOR UPDATE`. Batching keeps that window at one query
+round trip and stops it growing with how far into the batch a post sits.
+Reusing the first pass's verdicts would have removed the mitigation entirely
+while looking like a tidy-up, so the second pass is still a second pass — it
+just costs two queries for the whole batch instead of two per post.
+
+**`recordAuditEvents`** is the reusable half: N audit rows in one statement,
+built from a single `jsonb` parameter rather than one array per column. Bun's
+array binding cannot carry a NULL — it writes the literal string `null` without
+throwing — so an `unnest` over this table's eight nullable columns would have
+been eight chances to be silently wrong. `recordAuditEvent` is now a batch of
+one, so the two forms cannot drift.
+
+`evaluateContentQualityChecklistForContent` is likewise a batch of one over the
+new `evaluateContentQualityChecklistForBatch`, so the interactive
+publish/schedule endpoints and the sweep cannot come to disagree about what the
+checklist says.
+
+**And the audit writer's two ADR-0091 columns are now asserted where they are
+decided.** `tests/two-sided-attribution.test.ts` guards them by reading the
+source as text, which proves a spelling rather than a row — it failed on this
+change while the behaviour was intact. It stays (it is cheap and needs no
+database) but is no longer the only witness:
+`tests/integration/audit-log-writer.integration.test.ts` reads both columns back
+out of the table, along with NULL handling, `jsonb_typeof(attributes)`,
+per-row redaction, the one-statement budget, and the RLS refusal of a batch
+carrying a foreign tenant's row.
+
+**The third open item from that round is now measured, and the answer is no
+change.** The hypothesis was that `awcms_blog_post_terms_tenant_idx` is a
+redundant single low-cardinality column and a `(tenant_id, term_id)` composite
+would serve both it and the category archive. Against 24,000 posts: the archive
+uses neither index for a wide category (it drives from
+`awcms_blog_posts_tenant_status_published_idx` and probes the
+`(post_id, term_id)` unique index), and for a narrow one the planner flips to a
+term-driven plan using `(term_id)` — 27 buffers instead of 48,832. A composite
+serves that plan identically and is slightly wider per entry; dropping
+`(term_id)` in its favour would leave `awcms_blog_terms` parent deletes scanning
+the join table, exactly the residual `db:fk-index:check` documents. Recorded in
+`PROJECT_STATE.md` §4 so it is not re-derived.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:3ea30d883dca13d217a9db596dfe8b488bfe5be0256808d24573aa7400e01a55 -->
+<!-- i18n-source-hash: sha256:a041e9fbcfa275a9899245a0fb346528d1a0df77e4f156c9b5b28a46753f70e6 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,111 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN SAPUAN — 25 Agustus 2026: sapuan terjadwal berbiaya konstan PER
+  POST, dan indeks yang putaran sebelumnya tinggalkan sebagai tugas pengukuran
+  ternyata TIDAK perlu diubah. Kedua paruh itu sama-sama hasil.**
+
+  PUTARAN PERFORMA di bawah meninggalkan tiga hal yang disebut tetapi tidak
+  diperbaiki. Dua di antaranya kini ditutup.
+
+  **Sapuannya lebih buruk daripada yang dicatat.** Catatan itu menyebut
+  "`blog-scheduled-publish` memanggil `fetchPostTermIds` per-post di dalam loop
+  sapuannya". Per post jatuh tempo, sapuan itu JUGA membaca flag penegakan
+  managed-media SEKALI PER EVALUASI checklist — dan ia mengevaluasi dua kali —
+  me-resolve media post itu per evaluasi, menulis `UPDATE`-nya sendiri,
+  meng-enqueue purge edge-cache-nya sendiri, dan menulis baris auditnya sendiri.
+  Diukur terhadap implementasi sebelumnya:
+
+  | Sapuan (12 post jatuh tempo) | Sebelum | Sesudah |
+  | ---------------------------- | ------- | ------- |
+  | publish, penegakan mati      | 40      | 6       |
+  | publish, penegakan hidup     | 52      | 7       |
+  | unpublish                    | 27      | 4       |
+
+  Kemiringannya yang jadi temuan: `4 + 3N`, `4 + 4N`, dan `3 + 2N` melawan 6, 7,
+  dan 4 yang datar. Pada batas batch 200 itu berarti 604, 804, dan 403 pulang
+  pergi — per tenant, pada SATU koneksi `maintenance` yang job itu pegang, di
+  dalam job yang mendatangi setiap tenant aktif berurutan.
+
+  **Tidak ada yang per-post di sana kecuali putusannya.** Penegakan
+  managed-media adalah properti TENANT; resolusi media berkunci pada id objek
+  media, yang berlaku se-tenant. Me-resolve gabungan seluruh referensi satu
+  batch dalam satu `id = ANY(...)` mengembalikan baris yang identik dengan
+  me-resolve milik tiap post sendiri-sendiri. Evaluasinya sendiri tetap
+  per-post.
+
+  **Cek-ulang TOCTOU menjadi LEBIH KECIL, bukan lebih lemah** — bagian yang
+  paling berisiko hilang oleh "rapi-rapi" berikutnya. Sapuan mengevaluasi ulang
+  tepat sebelum menulis karena objek media yang dirujuk TIDAK dikunci oleh
+  `FOR UPDATE` batch. Membatch menjaga jendela itu tetap satu pulang-pergi dan
+  menghentikannya tumbuh mengikuti seberapa jauh sebuah post berada di dalam
+  batch. Memakai ulang putusan lintasan pertama akan MENGHAPUS mitigasinya
+  sambil tampak seperti pembersihan, jadi lintasan kedua tetap lintasan kedua —
+  dengan dua query untuk seluruh batch, bukan dua per post.
+
+  **`recordAuditEvents` adalah paruh yang bisa dipakai ulang**, dan bentuknya
+  yang layak dibawa ke depan. N baris dalam satu statement dari SATU parameter
+  `jsonb`, BUKAN idiom `INSERT ... SELECT unnest(...)` yang dipakai di tempat
+  lain: `unnest` menuntut satu array per kolom, tabel ini punya delapan kolom
+  nullable plus satu `jsonb`, dan binding array Bun TIDAK BISA membawa NULL — ia
+  menulis string harfiah `null` tanpa melempar. Itu delapan peluang salah secara
+  senyap, melawan satu parameter di mana JSON `null` memetakan ke SQL NULL dan
+  `attributes` tetap objek bersarang sungguhan. `jsonb_to_recordset` adalah
+  idiom untuk batch insert baris dengan kolom nullable atau `jsonb`.
+
+  **Sebuah test asersi-source memerah padahal perilakunya utuh, dan itu
+  pelajarannya sendiri.** `tests/two-sided-attribution.test.ts` menjaga dua kolom
+  atribusi ADR-0091 dengan mencari `${input.actorTenantId ?? null}` di
+  `audit-log.ts`. Penulis batch merakit nilai yang sama ke dalam objek baris
+  jsonb, jadi asersinya patah pada EJAAN. Ia tetap dipertahankan — murah, tanpa
+  basis data, paling cepat menangkap field yang hilang — tetapi bukan lagi
+  satu-satunya saksi: `tests/integration/audit-log-writer.integration.test.ts`
+  membaca kedua kolom itu KEMBALI DARI TABEL, dengan seluruh rantai FK
+  (partner → engagement → grant) di-seed, karena sebuah baris tidak bisa
+  mengklaim grant yang tidak ada.
+
+  **Pertanyaan indeks, diukur terhadap 24.000 post — dan hipotesisnya tidak
+  bertahan.** Catatannya berbunyi: "`awcms_blog_post_terms_tenant_idx` adalah
+  satu kolom berkardinalitas rendah. Arsip kategori memfilter `term_id` di bawah
+  predikat `tenant_id` milik RLS; `(term_id)` melayaninya dan komposit
+  `(tenant_id, term_id)` akan melayani keduanya."
+
+  - Untuk kategori LEBAR arsip tidak memakai satu pun: ia berjalan dari
+    `awcms_blog_posts_tenant_status_published_idx` terbaru-dulu lalu memeriksa
+    indeks UNIQUE `(post_id, term_id)`. 0,09 ms, 67 buffer.
+  - Untuk kategori SEMPIT planner berbalik ke rencana yang digerakkan term dan
+    memakai `(term_id)` — jadi `(term_id)` TIDAK redundan. 27 buffer.
+  - Komposit `(tenant_id, term_id)` melayani rencana sempit itu secara identik
+    (25 buffer) dan lebih lebar per entri. Mengganti KEDUA indeks satu-kolom
+    dengannya akan membuat penghapusan induk di `awcms_blog_terms` memindai
+    tabel join — persis residu yang didokumentasikan `db:fk-index:check` soal
+    komposit `(tenant_id, X)`. Dan `tenant_id` tidak bisa sekadar dibuang: tidak
+    ada query di repo yang memfilter tabel ini dengan `tenant_id` saja, tetapi
+    gerbang FK-index menuntutnya terjangkau indeks.
+  - Bulk insert 5.000 assignment: 110 ms dengan tiga indeks, 115 ms dengan dua.
+    Masih di dalam derau — tidak ada kemenangan tulis terukur untuk diklaim.
+
+    **Kesimpulan: tidak ada perubahan.** Nilainya ada pada penyangkalan dan
+    angkanya, bukan pada sebuah migration.
+
+  **Jebakan pengukuran yang layak dicatat, karena ia menghasilkan jawaban yang
+  salah dengan yakin selama dua puluh menit.** Ditulis dengan term id sebagai
+  subquery — `pt.term_id = (SELECT id FROM awcms_blog_terms WHERE slug = …)` —
+  kategori sempit berbiaya **24,7 ms dan 48.832 buffer**, memindai seluruh
+  24.000 post untuk mengembalikan 8 baris, karena InitPlan tidak di-konstanta-
+  lipat dan planner jatuh ke selektivitas generik (ia menduga 12.003 baris untuk
+  keduanya). Kode nyata mengikat `termId` sebagai PARAMETER, Postgres membangun
+  custom plan, dan query yang sama berbiaya 27 buffer. **Benchmark yang tidak
+  mengikat parameternya seperti pemanggilnya mengukur rencana yang tak pernah
+  didapat pemanggil itu.**
+
+  **Masih terbuka dari putaran di bawah, tidak berubah:** sembilan jalur tulis
+  ber-amplifikasi lebih rendah, masing-masing dibatasi oleh apa yang dikirim
+  SATU request. `enqueuePushToRecipients` yang layak disebut — satu query per
+  penerima plus satu `INSERT` per langganan — tetapi satu-satunya pemanggilnya
+  hari ini adalah `POST /api/v1/push/test` yang self-service, dengan satu
+  penerima. Ia menjadi fan-out sungguhan begitu ada pemanggil broadcast.
 
 - **PUTARAN PERFORMA — 24 Agustus 2026: seluruh anggaran query mengukur
   PEMBACAAN. Setiap N+1 di repo ada di jalur TULIS atau di job — paruh yang

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:a041e9fbcfa275a9899245a0fb346528d1a0df77e4f156c9b5b28a46753f70e6 -->
+<!-- i18n-source-hash: sha256:4352dc5113fe67a0ba92ff786cc3d12b67cde5cac30734aec721e9e2b035f4df -->
 
 # AWCMS — Project State & Continuation
 
@@ -401,6 +401,19 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   batch. Memakai ulang putusan lintasan pertama akan MENGHAPUS mitigasinya
   sambil tampak seperti pembersihan, jadi lintasan kedua tetap lintasan kedua —
   dengan dua query untuk seluruh batch, bukan dua per post.
+
+  **Mitigasi itu TIDAK dipegang apa pun, dan itulah sebabnya ia nyaris
+  hilang.** Sebuah anggaran justru akan lebih SENANG bila lintasan kedua
+  dihapus — angkanya turun — dan test kebenaran di atas fixture yang stabil
+  tidak bisa membedakan kedua lintasan, karena keduanya melihat media yang
+  sama. Ia hanya sebuah komentar. `scheduled-publish-toctou.integration.test.ts`
+  kini menjalankan stub `MediaLibraryPort` yang me-resolve media unggulan pada
+  panggilan PERTAMA lalu berhenti pada yang kedua — pelepasan itu, dibuat
+  deterministik — dan menuntut post-nya tetap `scheduled`; kasus kontrolnya,
+  media yang tak pernah hilang, WAJIB terbit, sehingga test yang lulus karena
+  checklist-nya tak pernah lulus tidak bisa bersembunyi. **Port-lah yang membuat
+  ini bisa diuji sama sekali**: keadaan media berada di balik satu jahitan,
+  jadi balapannya tak perlu dibalapkan.
 
   **`recordAuditEvents` adalah paruh yang bisa dipakai ulang**, dan bentuknya
   yang layak dibawa ke depan. N baris dalam satu statement dari SATU parameter

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,108 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **SWEEP ROUND — 25 August 2026: the scheduled sweeps cost a constant PER
+  POST, and the index the previous round left as a measurement task turns out
+  not to want changing. Both halves of that are results.**
+
+  The PERFORMANCE ROUND below left three things named rather than fixed. Two of
+  them are now closed.
+
+  **The sweep was worse than the note said.** It named "`blog-scheduled-publish`
+  calls the per-post `fetchPostTermIds` inside its sweep loop". Per due post the
+  sweep also read the managed-media enforcement flag ONCE PER CHECKLIST
+  EVALUATION — and it evaluates twice — resolved that post's media per
+  evaluation, wrote its own `UPDATE`, enqueued its own edge-cache purge and
+  wrote its own audit row. Measured against the previous implementation:
+
+  | Sweep (12 due posts)     | Before | After |
+  | ------------------------ | ------ | ----- |
+  | publish, enforcement off | 40     | 6     |
+  | publish, enforcement on  | 52     | 7     |
+  | unpublish                | 27     | 4     |
+
+  The slope is the finding: `4 + 3N`, `4 + 4N` and `3 + 2N` against a flat 6, 7
+  and 4. At the batch bound of 200 that is 604, 804 and 403 round trips — per
+  tenant, on the ONE reserved `maintenance` connection the job holds, in a job
+  that visits every active tenant in sequence.
+
+  **Nothing in it was per-post except the verdict.** Managed-media enforcement
+  is a property of the TENANT; media resolution is keyed by media object id,
+  which is tenant-wide. Resolving the union of a batch's references in one
+  `id = ANY(...)` returns byte-identical rows to resolving each post's own.
+  The evaluation itself stays strictly per post.
+
+  **The TOCTOU re-check got SMALLER, not weaker** — the part most at risk of
+  being lost to a later tidy-up. The sweep re-evaluates immediately before it
+  writes because the referenced media objects are not locked by the batch's
+  `FOR UPDATE`. Batching keeps that window at one round trip and stops it
+  growing with how far into the batch a post sits. Reusing the first pass's
+  verdicts would have removed the mitigation while looking like cleanup, so the
+  second pass is still a second pass, at two queries for the batch rather than
+  two per post.
+
+  **`recordAuditEvents` is the reusable half**, and its shape is the part worth
+  carrying forward. N rows in one statement built from a single `jsonb`
+  parameter, NOT the `INSERT ... SELECT unnest(...)` idiom this repo uses
+  elsewhere: `unnest` takes one array per column, this table has eight nullable
+  columns plus a `jsonb` one, and Bun's array binding cannot carry a NULL — it
+  writes the literal string `null` without throwing. That is eight chances to be
+  silently wrong, against one parameter where JSON `null` maps to SQL NULL and
+  `attributes` stays a real nested object. `jsonb_to_recordset` is the idiom for
+  a batch insert of rows with nullable or `jsonb` columns.
+
+  **A source-text test failed while the behaviour was intact, which is its own
+  lesson.** `tests/two-sided-attribution.test.ts` guards the two ADR-0091
+  attribution columns by looking for `${input.actorTenantId ?? null}` in
+  `audit-log.ts`. The batch writer assembles the same value into a jsonb row
+  object instead, so the assertion broke on a spelling. It is kept — cheap, no
+  database, catches a dropped field fastest — but is no longer the only witness:
+  `tests/integration/audit-log-writer.integration.test.ts` reads both columns
+  back OUT OF THE TABLE, with the whole FK chain (partner → engagement → grant)
+  seeded, because a row cannot claim a grant that does not exist.
+
+  **The index question, measured against 24,000 posts — and the hypothesis does
+  not survive.** The note read: "`awcms_blog_post_terms_tenant_idx` is a single
+  low-cardinality column. The category archive filters `term_id` under RLS's
+  `tenant_id` predicate; `(term_id)` serves it and a composite
+  `(tenant_id, term_id)` would serve both, making the single-column index
+  redundant."
+
+  - For a WIDE category the archive uses neither: it drives from
+    `awcms_blog_posts_tenant_status_published_idx` newest-first and probes the
+    `(post_id, term_id)` UNIQUE index. 0.09 ms, 67 buffers.
+  - For a NARROW category the planner flips to a term-driven plan using
+    `(term_id)` — so `(term_id)` is NOT redundant. 27 buffers.
+  - A `(tenant_id, term_id)` composite serves the narrow plan identically (25
+    buffers) and is wider per entry. Replacing BOTH single-column indexes with
+    it would leave `awcms_blog_terms` parent deletes scanning the join table —
+    exactly the residual `db:fk-index:check` documents about `(tenant_id, X)`
+    composites. And `tenant_id` cannot simply be dropped: no query in the repo
+    filters this table by `tenant_id` alone, but the FK-index gate requires it
+    to be index-reachable.
+  - Bulk insert of 5,000 assignments: 110 ms with three indexes, 115 ms with
+    two. Within noise — there is no measured write win to claim.
+
+    **Conclusion: no change.** The value here is the refutation and the numbers,
+    not a migration.
+
+  **A measurement trap worth recording, because it produced a confident wrong
+  answer for twenty minutes.** Written with the term id as a subquery —
+  `pt.term_id = (SELECT id FROM awcms_blog_terms WHERE slug = …)` — the narrow
+  category costs **24.7 ms and 48,832 buffers**, scanning all 24,000 posts to
+  return 8 rows, because an InitPlan is not constant-folded and the planner
+  falls back to generic selectivity (it estimated 12,003 rows either way). The
+  real code binds `termId` as a PARAMETER, Postgres builds a custom plan, and
+  the same query costs 27 buffers. **A benchmark that does not bind its
+  parameters the way the caller does measures a plan the caller never gets.**
+
+  **Still open from the round below, unchanged:** the nine lower-amplification
+  write paths, each bounded by what ONE request submits.
+  `enqueuePushToRecipients` is the one worth naming — a query per recipient plus
+  an `INSERT` per subscription — but its only caller today is the self-service
+  `POST /api/v1/push/test`, with one recipient. It becomes a real fan-out the
+  moment a broadcast caller exists.
+
 - **PERFORMANCE ROUND — 24 August 2026: the query budgets all measure READS.
   Every N+1 in the repo is on a WRITE path or in a job — the half nothing
   counts.**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -400,6 +400,18 @@ pioneered directly here after the ADR-0047 freeze.)
   second pass is still a second pass, at two queries for the batch rather than
   two per post.
 
+  **The mitigation had NOTHING holding it, which is why it was easy to nearly
+  lose.** A budget would be HAPPIER if the second pass were deleted — the number
+  drops — and a correctness test over a stable fixture cannot tell the two
+  passes apart, because both see the same media. It was a comment.
+  `scheduled-publish-toctou.integration.test.ts` now drives a `MediaLibraryPort`
+  stub that resolves the featured media on the FIRST call and stops on the
+  second — the detachment, made deterministic — and requires the post to stay
+  `scheduled`; the control case, media that never goes away, must publish, so a
+  test passing because the checklist never passed cannot hide. **The port is
+  what made this testable at all**: the media state is behind a seam, so the
+  race does not have to be raced.
+
   **`recordAuditEvents` is the reusable half**, and its shape is the part worth
   carrying forward. N rows in one statement built from a single `jsonb`
   parameter, NOT the `INSERT ... SELECT unnest(...)` idiom this repo uses

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 483   |
+| Test files                          | 484   |
 | Route files                         | 382   |
 | ADR                                 | 226   |
 
@@ -360,7 +360,7 @@
 | ------------- | ---------- |
 | `(root)`      | 401        |
 | `e2e`         | 17         |
-| `integration` | 64         |
+| `integration` | 65         |
 | `unit`        | 1          |
 
 ### Routes

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 481   |
+| Test files                          | 483   |
 | Route files                         | 382   |
 | ADR                                 | 226   |
 
@@ -360,7 +360,7 @@
 | ------------- | ---------- |
 | `(root)`      | 401        |
 | `e2e`         | 17         |
-| `integration` | 62         |
+| `integration` | 64         |
 | `unit`        | 1          |
 
 ### Routes

--- a/src/modules/blog-content/application/blog-scheduled-publish.ts
+++ b/src/modules/blog-content/application/blog-scheduled-publish.ts
@@ -1,10 +1,14 @@
 import { enqueueModuleContentPurge } from "../../../lib/edge-cache/content-purge";
 import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import { log } from "../../../lib/logging/logger";
-import { recordAuditEvent } from "../../logging/application/audit-log";
-import { fetchPostTermIds } from "./blog-taxonomy-directory";
+import {
+  recordAuditEvent,
+  recordAuditEvents,
+  type AuditEventInput
+} from "../../logging/application/audit-log";
+import { fetchPostTermIdsForPosts } from "./blog-taxonomy-directory";
 import { fetchBlogSettings } from "./blog-settings-directory";
-import { evaluateContentQualityChecklistForContent } from "./content-quality-checklist-gate";
+import { evaluateContentQualityChecklistForBatch } from "./content-quality-checklist-gate";
 import type { MediaLibraryPort } from "../../_shared/ports/media-library-port";
 import type { SocialPublishingPort } from "../../_shared/ports/social-publishing-port";
 
@@ -141,64 +145,94 @@ export async function publishDueScheduledPosts(
       }
 
       const blogSettings = await fetchBlogSettings(tx, tenantId);
-      const publishedPostIds: string[] = [];
-      const blockedPostIds: string[] = [];
 
-      for (const post of due) {
-        const termIds = await fetchPostTermIds(tx, tenantId, post.id);
-        const evaluateChecklist = () =>
-          evaluateContentQualityChecklistForContent(
-            tx,
-            tenantId,
-            "post",
-            {
-              title: post.title,
-              slug: post.slug,
-              excerpt: post.excerpt,
-              metaDescription: post.meta_description,
-              contentText: post.content_text,
-              contentJson: post.content_json,
-              featuredMediaId: post.featured_media_id,
-              seoImageMediaId: post.seo_image_media_id
-            },
-            termIds.length,
-            mediaPort,
-            blogSettings.contentQualityChecklistPolicy,
-            {
-              socialPreviewFallback: {
-                tenantFallbackImageMediaId:
-                  blogSettings.socialPreviewFallbackImageMediaId,
-                contentImageFallbackEnabled:
-                  blogSettings.socialPreviewContentImageFallbackEnabled
-              }
+      // One query for the whole batch, not one per post. The read side of this
+      // relationship was batched long ago (`fetchPostTermIdsForPosts` — "three
+      // round trips per page, not fifty-one"); this sweep was still asking per
+      // post, which at the batch bound is two hundred round trips on the one
+      // reserved `maintenance` connection the job holds for its duration. A
+      // post with no assignments is absent from the map, not an error: the
+      // checklist's term rule reads the count, and zero IS the count.
+      const termIdsByPost = await fetchPostTermIdsForPosts(
+        tx,
+        tenantId,
+        due.map((post) => post.id)
+      );
+
+      const checklistItems = due.map((post) => ({
+        key: post.id,
+        content: {
+          title: post.title,
+          slug: post.slug,
+          excerpt: post.excerpt,
+          metaDescription: post.meta_description,
+          contentText: post.content_text,
+          contentJson: post.content_json,
+          featuredMediaId: post.featured_media_id,
+          seoImageMediaId: post.seo_image_media_id
+        },
+        termCount: (termIdsByPost.get(post.id) ?? []).length
+      }));
+
+      const evaluateChecklists = (
+        items: readonly (typeof checklistItems)[number][]
+      ) =>
+        evaluateContentQualityChecklistForBatch(
+          tx,
+          tenantId,
+          "post",
+          items,
+          mediaPort,
+          blogSettings.contentQualityChecklistPolicy,
+          {
+            socialPreviewFallback: {
+              tenantFallbackImageMediaId:
+                blogSettings.socialPreviewFallbackImageMediaId,
+              contentImageFallbackEnabled:
+                blogSettings.socialPreviewContentImageFallbackEnabled
             }
-          );
+          }
+        );
 
-        let checklist = await evaluateChecklist();
+      const firstPass = await evaluateChecklists(checklistItems);
+      const candidates = checklistItems.filter(
+        (item) => firstPass.get(item.key)!.passed
+      );
 
-        /**
-         * TOCTOU mitigation (security-auditor Medium finding, PR #725): the
-         * post row itself is protected by the batch's own `FOR UPDATE` lock
-         * (above), but the R2 media objects it references are NOT locked —
-         * an editor could detach/invalidate the featured/gallery media
-         * between this first evaluation and the `UPDATE` below, especially
-         * for a large due-batch where earlier posts' evaluations/updates
-         * push that gap out further. Re-running the evaluation immediately
-         * before the `UPDATE` shrinks that window from "the rest of this
-         * tenant's whole batch" down to one query round-trip — it doesn't
-         * eliminate the race outright (that would need locking the
-         * referenced media rows too, a bigger change touching the shared
-         * `MediaLibraryPort` every read-only preview endpoint also uses), but
-         * closes the realistic exposure at negligible cost.
-         */
-        if (checklist.passed) {
-          checklist = await evaluateChecklist();
-        }
+      /**
+       * TOCTOU mitigation (security-auditor Medium finding, PR #725): the
+       * post rows themselves are protected by the batch's own `FOR UPDATE`
+       * lock (above), but the R2 media objects they reference are NOT locked
+       * — an editor could detach/invalidate the featured/gallery media
+       * between the first evaluation and the `UPDATE` below. Re-evaluating
+       * immediately before the write keeps that window at one query round
+       * trip. It does not eliminate the race outright (that would need
+       * locking the referenced media rows too, a bigger change touching the
+       * shared `MediaLibraryPort` every read-only preview endpoint also
+       * uses), but closes the realistic exposure at negligible cost.
+       *
+       * Batching made this window SMALLER, not larger, and that is the whole
+       * reason the two passes are still two passes: the second pass re-reads
+       * every candidate's media in one statement and the publish follows it
+       * immediately, so the gap no longer grows with how far into the batch a
+       * post happens to sit. Reusing the first pass's verdicts here would
+       * have removed the mitigation entirely while looking like a tidy-up.
+       */
+      const secondPass = await evaluateChecklists(candidates);
+
+      const publishedPosts: DuePostRow[] = [];
+      const blockedPostIds: string[] = [];
+      const auditEvents: AuditEventInput[] = [];
+
+      // Iterated in due order (`scheduled_at ASC`, from the SELECT) so the
+      // audit trail reads in the same sequence the per-post loop wrote it.
+      for (const post of due) {
+        const checklist = secondPass.get(post.id) ?? firstPass.get(post.id)!;
 
         if (!checklist.passed) {
           blockedPostIds.push(post.id);
 
-          await recordAuditEvent(tx, {
+          auditEvents.push({
             tenantId,
             moduleKey: "blog_content",
             action: "blog.post.scheduled_publish_blocked",
@@ -225,30 +259,9 @@ export async function publishDueScheduledPosts(
           continue;
         }
 
-        await tx`
-          UPDATE awcms_blog_posts
-          SET status = 'published',
-              published_at = COALESCE(published_at, ${now}),
-              scheduled_at = NULL,
-              version = version + 1,
-              updated_at = ${now}
-          WHERE tenant_id = ${tenantId} AND id = ${post.id}
-        `;
+        publishedPosts.push(post);
 
-        publishedPostIds.push(post.id);
-
-        // ADR-0042: invalidate this tenant's cached blog surfaces in the SAME
-        // transaction as the publish, so a rolled-back publish leaves no stray
-        // purge and a committed one can never lose its invalidation. No-op when
-        // the edge cache is disabled.
-        await enqueueModuleContentPurge(
-          tx,
-          tenantId,
-          "blog_content",
-          "blog.post.published"
-        );
-
-        await recordAuditEvent(tx, {
+        auditEvents.push({
           tenantId,
           moduleKey: "blog_content",
           action: "blog.post.published",
@@ -258,34 +271,75 @@ export async function publishDueScheduledPosts(
           message: `Blog post published by scheduled publish: ${post.slug}.`,
           correlationId
         });
+      }
 
-        log("info", "blog-content.post.published", {
-          correlationId,
+      const publishedPostIds = publishedPosts.map((post) => post.id);
+
+      if (publishedPostIds.length > 0) {
+        await tx`
+          UPDATE awcms_blog_posts
+          SET status = 'published',
+              published_at = COALESCE(published_at, ${now}),
+              scheduled_at = NULL,
+              version = version + 1,
+              updated_at = ${now}
+          WHERE tenant_id = ${tenantId}
+            AND id = ANY(${tx.array(publishedPostIds, "uuid")})
+        `;
+
+        // AFTER the write, not while classifying: a log line saying a post
+        // published is a claim about a statement that ran. Emitting it during
+        // classification would report every candidate as published even when
+        // the `UPDATE` below it threw.
+        for (const post of publishedPosts) {
+          log("info", "blog-content.post.published", {
+            correlationId,
+            tenantId,
+            moduleKey: "blog_content",
+            postId: post.id,
+            slug: post.slug,
+            trigger: "scheduled_publish"
+          });
+        }
+
+        // ADR-0042: invalidate this tenant's cached blog surfaces in the SAME
+        // transaction as the publish, so a rolled-back publish leaves no stray
+        // purge and a committed one can never lose its invalidation. No-op when
+        // the edge cache is disabled. ONE enqueue for the batch: the scope is
+        // the tenant's `blog_content` surfaces, so enqueueing it per post
+        // produced identical duplicate rows for the purge worker to collapse.
+        await enqueueModuleContentPurge(
+          tx,
           tenantId,
-          moduleKey: "blog_content",
-          postId: post.id,
-          slug: post.slug,
-          trigger: "scheduled_publish"
-        });
+          "blog_content",
+          "blog.post.published"
+        );
 
         if (socialPublishingPort) {
-          await socialPublishingPort.onArticlePublished(
-            tx,
-            tenantId,
-            {
-              articleId: post.id,
-              title: post.title,
-              slug: post.slug,
-              excerpt: post.excerpt,
-              featuredMediaId: post.featured_media_id,
-              trigger: "scheduled_published"
-            },
-            correlationId
-          );
+          // Per article by contract — `onArticlePublished` takes one. Kept
+          // after the publish `UPDATE`, as before, so a port that reads the
+          // row back sees it published.
+          for (const post of publishedPosts) {
+            await socialPublishingPort.onArticlePublished(
+              tx,
+              tenantId,
+              {
+                articleId: post.id,
+                title: post.title,
+                slug: post.slug,
+                excerpt: post.excerpt,
+                featuredMediaId: post.featured_media_id,
+                trigger: "scheduled_published"
+              },
+              correlationId
+            );
+          }
         }
       }
 
-      await recordAuditEvent(tx, {
+      // The per-post rows and the run summary in ONE statement, the summary
+      // last so the trail reads in the order the sweep decided things.
+      auditEvents.push({
         tenantId,
         moduleKey: "blog_content",
         action: "blog.post.scheduled_publish_executed",
@@ -298,6 +352,8 @@ export async function publishDueScheduledPosts(
         },
         correlationId
       });
+
+      await recordAuditEvents(tx, auditEvents);
 
       return {
         publishedCount: publishedPostIds.length,
@@ -381,51 +437,58 @@ export async function unpublishDuePosts(
       `) as DueUnpublishRow[];
 
       const partial = due.length === SCHEDULED_UNPUBLISH_BATCH_LIMIT;
-      const unpublishedPostIds: string[] = [];
+      const unpublishedPostIds = due.map((post) => post.id);
+      const auditEvents: AuditEventInput[] = [];
 
-      for (const post of due) {
+      if (unpublishedPostIds.length > 0) {
+        // One `UPDATE` and one audit `INSERT` for the batch, not two
+        // statements per post. Nothing here is per-post CONDITIONAL — every
+        // due row is archived, the checklist deliberately does not run (see
+        // above) — so the per-post loop was only ever a way of writing the
+        // same two statements two hundred times.
+        //
+        // `unpublish_at` is deliberately LEFT SET rather than nulled the way
+        // `scheduled_at` is cleared on publish. The two are not symmetric:
+        // `scheduled_at` describes an intent that has been carried out and
+        // would re-fire if kept, whereas `unpublish_at` is the RECORD of why
+        // this post is archived — clearing it would erase the only trace
+        // distinguishing "withdrawn on schedule" from "an editor archived
+        // it", and the CHECK keeps it consistent if the post is ever
+        // republished with a new window.
         await tx`
           UPDATE awcms_blog_posts
           SET status = 'archived',
               version = version + 1,
               updated_at = ${now}
-          WHERE tenant_id = ${tenantId} AND id = ${post.id}
+          WHERE tenant_id = ${tenantId}
+            AND id = ANY(${tx.array(unpublishedPostIds, "uuid")})
         `;
 
-        unpublishedPostIds.push(post.id);
+        for (const post of due) {
+          auditEvents.push({
+            tenantId,
+            moduleKey: "blog_content",
+            action: "blog.post.unpublished",
+            resourceType: "blog_post",
+            resourceId: post.id,
+            // `warning`, not `info`: content LEAVING the public surface
+            // without a human in the loop is the kind of event an operator
+            // should be able to find when a reader asks where an article went.
+            severity: "warning",
+            message: `Blog post unpublished by schedule: ${post.slug}.`,
+            correlationId
+          });
 
-        await recordAuditEvent(tx, {
-          tenantId,
-          moduleKey: "blog_content",
-          action: "blog.post.unpublished",
-          resourceType: "blog_post",
-          resourceId: post.id,
-          // `warning`, not `info`: content LEAVING the public surface without a
-          // human in the loop is the kind of event an operator should be able
-          // to find when a reader asks where an article went.
-          severity: "warning",
-          message: `Blog post unpublished by schedule: ${post.slug}.`,
-          correlationId
-        });
+          log("info", "blog-content.post.unpublished", {
+            correlationId,
+            tenantId,
+            moduleKey: "blog_content",
+            postId: post.id,
+            slug: post.slug,
+            trigger: "scheduled_unpublish"
+          });
+        }
 
-        log("info", "blog-content.post.unpublished", {
-          correlationId,
-          tenantId,
-          moduleKey: "blog_content",
-          postId: post.id,
-          slug: post.slug,
-          trigger: "scheduled_unpublish"
-        });
-      }
-
-      // `unpublish_at` is deliberately LEFT SET rather than nulled the way
-      // `scheduled_at` is cleared on publish. The two are not symmetric:
-      // `scheduled_at` describes an intent that has been carried out and would
-      // re-fire if kept, whereas `unpublish_at` is the RECORD of why this post
-      // is archived — clearing it would erase the only trace distinguishing
-      // "withdrawn on schedule" from "an editor archived it", and the CHECK
-      // keeps it consistent if the post is ever republished with a new window.
-      if (unpublishedPostIds.length > 0) {
         // ADR-0042 — same transaction as the transition, so a rollback leaves
         // no stray purge and a commit cannot lose its invalidation. This is the
         // half that matters most: a withdrawn article still sitting in the edge
@@ -438,7 +501,7 @@ export async function unpublishDuePosts(
         );
       }
 
-      await recordAuditEvent(tx, {
+      auditEvents.push({
         tenantId,
         moduleKey: "blog_content",
         action: "blog.post.scheduled_unpublish_executed",
@@ -448,6 +511,8 @@ export async function unpublishDuePosts(
         attributes: { unpublishedCount: unpublishedPostIds.length },
         correlationId
       });
+
+      await recordAuditEvents(tx, auditEvents);
 
       return {
         unpublishedCount: unpublishedPostIds.length,

--- a/src/modules/blog-content/application/content-quality-checklist-gate.ts
+++ b/src/modules/blog-content/application/content-quality-checklist-gate.ts
@@ -56,11 +56,38 @@ export type EvaluateContentQualityChecklistOptions = {
 };
 
 /**
+ * One piece of content to evaluate, plus the caller's key for finding its
+ * result again. The key is whatever the caller already has — a post id for the
+ * sweep, a literal for a single evaluation — and is never interpreted here.
+ */
+export type ChecklistBatchItem<K> = {
+  key: K;
+  content: ChecklistEvaluableContent;
+  /**
+   * `termCount` is the caller's job to fetch — for a batch that means
+   * `fetchPostTermIdsForPosts` (`blog-taxonomy-directory.ts`), not one
+   * `fetchPostTermIds` per item. This file doesn't take a `postId` at all,
+   * only content values, so it can also serve the "preview before the post
+   * exists yet" case a future admin UI draft-preview might want.
+   */
+  termCount: number;
+};
+
+/** The batch key the singular wrapper below uses; never leaves this file. */
+const SINGLE_ITEM_KEY = "single";
+
+/**
  * `termCount` is the caller's job to fetch (`fetchPostTermIds(tx, tenantId,
  * postId).length`, `blog-taxonomy-directory.ts`) — this file doesn't take a
  * `postId` at all, only content values, so it can also serve the "preview
  * before the post exists yet" case a future admin UI draft-preview might
  * want (not built by this issue, but the shape doesn't preclude it).
+ *
+ * A batch of one over `evaluateContentQualityChecklistForBatch`, so the
+ * interactive publish/schedule endpoints and the sweep job cannot come to
+ * disagree about what the checklist says. Costs exactly what it did before:
+ * one enforcement read, and one media resolve when there is anything to
+ * resolve.
  */
 export async function evaluateContentQualityChecklistForContent(
   tx: Bun.SQL,
@@ -73,6 +100,68 @@ export async function evaluateContentQualityChecklistForContent(
   options: EvaluateContentQualityChecklistOptions = {},
   env: NodeJS.ProcessEnv = process.env
 ): Promise<ContentQualityChecklistResult> {
+  const results = await evaluateContentQualityChecklistForBatch(
+    tx,
+    tenantId,
+    contentKind,
+    [{ key: SINGLE_ITEM_KEY, content, termCount }],
+    mediaPort,
+    overrides,
+    options,
+    env
+  );
+
+  // Present by construction: the batch returns one result per item it was
+  // given, and it was given exactly one.
+  return results.get(SINGLE_ITEM_KEY)!;
+}
+
+/**
+ * The checklist for a WHOLE batch of content — a fixed number of round trips
+ * rather than a fixed number PER ITEM.
+ *
+ * ## What is shared, and why sharing it is not an approximation
+ *
+ * Two of the three reads this gate makes are not per-item facts at all:
+ *
+ * - **Managed-media enforcement** is a property of the TENANT
+ *   (`awcms_media_library_tenant_state`, one row), read once per item before
+ *   this existed. Two hundred due posts asked the same question two hundred
+ *   times and got the same answer.
+ * - **Media resolution** is keyed by media object id, and ids are tenant-wide.
+ *   Resolving the union of every item's references in one `id = ANY(...)`
+ *   returns byte-identical rows to resolving each item's references
+ *   separately; the per-item verdicts below read the same map they would have
+ *   read from their own smaller one.
+ *
+ * The evaluation itself stays strictly per item: gallery references, the
+ * social-preview priority chain and the pure rule evaluator all run once per
+ * piece of content, against that content's own values.
+ *
+ * ## What a caller must still not do
+ *
+ * The batch is ONE consistent reading. A caller that needs a FRESH reading —
+ * the scheduled-publish sweep re-evaluates immediately before it writes, to
+ * shrink the window in which referenced media can be detached — must call this
+ * again rather than reuse the returned results. Nothing is cached across calls,
+ * which is what makes that second call meaningful.
+ */
+export async function evaluateContentQualityChecklistForBatch<K>(
+  tx: Bun.SQL,
+  tenantId: string,
+  contentKind: ChecklistContentKind,
+  items: readonly ChecklistBatchItem<K>[],
+  mediaPort: MediaLibraryPort,
+  overrides: ChecklistPolicyOverrides,
+  options: EvaluateContentQualityChecklistOptions = {},
+  env: NodeJS.ProcessEnv = process.env
+): Promise<Map<K, ContentQualityChecklistResult>> {
+  const results = new Map<K, ContentQualityChecklistResult>();
+
+  if (items.length === 0) {
+    return results;
+  }
+
   const modeActive = await mediaPort.isManagedMediaEnforcementActiveForTenant(
     tx,
     tenantId,
@@ -80,92 +169,123 @@ export async function evaluateContentQualityChecklistForContent(
   );
 
   if (!modeActive) {
-    return notApplicableChecklistResult();
-  }
+    for (const item of items) {
+      results.set(item.key, notApplicableChecklistResult());
+    }
 
-  const {
-    mediaObjectIds: galleryMediaObjectIds,
-    violations: galleryViolations
-  } = collectGalleryImageReferences(content.contentJson);
+    return results;
+  }
 
   const socialPreviewFallback = options.socialPreviewFallback ?? null;
 
+  // Indexed by POSITION, not by the caller's key. Two items sharing a key is a
+  // caller's bug either way, but keying the intermediate work by it would make
+  // one item evaluate against the OTHER's gallery — a wrong verdict rather than
+  // a missing one. Position cannot collide.
+  const galleryByIndex = items.map((item) =>
+    collectGalleryImageReferences(item.content.contentJson)
+  );
+
   const idsToResolve = new Set<string>();
-  if (content.featuredMediaId) {
-    idsToResolve.add(content.featuredMediaId);
-  }
-  if (content.seoImageMediaId) {
-    idsToResolve.add(content.seoImageMediaId);
-  }
-  for (const id of galleryMediaObjectIds) {
-    idsToResolve.add(id);
-  }
+
   if (socialPreviewFallback?.tenantFallbackImageMediaId) {
     idsToResolve.add(socialPreviewFallback.tenantFallbackImageMediaId);
+  }
+
+  for (const [index, item] of items.entries()) {
+    if (item.content.featuredMediaId) {
+      idsToResolve.add(item.content.featuredMediaId);
+    }
+    if (item.content.seoImageMediaId) {
+      idsToResolve.add(item.content.seoImageMediaId);
+    }
+    for (const id of galleryByIndex[index]!.mediaObjectIds) {
+      idsToResolve.add(id);
+    }
   }
 
   const resolved = await mediaPort.resolveMediaReferences(tx, tenantId, [
     ...idsToResolve
   ]);
+  const resolvedIds = new Set(resolved.keys());
 
-  const featuredMedia = content.featuredMediaId
-    ? (resolved.get(content.featuredMediaId) ?? null)
-    : null;
+  // One moment for the whole batch. Time-dependent rules (`scheduledAt` vs
+  // `now`) should not read a different clock for the two-hundredth post than
+  // for the first — that would be a difference nobody chose, produced by how
+  // long the loop took.
+  const now = options.now ?? new Date();
 
-  const unsafeGalleryMediaObjectIds = galleryMediaObjectIds.filter(
-    (id) => !resolved.has(id)
-  );
+  for (const [index, item] of items.entries()) {
+    const { content, termCount } = item;
+    const {
+      mediaObjectIds: galleryMediaObjectIds,
+      violations: galleryViolations
+    } = galleryByIndex[index]!;
 
-  // Issue #649 — same priority chain the render route uses
-  // (`news-article-seo-metadata.ts`'s `buildNewsArticleSeoMetadata`), so the
-  // checklist's readiness rules can never silently diverge from what a
-  // shared link actually renders.
-  const socialPreviewMediaId = resolveSocialPreviewImageSourceId(
-    {
-      explicitSocialImageMediaId: content.seoImageMediaId ?? null,
-      featuredMediaId: content.featuredMediaId,
-      contentImageMediaIds: socialPreviewFallback?.contentImageFallbackEnabled
-        ? galleryMediaObjectIds
-        : [],
-      tenantFallbackImageMediaId:
-        socialPreviewFallback?.tenantFallbackImageMediaId ?? null
-    },
-    new Set(resolved.keys())
-  );
-  const socialPreviewMedia = socialPreviewMediaId
-    ? (resolved.get(socialPreviewMediaId) ?? null)
-    : null;
+    const featuredMedia = content.featuredMediaId
+      ? (resolved.get(content.featuredMediaId) ?? null)
+      : null;
 
-  return evaluateContentQualityChecklist(
-    {
-      contentKind,
-      title: content.title,
-      slug: content.slug,
-      excerpt: content.excerpt,
-      metaDescription: content.metaDescription,
-      contentText: content.contentText,
-      contentJson: content.contentJson,
-      featuredMediaId: content.featuredMediaId,
-      featuredMedia: featuredMedia
-        ? {
-            altText: featuredMedia.altText,
-            width: featuredMedia.width,
-            height: featuredMedia.height,
-            mimeType: featuredMedia.mimeType,
-            sizeBytes: featuredMedia.sizeBytes
-          }
-        : null,
-      galleryViolations,
-      unsafeGalleryMediaObjectIds,
-      termCount,
-      scheduledAt: options.scheduledAt ?? null,
-      now: options.now ?? new Date(),
-      socialPreviewImage: socialPreviewMedia
-        ? { altText: socialPreviewMedia.altText }
-        : null
-    },
-    overrides
-  );
+    const unsafeGalleryMediaObjectIds = galleryMediaObjectIds.filter(
+      (id) => !resolved.has(id)
+    );
+
+    // Issue #649 — same priority chain the render route uses
+    // (`news-article-seo-metadata.ts`'s `buildNewsArticleSeoMetadata`), so the
+    // checklist's readiness rules can never silently diverge from what a
+    // shared link actually renders.
+    const socialPreviewMediaId = resolveSocialPreviewImageSourceId(
+      {
+        explicitSocialImageMediaId: content.seoImageMediaId ?? null,
+        featuredMediaId: content.featuredMediaId,
+        contentImageMediaIds: socialPreviewFallback?.contentImageFallbackEnabled
+          ? galleryMediaObjectIds
+          : [],
+        tenantFallbackImageMediaId:
+          socialPreviewFallback?.tenantFallbackImageMediaId ?? null
+      },
+      resolvedIds
+    );
+    const socialPreviewMedia = socialPreviewMediaId
+      ? (resolved.get(socialPreviewMediaId) ?? null)
+      : null;
+
+    results.set(
+      item.key,
+      evaluateContentQualityChecklist(
+        {
+          contentKind,
+          title: content.title,
+          slug: content.slug,
+          excerpt: content.excerpt,
+          metaDescription: content.metaDescription,
+          contentText: content.contentText,
+          contentJson: content.contentJson,
+          featuredMediaId: content.featuredMediaId,
+          featuredMedia: featuredMedia
+            ? {
+                altText: featuredMedia.altText,
+                width: featuredMedia.width,
+                height: featuredMedia.height,
+                mimeType: featuredMedia.mimeType,
+                sizeBytes: featuredMedia.sizeBytes
+              }
+            : null,
+          galleryViolations,
+          unsafeGalleryMediaObjectIds,
+          termCount,
+          scheduledAt: options.scheduledAt ?? null,
+          now,
+          socialPreviewImage: socialPreviewMedia
+            ? { altText: socialPreviewMedia.altText }
+            : null
+        },
+        overrides
+      )
+    );
+  }
+
+  return results;
 }
 
 /** `{ field: ruleId, message }` pairs for every failed blocking rule — matches the existing `ErrorDetail` envelope shape (`ApiError.error.details`) the rest of this API already uses (`VALIDATION_ERROR`, `NEWS_MEDIA_REFERENCE_INVALID`), so a blocked publish/schedule response needs no new response envelope shape. */

--- a/src/modules/logging/application/audit-log.ts
+++ b/src/modules/logging/application/audit-log.ts
@@ -48,24 +48,100 @@ export type AuditEventRecord = {
  * `attributes` is redacted here before the INSERT — never persist raw
  * password/token/NPWP/NIK/phone/email values, even if a caller forgot to
  * redact them first.
+ *
+ * A batch of one, deliberately: `recordAuditEvents` below holds the only copy
+ * of the column list, the redaction call and the null handling, so the singular
+ * and plural forms cannot drift into writing different rows for the same input.
  */
 export async function recordAuditEvent(
   tx: Bun.SQL,
   input: AuditEventInput
 ): Promise<void> {
-  const redactedAttributes = redactSensitiveAttributes(input.attributes);
+  await recordAuditEvents(tx, [input]);
+}
+
+/**
+ * The same write for a WHOLE batch — one statement, not one per event.
+ *
+ * ## Why this exists
+ *
+ * Every sweep job in this repo audits per item: the scheduled publish/unpublish
+ * sweeps, workflow escalation, the backfills. At a batch bound of 200 that is
+ * 200 round trips whose only variation is the message, on the one reserved
+ * `maintenance` connection the job holds for the duration. The read side of
+ * this pattern was fixed long ago (`fetchPostTermIdsForPosts`, "three round
+ * trips per page, not fifty-one"); the write side had nobody counting.
+ *
+ * ## `jsonb_to_recordset`, not `unnest`
+ *
+ * The `INSERT ... SELECT unnest(...)` idiom used elsewhere in this repo
+ * (`syncPostTermAssignments`, `comment-retention.ts`) takes one array per
+ * column, and this table has EIGHT nullable columns plus a `jsonb` one. Bun's
+ * array binding cannot carry a NULL — it writes the literal string `null`
+ * without throwing — so the unnest shape would need a sentinel and a `NULLIF`
+ * per nullable column, eight chances to get it silently wrong.
+ *
+ * One `jsonb` parameter carrying the rows sidesteps all of it: JSON `null` maps
+ * to SQL NULL, `attributes` stays a real nested object rather than a string,
+ * and the column types are declared once in the `AS entry (...)` list. The
+ * value is bound directly (`${rows}::jsonb`) — `JSON.stringify(rows)::jsonb`
+ * would store the jsonb SCALAR STRING, the trap `db:jsonb-binding:check` exists
+ * to refuse.
+ *
+ * Rows are inserted in one statement, so they share one `created_at`: the
+ * column defaults to `now()`, which is TRANSACTION START, so the per-item loop
+ * this replaces already stamped every row of a sweep identically. Ordering
+ * within a batch was never expressed by the timestamp and is not lost here.
+ *
+ * A batch mixing tenants is refused by RLS's `WITH CHECK`, exactly as the
+ * singular form is — there is no JS-side re-implementation of a boundary the
+ * database already enforces.
+ */
+export async function recordAuditEvents(
+  tx: Bun.SQL,
+  inputs: readonly AuditEventInput[]
+): Promise<void> {
+  if (inputs.length === 0) {
+    return;
+  }
+
+  const rows = inputs.map((input) => ({
+    tenant_id: input.tenantId,
+    actor_tenant_user_id: input.actorTenantUserId ?? null,
+    actor_tenant_id: input.actorTenantId ?? null,
+    delegated_grant_id: input.delegatedGrantId ?? null,
+    module_key: input.moduleKey,
+    action: input.action,
+    resource_type: input.resourceType,
+    resource_id: input.resourceId ?? null,
+    severity: input.severity ?? "info",
+    message: input.message,
+    attributes: redactSensitiveAttributes(input.attributes) ?? null,
+    correlation_id: input.correlationId ?? null
+  }));
 
   await tx`
     INSERT INTO awcms_audit_events
       (tenant_id, actor_tenant_user_id, actor_tenant_id, delegated_grant_id,
        module_key, action, resource_type, resource_id,
        severity, message, attributes, correlation_id)
-    VALUES (
-      ${input.tenantId}, ${input.actorTenantUserId ?? null},
-      ${input.actorTenantId ?? null}, ${input.delegatedGrantId ?? null},
-      ${input.moduleKey}, ${input.action},
-      ${input.resourceType}, ${input.resourceId ?? null}, ${input.severity ?? "info"},
-      ${input.message}, ${redactedAttributes ?? null}, ${input.correlationId ?? null}
+    SELECT entry.tenant_id, entry.actor_tenant_user_id, entry.actor_tenant_id,
+           entry.delegated_grant_id, entry.module_key, entry.action,
+           entry.resource_type, entry.resource_id, entry.severity,
+           entry.message, entry.attributes, entry.correlation_id
+    FROM jsonb_to_recordset(${rows}::jsonb) AS entry (
+      tenant_id uuid,
+      actor_tenant_user_id uuid,
+      actor_tenant_id uuid,
+      delegated_grant_id uuid,
+      module_key text,
+      action text,
+      resource_type text,
+      resource_id text,
+      severity text,
+      message text,
+      attributes jsonb,
+      correlation_id text
     )
   `;
 }

--- a/tests/integration/audit-log-writer.integration.test.ts
+++ b/tests/integration/audit-log-writer.integration.test.ts
@@ -1,0 +1,360 @@
+/**
+ * What the audit writer actually PUTS IN THE TABLE — against a real database.
+ *
+ * ## Why this exists
+ *
+ * `tests/two-sided-attribution.test.ts` guards the two ADR-0091 columns by
+ * reading `audit-log.ts` as TEXT and looking for the interpolation that writes
+ * them. That test caught a real class of bug — a parameter accepted and then
+ * ignored — and it is the only thing standing behind those columns. It is also
+ * the shape this repository keeps rediscovering the limits of: a test over
+ * source text proves a spelling, and a spelling is not a row. Change how the
+ * INSERT is written and the test fails while the behaviour is intact; change
+ * what the INSERT MEANS while keeping the spelling and it passes.
+ *
+ * So the columns are now asserted where they are decided: in the table. The
+ * source-text test stays — it is cheap, it runs without a database, and it
+ * still catches a dropped field faster than this does — but it is no longer
+ * the only witness.
+ *
+ * ## And the batch writer, which is new
+ *
+ * `recordAuditEvents` writes N rows in ONE statement, built from a single
+ * `jsonb` parameter rather than one array per column (Bun's array binding
+ * cannot carry a NULL — it writes the string `null` silently, so a per-column
+ * `unnest` over eight nullable columns would have eight chances to be wrong).
+ * Every claim in that reasoning is checked here: nulls stay null, `attributes`
+ * stays a jsonb OBJECT rather than a jsonb string, redaction still happens, and
+ * the singular form — now a batch of one — writes exactly what it wrote before.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  assertRejected,
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import {
+  recordAuditEvent,
+  recordAuditEvents
+} from "../../src/modules/logging/application/audit-log";
+
+const TENANT = "f9999999-9999-4999-8999-999999999999";
+const PARTNER_TENANT = "f9999999-9999-4999-8999-999999999aaa";
+const ACTOR = "f9000000-0000-4000-8000-000000000001";
+
+type AuditRow = {
+  actor_tenant_user_id: string | null;
+  actor_tenant_id: string | null;
+  delegated_grant_id: string | null;
+  module_key: string;
+  action: string;
+  resource_type: string;
+  resource_id: string | null;
+  severity: string;
+  message: string;
+  attributes: Record<string, unknown> | null;
+  attributes_type: string | null;
+  correlation_id: string | null;
+};
+
+async function seedFixtures(): Promise<{ grantId: string }> {
+  const admin = getAdminSql();
+
+  for (const [id, code] of [
+    [TENANT, "audit-writer"],
+    [PARTNER_TENANT, "audit-writer-partner"]
+  ] as const) {
+    await admin`
+      INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+      VALUES (${id}, ${code}, ${code})
+    `;
+  }
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Actor')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'audit-writer@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${ACTOR}, ${TENANT}, ${identity[0]!.id})
+  `;
+
+  // The delegated-grant column is FK-bound to a real grant, which is FK-bound
+  // to a real engagement and a real registered partner. Seeding the whole chain
+  // is the only way to write the column at all — which is itself the point:
+  // a row cannot claim a grant that does not exist.
+  const role = (await admin`
+    INSERT INTO awcms_roles (tenant_id, role_code, role_name)
+    VALUES (${TENANT}, 'audit-writer-role', 'Audit Writer Role')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_partners
+      (tenant_id, partner_tenant_id, partner_code, display_name)
+    VALUES (${TENANT}, ${PARTNER_TENANT}, 'partner-1', 'Partner One')
+  `;
+  await admin`
+    INSERT INTO awcms_partner_managed_tenants
+      (tenant_id, partner_tenant_id, engaged_by_tenant_user_id)
+    VALUES (${TENANT}, ${PARTNER_TENANT}, ${ACTOR})
+  `;
+  const grant = (await admin`
+    INSERT INTO awcms_delegated_access_grants
+      (tenant_id, partner_tenant_id, role_id, approved_by_tenant_user_id,
+       purpose, access_code_hash, expires_at)
+    VALUES (${TENANT}, ${PARTNER_TENANT}, ${role[0]!.id}, ${ACTOR},
+            'support', 'hash-1', now() + interval '7 days')
+    RETURNING id
+  `) as { id: string }[];
+
+  return { grantId: grant[0]!.id };
+}
+
+async function auditRows(): Promise<AuditRow[]> {
+  return (await getAdminSql()`
+    SELECT actor_tenant_user_id, actor_tenant_id, delegated_grant_id,
+           module_key, action, resource_type, resource_id, severity, message,
+           attributes, jsonb_typeof(attributes) AS attributes_type,
+           correlation_id
+    FROM awcms_audit_events
+    WHERE tenant_id = ${TENANT}
+    ORDER BY message
+  `) as AuditRow[];
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("the audit writer writes every column it accepts", () => {
+  let grantId = "";
+
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    ({ grantId } = await seedFixtures());
+  });
+
+  test("a single event lands with every field, ADR-0091 attribution included", async () => {
+    await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      recordAuditEvent(tx, {
+        tenantId: TENANT,
+        actorTenantUserId: ACTOR,
+        actorTenantId: PARTNER_TENANT,
+        delegatedGrantId: grantId,
+        moduleKey: "logging",
+        action: "test.single",
+        resourceType: "thing",
+        resourceId: "res-1",
+        severity: "critical",
+        message: "a",
+        attributes: { kept: "value", nested: { n: 1 } },
+        correlationId: "corr-1"
+      })
+    );
+
+    const rows = await auditRows();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      actor_tenant_user_id: ACTOR,
+      // The two columns the source-text test can only see spelled. A writer
+      // that accepted them and dropped them would pass that test on any day it
+      // kept the spelling in a comment.
+      actor_tenant_id: PARTNER_TENANT,
+      delegated_grant_id: grantId,
+      module_key: "logging",
+      action: "test.single",
+      resource_type: "thing",
+      resource_id: "res-1",
+      severity: "critical",
+      message: "a",
+      correlation_id: "corr-1"
+    });
+    // A jsonb OBJECT, not the jsonb scalar string a `JSON.stringify(...)::jsonb`
+    // binding would have stored — the trap `db:jsonb-binding:check` refuses.
+    expect(rows[0]!.attributes_type).toBe("object");
+    expect(rows[0]!.attributes).toEqual({ kept: "value", nested: { n: 1 } });
+  });
+
+  test('the optional fields become real NULLs, not the string "null"', async () => {
+    await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      recordAuditEvents(tx, [
+        {
+          tenantId: TENANT,
+          moduleKey: "logging",
+          action: "test.sparse",
+          resourceType: "thing",
+          message: "a"
+        }
+      ])
+    );
+
+    const rows = await auditRows();
+
+    expect(rows[0]).toMatchObject({
+      actor_tenant_user_id: null,
+      actor_tenant_id: null,
+      delegated_grant_id: null,
+      resource_id: null,
+      attributes: null,
+      correlation_id: null,
+      // The column default, applied because the writer sends the default
+      // itself rather than a NULL the NOT NULL column would reject.
+      severity: "info"
+    });
+    expect(rows[0]!.attributes_type).toBeNull();
+  });
+
+  test("three events cost ONE query, and all three land intact", async () => {
+    const { queries } = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        recordAuditEvents(counting, [
+          {
+            tenantId: TENANT,
+            moduleKey: "logging",
+            action: "test.batch",
+            resourceType: "thing",
+            resourceId: "res-a",
+            message: "a",
+            attributes: { i: 1 }
+          },
+          {
+            tenantId: TENANT,
+            actorTenantUserId: ACTOR,
+            moduleKey: "logging",
+            action: "test.batch",
+            resourceType: "thing",
+            severity: "warning",
+            message: "b"
+          },
+          {
+            tenantId: TENANT,
+            moduleKey: "logging",
+            action: "test.batch",
+            resourceType: "thing",
+            message: "c",
+            correlationId: "corr-c"
+          }
+        ])
+      )
+    );
+
+    // One statement, whatever the count. Three rows through the old singular
+    // writer would be three.
+    expect(queries).toBe(1);
+
+    const rows = await auditRows();
+
+    expect(rows.map((row) => row.message)).toEqual(["a", "b", "c"]);
+    // Per-row values must not bleed across rows — the failure mode a
+    // column-wise binding makes easy and this shape makes impossible.
+    expect(rows[0]!.attributes).toEqual({ i: 1 });
+    expect(rows[1]!.attributes).toBeNull();
+    expect(rows[0]!.actor_tenant_user_id).toBeNull();
+    expect(rows[1]!.actor_tenant_user_id).toBe(ACTOR);
+    expect(rows[1]!.severity).toBe("warning");
+    expect(rows[2]!.correlation_id).toBe("corr-c");
+  });
+
+  test("an empty batch writes nothing and issues no statement", async () => {
+    const { queries } = await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      countQueries(tx, (counting) => recordAuditEvents(counting, []))
+    );
+
+    // A legal `jsonb_to_recordset('[]')` INSERT is a wasted round trip, and
+    // every sweep with nothing to report would pay it.
+    expect(queries).toBe(0);
+    expect(await auditRows()).toHaveLength(0);
+  });
+
+  test("redaction applies to every row of a batch, not just the first", async () => {
+    await withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+      recordAuditEvents(tx, [
+        {
+          tenantId: TENANT,
+          moduleKey: "logging",
+          action: "test.redact",
+          resourceType: "thing",
+          message: "a",
+          attributes: { password: "hunter2" }
+        },
+        {
+          tenantId: TENANT,
+          moduleKey: "logging",
+          action: "test.redact",
+          resourceType: "thing",
+          message: "b",
+          attributes: { token: "abcdef", harmless: "kept" }
+        }
+      ])
+    );
+
+    const rows = await auditRows();
+
+    expect(rows[0]!.attributes).toEqual({ password: "[REDACTED]" });
+    expect(rows[1]!.attributes).toEqual({
+      token: "[REDACTED]",
+      harmless: "kept"
+    });
+  });
+
+  test("a batch may not smuggle a row for another tenant", async () => {
+    // RLS is the boundary, and it is the SAME boundary the singular writer
+    // has always been behind — the batch does not re-implement it in JS, so
+    // this proves the batch did not quietly escape it either.
+    const error = await assertRejected(
+      withTenantOrThrow(getRuntimeSql(), TENANT, (tx) =>
+        recordAuditEvents(tx, [
+          {
+            tenantId: TENANT,
+            moduleKey: "logging",
+            action: "test.mixed",
+            resourceType: "thing",
+            message: "mine"
+          },
+          {
+            tenantId: PARTNER_TENANT,
+            moduleKey: "logging",
+            action: "test.mixed",
+            resourceType: "thing",
+            message: "theirs"
+          }
+        ])
+      ),
+      "a batch carrying a foreign tenant's row"
+    );
+
+    expect(error.message).toMatch(/row-level security/i);
+
+    // And the statement is atomic: the permitted row did not land either.
+    expect(await auditRows()).toHaveLength(0);
+  });
+});

--- a/tests/integration/scheduled-publish-budget.integration.test.ts
+++ b/tests/integration/scheduled-publish-budget.integration.test.ts
@@ -1,0 +1,438 @@
+/**
+ * A query budget on a JOB — the scheduled publish/unpublish sweeps.
+ *
+ * ## Why this file exists
+ *
+ * `post-term-assignment-budget.integration.test.ts` opened the write side of
+ * the budget suites and said what it was leaving behind: nine more write paths
+ * with a query per item, and one of them — this sweep — calling the per-post
+ * `fetchPostTermIds` inside its loop, "bounded by how many posts are due in one
+ * sweep, which at a cutover is not small".
+ *
+ * It was worse than a term fetch. Per due post the sweep issued: one term
+ * fetch, one managed-media enforcement read PER checklist evaluation (and it
+ * evaluates twice), one media resolve per evaluation, one `UPDATE`, one edge
+ * cache purge enqueue, and one audit `INSERT`. At the batch bound of 200 that
+ * is well over a thousand round trips on the ONE reserved `maintenance`
+ * connection the job holds — and the job runs it for EVERY active tenant, in
+ * sequence.
+ *
+ * Nothing in it was per-post except the verdict.
+ *
+ * ## Measured, not estimated
+ *
+ * Every budget below was first run against the previous implementation, which
+ * is how the numbers in the second column were obtained:
+ *
+ * | Sweep (12 due posts)              | Before | After |
+ * | --------------------------------- | ------ | ----- |
+ * | publish, enforcement off          |     40 |     6 |
+ * | publish, enforcement on           |     52 |     7 |
+ * | unpublish                         |     27 |     4 |
+ *
+ * The slope is what matters: 4 + 3N, 4 + 4N and 3 + 2N respectively, against
+ * a flat 6, 7 and 4. At the batch bound of 200 due posts that is 604, 804 and
+ * 403 round trips — per tenant, on one reserved `maintenance` connection, in a
+ * job that visits every active tenant in sequence.
+ *
+ * ## The budgets are EXACT, and the fixture is far larger than they are
+ *
+ * Exact rather than a ceiling, for the reason the term-assignment budget gives:
+ * the property is that the number does NOT move with the number of due posts,
+ * and `toBeLessThanOrEqual` passes a per-post regression as long as the fixture
+ * stays small. Twelve posts are due in every case here, so any per-post query
+ * overshoots by at least twelve.
+ *
+ * Both bounds are asserted the same way at two sizes — twelve posts and one —
+ * because "the number does not move" is a claim about the DIFFERENCE, and a
+ * single measurement cannot make it.
+ *
+ * ## Both configurations, because they cost different things
+ *
+ * With managed-media enforcement OFF — every deployment that has not opted in —
+ * the checklist is not applicable and the port answers from `process.env`
+ * without touching the database. With it ON, each evaluation reads the tenant
+ * flag and resolves the batch's media references, and THAT is the shape that
+ * used to be paid per post. Both are measured; a fix that only helped the
+ * default configuration would have left the expensive one alone.
+ *
+ * ## Correctness is asserted beside every count
+ *
+ * A budget on its own is satisfied by a sweep that publishes nothing. Every
+ * case checks the statuses that actually landed and the audit rows that
+ * actually exist, because "fewer queries" and "did the same thing" are
+ * different claims.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countPoolQueries } from "./query-budget";
+import {
+  publishDueScheduledPosts,
+  unpublishDuePosts
+} from "../../src/modules/blog-content/application/blog-scheduled-publish";
+import { mediaLibraryPortAdapter } from "../../src/modules/media-library/application/media-library-port-adapter";
+
+const TENANT = "f8888888-8888-4888-8888-888888888888";
+const AUTHOR = "f8000000-0000-4000-8000-000000000001";
+
+/** An order of magnitude more than any budget here, so a per-post query cannot hide. */
+const DUE_COUNT = 12;
+
+/**
+ * `SET LOCAL` + `SELECT` the due batch + blog settings + term ids for the whole
+ * batch + the batched `UPDATE` + the batched audit `INSERT`.
+ *
+ * The edge cache is off in this suite, so `enqueueModuleContentPurge` is a JS
+ * no-op and contributes nothing; with it on it adds ONE, not one per post.
+ */
+const PUBLISH_QUERY_BUDGET = 6;
+
+/**
+ * The same, plus what the checklist costs when enforcement is active: the
+ * tenant flag and the media resolve, ONCE PER PASS rather than once per post.
+ * Only the first pass runs here — every post is blocked, so the second pass
+ * has no candidates to re-check and issues nothing — and no `UPDATE` follows.
+ */
+const PUBLISH_ENFORCED_BLOCKED_QUERY_BUDGET = 7;
+
+/** `SET LOCAL` + the due `SELECT` + the batched `UPDATE` + the batched audit `INSERT`. */
+const UNPUBLISH_QUERY_BUDGET = 4;
+
+/**
+ * A complete, separated `NEWS_MEDIA_R2_*` block: `evaluateManagedMediaReadiness`
+ * is fail-closed, so a missing var silently turns enforcement back OFF and the
+ * "enforced" cases below would measure the unenforced path while looking like
+ * they measured the other one.
+ */
+const R2_ENV: Record<string, string> = {
+  NEWS_MEDIA_R2_ENABLED: "true",
+  NEWS_MEDIA_R2_ACCOUNT_ID: "acct-news",
+  NEWS_MEDIA_R2_ACCESS_KEY_ID: "key-news",
+  NEWS_MEDIA_R2_SECRET_ACCESS_KEY: "secret-news",
+  NEWS_MEDIA_R2_BUCKET: "bucket-news",
+  NEWS_MEDIA_R2_PUBLIC_BASE_URL: "https://media.example.test"
+};
+
+function enableManagedMediaEnv(): void {
+  for (const [name, value] of Object.entries(R2_ENV)) {
+    process.env[name] = value;
+  }
+}
+
+function clearManagedMediaEnv(): void {
+  for (const name of Object.keys(R2_ENV)) {
+    delete process.env[name];
+  }
+}
+
+async function seedTenant(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'sweep-budget', 'Sweep Budget Tenant')
+  `;
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Author')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'sweep-budget@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${AUTHOR}, ${TENANT}, ${identity[0]!.id})
+  `;
+}
+
+/**
+ * `count` posts due for publication. `featuredMediaId` points at a media object
+ * that does not exist, which the checklist (when it runs at all) treats as an
+ * unsafe reference — the cheapest way to make a post fail every time without
+ * seeding a media registry.
+ */
+async function seedDuePosts(
+  count: number,
+  options: { featuredMediaId?: string | null } = {}
+): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+       status, visibility, locale, scheduled_at, featured_media_id)
+    SELECT ${TENANT}, ${AUTHOR}, 'Due ' || n, 'due-' || n, '{}'::jsonb, 'body',
+           'scheduled', 'public', 'id', now() - interval '1 hour',
+           ${options.featuredMediaId ?? null}
+    FROM generate_series(1, ${count}) AS n
+  `;
+}
+
+/** `count` published posts whose withdrawal window has closed. */
+async function seedDueUnpublishPosts(count: number): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+       status, visibility, locale, published_at, unpublish_at)
+    SELECT ${TENANT}, ${AUTHOR}, 'Live ' || n, 'live-' || n, '{}'::jsonb, 'body',
+           'published', 'public', 'id', now() - interval '2 hours',
+           now() - interval '1 hour'
+    FROM generate_series(1, ${count}) AS n
+  `;
+}
+
+/** Marks the tenant as having opted into managed-media enforcement. */
+async function enableManagedMediaForTenant(): Promise<void> {
+  await getAdminSql()`
+    INSERT INTO awcms_media_library_tenant_state
+      (tenant_id, managed_media_enforced_at, updated_at)
+    VALUES (${TENANT}, now(), now())
+  `;
+}
+
+async function statusCounts(): Promise<Record<string, number>> {
+  const rows = (await getAdminSql()`
+    SELECT status, count(*)::int AS count
+    FROM awcms_blog_posts WHERE tenant_id = ${TENANT}
+    GROUP BY status
+  `) as { status: string; count: number }[];
+
+  return Object.fromEntries(rows.map((row) => [row.status, row.count]));
+}
+
+async function auditActionCounts(): Promise<Record<string, number>> {
+  const rows = (await getAdminSql()`
+    SELECT action, count(*)::int AS count
+    FROM awcms_audit_events WHERE tenant_id = ${TENANT}
+    GROUP BY action
+  `) as { action: string; count: number }[];
+
+  return Object.fromEntries(rows.map((row) => [row.action, row.count]));
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("the scheduled sweeps cost the same for twelve posts as for one", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    clearManagedMediaEnv();
+    await resetDatabase();
+    await seedTenant();
+  });
+
+  afterEach(() => {
+    clearManagedMediaEnv();
+  });
+
+  test("twelve due posts publish within a fixed budget", async () => {
+    await seedDuePosts(DUE_COUNT);
+
+    const { result, queries } = await countPoolQueries(
+      getRuntimeSql(),
+      (counting) =>
+        publishDueScheduledPosts(counting, TENANT, mediaLibraryPortAdapter)
+    );
+
+    expect(queries).toBe(PUBLISH_QUERY_BUDGET);
+    expect(result.publishedCount).toBe(DUE_COUNT);
+    expect(result.blockedCount).toBe(0);
+    expect(await statusCounts()).toEqual({ published: DUE_COUNT });
+
+    // One row per post plus the run summary — batching the INSERT must not
+    // batch away the trail.
+    expect(await auditActionCounts()).toEqual({
+      "blog.post.published": DUE_COUNT,
+      "blog.post.scheduled_publish_executed": 1
+    });
+  });
+
+  test("one due post costs the same as twelve", async () => {
+    await seedDuePosts(1);
+
+    const { result, queries } = await countPoolQueries(
+      getRuntimeSql(),
+      (counting) =>
+        publishDueScheduledPosts(counting, TENANT, mediaLibraryPortAdapter)
+    );
+
+    // The number does not move with the input. That is the whole property.
+    expect(queries).toBe(PUBLISH_QUERY_BUDGET);
+    expect(result.publishedCount).toBe(1);
+  });
+
+  test("a sweep with nothing due writes only its summary", async () => {
+    const { result, queries } = await countPoolQueries(
+      getRuntimeSql(),
+      (counting) =>
+        publishDueScheduledPosts(counting, TENANT, mediaLibraryPortAdapter)
+    );
+
+    // `SET LOCAL` + the due `SELECT` + the "nothing due" audit row. The empty
+    // batch must not cost a settings read, a term read or an empty `UPDATE`.
+    expect(queries).toBe(3);
+    expect(result.publishedCount).toBe(0);
+    expect(await auditActionCounts()).toEqual({
+      "blog.post.scheduled_publish_skipped": 1
+    });
+  });
+
+  test("with enforcement ON, the checklist is asked once per pass, not once per post", async () => {
+    enableManagedMediaEnv();
+    await enableManagedMediaForTenant();
+    await seedDuePosts(DUE_COUNT, {
+      featuredMediaId: "f8999999-9999-4999-8999-999999999999"
+    });
+
+    const { result, queries } = await countPoolQueries(
+      getRuntimeSql(),
+      (counting) =>
+        publishDueScheduledPosts(counting, TENANT, mediaLibraryPortAdapter)
+    );
+
+    expect(queries).toBe(PUBLISH_ENFORCED_BLOCKED_QUERY_BUDGET);
+
+    // The checklist genuinely ran — nothing published, and every post is still
+    // `scheduled` for a later run rather than silently dropped.
+    expect(result.publishedCount).toBe(0);
+    expect(result.blockedCount).toBe(DUE_COUNT);
+    expect(await statusCounts()).toEqual({ scheduled: DUE_COUNT });
+    expect(await auditActionCounts()).toEqual({
+      "blog.post.scheduled_publish_blocked": DUE_COUNT,
+      "blog.post.scheduled_publish_executed": 1
+    });
+  });
+
+  test("with enforcement ON and one post due, the cost is unchanged", async () => {
+    enableManagedMediaEnv();
+    await enableManagedMediaForTenant();
+    await seedDuePosts(1, {
+      featuredMediaId: "f8999999-9999-4999-8999-999999999999"
+    });
+
+    const { result, queries } = await countPoolQueries(
+      getRuntimeSql(),
+      (counting) =>
+        publishDueScheduledPosts(counting, TENANT, mediaLibraryPortAdapter)
+    );
+
+    expect(queries).toBe(PUBLISH_ENFORCED_BLOCKED_QUERY_BUDGET);
+    expect(result.blockedCount).toBe(1);
+  });
+
+  test("blocked and publishable posts in one batch are separated correctly", async () => {
+    enableManagedMediaEnv();
+    await enableManagedMediaForTenant();
+
+    // Six with a dangling featured media reference, six with none. The
+    // checklist's other rules are not blocking by default, so the second group
+    // passes and the first does not — one batch, two verdicts.
+    await seedDuePosts(6, {
+      featuredMediaId: "f8999999-9999-4999-8999-999999999999"
+    });
+    await getAdminSql()`
+      INSERT INTO awcms_blog_posts
+        (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+         status, visibility, locale, scheduled_at)
+      SELECT ${TENANT}, ${AUTHOR}, 'Clean ' || n, 'clean-' || n, '{}'::jsonb, 'body',
+             'scheduled', 'public', 'id', now() - interval '1 hour'
+      FROM generate_series(1, 6) AS n
+    `;
+
+    const { result } = await countPoolQueries(getRuntimeSql(), (counting) =>
+      publishDueScheduledPosts(counting, TENANT, mediaLibraryPortAdapter)
+    );
+
+    expect(result.publishedCount).toBe(6);
+    expect(result.blockedCount).toBe(6);
+    expect(await statusCounts()).toEqual({ published: 6, scheduled: 6 });
+
+    const published = (await getAdminSql()`
+      SELECT slug FROM awcms_blog_posts
+      WHERE tenant_id = ${TENANT} AND status = 'published'
+      ORDER BY slug
+    `) as { slug: string }[];
+
+    // The right six, not just six of them: a batch that published the blocked
+    // half and blocked the clean half would satisfy every count above.
+    expect(published.map((row) => row.slug)).toEqual([
+      "clean-1",
+      "clean-2",
+      "clean-3",
+      "clean-4",
+      "clean-5",
+      "clean-6"
+    ]);
+  });
+
+  test("twelve due withdrawals cost a fixed budget", async () => {
+    await seedDueUnpublishPosts(DUE_COUNT);
+
+    const { result, queries } = await countPoolQueries(
+      getRuntimeSql(),
+      (counting) => unpublishDuePosts(counting, TENANT)
+    );
+
+    expect(queries).toBe(UNPUBLISH_QUERY_BUDGET);
+    expect(result.unpublishedCount).toBe(DUE_COUNT);
+    expect(await statusCounts()).toEqual({ archived: DUE_COUNT });
+    expect(await auditActionCounts()).toEqual({
+      "blog.post.unpublished": DUE_COUNT,
+      "blog.post.scheduled_unpublish_executed": 1
+    });
+  });
+
+  test("one due withdrawal costs the same as twelve", async () => {
+    await seedDueUnpublishPosts(1);
+
+    const { result, queries } = await countPoolQueries(
+      getRuntimeSql(),
+      (counting) => unpublishDuePosts(counting, TENANT)
+    );
+
+    expect(queries).toBe(UNPUBLISH_QUERY_BUDGET);
+    expect(result.unpublishedCount).toBe(1);
+  });
+
+  test("`unpublish_at` survives the batched UPDATE", async () => {
+    await seedDueUnpublishPosts(DUE_COUNT);
+
+    await unpublishDuePosts(getRuntimeSql(), TENANT);
+
+    const rows = (await getAdminSql()`
+      SELECT count(*)::int AS count FROM awcms_blog_posts
+      WHERE tenant_id = ${TENANT} AND unpublish_at IS NOT NULL
+    `) as { count: number }[];
+
+    // Deliberate, and documented at the statement: `unpublish_at` is the
+    // RECORD of why the post is archived. Batching the UPDATE must not quietly
+    // start clearing it.
+    expect(rows[0]!.count).toBe(DUE_COUNT);
+  });
+});

--- a/tests/integration/scheduled-publish-toctou.integration.test.ts
+++ b/tests/integration/scheduled-publish-toctou.integration.test.ts
@@ -1,0 +1,238 @@
+/**
+ * The scheduled publish sweep evaluates the content quality checklist TWICE,
+ * and the second evaluation is the one that decides.
+ *
+ * ## Why this needs its own file
+ *
+ * The re-evaluation exists because the post rows are locked by the batch's
+ * `FOR UPDATE` and the R2 media objects they reference are NOT: an editor can
+ * detach or invalidate a referenced image between the first evaluation and the
+ * `UPDATE`. Re-running immediately before the write keeps that window at one
+ * query round trip.
+ *
+ * Every part of that is invisible to the other suites. A budget counts queries
+ * and would be just as happy if the second pass were deleted — happier, in
+ * fact, since the number would drop. A correctness test that seeds a stable
+ * fixture cannot tell the two passes apart, because both see the same media.
+ * So the mitigation has always been a comment with nothing holding it, and
+ * batching the sweep is exactly the kind of change that would have quietly
+ * removed it while looking like a tidy-up: reusing the first pass's verdicts is
+ * one line shorter and reads as obviously equivalent.
+ *
+ * ## How it is proven
+ *
+ * A `MediaLibraryPort` stub that resolves the post's featured media on the
+ * FIRST call and stops resolving on the second — the detachment, made
+ * deterministic. Under it the sweep must leave the post `scheduled` and write a
+ * blocked audit row. The control case, the same stub resolving every time,
+ * must publish: without it, a test that "passes" because the checklist never
+ * passed at all would look identical.
+ *
+ * The stub also answers the enforcement question directly, so this file needs
+ * no `NEWS_MEDIA_R2_*` environment at all — the port is the seam, and using it
+ * is what makes the media state controllable in the first place.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { publishDueScheduledPosts } from "../../src/modules/blog-content/application/blog-scheduled-publish";
+import type {
+  MediaLibraryPort,
+  ResolvedMediaReferenceDTO
+} from "../../src/modules/_shared/ports/media-library-port";
+
+const TENANT = "fa000000-0000-4000-8000-000000000001";
+const AUTHOR = "fa000000-0000-4000-8000-000000000002";
+const MEDIA = "fa000000-0000-4000-8000-000000000003";
+
+const RESOLVED: ResolvedMediaReferenceDTO = {
+  publicUrl: "https://media.example.test/a.jpg",
+  altText: "A photograph of something",
+  mimeType: "image/jpeg",
+  width: 1200,
+  height: 800,
+  sizeBytes: 240_000
+};
+
+/**
+ * `stopResolvingAfter` calls. `Infinity` is the control: media that never goes
+ * away. `1` is the race: resolvable when the sweep first looks, gone when it
+ * looks again.
+ */
+function stubMediaPort(stopResolvingAfter: number): {
+  port: MediaLibraryPort;
+  resolveCalls: () => number;
+} {
+  let calls = 0;
+
+  return {
+    resolveCalls: () => calls,
+    port: {
+      async isManagedMediaEnforcementActiveForTenant(): Promise<boolean> {
+        return true;
+      },
+      async isMediaReferenceSafe(): Promise<boolean> {
+        return true;
+      },
+      async resolveMediaReferences(
+        _tx: Bun.SQL,
+        _tenantId: string,
+        mediaObjectIds: readonly string[]
+      ): Promise<ReadonlyMap<string, ResolvedMediaReferenceDTO>> {
+        calls += 1;
+
+        const resolved = new Map<string, ResolvedMediaReferenceDTO>();
+
+        if (calls > stopResolvingAfter) {
+          return resolved;
+        }
+
+        for (const id of mediaObjectIds) {
+          resolved.set(id, RESOLVED);
+        }
+
+        return resolved;
+      }
+    }
+  };
+}
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'sweep-toctou', 'Sweep TOCTOU Tenant')
+  `;
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Author')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'sweep-toctou@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${AUTHOR}, ${TENANT}, ${identity[0]!.id})
+  `;
+
+  await admin`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+       status, visibility, locale, scheduled_at, featured_media_id)
+    VALUES (${TENANT}, ${AUTHOR}, 'Due', 'due', '{}'::jsonb, 'body',
+            'scheduled', 'public', 'id', now() - interval '1 hour', ${MEDIA})
+  `;
+}
+
+async function postStatus(): Promise<string> {
+  const rows = (await getAdminSql()`
+    SELECT status FROM awcms_blog_posts WHERE tenant_id = ${TENANT}
+  `) as { status: string }[];
+
+  return rows[0]!.status;
+}
+
+async function auditActions(): Promise<string[]> {
+  const rows = (await getAdminSql()`
+    SELECT action FROM awcms_audit_events WHERE tenant_id = ${TENANT}
+    ORDER BY action
+  `) as { action: string }[];
+
+  return rows.map((row) => row.action);
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("the sweep re-checks the checklist before it writes", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("media that survives both looks: the post publishes", async () => {
+    const { port, resolveCalls } = stubMediaPort(Number.POSITIVE_INFINITY);
+
+    const result = await publishDueScheduledPosts(
+      getRuntimeSql(),
+      TENANT,
+      port
+    );
+
+    expect(result.publishedCount).toBe(1);
+    expect(await postStatus()).toBe("published");
+
+    // Two looks, not one: this is the control that gives the case below its
+    // meaning. If the sweep only ever resolved once, the test below would pass
+    // for the wrong reason.
+    expect(resolveCalls()).toBe(2);
+  });
+
+  test("media detached between the two looks: the post is BLOCKED, not published", async () => {
+    const { port, resolveCalls } = stubMediaPort(1);
+
+    const result = await publishDueScheduledPosts(
+      getRuntimeSql(),
+      TENANT,
+      port
+    );
+
+    // The first evaluation passed — that is what made this post a candidate at
+    // all — and the second one refused. Reusing the first verdict would have
+    // published an article whose featured image no longer resolves.
+    expect(resolveCalls()).toBe(2);
+    expect(result.publishedCount).toBe(0);
+    expect(result.blockedCount).toBe(1);
+    expect(await postStatus()).toBe("scheduled");
+    expect(await auditActions()).toEqual([
+      "blog.post.scheduled_publish_blocked",
+      "blog.post.scheduled_publish_executed"
+    ]);
+  });
+
+  test("media already gone at the first look never reaches the second", async () => {
+    const { port, resolveCalls } = stubMediaPort(0);
+
+    const result = await publishDueScheduledPosts(
+      getRuntimeSql(),
+      TENANT,
+      port
+    );
+
+    expect(result.blockedCount).toBe(1);
+    expect(await postStatus()).toBe("scheduled");
+
+    // One look. A post the first pass already refused is not a candidate, so
+    // the second pass has nothing to re-check — the batch of zero costs
+    // nothing rather than issuing an empty query.
+    expect(resolveCalls()).toBe(1);
+  });
+});

--- a/tests/two-sided-attribution.test.ts
+++ b/tests/two-sided-attribution.test.ts
@@ -36,9 +36,18 @@ describe("penulisnya benar-benar menulis kolomnya", () => {
     // …dan benar-benar sampai ke INSERT. Parameter yang diterima lalu diabaikan
     // adalah bug yang lulus setiap typecheck dan setiap test yang hanya
     // memanggilnya.
+    //
+    // Ejaannya berubah ketika penulis tunggal menjadi penulis BATCH: nilainya
+    // kini dirakit ke dalam satu parameter jsonb, bukan diinterpolasi langsung
+    // ke `VALUES`. Yang dijaga tetap sama — field-nya DIBACA dari input dan
+    // kolomnya DISEBUT di INSERT — tetapi test teks tidak bisa membuktikan
+    // barisnya. Sejak sekarang buktinya ada di
+    // `tests/integration/audit-log-writer.integration.test.ts`, yang membaca
+    // kedua kolom itu kembali dari tabel; yang di sini tinggal jaring cepat
+    // tanpa basis data, bukan satu-satunya saksi.
     expect(source).toContain("actor_tenant_id, delegated_grant_id");
-    expect(source).toContain("${input.actorTenantId ?? null}");
-    expect(source).toContain("${input.delegatedGrantId ?? null}");
+    expect(source).toContain("input.actorTenantId ?? null");
+    expect(source).toContain("input.delegatedGrantId ?? null");
   });
 
   test("decision log menerima DAN meneruskan `delegatedGrantId`", async () => {


### PR DESCRIPTION
The PERFORMANCE ROUND left three items named rather than fixed. Two are closed here.

## The sweep was worse than the note said

The note read: "`blog-scheduled-publish` calls the per-post `fetchPostTermIds` inside its sweep loop. Bounded by how many posts are due in one sweep — which at a cutover is not small."

Per due post the sweep also read the managed-media enforcement flag **once per checklist evaluation** — and it evaluates twice — resolved that post's media per evaluation, wrote its own `UPDATE`, enqueued its own edge-cache purge and wrote its own audit row.

Measured against the previous implementation, twelve due posts:

| Sweep (12 due posts)     | Before | After |
| ------------------------ | ------ | ----- |
| publish, enforcement off |     40 |     6 |
| publish, enforcement on  |     52 |     7 |
| unpublish                |     27 |     4 |

The slope is the finding: `4 + 3N`, `4 + 4N` and `3 + 2N` against a flat 6, 7 and 4. At the batch bound of 200 that is **604, 804 and 403 round trips** — per tenant, on the ONE reserved `maintenance` connection the job holds, in a job that visits every active tenant in sequence.

Nothing in it was per-post except the verdict. Managed-media enforcement is a property of the TENANT; media resolution is keyed by media object id, which is tenant-wide. Resolving the union of a batch's references in one `id = ANY(...)` returns byte-identical rows to resolving each post's own.

## The TOCTOU re-check got smaller, not weaker

The sweep re-evaluates the checklist immediately before it writes, because the referenced media objects are not locked by the batch's `FOR UPDATE`. Batching keeps that window at one round trip and stops it growing with how far into the batch a post sits. Reusing the first pass's verdicts would have removed the mitigation entirely while looking like a tidy-up, so the second pass is still a second pass — it just costs two queries for the whole batch instead of two per post.

## `recordAuditEvents`, and why not `unnest`

N rows in one statement from a single `jsonb` parameter. `unnest` takes one array per column, this table has eight nullable columns plus a `jsonb` one, and Bun's array binding cannot carry a NULL — it writes the literal string `null` without throwing. Eight chances to be silently wrong, against one parameter where JSON `null` maps to SQL NULL and `attributes` stays a real nested object. `recordAuditEvent` is now a batch of one so the two forms cannot drift; `evaluateContentQualityChecklistForContent` is likewise a batch of one over the new batch evaluator, so the interactive publish/schedule endpoints and the sweep cannot come to disagree about what the checklist says.

## A source-text test failed while the behaviour was intact

`tests/two-sided-attribution.test.ts` guards the two ADR-0091 attribution columns by looking for `${input.actorTenantId ?? null}` in `audit-log.ts`. The batch writer assembles the same value into a jsonb row object, so the assertion broke on a **spelling**. It is kept — cheap, needs no database, catches a dropped field fastest — but it is no longer the only witness: `tests/integration/audit-log-writer.integration.test.ts` reads both columns back **out of the table**, with the whole FK chain (partner → engagement → grant) seeded, because a row cannot claim a grant that does not exist. It also pins NULL handling, `jsonb_typeof(attributes)`, per-row redaction, the one-statement budget, and the RLS refusal of a batch carrying a foreign tenant's row.

## The index measurement task: answered, no change

The hypothesis was that `awcms_blog_post_terms_tenant_idx` is a redundant single low-cardinality column and a `(tenant_id, term_id)` composite would serve both it and the category archive. Against 24,000 posts:

- Wide category: the archive uses neither index — it drives from `awcms_blog_posts_tenant_status_published_idx` and probes the `(post_id, term_id)` UNIQUE index. 0.09 ms, 67 buffers.
- Narrow category: the planner flips to a term-driven plan using `(term_id)`, so **`(term_id)` is not redundant**. 27 buffers.
- The composite serves that plan identically (25 buffers) and is wider per entry. Dropping `(term_id)` in its favour would leave `awcms_blog_terms` parent deletes scanning the join table — the residual `db:fk-index:check` documents. And `tenant_id` cannot simply be dropped: no query filters this table by `tenant_id` alone, but the FK-index gate requires it to be index-reachable.
- Bulk insert of 5,000 assignments: 110 ms with three indexes, 115 ms with two — within noise.

**A measurement trap worth recording.** Written with the term id as a subquery, the narrow category costs 24.7 ms and 48,832 buffers, because an InitPlan is not constant-folded and the planner falls back to generic selectivity. The real code binds `termId` as a parameter, Postgres builds a custom plan, and the same query costs 27 buffers. A benchmark that does not bind its parameters the way the caller does measures a plan the caller never gets.

## Verification

- `bun run check` green (all 57 gates, 5,742 tests, build).
- New budgets mutation-proven: run against the previous implementation, 6 of 9 fail with the numbers in the table above.
- `bun test tests/integration/` — 541 pass, 2 fail; both fail identically on clean `main` with this local database (environment, not regression).
- Legacy DB-gated suite — 147 pass, 1 fail; that one also fails identically on clean `main` here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)