### PR TITLE
perf(blog): listing menus cost one query per menu, the item batch had no count bound, and the sweep that should have caught the first was looking for backticks

### DIFF
--- a/.changeset/menu-read-bound-and-batch.md
+++ b/.changeset/menu-read-bound-and-batch.md
@@ -1,0 +1,91 @@
+---
+"awcms": patch
+---
+
+perf(blog): listing menus cost one query per menu, the item batch had no count bound at all, and the sweep that should have caught the first was looking for backticks
+
+Three findings on the same pair of endpoints, and they compound: the write had
+no cap, and the read that embedded what the write stored had neither a batch nor
+a bound.
+
+## The batch was the only uncapped one in the API
+
+`validateMenuItemsInput` never checked `items.length`. Every other batch surface
+in this repo declares a count bound — `MAX_IMPORT_ITEMS = 200` on the redirect
+import, `MAX_IDS` on bulk comment moderation, `MAX_NODE_ACTIVATIONS = 128` on
+sync activation, and `/sync/push` gained one last round — so this was checked
+against all 18 routes that accept a body array, and it is the only one without.
+
+The only limit was the 128 KB `default` body tier. A minimal item
+(`{"id":…uuid…,"label":"a","linkType":"url","url":"http://a.co","sortOrder":0}`)
+is about 105 bytes, so one request could carry roughly **1,250 items**.
+
+`MAX_MENU_ITEMS = 200` now lives in `domain/menu-policy.ts`, enforced in the one
+validator both `POST /api/v1/blog/menus` and `PATCH /api/v1/blog/menus/{id}`
+already reach the database through — not in the two routes, which would be two
+places to drift apart.
+
+It is counted **before** the per-item pass. After it, an oversized array of
+invalid entries would still be walked in full and could emit several field
+errors per entry, so a request about to be refused would still choose how much
+work the server does and how large the refusal is. Asserting the error *count*,
+not just `valid: false`, is what separates the two orderings in the test.
+
+## The list endpoint was an N+1, and it is up to 100 SERIAL round trips
+
+`GET /api/v1/blog/menus` called `fetchMenuItems` once per menu, inside the
+request transaction, for up to the 100 menus `listMenus` returns. The loop was
+deliberately sequential — one Postgres connection serves one query at a time, so
+`Promise.all` over a shared `tx` hangs rather than parallelises — which made the
+cost 100 serial round trips holding the pooled connection and its work-class
+slot for the whole duration. Concurrency was never the fix; asking once is.
+
+`fetchMenuItemsForMenus` reads every menu's items in one `menu_id = ANY(…)` and
+groups them in memory. Two queries for the page, whatever the menu count.
+
+**Why the last N+1 sweep did not find it.** That sweep scanned for a tagged
+template `await` inside a loop body. This call site is
+`await fetchMenuItems(tx, …)` — a plain function call. Matching the SQL *syntax*
+rather than the query made every N+1 routed through a helper invisible to it;
+re-run against the helper set instead, the same 34-loop scan surfaces 45 sites.
+Nothing about this loop was subtle. The scanner was looking for backticks.
+
+## A bare `LIMIT` here would have been silent data loss
+
+`syncMenuItems` has full-replace semantics. A client that reads a menu, edits it
+and saves it back sends exactly what it was shown — so a read that quietly
+stopped at the cap would make that round trip **delete** every item past it.
+
+So the read returns `{ items, truncated }` and both endpoints surface
+`itemsTruncated`. It reads `MAX_MENU_ITEMS + 1` rows and keeps 200: with exactly
+the cap there is no way to tell "full" from "overflowing". Only a menu stored
+before the cap existed can report `true`; a write response is always `false`,
+because the request that produced it was itself capped.
+
+The bound is applied with `row_number() OVER (PARTITION BY menu_id …)` rather
+than a `LIMIT`, because a single `LIMIT` across the batch would spend the whole
+allowance on whichever menu sorted first and return nothing for the rest, with
+the truncation attributable to no menu in particular.
+
+## `sort_order` is not unique, so the old order was not defined
+
+Nothing stops two siblings sharing a `sort_order`, and the read ordered by it
+alone — leaving equal-ordered items in whatever order the scan produced. That
+was survivable while the read was unbounded and is not once a bound can cut the
+list, because an arbitrary order makes an arbitrary 200 of 250. Ties now break
+on `id`.
+
+## Contract
+
+`itemsTruncated` is added to `BlogMenu` (required) and `maxItems: 200` to the
+item arrays. `GET /api/v1/blog/menus` is consumed by `ahliweb/awcms-astro`, and
+the frozen consumer contract still passes **without regeneration** — the change
+is additive for a reader, and that repo reads menus at build time and never
+writes them. Its `Menu` type does not carry `itemsTruncated`, so a tenant whose
+menu exceeds 200 items would render 200 there without a warning; that is a
+cross-repo question, not a regression introduced here.
+
+Mutation-proven, each against the assertion that claims it: an unpartitioned
+window, a bare `LIMIT` at the cap, a dropped `id` tiebreaker, the per-menu loop
+restored, and the count check moved after the per-item pass each redden the
+corresponding case and only it.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:de83cb124eaac909251212c418985fe24841546e781e4ab99f6bda0f5924109c -->
+<!-- i18n-source-hash: sha256:6982d377c1ba2343501cb24e540cd5f1a4f9bc2857f71829c3cc4a5bb0424b43 -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,61 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN BATAS-DAN-BATCH — 25 Agustus 2026: satu-satunya batch tanpa cap di
+  API ini duduk persis di sebelah satu-satunya N+1 yang tak terlihat oleh
+  sapuan sebelumnya.**
+
+  **Pemindainya mencari BACKTICK.** PUTARAN BOUND di bawah memindai
+  `src/**/*.ts` untuk `await` tagged-template di dalam badan loop dan menemukan
+  34 loop. `GET /api/v1/blog/menus` memuat
+  `for (const menu of menus) { … await fetchMenuItems(tx, …) }` — sebuah
+  panggilan fungsi biasa, jadi ia tak pernah jadi kandidat. Dijalankan ulang
+  terhadap himpunan fungsi yang secara _transitif_ menerbitkan SQL alih-alih
+  terhadap sintaks SQL, sapuan yang sama memunculkan 45 lokasi. **Mencocokkan
+  SINTAKS alih-alih KUERI menyembunyikan setiap N+1 yang lewat helper**, yang di
+  repo ber-application-layer berarti sebagian besarnya.
+
+  Endpoint itu berbiaya 1 + N kueri, N sampai 100 yang dikembalikan `listMenus`,
+  seluruhnya serial karena keharusan — satu koneksi Postgres melayani satu kueri
+  pada satu waktu, jadi `Promise.all` yang justru diperingatkan kodenya akan
+  HANG alih-alih memparalelkan. Kini satu `menu_id = ANY(…)` yang dikelompokkan
+  di memori.
+
+  **Dan tulisan yang dibacanya TIDAK punya batas jumlah sama sekali.** Diperiksa
+  terhadap seluruh 18 rute yang menerima array di body: setiap rute lain
+  mendeklarasikan cap (`MAX_IMPORT_ITEMS = 200`, `MAX_IDS`,
+  `MAX_NODE_ACTIVATIONS = 128`, dan milik `/sync/push` yang baru), dan `items`
+  menu satu-satunya pengecualian. Tier body 128 KB mengizinkan sekitar 1.250
+  item per menu, jadi 100 menu × 1.250 adalah respons 125.000 baris.
+  `MAX_MENU_ITEMS = 200` kini duduk di SATU validator yang sudah dilalui kedua
+  rute menuju database.
+
+  **Batasnya TIDAK BISA berupa `LIMIT` telanjang, dan inilah bagian yang bisa
+  dipindahkan.** `syncMenuItems` adalah GANTI-SELURUHNYA. Klien yang membaca
+  sebuah menu, menyuntingnya lalu menyimpannya kembali mengirim apa yang
+  ditunjukkan kepadanya — sehingga baca yang diam-diam berhenti di cap akan
+  membuat perjalanan itu MENGHAPUS segala sesuatu di baliknya. Menambahkan
+  `LIMIT` yang tampak jelas akan mengubah baca tak-terbatas menjadi kehilangan
+  data yang senyap. Bacanya mengembalikan `{ items, truncated }`, membaca
+  cap + 1 baris agar tahu yang mana, dan kedua endpoint memunculkan
+  `itemsTruncated`.
+
+  Dua hal kecil ikut terjatuh. `sort_order` TIDAK unik dan bacanya mengurutkan
+  hanya dengannya, yang selamat selama bacanya tak terbatas dan tidak lagi
+  begitu setelah sebuah batas bisa memotong daftar — urutan tak terdefinisi
+  membuat 200-dari-250 yang sembarang. Dan jumlahnya diperiksa SEBELUM lintasan
+  per-item, karena sesudahnya array kelebihan berisi entri tak-valid tetap akan
+  dijelajahi penuh dan memancarkan beberapa galat per entri; menegakkan JUMLAH
+  galat, bukan sekadar `valid: false`, itulah yang memisahkan kedua urutan itu
+  di tesnya.
+
+  `GET /api/v1/blog/menus` dikonsumsi `ahliweb/awcms-astro`, dan kontrak
+  konsumen beku tetap LULUS TANPA regenerasi — perubahannya aditif bagi pembaca,
+  dan repo itu membaca menu saat build dan tak pernah menulisnya. Tipe `Menu`-nya
+  tidak membawa `itemsTruncated`, jadi tenant yang menunya melampaui 200 item
+  akan merender 200 di sana tanpa peringatan. Itu pertanyaan lintas-repo, bukan
+  regresi yang diperkenalkan di sini.
 
 - **PUTARAN KEPUTUSAN — 25 Agustus 2026: pemblokir tersisa #711 adalah sebuah
   KEPUTUSAN, dan keputusan itu sudah diambil (ADR-0113).**

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,55 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **BOUND-AND-BATCH ROUND — 25 August 2026: the one uncapped batch in the API
+  sat next to the one N+1 the last sweep could not see.**
+
+  **The scanner was looking for backticks.** The BOUND ROUND below scanned
+  `src/**/*.ts` for a tagged-template `await` inside a loop body and found 34
+  loops. `GET /api/v1/blog/menus` contains
+  `for (const menu of menus) { … await fetchMenuItems(tx, …) }` — a plain
+  function call, so it was never a candidate. Re-run against the set of
+  functions that _transitively_ issue SQL rather than against SQL syntax, the
+  same scan surfaces 45 sites. **Matching the syntax rather than the query hid
+  every N+1 routed through a helper**, which in a repo with an application layer
+  is most of them.
+
+  The endpoint cost 1 + N queries, N up to the 100 `listMenus` returns, all
+  serial by necessity — one Postgres connection serves one query at a time, so
+  the `Promise.all` the code explicitly warns against would hang rather than
+  parallelise. Now one `menu_id = ANY(…)` grouped in memory.
+
+  **And the write it reads from had no count bound at all.** Checked against all
+  18 routes that accept a body array: every other one declares a cap
+  (`MAX_IMPORT_ITEMS = 200`, `MAX_IDS`, `MAX_NODE_ACTIVATIONS = 128`,
+  `/sync/push`'s new one), and menu `items` was the only exception. The 128 KB
+  body tier allowed roughly 1,250 items per menu, so 100 menus × 1,250 was a
+  125,000-row response. `MAX_MENU_ITEMS = 200` now sits in the one validator
+  both routes already reach the database through.
+
+  **The bound could not be a bare `LIMIT`, and this is the transferable part.**
+  `syncMenuItems` is a FULL REPLACE. A client that reads a menu, edits it and
+  saves it back sends what it was shown — so a read that quietly stopped at the
+  cap would make that round trip DELETE everything past it. Adding the obvious
+  `LIMIT` would have converted an unbounded read into silent data loss. The
+  read returns `{ items, truncated }`, reads cap + 1 rows to know which it is,
+  and both endpoints surface `itemsTruncated`.
+
+  Two smaller things fell out. `sort_order` is not unique and the read ordered
+  by it alone, which was survivable while the read was unbounded and is not once
+  a bound can cut the list — an undefined order makes an arbitrary 200 of 250.
+  And the count is checked BEFORE the per-item pass, because after it an
+  oversized array of invalid entries would still be walked in full and emit
+  several errors per entry; asserting the error COUNT, not just `valid: false`,
+  is what separates the two orderings in the test.
+
+  `GET /api/v1/blog/menus` is consumed by `ahliweb/awcms-astro`, and the frozen
+  consumer contract still passes WITHOUT regeneration — the change is additive
+  for a reader, and that repo reads menus at build time and never writes them.
+  Its `Menu` type does not carry `itemsTruncated`, so a tenant whose menu
+  exceeds 200 items would render 200 there with no warning. That is a cross-repo
+  question, not a regression introduced here.
+
 - **DECISION ROUND — 25 August 2026: #711's remaining blocker was a decision,
   and it has been taken (ADR-0113).**
 

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -5922,7 +5922,12 @@ Gated by blog_content.menus.configure. Optionally seeds its initial items tree (
 - **operationId**: `blogUpdateMenu`
 - **Security**: bearerAuth + tenantHeader
 
-Gated by blog_content.menus.configure. Providing items replaces the whole tree.
+Gated by blog_content.menus.configure. Providing items REPLACES the
+whole tree — a partial list deletes the rest. At most 200 items.
+
+Read `itemsTruncated` on whatever you are editing before sending
+`items`: a menu stored before the cap existed reads back bounded, and
+saving that list back would delete everything past the bound.
 
 **Parameters**
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 490   |
+| Test files                          | 491   |
 | Route files                         | 383   |
 | ADR                                 | 228   |
 
@@ -361,7 +361,7 @@
 | ------------- | ---------- |
 | `(root)`      | 403        |
 | `e2e`         | 17         |
-| `integration` | 69         |
+| `integration` | 70         |
 | `unit`        | 1          |
 
 ### Routes

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -4403,6 +4403,8 @@ paths:
                   type: string
                 items:
                   type: array
+                  maxItems: 200
+                  description: At most 200 entries; a longer array is refused with `VALIDATION_ERROR` before any entry is validated.
                   items:
                     $ref: "#/components/schemas/BlogMenuItem"
       responses:
@@ -4444,7 +4446,13 @@ paths:
         - Blog Content
       operationId: blogUpdateMenu
       summary: Update a navigation menu (name and/or its items tree)
-      description: Gated by blog_content.menus.configure. Providing items replaces the whole tree.
+      description: |
+        Gated by blog_content.menus.configure. Providing items REPLACES the
+        whole tree — a partial list deletes the rest. At most 200 items.
+
+        Read `itemsTruncated` on whatever you are editing before sending
+        `items`: a menu stored before the cap existed reads back bounded, and
+        saving that list back would delete everything past the bound.
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       requestBody:
@@ -4458,6 +4466,8 @@ paths:
                   type: string
                 items:
                   type: array
+                  maxItems: 200
+                  description: At most 200 entries; a longer array is refused with `VALIDATION_ERROR` before any entry is validated. Omit the field entirely to leave the existing tree untouched — an empty array CLEARS it.
                   items:
                     $ref: "#/components/schemas/BlogMenuItem"
       responses:
@@ -19904,6 +19914,7 @@ components:
         - key
         - name
         - items
+        - itemsTruncated
       properties:
         id:
           type: string
@@ -19919,9 +19930,26 @@ components:
           description: Editorial label. NOT an identifier.
         items:
           type: array
+          maxItems: 200
           description: Already sorted by `sortOrder`. One level of nesting at most — an item whose parent itself has a parent is refused at write time.
           items:
             $ref: "#/components/schemas/BlogMenuItem"
+        itemsTruncated:
+          type: boolean
+          description: |
+            `true` when the menu holds more than the 200 items `items` is
+            bounded at, and `items` is only the first 200 of them.
+
+            **Do not save a truncated list back.** `PATCH /api/v1/blog/menus/{id}`
+            REPLACES the whole item set, so writing back what you were shown
+            would delete every item past the bound. Only a menu written before
+            the 200-item cap existed can report `true`; on a write response it
+            is always `false`, because the request that produced it was itself
+            capped.
+
+            Ties are broken by `id`, so items sharing a `sortOrder` keep the
+            same order between identical reads — without that the 200 kept
+            would be an arbitrary 200.
         createdAt:
           type: string
           format: date-time

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -2215,6 +2215,8 @@ paths:
                   type: string
                 items:
                   type: array
+                  maxItems: 200
+                  description: At most 200 entries; a longer array is refused with `VALIDATION_ERROR` before any entry is validated.
                   items:
                     $ref: "#/components/schemas/BlogMenuItem"
       responses:
@@ -2255,7 +2257,13 @@ paths:
         - Blog Content
       operationId: blogUpdateMenu
       summary: Update a navigation menu (name and/or its items tree)
-      description: Gated by blog_content.menus.configure. Providing items replaces the whole tree.
+      description: |
+        Gated by blog_content.menus.configure. Providing items REPLACES the
+        whole tree — a partial list deletes the rest. At most 200 items.
+
+        Read `itemsTruncated` on whatever you are editing before sending
+        `items`: a menu stored before the cap existed reads back bounded, and
+        saving that list back would delete everything past the bound.
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       requestBody:
@@ -2269,6 +2277,8 @@ paths:
                   type: string
                 items:
                   type: array
+                  maxItems: 200
+                  description: At most 200 entries; a longer array is refused with `VALIDATION_ERROR` before any entry is validated. Omit the field entirely to leave the existing tree untouched — an empty array CLEARS it.
                   items:
                     $ref: "#/components/schemas/BlogMenuItem"
       responses:
@@ -3919,7 +3929,7 @@ components:
         `footer`); `name` is the editorial label and may be renamed at any time.
         A consumer that keys off `name` breaks the first time somebody fixes a
         typo.
-      required: [id, tenantId, key, name, items]
+      required: [id, tenantId, key, name, items, itemsTruncated]
       properties:
         id:
           type: string
@@ -3935,9 +3945,26 @@ components:
           description: Editorial label. NOT an identifier.
         items:
           type: array
+          maxItems: 200
           description: Already sorted by `sortOrder`. One level of nesting at most — an item whose parent itself has a parent is refused at write time.
           items:
             $ref: "#/components/schemas/BlogMenuItem"
+        itemsTruncated:
+          type: boolean
+          description: |
+            `true` when the menu holds more than the 200 items `items` is
+            bounded at, and `items` is only the first 200 of them.
+
+            **Do not save a truncated list back.** `PATCH /api/v1/blog/menus/{id}`
+            REPLACES the whole item set, so writing back what you were shown
+            would delete every item past the bound. Only a menu written before
+            the 200-item cap existed can report `true`; on a write response it
+            is always `false`, because the request that produced it was itself
+            capped.
+
+            Ties are broken by `id`, so items sharing a `sortOrder` keep the
+            same order between identical reads — without that the 200 kept
+            would be an arbitrary 200.
         createdAt:
           type: string
           format: date-time

--- a/src/modules/blog-content/application/menu-directory.ts
+++ b/src/modules/blog-content/application/menu-directory.ts
@@ -1,4 +1,8 @@
-import type { MenuItemInput, MenuLinkType } from "../domain/menu-policy";
+import {
+  MAX_MENU_ITEMS,
+  type MenuItemInput,
+  type MenuLinkType
+} from "../domain/menu-policy";
 
 /** Read/write query module for `awcms_blog_menus`/`_menu_items` (Issue #542) — same "one directory, reads and writes" convention as `blog-taxonomy-directory.ts`. */
 export type BlogMenuView = {
@@ -270,17 +274,116 @@ export async function syncMenuItems(
   );
 }
 
+/**
+ * One menu's items, plus whether the read hit its bound (Issue #721).
+ *
+ * `truncated` is not decoration and not pagination metadata. `syncMenuItems`
+ * has FULL-REPLACE semantics, so a client that reads a menu, edits it and
+ * writes it back sends exactly what it was shown — and a read that quietly
+ * stopped at the cap would make that round trip DELETE every item past it. A
+ * bare `LIMIT` on this query would therefore have converted an unbounded read
+ * into silent data loss. The flag is the reason the bound is safe to add: a
+ * caller can see that what it holds is not the whole menu, before it writes.
+ *
+ * For everything written after `MAX_MENU_ITEMS` began being enforced the flag
+ * is always `false`; it can only be `true` for a menu stored before it.
+ */
+export type BlogMenuItemsPage = {
+  items: BlogMenuItemView[];
+  truncated: boolean;
+};
+
+/**
+ * Items for MANY menus in one round trip (Issue #721).
+ *
+ * `GET /api/v1/blog/menus` embeds each menu's items, and did it with one query
+ * per menu inside the request transaction — `1 + N`, N up to the 100
+ * `listMenus` returns. The loop was written sequentially on purpose (one
+ * Postgres connection serves one query at a time, so `Promise.all` over `tx`
+ * deadlocks rather than parallelising), which made the cost 100 SERIAL round
+ * trips holding a pooled connection and a work-class slot for their whole
+ * duration. The fix is not concurrency; it is asking once.
+ *
+ * Worth naming why the earlier sweep missed it: that scan looked for a tagged
+ * template `await` inside a loop body, and this call site is
+ * `await fetchMenuItems(tx, …)` — a plain function call. Matching the SQL
+ * SYNTAX rather than the query made every N+1 that goes through a helper
+ * invisible to it.
+ *
+ * ## The bound is per menu, which is why there is a window function
+ *
+ * A single `LIMIT` across the whole result set would spend the entire budget on
+ * the first menu and return nothing for the rest, and the truncation could not
+ * be attributed to any particular menu. `row_number()` partitioned by `menu_id`
+ * bounds each menu independently and still costs one query. Reading
+ * `MAX_MENU_ITEMS + 1` rows per partition is what makes `truncated` knowable:
+ * with exactly the cap there is no way to tell "full" from "overflowing".
+ *
+ * `ORDER BY sort_order, id` — `sort_order` is not unique (nothing constrains
+ * two siblings from sharing one), so ordering by it alone left equal-ordered
+ * items in whatever order the scan produced, varying between identical calls.
+ * That was survivable while the read was unbounded and is not once a bound can
+ * cut the list: an arbitrary order makes an arbitrary 200 of 250 items.
+ */
+export async function fetchMenuItemsForMenus(
+  tx: Bun.SQL,
+  tenantId: string,
+  menuIds: readonly string[]
+): Promise<Map<string, BlogMenuItemsPage>> {
+  const byMenu = new Map<string, BlogMenuItemsPage>();
+  const unique = [...new Set(menuIds)];
+
+  if (unique.length === 0) {
+    return byMenu;
+  }
+
+  // `tx.array(...)` rather than interpolating the array: Bun's tagged template
+  // delivers a plain JS array as a comma-joined string, which PostgreSQL
+  // rejects as `22P02` against a `uuid[]`.
+  const rows = (await tx`
+    SELECT id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order
+    FROM (
+      SELECT id, tenant_id, menu_id, parent_item_id, label, link_type,
+             target_id, url, sort_order,
+             row_number() OVER (
+               PARTITION BY menu_id ORDER BY sort_order ASC, id ASC
+             ) AS row_index
+      FROM awcms_blog_menu_items
+      WHERE tenant_id = ${tenantId}
+        AND menu_id = ANY(${tx.array(unique, "uuid")})
+    ) ranked
+    WHERE ranked.row_index <= ${MAX_MENU_ITEMS + 1}
+    ORDER BY ranked.menu_id ASC, ranked.sort_order ASC, ranked.id ASC
+  `) as BlogMenuItemRow[];
+
+  for (const row of rows) {
+    const page = byMenu.get(row.menu_id);
+
+    if (page) {
+      page.items.push(toItemView(row));
+    } else {
+      byMenu.set(row.menu_id, { items: [toItemView(row)], truncated: false });
+    }
+  }
+
+  // The `+ 1` row is the probe, never part of the answer.
+  for (const page of byMenu.values()) {
+    if (page.items.length > MAX_MENU_ITEMS) {
+      page.items.length = MAX_MENU_ITEMS;
+      page.truncated = true;
+    }
+  }
+
+  return byMenu;
+}
+
+/** One menu's items. Delegates to {@link fetchMenuItemsForMenus} so the single-menu and list paths cannot drift to different bounds or a different order. */
 export async function fetchMenuItems(
   tx: Bun.SQL,
   tenantId: string,
   menuId: string
-): Promise<BlogMenuItemView[]> {
-  const rows = (await tx`
-    SELECT id, tenant_id, menu_id, parent_item_id, label, link_type, target_id, url, sort_order
-    FROM awcms_blog_menu_items
-    WHERE tenant_id = ${tenantId} AND menu_id = ${menuId}
-    ORDER BY sort_order ASC
-  `) as BlogMenuItemRow[];
+): Promise<BlogMenuItemsPage> {
+  const byMenu = await fetchMenuItemsForMenus(tx, tenantId, [menuId]);
 
-  return rows.map(toItemView);
+  return byMenu.get(menuId) ?? { items: [], truncated: false };
 }

--- a/src/modules/blog-content/domain/menu-policy.ts
+++ b/src/modules/blog-content/domain/menu-policy.ts
@@ -35,6 +35,31 @@ export type MenuItemInput = {
   sortOrder: number;
 };
 
+/**
+ * How many items one menu may carry, on write and on read (Issue #721).
+ *
+ * Every other batch surface in this API declares a count bound —
+ * `MAX_IMPORT_ITEMS = 200` on the redirect import, `MAX_IDS` on bulk comment
+ * moderation, `MAX_NODE_ACTIVATIONS = 128` on sync — and this one declared
+ * none. The only limit was the 128 KB `default` body tier, which a minimal
+ * item (`{"id":…uuid…,"label":"a","linkType":"url","url":"http://a.co",
+ * "sortOrder":0}` ≈ 105 bytes) turns into roughly **1,250 items per menu**.
+ * `listMenus` returns up to 100 menus and `GET /api/v1/blog/menus` embeds
+ * every one's items, so the uncapped write is really a bound on a READ:
+ * 100 × 1,250 ≈ 125,000 rows in one response.
+ *
+ * 200 matches `MAX_IMPORT_ITEMS`, and site navigation authored by a human does
+ * not approach it — a 200-entry mega-menu is already past what any reader can
+ * use. The number is enforced HERE rather than in the two routes because both
+ * `POST /api/v1/blog/menus` and `PATCH /api/v1/blog/menus/{id}` reach the
+ * database through this one validator; a per-route check would have two places
+ * to drift apart, which is the shape #695 had to unpick across 77 handlers.
+ *
+ * `menu-directory.ts` bounds the READ at the same number, deliberately: a cap
+ * on new writes says nothing about rows already stored.
+ */
+export const MAX_MENU_ITEMS = 200;
+
 const UUID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -161,6 +186,23 @@ export function validateMenuItemsInput(
     return {
       valid: false,
       errors: [{ field: "items", message: "items must be an array." }]
+    };
+  }
+
+  // Counted BEFORE the per-item pass, not after it. Validating first would walk
+  // every element of an oversized array and could emit several field errors per
+  // element, so a request the server is about to refuse would still decide how
+  // much work it does and how large the refusal is — the request-amplification
+  // half of an uncapped batch, which a cap applied afterwards does not close.
+  if (body.length > MAX_MENU_ITEMS) {
+    return {
+      valid: false,
+      errors: [
+        {
+          field: "items",
+          message: `items must contain at most ${MAX_MENU_ITEMS} entries (received ${body.length}).`
+        }
+      ]
     };
   }
 

--- a/src/pages/api/v1/blog/menus/[id].ts
+++ b/src/pages/api/v1/blog/menus/[id].ts
@@ -109,8 +109,16 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       return fail(404, "RESOURCE_NOT_FOUND", "Menu not found.");
     }
 
+    // A write returns what it just stored (capped by `validateMenuItemsInput`,
+    // so never truncated); a read returns the bounded page and says whether it
+    // hit the bound. The distinction matters because this endpoint REPLACES the
+    // item set: a client that read a truncated list and saved it back would
+    // delete the items it was not shown.
     const currentItems = items
-      ? await syncMenuItems(tx, tenantId, id, items)
+      ? {
+          items: await syncMenuItems(tx, tenantId, id, items),
+          truncated: false
+        }
       : await fetchMenuItems(tx, tenantId, id);
 
     await recordAuditEvent(tx, {
@@ -133,7 +141,11 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       key: updated.key
     });
 
-    return ok({ ...updated, items: currentItems });
+    return ok({
+      ...updated,
+      items: currentItems.items,
+      itemsTruncated: currentItems.truncated
+    });
   });
 };
 

--- a/src/pages/api/v1/blog/menus/index.ts
+++ b/src/pages/api/v1/blog/menus/index.ts
@@ -16,7 +16,7 @@ import { log } from "../../../../../lib/logging/logger";
 import { recordAuditEvent } from "../../../../../modules/logging/application/audit-log";
 import {
   createMenu,
-  fetchMenuItems,
+  fetchMenuItemsForMenus,
   listMenus,
   syncMenuItems
 } from "../../../../../modules/blog-content/application/menu-directory";
@@ -66,24 +66,37 @@ export const GET: APIRoute = async ({ request, cookies }) => {
 
     const menus = await listMenus(tx, tenantId);
 
-    // Sequential loop, NOT `Promise.all(menus.map(async …))` — every iteration
-    // issues a query on the SAME transaction/connection (`tx`), and one Postgres
-    // connection serves one query at a time; running them concurrently produced
-    // a real hang in this repo (see
-    // `reporting/application/projection-reconciliation.ts:89-94`). This fan-out
-    // was also UNBOUNDED — one concurrent query per menu the tenant has.
-    const withItems: Array<
-      (typeof menus)[number] & {
-        items: Awaited<ReturnType<typeof fetchMenuItems>>;
-      }
-    > = [];
+    // TWO queries for the whole page, whatever the menu count (Issue #721).
+    //
+    // This was a per-menu `await fetchMenuItems(tx, …)` in a loop — sequential
+    // by necessity, since one Postgres connection serves one query at a time
+    // and `Promise.all` over a shared `tx` hangs rather than parallelises. So
+    // the cost was up to 100 SERIAL round trips, each holding the pooled
+    // connection and the work-class slot. Concurrency was never the fix; the
+    // fix is one `menu_id = ANY(…)` read grouped in memory.
+    //
+    // A menu absent from the map has no items — `[]`, never `undefined`: "this
+    // menu has no navigation" and "this payload does not carry navigation" are
+    // different facts, and a consumer cannot act on the second if it is
+    // rendered as the first.
+    const itemsByMenu = await fetchMenuItemsForMenus(
+      tx,
+      tenantId,
+      menus.map((menu) => menu.id)
+    );
 
-    for (const menu of menus) {
-      withItems.push({
+    const withItems = menus.map((menu) => {
+      const page = itemsByMenu.get(menu.id);
+
+      return {
         ...menu,
-        items: await fetchMenuItems(tx, tenantId, menu.id)
-      });
-    }
+        items: page?.items ?? [],
+        // Surfaced rather than swallowed: `PATCH .../menus/{id}` REPLACES the
+        // whole item set, so a client that saved back a truncated list would
+        // delete what it was never shown.
+        itemsTruncated: page?.truncated ?? false
+      };
+    });
 
     return ok({ menus: withItems });
   });
@@ -197,6 +210,10 @@ export const POST: APIRoute = async ({ request, cookies, locals }) => {
       key: menu.key
     });
 
-    return ok({ ...menu, items });
+    // Always `false` here: what came back is what this request just wrote, and
+    // `validateMenuItemsInput` refused anything above `MAX_MENU_ITEMS`. Stated
+    // rather than omitted so the field means the same thing on every menu
+    // response a client can receive.
+    return ok({ ...menu, items, itemsTruncated: false });
   });
 };

--- a/tests/blog-content-presentation-domain.test.ts
+++ b/tests/blog-content-presentation-domain.test.ts
@@ -6,6 +6,7 @@ import {
   validateUpdateTemplateInput
 } from "../src/modules/blog-content/domain/template-policy";
 import {
+  MAX_MENU_ITEMS,
   validateMenuItemsInput,
   isMenuLinkType
 } from "../src/modules/blog-content/domain/menu-policy";
@@ -203,6 +204,64 @@ describe("menu-policy", () => {
     };
     const result = validateMenuItemsInput([item, { ...item, label: "B" }]);
     expect(result.valid).toBe(false);
+  });
+
+  describe("the item count is bounded (Issue #721)", () => {
+    function validItem(n: number) {
+      return {
+        id: `11111111-1111-1111-1111-${String(n).padStart(12, "0")}`,
+        parentItemId: null,
+        label: `Item ${n}`,
+        linkType: "url",
+        url: "https://example.com",
+        sortOrder: n
+      };
+    }
+
+    test("exactly MAX_MENU_ITEMS is accepted", () => {
+      // The boundary belongs to the accepting side: a cap that rejects its own
+      // documented maximum is a different (and quieter) defect.
+      const result = validateMenuItemsInput(
+        Array.from({ length: MAX_MENU_ITEMS }, (_, n) => validItem(n))
+      );
+
+      expect(result.valid).toBe(true);
+    });
+
+    test("one over the cap is rejected, and the message names both numbers", () => {
+      const result = validateMenuItemsInput(
+        Array.from({ length: MAX_MENU_ITEMS + 1 }, (_, n) => validItem(n))
+      );
+
+      expect(result.valid).toBe(false);
+
+      if (result.valid) return;
+
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]!.field).toBe("items");
+      // An operator who sent 1,250 items needs to know the limit AND what they
+      // sent; "too many items" sends them to count an array by hand.
+      expect(result.errors[0]!.message).toContain(String(MAX_MENU_ITEMS));
+      expect(result.errors[0]!.message).toContain(String(MAX_MENU_ITEMS + 1));
+    });
+
+    test("an oversized batch is refused WITHOUT validating every entry", () => {
+      // The count is checked before the per-item pass, so an oversized array of
+      // entirely invalid items yields ONE error rather than several per item.
+      // This is the request-amplification half: without it, a 128 KB body of
+      // garbage decides how much validation work the server does and how large
+      // its refusal is. A cap applied after the per-item pass would still
+      // return `valid: false` here and would not close that, so asserting the
+      // error COUNT is what separates the two orderings.
+      const junk = Array.from({ length: MAX_MENU_ITEMS + 500 }, () => ({}));
+      const result = validateMenuItemsInput(junk);
+
+      expect(result.valid).toBe(false);
+
+      if (result.valid) return;
+
+      expect(result.errors).toHaveLength(1);
+    });
   });
 });
 

--- a/tests/integration/menu-item-read-budget.integration.test.ts
+++ b/tests/integration/menu-item-read-budget.integration.test.ts
@@ -1,0 +1,307 @@
+/**
+ * The READ side of the menu item paths (Issue #721) — a query budget, a bound,
+ * and the reason the bound needed a flag to be safe to add.
+ *
+ * `menu-item-sync-budget.integration.test.ts` pinned the WRITE at two
+ * statements. The read next to it stayed at one query per menu:
+ * `GET /api/v1/blog/menus` called `fetchMenuItems` in a loop over everything
+ * `listMenus` returned, so up to 100 SERIAL round trips inside the request
+ * transaction, each holding the pooled connection and its work-class slot.
+ *
+ * ## Why the earlier N+1 sweep did not see it
+ *
+ * That sweep looked for a tagged-template `await` inside a loop body. This call
+ * site is `await fetchMenuItems(tx, …)` — a plain function call — so matching
+ * the SQL SYNTAX rather than the query hid every N+1 routed through a helper.
+ * Nothing about the loop was subtle; the scanner was looking for backticks.
+ *
+ * ## The bound could not simply be a `LIMIT`
+ *
+ * `syncMenuItems` REPLACES the whole item set. A client that reads a menu,
+ * edits it and saves it back sends exactly what it was shown, so a read that
+ * quietly stopped at the cap would make that round trip DELETE everything past
+ * it — a bare `LIMIT` would have turned an unbounded read into silent data
+ * loss. `truncated` is what makes the bound safe, and the cases below assert it
+ * rather than assuming it.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { countQueries } from "./query-budget";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import {
+  fetchMenuItems,
+  fetchMenuItemsForMenus
+} from "../../src/modules/blog-content/application/menu-directory";
+import { MAX_MENU_ITEMS } from "../../src/modules/blog-content/domain/menu-policy";
+
+const TENANT = "fb000000-0000-4000-8000-000000000001";
+
+/** One `menu_id = ANY(…)` read, whatever the menu count. */
+const READ_QUERY_BUDGET = 1;
+
+/**
+ * Twelve menus, so the old per-menu shape costs 12 queries against a budget of
+ * 1 and a regression cannot hide behind a one-menu fixture.
+ */
+const MENU_COUNT = 12;
+
+function menuId(n: number): string {
+  return `fb000000-0000-4000-8000-0000000001${String(n).padStart(2, "0")}`;
+}
+
+async function seedTenant(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'menu-read-budget', 'Menu Read Budget Tenant')
+  `;
+}
+
+/** `count` items on `menu`, each with a distinct `sort_order`. */
+async function seedMenu(id: string, key: string, count: number): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_blog_menus (id, tenant_id, key, name)
+    VALUES (${id}, ${TENANT}, ${key}, ${key})
+  `;
+
+  if (count === 0) {
+    return;
+  }
+
+  await admin`
+    INSERT INTO awcms_blog_menu_items
+      (tenant_id, menu_id, label, link_type, url, sort_order)
+    SELECT ${TENANT}, ${id}, ${key} || ' ' || n, 'url',
+           'https://example.test/' || n, n
+    FROM generate_series(1, ${count}) AS n
+  `;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("reading menu items costs one query and is bounded per menu", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedTenant();
+  });
+
+  test("twelve menus cost ONE query, and every item lands under its own menu", async () => {
+    for (let n = 0; n < MENU_COUNT; n += 1) {
+      await seedMenu(menuId(n), `menu-${n}`, n + 1);
+    }
+
+    const runtime = getRuntimeSql();
+    const ids = Array.from({ length: MENU_COUNT }, (_, n) => menuId(n));
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        fetchMenuItemsForMenus(counting, TENANT, ids)
+      )
+    );
+
+    expect(queries).toBe(READ_QUERY_BUDGET);
+
+    // Grouping is the part a single query has to get right that twelve queries
+    // got right for free: menu n must hold exactly its own n + 1 items, and
+    // none of anybody else's.
+    for (let n = 0; n < MENU_COUNT; n += 1) {
+      const page = result.get(menuId(n));
+
+      expect(page?.items).toHaveLength(n + 1);
+      expect(page?.truncated).toBe(false);
+
+      for (const item of page!.items) {
+        expect(item.menuId).toBe(menuId(n));
+        expect(item.label.startsWith(`menu-${n} `)).toBe(true);
+      }
+    }
+  });
+
+  test("one menu costs the same one query", async () => {
+    await seedMenu(menuId(0), "solo", 5);
+
+    const runtime = getRuntimeSql();
+
+    const { queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        fetchMenuItemsForMenus(counting, TENANT, [menuId(0)])
+      )
+    );
+
+    // The number does not move with the input. That is the whole property.
+    expect(queries).toBe(READ_QUERY_BUDGET);
+  });
+
+  test("no menu ids costs NO query", async () => {
+    const runtime = getRuntimeSql();
+
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        fetchMenuItemsForMenus(counting, TENANT, [])
+      )
+    );
+
+    // A tenant with no menus must not pay a round trip to be told so.
+    expect(queries).toBe(0);
+    expect(result.size).toBe(0);
+  });
+
+  test("a menu with no items is ABSENT from the map, not an empty entry", async () => {
+    await seedMenu(menuId(0), "empty", 0);
+
+    const runtime = getRuntimeSql();
+    const result = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItemsForMenus(tx, TENANT, [menuId(0)])
+    );
+
+    // The caller supplies `[]`. Documented here so a future reader does not
+    // "fix" the absence by materialising empty entries in the query.
+    expect(result.has(menuId(0))).toBe(false);
+  });
+
+  test("exactly MAX_MENU_ITEMS is returned whole and NOT flagged", async () => {
+    await seedMenu(menuId(0), "at-cap", MAX_MENU_ITEMS);
+
+    const runtime = getRuntimeSql();
+    const page = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, menuId(0))
+    );
+
+    // The boundary belongs to the un-flagged side: a full menu that reports
+    // itself truncated would tell a client not to save a set that is complete.
+    expect(page.items).toHaveLength(MAX_MENU_ITEMS);
+    expect(page.truncated).toBe(false);
+  });
+
+  test("one item over the cap is flagged, and the extra item is NOT returned", async () => {
+    await seedMenu(menuId(0), "over-cap", MAX_MENU_ITEMS + 1);
+
+    const runtime = getRuntimeSql();
+    const page = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, menuId(0))
+    );
+
+    expect(page.items).toHaveLength(MAX_MENU_ITEMS);
+    expect(page.truncated).toBe(true);
+
+    // The probe row is a probe. Returning `MAX_MENU_ITEMS + 1` items would put
+    // the caller one over a limit its own writes are refused for.
+    expect(page.items.at(-1)!.sortOrder).toBe(MAX_MENU_ITEMS);
+  });
+
+  test("the bound is PER MENU, not one budget shared across the batch", async () => {
+    await seedMenu(menuId(0), "over-a", MAX_MENU_ITEMS + 1);
+    await seedMenu(menuId(1), "over-b", MAX_MENU_ITEMS + 1);
+
+    const runtime = getRuntimeSql();
+    const { result, queries } = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      countQueries(tx, (counting) =>
+        fetchMenuItemsForMenus(counting, TENANT, [menuId(0), menuId(1)])
+      )
+    );
+
+    expect(queries).toBe(READ_QUERY_BUDGET);
+
+    // A plain `LIMIT` would have spent the whole allowance on whichever menu
+    // sorted first and returned nothing for the second. This is the assertion
+    // that the window function is partitioned rather than global.
+    for (const id of [menuId(0), menuId(1)]) {
+      expect(result.get(id)?.items).toHaveLength(MAX_MENU_ITEMS);
+      expect(result.get(id)?.truncated).toBe(true);
+    }
+  });
+
+  test("items sharing a sort_order come back in the SAME order every time", async () => {
+    // `sort_order` is not unique — nothing stops two siblings sharing one — so
+    // ordering by it alone left equal-ordered items in whatever order the scan
+    // produced. Survivable while the read was unbounded; not once a bound can
+    // cut the list, because an arbitrary order makes an arbitrary 200 of 250.
+    const admin = getAdminSql();
+
+    await admin`
+      INSERT INTO awcms_blog_menus (id, tenant_id, key, name)
+      VALUES (${menuId(0)}, ${TENANT}, 'ties', 'Ties')
+    `;
+    await admin`
+      INSERT INTO awcms_blog_menu_items
+        (tenant_id, menu_id, label, link_type, url, sort_order)
+      SELECT ${TENANT}, ${menuId(0)}, 'Item ' || n, 'url',
+             'https://example.test/' || n, 1
+      FROM generate_series(1, 40) AS n
+    `;
+
+    const runtime = getRuntimeSql();
+    const first = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, menuId(0))
+    );
+    const second = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItems(tx, TENANT, menuId(0))
+    );
+
+    expect(first.items.map((item) => item.id)).toEqual(
+      second.items.map((item) => item.id)
+    );
+
+    // And the tiebreaker is the declared one, so the order is predictable from
+    // the data rather than merely repeatable on this machine today.
+    const ids = first.items.map((item) => item.id);
+    expect(ids).toEqual([...ids].sort());
+  });
+
+  test("another tenant's menu is not readable through the batch read", async () => {
+    const admin = getAdminSql();
+    const other = "fb000000-0000-4000-8000-0000000000ff";
+
+    await admin`
+      INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+      VALUES (${other}, 'menu-read-other', 'Other Tenant')
+    `;
+    await admin`
+      INSERT INTO awcms_blog_menus (id, tenant_id, key, name)
+      VALUES (${menuId(9)}, ${other}, 'theirs', 'Theirs')
+    `;
+    await admin`
+      INSERT INTO awcms_blog_menu_items
+        (tenant_id, menu_id, label, link_type, url, sort_order)
+      VALUES (${other}, ${menuId(9)}, 'Theirs', 'url', 'https://example.test/x', 1)
+    `;
+
+    const runtime = getRuntimeSql();
+    const result = await withTenantOrThrow(runtime, TENANT, (tx) =>
+      fetchMenuItemsForMenus(tx, TENANT, [menuId(9)])
+    );
+
+    // Batching widened the WHERE clause from one id to a list, which is exactly
+    // the shape that leaks if the tenant predicate is dropped. RLS and the
+    // explicit `tenant_id =` both have to hold.
+    expect(result.size).toBe(0);
+  });
+});

--- a/tests/integration/menu-item-sync-budget.integration.test.ts
+++ b/tests/integration/menu-item-sync-budget.integration.test.ts
@@ -152,9 +152,11 @@ suite("syncing a menu costs two queries, whatever the item count", () => {
     expect(queries).toBe(SYNC_QUERY_BUDGET);
     expect(result).toHaveLength(items.length);
 
-    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
-      fetchMenuItems(tx, TENANT, MENU)
-    );
+    const stored = (
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        fetchMenuItems(tx, TENANT, MENU)
+      )
+    ).items;
     expect(stored).toHaveLength(items.length);
   });
 
@@ -169,9 +171,11 @@ suite("syncing a menu costs two queries, whatever the item count", () => {
     const returned = await withTenantOrThrow(runtime, TENANT, (tx) =>
       syncMenuItems(tx, TENANT, MENU, items)
     );
-    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
-      fetchMenuItems(tx, TENANT, MENU)
-    );
+    const stored = (
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        fetchMenuItems(tx, TENANT, MENU)
+      )
+    ).items;
 
     const byId = (list: typeof stored) =>
       [...list].sort((left, right) => left.id.localeCompare(right.id));
@@ -204,9 +208,11 @@ suite("syncing a menu costs two queries, whatever the item count", () => {
 
     expect(queries).toBe(SYNC_QUERY_BUDGET);
 
-    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
-      fetchMenuItems(tx, TENANT, MENU)
-    );
+    const stored = (
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        fetchMenuItems(tx, TENANT, MENU)
+      )
+    ).items;
     expect(stored).toHaveLength(items.length);
 
     // Every child still points at a real parent row.
@@ -272,9 +278,11 @@ suite("syncing a menu costs two queries, whatever the item count", () => {
     expect(queries).toBe(1);
     expect(result).toEqual([]);
 
-    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
-      fetchMenuItems(tx, TENANT, MENU)
-    );
+    const stored = (
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        fetchMenuItems(tx, TENANT, MENU)
+      )
+    ).items;
     expect(stored).toEqual([]);
   });
 
@@ -289,9 +297,11 @@ suite("syncing a menu costs two queries, whatever the item count", () => {
       syncMenuItems(tx, TENANT, MENU, items.slice(0, 1))
     );
 
-    const stored = await withTenantOrThrow(runtime, TENANT, (tx) =>
-      fetchMenuItems(tx, TENANT, MENU)
-    );
+    const stored = (
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        fetchMenuItems(tx, TENANT, MENU)
+      )
+    ).items;
 
     expect(stored).toHaveLength(1);
     expect(stored[0]!.id).toBe(items[0]!.id);

--- a/tests/integration/menu-widget-response-shape.integration.test.ts
+++ b/tests/integration/menu-widget-response-shape.integration.test.ts
@@ -46,6 +46,7 @@ import {
 import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
 import {
   fetchMenuItems,
+  fetchMenuItemsForMenus,
   listMenus
 } from "../../src/modules/blog-content/application/menu-directory";
 import { listWidgets } from "../../src/modules/blog-content/application/widget-directory";
@@ -112,11 +113,25 @@ suite("menu and widget response shapes match their schemas", () => {
 
     const runtime = getRuntimeSql();
     const assembled = await withTenantOrThrow(runtime, TENANT, async (tx) => {
-      // Exactly what `src/pages/api/v1/blog/menus/index.ts` assembles.
+      // Exactly what `src/pages/api/v1/blog/menus/index.ts` assembles — the
+      // BATCHED read it uses since Issue #721, not the per-menu one it used to.
+      // This block is a hand-copy of the route, so it can drift from it; it
+      // caught its own drift once, when `itemsTruncated` became required and
+      // the copy did not have it.
       const menus = await listMenus(tx, TENANT);
       const first = menus[0]!;
+      const itemsByMenu = await fetchMenuItemsForMenus(
+        tx,
+        TENANT,
+        menus.map((menu) => menu.id)
+      );
+      const page = itemsByMenu.get(first.id);
 
-      return { ...first, items: await fetchMenuItems(tx, TENANT, first.id) };
+      return {
+        ...first,
+        items: page?.items ?? [],
+        itemsTruncated: page?.truncated ?? false
+      };
     });
 
     const row = assembled as unknown as AnyRecord;
@@ -149,9 +164,11 @@ suite("menu and widget response shapes match their schemas", () => {
     `;
 
     const runtime = getRuntimeSql();
-    const items = await withTenantOrThrow(runtime, TENANT, (tx) =>
-      fetchMenuItems(tx, TENANT, menu[0]!.id)
-    );
+    const items = (
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        fetchMenuItems(tx, TENANT, menu[0]!.id)
+      )
+    ).items;
 
     const item = items[0]! as unknown as AnyRecord;
 
@@ -183,9 +200,11 @@ suite("menu and widget response shapes match their schemas", () => {
     `;
 
     const runtime = getRuntimeSql();
-    const items = await withTenantOrThrow(runtime, TENANT, (tx) =>
-      fetchMenuItems(tx, TENANT, menu[0]!.id)
-    );
+    const items = (
+      await withTenantOrThrow(runtime, TENANT, (tx) =>
+        fetchMenuItems(tx, TENANT, menu[0]!.id)
+      )
+    ).items;
 
     expect(items.map((item) => item.label)).toEqual([
       "Pertama",


### PR DESCRIPTION
Closes #721.

Three findings on the same pair of endpoints, and they compound: the write had no cap, and the read that embedded what the write stored had neither a batch nor a bound.

## 1. The batch was the only uncapped one in the API

`validateMenuItemsInput` never checked `items.length`. Checked against **all 18 routes that accept a body array**, every other one declares a count bound — `MAX_IMPORT_ITEMS = 200` (redirect import), `MAX_IDS` (bulk comment moderation), `MAX_NODE_ACTIVATIONS = 128` (sync), and `/sync/push` gained one last round. This was the only exception.

The only limit was the 128 KB `default` body tier. A minimal item is ~105 bytes, so one request could carry roughly **1,250 items**.

`MAX_MENU_ITEMS = 200` now lives in `domain/menu-policy.ts`, enforced in the one validator both `POST` and `PATCH` already reach the database through — not in the two routes, which would be two places to drift apart.

It is counted **before** the per-item pass. After it, an oversized array of invalid entries would still be walked in full and could emit several field errors per entry, so a request about to be refused would still choose how much work the server does and how large the refusal is. Asserting the error *count*, not just `valid: false`, is what separates the two orderings in the test.

## 2. The list endpoint was an N+1 — up to 100 SERIAL round trips

`GET /api/v1/blog/menus` called `fetchMenuItems` once per menu, inside the request transaction, for up to the 100 menus `listMenus` returns. The loop was deliberately sequential — one Postgres connection serves one query at a time, so `Promise.all` over a shared `tx` hangs rather than parallelises — which made the cost 100 serial round trips holding the pooled connection and its work-class slot for the whole duration.

Concurrency was never the fix. Asking once is: `fetchMenuItemsForMenus` reads every menu's items in one `menu_id = ANY(…)` and groups them in memory.

**Why the last N+1 sweep did not find it.** That scan looked for a tagged-template `await` inside a loop body and found 34 loops. This call site is `await fetchMenuItems(tx, …)` — a plain function call. Matching the SQL *syntax* rather than the query hid every N+1 routed through a helper; re-run against the set of functions that transitively issue SQL, the same scan surfaces 45 sites. Nothing about this loop was subtle. The scanner was looking for backticks.

## 3. A bare `LIMIT` would have been silent data loss

`syncMenuItems` has **full-replace** semantics. A client that reads a menu, edits it and saves it back sends exactly what it was shown — so a read that quietly stopped at the cap would make that round trip **delete** every item past it.

So the read returns `{ items, truncated }` and both endpoints surface `itemsTruncated`. It reads `MAX_MENU_ITEMS + 1` rows and keeps 200: with exactly the cap there is no way to tell "full" from "overflowing". Only a menu stored before the cap existed can report `true`; a write response is always `false`.

The bound uses `row_number() OVER (PARTITION BY menu_id …)` rather than a `LIMIT`, because a single `LIMIT` across the batch would spend the whole allowance on whichever menu sorted first and return nothing for the rest, with the truncation attributable to no menu in particular.

## 4. `sort_order` is not unique, so the old order was not defined

Nothing stops two siblings sharing a `sort_order`, and the read ordered by it alone — leaving equal-ordered items in whatever order the scan produced. Survivable while the read was unbounded, and not once a bound can cut the list, because an arbitrary order makes an arbitrary 200 of 250. Ties now break on `id`.

## Contract

`itemsTruncated` is added to `BlogMenu` (required) and `maxItems: 200` to the item arrays. `GET /api/v1/blog/menus` is consumed by `ahliweb/awcms-astro`, and the frozen consumer contract **still passes without regeneration** — the change is additive for a reader, and that repo reads menus at build time and never writes them.

One thing worth flagging: its `Menu` type does not carry `itemsTruncated`, so a tenant whose menu exceeds 200 items would render 200 there without a warning. That is a cross-repo question, not a regression introduced here.

## Verification

Full `bun run check` green; integration suite **576 pass / 0 fail** (baseline 567, +9 new).

Mutation-proven, each against the assertion that claims it and only it:

| Mutation | Reddens |
| --- | --- |
| Window not partitioned | per-menu bound |
| Bare `LIMIT` at the cap | truncation flag (2 cases) |
| `id` tiebreaker dropped | deterministic order |
| Per-menu loop restored | query budget (2 cases) |
| Count check moved after per-item pass | "refused WITHOUT validating every entry" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)