### PR TITLE
feat(media-library): expose verified photo credit fields on the public media DTO

### DIFF
--- a/.changeset/media-rights-credit-fields.md
+++ b/.changeset/media-rights-credit-fields.md
@@ -1,0 +1,11 @@
+---
+"awcms": minor
+---
+
+feat(media-library): expose verified photo credit fields on the public media DTO (Issue #782)
+
+`ResolvedMediaReferenceDTO` (`_shared/ports/media-library-port.ts`), returned by `GET /api/v1/media/objects` and every in-process `MediaLibraryPort.resolveMediaReferences` consumer, gains `creditLine`, `sourceName`, and `copyrightStatus` — the photo credit a news site is legally/reputationally obliged to show, which existed on the registry row (`sql/137`, Issue #615) but never crossed the public read boundary.
+
+The three fields are populated ONLY when the source media object's internal `rightsVerificationStatus` is `'verified'`; on anything else (the default `'unverified'`, or an explicit `'rejected'`) all three come back `null` — fail-closed, never a partial/best-effort value, even when the underlying row has them set. `rightsVerifiedBy`/`rightsVerifiedAt` (an internal reviewer identity and review moment — same posture ADR-0109 already took for the opt-in byline) and `rightsNotes` (editorial-internal licensing/contact terms) never cross into this DTO at all, in any case. See `media-library/domain/media-rights-policy.ts#resolvePublicMediaRightsFields` for the gate.
+
+No new endpoint and no new permission — this widens data already returned by the existing `media_library.media.read`-gated route.

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -5356,7 +5356,9 @@ Gated by media_library.media.verify. High-risk, requires Idempotency-Key. Verifi
 - **operationId**: `mediaResolveObjects`
 - **Security**: bearerAuth + tenantHeader
 
-Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes, creditLine, sourceName, copyrightStatus}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+
+Issue #782 — `creditLine`/`sourceName`/`copyrightStatus` are populated ONLY when the object's rights-verification decision is `verified`; otherwise all three are `null`. This is a distinct verification concept from the upload-integrity `verified`/`attached` status below.
 
 An object resolves ONLY when it is `verified` or `attached`, belongs to the calling tenant, and is not soft-deleted. Everything else — unknown, cross-tenant, unverified, deleted — is returned in `unresolved` rather than dropped, so a caller can tell "this resource has no image" from "this resource's image reference is broken". A malformed (non-uuid) id is a 400 instead: "you sent junk" and "that object is not referenceable" are different facts.
 

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -23321,6 +23321,26 @@ components:
         sizeBytes:
           type: integer
           nullable: true
+        creditLine:
+          type: string
+          nullable: true
+          description: "Issue #782. The photo credit — what gets printed beside the image. `null` unless the source object's rights claim has been HUMAN-verified (internal `rightsVerificationStatus = 'verified'`); an unverified or rejected claim never reaches this field, even if the object has a credit line on file."
+        sourceName:
+          type: string
+          nullable: true
+          description: "Issue #782. Where the file came from (often distinct from who is credited). Same verification gate as `creditLine`: `null` unless the rights claim has been verified."
+        copyrightStatus:
+          type: string
+          nullable: true
+          enum:
+            - unknown
+            - owned
+            - licensed
+            - public_domain
+            - permission_granted
+            - fair_use
+            - null
+          description: 'Issue #782. Same verification gate as `creditLine`/`sourceName`: `null` unless the rights claim has been verified — including when the underlying object''s copyright status is the real, non-null `''unknown''` value (verification and "unknown" are different facts, and only one of them is nullability here).'
     RetentionPurgeResult:
       type: object
       properties:

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -10526,7 +10526,9 @@ paths:
         - News Media
       summary: Batch-resolve media object ids to their public reference.
       description: |
-        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes, creditLine, sourceName, copyrightStatus}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+
+        Issue #782 — `creditLine`/`sourceName`/`copyrightStatus` are populated ONLY when the object's rights-verification decision is `verified`; otherwise all three are `null`. This is a distinct verification concept from the upload-integrity `verified`/`attached` status below.
 
         An object resolves ONLY when it is `verified` or `attached`, belongs to the calling tenant, and is not soft-deleted. Everything else — unknown, cross-tenant, unverified, deleted — is returned in `unresolved` rather than dropped, so a caller can tell "this resource has no image" from "this resource's image reference is broken". A malformed (non-uuid) id is a 400 instead: "you sent junk" and "that object is not referenceable" are different facts.
 

--- a/openapi/modules/media-library.openapi.yaml
+++ b/openapi/modules/media-library.openapi.yaml
@@ -174,7 +174,9 @@ paths:
         - News Media
       summary: Batch-resolve media object ids to their public reference.
       description: |
-        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes, creditLine, sourceName, copyrightStatus}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+
+        Issue #782 — `creditLine`/`sourceName`/`copyrightStatus` are populated ONLY when the object's rights-verification decision is `verified`; otherwise all three are `null`. This is a distinct verification concept from the upload-integrity `verified`/`attached` status below.
 
         An object resolves ONLY when it is `verified` or `attached`, belongs to the calling tenant, and is not soft-deleted. Everything else — unknown, cross-tenant, unverified, deleted — is returned in `unresolved` rather than dropped, so a caller can tell "this resource has no image" from "this resource's image reference is broken". A malformed (non-uuid) id is a 400 instead: "you sent junk" and "that object is not referenceable" are different facts.
 

--- a/openapi/modules/media-library.openapi.yaml
+++ b/openapi/modules/media-library.openapi.yaml
@@ -854,6 +854,28 @@ components:
         sizeBytes:
           type: integer
           nullable: true
+        creditLine:
+          type: string
+          nullable: true
+          description: "Issue #782. The photo credit — what gets printed beside the image. `null` unless the source object's rights claim has been HUMAN-verified (internal `rightsVerificationStatus = 'verified'`); an unverified or rejected claim never reaches this field, even if the object has a credit line on file."
+        sourceName:
+          type: string
+          nullable: true
+          description: "Issue #782. Where the file came from (often distinct from who is credited). Same verification gate as `creditLine`: `null` unless the rights claim has been verified."
+        copyrightStatus:
+          type: string
+          nullable: true
+          enum:
+            [
+              unknown,
+              owned,
+              licensed,
+              public_domain,
+              permission_granted,
+              fair_use,
+              null
+            ]
+          description: 'Issue #782. Same verification gate as `creditLine`/`sourceName`: `null` unless the rights claim has been verified — including when the underlying object''s copyright status is the real, non-null `''unknown''` value (verification and "unknown" are different facts, and only one of them is nullability here).'
     CreateNewsMediaUploadSessionRequest:
       type: object
       required:

--- a/src/modules/_shared/ports/media-library-port.ts
+++ b/src/modules/_shared/ports/media-library-port.ts
@@ -50,6 +50,39 @@ export type ResolvedMediaReferenceDTO = {
   width: number | null;
   height: number | null;
   sizeBytes: number | null;
+  /**
+   * Credit/rights fields (Issue #782) — a news site's legal/reputational
+   * obligation to show who a photo is credited to. Unlike `mimeType`/`width`/
+   * `height`/`sizeBytes` above, these are NOT sourced verbatim: the concrete
+   * adapter populates all three ONLY when the source object's internal
+   * `rightsVerificationStatus` is `'verified'`. On anything else
+   * (`'unverified'`, `'rejected'`) they come back `null` here — fail-closed,
+   * never a partial/best-effort value — even if the underlying row has
+   * non-null `creditLine`/`sourceName`/`copyrightStatus`. This DTO
+   * deliberately carries no `rightsVerificationStatus` field of its own (a
+   * consumer has no business decision to make from it — the gate has already
+   * been applied) and no `rightsVerifiedBy`/`rightsVerifiedAt`/`rightsNotes`
+   * at all: the first pair names an internal reviewer and a review moment
+   * (same posture ADR-0109 took for publishing a byline — an internal
+   * identity must never cross into a public surface as a side effect), and
+   * the second can carry licensing/contact terms that are editorial-internal,
+   * not a credit. See `media-library`'s
+   * `domain/media-rights-policy.ts#resolvePublicMediaRightsFields` for the
+   * full rationale — this shape is intentionally its OWN, not a re-export of
+   * that module's `CopyrightStatus`/`RightsVerificationStatus` types (same
+   * "port depends on neither" rule as every other DTO in this file), so keep
+   * the literal union below in sync with `COPYRIGHT_STATUSES` by hand.
+   */
+  creditLine: string | null;
+  sourceName: string | null;
+  copyrightStatus:
+    | "unknown"
+    | "owned"
+    | "licensed"
+    | "public_domain"
+    | "permission_granted"
+    | "fair_use"
+    | null;
 };
 
 export type MediaLibraryPort = {

--- a/src/modules/media-library/README.id.md
+++ b/src/modules/media-library/README.id.md
@@ -1,6 +1,6 @@
 🇮🇩 Bahasa Indonesia · 🇬🇧 [English (source)](README.md)
 
-<!-- i18n-source-hash: sha256:b50923d5687979a0daf8209d26131a380dad63b083bfefd5f43afbe1087d7c3c -->
+<!-- i18n-source-hash: sha256:06e2fdbe6e9ff9c9ca220d31169f945ed001cd9da16226a79c78a92c2b90f749 -->
 
 # media_library
 
@@ -216,3 +216,39 @@ berbeda.
 
 Read-only, jadi kredensial mesin ([ADR-0049](../../../docs/adr/0049-machine-credentials-and-session-introspection.md))
 boleh memegangnya.
+
+### Field kredit/rights pada DTO publik (Issue #782)
+
+`sql/137` (Issue #615) memberi setiap objek media tujuh field rights:
+`creditLine`, `sourceName`, `rightsNotes`, `copyrightStatus`,
+`rightsVerificationStatus`, `rightsVerifiedBy`, `rightsVerifiedAt`. Sampai
+Issue #782, tidak satu pun menyeberangi batas `GET /api/v1/media/objects` —
+sebuah situs berita turunan bisa merender alt text sebuah foto tanpa kredit
+fotografernya, padahal kreditnya sudah ada di baris itu sejak awal.
+
+`ResolvedMediaReferenceDTO` (`_shared/ports/media-library-port.ts`) kini juga
+membawa `creditLine`, `sourceName`, dan `copyrightStatus` — tetapi **hanya
+tiga dari tujuh, dan hanya bersyarat**:
+
+- **`rightsVerifiedBy`/`rightsVerifiedAt` tidak pernah menyeberang sama
+  sekali.** Keduanya menyebut seorang reviewer internal dan momen review.
+  Postur yang sama dengan yang sudah diambil
+  [ADR-0109](../../../docs/adr/0109-a-byline-is-opted-into-and-it-is-not-your-account-name.md)
+  untuk `awcms_tenant_users.public_byline_name`: identitas internal tidak
+  boleh mencapai permukaan publik ber-kredensial sebagai efek samping field
+  lain yang diterbitkan.
+- **`rightsNotes` juga tidak pernah menyeberang.** Ia bisa memuat syarat
+  lisensi dan kontak — editorial-internal, bukan kredit.
+- **`creditLine`/`sourceName`/`copyrightStatus` menyeberang HANYA ketika
+  `rightsVerificationStatus === 'verified'`.** Pada keadaan lain — default
+  `'unverified'`, atau eksplisit `'rejected'` — ketiganya kembali sebagai
+  `null`, bahkan ketika baris di baliknya sudah terisi. Fail-closed: belum
+  ada yang mengonfirmasi ruang redaksi boleh mencetak kredit ini, jadi
+  endpoint pun tidak mencetaknya. Lihat
+  `domain/media-rights-policy.ts#resolvePublicMediaRightsFields` untuk fungsi
+  gerbang murni dan alasan lengkapnya, dan `resolveMediaReferences` di
+  `application/media-library-port-adapter.ts` untuk tempat ia diterapkan.
+
+Ini adalah pelebaran data yang sudah dikembalikan oleh rute yang ada,
+ber-gerbang `media_library.media.read` — tanpa endpoint baru, tanpa
+permission baru.

--- a/src/modules/media-library/README.md
+++ b/src/modules/media-library/README.md
@@ -214,3 +214,37 @@ different facts.
 
 Read-only, so machine credentials ([ADR-0049](../../../docs/adr/0049-machine-credentials-and-session-introspection.md))
 may hold it.
+
+### Credit/rights fields on the public DTO (Issue #782)
+
+`sql/137` (Issue #615) gave every media object seven rights fields:
+`creditLine`, `sourceName`, `rightsNotes`, `copyrightStatus`,
+`rightsVerificationStatus`, `rightsVerifiedBy`, `rightsVerifiedAt`. Until
+Issue #782, none of them crossed the `GET /api/v1/media/objects` boundary — a
+derived news site could render a photo's alt text with no photographer
+credit, even though the credit existed on the row all along.
+
+`ResolvedMediaReferenceDTO` (`_shared/ports/media-library-port.ts`) now also
+carries `creditLine`, `sourceName`, and `copyrightStatus` — but **only three
+of the seven, and only conditionally**:
+
+- **`rightsVerifiedBy`/`rightsVerifiedAt` never cross at all.** They name an
+  internal reviewer and a review moment. Same posture
+  [ADR-0109](../../../docs/adr/0109-a-byline-is-opted-into-and-it-is-not-your-account-name.md)
+  already took for `awcms_tenant_users.public_byline_name`: an internal
+  identity must never reach a public, credential-gated surface as a side
+  effect of some other field being published.
+- **`rightsNotes` never crosses either.** It can hold licensing terms and
+  contact details — editorial-internal, not a credit.
+- **`creditLine`/`sourceName`/`copyrightStatus` cross ONLY when
+  `rightsVerificationStatus === 'verified'`.** On anything else — the default
+  `'unverified'`, or an explicit `'rejected'` — all three come back `null`,
+  even when the underlying row has them populated. Fail-closed: nobody has
+  confirmed the newsroom may print this credit, so the endpoint does not print
+  it either. See `domain/media-rights-policy.ts#resolvePublicMediaRightsFields`
+  for the pure gate function and its full rationale, and
+  `application/media-library-port-adapter.ts`'s `resolveMediaReferences` for
+  where it is applied.
+
+This is a widening of data already returned by an existing
+`media_library.media.read`-gated route — no new endpoint, no new permission.

--- a/src/modules/media-library/application/media-library-port-adapter.ts
+++ b/src/modules/media-library/application/media-library-port-adapter.ts
@@ -50,6 +50,7 @@ import {
 } from "./media-object-directory";
 import { isManagedMediaEnforcedForTenant } from "./media-library-tenant-state";
 import { evaluateManagedMediaReadiness } from "../domain/managed-media-readiness";
+import { resolvePublicMediaRightsFields } from "../domain/media-rights-policy";
 import type {
   MediaLibraryPort,
   ResolvedMediaReferenceDTO
@@ -102,13 +103,24 @@ export const mediaLibraryPortAdapter: MediaLibraryPort = {
 
     for (const media of mediaObjects) {
       if (isNewsMediaObjectSafeForPublicReference(media.status)) {
+        // Issue #782 — the credit/rights fields are gated separately from the
+        // safe-to-reference check above: a `verified`/`attached` OBJECT (the
+        // bytes are fine to serve) is not the same fact as `verified`
+        // RIGHTS (a human cleared the credit for publication). See
+        // `resolvePublicMediaRightsFields` for why an unadjudicated claim
+        // fails closed to `null` rather than being passed through.
+        const rights = resolvePublicMediaRightsFields(media);
+
         resolved.set(media.id, {
           publicUrl: media.publicUrl,
           altText: media.altText,
           mimeType: media.mimeType,
           width: media.width,
           height: media.height,
-          sizeBytes: media.sizeBytes
+          sizeBytes: media.sizeBytes,
+          creditLine: rights.creditLine,
+          sourceName: rights.sourceName,
+          copyrightStatus: rights.copyrightStatus
         });
       }
     }

--- a/src/modules/media-library/domain/media-rights-policy.ts
+++ b/src/modules/media-library/domain/media-rights-policy.ts
@@ -247,3 +247,61 @@ export function changesRightsAdjudication(
     input.rightsVerificationStatus !== current
   );
 }
+
+export type PublicMediaRightsFields = {
+  creditLine: string | null;
+  sourceName: string | null;
+  copyrightStatus: CopyrightStatus | null;
+};
+
+/**
+ * Projects a media object's rights metadata onto the shape that may cross a
+ * PUBLIC read boundary (Issue #782 —
+ * `MediaLibraryPort.resolveMediaReferences` / `ResolvedMediaReferenceDTO`).
+ *
+ * Two of the seven rights fields never reach this function's return value at
+ * all, by design, not by oversight:
+ *
+ * - `rightsVerifiedBy` / `rightsVerifiedAt` name a STAFF MEMBER and a moment of
+ *   internal review. Same posture ADR-0109 already took for
+ *   `awcms_tenant_users.public_byline_name`: an internal identity does not
+ *   cross into a public, credential-gated surface as a side effect of some
+ *   other field being published. The failure mode of omitting it must stay
+ *   benign (a byline/credit is simply missing); leaking a reviewer's name and
+ *   timestamp is not something a takedown can undo.
+ * - `rightsNotes` can hold licensing terms and contact details — editorial
+ *   working notes, not a credit line, and not for a reader.
+ *
+ * The remaining three (`creditLine` / `sourceName` / `copyrightStatus`) ARE
+ * the credit a news site is legally/reputationally obliged to show — but only
+ * once a HUMAN has adjudicated the claim. Whenever
+ * `rightsVerificationStatus` is anything other than `'verified'` (the default
+ * `'unverified'`, or an explicit `'rejected'`), nobody has confirmed the
+ * newsroom may print this credit, so this fails CLOSED: every field comes
+ * back `null` — never the underlying value — even though the row itself may
+ * carry a fully-populated `creditLine`/`sourceName`/`copyrightStatus`. Same
+ * shape as `checkRedirectSafety` or `businessScopeFacts.resolved === false`
+ * elsewhere in this codebase: an unresolved/unadjudicated state denies, it
+ * never falls back to "show it anyway."
+ *
+ * A future reader who notices these fields read `null` for every
+ * not-yet-verified object and "fixes" this into always populating them would
+ * silently let an unadjudicated — possibly `rejected` — rights claim reach a
+ * live public site. Don't.
+ */
+export function resolvePublicMediaRightsFields(media: {
+  creditLine: string | null;
+  sourceName: string | null;
+  copyrightStatus: CopyrightStatus;
+  rightsVerificationStatus: RightsVerificationStatus;
+}): PublicMediaRightsFields {
+  if (media.rightsVerificationStatus !== "verified") {
+    return { creditLine: null, sourceName: null, copyrightStatus: null };
+  }
+
+  return {
+    creditLine: media.creditLine,
+    sourceName: media.sourceName,
+    copyrightStatus: media.copyrightStatus
+  };
+}

--- a/tests/content-quality-checklist-gate.test.ts
+++ b/tests/content-quality-checklist-gate.test.ts
@@ -87,7 +87,10 @@ describe("evaluateContentQualityChecklistForContent (Issue #640)", () => {
             mimeType: "image/jpeg",
             width: 800,
             height: 600,
-            sizeBytes: 1000
+            sizeBytes: 1000,
+            creditLine: null,
+            sourceName: null,
+            copyrightStatus: null
           }
         }
       }),
@@ -182,7 +185,10 @@ describe("evaluateContentQualityChecklistForContent (Issue #640)", () => {
               mimeType: "image/jpeg",
               width: 800,
               height: 600,
-              sizeBytes: 1000
+              sizeBytes: 1000,
+              creditLine: null,
+              sourceName: null,
+              copyrightStatus: null
             },
             [SEO_IMAGE_ID]: {
               publicUrl: "https://media.example.test/seo.jpg",
@@ -190,7 +196,10 @@ describe("evaluateContentQualityChecklistForContent (Issue #640)", () => {
               mimeType: "image/jpeg",
               width: 1200,
               height: 630,
-              sizeBytes: 2000
+              sizeBytes: 2000,
+              creditLine: null,
+              sourceName: null,
+              copyrightStatus: null
             }
           }
         }),
@@ -226,7 +235,10 @@ describe("evaluateContentQualityChecklistForContent (Issue #640)", () => {
               mimeType: "image/jpeg",
               width: 1200,
               height: 630,
-              sizeBytes: 2000
+              sizeBytes: 2000,
+              creditLine: null,
+              sourceName: null,
+              copyrightStatus: null
             }
           }
         }),

--- a/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
+++ b/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
@@ -629,7 +629,9 @@ paths:
         - News Media
       summary: Batch-resolve media object ids to their public reference.
       description: |
-        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+        Resolves up to 100 media object ids at once to `{publicUrl, altText, mimeType, width, height, sizeBytes, creditLine, sourceName, copyrightStatus}`. Gated on `media_library.media.read`; read-only, so a machine credential (ADR-0049) may hold it.
+
+        Issue #782 — `creditLine`/`sourceName`/`copyrightStatus` are populated ONLY when the object's rights-verification decision is `verified`; otherwise all three are `null`. This is a distinct verification concept from the upload-integrity `verified`/`attached` status below.
 
         An object resolves ONLY when it is `verified` or `attached`, belongs to the calling tenant, and is not soft-deleted. Everything else — unknown, cross-tenant, unverified, deleted — is returned in `unresolved` rather than dropped, so a caller can tell "this resource has no image" from "this resource's image reference is broken". A malformed (non-uuid) id is a 400 instead: "you sent junk" and "that object is not referenceable" are different facts.
 
@@ -1439,6 +1441,35 @@ components:
           type: string
           nullable: true
           maxLength: 120
+        redirectCapture:
+          description: "Issue #784 — present ONLY on a `PATCH /api/v1/blog/posts/{id}` response whose body actually changed `slug` (absent otherwise, including on `GET`/`POST` and every lifecycle action). Reports what `captureUrlChangeRedirect` (ADR-0039) did with the resulting old->new path change, gated by the tenant's own `url_change_auto_policy` (`POST /api/v1/seo/redirects/capture-url-change` is the same seam, driven here automatically instead of by a caller). A `rejected` or `invalid` outcome never fails the post update itself — the slug change is additive tooling around the edit, not a precondition for it."
+          type: object
+          required:
+            - outcome
+          properties:
+            outcome:
+              type: string
+              enum:
+                - created
+                - proposed
+                - skipped
+                - module_disabled
+                - invalid
+                - rejected
+            redirectId:
+              description: Present only when outcome is "created" or "proposed".
+              type: string
+              format: uuid
+            code:
+              description: Present only when outcome is "rejected".
+              type: string
+              enum:
+                - SOURCE_CONFLICT
+                - REDIRECT_LOOP
+                - REDIRECT_CHAIN_TOO_LONG
+            message:
+              description: Present only when outcome is "rejected" — a human-readable reason no redirect was created.
+              type: string
     BlogPostSummary:
       type: object
       description: |
@@ -1952,6 +1983,26 @@ components:
         sizeBytes:
           type: integer
           nullable: true
+        creditLine:
+          type: string
+          nullable: true
+          description: "Issue #782. The photo credit — what gets printed beside the image. `null` unless the source object's rights claim has been HUMAN-verified (internal `rightsVerificationStatus = 'verified'`); an unverified or rejected claim never reaches this field, even if the object has a credit line on file."
+        sourceName:
+          type: string
+          nullable: true
+          description: "Issue #782. Where the file came from (often distinct from who is credited). Same verification gate as `creditLine`: `null` unless the rights claim has been verified."
+        copyrightStatus:
+          type: string
+          nullable: true
+          enum:
+            - unknown
+            - owned
+            - licensed
+            - public_domain
+            - permission_granted
+            - fair_use
+            - null
+          description: 'Issue #782. Same verification gate as `creditLine`/`sourceName`: `null` unless the rights claim has been verified — including when the underlying object''s copyright status is the real, non-null `''unknown''` value (verification and "unknown" are different facts, and only one of them is nullability here).'
     SessionIntrospection:
       type: object
       description: Safe claims for a live session (ADR-0049 §7). Deliberately excludes the raw login identifier that GET /api/v1/auth/me returns.

--- a/tests/integration/media-object-resolve.integration.test.ts
+++ b/tests/integration/media-object-resolve.integration.test.ts
@@ -72,12 +72,27 @@ async function seedTenant(
  * into `blog_content`, but both deliberately kept the physical names — so these
  * literals are what a real row still carries, not leftovers in the fixture.
  */
+/**
+ * Issue #782 — a media object's rights/credit metadata, as it would look on a
+ * row a rights editor has actually filled in. Left undefined, the columns
+ * keep their `sql/137` defaults (`copyright_status = 'unknown'`,
+ * `rights_verification_status = 'unverified'`, everything else `NULL`).
+ */
+type RightsFixture = {
+  creditLine?: string;
+  sourceName?: string;
+  rightsNotes?: string;
+  copyrightStatus?: string;
+  rightsVerificationStatus?: "unverified" | "verified" | "rejected";
+  rightsVerifiedBy?: string;
+};
+
 async function seedMedia(
   tenantId: string,
   userId: string,
   label: string,
   status: string,
-  options: { deleted?: boolean } = {}
+  options: { deleted?: boolean; rights?: RightsFixture } = {}
 ): Promise<string> {
   // `object_key` is CHECK-constrained to `news-media/<tenant_id>/YYYY/MM/<uuid>.<ext>`,
   // verified per-row against the row's OWN tenant_id — so a fixture cannot use a
@@ -90,17 +105,34 @@ async function seedMedia(
   // alone — the database will not hold a half-attached row.
   const attached = status === "attached";
 
+  const rights = options.rights ?? {};
+  const verificationStatus = rights.rightsVerificationStatus ?? "unverified";
+  // `rights_adjudication_check` (sql/137) requires `rights_verified_by`/`_at`
+  // to be set together with any non-`unverified` status, and NULL otherwise —
+  // so a "verified"/"rejected" fixture must supply a verifier or the insert
+  // itself is rejected by the database, not merely by application code.
+  const verifiedBy =
+    verificationStatus === "unverified"
+      ? null
+      : (rights.rightsVerifiedBy ?? userId);
+  const verifiedAt = verificationStatus === "unverified" ? null : new Date();
+
   const rows = (await getAdminSql()`
     INSERT INTO awcms_news_media_objects
       (tenant_id, module_key, storage_driver, bucket_name, object_key,
        public_url, mime_type, alt_text, status, owner_resource_type,
-       owner_resource_id, created_by_tenant_user_id, deleted_at)
+       owner_resource_id, created_by_tenant_user_id, deleted_at,
+       credit_line, source_name, rights_notes, copyright_status,
+       rights_verification_status, rights_verified_by, rights_verified_at)
     VALUES (
       ${tenantId}, 'news_portal', 'cloudflare_r2', 'bucket', ${objectKey},
       ${`https://cdn.example.test/${label}.png`}, 'image/png', ${`alt ${label}`},
       ${status}, ${attached ? "blog_post" : null},
       ${attached ? crypto.randomUUID() : null},
-      ${userId}, ${options.deleted ? new Date() : null}
+      ${userId}, ${options.deleted ? new Date() : null},
+      ${rights.creditLine ?? null}, ${rights.sourceName ?? null},
+      ${rights.rightsNotes ?? null}, ${rights.copyrightStatus ?? "unknown"},
+      ${verificationStatus}, ${verifiedBy}, ${verifiedAt}
     )
     RETURNING id
   `) as { id: string }[];
@@ -205,3 +237,143 @@ suite("media object batch resolution", () => {
     expect(result.items).toEqual([ids.otherTenant!]);
   });
 });
+
+/**
+ * Issue #782 — the credit/rights fields the public DTO gained
+ * (`creditLine`/`sourceName`/`copyrightStatus`), and the verification gate
+ * that decides whether they cross at all. Its own suite because it needs its
+ * own fixture shape (a rights-metadata row, not just a status), separate from
+ * the safe-to-reference tests above.
+ */
+suite(
+  "media object batch resolution — rights/credit fields (Issue #782)",
+  () => {
+    beforeAll(async () => {
+      await setupIntegrationDatabase();
+    });
+
+    afterAll(async () => {
+      await teardownIntegrationDatabase();
+    });
+
+    beforeEach(async () => {
+      await resetDatabase();
+      await seedTenant(TENANT_A, "media-a", AUTHOR_A);
+    });
+
+    /** Every rights/credit field on the underlying row a public DTO must NEVER surface, in ANY case. */
+    const NEVER_PUBLIC_KEYS = [
+      "rightsNotes",
+      "rightsVerificationStatus",
+      "rightsVerifiedBy",
+      "rightsVerifiedAt"
+    ];
+
+    test("a verified media object's credit/rights fields cross to the public DTO", async () => {
+      const id = await seedMedia(
+        TENANT_A,
+        AUTHOR_A,
+        "verified-rights",
+        "verified",
+        {
+          rights: {
+            creditLine: "Foto: Ani Wijaya",
+            sourceName: "Kantor Berita Kalteng",
+            rightsNotes:
+              "Licensed for one-time web use only, contact agency for reuse.",
+            copyrightStatus: "licensed",
+            rightsVerificationStatus: "verified",
+            rightsVerifiedBy: AUTHOR_A
+          }
+        }
+      );
+
+      const result = await resolve(TENANT_A, [id]);
+      expect(result.items).toEqual([id]);
+
+      const resolved = await withTenantOrThrow(
+        getRuntimeSql(),
+        TENANT_A,
+        (tx) =>
+          mediaLibraryPortAdapter.resolveMediaReferences(tx, TENANT_A, [id])
+      );
+      const dto = resolved.get(id)!;
+
+      expect(dto.creditLine).toBe("Foto: Ani Wijaya");
+      expect(dto.sourceName).toBe("Kantor Berita Kalteng");
+      expect(dto.copyrightStatus).toBe("licensed");
+
+      // Positive proof, not absence-by-omission: the internal reviewer identity,
+      // the review moment, and the editorial-only notes must not be reachable on
+      // the object at all — not merely `undefined` on a widened type.
+      for (const key of NEVER_PUBLIC_KEYS) {
+        expect(Object.keys(dto)).not.toContain(key);
+      }
+    });
+
+    test.each([
+      ["unverified (the default — nobody has adjudicated it)", undefined],
+      ["rejected (a human explicitly refused it)", "rejected" as const]
+    ])(
+      "%s: credit/rights fields are null even though the row has them set",
+      async (_label, verificationStatus) => {
+        const id = await seedMedia(
+          TENANT_A,
+          AUTHOR_A,
+          "unverified-rights",
+          "verified",
+          {
+            rights: {
+              creditLine: "Foto: Budi",
+              sourceName: "Agency X",
+              rightsNotes: "Do not publish without agency sign-off.",
+              copyrightStatus: "owned",
+              rightsVerificationStatus: verificationStatus,
+              rightsVerifiedBy: verificationStatus ? AUTHOR_A : undefined
+            }
+          }
+        );
+
+        const resolved = await withTenantOrThrow(
+          getRuntimeSql(),
+          TENANT_A,
+          (tx) =>
+            mediaLibraryPortAdapter.resolveMediaReferences(tx, TENANT_A, [id])
+        );
+        const dto = resolved.get(id)!;
+
+        // Fail-closed: the object itself still resolves (bytes are fine to
+        // serve), but the credit is suppressed until a human clears it.
+        expect(dto.creditLine).toBeNull();
+        expect(dto.sourceName).toBeNull();
+        expect(dto.copyrightStatus).toBeNull();
+
+        for (const key of NEVER_PUBLIC_KEYS) {
+          expect(Object.keys(dto)).not.toContain(key);
+        }
+      }
+    );
+
+    test("the existing six fields are unaffected by the rights gate (no regression)", async () => {
+      const id = await seedMedia(TENANT_A, AUTHOR_A, "plain", "verified");
+
+      const resolved = await withTenantOrThrow(
+        getRuntimeSql(),
+        TENANT_A,
+        (tx) =>
+          mediaLibraryPortAdapter.resolveMediaReferences(tx, TENANT_A, [id])
+      );
+      const dto = resolved.get(id)!;
+
+      expect(dto.publicUrl).toBe("https://cdn.example.test/plain.png");
+      expect(dto.altText).toBe("alt plain");
+      expect(dto.mimeType).toBe("image/png");
+      expect(dto.width).toBeNull();
+      expect(dto.height).toBeNull();
+      expect(dto.sizeBytes).toBeNull();
+      expect(dto.creditLine).toBeNull();
+      expect(dto.sourceName).toBeNull();
+      expect(dto.copyrightStatus).toBeNull();
+    });
+  }
+);

--- a/tests/integration/scheduled-publish-toctou.integration.test.ts
+++ b/tests/integration/scheduled-publish-toctou.integration.test.ts
@@ -67,7 +67,10 @@ const RESOLVED: ResolvedMediaReferenceDTO = {
   mimeType: "image/jpeg",
   width: 1200,
   height: 800,
-  sizeBytes: 240_000
+  sizeBytes: 240_000,
+  creditLine: null,
+  sourceName: null,
+  copyrightStatus: null
 };
 
 /**

--- a/tests/media-rights-policy.test.ts
+++ b/tests/media-rights-policy.test.ts
@@ -30,6 +30,7 @@ import {
   isRightsAdjudication,
   isRightsVerificationStatus,
   MAX_CREDIT_LINE_LENGTH,
+  resolvePublicMediaRightsFields,
   RIGHTS_VERIFICATION_STATUSES,
   validateMediaRightsUpdateInput
 } from "../src/modules/media-library/domain/media-rights-policy";
@@ -38,6 +39,7 @@ const ROUTE = "src/pages/api/v1/media/objects/[id].ts";
 const DIRECTORY =
   "src/modules/media-library/application/media-object-directory.ts";
 const MIGRATION = "sql/137_awcms_media_rights_metadata.sql";
+const PORT = "src/modules/_shared/ports/media-library-port.ts";
 
 describe("the patch distinguishes 'leave alone' from 'clear'", () => {
   test("an omitted field is absent from the parsed value", () => {
@@ -196,5 +198,90 @@ describe("the adjudication is stamped from the server, never from the body", () 
 
     expect(migration).toContain("'media_library', 'media', 'update'");
     expect(route).toContain("export const PATCH");
+  });
+});
+
+/**
+ * Issue #782 — three of the seven rights fields (`creditLine`, `sourceName`,
+ * `copyrightStatus`) may cross into the public `ResolvedMediaReferenceDTO`,
+ * and only once a human has verified the claim. Two never cross at all:
+ * `rightsVerifiedBy`/`rightsVerifiedAt` (ADR-0109's posture — an internal
+ * reviewer identity is not a public field) and `rightsNotes` (editorial
+ * working notes, not a credit).
+ */
+describe("the public media DTO gate (Issue #782)", () => {
+  const VERIFIED_MEDIA = {
+    creditLine: "Foto: Ani Wijaya",
+    sourceName: "Kantor Berita Kalteng",
+    copyrightStatus: "licensed" as const,
+    rightsVerificationStatus: "verified" as const
+  };
+
+  test("a verified object's credit/rights fields pass through unchanged", () => {
+    const result = resolvePublicMediaRightsFields(VERIFIED_MEDIA);
+
+    expect(result).toEqual({
+      creditLine: "Foto: Ani Wijaya",
+      sourceName: "Kantor Berita Kalteng",
+      copyrightStatus: "licensed"
+    });
+  });
+
+  test.each([
+    ["unverified — the default, nobody has adjudicated it", "unverified"],
+    ["rejected — a human explicitly refused it", "rejected"]
+  ])("%s: all three fields come back null", (_label, status) => {
+    const result = resolvePublicMediaRightsFields({
+      ...VERIFIED_MEDIA,
+      rightsVerificationStatus: status as "unverified" | "rejected"
+    });
+
+    // Fail-closed: the values are SUPPRESSED, not merely a different shape —
+    // an unadjudicated claim must never leak through as "best effort".
+    expect(result).toEqual({
+      creditLine: null,
+      sourceName: null,
+      copyrightStatus: null
+    });
+  });
+
+  test("the gate never receives, and so can never leak, the verifier identity or editorial notes", () => {
+    // The function's own parameter type has no `rightsVerifiedBy`/
+    // `rightsVerifiedAt`/`rightsNotes` — this is enforced at compile time
+    // (see the type below), not by a runtime check. What this test pins is
+    // the SOURCE shape, so a future widening of the parameter type is caught
+    // even before anyone passes it a row that has those fields set.
+    expect(resolvePublicMediaRightsFields.length).toBe(1);
+    expect(Object.keys(resolvePublicMediaRightsFields(VERIFIED_MEDIA))).toEqual(
+      ["creditLine", "sourceName", "copyrightStatus"]
+    );
+  });
+
+  test("the public port type declares exactly the three new fields, and none of the excluded four", async () => {
+    const port = stripComments(
+      await readFile("src/modules/_shared/ports/media-library-port.ts", "utf8")
+    );
+    const start = port.indexOf("export type ResolvedMediaReferenceDTO = {");
+    expect(start).toBeGreaterThan(-1);
+    const end = port.indexOf("};", start);
+    expect(end).toBeGreaterThan(start);
+    const dtoBlock = port.slice(start, end);
+
+    expect(dtoBlock).toContain("creditLine:");
+    expect(dtoBlock).toContain("sourceName:");
+    expect(dtoBlock).toContain("copyrightStatus:");
+
+    // Positive proof the type itself was never widened past the decision in
+    // Issue #782 — not just that today's adapter happens not to populate them.
+    expect(dtoBlock).not.toContain("rightsVerifiedBy");
+    expect(dtoBlock).not.toContain("rightsVerifiedAt");
+    expect(dtoBlock).not.toContain("rightsNotes");
+    expect(dtoBlock).not.toContain("rightsVerificationStatus");
+  });
+
+  test("the port file still imports nothing (neutral-ground rule)", async () => {
+    const port = await readFile(PORT, "utf8");
+
+    expect(port).not.toMatch(/^import /m);
   });
 });

--- a/tests/theme-media-resolution.test.ts
+++ b/tests/theme-media-resolution.test.ts
@@ -41,7 +41,10 @@ function reference(publicUrl: string, altText: string | null = null) {
     mimeType: "image/png",
     width: null,
     height: null,
-    sizeBytes: null
+    sizeBytes: null,
+    creditLine: null,
+    sourceName: null,
+    copyrightStatus: null
   } satisfies ResolvedMediaReferenceDTO;
 }
 


### PR DESCRIPTION
## Summary

- `ResolvedMediaReferenceDTO` (`src/modules/_shared/ports/media-library-port.ts`) gains three new nullable fields — `creditLine`, `sourceName`, `copyrightStatus` — populated by `mediaLibraryPortAdapter.resolveMediaReferences` **only** when the source media object's `rightsVerificationStatus === 'verified'`; otherwise all three come back `null`, even if the underlying row has them set (fail-closed).
- The gate is a pure function, `resolvePublicMediaRightsFields` (`src/modules/media-library/domain/media-rights-policy.ts`), so it is unit-testable without a database.
- `GET /api/v1/media/objects` carries the widened DTO automatically (it spreads whatever the adapter returns) — no route code change was needed.
- OpenAPI (`openapi/modules/media-library.openapi.yaml`), the module READMEs (English + Indonesian mirror), and a changeset are updated.

Fixes #782.

## Answers to the issue's six questions

The issue asked six numbered questions before any field crossed the boundary. Answering them here so the decision is traceable from the issue itself:

1. **`creditLine`, `sourceName` — reader-facing?** Yes. They are exactly the photo credit a news site is obliged to print, and they now cross — gated on rights verification (see below).
2. **`copyrightStatus` — reader-facing?** Yes, same gate as (1). It lets a derived site distinguish e.g. `public_domain` from `licensed`/`permission_granted` when it chooses to.
3. **`rightsVerifiedBy` / `rightsVerifiedAt` — stay internal?** Yes, confirmed. Neither is added to the DTO, in any code path. This mirrors ADR-0109 exactly (an internal reviewer identity, like an internal account name, must never cross into a public, credential-gated surface as a side effect of some other field being published) — the failure mode of omitting them is benign (a credit is simply missing), while leaking a staff member's name/timestamp is not reversible.
4. **`rightsNotes` — publishable?** No. It is excluded entirely; it can carry licensing/contact terms that are editorial-internal, not a credit.
5. **`rightsVerificationStatus` itself — worth exposing?** No, deliberately not added to the public DTO. It is used only as the *gate* inside the adapter: `creditLine`/`sourceName`/`copyrightStatus` are populated only when it is `'verified'`, and come back `null` on `'unverified'`/`'rejected'`. A consumer has no decision left to make from the raw status once the gate has already been applied, so exposing it would only be a second, driftable way to reach the same suppression the DTO already enforces.
6. **Ride `GET /api/v1/media/objects`, or a separate public-facing shape?** Ride the existing endpoint. The widened fields are additive to an already `media_library.media.read`-gated, read-only, tenant-scoped surface (no new endpoint, no new permission, no ABAC/RLS change) — the same safety rule (`verified`/`attached`, same-tenant, not soft-deleted) already governs who gets to see the object at all, and the rights-verification gate is an *additional*, independent condition layered on top of it for these three fields specifically.

## Test plan

- [x] Unit: `resolvePublicMediaRightsFields` — verified object passes credit fields through; `unverified`/`rejected` return all three as `null` despite non-null underlying values; a source-level check pins that the port type never re-gains `rightsVerifiedBy`/`rightsVerifiedAt`/`rightsNotes`/`rightsVerificationStatus`.
- [x] Integration (real Postgres): a verified media object's credit fields cross to the public DTO; `unverified`/`rejected` objects return `null` for all three; a positive `Object.keys(dto)` proof that the four excluded fields never appear on the resolved DTO in any case; the existing six fields (`publicUrl`/`altText`/`mimeType`/`width`/`height`/`sizeBytes`) are unchanged (no regression).
- [x] `bun run typecheck`, `bun run api:spec:check`, `bun run api:docs:check`, `bun run api:consumer-contract:check`, `bun run check:docs:translation` all pass.
- [x] Full `bun run check` gate chain run individually (see PR description below) — all green except the documented local-only `memory:docs:check` false positive.
- [x] `DATABASE_URL="" bun run test` (CI parity): 6001 pass / 0 fail / 951 skip (DB-gated).
- [x] `DATABASE_URL=<superuser> bun run test` (full DB suite): 3 pre-existing failures unrelated to this change (confirmed present on a clean `main` checkout before this branch's changes: one role-privilege check that reads differently against this environment's local Postgres superuser connection, and two http/https scheme mismatches in unrelated sitemap/seo-distribution tests) — none touch `media-library`, `_shared/ports`, or anything this PR changed.
- [x] `bun run build` succeeds.

## Security notes

No new endpoint, no new permission, no ABAC/RLS surface change. The three new fields widen data already returned by the existing `media_library.media.read`-gated, read-only route. The exclusion of `rightsVerifiedBy`/`rightsVerifiedAt` (internal identity/PII-adjacent) and `rightsNotes` (potential licensing/contact terms) is enforced structurally (the port's own DTO type never declares them) and proven at runtime with a positive `Object.keys()` check, not just relied on by omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)