### PR TITLE
docs(state): record that #599 was split, so the recommendation stops reading as pending

### DIFF
--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:4352dc5113fe67a0ba92ff786cc3d12b67cde5cac30734aec721e9e2b035f4df -->
+<!-- i18n-source-hash: sha256:82ce9e2bfc81bb41c8780ddc983e71c1256fc3a799f2198418c26f084b2e3637 -->
 
 # AWCMS — Project State & Continuation
 
@@ -360,6 +360,39 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 ## 4. Backlog / langkah berikutnya
 
+- **#599 SUDAH DIPECAH — 25 Agustus 2026. Rekomendasi PUTARAN BENTUK
+  dijalankan, dan ini mencatat hasilnya supaya rekomendasi itu tidak dibaca
+  lagi sebagai masih-tertunda.**
+
+  PUTARAN BENTUK di bawah ditutup dengan: "pecah #599 alih-alih menahan satu
+  issue pada artefaknya yang paling lambat. Bentuk 1 plus tiga aturan statis
+  adalah peta yang siap cutover hari ini." Sudah dikerjakan:
+
+  - **#599, diganti judulnya** — "Cutover 301 SeputarBorneo: jalankan peta
+    artikel + tiga aturan halaman statis (kodenya sudah ada; sisanya artefak)".
+    Ketiga keluhan ASLINYA — tak ada kolom id legacy, tak ada impor redirect
+    massal, badan CKEditor tak bisa disimpan — semuanya SUDAH DIBANGUN
+    (`sql/138`, `blog:legacy:redirects:import`, `legacy-html-conversion.ts`),
+    dan itulah sebabnya judul lamanya menyesatkan. Yang tersisa adalah
+    menjalankannya: peta artikel, tiga aturan path-eksak yang diketikkan ke
+    `awcms_seo_redirects`, dan crawl pra-cutover terhadap URL sitemap yang
+    hidup.
+  - **#711, baru** — bentuk rubrik (2 dan 3) dan bentuk pencarian (4). Dua
+    pemblokir, keduanya di luar repo ini: daftar rubrik butuh data yang tidak
+    dimiliki salinan kerja (`seputa58_sbb.sql` 0 byte), dan rute TUJUAN dirender
+    oleh `ahliweb/awcms-astro` (ADR-0045/ADR-0070) — pertanyaan kontrak
+    lintas-repo lebih dulu, baru pertanyaan impor. Term juga tidak punya kolom
+    provenance, jadi tidak ada yang bisa diungkapkan `--path-template`.
+
+  **Yang sebenarnya dilindungi oleh pemecahan ini.** Bentuk 3 adalah catch-all
+  dua segmen telanjang, jadi ia keluarga yang akan dijatuhkan dalam jumlah
+  TERBESAR oleh peta yang dibangun dari bentuk-bentuk yang DISEBUT — secara
+  senyap. Menahannya di issue yang sama dengan paruh yang siap cutover justru
+  yang akan membuat cutover-nya berangkat sambil mengira dirinya lengkap.
+  Terpisah dari itu, `cari_berita/*.html` sama sekali TIDAK boleh 301 ke konten
+  — query sembarang tidak punya satu tujuan yang benar — dan itu keputusan yang
+  ditulis di #711, bukan sesuatu yang diturunkan dari peta.
+
 - **PUTARAN SAPUAN — 25 Agustus 2026: sapuan terjadwal berbiaya konstan PER
   POST, dan indeks yang putaran sebelumnya tinggalkan sebagai tugas pengukuran
   ternyata TIDAK perlu diubah. Kedua paruh itu sama-sama hasil.**
@@ -601,7 +634,7 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
   Direkomendasikan: PECAH #599 alih-alih menahan satu issue pada artefak
   terlambatnya. Bentuk 1 plus tiga aturan statis sudah menjadi peta siap-cutover
-  hari ini.
+  hari ini. **Dikerjakan 25 Agustus 2026 — lihat entri di puncak bagian ini.**
 
 - **PUTARAN LEDGER — 24 Agustus 2026: 121 endpoint MENOLAK pengguna tenant
   TANPA MENCATAT bahwa mereka melakukannya.**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,37 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **#599 IS SPLIT — 25 August 2026. The SHAPE ROUND's recommendation was
+  carried out, and this records the outcome so the recommendation is not read
+  again as still-pending.**
+
+  The SHAPE ROUND below closed with: "split #599 rather than keep one issue
+  blocked on its slowest artifact. Shape 1 plus the three static rules is a
+  cutover-ready map today." Done:
+
+  - **#599, retitled** — "Cutover 301 SeputarBorneo: jalankan peta artikel +
+    tiga aturan halaman statis (kodenya sudah ada; sisanya artefak)". Its
+    ORIGINAL three complaints — no legacy id column, no bulk redirect import, no
+    way to store CKEditor bodies — are all BUILT (`sql/138`,
+    `blog:legacy:redirects:import`, `legacy-html-conversion.ts`), which is why
+    the old title had become misleading. What remains is running them: the
+    article map, three exact-path rules typed into `awcms_seo_redirects`, and
+    the pre-cutover crawl against a live sitemap URL.
+  - **#711, new** — the rubrik shapes (2 and 3) and the search shape (4). Two
+    blockers, both outside this repo: the rubrik list needs data the working
+    copy does not have (`seputa58_sbb.sql` is 0 bytes), and the TARGET route is
+    rendered by `ahliweb/awcms-astro` (ADR-0045/ADR-0070) — a cross-repo
+    contract question before it is an import question. Terms also have no
+    provenance column, so there is nothing a `--path-template` could express.
+
+  **What the split is actually protecting.** Shape 3 is a bare two-segment
+  catch-all, so it is the family a map built from the LISTED shapes would drop
+  in the largest number, silently. Keeping it in the same issue as the
+  cutover-ready half is what would let the cutover ship believing it was
+  complete. Separately, `cari_berita/*.html` must NOT 301 onto content at all —
+  an arbitrary query has no single correct destination — and that is a decision
+  written into #711 rather than something derived from a map.
+
 - **SWEEP ROUND — 25 August 2026: the scheduled sweeps cost a constant PER
   POST, and the index the previous round left as a measurement task turns out
   not to want changing. Both halves of that are results.**
@@ -595,6 +626,7 @@ pioneered directly here after the ADR-0047 freeze.)
 
   Recommended: split #599 rather than keep one issue blocked on its slowest
   artifact. Shape 1 plus the three static rules is a cutover-ready map today.
+  **Done on 25 August 2026 — see the entry at the top of this section.**
 
 - **LEDGER ROUND — 24 August 2026: 121 endpoints refuse a tenant user WITHOUT
   RECORDING that they did.**


### PR DESCRIPTION
Follow-up to #710. Docs only — no code, no changeset (paths under `docs/` are exempt by `changesets:policy:check`).

The SHAPE ROUND in `PROJECT_STATE.md` §4 closed with *"split #599 rather than keep one issue blocked on its slowest artifact. Shape 1 plus the three static rules is a cutover-ready map today."* That has now been done, and a recommendation left standing after it was carried out is the same failure mode as a stale skill banner — the next reader spends the time re-deriving a decision that was already made.

## What the entry records

- **#599 keeps the cutover-ready half and is retitled.** Its ORIGINAL three complaints — no legacy id column, no bulk redirect import, no way to store CKEditor bodies — are all BUILT (`sql/138`, `blog:legacy:redirects:import`, `legacy-html-conversion.ts`), which made the old title actively misleading about what is left. What remains is running them: the article map, three exact-path rules typed into `awcms_seo_redirects`, and the pre-cutover crawl against a live sitemap URL.
- **#711 takes the rubrik shapes (2 and 3) and the search shape (4).** Two blockers, both outside this repo: the rubrik list needs data the working copy does not have (`seputa58_sbb.sql` is 0 bytes), and the target route is rendered by `ahliweb/awcms-astro` (ADR-0045/ADR-0070) — a cross-repo contract question before it is an import question. Terms also have no provenance column, so there is nothing a `--path-template` could express.

## Why it says what the split PROTECTS, not just what it did

Shape 3 is a bare two-segment catch-all, so it is the family a map built from the LISTED shapes would drop in the largest number, silently. Keeping it in the same issue as the cutover-ready half is exactly what would let a cutover ship believing it was complete. Separately, `cari_berita/*.html` must not 301 onto content at all — an arbitrary query has no single correct destination — and that is a decision written into #711 rather than something derived from a map.

The SHAPE ROUND's own recommendation line now points forward to the outcome, so the two cannot be read independently.

## Verification

`bun run check` green (exit 0), Indonesian mirror re-stamped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)