### PR TITLE
test(version-check): the non-vacuity guard made a release commit a red suite

### DIFF
--- a/.changeset/release-commit-was-a-red-suite.md
+++ b/.changeset/release-commit-was-a-red-suite.md
@@ -1,0 +1,23 @@
+---
+"awcms": patch
+---
+
+test(version-check): the non-vacuity guard made a release commit a red suite
+
+`every pending changeset has valid frontmatter` asserted `pending.length > 0`
+on the live repo. That holds on every commit except the one it exists to
+protect: a release consumes every changeset, so `.changeset/` is legitimately
+empty and the assertion fails precisely when the repo is in the state the whole
+version model is built around.
+
+It had never fired because the test landed **after** v9.1.2, and v10.0.0 is the
+first release since — the first time it was ever asked the question. Combined
+with `changesets:policy:check`, whose release-consumption carve-out requires the
+release commit to touch `package.json` and nothing else, a release PR could not
+be green: fixing the test inside the release commit breaks the policy gate, and
+leaving it breaks the suite. This fix has to land BEFORE a release, not with it.
+
+Non-vacuity moves onto the READER, against a planted directory: one real
+changeset plus the `README.md` it must skip, and an empty `.changeset/` proving
+that zero pending is a release rather than a failure. The live-repo assertion
+keeps checking frontmatter validity, which is what it was for.

--- a/tests/version-check.test.ts
+++ b/tests/version-check.test.ts
@@ -19,7 +19,14 @@
  * same "OK" as a rule that passed.
  */
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import {
   checkPackageVersion,
@@ -394,8 +401,46 @@ describe("the real repo satisfies every rule", () => {
   });
 
   test("every pending changeset has valid frontmatter", () => {
-    const pending = readPendingChangesets();
+    // No non-vacuity guard on the LIVE count here, and that is the point. The
+    // first draft asserted `pending.length > 0`, which is true on every commit
+    // except the one that matters: a release consumes every changeset, so
+    // `.changeset/` is legitimately empty and the guard turned the release
+    // commit into a red suite. It had never fired because this test was added
+    // AFTER v9.1.2 and the next release was v10.0.0 — the first time it was
+    // ever asked the question.
+    expect(checkPendingChangesets(readPendingChangesets())).toEqual([]);
+  });
+
+  test("the reader finds changesets and skips its own README", () => {
+    // Non-vacuity belongs on the READER, against a planted directory, rather
+    // than on whatever the repo happens to hold today.
+    const root = mkdtempSync(path.join(tmpdir(), "awcms-changesets-"));
+    mkdirSync(path.join(root, ".changeset"));
+    writeFileSync(
+      path.join(root, ".changeset", "README.md"),
+      "# Changesets\n\nnot a changeset\n"
+    );
+    writeFileSync(
+      path.join(root, ".changeset", "a-real-one.md"),
+      '---\n"awcms": patch\n---\n\nfix(x): something\n'
+    );
+
+    const pending = readPendingChangesets(root);
+
+    expect(pending.map((entry) => entry.name)).toEqual(["a-real-one.md"]);
     expect(checkPendingChangesets(pending)).toEqual([]);
-    expect(pending.length).toBeGreaterThan(0);
+
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test("an empty `.changeset/` is a release, not a failure", () => {
+    const root = mkdtempSync(path.join(tmpdir(), "awcms-changesets-empty-"));
+    mkdirSync(path.join(root, ".changeset"));
+    writeFileSync(path.join(root, ".changeset", "README.md"), "# Changesets\n");
+
+    expect(readPendingChangesets(root)).toEqual([]);
+    expect(checkPendingChangesets([])).toEqual([]);
+
+    rmSync(root, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
`every pending changeset has valid frontmatter` asserted `pending.length > 0` on
the live repo. That holds on every commit except the one it exists to protect: a
release consumes every changeset, so `.changeset/` is legitimately empty and the
assertion fails precisely when the repo is in the state the whole version model
is built around.

It had never fired because the test landed **after** v9.1.2, and v10.0.0 is the
first release since — the first time it was ever asked the question.

### Why this cannot ride along with the release

`changesets:policy:check`'s release-consumption carve-out requires the release
commit to touch `package.json` and nothing else. So fixing the test *inside* the
release commit breaks the policy gate, and leaving it breaks the suite. This has
to land **before** a release, not with it.

### The fix

Non-vacuity moves onto the READER, against a planted directory: one real
changeset plus the `README.md` it must skip, and an empty `.changeset/` proving
that zero pending is a release rather than a failure. The live-repo assertion
keeps checking frontmatter validity, which is what it was for.

### Verification

Run against the prepared `chore/release-v10.0.0` tree — the exact state that was
red: **45 pass, 0 fail** (was 42 pass / 1 fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)