### PR TITLE
fix(blog-content,seo-distribution): capture a redirect when a blog post's slug changes

### DIFF
--- a/.changeset/blog-slug-change-redirect-capture.md
+++ b/.changeset/blog-slug-change-redirect-capture.md
@@ -1,0 +1,7 @@
+---
+"awcms": patch
+---
+
+fix(blog-content,seo-distribution): `PATCH /api/v1/blog/posts/{id}` never called the ADR-0039 URL-change capture seam, so an editor fixing a headline's slug made the OLD slug permanently unrecoverable — not on the post row (overwritten in place), not in `awcms_blog_revisions` (no `slug` column), and no redirect was ever proposed. Every previously-shared link to that post 404ed silently, with nothing recording it happened (Issue #784).
+
+The handler now calls a new `captureBlogPostSlugChangeRedirect` (`src/modules/blog-content/application/slug-change-redirect-capture.ts`) inside the same transaction as the post update, whenever the submitted `slug` differs from the currently-stored one. It drives `seo_distribution`'s existing `captureUrlChangeRedirect` with `changeType: "slug_change"`, honoring the tenant's own `url_change_auto_policy` (a `propose` tenant gets an inactive rule for review; a `create` tenant gets an active one immediately) — the safety gate (`checkRedirectSafety`) that already refuses loops/conflicts/over-long chains before any row is persisted made this wiring purely additive. A rejection or an unexpected `invalid` outcome is logged and reported back in the response's new `redirectCapture` field; it never fails or rolls back the post update, and a tenant that has not enabled `seo_distribution` degrades safely to no capture at all. `GET /api/v1/seo/redirects` is unchanged by design — see its own doc comment.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -6352,7 +6352,7 @@ Gated by blog_content.posts.read.
 - **operationId**: `blogUpdatePost`
 - **Security**: bearerAuth + tenantHeader
 
-Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue
+Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue #784 — when `slug` is present and differs from the stored slug, the SAME transaction also captures an ADR-0039 redirect (proposed or active, per the tenant's url_change_auto_policy); see the response schema's `redirectCapture` field.
 
 **Parameters**
 

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -6352,7 +6352,7 @@ Gated by blog_content.posts.read.
 - **operationId**: `blogUpdatePost`
 - **Security**: bearerAuth + tenantHeader
 
-Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first.
+Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue
 
 **Parameters**
 

--- a/docs/awcms/repo-inventory.md
+++ b/docs/awcms/repo-inventory.md
@@ -12,7 +12,7 @@
 | `awcms_*` tables                    | 152   |
 | Tables with `FORCE` RLS             | 134   |
 | RLS-free tables (global, by design) | 18    |
-| Test files                          | 509   |
+| Test files                          | 510   |
 | Route files                         | 388   |
 | ADR                                 | 242   |
 
@@ -363,7 +363,7 @@
 | ------------- | ---------- |
 | `(root)`      | 414        |
 | `e2e`         | 19         |
-| `integration` | 75         |
+| `integration` | 76         |
 | `unit`        | 1          |
 
 ### Routes

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -5238,7 +5238,7 @@ paths:
         - Blog Content
       operationId: blogUpdatePost
       summary: Update a blog post
-      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue
+      description: "Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue #784 — when `slug` is present and differs from the stored slug, the SAME transaction also captures an ADR-0039 redirect (proposed or active, per the tenant's url_change_auto_policy); see the response schema's `redirectCapture` field."
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       requestBody:

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -5238,7 +5238,7 @@ paths:
         - Blog Content
       operationId: blogUpdatePost
       summary: Update a blog post
-      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first.
+      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       requestBody:
@@ -20271,6 +20271,35 @@ components:
           type: string
           nullable: true
           maxLength: 120
+        redirectCapture:
+          description: "Issue #784 — present ONLY on a `PATCH /api/v1/blog/posts/{id}` response whose body actually changed `slug` (absent otherwise, including on `GET`/`POST` and every lifecycle action). Reports what `captureUrlChangeRedirect` (ADR-0039) did with the resulting old->new path change, gated by the tenant's own `url_change_auto_policy` (`POST /api/v1/seo/redirects/capture-url-change` is the same seam, driven here automatically instead of by a caller). A `rejected` or `invalid` outcome never fails the post update itself — the slug change is additive tooling around the edit, not a precondition for it."
+          type: object
+          required:
+            - outcome
+          properties:
+            outcome:
+              type: string
+              enum:
+                - created
+                - proposed
+                - skipped
+                - module_disabled
+                - invalid
+                - rejected
+            redirectId:
+              description: Present only when outcome is "created" or "proposed".
+              type: string
+              format: uuid
+            code:
+              description: Present only when outcome is "rejected".
+              type: string
+              enum:
+                - SOURCE_CONFLICT
+                - REDIRECT_LOOP
+                - REDIRECT_CHAIN_TOO_LONG
+            message:
+              description: Present only when outcome is "rejected" — a human-readable reason no redirect was created.
+              type: string
     BlogPostSummary:
       type: object
       description: |

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -199,7 +199,7 @@ paths:
         - Blog Content
       operationId: blogUpdatePost
       summary: Update a blog post
-      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue #784 — when `slug` is present and differs from the stored slug, the SAME transaction also captures an ADR-0039 redirect (proposed or active, per the tenant's url_change_auto_policy); see the response schema's `redirectCapture` field.
+      description: "Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue #784 — when `slug` is present and differs from the stored slug, the SAME transaction also captures an ADR-0039 redirect (proposed or active, per the tenant's url_change_auto_policy); see the response schema's `redirectCapture` field."
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       requestBody:

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -199,7 +199,7 @@ paths:
         - Blog Content
       operationId: blogUpdatePost
       summary: Update a blog post
-      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first.
+      description: Gated by blog_content.posts.update (with an ownership carve-out — a draft's own author may update it without the broader permission). Only fields present in the body are changed. A significant title/contentJson/contentText change snapshots an append-only revision first. Issue #784 — when `slug` is present and differs from the stored slug, the SAME transaction also captures an ADR-0039 redirect (proposed or active, per the tenant's url_change_auto_policy); see the response schema's `redirectCapture` field.
       parameters:
         - $ref: "#/components/parameters/CorrelationId"
       requestBody:
@@ -3452,6 +3452,37 @@ components:
           type: string
           nullable: true
           maxLength: 120
+        redirectCapture:
+          description: >-
+            Issue #784 — present ONLY on a `PATCH /api/v1/blog/posts/{id}`
+            response whose body actually changed `slug` (absent otherwise,
+            including on `GET`/`POST` and every lifecycle action). Reports
+            what `captureUrlChangeRedirect` (ADR-0039) did with the resulting
+            old->new path change, gated by the tenant's own
+            `url_change_auto_policy` (`POST
+            /api/v1/seo/redirects/capture-url-change` is the same seam,
+            driven here automatically instead of by a caller). A `rejected`
+            or `invalid` outcome never fails the post update itself — the
+            slug change is additive tooling around the edit, not a
+            precondition for it.
+          type: object
+          required: [outcome]
+          properties:
+            outcome:
+              type: string
+              enum:
+                [created, proposed, skipped, module_disabled, invalid, rejected]
+            redirectId:
+              description: Present only when outcome is "created" or "proposed".
+              type: string
+              format: uuid
+            code:
+              description: Present only when outcome is "rejected".
+              type: string
+              enum: [SOURCE_CONFLICT, REDIRECT_LOOP, REDIRECT_CHAIN_TOO_LONG]
+            message:
+              description: Present only when outcome is "rejected" — a human-readable reason no redirect was created.
+              type: string
     BlogPageWriteInput:
       type: object
       description: Shared shape for POST /api/v1/blog/pages and PATCH /api/v1/blog/pages/{id} (all fields optional on update).

--- a/src/modules/blog-content/README.id.md
+++ b/src/modules/blog-content/README.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](README.md)
 
-<!-- i18n-source-hash: sha256:ae6ed57acf5731dd9c51c7f55ab8d00a97a124647afbce9414e1e108634069ae -->
+<!-- i18n-source-hash: sha256:1df8173049868261e51f3f932690ef833e5a6c6bc216dc2fef1fb25656e9ef98 -->
 
 # Blog Content
 
@@ -425,6 +425,20 @@ Hanya rute untuk **post** — doc issue #541 §Routes cuma mendaftarkan tiga rut
 Permission `blog_content.revisions.restore` **eksplisit wajib** — tidak ada ownership override seperti `PATCH /api/v1/blog/posts/{id}` (author pemilik post tidak otomatis boleh restore revisinya sendiri tanpa permission itu; lihat §ABAC di §Admin API — Blog Posts untuk kontras pola). `Idempotency-Key` wajib (scope `blog_revision_restore`) — replay key yang sama mengembalikan response tersimpan tanpa menambah revisi kedua.
 
 Audit: `blog.post.revision_restored` (severity `warning`, `attributes: { revisionId, revisionNumber }`).
+
+## Penangkapan redirect saat slug berubah (Issue #784)
+
+Sebelum ini, mengubah slug membuat slug LAMA tidak dapat dipulihkan — tidak ada di baris post (ditimpa langsung), tidak ada di `awcms_blog_revisions` (§Kapan revisi baru dibuat di atas: `slug` secara eksplisit salah satu field yang TIDAK memicu revisi, dan tabelnya sama sekali tidak punya kolom `slug`). Setiap tautan yang sudah dibagikan ke post itu menjadi 404 begitu editor memperbaiki slug sebuah judul, tanpa ada yang mencatat kejadian itu.
+
+`PATCH /api/v1/blog/posts/{id}` kini memanggil `captureBlogPostSlugChangeRedirect` dari `application/slug-change-redirect-capture.ts` di dalam transaksi yang SAMA dengan update post, tetapi hanya ketika `input.slug` hadir DAN berbeda dari slug yang tersimpan saat ini (PATCH yang tidak menyertakan `slug`, atau mengirim ulang slug yang sama, bukan perubahan dan tidak boleh mengajukan redirect dari sebuah path ke dirinya sendiri — ini juga yang membuat retry PATCH perubahan-slug yang sungguhan otomatis idempoten: `input.slug` pada panggilan kedua sudah sama dengan slug yang tersimpan saat itu). Fungsi ini:
+
+1. Memeriksa `resolveModuleEnabled(tx, tenantId, "seo_distribution")` lebih dulu — tenant yang belum mengaktifkan `seo_distribution` tetap bisa mengedit post persis seperti sebelumnya, hanya saja tanpa redirect yang diajukan (`outcome: "module_disabled"`). Ini pemeriksaan runtime, bukan edge `dependencies` di `module.ts`: `seo_distribution` sengaja TIDAK dideklarasikan sebagai dependency `blog_content` (lihat docblock berkas itu sendiri untuk alasannya — singkatnya, edge `dependencies` yang keras akan secara retroaktif menjebak tenant mana pun yang sudah menjalankan `blog_content` tanpa `seo_distribution` aktif, tanpa ada gerbang yang memperingatkannya, karena peringatan dependency di `tenant-module-lifecycle.ts` hanya dihitung untuk modul yang sedang DINONAKTIFKAN).
+2. Membangun path PUBLIK lama dan baru — `/blog/{tenantCode}/{slug}`, diberi prefiks locale lewat `withPublicLocalePrefix` persis seperti yang sudah dilakukan `listLegacyRedirectMappings` dan rute pratinjau internal-links — sehingga source/target yang ditulis adalah path publik yang sungguh akan diakses pembaca, bukan tebakan.
+3. Memanggil `captureUrlChangeRedirect` milik `seo_distribution` (ADR-0039) dengan `changeType: "slug_change"`, `url_change_auto_policy` milik tenant itu SENDIRI (tidak pernah ditimpa di sini — tenant yang ingin peninjauan tetap mendapat aturan proposed/inactive), dan daftar host terverifikasi tenant tersebut.
+
+Outcome `rejected` (konflik/loop/chain-terlalu-panjang dari `checkRedirectSafety`) atau `invalid` dicatat sebagai warning dan dilaporkan balik di field `redirectCapture` pada response — ini tidak pernah menggagalkan atau me-rollback update post. Redirect ini adalah tooling tambahan di sekitar penyuntingan, bukan prasyaratnya: `checkRedirectSafety` sudah menolak aturan yang tidak aman sebelum apa pun disimpan, sehingga pengkabelan ini tidak bisa menciptakan open redirect atau loop.
+
+`GET /api/v1/seo/redirects` sengaja DIBIARKAN TIDAK BERUBAH oleh issue ini (baris satu-hop mentah, tanpa pra-penggabungan chain) — lihat komentar dokumentasi rute itu sendiri untuk alasannya.
 
 ## Scheduled publishing (Issue #541, direstrukturisasi Issue #640)
 

--- a/src/modules/blog-content/README.md
+++ b/src/modules/blog-content/README.md
@@ -424,6 +424,20 @@ The `blog_content.revisions.restore` permission is **explicitly required** — t
 
 Audit: `blog.post.revision_restored` (severity `warning`, `attributes: { revisionId, revisionNumber }`).
 
+## Slug-change redirect capture (Issue #784)
+
+Before this, a slug edit made the OLD slug unrecoverable — not on the post row (overwritten in place), not in `awcms_blog_revisions` (§When a new revision is created above: `slug` is explicitly one of the fields that does NOT trigger a revision, and the table has no `slug` column at all). Every previously-shared link to that post 404ed the moment an editor fixed a headline's slug, with nothing recording that it happened.
+
+`PATCH /api/v1/blog/posts/{id}` now calls `application/slug-change-redirect-capture.ts`'s `captureBlogPostSlugChangeRedirect` inside the SAME transaction as the post update, but only when `input.slug` is present AND differs from the post's currently-stored slug (a PATCH that omits `slug`, or resubmits the current one, is not a change and must not propose a redirect from a path to itself — this is also what makes a retry of a real slug-change PATCH naturally idempotent: the second call's `input.slug` already matches the now-current stored slug). It:
+
+1. Checks `resolveModuleEnabled(tx, tenantId, "seo_distribution")` first — a tenant that has not enabled `seo_distribution` keeps editing posts exactly as before, just without a redirect being proposed (`outcome: "module_disabled"`). This is a runtime check, not a `dependencies` edge in `module.ts`: `seo_distribution` is not declared as a `blog_content` dependency (see the file's own docblock for why — briefly, a hard `dependencies` edge would retroactively strand any tenant that already runs `blog_content` without `seo_distribution` enabled, with no gate warning it, since `tenant-module-lifecycle.ts`'s dependency warning is only computed for a currently-DISABLED module).
+2. Builds the old and new PUBLIC paths — `/blog/{tenantCode}/{slug}`, locale-prefixed via `withPublicLocalePrefix` exactly as `listLegacyRedirectMappings` and the internal-links preview route already do — so the source/target this writes are the literal paths a reader would hit, not a guess at them.
+3. Calls `seo_distribution`'s `captureUrlChangeRedirect` (ADR-0039) with `changeType: "slug_change"`, the tenant's OWN `url_change_auto_policy` (never overridden here — a tenant that wants review keeps getting a proposed, inactive rule), and the tenant's verified hosts.
+
+A `rejected` (conflict/loop/chain-too-long from `checkRedirectSafety`) or `invalid` outcome is logged as a warning and reported back in the response's `redirectCapture` field — it never fails or rolls back the post update. The redirect is additive tooling around the edit, not a precondition for it: `checkRedirectSafety` already refuses an unsafe rule before anything is persisted, so wiring this in cannot itself create an open redirect or a loop.
+
+`GET /api/v1/seo/redirects` was deliberately left UNCHANGED by this issue (raw one-hop rows, no chain pre-collapsing) — see that route's own doc comment for the reasoning.
+
 ## Scheduled publishing (Issue #541, restructured by Issue #640)
 
 `bun run blog:publish:scheduled` (`scripts/blog-scheduled-publish.ts`) — an internal worker, not an HTTP endpoint, scheduled by cron/a systemd timer (the same pattern as `scripts/form-draft-purge.ts`). For every active tenant it calls `blog-scheduled-publish.ts`'s `publishDueScheduledPosts(sql, tenantId, mediaPort, options?)`.

--- a/src/modules/blog-content/application/slug-change-redirect-capture.ts
+++ b/src/modules/blog-content/application/slug-change-redirect-capture.ts
@@ -1,0 +1,206 @@
+import { log } from "../../../lib/logging/logger";
+import { isSupportedLocale } from "../../../lib/i18n/locales";
+import { withPublicLocalePrefix } from "../../../lib/i18n/public-locale-path";
+import { resolveModuleEnabled } from "../../identity-access/application/auth-context";
+import { recordAuditEvent } from "../../logging/application/audit-log";
+import { captureUrlChangeRedirect } from "../../seo-distribution/application/url-change-capture";
+import { fetchRedirectSettings } from "../../seo-distribution/application/redirect-settings-directory";
+import { resolveTenantAllowedHosts } from "../../seo-distribution/application/tenant-allowed-hosts";
+
+/**
+ * Issue #784 — the seam `POST /api/v1/seo/redirects/capture-url-change`
+ * (ADR-0039) documents as "the seam a content module ... drives when a URL
+ * changes", now actually driven by one: `PATCH /api/v1/blog/posts/{id}` calls
+ * this when `input.slug` differs from the post's stored slug. Before this, a
+ * slug edit made the OLD slug unrecoverable — not on the post row, not in
+ * `awcms_blog_revisions` (no `slug` column, see `revision-policy.ts`) — so
+ * every previously-shared link 404ed with nothing to notice it, let alone fix
+ * it.
+ *
+ * ## Why a direct application-layer import, not a capability port
+ *
+ * `media_library`/`social_publishing` go through `_shared/ports/*` because
+ * this repo may run without a real implementation of them (a no-op adapter is
+ * injected instead) and `blog_content` must degrade safely either way.
+ * `seo_distribution` is not that kind of dependency: this function only
+ * calls a plain application function with no swappable implementation, the
+ * same shape `seo_distribution/application/redirect-resolution-service.ts`
+ * already uses to import `blog_content`'s `fetchEffectivePublicRouteSettings`
+ * directly, in the opposite direction. Declaring `seo_distribution` in
+ * `blog_content.module.ts`'s `dependencies` instead would make it a hard
+ * tenant-enablement gate (`tenant-module-lifecycle.ts`'s
+ * `MODULE_DEPENDENCY_DISABLED`) — a tenant that already runs `blog_content`
+ * without `seo_distribution` enabled would be silently stuck the moment that
+ * edge shipped, with no gate warning it (the module matrix only computes a
+ * dependency warning for a currently-DISABLED module, on the documented
+ * assumption "an enabled module's dependencies are satisfied by
+ * construction"). Checking `resolveModuleEnabled` at the call site instead —
+ * same helper the route already calls for `blog_content` itself — keeps this
+ * additive: a tenant that has not enabled `seo_distribution` keeps editing
+ * posts exactly as before, just without a redirect being proposed.
+ *
+ * ## Why a rejection/failure never fails the post update
+ *
+ * `checkRedirectSafety` (loop/conflict/chain-length) can refuse to persist a
+ * rule; a server-derived path pair can, in principle, fail
+ * `validateRedirectInput`. Neither is a reason to block an editor from fixing
+ * a headline's slug — the redirect is additive tooling around the edit, not a
+ * precondition for it (same reasoning the ADR-0039 route docblock states:
+ * "wiring this in is additive — it cannot itself create an unsafe redirect").
+ * A non-`created`/`proposed` outcome is logged as a warning and reported back
+ * to the caller in the response's `redirectCapture` field so an operator can
+ * follow up, but it never throws and never rolls back the post update.
+ */
+export type SlugChangeRedirectOutcome =
+  | { outcome: "module_disabled" }
+  | { outcome: "skipped" }
+  | { outcome: "created" | "proposed"; redirectId: string }
+  | { outcome: "invalid" }
+  | {
+      outcome: "rejected";
+      code: "SOURCE_CONFLICT" | "REDIRECT_LOOP" | "REDIRECT_CHAIN_TOO_LONG";
+      message: string;
+    };
+
+export type SlugChangeRedirectInput = {
+  postId: string;
+  oldSlug: string;
+  newSlug: string;
+  /** The post's locale BEFORE this update — decides the old path's prefix. */
+  oldLocale: string;
+  /** The post's locale AFTER this update — decides the new path's prefix. */
+  newLocale: string;
+};
+
+type TenantCodeRow = { tenant_code: string };
+
+/**
+ * `/blog/{tenantCode}/{slug}` (ADR-0009), locale-prefixed when the locale is
+ * one this deployment serves (ADR-0098) — the same construction
+ * `listLegacyRedirectMappings` (`blog-post-directory.ts`) and the
+ * internal-links preview route already use, so the source/target this writes
+ * are the literal public paths a reader would hit, not a guess at them.
+ */
+function buildBlogPostPublicPath(
+  tenantCode: string,
+  slug: string,
+  locale: string
+): string {
+  const barePath = `/blog/${tenantCode}/${slug}`;
+  return isSupportedLocale(locale)
+    ? withPublicLocalePrefix(barePath, locale)
+    : barePath;
+}
+
+/**
+ * Capture a blog post's slug change as a redirect (ADR-0039 `slug_change`
+ * origin), gated by the tenant's own `url_change_auto_policy` — never
+ * overridden here, so a tenant that wants review keeps getting a proposed
+ * (inactive) rule rather than one this hook activates on its behalf. Runs
+ * inside the caller's tenant transaction (same one the post update itself
+ * runs in), so a proposal/rule and the slug change land together or not at
+ * all.
+ */
+export async function captureBlogPostSlugChangeRedirect(
+  tx: Bun.SQL,
+  tenantId: string,
+  actorTenantUserId: string,
+  input: SlugChangeRedirectInput,
+  correlationId: string | undefined,
+  now: Date = new Date()
+): Promise<SlugChangeRedirectOutcome> {
+  const seoDistributionEnabled = await resolveModuleEnabled(
+    tx,
+    tenantId,
+    "seo_distribution"
+  );
+
+  if (!seoDistributionEnabled) {
+    return { outcome: "module_disabled" };
+  }
+
+  const tenantRows = (await tx`
+    SELECT tenant_code FROM awcms_tenants WHERE id = ${tenantId}
+  `) as TenantCodeRow[];
+  const tenantCode = tenantRows[0]?.tenant_code ?? "";
+
+  const oldPath = buildBlogPostPublicPath(
+    tenantCode,
+    input.oldSlug,
+    input.oldLocale
+  );
+  const newPath = buildBlogPostPublicPath(
+    tenantCode,
+    input.newSlug,
+    input.newLocale
+  );
+
+  // Sequential, not concurrent: two queries on one transaction connection in
+  // parallel leak it (same rule `GET /api/v1/blog/posts/{id}` documents).
+  const allowedHosts = await resolveTenantAllowedHosts(tx, tenantId);
+  const settings = await fetchRedirectSettings(tx, tenantId);
+
+  const result = await captureUrlChangeRedirect(
+    tx,
+    tenantId,
+    actorTenantUserId,
+    {
+      oldPath,
+      newPath,
+      changeType: "slug_change",
+      reason: "Slug changed on blog post update (Issue #784)."
+    },
+    allowedHosts,
+    settings.urlChangeAutoPolicy,
+    async (auditTx, detail) => {
+      await recordAuditEvent(auditTx, {
+        tenantId,
+        actorTenantUserId,
+        moduleKey: "blog_content",
+        action: "blog.post.slug_changed.redirect_captured",
+        resourceType: "seo_redirect",
+        resourceId: detail.redirect.id,
+        severity: "info",
+        message: `Slug change captured as redirect: ${detail.redirect.normalizedSourcePath} -> ${detail.redirect.target} [${detail.action}].`,
+        attributes: {
+          postId: input.postId,
+          action: detail.action,
+          state: detail.redirect.state
+        },
+        correlationId
+      });
+    },
+    now
+  );
+
+  if (result.outcome === "created" || result.outcome === "proposed") {
+    return { outcome: result.outcome, redirectId: result.redirect.id };
+  }
+
+  if (result.outcome === "rejected") {
+    log("warning", "blog-content.post.slug-change-redirect.rejected", {
+      correlationId,
+      tenantId,
+      postId: input.postId,
+      oldPath,
+      newPath,
+      code: result.code,
+      message: result.message
+    });
+    return { outcome: "rejected", code: result.code, message: result.message };
+  }
+
+  if (result.outcome === "invalid") {
+    log("warning", "blog-content.post.slug-change-redirect.invalid", {
+      correlationId,
+      tenantId,
+      postId: input.postId,
+      oldPath,
+      newPath,
+      errors: result.errors
+    });
+    return { outcome: "invalid" };
+  }
+
+  return { outcome: "skipped" };
+}

--- a/src/pages/api/v1/blog/posts/[id].ts
+++ b/src/pages/api/v1/blog/posts/[id].ts
@@ -47,6 +47,7 @@ import {
 import { validateAndNormalizeContentJsonVideoBlocks } from "../../../../../modules/blog-content/domain/video-news-block-validation";
 import { evaluatePostUpdateAccess } from "../../../../../modules/blog-content/domain/post-access-policy";
 import { isSignificantContentChange } from "../../../../../modules/blog-content/domain/revision-policy";
+import { captureBlogPostSlugChangeRedirect } from "../../../../../modules/blog-content/application/slug-change-redirect-capture";
 
 const READ_GUARD = {
   moduleKey: "blog_content",
@@ -121,7 +122,14 @@ export const GET: APIRoute = async ({ request, params, cookies }) => {
  * `workflows/tasks/{id}/decisions.ts` uses for its self-approval check.
  * Not idempotent (recommended, not required, per doc issue #538
  * §Idempotency Requirements) — same-body PATCH retries converge to the
- * same end state.
+ * same end state, which also makes the Issue #784 redirect capture below
+ * naturally idempotent: a retry's `input.slug` matches the now-current
+ * stored slug, so the diff that triggers capture is gone by the second call.
+ *
+ * Issue #784 — when `input.slug` differs from the stored slug,
+ * `captureBlogPostSlugChangeRedirect` turns the change into an ADR-0039
+ * redirect (proposed or active, per the tenant's `url_change_auto_policy`)
+ * in the SAME transaction, so the old slug is never silently unrecoverable.
  */
 export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
@@ -342,6 +350,33 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       return fail(404, "RESOURCE_NOT_FOUND", "Blog post not found.");
     }
 
+    // Issue #784 — a slug edit used to make the OLD slug unrecoverable (not on
+    // the post row, not in `awcms_blog_revisions`), so every previously-shared
+    // link silently 404ed. Only runs when `slug` actually changed value — a
+    // PATCH that omits it, or resubmits the current one, is not a change and
+    // must not propose a redirect from a path to itself. Gated by the
+    // tenant's own `url_change_auto_policy`; a rejection (conflict/loop/chain)
+    // or an unexpected `invalid` outcome is reported back and logged, never
+    // thrown — this is additive tooling around the edit, not a precondition
+    // for it (see `slug-change-redirect-capture.ts`'s docblock).
+    const redirectCapture =
+      input.slug !== undefined && input.slug !== post.slug
+        ? await captureBlogPostSlugChangeRedirect(
+            tx,
+            tenantId,
+            context.tenantUserId,
+            {
+              postId,
+              oldSlug: post.slug,
+              newSlug: updated.slug,
+              oldLocale: post.locale,
+              newLocale: updated.locale
+            },
+            correlationId,
+            now
+          )
+        : undefined;
+
     if (input.termIds) {
       await syncPostTermAssignments(tx, tenantId, postId, input.termIds);
     }
@@ -422,10 +457,16 @@ export const PATCH: APIRoute = async ({ request, params, cookies, locals }) => {
       tenantId,
       moduleKey: "blog_content",
       postId,
-      slug: updated.slug
+      slug: updated.slug,
+      redirectCaptureOutcome: redirectCapture?.outcome
     });
 
-    return ok({ ...updated, termIds, institutionIds });
+    return ok({
+      ...updated,
+      termIds,
+      institutionIds,
+      ...(redirectCapture ? { redirectCapture } : {})
+    });
   });
 };
 

--- a/src/pages/api/v1/seo/redirects/index.ts
+++ b/src/pages/api/v1/seo/redirects/index.ts
@@ -59,6 +59,16 @@ const CREATE_GUARD = {
 
 const IDEMPOTENCY_SCOPE = "seo_distribution_redirect_create";
 
+/**
+ * Issue #784 raised, and deliberately did NOT resolve, whether this should
+ * pre-collapse redirect CHAINS for a consumer instead of returning raw
+ * one-hop rows. Decision: leave it as-is. Chains are already bounded to
+ * <= `MAX_REDIRECT_HOPS` (`domain/redirect-chain.ts`) at write time
+ * (`redirect-safety.ts`'s `checkRedirectSafety`), and the one documented
+ * consumer (LenteraKalteng's build) already walks/guards them independently.
+ * Collapsing here would be a second place that same bounded walk has to stay
+ * correct, for no consumer that has asked for it.
+ */
 export const GET: APIRoute = async ({ request, cookies, url }) => {
   const { tenantId, token } = resolveAuthInputs(request, cookies);
 

--- a/tests/integration/blog-post-slug-change-redirect.integration.test.ts
+++ b/tests/integration/blog-post-slug-change-redirect.integration.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Issue #784 — `PATCH /api/v1/blog/posts/{id}` used to change `slug` in place
+ * with nothing recording the OLD value anywhere: not on the post row, not in
+ * `awcms_blog_revisions` (no `slug` column, see `revision-policy.ts`). Every
+ * previously-shared link to that post 404ed the moment an editor fixed a
+ * headline's slug, silently.
+ *
+ * `captureBlogPostSlugChangeRedirect` (`blog-content/application/
+ * slug-change-redirect-capture.ts`) closes that gap by driving the ADR-0039
+ * seam (`captureUrlChangeRedirect`) from inside the SAME transaction as the
+ * post update. These tests prove the actual wiring end to end, through the
+ * real `PATCH` handler — not just the extracted function — because the
+ * property that most needs proving ("an unrelated field-only update produces
+ * no redirect row at all") lives in the ROUTE's own guard
+ * (`input.slug !== undefined && input.slug !== post.slug`), not in the
+ * function that only runs once that guard has already passed.
+ *
+ * ## Why this needs a real database
+ *
+ * The outcome depends on `awcms_seo_redirect_settings.url_change_auto_policy`,
+ * on `checkRedirectSafety`'s conflict/loop/chain lookups against OTHER rows in
+ * `awcms_seo_redirects`, and on `awcms_tenant_modules.enabled` — three real
+ * tables a mock `Bun.SQL` would only be echoing back.
+ *
+ * MUTATION PROOFS this shape would catch:
+ * - Deleting the route's `input.slug !== post.slug` guard → "an unrelated
+ *   field-only update produces no redirect row" goes RED (every PATCH would
+ *   start proposing a self-redirect).
+ * - Making a `rejected`/`invalid` outcome `throw` instead of returning →
+ *   "a conflicting existing rule doesn't block the post update" goes RED.
+ * - Dropping the `resolveModuleEnabled(tx, tenantId, "seo_distribution")`
+ *   guard → the module-disabled test starts creating a row it must not.
+ *
+ * WORLD 2 (harness.ts) — the real route handler reaches for
+ * `getDatabaseClient()` internally, so this runs against the migrated
+ * `DATABASE_URL` database. Skipped unless one is configured.
+ */
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test
+} from "bun:test";
+
+import {
+  ensureHandlerDatabaseReady,
+  getHandlerAdminSql,
+  integrationEnabled,
+  invoke,
+  resetHandlerDatabase,
+  teardownHandlerDatabase
+} from "./harness";
+import { PATCH as postsPatch } from "../../src/pages/api/v1/blog/posts/[id]";
+import {
+  generateSessionToken,
+  hashSessionToken
+} from "../../src/lib/auth/session-token";
+import { withPublicLocalePrefix } from "../../src/lib/i18n/public-locale-path";
+
+const TENANT = "78478478-7847-4784-8784-784784784784";
+const TENANT_CODE = "slug-redirect-784";
+const PROFILE = "78478478-0000-4784-8784-784784784701";
+const IDENTITY = "78478478-0000-4784-8784-784784784702";
+const AUTHOR = "78478478-0000-4784-8784-784784784703";
+const POST_ID = "78478478-0000-4784-8784-784784784999";
+
+const OLD_SLUG = "judul-lama";
+const NEW_SLUG = "judul-baru";
+/** The post's locale is 'id' throughout — `withPublicLocalePrefix` mirrors exactly what production builds. */
+const OLD_PATH = withPublicLocalePrefix(
+  `/blog/${TENANT_CODE}/${OLD_SLUG}`,
+  "id"
+);
+const NEW_PATH = withPublicLocalePrefix(
+  `/blog/${TENANT_CODE}/${NEW_SLUG}`,
+  "id"
+);
+
+let handlerReady = false;
+let sessionToken = "";
+
+async function seed(): Promise<void> {
+  const sql = getHandlerAdminSql();
+
+  await sql`
+    INSERT INTO awcms_tenants (id, tenant_code, tenant_name, status)
+    VALUES (${TENANT}, ${TENANT_CODE}, 'Slug Redirect 784', 'active')
+    ON CONFLICT (id) DO NOTHING
+  `;
+
+  await sql`
+    INSERT INTO awcms_profiles (id, tenant_id, profile_type, display_name)
+    VALUES (${PROFILE}, ${TENANT}, 'person', 'Author 784')
+  `;
+
+  await sql`
+    INSERT INTO awcms_identities
+      (id, tenant_id, profile_id, login_identifier, password_hash, status)
+    VALUES (${IDENTITY}, ${TENANT}, ${PROFILE}, 'author-784@example.test',
+            'not-a-real-hash', 'active')
+  `;
+
+  await sql`
+    INSERT INTO awcms_tenant_users (id, tenant_id, identity_id, status)
+    VALUES (${AUTHOR}, ${TENANT}, ${IDENTITY}, 'active')
+  `;
+
+  sessionToken = generateSessionToken();
+
+  await sql`
+    INSERT INTO awcms_sessions (tenant_id, identity_id, token_hash, expires_at)
+    VALUES (${TENANT}, ${IDENTITY}, ${hashSessionToken(sessionToken)},
+            now() + interval '1 hour')
+  `;
+
+  // `status = 'draft'` + `author_tenant_user_id = AUTHOR` is deliberate: it
+  // lets `evaluatePostUpdateAccess`'s ownership carve-out (an author may edit
+  // their own unpublished post) authorize the PATCH below without seeding a
+  // role/permission grant — this suite is about the redirect-capture wiring,
+  // not about RBAC, and the carve-out is real production behavior either way.
+  await sql`
+    INSERT INTO awcms_blog_posts
+      (id, tenant_id, author_tenant_user_id, title, slug, content_json,
+       content_text, body_portable_text, status, visibility, locale)
+    VALUES
+      (${POST_ID}, ${TENANT}, ${AUTHOR}, 'Judul Awal', ${OLD_SLUG}, '{}'::jsonb,
+       'Isi awal', '[]'::jsonb, 'draft', 'public', 'id')
+  `;
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    "content-type": "application/json",
+    "x-awcms-tenant-id": TENANT,
+    authorization: `Bearer ${sessionToken}`
+  };
+}
+
+async function patchSlug(body: Record<string, unknown>) {
+  return invoke<{
+    data: {
+      slug: string;
+      redirectCapture?: {
+        outcome: string;
+        code?: string;
+        message?: string;
+        redirectId?: string;
+      };
+    };
+  }>(postsPatch, {
+    method: "PATCH",
+    path: `/api/v1/blog/posts/${POST_ID}`,
+    params: { id: POST_ID },
+    headers: authHeaders(),
+    body
+  });
+}
+
+type RedirectRow = {
+  normalized_source_path: string;
+  target: string;
+  state: string;
+  origin: string;
+};
+
+async function redirectRowsForTenant(): Promise<RedirectRow[]> {
+  return (await getHandlerAdminSql()`
+    SELECT normalized_source_path, target, state, origin
+    FROM awcms_seo_redirects
+    WHERE tenant_id = ${TENANT}
+    ORDER BY created_at ASC
+  `) as RedirectRow[];
+}
+
+const describeOrSkip = integrationEnabled ? describe : describe.skip;
+
+describeOrSkip(
+  "Issue #784 — PATCH /api/v1/blog/posts/{id} slug change drives ADR-0039 redirect capture",
+  () => {
+    beforeAll(async () => {
+      handlerReady = await ensureHandlerDatabaseReady();
+    });
+
+    afterAll(async () => {
+      if (handlerReady) await teardownHandlerDatabase();
+    });
+
+    beforeEach(async () => {
+      if (!handlerReady) return;
+      await resetHandlerDatabase();
+      await seed();
+    });
+
+    afterEach(async () => {
+      if (handlerReady) await resetHandlerDatabase();
+    });
+
+    test("default policy ('propose'): a slug change proposes an INACTIVE redirect, and the post update itself succeeds", async () => {
+      if (!handlerReady) return;
+
+      const res = await patchSlug({ slug: NEW_SLUG });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.slug).toBe(NEW_SLUG);
+      expect(res.body.data.redirectCapture).toEqual({
+        outcome: "proposed",
+        redirectId: expect.any(String)
+      });
+
+      const rows = await redirectRowsForTenant();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        normalized_source_path: OLD_PATH,
+        target: NEW_PATH,
+        state: "inactive",
+        origin: "slug_change"
+      });
+    });
+
+    test("policy 'create': the same slug change produces an ACTIVE redirect instead", async () => {
+      if (!handlerReady) return;
+
+      await getHandlerAdminSql()`
+        INSERT INTO awcms_seo_redirect_settings (tenant_id, url_change_auto_policy)
+        VALUES (${TENANT}, 'create')
+      `;
+
+      const res = await patchSlug({ slug: NEW_SLUG });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.redirectCapture?.outcome).toBe("created");
+
+      const rows = await redirectRowsForTenant();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.state).toBe("active");
+    });
+
+    test("an unrelated field-only update produces NO redirect row", async () => {
+      if (!handlerReady) return;
+
+      const res = await patchSlug({ title: "Judul Diperbarui" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.slug).toBe(OLD_SLUG);
+      // Absent, not merely falsy — the field must not appear at all when no
+      // slug change was submitted (the OpenAPI contract's own distinction).
+      expect(res.body.data.redirectCapture).toBeUndefined();
+
+      const rows = await redirectRowsForTenant();
+      expect(rows).toHaveLength(0);
+    });
+
+    test("resubmitting the CURRENT slug is not a change — no redirect row (and the same guard is what makes a retry of the real change idempotent)", async () => {
+      if (!handlerReady) return;
+
+      const res = await patchSlug({ slug: OLD_SLUG });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.redirectCapture).toBeUndefined();
+
+      const rows = await redirectRowsForTenant();
+      expect(rows).toHaveLength(0);
+    });
+
+    test("a safety-gate rejection (SOURCE_CONFLICT) surfaces in the response and never blocks the post update", async () => {
+      if (!handlerReady) return;
+
+      // A pre-existing LIVE rule already governs the post's current path — the
+      // exact conflict `checkRedirectSafety` exists to catch before a second
+      // rule for the same source is ever written. The conflicting target is
+      // resolved to a plain JS string FIRST — interpolating a partial value
+      // into the middle of a quoted SQL literal inside a tagged template
+      // parameterizes only the substituted fragment, not the literal text
+      // around it, which is not what a "whole string" parameter needs here.
+      const conflictTarget = `/blog/${TENANT_CODE}/somewhere-else`;
+      await getHandlerAdminSql()`
+        INSERT INTO awcms_seo_redirects
+          (tenant_id, source_path, normalized_source_path, target_type, target,
+           status_code, state, created_by, updated_by)
+        VALUES (
+          ${TENANT}, ${OLD_PATH}, ${OLD_PATH}, 'relative_same_tenant',
+          ${conflictTarget}, 301, 'active', ${AUTHOR}, ${AUTHOR}
+        )
+      `;
+
+      const res = await patchSlug({ slug: NEW_SLUG });
+
+      // The slug edit itself is NOT blocked by the redirect conflict — this is
+      // additive tooling around the edit, not a precondition for it.
+      expect(res.status).toBe(200);
+      expect(res.body.data.slug).toBe(NEW_SLUG);
+      expect(res.body.data.redirectCapture).toEqual({
+        outcome: "rejected",
+        code: "SOURCE_CONFLICT",
+        message: expect.any(String)
+      });
+
+      // No second row was written — only the pre-existing conflicting rule.
+      const rows = await redirectRowsForTenant();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.target).toBe(conflictTarget);
+    });
+
+    test("seo_distribution disabled for the tenant: the post update still succeeds, degrading to no capture", async () => {
+      if (!handlerReady) return;
+
+      await getHandlerAdminSql()`
+        INSERT INTO awcms_modules (module_key, module_name)
+        VALUES ('seo_distribution', 'SEO Distribution')
+        ON CONFLICT (module_key) DO NOTHING
+      `;
+      await getHandlerAdminSql()`
+        INSERT INTO awcms_tenant_modules (tenant_id, module_key, enabled)
+        VALUES (${TENANT}, 'seo_distribution', false)
+      `;
+
+      const res = await patchSlug({ slug: NEW_SLUG });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.slug).toBe(NEW_SLUG);
+      expect(res.body.data.redirectCapture).toEqual({
+        outcome: "module_disabled"
+      });
+
+      const rows = await redirectRowsForTenant();
+      expect(rows).toHaveLength(0);
+    });
+  }
+);

--- a/tests/module-boundary.test.ts
+++ b/tests/module-boundary.test.ts
@@ -146,6 +146,29 @@ const DOCUMENTED_EXCEPTIONS: {
       "`identity:principal-access:check`, so a port adapter would have to live " +
       "there anyway and be called from here just the same. Revisit if tenant " +
       "bootstrap ever stops writing identity rows itself."
+  },
+  {
+    from: "blog_content",
+    to: "seo_distribution",
+    reason:
+      "Issue #784. `application/slug-change-redirect-capture.ts` calls " +
+      "`seo_distribution`'s `captureUrlChangeRedirect` directly so a blog " +
+      "post's slug change drives the ADR-0039 redirect-capture seam. It " +
+      "cannot be a `dependencies` edge: that would make tenant enablement " +
+      "of `blog_content` HARD-gated on `seo_distribution` also being " +
+      "enabled (`tenant-module-lifecycle.ts`'s `MODULE_DEPENDENCY_DISABLED`), " +
+      "silently stranding any tenant that already runs `blog_content` " +
+      "without `seo_distribution` enabled — with no gate warning it, since " +
+      "`module-matrix.ts`'s dependency warning is computed only for a " +
+      "currently-DISABLED module. It is not a capability either — " +
+      "`capabilities.consumes` is for a PORT-backed, swappable adapter " +
+      "(ADR-0011, this file's own type doc above); this is a plain " +
+      "application function with no alternate implementation, and a port " +
+      "would relocate the concrete import rather than remove it. The call " +
+      "site itself checks `resolveModuleEnabled(tx, tenantId, " +
+      "\"seo_distribution\")` before calling, so a tenant without it " +
+      "enabled degrades safely to no capture. Revisit if redirect capture " +
+      "ever needs a swappable adapter."
   }
 ];
 

--- a/tests/module-boundary.test.ts
+++ b/tests/module-boundary.test.ts
@@ -166,7 +166,7 @@ const DOCUMENTED_EXCEPTIONS: {
       "application function with no alternate implementation, and a port " +
       "would relocate the concrete import rather than remove it. The call " +
       "site itself checks `resolveModuleEnabled(tx, tenantId, " +
-      "\"seo_distribution\")` before calling, so a tenant without it " +
+      '"seo_distribution")` before calling, so a tenant without it ' +
       "enabled degrades safely to no capture. Revisit if redirect capture " +
       "ever needs a swappable adapter."
   }


### PR DESCRIPTION
## Summary

- `PATCH /api/v1/blog/posts/{id}` never called the ADR-0039 URL-change capture seam (`captureUrlChangeRedirect`), so an editor fixing a headline's slug made the OLD slug permanently unrecoverable — not on the post row (overwritten in place), not in `awcms_blog_revisions` (no `slug` column) — and every previously-shared link 404ed silently.
- The handler now calls a new `captureBlogPostSlugChangeRedirect` (`src/modules/blog-content/application/slug-change-redirect-capture.ts`) inside the SAME transaction as the post update, whenever the submitted `slug` differs from the currently-stored one. It drives `seo_distribution`'s existing `captureUrlChangeRedirect` with `changeType: "slug_change"`, honoring the tenant's own `url_change_auto_policy` (never overridden) — `checkRedirectSafety`'s existing conflict/loop/chain-length gate makes this wiring purely additive.
- A `rejected`/`invalid` outcome is logged and reported back in the response's new `redirectCapture` field; it never fails or rolls back the post update. A tenant that has not enabled `seo_distribution` degrades safely (`resolveModuleEnabled` check) to no capture.
- `GET /api/v1/seo/redirects` is deliberately left UNCHANGED (raw one-hop rows, no chain pre-collapsing) — a doc comment on the route now records that decision, citing this issue.
- `seo_distribution` is intentionally NOT added to `blog_content`'s `dependencies` (would hard-gate tenant enablement and could strand existing tenants) nor modeled as a capability port (there's no swappable adapter, just a plain function call) — the direct cross-module import is instead recorded as a `DOCUMENTED_EXCEPTIONS` entry in `tests/module-boundary.test.ts`, with full reasoning inline.

## `captureUrlChangeRedirect` call signature actually used

```ts
captureUrlChangeRedirect(
  tx,
  tenantId,
  actorTenantUserId,
  { oldPath, newPath, changeType: "slug_change", reason },
  allowedHosts,
  policy,          // tenant's own url_change_auto_policy, never overridden
  recordAuditCallback,
  now
)
```

`oldPath`/`newPath` are built as `/blog/{tenantCode}/{slug}`, locale-prefixed via `withPublicLocalePrefix` — the same construction `listLegacyRedirectMappings` and the internal-links preview route already use, so the source/target are the literal public paths a reader would hit.

## Deviations from the initial plan (with reasoning)

1. **Module coupling**: the plan didn't specify how `blog_content` should reach `seo_distribution`'s application layer. I researched the existing precedent (`seo_distribution` already imports `blog_content`'s `fetchEffectivePublicRouteSettings` directly, undeclared) and the module-management dependency-lifecycle semantics, and landed on a `resolveModuleEnabled` runtime guard + a `DOCUMENTED_EXCEPTIONS` entry in `tests/module-boundary.test.ts` (a real gate that runs under `bun test`, not just the named `bun run` scripts) — not a `dependencies` edge (would retroactively strand any tenant running `blog_content` without `seo_distribution` enabled) and not a capability port (that pattern is reserved for swappable adapters per this module's own type doc; this is a plain function call).
2. **Response shape**: added an optional `redirectCapture` field to the `PATCH` response (present only when a slug change was submitted), rather than exposing the full redirect record — avoids leaking `seo_distribution`-owned data to a caller who only holds `blog_content.posts.update`.

## Test plan

- [x] `bun run typecheck`
- [x] `bun run db:migrate` (no schema change; 0 applied / 150 skipped)
- [x] `bun run api:spec:check` / `api:docs:check` / `api:consumer-contract:check` (OpenAPI bundle + docs regenerated)
- [x] `bun test` — full suite green except 3 pre-existing failures verified to reproduce identically on unmodified `main` in this same local DB environment (an http/https protocol-detection artifact in two sitemap tests, and a worker/setup role-grant check tied to this sandbox's Postgres container) — none touch blog/seo code.
- [x] New integration suite `tests/integration/blog-post-slug-change-redirect.integration.test.ts` (6 tests, real Postgres, via the actual `PATCH` handler): default `propose` policy → proposed/inactive row; `create` policy → active row; unrelated field-only update → no row; resubmitting the current slug → no row (idempotent-retry proof); `SOURCE_CONFLICT` rejection → post update still succeeds, no second row written; `seo_distribution` disabled → degrades safely.
- [x] Mutation proof: reverted the route's slug-changed guard to `false && ...` — 4 of the 6 new tests went red as expected, then restored.
- [x] `bun run build`
- [x] Added changeset (`patch`)

## Security notes

- No new endpoint, no new permission — reuses `blog_content.posts.update`'s existing ABAC gate (`authorizeInTransaction`, ownership carve-out included) for the primary action; the redirect capture is a same-transaction side effect, not a separately user-invokable capability, mirroring how `enqueueModuleContentPurge`/`recordAuditEvent` are already called from this handler.
- `checkRedirectSafety` (loop/conflict/chain length, already shipped) runs before any redirect row is persisted — this change cannot create an open redirect or a loop.
- Cross-tenant isolation unchanged: `resolveTenantAllowedHosts`/`fetchRedirectSettings`/`captureUrlChangeRedirect` all run inside the same `withTenant` transaction (RLS FORCE'd) as the post update.

Fixes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)