### PR TITLE
fix(i18n,blog-content): v10.0.0 served the entire public blog as 404, and no test had ever fetched the URL it broke

### DIFF
--- a/.changeset/locale-prefixed-blog-routes.md
+++ b/.changeset/locale-prefixed-blog-routes.md
@@ -1,0 +1,70 @@
+---
+"awcms": patch
+---
+
+fix(i18n,blog-content): v10.0.0 served the entire public blog as 404, and no test at any level had ever fetched the URL it broke
+
+ADR-0098 moved the locale into the PATH and served the prefixed URL by rewriting
+it back to the bare route. Shipped in v10.0.0, that meant `/blog/{tenant}` `307`d
+to `/id/blog/{tenant}`, and `/id/blog/{tenant}` answered **404** — the index and
+every article, plus a feed whose `<link>` elements all pointed at those 404s.
+`/`, `/login` and `/search` were unaffected, which is why the site looked alive.
+
+### The mechanism, measured rather than reasoned about
+
+A rewrite whose TARGET is a parameterised route resolves the route and computes
+its params correctly and then never executes it; the catch-all answers instead.
+Verified against the production image in an isolated container, on the same
+route:
+
+| rewrite target                              | reached directly | reached by rewrite |
+| ------------------------------------------- | ---------------- | ------------------ |
+| `/login`, `/search`, `/robots.txt` (static)  | 200              | 200                |
+| `/blog/{tenant}/search` (parameterised)      | 200              | **404**            |
+
+Every `/blog/{tenantCode}` surface is parameterised, so every one of them fell.
+`context.rewrite()` re-runs middleware and loops (`307`); passing a `URL` or a
+`Request` to `next()` changes nothing. There is no one-line spelling of the
+original mechanism that works, which is why the mechanism changed and ADR-0098
+was amended rather than re-argued.
+
+(Deliberately not a markdown link. A changeset is validated by `check:docs`
+while it sits in `.changeset/`, and then `changeset version` inlines it into
+`CHANGELOG.md` at the repo ROOT — so `../docs/…` is broken in the first place
+and `docs/…` is broken in the second. There is no relative spelling that is
+correct in both, and the v10.0.0 release found that out the hard way: two
+changesets carried `../docs/adr/…` and turned the release commit red.)
+
+### What replaces it
+
+Real routes at `src/pages/[locale]/blog/[tenantCode]/…` — five files that are
+**registration only**: each re-exports the bare route's `GET` through
+`localisedPublicRoute()`. ADR-0098's objection to a `[locale]` tree was
+duplicated LOGIC, and re-export does not duplicate logic — a change to the bare
+route is a change to the prefixed one by construction.
+
+`localisedPublicRoute()` exists because `[locale]` is a dynamic segment, so
+`/anything/blog/acme` matches the pattern too. Without the check a bogus prefix
+would SERVE the tenant's content under an unbounded number of addresses, each
+its own cache key. It 404s with the same generic response an unknown tenant
+gets, so "no such locale" and "no such tenant" stay indistinguishable.
+
+`src/middleware.ts` no longer rewrites. It still sets `locals.locale` from the
+path, still resolves `seo_distribution` rules against the bare path, and still
+`307`s a bare URL to its prefixed spelling. **The URL shape a reader sees is
+unchanged** — this fix is invisible from outside the server.
+
+### The coverage gap is the finding
+
+Not one test, at any level, ever fetched a locale-prefixed public URL. ADR-0098
+made the prefixed spelling canonical for every reader-facing blog surface and
+the suite went on exercising only the bare ones, which redirect — so a fully
+green CI was consistent with a fully 404 blog.
+
+`tests/localised-public-routes.test.ts` derives the required prefixed routes
+from the filesystem rather than a hand-written list, so a new prefixed surface
+cannot be added without its route. It is mutation-proven against both real
+defects: deleting a prefixed route and restoring the rewrite each turn it red,
+and it is green again once restored. It also pins the converse — `feed.xml`,
+`sitemap-blog.xml` and `search` must have NO prefixed twin, because a second
+address for one inventory document is its own defect.

--- a/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.id.md
+++ b/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](0098-the-cache-key-carries-the-locale-in-the-path.md)
 
-<!-- i18n-source-hash: sha256:3249dfe9efc7930a0aab5e42a825609ce8957c003c439d66d6712474cd92243c -->
+<!-- i18n-source-hash: sha256:712c211f16d52b1d7ba059b4a99f1d1ad44d600c1344c12793b5a95e9d1d7bbf -->
 
 # ADR-0098 — Kunci cache membawa locale, dan ia membawanya di PATH
 
@@ -60,3 +60,27 @@ Tiga mekanisme bisa membuat badan ter-cache benar secara locale.
 - **Netral:** `seo_distribution` sudah membangun URL absolut lewat `site-origin.ts` (putaran ADR-0097, #573), jadi prefiksnya masuk lewat satu pembangun origin yang sudah ada, bukan yang kedua.
 
 - **Ditolak: `Vary` pada header yang dinormalisasi.** Ia mekanisme yang dipakai kebanyakan situs dan ia yang salah di sini, karena alasan khas produk ini: pengalih bahasa adalah kendali yang sudah pernah dikirim, dirusak, dan diperbaiki dua kali oleh repo ini (v9.1.1, v9.1.2). Desain yang membuat klik eksplisit tidak bisa mengalahkan header peramban akan menjadikan kendali itu dekoratif tepat pada permukaan yang dilihat paling banyak pembaca.
+
+## Amandemen (2026-08-27, v10.0.1) — URL ber-prefix disajikan RUTE, bukan rewrite
+
+**Yang berubah:** mekanisme penyajian di dalam keputusan 3, dan tidak ada yang lain.
+
+Keputusan 3 menyatakan URL ber-prefix disajikan dengan me-_rewrite_-nya kembali ke rute telanjang (`next("/blog/acme")`), dan bagian Konsekuensi ADR ini membenarkannya dengan alasan "tanpa pohon `[locale]` ganda". **Mekanisme itu tidak berfungsi di build ini.** Rewrite yang sasarannya rute BERPARAMETER meresolusi rutenya dan menghitung params-nya dengan benar, lalu tidak pernah mengeksekusinya — yang menjawab justru catch-all.
+
+Diukur terhadap image produksi, di container terisolasi, pada rute yang sama:
+
+| sasaran rewrite                             | diakses langsung | lewat rewrite |
+| ------------------------------------------- | ---------------- | ------------- |
+| `/login`, `/search`, `/robots.txt` (statis) | 200              | 200           |
+| `/blog/{tenant}/search` (berparameter)      | 200              | **404**       |
+| `/blog/{tenant}`, `/blog/{tenant}/{slug}`   | —                | **404**       |
+
+Karena setiap permukaan `/blog/{tenantCode}` berparameter, v10.0.0 merilis blog publik yang URL telanjangnya `307` ke URL ber-prefix yang menjawab 404 — indeks dan setiap artikel. `context.rewrite()` menjalankan ulang middleware sehingga berputar; memberi `URL` atau `Request` ke `next()` tidak mengubah apa pun. Tidak ada ejaan satu-baris dari mekanisme asli yang berhasil.
+
+**Mekanisme baru:** keempat permukaan yang dibaca manusia punya rute nyata di `src/pages/[locale]/blog/[tenantCode]/…`. Masing-masing **hanya pendaftaran** — ia me-re-export handler rute telanjangnya lewat `localisedPublicRoute()`, yang mem-404-kan segmen yang bukan locale yang didukung. Keberatan ADR ini terhadap pohon `[locale]` adalah duplikasi LOGIKA, dan re-export tidak menduplikasi logika: perubahan pada rute telanjang otomatis menjadi perubahan pada rute ber-prefix.
+
+`src/middleware.ts` tidak lagi me-rewrite. Ia tetap menyetel `locals.locale` dari path, tetap meresolusi aturan `seo_distribution` terhadap path telanjang, dan tetap me-`307` URL telanjang ke ejaan ber-prefix-nya.
+
+**Yang TIDAK berubah:** keputusan 1, 2, 4, 5 dan 6 berlaku tanpa perubahan, begitu pula seluruh keputusan 3 kecuali mekanisme penyajiannya. Kunci cache tetap `(host, url)`, tidak ada `Vary` ditambahkan, pemilihan locale tetap `307` ber-`private, no-store`, path telanjang tetap alias yang tidak me-render, dan `/admin` tetap tak tersentuh. **Bentuk URL yang dilihat pembaca identik** — amandemen ini tak terlihat dari luar server.
+
+**Kenapa ia sampai ke produksi dalam keadaan hijau.** Tak satu pun tes di level mana pun pernah mengambil URL publik ber-prefix locale. ADR ini menjadikan ejaan ber-prefix sebagai kanonik untuk setiap permukaan blog yang dibaca manusia, sementara suite terus menguji hanya ejaan telanjang, yang me-redirect. `tests/localised-public-routes.test.ts` menutupnya: ia menurunkan rute ber-prefix yang diwajibkan dari sistem berkas, sehingga permukaan ber-prefix baru tak bisa ditambahkan tanpa rutenya, dan ia terbukti lewat mutasi terhadap kedua cacat asli — menghapus satu rute ber-prefix dan mengembalikan rewrite masing-masing memerahkannya.

--- a/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.md
+++ b/docs/adr/0098-the-cache-key-carries-the-locale-in-the-path.md
@@ -58,3 +58,27 @@ Three mechanisms can make a cached body locale-correct.
 - **Neutral:** `seo_distribution` already builds absolute URLs through `site-origin.ts` (ADR-0097 round, #573), so the prefix enters through the existing single origin builder rather than a second one.
 
 - **Rejected: `Vary` on a normalised header.** It is the mechanism most sites use and it is the wrong one here, for a reason specific to this product: the language switcher is a control this repo already shipped, broke, and fixed twice (v9.1.1, v9.1.2). A design in which an explicit click cannot win over a browser header would make that control decorative on exactly the surface most readers see.
+
+## Amendment (2026-08-27, v10.0.1) — the prefixed URL is served by a route, not by a rewrite
+
+**What changed:** the serving mechanism inside decision 3, and nothing else.
+
+Decision 3 said the prefixed URL is served by rewriting it back to the bare route (`next("/blog/acme")`), and this ADR's Consequences justified that with "no duplicated `[locale]` tree". **That mechanism does not work in this build.** A rewrite whose target is a PARAMETERISED route resolves the route and computes its params correctly and then never executes it — the catch-all answers instead.
+
+Measured against the production image, in an isolated container, on the same route:
+
+| rewrite target                              | reached directly | reached by rewrite |
+| ------------------------------------------- | ---------------- | ------------------ |
+| `/login`, `/search`, `/robots.txt` (static) | 200              | 200                |
+| `/blog/{tenant}/search` (parameterised)     | 200              | **404**            |
+| `/blog/{tenant}`, `/blog/{tenant}/{slug}`   | —                | **404**            |
+
+Because every `/blog/{tenantCode}` surface is parameterised, v10.0.0 shipped a public blog in which the bare URL `307`d to a prefixed URL that answered 404 — index and every article. `context.rewrite()` re-runs middleware and loops; passing a `URL` or a `Request` to `next()` changes nothing. There is no one-line spelling of the original mechanism that works.
+
+**The new mechanism:** the four reader-facing surfaces have real routes at `src/pages/[locale]/blog/[tenantCode]/…`. Each is **registration only** — it re-exports the bare route's handler through `localisedPublicRoute()`, which 404s a segment that is not a supported locale. The objection this ADR raised to a `[locale]` tree was duplicated LOGIC, and re-export does not duplicate logic: a change to the bare route is a change to the prefixed one by construction.
+
+`src/middleware.ts` no longer rewrites. It still sets `locals.locale` from the path, still resolves `seo_distribution` rules against the bare path, and still `307`s a bare URL to its prefixed spelling.
+
+**What did NOT change:** decisions 1, 2, 4, 5 and 6 stand unmodified, and so does the whole of decision 3 except its serving mechanism. The cache key is still `(host, url)`, no `Vary` is added, locale selection is still a `private, no-store` `307`, the bare path is still an alias that does not render, and `/admin` is still untouched. **The URL shape a reader sees is identical** — this amendment is invisible from outside the server.
+
+**Why it reached production green.** Not one test at any level fetched a locale-prefixed public URL. The ADR made the prefixed spelling the canonical one for every reader-facing blog surface, and the suite went on exercising only the bare spellings, which redirect. `tests/localised-public-routes.test.ts` closes that: it derives the required prefixed routes from the filesystem, so a new prefixed surface cannot be added without one, and it is mutation-proven against both real defects — deleting a prefixed route and restoring the rewrite each turn it red.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,8 +12,8 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 501   |
-| Route files                         | 383   |
+| Test files                          | 503   |
+| Route files                         | 388   |
 | ADR                                 | 234   |
 
 ### Modules
@@ -359,8 +359,8 @@
 
 | Directory     | Test files |
 | ------------- | ---------- |
-| `(root)`      | 411        |
-| `e2e`         | 17         |
+| `(root)`      | 412        |
+| `e2e`         | 18         |
 | `integration` | 72         |
 | `unit`        | 1          |
 
@@ -370,7 +370,7 @@
 | --------------- | ----- |
 | `/api/v1/**`    | 308   |
 | `/admin/**`     | 50    |
-| publik / anonim | 25    |
+| publik / anonim | 30    |
 
 <!-- END GENERATED: repo-inventory -->
 

--- a/src/lib/i18n/localised-route.ts
+++ b/src/lib/i18n/localised-route.ts
@@ -1,0 +1,70 @@
+/**
+ * ADR-0098 amendment (see `docs/adr/0098-*.md` §Amendment): the locale-prefixed
+ * public URLs are served by REAL routes, not by a middleware rewrite.
+ *
+ * ## Why this file exists at all
+ *
+ * ADR-0098 decision 3 put the locale in the PATH and served the prefixed URL by
+ * rewriting it back to the bare route (`next("/blog/acme")`), explicitly to
+ * avoid "a duplicated `[locale]` tree". That mechanism does not work in this
+ * build: a rewrite whose TARGET is a parameterised route resolves the route and
+ * computes its params correctly and then never executes it — the request is
+ * answered by the catch-all instead. Measured against the production image, on
+ * the same route:
+ *
+ * | rewrite target                  | reached directly | reached by rewrite |
+ * | ------------------------------- | ---------------- | ------------------ |
+ * | `/login`, `/search`, `/robots.txt` (static) | 200  | 200                |
+ * | `/blog/{tenant}/search` (parameterised)     | 200  | **404**            |
+ *
+ * So every locale-prefixed blog URL answered 404 while the bare URL redirected
+ * into it — the whole public blog, index and articles alike. `context.rewrite()`
+ * re-runs middleware and loops; passing a `URL` or a `Request` to `next()`
+ * changes nothing. There is no one-line spelling of the ADR's mechanism that
+ * works, which is why the mechanism changed and the ADR was amended.
+ *
+ * ## Why a wrapper rather than a copy of each handler
+ *
+ * The `[locale]` tree duplicates ROUTE REGISTRATION, never logic: each file
+ * re-exports the bare route's handler through this wrapper. That is the part of
+ * ADR-0098's objection that still holds — a second copy of the blog index would
+ * be a real cost — and it is the part this shape does not pay.
+ *
+ * ## What the wrapper is FOR
+ *
+ * `[locale]` is a dynamic segment, so `/blog` in `src/pages/[locale]/blog/…`
+ * is the only literal in the pattern: `/anything/blog/acme` matches it too.
+ * Without this check a bogus prefix would SERVE the tenant's content under a
+ * URL that is not one of its canonical spellings — a duplicate-content surface
+ * with an unbounded number of addresses, and a cache key per address.
+ * `splitPublicLocalePath` cannot catch it, because a segment that is not a
+ * supported locale is not a locale segment to it at all: `/foo/blog/acme`
+ * splits to `{ locale: null, pathname: "/foo/blog/acme" }`, needs no prefix,
+ * and would reach the route unexamined.
+ *
+ * The 404 is the same generic `notFoundHtmlResponse()` the blog routes give an
+ * unknown tenant, deliberately: "that locale does not exist" and "that tenant
+ * does not exist" must not be distinguishable by response.
+ */
+import type { APIRoute } from "astro";
+
+import { notFoundHtmlResponse } from "../html/error-responses";
+import { isSupportedLocale } from "./locales";
+
+/**
+ * Wraps a bare public route handler so it only answers under a SUPPORTED
+ * locale segment.
+ *
+ * The wrapped handler is the same function object the bare route exports — no
+ * behaviour is re-implemented here, and a change to the bare route is a change
+ * to the prefixed one by construction.
+ */
+export function localisedPublicRoute(handler: APIRoute): APIRoute {
+  return (context) => {
+    if (!isSupportedLocale(context.params.locale)) {
+      return notFoundHtmlResponse();
+    }
+
+    return handler(context);
+  };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -358,16 +358,22 @@ export const onRequest = defineMiddleware(async (context, next) => {
         ? redirectResult.capture
         : null;
 
-    // `next(path)` is a REWRITE, not a second request: the prefixed URL is what
-    // the reader sees and what the edge keys on, while the route file that
-    // serves it stays at `src/pages/blog/…` with no duplicated `[locale]` tree.
-    // Routes read the reader's language from `locals.locale`, set above, rather
-    // than from `Astro.url` — which a rewrite deliberately moves to the bare
-    // path (`Astro.originPathname` keeps the prefixed one).
-    const response =
-      localeRoute.action === "serve"
-        ? await next(barePathname + context.url.search)
-        : await next();
+    // No rewrite. The prefixed URL is served by a REAL route
+    // (`src/pages/[locale]/blog/…`), which is the ADR-0098 amendment.
+    //
+    // This line used to be `next(barePathname + context.url.search)`, and that
+    // is the defect v10.0.0 shipped: a rewrite whose target is a PARAMETERISED
+    // route resolves the route and computes its params correctly and then never
+    // executes it — the catch-all answers instead, so every locale-prefixed
+    // blog URL 404'd while every bare one redirected into it. Rewrites to
+    // STATIC targets (`/login`, `/search`, `/robots.txt`) work, which is why
+    // nothing else on the site was affected and why the shape of the bug was
+    // not obvious. `src/lib/i18n/localised-route.ts` carries the measurements.
+    //
+    // Routes still read the reader's language from `locals.locale`, set above,
+    // rather than from `Astro.url` — that contract is unchanged, and it is now
+    // simply true rather than true-after-a-rewrite.
+    const response = await next();
 
     if (notFoundCapture && response.status === 404) {
       await recordPublicNotFound(

--- a/src/modules/blog-content/module.ts
+++ b/src/modules/blog-content/module.ts
@@ -445,7 +445,13 @@ export const blogContentModule = defineModule({
     // ADR-0059: `/news` is the HOST-RESOLVED public content family (index,
     // detail, category, tag) — this module's surface too, resolved from the
     // request rather than from a `{tenantCode}` path segment.
-    routes: ["/api/v1/blog", "/blog", "/api/v1/news-portal"]
+    // ADR-0098 (as amended): `/[locale]/blog` is the CANONICAL spelling of the
+    // four reader-facing public surfaces — the bare `/blog` family stays as the
+    // unprefixed alias the middleware `307`s away from, and as the module the
+    // prefixed routes re-export. Both belong to this module; the prefixed one
+    // needs its own claim because `[locale]` is a leading dynamic segment and
+    // no `/blog` prefix can cover it.
+    routes: ["/api/v1/blog", "/blog", "/[locale]/blog", "/api/v1/news-portal"]
   },
   // Public search-source contribution to `site_search` (ADR-0040 §3, ported
   // from awcms-micro Issue #270). Pure DATA — no executable extractor, no SQL:

--- a/src/pages/[locale]/blog/[tenantCode]/[slug].ts
+++ b/src/pages/[locale]/blog/[tenantCode]/[slug].ts
@@ -1,0 +1,11 @@
+/**
+ * `GET /{locale}/blog/{tenantCode}/{slug}` — the canonical, locale-prefixed
+ * spelling of a public blog post (ADR-0098, as amended).
+ *
+ * Registration only: the handler IS `src/pages/blog/[tenantCode]/[slug].ts`'s,
+ * wrapped so an unsupported locale segment 404s.
+ */
+import { GET as bareGet } from "../../../blog/[tenantCode]/[slug]";
+import { localisedPublicRoute } from "../../../../lib/i18n/localised-route";
+
+export const GET = localisedPublicRoute(bareGet);

--- a/src/pages/[locale]/blog/[tenantCode]/category/[slug].ts
+++ b/src/pages/[locale]/blog/[tenantCode]/category/[slug].ts
@@ -1,0 +1,12 @@
+/**
+ * `GET /{locale}/blog/{tenantCode}/category/{slug}` — the canonical,
+ * locale-prefixed spelling of a public category archive (ADR-0098, as amended).
+ *
+ * Registration only: the handler IS
+ * `src/pages/blog/[tenantCode]/category/[slug].ts`'s, wrapped so an unsupported
+ * locale segment 404s.
+ */
+import { GET as bareGet } from "../../../../blog/[tenantCode]/category/[slug]";
+import { localisedPublicRoute } from "../../../../../lib/i18n/localised-route";
+
+export const GET = localisedPublicRoute(bareGet);

--- a/src/pages/[locale]/blog/[tenantCode]/index.ts
+++ b/src/pages/[locale]/blog/[tenantCode]/index.ts
@@ -1,0 +1,13 @@
+/**
+ * `GET /{locale}/blog/{tenantCode}` — the canonical, locale-prefixed spelling
+ * of the public blog index (ADR-0098, as amended).
+ *
+ * Registration only: the handler IS `src/pages/blog/[tenantCode]/index.ts`'s,
+ * wrapped so an unsupported locale segment 404s. See
+ * `src/lib/i18n/localised-route.ts` for why the middleware rewrite this
+ * replaces could not work.
+ */
+import { GET as bareGet } from "../../../blog/[tenantCode]/index";
+import { localisedPublicRoute } from "../../../../lib/i18n/localised-route";
+
+export const GET = localisedPublicRoute(bareGet);

--- a/src/pages/[locale]/blog/[tenantCode]/pages/[slug].ts
+++ b/src/pages/[locale]/blog/[tenantCode]/pages/[slug].ts
@@ -1,0 +1,12 @@
+/**
+ * `GET /{locale}/blog/{tenantCode}/pages/{slug}` — the canonical,
+ * locale-prefixed spelling of a public static page (ADR-0098, as amended).
+ *
+ * Registration only: the handler IS
+ * `src/pages/blog/[tenantCode]/pages/[slug].ts`'s, wrapped so an unsupported
+ * locale segment 404s.
+ */
+import { GET as bareGet } from "../../../../blog/[tenantCode]/pages/[slug]";
+import { localisedPublicRoute } from "../../../../../lib/i18n/localised-route";
+
+export const GET = localisedPublicRoute(bareGet);

--- a/src/pages/[locale]/blog/[tenantCode]/tag/[slug].ts
+++ b/src/pages/[locale]/blog/[tenantCode]/tag/[slug].ts
@@ -1,0 +1,12 @@
+/**
+ * `GET /{locale}/blog/{tenantCode}/tag/{slug}` — the canonical, locale-prefixed
+ * spelling of a public tag archive (ADR-0098, as amended).
+ *
+ * Registration only: the handler IS
+ * `src/pages/blog/[tenantCode]/tag/[slug].ts`'s, wrapped so an unsupported
+ * locale segment 404s.
+ */
+import { GET as bareGet } from "../../../../blog/[tenantCode]/tag/[slug]";
+import { localisedPublicRoute } from "../../../../../lib/i18n/localised-route";
+
+export const GET = localisedPublicRoute(bareGet);

--- a/tests/e2e/public-blog-locale-prefix.e2e.ts
+++ b/tests/e2e/public-blog-locale-prefix.e2e.ts
@@ -1,0 +1,58 @@
+/**
+ * The spec whose absence let v10.0.0 ship a public blog that answered 404.
+ *
+ * ADR-0098 made `/{locale}/blog/{tenant}` the CANONICAL spelling of every
+ * reader-facing blog surface, and the whole suite went on exercising only the
+ * bare spellings — which redirect. So a fully green CI was consistent with an
+ * index and every article answering 404 behind that redirect. Nothing here is
+ * subtle; it simply had never been fetched.
+ *
+ * `tests/localised-public-routes.test.ts` guards the STRUCTURE (a prefixed
+ * surface has a route). This guards the thing structure cannot prove: that
+ * fetching the canonical URL over HTTP actually serves the page.
+ *
+ * Needs no content fixture. The blog index of a tenant with no posts renders
+ * `200` with "No posts yet." — which is exactly the property under test, since
+ * the defect answered 404 regardless of what the tenant held. The tenant is the
+ * one `ci.yml` bootstraps through the real setup wizard (`tenantCode: "e2e"`).
+ */
+import { test, expect } from "./support/e2e-read-wave";
+
+const TENANT = "e2e";
+
+test.describe("public blog — locale-prefixed URLs", () => {
+  for (const locale of ["id", "en"]) {
+    test(`/${locale}/blog/${TENANT} is SERVED, not 404`, async ({ page }) => {
+      const response = await page.goto(`/${locale}/blog/${TENANT}`);
+
+      // Exactly 200. The defect this replaces produced a clean, well-formed
+      // 404 page, so "did it render something" is not the question.
+      expect(response?.status()).toBe(200);
+      await expect(page.locator("h1")).toContainText("Blog");
+    });
+  }
+
+  test("the bare URL redirects INTO a prefixed URL that serves", async ({
+    page
+  }) => {
+    // The pairing is the point: v10.0.0 had a working redirect pointing at a
+    // 404, and each half looked healthy when tested alone.
+    const response = await page.goto(`/blog/${TENANT}`);
+
+    expect(response?.status()).toBe(200);
+    expect(page.url()).toMatch(
+      new RegExp(`/(en|id)/blog/${TENANT}(?:[/?#]|$)`)
+    );
+  });
+
+  test("a segment that is not a supported locale does not serve the tenant", async ({
+    page
+  }) => {
+    // `[locale]` is a dynamic segment, so `/zz/blog/e2e` matches the route
+    // pattern. Serving it would publish the tenant's content at an unbounded
+    // number of addresses, each its own cache key.
+    const response = await page.goto(`/zz/blog/${TENANT}`);
+
+    expect(response?.status()).toBe(404);
+  });
+});

--- a/tests/e2e/support/e2e-waves.ts
+++ b/tests/e2e/support/e2e-waves.ts
@@ -73,7 +73,11 @@ export const READ_WAVE: readonly string[] = [
   "admin-screens-render.e2e.ts",
   "cwv-lab.e2e.ts",
   "login.e2e.ts",
-  "not-found.e2e.ts"
+  "not-found.e2e.ts",
+  // Anonymous GETs against the public blog. Read-wave in the strictest sense:
+  // it never logs in and never touches tenant state, and it needs no content
+  // fixture because an empty blog index is itself a `200`.
+  "public-blog-locale-prefix.e2e.ts"
 ];
 
 /**

--- a/tests/localised-public-routes.test.ts
+++ b/tests/localised-public-routes.test.ts
@@ -1,0 +1,164 @@
+/**
+ * The coverage whose absence shipped a 404 over the entire public blog.
+ *
+ * v10.0.0 moved the locale into the PATH (ADR-0098) and served the prefixed URL
+ * by rewriting it back to the bare route. Every bare blog URL `307`d to its
+ * prefixed spelling, and every prefixed spelling answered 404, because a
+ * rewrite whose TARGET is a parameterised route resolves the route and computes
+ * its params and then never executes it. CI was green through all of it: not
+ * one test, at any level, ever fetched a locale-prefixed public URL.
+ *
+ * So the gate here is not "does the rewrite work" — there is no rewrite any
+ * more. It is the structural property the rewrite was standing in for:
+ *
+ *   **every public path that REQUIRES a locale prefix has a route that serves
+ *   the prefixed spelling, and that route is the bare route's own handler.**
+ *
+ * Derived from the filesystem rather than from a hand-written list, so a new
+ * prefixed blog surface cannot be added without its prefixed route: the new
+ * bare file appears here on its own, and the assertion fails until its mirror
+ * exists.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { requiresPublicLocalePrefix } from "../src/lib/i18n/public-locale-path";
+import { localisedPublicRoute } from "../src/lib/i18n/localised-route";
+
+const REPO_ROOT = path.resolve(import.meta.dir, "..");
+const BARE_DIR = path.join(REPO_ROOT, "src/pages/blog/[tenantCode]");
+const PREFIXED_DIR = path.join(
+  REPO_ROOT,
+  "src/pages/[locale]/blog/[tenantCode]"
+);
+
+/** `category/[slug].ts` -> `/blog/acme/category/a-slug`; `index.ts` -> `/blog/acme`. */
+function samplePathFor(relativeFile: string): string {
+  const withoutExtension = relativeFile.replace(/\.ts$/, "");
+  const segments = withoutExtension
+    .split("/")
+    .filter((segment) => segment !== "index")
+    .map((segment) =>
+      segment === "[slug]" ? "a-slug" : segment.replace("[tenantCode]", "acme")
+    );
+
+  return ["", "blog", "acme", ...segments].join("/").replace("//", "/");
+}
+
+/** Every `.ts` route file under a directory, relative to it, nested included. */
+function routeFilesIn(dir: string): string[] {
+  const walk = (current: string, prefix: string): string[] =>
+    readdirSync(current, { withFileTypes: true }).flatMap((entry) =>
+      entry.isDirectory()
+        ? walk(path.join(current, entry.name), `${prefix}${entry.name}/`)
+        : entry.name.endsWith(".ts")
+          ? [`${prefix}${entry.name}`]
+          : []
+    );
+
+  return walk(dir, "").sort();
+}
+
+const bareRouteFiles = routeFilesIn(BARE_DIR);
+
+describe("locale-prefixed public routes", () => {
+  test("the fixture itself is non-vacuous", () => {
+    // Guarding the guard: a `readdirSync` that silently returned nothing would
+    // make every assertion below pass by having nothing to check.
+    expect(bareRouteFiles.length).toBeGreaterThan(4);
+    expect(bareRouteFiles).toContain("index.ts");
+  });
+
+  test("every bare blog surface that requires a prefix has a prefixed route", () => {
+    const needingPrefix = bareRouteFiles.filter((file) =>
+      requiresPublicLocalePrefix(samplePathFor(file))
+    );
+
+    // The four reader-facing surfaces: index, post, category, tag, page.
+    expect(needingPrefix.length).toBeGreaterThan(0);
+
+    const prefixedRouteFiles = routeFilesIn(PREFIXED_DIR);
+
+    for (const file of needingPrefix) {
+      expect(prefixedRouteFiles).toContain(file);
+    }
+  });
+
+  test("a surface that must NOT be prefixed has no prefixed route", () => {
+    // The converse, and it is not decoration: `feed.xml`, `sitemap-blog.xml`
+    // and `search` are excluded from prefixing on purpose (a crawler will not
+    // follow a redirect to find an inventory). A prefixed twin would publish a
+    // second address for the same document.
+    const neverPrefixed = bareRouteFiles.filter(
+      (file) => !requiresPublicLocalePrefix(samplePathFor(file))
+    );
+
+    expect(neverPrefixed.length).toBeGreaterThan(0);
+
+    const prefixedRouteFiles = routeFilesIn(PREFIXED_DIR);
+
+    for (const file of neverPrefixed) {
+      expect(prefixedRouteFiles).not.toContain(file);
+    }
+  });
+
+  test("each prefixed route re-exports the bare handler, never a copy of it", () => {
+    // The whole reason a `[locale]` tree is acceptable at all: it duplicates
+    // route REGISTRATION, not logic. A prefixed file that grew its own handler
+    // would drift from the bare one silently.
+    for (const file of routeFilesIn(PREFIXED_DIR)) {
+      const source = readFileSync(path.join(PREFIXED_DIR, file), "utf8");
+      const withoutComments = source
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/^\s*\/\/.*$/gm, "");
+
+      expect(withoutComments).toContain("localisedPublicRoute(bareGet)");
+      expect(withoutComments).toMatch(
+        /import \{ GET as bareGet \} from "[^"]*blog\/\[tenantCode\]/
+      );
+    }
+  });
+
+  test("the middleware no longer rewrites — it serves the prefixed URL", () => {
+    // Source assertion, comments stripped FIRST: the explanation of the defect
+    // that this line used to be is written directly above it, and a naive
+    // `includes` would match the prose and pass while the code regressed.
+    const middleware = readFileSync(
+      path.join(REPO_ROOT, "src/middleware.ts"),
+      "utf8"
+    )
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
+
+    expect(middleware).not.toContain("next(barePathname");
+    expect(middleware).toContain("const response = await next();");
+  });
+});
+
+describe("localisedPublicRoute", () => {
+  const ok = new Response("served", { status: 200 });
+  const handler = (() => ok) as Parameters<typeof localisedPublicRoute>[0];
+
+  const contextWith = (locale: unknown) =>
+    ({ params: { locale } }) as unknown as Parameters<
+      ReturnType<typeof localisedPublicRoute>
+    >[0];
+
+  test("a supported locale reaches the wrapped handler", async () => {
+    for (const locale of ["en", "id"]) {
+      const response = await localisedPublicRoute(handler)(contextWith(locale));
+      expect((response as Response).status).toBe(200);
+    }
+  });
+
+  test("an unsupported segment 404s instead of serving the tenant", async () => {
+    // `[locale]` is a dynamic segment, so `/anything/blog/acme` matches the
+    // route pattern. Without this the tenant's content would be served under an
+    // unbounded number of addresses, each its own cache key.
+    for (const bogus of ["fr", "blog", "admin", "", "EN", undefined]) {
+      const response = await localisedPublicRoute(handler)(contextWith(bogus));
+      expect((response as Response).status).toBe(404);
+    }
+  });
+});


### PR DESCRIPTION
Found by running the release, not by reading it: after deploying v10.0.0 the
host's own synthetic check reported `blog index returned 307`, and following
that redirect landed on a 404.

`/blog/{tenant}` → `307` → `/id/blog/{tenant}` → **404**. The index and every
article, plus a feed whose `<link>` elements all pointed at those 404s. `/`,
`/login` and `/search` were fine, which is why the site looked alive.

### The mechanism, measured rather than reasoned about

A rewrite whose TARGET is a parameterised route resolves the route and computes
its params correctly and then **never executes it** — the catch-all answers
instead. Verified by instrumenting the production image itself in an isolated
throwaway container (live traffic untouched), on the same route:

| rewrite target                              | reached directly | reached by rewrite |
| ------------------------------------------- | ---------------- | ------------------ |
| `/login`, `/search`, `/robots.txt` (static)  | 200              | 200                |
| `/blog/{tenant}/search` (parameterised)      | **200**          | **404**            |
| `/blog/{tenant}`, `/blog/{tenant}/{slug}`    | —                | **404**            |

Every `/blog/{tenantCode}` surface is parameterised, so all of them fell.

Ruled out first, each against production rather than by argument: tenant
resolution (`resolvePublicTenantByCode("ahliweb")` returns the tenant), the
`legacyTenantRouteEnabled` gate (`true`), manifest route order (index at 370,
catch-all at 385, matcher breaks on first match), params (`{"tenantCode":
"ahliweb"}`), and the locale config (`["en","id"]`, resolver returns `serve`).

Candidate one-line fixes, all tested and all rejected: `context.rewrite()`
re-runs middleware and loops (`307`); `next(new URL(...))` → 404;
`next(new Request(...))` → 404.

### What replaces it

Five routes at `src/pages/[locale]/blog/[tenantCode]/…`, **registration only** —
each re-exports the bare route's `GET` through `localisedPublicRoute()`.
ADR-0098's objection to a `[locale]` tree was duplicated LOGIC, and re-export
does not duplicate logic: a change to the bare route is a change to the prefixed
one by construction.

`localisedPublicRoute()` is not decoration. `[locale]` is a dynamic segment, so
`/anything/blog/acme` matches the pattern too; without the check a bogus prefix
would SERVE the tenant's content at an unbounded number of addresses, each its
own cache key. It 404s with the same generic response an unknown tenant gets, so
"no such locale" and "no such tenant" stay indistinguishable.

`src/middleware.ts` no longer rewrites. **The URL shape a reader sees is
unchanged** — the cache key, the `307`, its `private, no-store`, and `/admin`
are all untouched. ADR-0098 is amended (both language copies) rather than
re-argued: only the serving mechanism inside decision 3 changed.

### The coverage gap is the real finding

Not one test, at any level, had ever fetched a locale-prefixed public URL.
ADR-0098 made the prefixed spelling canonical for every reader-facing blog
surface and the suite went on exercising only the bare ones, which redirect — so
a fully green CI was consistent with a fully 404 blog.

- `tests/localised-public-routes.test.ts` — derives the required prefixed routes
  from the filesystem, so a new prefixed surface cannot be added without its
  route. **Mutation-proven against both real defects:** deleting a prefixed
  route and restoring the rewrite each turn it red; green again once restored.
  It also pins the converse — `feed.xml`, `sitemap-blog.xml` and `search` must
  have no prefixed twin.
- `tests/e2e/public-blog-locale-prefix.e2e.ts` — fetches the canonical URL over
  HTTP and asserts exactly `200`, plus the bare→prefixed→served chain and a
  bogus locale segment. Needs no content fixture: an empty blog index is itself
  a `200`.

### Verification

All 52 gates + typecheck + astro checks + build green; suite **5945 pass**. The
single failure is `the committed bundle > matches its TypeScript source`, a
local-only artefact of Bun 1.4.0 vs CI's pinned 1.3.14 (minifier identifier
naming); the bundle was deliberately not regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)