### PR TITLE
fix(sync): a push batch had no count bound, and a self-declared twin kept the defect its sibling had fixed

### DIFF
--- a/.changeset/sync-push-batch-bound.md
+++ b/.changeset/sync-push-batch-bound.md
@@ -1,0 +1,66 @@
+---
+"awcms": patch
+---
+
+fix(sync): a push batch had no count bound, and the write side of one protocol was capped while the read side was not
+
+`POST /api/v1/sync/push` validated every event in the `events` array and never
+the array's length. The only limit was the body tier:
+`readTextBody(request, "large")` allows 5 MB, and a minimal event serialises to
+a couple of hundred bytes, so one authenticated request could carry on the order
+of **30,000 events**.
+
+That is not merely slow. Each accepted event costs a compare-and-set on the
+aggregate version plus an inbox `INSERT`, each conflicted one a conflict
+`INSERT` — all sequential, all inside a single transaction that holds a
+connection and keeps every aggregate row it has advanced locked until commit.
+The cost is not the round trips; it is how long everything else waits behind
+them.
+
+Meanwhile `/sync/pull` has clamped reads to 500 since it shipped. The two halves
+of one protocol had asymmetric bounds, and the unbounded half was the one that
+writes.
+
+`MAX_SYNC_PUSH_EVENTS` is now defined **as** `MAX_SYNC_PULL_EVENTS` rather than
+as a second `500`, because the reason for the number is the relationship — a
+node must not be able to push more in one batch than it can pull in one page.
+`pull.ts` imports the same constant. Two independent literals that happen to
+agree today are how the asymmetry comes back the next time one of them is tuned,
+so the test asserts the relationship and not the value.
+
+**Refused, never truncated.** Truncation on a write path silently drops events a
+node believes it delivered: a node treats an accepted batch as accepted in full
+and would advance its own cursor past events that never landed. This is the
+bound posture #180 settled for the business-scope resolver — every bound refuses
+rather than truncating. The read side clamps instead, correctly, because a
+clamped page still says `hasMore`.
+
+The refusal is reported as ONE error, not one per event. An error body carrying
+a field error for each of 30,000 events is its own denial of service, and the
+verdict does not depend on their contents. `maxItems: 500` and `minItems: 1` are
+in the OpenAPI schema so the contract says it too.
+
+**Found by a sweep, and it turned up a second thing.** Scanning `src/` for SQL
+issued inside a loop found 34 sites. Most are bounded — by a code registry
+(`append-domain-event`), by a declared cap (`MAX_NODE_ACTIVATIONS = 128`,
+`MAX_SIDEBAR_ROWS`), or by a job's batch size — and several were already batched
+(`/sync/objects` under #435). One was not bounded at all, above.
+
+And one was a **twin of an already-fixed defect**.
+`syncPostInstitutionAssignments` issued one `INSERT` per institution. Its own
+docstring says it is "exactly like `syncPostTermAssignments`" — and it was, in
+contract and not in cost: the term path was flattened to two statements when
+`blog:legacy:import` made a 23,906-article archive its caller, and this path,
+which the same importer drives through the same post payload, kept the loop. It
+now uses the same `DELETE` + `INSERT ... unnest`, with its own budget file
+because two budgets in one file go green the moment either regresses and the
+other absorbs it.
+
+A sibling that advertises itself as a sibling is the easiest kind of defect to
+miss: whoever fixed the first one had already read the second and remembered
+agreeing with it.
+
+`replaceMenuItems` has the same shape and is deliberately NOT changed here — it
+carries a self-referencing FK and its callers depend on the order of its
+`RETURNING`, so it needs a decision rather than a drive-by. Recorded with the
+rest of the sweep.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:01ee89ccc6e05c400cc7f53ceeb4a148d2fec6106e5e46aca3202af0b6b26315 -->
+<!-- i18n-source-hash: sha256:808f8cb71620561e7c0502410cad7ac5b7b961101f34759c3b5558d80e43c113 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,81 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN BATAS — 25 Agustus 2026: satu endpoint API menerima batch TANPA
+  batas, dan fungsi yang menyebut dirinya kembaran fungsi yang sudah diperbaiki
+  justru menyimpan cacatnya.**
+
+  Pemindaian `src/**/*.ts` atas `await` bertag-template di dalam badan loop
+  menemukan **34 loop**. Mayoritas terbatas — oleh registry kode, oleh cap yang
+  dideklarasikan (`MAX_NODE_ACTIVATIONS = 128`, `MAX_SIDEBAR_ROWS`), atau oleh
+  ukuran batch sebuah job — dan beberapa sudah ter-batch atau memang false
+  positive pemindai. Dua tidak, dan keduanya jenis temuan yang berbeda.
+
+  **`POST /api/v1/sync/push` sama sekali tak punya batas jumlah.** Validator
+  memeriksa setiap event dalam array `events` dan TIDAK PERNAH panjang
+  array-nya; satu-satunya batas adalah `readTextBody(request, "large")` di 5 MB.
+  Event minimal terserialisasi beberapa ratus byte, jadi satu request
+  terautentikasi bisa membawa sekitar **30.000 event** — tiap yang diterima
+  berbiaya compare-and-set pada versi agregat plus INSERT inbox, tiap yang
+  konflik satu INSERT konflik, semuanya berurutan, semuanya di dalam SATU
+  transaksi yang memegang koneksi dan mengunci setiap baris agregat yang sudah
+  dimajukan sampai commit. Biayanya bukan perjalanan pulang-perginya; melainkan
+  berapa lama semua hal lain menunggu di belakangnya.
+
+  Sementara itu `/sync/pull` sudah menjepit baca di 500 sejak dikirim. **Dua
+  paruh dari SATU protokol punya batas asimetris, dan paruh yang tak terbatas
+  adalah yang MENULIS.** `MAX_SYNC_PUSH_EVENTS` kini didefinisikan SEBAGAI
+  `MAX_SYNC_PULL_EVENTS`, bukan sebagai `500` kedua, dan `pull.ts` mengimpor
+  konstanta yang sama — alasan angkanya adalah RELASINYA, dan dua literal
+  independen yang kebetulan sama hari ini adalah cara asimetri itu kembali saat
+  salah satunya disetel. Tesnya menegakkan relasinya, bukan nilainya.
+
+  DITOLAK, tak pernah dipotong (postur #180): sebuah node memperlakukan batch
+  yang diterima sebagai diterima UTUH dan akan memajukan cursor-nya melewati
+  event yang tak pernah mendarat. Dilaporkan sebagai SATU error, bukan satu per
+  event — badan error yang memuat error field untuk tiap dari 30.000 event
+  adalah denial of service-nya sendiri.
+
+  **Gerbang yang membuat ini jujur.** Menambahkan `maxItems: 500` ke skema
+  OpenAPI memerahkan `openapi-bundle.test.ts`, yang membekukan setiap path
+  pra-migrasi. Daftar izin yang menuntut entri itu bernama
+  `INTENTIONALLY_EVOLVED_PATHS` dan dua entri lamanya sama-sama berbunyi
+  "backward-compatible". Yang ini TIDAK: ia aditif secara dokumen tetapi
+  PENYEMPITAN nyata bagi pemanggil, dan entrinya menyatakan begitu. Test kontrak
+  beku membuktikan nilainya persis di sini — bukan dengan memblokir
+  perubahannya, melainkan dengan menolak membiarkannya diarsipkan dengan
+  deskripsi yang salah.
+
+  **Dan temuan kedua, yang soal BAGAIMANA cacat kembaran bertahan hidup.**
+  `syncPostInstitutionAssignments` mengeluarkan satu INSERT per institusi.
+  Docstring-nya sendiri menyatakan ia "exactly like `syncPostTermAssignments`" —
+  dan memang begitu, dalam KONTRAK dan bukan dalam BIAYA. Jalur term diratakan
+  jadi dua statement di PUTARAN PERFORMA saat `blog:legacy:import` menjadikan
+  arsip 23.906 artikel sebagai pemanggilnya; jalur INI, yang digerakkan importer
+  yang SAMA lewat payload post yang SAMA, menyimpan loop-nya. Kini memakai
+  `DELETE` + `INSERT ... unnest` yang sama.
+
+  Layak disimpan: **saudara kembar yang MENGIKLANKAN dirinya sebagai kembaran
+  adalah jenis cacat yang paling mudah terlewat**, karena orang yang memperbaiki
+  yang pertama sudah membaca yang kedua dan ingat menyetujuinya. Docstring yang
+  seharusnya menuntun pembaca ke sana justru yang membuatnya terasa sudah
+  ditangani.
+
+  Anggarannya berkas TERPISAH dari anggaran term, sengaja: dua anggaran dalam
+  satu berkas menjadi hijau begitu salah satunya regresi dan yang lain
+  menyerapnya. Dan bukti-mutasinya memperlihatkan kenapa fixture WAJIB melebihi
+  anggaran — mengembalikan loop memerahkan kasus sepuluh-institusi dan
+  meninggalkan kasus satu-institusi tetap lolos, karena `1 + 1 = 2` di kedua
+  bentuk.
+
+  **`replaceMenuItems` berbentuk sama dan sengaja TIDAK diubah.** Ia membawa FK
+  yang menunjuk dirinya sendiri (loop-nya menyisipkan root sebelum child dengan
+  sengaja) dan pemanggilnya bergantung pada urutan `RETURNING`-nya, yang tidak
+  dijamin Postgres. Itu pertanyaan KONTRAK, bukan substitusi mekanis. Dicatat
+  bersama triase lengkapnya di **#715**, yang juga memuat situs yang belum
+  dibaca — job backfill paling layak diambil bersama, karena mereka mengiterasi
+  TENANT di lapis terluar sehingga biayanya adalah PERKALIAN.
 
 - **PUTARAN ARAH — 25 Agustus 2026: gerbang enforcement menanyakan
   pertanyaannya SATU arah saja, dan arah yang hilang justru yang berakibat

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,74 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **BOUND ROUND — 25 August 2026: one API endpoint accepted an unbounded batch,
+  and a function that calls itself a twin of a fixed one kept the defect.**
+
+  A scan of `src/**/*.ts` for a tagged-template `await` inside a loop body found
+  **34 loops**. Most are bounded — by a code registry, by a declared cap
+  (`MAX_NODE_ACTIVATIONS = 128`, `MAX_SIDEBAR_ROWS`), or by a job's batch size —
+  and several were already batched or were scanner false positives. Two were
+  not, and they are different kinds of finding.
+
+  **`POST /api/v1/sync/push` had no count bound at all.** The validator checked
+  every event in the `events` array and never the array's length; the only limit
+  was `readTextBody(request, "large")` at 5 MB. A minimal event serialises to a
+  couple of hundred bytes, so one authenticated request could carry on the order
+  of **30,000 events** — each accepted one costing a compare-and-set on the
+  aggregate version plus an inbox INSERT, each conflicted one a conflict INSERT,
+  all sequential, all inside a single transaction that holds a connection and
+  keeps every aggregate row it has advanced locked until commit. The cost is not
+  the round trips; it is how long everything else waits behind them.
+
+  Meanwhile `/sync/pull` has clamped reads to 500 since it shipped. **The two
+  halves of one protocol had asymmetric bounds, and the unbounded half was the
+  one that writes.** `MAX_SYNC_PUSH_EVENTS` is now defined AS
+  `MAX_SYNC_PULL_EVENTS` rather than as a second `500`, and `pull.ts` imports
+  the same constant — the reason for the number is the relationship, and two
+  independent literals that agree today are how the asymmetry returns the next
+  time one is tuned. The test asserts the relationship, not the value.
+
+  REFUSED, never truncated (the #180 posture): a node treats an accepted batch
+  as accepted in full and would advance its cursor past events that never
+  landed. Reported as ONE error, not one per event — an error body carrying a
+  field error for each of 30,000 events is its own denial of service.
+
+  **The gate that made this honest.** Adding `maxItems: 500` to the OpenAPI
+  schema reddened `openapi-bundle.test.ts`, which freezes every pre-migration
+  path. The allow-list it wanted the entry in is called
+  `INTENTIONALLY_EVOLVED_PATHS` and its two existing entries both read
+  "backward-compatible". This one is not: it is document-additive but a genuine
+  NARROWING for a caller, and the entry says so. A frozen-contract test earns
+  its keep exactly here — not by blocking the change, but by refusing to let it
+  be filed under the wrong description.
+
+  **And the second finding, which is about how sibling defects survive.**
+  `syncPostInstitutionAssignments` issued one INSERT per institution. Its own
+  docstring says it is "exactly like `syncPostTermAssignments`" — and it was, in
+  contract and not in cost. The term path was flattened to two statements in the
+  PERFORMANCE ROUND when `blog:legacy:import` made a 23,906-article archive its
+  caller; this path, which the SAME importer drives through the SAME post
+  payload, kept the loop. It now uses the same `DELETE` + `INSERT ... unnest`.
+
+  Worth keeping: **a sibling that advertises itself as a sibling is the easiest
+  kind of defect to miss**, because whoever fixed the first one had already read
+  the second and remembers agreeing with it. The docstring that should have led
+  a reader there is the very thing that made it feel already handled.
+
+  Its budget is a SEPARATE file from the term one, deliberately: two budgets in
+  one file go green the moment either regresses and the other absorbs it. And
+  the mutation proof shows why the fixture must exceed the budget — restoring
+  the loop reddens the ten-institution case and leaves the one-institution case
+  passing, because `1 + 1 = 2` either way.
+
+  **`replaceMenuItems` has the same shape and was deliberately NOT changed.** It
+  carries a self-referencing FK (the loop inserts roots before children on
+  purpose) and its callers depend on the order of its `RETURNING`, which
+  Postgres does not specify. Those are contract questions, not a mechanical
+  substitution. Recorded with the full triage in **#715**, which also carries
+  the sites not yet read — the backfill jobs are the ones worth taking together,
+  since they iterate TENANTS at the outer level and their cost is a product.
+
 - **DIRECTION ROUND — 25 August 2026: the enforcement gate asked its question
   one way round, and the missing direction is the one with the dead endpoint
   behind it.** Recorded as open by the REGISTER ROUND below; closed here.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 487   |
+| Test files                          | 488   |
 | Route files                         | 383   |
 | ADR                                 | 226   |
 
@@ -361,7 +361,7 @@
 | ------------- | ---------- |
 | `(root)`      | 402        |
 | `e2e`         | 17         |
-| `integration` | 67         |
+| `integration` | 68         |
 | `unit`        | 1          |
 
 ### Routes

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -16028,6 +16028,8 @@ paths:
                   type: string
                 events:
                   type: array
+                  minItems: 1
+                  maxItems: 500
                   items:
                     type: object
                     required:

--- a/openapi/modules/sync-storage.openapi.yaml
+++ b/openapi/modules/sync-storage.openapi.yaml
@@ -470,6 +470,13 @@ paths:
                   type: string
                 events:
                   type: array
+                  minItems: 1
+                  # The same page size /sync/pull returns, so a node cannot push
+                  # more in one batch than it can pull in one page. Over the
+                  # limit is REFUSED with VALIDATION_ERROR, never truncated: a
+                  # node treats an accepted batch as accepted in full and would
+                  # otherwise advance its cursor past events that never landed.
+                  maxItems: 500
                   items:
                     type: object
                     required:

--- a/src/modules/blog-content/application/institution-directory.ts
+++ b/src/modules/blog-content/application/institution-directory.ts
@@ -355,13 +355,28 @@ export async function syncPostInstitutionAssignments(
     WHERE tenant_id = ${tenantId} AND post_id = ${postId}
   `;
 
-  for (const institutionId of institutionIds) {
-    await tx`
-      INSERT INTO awcms_blog_post_institutions
-        (tenant_id, post_id, institution_id)
-      VALUES (${tenantId}, ${postId}, ${institutionId})
-    `;
+  if (institutionIds.length === 0) {
+    return;
   }
+
+  // ONE round trip, not one per institution — the same `unnest` shape
+  // `syncPostTermAssignments` uses, and the docstring above already claimed
+  // this function was "exactly like" it. It was, in contract and not in cost:
+  // the term path was flattened to two statements when `blog:legacy:import`
+  // made a 23,906-article archive its caller, and THIS path, which the same
+  // importer drives through the same post payload, kept the loop. A twin that
+  // declares itself a twin is the easiest kind of sibling defect to miss,
+  // because the reader who fixed one has already read the other and remembers
+  // agreeing with it.
+  //
+  // Deliberately NOT deduplicated, for the reason its twin records: the unique
+  // constraint refuses a repeated (post, institution) pair and refused one
+  // before this change too. Swallowing it here would turn a loud constraint
+  // error into a silent difference between what was asked for and what landed.
+  await tx`
+    INSERT INTO awcms_blog_post_institutions (tenant_id, post_id, institution_id)
+    SELECT ${tenantId}, ${postId}, unnest(${tx.array([...institutionIds], "uuid")}::uuid[])
+  `;
 }
 
 export async function fetchPostInstitutionIds(

--- a/src/modules/sync-storage/domain/sync-validation.ts
+++ b/src/modules/sync-storage/domain/sync-validation.ts
@@ -20,6 +20,41 @@ export type SyncPushValidationResult =
   | { valid: true; value: SyncPushRequestBody }
   | { valid: false; errors: ValidationError[] };
 
+/**
+ * The most events one PULL page may return. `pull.ts` has clamped to this since
+ * it shipped; it lives here rather than in the route so the push bound below
+ * can be defined in terms of it instead of repeating the number.
+ */
+export const MAX_SYNC_PULL_EVENTS = 500;
+
+/**
+ * The most events one push batch may carry.
+ *
+ * Defined AS the pull page size rather than as a second 500, because the reason
+ * for the number is the relationship: a node must not be able to push more in
+ * one batch than it can pull in one page. The two halves of this protocol had
+ * asymmetric bounds — the read side capped since it shipped, the write side
+ * with no count bound at all — and two independent literals are how that
+ * asymmetry comes back the next time one of them is tuned.
+ *
+ * What "no bound" meant in practice. `readTextBody(request, "large")` allows
+ * 5 MB, and a minimal event serialises to a couple of hundred bytes, so a
+ * single authenticated request could carry on the order of 30,000 events. Each
+ * accepted one costs a compare-and-set on the aggregate version plus an inbox
+ * INSERT, each conflicted one a conflict INSERT — all sequential, all inside
+ * ONE transaction that holds a connection and keeps the aggregate rows it has
+ * advanced locked until commit. The cost is not the round trips alone; it is
+ * how long everything else waits behind them.
+ *
+ * REFUSED, never truncated. Truncation on a write path silently drops events a
+ * node believes it delivered, and the node's whole model is that an accepted
+ * batch was accepted in full — it would advance its own cursor past events that
+ * never landed. This is the bound posture #180 settled for the business-scope
+ * resolver: every bound refuses rather than truncating. The read side clamps
+ * instead, correctly, because a clamped page still says `hasMore`.
+ */
+export const MAX_SYNC_PUSH_EVENTS = MAX_SYNC_PULL_EVENTS;
+
 export function validateSyncPushRequestBody(
   body: unknown
 ): SyncPushValidationResult {
@@ -37,6 +72,14 @@ export function validateSyncPushRequestBody(
     errors.push({
       field: "events",
       message: "events must be a non-empty array."
+    });
+  } else if (record.events.length > MAX_SYNC_PUSH_EVENTS) {
+    // Reported on its own, without also validating 30,000 events: the answer
+    // does not depend on their contents, and an error body listing a field
+    // error per event is its own denial-of-service.
+    errors.push({
+      field: "events",
+      message: `events may contain at most ${MAX_SYNC_PUSH_EVENTS} entries per batch; received ${record.events.length}. Split the batch.`
     });
   } else {
     record.events.forEach((event, index) => {

--- a/src/pages/api/v1/sync/pull.ts
+++ b/src/pages/api/v1/sync/pull.ts
@@ -14,9 +14,12 @@ import {
   SYNC_REPLICABLE_EVENT_TYPES,
   syncReplicationIsDisabled
 } from "../../../../modules/sync-storage/domain/sync-replication";
+import { MAX_SYNC_PULL_EVENTS } from "../../../../modules/sync-storage/domain/sync-validation";
 
 const DEFAULT_LIMIT = 100;
-const MAX_LIMIT = 500;
+// Shared with the push bound so the two halves of this protocol cannot drift
+// apart — see `MAX_SYNC_PUSH_EVENTS`.
+const MAX_LIMIT = MAX_SYNC_PULL_EVENTS;
 
 export const POST: APIRoute = async ({ request }) => {
   const tenantId = request.headers.get("x-awcms-tenant-id");

--- a/tests/integration/post-institution-assignment-budget.integration.test.ts
+++ b/tests/integration/post-institution-assignment-budget.integration.test.ts
@@ -1,0 +1,246 @@
+/**
+ * A query budget on the OTHER post-assignment write path.
+ *
+ * ## Why a second file rather than a case in the first
+ *
+ * `post-term-assignment-budget.integration.test.ts` pins
+ * `syncPostTermAssignments` at two statements. `syncPostInstitutionAssignments`
+ * is its twin — its own docstring says so, "exactly like
+ * `syncPostTermAssignments`", because an article names its institutions the way
+ * it names its terms and the post payload carries both.
+ *
+ * It was a twin in contract and not in cost. The term path was flattened when
+ * `blog:legacy:import` made a 23,906-article archive its caller; this path,
+ * which the SAME importer drives through the SAME payload, kept one `INSERT`
+ * per institution. A sibling that advertises itself as a sibling is the easiest
+ * kind to miss, because whoever fixed the first one has already read the second
+ * and remembers agreeing with it.
+ *
+ * The budgets live in separate files because they are separate claims about
+ * separate functions. One file asserting both would go green the moment either
+ * regressed and the other absorbed it.
+ *
+ * ## Exact, with a fixture larger than the budget
+ *
+ * One `DELETE`, one `INSERT ... unnest`. Exact rather than a ceiling: the
+ * property is that the number does not move with the number of institutions,
+ * and `toBeLessThanOrEqual` would pass a per-item regression as long as the
+ * fixture stayed small. Ten institutions is 11 queries under the old shape
+ * against a budget of 2.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { syncPostInstitutionAssignments } from "../../src/modules/blog-content/application/institution-directory";
+
+const TENANT = "f9999999-9999-4999-8999-999999999999";
+const AUTHOR = "f9000000-0000-4000-8000-000000000001";
+
+/** An order of magnitude past the budget, so a per-item query cannot hide. */
+const INSTITUTION_COUNT = 10;
+
+/** One `DELETE` for the old set, one `INSERT ... unnest` for the new one. */
+const ASSIGNMENT_QUERY_BUDGET = 2;
+
+async function seedFixtures(): Promise<string[]> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'inst-budget', 'Institution Budget Tenant')
+  `;
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Author')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'inst-budget@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${AUTHOR}, ${TENANT}, ${identity[0]!.id})
+  `;
+
+  await admin`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+       status, visibility, locale)
+    VALUES (${TENANT}, ${AUTHOR}, 'Filed', 'filed', '{}'::jsonb, '',
+            'published', 'public', 'id')
+  `;
+
+  const institutions = (await admin`
+    INSERT INTO awcms_blog_institutions (tenant_id, branch, name, slug)
+    SELECT ${TENANT}, 'legislative', 'DPRD ' || n, 'dprd-' || n
+    FROM generate_series(1, ${INSTITUTION_COUNT}) AS n
+    RETURNING id
+  `) as { id: string }[];
+
+  return institutions.map((row) => row.id);
+}
+
+async function postId(): Promise<string> {
+  const rows = (await getAdminSql()`
+    SELECT id FROM awcms_blog_posts WHERE tenant_id = ${TENANT} AND slug = 'filed'
+  `) as { id: string }[];
+
+  return rows[0]!.id;
+}
+
+async function assignedInstitutionIds(id: string): Promise<string[]> {
+  const rows = (await getAdminSql()`
+    SELECT institution_id FROM awcms_blog_post_institutions
+    WHERE tenant_id = ${TENANT} AND post_id = ${id}
+    ORDER BY institution_id
+  `) as { institution_id: string }[];
+
+  return rows.map((row) => row.institution_id);
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite(
+  "filing a post under institutions costs two queries, whatever the count",
+  () => {
+    let institutionIds: string[] = [];
+
+    beforeAll(async () => {
+      await setupIntegrationDatabase();
+    });
+
+    afterAll(async () => {
+      await teardownIntegrationDatabase();
+    });
+
+    beforeEach(async () => {
+      await resetDatabase();
+      institutionIds = await seedFixtures();
+    });
+
+    test("ten institutions cost two queries, and all ten land", async () => {
+      const id = await postId();
+      const runtime = getRuntimeSql();
+
+      const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+        countQueries(tx, (counting) =>
+          syncPostInstitutionAssignments(counting, TENANT, id, institutionIds)
+        )
+      );
+
+      expect(queries).toBe(ASSIGNMENT_QUERY_BUDGET);
+      expect(await assignedInstitutionIds(id)).toEqual(
+        [...institutionIds].sort()
+      );
+    });
+
+    test("one institution costs the same two queries", async () => {
+      const id = await postId();
+      const runtime = getRuntimeSql();
+
+      const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+        countQueries(tx, (counting) =>
+          syncPostInstitutionAssignments(counting, TENANT, id, [
+            institutionIds[0]!
+          ])
+        )
+      );
+
+      // The number does not move with the input. That is the whole property.
+      expect(queries).toBe(ASSIGNMENT_QUERY_BUDGET);
+      expect(await assignedInstitutionIds(id)).toEqual([institutionIds[0]!]);
+    });
+
+    test("filing under nothing skips the INSERT entirely", async () => {
+      const id = await postId();
+      const runtime = getRuntimeSql();
+
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        syncPostInstitutionAssignments(
+          tx,
+          TENANT,
+          id,
+          institutionIds.slice(0, 3)
+        )
+      );
+
+      const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+        countQueries(tx, (counting) =>
+          syncPostInstitutionAssignments(counting, TENANT, id, [])
+        )
+      );
+
+      // An empty `unnest` would be a legal statement and a wasted round trip —
+      // and the DELETE still has to run, or clearing an article's institutions
+      // would silently do nothing.
+      expect(queries).toBe(1);
+      expect(await assignedInstitutionIds(id)).toEqual([]);
+    });
+
+    test("it REPLACES the set rather than adding to it", async () => {
+      const id = await postId();
+      const runtime = getRuntimeSql();
+
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        syncPostInstitutionAssignments(
+          tx,
+          TENANT,
+          id,
+          institutionIds.slice(0, 4)
+        )
+      );
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        syncPostInstitutionAssignments(tx, TENANT, id, institutionIds.slice(7))
+      );
+
+      expect(await assignedInstitutionIds(id)).toEqual(
+        [...institutionIds.slice(7)].sort()
+      );
+    });
+
+    test("a repeated id still raises the unique constraint rather than being swallowed", async () => {
+      // Deliberately not deduplicated, the same decision its twin records: the
+      // constraint refused a repeated pair before this change, and swallowing it
+      // now would turn a loud error into a silent difference between what was
+      // asked for and what landed. `unnest` changes the shape of the statement,
+      // not the contract.
+      const id = await postId();
+      const runtime = getRuntimeSql();
+
+      let raised = false;
+      try {
+        await withTenantOrThrow(runtime, TENANT, (tx) =>
+          syncPostInstitutionAssignments(tx, TENANT, id, [
+            institutionIds[0]!,
+            institutionIds[0]!
+          ])
+        );
+      } catch {
+        raised = true;
+      }
+
+      expect(raised).toBe(true);
+    });
+  }
+);

--- a/tests/openapi-bundle.test.ts
+++ b/tests/openapi-bundle.test.ts
@@ -220,7 +220,19 @@ describe("openapi bundle — contract equivalence to pre-migration monolith", ()
       "/api/v1/auth/login":
         "#186 optional turnstileToken (backward-compatible)",
       "/api/v1/setup/initialize":
-        "#186 optional turnstileToken (backward-compatible)"
+        "#186 optional turnstileToken (backward-compatible)",
+      // The one entry here that is NOT backward-compatible, and is listed as
+      // such on purpose. `events` gains `maxItems: 500` — a document-additive
+      // change (no field removed, no type changed, so `isAdditiveSuperset`
+      // holds) that is a genuine NARROWING for a caller: a node pushing more
+      // than 500 events in one batch now gets VALIDATION_ERROR where it used to
+      // be accepted. Accepted deliberately. The write side had no count bound
+      // at all behind a 5 MB body, so one request could carry ~30,000 events,
+      // each costing a compare-and-set plus an INSERT, sequentially, inside one
+      // transaction holding the aggregate rows it had advanced. `minItems: 1`
+      // in the same schema documents a refusal that already existed.
+      "/api/v1/sync/push":
+        "maxItems: 500 on events — a deliberate NARROWING, not an addition; matches the /sync/pull page cap"
     };
 
     // Per-operation contract: every pre-migration path is byte-identical now,

--- a/tests/sync-storage.test.ts
+++ b/tests/sync-storage.test.ts
@@ -8,7 +8,9 @@ import {
 import { evaluatePushEventConflict } from "../src/modules/sync-storage/domain/sync-conflict";
 import {
   validateConflictResolutionRequestBody,
-  validateSyncPushRequestBody
+  validateSyncPushRequestBody,
+  MAX_SYNC_PUSH_EVENTS,
+  MAX_SYNC_PULL_EVENTS
 } from "../src/modules/sync-storage/domain/sync-validation";
 import {
   evaluateObjectRetry,
@@ -172,6 +174,59 @@ describe("validateSyncPushRequestBody", () => {
 
   test("rejects a null body", () => {
     expect(validateSyncPushRequestBody(null).valid).toBe(false);
+  });
+
+  test("accepts a batch of exactly MAX_SYNC_PUSH_EVENTS", () => {
+    const result = validateSyncPushRequestBody({
+      batchId: "b1",
+      events: Array.from({ length: MAX_SYNC_PUSH_EVENTS }, () => ({
+        eventType: "created",
+        aggregateType: "example",
+        payload: {}
+      }))
+    });
+
+    // The boundary is inclusive. Asserted alongside the refusal below, because
+    // an off-by-one here refuses a batch a well-behaved node is entitled to
+    // send and would read as an outage on the node's side.
+    expect(result.valid).toBe(true);
+  });
+
+  test("refuses a batch of one more than the maximum, and does not truncate it", () => {
+    // The write side had NO count bound: `readTextBody(request, "large")` allows
+    // 5 MB, so one authenticated request could carry on the order of 30,000
+    // events, each costing a compare-and-set plus an INSERT, all sequential and
+    // all inside one transaction holding the aggregate rows it had advanced.
+    const events = Array.from({ length: MAX_SYNC_PUSH_EVENTS + 1 }, () => ({
+      eventType: "created",
+      aggregateType: "example",
+      payload: {}
+    }));
+
+    const result = validateSyncPushRequestBody({ batchId: "b1", events });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.errors).toContainEqual({
+        field: "events",
+        message: `events may contain at most ${MAX_SYNC_PUSH_EVENTS} entries per batch; received ${MAX_SYNC_PUSH_EVENTS + 1}. Split the batch.`
+      });
+
+      // ONE error, not one per event. An error body carrying a field error for
+      // each of 30,000 events is its own denial of service, and the verdict
+      // does not depend on their contents.
+      expect(result.errors).toHaveLength(1);
+    }
+  });
+
+  test("the push bound IS the pull page size, not a second number equal to it", () => {
+    // A node must not be able to push more in one batch than it can pull in one
+    // page. `pull.ts` has clamped reads since it shipped; the write side was
+    // uncapped. Asserting the RELATIONSHIP rather than the literal 500 is the
+    // point — two independent constants that happen to agree today are how the
+    // asymmetry comes back the next time one of them is tuned.
+    expect(MAX_SYNC_PUSH_EVENTS).toBe(MAX_SYNC_PULL_EVENTS);
+    expect(MAX_SYNC_PUSH_EVENTS).toBeGreaterThan(0);
   });
 
   test("accepts an event with a valid baseVersion", () => {


### PR DESCRIPTION
A scan of `src/**/*.ts` for a tagged-template `await` inside a loop body found **34 loops**. Most are bounded — by a code registry, by a declared cap (`MAX_NODE_ACTIVATIONS = 128`, `MAX_SIDEBAR_ROWS`), or by a job's batch size — and several were already batched or were scanner false positives. Two were not, and they are different kinds of finding. Full triage of the rest is **#715**.

## 1. `POST /api/v1/sync/push` had no count bound at all

The validator checked every event in the `events` array and never the array's **length**. The only limit was the body tier — `readTextBody(request, "large")` allows 5 MB — and a minimal event serialises to a couple of hundred bytes, so one authenticated request could carry on the order of **30,000 events**.

That is not merely slow. Each accepted event costs a compare-and-set on the aggregate version plus an inbox `INSERT`; each conflicted one a conflict `INSERT`. All sequential, all inside a single transaction that holds a connection and keeps **every aggregate row it has advanced locked until commit**. The cost is not the round trips — it is how long everything else waits behind them.

Meanwhile `/sync/pull` has clamped reads to 500 since it shipped. **The two halves of one protocol had asymmetric bounds, and the unbounded half was the one that writes.**

`MAX_SYNC_PUSH_EVENTS` is now defined **as** `MAX_SYNC_PULL_EVENTS`, and `pull.ts` imports the same constant, because the reason for the number is the relationship: a node must not be able to push more in one batch than it can pull in one page. Two independent literals that agree today are how the asymmetry comes back the next time one is tuned — so the test asserts the **relationship**, not the value.

**Refused, never truncated** (the #180 posture). Truncation on a write path silently drops events a node believes it delivered: a node treats an accepted batch as accepted in full and would advance its own cursor past events that never landed. The read side clamps instead, correctly, because a clamped page still says `hasMore`.

Reported as **one** error, not one per event — an error body carrying a field error for each of 30,000 events is its own denial of service, and the verdict does not depend on their contents.

### The gate that made this honest

Adding `maxItems: 500` to the OpenAPI schema reddened `openapi-bundle.test.ts`, which freezes every pre-migration path. The allow-list it wants the entry in is `INTENTIONALLY_EVOLVED_PATHS`, and its two existing entries both read *"backward-compatible"*. **This one is not.** It is document-additive (`isAdditiveSuperset` holds — nothing removed, no type changed) but a genuine **narrowing** for a caller: a node pushing more than 500 events now gets `VALIDATION_ERROR` where it used to be accepted. The entry says exactly that.

A frozen-contract test earns its keep precisely here — not by blocking the change, but by refusing to let it be filed under the wrong description.

## 2. A twin that advertised itself as a twin

`syncPostInstitutionAssignments` issued one `INSERT` per institution. Its own docstring says it is *"exactly like `syncPostTermAssignments`"* — and it was, in contract and not in cost. The term path was flattened to two statements in the performance round when `blog:legacy:import` made a 23,906-article archive its caller. This path, which the **same importer** drives through the **same post payload**, kept the loop.

It now uses the same `DELETE` + `INSERT ... unnest`.

Worth stating, because it is the transferable part: **a sibling that advertises itself as a sibling is the easiest kind of defect to miss.** Whoever fixed the first one had already read the second and remembers agreeing with it. The docstring that should have led a reader there is the very thing that made it feel already handled.

Its budget is a **separate file** from the term one, deliberately: two budgets in one file go green the moment either regresses and the other absorbs it.

### `replaceMenuItems` is deliberately NOT changed

Same shape, but not a mechanical substitution: `parent_item_id` is a **self-referencing FK** (the loop inserts roots before children on purpose), and callers depend on the order of its `RETURNING`, which Postgres does not specify. Those are contract questions. Recorded in #715 with both complications written out.

## Verification

| Mutation | Result |
| --- | --- |
| Remove the `events.length` check | the refusal test fails |
| Restore the per-institution `INSERT` loop | **ten**-institution budget fails; one-institution passes |

That second row is the point of the fixture size: `1 + 1 = 2` either way, so a fixture at the budget would have proven nothing. It is the rationale the sibling budget file already states, demonstrated rather than repeated.

All five institution cases run against a real Postgres, including the repeated-id case (`23505` visible in the log) — the `unnest` rewrite changes the shape of the statement, not the contract, and the constraint still refuses a duplicate rather than it being silently swallowed.

Local: `bun run check` exit 0, 5,756 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)