### PR TITLE
fix(access): a guard may only demand a permission some module declares, and push fan-out costs two queries

### DIFF
--- a/.changeset/guards-must-name-declared-permissions.md
+++ b/.changeset/guards-must-name-declared-permissions.md
@@ -1,0 +1,62 @@
+---
+"awcms": patch
+---
+
+fix(access): a guard may now only demand a permission some module declares, and the scanner stopped inventing one out of a ternary
+
+`access:permissions:enforcement:check` has asked one question since ADR-0057 §F:
+does every permission a module descriptor **declares** have an
+`authorizeInTransaction` guard? It never asked it backwards — does every guard
+name a permission some descriptor declares? — and the reverse is the direction
+with the worse failure behind it.
+
+`authorizeInTransaction` answers from `grantedPermissionKeys`, built by joining
+the actor's active role grants to `awcms_permissions`. A key no descriptor
+declares has no catalogue row to join to, so **no role can hold it**, so
+`evaluateAccess` returns `default_deny` — for the tenant owner, for the platform
+tenant, for every actor in every deployment, permanently. The endpoint is not
+weakly guarded; it is dead, and it answers 403 in a shape indistinguishable from
+a legitimate refusal.
+
+This repo has shipped that exact defect twice.
+`POST /api/v1/identity/business-scope/assignments` refused every input in every
+deployment (#180 F2), and `blog_content.pages.publish` meant no page could be
+published by any code path while public search filtered on
+`status = 'published'` and therefore always returned nothing (ADR-0057). Both
+were found by hand, months later, by someone who set out to build a screen.
+Neither is visible to the forward question: a key nobody declared is not in the
+set the forward loop walks.
+
+**The gap was not theoretical, and the proof came from the gate's own scanner.**
+Asked backwards, the repo produced exactly one violation:
+`seo_distribution.redirect.purge`, from
+`src/pages/api/v1/seo/redirects/[id]/lifecycle.ts`. That route guards on
+
+```ts
+action: (lifecycleAction === "purge" ? "delete" : "update") as "delete" | "update"
+```
+
+and `readActionValues` collected **every** string literal in the expression,
+including the one the ternary tests **against**. So the scanner invented a third
+permission the route never demands. Harmless for exactly as long as nothing read
+the enforced set back — which is what the reverse direction does.
+
+Both halves are fixed. Comparison operands are dropped before literals are
+collected, and only the operand rather than the whole condition, because the two
+comments routes write `decision === "approve" ? "approve" : "reject"` where
+`approve` is both tested for and yielded. The operand is removed **whole, quotes
+included**: blanking it to `""` re-pairs the surrounding quotes so the gaps
+between the real literals start matching as literals themselves — this fix's own
+first draft did that and invented four permissions per route, which is why it is
+pinned by a test.
+
+The staleness rule had to change with it. It was "an exception is stale if the
+permission is not declared", and that makes an exception excusing an
+**undeclared guard** impossible to write — recording one would immediately
+report it stale. An exception is now stale only when it excuses nothing: neither
+a declared permission that lacks an enforcer, nor a guard that lacks a
+declaration.
+
+The gate ships with the exception list still **empty**, both directions:
+244/244 declared permissions have a guard, and every guard names a declared
+permission.

--- a/.changeset/push-fanout-costs-two-queries.md
+++ b/.changeset/push-fanout-costs-two-queries.md
@@ -1,0 +1,50 @@
+---
+"awcms": patch
+---
+
+perf(push): a notification fan-out costs two queries instead of one per device
+
+`enqueuePushToRecipients` cost `R + (R x S)` queries — one subscription lookup
+per recipient, then one `INSERT` per device — all inside a single transaction
+holding one connection. A notification to 500 users with two devices each was
+1,500 round trips.
+
+Nothing in production ever paid it, and that is the reason to fix it rather than
+to leave it. The only caller today, `POST /api/v1/push/test`, passes exactly one
+recipient. But the helper's whole contract is "every ACTIVE subscription of
+every recipient", so the cost is not a property of the function as used — it is
+a property waiting for the first caller that broadcasts, at which point it
+arrives as a production incident rather than a review comment. This is the same
+write-side blind spot the performance round found in the scheduled sweeps and in
+`syncPostTermAssignments`: a per-item query inside a path hit once per save
+looks like nothing until a bulk caller appears.
+
+Now two statements regardless of fan-out: `fetchActiveSubscriptionIdsForUsers`
+resolves every recipient in one round trip, and one
+`INSERT ... jsonb_to_recordset` writes the whole batch.
+`fetchActiveSubscriptionIds` is now a batch of one so the two cannot drift — a
+predicate fixed in one and not the other is how a batch path quietly stops
+matching the path everything was tested against.
+
+`jsonb_to_recordset` rather than `unnest` for the reason `recordAuditEvents`
+uses it: this table has four nullable columns and a `jsonb` one, and a Bun.SQL
+array cannot carry NULL — it writes the literal string `'null'` without
+throwing.
+
+The cheap cases did not get more expensive to make the expensive case cheap:
+zero recipients still costs zero queries, and every-recipient-skipped — the
+COMMON case, since most users never enable push — costs one, not two.
+
+Behaviour is unchanged, deliberately including the odd part: recipients are
+still fanned out in the order given, and a caller passing the same id twice
+still gets two notifications. That is arguably a caller bug, but changing it
+here would be a silent behaviour change riding along with a performance fix.
+
+Pinned by `tests/integration/push-enqueue-budget.integration.test.ts` — exact
+budgets against a fixture of 4 recipients and 9 devices, which is 13 queries
+under the old shape, so it cannot pass by accident. The tests read the rows back
+out of the table as well as counting, because a `jsonb_to_recordset` rewrite is
+exactly the kind of change that satisfies a counter while corrupting what lands:
+`data` arriving as a jsonb STRING, or a NULL arriving as the literal text
+`'null'`, are both silent. Mutation-proven: restoring the per-row `INSERT` fails
+the two budget tests and passes every correctness one.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:eb78b6a2fd718095696c90deb15ca7d49f5d327edd534139a4311ce88f7b9817 -->
+<!-- i18n-source-hash: sha256:01ee89ccc6e05c400cc7f53ceeb4a148d2fec6106e5e46aca3202af0b6b26315 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,100 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN ARAH — 25 Agustus 2026: gerbang enforcement menanyakan
+  pertanyaannya SATU arah saja, dan arah yang hilang justru yang berakibat
+  endpoint MATI.** Dicatat sebagai terbuka oleh PUTARAN REGISTER di bawah;
+  ditutup di sini.
+
+  Sejak ADR-0057 §F, `access:permissions:enforcement:check` menanyakan apakah
+  setiap permission yang DIDEKLARASIKAN deskriptor punya guard
+  `authorizeInTransaction`. Ia membangun himpunan setiap guard yang dibentuk
+  teks sumber lalu TIDAK PERNAH membaca himpunan itu kembali. Pertanyaan
+  sebaliknya — apakah setiap guard MENYEBUT permission yang dideklarasikan
+  suatu deskriptor? — berbiaya satu loop tambahan dan menangkap kegagalan yang
+  jelas lebih buruk.
+
+  **Kenapa lebih buruk.** `authorizeInTransaction` menjawab dari
+  `grantedPermissionKeys`, hasil join role grant aktif ke `awcms_permissions`.
+  Kunci yang tak dideklarasikan deskriptor mana pun tak punya baris katalog
+  untuk di-join, sehingga TIDAK ADA role yang bisa memegangnya, sehingga
+  `evaluateAccess` mengembalikan `default_deny` — untuk owner tenant, untuk
+  tenant platform, untuk setiap aktor di setiap deployment, selamanya. Endpoint
+  itu bukan berpenjagaan lemah; ia MATI, dan menjawab 403 dalam bentuk yang tak
+  bisa dibedakan dari penolakan yang sah. Repo ini sudah mengirimkan cacat itu
+  DUA KALI: `POST /api/v1/identity/business-scope/assignments` menolak setiap
+  input di setiap deployment (#180 F2), dan `blog_content.pages.publish` berarti
+  tak ada halaman yang bisa dipublikasikan oleh jalur kode mana pun sementara
+  pencarian publik memfilter `status = 'published'` sehingga selalu
+  mengembalikan kosong (ADR-0057). Keduanya ditemukan dengan tangan, berbulan
+  kemudian, oleh orang yang hendak membangun layar.
+
+  **Celahnya NYATA, dan pemindai gerbang itu sendiri yang membuktikannya.**
+  Ditanya terbalik, repo menghasilkan tepat satu pelanggaran:
+  `seo_distribution.redirect.purge`. Route itu menjaga dengan
+  `action: (lifecycleAction === "purge" ? "delete" : "update")`, dan
+  `readActionValues` mengumpulkan SETIAP literal string dalam ekspresi —
+  termasuk yang justru DIBANDINGKAN oleh ternary. Pemindai mengarang permission
+  yang tak pernah dituntut route itu, dan ia duduk di himpunan enforced tanpa
+  disorot selama tak ada yang membaca himpunan itu kembali.
+
+  Layak disimpan, karena inilah alasan gerbang satu-arah bukan sekadar setengah
+  gerbang: **false positive yang tak berbahaya di satu arah adalah KEGAGALAN di
+  arah lain.** Kunci ENFORCED karangan tak cocok dengan apa pun dan diabaikan
+  loop maju. Kunci yang sama, dibaca sebagai "permission yang dituntut repo
+  ini", adalah cacat yang dilaporkan. Gerbang mana pun yang mengakumulasi
+  himpunan untuk satu tujuan WAJIB diaudit ulang sebelum himpunan itu dibaca
+  untuk tujuan kedua.
+
+  Kedua sisi diperbaiki. Operand pembanding dibuang sebelum literal
+  dikumpulkan — hanya OPERAND-nya, tak pernah seluruh kondisi, karena route
+  comments menulis `decision === "approve" ? "approve" : "reject"` di mana
+  `approve` sekaligus dibandingkan DAN dihasilkan. Dibuang UTUH, berikut tanda
+  kutipnya: mengosongkannya jadi `""` memasangkan ulang kutip di sekitarnya
+  sehingga CELAH antar-literal asli (`" ? "`, `" : "`) mulai cocok sebagai
+  literal. Draf pertama perbaikan ini sendiri melakukan itu dan mengarang empat
+  permission per route — itulah sebabnya ia dipatok tes, bukan diserahkan pada
+  bentuk sebuah regex.
+
+  Aturan basi ikut berubah. "Basi bila permission tak dideklarasikan" membuat
+  exception yang memaafkan guard TAK-TERDEKLARASI mustahil ditulis — mencatat
+  satu akan langsung melaporkannya basi. Exception kini basi hanya bila ia tak
+  memaafkan apa pun.
+
+  Dikirim dengan daftar exception tetap KOSONG di kedua arah: 244/244 permission
+  terdeklarasi punya guard, dan setiap guard menyebut permission terdeklarasi.
+  Terbukti-mutasi dua kali di gerbang (kembalikan perbaikan pemindai → phantom
+  dilaporkan; salah-ketik satu activity code → kedua action-nya dilaporkan) dan
+  sekali per tes baru.
+
+  Ditutup di sini juga, item lain yang ditinggalkan terbuka PUTARAN REGISTER:
+  **fan-out push berbiaya `R + (R x S)` query.** `enqueuePushToRecipients`
+  melakukan satu lookup subscription per penerima lalu satu `INSERT` per
+  perangkat, di dalam SATU transaksi pada satu koneksi — 1.500 perjalanan
+  pulang-pergi untuk 500 pengguna dengan dua perangkat. Tak ada di produksi yang
+  pernah membayarnya: satu-satunya pemanggil, `POST /api/v1/push/test`, mengirim
+  satu penerima. Justru itu alasan memperbaikinya — biayanya bukan properti
+  fungsi SEBAGAIMANA DIPAKAI melainkan properti KONTRAK-nya ("setiap penerima"),
+  menunggu pemanggil pertama yang menyiarkan, dan akan tiba sebagai insiden
+  bukan komentar review. Kini satu lookup ter-batch dan satu
+  `INSERT ... jsonb_to_recordset`. Kasus murah TIDAK jadi lebih mahal: nol
+  penerima tetap nol query, dan semua-penerima-dilewati — kasus UMUM, karena
+  kebanyakan pengguna tak pernah mengaktifkan push — berbiaya satu. Perilaku tak
+  berubah, sengaja termasuk bagian ganjilnya (id duplikat tetap menghasilkan
+  notifikasi duplikat); mengubahnya berarti perubahan perilaku senyap yang
+  menumpang pada perbaikan performa. Dipatok anggaran terhadap fixture 4
+  penerima dan 9 perangkat — 13 query di bentuk lama — dan tesnya membaca
+  barisnya kembali dari tabel karena penulisan ulang `jsonb_to_recordset`
+  memuaskan penghitung sambil merusak apa yang mendarat.
+
+  **Masih terbuka setelah putaran ini** (keduanya disebut PUTARAN REGISTER dan
+  tak satu pun ditutup olehnya): route API yang menyebut permission yang tak
+  dideklarasikan modul mana pun KINI tertangkap, tetapi route yang menyebut
+  permission TERDEKLARASI sambil menegakkannya pada resource yang SALAH tidak,
+  dan tak bisa ditangkap pemindaian sintaktik — tes kontrak per-layar adalah
+  lapisan untuk itu, dan ia hanya ada untuk layar admin. #599 dan #711 tetap
+  terblokir artefak eksternal, bukan kode.
 
 - **PUTARAN REGISTER — 25 Agustus 2026: dua register menggambarkan permission
   yang sama, tak ada yang membandingkannya, dan gara-gara itu SATU permukaan

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,93 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **DIRECTION ROUND — 25 August 2026: the enforcement gate asked its question
+  one way round, and the missing direction is the one with the dead endpoint
+  behind it.** Recorded as open by the REGISTER ROUND below; closed here.
+
+  `access:permissions:enforcement:check` has asked, since ADR-0057 §F, whether
+  every permission a descriptor DECLARES has an `authorizeInTransaction` guard.
+  It builds a set of every guard the source text constructs and then never reads
+  that set back. The reverse question — does every guard NAME a permission some
+  descriptor declares? — costs one more loop and catches the strictly worse
+  failure.
+
+  **Why it is worse.** `authorizeInTransaction` answers from
+  `grantedPermissionKeys`, built by joining the actor's active role grants to
+  `awcms_permissions`. A key no descriptor declares has no catalogue row to join
+  to, so no role can hold it, so `evaluateAccess` returns `default_deny` — for
+  the tenant owner, for the platform tenant, for every actor in every
+  deployment, permanently. The endpoint is not weakly guarded; it is DEAD, and
+  it answers 403 in a shape indistinguishable from a legitimate refusal. This
+  repo has shipped that twice: `POST /api/v1/identity/business-scope/assignments`
+  refused every input in every deployment (#180 F2), and
+  `blog_content.pages.publish` meant no page could be published by any code path
+  while public search filtered on `status = 'published'` and therefore always
+  returned nothing (ADR-0057). Both were found by hand, months later, by
+  someone building a screen.
+
+  **The gap was live, and the gate's own scanner is what proved it.** Asked
+  backwards, the repo produced exactly one violation:
+  `seo_distribution.redirect.purge`. That route guards on
+  `action: (lifecycleAction === "purge" ? "delete" : "update")`, and
+  `readActionValues` collected every string literal in the expression —
+  including the one the ternary tests AGAINST. The scanner invented a permission
+  the route never demands, and it sat in the enforced set unremarked for as long
+  as nothing read that set back.
+
+  Worth keeping, because it is the reason a one-directional gate is not merely
+  half a gate: **a false positive that is harmless in one direction is a
+  failure in the other.** An invented ENFORCED key matches nothing and is
+  ignored by the forward loop. The same key, read as "a permission this repo
+  demands", is a reported defect. Any gate that accumulates a set for one
+  purpose has to be re-audited before that set is read for a second.
+
+  Both halves fixed. Comparison operands are dropped before literals are
+  collected — only the operand, never the whole condition, because the comments
+  routes write `decision === "approve" ? "approve" : "reject"` where `approve` is
+  both tested for and yielded. Removed WHOLE, quotes included: blanking to `""`
+  re-pairs the surrounding quotes so the GAPS between real literals (`" ? "`,
+  `" : "`) start matching as literals. This fix's own first draft did that and
+  invented four permissions per route, which is why it is pinned by a test
+  rather than left to the shape of a regex.
+
+  The staleness rule changed with it. "Stale if the permission is not declared"
+  makes an exception excusing an UNDECLARED guard impossible to write —
+  recording one would immediately report it stale. An exception is now stale
+  only when it excuses nothing.
+
+  Ships with the exception list still EMPTY in both directions: 244/244 declared
+  permissions have a guard, and every guard names a declared permission.
+  Mutation-proven twice at the gate (revert the scanner fix → the phantom is
+  reported; typo an activity code → both its actions are reported) and once per
+  new test.
+
+  Also closed here, the other item the REGISTER ROUND left open: **the push
+  fan-out was `R + (R x S)` queries.** `enqueuePushToRecipients` did one
+  subscription lookup per recipient and then one `INSERT` per device, inside a
+  single transaction on one connection — 1,500 round trips for 500 users with
+  two devices each. Nothing in production ever paid it: the only caller,
+  `POST /api/v1/push/test`, passes one recipient. That is the reason to fix it
+  rather than leave it — the cost is not a property of the function as used but
+  of its contract ("every recipient"), waiting for the first caller that
+  broadcasts, and it would arrive as an incident rather than a review comment.
+  Now one batched lookup and one `INSERT ... jsonb_to_recordset`. The cheap
+  cases did not get more expensive: zero recipients still costs zero queries,
+  and every-recipient-skipped — the COMMON case, since most users never enable
+  push — costs one. Behaviour is unchanged deliberately including the odd part
+  (duplicate ids still produce duplicate notifications); changing it would be a
+  silent behaviour change riding along with a performance fix. Budget-pinned
+  against a fixture of 4 recipients and 9 devices, which is 13 queries under the
+  old shape, and the tests read the rows back out because a
+  `jsonb_to_recordset` rewrite satisfies a counter while corrupting what lands.
+
+  **Still open after this round** (both were named in the REGISTER ROUND and
+  neither is closed by it): an API route naming a permission no module declares
+  is NOW caught, but a route naming one that IS declared while enforcing it on
+  the wrong resource is not, and cannot be by a syntactic scan — the per-screen
+  contract tests are the layer for that, and they exist only for admin screens.
+  #599 and #711 remain blocked on external artefacts, not on code.
+
 - **REGISTER ROUND — 25 August 2026: two registers describe the same
   permissions, nothing compared them, and an entire authorization surface had
   no screen because of it.**

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 486   |
+| Test files                          | 487   |
 | Route files                         | 383   |
 | ADR                                 | 226   |
 
@@ -361,7 +361,7 @@
 | ------------- | ---------- |
 | `(root)`      | 402        |
 | `e2e`         | 17         |
-| `integration` | 66         |
+| `integration` | 67         |
 | `unit`        | 1          |
 
 ### Routes

--- a/scripts/permission-enforcement-check.ts
+++ b/scripts/permission-enforcement-check.ts
@@ -1,15 +1,25 @@
 /**
  * permission-enforcement-check.ts — `bun run access:permissions:enforcement:check`.
  *
- * ADR-0057 §F. Every permission a module descriptor declares must have an
- * `authorizeInTransaction` guard somewhere in `src/`, or a recorded reason why
- * it does not. Pure: registry + source text, no database, no network.
+ * ADR-0057 §F. The descriptors and the code must name the same permissions, in
+ * both directions:
+ *
+ * - every permission a module descriptor DECLARES has an
+ *   `authorizeInTransaction` guard somewhere in `src/`, or a recorded reason;
+ * - every guard `src/` builds NAMES a permission some descriptor declares, or a
+ *   recorded reason.
+ *
+ * Pure: registry + source text, no database, no network.
  *
  * The gate exists because two modules shipped seeded-but-unchecked permissions
  * and both were caught by hand, months later, only when someone tried to build
  * their admin screen. For `blog_content` the consequence was that a page could
- * never be published at all. See `permission-enforcement-coverage.ts` for what
- * this can and cannot prove.
+ * never be published at all.
+ *
+ * The second direction was added later and catches the worse failure: a key no
+ * descriptor declares has no catalogue row, no role can hold it, and the
+ * endpoint denies everyone forever while looking exactly like a legitimate 403.
+ * See `permission-enforcement-coverage.ts` for what this can and cannot prove.
  */
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -79,12 +89,13 @@ function main(): void {
   const result = evaluateEnforcementCoverage(
     listModules(),
     sources,
-    EXCEPTIONS
+    EXCEPTIONS,
+    files
   );
 
   if (result.valid) {
     console.log(
-      `access:permissions:enforcement:check OK — ${result.enforcedCount}/${result.declaredCount} declared permission(s) have an authorizeInTransaction guard; ${EXCEPTIONS.length} recorded exception(s).`
+      `access:permissions:enforcement:check OK — ${result.enforcedCount}/${result.declaredCount} declared permission(s) have an authorizeInTransaction guard, and every guard names a declared permission; ${EXCEPTIONS.length} recorded exception(s).`
     );
     return;
   }
@@ -94,6 +105,12 @@ function main(): void {
   for (const permission of result.unenforced) {
     console.error(
       `  ${permission.key} — declared by module "${permission.moduleKey}" and enforced by nothing. Add an authorizeInTransaction guard, or record the reason in EXCEPTIONS in this script (with the ADR that decided it).`
+    );
+  }
+
+  for (const guard of result.undeclaredGuards) {
+    console.error(
+      `  ${guard.key} — guarded by ${guard.sources.join(", ") || "a scanned source"} and declared by no module. No catalogue row backs this key, so no role can hold it and authorizeInTransaction denies EVERY actor, including the tenant owner, in every deployment. Fix the spelling, declare it in the module descriptor with a seed migration, or record the reason in EXCEPTIONS in this script.`
     );
   }
 

--- a/src/modules/_shared/permission-enforcement-coverage.ts
+++ b/src/modules/_shared/permission-enforcement-coverage.ts
@@ -18,10 +18,23 @@ import { stripComments } from "../../../scripts/lib/source-text";
  * them asks whether a DECLARED permission has an enforcer at all, which is why
  * both gaps sat in `main` with `bun run check` green.
  *
- * This module answers exactly that, and nothing more: for every permission a
- * module descriptor declares, does some source file build an
- * `authorizeInTransaction` guard for it — or is its absence recorded as a
- * decision?
+ * This module answers exactly that: for every permission a module descriptor
+ * declares, does some source file build an `authorizeInTransaction` guard for
+ * it — or is its absence recorded as a decision?
+ *
+ * ## And the same question backwards
+ *
+ * It shipped asking only the forward half, and the reverse half is the one with
+ * the worse failure behind it: a guard naming a permission NO descriptor
+ * declares has no catalogue row, so no role can hold it, so every actor is
+ * denied in every deployment (`evaluateEnforcementCoverage` has the full
+ * argument). The forward loop cannot see it — it walks the declared set, and an
+ * undeclared key is by definition not in it.
+ *
+ * The proof that this was a live gap and not a tidy symmetry: the repo's own
+ * scanner invented `seo_distribution.redirect.purge` out of a ternary's
+ * comparison operand, and that phantom sat in the enforced set unremarked for
+ * as long as nothing ever read that set back.
  *
  * ## What counts as an enforcer, and why the shape is the whole test
  *
@@ -67,11 +80,24 @@ export type UnenforcedPermission = {
   moduleKey: string;
 };
 
+/** A guard built in `src/` for a permission no module descriptor declares. */
+export type UndeclaredGuard = {
+  key: string;
+  /** Every scanned source that builds it, so the report names the route to fix. */
+  sources: string[];
+};
+
 export type EnforcementCoverageResult = {
   valid: boolean;
   declaredCount: number;
   enforcedCount: number;
   unenforced: UnenforcedPermission[];
+  /**
+   * The other direction: guards that demand a permission nothing declares.
+   * See `evaluateEnforcementCoverage` for why an entry here is a dead endpoint
+   * rather than an untidy name.
+   */
+  undeclaredGuards: UndeclaredGuard[];
   /** Exceptions whose permission is no longer declared, or has since gained an enforcer — a stale allow-list entry is how a gate quietly stops asking. */
   staleExceptions: string[];
 };
@@ -120,6 +146,17 @@ function readStringField(
 }
 
 /**
+ * A string compared against, rather than assigned — `lifecycleAction === "purge"`.
+ *
+ * Removed WHOLE, quotes included, rather than blanked to `""`. Blanking looks
+ * equivalent and is not: `("" ? "delete" : "update")` re-pairs the quotes, so
+ * the GAPS between the real literals (`" ? "`, `" : "`) start matching as
+ * literals themselves. The first draft of this fix did exactly that and
+ * invented four permissions per route.
+ */
+const COMPARISON_OPERAND = /(?:===|!==|==|!=)\s*"[^"]*"/g;
+
+/**
  * `action` is the one guard field that is not always a single value. Two
  * comments routes decide it per request:
  *
@@ -129,6 +166,26 @@ function readStringField(
  * `comments.moderation.approve` and `.reject` as unenforced while the route
  * gates every request on one of them. So every string literal in the
  * expression counts — the guard really can require any of them.
+ *
+ * Every literal in a VALUE position, that is. The string a ternary tests
+ * against is not one of the actions the guard can require:
+ *
+ *     action: (lifecycleAction === "purge" ? "delete" : "update") as ...
+ *
+ * requires `delete` or `update` and never `purge`, but reading every literal
+ * alike invented a third permission, `seo_distribution.redirect.purge`, that no
+ * module declares and no catalogue row backs. That phantom was harmless only
+ * for as long as this file asked its question in one direction: an invented
+ * ENFORCED key that matches nothing simply never gets looked at. It stops being
+ * harmless the moment a phantom collides with a declared-but-genuinely-
+ * unenforced permission — the gate would then report it covered — and it stops
+ * being harmless immediately for `undeclaredGuards` below, which reads the
+ * enforced set as the set of permissions this repo actually demands.
+ *
+ * Note the two routes above are the reason to drop only the OPERAND and not the
+ * whole condition: `approve` is both what the request is tested against and
+ * what the guard requires, and it survives here because it also appears in a
+ * value position.
  *
  * The expression ends at the field separator, and the scan is over a literal
  * with nested objects already blanked, so a comma inside a nested value cannot
@@ -143,7 +200,7 @@ function readActionValues(
   );
   if (!match) return [];
 
-  const expression = match[1]!;
+  const expression = match[1]!.replace(COMPARISON_OPERAND, "");
   const literals = [...expression.matchAll(/"([^"]+)"/g)].map(
     (found) => found[1]!
   );
@@ -363,19 +420,67 @@ export function collectGuardTriples(
   return triples;
 }
 
+/**
+ * Both directions between the two things that must agree about a permission:
+ * what the descriptors DECLARE, and what the code DEMANDS.
+ *
+ * The forward direction — a declared permission nothing enforces — is the one
+ * this file was written for, and its consequence is a catalogue row that grants
+ * nothing.
+ *
+ * The reverse direction costs one more loop and catches the strictly worse
+ * failure. `authorizeInTransaction` answers from `grantedPermissionKeys`, built
+ * by joining the actor's active role grants to `awcms_permissions`. A key that
+ * no descriptor declares has no catalogue row to join to, so no role can hold
+ * it, so `evaluateAccess` returns `default_deny` — for the tenant owner, for
+ * the platform tenant, for every actor in every deployment, permanently. The
+ * endpoint is not weakly guarded; it is DEAD, and it answers 403 in a shape
+ * indistinguishable from a legitimate refusal.
+ *
+ * This repo has shipped that exact defect twice. `POST /api/v1/identity/
+ * business-scope/assignments` refused every input in every deployment (#180
+ * F2), and `blog_content.pages.publish` meant no page could be published by any
+ * code path while public search filtered on `status = 'published'` and
+ * therefore always returned nothing (ADR-0057). Both were found by hand, months
+ * later, by someone who set out to build a screen. Neither is visible to the
+ * forward question: a guard whose key matches no declaration is simply not in
+ * the set the forward loop iterates.
+ *
+ * `undeclaredGuards` shares the EXCEPTIONS list with the forward direction, and
+ * deliberately so — an entry there asserts that a permission key and its
+ * enforcement may legitimately disagree, which is the same claim in both
+ * directions and should be argued once, in an ADR.
+ */
 export function evaluateEnforcementCoverage(
   modules: readonly ModuleDescriptor[],
   sources: readonly string[],
-  exceptions: readonly EnforcementException[]
+  exceptions: readonly EnforcementException[],
+  /**
+   * Paths parallel to `sources`, used only to name the offending file in the
+   * reverse report. Absent for callers that scan text they built themselves.
+   */
+  sourceNames: readonly string[] = []
 ): EnforcementCoverageResult {
   const crossFileConstants = collectStringConstants(sources);
   const enforced = new Set<string>();
+  const guardSources = new Map<string, string[]>();
 
-  for (const source of sources) {
+  for (const [index, source] of sources.entries()) {
     const constants = resolveConstantsForSource(source, crossFileConstants);
 
     for (const triple of collectGuardTriples(source, constants)) {
-      enforced.add(permissionTripleKey(triple));
+      const key = permissionTripleKey(triple);
+      enforced.add(key);
+
+      const name = sourceNames[index];
+      if (name === undefined) continue;
+
+      const seen = guardSources.get(key);
+      if (seen) {
+        if (!seen.includes(name)) seen.push(name);
+        continue;
+      }
+      guardSources.set(key, [name]);
     }
   }
 
@@ -401,22 +506,41 @@ export function evaluateEnforcementCoverage(
     unenforced.push({ key, moduleKey });
   }
 
+  const undeclaredGuards: UndeclaredGuard[] = [];
+
+  for (const key of enforced) {
+    if (declared.has(key) || excused.has(key)) continue;
+    undeclaredGuards.push({ key, sources: guardSources.get(key) ?? [] });
+  }
+
   // An exception for a permission that is gone, or that now HAS an enforcer,
   // is worse than no exception: it is a documented reason that no longer
   // applies to anything, and it keeps the gate from asking again.
+  //
+  // "Gone" cannot mean "not declared" alone once the reverse direction exists:
+  // an exception excusing an UNDECLARED guard is doing its job precisely
+  // because the permission is undeclared, and calling it stale would make that
+  // kind of exception impossible to write.
   const staleExceptions = [...excused].filter(
-    (key) => !declared.has(key) || enforced.has(key)
+    (key) =>
+      (!declared.has(key) && !enforced.has(key)) ||
+      (declared.has(key) && enforced.has(key))
   );
 
   unenforced.sort((left, right) => left.key.localeCompare(right.key));
+  undeclaredGuards.sort((left, right) => left.key.localeCompare(right.key));
   staleExceptions.sort();
 
   return {
-    valid: unenforced.length === 0 && staleExceptions.length === 0,
+    valid:
+      unenforced.length === 0 &&
+      undeclaredGuards.length === 0 &&
+      staleExceptions.length === 0,
     declaredCount: declared.size,
     enforcedCount: [...declared.keys()].filter((key) => enforced.has(key))
       .length,
     unenforced,
+    undeclaredGuards,
     staleExceptions
   };
 }

--- a/src/modules/push-delivery/application/push-enqueue.ts
+++ b/src/modules/push-delivery/application/push-enqueue.ts
@@ -13,7 +13,7 @@
  */
 import { log } from "../../../lib/logging/logger";
 import { validatePushTargetPath } from "../domain/push-target-path";
-import { fetchActiveSubscriptionIds } from "./subscription-directory";
+import { fetchActiveSubscriptionIdsForUsers } from "./subscription-directory";
 
 const MODULE_KEY = "push_delivery";
 
@@ -39,6 +39,53 @@ export type EnqueuePushResult = {
 export class PushTargetPathError extends Error {}
 
 /**
+ * One INSERT for the whole fan-out.
+ *
+ * `jsonb_to_recordset` rather than `INSERT ... SELECT unnest(...)` for the same
+ * reason `recordAuditEvents` uses it: this table has four nullable columns and
+ * a `jsonb` one, and a Bun.SQL array cannot carry NULL — it writes the literal
+ * string `'null'` without throwing. JSON `null` maps to SQL NULL natively, and
+ * `data` arrives as a jsonb object rather than a jsonb STRING.
+ *
+ * `ORDER BY entry.ordinal` makes the insert order deterministic. It is NOT a
+ * promise about `RETURNING`: Postgres does not specify the order rows come back
+ * in, and no caller may treat `messageIds` as positionally aligned with the
+ * recipients — it is a set of receipts. The ordering is here so that two runs
+ * of the same batch write rows in the same sequence, which is what makes the
+ * `created_at` tiebreak in the dispatcher's claim stable.
+ */
+async function insertMessages(
+  tx: Bun.TransactionSQL,
+  rows: readonly Record<string, unknown>[]
+): Promise<string[]> {
+  const inserted = (await tx`
+    INSERT INTO awcms_push_messages
+      (tenant_id, correlation_id, category, subscription_id, priority,
+       title, body, target_path, data, created_by)
+    SELECT entry.tenant_id, entry.correlation_id, entry.category,
+           entry.subscription_id, entry.priority, entry.title, entry.body,
+           entry.target_path, entry.data, entry.created_by
+    FROM jsonb_to_recordset(${rows}::jsonb) AS entry (
+      ordinal integer,
+      tenant_id uuid,
+      correlation_id text,
+      category text,
+      subscription_id uuid,
+      priority text,
+      title text,
+      body text,
+      target_path text,
+      data jsonb,
+      created_by uuid
+    )
+    ORDER BY entry.ordinal
+    RETURNING id
+  `) as { id: string }[];
+
+  return inserted.map((row) => row.id);
+}
+
+/**
  * Fans one notification out to every ACTIVE subscription of every recipient.
  *
  * One row per (message, subscription) — the "one row per delivery unit" shape
@@ -50,6 +97,20 @@ export class PushTargetPathError extends Error {}
  * Most users will never enable push, and a notification helper that throws for
  * the common case would push every caller into a try/catch that swallows real
  * failures too.
+ *
+ * ## Cost: 2 queries, whatever the fan-out
+ *
+ * It was `R + (R x S)` — one subscription lookup per recipient, then one INSERT
+ * per device — inside a single transaction. The only caller today passes ONE
+ * recipient, so nothing in production ever paid it; the shape is what mattered,
+ * because the function's entire contract is "every recipient" and the first
+ * caller that broadcasts would have inherited it. A notification to 500 users
+ * with two devices each cost 1,500 round trips on one connection.
+ *
+ * Now: one batched lookup, one batched INSERT. Zero recipients costs zero
+ * queries and every-recipient-skipped costs one, so the cheap cases did not get
+ * more expensive to make the expensive case cheap. Pinned by an exact query
+ * budget in `tests/integration/push-enqueue-budget.integration.test.ts`.
  */
 export async function enqueuePushToRecipients(
   tx: Bun.TransactionSQL,
@@ -72,38 +133,64 @@ export async function enqueuePushToRecipients(
     targetPath = validation.path;
   }
 
-  const messageIds: string[] = [];
   const skippedRecipients: string[] = [];
 
-  for (const tenantUserId of recipientTenantUserIds) {
-    const subscriptionIds = await fetchActiveSubscriptionIds(
-      tx,
-      tenantId,
-      tenantUserId
-    );
+  if (recipientTenantUserIds.length === 0) {
+    return { messageIds: [], skippedRecipients };
+  }
 
-    if (subscriptionIds.length === 0) {
+  const subscriptionsByUser = await fetchActiveSubscriptionIdsForUsers(
+    tx,
+    tenantId,
+    recipientTenantUserIds
+  );
+
+  const rows: {
+    ordinal: number;
+    tenant_id: string;
+    correlation_id: string | null;
+    category: string;
+    subscription_id: string;
+    priority: string;
+    title: string;
+    body: string;
+    target_path: string | null;
+    data: Record<string, string> | null;
+    created_by: string | null;
+  }[] = [];
+
+  // Walks the caller's list AS GIVEN rather than the map, which keeps two
+  // things the per-recipient loop did: recipients are fanned out in the order
+  // they were passed, and a caller that passes the same id twice still gets two
+  // notifications. The second is arguably a caller bug, but changing it here
+  // would be a silent behaviour change riding along with a performance fix.
+  for (const tenantUserId of recipientTenantUserIds) {
+    const subscriptionIds = subscriptionsByUser.get(tenantUserId);
+
+    if (!subscriptionIds || subscriptionIds.length === 0) {
       skippedRecipients.push(tenantUserId);
       continue;
     }
 
     for (const subscriptionId of subscriptionIds) {
-      const rows = (await tx`
-        INSERT INTO awcms_push_messages
-          (tenant_id, correlation_id, category, subscription_id, priority,
-           title, body, target_path, data, created_by)
-        VALUES (
-          ${tenantId}, ${input.correlationId ?? null}, ${input.category},
-          ${subscriptionId}, ${input.priority ?? "normal"}, ${input.title},
-          ${input.body}, ${targetPath}, ${input.data ?? null},
-          ${input.createdBy ?? null}
-        )
-        RETURNING id
-      `) as { id: string }[];
-
-      messageIds.push(rows[0]!.id);
+      rows.push({
+        ordinal: rows.length,
+        tenant_id: tenantId,
+        correlation_id: input.correlationId ?? null,
+        category: input.category,
+        subscription_id: subscriptionId,
+        priority: input.priority ?? "normal",
+        title: input.title,
+        body: input.body,
+        target_path: targetPath,
+        data: input.data ?? null,
+        created_by: input.createdBy ?? null
+      });
     }
   }
+
+  // Every recipient skipped is a normal outcome and must not cost a write.
+  const messageIds = rows.length === 0 ? [] : await insertMessages(tx, rows);
 
   log("info", "push.enqueue.queued", {
     tenantId,

--- a/src/modules/push-delivery/application/subscription-directory.ts
+++ b/src/modules/push-delivery/application/subscription-directory.ts
@@ -165,16 +165,56 @@ export async function fetchActiveSubscriptionIds(
   tenantId: string,
   tenantUserId: string
 ): Promise<string[]> {
+  const byUser = await fetchActiveSubscriptionIdsForUsers(tx, tenantId, [
+    tenantUserId
+  ]);
+
+  return byUser.get(tenantUserId) ?? [];
+}
+
+/**
+ * The same question for many users in ONE round trip.
+ *
+ * `enqueuePushToRecipients` asked it per recipient, so fanning a notification
+ * out to R recipients cost R queries before a single row was written. The
+ * single-user form above is now a batch of one, so the two cannot drift: a
+ * predicate fixed in one and not the other is the way a batch path quietly
+ * stops matching the path everything was tested against.
+ *
+ * Users with no active subscription are ABSENT from the map rather than present
+ * with an empty array — the caller distinguishes "skipped" from "queued" by
+ * exactly that, and materialising empty entries would make the two look alike.
+ */
+export async function fetchActiveSubscriptionIdsForUsers(
+  tx: Bun.TransactionSQL,
+  tenantId: string,
+  tenantUserIds: readonly string[]
+): Promise<Map<string, string[]>> {
+  const byUser = new Map<string, string[]>();
+
+  if (tenantUserIds.length === 0) return byUser;
+
   const rows = (await tx`
-    SELECT id
+    SELECT tenant_user_id, id
     FROM awcms_push_subscriptions
     WHERE tenant_id = ${tenantId}
-      AND tenant_user_id = ${tenantUserId}
+      AND tenant_user_id = ANY(${tx.array([...new Set(tenantUserIds)], "uuid")})
       AND status = 'active'
-    ORDER BY created_at
-  `) as { id: string }[];
+    ORDER BY tenant_user_id, created_at
+  `) as { tenant_user_id: string; id: string }[];
 
-  return rows.map((row) => row.id);
+  for (const row of rows) {
+    const existing = byUser.get(row.tenant_user_id);
+
+    if (existing) {
+      existing.push(row.id);
+      continue;
+    }
+
+    byUser.set(row.tenant_user_id, [row.id]);
+  }
+
+  return byUser;
 }
 
 type TargetRow = {

--- a/tests/integration/push-enqueue-budget.integration.test.ts
+++ b/tests/integration/push-enqueue-budget.integration.test.ts
@@ -1,0 +1,320 @@
+/**
+ * A query budget on the push fan-out.
+ *
+ * ## The defect this pins, and why nobody felt it
+ *
+ * `enqueuePushToRecipients` cost `R + (R x S)` queries — one subscription
+ * lookup per recipient, then one `INSERT` per device — all inside a single
+ * transaction holding one connection. A broadcast to 500 users with two devices
+ * each was 1,500 round trips.
+ *
+ * Nothing in production ever paid it: the only caller today,
+ * `POST /api/v1/push/test`, passes exactly one recipient. That is precisely why
+ * it needed a test rather than a fix and a shrug. The helper's contract is
+ * "every ACTIVE subscription of every recipient", so the cost is not a property
+ * of the function as used — it is a property waiting for the first caller that
+ * broadcasts, at which point it arrives as a production incident rather than a
+ * review comment.
+ *
+ * ## The budget is EXACT, and the fixture is much larger than it
+ *
+ * Two statements: one batched subscription lookup, one
+ * `INSERT ... jsonb_to_recordset`. Exact rather than a ceiling, because the
+ * whole property being asserted is that the number does NOT move with the
+ * fan-out — `toBeLessThanOrEqual` would pass a regression that reintroduced a
+ * per-device query as long as the fixture stayed small.
+ *
+ * The fixture is 4 recipients with 9 subscriptions between them. Under the old
+ * shape that is 4 + 9 = 13 queries against a budget of 2, so it cannot pass by
+ * accident.
+ *
+ * ## Correctness is asserted alongside the count
+ *
+ * A budget on its own is satisfied by a function that writes nothing. The
+ * `jsonb_to_recordset` rewrite is exactly the kind of change that can satisfy a
+ * counter while corrupting what lands: `data` can arrive as a jsonb STRING
+ * instead of an object, and a NULL can arrive as the literal text `'null'`,
+ * both silently. Every case below reads the rows back out of the table.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { enqueuePushToRecipients } from "../../src/modules/push-delivery/application/push-enqueue";
+
+const TENANT = "f8888888-8888-4888-8888-888888888888";
+
+/**
+ * Deliberately uneven: one recipient with four devices, one with three, one
+ * with two, and one with none. The last is what separates "queued" from
+ * "skipped", and an even fan-out would let an off-by-one in the grouping pass.
+ */
+const RECIPIENTS = [
+  { id: "f8000000-0000-4000-8000-000000000001", devices: 4 },
+  { id: "f8000000-0000-4000-8000-000000000002", devices: 3 },
+  { id: "f8000000-0000-4000-8000-000000000003", devices: 2 },
+  { id: "f8000000-0000-4000-8000-000000000004", devices: 0 }
+] as const;
+
+const TOTAL_DEVICES = RECIPIENTS.reduce(
+  (total, recipient) => total + recipient.devices,
+  0
+);
+
+/** One batched lookup, one batched INSERT. */
+const ENQUEUE_QUERY_BUDGET = 2;
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'push-budget', 'Push Budget Tenant')
+  `;
+
+  for (const recipient of RECIPIENTS) {
+    const profile = (await admin`
+      INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+      VALUES (${TENANT}, 'person', 'Recipient')
+      RETURNING id
+    `) as { id: string }[];
+    const identity = (await admin`
+      INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+      VALUES (${TENANT}, ${profile[0]!.id}, ${`${recipient.id}@example.test`}, 'x')
+      RETURNING id
+    `) as { id: string }[];
+    await admin`
+      INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+      VALUES (${recipient.id}, ${TENANT}, ${identity[0]!.id})
+    `;
+
+    if (recipient.devices === 0) continue;
+
+    await admin`
+      INSERT INTO awcms_push_subscriptions
+        (tenant_id, tenant_user_id, transport, endpoint, endpoint_hash,
+         endpoint_masked, status)
+      SELECT ${TENANT}, ${recipient.id}, 'fcm',
+             ${`${recipient.id}-device-`} || n,
+             ${`${recipient.id}-hash-`} || n,
+             'device-…token', 'active'
+      FROM generate_series(1, ${recipient.devices}) AS n
+    `;
+  }
+
+  // A disabled device on the busiest recipient. The lookup filters on
+  // `status = 'active'`, and a batched predicate that dropped that filter would
+  // otherwise look correct in every count.
+  await admin`
+    INSERT INTO awcms_push_subscriptions
+      (tenant_id, tenant_user_id, transport, endpoint, endpoint_hash,
+       endpoint_masked, status)
+    VALUES (${TENANT}, ${RECIPIENTS[0].id}, 'fcm', 'disabled-endpoint',
+            'disabled-hash', 'device-…token', 'disabled')
+  `;
+}
+
+async function queuedMessages(): Promise<
+  {
+    subscription_id: string;
+    category: string;
+    title: string;
+    data: unknown;
+    target_path: string | null;
+    correlation_id: string | null;
+    created_by: string | null;
+  }[]
+> {
+  return (await getAdminSql()`
+    SELECT subscription_id, category, title, data, target_path, correlation_id,
+           created_by
+    FROM awcms_push_messages
+    WHERE tenant_id = ${TENANT}
+    ORDER BY created_at, id
+  `) as never;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("a push fan-out costs two queries, whatever its size", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("nine devices across four recipients cost two queries", async () => {
+    const runtime = getRuntimeSql();
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        enqueuePushToRecipients(
+          counting,
+          TENANT,
+          RECIPIENTS.map((recipient) => recipient.id),
+          { category: "test.broadcast", title: "T", body: "B" }
+        )
+      )
+    );
+
+    expect(queries).toBe(ENQUEUE_QUERY_BUDGET);
+    expect(result.messageIds).toHaveLength(TOTAL_DEVICES);
+    expect(result.skippedRecipients).toEqual([RECIPIENTS[3].id]);
+
+    // The disabled device got nothing, which is the `status = 'active'` filter
+    // surviving the move into a batched predicate.
+    expect(await queuedMessages()).toHaveLength(TOTAL_DEVICES);
+  });
+
+  test("one recipient with one device costs the same two queries", async () => {
+    const runtime = getRuntimeSql();
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        enqueuePushToRecipients(counting, TENANT, [RECIPIENTS[2].id], {
+          category: "test.single",
+          title: "T",
+          body: "B"
+        })
+      )
+    );
+
+    // The number does not move with the input. That is the whole property, and
+    // the cheap case did not get more expensive to make the expensive one cheap.
+    expect(queries).toBe(ENQUEUE_QUERY_BUDGET);
+    expect(result.messageIds).toHaveLength(2);
+  });
+
+  test("a recipient with no active device costs ONE query and writes nothing", async () => {
+    const runtime = getRuntimeSql();
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        enqueuePushToRecipients(counting, TENANT, [RECIPIENTS[3].id], {
+          category: "test.skipped",
+          title: "T",
+          body: "B"
+        })
+      )
+    );
+
+    // An empty `jsonb_to_recordset` INSERT would be legal and a wasted round
+    // trip. Most users never enable push, so this is the COMMON case.
+    expect(queries).toBe(1);
+    expect(result.messageIds).toEqual([]);
+    expect(result.skippedRecipients).toEqual([RECIPIENTS[3].id]);
+    expect(await queuedMessages()).toEqual([]);
+  });
+
+  test("no recipients at all costs no queries", async () => {
+    const runtime = getRuntimeSql();
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        enqueuePushToRecipients(counting, TENANT, [], {
+          category: "test.empty",
+          title: "T",
+          body: "B"
+        })
+      )
+    );
+
+    expect(queries).toBe(0);
+    expect(result).toEqual({ messageIds: [], skippedRecipients: [] });
+  });
+
+  test("`data` lands as a jsonb OBJECT, and absent columns as real NULLs", async () => {
+    // The two ways `jsonb_to_recordset` goes wrong silently. A stringified
+    // binding stores `'{"a":"b"}'` as a jsonb STRING that reads back as text,
+    // and a Bun.SQL array cannot carry NULL — it writes the literal `'null'`.
+    // Both satisfy any query counter.
+    const runtime = getRuntimeSql();
+
+    await withTenantOrThrow(runtime, TENANT, (tx) =>
+      enqueuePushToRecipients(tx, TENANT, [RECIPIENTS[2].id], {
+        category: "test.payload",
+        title: "Titled",
+        body: "B",
+        data: { postId: "abc", kind: "article" }
+      })
+    );
+
+    const rows = await queuedMessages();
+    expect(rows).toHaveLength(2);
+
+    for (const row of rows) {
+      expect(row.data).toEqual({ postId: "abc", kind: "article" });
+      // Not the string "null", and not the string "undefined".
+      expect(row.target_path).toBeNull();
+      expect(row.correlation_id).toBeNull();
+      expect(row.created_by).toBeNull();
+    }
+
+    // Read back through jsonb operators too: a jsonb STRING would answer
+    // `string` here while `toEqual` above could still pass on a parsed value.
+    const typed = (await getAdminSql()`
+      SELECT jsonb_typeof(data) AS kind, data ->> 'postId' AS post_id
+      FROM awcms_push_messages
+      WHERE tenant_id = ${TENANT}
+      LIMIT 1
+    `) as { kind: string; post_id: string | null }[];
+
+    expect(typed[0]!.kind).toBe("object");
+    expect(typed[0]!.post_id).toBe("abc");
+  });
+
+  test("every queued row carries the same message, one per device", async () => {
+    const runtime = getRuntimeSql();
+
+    await withTenantOrThrow(runtime, TENANT, (tx) =>
+      enqueuePushToRecipients(
+        tx,
+        TENANT,
+        RECIPIENTS.map((recipient) => recipient.id),
+        {
+          category: "test.broadcast",
+          title: "Shared title",
+          body: "B",
+          targetPath: "/news/hello"
+        }
+      )
+    );
+
+    const rows = await queuedMessages();
+    const subscriptionIds = new Set(rows.map((row) => row.subscription_id));
+
+    // One row per DEVICE, never one per recipient, and never a duplicate.
+    expect(rows).toHaveLength(TOTAL_DEVICES);
+    expect(subscriptionIds.size).toBe(TOTAL_DEVICES);
+
+    for (const row of rows) {
+      expect(row.title).toBe("Shared title");
+      expect(row.category).toBe("test.broadcast");
+      expect(row.target_path).toBe("/news/hello");
+    }
+  });
+});

--- a/tests/permission-enforcement-coverage.test.ts
+++ b/tests/permission-enforcement-coverage.test.ts
@@ -36,6 +36,13 @@ function guard(
   return permissionTripleKey({ moduleKey, activityCode, action });
 }
 
+/** Sorted, de-duplicated permission keys a source builds guards for. */
+function distinctKeys(source: string): string[] {
+  return [
+    ...new Set(collectGuardTriples(source).map(permissionTripleKey))
+  ].sort();
+}
+
 function moduleWith(
   key: string,
   permissions: { activityCode: string; action: string }[]
@@ -254,6 +261,70 @@ describe("collectGuardTriples", () => {
 
     expect(collectGuardTriples(source)).toEqual([]);
   });
+
+  test("does not mistake the string a ternary TESTS for one it yields", () => {
+    // `src/pages/api/v1/seo/redirects/[id]/lifecycle.ts`, verbatim in shape.
+    // The guard can require `delete` or `update`; `purge` is what the request
+    // is compared against. Reading it as a third action invented
+    // `seo_distribution.redirect.purge` — a permission no module declares and
+    // no catalogue row backs.
+    const source = `
+      const guard = {
+        moduleKey: "seo_distribution",
+        activityCode: "redirect",
+        action: (lifecycleAction === "purge" ? "delete" : "update") as
+          "delete" | "update"
+      };
+    `;
+
+    // Distinct keys, because the captured expression runs on to the end of the
+    // `as "delete" | "update"` annotation and every action is therefore seen
+    // twice. Every consumer collects into a Set, so the repetition is inert —
+    // but asserting an exact array here would be pinning that accident rather
+    // than the rule under test.
+    expect(distinctKeys(source)).toEqual([
+      "seo_distribution.redirect.delete",
+      "seo_distribution.redirect.update"
+    ]);
+  });
+
+  test("keeps a literal that is both tested for AND yielded", () => {
+    // The comments routes: `approve` appears in the condition and again as a
+    // value. Dropping the whole CONDITION rather than just the operand would
+    // lose it, and report a fully enforced permission as unenforced.
+    const source = `
+      const guard = {
+        moduleKey: "comments",
+        activityCode: "moderation",
+        action: (decision === "approve" ? "approve" : "reject") as
+          "approve" | "reject"
+      };
+    `;
+
+    expect(distinctKeys(source)).toEqual([
+      "comments.moderation.approve",
+      "comments.moderation.reject"
+    ]);
+  });
+
+  test("removing an operand does not re-pair the quotes around it", () => {
+    // Blanking `=== "purge"` to `=== ""` looks equivalent and is not: the empty
+    // pair shifts which quotes match, so the GAPS between the real literals
+    // (`" ? "`, `" : "`) start matching as literals themselves. That is a
+    // defect this fix's own first draft shipped, so it is pinned here rather
+    // than left to the shape of a regex.
+    const source = `
+      const guard = {
+        moduleKey: "comments",
+        activityCode: "moderation",
+        action: (decision === "approve" ? "approve" : "reject")
+      };
+    `;
+
+    for (const triple of collectGuardTriples(source)) {
+      expect(triple.action).toMatch(/^[a-z_]+$/);
+    }
+  });
 });
 
 describe("evaluateEnforcementCoverage", () => {
@@ -367,5 +438,111 @@ describe("evaluateEnforcementCoverage", () => {
 
     expect(result.valid).toBe(false);
     expect(result.staleExceptions).toEqual(["media_library.media.attach"]);
+  });
+
+  test("reports a guard for a permission no module declares, and names the file", () => {
+    // The reverse direction, and the worse of the two failures: no catalogue
+    // row backs the key, so no role can hold it and every actor is denied.
+    // Invisible to the forward question, which only ever iterates DECLARED
+    // permissions — a key nobody declared is not in the set being walked.
+    const result = evaluateEnforcementCoverage(
+      modules,
+      [
+        `const A = { moduleKey: "blog_content", activityCode: "pages", action: "publish" };`,
+        `const B = { moduleKey: "blog_content", activityCode: "pages", action: "unpublish" };`
+      ],
+      [
+        {
+          key: "blog_content.posts.export",
+          reason: "No endpoint; ADR pending."
+        }
+      ],
+      [
+        "src/pages/api/v1/blog/pages/publish.ts",
+        "src/pages/api/v1/blog/pages/unpublish.ts"
+      ]
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.undeclaredGuards).toEqual([
+      {
+        key: "blog_content.pages.unpublish",
+        sources: ["src/pages/api/v1/blog/pages/unpublish.ts"]
+      }
+    ]);
+    // The forward direction stays silent about it — which is the whole reason
+    // the reverse one had to be added rather than assumed covered.
+    expect(result.unenforced).toEqual([]);
+  });
+
+  test("collects every file that builds the same undeclared guard", () => {
+    const result = evaluateEnforcementCoverage(
+      modules,
+      [
+        `const A = { moduleKey: "blog_content", activityCode: "pages", action: "archive" };`,
+        `const B = { moduleKey: "blog_content", activityCode: "pages", action: "archive" };`
+      ],
+      [],
+      ["src/one.ts", "src/two.ts"]
+    );
+
+    expect(result.undeclaredGuards[0]?.sources).toEqual([
+      "src/one.ts",
+      "src/two.ts"
+    ]);
+  });
+
+  test("an exception can excuse an UNDECLARED guard, and is not stale for being one", () => {
+    // Staleness had one rule — "not declared" — and the reverse direction makes
+    // that rule wrong: an exception excusing an undeclared guard is doing its
+    // job precisely BECAUSE the permission is undeclared. Left alone, it would
+    // have been impossible to write such an exception at all: recording one
+    // would immediately report it stale.
+    const result = evaluateEnforcementCoverage(
+      modules,
+      [
+        `const A = { moduleKey: "blog_content", activityCode: "pages", action: "publish" };`,
+        `const B = { moduleKey: "blog_content", activityCode: "pages", action: "unpublish" };`
+      ],
+      [
+        {
+          key: "blog_content.posts.export",
+          reason: "No endpoint; ADR pending."
+        },
+        {
+          key: "blog_content.pages.unpublish",
+          reason: "Guarded ahead of its seed migration; ADR-XXXX."
+        }
+      ],
+      ["src/a.ts", "src/b.ts"]
+    );
+
+    expect(result.undeclaredGuards).toEqual([]);
+    expect(result.staleExceptions).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  test("the source list is optional, and its absence costs only the file name", () => {
+    // Callers that scan text they built themselves pass no paths. The finding
+    // must still be reported — a gate that needs a filename to notice a defect
+    // would be a gate with an off switch.
+    const result = evaluateEnforcementCoverage(
+      modules,
+      [
+        `const B = { moduleKey: "blog_content", activityCode: "pages", action: "unpublish" };`
+      ],
+      [
+        {
+          key: "blog_content.posts.export",
+          reason: "No endpoint; ADR pending."
+        },
+        { key: "blog_content.pages.publish", reason: "Not yet built." }
+      ]
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.undeclaredGuards).toEqual([
+      { key: "blog_content.pages.unpublish", sources: [] }
+    ]);
   });
 });


### PR DESCRIPTION
Two directions of the same idea: **a set accumulated for one purpose must be re-audited before it is read for a second.**

## 1. The enforcement gate asked its question one way round

`access:permissions:enforcement:check` has asked, since ADR-0057 §F: does every permission a module descriptor **declares** have an `authorizeInTransaction` guard? It builds a set of every guard the source text constructs — and then never reads that set back.

The reverse question costs one more loop and catches the strictly worse failure.

`authorizeInTransaction` answers from `grantedPermissionKeys`, built by joining the actor's active role grants to `awcms_permissions`. A key **no descriptor declares has no catalogue row to join to**, so no role can hold it, so `evaluateAccess` returns `default_deny` — for the tenant owner, for the platform tenant, for every actor in every deployment, permanently. The endpoint is not weakly guarded; it is **dead**, and it answers 403 in a shape indistinguishable from a legitimate refusal.

This repo has shipped that exact defect twice. `POST /api/v1/identity/business-scope/assignments` refused every input in every deployment (#180 F2), and `blog_content.pages.publish` meant no page could be published by any code path while public search filtered on `status = 'published'` and therefore always returned nothing (ADR-0057). Both were found by hand, months later, by someone building a screen.

### The gap was live, and the gate's own scanner proved it

Asked backwards, the repo produced exactly one violation: `seo_distribution.redirect.purge`, from `src/pages/api/v1/seo/redirects/[id]/lifecycle.ts`. That route guards on

```ts
action: (lifecycleAction === "purge" ? "delete" : "update") as "delete" | "update"
```

and `readActionValues` collected **every** string literal in the expression, including the one the ternary tests **against**. The scanner invented a permission the route never demands.

Worth stating plainly, because it is the reason a one-directional gate is not merely half a gate: **a false positive that is harmless in one direction is a failure in the other.** An invented ENFORCED key matches nothing and the forward loop ignores it. The same key, read as "a permission this repo demands", is a reported defect.

Both halves are fixed. Comparison operands are dropped before literals are collected — only the operand, never the whole condition, because the comments routes write `decision === "approve" ? "approve" : "reject"` where `approve` is both tested for and yielded. Removed **whole, quotes included**: blanking to `""` re-pairs the surrounding quotes so the gaps between the real literals (`" ? "`, `" : "`) start matching as literals themselves — this fix's own first draft did that and invented four permissions per route, which is why it is pinned by a test rather than left to the shape of a regex.

The staleness rule changed with it. "Stale if the permission is not declared" makes an exception excusing an **undeclared guard** impossible to write. An exception is now stale only when it excuses nothing.

Ships with the exception list still **empty in both directions**: 244/244 declared permissions have a guard, and every guard names a declared permission.

## 2. The push fan-out was `R + (R × S)` queries

`enqueuePushToRecipients` did one subscription lookup per recipient, then one `INSERT` per device, inside a single transaction holding one connection — 1,500 round trips for 500 users with two devices each.

Nothing in production ever paid it: the only caller, `POST /api/v1/push/test`, passes one recipient. **That is the reason to fix it rather than leave it** — the cost is not a property of the function as used but of its contract ("every recipient"), waiting for the first caller that broadcasts, at which point it arrives as an incident rather than a review comment. Same write-side blind spot the performance round found in the scheduled sweeps and `syncPostTermAssignments`.

Now one batched lookup and one `INSERT ... jsonb_to_recordset`. The cheap cases did not get more expensive to make the expensive case cheap: zero recipients still costs zero queries, and every-recipient-skipped — the **common** case, since most users never enable push — costs one.

Behaviour is unchanged, deliberately including the odd part: duplicate ids still produce duplicate notifications. Arguably a caller bug, but changing it here would be a silent behaviour change riding along with a performance fix.

## Verification

Mutation-proven throughout:

| Mutation | Result |
| --- | --- |
| Revert the scanner fix | gate reports `seo_distribution.redirect.purge` |
| Typo an activity code in a real guard | gate reports both its actions |
| Neutralise the reverse direction | 3 new unit tests fail |
| Revert the staleness rule | the undeclared-exception test fails |
| Restore the per-row `INSERT` | both budget tests fail, **every correctness test passes** |

That last row is the separation I wanted: the budget catches the regression, and the correctness tests are indifferent to it.

The budget fixture is 4 recipients / 9 devices — 13 queries under the old shape against a budget of 2, so it cannot pass by accident. The tests read rows back out of the table as well as counting, because a `jsonb_to_recordset` rewrite is exactly the kind of change that satisfies a counter while corrupting what lands (`data` as a jsonb STRING, a NULL as the literal text `'null'` — both silent).

Local: `bun run check` exit 0, 5,753 pass / 0 fail. The integration suite shows 9 failures **both with and without this branch** — verified by stashing to `9ddc624c` and re-running (493 pass baseline → 499 with the 6 new tests here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)