### PR TITLE
fix(ci): install Bun in release publish job

### DIFF
--- a/.changeset/release-publish-installs-bun-before-the-latest-decision.md
+++ b/.changeset/release-publish-installs-bun-before-the-latest-decision.md
@@ -1,0 +1,16 @@
+---
+"awcms": patch
+---
+
+fix(ci): install Bun in the release publish job before deciding the "Latest" badge
+
+`sign-attest-publish` runs `bun scripts/release-latest-flag.ts` to decide the
+"Latest" badge (ADR-0119), but that job runs in its own isolated `needs: build`
+job — the `Setup Bun` step from `validate` does not carry over, so the
+invocation had no `bun` on `PATH`. `.github/workflows/release.yml` now installs
+the pinned Bun toolchain in `sign-attest-publish` before that decision step
+runs.
+
+A regression test was added (`tests/release-latest-flag.test.ts`) asserting
+that `sign-attest-publish` installs Bun (`oven-sh/setup-bun@`) before invoking
+`bun scripts/release-latest-flag.ts`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,6 +409,11 @@ jobs:
       # On 28 August 2026 approving the parked `v10.0.0`/`v10.0.1` runs moved
       # the "Latest" badge off `v10.0.4` and onto a version four releases stale.
       # The flag is therefore DECIDED, never inherited.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
       - name: Decide the "Latest" badge for this release
         id: latest_flag
         if: github.event_name == 'push'

--- a/tests/release-latest-flag.test.ts
+++ b/tests/release-latest-flag.test.ts
@@ -190,4 +190,22 @@ describe("release.yml actually uses the decision", () => {
     expect(workflow).toContain("releases/latest");
     expect(workflow).toContain("Verify the badge landed where it was decided");
   });
+
+  test("`sign-attest-publish` installs Bun before invoking it", () => {
+    // `sign-attest-publish` runs in its own isolated job (`needs: build`), so
+    // the `Setup Bun` step from `validate` does not carry over — the decision
+    // step's `bun scripts/release-latest-flag.ts` needs its own install.
+    const jobStart = workflow.indexOf("sign-attest-publish:");
+    expect(jobStart).toBeGreaterThan(-1);
+
+    const bunInvocation = workflow.indexOf(
+      "bun scripts/release-latest-flag.ts",
+      jobStart
+    );
+    expect(bunInvocation).toBeGreaterThan(jobStart);
+
+    const setupBun = workflow.indexOf("oven-sh/setup-bun@", jobStart);
+    expect(setupBun).toBeGreaterThan(jobStart);
+    expect(setupBun).toBeLessThan(bunInvocation);
+  });
 });


### PR DESCRIPTION
## Summary
- Install the pinned Bun 1.3.14 runtime in the isolated release publish job.
- Prevent exit 127 in the Latest badge decision step.
- Add a regression test for workflow ordering.

## Verification
- `bun test tests/release-latest-flag.test.ts` — 14 pass, 0 fail
- Workflow YAML parse — OK
- `git diff --check` — OK

Fixes the failure in run 33156564375 / job 98802072458.