### PR TITLE
docs(state): #711's first blocker does not exist — the rubrik list is 102 pairs in a Docker volume

### DIFF
--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:9688f2c46f03420d53d4fb0a8cac1c9b46ac344acfb38af74616f4b60e658975 -->
+<!-- i18n-source-hash: sha256:6a3b7e6effa19b3a0cd0081dd154660ad6d45eea717eff62d0c133ff167c8204 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,53 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN VOLUME — 25 Agustus 2026: pemblokir PERTAMA #711 tidak ada, dan
+  berkas 0-byte yang dibaca semua orang sebagai buktinya justru INERT.**
+
+  Dua entri di bawah menyatakan bentuk rubrik terhalang karena "daftar rubrik
+  butuh data yang tak dimiliki salinan kerja (`seputa58_sbb.sql` 0 byte)".
+  Berkas itu MEMANG 0 byte. Ia juga **bukan tempat datanya berada**, dan sudah
+  begitu sejak container itu pertama kali jalan.
+
+  `docker-compose.yml` memasangnya HANYA sebagai seed initdb
+  (`/docker-entrypoint-initdb.d/`), sedangkan datadir-nya volume bernama. Di
+  mesin ini `seputarborneocom_db_data` memuat **411 MB** dengan `seputa58_sbb`
+  yang TERISI. Skrip initdb hanya jalan pada datadir KOSONG, jadi berkas kosong
+  itu inert sejak saat itu — dan justru itulah sebabnya tak ada yang sadar ia
+  kosong: tak pernah ada yang bergantung padanya.
+
+  **Dan tak ada tabel rubrik karena memang tak pernah dimaksudkan ada.**
+  `include/rubrik.php` menjawab `/rubriks/?news=X&kt=Y` dengan
+  `SELECT ... FROM berita_red_tayang WHERE jenis_rubrik = ? AND kategori = ?` —
+  `jenis_rubrik` dan `kategori` adalah KOLOM di `berita_red`. Terukur terhadap
+  salinan sekali-pakai volume itu: **25.029 artikel, 47 `jenis_rubrik` distinct,
+  46 `kategori` distinct, 102 pasangan distinct.** Daftarnya cuma sejauh satu
+  `SELECT DISTINCT` selama ini, sepanjang issue-nya menyatakan ia hilang.
+
+  **Satu hal yang diperlihatkan DATANYA dan tak mungkin diperlihatkan
+  perencanaan.** Ada `MITRA BORNEO` (11.767 artikel) DAN `MITRA-BORNEO` (133).
+  Segmen URL bentuk-3 adalah keluaran `seo_title()` — tanda baca dibuang, spasi
+  jadi `-` — jadi keduanya runtuh ke slug yang SAMA sementara `DISTINCT` polos
+  melaporkan dua rubrik. Peta yang dibangun dari daftar distinct tanpa
+  menormalkan lewat `seo_title()` yang sama akan SALAH-KUNCI rubrik TERBESAR di
+  arsip. Itu peringatan bentuk-3 satu tingkat lebih dalam: mengenumerasi
+  bentuknya tidak cukup bila NILAI di dalamnya tak dinormalkan sebagaimana kode
+  legacy menormalkannya.
+
+  **Pemblokir kedua TETAP berlaku dan itulah yang sebenarnya.** Ke mana
+  `/rubrik/x.html` harus 301 adalah pertanyaan kontrak lintas-repo
+  (ADR-0045/0070: arsip berita dirender `ahliweb/awcms-astro`). Memiliki
+  daftarnya tidak menjawabnya, dan menebak kosakata tujuannya menghasilkan
+  persis akibat 301-salah-massal yang issue itu ada untuk mencegahnya. Jadi
+  tidak ada peta yang dibangun — #711 kini terhalang SATU hal, dan itu
+  keputusan, bukan artefak yang hilang.
+
+  Bagian yang bisa dipindahkan: **"artefaknya hilang" adalah klaim tentang
+  SISTEM BERKAS, dan sistem berkas bukan satu-satunya tempat sebuah artefak bisa
+  berada.** Dump 0-byte itu diperiksa, dengan benar, dan kesimpulan yang ditarik
+  darinya keliru karena pemeriksaannya berhenti di berkas yang disebut pertama
+  oleh entri compose.
 
 - **PUTARAN KOSONG — 25 Agustus 2026: suite integrasi punya NOL tes gagal, dan
   sembilan yang dua kali saya laporkan sebagai pre-existing itu LINGKUNGAN SAYA
@@ -766,9 +813,10 @@ to the database.`
     menjalankannya: peta artikel, tiga aturan path-eksak yang diketikkan ke
     `awcms_seo_redirects`, dan crawl pra-cutover terhadap URL sitemap yang
     hidup.
-  - **#711, baru** — bentuk rubrik (2 dan 3) dan bentuk pencarian (4). Dua
-    pemblokir, keduanya di luar repo ini: daftar rubrik butuh data yang tidak
-    dimiliki salinan kerja (`seputa58_sbb.sql` 0 byte), dan rute TUJUAN dirender
+  - **#711, baru** — bentuk rubrik (2 dan 3) dan bentuk pencarian (4). Diajukan
+    dengan dua pemblokir; PUTARAN VOLUME di atas menemukan yang PERTAMA tidak
+    ada (daftar rubriknya 102 pasangan di volume Docker yang terisi, bukan data
+    yang hilang), menyisakan satu: rute TUJUAN dirender
     oleh `ahliweb/awcms-astro` (ADR-0045/ADR-0070) — pertanyaan kontrak
     lintas-repo lebih dulu, baru pertanyaan impor. Term juga tidak punya kolom
     provenance, jadi tidak ada yang bisa diungkapkan `--path-template`.
@@ -1012,9 +1060,13 @@ to the database.`
   `(int) $_GET['news']`, jadi id-nya adalah digit terdepan dan slug-nya dekoratif
   — `/news/{legacyId}_{slug}.html` memang template yang tepat.
 
-  **Yang MASIH terhalang lebih sempit daripada "artefaknya".** Bentuk rubrik butuh
-  daftar rubrik, yang butuh data yang tak dimiliki salinan kerja itu (dump-nya,
-  `seputa58_sbb.sql`, berukuran 0 byte), DAN rute target yang dirender
+  **Yang MASIH terhalang lebih sempit daripada "artefaknya", dan lebih sempit
+  lagi sejak PUTARAN VOLUME.** Paragraf ini semula menyatakan bentuk rubrik
+  butuh daftar rubrik "yang butuh data yang tak dimiliki salinan kerja itu
+  (dump-nya, `seputa58_sbb.sql`, berukuran 0 byte)". Dump-nya 0 byte dan ia
+  INERT — datanya ada di volume `seputarborneocom_db_data`, dan daftarnya 102
+  pasangan `(jenis_rubrik, kategori)`. Yang tersisa adalah rute target yang
+  dirender
   `ahliweb/awcms-astro`, bukan di sini (ADR-0045/ADR-0070) — pertanyaan kontrak
   lintas-repo sebelum menjadi pertanyaan impor. Crawl pra-cutover tak berubah:
   `blog:legacy:cutover:verify` sudah ada dan butuh URL sitemap hidup, pada level

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,51 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **VOLUME ROUND — 25 August 2026: #711's first blocker does not exist, and the
+  0-byte file everyone read as the evidence is inert.**
+
+  Two entries below say the rubrik shapes are blocked because "the rubrik list
+  needs data the working copy does not have (`seputa58_sbb.sql` is 0 bytes)".
+  The file IS 0 bytes. It is also **not where the data lives**, and has not been
+  since the first time that container started.
+
+  `docker-compose.yml` mounts it only as an initdb seed
+  (`/docker-entrypoint-initdb.d/`), while the datadir is a named volume. On this
+  machine `seputarborneocom_db_data` holds **411 MB** with a populated
+  `seputa58_sbb`. An initdb script runs ONLY against an empty datadir, so the
+  empty file has been inert ever since — which is exactly why nobody noticed it
+  was empty: nothing ever depended on it.
+
+  **And there is no rubrik table because there was never meant to be one.**
+  `include/rubrik.php` answers `/rubriks/?news=X&kt=Y` with
+  `SELECT ... FROM berita_red_tayang WHERE jenis_rubrik = ? AND kategori = ?` —
+  `jenis_rubrik` and `kategori` are COLUMNS on `berita_red`. Measured against a
+  throwaway copy of the volume: **25,029 articles, 47 distinct `jenis_rubrik`,
+  46 distinct `kategori`, 102 distinct pairs.** The list was a `SELECT DISTINCT`
+  away for as long as the issue has said it was missing.
+
+  **One thing the data shows that no amount of planning could have.** Both
+  `MITRA BORNEO` (11,767 articles) and `MITRA-BORNEO` (133) exist. Shape 3's URL
+  segments are `seo_title()` output — punctuation stripped, spaces to `-` — so
+  the two collapse to the SAME slug while a plain `DISTINCT` reports two
+  rubriks. A map built from the distinct list without normalising through the
+  same `seo_title()` mis-keys the LARGEST rubrik in the archive. That is the
+  shape-3 warning one level down: enumerating the shapes is not enough if the
+  values inside them are not normalised the way the legacy code normalised them.
+
+  **The second blocker stands and is the real one.** Where `/rubrik/x.html`
+  should 301 to is a cross-repo contract question (ADR-0045/0070: the news
+  archive is rendered by `ahliweb/awcms-astro`). Having the list does not answer
+  it, and guessing the destination vocabulary produces exactly the
+  mass-wrong-301 outcome the issue exists to prevent. So no map was built —
+  #711 is now blocked on ONE thing, and it is a decision rather than a missing
+  artefact.
+
+  The transferable part: **"the artefact is missing" is a claim about a
+  filesystem, and a filesystem is not the only place an artefact can be.** The
+  0-byte dump was checked, correctly, and the conclusion drawn from it was
+  wrong because the check stopped at the file the compose entry named first.
+
 - **BLANK ROUND — 25 August 2026: the integration suite has ZERO failing tests,
   and the nine I twice reported as pre-existing were my own environment.**
 
@@ -740,9 +785,10 @@ to the database.`
     the old title had become misleading. What remains is running them: the
     article map, three exact-path rules typed into `awcms_seo_redirects`, and
     the pre-cutover crawl against a live sitemap URL.
-  - **#711, new** — the rubrik shapes (2 and 3) and the search shape (4). Two
-    blockers, both outside this repo: the rubrik list needs data the working
-    copy does not have (`seputa58_sbb.sql` is 0 bytes), and the TARGET route is
+  - **#711, new** — the rubrik shapes (2 and 3) and the search shape (4). Filed
+    with two blockers; the VOLUME ROUND above found the FIRST one does not
+    exist (the rubrik list is 102 pairs in a populated Docker volume, not
+    missing data), leaving one: the TARGET route is
     rendered by `ahliweb/awcms-astro` (ADR-0045/ADR-0070) — a cross-repo
     contract question before it is an import question. Terms also have no
     provenance column, so there is nothing a `--path-template` could express.
@@ -979,9 +1025,12 @@ to the database.`
   `(int) $_GET['news']`, so the id is the leading digits and the slug is
   decorative — `/news/{legacyId}_{slug}.html` is the correct template.
 
-  **What is still blocked is narrower than "the artifacts".** The rubrik shapes
-  need the rubrik list, which needs data the working copy does not have (its
-  dump, `seputa58_sbb.sql`, is 0 bytes), AND a target route rendered by
+  **What is still blocked is narrower than "the artifacts", and narrower again
+  since the VOLUME ROUND.** This paragraph originally said the rubrik shapes
+  need a rubrik list "which needs data the working copy does not have (its dump,
+  `seputa58_sbb.sql`, is 0 bytes)". The dump is 0 bytes and it is INERT — the
+  data is in the `seputarborneocom_db_data` volume, and the list is 102
+  `(jenis_rubrik, kategori)` pairs. What remains is a target route rendered by
   `ahliweb/awcms-astro`, not here (ADR-0045/ADR-0070) — a cross-repo contract
   question before it is an import question. The pre-cutover crawl is unchanged:
   `blog:legacy:cutover:verify` is built and needs the live sitemap URL, at page


### PR DESCRIPTION
Two entries in `PROJECT_STATE` §4 say the rubrik shapes of the SeputarBorneo cutover are blocked because *"the rubrik list needs data the working copy does not have (`seputa58_sbb.sql` is 0 bytes)"*.

**The file is 0 bytes. It is also not where the data lives**, and has not been since the first time that container started.

`docker-compose.yml` mounts it only as an **initdb seed**:

```yaml
volumes:
  - db_data:/var/lib/mysql
  - ./seputa58_sbb.sql:/docker-entrypoint-initdb.d/001-seputa58_sbb.sql:ro
```

`seputarborneocom_db_data` exists on this machine and holds **411 MB**, including a populated `seputa58_sbb`. An initdb script runs *only* against an empty datadir, so the empty file has been inert ever since — which is precisely why nobody noticed it was empty. Nothing ever depended on it.

## And there is no rubrik table because there was never meant to be one

`include/rubrik.php` shows where `news`/`kt` actually go:

```php
"SELECT ... FROM berita_red_tayang WHERE jenis_rubrik = ? AND kategori = ?"
```

Both are **columns on `berita_red`**. The list is a `SELECT DISTINCT` away, not an absent artefact. Measured against a throwaway copy of the volume:

| | |
| --- | --- |
| articles in `berita_red` | **25,029** |
| distinct `jenis_rubrik` | **47** |
| distinct `kategori` | **46** |
| distinct `(jenis_rubrik, kategori)` pairs | **102** |

## What the data shows that planning could not

Both `MITRA BORNEO` (11,767 articles) and `MITRA-BORNEO` (133) exist. Shape 3's URL segments are `seo_title()` output — punctuation stripped, spaces to `-` — so the two **collapse to the same slug**, while a plain `DISTINCT` reports two rubriks.

A map built from the distinct list without normalising through the same `seo_title()` the legacy site used would mis-key the **largest rubrik in the archive**. That is the shape-3 warning one level down: enumerating the shapes is not enough if the values inside them aren't normalised the way the legacy code normalised them.

## The second blocker stands, and it is the real one

Where `/rubrik/x.html` should 301 to is a cross-repo contract question (ADR-0045/0070 — the news archive is rendered by `ahliweb/awcms-astro`). Having the list does not answer it.

**No map was built.** Guessing the destination vocabulary produces exactly the mass-wrong-301 outcome #711 exists to prevent. What changed is that #711 is now blocked on **one** thing rather than two, and the remaining one is a decision rather than a missing artefact.

## The transferable part

*"The artefact is missing"* is a claim about a **filesystem**, and a filesystem is not the only place an artefact can be. The 0-byte dump was checked, correctly — and the conclusion drawn from it was wrong because the check stopped at the file the compose entry named first.

Docs only; no code change. Issue #711 has the same correction with the evidence.

*Method: the volume was mounted read-only and copied out; the probe container ran against the copy and has been deleted. The original is untouched at 411.3 MB.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)