### PR TITLE
fix(blog): editing a post through /admin/blog destroyed content_json.awcmsAstro, and the repo that SERVES it then built no page

### DIFF
--- a/.changeset/editing-an-article-destroyed-the-key-that-builds-it.md
+++ b/.changeset/editing-an-article-destroyed-the-key-that-builds-it.md
@@ -1,0 +1,64 @@
+---
+"awcms": patch
+---
+
+fix(blog): editing a post through `/admin/blog` destroyed `content_json.awcmsAstro`, and the repo that SERVES the article then built no page for it
+
+`content_json` survived the Portable Text cutover for one reason. ADR-0100 §4
+keeps it as the non-body ENVELOPE because `ahliweb/awcms-astro` stores a sidecar
+in it, and ADR-0115 §2 then made that a written contract:
+`content_json.awcmsAstro.kategori` carries the SECTION, populated by
+`blog:legacy:import --section-map`.
+
+`updateBlogPost` had **two** branches for that column, and a body-only `PATCH`
+took the projection branch with `input.contentJson === undefined`.
+`withProjectedBlocks` spreads a non-object envelope to `{}`, so the row came
+back holding `blocks` and nothing else. **The sidecar was destroyed on every
+save.**
+
+The admin edit screen is exactly that caller: `admin/blog.astro:2092` sets
+`body.bodyPortableText` and has never set `body.contentJson`. `PATCH
+/api/v1/blog/posts/{id}` passes `input.contentJson` straight through without
+hydrating it from the stored row, so the destruction is not specific to the
+screen — every client that sends a body without an envelope had it.
+
+## Why nothing caught it, and why it is the same rung the CONSUMER ROUND named
+
+Nothing fails. The article still renders perfectly **here**, because
+`/blog/{code}/{slug}` reads `body_portable_text`. What breaks is one repository
+away: `getArticles` in `ahliweb/awcms-astro` keeps a post only when the sidecar
+names a configured tab, so the article silently stops being **built** — green
+build, no page, no warning on either side. An imported article an editor opens
+once and saves simply disappears from the site.
+
+`portable-text-conversion.ts`'s own docblock says `withProjectedBlocks`
+preserves _"every other key — including `awcmsAstro`"_. That is true **of the
+function** and false of every call the admin screen makes, because the caller
+never passes the envelope there is to preserve. A comment is not a call.
+
+## The repair
+
+Three branches instead of two. A body-only update now re-projects onto the
+**stored** envelope with `jsonb_set`, so every key the caller never mentioned
+survives. Merged in SQL rather than by reading the row first: a
+read-modify-write would race with a concurrent update of the same envelope, and
+`jsonb_set` cannot.
+
+The other two branches are unchanged on purpose. A caller that sends an envelope
+still **owns** it — quietly merging for those callers would make it impossible
+to remove a key.
+
+`blog-page-directory.ts` gets the identical three branches. No consumer stores a
+sidecar on a page today, so that half repairs nothing currently broken; it is
+changed because the two functions were identical when the defect was written,
+and a twin that keeps its sibling's defect is how the defect returns.
+
+## Coverage
+
+`tests/integration/blog-envelope-sidecar.integration.test.ts` — six cases,
+DB-gated, named for the consequence rather than the column. It asserts the
+sidecar survives, that a key **this repo has never heard of** survives too (an
+allowlist keyed on `awcmsAstro` would pass the first assertion and lose the next
+consumer's data), that `blocks` is still re-derived (so "stop touching
+`content_json`" is not a passing answer), that an explicit envelope still
+replaces, and that pages behave identically.

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 503   |
+| Test files                          | 504   |
 | Route files                         | 388   |
 | ADR                                 | 234   |
 
@@ -361,7 +361,7 @@
 | ------------- | ---------- |
 | `(root)`      | 412        |
 | `e2e`         | 18         |
-| `integration` | 72         |
+| `integration` | 73         |
 | `unit`        | 1          |
 
 ### Routes

--- a/src/modules/blog-content/application/blog-page-directory.ts
+++ b/src/modules/blog-content/application/blog-page-directory.ts
@@ -13,6 +13,7 @@ import {
   boundedPageSize
 } from "../../_shared/offset-pagination";
 import {
+  portableTextToContentBlocks,
   portableTextToPlainText,
   withProjectedBlocks
 } from "../domain/portable-text-conversion";
@@ -366,7 +367,25 @@ export async function listBlogPagesForAdmin(
   };
 }
 
-/** Partial update; `version` bumped on every successful write (same monotonic-counter convention as `updateBlogPost`, no optimistic-concurrency check yet). */
+/**
+ * Partial update; `version` bumped on every successful write (same
+ * monotonic-counter convention as `updateBlogPost`, no optimistic-concurrency
+ * check yet).
+ *
+ * ## `content_json` has the same three branches as `updateBlogPost`, on purpose
+ *
+ * The defect they repair was found on the POSTS side: a body-only PATCH took
+ * the projection branch with `input.contentJson === undefined`, so
+ * `withProjectedBlocks` spread `{}` and every key of the stored envelope was
+ * destroyed on save. There the lost key is `awcmsAstro` and the consequence is
+ * an article `ahliweb/awcms-astro` silently stops building.
+ *
+ * **No consumer stores a sidecar on a PAGE today, so this half repairs nothing
+ * that is currently broken** — and it is changed anyway. The two functions were
+ * identical when the defect was written; leaving one of them holding it is how
+ * it comes back, and a reader finding the difference later would have to guess
+ * whether the divergence was deliberate.
+ */
 export async function updateBlogPage(
   tx: Bun.SQL,
   tenantId: string,
@@ -382,10 +401,23 @@ export async function updateBlogPage(
         -- partial update that changed the envelope without the body, or the
         -- body without the derived search text, would leave the row internally
         -- inconsistent in a way nothing downstream could detect.
+        --
+        -- THREE branches, the same shape as updateBlogPost's, and kept that
+        -- way on purpose. See this function's docblock.
         content_json = CASE
-          WHEN ${input.bodyPortableText !== undefined}
+          -- Body untouched: the envelope moves only if the caller sent one.
+          WHEN ${input.bodyPortableText === undefined}
+            THEN COALESCE(${input.contentJson ?? null}, content_json)
+          -- Body AND envelope supplied: the caller owns both, unchanged.
+          WHEN ${input.contentJson !== undefined}
             THEN ${input.bodyPortableText === undefined ? null : withProjectedBlocks(input.contentJson, input.bodyPortableText)}
-          ELSE COALESCE(${input.contentJson ?? null}, content_json)
+          -- Body only: re-project onto the STORED envelope, so every key the
+          -- caller never mentioned survives the write.
+          ELSE jsonb_set(
+            CASE WHEN jsonb_typeof(content_json) = 'object' THEN content_json ELSE '{}'::jsonb END,
+            '{blocks}',
+            ${input.bodyPortableText === undefined ? null : portableTextToContentBlocks(input.bodyPortableText)}::jsonb
+          )
         END,
         content_text = CASE
           WHEN ${input.bodyPortableText !== undefined}

--- a/src/modules/blog-content/application/blog-post-directory.ts
+++ b/src/modules/blog-content/application/blog-post-directory.ts
@@ -16,6 +16,7 @@ import {
   type KeysetCursor
 } from "../../_shared/keyset-pagination";
 import {
+  portableTextToContentBlocks,
   portableTextToPlainText,
   withProjectedBlocks
 } from "../domain/portable-text-conversion";
@@ -545,7 +546,39 @@ export async function listBlogPostsByStatus(
   return listBlogPosts(tx, tenantId, { status, limit });
 }
 
-/** Partial update; `version` is bumped on every successful write (monotonic change counter — no optimistic-concurrency check is enforced yet, see module README). */
+/**
+ * Partial update; `version` is bumped on every successful write (monotonic
+ * change counter — no optimistic-concurrency check is enforced yet, see module
+ * README).
+ *
+ * ## Why `content_json` has THREE branches and not two
+ *
+ * ADR-0100 §4 keeps `content_json` alive as the non-body ENVELOPE precisely
+ * because `ahliweb/awcms-astro` stores a sidecar in it — `awcmsAstro.kategori`,
+ * which ADR-0115 §2 then turned into a written contract that
+ * `blog:legacy:import` populates from `--section-map`.
+ *
+ * This function used to have two branches, and a **body-only** PATCH took the
+ * projection branch with `input.contentJson === undefined`. `withProjectedBlocks`
+ * spreads a non-object envelope to `{}`, so the row came back holding `blocks`
+ * and nothing else: **the sidecar was destroyed on every save.** The admin edit
+ * screen is exactly that caller — `admin/blog.astro` sends `bodyPortableText`
+ * and has never sent `contentJson`.
+ *
+ * Nothing failed, and that is the whole shape of it. The article still renders
+ * perfectly HERE, because `/blog/{code}/{slug}` reads `body_portable_text`. What
+ * breaks is in the other repo, where `getArticles` keeps a post only when the
+ * sidecar names a configured tab — so the article silently stops being BUILT.
+ * Green build, no page, no warning on either side.
+ *
+ * The projection is therefore merged onto the STORED envelope, and merged **in
+ * SQL** rather than by reading the row first: a read-modify-write would race
+ * with a concurrent update of the same envelope, and `jsonb_set` cannot.
+ *
+ * `blog-page-directory.ts` carries the identical three branches. No consumer
+ * stores a sidecar on a page today, so that half repairs nothing currently
+ * broken — but a twin that keeps its sibling's defect is how the defect returns.
+ */
 export async function updateBlogPost(
   tx: Bun.SQL,
   tenantId: string,
@@ -561,10 +594,24 @@ export async function updateBlogPost(
         -- partial update that changed the envelope without the body, or the
         -- body without the derived search text, would leave the row internally
         -- inconsistent in a way nothing downstream could detect.
+        --
+        -- THREE branches, not two. See this function's docblock for why the
+        -- third one has to exist; in short, a body-only PATCH must not be
+        -- allowed to rebuild the envelope from nothing.
         content_json = CASE
-          WHEN ${input.bodyPortableText !== undefined}
+          -- Body untouched: the envelope moves only if the caller sent one.
+          WHEN ${input.bodyPortableText === undefined}
+            THEN COALESCE(${input.contentJson ?? null}, content_json)
+          -- Body AND envelope supplied: the caller owns both, unchanged.
+          WHEN ${input.contentJson !== undefined}
             THEN ${input.bodyPortableText === undefined ? null : withProjectedBlocks(input.contentJson, input.bodyPortableText)}
-          ELSE COALESCE(${input.contentJson ?? null}, content_json)
+          -- Body only: re-project onto the STORED envelope, so every key the
+          -- caller never mentioned survives the write.
+          ELSE jsonb_set(
+            CASE WHEN jsonb_typeof(content_json) = 'object' THEN content_json ELSE '{}'::jsonb END,
+            '{blocks}',
+            ${input.bodyPortableText === undefined ? null : portableTextToContentBlocks(input.bodyPortableText)}::jsonb
+          )
         END,
         content_text = CASE
           WHEN ${input.bodyPortableText !== undefined}

--- a/tests/integration/blog-envelope-sidecar.integration.test.ts
+++ b/tests/integration/blog-envelope-sidecar.integration.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Editing an article must not make it vanish from the site that serves it.
+ *
+ * ## What this is actually about
+ *
+ * `content_json` is the non-body ENVELOPE (ADR-0100 §4), and it survived the
+ * Portable Text cutover for one reason: `ahliweb/awcms-astro` stores a sidecar
+ * in it. ADR-0115 §2 then made that a written contract —
+ * `content_json.awcmsAstro.kategori` carries the SECTION, and
+ * `blog:legacy:import` populates it from `--section-map`.
+ *
+ * `updateBlogPost` used to have two branches for that column, and a **body-only**
+ * PATCH took the projection branch with `input.contentJson === undefined`.
+ * `withProjectedBlocks` spreads a non-object envelope to `{}`, so the row came
+ * back holding `blocks` and nothing else. The sidecar was destroyed on save.
+ *
+ * The admin edit screen is exactly that caller: `admin/blog.astro` sets
+ * `body.bodyPortableText` and has never set `body.contentJson`.
+ *
+ * ## Why the consequence is in the test names and the column is not
+ *
+ * Nothing fails when the sidecar goes. The article still renders perfectly in
+ * THIS repo, because `/blog/{code}/{slug}` reads `body_portable_text`. What
+ * breaks is one repository away: `getArticles` in `ahliweb/awcms-astro` keeps a
+ * post only when the sidecar names a configured tab, so the article silently
+ * stops being BUILT — green build, no page, no warning on either side.
+ *
+ * A test called "content_json keeps its keys" describes the mechanism and hides
+ * the stake. These are named for what a reader loses.
+ *
+ * ## Why this needs a database
+ *
+ * The repair is a `jsonb_set` inside the `UPDATE`, chosen over reading the row
+ * first precisely because a read-modify-write would race. There is no way to
+ * prove a SQL `CASE` picks the right branch without executing it, and the
+ * failing branch returned a perfectly valid row — which is why nothing caught
+ * this for the life of the column.
+ *
+ * Gated on `DATABASE_URL` (harness §Gating).
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  getAdminSql,
+  getRuntimeSql,
+  integrationEnabled,
+  resetDatabase,
+  setupIntegrationDatabase,
+  teardownIntegrationDatabase
+} from "./harness";
+import { withTenantOrThrow } from "../../src/lib/database/tenant-context";
+import { updateBlogPost } from "../../src/modules/blog-content/application/blog-post-directory";
+import { updateBlogPage } from "../../src/modules/blog-content/application/blog-page-directory";
+import type { PortableTextDocument } from "../../src/modules/blog-content/domain/portable-text";
+
+const TENANT = "f3333333-3333-4333-8333-333333333333";
+const AUTHOR = "f3000000-0000-4000-8000-000000000001";
+
+/**
+ * The envelope as `blog:legacy:import` writes it: the derived projection PLUS
+ * the consumer's sidecar, and one extra key nobody in this repo reads.
+ *
+ * The extra key is not padding. The repair must preserve every key it was never
+ * told about, not a hard-coded allowlist containing `awcmsAstro` — an allowlist
+ * would pass this file and lose the next consumer's data.
+ */
+const ENVELOPE_TERSIMPAN = {
+  blocks: [{ type: "paragraph", text: "Badan lama" }],
+  awcmsAstro: { schemaVersion: 1, kategori: "panduan", urutan: 3 },
+  catatanKonsumenLain: { apaPun: true }
+};
+
+/** A new body, with a mark the old projection cannot carry — so `blocks` must visibly change. */
+const BADAN_BARU: PortableTextDocument = [
+  {
+    _type: "block",
+    _key: "n0",
+    style: "normal",
+    children: [
+      { _type: "span", _key: "n0s0", text: "Badan ", marks: [] },
+      { _type: "span", _key: "n0s1", text: "baru", marks: ["strong"] }
+    ],
+    markDefs: []
+  }
+];
+
+async function seedFixtures(): Promise<void> {
+  const admin = getAdminSql();
+
+  await admin`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name)
+    VALUES (${TENANT}, 'sidecar-tenant', 'Sidecar Tenant')
+  `;
+
+  const profile = (await admin`
+    INSERT INTO awcms_profiles (tenant_id, profile_type, display_name)
+    VALUES (${TENANT}, 'person', 'Author')
+    RETURNING id
+  `) as { id: string }[];
+  const identity = (await admin`
+    INSERT INTO awcms_identities (tenant_id, profile_id, login_identifier, password_hash)
+    VALUES (${TENANT}, ${profile[0]!.id}, 'sidecar@example.test', 'x')
+    RETURNING id
+  `) as { id: string }[];
+  await admin`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id)
+    VALUES (${AUTHOR}, ${TENANT}, ${identity[0]!.id})
+  `;
+}
+
+/** Inserts one post carrying the stored envelope and returns its id. */
+async function postDenganSidecar(): Promise<string> {
+  const rows = (await getAdminSql()`
+    INSERT INTO awcms_blog_posts
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+       body_portable_text, status, visibility, locale)
+    VALUES
+      (${TENANT}, ${AUTHOR}, 'Artikel impor', 'artikel-impor',
+       ${ENVELOPE_TERSIMPAN}::jsonb, 'Badan lama', '[]'::jsonb,
+       'published', 'public', 'id')
+    RETURNING id
+  `) as { id: string }[];
+
+  return rows[0]!.id;
+}
+
+/** Inserts one page carrying the stored envelope and returns its id. */
+async function pageDenganSidecar(): Promise<string> {
+  const rows = (await getAdminSql()`
+    INSERT INTO awcms_blog_pages
+      (tenant_id, author_tenant_user_id, title, slug, content_json, content_text,
+       body_portable_text, status, visibility, locale)
+    VALUES
+      (${TENANT}, ${AUTHOR}, 'Halaman impor', 'halaman-impor',
+       ${ENVELOPE_TERSIMPAN}::jsonb, 'Badan lama', '[]'::jsonb,
+       'published', 'public', 'id')
+    RETURNING id
+  `) as { id: string }[];
+
+  return rows[0]!.id;
+}
+
+const suite = integrationEnabled ? describe : describe.skip;
+
+suite("editing an article does not unpublish it from the consuming site", () => {
+  beforeAll(async () => {
+    await setupIntegrationDatabase();
+  });
+
+  afterAll(async () => {
+    await teardownIntegrationDatabase();
+  });
+
+  beforeEach(async () => {
+    await resetDatabase();
+    await seedFixtures();
+  });
+
+  test("a body-only edit keeps the section the consuming site builds the article from", async () => {
+    const id = await postDenganSidecar();
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+      // Exactly what `admin/blog.astro` sends: a body, and no envelope.
+      const updated = await updateBlogPost(tx, TENANT, id, {
+        bodyPortableText: BADAN_BARU
+      });
+
+      expect(updated).not.toBeNull();
+
+      // The whole point. Before the repair this was `undefined`, and the
+      // article stopped being built one repository away.
+      expect(updated!.contentJson.awcmsAstro).toEqual(
+        ENVELOPE_TERSIMPAN.awcmsAstro
+      );
+    });
+  });
+
+  test("a key this repo has never heard of survives too", async () => {
+    const id = await postDenganSidecar();
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+      const updated = await updateBlogPost(tx, TENANT, id, {
+        bodyPortableText: BADAN_BARU
+      });
+
+      // Guards against the repair that would pass the test above and still be
+      // wrong: an allowlist that preserves `awcmsAstro` by name. The envelope
+      // belongs to its consumers, and this repo does not know their keys.
+      expect(updated!.contentJson.catatanKonsumenLain).toEqual(
+        ENVELOPE_TERSIMPAN.catatanKonsumenLain
+      );
+    });
+  });
+
+  test("the projection is still re-derived — preserving the envelope must not freeze the body", async () => {
+    const id = await postDenganSidecar();
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+      const updated = await updateBlogPost(tx, TENANT, id, {
+        bodyPortableText: BADAN_BARU
+      });
+
+      // The green direction, and it is not decoration: "stop touching
+      // content_json at all" would satisfy every assertion above while leaving
+      // `blocks` describing an article nobody can read any more.
+      const blocks = updated!.contentJson.blocks as { text?: string }[];
+      expect(blocks).toHaveLength(1);
+      // Marks flatten on the way across (ADR-0100 §4, lossy by construction).
+      expect(blocks[0]!.text).toBe("Badan baru");
+    });
+  });
+
+  test("a caller that DOES send an envelope still owns it", async () => {
+    const id = await postDenganSidecar();
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+      const updated = await updateBlogPost(tx, TENANT, id, {
+        bodyPortableText: BADAN_BARU,
+        contentJson: { awcmsAstro: { schemaVersion: 1, kategori: "berita" } }
+      });
+
+      // Unchanged contract: supplying the envelope replaces it. The repair adds
+      // a branch for callers who send NO envelope; it does not quietly merge
+      // for callers who send one, because that would make it impossible to
+      // REMOVE a key.
+      expect(updated!.contentJson.awcmsAstro).toEqual({
+        schemaVersion: 1,
+        kategori: "berita"
+      });
+      expect(updated!.contentJson.catatanKonsumenLain).toBeUndefined();
+    });
+  });
+
+  test("an edit that does not touch the body leaves the envelope alone", async () => {
+    const id = await postDenganSidecar();
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+      const updated = await updateBlogPost(tx, TENANT, id, {
+        title: "Judul baru"
+      });
+
+      expect(updated!.title).toBe("Judul baru");
+      expect(updated!.contentJson).toEqual(ENVELOPE_TERSIMPAN);
+    });
+  });
+
+  test("a page behaves identically — the twin does not keep its sibling's defect", async () => {
+    const id = await pageDenganSidecar();
+
+    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+      const updated = await updateBlogPage(tx, TENANT, id, {
+        bodyPortableText: BADAN_BARU
+      });
+
+      // No consumer stores a sidecar on a page today, so this proves nothing a
+      // reader currently depends on. It proves the two functions did not
+      // diverge — which is how the defect would come back.
+      expect(updated!.contentJson.awcmsAstro).toEqual(
+        ENVELOPE_TERSIMPAN.awcmsAstro
+      );
+      expect(updated!.contentJson.catatanKonsumenLain).toEqual(
+        ENVELOPE_TERSIMPAN.catatanKonsumenLain
+      );
+    });
+  });
+});

--- a/tests/integration/blog-envelope-sidecar.integration.test.ts
+++ b/tests/integration/blog-envelope-sidecar.integration.test.ts
@@ -149,125 +149,128 @@ async function pageDenganSidecar(): Promise<string> {
 
 const suite = integrationEnabled ? describe : describe.skip;
 
-suite("editing an article does not unpublish it from the consuming site", () => {
-  beforeAll(async () => {
-    await setupIntegrationDatabase();
-  });
-
-  afterAll(async () => {
-    await teardownIntegrationDatabase();
-  });
-
-  beforeEach(async () => {
-    await resetDatabase();
-    await seedFixtures();
-  });
-
-  test("a body-only edit keeps the section the consuming site builds the article from", async () => {
-    const id = await postDenganSidecar();
-
-    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
-      // Exactly what `admin/blog.astro` sends: a body, and no envelope.
-      const updated = await updateBlogPost(tx, TENANT, id, {
-        bodyPortableText: BADAN_BARU
-      });
-
-      expect(updated).not.toBeNull();
-
-      // The whole point. Before the repair this was `undefined`, and the
-      // article stopped being built one repository away.
-      expect(updated!.contentJson.awcmsAstro).toEqual(
-        ENVELOPE_TERSIMPAN.awcmsAstro
-      );
+suite(
+  "editing an article does not unpublish it from the consuming site",
+  () => {
+    beforeAll(async () => {
+      await setupIntegrationDatabase();
     });
-  });
 
-  test("a key this repo has never heard of survives too", async () => {
-    const id = await postDenganSidecar();
-
-    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
-      const updated = await updateBlogPost(tx, TENANT, id, {
-        bodyPortableText: BADAN_BARU
-      });
-
-      // Guards against the repair that would pass the test above and still be
-      // wrong: an allowlist that preserves `awcmsAstro` by name. The envelope
-      // belongs to its consumers, and this repo does not know their keys.
-      expect(updated!.contentJson.catatanKonsumenLain).toEqual(
-        ENVELOPE_TERSIMPAN.catatanKonsumenLain
-      );
+    afterAll(async () => {
+      await teardownIntegrationDatabase();
     });
-  });
 
-  test("the projection is still re-derived — preserving the envelope must not freeze the body", async () => {
-    const id = await postDenganSidecar();
-
-    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
-      const updated = await updateBlogPost(tx, TENANT, id, {
-        bodyPortableText: BADAN_BARU
-      });
-
-      // The green direction, and it is not decoration: "stop touching
-      // content_json at all" would satisfy every assertion above while leaving
-      // `blocks` describing an article nobody can read any more.
-      const blocks = updated!.contentJson.blocks as { text?: string }[];
-      expect(blocks).toHaveLength(1);
-      // Marks flatten on the way across (ADR-0100 §4, lossy by construction).
-      expect(blocks[0]!.text).toBe("Badan baru");
+    beforeEach(async () => {
+      await resetDatabase();
+      await seedFixtures();
     });
-  });
 
-  test("a caller that DOES send an envelope still owns it", async () => {
-    const id = await postDenganSidecar();
+    test("a body-only edit keeps the section the consuming site builds the article from", async () => {
+      const id = await postDenganSidecar();
 
-    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
-      const updated = await updateBlogPost(tx, TENANT, id, {
-        bodyPortableText: BADAN_BARU,
-        contentJson: { awcmsAstro: { schemaVersion: 1, kategori: "berita" } }
+      await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+        // Exactly what `admin/blog.astro` sends: a body, and no envelope.
+        const updated = await updateBlogPost(tx, TENANT, id, {
+          bodyPortableText: BADAN_BARU
+        });
+
+        expect(updated).not.toBeNull();
+
+        // The whole point. Before the repair this was `undefined`, and the
+        // article stopped being built one repository away.
+        expect(updated!.contentJson.awcmsAstro).toEqual(
+          ENVELOPE_TERSIMPAN.awcmsAstro
+        );
       });
-
-      // Unchanged contract: supplying the envelope replaces it. The repair adds
-      // a branch for callers who send NO envelope; it does not quietly merge
-      // for callers who send one, because that would make it impossible to
-      // REMOVE a key.
-      expect(updated!.contentJson.awcmsAstro).toEqual({
-        schemaVersion: 1,
-        kategori: "berita"
-      });
-      expect(updated!.contentJson.catatanKonsumenLain).toBeUndefined();
     });
-  });
 
-  test("an edit that does not touch the body leaves the envelope alone", async () => {
-    const id = await postDenganSidecar();
+    test("a key this repo has never heard of survives too", async () => {
+      const id = await postDenganSidecar();
 
-    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
-      const updated = await updateBlogPost(tx, TENANT, id, {
-        title: "Judul baru"
+      await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+        const updated = await updateBlogPost(tx, TENANT, id, {
+          bodyPortableText: BADAN_BARU
+        });
+
+        // Guards against the repair that would pass the test above and still be
+        // wrong: an allowlist that preserves `awcmsAstro` by name. The envelope
+        // belongs to its consumers, and this repo does not know their keys.
+        expect(updated!.contentJson.catatanKonsumenLain).toEqual(
+          ENVELOPE_TERSIMPAN.catatanKonsumenLain
+        );
       });
-
-      expect(updated!.title).toBe("Judul baru");
-      expect(updated!.contentJson).toEqual(ENVELOPE_TERSIMPAN);
     });
-  });
 
-  test("a page behaves identically — the twin does not keep its sibling's defect", async () => {
-    const id = await pageDenganSidecar();
+    test("the projection is still re-derived — preserving the envelope must not freeze the body", async () => {
+      const id = await postDenganSidecar();
 
-    await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
-      const updated = await updateBlogPage(tx, TENANT, id, {
-        bodyPortableText: BADAN_BARU
+      await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+        const updated = await updateBlogPost(tx, TENANT, id, {
+          bodyPortableText: BADAN_BARU
+        });
+
+        // The green direction, and it is not decoration: "stop touching
+        // content_json at all" would satisfy every assertion above while leaving
+        // `blocks` describing an article nobody can read any more.
+        const blocks = updated!.contentJson.blocks as { text?: string }[];
+        expect(blocks).toHaveLength(1);
+        // Marks flatten on the way across (ADR-0100 §4, lossy by construction).
+        expect(blocks[0]!.text).toBe("Badan baru");
       });
-
-      // No consumer stores a sidecar on a page today, so this proves nothing a
-      // reader currently depends on. It proves the two functions did not
-      // diverge — which is how the defect would come back.
-      expect(updated!.contentJson.awcmsAstro).toEqual(
-        ENVELOPE_TERSIMPAN.awcmsAstro
-      );
-      expect(updated!.contentJson.catatanKonsumenLain).toEqual(
-        ENVELOPE_TERSIMPAN.catatanKonsumenLain
-      );
     });
-  });
-});
+
+    test("a caller that DOES send an envelope still owns it", async () => {
+      const id = await postDenganSidecar();
+
+      await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+        const updated = await updateBlogPost(tx, TENANT, id, {
+          bodyPortableText: BADAN_BARU,
+          contentJson: { awcmsAstro: { schemaVersion: 1, kategori: "berita" } }
+        });
+
+        // Unchanged contract: supplying the envelope replaces it. The repair adds
+        // a branch for callers who send NO envelope; it does not quietly merge
+        // for callers who send one, because that would make it impossible to
+        // REMOVE a key.
+        expect(updated!.contentJson.awcmsAstro).toEqual({
+          schemaVersion: 1,
+          kategori: "berita"
+        });
+        expect(updated!.contentJson.catatanKonsumenLain).toBeUndefined();
+      });
+    });
+
+    test("an edit that does not touch the body leaves the envelope alone", async () => {
+      const id = await postDenganSidecar();
+
+      await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+        const updated = await updateBlogPost(tx, TENANT, id, {
+          title: "Judul baru"
+        });
+
+        expect(updated!.title).toBe("Judul baru");
+        expect(updated!.contentJson).toEqual(ENVELOPE_TERSIMPAN);
+      });
+    });
+
+    test("a page behaves identically — the twin does not keep its sibling's defect", async () => {
+      const id = await pageDenganSidecar();
+
+      await withTenantOrThrow(getRuntimeSql(), TENANT, async (tx) => {
+        const updated = await updateBlogPage(tx, TENANT, id, {
+          bodyPortableText: BADAN_BARU
+        });
+
+        // No consumer stores a sidecar on a page today, so this proves nothing a
+        // reader currently depends on. It proves the two functions did not
+        // diverge — which is how the defect would come back.
+        expect(updated!.contentJson.awcmsAstro).toEqual(
+          ENVELOPE_TERSIMPAN.awcmsAstro
+        );
+        expect(updated!.contentJson.catatanKonsumenLain).toEqual(
+          ENVELOPE_TERSIMPAN.catatanKonsumenLain
+        );
+      });
+    });
+  }
+);


### PR DESCRIPTION
Closes #739.

## The path, end to end

`content_json` survived the Portable Text cutover for one reason: ADR-0100 §4 keeps it as the non-body **envelope** because `ahliweb/awcms-astro` stores a sidecar in it, and ADR-0115 §2 then made that a written contract — `awcmsAstro.kategori` carries the SECTION, populated by `blog:legacy:import --section-map`.

`updateBlogPost` had **two** branches for that column:

1. `admin/blog.astro:2092` sets `body.bodyPortableText` and has never set `body.contentJson`.
2. `PATCH /api/v1/blog/posts/{id}` passes `input.contentJson` straight through — no hydration from the stored row.
3. The SQL took the projection branch, because `bodyPortableText !== undefined`.
4. `withProjectedBlocks(undefined, doc)` spreads a non-object envelope to `{}` and writes back `{ blocks: [...] }`.

**The sidecar was destroyed on every save**, for every client that sends a body without an envelope — not just this screen.

## Why nothing caught it

Nothing fails. The article still renders perfectly **here**, because `/blog/{code}/{slug}` reads `body_portable_text`. What breaks is one repository away: `getArticles` in `ahliweb/awcms-astro` keeps a post only when the sidecar names a configured tab, so the article silently stops being **built** — green build, no page, no warning on either side. An imported article an editor opens once and saves disappears from the site.

`portable-text-conversion.ts`'s docblock says `withProjectedBlocks` preserves *"every other key — including `awcmsAstro`"*. True of the **function**, false of every call the admin screen makes, because the caller never passes the envelope there is to preserve. A comment is not a call.

## The repair

Three branches instead of two. A body-only update re-projects onto the **stored** envelope with `jsonb_set`, so every key the caller never mentioned survives. Merged in SQL rather than by reading the row first — a read-modify-write would race with a concurrent update of the same envelope, and `jsonb_set` cannot.

The other two branches are unchanged **on purpose**. A caller that sends an envelope still *owns* it; quietly merging for those callers would make it impossible to remove a key.

`blog-page-directory.ts` gets the identical three branches. No consumer stores a sidecar on a page today, so that half repairs nothing currently broken — it is changed because the two functions were identical when the defect was written, and a twin that keeps its sibling's defect is how the defect returns.

## Coverage

`tests/integration/blog-envelope-sidecar.integration.test.ts` — six DB-gated cases, named for the consequence rather than the column:

- the sidecar survives a body-only edit
- **a key this repo has never heard of survives too** — guards against the repair that passes the first case and is still wrong: an allowlist keyed on `awcmsAstro`, which would lose the next consumer's data
- `blocks` is still re-derived, so "stop touching `content_json`" is not a passing answer
- an explicit envelope still replaces
- an edit that does not touch the body leaves the envelope alone
- pages behave identically

## What was NOT verified here

No PostgreSQL was reachable in the authoring environment, so the six integration cases **have not been executed locally** — they are gated on `DATABASE_URL` and run in the `integration-tests` job, which is directory-scoped (`bun test tests/integration/`), so this file is picked up without a registration step. Schema, view shape and function signatures were checked statically against `sql/035`, `sql/134`, `BlogPageView` and `UpdateBlogPageInput`.

`bun run typecheck` and `bun run db:jsonb-binding:check` pass.

Companion: ahliweb/awcms-astro#73 (the read-side half).

🤖 Generated with [Claude Code](https://claude.com/claude-code)