### PR TITLE
chore(api): the three newsletter paths are CONSUMED now, not merely promised

### DIFF
--- a/.changeset/newsletter-paths-are-consumed-not-promised.md
+++ b/.changeset/newsletter-paths-are-consumed-not-promised.md
@@ -1,0 +1,50 @@
+---
+"awcms": patch
+---
+
+chore(api): the three newsletter paths are CONSUMED now, not merely promised
+
+`/api/v1/newsletter/subscribe`, `/confirm` and `/unsubscribe` were frozen as
+COMMITTED on 27 August in the change that made them reachable at all (ADR-0118)
+— a shape this repo agreed to keep for a consumer that could not yet call it.
+`ahliweb/awcms-astro`#90 shipped the form on 28 August and released it as its
+v0.4.0, so all three move to `CONSUMED_PATHS`.
+
+That is the direction the cross-repo Definition of Done requires — freeze here
+first, call there second — and the split is only worth having if entries
+actually move. A promise and a dependency both deserve stability and fail
+differently: breaking a committed path breaks a design that has been agreed,
+breaking a consumed one breaks something that exists.
+
+The neighbour is the authority and already answered. Its
+`tests/kontrak-awcms.test.mjs` asserts an exact set of **thirteen** called
+surfaces with the three newsletter paths among them, and its failure message
+says so out loud: tell `awcms`, because that repo composes its consumer contract
+from this list. This repo still said ten.
+
+## What is recorded, beyond the move
+
+**One of these WRITES, and none of the ten before it did.** Every reader-browser
+path so far was a read, or a beacon whose entire answer is `202`. A subscription
+makes this deployment send mail to an address a stranger typed, so a wrong shape
+does not blank a page — it sends something, or silently stops sending it, to the
+person who asked. That is the one breakage on this list a reader would report as
+a fault of the newsroom rather than of the site, and it is written into the
+docblock and the gate's own comment rather than left to be inferred from three
+paths that look like every other `POST`.
+
+**The neutral 200 is part of the frozen shape, not a courtesy.** The endpoint
+answers identically for a new address, an already-active one, a suppressed one
+and a host resolving to no tenant. A consumer that distinguishes them rebuilds
+the subscriber oracle the endpoint refuses to be — from the one place nobody
+would think to look for it.
+
+**The reader-browser class now splits six ways on header rules, not three.** The
+two search paths must carry NO custom header, because nothing answers a
+preflight for them; the beacon and these three MUST send
+`content-type: application/json`, because `checkOrigin` refuses the
+alternatives. Making them consistent in either direction kills one of them in a
+reader's browser.
+
+No behaviour changes: `CONSUMER_PATHS` is the union of both lists, so the frozen
+fixture is byte-identical and the same fifteen paths stay guarded.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:32e5d3db63ec7807ce4300d1f0133770d359c49c55f972794ce2c0a3244ce9b5 -->
+<!-- i18n-source-hash: sha256:e492f7d859c9630075750a69caf99779af6d741c3649a34bcea973025b92fbfa -->
 
 # AWCMS — Project State & Continuation
 
@@ -359,6 +359,109 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   [`awcms/environments.md`](awcms/environments.md).
 
 ## 4. Backlog / langkah berikutnya
+
+- **PUTARAN INSPEKSI — 28 Agustus 2026: tracker kosong, dan repo ini masih
+  tertinggal satu langkah dari konsumennya sendiri.**
+
+  Inspeksi seluruh repo tanpa satu pun yang terbuka: 0 issue, 0 PR, CI hijau di
+  `main`, `main` sejajar dengan `origin/main`. Semua di bawah ini DIUKUR, bukan
+  dibaca — seluruh rangkaian gerbang, `typecheck`, 6.869 tes, build, state rilis
+  GitHub, container registry, dan gerbang milik repo konsumen.
+
+  **Satu-satunya celah yang berarti justru tak terlihat dari dalam repo ini.**
+  `/api/v1/newsletter/subscribe`, `/confirm` dan `/unsubscribe` dibekukan sebagai
+  COMMITTED pada 27 Agustus oleh ADR-0118 — perubahan yang membuat ketiganya
+  terjangkau dari peramban sama sekali. `ahliweb/awcms-astro`#90 menerbitkan
+  formulirnya keesokan paginya dan merilisnya sebagai v0.4.0, jadi janji itu
+  sudah menjadi ketergantungan sementara daftar di repo ini masih berkata lain.
+  **Tetangganya sudah menjawab pertanyaan itu**: `tests/kontrak-awcms.test.mjs`
+  di sana menegaskan himpunan PERSIS tiga belas permukaan terpanggil dengan
+  ketiganya di dalamnya, dan pesan gagalnya menyebut kewajibannya terang-terangan
+  — beri tahu `awcms`, sebab repo itu menyusun kontrak konsumennya dari daftar
+  ini. Tak ada yang bisa memerah di sini: kedua daftar dibekukan ke fixture yang
+  sama, sehingga `CONSUMER_PATHS` sudah benar dan yang salah hanya
+  PEMBEDAANNYA. **Selesai** — ketiganya dipindahkan ke `CONSUMED_PATHS`, dengan
+  kelas-tulisnya dicatat (lihat di bawah).
+
+  **Kelas peramban-pembaca berhenti menjadi hanya-baca, dan itulah bagian yang
+  layak dibawa ke depan.** Sepuluh jalur consumed sebelum ini adalah panggilan
+  build, pembacaan, atau beacon yang seluruh jawabannya `202`. Sebuah langganan
+  membuat deployment ini MENGIRIM SURAT ke alamat yang diketik orang asing, jadi
+  bentuk yang salah bukan mengosongkan halaman — ia mengirimkan sesuatu, atau
+  diam-diam berhenti mengirimkannya, kepada orang yang memintanya. Itulah satu
+  kerusakan di daftar tersebut yang akan dilaporkan pembaca sebagai kesalahan
+  ruang redaksi, bukan kesalahan situs. Jawaban 200 yang netral dibekukan dengan
+  alasan yang sama: konsumen yang membedakan "sudah berlangganan" membangun
+  ulang orakel pelanggan yang justru ditolak oleh endpoint itu.
+
+  **Tiga run rilis masih terparkir di gerbang approval, dan pembersihan ADR-0117
+  ternyata PARSIAL.** ADR itu menolak memperbaiki run tertahan yang ditemukannya;
+  empat di antaranya (`v8.0.0`, `v9.0.0`, `v9.1.0`, `v9.1.1`) toh disetujui pada
+  27 Agustus dan mendapat Release-nya pukul 22:05. **Tiga terlewat** — `v8.1.0`
+  (menunggu sejak 11 Agustus), `v10.0.0` dan `v10.0.1` — masing-masing
+  menunjukkan `Build image + SBOM: success` / `Sign, attest, publish: waiting`.
+  Diukur terhadap registry, bukan dikira-kira:
+
+  ```
+  latest   exit=0            ← bertanda tangan, menunjuk v10.0.4
+  10.0.4   exit=0
+  10.0.1   exit=1  HTTP 404  ← image terbit, tanpa atestasi
+  10.0.0   exit=1  HTTP 404
+  8.1.0    exit=1  HTTP 404
+  ```
+
+  Jadi penahanan yang dibeli ADR-0117 memang bertahan — `:latest` terverifikasi
+  bersih dan tak pernah pindah ke digest tak bertanda tangan — tetapi ada tiga
+  tag versi immutable terbit yang JUSTRU GAGAL terhadap resep
+  `gh attestation verify` yang didokumentasikan repo ini sendiri, dan ketiganya
+  pula satu-satunya tag dalam dua puluh terakhir yang **tanpa GitHub Release sama
+  sekali**. Pelajarannya lebih sempit dari ADR-nya: gerbang approval tanpa masa
+  kedaluwarsa tidak gagal, ia MENUMPUK, dan pembersihan parsial meninggalkan
+  persis sisa yang tak diawasi siapa pun.
+
+  **Gerbang yang sensitif terhadap toolchain-nya sendiri memblokir semua yang di
+  belakangnya.** `build:preview-overlay:check` membandingkan bundle ter-commit
+  bita-per-bita dengan bundle segar, jadi ia gagal pada Bun apa pun yang bukan
+  `1.3.14` yang dipatok (lokal `1.4.0`). Dua akibat di luar merah palsunya: satu
+  kegagalan dari 6.869 tes adalah `tests/blog-preview-overlay.test.ts`, yang
+  memanggil gerbang yang sama lalu meng-assert `toContain("OK")`; dan di rantai
+  `check` gerbang itu duduk persis sebelum `typecheck && … && test && build`,
+  sehingga pada Bun tak-terpatok ia MENYEMBUNYIKAN setiap tahap yang penting.
+  Meregenerasi bundle "memperbaikinya" secara lokal dan memerahkan CI. **Tidak
+  diperbaiki — sengaja dibiarkan terbuka** sebagai keputusan tersendiri (naikkan
+  patokan CI ke field `packageManager`, atau bandingkan secara semantik);
+  mitigasi satu baris berupa memindahkan gerbang ke setelah `test` tetap layak
+  dikerjakan.
+
+  **Himpunan Turnstile tak punya gerbang, dan newsletter berada di luarnya.**
+  Enam permukaan anonim memanggil `enforceTurnstileIfRequired` —
+  setup/initialize, register, login (×2), password/forgot, password/reset,
+  invitations/accept — masing-masing dengan konstanta action-nya sendiri agar
+  satu token tak bisa diputar-ulang lintas formulir.
+  `POST /api/v1/newsletter/subscribe` menulis baris dan mengantrekan surat hanya
+  di balik 5 permintaan / 300 dtk per IP. Sampai ADR-0118 ia tak terjangkau dari
+  peramban, jadi kelalaian itu tak berbiaya; sekarang ia terjangkau.
+  `TURNSTILE_REQUIRED_WHEN_ENABLED` adalah daftar ENV, bukan registry action,
+  jadi "endpoint mana yang wajib menantang" dipelihara dengan tangan di lima
+  berkas dan tak ada yang membacanya. **Tidak diperbaiki, dan BUKAN pekerjaan
+  salin-pola-login**: `TURNSTILE_EXPECTED_HOSTNAME` bernilai tunggal sedangkan
+  widget-nya akan diselesaikan di hostname SITUS, bukan hostname ini — pemeriksaan
+  itu ada untuk gagal-tertutup, dan lintas-origin justru kasus yang tak
+  dirancangnya. Cooldown per-alamat bisa jadi jawaban yang lebih baik ketimbang
+  tantangan. Butuh keputusan, jadi ia tinggal di sini alih-alih menjadi tambalan.
+
+  **Yang bersih, disebutkan agar tak diturunkan ulang.** Tak ada regresi isolasi
+  tenant, ABAC, RLS, N+1, maupun jsonb-binding — `access:chokepoint`,
+  `db:tenant-context` dan `api:body-limit` semuanya lolos di 308 berkas rute, dan
+  build tetap di dalam anggaran asetnya (pembaca 21,4 kB / 24 kB). Perbaikan
+  sidecar `#743` diterapkan pula pada SAUDARANYA: `updateBlogPage` membawa tiga
+  cabang `content_json` yang sama dengan `updateBlogPost`, di bawah docblock yang
+  menyatakan terus terang bahwa tak ada konsumen yang menyimpan sidecar halaman
+  hari ini dan ia tetap diubah, sebab meninggalkan salah satu dari dua fungsi
+  identik memegang cacatnya adalah cara cacat itu kembali.
+  `site-search/suggest` berbagi CORS milik `query` lewat `withPublicSearchTenant`
+  — meng-grep STRING header-nya berkata sebaliknya, dan itu galat
+  grep-definisi-bukan-panggilan yang sama yang terus dipelajari ulang repo ini.
 
 - **PUTARAN LINGKUP — 26 Agustus 2026: premis yang dipijak kedua issue cutover
   terbuka DICABUT, dan kewajiban 301-nya ikut bersamanya.**

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:e492f7d859c9630075750a69caf99779af6d741c3649a34bcea973025b92fbfa -->
+<!-- i18n-source-hash: sha256:55bccac23102633d233e7701be99c788ab3b73f4012438ad116789d4bfc96129 -->
 
 # AWCMS — Project State & Continuation
 
@@ -418,6 +418,30 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   sekali**. Pelajarannya lebih sempit dari ADR-nya: gerbang approval tanpa masa
   kedaluwarsa tidak gagal, ia MENUMPUK, dan pembersihan parsial meninggalkan
   persis sisa yang tak diawasi siapa pun.
+
+  **Dibereskan 28 Agustus, dan pembereskan itu menemukan hal yang terlewat oleh
+  ADR-nya.** Ketiganya disetujui; masing-masing hanya melanjutkan
+  `sign-attest-publish` (job `build`-nya sudah rampung berhari-hari atau
+  berminggu-minggu sebelumnya), jadi tak ada image yang dibangun ulang dan
+  `:latest` tidak bergerak — workflow di tag-tag itu mendahului ADR-0117 dan tak
+  punya job `promote-latest` sama sekali. `10.0.0`, `10.0.1` dan `8.1.0` kini
+  terverifikasi, dan setiap tag versi terbit sejak `v5.1.0` sudah berbadge
+  atestasi.
+
+  **`gh release create` MEREBUT badge "Latest", jadi sebuah backfill
+  menyerahkannya kepada versi LAMA.** Diprediksi tidak akan terjadi dan tetap
+  terjadi: begitu release `v10.0.0` terbit, badge itu meninggalkan `v10.0.4`
+  untuknya. Prediksinya bersandar pada empat backfill kemarin yang tampak tidak
+  memindahkannya — padahal MEMINDAHKAN, dan `v10.0.3`/`v10.0.4` yang terbit satu
+  jam kemudian merebutnya kembali, sehingga bukti yang tampak seperti "backfill
+  itu aman" sebenarnya "dua release berikutnya menutupinya". Dipulihkan dengan
+  `gh release edit v10.0.4 --latest`. **`gh release create` di workflow tidak
+  mengoper flag `--latest` apa pun**, jadi setiap penerbitan di luar urutan akan
+  mengulanginya: konsumen yang membaca badge itu, atau alat apa pun yang
+  mengikuti `/releases/latest`, diarahkan ke versi usang selama tak ada yang
+  memeriksa. Perbaikan sempitnya `--latest=false` pada setiap backfill;
+  perbaikan tahan-lamanya adalah membuat workflow MEMUTUSKAN flag itu, bukan
+  mewarisi default yang mengandaikan rilis selalu bergerak maju.
 
   **Gerbang yang sensitif terhadap toolchain-nya sendiri memblokir semua yang di
   belakangnya.** `build:preview-overlay:check` membandingkan bundle ter-commit

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -408,13 +408,34 @@ pioneered directly here after the ADR-0047 freeze.)
   8.1.0    exit=1  HTTP 404
   ```
 
-  So the containment ADR-0117 bought is holding — `:latest` verifies clean and
-  never moved to an unsigned digest — but three immutable version tags are
+  So the containment ADR-0117 bought was holding — `:latest` verified clean and
+  never moved to an unsigned digest — but three immutable version tags were
   published that this repo's own documented `gh attestation verify` recipe
-  fails against, and those same three are the only tags in the last twenty with
-  **no GitHub Release at all**. The lesson is narrower than the ADR's: an
+  failed against, and those same three were the only tags in the last twenty
+  with **no GitHub Release at all**. The lesson is narrower than the ADR's: an
   approval gate with no expiry does not fail, it ACCUMULATES, and a partial
   cleanup leaves exactly the residue nobody is watching for.
+
+  **Cleared on 28 August, and the clearing found the thing the ADR missed.** All
+  three were approved; each resumed only `sign-attest-publish` (their `build`
+  job had completed days or weeks earlier), so no image was rebuilt and
+  `:latest` did not move — those tags' workflows predate ADR-0117 and have no
+  `promote-latest` job at all. `10.0.0`, `10.0.1` and `8.1.0` now verify, and
+  every published version tag from `v5.1.0` onward is attested.
+
+  **`gh release create` takes the "Latest" badge, and a backfill therefore hands
+  it to an OLD version.** Predicted not to happen and it happened anyway: the
+  moment `v10.0.0`'s release was published the badge left `v10.0.4` for it. The
+  prediction rested on yesterday's four backfills appearing not to have moved
+  it — but they DID, and `v10.0.3`/`v10.0.4` publishing an hour later took it
+  back, so the evidence that looked like "backfills are safe" was really "two
+  later releases masked it". Restored with `gh release edit v10.0.4 --latest`.
+  **The workflow's `gh release create` passes no `--latest` flag**, so any
+  future out-of-order publish does this again: a consumer reading the badge, or
+  any tool that follows `/releases/latest`, is pointed at a superseded version
+  for as long as nobody looks. The narrow fix is `--latest=false` on any
+  backfill; the durable one is for the workflow to decide the flag rather than
+  inherit a default that assumes releases only ever go forward.
 
   **A gate that is sensitive to its own toolchain blocked everything behind it.**
   `build:preview-overlay:check` compares a committed bundle byte-for-byte

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -360,6 +360,104 @@ pioneered directly here after the ADR-0047 freeze.)
 
 ## 4. Backlog / next steps
 
+- **INSPECTION ROUND — 28 August 2026: the tracker was empty, and the repo was
+  still one step behind its own consumer.**
+
+  A full-repo inspection with nothing open: 0 issues, 0 PRs, CI green on `main`,
+  `main` level with `origin/main`. Everything below was measured rather than
+  read — the whole gate suite, `typecheck`, 6,869 tests, the build, the GitHub
+  release state, the container registry, and the consumer repo's own gate.
+
+  **The one gap that mattered was invisible from inside this repo.**
+  `/api/v1/newsletter/subscribe`, `/confirm` and `/unsubscribe` were frozen as
+  COMMITTED on 27 August by ADR-0118 — the change that made them reachable from
+  a browser at all. `ahliweb/awcms-astro`#90 shipped the form the next morning
+  and released it as v0.4.0, so the promise became a dependency and this repo's
+  list still said otherwise. **The neighbour had already answered the question**:
+  its `tests/kontrak-awcms.test.mjs` asserts an exact set of thirteen called
+  surfaces with all three among them, and its failure message names the
+  obligation out loud — tell `awcms`, because that repo composes its consumer
+  contract from this list. Nothing here could have gone red: both lists are
+  frozen into the same fixture, so `CONSUMER_PATHS` was already correct and only
+  the DISTINCTION was wrong. **Done** — all three moved to `CONSUMED_PATHS`,
+  with the write class recorded (see below).
+
+  **The reader-browser class stopped being read-only, and that is the part worth
+  carrying forward.** The ten consumed paths before these were build calls,
+  reads, or a beacon whose whole answer is `202`. A subscription makes this
+  deployment SEND MAIL to an address a stranger typed, so a wrong shape does not
+  blank a page — it sends something, or silently stops sending it, to the person
+  who asked. It is the one breakage on that list a reader would report as a
+  fault of the newsroom rather than of the site. The neutral 200 is frozen for
+  the same reason: a consumer that distinguishes "already subscribed" rebuilds
+  the subscriber oracle the endpoint refuses to be.
+
+  **Three release runs were still parked at the approval gate, and the ADR-0117
+  cleanup had been partial.** That ADR declined to repair the stalled runs it
+  found; four of them (`v8.0.0`, `v9.0.0`, `v9.1.0`, `v9.1.1`) were nonetheless
+  approved on 27 August and got their Releases at 22:05. **Three were missed** —
+  `v8.1.0` (waiting since 11 August), `v10.0.0` and `v10.0.1` — each showing
+  `Build image + SBOM: success` / `Sign, attest, publish: waiting`. Measured
+  against the registry rather than inferred:
+
+  ```
+  latest   exit=0            ← signed, resolves to v10.0.4
+  10.0.4   exit=0
+  10.0.1   exit=1  HTTP 404  ← image published, no attestation
+  10.0.0   exit=1  HTTP 404
+  8.1.0    exit=1  HTTP 404
+  ```
+
+  So the containment ADR-0117 bought is holding — `:latest` verifies clean and
+  never moved to an unsigned digest — but three immutable version tags are
+  published that this repo's own documented `gh attestation verify` recipe
+  fails against, and those same three are the only tags in the last twenty with
+  **no GitHub Release at all**. The lesson is narrower than the ADR's: an
+  approval gate with no expiry does not fail, it ACCUMULATES, and a partial
+  cleanup leaves exactly the residue nobody is watching for.
+
+  **A gate that is sensitive to its own toolchain blocked everything behind it.**
+  `build:preview-overlay:check` compares a committed bundle byte-for-byte
+  against a fresh one, so it fails on any Bun that is not the pinned `1.3.14`
+  (local was `1.4.0`). Two consequences beyond the false red: the single failure
+  in 6,869 tests is `tests/blog-preview-overlay.test.ts`, which shells out to
+  the same gate and asserts `toContain("OK")`; and in the `check` chain the gate
+  sits immediately before `typecheck && … && test && build`, so on any
+  non-pinned Bun it hides every stage that matters. Regenerating the bundle
+  "fixes" it locally and reddens CI. **Not fixed — deliberately left open** as
+  its own decision (raise the CI pin to the `packageManager` field, or compare
+  semantically); the one-line mitigation of moving the gate after `test` is
+  worth doing regardless.
+
+  **The Turnstile set has no gate, and the newsletter is outside it.** Six
+  anonymous surfaces call `enforceTurnstileIfRequired` — setup/initialize,
+  register, login (×2), password/forgot, password/reset, invitations/accept —
+  each with its own action constant so a token cannot be replayed across forms.
+  `POST /api/v1/newsletter/subscribe` writes a row and enqueues mail behind
+  nothing but 5 requests / 300 s per IP. Until ADR-0118 it was unreachable from
+  a browser, so the omission cost nothing; it is reachable now.
+  `TURNSTILE_REQUIRED_WHEN_ENABLED` is an ENV list, not an action registry, so
+  "which endpoints must challenge" is maintained by hand across five files and
+  nothing reads it. **Not fixed, and not a copy-the-login-pattern job**:
+  `TURNSTILE_EXPECTED_HOSTNAME` is a single value and the widget would be solved
+  on the SITE's hostname, not this one — that check exists to fail closed, and
+  cross-origin is the case it was not designed for. A per-address cooldown may
+  be the better answer than a challenge. Needs a decision, so it stays here
+  rather than becoming a patch.
+
+  **What was clean, stated so it is not re-derived.** No tenant-isolation, ABAC,
+  RLS, N+1 or jsonb-binding regression — `access:chokepoint`, `db:tenant-context`
+  and `api:body-limit` all pass across 308 route files, and the build stays
+  inside its asset budget (reader 21.4 kB / 24 kB). The `#743` sidecar fix was
+  applied to its sibling too: `updateBlogPage` carries the same three
+  `content_json` branches as `updateBlogPost`, under a docblock saying plainly
+  that no consumer stores a page sidecar today and that it is changed anyway,
+  because leaving one of two identical functions holding the defect is how it
+  comes back. `site-search/suggest` shares `query`'s CORS through
+  `withPublicSearchTenant` — grepping for the header STRING says otherwise, and
+  that is the same grep-the-definition-not-the-call error this repo keeps
+  re-learning.
+
 - **SCOPE ROUND — 26 August 2026: the premise both open cutover issues stood on
   was withdrawn, and the 301 obligation went with it.**
 

--- a/docs/awcms/agent-memory.md
+++ b/docs/awcms/agent-memory.md
@@ -1019,7 +1019,7 @@ description: "Gerbang approval `release` menggerbangi TANDA TANGAN, bukan PENERB
 metadata: 
   node_type: memory
   type: feedback
-  modified: 2026-08-27T23:07:55.053Z
+  modified: 2026-08-28T03:29:20.978Z
 ---
 
 Dari 2026-08-28 (ADR-0117, PR #746). Dua hal yang mahal kalau diturunkan ulang.
@@ -1072,6 +1072,23 @@ benar, lalu verifikasi lewat `gh api repos/:o/:r/releases/latest --jq .tag_name`
 **Selalu periksa flag Latest sesudah menerbitkan rilis apa pun yang BUKAN yang
 paling baru.** Catatan terkait: memperbaiki workflow di `main` TIDAK memperbaiki
 run tertahan — run yang dipicu push tag mengeksekusi workflow versi TAG-nya.
+
+**2a. KONFIRMASI 2026-08-28, dan cara catatan ini sempat DIABAIKAN.** Tiga run
+sisa (`v8.1.0`, `v10.0.0`, `v10.0.1`) disetujui; badge langsung pindah ke
+`v10.0.0`. Yang penting bukan faktanya — sudah tertulis di atas — melainkan
+alasan ia diprediksi TIDAK terjadi: state saat itu diperiksa
+(`/releases/latest` → `v10.0.4`, padahal empat backfill kemarin terbit pukul
+22:05) lalu disimpulkan "berarti backfill tidak merebut badge". Salah:
+backfill-nya MEREBUT, dan `v10.0.3` (22:36) + `v10.0.4` (23:06) merebutnya
+kembali sejam kemudian. **State AKHIR tak bisa menjawab pertanyaan tentang
+URUTAN — dua peristiwa yang saling menutupi terlihat seperti satu peristiwa yang
+tak pernah terjadi.** Sekelas dengan cacat induknya di §1: sama-sama soal urutan
+yang tak meninggalkan jejak pada artefak mana pun. Kalau memory sudah menyebut
+sebuah jebakan, jangan mencari bukti pembatalnya di state sekarang — jebakannya
+soal transisi. Pulihkan dengan `gh release edit <tag> --latest`.
+
+Yang masih TERBUKA: `gh release create` di `release.yml` tak mengoper flag
+`--latest` apa pun, jadi setiap penerbitan di luar urutan mengulanginya.
 
 **2b. `docker buildx imagetools create` MENGUBAH digest — ia BUKAN retag.**
 Ini menggagalkan `v10.0.3`, rilis pertama yang menjalankan `promote-latest`.

--- a/docs/awcms/agent-memory.md
+++ b/docs/awcms/agent-memory.md
@@ -21,7 +21,7 @@ Memory agent Claude Code disimpan di `~/.claude/projects/<slug-cwd>/memory/` —
 - Repo ini **publik**. Jangan pernah menulis secret/kredensial nyata ke memory — nilai seperti `awcms_password` adalah placeholder yang sama dengan `.env.example` dan memang sudah publik.
 - `MEMORY.md` adalah indeks yang dimuat tiap sesi; file lain dimuat sesuai relevansi.
 
-**Jumlah memory saat snapshot terakhir: 119.**
+**Jumlah memory saat snapshot terakhir: 123.**
 
 ## Sengaja TIDAK disertakan
 
@@ -51,6 +51,9 @@ Konsekuensi yang disengaja: `MEMORY.md` dan beberapa memory lain **tetap** meruj
 - [Standar keamanan/performa = dokumen HIDUP](awcms-standards-anchor-and-second-pass.md) — C19 ledger hanya-mengecil 121→11 (pindahkan JAWABANNYA bukan pekerjaannya); `sql/NNN` baru menyentuh 6 dokumen
 - [Skill DIGERBANGI CI](awcms-skills-now-gated.md) — ADR-0062 `skills:check`; path arsip WAJIB `awcms-mini:src/…`; ekstraktor hanya lihat backtick SATU BARIS
 - [Skill "FIKTIF" bisa salah ARAH](awcms-stale-skill-flips-direction.md) — banner "belum ada" menua sebalik arah dan agen MENGIKUTI skill; wajib §Peta ke artefak nyata
+- [Tautan changeset TAK PUNYA bentuk relatif yang benar](awcms-changeset-links-have-no-correct-relative-form.md) — dua lokasi, dua ejaan, saling meniadakan; sebut nomor ADR saja
+- [Gerbang approval berjalan SESUDAH penerbitan](awcms-approval-gate-ran-after-the-publish.md) — ADR-0117: `:latest` pindah sebelum ada yang mengklik; 4 rilis tak bertanda tangan; backfill MEMBALIK flag "Latest"
+- [Gerbang yang hanya menyala saat RILIS](awcms-gates-that-only-fire-at-release.md) — v10.0.0: `pending.length > 0` + tautan `../docs/…` di changeset; fix WAJIB mendarat di main lebih dulu
 - [Pelajaran desain gate](awcms-gate-design-lessons.md) — gate CAKUPAN hijau sambil jawabannya salah; uji dengan cacat ASLI; `.generated` tanpa generator
 - ["Jalankan, jangan dibaca" — 4 cacat lolos 37 gerbang](awcms-run-it-dont-read-it.md) — migrasi tak-apply, `isBlockedAddress` non-IP, `withTenant` MENGEMBALIKAN Response
 - [Retensi outbox SELESAI — dua registry](awcms-lifecycle-two-registries-and-bounded-list.md) — #468: 5 deskriptor + `BOUNDED_BY_DESIGN`; ADR-0076 registry KEDUA
@@ -108,6 +111,7 @@ Konsekuensi yang disengaja: `MEMORY.md` dan beberapa memory lain **tetap** meruj
 - [Artefak ter-generate DRIFT setelah dua squash-merge](awcms-generated-artifact-merge-drift.md) — regenerasi, jangan tangan
 - [Berkas untracked IKUT `git checkout`](awcms-untracked-file-follows-checkout.md) — `check:docs` cuma lihat berkas ter-track → `git add -A` DULU
 - [Full check sebelum PR](awcms-full-check-before-pr.md) — `bun run check` PENUH; paritas CI = `DATABASE_URL="" bun run test` + `build`
+- [Bun lokal > Bun CI = artefak "STALE" PALSU](awcms-local-bun-newer-than-ci-fakes-stale-artifacts.md) — 1.4.0 vs 1.3.14; JANGAN commit bundle regenerasi, itu justru memerahkan CI
 - [Security readiness gate](awcms-security-readiness-notes.md) — cek harus dibuktikan GAGAL pada kondisi seharusnya; role-check sengaja warning
 - [PR stacked = NOL CI](awcms-stacked-pr-no-ci.md) — workflow hanya trigger `branches: [main]`; GitGuardian tetap `pass` sehingga tampak hijau
 - [False-positive scanner keamanan](awcms-security-scanner-falsepos.md) — GitGuardian scan SEMUA commit PR; ia GitHub App, tak bisa ditutup dari env ini
@@ -153,7 +157,7 @@ Konsekuensi yang disengaja: `MEMORY.md` dan beberapa memory lain **tetap** meruj
 - [Pilot turunan #187 (historis)](awcms-derived-pilot-notes.md) — jalur repo turunan DIHAPUS ADR-0034; katalog `awcms_permissions` global tanpa RLS
 - [Image produksi TIDAK BISA menjalankan job](awcms-prod-image-cannot-run-jobs.md) — runtime hanya `dist/`; 29 job = `Script not found`
 - [Resep gladi migrasi produksi](awcms-migration-rehearsal-on-prod-copy.md) — restore dump ke throwaway (buat ROLE dulu); DUA backfill pasca-rilis
-- [Runbook deploy Coolify](awcms-deploy-runbook-coolify.md) — SATU environment; varnish compose ber-IP HARDCODED; 200 di domain ≠ produksi hidup
+- [Runbook deploy Coolify](awcms-deploy-runbook-coolify.md) — SATU environment; varnish IP HARDCODED; 200 di domain ≠ produksi hidup. KOREKSI 27 Agu: backup terjadwal ADA, image `awcms-jobs` diterbitkan release.yml, peran migrasi = PEMILIK DB bukan `awcms_setup`
 - [`graphify install` MENGHAPUS patch skill lokal](graphify-install-wipes-local-skill-patches.md) — backup lalu re-apply tiap upgrade
 - [Kebijakan artefak graphify-out SUDAH settled](awcms-graphify-out-artefact-policy.md) — rebuild graf bebas changeset; JANGAN kecualikan `.changeset/`
 - [graphify butuh extra yang install polos hilangkan](graphify-svg-export-needs-matplotlib.md) — tanpa `[sql]` file `.sql` nol node; svg butuh matplotlib DAN scipy
@@ -1006,6 +1010,131 @@ metadata:
 Terkait: [[awcms-workflow-concurrency-notes]] (DML pada tabel FORCE RLS: hijau di CI kosong, jebol di produksi berisi) — pola "hijau di CI, jebol di deployment nyata" yang sama. Lihat juga [[awcms-full-check-before-pr]].
 `````
 
+<!-- memory-file: awcms-approval-gate-ran-after-the-publish.md -->
+
+`````markdown
+---
+name: awcms-approval-gate-ran-after-the-publish
+description: "Gerbang approval `release` menggerbangi TANDA TANGAN, bukan PENERBITAN — `:latest` sudah pindah sebelum siapa pun mengklik; plus jebakan \"Latest\" membalik saat mem-backfill rilis lama"
+metadata: 
+  node_type: memory
+  type: feedback
+  modified: 2026-08-27T23:07:55.053Z
+---
+
+Dari 2026-08-28 (ADR-0117, PR #746). Dua hal yang mahal kalau diturunkan ulang.
+
+**1. Gerbang yang berjalan SESUDAH hal yang seharusnya ia gerbangi.**
+`release.yml` menggerbangi job `sign-attest-publish` di belakang environment
+`release` dengan required reviewer. Tetapi job `build` — yang berjalan SEBELUM
+gerbang — memikul `push: true` dengan daftar tag yang memuat `${REPO}:latest`.
+Jadi "belum disetujui" tak pernah berarti "belum diterbitkan"; ia hanya berarti
+"belum ditandatangani". **EMPAT rilis membuktikannya**: `v8.0.0`, `v9.0.0`,
+`v9.1.0`, `v9.1.1` duduk `status: waiting` 13–17 hari sementara `:latest` sudah
+menunjuk image mereka. Diukur, bukan disimpulkan —
+`gh attestation verify oci://ghcr.io/ahliweb/awcms:9.1.1 --owner ahliweb`
+mengembalikan **exit 1 / HTTP 404**, sementara `9.1.2` exit 0.
+
+Yang membuatnya bertahan lama: **rasional tertulisnya bernalar tentang KREDENSIAL
+saja** — "`build` holds no signing/attestation credentials, [so] gating it would
+only add friction with no security benefit". Benar soal kredensial, BISU soal
+fakta bahwa job yang sama juga MENERBITKAN. Pola yang bisa dibawa:
+**saat sebuah dokumen membenarkan "X tak perlu digerbangi", periksa DAFTAR
+LENGKAP efek samping X, bukan hanya kategori yang disebut alasannya.**
+
+Kenapa nol gerbang menangkapnya: cacatnya adalah **URUTAN DUA JOB yang
+masing-masing benar**. Tak ada artefak yang isinya salah, jadi tak ada gerbang
+berbasis sumber yang bisa membacanya — dan seluruh 50+ gerbang repo ini berbasis
+sumber. Satu-satunya jejak tertulis justru MENGUATKAN cacatnya: komentar header
+workflow mendaftar `image :latest moved, GitHub Release published` sebagai satu
+hasil atomik. Sekerabat dengan [[awcms-gates-that-only-fire-at-release]] dan
+[[awcms-gate-design-lessons]], tapi kelasnya beda: bukan gate yang salah baca,
+melainkan **tak ada gate yang BISA membacanya**.
+
+Perbaikannya (ADR-0117): `build` hanya memancarkan `:${VERSION}`/`:sha-<12>`
+(imutabel, inert); job baru `promote-latest` (`needs: [build,
+sign-attest-publish]`) me-retag `:latest` lewat `docker buildx imagetools create`
+terhadap `@${APP_DIGEST}` — digest PERSIS yang diserahkan ke `cosign sign` —
+lalu MEMBACA ULANG `:latest` dan gagal kecuali menunjuk ke sana. Job terpisah,
+bukan langkah di dalam job berprivilese, karena `id-token`/`attestations`
+per-JOB: menambah `docker/setup-buildx-action` ke sana justru membelanjakan
+properti pengurungan yang sedang dipertahankan. Promosi berjalan SETELAH
+`gh release create` — langkah release-notes adalah yang benar-benar pernah gagal
+(`v7.0.0`, body 186.449 karakter).
+
+**2. Mem-backfill rilis lama MEMBALIK flag "Latest" — dan diam-diam.**
+Menyetujui empat run tertahan itu menjalankan `gh release create` milik workflow
+**sebagaimana adanya pada tag masing-masing**, yang tidak memakai `--latest=false`.
+Default REST `make_latest` adalah true, jadi sesudah backfill **`v9.1.1` menjadi
+"Latest"** sementara `v10.0.2` yang sebenarnya terbaru turun ke daftar. Perbaikan:
+`PATCH /repos/:o/:r/releases/:id` dengan `{"make_latest":"true"}` pada rilis yang
+benar, lalu verifikasi lewat `gh api repos/:o/:r/releases/latest --jq .tag_name`.
+**Selalu periksa flag Latest sesudah menerbitkan rilis apa pun yang BUKAN yang
+paling baru.** Catatan terkait: memperbaiki workflow di `main` TIDAK memperbaiki
+run tertahan — run yang dipicu push tag mengeksekusi workflow versi TAG-nya.
+
+**2b. `docker buildx imagetools create` MENGUBAH digest — ia BUKAN retag.**
+Ini menggagalkan `v10.0.3`, rilis pertama yang menjalankan `promote-latest`.
+`imagetools create` SELALU membangun dan mem-push **manifest list BARU** yang
+membungkus sumbernya, jadi `:latest` mendarat di index hasil serialisasi ulang
+(`sha256:5dde705e…`) sementara manifest tertandatangani adalah `sha256:d5423378…`
+— sebuah `application/vnd.oci.image.manifest.v1+json` POLOS yang ia bungkus.
+Layer sama, config sama, **digest beda**. Karena **attestation terikat pada
+DIGEST**, `gh attestation verify oci://…:latest` exit 1 sementara `:10.0.3`
+exit 0 — mekanisme yang dipilih untuk menjamin properti itu justru mematahkannya
+di run pertamanya.
+
+Retag yang menjaga digest itu harfiah — sebuah tag hanyalah NAMA yang dipetakan
+registry ke byte manifest, jadi ambil byte-nya dan taruh di bawah nama lain:
+
+```bash
+token=$(curl -fsSL -u "$USER:$TOKEN" \
+  "https://ghcr.io/token?service=ghcr.io&scope=repository:${path}:pull,push" | jq -r .token)
+ct=$(curl -fsSL -o m.json -D - -H "Authorization: Bearer $token" \
+  -H 'Accept: application/vnd.oci.image.index.v1+json' \
+  -H 'Accept: application/vnd.docker.distribution.manifest.list.v2+json' \
+  -H 'Accept: application/vnd.oci.image.manifest.v1+json' \
+  -H 'Accept: application/vnd.docker.distribution.manifest.v2+json' \
+  "https://ghcr.io/v2/${path}/manifests/${digest}" \
+  | tr -d '\r' | awk 'tolower($1)=="content-type:"{print $2}' | tail -1)
+curl -fsSL -X PUT -H "Authorization: Bearer $token" -H "Content-Type: $ct" \
+  --data-binary @m.json "https://ghcr.io/v2/${path}/manifests/latest"
+```
+
+Hanya `curl` + `jq`. Bisa diuji SEBELUM dikirim, dan WAJIB: ambil manifest-nya
+lalu `sha256sum` — kalau byte-nya mereproduksi digest yang ditandatangani, PUT
+balik pasti mendarat di sana. Untuk membaca digest sebuah tag, pakai header
+`Docker-Content-Digest` dari `curl -I`, bukan alat lokal yang menghitung ulang.
+
+**Pelajaran yang lebih besar: langkah verifikasi yang tampak MUBAZIR adalah yang
+menangkap mekanisme yang Anda pilih keliru.** Asersi "`:latest` benar-benar
+menunjuk digest tertandatangani" nyaris tak ditulis karena terasa jelas; ia
+satu-satunya sebab cacat ini ketahuan di rilis yang melahirkannya, bukan oleh
+konsumen berminggu kemudian. Dan: **run yang dipicu push tag mengeksekusi
+workflow versi TAG-nya**, jadi memperbaiki `main` tidak memperbaiki rilis yang
+sudah terlanjur — `:latest` yang rusak hanya bisa dibetulkan dengan MEMOTONG
+rilis berikutnya.
+
+**3. Dua kegagalan lokal yang BUKAN milik Anda, di repo ini, hari ini.**
+`bun run check` merah dua kali tanpa hubungan dengan perubahan:
+(a) `memory:docs:check` — membandingkan direktori memory di LUAR repo dengan
+`docs/awcms/agent-memory.md`; CI melewatinya karena direktori itu tak ada di
+path CI. (b) `build:preview-overlay:check` + test yang men-`spawnSync`-nya —
+false STALE dari [[awcms-local-bun-newer-than-ci-fakes-stale-artifacts]].
+**Buktikan pre-existing dengan `git worktree add <tmp> main` lalu jalankan
+gerbangnya di sana**, jangan menyimpulkan. Peringatan: worktree ber-path lain
+membuat gerbang yang PATH-SENSITIF (seperti `memory:docs:check`) "PASS" secara
+hampa — itu bukan bukti.
+
+Menambah ADR baru memerahkan DUA artefak ter-generate yang wajib diregenerasi
+(bukan disunting): `bun run repo:inventory:generate` dan
+`bun run project-state:inventory:generate` (baris "ADR" di §2), keduanya diikuti
+`bun run format` lalu `bun run docs:i18n:stamp`.
+
+Terkait: [[awcms-deploy-runbook-coolify]], [[awcms-full-check-before-pr]],
+[[awcms-generated-artifact-merge-drift]], [[awcms-untracked-file-follows-checkout]].
+`````
+
 <!-- memory-file: awcms-astro-bun-runtime.md -->
 
 `````markdown
@@ -1731,6 +1860,40 @@ Terkait: [[awcms-tenant-admin-office-notes]] (composite FK/RLS), [[awcms-integra
 [[awcms-applied-migration-immutable]] (sql/027 masih bisa direfine — belum di deployment nyata).
 `````
 
+<!-- memory-file: awcms-changeset-links-have-no-correct-relative-form.md -->
+
+`````markdown
+---
+name: awcms-changeset-links-have-no-correct-relative-form
+description: "Tautan relatif di `.changeset/*.md` TAK BISA benar di dua tempat: `docs/…` merahkan check:docs, `../docs/…` merahkan CHANGELOG saat rilis — jangan ditautkan"
+metadata: 
+  node_type: memory
+  type: project
+  modified: 2026-08-27T07:54:25.180Z
+---
+
+Berkas changeset hidup di DUA lokasi, dan tautan relatif hanya bisa benar di
+salah satunya:
+
+1. Saat masih `.changeset/nama.md` → `bun run check:docs` menyelesaikan tautan
+   relatif terhadap **`.changeset/`**. Jadi `docs/adr/x.md` = RUSAK.
+2. Setelah `bun run changeset:version` → isinya di-inline ke `CHANGELOG.md` di
+   **AKAR REPO**. Jadi `../docs/adr/x.md` = RUSAK (menunjuk ke luar repo).
+
+**Tidak ada ejaan relatif yang benar di keduanya.** Terbukti dua arah pada
+rilis v10.0.0 (27 Agu 2026): dua changeset memakai `../docs/adr/…`, lolos
+`check:docs` selama berbulan-bulan, lalu memerahkan commit rilis; memperbaikinya
+ke `docs/adr/…` justru memerahkan `check:docs` pada changeset berikutnya.
+
+**Aturan: JANGAN menautkan dokumen repo dari changeset.** Sebut nomornya saja
+(`ADR-0098`) dalam teks biasa. Nomor ADR sudah cukup untuk menemukannya, dan
+gerbang tak punya yang bisa dirusak.
+
+Ini kelas yang sama dengan [[awcms-gates-that-only-fire-at-release]] — cacatnya
+hanya menyala saat berkasnya BERPINDAH tempat, yaitu hanya saat rilis. Belum ada
+gerbang yang memeriksa tautan changeset terhadap KEDUA lokasi; itu masih utang.
+`````
+
 <!-- memory-file: awcms-check-the-sibling-endpoint.md -->
 
 `````markdown
@@ -2185,7 +2348,7 @@ description: "SATU environment (produksi v8.0.0) sejak 11 Agu — app n3gg3qud�
 metadata: 
   node_type: memory
   type: project
-  modified: 2026-08-11T04:26:03.917Z
+  modified: 2026-08-27T08:28:42.783Z
 ---
 
 > **STATE 11 Agustus 2026 (setelah standup) — SATU environment, produksi saja.**
@@ -2228,6 +2391,39 @@ metadata:
 > (`${GITHUB_REF_NAME#v}`). Job `sign-attest-publish` butuh approval maintainer
 > di environment `release`; job `build` menerbitkan image SEBELUM gerbang itu,
 > jadi deploy tak perlu menunggu approval.
+
+> **KOREKSI 27 Agustus 2026 (deploy v10.0.0 → v10.0.1). Empat hal di bawah
+> sudah TIDAK BERLAKU atau berubah:**
+>
+> 1. **Backup terjadwal SUDAH ADA.** `/home/admin1/awcms-jobs/backup-awcms.sh`
+>    (cron 17:30 UTC) + `restore-drill-awcms.sh`. Ia memverifikasi tiap dump
+>    dengan `pg_restore -l` DAN membandingkan jumlah objek. Jalankan tangan
+>    sebelum migrasi: exit 0 = sah. Kalimat "nol backup terjadwal" di bawah
+>    sudah kedaluwarsa.
+> 2. **Image job kini DITERBITKAN `release.yml`** — `ghcr.io/ahliweb/awcms-jobs:<versi>`
+>    dari commit yang SAMA dengan image app, publik. `ops/run-job.sh` ada di REPO
+>    dan meresolusi: `$AWCMS_JOBS_IMAGE` → `ghcr.io/…:$AWCMS_JOBS_TAG` (default
+>    `latest`) → build lokal. Utang "snapshot sumber menua" LUNAS — tapi salinan
+>    di HOST bisa tetap basi: verifikasi sha256 tiap berkas `ops/*` vs
+>    `git show origin/main:ops/<f>` SETIAP rilis.
+> 3. **`run-job.sh` baru MENOLAK jalan tanpa `ops/awcms-jobs.env-allowlist`**
+>    (176 nama, ter-generate). Versi lama menyaring env dengan PREFIX dan
+>    menjatuhkan 81 dari 171 variabel — job jalan, mengambil default kode,
+>    melapor sukses. Kirim allow-list DULU baru runner-nya.
+>    Ia juga meng-`mkdir` `/var/lib/awcms-jobs` yang **butuh root**; `admin1`
+>    tak punya sudo tanpa password. Buat sekali:
+>    `docker run --rm -v /var/lib:/hostlib alpine:3 sh -c "mkdir -p /hostlib/awcms-jobs && chown 1000:1000 /hostlib/awcms-jobs"`.
+>    Tanpa ini KE-62 baris cron mati.
+> 4. **Peran migrasi BUKAN `awcms_setup`** (itu peran sempit khusus
+>    `POST /api/v1/setup/initialize`; ia memberi `permission denied for schema
+>    public`). Yang benar PEMILIK database = `POSTGRES_USER` container DB
+>    (`awcms_staging`). Password WAJIB di-URL-encode (`jq -sRr @uri`):
+>    `docker run --rm --network coolify -e DATABASE_URL="postgres://$U:$P@my85c1xd4txesedhic72maeu:5432/awcms" ghcr.io/ahliweb/awcms-jobs:<versi> bun run db:migrate`
+>
+> Verifikasi pasca-deploy yang benar-benar menangkap sesuatu: `synthetic-check.sh`
+> (ia menemukan blog 404 total yang lolos 10 check CI). IP `extra_hosts` Varnish
+> tetap wajib dicek tiap redeploy — 27 Agu kebetulan sama (`10.0.1.61`), bukan
+> jaminan.
 
 Dua fakta yang **tidak tercatat di repo** dan baru terlihat saat deploy nyata 5 Agustus 2026 (v7.0.0 ke staging + produksi):
 
@@ -3272,6 +3468,56 @@ Terkait: [[awcms-check-the-sibling-endpoint]],
 [[awcms-stale-skill-flips-direction]].
 `````
 
+<!-- memory-file: awcms-gates-that-only-fire-at-release.md -->
+
+`````markdown
+---
+name: awcms-gates-that-only-fire-at-release
+description: "v10.0.0: DUA pemblokir yang mustahil terlihat sebelum commit rilis — guard non-vacuity `pending.length > 0` dan tautan `../docs/…` di changeset"
+metadata: 
+  node_type: memory
+  type: project
+  modified: 2026-08-27T02:17:46.306Z
+---
+
+Rilis v10.0.0 (27 Agu 2026) diblokir dua kali oleh gerbang yang **hijau di
+setiap commit kecuali commit rilis itu sendiri**. Keduanya lolos berbulan-bulan
+karena tak ada rilis yang menanyainya.
+
+**1. Guard non-vacuity membunuh commit rilis.**
+`tests/version-check.test.ts` meng-assert `pending.length > 0` pada repo HIDUP.
+Benar selalu — kecuali pada commit yang mengonsumsi seluruh `.changeset/`, yaitu
+keadaan yang justru menjadi pusat seluruh model versi. Test itu mendarat SETELAH
+v9.1.2, jadi v10.0.0 adalah kali pertama ia ditanya.
+
+Yang membuatnya jadi deadlock, bukan sekadar bug: `changesets:policy:check`
+punya carve-out release-consumption yang menuntut commit rilis menyentuh
+`package.json` DAN TIDAK ADA LAIN. Jadi memperbaiki test DI DALAM commit rilis
+merusak gerbang policy; membiarkannya merusak suite. **Perbaikannya wajib
+mendarat di `main` LEBIH DULU** (PR #736), baru branch rilis dibangun ulang di
+atasnya. Non-vacuity dipindah ke PEMBACA dengan direktori tertanam.
+
+**2. Changeset menulis `../docs/adr/…`.**
+Benar relatif terhadap `.changeset/`, RUSAK begitu `changeset version`
+menyatukannya ke `CHANGELOG.md` di AKAR repo — `../docs/` menunjuk ke luar repo.
+`check:docs` menangkap 2 temuan; obatnya buang `../`. **Tulis tautan changeset
+relatif terhadap AKAR repo (`docs/adr/…`), bukan terhadap `.changeset/`.**
+Belum ada gerbang yang memeriksa ini saat changeset DIBUAT — masih utang.
+
+**3. `docs/PROJECT_STATE.md` §2 memuat nomor versi** di kedua salinan bahasa,
+jadi ia PASTI basi setelah bump. `bun run project-state:inventory:generate` lalu
+`bun run format` — jangan tangan ([[awcms-project-state-doc]]).
+
+Urutan yang terbukti benar untuk rilis berikutnya:
+`fix pemblokir → merge ke main → bangun ULANG branch rilis dari origin/main →
+cherry-pick fix config → changeset:version → perbaiki tautan + regenerate §2 →
+amend → release:verify + version:check + changesets:policy:check`.
+
+Terkait: [[awcms-gate-design-lessons]], [[awcms-gate-reads-one-of-a-pair]],
+[[awcms-run-it-dont-read-it]] — kelas yang sama: gerbang yang tak pernah
+ditanyai pada kondisi yang seharusnya ia jaga.
+`````
+
 <!-- memory-file: awcms-gelombang-2-session-surface-complete.md -->
 
 `````markdown
@@ -3822,6 +4068,49 @@ Yang menahan registry kedua jadi tempat parkir bukan aturan tertulis: `data-life
 Deskripsi **operasi** OpenAPI tak bisa diubah (snapshot pra-migrasi beku, byte-identical); deskripsi **TAG** tidak dibekukan dan ter-render ke `awcms/api-reference.md` — itu lever yang tersedia.
 
 Lihat [[awcms-outbox-retention-two-blockers]] (superseded), [[awcms-gate-design-lessons]].
+`````
+
+<!-- memory-file: awcms-local-bun-newer-than-ci-fakes-stale-artifacts.md -->
+
+`````markdown
+---
+name: awcms-local-bun-newer-than-ci-fakes-stale-artifacts
+description: "Bun lokal 1.4.0 vs CI 1.3.14 membuat gerbang artefak ter-bundle MERAH PALSU; JANGAN regenerasi — commit-nya akan memerahkan CI"
+metadata: 
+  node_type: memory
+  type: project
+  modified: 2026-08-27T02:11:28.445Z
+---
+
+`bun run check` lokal bisa GAGAL di gerbang yang membandingkan bundle ter-commit
+dengan hasil bundle segar, padahal repo BENAR:
+
+- `build:preview-overlay:check` → "public/js/blog-preview-overlay.js is STALE"
+- `tests/preview-overlay-bundle.test.ts` → "the committed bundle > matches its
+  TypeScript source"
+
+**Sebabnya versi Bun, bukan kode.** `package.json` `packageManager: bun@1.3.14`
+dan `.github/workflows/ci.yml` memasang `bun-version: "1.3.14"` di SEMUA job.
+Bun lokal di mesin ini 1.4.0. Minifier Bun mengganti skema penamaan variabel
+antar versi, jadi keluarannya beda byte sambil identik secara semantik
+(`var x={strong:…}` vs `var Q={strong:…}` — hanya nama).
+
+**Cara membedakan palsu dari nyata — dua bukti, bukan tebakan:**
+1. `gh run list --branch main --limit 3` hijau pada commit yang memuat bundle
+   yang SAMA (CI menjalankan `bun run check` di ci.yml baris 83).
+2. `diff` bundle ter-commit vs hasil `bun run build:preview-overlay` hanya
+   berisi perbedaan nama identifier satu-huruf.
+
+**JANGAN `git add` bundle hasil regenerasi lokal.** Ia dibangun 1.4.0; CI
+membangun ulang dengan 1.3.14 dan akan melihatnya STALE — memerahkan CI justru
+karena "memperbaiki" merah palsu. Kembalikan dengan
+`git checkout -- public/js/blog-preview-overlay.js`.
+
+Perbaikan benar bila ingin run lokal setia: pasang Bun 1.3.14. Selain itu,
+percayakan gerbang bundle ke CI dan jalankan sisa rantainya lokal.
+
+Terkait: [[awcms-generated-artifact-merge-drift]] (di sana regenerasi MEMANG
+jawabannya — bedanya di sana sumbernya yang bergerak, di sini toolchain-nya).
 `````
 
 <!-- memory-file: awcms-local-dev-bootstrap.md -->
@@ -5768,7 +6057,7 @@ description: "Working tree bersama memindahkan HEAD — `git branch --show-curre
 metadata: 
   node_type: memory
   type: feedback
-  modified: 2026-08-08T04:47:13.952Z
+  modified: 2026-08-27T08:28:20.779Z
 ---
 
 Subagent (awcms-coder dll.) bekerja di **working tree yang SAMA** dengan orchestrator. Meski di-instruksikan "jangan git ops", agent bisa menjalankan `git checkout main`/`git switch` untuk inspeksi (mis. diff terhadap main) dan **memindahkan HEAD**. Terjadi di PR #189 (#184 MFA): setelah `git switch -c feature/184-...`, HEAD balik ke `main` sebelum commit pertama → 3 commit MFA mendarat di `main` lokal, bukan branch fitur. `gh pr create` gagal "No commits between main and feature".
@@ -5796,6 +6085,35 @@ Yang benar-benar menangkapnya:
   bukan gerbang. Di sesi yang sama, agen verifikasi malah MELAKSANAKAN ADR-0071
   (menghapus rute, men-stage penghapusan) di `main`. Pakai `isolation: "worktree"`,
   atau lakukan penulisan sendiri dan `git status` tiap selesai fase.
+
+**TAMBAHAN 2026-08-27 — bukan cuma subagent: SESI LAIN yang berjalan bersamaan.**
+Saat rilis v10.0.0/v10.0.1 ada sesi kedua bekerja di working tree yang sama
+(`fix/amplop-sidecar-dipertahankan`). Reflog memperlihatkan kami bergantian
+memindahkan HEAD dalam hitungan detik. Dua kerusakan BARU, di luar yang di atas:
+
+1. **`git add -A` menyapu berkas sesi lain** ke commit saya — PR #742 lahir
+   dengan 4 berkas padahal punya saya 2. Sinyalnya persis seperti dicatat di
+   atas: `gh pr view <n> --json files` menunjukkan jumlah yang tak terduga.
+   **Periksa itu SEBELUM merge, tiap PR** — dua PR saya yang lain (#740/#741,
+   salah satunya rilis yang sudah ditag) ternyata bersih, tapi itu keberuntungan.
+2. **`git reset --hard origin/main` di tree bersama MEMBUANG perubahan
+   belum-ter-commit milik sesi lain.** Tak ada peringatan, tak ada cara
+   memulihkan. Ini yang paling berbahaya dan saya melakukannya beberapa kali.
+
+**Perbaikan yang tidak mengganggu mereka** (dipakai untuk membersihkan #742):
+```
+git worktree add --detach /tmp/wt origin/main
+git -C /tmp/wt checkout origin/<branch-saya> -- <path> <path>   # ambil HANYA milik sendiri
+git -C /tmp/wt commit && git -C /tmp/wt push --force-with-lease origin HEAD:<branch-saya>
+git worktree remove --force /tmp/wt
+```
+Pakai `git -C <wt>`, JANGAN `cd` ([[bash-cwd-persists-cross-repo-audit-hazard]]).
+`gh pr merge` murni remote — ia tak pernah menyentuh working tree, jadi aman.
+
+**Aturannya: begitu ada tanda sesi lain hidup di repo ini, pindah ke worktree
+sendiri untuk SELURUH sisa pekerjaan.** Tandanya murah dicek: `git branch
+--show-current` mengembalikan nama yang tak Anda buat, atau `git log -1` memuat
+pekerjaan yang bukan milik Anda.
 
 **How to apply:**
 - SEBELUM setiap `git commit`, jalankan `git branch --show-current` dan pastikan = branch fitur yang diniatkan.

--- a/scripts/api-consumer-contract.ts
+++ b/scripts/api-consumer-contract.ts
@@ -54,22 +54,32 @@ const FIXTURE_PATH =
  * ## "Calls" stopped meaning "the build calls" on 23 August 2026
  *
  * Seven of these are called by `astro build` over there, from a machine holding
- * a read-only credential. THREE are called by the READER's BROWSER, anonymously
- * and cross-origin — the two `site-search` entries and the analytics beacon —
- * and that difference is invisible from this side, because the gate over there
- * extracts string literals from `src/` without knowing who executes them.
+ * a read-only credential. SIX are called by the READER's BROWSER, anonymously
+ * and cross-origin — the two `site-search` entries, the analytics beacon, and
+ * the three `newsletter` paths — and that difference is invisible from this
+ * side, because the gate over there extracts string literals from `src/`
+ * without knowing who executes them.
  *
- * The three do not even share one rule. The two search paths must carry NO
- * custom header, because nothing answers a preflight for them. The beacon MUST
- * carry `content-type: application/json`, because `checkOrigin` refuses the
- * alternatives — and its `OPTIONS` handler exists for the preflight that
- * follows. Making them consistent, in either direction, kills one of them in a
- * reader's browser.
+ * The six do not even share one rule. The two search paths must carry NO custom
+ * header, because nothing answers a preflight for them. The beacon and the
+ * three newsletter paths MUST carry `content-type: application/json`, because
+ * `checkOrigin` refuses the alternatives — and each has an `OPTIONS` handler
+ * precisely for the preflight that follows. Making them consistent, in either
+ * direction, kills one of them in a reader's browser.
+ *
+ * ## Since 28 August 2026 one of them WRITES
+ *
+ * Every reader-browser path before the newsletter was a read, or a beacon whose
+ * whole answer is `202`. A subscription makes this deployment SEND MAIL to an
+ * address a stranger typed, so a wrong shape here does not merely blank a page
+ * — it sends something, or silently stops sending it, to the person who asked.
+ * That is the one class of breakage on this list a reader would report as a
+ * fault of the newsroom rather than of the site.
  *
  * It is written here because it changes what breaking one costs. A shape change
  * on a build-called path reddens a build somebody is watching. A shape change on
- * these two fails silently in a stranger's browser, on a site that was published
- * weeks ago and will not be rebuilt because of it.
+ * the other six fails silently in a stranger's browser, on a site that was
+ * published weeks ago and will not be rebuilt because of it.
  *
  * The neighbour repo is the authority for this list, and it has a gate for it:
  * `tests/kontrak-awcms.test.mjs` there asserts an exact set of surfaces,
@@ -126,7 +136,13 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
   "/api/v1/site-search/suggest":
     "the typeahead behind the same box, same origin rule, same anonymity (ADR-0107). Consumed through a `<datalist>` there, debounced client-side; this repo still enforces its own `min_query_length` and per-IP limit, because a consumer's debounce is a courtesy and not a control.",
   "/api/v1/analytics/collect":
-    "one page view, posted from the READER's browser (#597 item 9; `awcms-astro` ADR-0044 decided WHETHER, and its `src/lib/beacon.ts` is the caller). Third of the reader-browser class and the only one that must carry a HEADER: `security.checkOrigin` refuses a cross-origin POST whose content type is form-like, so only `application/json` gets through — which is what the `OPTIONS` handler added in #637 exists for, and why `navigator.sendBeacon` cannot be used there. The consumer calls it WITHOUT credentials by decision, so the `awcms_visitor_key` cookie this endpoint sets is discarded by the browser and every view arrives as a first visit; nothing here should be changed on the assumption that a repeat visitor is recognisable. Frozen: the request body (`tenantCode`, `path`, optional `referrer`), its bounds, and the always-`202` answer."
+    "one page view, posted from the READER's browser (#597 item 9; `awcms-astro` ADR-0044 decided WHETHER, and its `src/lib/beacon.ts` is the caller). Third of the reader-browser class and the FIRST that must carry a HEADER: `security.checkOrigin` refuses a cross-origin POST whose content type is form-like, so only `application/json` gets through — which is what the `OPTIONS` handler added in #637 exists for, and why `navigator.sendBeacon` cannot be used there. The consumer calls it WITHOUT credentials by decision, so the `awcms_visitor_key` cookie this endpoint sets is discarded by the browser and every view arrives as a first visit; nothing here should be changed on the assumption that a repeat visitor is recognisable. Frozen: the request body (`tenantCode`, `path`, optional `referrer`), its bounds, and the always-`202` answer.",
+  "/api/v1/newsletter/subscribe":
+    "a reader subscribes from the site's own page, in their own browser, cross-origin and anonymously (ADR-0103 built it, ADR-0118 made it reachable). `src/lib/newsletter.ts` and `src/components/FormBuletin.astro` there. FOURTH of the reader-browser class and the FIRST THAT WRITES: it sends mail on this deployment's behalf, which is why its CORS grant is narrower than the beacon's (no credentials) and why its tenant comes from an `Origin` verified against `awcms_tenant_domains` rather than from the host chain — the host of such a request is this CMS, and the default-tenant fallback would have put a stranger's address in somebody else's list. Frozen: the request body (`email`, optional `locale`), the ALWAYS-neutral 200 body, and the 400 that speaks about the request rather than about any address. The neutral answer is a CONTRACT, not a courtesy: a consumer that distinguishes 'already subscribed' rebuilds the oracle this endpoint refuses to be. Promised as COMMITTED in #748 and moved here when `ahliweb/awcms-astro`#90 shipped the form in its v0.4.0.",
+  "/api/v1/newsletter/confirm":
+    "the POST behind the link in the confirmation email, made by the page the SITE serves at `/newsletter/confirm` (ADR-0070: the family's reader pages are not in this repo; `src/components/views/HalamanTokenBuletin.astro` is that page). This is where `consent_at` is written, so it is the endpoint double opt-in actually depends on — and the reason the link is built on the GRANTED origin rather than on this one, where no such page exists. Frozen: the `{ token }` body and the neutral 200.",
+  "/api/v1/newsletter/unsubscribe":
+    "the same shape from the same kind of page, and PRD §30 makes it the one that must never require proving who you are. Sharing `HalamanTokenBuletin.astro` with `/confirm` there is deliberate — two pages that differ only in which endpoint they POST to. Frozen: the `{ token }` body and the neutral 200."
 };
 
 /**
@@ -144,12 +160,6 @@ export const CONSUMED_PATHS: Readonly<Record<string, string>> = {
  * acquire the authority of a contract.
  */
 export const COMMITTED_PATHS: Readonly<Record<string, string>> = {
-  "/api/v1/newsletter/subscribe":
-    "ADR-0118 — a reader subscribes from the site's own page, in their own browser, cross-origin and anonymously. FOURTH of the reader-browser class, and the first that WRITES: it sends mail on this deployment's behalf, which is why its CORS grant is narrower than the beacon's (no credentials) and why its tenant comes from an `Origin` verified against `awcms_tenant_domains` rather than from the host chain — the host of such a request is this CMS, and the default-tenant fallback would have put a stranger's address in somebody else's list. Frozen: the request body (`email`, optional `locale`), the ALWAYS-neutral 200 body, and the 400 that speaks about the request rather than about any address. `awcms-astro`#79 wrote the caller and held it behind a flag until this entry existed.",
-  "/api/v1/newsletter/confirm":
-    "ADR-0118 — the POST behind the link in the confirmation email, made by the page the SITE serves at `/newsletter/confirm` (ADR-0070: the family's reader pages are not in this repo). This is where `consent_at` is written, so it is the endpoint double opt-in actually depends on. Frozen: the `{ token }` body and the neutral 200.",
-  "/api/v1/newsletter/unsubscribe":
-    "ADR-0118 — the same shape from the same kind of page, and PRD §30 makes it the one that must never require proving who you are. Frozen: the `{ token }` body and the neutral 200.",
   "/api/v1/auth/session":
     "ADR-0049 — session introspection for the BFF of ADR-0050. The static build must NOT call it (it refuses machine credentials by design); the BFF that will is not built yet.",
   "/api/v1/access/machine-credentials":

--- a/tests/api-consumer-contract.test.ts
+++ b/tests/api-consumer-contract.test.ts
@@ -186,7 +186,7 @@ describe("the live contract", () => {
  * a fourth consumed surface here has to be a deliberate edit in both places.
  */
 describe("consumed vs committed", () => {
-  test("exactly ten surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
+  test("exactly thirteen surfaces are CONSUMED — the same number the neighbour's gate asserts", () => {
     // If this fails, one of two things happened, and they need opposite fixes:
     //   - awcms-astro started (or stopped) calling a surface -> update both
     //     this list and the marker block in that repo, in the same change;
@@ -224,11 +224,25 @@ describe("consumed vs committed", () => {
     // on account of it.
     //
     // The tenth, `/analytics/collect`, is in that same reader-browser class and
-    // breaks its rule again: it is the only consumed path that must carry a
+    // breaks its rule again: it is the first consumed path that must carry a
     // HEADER. `security.checkOrigin` refuses a cross-origin POST whose content
     // type is form-like, so only `application/json` gets through — which is what
     // the `OPTIONS` handler from #637 exists for. Three reader-browser paths,
     // two opposite header rules, and no way to tell them apart from this side.
+    //
+    // The eleventh to thirteenth — the three `newsletter` paths — are the same
+    // class again and break the rule that had held for all ten: they WRITE. A
+    // subscription makes this deployment send mail to an address a stranger
+    // typed, so a wrong shape does not blank a page, it sends something (or
+    // silently stops sending it) to the person who asked.
+    //
+    // They also arrived by the intended route at its shortest: frozen as
+    // COMMITTED in #748 on 27 August with ADR-0118, moved here on 28 August when
+    // `ahliweb/awcms-astro`#90 shipped the form in its v0.4.0 — one day in the
+    // promise block. That is the split working, not a formality skipped: the
+    // caller was written FIRST and held behind a flag precisely because four
+    // measured blockers in this repo made the endpoint unreachable, and it could
+    // not be un-held until they were closed here.
     expect(Object.keys(CONSUMED_PATHS)).toEqual([
       "/api/v1/blog/posts",
       "/api/v1/media/objects",
@@ -239,7 +253,10 @@ describe("consumed vs committed", () => {
       "/api/v1/blog/widgets",
       "/api/v1/site-search/query",
       "/api/v1/site-search/suggest",
-      "/api/v1/analytics/collect"
+      "/api/v1/analytics/collect",
+      "/api/v1/newsletter/subscribe",
+      "/api/v1/newsletter/confirm",
+      "/api/v1/newsletter/unsubscribe"
     ]);
   });
 


### PR DESCRIPTION
`/api/v1/newsletter/subscribe`, `/confirm` and `/unsubscribe` were frozen as COMMITTED on 27 August by the change that made them reachable at all (#748, ADR-0118) — a shape this repo agreed to keep for a consumer that could not yet call it. `ahliweb/awcms-astro`#90 shipped the form the next morning and released it as **v0.4.0**, so all three move to `CONSUMED_PATHS`.

That is the direction the cross-repo Definition of Done requires — freeze here first, call there second — and the split is only worth having if entries actually move.

## The neighbour had already answered

Its `tests/kontrak-awcms.test.mjs` asserts an exact set of **thirteen** called surfaces with the three newsletter paths among them, and its failure message names the obligation out loud: tell `awcms`, because that repo composes its consumer contract from this list. This repo still said ten.

**Nothing here could have gone red, and that is the point worth recording.** Both lists are frozen into the same fixture, so `CONSUMER_PATHS` was already correct and only the DISTINCTION was wrong. A promise and a dependency fail differently — breaking a committed path breaks a design that has been agreed, breaking a consumed one breaks something that exists — and no gate can see the difference between them.

## One of these WRITES, and none of the ten before it did

Every reader-browser path so far was a read, or a beacon whose entire answer is `202`. A subscription makes this deployment send mail to an address a stranger typed, so a wrong shape does not blank a page — it sends something, or silently stops sending it, to the person who asked. It is the one breakage on that list a reader would report as a fault of the newsroom rather than of the site.

Written into the docblock and the gate's own comment rather than left to be inferred from three paths that look like every other `POST`.

Also recorded:

- **The neutral 200 is part of the frozen shape, not a courtesy.** A consumer that distinguishes "already subscribed" rebuilds the subscriber oracle the endpoint refuses to be.
- **The reader-browser class now splits six ways on header rules, not three.** The two search paths must carry NO custom header, because nothing answers a preflight for them; the beacon and these three MUST send `application/json`, because `checkOrigin` refuses the alternatives. Making them consistent in either direction kills one of them in a reader's browser.

## Verification

- `api:consumer-contract:check` — OK, **15 paths either way**; the frozen fixture is byte-identical, so this is a pure re-classification with no behaviour change.
- Full gate suite, `typecheck`, `check:astro-scripts`, `check:astro-frontmatter`, `build` + asset budget — all pass.
- `bun test` — 5962 pass / 906 skip / 1 fail, and that one failure is `build:preview-overlay:check` reached through `tests/blog-preview-overlay.test.ts`: a byte-comparison against a bundle built by the pinned Bun `1.3.14` while this machine runs `1.4.0`. It fails identically on `main` at this commit, and regenerating the bundle would redden CI. Called out below rather than papered over.

## The release backlog this branch documents — now CLEARED

`PROJECT_STATE` §4 records the inspection round this came out of. The three stalled release runs it found (`v8.1.0` since 11 August, `v10.0.0`, `v10.0.1`) **have been approved and are done**: each resumed only `sign-attest-publish`, so no image was rebuilt and `:latest` never moved — those tags' workflows predate ADR-0117 and have no `promote-latest` job. Every published version tag from `v5.1.0` onward now passes `gh attestation verify`.

**Clearing them exposed a defect ADR-0117 did not cover, and it is recorded rather than patched here.** `gh release create` TAKES the "Latest" badge, so a backfill hands it to an old version — publishing `v10.0.0`'s release moved the badge off `v10.0.4`. This was predicted *not* to happen, on the evidence that the previous day's four backfills appeared not to have moved it; they did, and `v10.0.3`/`v10.0.4` publishing an hour later took it back, so what looked like "backfills are safe" was "two later releases masked it". Restored with `gh release edit v10.0.4 --latest`.

The workflow passes no `--latest` flag, so any future out-of-order publish repeats it and anything following `/releases/latest` points at a superseded version. Not fixed on this branch — that is release-workflow ADR territory, and this branch is a contract re-classification.

## Still open, deliberately

1. **`build:preview-overlay:check` is sensitive to its own toolchain** and sits immediately before `typecheck && … && test && build`, so on any non-pinned Bun it hides every stage that matters — and fails a test that shells out to it.
2. **The newsletter sits outside the Turnstile set**, and `TURNSTILE_REQUIRED_WHEN_ENABLED` is an ENV list rather than an action registry, so nothing gates that set. Not a copy-the-login-pattern job: `TURNSTILE_EXPECTED_HOSTNAME` is single-valued and the widget would be solved on the SITE's hostname.

The second commit refreshes `docs/awcms/agent-memory.md`, which `memory:docs:check` had flagged as 123 files stale. That gate skips on CI and only fires on a machine that has a memory directory — so a green CI says nothing about it, and it blocks the local `check` run four gates in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
