### PR TITLE
perf(identity-access): the expiry job costs the same for twelve elapsed items as for one

### DIFF
--- a/.changeset/expiry-job-batched-writes.md
+++ b/.changeset/expiry-job-batched-writes.md
@@ -1,0 +1,46 @@
+---
+"awcms": patch
+---
+
+perf(identity-access): the expiry job costs the same for twelve elapsed items as for one, and its SoD audit rows were never asserted
+
+Both passes of `business-scope-expiry-job` issued one `INSERT` per expired item.
+Both are capped at 500, so the worst case was **500 sequential statements inside
+one transaction**, per tenant, per pass, across every tenant
+`iterateTenantsInBatches` visits.
+
+A bound of 500 is not a defence against a per-item query; it is the size at
+which one starts to matter. It is more than twice the batch bound of the
+scheduled blog sweeps that were flattened for exactly this reason.
+
+- The assignment pass writes its `awcms_business_scope_assignment_events` rows
+  with one `unnest` — an append-only log with no conflict target, and every
+  column except the id is constant for the pass.
+- The exception pass now uses `recordAuditEvents`, the batch form of the very
+  writer its per-row loop was calling. **The rows are unchanged**: each expired
+  exception still gets its own `critical` entry naming the rule that lapsed,
+  because that is what an auditor reads one at a time. Only the number of round
+  trips moved.
+
+The asymmetry between the two passes is deliberate and stays: an assignment
+expiring on schedule is routine and gets one summary event, an SoD exception
+lapsing is a control coming off and gets one entry each.
+
+**A gap this uncovered.** The SoD expiry test asserted the status flip and
+nothing else — no assertion touched the audit rows at all. Moving that write to
+a batch writer would have left every existing assertion in the file green even
+if the batch had dropped its rows entirely. The test now checks the entry
+exists, is `critical`, carries the resource id, and that `attributes.ruleKey`
+reads back as a jsonb **object** rather than a jsonb string. Mutation-proven:
+passing an empty batch fails it.
+
+The budget is asserted as a **relation**, not an absolute: a run with twelve
+elapsed assignments must cost exactly what a run with one costs. An absolute
+number here would have to encode the fixed per-tenant overhead of every pass in
+this job and would move for reasons unrelated to the defect. Measured through
+`countPoolQueries`, because a job reaches its transaction itself via
+`withTenantOrThrow` → `sql.begin` and counting only the pool's own tagged
+templates would see none of the statements that matter.
+
+Mutation-proven: restoring the per-item `INSERT` takes the twelve-item run from
+17 queries to 28 — exactly eleven more, for eleven more items.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:f5f916e6d5ecd048b19eca3f149152fa58b93195073ea8ed4b2bb6a614137aba -->
+<!-- i18n-source-hash: sha256:fc50a36528152e21a63527e88441ddbede97a270341847e6f5febe4570ee220b -->
 
 # AWCMS — Project State & Continuation
 
@@ -487,9 +487,37 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   di atas. **Dua hal yang semula dinyatakan entri ini tentangnya SALAH**, dan
   keduanya dikoreksi di sana: ia dinamai `replaceMenuItems`, fungsi yang tidak
   ada, dan pemanggilnya disebut bergantung pada urutan `RETURNING`-nya. Triase
-  lengkap situs yang belum dibaca ada di **#715** — job backfill paling layak
-  diambil bersama, karena mereka mengiterasi TENANT di lapis terluar sehingga
-  biayanya adalah PERKALIAN.
+  lengkap situs yang belum dibaca ada di **#715**.
+
+  **Sapuan itu kini ditutup di #715, dan DUA klaimnya lagi ternyata salah.**
+  "Job backfill mengiterasi TENANT di lapis terluar sehingga biayanya PERKALIAN"
+  — benar, dan BUKAN cacat: `withTenantOrThrow` membuka transaksi dengan GUC
+  tenant ter-set, jadi mem-batch lintas tenant berarti MELEWATI RLS, dan KEDUA
+  job menyatakannya di komentarnya sendiri (`entitlement-backfill-job.ts:94`:
+  _"a single cross-tenant SELECT would return nothing at all rather than
+  everything"_). Temuan kedua yang saya ajukan di sana — bahwa backfill
+  entitlement melebih-lapor jumlah grant dan membuat grant satu tenant
+  tak-atomik — juga BERLEBIHAN dan dikoreksi di issue-nya: plan-nya sudah
+  melewati `already_held`, dan job-nya idempoten serta bisa dijalankan ulang,
+  jadi hitungannya akurat di luar race dan keadaan separuh menyatu pada
+  jalannya berikutnya.
+
+  Dari 34 situs, **empat layak ditindaklanjuti**. Tiga ada di atas; keempat
+  adalah `business-scope-expiry-job`, yang kedua pass-nya masing-masing
+  mengeluarkan satu INSERT per item kedaluwarsa di bawah cap **500** — dua kali
+  lebih besar dari batas sapuan blog. Pass exception-nya kini memakai
+  `recordAuditEvents`, bentuk batch dari writer yang loop-nya sendiri panggil,
+  dengan BARISNYA tak berubah. Sisanya terbatas oleh registry, disengaja dengan
+  alasan tertulis, atau butuh penulisan ulang alih-alih batch
+  (`module-usage-report` adalah 21 query BERBEDA lewat `switch`, jadi
+  `UNION ALL`, bukan batch).
+
+  Satu hal yang disingkap pass itu dan BUKAN soal performa: **tes kedaluwarsa
+  SoD menegakkan perpindahan status dan tidak lebih.** Memindahkan tulisan itu
+  ke batch writer akan membiarkan setiap asersi di berkas itu hijau bahkan bila
+  batch-nya membuang seluruh baris auditnya. Bentuk yang berulang — tes yang
+  mencakup PERPINDAHAN keadaan dan bukan CATATAN atas perpindahan itu persis tes
+  yang tak bisa menyadari writer-nya ditukar di bawahnya.
 
 - **PUTARAN ARAH — 25 Agustus 2026: gerbang enforcement menanyakan
   pertanyaannya SATU arah saja, dan arah yang hilang justru yang berakibat

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -478,9 +478,36 @@ pioneered directly here after the ADR-0047 freeze.)
   NAME ROUND above. **Two things this entry originally said about it were
   wrong**, and both are corrected there: it was named `replaceMenuItems`, a
   function that does not exist, and its callers were said to depend on the order
-  of its `RETURNING`. The full triage of the sites not yet read is **#715** —
-  the backfill jobs are the ones worth taking together, since they iterate
-  TENANTS at the outer level and their cost is a product.
+  of its `RETURNING`.
+
+  **The sweep is now closed out in #715, and two more of its claims were
+  wrong.** "The backfill jobs iterate TENANTS at the outer level, so their cost
+  is a product" — true, and not a defect: `withTenantOrThrow` opens a
+  transaction with the tenant GUC set, so batching across tenants would mean
+  bypassing RLS, and BOTH jobs say so in their own comments
+  (`entitlement-backfill-job.ts:94`: _"a single cross-tenant SELECT would return
+  nothing at all rather than everything"_). A second finding filed there — that
+  the entitlement backfill over-reports its grant count and leaves a tenant's
+  grants non-atomic — was also overstated and is corrected in the issue: the
+  plan already skips `already_held`, and the job is idempotent and re-runnable,
+  so the count is accurate outside a race and partial state converges on the
+  next run.
+
+  Of 34 sites, **four were worth acting on**. Three are above; the fourth is
+  `business-scope-expiry-job`, whose two passes each issued one INSERT per
+  expired item under a cap of **500** — more than twice the blog sweeps' bound.
+  Its exception pass now uses `recordAuditEvents`, the batch form of the writer
+  its own loop was calling, with the rows unchanged. Everything else is bounded
+  by a registry, deliberate with a written rationale, or needs a rewrite rather
+  than a batch (`module-usage-report` is 21 DIFFERENT queries via a `switch`, so
+  a `UNION ALL`, not a batch).
+
+  One thing that pass exposed which is not about performance: **the SoD expiry
+  test asserted the status flip and nothing else.** Moving that write to a batch
+  writer would have left every assertion in the file green even if the batch had
+  dropped its audit rows entirely. Recurring shape — a test that covers the
+  state transition and not the record OF the transition is exactly the test that
+  cannot notice a writer being swapped underneath it.
 
 - **DIRECTION ROUND — 25 August 2026: the enforcement gate asked its question
   one way round, and the missing direction is the one with the dead endpoint

--- a/src/modules/identity-access/application/business-scope-expiry-job.ts
+++ b/src/modules/identity-access/application/business-scope-expiry-job.ts
@@ -26,13 +26,31 @@
  * already treats an `approved` row past its `effective_to` as ineffective at
  * decision time, so expiry takes effect IMMEDIATELY (issue #181).
  *
+ * ## Rows per pass, round trips per pass
+ *
+ * Which rows get written is unchanged by the batching below. HOW MANY
+ * STATEMENTS write them is: each pass used to issue one INSERT per expired
+ * item, and both passes are capped at 500, so the worst case was 500 sequential
+ * statements inside one transaction — per tenant, per pass, across every
+ * tenant `iterateTenantsInBatches` visits. A bound of 500 is not a defence
+ * against a per-item query; it is the size at which one starts to matter.
+ *
+ * Now two statements per pass regardless: the assignment pass writes its event
+ * rows with one `unnest`, and the exception pass writes its audit rows with
+ * `recordAuditEvents`. Note that the second is the batch form of the SAME
+ * writer the per-row loop used — the individually addressable entries the
+ * paragraph above insists on are all still written, one row each.
+ *
  * Flipping `status` to `expired` here is a BACKGROUND CLEANUP, not the
  * authorization gate: `isBusinessScopeAssignmentCurrentlyActive` already
  * treats an `active` row past its `effective_to` as not-in-force at decision
  * time (`business-scope-facts.ts`), so revocation/expiry takes effect
  * immediately regardless of when this job runs.
  */
-import { recordAuditEvent } from "../../logging/application/audit-log";
+import {
+  recordAuditEvent,
+  recordAuditEvents
+} from "../../logging/application/audit-log";
 import { withTenantOrThrow } from "../../../lib/database/tenant-context";
 import {
   recordCounter,
@@ -73,15 +91,28 @@ async function expireAssignmentsPass(
         RETURNING id
       `) as { id: string }[];
 
-      for (const row of expiredRows) {
+      // ONE round trip, not one per expired assignment. The UPDATE above is
+      // capped at `ASSIGNMENT_EXPIRY_BATCH_LIMIT`, so the old loop's worst case
+      // was 500 sequential INSERTs inside this transaction, for every tenant,
+      // on every pass — the same magnitude as the scheduled sweeps before they
+      // were flattened. A bound of 500 is not a defence against a per-item
+      // query; it is the exact size at which one starts to matter.
+      //
+      // Append-only event log with no conflict target, so the batch is a plain
+      // `unnest` over the ids and every other column is constant for the pass.
+      if (expiredRows.length > 0) {
         await tx`
           INSERT INTO awcms_business_scope_assignment_events
             (tenant_id, assignment_id, event_type, reason)
-          VALUES (${tenantId}, ${row.id}, 'expired', 'Automatic expiry (effective_to elapsed)')
+          SELECT ${tenantId},
+                 unnest(${tx.array(
+                   expiredRows.map((row) => row.id),
+                   "uuid"
+                 )}::uuid[]),
+                 'expired',
+                 'Automatic expiry (effective_to elapsed)'
         `;
-      }
 
-      if (expiredRows.length > 0) {
         await recordAuditEvent(tx, {
           tenantId,
           moduleKey: IDENTITY_ACCESS_MODULE_KEY,
@@ -126,18 +157,28 @@ async function expireSoDConflictExceptionsPass(
         RETURNING id, rule_key
       `) as { id: string; rule_key: string }[];
 
-      for (const row of expiredRows) {
-        await recordAuditEvent(tx, {
+      // One INSERT for the whole pass. Each expiry keeps its OWN audit row —
+      // a `critical` event naming the rule that lapsed is exactly what an
+      // auditor reads one at a time, so this is not a place to collapse 500
+      // events into a summary. `recordAuditEvents` exists for precisely this:
+      // the same rows, one round trip.
+      //
+      // The assignment pass above writes a single SUMMARY event instead, and
+      // the asymmetry is deliberate — an assignment expiring on schedule is
+      // routine, an SoD exception lapsing is a control coming off.
+      await recordAuditEvents(
+        tx,
+        expiredRows.map((row) => ({
           tenantId,
           moduleKey: IDENTITY_ACCESS_MODULE_KEY,
           action: "expire",
           resourceType: "sod_conflict_exception",
           resourceId: row.id,
-          severity: "critical",
+          severity: "critical" as const,
           message: `SoD conflict exception for rule "${row.rule_key}" expired automatically.`,
           attributes: { ruleKey: row.rule_key }
-        });
-      }
+        }))
+      );
 
       if (expiredRows.length > 0) {
         recordCounter(

--- a/tests/integration/business-scope.integration.test.ts
+++ b/tests/integration/business-scope.integration.test.ts
@@ -46,6 +46,7 @@ import {
 } from "../../src/modules/identity-access/application/business-scope-assignment-service";
 import { resolveBusinessScopeFacts } from "../../src/modules/identity-access/application/business-scope-facts";
 import { runBusinessScopeExpiry } from "../../src/modules/identity-access/application/business-scope-expiry-job";
+import { countPoolQueries } from "./query-budget";
 import { evaluateAccess } from "../../src/modules/identity-access/domain/access-control";
 import {
   createDummyBusinessScopeHierarchyResolver,
@@ -569,6 +570,66 @@ suite("business-scope hierarchy + assignments (Issue #180)", () => {
       WHERE assignment_id = ${assignmentId}
     `) as { event_type: string }[];
     expect(events.map((e) => e.event_type)).toContain("expired");
+  });
+
+  test("the expiry job costs the same whether one assignment elapsed or twelve", async () => {
+    // Both passes are capped at 500, and the old shape issued one INSERT per
+    // expired item — so the worst case was 500 sequential statements inside one
+    // transaction, per tenant, per pass. A bound of 500 is not a defence
+    // against a per-item query; it is the size at which one starts to matter.
+    //
+    // Measured through `countPoolQueries` because a JOB reaches its transaction
+    // itself, via `withTenantOrThrow` -> `sql.begin`. Counting only the pool's
+    // own tagged templates would see none of the statements that matter.
+    const admin = getAdminSql();
+    const past = new Date(Date.now() - 60_000);
+    const older = new Date(Date.now() - 120_000);
+
+    const ctx = {
+      runId: "test-expiry-budget",
+      correlationId: "test-expiry-budget",
+      dryRun: false,
+      signal: new AbortController().signal
+    };
+
+    // ONE elapsed assignment: establishes the fixed cost of a run — tenant
+    // enumeration, both passes, the gauges refresh, the backlog count.
+    await admin`
+      INSERT INTO awcms_business_scope_assignments
+        (tenant_id, tenant_user_id, scope_type, scope_id, effective_from, effective_to,
+         is_temporary, granted_by_tenant_user_id, status)
+      VALUES (${TENANT_A}, ${A_SUBJECT}, 'office', ${OFFICE_A}, ${older}, ${past},
+              true, ${A_ACTOR}, 'active')
+    `;
+
+    const one = await countPoolQueries(getRuntimeSql(), (sql) =>
+      runBusinessScopeExpiry(sql, ctx)
+    );
+    expect(one.result.assignmentsExpired).toBe(1);
+
+    // TWELVE, seeded the same way.
+    await admin`
+      INSERT INTO awcms_business_scope_assignments
+        (tenant_id, tenant_user_id, scope_type, scope_id, effective_from, effective_to,
+         is_temporary, granted_by_tenant_user_id, status)
+      SELECT ${TENANT_A}, ${A_SUBJECT}, 'office', ${OFFICE_A}, ${older}, ${past},
+             true, ${A_ACTOR}, 'active'
+      FROM generate_series(1, 12) AS n
+    `;
+
+    const twelve = await countPoolQueries(getRuntimeSql(), (sql) =>
+      runBusinessScopeExpiry(sql, ctx)
+    );
+    expect(twelve.result.assignmentsExpired).toBe(12);
+
+    // The whole property, asserted as a RELATION rather than an absolute: the
+    // run costs the same for twelve as for one. An absolute budget here would
+    // have to encode the fixed per-tenant overhead of every pass in this job,
+    // and would move for reasons that have nothing to do with the defect.
+    //
+    // Under the per-item shape the second run costs eleven more than the first,
+    // so this cannot pass by accident.
+    expect(twelve.queries).toBe(one.queries);
   });
 
   test("performance: resolving one scope over a wide+deep hierarchy stays within a realistic bound", async () => {

--- a/tests/integration/sod.integration.test.ts
+++ b/tests/integration/sod.integration.test.ts
@@ -818,5 +818,29 @@ suite("segregation of duties (Issue #181)", () => {
       SELECT status FROM awcms_sod_conflict_exceptions WHERE tenant_id = ${TENANT_A}
     `) as { status: string }[];
     expect(rows[0]!.status).toBe("expired");
+
+    // The audit row, which nothing here used to check. An SoD exception lapsing
+    // is a control coming off, and this pass deliberately writes ONE
+    // `critical` entry per exception rather than a summary — so "the status
+    // flipped" is only half of what the job promises. Asserted now because the
+    // write moved to `recordAuditEvents`: a batch writer that dropped its rows
+    // would have left every existing assertion in this file green.
+    const audit = (await admin`
+      SELECT severity, resource_id, attributes
+      FROM awcms_audit_events
+      WHERE tenant_id = ${TENANT_A}
+        AND resource_type = 'sod_conflict_exception'
+        AND action = 'expire'
+    `) as {
+      severity: string;
+      resource_id: string | null;
+      attributes: { ruleKey?: string } | null;
+    }[];
+
+    expect(audit).toHaveLength(1);
+    expect(audit[0]!.severity).toBe("critical");
+    expect(audit[0]!.resource_id).not.toBeNull();
+    // A jsonb OBJECT, not a jsonb string — the `recordAuditEvents` trap.
+    expect(audit[0]!.attributes?.ruleKey).toBe(RULE_VENDOR_PAYMENT);
   });
 });


### PR DESCRIPTION
Both passes of `business-scope-expiry-job` issued one `INSERT` per expired item. Both are capped at 500, so the worst case was **500 sequential statements inside one transaction**, per tenant, per pass, across every tenant `iterateTenantsInBatches` visits.

A bound of 500 is not a defence against a per-item query — it is the size at which one starts to matter. It is more than twice the batch bound of the scheduled blog sweeps that were flattened for exactly this reason.

## What changed

- **Assignment pass** — its `awcms_business_scope_assignment_events` rows now go in with one `unnest`. Append-only log, no conflict target, every column but the id constant for the pass.
- **Exception pass** — now uses `recordAuditEvents`, the batch form of the very writer its per-row loop was already calling. **The rows are unchanged**: each expired exception still gets its own `critical` entry naming the rule that lapsed, because that is what an auditor reads one at a time. Only the round trips moved.

The asymmetry between the two passes is deliberate and stays: an assignment expiring on schedule is routine and gets one summary event; an SoD exception lapsing is a control coming off and gets one entry each.

## A gap this uncovered

The SoD expiry test asserted the status flip and **nothing else** — no assertion touched the audit rows at all. Moving that write to a batch writer would have left every existing assertion in the file green *even if the batch had dropped its rows entirely*.

It now checks the entry exists, is `critical`, carries the resource id, and that `attributes.ruleKey` reads back as a jsonb **object** rather than a jsonb string — the `recordAuditEvents` trap.

## The budget is a relation, not an absolute

A run with twelve elapsed assignments must cost **exactly** what a run with one costs. An absolute number here would have to encode the fixed per-tenant overhead of every pass in this job, and would move for reasons that have nothing to do with the defect.

Measured through `countPoolQueries` rather than `countQueries`, because a **job** reaches its transaction itself via `withTenantOrThrow` → `sql.begin`; counting only the pool's own tagged templates would see none of the statements that matter. (That helper already existed — I started writing a second one before finding it, and the existing one is better: it also counts the `SET LOCAL` issued through `tx.unsafe`, and documents that `BEGIN`/`COMMIT` stay invisible so the number is a floor.)

## Verification

| Mutation | Result |
| --- | --- |
| Restore the per-item event `INSERT` | twelve-item run goes **17 → 28** queries — exactly eleven more, for eleven more items |
| Pass an empty batch to `recordAuditEvents` | the new SoD audit assertion fails |

Local: `bun run check` exit 0, 5,756 pass / 0 fail. Both integration files green together (25 tests).

Closes the last item from the #715 sweep worth acting on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)