### PR TITLE
chore(actions): bump codeql-action to 4.37.9 and sbom-action to 0.24.2 together

### DIFF
--- a/.changeset/codeql-init-and-analyze-must-move-together.md
+++ b/.changeset/codeql-init-and-analyze-must-move-together.md
@@ -1,0 +1,22 @@
+---
+"awcms": patch
+---
+
+chore(actions): bump github/codeql-action to 4.37.9 and anchore/sbom-action to 0.24.2 — as one change, because half a CodeQL bump breaks CodeQL
+
+Dependabot opened these as three PRs (#758, #759, #760) and **two of them were
+individually un-mergeable, for a reason no single PR could show.**
+`github/codeql-action/init` and `.../analyze` are pinned to the same SHA and
+must stay that way: `init` writes a config file stamped with its own version and
+`analyze` refuses to read one from a different version. #759 moved `analyze`
+alone and #760 moved `init` alone, so each PR's own CodeQL run failed with
+`Loaded a configuration file for version '4.37.8', but running version
+'4.37.9'`. Merging either one first would have put that failure on `main`.
+
+Both halves move here in one commit. `anchore/sbom-action` (0.24.0 → 0.24.2,
+both call sites in `release.yml`) joins them because it is the same class of
+change and was blocked only by the changeset gate, which correctly does not
+exempt workflow files.
+
+No behaviour change to the application; this touches CI and release plumbing
+only. The SHAs are the ones Dependabot resolved, unchanged.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,14 +56,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-extended,security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:${{ matrix.language }}"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,7 +262,7 @@ jobs:
           sbom: false
 
       - name: SBOM — source tree
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
           path: .
           format: cyclonedx-json
@@ -270,7 +270,7 @@ jobs:
           upload-artifact: false
 
       - name: SBOM — built image
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
         with:
           image: ${{ steps.tags.outputs.primary }}@${{ steps.push.outputs.digest }}
           format: cyclonedx-json


### PR DESCRIPTION
Supersedes #758, #759 and #760, which Dependabot opened as three PRs — **two of which were individually un-mergeable, for a reason no single PR could show.**

## Why the CodeQL bumps had to be one change

`github/codeql-action/init` and `.../analyze` are pinned to the same SHA and must stay that way: `init` writes a config file stamped with its own version, and `analyze` refuses to read a config from a different version.

- #759 moved `analyze` alone → its own CodeQL run failed with `Loaded a configuration file for version '4.37.8', but running version '4.37.9'`
- #760 moved `init` alone → same failure, mirrored

Merging either first would have put that failure on `main`, and the second PR would then have looked like the one that fixed it. Both halves move here in one commit, to the same SHA Dependabot resolved (`cdf488f`).

## Why sbom-action rides along

`anchore/sbom-action` 0.24.0 → 0.24.2 (both call sites in `release.yml`) was blocked only by the changeset gate, which correctly does **not** exempt workflow files. Same class of change, one changeset.

## Scope

CI and release plumbing only — no application behaviour changes. SHAs unchanged from Dependabot's resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)