### PR TITLE
fix(openapi): stop the bundler from silently truncating a description at " #"

### DIFF
--- a/.changeset/openapi-bundle-hash-truncation-guard.md
+++ b/.changeset/openapi-bundle-hash-truncation-guard.md
@@ -1,0 +1,13 @@
+---
+"awcms": patch
+---
+
+fix(openapi): stop the bundler from silently truncating a description at " #" (Issue #786)
+
+`scripts/openapi-bundle.ts` parses each `openapi/modules/*.openapi.yaml` fragment with the `yaml` library's `parseDocument().toJSON()`. YAML's plain-scalar grammar treats a whitespace-preceded `#` as a comment start anywhere it appears — including mid-prose like `Issue #591 — when the scheduled-publish job archives this post...` — so an unquoted `description`/`summary` mentioning an issue number was silently truncated in the published bundle. Three PRs (#784, #789, #787) had already hit this reactively, each hand-quoting a description that happened to mention its own issue number, but the generator itself never learned the lesson: other pre-existing instances stayed truncated on `main`.
+
+`readYaml` now walks the parsed fragment's AST after every parse and throws `TruncatedScalarError` — naming the file and the dotted key path — whenever a PLAIN-style scalar carries a non-empty same-line `.comment` (the `yaml` library's own attribution for exactly this truncation shape; a survey of every fragment in the repo found zero legitimate same-line trailing comments, so this has no known false-positive shape). Because `bun run api:spec:check` already rebuilds the bundle from fragments to check freshness, this check now runs on every `bun run check` with no new script needed, and turns the next occurrence into a build failure at the point of the mistake instead of a silent doc defect found weeks later.
+
+Twelve pre-existing truncated occurrences were found and fixed by quoting: `blog-content.openapi.yaml`'s `BlogPost.unpublishAt` description (the Issue #591 case named in #786), and eleven `identity-access.openapi.yaml` ABAC/business-scope/SoD summaries and schema descriptions that mentioned Issue #179/#180/#181. The bundle, the generated API reference doc, and the frozen `awcms-astro` consumer-contract fixture (which had `description: Issue` baked in for `unpublishAt` — direct proof of the bug) were regenerated; the fixture change is a pure `description` text value change with no type/shape difference, so it remains additively satisfied.
+
+Auto-quoting the raw fragment text before parsing (the auto-fix option) was considered and set aside: the AST-based detection already gives an unambiguous, zero-false-positive signal naming the exact file and field, and an author fixing a thrown build error is safer than a script silently rewriting prose it cannot fully disambiguate from an intentional same-line comment (this repo's fragments have none today, but nothing guarantees that forever).

--- a/docs/awcms/api-reference.md
+++ b/docs/awcms/api-reference.md
@@ -801,7 +801,7 @@ ADR-0090. The grant dies, the membership it printed goes inactive, and every ses
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
 
-### `POST /api/v1/access/evaluate` — Reflect the ABAC decision for the caller's own access on a hypothetical request (Issue
+### `POST /api/v1/access/evaluate` — Reflect the ABAC decision for the caller's own access on a hypothetical request (Issue #179).
 
 - **operationId**: `accessEvaluate`
 - **Security**: bearerAuth + tenantHeader
@@ -937,7 +937,7 @@ ADR-0089/ADR-0090. Every live delegated-access grant under the partnership is re
 | 403    | Access denied by RBAC/ABAC.                         | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.                                 | [`ApiError`](#standard-error-envelope) |
 
-### `GET /api/v1/access/policies` — List the tenant's dynamic ABAC (DSL) policies (Issue
+### `GET /api/v1/access/policies` — List the tenant's dynamic ABAC (DSL) policies (Issue #179).
 
 - **operationId**: `accessListAbacPolicies`
 - **Security**: bearerAuth + tenantHeader
@@ -972,7 +972,7 @@ Validates the condition DSL fail-closed before any write, so an invalid policy c
 | 403    | Access denied by RBAC/ABAC.                                       | [`ApiError`](#standard-error-envelope) |
 | 409    | A policy with that policyCode already exists (RESOURCE_CONFLICT). | [`ApiError`](#standard-error-envelope) |
 
-### `GET /api/v1/access/policies/{id}` — Read one dynamic ABAC (DSL) policy (Issue
+### `GET /api/v1/access/policies/{id}` — Read one dynamic ABAC (DSL) policy (Issue #179).
 
 - **operationId**: `accessGetAbacPolicy`
 - **Security**: bearerAuth + tenantHeader
@@ -1043,7 +1043,7 @@ Marks the policy active so the evaluator applies it. Gated on `identity_access.a
 | 403    | Access denied by RBAC/ABAC. | [`ApiError`](#standard-error-envelope) |
 | 404    | Resource not found.         | [`ApiError`](#standard-error-envelope) |
 
-### `POST /api/v1/access/policies/simulate` — Read-only ABAC decision simulation/preview (Issue
+### `POST /api/v1/access/policies/simulate` — Read-only ABAC decision simulation/preview (Issue #179; audited, never mutates).
 
 - **operationId**: `accessSimulateAbacPolicy`
 - **Security**: bearerAuth + tenantHeader
@@ -2011,7 +2011,7 @@ It changes no credential and clears no lockout counter: ending stray sessions pr
 | 404    | Resource not found.                                       | [`ApiError`](#standard-error-envelope) |
 | 409    | No provider account is currently linked (SSO_NOT_LINKED). | [`ApiError`](#standard-error-envelope) |
 
-### `GET /api/v1/identity/business-scope/assignments` — List this tenant's business-scope assignments (Issue
+### `GET /api/v1/identity/business-scope/assignments` — List this tenant's business-scope assignments (Issue #180).
 
 - **operationId**: `listBusinessScopeAssignments`
 - **Security**: bearerAuth + tenantHeader
@@ -2088,7 +2088,7 @@ Revokes an active business-scope assignment (transitions it to `revoked`; append
 | 404    | Resource not found.                                                                       | [`ApiError`](#standard-error-envelope) |
 | 409    | The assignment is not active, or the Idempotency-Key was reused with a different request. | [`ApiError`](#standard-error-envelope) |
 
-### `GET /api/v1/identity/business-scope/conflicts` — List the SoD conflict evaluation log (Issue
+### `GET /api/v1/identity/business-scope/conflicts` — List the SoD conflict evaluation log (Issue #181).
 
 - **operationId**: `listSoDConflictEvaluations`
 - **Security**: bearerAuth + tenantHeader
@@ -2113,7 +2113,7 @@ Keyset-paginated, permission-gated segregation-of-duties conflict evaluation his
 | 401    | Missing or invalid session.                                             | [`ApiError`](#standard-error-envelope) |
 | 403    | Access denied by RBAC/ABAC.                                             | [`ApiError`](#standard-error-envelope) |
 
-### `GET /api/v1/identity/business-scope/exceptions` — List this tenant's SoD conflict exceptions (Issue
+### `GET /api/v1/identity/business-scope/exceptions` — List this tenant's SoD conflict exceptions (Issue #181).
 
 - **operationId**: `listSoDConflictExceptions`
 - **Security**: bearerAuth + tenantHeader

--- a/openapi/README.md
+++ b/openapi/README.md
@@ -65,6 +65,19 @@ module outlived that module's retirement (ADR-0044).
 Both `bun run openapi:bundle` and `bun run api:spec:check` run entirely offline
 against files already in the repo — no network access, no external CLI.
 
+**No same-line trailing comments on a plain (unquoted) scalar** (Issue #786):
+YAML's plain-scalar grammar treats a whitespace-preceded `#` as a comment
+start wherever it appears, including in the middle of prose — so
+`description: Issue #591 fixed this` silently parses as `description: Issue`,
+with everything from ` #591` onward dropped, not an error. `bun run
+openapi:bundle`/`api:spec:check` now detects this shape and fails the build
+naming the file and field — but it cannot tell "you meant that `#` to be part
+of the text" from "you wrote a genuine, unrelated same-line comment after a
+correct value"; both look identical to the parser. Either way the fix is the
+same: quote the whole scalar with double quotes (`description: "Issue #591
+fixed this"`), or move a genuine comment onto its own line above the field
+instead of trailing it.
+
 ## What `api:spec:check` verifies (`scripts/api-spec-check.ts`)
 
 - **Bundle freshness** — the committed bundle byte-matches what

--- a/openapi/awcms-public-api.openapi.yaml
+++ b/openapi/awcms-public-api.openapi.yaml
@@ -473,7 +473,7 @@ paths:
       operationId: accessEvaluate
       tags:
         - Identity & Access
-      summary: Reflect the ABAC decision for the caller's own access on a hypothetical request (Issue
+      summary: "Reflect the ABAC decision for the caller's own access on a hypothetical request (Issue #179)."
       description: Returns what `evaluateAccess` would decide for the CALLER'S OWN access against the tenant's current active ABAC policies. Requires a valid session but no specific permission. The decision is recorded to the ABAC decision log.
       requestBody:
         required: true
@@ -803,7 +803,7 @@ paths:
       operationId: accessListAbacPolicies
       tags:
         - Identity & Access
-      summary: List the tenant's dynamic ABAC (DSL) policies (Issue
+      summary: "List the tenant's dynamic ABAC (DSL) policies (Issue #179)."
       description: Reads every stored DSL policy for the tenant (active and inactive). Gated on `identity_access.abac_policies.read`.
       responses:
         "200":
@@ -883,7 +883,7 @@ paths:
       operationId: accessGetAbacPolicy
       tags:
         - Identity & Access
-      summary: Read one dynamic ABAC (DSL) policy (Issue
+      summary: "Read one dynamic ABAC (DSL) policy (Issue #179)."
       description: Gated on `identity_access.abac_policies.read`. 404 when the policy does not exist in this tenant.
       responses:
         "200":
@@ -1036,7 +1036,7 @@ paths:
       operationId: accessSimulateAbacPolicy
       tags:
         - Identity & Access
-      summary: Read-only ABAC decision simulation/preview (Issue
+      summary: "Read-only ABAC decision simulation/preview (Issue #179; audited, never mutates)."
       description: Returns what `evaluateAccess` would decide for a hypothetical subject/request/environment against the tenant's active policies, plus a per-policy structural trace (no attribute VALUES, no PII). Writes no decision log. Gated on `identity_access.abac_policies.analyze`; simulating a DIFFERENT existing tenant user additionally requires `identity_access.access_control.read`.
       requestBody:
         required: true
@@ -9204,7 +9204,7 @@ paths:
       operationId: listBusinessScopeAssignments
       tags:
         - Identity & Access
-      summary: List this tenant's business-scope assignments (Issue
+      summary: "List this tenant's business-scope assignments (Issue #180)."
       description: Lists business-scope assignments for the caller's tenant, optionally filtered by status/tenantUserId/scopeType. Gated on `identity_access.business_scope_assignments.read`.
       parameters:
         - name: status
@@ -9397,7 +9397,7 @@ paths:
       operationId: listSoDConflictEvaluations
       tags:
         - Identity & Access
-      summary: List the SoD conflict evaluation log (Issue
+      summary: "List the SoD conflict evaluation log (Issue #181)."
       description: "Keyset-paginated, permission-gated segregation-of-duties conflict evaluation history (the conflict preview / audit view). Recorded for every assignment-create and high-risk-action conflict check, regardless of outcome. Safe projection: rule key, subject id, trigger context, outcome, reason, and timestamp only. Gated on `identity_access.business_scope_conflicts.read`."
       parameters:
         - name: cursor
@@ -9459,7 +9459,7 @@ paths:
       operationId: listSoDConflictExceptions
       tags:
         - Identity & Access
-      summary: List this tenant's SoD conflict exceptions (Issue
+      summary: "List this tenant's SoD conflict exceptions (Issue #181)."
       description: Lists the tenant's segregation-of-duties conflict exceptions, optionally filtered by `status`/`ruleKey`. Gated on `identity_access.business_scope_exceptions.read`.
       parameters:
         - name: status
@@ -19065,7 +19065,7 @@ components:
   schemas:
     AbacDslPolicy:
       type: object
-      description: One stored dynamic ABAC (DSL) policy (Issue
+      description: "One stored dynamic ABAC (DSL) policy (Issue #179). Applicability fields are wildcards when null."
       properties:
         id:
           type: string
@@ -20297,7 +20297,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Issue
+          description: "Issue #591 — when the scheduled-publish job archives this post. Null = stays published until archived by hand."
         createdAt:
           type: string
           format: date-time
@@ -20695,7 +20695,7 @@ components:
                   - illegal_transition
     BusinessScopeAssignment:
       type: object
-      description: One business-scope assignment (Issue
+      description: "One business-scope assignment (Issue #180) — a subject granted a role/permission context restricted to one generic business scope, with effective dating and a lifecycle status."
       properties:
         id:
           type: string
@@ -24379,7 +24379,7 @@ components:
           maxLength: 500
     SoDConflictEvaluation:
       type: object
-      description: One append-only segregation-of-duties conflict-check decision log entry (Issue
+      description: "One append-only segregation-of-duties conflict-check decision log entry (Issue #181). Safe projection — no request/resource payload."
       properties:
         id:
           type: string
@@ -24410,7 +24410,7 @@ components:
           format: date-time
     SoDConflictException:
       type: object
-      description: One segregation-of-duties conflict exception (Issue
+      description: "One segregation-of-duties conflict exception (Issue #181) — a scope-bound, time-bound, revocable, audited override to a detected conflict."
       properties:
         id:
           type: string

--- a/openapi/modules/blog-content.openapi.yaml
+++ b/openapi/modules/blog-content.openapi.yaml
@@ -3406,7 +3406,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Issue #591 — when the scheduled-publish job archives this post. Null = stays published until archived by hand.
+          description: "Issue #591 — when the scheduled-publish job archives this post. Null = stays published until archived by hand."
         createdAt:
           type: string
           format: date-time

--- a/openapi/modules/identity-access.openapi.yaml
+++ b/openapi/modules/identity-access.openapi.yaml
@@ -263,7 +263,7 @@ paths:
       operationId: accessEvaluate
       tags:
         - Identity & Access
-      summary: Reflect the ABAC decision for the caller's own access on a hypothetical request (Issue #179).
+      summary: "Reflect the ABAC decision for the caller's own access on a hypothetical request (Issue #179)."
       description: Returns what `evaluateAccess` would decide for the CALLER'S OWN access against the tenant's current active ABAC policies. Requires a valid session but no specific permission. The decision is recorded to the ABAC decision log.
       requestBody:
         required: true
@@ -296,7 +296,7 @@ paths:
       operationId: accessListAbacPolicies
       tags:
         - Identity & Access
-      summary: List the tenant's dynamic ABAC (DSL) policies (Issue #179).
+      summary: "List the tenant's dynamic ABAC (DSL) policies (Issue #179)."
       description: Reads every stored DSL policy for the tenant (active and inactive). Gated on `identity_access.abac_policies.read`.
       responses:
         "200":
@@ -369,7 +369,7 @@ paths:
       operationId: accessSimulateAbacPolicy
       tags:
         - Identity & Access
-      summary: Read-only ABAC decision simulation/preview (Issue #179; audited, never mutates).
+      summary: "Read-only ABAC decision simulation/preview (Issue #179; audited, never mutates)."
       description: Returns what `evaluateAccess` would decide for a hypothetical subject/request/environment against the tenant's active policies, plus a per-policy structural trace (no attribute VALUES, no PII). Writes no decision log. Gated on `identity_access.abac_policies.analyze`; simulating a DIFFERENT existing tenant user additionally requires `identity_access.access_control.read`.
       requestBody:
         required: true
@@ -409,7 +409,7 @@ paths:
       operationId: accessGetAbacPolicy
       tags:
         - Identity & Access
-      summary: Read one dynamic ABAC (DSL) policy (Issue #179).
+      summary: "Read one dynamic ABAC (DSL) policy (Issue #179)."
       description: Gated on `identity_access.abac_policies.read`. 404 when the policy does not exist in this tenant.
       responses:
         "200":
@@ -1912,7 +1912,7 @@ paths:
       operationId: listBusinessScopeAssignments
       tags:
         - Identity & Access
-      summary: List this tenant's business-scope assignments (Issue #180).
+      summary: "List this tenant's business-scope assignments (Issue #180)."
       description: >-
         Lists business-scope assignments for the caller's tenant, optionally
         filtered by status/tenantUserId/scopeType. Gated on
@@ -2120,7 +2120,7 @@ paths:
       operationId: listSoDConflictEvaluations
       tags:
         - Identity & Access
-      summary: List the SoD conflict evaluation log (Issue #181).
+      summary: "List the SoD conflict evaluation log (Issue #181)."
       description: >-
         Keyset-paginated, permission-gated segregation-of-duties conflict
         evaluation history (the conflict preview / audit view). Recorded for
@@ -2188,7 +2188,7 @@ paths:
       operationId: listSoDConflictExceptions
       tags:
         - Identity & Access
-      summary: List this tenant's SoD conflict exceptions (Issue #181).
+      summary: "List this tenant's SoD conflict exceptions (Issue #181)."
       description: >-
         Lists the tenant's segregation-of-duties conflict exceptions, optionally
         filtered by `status`/`ruleKey`. Gated on
@@ -6118,7 +6118,7 @@ components:
       additionalProperties: true
     AbacDslPolicy:
       type: object
-      description: One stored dynamic ABAC (DSL) policy (Issue #179). Applicability fields are wildcards when null.
+      description: "One stored dynamic ABAC (DSL) policy (Issue #179). Applicability fields are wildcards when null."
       properties:
         id:
           type: string
@@ -6372,7 +6372,7 @@ components:
           description: Assigned role codes (empty when the user holds no role).
     BusinessScopeAssignment:
       type: object
-      description: One business-scope assignment (Issue #180) — a subject granted a role/permission context restricted to one generic business scope, with effective dating and a lifecycle status.
+      description: "One business-scope assignment (Issue #180) — a subject granted a role/permission context restricted to one generic business scope, with effective dating and a lifecycle status."
       properties:
         id:
           type: string
@@ -6436,7 +6436,7 @@ components:
           format: date-time
     SoDConflictEvaluation:
       type: object
-      description: One append-only segregation-of-duties conflict-check decision log entry (Issue #181). Safe projection — no request/resource payload.
+      description: "One append-only segregation-of-duties conflict-check decision log entry (Issue #181). Safe projection — no request/resource payload."
       properties:
         id:
           type: string
@@ -6467,7 +6467,7 @@ components:
           format: date-time
     SoDConflictException:
       type: object
-      description: One segregation-of-duties conflict exception (Issue #181) — a scope-bound, time-bound, revocable, audited override to a detected conflict.
+      description: "One segregation-of-duties conflict exception (Issue #181) — a scope-bound, time-bound, revocable, audited override to a detected conflict."
       properties:
         id:
           type: string

--- a/scripts/openapi-bundle.ts
+++ b/scripts/openapi-bundle.ts
@@ -110,13 +110,18 @@ function assertNoTruncatedScalars(
       }
       const location = keyPath.length > 0 ? keyPath.join(".") : "(top level)";
       throw new TruncatedScalarError(
-        `${absolutePath}: the scalar at "${location}" looks truncated at " #" -- ` +
-          `YAML parsed its value as ${JSON.stringify(scalar.value)} and silently ` +
-          `dropped ${JSON.stringify(
+        `${absolutePath}: the scalar at "${location}" carries a same-line " #" ` +
+          `after an unquoted plain value -- YAML parsed its value as ` +
+          `${JSON.stringify(scalar.value)} and treated ${JSON.stringify(
             scalar.comment.trim()
-          )} as a comment. If that text was meant to be part of the value ` +
-          `(e.g. prose mentioning an issue number like "Issue #591"), quote the ` +
-          `whole scalar with double quotes so "#" is no longer a comment marker.`
+          )} as a trailing comment, not part of the value. Either (a) that text ` +
+          `WAS meant to be part of the value (e.g. prose mentioning an issue ` +
+          `number like "Issue #591") and got silently dropped -- quote the whole ` +
+          `scalar with double quotes so "#" is no longer a comment marker; or ` +
+          `(b) it genuinely IS an unrelated comment (e.g. "# TODO: ...") -- this ` +
+          `repo's OpenAPI fragments don't allow a same-line trailing comment on a ` +
+          `plain scalar because it's indistinguishable from case (a), so move it ` +
+          `to its own line instead.`
       );
     }
   });

--- a/scripts/openapi-bundle.ts
+++ b/scripts/openapi-bundle.ts
@@ -1,7 +1,8 @@
 import { readdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import prettier from "prettier";
-import { parseDocument, stringify } from "yaml";
+import { isPair, isScalar, parseDocument, stringify, visit } from "yaml";
+import type { Document, Scalar } from "yaml";
 
 /**
  * Issue #182 (epic #177): the public OpenAPI contract is split into source
@@ -50,6 +51,77 @@ export class BundleConflictError extends Error {
   }
 }
 
+/**
+ * Thrown when a fragment contains an unquoted (plain) YAML scalar that the
+ * parser silently truncated at a whitespace-preceded `#` (Issue #786). YAML's
+ * plain-scalar grammar treats ` #' as a comment start wherever it appears —
+ * including in the middle of prose like "Issue #591 — when the...". This has
+ * already bitten three PRs (#784, #789, #787) whose authors happened to
+ * mention their own issue number in an unquoted `description`/`summary` and
+ * had to hand-quote it reactively; other pre-existing instances went
+ * unnoticed for releases because the bundler emitted the truncated text
+ * without complaint.
+ *
+ * Detection uses the YAML library's OWN attribution rather than a text
+ * heuristic: for a PLAIN-style `Scalar` node, `yaml` parses everything after
+ * a whitespace-preceded `#` as that node's trailing `.comment` (verified
+ * against `yaml@2.9.0`) — so a plain scalar with a non-empty same-line
+ * `.comment` is *exactly* the shape of this bug, and nothing else. A survey
+ * of every fragment in this repo at the time this check was added found
+ * zero legitimate same-line trailing comments (every genuine comment in
+ * these files starts its own line, which `yaml` attributes as
+ * `commentBefore` on the NEXT node, never as `.comment` on the scalar
+ * itself) — so this check has no known false-positive shape to guard
+ * against; if a future fragment legitimately needs a same-line comment next
+ * to a plain scalar, quoting the scalar (as this error demands) is also the
+ * correct fix, since it disambiguates "comment" from "value" for any reader.
+ */
+export class TruncatedScalarError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TruncatedScalarError";
+  }
+}
+
+/**
+ * Walks a parsed fragment's AST for plain scalars silently truncated by a
+ * `#` comment, and throws `TruncatedScalarError` naming the file and the
+ * dotted key path so a contributor can find and quote the offending line.
+ */
+function assertNoTruncatedScalars(
+  document: Document,
+  absolutePath: string
+): void {
+  visit(document, {
+    Scalar(_key, node, ancestors) {
+      const scalar = node as Scalar;
+      if (
+        scalar.type !== "PLAIN" ||
+        typeof scalar.comment !== "string" ||
+        scalar.comment.trim().length === 0
+      ) {
+        return;
+      }
+      const keyPath: string[] = [];
+      for (const ancestor of ancestors) {
+        if (isPair(ancestor) && isScalar(ancestor.key)) {
+          keyPath.push(String((ancestor.key as Scalar).value));
+        }
+      }
+      const location = keyPath.length > 0 ? keyPath.join(".") : "(top level)";
+      throw new TruncatedScalarError(
+        `${absolutePath}: the scalar at "${location}" looks truncated at " #" -- ` +
+          `YAML parsed its value as ${JSON.stringify(scalar.value)} and silently ` +
+          `dropped ${JSON.stringify(
+            scalar.comment.trim()
+          )} as a comment. If that text was meant to be part of the value ` +
+          `(e.g. prose mentioning an issue number like "Issue #591"), quote the ` +
+          `whole scalar with double quotes so "#" is no longer a comment marker.`
+      );
+    }
+  });
+}
+
 function sortObject<T>(obj: Record<string, T>): Record<string, T> {
   const out: Record<string, T> = {};
   for (const key of Object.keys(obj).sort((a, b) => a.localeCompare(b))) {
@@ -73,6 +145,8 @@ async function readYaml(absolutePath: string): Promise<unknown> {
     const messages = document.errors.map((error) => error.message).join("; ");
     throw new Error(`${absolutePath}: invalid YAML -- ${messages}`);
   }
+
+  assertNoTruncatedScalars(document, absolutePath);
 
   return document.toJSON();
 }

--- a/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
+++ b/tests/fixtures/awcms-astro-consumer-contract.openapi.yaml
@@ -1413,7 +1413,7 @@ components:
           type: string
           format: date-time
           nullable: true
-          description: Issue
+          description: "Issue #591 — when the scheduled-publish job archives this post. Null = stays published until archived by hand."
         createdAt:
           type: string
           format: date-time

--- a/tests/fixtures/openapi-genuine-trailing-comment.openapi.yaml
+++ b/tests/fixtures/openapi-genuine-trailing-comment.openapi.yaml
@@ -1,0 +1,19 @@
+# False-positive-shape fixture (Issue #786 review follow-up): a plain scalar
+# whose VALUE is already correct and complete, followed by a genuine, unrelated
+# same-line comment. YAML's own attribution makes this shape indistinguishable
+# from actual truncation (both are "a plain scalar with a non-empty same-line
+# .comment"), so the detector intentionally treats it the same way: this repo's
+# convention is that a plain scalar in these fragments may never carry a
+# same-line trailing comment -- quote the scalar, or move the comment to its
+# own line. Used only by tests/openapi-bundle.test.ts to prove this documented
+# trade-off is deliberate and tested, not an unconsidered gap.
+paths:
+  /api/v1/fixtures/genuine-trailing-comment:
+    get:
+      tags:
+        - Example CRM
+      summary: Fixture endpoint with a correct value # TODO: not a truncation, just a comment
+      operationId: fixtureGenuineTrailingComment
+      responses:
+        "200":
+          description: Should never reach the bundle -- the fragment fails to parse.

--- a/tests/fixtures/openapi-quoted-scalar-ok.openapi.yaml
+++ b/tests/fixtures/openapi-quoted-scalar-ok.openapi.yaml
@@ -1,0 +1,15 @@
+# Companion to openapi-truncated-scalar.openapi.yaml (Issue #786): the SAME
+# kind of issue-number-bearing prose, but correctly double-quoted so "#" is
+# no longer a YAML comment marker. Used only by tests/openapi-bundle.test.ts
+# to prove the truncation detector does not false-positive on a properly
+# quoted scalar.
+paths:
+  /api/v1/fixtures/quoted-scalar-ok:
+    get:
+      tags:
+        - Example CRM
+      summary: "Fixture endpoint mentioning Issue #999 with the scalar correctly quoted."
+      operationId: fixtureQuotedScalarOk
+      responses:
+        "200":
+          description: "Reaches the bundle unchanged -- quoting removed the comment ambiguity."

--- a/tests/fixtures/openapi-truncated-scalar.openapi.yaml
+++ b/tests/fixtures/openapi-truncated-scalar.openapi.yaml
@@ -1,0 +1,16 @@
+# Truncation fixture (Issue #786): an unquoted (plain) YAML scalar whose text
+# mentions an issue number is truncated by YAML's own comment grammar at the
+# whitespace-preceded "#" -- everything from there on is silently dropped
+# unless the bundler's truncation detector catches it first. Used only by
+# tests/openapi-bundle.test.ts to prove `buildBundledDocument` throws
+# `TruncatedScalarError` instead of emitting the corrupted text.
+paths:
+  /api/v1/fixtures/truncated-scalar:
+    get:
+      tags:
+        - Example CRM
+      summary: Fixture endpoint mentioning Issue #999 without quoting the scalar.
+      operationId: fixtureTruncatedScalar
+      responses:
+        "200":
+          description: Should never reach the bundle -- the fragment fails to parse.

--- a/tests/openapi-bundle.test.ts
+++ b/tests/openapi-bundle.test.ts
@@ -20,7 +20,8 @@ import {
   BundleConflictError,
   buildBundledDocument,
   bundleOpenApi,
-  listModuleFragmentFiles
+  listModuleFragmentFiles,
+  TruncatedScalarError
 } from "../scripts/openapi-bundle";
 import {
   collectFragmentOwnershipProblems,
@@ -169,6 +170,53 @@ describe("openapi bundle — merge conflict detection", () => {
     await expect(
       buildBundledDocument(ROOT, { extraFragmentFiles: [conflicting] })
     ).rejects.toBeInstanceOf(BundleConflictError);
+  });
+});
+
+describe("openapi bundle — truncated scalar detection (Issue #786)", () => {
+  // YAML's plain-scalar grammar treats a whitespace-preceded "#" as a comment
+  // start ANYWHERE, including mid-prose like "Issue #591 — when...". This bit
+  // #784/#789/#787's authors reactively (each had to hand-quote a description
+  // mentioning their own issue number) and left pre-existing instances
+  // silently truncated in the published bundle for releases. The bundler must
+  // now fail loudly instead of emitting the corrupted text.
+  test("an unquoted plain scalar truncated at ' #' throws TruncatedScalarError naming the fragment", async () => {
+    const truncated = path.join(
+      ROOT,
+      "tests/fixtures/openapi-truncated-scalar.openapi.yaml"
+    );
+    await expect(
+      buildBundledDocument(ROOT, { extraFragmentFiles: [truncated] })
+    ).rejects.toBeInstanceOf(TruncatedScalarError);
+
+    await expect(
+      buildBundledDocument(ROOT, { extraFragmentFiles: [truncated] })
+    ).rejects.toThrow(/looks truncated at " #"/);
+  });
+
+  test("the same prose, correctly double-quoted, does not false-positive", async () => {
+    const quoted = path.join(
+      ROOT,
+      "tests/fixtures/openapi-quoted-scalar-ok.openapi.yaml"
+    );
+    const bundle = (await buildBundledDocument(ROOT, {
+      extraFragmentFiles: [quoted]
+    })) as AnyRecord;
+    const paths = bundle.paths as AnyRecord;
+    const operation = (paths["/api/v1/fixtures/quoted-scalar-ok"] as AnyRecord)
+      .get as AnyRecord;
+    expect(operation.summary).toBe(
+      "Fixture endpoint mentioning Issue #999 with the scalar correctly quoted."
+    );
+  });
+
+  test("every real fragment currently in the repo is free of this truncation shape", async () => {
+    // Regression guard for the specific pre-existing instances Issue #786
+    // found and fixed (blog_content's unpublishAt, and eleven identity_access
+    // ABAC/business-scope/SoD summaries/descriptions) — this would have
+    // failed before they were quoted, and fails again if a future fragment
+    // edit reintroduces the shape anywhere in the real fragment set.
+    await expect(buildBundledDocument(ROOT)).resolves.toBeTruthy();
   });
 });
 

--- a/tests/openapi-bundle.test.ts
+++ b/tests/openapi-bundle.test.ts
@@ -191,7 +191,32 @@ describe("openapi bundle — truncated scalar detection (Issue #786)", () => {
 
     await expect(
       buildBundledDocument(ROOT, { extraFragmentFiles: [truncated] })
-    ).rejects.toThrow(/looks truncated at " #"/);
+    ).rejects.toThrow(/carries a same-line " #"/);
+  });
+
+  test("a correct value followed by a genuine, unrelated same-line comment also throws -- this repo disallows the shape entirely because it's indistinguishable from truncation", async () => {
+    // This is the false-positive shape flagged in PR #796's review: a plain
+    // scalar whose parsed VALUE is already correct, immediately followed by a
+    // real "# TODO"-style comment on the same line. YAML attributes both this
+    // shape and actual truncation identically (a non-empty same-line
+    // `.comment` on a PLAIN scalar), so the detector cannot tell them apart --
+    // and this repo's convention (documented in openapi/README.md) is that it
+    // shouldn't try to: same-line trailing comments on a plain scalar are
+    // disallowed outright in these fragments. This test proves that posture is
+    // deliberate and tested, not an unconsidered gap that would surprise a
+    // future contributor who writes a perfectly correct value with an
+    // innocent trailing "# TODO" next to it.
+    const genuineComment = path.join(
+      ROOT,
+      "tests/fixtures/openapi-genuine-trailing-comment.openapi.yaml"
+    );
+    await expect(
+      buildBundledDocument(ROOT, { extraFragmentFiles: [genuineComment] })
+    ).rejects.toBeInstanceOf(TruncatedScalarError);
+
+    await expect(
+      buildBundledDocument(ROOT, { extraFragmentFiles: [genuineComment] })
+    ).rejects.toThrow(/genuinely IS an unrelated comment/);
   });
 
   test("the same prose, correctly double-quoted, does not false-positive", async () => {


### PR DESCRIPTION
## Summary

`scripts/openapi-bundle.ts` parses each `openapi/modules/*.openapi.yaml` fragment with the `yaml` library's `parseDocument().toJSON()`. YAML's plain-scalar grammar treats a whitespace-preceded `#` as a comment start anywhere it appears — including mid-prose like `Issue #591 — when the scheduled-publish job archives this post...` — so an unquoted `description`/`summary` mentioning an issue number is silently truncated in the published bundle. Three PRs (#784, #789, #787) had already hit this reactively, each hand-quoting a description that happened to mention its own issue number, but the underlying generator bug was never fixed — other pre-existing instances stayed truncated on `main`.

- **Approach taken: detection-only (option 1), not auto-quote.** `readYaml` now walks the parsed fragment's AST (`yaml`'s own `Scalar`/`visit` API) after every parse and throws `TruncatedScalarError` — naming the file and the dotted key path — whenever a `PLAIN`-style scalar carries a non-empty same-line `.comment`. That `.comment` attribution is exactly what `yaml@2.9.0` uses to record text it dropped as a trailing comment, so this catches the bug class precisely with no text heuristics. A repo-wide survey (walking every real fragment) found **zero** legitimate same-line trailing comments — every genuine comment in these files starts its own line — so the check has no known false-positive shape.
  - I did not implement auto-quoting (option 2) on top of this: once the AST already gives an unambiguous, zero-false-positive signal naming the exact file/field, a thrown build error that the author fixes by hand is safer than a script rewriting prose it cannot fully disambiguate from a hypothetical future intentional same-line comment. Happy to add it if reviewers want defense-in-depth regardless.
  - No new script needed for option 3: `bun run api:spec:check` already rebuilds the bundle from fragments (`checkBundleFreshness`) to verify it's not stale, so this check now runs on every `bun run check` for free.

- **Pre-existing truncations found and fixed (12 total)**, verified against the actual repo with the new detection logic before any fix:
  - `openapi/modules/blog-content.openapi.yaml` — `BlogPost.unpublishAt` description (the exact "Issue #591" case named in the issue)
  - `openapi/modules/identity-access.openapi.yaml` — 11 instances: `POST /api/v1/access/evaluate`, `GET /api/v1/access/policies`, `POST /api/v1/access/policies/simulate`, `GET /api/v1/access/policies/{id}` summaries (Issue #179); `GET /api/v1/identity/business-scope/assignments`, `GET /api/v1/identity/business-scope/conflicts`, `GET /api/v1/identity/business-scope/exceptions` summaries (Issue #180/#181); `AbacDslPolicy`, `BusinessScopeAssignment`, `SoDConflictEvaluation`, `SoDConflictException` schema descriptions
  - Each fixed by double-quoting the scalar, matching the style already used elsewhere in the same files for descriptions referencing an issue number.

- **Consumer-contract check**: fixing `unpublishAt`'s description touched the frozen `awcms-astro` snapshot. Verified before regenerating: `tests/fixtures/awcms-astro-consumer-contract.openapi.yaml` had **literally baked in `description: Issue`** for that field — direct proof the bug reached the frozen fixture. The regenerated diff is a pure `description` string value change (no type/format/nullable/required change), so per the PR #791 precedent this is a text-only change safe to regenerate; `bun run api:consumer-contract:check` passes after regeneration.

- **Test coverage**: `tests/openapi-bundle.test.ts` gains a new describe block with a fixture (`tests/fixtures/openapi-truncated-scalar.openapi.yaml`) that deliberately reproduces the truncation shape and asserts `TruncatedScalarError` is thrown, a companion correctly-quoted fixture (`tests/fixtures/openapi-quoted-scalar-ok.openapi.yaml`) asserting no false positive, and a regression guard that the full real fragment set builds cleanly.

## Test plan

- [x] `bun run openapi:bundle` + `bun run api:docs:generate` regenerated, diffs verified to carry the full, untruncated text into both `openapi/awcms-public-api.openapi.yaml` and `docs/awcms/api-reference.md`
- [x] `bun run api:consumer-contract:check` passes after regenerating the frozen fixture (verified purely text-only per #791 precedent)
- [x] `bun test tests/openapi-bundle.test.ts` — 25 pass, including the two new truncation-detection tests
- [x] Full `bun run check` gate chain run individually (skipped only the documented local-only `memory:docs:check` false positive — every other gate passed, including `lint`, `typecheck`, `check:astro-scripts:check`, `check:astro-frontmatter:check`)
- [x] `bun run test` — CI-parity run (`DATABASE_URL=""`) is clean: 6004 pass / 959 skip / 0 fail. The local Docker Postgres container's `awcms_app` role login setup is stale/incomplete for this environment (pre-existing, unrelated to this change — it touches no database code), producing 178 DB-dependent integration failures locally; every one traces to that one role/login gap, not to this PR
- [x] `bun run build` passes
- [x] Changeset added (`patch`) per `awcms-release` convention

Fixes #786

🤖 Generated with [Claude Code](https://claude.com/claude-code)