### PR TITLE
fix(gate): `build:preview-overlay:check` said STALE when it meant "different Bun"

### DIFF
--- a/.changeset/preview-overlay-gate-states-its-precondition.md
+++ b/.changeset/preview-overlay-gate-states-its-precondition.md
@@ -1,0 +1,58 @@
+---
+"awcms": patch
+---
+
+fix(gate): `build:preview-overlay:check` said STALE when it meant "different Bun"
+
+The gate rebuilds `public/js/blog-preview-overlay.js` in memory and compares
+bytes. A minified bundle is the output of a specific bundler, so those bytes
+change when the bundler does — which means the comparison was asking two
+questions and reporting only one answer: "was the artefact rebuilt after its
+source changed", and "is this machine running the same Bun that produced it".
+
+On a developer machine one minor ahead of the `1.3.14` pin it answered
+`is STALE` — a claim about the artefact — when the artefact was correct and the
+toolchain differed.
+
+## Why that was worse than a false red
+
+- **It failed the test suite too.** `tests/blog-preview-overlay.test.ts` shells
+  out to the gate, so the single failure in a 6,869-test run was this, on a tree
+  with nothing wrong with it.
+- **It hid every stage behind it.** In the `check` chain the gate sits
+  immediately before `typecheck && … && test && build`, and `&&` stops there —
+  so off the pin, `bun run check` never reached the stages that matter.
+- **Its remedy made things worse.** The message names
+  `bun run build:preview-overlay`, and running that off the pin writes a bundle
+  CI rejects. The gate handed out the instruction that breaks the thing it
+  guards, and the resulting commit reddens CI for everyone.
+
+## What changed
+
+The Bun version is now a stated **precondition** instead of a hidden
+assumption, read from `packageManager` so the pin is not written down twice.
+`family:conformance:check` already asserts CI's `bun-version:` set equals
+{`packageManager` pin, `engines` floor}, so that reading cannot drift from the
+version CI installs.
+
+- **On the pin** — unchanged, full strength: a byte difference is `STALE` and
+  exits 1. This is what CI runs, in every job.
+- **Off the pin** — a difference is reported as `UNVERIFIED` and exits 0, saying
+  which Bun is running, which is pinned, and that rebuilding here is not the
+  fix.
+- **`build:preview-overlay` now REFUSES to write off the pin**, rather than
+  warning: a warning above a successful write reads as success, and by then the
+  wrong bytes are already staged. `--allow-version-mismatch` exists for the one
+  legitimate case — deliberately moving the pin, where the new Bun *is* the
+  correct builder.
+- Two outcomes stay version-independent and still fail anywhere: a **missing**
+  artefact, and a **match** (a match is a match, whoever built it).
+
+## Proven in both directions, not just asserted
+
+The strict branch was exercised by pointing the pin at the running Bun and then
+introducing a genuine source change: the gate fails, and passes again once the
+bundle is rebuilt. The test carries the same precondition rather than accepting
+any output — off the pin it asserts the half that was broken (must not claim
+staleness, must not exit non-zero); on the pin, which is CI, it demands `OK`
+exactly as before.

--- a/docs/PROJECT_STATE.id.md
+++ b/docs/PROJECT_STATE.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](PROJECT_STATE.md)
 
-<!-- i18n-source-hash: sha256:55bccac23102633d233e7701be99c788ab3b73f4012438ad116789d4bfc96129 -->
+<!-- i18n-source-hash: sha256:b38f5881e8a27b4ec21023e34f0385e5fa0245623eaa17db8998edf8a03050f5 -->
 
 # AWCMS — Project State & Continuation
 
@@ -451,11 +451,31 @@ dirintis langsung di sini setelah pembekuan ADR-0047.)
   memanggil gerbang yang sama lalu meng-assert `toContain("OK")`; dan di rantai
   `check` gerbang itu duduk persis sebelum `typecheck && … && test && build`,
   sehingga pada Bun tak-terpatok ia MENYEMBUNYIKAN setiap tahap yang penting.
-  Meregenerasi bundle "memperbaikinya" secara lokal dan memerahkan CI. **Tidak
-  diperbaiki — sengaja dibiarkan terbuka** sebagai keputusan tersendiri (naikkan
-  patokan CI ke field `packageManager`, atau bandingkan secara semantik);
-  mitigasi satu baris berupa memindahkan gerbang ke setelah `test` tetap layak
-  dikerjakan.
+  Meregenerasi bundle "memperbaikinya" secara lokal dan memerahkan CI — gerbang
+  itu membagikan instruksi yang justru merusak hal yang dijaganya.
+
+  **Diperbaiki 28 Agustus dengan menjadikan versi sebagai PRASYARAT yang
+  dinyatakan, bukan asumsi tersembunyi.** Patokannya dibaca dari
+  `packageManager` (tidak ditulis kedua kalinya), dan `family:conformance:check`
+  sudah menegaskan himpunan `bun-version:` di CI sama dengan {patokan itu, lantai
+  `engines`}, jadi pembacaannya tak bisa hanyut dari Bun yang benar-benar
+  dipasang CI. Pada patokannya gerbang ini TIDAK berubah dan berkekuatan penuh —
+  beda bita berarti `STALE`, exit 1, dan itulah yang dijalankan setiap job CI.
+  Di luar patokan ia melaporkan `UNVERIFIED` dan exit 0. Perintah `build:` kini
+  MENOLAK menulis di luar patokan alih-alih memperingatkan, sebab peringatan di
+  atas penulisan yang sukses dibaca sebagai sukses dan bita yang salah sudah
+  ter-stage saat itu; `--allow-version-mismatch` menutup satu kasus sah, yaitu
+  memindahkan patokannya sendiri. Artefak yang HILANG dan yang COCOK tetap
+  tak-bergantung-versi.
+
+  **Pelajaran umumnya tentang apa yang boleh DIKLAIM sebuah diagnostik.** Bitanya
+  memang berbeda, jadi gerbang itu tidak keliru soal pengamatannya — ia keliru
+  soal apa yang dibuktikan pengamatan itu, dan memilih kesimpulan yang lebih kuat
+  dari dua yang tersedia. Pemeriksaan yang tak bisa memisahkan subjeknya dari
+  lingkungannya WAJIB mengatakannya, bukan memilih. Kedua cabangnya dibuktikan
+  dengan mengarahkan patokan ke Bun yang sedang berjalan lalu memasukkan
+  perubahan sumber sungguhan, sebab gerbang yang belum pernah dilihat GAGAL
+  adalah gerbang yang belum diuji.
 
   **Himpunan Turnstile tak punya gerbang, dan newsletter berada di luarnya.**
   Enam permukaan anonim memanggil `enforceTurnstileIfRequired` —

--- a/docs/PROJECT_STATE.md
+++ b/docs/PROJECT_STATE.md
@@ -445,10 +445,28 @@ pioneered directly here after the ADR-0047 freeze.)
   the same gate and asserts `toContain("OK")`; and in the `check` chain the gate
   sits immediately before `typecheck && … && test && build`, so on any
   non-pinned Bun it hides every stage that matters. Regenerating the bundle
-  "fixes" it locally and reddens CI. **Not fixed — deliberately left open** as
-  its own decision (raise the CI pin to the `packageManager` field, or compare
-  semantically); the one-line mitigation of moving the gate after `test` is
-  worth doing regardless.
+  "fixes" it locally and reddens CI — the gate handed out the instruction that
+  breaks the thing it guards.
+
+  **Fixed on 28 August by making the version a stated PRECONDITION rather than
+  a hidden assumption.** The pin is read from `packageManager` (not written
+  down a second time), and `family:conformance:check` already asserts CI's
+  `bun-version:` set equals {that pin, the `engines` floor}, so the reading
+  cannot drift from the Bun CI installs. On the pin the gate is unchanged and
+  full-strength — a byte difference is `STALE`, exit 1, and that is what every
+  CI job runs. Off the pin it reports `UNVERIFIED` and exits 0. `build:` now
+  REFUSES to write off the pin instead of warning, because a warning above a
+  successful write reads as success and the wrong bytes are already staged by
+  then; `--allow-version-mismatch` covers the one legitimate case, moving the
+  pin itself. A missing artefact and a matching one stay version-independent.
+
+  **The general lesson is about what a diagnostic is allowed to CLAIM.** The
+  bytes really did differ, so the gate was not wrong about its observation —
+  it was wrong about what the observation established, and it stated the
+  stronger of two available conclusions. A check that cannot separate its
+  subject from its environment must say so rather than pick. Both branches were
+  proven by pointing the pin at the running Bun and introducing a genuine source
+  change, because a gate nobody has watched fail is a gate nobody has tested.
 
   **The Turnstile set has no gate, and the newsletter is outside it.** Six
   anonymous surfaces call `enforceTurnstileIfRequired` — setup/initialize,

--- a/scripts/build-preview-overlay.ts
+++ b/scripts/build-preview-overlay.ts
@@ -33,6 +33,36 @@
  * `:check` rebuilds into memory and compares bytes. It does NOT write, so a
  * stale artefact fails CI instead of being silently repaired by the check that
  * was supposed to catch it.
+ *
+ * ## The comparison is only MEANINGFUL on the pinned Bun
+ *
+ * A minified bundle is the output of a specific bundler, so its bytes change
+ * when the bundler does — identifier renaming and codegen are not stable across
+ * Bun releases. Comparing them therefore asks TWO questions at once, and only
+ * one of them is this gate's: "was the artefact rebuilt after its source
+ * changed", and "is the machine running the same Bun that produced it".
+ *
+ * Conflating them made the gate LIE. On a developer machine one minor ahead of
+ * the pin it reported `is STALE` — a claim about the artefact — when the
+ * artefact was correct and the toolchain differed. Two things followed from
+ * that, and the second is the expensive one:
+ *
+ *   - `tests/blog-preview-overlay.test.ts` shells out to this gate, so the
+ *     false failure also failed the test suite;
+ *   - the message names `bun run build:preview-overlay` as the remedy, and
+ *     running it on the wrong Bun commits a bundle that reddens CI — the gate
+ *     handed out the instruction that breaks the thing it guards.
+ *
+ * So the version is now a stated PRECONDITION rather than a hidden assumption.
+ * Off the pin, a byte difference is reported as UNVERIFIED (exit 0) instead of
+ * as staleness: CI runs every job at the pinned version, so the gate keeps its
+ * full strength exactly where it is enforced. `family:conformance:check`
+ * already asserts CI's `bun-version:` set equals {`packageManager` pin,
+ * `engines` floor}, so reading the pin from `packageManager` cannot drift away
+ * from the version CI actually installs.
+ *
+ * Two cases stay version-independent and still FAIL anywhere: a missing
+ * artefact, and bytes that MATCH (a match is a match, whoever built it).
  */
 import path from "node:path";
 
@@ -40,6 +70,24 @@ const ROOT = path.resolve(import.meta.dir, "..");
 const ENTRYPOINT = path.join(ROOT, "src/lib/ui/blog-preview-overlay.ts");
 const OUTPUT = path.join(ROOT, "public/js/blog-preview-overlay.js");
 const OUTPUT_LABEL = "public/js/blog-preview-overlay.js";
+
+/**
+ * The Bun this artefact must be built by, read from the single place the repo
+ * already declares it. Not duplicated here: a second literal is a second thing
+ * to forget when the pin moves.
+ */
+export function pinnedBunVersion(packageManager: unknown): string {
+  if (typeof packageManager !== "string") return "";
+  const at = packageManager.indexOf("@");
+  return at >= 0 ? packageManager.slice(at + 1).trim() : "";
+}
+
+async function readPinnedBunVersion(): Promise<string> {
+  const pkg = (await Bun.file(path.join(ROOT, "package.json")).json()) as {
+    packageManager?: unknown;
+  };
+  return pinnedBunVersion(pkg.packageManager);
+}
 
 /**
  * Minified, because nobody reads a generated bundle and every byte is charged
@@ -75,15 +123,41 @@ export async function buildPreviewOverlayBundle(): Promise<string> {
 
 async function main(): Promise<void> {
   const checkOnly = process.argv.includes("--check");
-  const bundled = await buildPreviewOverlayBundle();
+  const allowVersionMismatch = process.argv.includes(
+    "--allow-version-mismatch"
+  );
+  const pinned = await readPinnedBunVersion();
+  const running = Bun.version;
+  const onPin = pinned !== "" && running === pinned;
 
   if (!checkOnly) {
+    // Writing on the wrong Bun produces a bundle this gate rejects in CI, and
+    // the developer finds out one push later. Refused rather than warned:
+    // a warning above a successful write is read as success, and the artefact
+    // is already committed by then. The override exists for the one legitimate
+    // case — moving the pin itself, where the NEW Bun is the correct builder.
+    if (!onPin && !allowVersionMismatch) {
+      console.error(
+        `build:preview-overlay REFUSED — this is Bun ${running}, the pin is ${pinned || "(unreadable)"}.\n\n` +
+          "  A minified bundle is the output of a specific bundler. Writing one\n" +
+          "  here produces bytes CI (which runs the pinned Bun) rejects, so the\n" +
+          "  commit that 'fixes' the gate is the commit that reddens it.\n\n" +
+          `  Rebuild with Bun ${pinned}, or pass --allow-version-mismatch if you\n` +
+          "  are deliberately moving the pin.\n"
+      );
+      process.exitCode = 1;
+      return;
+    }
+
+    const bundled = await buildPreviewOverlayBundle();
     await Bun.write(OUTPUT, bundled);
     console.log(
-      `build:preview-overlay OK — wrote ${OUTPUT_LABEL} (${Buffer.byteLength(bundled)} bytes).`
+      `build:preview-overlay OK — wrote ${OUTPUT_LABEL} (${Buffer.byteLength(bundled)} bytes) with Bun ${running}.`
     );
     return;
   }
+
+  const bundled = await buildPreviewOverlayBundle();
 
   const existing = Bun.file(OUTPUT);
 
@@ -97,6 +171,24 @@ async function main(): Promise<void> {
   }
 
   if ((await existing.text()) !== bundled) {
+    // Off the pin this difference answers no question. Saying "STALE" here
+    // would be a claim about the artefact made on evidence about the toolchain,
+    // and the remedy it names would commit a bundle CI rejects.
+    if (!onPin) {
+      console.log(
+        `build:preview-overlay:check UNVERIFIED — this is Bun ${running}, the pin is ${pinned || "(unreadable)"}.\n\n` +
+          `  ${OUTPUT_LABEL} differs from a bundle built here, but a minified\n` +
+          "  bundle's bytes are a property of the bundler as much as of the\n" +
+          "  source, so on a different Bun this difference does not distinguish\n" +
+          "  a stale artefact from a newer minifier. So it is not reported as\n" +
+          "  one, and it is NOT a reason to rebuild: doing that here commits\n" +
+          "  bytes CI rejects.\n\n" +
+          `  CI runs every job on Bun ${pinned}, so this gate is enforced there\n` +
+          "  at full strength. To check it locally, use that Bun.\n"
+      );
+      return;
+    }
+
     console.error(
       `build:preview-overlay:check FAILED — ${OUTPUT_LABEL} is STALE.\n\n` +
         "  It no longer matches a fresh bundle of\n" +
@@ -110,8 +202,11 @@ async function main(): Promise<void> {
     return;
   }
 
+  // A MATCH is version-independent evidence: whatever built the committed file,
+  // a fresh bundle of the current source reproduces it byte for byte.
   console.log(
-    `build:preview-overlay:check OK — ${OUTPUT_LABEL} matches its source.`
+    `build:preview-overlay:check OK — ${OUTPUT_LABEL} matches its source` +
+      (onPin ? "." : ` (built here on Bun ${running}, pin is ${pinned}).`)
   );
 }
 

--- a/tests/blog-preview-overlay.test.ts
+++ b/tests/blog-preview-overlay.test.ts
@@ -39,6 +39,7 @@ import {
   renderPortableTextToHtml
 } from "../src/modules/blog-content/domain/portable-text-rendering";
 import { renderBlogBodyHtml } from "../src/modules/blog-content/domain/blog-body-rendering";
+import { pinnedBunVersion } from "../scripts/build-preview-overlay";
 import { PUBLIC_ASSET_AUDIENCE } from "../scripts/client-asset-budget";
 import type {
   PortableTextBlock,
@@ -260,18 +261,54 @@ describe("the overlay's own logic", () => {
 });
 
 describe("the committed bundle", () => {
+  test("the pin is read from `packageManager`, not written down twice", () => {
+    expect(pinnedBunVersion("bun@1.3.14")).toBe("1.3.14");
+    expect(pinnedBunVersion("bun@1.3.14 ")).toBe("1.3.14");
+    // No `@`, wrong type, or absent: an unreadable pin must not silently
+    // become a version that some Bun could equal, because that would turn the
+    // strict branch on by accident on an arbitrary machine.
+    expect(pinnedBunVersion("bun")).toBe("");
+    expect(pinnedBunVersion(undefined)).toBe("");
+    expect(pinnedBunVersion(42)).toBe("");
+  });
+
   test("matches its TypeScript source", async () => {
     // `public/js/blog-preview-overlay.js` is generated. The point of generating
     // it — rather than hand-writing it beside `news-share.js` — is that the
     // block <-> Portable Text conversion has ONE definition, and a stale bundle
     // is that guarantee quietly expiring.
+    //
+    // The assertion carries the gate's own precondition, and is NOT weakened by
+    // it. A minified bundle's bytes belong to the bundler as much as to the
+    // source, so only a run on the PINNED Bun can tell a stale artefact from a
+    // newer minifier. CI installs that Bun in every job, so there the strict
+    // branch below is what runs — the same demand this test always made.
+    //
+    // Off the pin it asserts the other half, which is the half that was broken:
+    // the gate must NOT claim staleness it cannot have established, and must
+    // not exit non-zero for it. Accepting any output here instead would make
+    // the test blind, which is the defect one layer up.
+    const pkg = (await Bun.file("package.json").json()) as {
+      packageManager?: unknown;
+    };
+    const pinned = pinnedBunVersion(pkg.packageManager);
+    expect(pinned).not.toBe("");
+
     const { spawnSync } = await import("node:child_process");
     const result = spawnSync("bun", ["run", "build:preview-overlay:check"], {
       cwd: process.cwd(),
       encoding: "utf8"
     });
+    const output = result.stdout + result.stderr;
 
-    expect(result.stdout + result.stderr).toContain("OK");
     expect(result.status).toBe(0);
+
+    if (Bun.version === pinned) {
+      expect(output).toContain("OK");
+      expect(output).not.toContain("UNVERIFIED");
+    } else {
+      expect(output).toMatch(/OK|UNVERIFIED/);
+      expect(output).not.toContain("STALE");
+    }
   });
 });


### PR DESCRIPTION
The gate rebuilds `public/js/blog-preview-overlay.js` in memory and compares bytes. A minified bundle is the output of a *specific bundler*, so those bytes move when the bundler does — the comparison was asking two questions and reporting one answer:

- was the artefact rebuilt after its source changed?
- is this machine running the same Bun that produced it?

One minor ahead of the `1.3.14` pin it answered **`is STALE`** — a claim about the *artefact* — on evidence about the *toolchain*.

## Three costs, and the third is the one that matters

1. **It failed the test suite too.** `tests/blog-preview-overlay.test.ts` shells out to the gate, so the single failure in a 6,869-test run was this, on a tree with nothing wrong with it.
2. **It hid every stage behind it.** The gate sits immediately before `typecheck && … && test && build` in the `check` chain, and `&&` stops there — so off the pin, `bun run check` never reached the stages that matter.
3. **Its remedy made things worse.** The message names `bun run build:preview-overlay`, and running that off the pin writes bytes CI rejects. The gate handed out the instruction that breaks the thing it guards, and the commit that "fixes" it reddens CI for everyone.

## What changed

The Bun version is now a stated **precondition** instead of a hidden assumption, read from `packageManager` so the pin is not written down twice. `family:conformance:check` already asserts CI's `bun-version:` set equals {`packageManager` pin, `engines` floor}, so that reading cannot drift from the version CI installs.

| | behaviour |
|---|---|
| **On the pin** | Unchanged, full strength — a byte difference is `STALE`, exit 1. This is what every CI job runs. |
| **Off the pin** | `UNVERIFIED`, exit 0 — names both versions and says rebuilding here is not the fix. |
| **Writing off the pin** | **Refused**, not warned. A warning above a successful write reads as success, and the wrong bytes are staged by then. `--allow-version-mismatch` covers the one legitimate case: moving the pin itself. |
| **Missing / matching artefact** | Version-independent, unchanged. A match is a match, whoever built it. |

## Proven in both directions, not just asserted

Pointing the pin at the running Bun and introducing a genuine source change makes the gate **fail**; it passes again once the bundle is rebuilt. A gate nobody has watched fail is a gate nobody has tested.

The test carries the same precondition rather than accepting any output — off the pin it asserts the half that was broken (must not claim staleness, must not exit non-zero); **on the pin, which is CI, it demands `OK` exactly as before.** Accepting any output would have made the test blind, which is the defect one layer up.

## Verification

`bun run check` now completes on a non-pinned machine for the first time: **exit 0, 5964 pass / 906 skip / 0 fail**, `build` included. Previously it stopped at gate 53 of ~55.

## The general lesson

Recorded in `PROJECT_STATE` §4: the bytes really did differ, so the gate was not wrong about its *observation* — it was wrong about what the observation *established*, and it stated the stronger of two available conclusions. **A check that cannot separate its subject from its environment must say so rather than pick.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
