### PR TITLE
fix(db): a blank WORKER/SETUP_DATABASE_URL shadowed the DATABASE_URL fallback it claims to have

### DIFF
--- a/.changeset/blank-database-url-falls-back.md
+++ b/.changeset/blank-database-url-falls-back.md
@@ -1,0 +1,46 @@
+---
+"awcms": patch
+---
+
+fix(db): a blank `WORKER_DATABASE_URL`/`SETUP_DATABASE_URL` shadowed the `DATABASE_URL` fallback it claims to have
+
+`getNamedDatabaseClient` resolved its connection string as
+
+```ts
+process.env[envVarName] ?? process.env.DATABASE_URL
+```
+
+and `??` falls back only on `null`/`undefined`. A **blank** value is therefore
+"configured": the fallback never runs, and the operator gets
+
+```
+WORKER_DATABASE_URL (or DATABASE_URL as a fallback) is required to connect to the database.
+```
+
+with `DATABASE_URL` set and correct. An error that names the fallback it has
+just refused to use, which is close to the worst possible message — it sends the
+reader to check the variable that is already right.
+
+The per-kind URLs are documented as **opt-in**: unset means fall back to
+`DATABASE_URL` so a deployment managing one connection string keeps working.
+Blank is what an operator produces when trying to express exactly that, and it
+did the opposite.
+
+A blank value is not an exotic input:
+
+- a compose file with `WORKER_DATABASE_URL:` and nothing after it;
+- a PaaS environment row saved empty (Coolify, and this deployment uses one);
+- `export A=1 B=$A` — `$A` is expanded before `A` is assigned, so `B` is blank.
+
+None of those look like "unset" to whoever wrote them, which is why the failure
+reads as a contradiction rather than as a hint.
+
+`readConfiguredUrl` now treats blank and whitespace-only as unset, so the
+fallback behaves the way the error message and the module header both already
+claimed. Trimming matters for the same reason: a variable holding only spaces
+otherwise reaches `new Bun.SQL(" ")` and fails somewhere far from its cause.
+
+Found while running the integration suite locally — seven of the "nine
+pre-existing failures" reported earlier in this work were this, triggered by the
+`export A=1 B=$A` form. They were never repo failures. With the environment set
+correctly the suite is **565 pass, 0 fail**.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:fc50a36528152e21a63527e88441ddbede97a270341847e6f5febe4570ee220b -->
+<!-- i18n-source-hash: sha256:9688f2c46f03420d53d4fb0a8cac1c9b46ac344acfb38af74616f4b60e658975 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,49 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN KOSONG — 25 Agustus 2026: suite integrasi punya NOL tes gagal, dan
+  sembilan yang dua kali saya laporkan sebagai pre-existing itu LINGKUNGAN SAYA
+  SENDIRI.**
+
+  Dinyatakan terang-terangan karena dua kali dinyatakan keliru, sekali di badan
+  PR yang sudah ter-merge (#716: _"the integration suite shows 9 failures both
+  with and without this branch"_). Benar sebagaimana ditulis — memang gagal di
+  kedua sisi, jadi perbandingan tanpa-regresi tetap sahih — tetapi terbaca
+  sebagai kerusakan repo, dan tidak ada. Dengan lingkungan yang benar suite-nya
+  **567 lolos, 0 gagal**.
+
+  Tujuh dari sembilan berasal dari `export A=... B=$A` di shell saya sendiri:
+  **`$A` diekspansi SEBELUM `A` di-assign**, jadi `SETUP_DATABASE_URL`/
+  `WORKER_DATABASE_URL` ter-set ke STRING KOSONG, bukan ke URL-nya. Dua sisanya
+  dari `APP_URL=http://localhost:4321` lokal — `site-origin` mengambil skema
+  dari `APP_URL`, dan dua tes menegakkan URL host-absolut `https://`. Tak satu
+  pun cacat, kecuali pada cara saya memanggilnya.
+
+  **Paruh string-kosongnya MEMANG cacat nyata, di kodenya.**
+  `getNamedDatabaseClient` menyelesaikan
+  `process.env[name] ?? process.env.DATABASE_URL`, dan `??` hanya jatuh-balik
+  pada null/undefined — jadi nilai kosong itu "terkonfigurasi", menutupi
+  fallback-nya, dan menghasilkan
+
+  > `WORKER_DATABASE_URL (or DATABASE_URL as a fallback) is required to connect
+to the database.`
+
+  dengan `DATABASE_URL` ter-set dan benar. **Pesan galat yang menyebut fallback
+  yang baru saja ia tolak pakai** — nyaris pesan terburuk yang mungkin, karena
+  ia mengirim pembacanya memeriksa variabel yang sudah benar. URL per-kind
+  didokumentasikan OPT-IN (tak-diset berarti jatuh-balik), dan KOSONG persis
+  yang dihasilkan operator saat mencoba menyatakan itu: kunci compose tanpa isi,
+  baris PaaS tersimpan kosong (deployment ini memakai Coolify), atau bentuk
+  shell di atas. `readConfiguredUrl` kini memperlakukan kosong dan
+  hanya-spasi sebagai tak-diset.
+
+  Bagian yang bisa dipindahkan bukan soal `??`-nya. Melainkan bahwa **kegagalan
+  yang SUDAH saya tulis ke memori sendiri sebagai jebatan diketahui tetap
+  memakan dua putaran pelaporan yang salah**, karena pesan galatnya tegas dan
+  menunjuk ke tempat yang masuk akal. Galat yang dengan percaya diri menyebut
+  sebab yang KELIRU lebih buruk daripada yang kabur; ia merekrut pembacanya
+  untuk mengonfirmasinya.
 
 - **PUTARAN NAMA — 25 Agustus 2026: jalur tulis N+1 ketiga ditutup, dan alasan
   ia tampak sulit adalah cacat di TRIASE SAYA SENDIRI, bukan di kodenya.**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,45 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **BLANK ROUND — 25 August 2026: the integration suite has ZERO failing tests,
+  and the nine I twice reported as pre-existing were my own environment.**
+
+  Stated plainly because it was stated wrongly twice, once in a merged PR body
+  (#716: _"the integration suite shows 9 failures both with and without this
+  branch"_). True as written — they did fail both ways, so the no-regression
+  comparison held — but it reads as repo breakage and there was none. With the
+  environment set correctly the suite is **567 pass, 0 fail**.
+
+  Seven of the nine came from `export A=... B=$A` in my own shell: **`$A` is
+  expanded before `A` is assigned**, so `SETUP_DATABASE_URL`/
+  `WORKER_DATABASE_URL` were set to the EMPTY STRING rather than to the URL.
+  The other two came from local `APP_URL=http://localhost:4321` — `site-origin`
+  takes the scheme from `APP_URL`, and two tests assert host-absolute `https://`
+  URLs. Neither is a defect in anything but the way I invoked it.
+
+  **The empty-string half WAS a real defect, in the code.**
+  `getNamedDatabaseClient` resolved
+  `process.env[name] ?? process.env.DATABASE_URL`, and `??` falls back only on
+  null/undefined — so a blank value is "configured", shadows the fallback, and
+  produces
+
+  > `WORKER_DATABASE_URL (or DATABASE_URL as a fallback) is required to connect
+to the database.`
+
+  with `DATABASE_URL` set and correct. **An error that names the fallback it has
+  just refused to use** — close to the worst possible message, because it sends
+  the reader to check the variable that is already right. The per-kind URLs are
+  documented as OPT-IN (unset means fall back), and blank is exactly what an
+  operator produces trying to express that: a compose key with nothing after it,
+  a PaaS row saved empty (this deployment uses Coolify), or the shell form
+  above. `readConfiguredUrl` now treats blank and whitespace-only as unset.
+
+  The transferable part is not the `??`. It is that **a failure I had already
+  written into my own memory as a known trap still cost me two rounds of wrong
+  reporting**, because the error message was assertive and pointed somewhere
+  plausible. An error that confidently names the wrong cause is worse than a
+  vague one; it recruits the reader into confirming it.
+
 - **NAME ROUND — 25 August 2026: the third N+1 write path is closed, and the
   reason it looked hard was a defect in MY OWN triage rather than in the code.**
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 489   |
+| Test files                          | 490   |
 | Route files                         | 383   |
 | ADR                                 | 226   |
 
@@ -359,7 +359,7 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 402        |
+| `(root)`      | 403        |
 | `e2e`         | 17         |
 | `integration` | 69         |
 | `unit`        | 1          |

--- a/src/lib/database/client.ts
+++ b/src/lib/database/client.ts
@@ -112,6 +112,34 @@ function buildClient(databaseUrl: string, kind: ClientKind): Bun.SQL {
 }
 
 /**
+ * One connection-string variable, or `undefined` when it is not CONFIGURED.
+ *
+ * Blank counts as unset, and the distinction is not academic. The fallback
+ * above was written as `process.env[name] ?? process.env.DATABASE_URL`, and
+ * `??` only falls back on null/undefined — so `WORKER_DATABASE_URL=""` is
+ * "present" and shadows the fallback entirely. What the operator then sees is
+ *
+ *     WORKER_DATABASE_URL (or DATABASE_URL as a fallback) is required
+ *
+ * while `DATABASE_URL` is set and correct: an error that names the fallback it
+ * just refused to use. A blank value is what you get from a compose file with
+ * `WORKER_DATABASE_URL:` and nothing after it, from a PaaS UI row saved empty,
+ * and from `export A=1 B=$A` (where `$A` expands before `A` is assigned) — none
+ * of which look like "unset" to the person who wrote them.
+ *
+ * Trimmed, because a variable holding only whitespace is the same mistake with
+ * an invisible cause: `new Bun.SQL(" ")` fails somewhere far from here.
+ */
+export function readConfiguredUrl(name: string): string | undefined {
+  const raw = process.env[name];
+
+  if (raw === undefined) return undefined;
+
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
  * Resolves the connection string for one named client kind.
  *
  * ROLE MAPPING — what this repo actually ships (Issues #141, #160, #163;
@@ -167,7 +195,8 @@ function getNamedDatabaseClient(kind: ClientKind): Bun.SQL {
       : kind === "worker"
         ? "WORKER_DATABASE_URL"
         : "SETUP_DATABASE_URL";
-  const databaseUrl = process.env[envVarName] ?? process.env.DATABASE_URL;
+  const databaseUrl =
+    readConfiguredUrl(envVarName) ?? readConfiguredUrl("DATABASE_URL");
 
   if (!databaseUrl) {
     throw new Error(

--- a/tests/database-url-blank-falls-back.test.ts
+++ b/tests/database-url-blank-falls-back.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { readConfiguredUrl } from "../src/lib/database/client";
+
+/**
+ * `WORKER_DATABASE_URL=""` used to shadow the `DATABASE_URL` fallback.
+ *
+ * The resolution was `process.env[name] ?? process.env.DATABASE_URL`, and `??`
+ * falls back only on null/undefined — so a blank value counted as CONFIGURED,
+ * the fallback never ran, and the operator got
+ *
+ *     WORKER_DATABASE_URL (or DATABASE_URL as a fallback) is required
+ *
+ * with `DATABASE_URL` set and correct. An error naming the fallback it had just
+ * refused to use.
+ *
+ * A blank value is not an exotic input. It is what a compose file produces from
+ * `WORKER_DATABASE_URL:` with nothing after it, what a PaaS UI row saved empty
+ * produces, and what `export A=1 B=$A` produces — `$A` is expanded before `A`
+ * is assigned, so `B` is blank. None of those look like "unset" to whoever
+ * wrote them, which is why the failure reads as a contradiction.
+ */
+const NAME = "AWCMS_TEST_CONNECTION_URL";
+
+afterEach(() => {
+  delete process.env[NAME];
+});
+
+describe("readConfiguredUrl", () => {
+  test("returns a configured value", () => {
+    process.env[NAME] = "postgres://user@host/db";
+
+    expect(readConfiguredUrl(NAME)).toBe("postgres://user@host/db");
+  });
+
+  test("an unset variable is undefined, so a caller's `??` falls back", () => {
+    expect(readConfiguredUrl(NAME)).toBeUndefined();
+  });
+
+  test("a BLANK variable is undefined too — the defect this exists for", () => {
+    process.env[NAME] = "";
+
+    // The old expression returned "" here, which is not nullish, so `??` kept
+    // it and the fallback was skipped.
+    expect(readConfiguredUrl(NAME)).toBeUndefined();
+  });
+
+  test("whitespace-only is undefined — the same mistake with an invisible cause", () => {
+    process.env[NAME] = "   ";
+
+    // `new Bun.SQL(" ")` fails somewhere far from the variable that caused it.
+    expect(readConfiguredUrl(NAME)).toBeUndefined();
+  });
+
+  test("surrounding whitespace is trimmed rather than passed through", () => {
+    process.env[NAME] = "  postgres://user@host/db\n";
+
+    expect(readConfiguredUrl(NAME)).toBe("postgres://user@host/db");
+  });
+
+  test("the fallback chain works the way the error message claims", () => {
+    // The whole point, expressed as the caller expresses it.
+    process.env[NAME] = "";
+    process.env.AWCMS_TEST_FALLBACK_URL = "postgres://fallback@host/db";
+
+    const resolved =
+      readConfiguredUrl(NAME) ?? readConfiguredUrl("AWCMS_TEST_FALLBACK_URL");
+
+    expect(resolved).toBe("postgres://fallback@host/db");
+
+    delete process.env.AWCMS_TEST_FALLBACK_URL;
+  });
+});


### PR DESCRIPTION
`getNamedDatabaseClient` resolved its connection string as

```ts
process.env[envVarName] ?? process.env.DATABASE_URL
```

and `??` falls back only on `null`/`undefined`. A **blank** value is therefore "configured": the fallback never runs, and the operator gets

```
WORKER_DATABASE_URL (or DATABASE_URL as a fallback) is required to connect to the database.
```

with `DATABASE_URL` set and correct.

**An error that names the fallback it has just refused to use.** That is close to the worst possible message — it doesn't merely fail to help, it sends the reader to check the variable that is already right.

The per-kind URLs are documented as **opt-in**: unset means fall back to `DATABASE_URL`, so a deployment managing one connection string keeps working unchanged. Blank is what an operator produces trying to express exactly that, and it did the opposite.

A blank value is not an exotic input:

- a compose file with `WORKER_DATABASE_URL:` and nothing after it;
- a PaaS environment row saved empty — this deployment runs on Coolify;
- `export A=1 B=$A` — `$A` is expanded before `A` is assigned, so `B` is blank.

`readConfiguredUrl` now treats blank and whitespace-only as unset. Trimming matters for the same reason: a whitespace-only value otherwise reaches `new Bun.SQL(" ")` and fails somewhere far from the variable that caused it.

## This also corrects the record

I twice reported "nine pre-existing integration failures", including in the body of merged PR #716. That was true as stated — they failed with and without the branch, so the no-regression comparison held — but it reads as repo breakage, and **there was none**:

- **seven** were this defect, triggered by the `export A=1 B=$A` form in my own shell;
- **two** were local `APP_URL=http://localhost:4321`, since `site-origin` takes the scheme from `APP_URL` and two tests assert host-absolute `https://` URLs.

With the environment set correctly: **567 pass, 0 fail** across the whole integration suite.

The transferable part is not the `??`. It is that a trap already written into my own notes still cost two rounds of wrong reporting, because the error message was assertive and pointed somewhere plausible. **An error that confidently names the wrong cause is worse than a vague one — it recruits the reader into confirming it.**

## Verification

Mutation-proven: returning `raw` unchanged (dropping the trim-and-blank check) fails 4 of the 6 new tests, including the one that expresses the fallback chain the way the caller does.

Local: `bun run check` exit 0, 5,762 pass / 0 fail. Integration suite 567 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)