### PR TITLE
chore(docs): the legacy-site memory read as a live work order after ADR-0116 closed the cutover

### DIFF
--- a/docs/awcms/agent-memory.md
+++ b/docs/awcms/agent-memory.md
@@ -65,7 +65,7 @@ Konsekuensi yang disengaja: `MEMORY.md` dan beberapa memory lain **tetap** meruj
 - [Aturan dalam URUTAN pernyataan = aturan TANPA tes](awcms-rule-in-statement-order-has-no-test.md) — ADR-0111: presedensi 2 `await` menelan 23.906 redirect
 - [Kesiapan CMS berita /news/](awcms-news-site-readiness.md) — backend matang, AUTHORING & PRESENTASI putus; 9 pemblokir
 - [Putaran gap portal berita 19 Agu 2026](awcms-news-portal-gap-round-2026-08-19.md) — 132 fitur legacy → #588–#599; TipTap menabrak postur 2-dependency
-- [Situs legacy SeputarBorneo ADA di mesin ini](seputarborneo-legacy-site-is-on-this-machine.md) — EMPAT bentuk URL hidup (`cari_berita` dibayangi catch-all); dump 0-byte UMPAN PALSU, data di volume `seputarborneocom_db_data`
+- [Situs legacy SeputarBorneo = RUJUKAN FITUR, bukan sumber migrasi](seputarborneo-legacy-site-is-on-this-machine.md) — ADR-0116 mencabut cutover 301; #599/#711 DITUTUP. Faktanya tetap: EMPAT bentuk URL hidup, dump 0-byte UMPAN PALSU, data di volume `seputarborneocom_db_data`
 - [Tanya: pemanggilnya ADA di jalur permintaan?](awcms-is-the-caller-even-in-the-request-path.md) — ADR-0114: `awcms_seo_redirects` 1 call site di `src/middleware.ts`, targetnya disajikan `awcms-astro`; TEPI yang memikul 301
 - [PRD LenteraKalteng menggerakkan kerja awcms](lenterakalteng-prd-drives-awcms-work.md) — PRD di ~/Downloads BUKAN di repo; awcms-astro TIDAK boleh jadi situs Lentera
 - [Rekomendasi WAJIB ditulis ke PROJECT_STATE §4](awcms-recommendation-rounds-live-in-project-state.md) — termasuk penolakan DAN pelaksanaannya; menurunkan ulang = satu audit penuh
@@ -7181,12 +7181,23 @@ atau `UPDATE … WHERE`, ia butuh SELECT.
 `````markdown
 ---
 name: seputarborneo-legacy-site-is-on-this-machine
-description: "Artefak legacy SeputarBorneo ADA di /home/data/dev_php/seputarborneo.com; dump 0-byte UMPAN PALSU — 25.029 artikel + 102 pasangan rubrik ada di volume Docker seputarborneocom_db_data"
+description: "ADR-0116: situs legacy kini RUJUKAN FITUR bukan sumber migrasi — cutover 301 DICABUT, #599/#711 DITUTUP; faktanya tetap benar (dump 0-byte UMPAN PALSU; 25.029 artikel + 102 pasangan rubrik di volume Docker seputarborneocom_db_data)"
 metadata: 
   node_type: memory
   type: project
-  modified: 2026-08-26T08:43:41.880Z
+  modified: 2026-08-26T21:01:58.752Z
 ---
+
+> **LINGKUP BERUBAH 26 Agustus 2026 (ADR-0116) — baca ini dulu.** Situs legacy
+> kini **RUJUKAN FITUR, bukan sumber migrasi**: tidak semua artikel perlu
+> diimpor, dan **kewajiban cutover 301 DICABUT** bersamanya. #599 dan #711
+> DITUTUP (PR #734). Seluruh FAKTA di bawah tetap benar dan tetap berguna —
+> situsnya masih dipakai sebagai rujukan — tetapi **jangan baca satu pun sebagai
+> pekerjaan tertunda**. Yang di bawah menyebut "pemblokir", "tugas nyatanya
+> ~25.031 unggahan / 4,1 GB", atau "konsekuensi yang mengubah rencana" kini
+> bersyarat pada **impor SELEKTIF** yang belum tentu terjadi. Aturannya:
+> **URL tak bisa dibawa tanpa membawa kontennya** — untuk artikel yang sengaja
+> tak diimpor, jawabannya 410, bukan 301.
 
 **#599 dan `docs/PROJECT_STATE.md` sama-sama menyatakan artefak legacy "tidak ada
 di kedua repo". Itu SALAH sejak awal** — salinan kerja situs legacy ada di


### PR DESCRIPTION
Follow-up to #734. A memory that an agent reads before touching anything legacy now points the wrong way.

`seputarborneo-legacy-site-is-on-this-machine` is the entry that carries the hard-won forensics about the legacy site: the 0-byte `seputa58_sbb.sql` is a decoy and the real data is in the Docker volume; `cari_berita` is shadowed by the two-segment catch-all on the line above it; 25,029 articles across 102 rubrik pairs; the recipe for reading the volume read-only without corrupting it.

**All of that is still true, and still worth having** — the site remains a feature reference under ADR-0116, so the forensics are exactly what a future selective import or feature comparison needs.

**What inverted is the framing.** The file says:

- _"Pemblokir #711 yang TERSISA cuma satu"_
- _"Tugas nyatanya ~25.031 unggahan / 4,1 GB"_
- _"Konsekuensi yang mengubah rencana"_

#599 and #711 are closed and the cutover obligation is withdrawn. An agent reading this goes looking for a migration nobody is asking for — and this repo has already been bitten by precisely that: a stale note that had aged into pointing the wrong direction, and was **followed**.

## What changed

- A scope banner leads the file: legacy site = feature reference, 301 obligation withdrawn, both issues closed, and the rule that replaces them — **you cannot carry the URLs without carrying the content**; for a deliberately un-imported article the answer is 410, not a 301.
- The `description` and the `MEMORY.md` row lead with the change rather than the old headline, so the drift is visible from the index without opening the file.
- Everything below the banner is marked conditional on a **selective** import that may never happen.

**Nothing was deleted.** The correction goes at the top; erasing the facts would throw away the expensive half to fix the cheap half.

## Verification

```text
lint · check:docs · check:docs:translation · memory:docs:check · docs:i18n:stamp:check   exit 0
Snapshot memory sinkron (119 file).
```

Snapshot regenerated with `bun run memory:docs:sync`, not hand-edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
