### PR TITLE
perf(blog): syncing a menu costs two queries, and two claims about why it couldn't were wrong

### DIFF
--- a/.changeset/menu-items-cost-two-queries.md
+++ b/.changeset/menu-items-cost-two-queries.md
@@ -1,0 +1,60 @@
+---
+"awcms": patch
+---
+
+perf(blog): syncing a menu costs two queries instead of one per item, and two claims about why it couldn't be were wrong
+
+`syncMenuItems` issued one `INSERT` per menu item — the third instance of the
+shape `syncPostTermAssignments` and `syncPostInstitutionAssignments` already
+had fixed, and the one deferred as needing "a decision rather than a drive-by".
+
+**Both halves of that stated reason were wrong, and they were mine.**
+
+The note called the function `replaceMenuItems`. No such function exists. The
+name was written from memory instead of read from the signature, and it reached
+a GitHub issue, a merged PR body, a merged changeset and both copies of
+`PROJECT_STATE` before anything caught it — nothing checks a function name that
+appears only in prose.
+
+The note also said its callers depend on the order of its `RETURNING`. They do
+not. `blog/menus/[id].ts` fills the same response field from `syncMenuItems`
+(roots-then-children) or from `fetchMenuItems` (`ORDER BY sort_order`) depending
+only on whether the request supplied `items` — the endpoint already answers in
+two different orders, so no client can be depending on either. That claim was
+inferred from the presence of a `RETURNING` clause, never verified.
+
+With both checked, nothing needed deciding:
+
+- The self-FK is `NOT DEFERRABLE`, and a `NOT DEFERRABLE` foreign key is checked
+  by an AFTER ROW trigger that fires at the end of the **statement**, not after
+  each row. Verified against a real Postgres with the child listed **first** —
+  the arrangement that must fail if checking were per-row. One multi-row
+  `INSERT` is therefore safe whatever the order within it.
+- `RETURNING` was not needed at all. `MenuItemInput` carries all seven columns,
+  `tenantId`/`menuId` are parameters, the table has no user triggers, and no
+  `DEFAULT` applies to a column that is always given a value — so the clause read
+  back exactly what had just been sent.
+
+Now one `DELETE` and one `INSERT ... jsonb_to_recordset`
+(`jsonb_to_recordset` rather than `unnest`: four nullable columns, and a Bun.SQL
+array cannot carry NULL — it writes the literal string `'null'` without
+throwing).
+
+Behaviour is unchanged, including the returned roots-then-children order. It is
+kept because it is what this function returns and changing it would be a silent
+API change riding along with a performance fix — but its docstring no longer
+claims the ordering is load-bearing for the FK, because it is not.
+
+**One test in the first draft asserted something false and passed.** A case
+named "a child listed BEFORE its parent still lands" claimed the old code could
+not have done it. It could: `syncMenuItems` filters roots and children itself,
+so the caller's order never reaches the `INSERT`, and the case passed under the
+per-item loop too. It now asserts what it actually covers — input order changes
+neither what lands nor what returns — and the file header states outright that
+the FK property is **not** reproducible through this function, so the case is
+not mistaken for evidence of it later.
+
+Mutation-proven on both real properties: dropping a field from the batch so the
+stored row diverges from the input reddens "what it RETURNS is what the table
+holds" — the check that makes building the answer from input safe at all — and
+restoring the per-item loop reddens the budget.

--- a/.changeset/sync-push-batch-bound.md
+++ b/.changeset/sync-push-batch-bound.md
@@ -60,7 +60,10 @@ A sibling that advertises itself as a sibling is the easiest kind of defect to
 miss: whoever fixed the first one had already read the second and remembered
 agreeing with it.
 
-`replaceMenuItems` has the same shape and is deliberately NOT changed here — it
-carries a self-referencing FK and its callers depend on the order of its
-`RETURNING`, so it needs a decision rather than a drive-by. Recorded with the
-rest of the sweep.
+`syncMenuItems` has the same shape and is not changed here — it carries a
+self-referencing FK and returns its rows, so it was deferred rather than done as
+a drive-by. Recorded with the rest of the sweep. (Two corrections to an earlier
+draft of this note, which named it `replaceMenuItems` — a function that does not
+exist — and said its callers depend on the order of its `RETURNING`. The
+endpoint already returns two different orderings depending on whether `items`
+was supplied, so no caller can depend on either.)

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:808f8cb71620561e7c0502410cad7ac5b7b961101f34759c3b5558d80e43c113 -->
+<!-- i18n-source-hash: sha256:f5f916e6d5ecd048b19eca3f149152fa58b93195073ea8ed4b2bb6a614137aba -->
 
 # AWCMS — Project State & Continuation
 
@@ -360,6 +360,62 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
 
 ## 4. Backlog / langkah berikutnya
 
+- **PUTARAN NAMA — 25 Agustus 2026: jalur tulis N+1 ketiga ditutup, dan alasan
+  ia tampak sulit adalah cacat di TRIASE SAYA SENDIRI, bukan di kodenya.**
+
+  PUTARAN BATAS di bawah menunda satu situs dengan alasan tertulis. Kedua paruh
+  alasan itu salah, dan CARA salahnya justru intinya.
+
+  **Ia disebut `replaceMenuItems`. Fungsi itu tidak ada.** Yang asli
+  `syncMenuItems`. Namanya ditulis dari INGATAN, bukan dibaca dari signature-nya,
+  dan menyebar ke sebuah issue GitHub, badan PR yang sudah ter-merge, changeset
+  yang sudah ter-merge, dan KEDUA salinan dokumen ini sebelum ada yang
+  menangkapnya — karena tak ada yang memeriksa nama fungsi yang hanya muncul di
+  prosa. Ini persis aturan yang sudah tercatat, "kutip BERKAS, bukan catatan
+  tentang berkas", dan kali ini catatannya milik saya sendiri sepuluh menit
+  sebelumnya.
+
+  **Dan "pemanggilnya bergantung pada urutan `RETURNING`" itu KELIRU.** Ia punya
+  dua pemanggil, dan `blog/menus/[id].ts` mengisi field respons yang SAMA dari
+  `syncMenuItems` (root-lalu-anak) ATAU dari `fetchMenuItems`
+  (`ORDER BY sort_order`) hanya bergantung apakah request mengirim `items`.
+  Endpoint-nya SUDAH menjawab dalam dua urutan berbeda, jadi tak ada klien yang
+  bisa bergantung pada salah satunya. Klaim itu tak pernah diverifikasi; ia
+  DISIMPULKAN dari adanya klausa `RETURNING`.
+
+  Yang tersisa setelah keduanya diperiksa: **tak ada yang butuh keputusan.**
+
+  - FK-diri itu `NOT DEFERRABLE`, dan foreign key `NOT DEFERRABLE` diperiksa
+    trigger AFTER ROW yang menyala di akhir STATEMENT, bukan sesudah tiap baris.
+    Diverifikasi terhadap Postgres nyata dengan anak diletakkan PERTAMA — susunan
+    yang WAJIB gagal bila pemeriksaannya per-baris. Jadi satu INSERT multi-baris
+    aman apa pun urutan di dalamnya.
+  - `RETURNING` sama sekali tak diperlukan. `MenuItemInput` membawa ketujuh
+    kolomnya, `tenantId`/`menuId` adalah parameter, tabelnya tak punya trigger
+    pengguna, dan tak ada `DEFAULT` yang berlaku pada kolom yang selalu diberi
+    nilai — jadi klausa itu membaca balik persis apa yang baru saja dikirim.
+
+  Kini dua statement. Urutan root-sebelum-anak dipertahankan, tetapi
+  docstring-nya tak lagi mengklaim menanggung beban: ia dipertahankan karena
+  itulah yang DIKEMBALIKAN fungsi ini, dan mengubahnya berarti perubahan API
+  senyap yang menumpang pada perbaikan performa.
+
+  **Satu tes di draf pertama menegakkan hal yang SALAH, dan ia LOLOS.** Kasus
+  bernama "anak diletakkan SEBELUM induknya tetap mendarat" mengklaim kode lama
+  "tak mungkin bisa melakukan ini". Bisa: `syncMenuItems` menyaring root dan anak
+  sendiri, jadi urutan pemanggil tak pernah sampai ke INSERT dan kasus itu lolos
+  di loop per-item juga. Hijau, dan tak membuktikan apa pun yang diakuinya.
+  Ditulis ulang agar menegakkan yang benar-benar dicakupnya — bahwa urutan input
+  tak mengubah apa yang mendarat maupun apa yang dikembalikan — dan header-nya
+  kini menyatakan terang-terangan bahwa properti FK itu TIDAK bisa direproduksi
+  lewat fungsi ini, supaya pembaca berikutnya tak menyalahartikan kasus itu
+  sebagai buktinya.
+
+  Kedua properti nyata terbukti-mutasi: membuang satu field dari batch sehingga
+  baris tersimpan menyimpang dari input memerahkan "apa yang DIKEMBALIKAN adalah
+  isi tabel" (pemeriksaan yang membuat membangun jawaban dari input aman sama
+  sekali), dan mengembalikan loop per-item memerahkan anggarannya.
+
 - **PUTARAN BATAS — 25 Agustus 2026: satu endpoint API menerima batch TANPA
   batas, dan fungsi yang menyebut dirinya kembaran fungsi yang sudah diperbaiki
   justru menyimpan cacatnya.**
@@ -427,13 +483,13 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   meninggalkan kasus satu-institusi tetap lolos, karena `1 + 1 = 2` di kedua
   bentuk.
 
-  **`replaceMenuItems` berbentuk sama dan sengaja TIDAK diubah.** Ia membawa FK
-  yang menunjuk dirinya sendiri (loop-nya menyisipkan root sebelum child dengan
-  sengaja) dan pemanggilnya bergantung pada urutan `RETURNING`-nya, yang tidak
-  dijamin Postgres. Itu pertanyaan KONTRAK, bukan substitusi mekanis. Dicatat
-  bersama triase lengkapnya di **#715**, yang juga memuat situs yang belum
-  dibaca — job backfill paling layak diambil bersama, karena mereka mengiterasi
-  TENANT di lapis terluar sehingga biayanya adalah PERKALIAN.
+  Instans ketiga, `syncMenuItems`, ditunda di sini dan ditutup oleh PUTARAN NAMA
+  di atas. **Dua hal yang semula dinyatakan entri ini tentangnya SALAH**, dan
+  keduanya dikoreksi di sana: ia dinamai `replaceMenuItems`, fungsi yang tidak
+  ada, dan pemanggilnya disebut bergantung pada urutan `RETURNING`-nya. Triase
+  lengkap situs yang belum dibaca ada di **#715** — job backfill paling layak
+  diambil bersama, karena mereka mengiterasi TENANT di lapis terluar sehingga
+  biayanya adalah PERKALIAN.
 
 - **PUTARAN ARAH — 25 Agustus 2026: gerbang enforcement menanyakan
   pertanyaannya SATU arah saja, dan arah yang hilang justru yang berakibat

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,60 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **NAME ROUND — 25 August 2026: the third N+1 write path is closed, and the
+  reason it looked hard was a defect in MY OWN triage rather than in the code.**
+
+  The BOUND ROUND below deferred one site with a stated reason. Both halves of
+  that reason were wrong, and the way they were wrong is the point.
+
+  **It was called `replaceMenuItems`. No such function exists.** The real one is
+  `syncMenuItems`. The name was written from memory rather than read from the
+  signature, and it propagated into a GitHub issue, a merged PR body, a merged
+  changeset and BOTH copies of this document before anything caught it —
+  because nothing checks a function name that appears only in prose. This is the
+  rule already recorded as "cite the FILE, not a note about the file", and this
+  time the note was my own from ten minutes earlier.
+
+  **And "its callers depend on the order of its `RETURNING`" is false.** It has
+  two callers, and `blog/menus/[id].ts` fills the SAME response field from
+  `syncMenuItems` (roots-then-children) or from `fetchMenuItems`
+  (`ORDER BY sort_order`) depending only on whether the request supplied
+  `items`. The endpoint already answers in two different orders, so no client
+  can be depending on either. The claim was never verified; it was inferred from
+  the presence of a `RETURNING` clause.
+
+  What was left once both were checked: **nothing needing a decision.**
+
+  - The self-FK is `NOT DEFERRABLE`, and a `NOT DEFERRABLE` foreign key is
+    checked by an AFTER ROW trigger firing at the end of the STATEMENT, not
+    after each row. Verified against a real Postgres with the child listed
+    FIRST — the arrangement that must fail if checking were per-row. So one
+    multi-row INSERT is safe whatever the order within it.
+  - `RETURNING` was not needed at all. `MenuItemInput` carries all seven
+    columns, `tenantId`/`menuId` are parameters, the table has no user triggers,
+    and no `DEFAULT` applies to a column that is always given a value — so the
+    clause read back exactly what had just been sent.
+
+  Now two statements. The roots-before-children order is kept, but its docstring
+  no longer claims to be load-bearing: it is retained because it is what the
+  function RETURNS, and changing that would be a silent API change riding along
+  with a performance fix.
+
+  **One test in the first draft asserted something false, and it passed.** A
+  case named "a child listed BEFORE its parent still lands" claimed the old code
+  "could not have done this at all". It could: `syncMenuItems` filters roots and
+  children itself, so the caller's order never reaches the INSERT and the case
+  passed under the per-item loop too. Green, and proving nothing it said it
+  proved. Rewritten to assert what it actually covers — that input order changes
+  neither what lands nor what returns — and the header now says outright that
+  the FK property is NOT reproducible through this function, so no future reader
+  mistakes the case for evidence of it.
+
+  Both real properties are mutation-proven: dropping a field from the batch so
+  the stored row diverges from the input reddens "what it RETURNS is what the
+  table holds" (the check that makes building the answer from input safe at
+  all), and restoring the per-item loop reddens the budget.
+
 - **BOUND ROUND — 25 August 2026: one API endpoint accepted an unbounded batch,
   and a function that calls itself a twin of a fixed one kept the defect.**
 
@@ -420,13 +474,13 @@ pioneered directly here after the ADR-0047 freeze.)
   the loop reddens the ten-institution case and leaves the one-institution case
   passing, because `1 + 1 = 2` either way.
 
-  **`replaceMenuItems` has the same shape and was deliberately NOT changed.** It
-  carries a self-referencing FK (the loop inserts roots before children on
-  purpose) and its callers depend on the order of its `RETURNING`, which
-  Postgres does not specify. Those are contract questions, not a mechanical
-  substitution. Recorded with the full triage in **#715**, which also carries
-  the sites not yet read — the backfill jobs are the ones worth taking together,
-  since they iterate TENANTS at the outer level and their cost is a product.
+  The third instance, `syncMenuItems`, was deferred here and is closed by the
+  NAME ROUND above. **Two things this entry originally said about it were
+  wrong**, and both are corrected there: it was named `replaceMenuItems`, a
+  function that does not exist, and its callers were said to depend on the order
+  of its `RETURNING`. The full triage of the sites not yet read is **#715** —
+  the backfill jobs are the ones worth taking together, since they iterate
+  TENANTS at the outer level and their cost is a product.
 
 - **DIRECTION ROUND — 25 August 2026: the enforcement gate asked its question
   one way round, and the missing direction is the one with the dead endpoint

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 488   |
+| Test files                          | 489   |
 | Route files                         | 383   |
 | ADR                                 | 226   |
 
@@ -361,7 +361,7 @@
 | ------------- | ---------- |
 | `(root)`      | 402        |
 | `e2e`         | 17         |
-| `integration` | 68         |
+| `integration` | 69         |
 | `unit`        | 1          |
 
 ### Routes

--- a/src/modules/blog-content/application/menu-directory.ts
+++ b/src/modules/blog-content/application/menu-directory.ts
@@ -165,9 +165,39 @@ export async function softDeleteMenu(
  * above, so `parentItemId` can only ever resolve against ids the caller
  * itself provides in this same payload (`domain/menu-policy.ts`'s
  * `validateMenuItemsInput` already checked every `parentItemId` resolves
- * within the batch and nests at most one level deep). Inserted
- * roots-before-children so a child's FK to its parent is always satisfied
- * by the time it's inserted.
+ * within the batch and nests at most one level deep).
+ *
+ * ## Cost: 2 queries, whatever the item count
+ *
+ * It was one `INSERT` per item — the third instance of the shape
+ * `syncPostTermAssignments` and `syncPostInstitutionAssignments` already had
+ * fixed, and the one that looked hardest because of the self-FK.
+ *
+ * The roots-before-children ordering was there so "a child's FK to its parent
+ * is always satisfied by the time it's inserted", which is true of separate
+ * statements and NOT the constraint it appears to be for one. The FK is
+ * `NOT DEFERRABLE`, and a `NOT DEFERRABLE` foreign key is checked by an AFTER
+ * ROW trigger that fires at the end of the STATEMENT, not after each row — so a
+ * single multi-row `INSERT` satisfies a child that references a parent in the
+ * same statement regardless of their order within it. Verified against a real
+ * Postgres with the child listed FIRST, which is the arrangement that must fail
+ * if the checking were per-row.
+ *
+ * The order is preserved anyway, because it is what this function RETURNS and
+ * changing that would be a silent API change riding along with a performance
+ * fix.
+ *
+ * ## Why the rows come from the input rather than from `RETURNING`
+ *
+ * Every column this statement writes is caller-supplied — `MenuItemInput`
+ * carries all seven, and `tenantId`/`menuId` are parameters. The table has no
+ * user triggers and no `DEFAULT` can apply to a column that is always given a
+ * value, so a `RETURNING` clause here reads back exactly what was just sent.
+ * Dropping it removes the only reason this function would have needed to care
+ * about the order `RETURNING` emits, which Postgres does not specify.
+ *
+ * The integration test asserts the returned views against a fresh read of the
+ * table, so "the input equals what landed" is checked rather than assumed.
  */
 export async function syncMenuItems(
   tx: Bun.SQL,
@@ -182,23 +212,62 @@ export async function syncMenuItems(
 
   const roots = items.filter((item) => item.parentItemId === null);
   const children = items.filter((item) => item.parentItemId !== null);
-  const inserted: BlogMenuItemRow[] = [];
+  const ordered = [...roots, ...children];
 
-  for (const item of [...roots, ...children]) {
-    const rows = (await tx`
-      INSERT INTO awcms_blog_menu_items
-        (id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order)
-      VALUES (
-        ${item.id}, ${tenantId}, ${menuId}, ${item.parentItemId}, ${item.label},
-        ${item.linkType}, ${item.targetId}, ${item.url}, ${item.sortOrder}
-      )
-      RETURNING id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order
-    `) as BlogMenuItemRow[];
-
-    inserted.push(rows[0]!);
+  if (ordered.length === 0) {
+    return [];
   }
 
-  return inserted.map(toItemView);
+  const rows = ordered.map((item, index) => ({
+    ordinal: index,
+    id: item.id,
+    tenant_id: tenantId,
+    menu_id: menuId,
+    parent_item_id: item.parentItemId,
+    label: item.label,
+    link_type: item.linkType,
+    target_id: item.targetId,
+    url: item.url,
+    sort_order: item.sortOrder
+  }));
+
+  // `jsonb_to_recordset` rather than `unnest`: this row has four nullable
+  // columns, and a Bun.SQL array cannot carry NULL — it writes the literal
+  // string `'null'` without throwing. JSON `null` maps to SQL NULL natively.
+  await tx`
+    INSERT INTO awcms_blog_menu_items
+      (id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order)
+    SELECT entry.id, entry.tenant_id, entry.menu_id, entry.parent_item_id,
+           entry.label, entry.link_type, entry.target_id, entry.url,
+           entry.sort_order
+    FROM jsonb_to_recordset(${rows}::jsonb) AS entry (
+      ordinal integer,
+      id uuid,
+      tenant_id uuid,
+      menu_id uuid,
+      parent_item_id uuid,
+      label text,
+      link_type text,
+      target_id uuid,
+      url text,
+      sort_order integer
+    )
+    ORDER BY entry.ordinal
+  `;
+
+  return ordered.map((item) =>
+    toItemView({
+      id: item.id,
+      tenant_id: tenantId,
+      menu_id: menuId,
+      parent_item_id: item.parentItemId,
+      label: item.label,
+      link_type: item.linkType,
+      target_id: item.targetId,
+      url: item.url,
+      sort_order: item.sortOrder
+    })
+  );
 }
 
 export async function fetchMenuItems(

--- a/tests/integration/menu-item-sync-budget.integration.test.ts
+++ b/tests/integration/menu-item-sync-budget.integration.test.ts
@@ -1,0 +1,299 @@
+/**
+ * A query budget on the THIRD post-assignment write path, and the one that
+ * looked hardest.
+ *
+ * `syncPostTermAssignments` and `syncPostInstitutionAssignments` are already
+ * pinned at two statements each. `syncMenuItems` had the same one-INSERT-per-
+ * item shape and two complications that made it look like it needed a design
+ * decision rather than a substitution:
+ *
+ * 1. `awcms_blog_menu_items.parent_item_id` is a SELF-REFERENCING FK, and the
+ *    loop inserted roots before children so "a child's FK to its parent is
+ *    always satisfied by the time it's inserted";
+ * 2. it returns its rows, and Postgres does not specify the order `RETURNING`
+ *    emits.
+ *
+ * Both dissolved. The FK is `NOT DEFERRABLE`, which is checked by an AFTER ROW
+ * trigger firing at the end of the STATEMENT — so one multi-row INSERT
+ * satisfies a child referencing a parent in the same statement whatever their
+ * order. And every column the statement writes is caller-supplied, so
+ * `RETURNING` read back exactly what was sent and could simply go.
+ *
+ * The FK half was settled by a direct probe against Postgres with the child
+ * listed FIRST — the arrangement that must fail if checking were per-row.
+ * That probe is NOT reproducible through this function, which filters roots and
+ * children before inserting, so no test here should be read as proving it.
+ * Saying so explicitly because the reverse-order case below looks like it
+ * proves that and does not: it passed under the per-item loop too.
+ *
+ * ## What this file has to prove that the other two budgets do not
+ *
+ * The other two write join-table rows nobody reads back in the same call. This
+ * one RETURNS what it wrote, and it now builds that answer from the INPUT
+ * rather than from the database. That is only safe if the input really is what
+ * lands — so the cases below read the table back and compare, instead of
+ * trusting the function's own return value to describe itself.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import {
+  fetchMenuItems,
+  syncMenuItems
+} from "../../src/modules/blog-content/application/menu-directory";
+import type { MenuItemInput } from "../../src/modules/blog-content/domain/menu-policy";
+
+const TENANT = "fa000000-0000-4000-8000-000000000001";
+const MENU = "fa000000-0000-4000-8000-000000000002";
+
+/** One `DELETE` for the old set, one `INSERT ... jsonb_to_recordset` for the new one. */
+const SYNC_QUERY_BUDGET = 2;
+
+function itemId(n: number): string {
+  return `fa000000-0000-4000-8000-0000000001${String(n).padStart(2, "0")}`;
+}
+
+/**
+ * Four roots, each with two children — 12 items, so the old shape costs 13
+ * queries against a budget of 2 and a per-item regression cannot hide behind a
+ * small fixture.
+ */
+function buildItems(): MenuItemInput[] {
+  const items: MenuItemInput[] = [];
+  let n = 0;
+
+  for (let root = 0; root < 4; root += 1) {
+    const rootId = itemId(n);
+    items.push({
+      id: rootId,
+      parentItemId: null,
+      label: `Root ${root}`,
+      linkType: "url",
+      targetId: null,
+      url: `/root-${root}`,
+      sortOrder: n
+    });
+    n += 1;
+
+    for (let child = 0; child < 2; child += 1) {
+      items.push({
+        id: itemId(n),
+        parentItemId: rootId,
+        label: `Child ${root}.${child}`,
+        linkType: "url",
+        targetId: null,
+        url: `/root-${root}/child-${child}`,
+        sortOrder: n
+      });
+      n += 1;
+    }
+  }
+
+  return items;
+}
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'menu-budget', 'Menu Budget Tenant')
+  `;
+  await admin`
+    INSERT INTO awcms_blog_menus (id, tenant_id, key, name)
+    VALUES (${MENU}, ${TENANT}, 'main', 'Main')
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("syncing a menu costs two queries, whatever the item count", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("twelve items cost two queries, and all twelve land", async () => {
+    const items = buildItems();
+    const runtime = getRuntimeSql();
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        syncMenuItems(counting, TENANT, MENU, items)
+      )
+    );
+
+    expect(queries).toBe(SYNC_QUERY_BUDGET);
+    expect(result).toHaveLength(items.length);
+
+    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, MENU)
+    );
+    expect(stored).toHaveLength(items.length);
+  });
+
+  test("what it RETURNS is what the table holds, field for field", async () => {
+    // The return value is now built from the input rather than from RETURNING.
+    // That is the claim this test exists to check: if the database were to
+    // store anything other than what was sent — a coercion, a default, a
+    // trigger — the function would be describing itself rather than reporting.
+    const items = buildItems();
+    const runtime = getRuntimeSql();
+
+    const returned = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      syncMenuItems(tx, TENANT, MENU, items)
+    );
+    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, MENU)
+    );
+
+    const byId = (list: typeof stored) =>
+      [...list].sort((left, right) => left.id.localeCompare(right.id));
+
+    expect(byId(returned)).toEqual(byId(stored));
+  });
+
+  test("input order changes neither what lands nor what comes back", async () => {
+    // NOT a test that a child can precede its parent inside the statement: the
+    // function filters roots and children itself, so the caller's order never
+    // reaches the INSERT and this passed under the per-item loop too.
+    //
+    // Said plainly because the distinction is the whole reason this change was
+    // safe. The self-FK made the batch look risky; what actually removed the
+    // risk is that `NOT DEFERRABLE` FKs are checked by an AFTER ROW trigger
+    // firing at end of STATEMENT — verified directly against Postgres with the
+    // child listed first, a probe this function cannot express. So the
+    // roots-before-children ordering is no longer load-bearing for
+    // CORRECTNESS; it is retained only because it is the order this function
+    // returns.
+    const items = buildItems();
+    const reversed = [...items].reverse();
+    const runtime = getRuntimeSql();
+
+    const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        syncMenuItems(counting, TENANT, MENU, reversed)
+      )
+    );
+
+    expect(queries).toBe(SYNC_QUERY_BUDGET);
+
+    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, MENU)
+    );
+    expect(stored).toHaveLength(items.length);
+
+    // Every child still points at a real parent row.
+    const ids = new Set(stored.map((item) => item.id));
+    for (const item of stored) {
+      if (item.parentItemId === null) continue;
+      expect(ids.has(item.parentItemId)).toBe(true);
+    }
+  });
+
+  test("the returned order is unchanged: roots first, then children", async () => {
+    // Preserved deliberately. It is what this function returned before, and
+    // changing it would be a silent API change riding along with a performance
+    // fix — even though the endpoint's OTHER branch (`fetchMenuItems`, when a
+    // PATCH omits `items`) already answers in `sort_order` order instead.
+    const items = buildItems();
+    const runtime = getRuntimeSql();
+
+    const returned = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      syncMenuItems(tx, TENANT, MENU, items)
+    );
+
+    const firstChildAt = returned.findIndex(
+      (item) => item.parentItemId !== null
+    );
+    const lastRootAt = returned.reduce(
+      (last, item, index) => (item.parentItemId === null ? index : last),
+      -1
+    );
+
+    expect(firstChildAt).toBeGreaterThan(lastRootAt);
+    expect(returned.filter((item) => item.parentItemId === null)).toHaveLength(
+      4
+    );
+  });
+
+  test("one item costs the same two queries", async () => {
+    const runtime = getRuntimeSql();
+
+    const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        syncMenuItems(counting, TENANT, MENU, [buildItems()[0]!])
+      )
+    );
+
+    // The number does not move with the input. That is the whole property.
+    expect(queries).toBe(SYNC_QUERY_BUDGET);
+  });
+
+  test("syncing an empty menu costs ONE query and clears the items", async () => {
+    const runtime = getRuntimeSql();
+
+    await withTenantOrThrow(runtime, TENANT, (tx) =>
+      syncMenuItems(tx, TENANT, MENU, buildItems())
+    );
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) => syncMenuItems(counting, TENANT, MENU, []))
+    );
+
+    // The DELETE still has to run, or emptying a menu would silently do
+    // nothing; the INSERT must not.
+    expect(queries).toBe(1);
+    expect(result).toEqual([]);
+
+    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, MENU)
+    );
+    expect(stored).toEqual([]);
+  });
+
+  test("it REPLACES the set rather than adding to it", async () => {
+    const runtime = getRuntimeSql();
+    const items = buildItems();
+
+    await withTenantOrThrow(runtime, TENANT, (tx) =>
+      syncMenuItems(tx, TENANT, MENU, items)
+    );
+    await withTenantOrThrow(runtime, TENANT, (tx) =>
+      syncMenuItems(tx, TENANT, MENU, items.slice(0, 1))
+    );
+
+    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, MENU)
+    );
+
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.id).toBe(items[0]!.id);
+  });
+});


### PR DESCRIPTION
`syncMenuItems` issued one `INSERT` per menu item — the third instance of the shape `syncPostTermAssignments` and `syncPostInstitutionAssignments` already had fixed, and the one #716 deferred as needing *"a decision rather than a drive-by"*.

**Both halves of that stated reason were wrong, and they were mine.**

## 1. The function it named does not exist

The note called it `replaceMenuItems`. The real one is **`syncMenuItems`**. I wrote the name from memory instead of reading the signature, and it propagated into issue #715, PR #716's body, a merged changeset, and both copies of `docs/PROJECT_STATE.md` before anything caught it — nothing checks a function name that appears only in prose. This PR corrects all four.

## 2. "Callers depend on the order of its `RETURNING`" is false

It has two callers, and [`blog/menus/[id].ts`](src/pages/api/v1/blog/menus/%5Bid%5D.ts) fills the **same response field** from either branch:

```ts
const currentItems = items
  ? await syncMenuItems(tx, tenantId, id, items)   // roots-then-children
  : await fetchMenuItems(tx, tenantId, id);        // ORDER BY sort_order
```

The endpoint already answers in two different orders depending only on whether the request supplied `items`, so no client can be depending on either. I inferred the claim from the presence of a `RETURNING` clause and never checked it.

## With both checked, nothing needed deciding

- **The self-FK.** `parent_item_id`'s constraint is `NOT DEFERRABLE`, and a `NOT DEFERRABLE` foreign key is checked by an AFTER ROW trigger firing at the end of the **statement**, not after each row. Verified against a real Postgres with the child listed **first** — the arrangement that must fail if checking were per-row. One multi-row `INSERT` is safe whatever the order within it.
- **`RETURNING` wasn't needed at all.** `MenuItemInput` carries all seven columns, `tenantId`/`menuId` are parameters, the table has no user triggers, and no `DEFAULT` applies to a column that is always given a value — so the clause read back exactly what had just been sent.

Now one `DELETE` and one `INSERT ... jsonb_to_recordset` (rather than `unnest`: four nullable columns, and a Bun.SQL array cannot carry NULL — it writes the literal string `'null'` without throwing).

Behaviour unchanged, including the returned roots-then-children order — kept because it is what the function returns, and changing it would be a silent API change riding along with a performance fix. Its docstring no longer claims the ordering is load-bearing for the FK, because it is not.

## A test in the first draft asserted something false, and passed

A case named *"a child listed BEFORE its parent still lands"* claimed the old code "could not have done this at all". **It could.** `syncMenuItems` filters roots and children itself, so the caller's order never reaches the `INSERT` — the case passed under the per-item loop too. Green, and proving nothing it claimed.

It now asserts what it actually covers (input order changes neither what lands nor what returns), and the file header states outright that the FK property is **not** reproducible through this function, so no later reader mistakes the case for evidence of it.

## Verification

| Mutation | Result |
| --- | --- |
| Drop a field from the batch so the stored row diverges from the input | *"what it RETURNS is what the table holds"* fails |
| Restore the per-item `INSERT` loop | the budget fails |

The first is the one that matters: the return value is now built from the **input** rather than from the database, which is only sound if the input really is what lands. That test reads the table back and compares field for field.

Fixture is 4 roots × 2 children = 12 items — 13 queries under the old shape against a budget of 2.

Local: `bun run check` exit 0, 5,756 pass / 0 fail. All three assignment budgets green together (16 tests).

Corrects #715.

🤖 Generated with [Claude Code](https://claude.com/claude-code)