### PR TITLE
fix(ops): the synthetic check asserted 200 on a URL designed to redirect, and would have sat red forever

### DIFF
--- a/.changeset/synthetic-check-follows-the-redirect.md
+++ b/.changeset/synthetic-check-follows-the-redirect.md
@@ -1,0 +1,27 @@
+---
+"awcms": patch
+---
+
+fix(ops): the synthetic check asserted `200` on a URL that is designed to redirect, and would have sat red forever
+
+ADR-0098 made `/blog/{tenant}` an ALIAS: it answers `307` to
+`/{locale}/blog/{tenant}`. Probe 6 asserted `200` on the bare URL without
+following, so it went red the day that landed — and its own §ALERT DISCIPLINE
+describes exactly what happens next: the first failure alerts, repeats stay
+quiet, and the check becomes one people have learned to ignore.
+
+Worse than noisy: red for the wrong reason, with the real defect hiding behind
+it. v10.0.0 shipped that redirect pointing at a **404** — the hop was healthy
+and the destination was not, and each half looked fine when probed alone. A
+probe that stopped at the `307` could not tell those two states apart.
+
+So the assertion is now the PAIR. `-L` follows the hop and requires the
+destination to serve; `%{url_effective}` requires it to be the locale-prefixed
+spelling. The second half is not decoration — a `200` on a bare URL would mean
+the prefix silently stopped being canonical, and every cache entry and every
+`hreflang` this site publishes would then disagree with what it serves.
+
+Verified against production after v10.0.1: `blog index 200 at its
+locale-prefixed URL (https://awcms.ahlikoding.com/id/blog/ahliweb)`, whole
+check `VERDICT: all probes passed`, exit 0 — through Cloudflare and Varnish,
+not against the container.

--- a/ops/synthetic-check.sh
+++ b/ops/synthetic-check.sh
@@ -145,9 +145,32 @@ else
   fi
 fi
 
-# --- 6. a real content route -------------------------------------------------
-CODE=$($CURL -o /dev/null -w '%{http_code}' "${BASE}/blog/${TENANT}" || echo 000)
-[ "$CODE" = "200" ] && ok "blog index 200" || fail "blog index returned ${CODE}"
+# --- 6. a real content route, FOLLOWED to where it actually serves ------------
+#
+# This probe asserted `200` on the bare URL and went red the day ADR-0098 landed,
+# because the bare URL is an ALIAS: it answers `307` to `/{locale}/blog/{tenant}`
+# by design. Left alone it would have alerted once and then sat "failing"
+# forever — the muted-check failure its own §ALERT DISCIPLINE warns about.
+#
+# Worse, it would have been red for the WRONG reason while the real defect hid
+# behind it. v10.0.0 shipped that redirect pointing at a 404: the hop was
+# healthy and the destination was not, and each half looked fine when probed
+# alone. So the assertion is the PAIR — follow the redirect, and require both
+# that the destination serves and that it is the locale-prefixed spelling.
+# `-L` plus `%{url_effective}` is what makes the second half observable.
+CODE=$($CURL -L -o /dev/null -w '%{http_code}' "${BASE}/blog/${TENANT}" || echo 000)
+FINAL=$($CURL -L -o /dev/null -w '%{url_effective}' "${BASE}/blog/${TENANT}" || echo "")
+
+if [ "$CODE" != "200" ]; then
+  fail "blog index returned ${CODE} after following redirects (final: ${FINAL:-none})"
+elif ! printf '%s' "$FINAL" | grep -qE "/(en|id)/blog/${TENANT}([/?#]|$)"; then
+  # A `200` on a bare URL means the locale prefix silently stopped being
+  # canonical — the reader is being served an alias, and every cache entry and
+  # every `hreflang` this site publishes now disagrees with what it serves.
+  fail "blog index served an UNPREFIXED URL (${FINAL}) — ADR-0098 regression"
+else
+  ok "blog index 200 at its locale-prefixed URL (${FINAL})"
+fi
 
 # --- verdict + alert discipline ----------------------------------------------
 PREV=""; [ -f "$STATE" ] && PREV=$(cat "$STATE")


### PR DESCRIPTION
ADR-0098 made `/blog/{tenant}` an **alias**: it answers `307` to
`/{locale}/blog/{tenant}`. Probe 6 asserted `200` on the bare URL without
following, so it went red the day that landed — and the script's own
§ALERT DISCIPLINE describes exactly what happens next: the first failure alerts,
repeats stay quiet, and the check becomes one people have learned to ignore.

### Worse than noisy — red for the wrong reason, with the real defect behind it

v10.0.0 shipped that redirect pointing at a **404**. The hop was healthy and the
destination was not, and each half looked fine when probed alone. A probe that
stops at the `307` cannot tell those two states apart, and this one reported the
`307` — the correct half — while the whole public blog was down.

### The assertion is now the pair

`-L` follows the hop and requires the destination to serve; `%{url_effective}`
requires it to be the locale-prefixed spelling. The second half is not
decoration: a `200` on a bare URL would mean the prefix silently stopped being
canonical, and every cache entry and every `hreflang` this site publishes would
then disagree with what it serves.

### Verified against production, not against the container

Run after v10.0.1 deployed, through Cloudflare and Varnish:

```
synthetic: ok   blog index 200 at its locale-prefixed URL (https://awcms.ahlikoding.com/id/blog/ahliweb)
synthetic: VERDICT: all probes passed
EXIT=0
```

Before this change, the same run against the same healthy site reported
`FAIL blog index returned 307`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)